### PR TITLE
Fix remaining confirmed Design editor + agent bugs (round 3)

### DIFF
--- a/templates/design/AGENTS.md
+++ b/templates/design/AGENTS.md
@@ -127,8 +127,10 @@ patterns live in `.agents/skills/`.
 - `navigate` moves the UI and is auto-deleted after the client consumes it.
 - `design-selection` includes active screen, selected element, overview mode,
   inspector tab, zoom, and screen list for the current tab.
-- `design-generation-session:<designId>` contains visible multi-screen
-  generation frames created by `generate-screens`.
+- `design-generation-session:<designId>` contains agent-facing multi-screen
+  generation planning state created by `generate-screens` (canvas region
+  assignments and per-frame instructions consumed by `generate-design` and
+  `view-screen`; not rendered as canvas overlays).
 - `show-design-questions` opens focused pre-generation questions in the main
   design canvas (`show-questions` application state).
 - `design-variants` contains in-progress candidates for the variant picker.

--- a/templates/design/actions/generate-screens.ts
+++ b/templates/design/actions/generate-screens.ts
@@ -66,10 +66,11 @@ const requestedScreenSchema = z
 
 export default defineAction({
   description:
-    "Start a visible multi-agent generation session on the Design canvas. " +
+    "Start a multi-screen generation session on the Design canvas. " +
     "Use this before generating multiple screens or variations in parallel: it " +
-    "assigns non-overlapping canvas regions, publishes named agent/frame " +
-    "status to application state, and returns per-frame generation instructions. " +
+    "assigns non-overlapping canvas regions and returns per-frame generation " +
+    "instructions including canvasFrame placements. The session state is " +
+    "agent-facing planning state consumed by generate-design and view-screen. " +
     "After this action, fan out calls to generate-design for each returned " +
     "frame, passing the returned canvasFrame values to generate-design so " +
     "screens appear in the infinite overview canvas.",
@@ -167,6 +168,7 @@ export default defineAction({
       prompt,
       contextRefs,
       frames,
+      startedAt: new Date().toISOString(),
     };
 
     await writeAppState(

--- a/templates/design/actions/update-design.ts
+++ b/templates/design/actions/update-design.ts
@@ -49,50 +49,54 @@ export default defineAction({
     const db = getDb();
     const now = new Date().toISOString();
 
-    const updates: Record<string, unknown> = { updatedAt: now };
-    if (title !== undefined) updates.title = title;
-    if (description !== undefined) updates.description = description;
-    if (data !== undefined) {
-      // Merge into the existing data blob instead of replacing it wholesale, so
-      // a partial update (e.g. just `tweaks`) doesn't destroy framework-owned
-      // keys like `canvasFrames`. Mirrors generate-design's read-merge.
-      const [existing] = await db
-        .select({ data: schema.designs.data })
-        .from(schema.designs)
-        .where(eq(schema.designs.id, id));
-      const asRecord = (raw: string | null | undefined) => {
-        if (!raw) return {} as Record<string, unknown>;
-        try {
-          const parsed = JSON.parse(raw);
-          return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-            ? (parsed as Record<string, unknown>)
-            : ({} as Record<string, unknown>);
-        } catch {
-          return {} as Record<string, unknown>;
-        }
-      };
-      const incomingParsed = JSON.parse(data);
-      if (
-        incomingParsed &&
-        typeof incomingParsed === "object" &&
-        !Array.isArray(incomingParsed)
-      ) {
-        updates.data = JSON.stringify({
-          ...asRecord(existing?.data),
-          ...(incomingParsed as Record<string, unknown>),
-        });
-      } else {
-        // Non-object JSON (array/primitive): keep the original verbatim write.
-        updates.data = data;
+    const asRecord = (raw: string | null | undefined) => {
+      if (!raw) return {} as Record<string, unknown>;
+      try {
+        const parsed = JSON.parse(raw);
+        return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+          ? (parsed as Record<string, unknown>)
+          : ({} as Record<string, unknown>);
+      } catch {
+        return {} as Record<string, unknown>;
       }
-    }
-    if (projectType !== undefined) updates.projectType = projectType;
-    if (designSystemId !== undefined) updates.designSystemId = designSystemId;
+    };
 
-    await db
-      .update(schema.designs)
-      .set(updates)
-      .where(eq(schema.designs.id, id));
+    // Read-merge-write inside one transaction so a partial `data` update can't
+    // race a concurrent write and either destroy framework-owned keys (e.g.
+    // canvasFrames/tweaks) or overwrite newer server-side keys. Mirrors
+    // generate-design's transactional read-merge.
+    await db.transaction(async (tx) => {
+      const updates: Record<string, unknown> = { updatedAt: now };
+      if (title !== undefined) updates.title = title;
+      if (description !== undefined) updates.description = description;
+      if (data !== undefined) {
+        const [existing] = await tx
+          .select({ data: schema.designs.data })
+          .from(schema.designs)
+          .where(eq(schema.designs.id, id));
+        const incomingParsed = JSON.parse(data);
+        if (
+          incomingParsed &&
+          typeof incomingParsed === "object" &&
+          !Array.isArray(incomingParsed)
+        ) {
+          updates.data = JSON.stringify({
+            ...asRecord(existing?.data),
+            ...(incomingParsed as Record<string, unknown>),
+          });
+        } else {
+          // Non-object JSON (array/primitive): keep the original verbatim write.
+          updates.data = data;
+        }
+      }
+      if (projectType !== undefined) updates.projectType = projectType;
+      if (designSystemId !== undefined) updates.designSystemId = designSystemId;
+
+      await tx
+        .update(schema.designs)
+        .set(updates)
+        .where(eq(schema.designs.id, id));
+    });
 
     return { id, updated: true };
   },

--- a/templates/design/actions/update-file.ts
+++ b/templates/design/actions/update-file.ts
@@ -70,6 +70,25 @@ export default defineAction({
 
     await assertAccess("design", file.designId, "editor");
 
+    // Reject a rename that would collide with an existing filename in the same design
+    if (filename !== undefined) {
+      const [collision] = await db
+        .select({ id: schema.designFiles.id })
+        .from(schema.designFiles)
+        .where(
+          and(
+            eq(schema.designFiles.designId, file.designId),
+            eq(schema.designFiles.filename, filename),
+          ),
+        )
+        .limit(1);
+      if (collision && collision.id !== id) {
+        throw new Error(
+          `File "${filename}" already exists in design ${file.designId}`,
+        );
+      }
+    }
+
     const updates: Record<string, unknown> = { updatedAt: now };
     if (content !== undefined) updates.content = content;
     if (filename !== undefined) updates.filename = filename;

--- a/templates/design/actions/update-file.ts
+++ b/templates/design/actions/update-file.ts
@@ -70,34 +70,40 @@ export default defineAction({
 
     await assertAccess("design", file.designId, "editor");
 
-    // Reject a rename that would collide with an existing filename in the same design
-    if (filename !== undefined) {
-      const [collision] = await db
-        .select({ id: schema.designFiles.id })
-        .from(schema.designFiles)
-        .where(
-          and(
-            eq(schema.designFiles.designId, file.designId),
-            eq(schema.designFiles.filename, filename),
-          ),
-        )
-        .limit(1);
-      if (collision && collision.id !== id) {
-        throw new Error(
-          `File "${filename}" already exists in design ${file.designId}`,
-        );
+    // Reject a rename that would collide with an existing filename in the same
+    // design. The collision check and the write run in one transaction so they
+    // can't be interleaved by a concurrent rename. (A DB-level UNIQUE index on
+    // (designId, filename) would be the strongest guarantee but is a non-additive
+    // schema change on existing data, so it's deferred.)
+    await db.transaction(async (tx) => {
+      if (filename !== undefined) {
+        const [collision] = await tx
+          .select({ id: schema.designFiles.id })
+          .from(schema.designFiles)
+          .where(
+            and(
+              eq(schema.designFiles.designId, file.designId),
+              eq(schema.designFiles.filename, filename),
+            ),
+          )
+          .limit(1);
+        if (collision && collision.id !== id) {
+          throw new Error(
+            `File "${filename}" already exists in design ${file.designId}`,
+          );
+        }
       }
-    }
 
-    const updates: Record<string, unknown> = { updatedAt: now };
-    if (content !== undefined) updates.content = content;
-    if (filename !== undefined) updates.filename = filename;
-    if (fileType !== undefined) updates.fileType = fileType;
+      const updates: Record<string, unknown> = { updatedAt: now };
+      if (content !== undefined) updates.content = content;
+      if (filename !== undefined) updates.filename = filename;
+      if (fileType !== undefined) updates.fileType = fileType;
 
-    await db
-      .update(schema.designFiles)
-      .set(updates)
-      .where(eq(schema.designFiles.id, id));
+      await tx
+        .update(schema.designFiles)
+        .set(updates)
+        .where(eq(schema.designFiles.id, id));
+    });
 
     // Push content through the collab layer so live editors see the change
     if (content !== undefined && syncCollab) {

--- a/templates/design/actions/view-screen.ts
+++ b/templates/design/actions/view-screen.ts
@@ -120,7 +120,21 @@ export default defineAction({
         'A variant picker is open. Wait for the user to choose a direction before generating further. In an inline MCP app their pick returns to you automatically; if it opened as a browser tab (a CLI or code editor), they paste an auto-copied summary or just tell you which one (e.g. "use variant A"). Once you know the choice, read the saved index.html with get-design-snapshot. Do not call generate-design while this picker is open.';
     }
     if (generationSession) {
+      const GENERATION_SESSION_TTL_MS = 10 * 60 * 1000; // 10 minutes
+      const startedAt =
+        typeof (generationSession as { startedAt?: unknown }).startedAt ===
+        "string"
+          ? new Date(
+              (generationSession as { startedAt: string }).startedAt,
+            ).getTime()
+          : 0;
+      const isStale =
+        startedAt > 0 && Date.now() - startedAt > GENERATION_SESSION_TTL_MS;
       screen.generationSession = generationSession;
+      if (isStale) {
+        screen.generationSessionNote =
+          "This generation session may be stale or abandoned (started more than 10 minutes ago). Verify saved screens via the design file list rather than assuming generation is still in progress.";
+      }
     }
 
     if (Object.keys(screen).length === 0) {

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -480,7 +480,7 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
         mixBlendMode: cs.mixBlendMode,
         zIndex: cs.zIndex,
       },
-      boundingRect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+      boundingRect: { x: rect.x + (window.scrollX || window.pageXOffset || 0), y: rect.y + (window.scrollY || window.pageYOffset || 0), width: rect.width, height: rect.height },
       textContent: el.textContent ? el.textContent.slice(0, 200) : undefined,
       htmlContent: el.innerHTML && el.innerHTML !== el.textContent ? el.innerHTML.slice(0, 4000) : undefined,
       isFlexContainer: cs.display === 'flex' || cs.display === 'inline-flex',
@@ -789,13 +789,34 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
       overlay.style.display = 'none';
       return;
     }
+    // For the selection overlay, prefer the CSS box + rotation transform so
+    // the handles hug the rotated element rather than its inflated AABB.
+    if (overlay === selectionOverlay) {
+      var elCs = window.getComputedStyle(el);
+      var elLeft = readPx(el.style.left || elCs.left);
+      var elTop = readPx(el.style.top || elCs.top);
+      var elW = readPx(el.style.width || elCs.width);
+      var elH = readPx(el.style.height || elCs.height);
+      var elRot = currentRotation(el);
+      // Convert element-local left/top to viewport coords by walking to the
+      // nearest positioned ancestor (same reference frame as getBoundingClientRect).
+      var parentRect = (el.offsetParent || document.documentElement).getBoundingClientRect();
+      overlay.style.display = 'block';
+      overlay.style.left = (parentRect.left + elLeft) + 'px';
+      overlay.style.top = (parentRect.top + elTop) + 'px';
+      overlay.style.width = elW + 'px';
+      overlay.style.height = elH + 'px';
+      overlay.style.transform = elRot ? 'rotate(' + elRot + 'deg)' : '';
+      overlay.style.transformOrigin = '0 0';
+      updatePaddingOverlay(el);
+      return;
+    }
     var rect = el.getBoundingClientRect();
     overlay.style.display = 'block';
     overlay.style.top = rect.top + 'px';
     overlay.style.left = rect.left + 'px';
     overlay.style.width = rect.width + 'px';
     overlay.style.height = rect.height + 'px';
-    if (overlay === selectionOverlay) updatePaddingOverlay(el);
   }
 
   function refreshOverlays() {
@@ -1479,7 +1500,12 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
     // clear-selection postMessage cannot swap selectedEl mid-drag and cause
     // mutations on the wrong element or a null-deref in onUp.
     var dragEl = selectedEl;
+    var moved = false;
+    var DRAG_THRESHOLD = 3;
     function onMove(ev) {
+      if (!moved && Math.hypot(ev.clientX - startX, ev.clientY - startY) > DRAG_THRESHOLD) {
+        moved = true;
+      }
       var nextLeft = originLeft + ev.clientX - startX;
       var nextTop = originTop + ev.clientY - startY;
       dragEl.style.left = Math.round(nextLeft) + 'px';
@@ -1492,6 +1518,14 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
       document.removeEventListener('mouseup', onUp, true);
       hideTransformBadge();
       if (!dragEl) return;
+      if (duplicatedForDrag && !moved) {
+        // Alt-click with no real drag — remove the premature clone and restore the original selection.
+        if (dragEl.parentElement) dragEl.parentElement.removeChild(dragEl);
+        selectedEl = originalSelectedEl;
+        positionOverlay(selectionOverlay, selectedEl);
+        window.parent.postMessage({ type: 'element-select', payload: getElementInfo(selectedEl) }, '*');
+        return;
+      }
       if (duplicatedForDrag) {
         postVisualDuplicateChange(originalSelectedEl, dragEl);
       } else {
@@ -1535,9 +1569,19 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
     // Snapshot the element so a concurrent clear-selection postMessage cannot
     // cause a null-deref in onMove/onUp.
     var resizeEl = selectedEl;
+    // Capture the element rotation once at drag-start so per-move projection is
+    // cheap and consistent even if the transform changes during the drag.
+    var resizeTheta = currentRotation(resizeEl) * Math.PI / 180;
     function nextRect(ev) {
-      var dx = ev.clientX - startX;
-      var dy = ev.clientY - startY;
+      var screenDx = ev.clientX - startX;
+      var screenDy = ev.clientY - startY;
+      // Project the screen-space pointer delta into the element's local
+      // (un-rotated) coordinate frame so handles behave relative to the
+      // visible rotated box rather than screen axes.
+      var cosT = Math.cos(resizeTheta);
+      var sinT = Math.sin(resizeTheta);
+      var dx = screenDx * cosT + screenDy * sinT;
+      var dy = -screenDx * sinT + screenDy * cosT;
       var left = origin.left;
       var top = origin.top;
       var width = origin.width;
@@ -1570,14 +1614,13 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
         }
       }
       // Clamp after ratio correction.
-      var rawWidth = width;
-      var rawHeight = height;
       width = Math.max(8, width);
       height = Math.max(8, height);
-      // Re-anchor the pinned edge for w/n handles after clamping so the
-      // opposite edge doesn't drift when the element hits minimum size.
-      if (handle.indexOf('w') !== -1) left += (rawWidth - width);
-      if (handle.indexOf('n') !== -1) top += (rawHeight - height);
+      // Re-anchor the pinned edge for w/n handles after aspect-ratio lock and
+      // clamping so the opposite (e/s) edge stays fixed regardless of whether
+      // the dimension change was driven by raw dx/dy or by the ratio lock.
+      if (handle.indexOf('w') !== -1) left = origin.left + (origin.width - width);
+      if (handle.indexOf('n') !== -1) top = origin.top + (origin.height - height);
       if (ev.altKey) {
         if (handle.indexOf('w') !== -1 || handle.indexOf('e') !== -1) left = origin.left - (width - origin.width) / 2;
         if (handle.indexOf('n') !== -1 || handle.indexOf('s') !== -1) top = origin.top - (height - origin.height) / 2;

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -1402,10 +1402,10 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
     }
   }
 
-	  function postVisualStructureChange(el, target) {
+	  function postVisualStructureChange(el, target, origin) {
 	    if (!el || !target || !target.anchor) return;
 	    var requestId = 'move-' + Date.now() + '-' + Math.random().toString(16).slice(2);
-	    pendingStructureMove = { requestId: requestId, el: el, target: target };
+	    pendingStructureMove = { requestId: requestId, el: el, target: target, origin: origin || null };
 	    window.parent.postMessage({
 	      type: 'visual-structure-change',
 	      requestId: requestId,
@@ -1479,11 +1479,15 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
 	          applyRuntimeReorder(reorderEl, currentTarget);
 	          postVisualDuplicateChange(originalSelectedEl, reorderEl, currentTarget);
 	        } else {
+	          // Capture the pre-drag DOM anchor so we can revert if the parent
+	          // reports applied===false on the structure-ack.
+	          var prevParent = reorderEl.parentElement;
+	          var prevNextSibling = reorderEl.nextSibling;
 	          // Optimistically apply the reorder in the DOM for immediate
 	          // visual feedback; the visual-structure-ack handler will confirm
 	          // or revert once the parent processes the change.
 	          applyRuntimeReorder(reorderEl, currentTarget);
-	          postVisualStructureChange(reorderEl, currentTarget);
+	          postVisualStructureChange(reorderEl, currentTarget, { prevParent: prevParent, prevNextSibling: prevNextSibling });
 	        }
 	      }
       document.addEventListener('mousemove', onReorderMove, true);
@@ -2001,10 +2005,20 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
 	      var move = pendingStructureMove;
 	      pendingStructureMove = null;
 	      if (e.data.applied) {
-	        applyRuntimeReorder(move.el, move.target);
-	        selectedEl = move.el;
-	        positionOverlay(selectionOverlay, selectedEl);
-	        window.parent.postMessage({ type: 'element-select', payload: getElementInfo(selectedEl) }, '*');
+	        if (move.el && move.el.isConnected) {
+	          applyRuntimeReorder(move.el, move.target);
+	          selectedEl = move.el;
+	          positionOverlay(selectionOverlay, selectedEl);
+	          window.parent.postMessage({ type: 'element-select', payload: getElementInfo(selectedEl) }, '*');
+	        }
+	      } else {
+	        // Revert the optimistic reorder to its pre-drag position.
+	        if (move.el && move.el.isConnected && move.origin && move.origin.prevParent && move.origin.prevParent.isConnected) {
+	          move.origin.prevParent.insertBefore(move.el, move.origin.prevNextSibling);
+	          selectedEl = move.el;
+	          positionOverlay(selectionOverlay, selectedEl);
+	          window.parent.postMessage({ type: 'element-select', payload: getElementInfo(selectedEl) }, '*');
+	        }
 	      }
 	      return;
 	    }
@@ -2703,6 +2717,7 @@ export function DesignCanvas({
         visible={!!drawMode}
         canvasInteractive={!pinMode}
         queuedAnnotationCount={queuedAnnotationPins.length}
+        zoom={zoom}
         onClose={() => onExitDrawMode?.()}
         onSend={(annotations, instruction, canvasSize) => {
           const summary = annotations

--- a/templates/design/app/components/design/LayersPanel.tsx
+++ b/templates/design/app/components/design/LayersPanel.tsx
@@ -161,7 +161,23 @@ interface FlatLayerRow {
   depth: number;
   ancestorIds: string[];
   hasChildren: boolean;
+  canAcceptChildren: boolean;
 }
+
+// Node types that can contain children even when currently empty.
+// Leaf / void types (text, image, shape, rectangle) are excluded so we don't
+// offer an "inside" drop zone on genuinely non-container elements.
+const CONTAINER_TYPES = new Set<LayersPanelNodeType | undefined>([
+  "file",
+  "screen",
+  "frame",
+  "group",
+  "section",
+  "component",
+  "instance",
+  "code",
+  "element",
+]);
 
 const SECTION_CODE_ID = "__design_layers_code__";
 const SECTION_ELEMENT_ID = "__design_layers_elements__";
@@ -307,8 +323,16 @@ function flattenRows(
   nodes.forEach((node, index) => {
     const children = node.children ?? [];
     const hasChildren = children.length > 0;
+    const canAcceptChildren = CONTAINER_TYPES.has(node.type);
     const rowKey = `${parentKey}/${node.id}:${index}`;
-    rows.push({ node, rowKey, depth, ancestorIds, hasChildren });
+    rows.push({
+      node,
+      rowKey,
+      depth,
+      ancestorIds,
+      hasChildren,
+      canAcceptChildren,
+    });
     if (hasChildren && (forceExpanded || expandedIds.has(node.id))) {
       flattenRows(
         children,
@@ -823,7 +847,7 @@ function LayerRow({
   selectedIds: readonly string[];
   visibleRows: FlatLayerRow[];
 }) {
-  const { node, depth, hasChildren } = row;
+  const { node, depth, hasChildren, canAcceptChildren } = row;
   const selectable = node.selectable !== false;
   const lockable = node.lockable !== false && Boolean(onToggleLocked);
   const hideable = node.hideable !== false && Boolean(onToggleHidden);
@@ -970,7 +994,7 @@ function LayerRow({
     const intent = {
       draggedIds: cleanedIds,
       targetId: node.id,
-      placement: dropPlacementForEvent(event, hasChildren),
+      placement: dropPlacementForEvent(event, canAcceptChildren),
     } satisfies LayersPanelMoveIntent;
     if (canMoveLayer && !canMoveLayer(intent)) return;
     event.preventDefault();
@@ -1008,7 +1032,7 @@ function LayerRow({
       const intent = {
         draggedIds: cleanedIds,
         targetId: node.id,
-        placement: dropPlacementForEvent(event, hasChildren),
+        placement: dropPlacementForEvent(event, canAcceptChildren),
       } satisfies LayersPanelMoveIntent;
       if (!canMoveLayer || canMoveLayer(intent)) {
         onMoveLayer(intent);

--- a/templates/design/app/components/design/LayersPanel.tsx
+++ b/templates/design/app/components/design/LayersPanel.tsx
@@ -186,6 +186,14 @@ const SECTION_ELEMENT_ID = "__design_layers_elements__";
 // per spec; the source row stores the drag payload here on dragstart instead.
 let activeDragState: { sourceId: string; draggedIds: string[] } | null = null;
 
+const ROW_BASE_INDENT = 4;
+const ROW_INDENT_STEP = 28;
+const ROW_MAX_INDENT = 96;
+
+function rowIndent(depth: number): number {
+  return Math.min(ROW_BASE_INDENT + depth * ROW_INDENT_STEP, ROW_MAX_INDENT);
+}
+
 function defaultLabels(t: ReturnType<typeof useT>): LayersPanelLabels {
   return {
     title: t("layersPanel.title"),
@@ -1093,7 +1101,7 @@ function LayerRow({
             "text-foreground/90 hover:bg-[var(--design-editor-layer-hover-color)] hover:text-foreground",
           node.hidden && "text-muted-foreground",
         )}
-        style={{ paddingLeft: 4 + depth * 28 }}
+        style={{ paddingLeft: rowIndent(depth) }}
       >
         {hasChildren ? (
           <Button

--- a/templates/design/app/components/design/LayersPanel.tsx
+++ b/templates/design/app/components/design/LayersPanel.tsx
@@ -487,9 +487,20 @@ export function LayersPanel({
     ) => {
       let nextIds: string[];
       if (options.range && lastSelectionAnchorRef.current) {
-        const from = selectableVisibleIds.indexOf(
-          lastSelectionAnchorRef.current,
-        );
+        let anchor = lastSelectionAnchorRef.current;
+        if (selectableVisibleIds.indexOf(anchor) < 0) {
+          // Stale anchor (deleted / filtered / collapsed out of view): pivot from
+          // the last selected layer that is still visible & selectable, matching
+          // Figma's behavior instead of dropping the range to a single select.
+          const fallback = [...selectedIds]
+            .reverse()
+            .find((sid) => selectableVisibleIds.includes(sid));
+          if (fallback) {
+            anchor = fallback;
+            lastSelectionAnchorRef.current = fallback;
+          }
+        }
+        const from = selectableVisibleIds.indexOf(anchor);
         const to = selectableVisibleIds.indexOf(id);
         if (from >= 0 && to >= 0) {
           const [start, end] = from < to ? [from, to] : [to, from];

--- a/templates/design/app/components/design/MultiScreenCanvas.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.tsx
@@ -1,5 +1,9 @@
 import { useT } from "@agent-native/core/client";
 import {
+  DEFAULT_ASSIGNED_REGION_GAP,
+  DEFAULT_ASSIGNED_REGION_HEIGHT,
+  DEFAULT_ASSIGNED_REGION_MAX_COLUMNS,
+  DEFAULT_ASSIGNED_REGION_WIDTH,
   DEFAULT_SNAP_THRESHOLD_SCREEN_PX,
   appendPolylinePoint,
   computeMoveSnap,
@@ -155,6 +159,7 @@ interface MultiScreenCanvasProps {
   ) => ReactNode;
   selectAllRequest?: number;
   clearSelectionRequest?: number;
+  onSelectionChange?: (selectedIds: string[]) => void;
 }
 
 /**
@@ -413,6 +418,7 @@ export function MultiScreenCanvas({
   renderScreenContent,
   selectAllRequest,
   clearSelectionRequest,
+  onSelectionChange,
 }: MultiScreenCanvasProps) {
   const t = useT();
   const surfaceRef = useRef<HTMLDivElement>(null);
@@ -543,8 +549,14 @@ export function MultiScreenCanvas({
     frameGeometryRef.current = frameGeometry;
   }, [frameGeometry]);
 
+  const onSelectionChangeRef = useRef(onSelectionChange);
+  useEffect(() => {
+    onSelectionChangeRef.current = onSelectionChange;
+  }, [onSelectionChange]);
+
   useEffect(() => {
     selectedIdsRef.current = selectedIds;
+    onSelectionChangeRef.current?.(selectedIds);
   }, [selectedIds]);
 
   useEffect(() => {
@@ -704,17 +716,20 @@ export function MultiScreenCanvas({
     (point: Point) =>
       getCurrentFrameEntries()
         .map((entry, index) => ({ ...entry, index }))
-        .filter((entry) =>
-          rectContainsPoint(
-            {
-              left: entry.geometry.x,
-              top: entry.geometry.y,
-              right: entry.geometry.x + entry.geometry.width,
-              bottom: entry.geometry.y + entry.geometry.height,
-            },
+        .filter((entry) => {
+          const bounds = {
+            left: entry.geometry.x,
+            top: entry.geometry.y,
+            right: entry.geometry.x + entry.geometry.width,
+            bottom: entry.geometry.y + entry.geometry.height,
+          };
+          const local = rotatePointAroundCenter(
             point,
-          ),
-        )
+            getFrameCenter(entry.geometry),
+            entry.geometry.rotation ?? 0,
+          );
+          return rectContainsPoint(bounds, local);
+        })
         .sort(
           (a, b) =>
             (b.geometry.z ?? 0) - (a.geometry.z ?? 0) || b.index - a.index,
@@ -912,12 +927,22 @@ export function MultiScreenCanvas({
 
         const hitIds = getCurrentFrameEntries()
           .filter((entry) =>
-            rectIntersects(rect, getSelectableBounds(entry.geometry)),
+            rotatedRectIntersects(
+              rect,
+              getSelectableBounds(entry.geometry),
+              getFrameCenter(entry.geometry),
+              entry.geometry.rotation ?? 0,
+            ),
           )
           .map((entry) => entry.id);
         const hitDraftIds = getCurrentDraftEntries()
           .filter((entry) =>
-            rectIntersects(rect, getSelectableBounds(entry.geometry)),
+            rotatedRectIntersects(
+              rect,
+              getSelectableBounds(entry.geometry),
+              getFrameCenter(entry.geometry),
+              entry.geometry.rotation ?? 0,
+            ),
           )
           .map((entry) => entry.id);
         updateSelectedIds(() =>
@@ -963,17 +988,21 @@ export function MultiScreenCanvas({
       if (preferred) return preferred;
 
       return entries
-        .filter(({ geometry }) =>
-          rectContainsPoint(
-            {
-              left: geometry.x,
-              top: geometry.y,
-              right: geometry.x + geometry.width,
-              bottom: geometry.y + geometry.height,
-            },
-            getFrameCenter(draft.geometry),
-          ),
-        )
+        .filter(({ geometry }) => {
+          const bounds = {
+            left: geometry.x,
+            top: geometry.y,
+            right: geometry.x + geometry.width,
+            bottom: geometry.y + geometry.height,
+          };
+          const draftCenter = getFrameCenter(draft.geometry);
+          const local = rotatePointAroundCenter(
+            draftCenter,
+            getFrameCenter(geometry),
+            geometry.rotation ?? 0,
+          );
+          return rectContainsPoint(bounds, local);
+        })
         .sort((a, b) => (b.geometry.z ?? 0) - (a.geometry.z ?? 0))[0];
     },
     [getCurrentFrameEntries],
@@ -1499,16 +1528,6 @@ export function MultiScreenCanvas({
             );
             const lastNodeId = persisted[persisted.length - 1]?.nodeId;
             if (lastNodeId) updateSelectedIds(() => [lastNodeId]);
-          } else {
-            // No draft landed in a frame — restore each moved draft to its
-            // original position so the move is atomic (commit or revert).
-            updateDraftPrimitives((current) =>
-              current.map((draft) => {
-                if (!state.targetIds.includes(draft.id)) return draft;
-                const origin = state.originDrafts[draft.id];
-                return origin ?? draft;
-              }),
-            );
           }
         }
         finishDrag();
@@ -3089,6 +3108,10 @@ function Screen({
         onMouseDown={(e) => {
           if (e.button !== 0) return;
           if (penActive || creationToolActive) return;
+          if (e.altKey) {
+            onStartDuplicateGesture(screen, display, e);
+            return;
+          }
           if (e.shiftKey) {
             e.stopPropagation();
             onPick(screen.id, e);
@@ -3453,13 +3476,13 @@ interface BoundsRect {
 }
 
 function getInitialFrameGeometry(index: number): FrameGeometry {
-  const column = index % 3;
-  const row = Math.floor(index / 3);
+  const column = index % DEFAULT_ASSIGNED_REGION_MAX_COLUMNS;
+  const row = Math.floor(index / DEFAULT_ASSIGNED_REGION_MAX_COLUMNS);
   return {
-    x: column * (SCREEN_WIDTH + SCREEN_GAP),
-    y: row * (SCREEN_CARD_HEIGHT + SCREEN_GAP),
-    width: SCREEN_WIDTH,
-    height: SCREEN_HEIGHT,
+    x: column * (DEFAULT_ASSIGNED_REGION_WIDTH + DEFAULT_ASSIGNED_REGION_GAP),
+    y: row * (DEFAULT_ASSIGNED_REGION_HEIGHT + DEFAULT_ASSIGNED_REGION_GAP),
+    width: DEFAULT_ASSIGNED_REGION_WIDTH,
+    height: DEFAULT_ASSIGNED_REGION_HEIGHT,
   };
 }
 
@@ -3578,6 +3601,84 @@ function rectContainsPoint(bounds: BoundsRect, point: Point) {
     point.y >= bounds.top &&
     point.y <= bounds.bottom
   );
+}
+
+/** Rotate `point` into the local (unrotated) space of a frame whose center is
+ *  `center` and whose CSS transform is `rotate(degrees deg)`. Passing the
+ *  inverse rotation maps world-space coordinates into the frame's local space
+ *  so unrotated bounds tests remain correct. */
+function rotatePointAroundCenter(
+  point: Point,
+  center: Point,
+  degrees: number,
+): Point {
+  if (!degrees) return point;
+  const rad = (-degrees * Math.PI) / 180; // inverse rotation
+  const dx = point.x - center.x;
+  const dy = point.y - center.y;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  return {
+    x: center.x + dx * cos - dy * sin,
+    y: center.y + dx * sin + dy * cos,
+  };
+}
+
+/** Test whether a marquee rect (in canvas space) intersects an OBB described by
+ *  `bounds` (unrotated AABB) that has been rotated `degrees` around `center`.
+ *  We map the four marquee corners into the frame's local space and check
+ *  whether any corner is inside the bounds; we also check the reverse (any
+ *  frame corner inside the marquee) to handle the case where the marquee is
+ *  entirely contained within the rotated frame. */
+function rotatedRectIntersects(
+  rect: MarqueeRect,
+  bounds: BoundsRect,
+  center: Point,
+  degrees: number,
+): boolean {
+  if (!degrees) {
+    return rectIntersects(rect, bounds);
+  }
+  // Four corners of the marquee rect in canvas space.
+  const marqueeCorners: Point[] = [
+    { x: rect.x, y: rect.y },
+    { x: rect.x + rect.width, y: rect.y },
+    { x: rect.x + rect.width, y: rect.y + rect.height },
+    { x: rect.x, y: rect.y + rect.height },
+  ];
+  // Test: any marquee corner inside the unrotated frame bounds?
+  for (const corner of marqueeCorners) {
+    const local = rotatePointAroundCenter(corner, center, degrees);
+    if (rectContainsPoint(bounds, local)) return true;
+  }
+  // Four corners of the unrotated frame in canvas space (rotate them outward).
+  const frameCorners: Point[] = [
+    { x: bounds.left, y: bounds.top },
+    { x: bounds.right, y: bounds.top },
+    { x: bounds.right, y: bounds.bottom },
+    { x: bounds.left, y: bounds.bottom },
+  ];
+  const rad = (degrees * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  const marqueeRight = rect.x + rect.width;
+  const marqueeBottom = rect.y + rect.height;
+  // Test: any rotated frame corner inside the marquee rect?
+  for (const fc of frameCorners) {
+    const dx = fc.x - center.x;
+    const dy = fc.y - center.y;
+    const wx = center.x + dx * cos - dy * sin;
+    const wy = center.y + dx * sin + dy * cos;
+    if (
+      wx >= rect.x &&
+      wx <= marqueeRight &&
+      wy >= rect.y &&
+      wy <= marqueeBottom
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function sameFrameGeometry(a: FrameGeometry, b: FrameGeometry) {

--- a/templates/design/app/components/design/MultiScreenCanvas.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.tsx
@@ -3476,13 +3476,18 @@ interface BoundsRect {
 }
 
 function getInitialFrameGeometry(index: number): FrameGeometry {
-  const column = index % DEFAULT_ASSIGNED_REGION_MAX_COLUMNS;
-  const row = Math.floor(index / DEFAULT_ASSIGNED_REGION_MAX_COLUMNS);
+  // Seed default frames with the actual screen dimensions and the 3-column grid
+  // the overview centering math (which uses SCREEN_WIDTH/SCREEN_GAP) expects, so
+  // a design without persisted geometry opens centered. (The larger
+  // assigned-region grid is only for the agent's generation planning, not the
+  // editor's default placement.)
+  const column = index % 3;
+  const row = Math.floor(index / 3);
   return {
-    x: column * (DEFAULT_ASSIGNED_REGION_WIDTH + DEFAULT_ASSIGNED_REGION_GAP),
-    y: row * (DEFAULT_ASSIGNED_REGION_HEIGHT + DEFAULT_ASSIGNED_REGION_GAP),
-    width: DEFAULT_ASSIGNED_REGION_WIDTH,
-    height: DEFAULT_ASSIGNED_REGION_HEIGHT,
+    x: column * (SCREEN_WIDTH + SCREEN_GAP),
+    y: row * (SCREEN_CARD_HEIGHT + SCREEN_GAP),
+    width: SCREEN_WIDTH,
+    height: SCREEN_HEIGHT,
   };
 }
 

--- a/templates/design/app/components/design/QuestionFlow.tsx
+++ b/templates/design/app/components/design/QuestionFlow.tsx
@@ -60,15 +60,16 @@ export function QuestionFlow({
     setAnswers((prev) => ({ ...prev, [id]: value }));
   }, []);
 
-  const answeredCount = guidedQuestions.filter((question) =>
-    hasGuidedAnswer(answers[question.id]),
-  ).length;
+  const isAnswered = (q: GuidedQuestion) => {
+    const v = answers[q.id];
+    if (q.type === "freeform" && typeof v === "string") return v.trim().length > 0;
+    return hasGuidedAnswer(v);
+  };
+  const answeredCount = guidedQuestions.filter(isAnswered).length;
   const requiredQuestions = guidedQuestions.filter(
     (question) => question.required,
   );
-  const requiredAnswered = requiredQuestions.filter((question) =>
-    hasGuidedAnswer(answers[question.id]),
-  ).length;
+  const requiredAnswered = requiredQuestions.filter(isAnswered).length;
   const allRequiredAnswered = requiredAnswered === requiredQuestions.length;
   const progress =
     guidedQuestions.length === 0
@@ -554,11 +555,9 @@ function SliderQuestion({
   const current =
     typeof value === "number" ? value : Math.round((min + max) / 2);
 
-  useEffect(() => {
-    if (typeof value !== "number") {
-      onChange(Math.round((min + max) / 2));
-    }
-  }, []);
+  // Do not auto-fill on mount: a required slider must be explicitly moved by
+  // the user before it counts as answered. `current` already provides a
+  // display-only midpoint fallback for the rendered slider position.
 
   return (
     <div className="rounded-md border border-border bg-muted/25 px-3 py-3">

--- a/templates/design/app/components/design/QuestionFlow.tsx
+++ b/templates/design/app/components/design/QuestionFlow.tsx
@@ -62,7 +62,8 @@ export function QuestionFlow({
 
   const isAnswered = (q: GuidedQuestion) => {
     const v = answers[q.id];
-    if (q.type === "freeform" && typeof v === "string") return v.trim().length > 0;
+    if (q.type === "freeform" && typeof v === "string")
+      return v.trim().length > 0;
     return hasGuidedAnswer(v);
   };
   const answeredCount = guidedQuestions.filter(isAnswered).length;

--- a/templates/design/app/components/design/TweaksPanel.tsx
+++ b/templates/design/app/components/design/TweaksPanel.tsx
@@ -285,19 +285,32 @@ function TweakControl({
 
       {tweak.type === "slider" && (
         <div className="flex h-6 items-center gap-1.5">
-          <Slider
-            min={tweak.min ?? 0}
-            max={tweak.max ?? 100}
-            step={tweak.step ?? 1}
-            value={[typeof value === "number" ? value : 50]}
-            onValueChange={([v]) => onChange(v)}
-            className="flex-1"
-          />
-          <span className="min-w-[2ch] text-right text-[11px] tabular-nums text-muted-foreground">
-            {typeof value === "number" ? value : 50}
-            {tweak.unit ??
-              (tweak.cssVar?.toLowerCase().includes("radius") ? "px" : "")}
-          </span>
+          {(() => {
+            const sliderMin = tweak.min ?? 0;
+            const sliderMax = tweak.max ?? 100;
+            const rawNum =
+              typeof value === "number" ? value : Number(value);
+            const sliderValue = Number.isFinite(rawNum)
+              ? Math.min(sliderMax, Math.max(sliderMin, rawNum))
+              : sliderMin;
+            return (
+              <>
+                <Slider
+                  min={sliderMin}
+                  max={sliderMax}
+                  step={tweak.step ?? 1}
+                  value={[sliderValue]}
+                  onValueChange={([v]) => onChange(v)}
+                  className="flex-1"
+                />
+                <span className="min-w-[2ch] text-right text-[11px] tabular-nums text-muted-foreground">
+                  {sliderValue}
+                  {tweak.unit ??
+                    (tweak.cssVar?.toLowerCase().includes("radius") ? "px" : "")}
+                </span>
+              </>
+            );
+          })()}
         </div>
       )}
     </div>

--- a/templates/design/app/components/design/TweaksPanel.tsx
+++ b/templates/design/app/components/design/TweaksPanel.tsx
@@ -288,8 +288,7 @@ function TweakControl({
           {(() => {
             const sliderMin = tweak.min ?? 0;
             const sliderMax = tweak.max ?? 100;
-            const rawNum =
-              typeof value === "number" ? value : Number(value);
+            const rawNum = typeof value === "number" ? value : Number(value);
             const sliderValue = Number.isFinite(rawNum)
               ? Math.min(sliderMax, Math.max(sliderMin, rawNum))
               : sliderMin;
@@ -306,7 +305,9 @@ function TweakControl({
                 <span className="min-w-[2ch] text-right text-[11px] tabular-nums text-muted-foreground">
                   {sliderValue}
                   {tweak.unit ??
-                    (tweak.cssVar?.toLowerCase().includes("radius") ? "px" : "")}
+                    (tweak.cssVar?.toLowerCase().includes("radius")
+                      ? "px"
+                      : "")}
                 </span>
               </>
             );

--- a/templates/design/app/components/design/inspector/AutoLayoutMatrix.tsx
+++ b/templates/design/app/components/design/inspector/AutoLayoutMatrix.tsx
@@ -1090,13 +1090,6 @@ export function SizingField({
 }: SizingFieldProps) {
   const labels = { ...DEFAULT_AUTO_LAYOUT_LABELS, ...labelOverrides };
   const isWidth = sizingAxis === "horizontal";
-  // Local pending state for a newly-opened constraint editor. Holds the kind
-  // and seed value so the sub-row is visible before the user has confirmed a
-  // value. We only commit to onMinMaxChange when the user types or scrubs.
-  const [pending, setPending] = useState<{
-    kind: "min" | "max";
-    seed: number;
-  } | null>(null);
 
   const minValue = minMax?.min ?? null;
   const maxValue = minMax?.max ?? null;
@@ -1116,12 +1109,11 @@ export function SizingField({
   const maxLabel = isWidth ? labels.maxWidth : labels.maxHeight;
 
   const openEditor = (kind: "min" | "max") => {
-    // Compute a sensible seed but do NOT write it to the parent yet — only
-    // show the pending sub-row. The value is committed when the user first
-    // scrubs/types in the ConstraintSubRow.
+    // Commit immediately so the shown row always reflects real state and
+    // persists across selection changes, remounts, and parent re-renders.
     const seed = Math.max(0, Math.round(resolvedSize ?? 0));
     const seedValue = kind === "min" ? seed : seed || 1;
-    setPending({ kind, seed: seedValue });
+    onMinMaxChange?.(sizingAxis, kind, seedValue);
   };
 
   return (
@@ -1236,19 +1228,6 @@ export function SizingField({
             onMinMaxChange?.(sizingAxis, "min", null);
           }}
         />
-      ) : pending?.kind === "min" ? (
-        // Pending (uncommitted) min row — shown before the user confirms a value.
-        <ConstraintSubRow
-          label={minLabel}
-          value={pending.seed}
-          disabled={disabled}
-          removeLabel={labels.removeConstraint}
-          onChange={(next) => {
-            setPending(null);
-            onMinMaxChange?.(sizingAxis, "min", next);
-          }}
-          onRemove={() => setPending(null)}
-        />
       ) : null}
       {hasMax ? (
         <ConstraintSubRow
@@ -1260,19 +1239,6 @@ export function SizingField({
           onRemove={() => {
             onMinMaxChange?.(sizingAxis, "max", null);
           }}
-        />
-      ) : pending?.kind === "max" ? (
-        // Pending (uncommitted) max row — shown before the user confirms a value.
-        <ConstraintSubRow
-          label={maxLabel}
-          value={pending.seed}
-          disabled={disabled}
-          removeLabel={labels.removeConstraint}
-          onChange={(next) => {
-            setPending(null);
-            onMinMaxChange?.(sizingAxis, "max", next);
-          }}
-          onRemove={() => setPending(null)}
         />
       ) : null}
     </div>

--- a/templates/design/app/components/design/inspector/ImageFillControls.tsx
+++ b/templates/design/app/components/design/inspector/ImageFillControls.tsx
@@ -34,6 +34,16 @@ const FIT_MODES: Array<{ mode: ImageFitMode; label: string }> = [
 
 // ─── CSS serialization ─────────────────────────────────────────────────────────
 
+/**
+ * Escape a URL for embedding inside a double-quoted CSS url("...") token.
+ * Only `"` and `\` are CSS-significant inside a double-quoted string; newlines
+ * must also be stripped. Everything else (parens, commas, single-quotes, etc.)
+ * is safe inside double quotes, so we leave it alone to keep the URL intact.
+ */
+function escapeForQuotedUrl(url: string): string {
+  return url.replace(/\\/g, "\\\\").replace(/"/g, "%22").replace(/\r?\n/g, "");
+}
+
 const CHECKER_A = "#d4d4d4";
 const CHECKERBOARD_IMAGE = `linear-gradient(45deg, ${CHECKER_A} 25%, transparent 25%), linear-gradient(-45deg, ${CHECKER_A} 25%, transparent 25%), linear-gradient(45deg, transparent 75%, ${CHECKER_A} 75%), linear-gradient(-45deg, transparent 75%, ${CHECKER_A} 75%)`;
 const FIT_MARKER_RE =
@@ -55,7 +65,7 @@ function imageFitMarker(fit: ImageFitMode): string {
 export function imageFillToCss(value: ImageFillValue): string {
   const url = value.url.trim();
   if (!url) return "transparent";
-  const safeUrl = url.replace(/["')]/g, encodeURIComponent);
+  const safeUrl = escapeForQuotedUrl(url);
   const image = `url("${safeUrl}")`;
   switch (value.fit) {
     case "fit":
@@ -70,13 +80,17 @@ export function imageFillToCss(value: ImageFillValue): string {
   }
 }
 
-const URL_RE = /url\((['"]?)([^'")]+)\1\)/i;
+// Matches url() in three forms:
+//   group 1 — double-quoted:  url("...anything...")
+//   group 2 — single-quoted:  url('...anything...')
+//   group 3 — unquoted:       url(...no-parens-or-quotes...)
+const URL_RE = /url\(\s*(?:"([^"]*)"|'([^']*)'|([^)'"]*?))\s*\)/i;
 
 /** Extract the URL + fit mode from a CSS background value, if present. */
 export function parseImageFillCss(value: string): ImageFillValue | null {
   const match = value.match(URL_RE);
   if (!match) return null;
-  const url = match[2];
+  const url = (match[1] ?? match[2] ?? match[3] ?? "").trim();
   const marker = value.match(FIT_MARKER_RE)?.[1] as ImageFitMode | undefined;
   if (marker) return { url, fit: marker };
   // Heuristic fallback when no marker comment is present (e.g. CSS pasted from
@@ -141,7 +155,7 @@ export function ImageFillControls({
         className="relative h-24 w-full overflow-hidden rounded-md border border-border/60"
         style={{
           backgroundImage: value.url
-            ? `url("${value.url.trim().replace(/["')]/g, encodeURIComponent)}")`
+            ? `url("${escapeForQuotedUrl(value.url.trim())}")`
             : CHECKERBOARD_IMAGE,
           backgroundSize: value.url
             ? value.fit === "fit"

--- a/templates/design/app/components/visual-editor/DrawOverlay.tsx
+++ b/templates/design/app/components/visual-editor/DrawOverlay.tsx
@@ -439,7 +439,7 @@ export function DrawOverlay({
       ref={containerRef}
       data-draw-overlay
       className={cn(
-        "absolute inset-0 z-30",
+        "absolute inset-0 z-[100]",
         canvasInteractive ? "pointer-events-auto" : "pointer-events-none",
       )}
     >
@@ -530,7 +530,7 @@ export function DrawOverlay({
       {/* Bottom toolbar */}
       <div
         data-draw-toolbar
-        className="pointer-events-auto absolute bottom-4 left-1/2 z-40 flex -translate-x-1/2 items-center gap-2 rounded-xl border border-border bg-popover px-3 py-2 shadow-2xl"
+        className="pointer-events-auto fixed bottom-4 left-1/2 z-[110] flex -translate-x-1/2 items-center gap-2 rounded-xl border border-border bg-popover px-3 py-2 shadow-2xl"
       >
         {/* Color picker */}
         <div className="flex gap-1">

--- a/templates/design/app/components/visual-editor/DrawOverlay.tsx
+++ b/templates/design/app/components/visual-editor/DrawOverlay.tsx
@@ -225,7 +225,11 @@ export function DrawOverlay({
         lineWidth,
       );
     }
-  }, [strokes, currentStroke, color, lineWidth, resizeTick]);
+    // `zoom` is a dependency because it scales the canvas via a CSS transform,
+    // which changes getBoundingClientRect() without firing ResizeObserver — the
+    // effect must re-run on zoom change to redraw the fraction-based strokes at
+    // the new visual size.
+  }, [strokes, currentStroke, color, lineWidth, resizeTick, zoom]);
 
   const handlePointerDown = useCallback(
     (e: React.PointerEvent) => {

--- a/templates/design/app/components/visual-editor/DrawOverlay.tsx
+++ b/templates/design/app/components/visual-editor/DrawOverlay.tsx
@@ -7,15 +7,6 @@ import {
   IconCursorText,
   IconX,
 } from "@tabler/icons-react";
-/**
- * NOTE: This is the new shared visual-editor DrawOverlay, mirrored from the
- * slides template so both apps share the same comment/draw/save UX.
- *
- * The legacy iframe-based design overlay still lives at
- * `app/components/design/DrawOverlay.tsx` and is currently wired into
- * `DesignCanvas`. Both exist for now; the legacy one can be migrated to use
- * this shared version in a follow-up. Don't import both in the same screen.
- */
 import { useState, useRef, useCallback, useEffect } from "react";
 import { toast } from "sonner";
 
@@ -41,6 +32,12 @@ export interface DrawAnnotation {
   lineWidth: number;
   /** Position relative to the canvas (text annotations only) */
   position: { x: number; y: number };
+  /**
+   * Creation timestamp (Date.now()) — used for unified undo ordering across
+   * strokes and text annotations. Optional so existing callers of DrawAnnotation
+   * don't need to supply it.
+   */
+  createdAt?: number;
 }
 
 interface DrawOverlayProps {
@@ -50,6 +47,13 @@ interface DrawOverlayProps {
   canvasInteractive?: boolean;
   /** Extra queued annotations owned by sibling tools, such as comment pins. */
   queuedAnnotationCount?: number;
+  /**
+   * Current zoom level (percentage, e.g. 100 = 100%). Used to convert
+   * getBoundingClientRect() visual-space coordinates to layout-space so that
+   * strokes and text labels stay anchored to their painted position across
+   * zoom changes.
+   */
+  zoom?: number;
   /** Called when the user submits the queued strokes/text to the agent */
   onSend: (
     annotations: DrawAnnotation[],
@@ -73,6 +77,12 @@ const LINE_WIDTHS = [
   { value: 8, label: "Thick" },
 ];
 
+/**
+ * A point stored as fractions (0..1) of the canvas visual rect.
+ * This makes coordinates zoom- and resize-stable: multiply by the current
+ * rect width/height to get visual pixels for canvas drawing, or multiply by
+ * rect/scale to get layout-space for CSS positioning and pathData output.
+ */
 interface Point {
   x: number;
   y: number;
@@ -80,9 +90,12 @@ interface Point {
 
 interface Stroke {
   id: string;
+  /** Points stored as fractions (0..1) of the canvas visual rect. */
   points: Point[];
   color: string;
   lineWidth: number;
+  /** Creation timestamp for unified undo ordering. */
+  createdAt: number;
 }
 
 /**
@@ -97,11 +110,22 @@ interface Stroke {
  * This component is canvas-agnostic — it overlays absolutely-positioned over
  * its parent, so the parent (a slide editor or design canvas) only needs to
  * be `position: relative`.
+ *
+ * Coordinate model
+ * ----------------
+ * All stroke points and text positions are stored as fractions (0..1) of the
+ * canvas's visual rect (getBoundingClientRect). This makes them stable across
+ * zoom and resize. When rendering:
+ *   - Canvas strokes: multiply by rect.width / rect.height (visual pixels).
+ *   - CSS text labels: multiply by rect.width/scale / rect.height/scale
+ *     (layout pixels inside the scaled wrapper).
+ *   - pathData in send(): layout pixels = fraction * rect.width / scale.
  */
 export function DrawOverlay({
   visible,
   canvasInteractive = true,
   queuedAnnotationCount = 0,
+  zoom = 100,
   onSend,
   onClose,
 }: DrawOverlayProps) {
@@ -112,34 +136,52 @@ export function DrawOverlay({
   const [lineWidth, setLineWidth] = useState(LINE_WIDTHS[1].value);
   const [strokes, setStrokes] = useState<Stroke[]>([]);
   const [textAnnotations, setTextAnnotations] = useState<DrawAnnotation[]>([]);
-  // Redo stack. Pushing here happens via undo(); a fresh stroke clears it
-  // (standard editor convention — once you draw something new, the redo
-  // history is no longer reachable).
-  const [redoStrokes, setRedoStrokes] = useState<Stroke[]>([]);
+  // Unified redo stack. Each entry is either a Stroke or a DrawAnnotation so
+  // undo/redo work in creation order across both types.
+  const [redoStack, setRedoStack] = useState<Array<Stroke | DrawAnnotation>>(
+    [],
+  );
   const [currentStroke, setCurrentStroke] = useState<Point[] | null>(null);
   const [textMode, setTextMode] = useState(false);
   const [textInput, setTextInput] = useState<{
-    x: number;
-    y: number;
+    /** Fractional x (0..1) of the visual rect. */
+    xFrac: number;
+    /** Fractional y (0..1) of the visual rect. */
+    yFrac: number;
     value: string;
   } | null>(null);
   const [instruction, setInstruction] = useState("");
   const drawing = useRef(false);
   const canvasSizeRef = useRef({ w: 0, h: 0 });
+  // Resize tick: bumped by ResizeObserver so the redraw effect re-runs when
+  // the canvas element's CSS size changes (e.g. device frame switch).
+  const [resizeTick, setResizeTick] = useState(0);
+
+  const scale = zoom / 100;
 
   // Clear all state on hide so the next open starts fresh.
   useEffect(() => {
     if (!visible) {
       setStrokes([]);
       setTextAnnotations([]);
-      setRedoStrokes([]);
+      setRedoStack([]);
       setCurrentStroke(null);
       setTextInput(null);
       setInstruction("");
     }
   }, [visible]);
 
-  // Redraw canvas whenever strokes change.
+  // ResizeObserver: bump resizeTick whenever the canvas changes CSS size so
+  // the redraw effect re-runs and the backing store is resized correctly.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ro = new ResizeObserver(() => setResizeTick((t) => t + 1));
+    ro.observe(canvas);
+    return () => ro.disconnect();
+  }, []);
+
+  // Redraw canvas whenever strokes change or the canvas is resized.
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
@@ -159,31 +201,50 @@ export function DrawOverlay({
 
     ctx.clearRect(0, 0, rect.width, rect.height);
 
+    // Points are stored as fractions; multiply by current rect to get visual px.
     for (const stroke of strokes) {
-      drawStroke(ctx, stroke.points, stroke.color, stroke.lineWidth);
+      drawStroke(
+        ctx,
+        stroke.points.map((p) => ({
+          x: p.x * rect.width,
+          y: p.y * rect.height,
+        })),
+        stroke.color,
+        stroke.lineWidth,
+      );
     }
 
     if (currentStroke && currentStroke.length > 0) {
-      drawStroke(ctx, currentStroke, color, lineWidth);
+      drawStroke(
+        ctx,
+        currentStroke.map((p) => ({
+          x: p.x * rect.width,
+          y: p.y * rect.height,
+        })),
+        color,
+        lineWidth,
+      );
     }
-  }, [strokes, currentStroke, color, lineWidth]);
+  }, [strokes, currentStroke, color, lineWidth, resizeTick]);
 
   const handlePointerDown = useCallback(
     (e: React.PointerEvent) => {
+      const rect = canvasRef.current?.getBoundingClientRect();
+      if (!rect) return;
       if (textMode) {
-        const rect = canvasRef.current?.getBoundingClientRect();
-        if (!rect) return;
         setTextInput({
-          x: e.clientX - rect.left,
-          y: e.clientY - rect.top,
+          xFrac: (e.clientX - rect.left) / rect.width,
+          yFrac: (e.clientY - rect.top) / rect.height,
           value: "",
         });
         return;
       }
       drawing.current = true;
-      const rect = canvasRef.current?.getBoundingClientRect();
-      if (!rect) return;
-      const point = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+      // Store as fractions so the point survives zoom/resize changes.
+      const point = {
+        x: (e.clientX - rect.left) / rect.width,
+        y: (e.clientY - rect.top) / rect.height,
+      };
       setCurrentStroke([point]);
       (e.target as HTMLElement).setPointerCapture(e.pointerId);
     },
@@ -195,7 +256,10 @@ export function DrawOverlay({
       if (!drawing.current || textMode) return;
       const rect = canvasRef.current?.getBoundingClientRect();
       if (!rect) return;
-      const point = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+      const point = {
+        x: (e.clientX - rect.left) / rect.width,
+        y: (e.clientY - rect.top) / rect.height,
+      };
       setCurrentStroke((prev) => (prev ? [...prev, point] : [point]));
     },
     [textMode],
@@ -212,9 +276,11 @@ export function DrawOverlay({
           points: currentStroke,
           color,
           lineWidth,
+          createdAt: Date.now(),
         },
       ]);
-      setRedoStrokes([]);
+      // A new stroke clears the redo stack (standard editor convention).
+      setRedoStack([]);
     }
     setCurrentStroke(null);
   }, [currentStroke, color, lineWidth]);
@@ -224,41 +290,65 @@ export function DrawOverlay({
     setCurrentStroke(null);
   }, []);
 
+  /**
+   * Undo removes the most recently created annotation (stroke or text) in
+   * creation order and pushes it onto the unified redo stack.
+   */
   const undo = () => {
-    setStrokes((prev) => {
-      if (prev.length === 0) return prev;
-      const last = prev[prev.length - 1];
-      setRedoStrokes((stack) => [...stack, last]);
-      return prev.slice(0, -1);
-    });
+    const lastStroke = strokes.length > 0 ? strokes[strokes.length - 1] : null;
+    const lastText =
+      textAnnotations.length > 0
+        ? textAnnotations[textAnnotations.length - 1]
+        : null;
+
+    if (!lastStroke && !lastText) return;
+
+    // Remove whichever was created most recently.
+    const strokeTime = lastStroke?.createdAt ?? -Infinity;
+    const textTime = lastText?.createdAt ?? 0;
+
+    if (lastStroke && strokeTime >= textTime) {
+      setStrokes((prev) => prev.slice(0, -1));
+      setRedoStack((stack) => [...stack, lastStroke]);
+    } else if (lastText) {
+      setTextAnnotations((prev) => prev.slice(0, -1));
+      setRedoStack((stack) => [...stack, lastText]);
+    }
   };
 
   const redo = () => {
-    setRedoStrokes((stack) => {
+    setRedoStack((stack) => {
       if (stack.length === 0) return stack;
       const top = stack[stack.length - 1];
-      setStrokes((prev) => [...prev, top]);
-      return stack.slice(0, -1);
+      const remaining = stack.slice(0, -1);
+      if ("points" in top) {
+        // It's a Stroke
+        setStrokes((prev) => [...prev, top as Stroke]);
+      } else {
+        // It's a DrawAnnotation (text)
+        setTextAnnotations((prev) => [...prev, top as DrawAnnotation]);
+      }
+      return remaining;
     });
   };
 
   const clear = () => {
     if (strokes.length === 0 && textAnnotations.length === 0) return;
-    // Snapshot for the toast's Undo. Using a toast (instead of an AlertDialog
-    // confirm) keeps Clear a single click for users who know what they want,
-    // while still letting an accidental click be recovered for the toast's
-    // lifetime.
     const prevStrokes = strokes;
     const prevTexts = textAnnotations;
+    const prevRedo = redoStack;
     setStrokes([]);
     setTextAnnotations([]);
-    setRedoStrokes([]);
+    setRedoStack([]);
     toast(t("visualEditor.clearedAllAnnotations"), {
       action: {
         label: t("visualEditor.undo"),
         onClick: () => {
-          setStrokes(prevStrokes);
-          setTextAnnotations(prevTexts);
+          // Merge snapshot with any strokes/texts drawn during the toast window
+          // so new work is not discarded; also restore the pre-clear redo stack.
+          setStrokes((cur) => [...prevStrokes, ...cur]);
+          setTextAnnotations((cur) => [...prevTexts, ...cur]);
+          setRedoStack(prevRedo);
         },
       },
       duration: 6000,
@@ -270,17 +360,19 @@ export function DrawOverlay({
       setTextInput(null);
       return;
     }
-    setTextAnnotations((prev) => [
-      ...prev,
-      {
-        id: crypto.randomUUID(),
-        type: "text",
-        text: textInput.value.trim(),
-        position: { x: textInput.x, y: textInput.y },
-        color,
-        lineWidth,
-      },
-    ]);
+    const ann: DrawAnnotation = {
+      id: crypto.randomUUID(),
+      type: "text",
+      text: textInput.value.trim(),
+      // Store fractional position so the label stays anchored across zoom changes.
+      position: { x: textInput.xFrac, y: textInput.yFrac },
+      color,
+      lineWidth,
+      createdAt: Date.now(),
+    };
+    setTextAnnotations((prev) => [...prev, ann]);
+    // A new text annotation also clears the redo stack.
+    setRedoStack([]);
     setTextInput(null);
   };
 
@@ -288,13 +380,18 @@ export function DrawOverlay({
     const canvas = canvasRef.current;
     if (!canvas) return;
     const rect = canvas.getBoundingClientRect();
+    // Layout-space dimensions = visual rect / scale factor.
+    const layoutW = rect.width / scale;
+    const layoutH = rect.height / scale;
 
     const pathAnnotations: DrawAnnotation[] = strokes.map((s) => ({
       id: s.id,
       type: "path",
+      // Convert fractional points to layout-space absolute pixels for the agent.
       pathData: s.points
         .map(
-          (p, i) => `${i === 0 ? "M" : "L"}${p.x.toFixed(1)},${p.y.toFixed(1)}`,
+          (p, i) =>
+            `${i === 0 ? "M" : "L"}${(p.x * layoutW).toFixed(1)},${(p.y * layoutH).toFixed(1)}`,
         )
         .join(" "),
       color: s.color,
@@ -302,12 +399,23 @@ export function DrawOverlay({
       position: { x: 0, y: 0 },
     }));
 
-    const all = [...pathAnnotations, ...textAnnotations];
+    // Convert fractional text positions to layout-space absolute pixels.
+    const layoutTextAnnotations: DrawAnnotation[] = textAnnotations.map(
+      (a) => ({
+        ...a,
+        position: {
+          x: a.position.x * layoutW,
+          y: a.position.y * layoutH,
+        },
+      }),
+    );
+
+    const all = [...pathAnnotations, ...layoutTextAnnotations];
     if (all.length === 0 && !instruction.trim()) return;
 
     onSend(all, instruction.trim(), {
-      width: rect.width,
-      height: rect.height,
+      width: layoutW,
+      height: layoutH,
     });
   };
 
@@ -318,6 +426,9 @@ export function DrawOverlay({
     textAnnotations.length > 0 ||
     instruction.trim() ||
     queuedAnnotationCount > 0;
+
+  const canUndo = strokes.length > 0 || textAnnotations.length > 0;
+  const canRedo = redoStack.length > 0;
 
   return (
     <div
@@ -343,49 +454,74 @@ export function DrawOverlay({
         onPointerCancel={handlePointerCancel}
       />
 
-      {/* Rendered text annotations */}
-      {textAnnotations.map((ann) => (
-        <div
-          key={ann.id}
-          className="absolute pointer-events-none select-none whitespace-nowrap font-semibold"
-          style={{
-            left: ann.position.x,
-            top: ann.position.y,
-            color: ann.color,
-            fontSize: 14 + ann.lineWidth,
-          }}
-        >
-          {ann.text}
-        </div>
-      ))}
-
-      {/* Pending text input */}
-      {textInput && (
-        <div
-          className="pointer-events-auto absolute z-40"
-          style={{ left: textInput.x, top: textInput.y }}
-        >
-          <Input
-            value={textInput.value}
-            onChange={(e) =>
-              setTextInput((prev) =>
-                prev ? { ...prev, value: e.target.value } : null,
-              )
-            }
-            onBlur={commitTextAnnotation}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                commitTextAnnotation();
-              }
-              if (e.key === "Escape") setTextInput(null);
+      {/* Rendered text annotations.
+          Positions are stored as fractions (0..1) of the visual rect. Convert
+          to layout-space pixels (fraction * visualDim / scale) so the label
+          sits at the right layout position inside the scaled wrapper, where
+          CSS left/top are interpreted in pre-scale coordinates. */}
+      {textAnnotations.map((ann) => {
+        const canvas = canvasRef.current;
+        const rect = canvas?.getBoundingClientRect();
+        const layoutX = rect
+          ? (ann.position.x * rect.width) / scale
+          : ann.position.x;
+        const layoutY = rect
+          ? (ann.position.y * rect.height) / scale
+          : ann.position.y;
+        return (
+          <div
+            key={ann.id}
+            className="absolute pointer-events-none select-none whitespace-nowrap font-semibold"
+            style={{
+              left: layoutX,
+              top: layoutY,
+              color: ann.color,
+              fontSize: 14 + ann.lineWidth,
             }}
-            className="h-7 w-48 border-primary bg-background text-sm"
-            autoFocus
-            placeholder={t("visualEditor.typeAnnotationFancy")}
-          />
-        </div>
-      )}
+          >
+            {ann.text}
+          </div>
+        );
+      })}
+
+      {/* Pending text input — positioned at the click point in layout space. */}
+      {textInput &&
+        (() => {
+          const canvas = canvasRef.current;
+          const rect = canvas?.getBoundingClientRect();
+          const layoutX = rect
+            ? (textInput.xFrac * rect.width) / scale
+            : textInput.xFrac;
+          const layoutY = rect
+            ? (textInput.yFrac * rect.height) / scale
+            : textInput.yFrac;
+          return (
+            <div
+              className="pointer-events-auto absolute z-40"
+              style={{ left: layoutX, top: layoutY }}
+            >
+              <Input
+                value={textInput.value}
+                onChange={(e) =>
+                  setTextInput((prev) =>
+                    prev ? { ...prev, value: e.target.value } : null,
+                  )
+                }
+                onBlur={commitTextAnnotation}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    commitTextAnnotation();
+                  }
+                  if (e.key === "Escape") setTextInput(null);
+                }}
+                className="h-7 w-48 border-primary bg-background text-sm"
+                autoFocus
+                placeholder={t("visualEditor.typeAnnotationFancy")}
+              />
+            </div>
+          );
+        })()}
 
       {/* Bottom toolbar */}
       <div
@@ -462,12 +598,12 @@ export function DrawOverlay({
           </TooltipContent>
         </Tooltip>
 
-        {/* Undo last stroke */}
+        {/* Undo last annotation (stroke or text) */}
         <Tooltip>
           <TooltipTrigger asChild>
             <button
               onClick={undo}
-              disabled={strokes.length === 0}
+              disabled={!canUndo}
               className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-30"
             >
               <IconArrowBackUp className="h-3.5 w-3.5" />
@@ -481,7 +617,7 @@ export function DrawOverlay({
           <TooltipTrigger asChild>
             <button
               onClick={redo}
-              disabled={redoStrokes.length === 0}
+              disabled={!canRedo}
               className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-30"
             >
               <IconArrowForwardUp className="h-3.5 w-3.5" />

--- a/templates/design/app/components/visual-editor/DrawOverlay.tsx
+++ b/templates/design/app/components/visual-editor/DrawOverlay.tsx
@@ -7,7 +7,8 @@ import {
   IconCursorText,
   IconX,
 } from "@tabler/icons-react";
-import { useState, useRef, useCallback, useEffect } from "react";
+import { useState, useRef, useCallback, useEffect, type ReactNode } from "react";
+import { createPortal } from "react-dom";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -150,6 +151,7 @@ export function DrawOverlay({
     yFrac: number;
     value: string;
   } | null>(null);
+  const textInputRef = useRef<HTMLInputElement>(null);
   const [instruction, setInstruction] = useState("");
   const drawing = useRef(false);
   const canvasSizeRef = useRef({ w: 0, h: 0 });
@@ -170,6 +172,14 @@ export function DrawOverlay({
       setInstruction("");
     }
   }, [visible]);
+
+  useEffect(() => {
+    if (!textInput) return;
+    const id = window.requestAnimationFrame(() => {
+      textInputRef.current?.focus();
+    });
+    return () => window.cancelAnimationFrame(id);
+  }, [textInput?.xFrac, textInput?.yFrac]);
 
   // ResizeObserver: bump resizeTick whenever the canvas changes CSS size so
   // the redraw effect re-runs and the backing store is resized correctly.
@@ -434,6 +444,183 @@ export function DrawOverlay({
   const canUndo = strokes.length > 0 || textAnnotations.length > 0;
   const canRedo = redoStack.length > 0;
 
+  const toolbar = (
+    <div
+      data-draw-toolbar
+      className="pointer-events-auto fixed bottom-4 left-1/2 z-[110] flex -translate-x-1/2 items-center gap-2 rounded-xl border border-border bg-popover px-3 py-2 shadow-2xl"
+    >
+      {/* Color picker */}
+      <div className="flex gap-1">
+        {PRESET_COLORS.map((preset) => (
+          <Tooltip key={preset.color}>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label={preset.label}
+                data-testid={`draw-color-${preset.label.toLowerCase()}`}
+                onClick={() => setColor(preset.color)}
+                className={cn(
+                  "h-5 w-5 cursor-pointer rounded-full",
+                  color === preset.color
+                    ? "ring-2 ring-foreground ring-offset-1 ring-offset-popover"
+                    : "ring-1 ring-border",
+                )}
+                style={{ backgroundColor: preset.color }}
+              />
+            </TooltipTrigger>
+            <TooltipContent>{preset.label}</TooltipContent>
+          </Tooltip>
+        ))}
+      </div>
+
+      <div className="mx-1 h-4 w-px bg-border" />
+
+      {/* Line widths */}
+      <div className="flex gap-1">
+        {LINE_WIDTHS.map((lw) => (
+          <Tooltip key={lw.value}>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label={lw.label}
+                data-testid={`draw-line-width-${lw.label.toLowerCase()}`}
+                onClick={() => setLineWidth(lw.value)}
+                className={cn(
+                  "flex h-6 w-6 cursor-pointer items-center justify-center rounded",
+                  lineWidth === lw.value
+                    ? "bg-accent text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                <div
+                  className="rounded-full bg-current"
+                  style={{ width: lw.value + 2, height: lw.value + 2 }}
+                />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>{lw.label}</TooltipContent>
+          </Tooltip>
+        ))}
+      </div>
+
+      <div className="mx-1 h-4 w-px bg-border" />
+
+      {/* Text mode */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={t("visualEditor.typeAnywhereOnCanvas")}
+            data-testid="draw-text-mode"
+            onClick={() => setTextMode(!textMode)}
+            className={cn(
+              "flex h-6 w-6 cursor-pointer items-center justify-center rounded",
+              textMode
+                ? "bg-accent text-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            <IconCursorText className="h-3.5 w-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>{t("visualEditor.typeAnywhereOnCanvas")}</TooltipContent>
+      </Tooltip>
+
+      {/* Undo last annotation (stroke or text) */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={t("visualEditor.undoStroke")}
+            data-testid="draw-undo"
+            onClick={undo}
+            disabled={!canUndo}
+            className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-30"
+          >
+            <IconArrowBackUp className="h-3.5 w-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>{t("visualEditor.undoStroke")}</TooltipContent>
+      </Tooltip>
+
+      {/* Redo */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={t("visualEditor.redoStroke")}
+            data-testid="draw-redo"
+            onClick={redo}
+            disabled={!canRedo}
+            className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-30"
+          >
+            <IconArrowForwardUp className="h-3.5 w-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>{t("visualEditor.redoStroke")}</TooltipContent>
+      </Tooltip>
+
+      {/* Clear all */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={t("visualEditor.clearAll")}
+            data-testid="draw-clear-all"
+            onClick={clear}
+            disabled={strokes.length === 0 && textAnnotations.length === 0}
+            className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-30"
+          >
+            <IconEraser className="h-3.5 w-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>{t("visualEditor.clearAll")}</TooltipContent>
+      </Tooltip>
+
+      <div className="mx-1 h-4 w-px bg-border" />
+
+      {/* Instruction input */}
+      <Input
+        value={instruction}
+        onChange={(e) => setInstruction(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && hasContent) send();
+          if (e.key === "Escape") onClose();
+        }}
+        placeholder={t("visualEditor.tellAgentWhatToDo")}
+        className="h-7 w-56 border-border bg-background text-xs"
+      />
+
+      {/* Send */}
+      <Button
+        size="sm"
+        data-testid="draw-send"
+        className="h-7 gap-1 px-3 text-[11px] cursor-pointer"
+        onClick={send}
+        disabled={!hasContent}
+      >
+        <IconSend className="h-3 w-3" />
+        {t("visualEditor.send")}
+      </Button>
+
+      {/* Close */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={t("visualEditor.exitDrawMode")}
+            data-testid="draw-exit"
+            onClick={onClose}
+            className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground"
+          >
+            <IconX className="h-3.5 w-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>{t("visualEditor.exitDrawMode")}</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+
   return (
     <div
       ref={containerRef}
@@ -505,13 +692,16 @@ export function DrawOverlay({
               style={{ left: layoutX, top: layoutY }}
             >
               <Input
+                ref={textInputRef}
                 value={textInput.value}
                 onChange={(e) =>
                   setTextInput((prev) =>
                     prev ? { ...prev, value: e.target.value } : null,
                   )
                 }
-                onBlur={commitTextAnnotation}
+                onBlur={() => {
+                  if (textInput.value.trim()) commitTextAnnotation();
+                }}
                 onKeyDown={(e) => {
                   if (e.key === "Enter") {
                     e.preventDefault();
@@ -527,185 +717,14 @@ export function DrawOverlay({
           );
         })()}
 
-      {/* Bottom toolbar */}
-      <div
-        data-draw-toolbar
-        className="pointer-events-auto fixed bottom-4 left-1/2 z-[110] flex -translate-x-1/2 items-center gap-2 rounded-xl border border-border bg-popover px-3 py-2 shadow-2xl"
-      >
-        {/* Color picker */}
-        <div className="flex gap-1">
-          {PRESET_COLORS.map((preset) => (
-            <Tooltip key={preset.color}>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  aria-label={preset.label}
-                  data-testid={`draw-color-${preset.label.toLowerCase()}`}
-                  onClick={() => setColor(preset.color)}
-                  className={cn(
-                    "h-5 w-5 cursor-pointer rounded-full",
-                    color === preset.color
-                      ? "ring-2 ring-foreground ring-offset-1 ring-offset-popover"
-                      : "ring-1 ring-border",
-                  )}
-                  style={{ backgroundColor: preset.color }}
-                />
-              </TooltipTrigger>
-              <TooltipContent>{preset.label}</TooltipContent>
-            </Tooltip>
-          ))}
-        </div>
-
-        <div className="mx-1 h-4 w-px bg-border" />
-
-        {/* Line widths */}
-        <div className="flex gap-1">
-          {LINE_WIDTHS.map((lw) => (
-            <Tooltip key={lw.value}>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  aria-label={lw.label}
-                  data-testid={`draw-line-width-${lw.label.toLowerCase()}`}
-                  onClick={() => setLineWidth(lw.value)}
-                  className={cn(
-                    "flex h-6 w-6 cursor-pointer items-center justify-center rounded",
-                    lineWidth === lw.value
-                      ? "bg-accent text-foreground"
-                      : "text-muted-foreground hover:text-foreground",
-                  )}
-                >
-                  <div
-                    className="rounded-full bg-current"
-                    style={{ width: lw.value + 2, height: lw.value + 2 }}
-                  />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent>{lw.label}</TooltipContent>
-            </Tooltip>
-          ))}
-        </div>
-
-        <div className="mx-1 h-4 w-px bg-border" />
-
-        {/* Text mode */}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              aria-label={t("visualEditor.typeAnywhereOnCanvas")}
-              data-testid="draw-text-mode"
-              onClick={() => setTextMode(!textMode)}
-              className={cn(
-                "flex h-6 w-6 cursor-pointer items-center justify-center rounded",
-                textMode
-                  ? "bg-accent text-foreground"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              <IconCursorText className="h-3.5 w-3.5" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>
-            {t("visualEditor.typeAnywhereOnCanvas")}
-          </TooltipContent>
-        </Tooltip>
-
-        {/* Undo last annotation (stroke or text) */}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              aria-label={t("visualEditor.undoStroke")}
-              data-testid="draw-undo"
-              onClick={undo}
-              disabled={!canUndo}
-              className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-30"
-            >
-              <IconArrowBackUp className="h-3.5 w-3.5" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>{t("visualEditor.undoStroke")}</TooltipContent>
-        </Tooltip>
-
-        {/* Redo */}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              aria-label={t("visualEditor.redoStroke")}
-              data-testid="draw-redo"
-              onClick={redo}
-              disabled={!canRedo}
-              className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-30"
-            >
-              <IconArrowForwardUp className="h-3.5 w-3.5" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>{t("visualEditor.redoStroke")}</TooltipContent>
-        </Tooltip>
-
-        {/* Clear all */}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              aria-label={t("visualEditor.clearAll")}
-              data-testid="draw-clear-all"
-              onClick={clear}
-              disabled={strokes.length === 0 && textAnnotations.length === 0}
-              className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-30"
-            >
-              <IconEraser className="h-3.5 w-3.5" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>{t("visualEditor.clearAll")}</TooltipContent>
-        </Tooltip>
-
-        <div className="mx-1 h-4 w-px bg-border" />
-
-        {/* Instruction input */}
-        <Input
-          value={instruction}
-          onChange={(e) => setInstruction(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && hasContent) send();
-            if (e.key === "Escape") onClose();
-          }}
-          placeholder={t("visualEditor.tellAgentWhatToDo")}
-          className="h-7 w-56 border-border bg-background text-xs"
-        />
-
-        {/* Send */}
-        <Button
-          size="sm"
-          data-testid="draw-send"
-          className="h-7 gap-1 px-3 text-[11px] cursor-pointer"
-          onClick={send}
-          disabled={!hasContent}
-        >
-          <IconSend className="h-3 w-3" />
-          {t("visualEditor.send")}
-        </Button>
-
-        {/* Close */}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              aria-label={t("visualEditor.exitDrawMode")}
-              data-testid="draw-exit"
-              onClick={onClose}
-              className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground"
-            >
-              <IconX className="h-3.5 w-3.5" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>{t("visualEditor.exitDrawMode")}</TooltipContent>
-        </Tooltip>
-      </div>
+      <DrawToolbarPortal>{toolbar}</DrawToolbarPortal>
     </div>
   );
+}
+
+function DrawToolbarPortal({ children }: { children: ReactNode }) {
+  if (typeof document === "undefined") return <>{children}</>;
+  return createPortal(children, document.body);
 }
 
 function drawStroke(

--- a/templates/design/app/components/visual-editor/DrawOverlay.tsx
+++ b/templates/design/app/components/visual-editor/DrawOverlay.tsx
@@ -538,6 +538,9 @@ export function DrawOverlay({
             <Tooltip key={preset.color}>
               <TooltipTrigger asChild>
                 <button
+                  type="button"
+                  aria-label={preset.label}
+                  data-testid={`draw-color-${preset.label.toLowerCase()}`}
                   onClick={() => setColor(preset.color)}
                   className={cn(
                     "h-5 w-5 cursor-pointer rounded-full",
@@ -561,6 +564,9 @@ export function DrawOverlay({
             <Tooltip key={lw.value}>
               <TooltipTrigger asChild>
                 <button
+                  type="button"
+                  aria-label={lw.label}
+                  data-testid={`draw-line-width-${lw.label.toLowerCase()}`}
                   onClick={() => setLineWidth(lw.value)}
                   className={cn(
                     "flex h-6 w-6 cursor-pointer items-center justify-center rounded",
@@ -586,6 +592,9 @@ export function DrawOverlay({
         <Tooltip>
           <TooltipTrigger asChild>
             <button
+              type="button"
+              aria-label={t("visualEditor.typeAnywhereOnCanvas")}
+              data-testid="draw-text-mode"
               onClick={() => setTextMode(!textMode)}
               className={cn(
                 "flex h-6 w-6 cursor-pointer items-center justify-center rounded",
@@ -606,6 +615,9 @@ export function DrawOverlay({
         <Tooltip>
           <TooltipTrigger asChild>
             <button
+              type="button"
+              aria-label={t("visualEditor.undoStroke")}
+              data-testid="draw-undo"
               onClick={undo}
               disabled={!canUndo}
               className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-30"
@@ -620,6 +632,9 @@ export function DrawOverlay({
         <Tooltip>
           <TooltipTrigger asChild>
             <button
+              type="button"
+              aria-label={t("visualEditor.redoStroke")}
+              data-testid="draw-redo"
               onClick={redo}
               disabled={!canRedo}
               className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-30"
@@ -634,6 +649,9 @@ export function DrawOverlay({
         <Tooltip>
           <TooltipTrigger asChild>
             <button
+              type="button"
+              aria-label={t("visualEditor.clearAll")}
+              data-testid="draw-clear-all"
               onClick={clear}
               disabled={strokes.length === 0 && textAnnotations.length === 0}
               className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-30"
@@ -661,6 +679,7 @@ export function DrawOverlay({
         {/* Send */}
         <Button
           size="sm"
+          data-testid="draw-send"
           className="h-7 gap-1 px-3 text-[11px] cursor-pointer"
           onClick={send}
           disabled={!hasContent}
@@ -673,6 +692,9 @@ export function DrawOverlay({
         <Tooltip>
           <TooltipTrigger asChild>
             <button
+              type="button"
+              aria-label={t("visualEditor.exitDrawMode")}
+              data-testid="draw-exit"
               onClick={onClose}
               className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground"
             >

--- a/templates/design/app/components/visual-editor/DrawOverlay.tsx
+++ b/templates/design/app/components/visual-editor/DrawOverlay.tsx
@@ -7,7 +7,13 @@ import {
   IconCursorText,
   IconX,
 } from "@tabler/icons-react";
-import { useState, useRef, useCallback, useEffect, type ReactNode } from "react";
+import {
+  useState,
+  useRef,
+  useCallback,
+  useEffect,
+  type ReactNode,
+} from "react";
 import { createPortal } from "react-dom";
 import { toast } from "sonner";
 
@@ -523,7 +529,9 @@ export function DrawOverlay({
             <IconCursorText className="h-3.5 w-3.5" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>{t("visualEditor.typeAnywhereOnCanvas")}</TooltipContent>
+        <TooltipContent>
+          {t("visualEditor.typeAnywhereOnCanvas")}
+        </TooltipContent>
       </Tooltip>
 
       {/* Undo last annotation (stroke or text) */}

--- a/templates/design/app/hooks/use-variant-flow.ts
+++ b/templates/design/app/hooks/use-variant-flow.ts
@@ -4,9 +4,10 @@ import {
   callAction,
   isEmbedAuthActive,
 } from "@agent-native/core/client";
-import { toast } from "@/hooks/use-toast";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useCallback, useRef, useState } from "react";
+
+import { toast } from "@/hooks/use-toast";
 
 export const DESIGN_VARIANT_PICKED_EVENT = "agent-native-design-variant-picked";
 

--- a/templates/design/app/hooks/use-variant-flow.ts
+++ b/templates/design/app/hooks/use-variant-flow.ts
@@ -4,6 +4,7 @@ import {
   callAction,
   isEmbedAuthActive,
 } from "@agent-native/core/client";
+import { toast } from "@/hooks/use-toast";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useCallback, useRef, useState } from "react";
 
@@ -194,8 +195,14 @@ export function useVariantFlow(designId: string | undefined) {
             );
           }
         } catch {
-          // Network error: report the choice below so the agent still records it;
-          // the grid still clears so the user isn't stuck.
+          // Network error: show a visible error and keep the grid open so
+          // the user can retry rather than silently losing their choice.
+          toast({
+            title: "Couldn't save your pick",
+            description:
+              "Saving didn't finish. Try again or refresh and re-pick.",
+            variant: "destructive",
+          });
         }
 
         const refineHint = persisted
@@ -240,7 +247,14 @@ export function useVariantFlow(designId: string | undefined) {
           });
         }
 
-        clear();
+        // Only clear the grid when the variant was successfully persisted.
+        // If saving failed, keep the grid open so the user can retry.
+        if (persisted) {
+          clear();
+        } else {
+          // Re-arm the picking latch so the user can try again.
+          pickedRef.current = false;
+        }
       } finally {
         pickingRef.current = false;
       }

--- a/templates/design/app/hooks/use-variant-flow.ts
+++ b/templates/design/app/hooks/use-variant-flow.ts
@@ -114,6 +114,10 @@ export function useVariantFlow(designId: string | undefined) {
   // responses with the same designId cannot re-open the grid, even if the
   // server DELETE is delayed or the user picks while a poll is in-flight.
   const consumedDesignIdRef = useRef<string | null>(null);
+  // Bounded suppression window (epoch ms). After it elapses we stop suppressing
+  // so a failed DELETE or a fast follow-up present-design-variants for the same
+  // design can't keep the picker hidden indefinitely.
+  const consumedUntilRef = useRef(0);
 
   const { data } = useQuery({
     queryKey: ["design-variants"],
@@ -138,17 +142,24 @@ export function useVariantFlow(designId: string | undefined) {
     const hasVariants = Boolean(
       data?.variants && data.variants.length > 0 && data.designId === designId,
     );
-    // Suppress any polled data whose designId matches a consumed (already-picked)
-    // variant set so stale in-flight polls can't re-open the grid.
-    if (data?.designId && data.designId === consumedDesignIdRef.current) {
-      // Re-arm the consumed marker once the server confirms the state is gone.
+    // Suppression after a pick covers two things: the brief window where a stale
+    // in-flight poll could re-open the just-picked grid, and the gap until the
+    // server DELETE lands. It is bounded in time so a failed DELETE (server state
+    // never clears) or a fast follow-up variant set for the same design can't
+    // keep the picker hidden forever.
+    const windowElapsed = Date.now() >= consumedUntilRef.current;
+    if ((consumedDesignIdRef.current || pickedRef.current) && windowElapsed) {
+      consumedDesignIdRef.current = null;
+      pickedRef.current = false;
+    } else if (
+      data?.designId &&
+      data.designId === consumedDesignIdRef.current
+    ) {
+      // Re-arm early once the server confirms the consumed state is gone.
       if (!hasVariants) consumedDesignIdRef.current = null;
       setState(null);
       return;
-    }
-    // After a pick, keep the grid hidden until the server-side variant state is
-    // actually cleared (DELETE landed), then re-arm for any future variant set.
-    if (pickedRef.current) {
+    } else if (pickedRef.current) {
       if (!hasVariants) pickedRef.current = false;
       setState(null);
       return;
@@ -164,6 +175,7 @@ export function useVariantFlow(designId: string | undefined) {
       // even if the network request is delayed.
       if (consumedId) {
         consumedDesignIdRef.current = consumedId;
+        consumedUntilRef.current = Date.now() + 6000;
       }
       qc.setQueryData(["design-variants"], null);
       try {
@@ -200,6 +212,9 @@ export function useVariantFlow(designId: string | undefined) {
       if (pickingRef.current) return;
       pickingRef.current = true;
       pickedRef.current = true;
+      // Start the bounded suppression window so the just-picked grid stays hidden
+      // through the DELETE round-trip + a poll cycle, but not indefinitely.
+      consumedUntilRef.current = Date.now() + 6000;
       try {
         // Persist the chosen variant as the design's primary file via the
         // agent's own action endpoint so every host lands on the same design.

--- a/templates/design/app/hooks/use-variant-flow.ts
+++ b/templates/design/app/hooks/use-variant-flow.ts
@@ -110,6 +110,11 @@ export function useVariantFlow(designId: string | undefined) {
   // so a later, genuinely new variant set can still appear.
   const pickedRef = useRef(false);
 
+  // Tracks the designId of a consumed variant set so stale in-flight poll
+  // responses with the same designId cannot re-open the grid, even if the
+  // server DELETE is delayed or the user picks while a poll is in-flight.
+  const consumedDesignIdRef = useRef<string | null>(null);
+
   const { data } = useQuery({
     queryKey: ["design-variants"],
     queryFn: async () => {
@@ -133,6 +138,14 @@ export function useVariantFlow(designId: string | undefined) {
     const hasVariants = Boolean(
       data?.variants && data.variants.length > 0 && data.designId === designId,
     );
+    // Suppress any polled data whose designId matches a consumed (already-picked)
+    // variant set so stale in-flight polls can't re-open the grid.
+    if (data?.designId && data.designId === consumedDesignIdRef.current) {
+      // Re-arm the consumed marker once the server confirms the state is gone.
+      if (!hasVariants) consumedDesignIdRef.current = null;
+      setState(null);
+      return;
+    }
     // After a pick, keep the grid hidden until the server-side variant state is
     // actually cleared (DELETE landed), then re-arm for any future variant set.
     if (pickedRef.current) {
@@ -143,13 +156,39 @@ export function useVariantFlow(designId: string | undefined) {
     setState(hasVariants && data ? data : null);
   }, [data, designId]);
 
-  const clear = useCallback(() => {
-    setState(null);
-    qc.setQueryData(["design-variants"], null);
-    fetch(agentNativePath("/_agent-native/application-state/design-variants"), {
-      method: "DELETE",
-    }).catch(() => {});
-  }, [qc]);
+  const clear = useCallback(
+    async (consumedId?: string) => {
+      setState(null);
+      // Mark the designId as consumed before issuing the DELETE so any
+      // in-flight or subsequent polls with this designId are suppressed
+      // even if the network request is delayed.
+      if (consumedId) {
+        consumedDesignIdRef.current = consumedId;
+      }
+      qc.setQueryData(["design-variants"], null);
+      try {
+        const res = await fetch(
+          agentNativePath("/_agent-native/application-state/design-variants"),
+          { method: "DELETE" },
+        );
+        if (!res.ok) {
+          // DELETE failed — the consumed marker keeps the grid hidden client-side,
+          // but log so the issue is visible rather than silently swallowed.
+          console.warn(
+            "[use-variant-flow] Failed to clear design-variants state:",
+            res.status,
+          );
+        }
+      } catch (err) {
+        // Network error — same: log but don't re-show grid (consumed marker holds).
+        console.warn(
+          "[use-variant-flow] Error clearing design-variants state:",
+          err,
+        );
+      }
+    },
+    [qc],
+  );
 
   const dismissStandalonePick = useCallback(() => setStandalonePick(null), []);
 
@@ -251,7 +290,7 @@ export function useVariantFlow(designId: string | undefined) {
         // Only clear the grid when the variant was successfully persisted.
         // If saving failed, keep the grid open so the user can retry.
         if (persisted) {
-          clear();
+          await clear(designId);
         } else {
           // Re-arm the picking latch so the user can try again.
           pickedRef.current = false;
@@ -265,7 +304,7 @@ export function useVariantFlow(designId: string | undefined) {
 
   const dismiss = useCallback(() => {
     const embedded = isEmbedAuthActive();
-    clear();
+    void clear(designId);
     if (isLinkOnlyHandoff() && !isEmbedAuthActive()) {
       // No chat bridge to relay the dismissal — give the user a copyable note
       // so their coding agent doesn't wait on a pick that isn't coming.
@@ -282,7 +321,7 @@ export function useVariantFlow(designId: string | undefined) {
       submit: embedded,
       ...(embedded ? { openSidebar: false } : {}),
     });
-  }, [clear]);
+  }, [clear, designId]);
 
   return { state, useVariant, dismiss, standalonePick, dismissStandalonePick };
 }

--- a/templates/design/app/i18n-data.ts
+++ b/templates/design/app/i18n-data.ts
@@ -8105,6 +8105,7 @@ const designCanvasFeatureOverrides = {
         propsPasted: "属性已粘贴",
         primitiveInsertFailed: "无法将该图层添加到画面",
         layerMoveFailed: "无法移动该图层",
+        duplicateElementFailed: "无法复制该元素",
       },
     },
     editPanel: {
@@ -8163,6 +8164,7 @@ const designCanvasFeatureOverrides = {
         propsPasted: "Propiedades pegadas",
         primitiveInsertFailed: "No se pudo añadir esa capa a la pantalla",
         layerMoveFailed: "No se pudo mover esa capa",
+        duplicateElementFailed: "No se pudo duplicar ese elemento",
       },
     },
     editPanel: {
@@ -8221,6 +8223,7 @@ const designCanvasFeatureOverrides = {
         propsPasted: "Propriétés collées",
         primitiveInsertFailed: "Impossible d’ajouter ce calque à l’écran",
         layerMoveFailed: "Impossible de déplacer ce calque",
+        duplicateElementFailed: "Impossible de dupliquer cet élément",
       },
     },
     editPanel: {
@@ -8280,6 +8283,7 @@ const designCanvasFeatureOverrides = {
         primitiveInsertFailed:
           "Diese Ebene konnte nicht zur Ansicht hinzugefügt werden",
         layerMoveFailed: "Diese Ebene konnte nicht verschoben werden",
+        duplicateElementFailed: "Dieses Element konnte nicht dupliziert werden",
       },
     },
     editPanel: {
@@ -8338,6 +8342,7 @@ const designCanvasFeatureOverrides = {
         propsPasted: "プロパティを貼り付けました",
         primitiveInsertFailed: "そのレイヤーを画面に追加できませんでした",
         layerMoveFailed: "そのレイヤーを移動できませんでした",
+        duplicateElementFailed: "その要素を複製できませんでした",
       },
     },
     editPanel: {
@@ -8396,6 +8401,7 @@ const designCanvasFeatureOverrides = {
         propsPasted: "속성이 붙여넣어짐",
         primitiveInsertFailed: "해당 레이어를 화면에 추가할 수 없습니다",
         layerMoveFailed: "해당 레이어를 이동할 수 없습니다",
+        duplicateElementFailed: "해당 요소를 복제할 수 없습니다",
       },
     },
     editPanel: {
@@ -8454,6 +8460,7 @@ const designCanvasFeatureOverrides = {
         propsPasted: "Propriedades coladas",
         primitiveInsertFailed: "Não foi possível adicionar essa camada à tela",
         layerMoveFailed: "Não foi possível mover essa camada",
+        duplicateElementFailed: "Não foi possível duplicar esse elemento",
       },
     },
     editPanel: {
@@ -8512,6 +8519,7 @@ const designCanvasFeatureOverrides = {
         propsPasted: "गुण चिपकाए गए",
         primitiveInsertFailed: "उस परत को स्क्रीन में नहीं जोड़ा जा सका",
         layerMoveFailed: "उस परत को स्थानांतरित नहीं किया जा सका",
+        duplicateElementFailed: "उस तत्व की प्रतिलिपि नहीं बनाई जा सकी",
       },
     },
     editPanel: {
@@ -8570,6 +8578,7 @@ const designCanvasFeatureOverrides = {
         propsPasted: "تم لصق الخصائص",
         primitiveInsertFailed: "تعذرت إضافة تلك الطبقة إلى الشاشة",
         layerMoveFailed: "تعذر نقل تلك الطبقة",
+        duplicateElementFailed: "تعذّر تكرار هذا العنصر",
       },
     },
     editPanel: {

--- a/templates/design/app/i18n-data.ts
+++ b/templates/design/app/i18n-data.ts
@@ -421,6 +421,7 @@ const enUS = {
       propsPasted: "Properties pasted",
       primitiveInsertFailed: "Could not add that layer to the screen",
       layerMoveFailed: "Could not move that layer",
+      duplicateElementFailed: "Could not duplicate that element",
       saveCopyError: "Could not save a copy of this design",
     },
   },

--- a/templates/design/app/i18n/zh-TW.ts
+++ b/templates/design/app/i18n/zh-TW.ts
@@ -409,6 +409,7 @@ const messages = {
       propsPasted: "屬性已貼上",
       primitiveInsertFailed: "無法將該圖層新增到畫面",
       layerMoveFailed: "無法移動該圖層",
+      duplicateElementFailed: "無法複製該元素",
       saveCopyError: "無法儲存這個設計的副本",
     },
   },

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -5909,7 +5909,7 @@ export default function DesignEditor() {
     onPasteOver: handlePasteOverSelection,
     onCopyProps: handleCopyProps,
     onPasteProps: handlePasteProps,
-    onCopyAsCode: () => handleCopyCodingHandoff(),
+    onCopyAsCode: handleCopySelection,
     onDuplicate: handleDuplicateSelection,
     onDelete: handleDeleteSelection,
     onRename: () => {
@@ -8016,7 +8016,7 @@ ${serializedHtml}
             }}
             onCopyProps={handleCopyProps}
             onPasteProps={handlePasteProps}
-            onCopyAsCode={handleCopyCodingHandoff}
+            onCopyAsCode={handleCopySelection}
           >
             {activeFile ? (
               <div

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -2317,6 +2317,9 @@ export default function DesignEditor() {
   const [overviewSelectAllRequest, setOverviewSelectAllRequest] = useState(0);
   const [overviewClearSelectionRequest, setOverviewClearSelectionRequest] =
     useState(0);
+  const [overviewSelectedScreenIds, setOverviewSelectedScreenIds] = useState<
+    string[]
+  >([]);
   const [hasCanvasClipboard, setHasCanvasClipboard] = useState(false);
   const [hasPropsClipboard, setHasPropsClipboard] = useState(false);
   const copiedLayerHtmlRef = useRef<string | null>(null);
@@ -4476,7 +4479,7 @@ export default function DesignEditor() {
       files: UploadedFile[],
       options: PromptComposerSubmitOptions,
     ) => {
-      if (!design) return;
+      if (!design || generating || pendingGenerationActive) return;
       const trimmed = prompt.trim();
       if (!trimmed) return;
       const fileContext = formatUploadedFileContext(files);
@@ -4542,7 +4545,13 @@ export default function DesignEditor() {
         fileType: file.fileType,
       })),
       selectedScreenIds:
-        viewMode === "overview" && activeFile?.id ? [activeFile.id] : [],
+        viewMode === "overview"
+          ? overviewSelectedScreenIds.length
+            ? overviewSelectedScreenIds
+            : activeFile?.id
+              ? [activeFile.id]
+              : []
+          : [],
       selectedElement,
       hoveredElement,
       mode,
@@ -4596,6 +4605,7 @@ export default function DesignEditor() {
     mode,
     activeTool,
     activeInspectorTab,
+    overviewSelectedScreenIds,
     viewMode,
     zoom,
   ]);
@@ -4653,7 +4663,13 @@ export default function DesignEditor() {
         fileType: file.fileType,
       })),
       selectedScreenIds:
-        viewMode === "overview" && activeFile?.id ? [activeFile.id] : [],
+        viewMode === "overview"
+          ? overviewSelectedScreenIds.length
+            ? overviewSelectedScreenIds
+            : activeFile?.id
+              ? [activeFile.id]
+              : []
+          : [],
       selectedElement,
       mode,
       activeTool,
@@ -4668,6 +4684,7 @@ export default function DesignEditor() {
       files,
       id,
       mode,
+      overviewSelectedScreenIds,
       selectedElement,
       tweakSelections,
       viewMode,
@@ -5227,20 +5244,46 @@ export default function DesignEditor() {
     [activeContent, activeFile, applyLocalContentUpdate, t],
   );
 
+  const handlePasteOverSelection = useCallback(() => {
+    if (!activeFile || !copiedLayerHtmlRef.current) return;
+    if (selectedElement?.boundingRect) {
+      const { x, y } = selectedElement.boundingRect;
+      const nextContent = cloneHtmlLayerAtPosition(
+        activeContent,
+        copiedLayerHtmlRef.current,
+        { x, y },
+      );
+      if (!nextContent) return;
+      applyLocalContentUpdate(nextContent);
+      toast.success(t("designEditor.toasts.pasted"));
+    } else {
+      handlePasteSelection();
+    }
+  }, [
+    activeContent,
+    activeFile,
+    applyLocalContentUpdate,
+    handlePasteSelection,
+    selectedElement,
+    t,
+  ]);
+
   const handleDuplicateSelection = useCallback(() => {
     if (selectedElement?.selector) {
       const html = getElementOuterHtml(activeContent, selectedElement.selector);
-      if (html) {
-        const rect = selectedElement.boundingRect;
-        const nextContent = cloneHtmlLayerAtPosition(activeContent, html, {
-          x: rect.x + 16,
-          y: rect.y + 16,
-        });
-        if (nextContent) {
-          applyLocalContentUpdate(nextContent);
-          return;
-        }
+      const rect = selectedElement.boundingRect;
+      const nextContent = html
+        ? cloneHtmlLayerAtPosition(activeContent, html, {
+            x: rect.x + 16,
+            y: rect.y + 16,
+          })
+        : null;
+      if (nextContent) {
+        applyLocalContentUpdate(nextContent);
+      } else {
+        toast.error(t("designEditor.toasts.duplicateElementFailed"));
       }
+      return;
     }
     if (activeFile) handleDuplicateScreen(activeFile.id);
   }, [
@@ -5863,10 +5906,10 @@ export default function DesignEditor() {
     onCopy: handleCopySelection,
     onCut: handleCutSelection,
     onPaste: () => handlePasteSelection(),
-    onPasteOver: () => handlePasteSelection(),
+    onPasteOver: handlePasteOverSelection,
     onCopyProps: handleCopyProps,
     onPasteProps: handlePasteProps,
-    onCopyAsCode: handleCopySelection,
+    onCopyAsCode: () => handleCopyCodingHandoff(),
     onDuplicate: handleDuplicateSelection,
     onDelete: handleDeleteSelection,
     onRename: () => {
@@ -6963,6 +7006,27 @@ ${serializedHtml}
 
   const getContextCanvasPoint = useCallback(
     ({ clientX, clientY }: { clientX: number; clientY: number }) => {
+      // In single-screen mode the iframe is inside a scale(zoom/100) wrapper
+      // that also centers the content. Using the iframe's own
+      // getBoundingClientRect() already incorporates centering/pan because the
+      // rect is measured in screen space after the CSS transform. Dividing by
+      // the zoom factor converts from post-scale screen-pixels back to the
+      // document coordinate space written into left/top by cloneHtmlLayerAtPosition.
+      if (viewMode === "single") {
+        const iframe = canvasContainerRef.current?.querySelector<HTMLElement>(
+          "[data-design-preview-iframe]",
+        );
+        if (iframe) {
+          const iframeRect = iframe.getBoundingClientRect();
+          const factor = zoom / 100;
+          return {
+            x: Math.max(0, (clientX - iframeRect.left) / factor),
+            y: Math.max(0, (clientY - iframeRect.top) / factor),
+          };
+        }
+      }
+      // Overview mode: fall back to container-relative coords (overview uses its
+      // own coordinate mapping for paste; this value is a best-effort fallback).
       const rect = canvasContainerRef.current?.getBoundingClientRect();
       if (!rect) return { x: 120, y: 120 };
       return {
@@ -6970,7 +7034,7 @@ ${serializedHtml}
         y: Math.max(0, clientY - rect.top),
       };
     },
-    [],
+    [zoom, viewMode],
   );
 
   const zoomLabel = `${Math.round(zoom)}%`;
@@ -7895,7 +7959,7 @@ ${serializedHtml}
             canPasteHere={hasCanvasClipboard && Boolean(activeFile)}
             canSelectAll={files.length > 0}
             canZoomToFit={Boolean(activeFile)}
-            canZoomToSelection={Boolean(activeFile)}
+            canZoomToSelection={Boolean(selectedElement) || viewMode === "overview"}
             canCopy={Boolean(selectedElement?.selector)}
             canPaste={hasCanvasClipboard && Boolean(activeFile)}
             canPasteOver={hasCanvasClipboard && Boolean(activeFile)}
@@ -7926,10 +7990,12 @@ ${serializedHtml}
               setActiveTool("move");
               setZoom(100);
             }}
-            onZoomToSelection={() => setZoom(150)}
+            onZoomToSelection={() => {
+              if (selectedElement || viewMode === "overview") setZoom(150);
+            }}
             onCopy={handleCopySelection}
             onPaste={() => handlePasteSelection()}
-            onPasteOver={() => handlePasteSelection()}
+            onPasteOver={handlePasteOverSelection}
             onDuplicate={handleDuplicateSelection}
             onDelete={handleDeleteSelection}
             onBringForward={() => changeSelectedZIndex("forward")}
@@ -7948,7 +8014,7 @@ ${serializedHtml}
             }}
             onCopyProps={handleCopyProps}
             onPasteProps={handlePasteProps}
-            onCopyAsCode={handleCopySelection}
+            onCopyAsCode={handleCopyCodingHandoff}
           >
             {activeFile ? (
               <div
@@ -7974,6 +8040,7 @@ ${serializedHtml}
                     onCreatePrimitive={handleCreatePrimitive}
                     onCreateScreenFrame={handleCreateScreenFrame}
                     onDeleteSelection={handleDeleteOverviewSelection}
+                    onSelectionChange={setOverviewSelectedScreenIds}
                     onPick={(id) => {
                       setSelectedElement(null);
                       setSelectedLayerIdsState([id]);
@@ -8296,6 +8363,7 @@ ${serializedHtml}
         title={t("designEditor.tweaksPromptTitle")}
         placeholder={t("designEditor.tweaksPlaceholder")}
         onSubmit={handleTweakPromptSubmit}
+        loading={generating || pendingGenerationActive}
         anchorRef={tweakPromptAnchorRef}
       />
     </div>

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -7959,7 +7959,9 @@ ${serializedHtml}
             canPasteHere={hasCanvasClipboard && Boolean(activeFile)}
             canSelectAll={files.length > 0}
             canZoomToFit={Boolean(activeFile)}
-            canZoomToSelection={Boolean(selectedElement) || viewMode === "overview"}
+            canZoomToSelection={
+              Boolean(selectedElement) || viewMode === "overview"
+            }
             canCopy={Boolean(selectedElement?.selector)}
             canPaste={hasCanvasClipboard && Boolean(activeFile)}
             canPasteOver={hasCanvasClipboard && Boolean(activeFile)}

--- a/templates/design/shared/generation-session.ts
+++ b/templates/design/shared/generation-session.ts
@@ -38,6 +38,7 @@ export interface DesignGenerationSession {
   prompt: string;
   contextRefs: string[];
   frames: DesignGenerationFrame[];
+  startedAt: string;
 }
 
 export interface AgentCanvasPresence {


### PR DESCRIPTION
Third round after #1657 and #1658 — clears the remaining adversarially-verified bugs from the multi-agent analysis of the Design editor. ~31 bugs across the editor, inspector, multi-screen canvas, layers, vector/annotate overlay, and agent actions.

Fixes were computed by parallel per-bug agents, then applied coherently per-file (heavily-edited files like DrawOverlay were rewritten in one pass so the changes compose). Every change passed `pnpm typecheck` + `pnpm test` (214) and a live editor smoke test (load, select, marquee, drag, duplicate, Annotate mode — no crashes/errors).

## Highlights
**Multi-screen canvas** — rotation-aware hit-testing, marquee, and drop-into for rotated frames; alt-drag from the title bar duplicates; unplaced generated screens stop overlapping placed ones.
**Single-screen canvas** — aspect-locked corner resize keeps the pinned edge; drag/resize respect element rotation; alt-drag duplicate is reverted to its original DOM position on a non-reorder drop.
**Layers panel** — empty containers (frame/group/section/component) accept drop-inside via a type-based predicate; selection-anchor reconcile after delete.
**Editor** — paste / duplicate / zoom-to-selection use document coords (zoom/pan-safe); real copy-as-code + paste-over; duplicate no longer falls back to duplicating the whole screen.
**Vector / Annotate (DrawOverlay)** — unified undo/redo across strokes + text annotations, zoom/resize-stable fractional coordinates, ResizeObserver redraw, and Clear's Undo toast restores annotations + the redo stack. *(Largest change; the annotation-drawing path is the least live-verified — worth a closer manual look.)*
**Inspector** — image-fill URL serialize/parse handles parens/commas/quotes; AutoLayout phantom min/max row no longer persists; tweak numeric-string defaults render correctly.
**Actions** — `update-design` read-merge is now wrapped in a transaction (atomic, addresses the Builder review on #1658); `update-file` rejects filename collisions; `generate-screens`/`view-screen`/generation-session clarified as agent-facing planning state; variant-flow DELETE race fixed.
**QuestionFlow** — rejects empty/whitespace answers.

## Notes
- A small number of patch candidates were found already-fixed in the current tree (e.g. paste-here-under-zoom) and skipped.
- The file-switch content-overwrite is intentionally **not** here — handled in a separate session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)