### PR TITLE
Test Design editor deep layer hit targets in Chrome e2e

### DIFF
--- a/templates/design/e2e/README.md
+++ b/templates/design/e2e/README.md
@@ -10,6 +10,7 @@ resizing, moving/reparenting, the layers panel, and the iframe bridge.
 pnpm e2e          # headless
 pnpm e2e:headed   # watch it drive a real browser
 pnpm e2e:ui       # Playwright UI mode
+E2E_BROWSER_CHANNEL=chrome pnpm e2e  # run the suite in installed Google Chrome
 ```
 
 - `playwright.config.ts` starts its own dev server on **:9333** backed by a

--- a/templates/design/e2e/editor.spec.ts
+++ b/templates/design/e2e/editor.spec.ts
@@ -80,6 +80,32 @@ test("the layers panel lists layers and a layer row selects on the canvas", asyn
   ).toBeVisible();
 });
 
+test("deeply nested layer rows keep a clickable hit target", async ({
+  page,
+}) => {
+  const deepLayer = page.getByRole("button", {
+    name: "Deep Layer Button",
+    exact: true,
+  });
+
+  for (let attempt = 0; attempt < 12 && !(await deepLayer.count()); attempt++) {
+    const expand = page.getByRole("button", { name: "Expand layer" }).first();
+    if (!(await expand.count())) break;
+    await expand.click();
+  }
+
+  await expect(deepLayer).toBeVisible();
+
+  const box = await deepLayer.boundingBox();
+  expect(box).toBeTruthy();
+  expect(box!.width).toBeGreaterThanOrEqual(44);
+
+  await page.mouse.click(box!.x + box!.width / 2, box!.y + box!.height / 2);
+  await expect(
+    page.locator('[role="treeitem"][aria-selected="true"]'),
+  ).toContainText("Deep Layer Button");
+});
+
 test("dragging an element on the canvas drives the bridge (move/reorder)", async ({
   page,
 }) => {

--- a/templates/design/e2e/global-setup.ts
+++ b/templates/design/e2e/global-setup.ts
@@ -18,6 +18,7 @@ export const SEED_TITLE = "E2E Seed Design";
 const AUTH_DIR = path.join(import.meta.dirname, ".auth");
 const STATE_PATH = path.join(AUTH_DIR, "state.json");
 const SEED_PATH = path.join(AUTH_DIR, "seed.json");
+const BROWSER_CHANNEL = process.env.E2E_BROWSER_CHANNEL;
 
 /**
  * Fixture HTML with distinct, text-identifiable elements. Plain inline styles
@@ -39,6 +40,15 @@ export const FIXTURE_HTML = `<!doctype html>
       <div style="display:flex;flex-direction:row;gap:16px">
         <button style="padding:14px 28px;border-radius:10px;border:0;background:#6366f1;color:#fff;font-size:16px">Alpha Button</button>
         <button style="padding:14px 28px;border-radius:10px;border:0;background:#22c55e;color:#06240f;font-size:16px">Beta Button</button>
+      </div>
+      <div style="padding:8px;border:1px solid #27272a;border-radius:12px">
+        <div style="padding:8px;border:1px solid #3f3f46;border-radius:10px">
+          <div style="padding:8px;border:1px solid #52525b;border-radius:8px">
+            <div style="padding:8px;border:1px solid #71717a;border-radius:6px">
+              <button style="padding:10px 18px;border-radius:8px;border:0;background:#f59e0b;color:#111827;font-size:14px">Deep Layer Button</button>
+            </div>
+          </div>
+        </div>
       </div>
       <section style="margin-top:16px;padding:24px;border-radius:14px;background:#1a1d24">
         <h2 style="font-size:24px;margin:0 0 8px">Fixture Card Title</h2>
@@ -72,7 +82,9 @@ export default async function globalSetup(config: FullConfig) {
     "http://127.0.0.1:9333";
   await mkdir(AUTH_DIR, { recursive: true });
 
-  const browser = await chromium.launch();
+  const browser = await chromium.launch(
+    BROWSER_CHANNEL ? { channel: BROWSER_CHANNEL } : {},
+  );
   const context = await browser.newContext();
   const page = await context.newPage();
 

--- a/templates/design/playwright.config.ts
+++ b/templates/design/playwright.config.ts
@@ -15,6 +15,7 @@ import { defineConfig, devices } from "@playwright/test";
  */
 const PORT = Number(process.env.E2E_PORT ?? 9333);
 const BASE_URL = process.env.E2E_BASE_URL ?? `http://127.0.0.1:${PORT}`;
+const BROWSER_CHANNEL = process.env.E2E_BROWSER_CHANNEL;
 
 export default defineConfig({
   testDir: "./e2e",
@@ -33,7 +34,15 @@ export default defineConfig({
     actionTimeout: 15_000,
     navigationTimeout: 30_000,
   },
-  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  projects: [
+    {
+      name: BROWSER_CHANNEL ? `chromium-${BROWSER_CHANNEL}` : "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        ...(BROWSER_CHANNEL ? { channel: BROWSER_CHANNEL } : {}),
+      },
+    },
+  ],
   webServer: process.env.E2E_BASE_URL
     ? undefined
     : {


### PR DESCRIPTION
## Summary
- Add an opt-in Chrome browser channel for Design Playwright e2e runs, including global setup
- Add a deeply nested fixture layer and regression coverage for layer-row hit targets
- Document the Chrome e2e command

## Validation
- pnpm --dir templates/design typecheck
- pnpm --dir templates/design exec vitest run shared/canvas-math.test.ts shared/code-layer.test.ts shared/pen-path.test.ts app/hooks/use-navigation-state.test.ts

Note: I also attempted the managed Chrome e2e run locally, but the harness wedged during global setup/server management before reaching test execution; the branch includes the Chrome-channel fix that removes the missing bundled-browser blocker.