### PR TITLE
Fix design AI-chat reliability bugs: editor crash, data loss, variant-pick

### DIFF
--- a/templates/design/actions/edit-design.ts
+++ b/templates/design/actions/edit-design.ts
@@ -91,11 +91,14 @@ function findUniqueStableIdAgnosticSpan(
   }
   if (count !== 1) return null;
 
+  // Anchor `end` to one byte past the LAST matched stripped character rather than
+  // the mapped index of the NEXT character. Mapping the next index can land before
+  // a stripped node-id attribute that sits right after the match, so the splice
+  // would cross it and corrupt the file (e.g. duplicate/mangled tags).
+  const lastMatched = onlyIndex + strippedSearch.length - 1;
   return {
     start: strippedContent.indexMap[onlyIndex] ?? 0,
-    end:
-      strippedContent.indexMap[onlyIndex + strippedSearch.length] ??
-      content.length,
+    end: (strippedContent.indexMap[lastMatched] ?? content.length - 1) + 1,
   };
 }
 

--- a/templates/design/actions/update-design.ts
+++ b/templates/design/actions/update-design.ts
@@ -52,7 +52,40 @@ export default defineAction({
     const updates: Record<string, unknown> = { updatedAt: now };
     if (title !== undefined) updates.title = title;
     if (description !== undefined) updates.description = description;
-    if (data !== undefined) updates.data = data;
+    if (data !== undefined) {
+      // Merge into the existing data blob instead of replacing it wholesale, so
+      // a partial update (e.g. just `tweaks`) doesn't destroy framework-owned
+      // keys like `canvasFrames`. Mirrors generate-design's read-merge.
+      const [existing] = await db
+        .select({ data: schema.designs.data })
+        .from(schema.designs)
+        .where(eq(schema.designs.id, id));
+      const asRecord = (raw: string | null | undefined) => {
+        if (!raw) return {} as Record<string, unknown>;
+        try {
+          const parsed = JSON.parse(raw);
+          return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+            ? (parsed as Record<string, unknown>)
+            : ({} as Record<string, unknown>);
+        } catch {
+          return {} as Record<string, unknown>;
+        }
+      };
+      const incomingParsed = JSON.parse(data);
+      if (
+        incomingParsed &&
+        typeof incomingParsed === "object" &&
+        !Array.isArray(incomingParsed)
+      ) {
+        updates.data = JSON.stringify({
+          ...asRecord(existing?.data),
+          ...(incomingParsed as Record<string, unknown>),
+        });
+      } else {
+        // Non-object JSON (array/primitive): keep the original verbatim write.
+        updates.data = data;
+      }
+    }
     if (projectType !== undefined) updates.projectType = projectType;
     if (designSystemId !== undefined) updates.designSystemId = designSystemId;
 

--- a/templates/design/app/hooks/use-variant-flow.ts
+++ b/templates/design/app/hooks/use-variant-flow.ts
@@ -5,7 +5,7 @@ import {
   isEmbedAuthActive,
 } from "@agent-native/core/client";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useCallback, useState } from "react";
+import { useEffect, useCallback, useRef, useState } from "react";
 
 export const DESIGN_VARIANT_PICKED_EVENT = "agent-native-design-variant-picked";
 
@@ -100,6 +100,13 @@ export function useVariantFlow(designId: string | undefined) {
   const [standalonePick, setStandalonePick] = useState<StandalonePick | null>(
     null,
   );
+  // Re-entry latch so a double-click on "Use this direction" can't fire two
+  // generate-design writes + two pick messages.
+  const pickingRef = useRef(false);
+  // Set once a pick commits; keeps the 2s poll from re-showing the grid in the
+  // window before the server DELETE lands. Cleared once the server state is gone
+  // so a later, genuinely new variant set can still appear.
+  const pickedRef = useRef(false);
 
   const { data } = useQuery({
     queryKey: ["design-variants"],
@@ -121,15 +128,17 @@ export function useVariantFlow(designId: string | undefined) {
   });
 
   useEffect(() => {
-    if (
-      data?.variants &&
-      data.variants.length > 0 &&
-      data.designId === designId
-    ) {
-      setState(data);
-    } else {
+    const hasVariants = Boolean(
+      data?.variants && data.variants.length > 0 && data.designId === designId,
+    );
+    // After a pick, keep the grid hidden until the server-side variant state is
+    // actually cleared (DELETE landed), then re-arm for any future variant set.
+    if (pickedRef.current) {
+      if (!hasVariants) pickedRef.current = false;
       setState(null);
+      return;
     }
+    setState(hasVariants && data ? data : null);
   }, [data, designId]);
 
   const clear = useCallback(() => {
@@ -147,88 +156,94 @@ export function useVariantFlow(designId: string | undefined) {
       if (!state || !designId) return;
       const chosen = state.variants.find((v) => v.id === variantId);
       if (!chosen) return;
-
-      // Persist the chosen variant as the design's primary file via the
-      // agent's own action endpoint so every host lands on the same design.
-      let persisted = false;
+      if (pickingRef.current) return;
+      pickingRef.current = true;
+      pickedRef.current = true;
       try {
-        await callAction(
-          "generate-design" as any,
-          {
-            designId,
-            prompt: `User picked variant "${chosen.label}"`,
-            files: [
-              {
-                filename: "index.html",
-                content: chosen.content,
-                fileType: "html",
-              },
-            ],
-          } as any,
-        );
-        await Promise.all([
-          qc.invalidateQueries({
-            queryKey: ["action", "get-design", { id: designId }],
-          }),
-          qc.invalidateQueries({ queryKey: ["action", "get-design"] }),
-          qc.invalidateQueries({ queryKey: ["action", "list-designs"] }),
-        ]);
-        persisted = true;
-        if (typeof window !== "undefined") {
-          window.dispatchEvent(
-            new CustomEvent(DESIGN_VARIANT_PICKED_EVENT, {
-              detail: { designId, content: chosen.content },
-            }),
+        // Persist the chosen variant as the design's primary file via the
+        // agent's own action endpoint so every host lands on the same design.
+        let persisted = false;
+        try {
+          await callAction(
+            "generate-design" as any,
+            {
+              designId,
+              prompt: `User picked variant "${chosen.label}"`,
+              files: [
+                {
+                  filename: "index.html",
+                  content: chosen.content,
+                  fileType: "html",
+                },
+              ],
+            } as any,
           );
+          await Promise.all([
+            qc.invalidateQueries({
+              queryKey: ["action", "get-design", { id: designId }],
+            }),
+            qc.invalidateQueries({ queryKey: ["action", "get-design"] }),
+            qc.invalidateQueries({ queryKey: ["action", "list-designs"] }),
+          ]);
+          persisted = true;
+          if (typeof window !== "undefined") {
+            window.dispatchEvent(
+              new CustomEvent(DESIGN_VARIANT_PICKED_EVENT, {
+                detail: { designId, content: chosen.content },
+              }),
+            );
+          }
+        } catch {
+          // Network error: report the choice below so the agent still records it;
+          // the grid still clears so the user isn't stuck.
         }
-      } catch {
-        // Network error: report the choice below so the agent still records it;
-        // the grid still clears so the user isn't stuck.
+
+        const refineHint = persisted
+          ? `Its content has been saved as index.html. Continue refining from there if the user asks.`
+          : `Saving the chosen variant did not complete. Ask the user whether to retry before refining it.`;
+        const guardHint = persisted
+          ? `Do not show further variants unless the user explicitly asks for "more options" or "alternatives".`
+          : `Do not claim the design file was updated until generate-design succeeds.`;
+
+        if (isEmbedAuthActive()) {
+          // Embedded MCP host (ChatGPT / Claude): the pick rides the host chat
+          // bridge straight into the conversation.
+          sendToAgentChat({
+            message: `I picked "${chosen.label}".`,
+            context: [
+              `The user chose variant "${chosen.label}" (id: ${chosen.id}) for design ${designId} inside the embedded Design app.`,
+              refineHint,
+              guardHint,
+            ].join("\n"),
+            submit: true,
+            openSidebar: false,
+          });
+        } else if (isLinkOnlyHandoff()) {
+          // Link-only host (CLI / Codex / Claude Code): no chat bridge — show a
+          // copyable summary the user pastes back into their coding agent. The
+          // card owns the clipboard write so its "Copied" state stays truthful.
+          setStandalonePick({
+            heading: "Direction selected",
+            label: chosen.label,
+            text: variantHandoffText(designId, chosen, persisted),
+          });
+        } else {
+          // First-party app: post the pick to its own agent sidebar composer.
+          sendToAgentChat({
+            message: `I picked "${chosen.label}".`,
+            context: [
+              `The user chose variant "${chosen.label}" (id: ${chosen.id}) for design ${designId}.`,
+              refineHint,
+              guardHint,
+            ].join("\n"),
+            submit: true,
+          });
+        }
+
+        clear();
+      } finally {
+        pickingRef.current = false;
       }
-
-      const refineHint = persisted
-        ? `Its content has been saved as index.html. Continue refining from there if the user asks.`
-        : `Saving the chosen variant did not complete. Ask the user whether to retry before refining it.`;
-      const guardHint = persisted
-        ? `Do not show further variants unless the user explicitly asks for "more options" or "alternatives".`
-        : `Do not claim the design file was updated until generate-design succeeds.`;
-
-      if (isEmbedAuthActive()) {
-        // Embedded MCP host (ChatGPT / Claude): the pick rides the host chat
-        // bridge straight into the conversation.
-        sendToAgentChat({
-          message: `I picked "${chosen.label}".`,
-          context: [
-            `The user chose variant "${chosen.label}" (id: ${chosen.id}) for design ${designId} inside the embedded Design app.`,
-            refineHint,
-            guardHint,
-          ].join("\n"),
-          submit: true,
-          openSidebar: false,
-        });
-      } else if (isLinkOnlyHandoff()) {
-        // Link-only host (CLI / Codex / Claude Code): no chat bridge — show a
-        // copyable summary the user pastes back into their coding agent. The
-        // card owns the clipboard write so its "Copied" state stays truthful.
-        setStandalonePick({
-          heading: "Direction selected",
-          label: chosen.label,
-          text: variantHandoffText(designId, chosen, persisted),
-        });
-      } else {
-        // First-party app: post the pick to its own agent sidebar composer.
-        sendToAgentChat({
-          message: `I picked "${chosen.label}".`,
-          context: [
-            `The user chose variant "${chosen.label}" (id: ${chosen.id}) for design ${designId}.`,
-            refineHint,
-            guardHint,
-          ].join("\n"),
-          submit: false,
-        });
-      }
-
-      clear();
     },
     [state, designId, qc, clear],
   );

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -1367,12 +1367,29 @@ function codeLayerTreeToPanelNodes(
   hiddenIds: Set<string>,
   inheritedLocked = false,
   inheritedHidden = false,
+  // Ancestor-path ids guarding against a cyclic projection (e.g. duplicate or
+  // empty node ids like "an-" that make a node its own descendant) recursing
+  // forever and crashing the whole editor with a stack overflow.
+  ancestors: Set<string> = new Set(),
 ): LayersPanelNode[] {
   return nodes.map((node) => {
     const selfLocked = lockedIds.has(node.id);
     const selfHidden = hiddenIds.has(node.id);
     const locked = inheritedLocked || selfLocked;
     const hidden = inheritedHidden || selfHidden;
+    let children: LayersPanelNode[] = [];
+    if (!ancestors.has(node.id)) {
+      ancestors.add(node.id);
+      children = codeLayerTreeToPanelNodes(
+        node.children,
+        lockedIds,
+        hiddenIds,
+        locked,
+        hidden,
+        ancestors,
+      );
+      ancestors.delete(node.id);
+    }
     return {
       id: node.id,
       name: node.name,
@@ -1386,13 +1403,7 @@ function codeLayerTreeToPanelNodes(
       hideable: true,
       locked,
       hidden,
-      children: codeLayerTreeToPanelNodes(
-        node.children,
-        lockedIds,
-        hiddenIds,
-        locked,
-        hidden,
-      ),
+      children,
     };
   });
 }

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -4198,7 +4198,6 @@ export default function DesignEditor() {
       setCollabContent(nextContent);
       lastLocalContentRef.current = nextContent;
       if (id) {
-        const optimisticUpdatedAt = new Date().toISOString();
         queryClient.setQueryData(
           ["action", "get-design", { id }],
           (old: any) => {
@@ -4209,11 +4208,12 @@ export default function DesignEditor() {
               ...old,
               files: old.files.map((file: DesignFile) =>
                 file.id === activeFile.id
-                  ? {
-                      ...file,
-                      content: nextContent,
-                      updatedAt: optimisticUpdatedAt,
-                    }
+                  ? // Update content optimistically but keep the file's prior
+                    // (server-clock) updatedAt. Seeding the reconcile watermark
+                    // from a client-clock timestamp can, under clock skew, make a
+                    // later server-authored agent edit look "older" and get
+                    // dropped by the watermark gate (agent edit silently lost).
+                    { ...file, content: nextContent }
                   : file,
               ),
             };

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -3398,7 +3398,12 @@ export default function DesignEditor() {
                 ? command.screen
                 : null;
       const targetFile = findDesignFileByScreenTarget(files, target);
-      if (target && !targetFile && files.length === 0) return false;
+      // A navigate command can name a screen the agent just created that the
+      // get-design query hasn't refetched yet. Treat any unresolved named target
+      // as not-yet-applied (return false) so the app-state key is preserved and
+      // re-applied on the next tick once the file loads — not just when there are
+      // zero files. Otherwise the navigate is silently consumed and dropped.
+      if (target && !targetFile) return false;
 
       const inspectorTab =
         command.inspectorTab === "design" ||

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -804,6 +804,20 @@ function uniqueLayerId(prefix: string): string {
     : `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
 
+/**
+ * Re-stamp every `data-agent-native-node-id` in duplicated screen content with a
+ * fresh unique id. Without this, a duplicated screen carries the SAME node ids as
+ * its source, which collapses the cross-file layer-owner map (selecting a layer
+ * in one screen resolves to the other) and can produce a malformed aggregate
+ * projection.
+ */
+function reassignDuplicatedNodeIds(content: string): string {
+  return content.replace(
+    /data-agent-native-node-id="[^"]*"/g,
+    () => `data-agent-native-node-id="${uniqueLayerId("copy")}"`,
+  );
+}
+
 function primitiveLayerName(primitive: CanvasPrimitiveInsert): string {
   switch (primitive.kind) {
     case "frame":
@@ -1395,12 +1409,20 @@ function collectEffectiveCodeLayerState(
   inheritedLocked: boolean,
   inheritedHidden: boolean,
   state: EffectiveCodeLayerState,
+  // Ids on the current ancestor path — guards against a malformed/cyclic
+  // projection (e.g. a node that appears as its own descendant from duplicate
+  // node ids) recursing forever and crashing the whole editor with a stack
+  // overflow. A true cycle is skipped; duplicate ids in disjoint subtrees are
+  // still visited.
+  ancestors: Set<string> = new Set(),
 ): EffectiveCodeLayerState {
   nodes.forEach((node) => {
+    if (ancestors.has(node.id)) return;
     const locked = inheritedLocked || lockedIds.has(node.id);
     const hidden = inheritedHidden || hiddenIds.has(node.id);
     if (locked) state.lockedIds.add(node.id);
     if (hidden) state.hiddenIds.add(node.id);
+    ancestors.add(node.id);
     collectEffectiveCodeLayerState(
       node.children,
       lockedIds,
@@ -1408,7 +1430,9 @@ function collectEffectiveCodeLayerState(
       locked,
       hidden,
       state,
+      ancestors,
     );
+    ancestors.delete(node.id);
   });
   return state;
 }
@@ -3478,7 +3502,7 @@ export default function DesignEditor() {
         {
           designId: id,
           filename,
-          content: source.content,
+          content: reassignDuplicatedNodeIds(source.content),
           fileType: normalizedDesignFileType(source.fileType),
         } as any,
         {

--- a/templates/design/changelog/2026-06-29-agent-edits-to-a-design-are-no-longer-occasionally-dropped-o.md
+++ b/templates/design/changelog/2026-06-29-agent-edits-to-a-design-are-no-longer-occasionally-dropped-o.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-06-29
+---
+
+Agent edits to a design are no longer occasionally dropped or corrupted when local and agent changes overlap.

--- a/templates/design/changelog/2026-06-29-duplicating-a-screen-now-gives-the-copy-its-own-layer-ids-so.md
+++ b/templates/design/changelog/2026-06-29-duplicating-a-screen-now-gives-the-copy-its-own-layer-ids-so.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-06-29
+---
+
+Duplicating a screen now gives the copy its own layer ids, so selecting a layer in one screen no longer affects the other.

--- a/templates/design/changelog/2026-06-29-picking-a-design-direction-now-submits-to-the-agent-right-aw.md
+++ b/templates/design/changelog/2026-06-29-picking-a-design-direction-now-submits-to-the-agent-right-aw.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-06-29
+---
+
+Picking a design direction now submits to the agent right away and reliably saves, instead of leaving the message sitting unsent in the chat box or firing twice on a double-click.

--- a/templates/design/changelog/2026-06-29-the-editor-no-longer-crashes-when-a-screen-ends-up-with-dupl.md
+++ b/templates/design/changelog/2026-06-29-the-editor-no-longer-crashes-when-a-screen-ends-up-with-dupl.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-06-29
+---
+
+The editor no longer crashes when a screen ends up with duplicate or malformed layer ids (e.g. from a bad agent edit); the layer tree is now resilient to it.


### PR DESCRIPTION
Follow-up to #1657. After connecting Builder.io and testing the **agent chat** (design generation/editing) live in Chrome, plus a focused static-analysis pass over the chat→canvas→action integration, this fixes a batch of reliability/data-loss bugs.

## Fixes
**Editor crash (critical)**
- A malformed projection — duplicate or empty layer ids like `an-` (which a bad agent edit producing two `<html>` roots can create) — made the recursive layer-tree builders (`collectEffectiveCodeLayerState`, `codeLayerTreeToPanelNodes`) recurse forever and **crash the entire editor** via the error boundary. Both now have an ancestor-path cycle guard. *(found live: agent edit → `RangeError: Maximum call stack`; verified the editor loads clean afterward.)*

**Data loss (high)**
- `update-design` overwrote the whole `data` JSON, **destroying `canvasFrames`/`tweaks`** on any partial update → now read-merges.
- Optimistic **client-clock `updatedAt`** could make a later server-authored agent edit look "older" and be silently dropped by the reconcile watermark → keep the prior server timestamp.
- `edit-design`'s stable-id-agnostic fallback could splice at the **wrong byte offset** across a stripped node-id attribute and corrupt the file → end anchored to the last matched char.
- **Duplicating a screen** copied node ids verbatim, colliding across files (broke layer selection + fed the crash above) → ids are re-stamped on duplicate. *(verified live: copy gets fresh `copy-…` ids.)*

**Variant pick (high)**
- "Use this direction" had no in-flight guard (double-click → two `generate-design` writes + double pick); the grid could flicker back after a pick (2s poll vs DELETE race); and the first-party pick was placed in the composer with `submit:false` so it **sat there unsent** (hit live this session). Now: re-entry latch, grid stays cleared, and the pick auto-submits.

**Navigation**
- A `navigate` to a just-created screen was consumed and dropped when the screen hadn't refetched yet → unresolved targets are now retried until the file loads.

## Testing
- `pnpm test` green (214), `pnpm typecheck` green, oxfmt applied.
- Live in Chrome: agent edit round-trip (prompt → `edit-design` → persisted), the crash repro + fix, screen-duplicate id check.

## Not fixed here (lower-priority, from the same analysis)
update-file rename collisions, agent-vs-human edit races on shared content, QuestionFlow empty-answer submit, tweaks composer not disabled during generation, generation-session cleanup on abort. Plus the previously-flagged file-switch content-overwrite (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)