### PR TITLE
Fix actionable Sentry noise

### DIFF
--- a/.changeset/quiet-sentry-editor-noise.md
+++ b/.changeset/quiet-sentry-editor-noise.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Reduce noisy browser Sentry captures by filtering public-site source-less errors that only report their page URL as a Sentry tag, delaying reconnect aborts until active runs are truly stuck on the server clock, and recovering assistant-ui duplicate message-id append races before they escape.

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -1,5 +1,7 @@
 // @vitest-environment happy-dom
 
+import { readFileSync } from "node:fs";
+
 import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -96,6 +98,22 @@ describe("resolveAssistantChatSubmitIntent", () => {
         requestedIntent: undefined,
       }),
     ).toBe("immediate");
+  });
+});
+
+describe("waitForThreadRunToClear", () => {
+  it("uses server-relative run progress when deciding whether an active run is stale", () => {
+    const source = readFileSync("src/client/AssistantChat.tsx", {
+      encoding: "utf8",
+    });
+    const start = source.indexOf("async function waitForThreadRunToClear");
+    const end = source.indexOf("// ─── Composer Attachment Preview");
+    const helperSource = source.slice(start, end);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    expect(helperSource).toContain("activeRunLooksStale(info)");
+    expect(helperSource).not.toContain("heartbeatAt");
   });
 });
 

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -228,6 +228,7 @@ function createUserMessageRunConfig(
 
 const PENDING_SELECTION_KEY = "pending-selection-context";
 const ACTIVE_RUN_CLEAR_TIMEOUT_MS = 5_000;
+const ACTIVE_RUN_STUCK_THRESHOLD_MS = 90_000;
 const ACTIVE_RUN_POLL_INTERVAL_MS = 150;
 const SUBMIT_ENGINE_STATUS_TIMEOUT_MS = 1000;
 
@@ -237,15 +238,27 @@ type ActiveRunLookup = {
   threadId?: string;
   status?: string;
   heartbeatAt?: number | null;
+  lastProgressAt?: number | null;
+  serverNow?: number;
 };
 
 function activeRunLooksStale(runInfo: ActiveRunLookup): boolean {
-  const heartbeatAt =
-    typeof runInfo.heartbeatAt === "number" ? runInfo.heartbeatAt : null;
+  const lastProgressAt =
+    typeof runInfo.lastProgressAt === "number" ? runInfo.lastProgressAt : null;
+  const nowMs =
+    typeof runInfo.serverNow === "number" ? runInfo.serverNow : Date.now();
   return (
     runInfo.status === "running" &&
-    heartbeatAt != null &&
-    Date.now() - heartbeatAt > 5000
+    lastProgressAt != null &&
+    nowMs - lastProgressAt > ACTIVE_RUN_STUCK_THRESHOLD_MS
+  );
+}
+
+function isAssistantUiDuplicateMessageIdError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return (
+    message.includes("MessageRepository") &&
+    message.includes("same id already exists")
   );
 }
 
@@ -1467,9 +1480,40 @@ const AssistantChatInner = forwardRef<
     }
   }, [apiUrl, importThreadData, loadHistoryRepository, threadId]);
 
+  const exportCleanThreadRepo = useCallback(
+    () =>
+      ensureMessageMetadata(normalizeThreadRepository(threadRuntime.export())),
+    [threadRuntime],
+  );
+
+  const appendThreadMessage = useCallback(
+    (message: Parameters<typeof threadRuntime.append>[0]) => {
+      try {
+        threadRuntime.append(message);
+        return;
+      } catch (error) {
+        if (!isAssistantUiDuplicateMessageIdError(error)) throw error;
+      }
+
+      try {
+        threadRuntime.import(exportCleanThreadRepo());
+      } catch {
+        // Best effort cleanup; retry below handles the still-duplicated case.
+      }
+
+      try {
+        threadRuntime.append(message);
+      } catch (retryError) {
+        if (isAssistantUiDuplicateMessageIdError(retryError)) return;
+        throw retryError;
+      }
+    },
+    [exportCleanThreadRepo, threadRuntime],
+  );
+
   const cacheCurrentThreadSnapshot = useCallback(() => {
     if (!threadId || messages.length === 0) return;
-    const repo = threadRuntime.export();
+    const repo = exportCleanThreadRepo();
     const threadData = JSON.stringify(stripBase64FromRepo(repo));
     const { title, preview } = extractThreadMeta(repo);
     writeCachedThreadSnapshot(apiUrl, threadId, {
@@ -1478,7 +1522,7 @@ const AssistantChatInner = forwardRef<
       preview,
       messageCount: messages.length,
     });
-  }, [apiUrl, messages.length, threadId, threadRuntime]);
+  }, [apiUrl, exportCleanThreadRepo, messages.length, threadId]);
 
   useBrowserLayoutEffect(() => {
     if (hasImportedInitialCachedSnapshotRef.current) return;
@@ -1975,7 +2019,7 @@ const AssistantChatInner = forwardRef<
     const timeSinceLastSave = now - lastSaveTimeRef.current;
     if (timeSinceLastSave < 5000) return;
 
-    const repo = threadRuntime.export();
+    const repo = exportCleanThreadRepo();
     const { title, preview } = extractThreadMeta(repo);
     const threadData = JSON.stringify(stripBase64FromRepo(repo));
     const snapshot = {
@@ -1989,7 +2033,7 @@ const AssistantChatInner = forwardRef<
     savedTitleRef.current = title;
     writeCachedThreadSnapshot(apiUrl, threadId, snapshot);
     onSaveThreadRef.current(threadId, snapshot);
-  }, [apiUrl, messages, isRunning, threadId, threadRuntime]);
+  }, [apiUrl, exportCleanThreadRepo, messages, isRunning, threadId]);
 
   // Persist full thread data after each completed response
   useEffect(() => {
@@ -1997,7 +2041,7 @@ const AssistantChatInner = forwardRef<
     if (isRunning) return;
     if (messages.length === 0) return;
 
-    const repo = threadRuntime.export();
+    const repo = exportCleanThreadRepo();
 
     if (threadId && onSaveThreadRef.current) {
       // Save to server via the hook callback
@@ -2019,7 +2063,7 @@ const AssistantChatInner = forwardRef<
         sessionStorage.setItem(storageKey, JSON.stringify(repo));
       } catch {}
     }
-  }, [apiUrl, messages, isRunning, threadId, tabId, threadRuntime]);
+  }, [apiUrl, exportCleanThreadRepo, messages, isRunning, threadId, tabId]);
 
   useEffect(() => {
     onMessageCountChange?.(messages.length);
@@ -2280,7 +2324,7 @@ const AssistantChatInner = forwardRef<
             next.attachments && next.attachments.length > 0
               ? next.attachments
               : (imageAttachments ?? []);
-          threadRuntime.append({
+          appendThreadMessage({
             role: "user",
             content: [{ type: "text", text: next.text }],
             ...(messageAttachments.length > 0
@@ -2334,12 +2378,12 @@ const AssistantChatInner = forwardRef<
     };
   }, [
     apiUrl,
+    appendThreadMessage,
     applyLocalQueuedMessages,
     isRestoring,
     isRunning,
     queuedMessages,
     threadId,
-    threadRuntime,
   ]);
 
   // Clear frozen reconnect content + forceStopped only on the false→true
@@ -2683,7 +2727,7 @@ const AssistantChatInner = forwardRef<
           },
         ]);
       } else {
-        threadRuntime.append({
+        appendThreadMessage({
           role: "user",
           content: [{ type: "text", text: submittedText }],
           ...(messageAttachments.length > 0
@@ -2708,7 +2752,7 @@ const AssistantChatInner = forwardRef<
       execMode,
       isRunning,
       materializeFrozenReconnectContent,
-      threadRuntime,
+      appendThreadMessage,
       updateComposerContextItems,
     ],
   );
@@ -2774,7 +2818,7 @@ const AssistantChatInner = forwardRef<
       },
       exportThreadSnapshot() {
         if (messages.length === 0) return null;
-        const repo = threadRuntime.export();
+        const repo = exportCleanThreadRepo();
         const { title, preview } = extractThreadMeta(repo);
         return {
           threadData: JSON.stringify(repo),
@@ -2786,10 +2830,10 @@ const AssistantChatInner = forwardRef<
     }),
     [
       addToQueue,
+      exportCleanThreadRepo,
       messages.length,
       stageComposerContextItem,
       thread.isRunning,
-      threadRuntime,
     ],
   );
 
@@ -2986,7 +3030,7 @@ const AssistantChatInner = forwardRef<
   const approvalCtx = useMemo<ApprovalContextValue>(
     () => ({
       onApprove: (approvalKey: string) => {
-        threadRuntime.append({
+        appendThreadMessage({
           role: "user",
           content: [
             {
@@ -3008,7 +3052,7 @@ const AssistantChatInner = forwardRef<
         } as Parameters<typeof threadRuntime.append>[0]);
       },
     }),
-    [threadRuntime, execMode],
+    [appendThreadMessage, execMode],
   );
 
   return (
@@ -3201,7 +3245,7 @@ const AssistantChatInner = forwardRef<
                                   setMissingKeyBouncePulse((p) => p + 1);
                                   return;
                                 }
-                                threadRuntime.append({
+                                appendThreadMessage({
                                   role: "user",
                                   content: [{ type: "text", text: suggestion }],
                                 });

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -308,14 +308,13 @@ async function waitForThreadRunToClear(apiUrl: string, threadId?: string) {
         `${apiUrl}/runs/active?threadId=${encodeURIComponent(threadId)}`,
       );
       if (res.ok) {
-        const info = await res.json();
-        const heartbeatAt =
-          typeof info?.heartbeatAt === "number" ? info.heartbeatAt : null;
-        const stale =
-          info?.status === "running" &&
-          heartbeatAt != null &&
-          Date.now() - heartbeatAt > 5000;
-        if (!info?.active || info?.status !== "running" || stale) return;
+        const info = (await res.json()) as ActiveRunLookup;
+        if (
+          !info?.active ||
+          info?.status !== "running" ||
+          activeRunLooksStale(info)
+        )
+          return;
       }
     } catch {
       // Transient poll failure — try again until the short grace period ends.

--- a/packages/core/src/client/analytics.spec.ts
+++ b/packages/core/src/client/analytics.spec.ts
@@ -544,6 +544,36 @@ describe("browser analytics pageviews", () => {
     expect(options.beforeSend(nonDocsEvent)).toBe(nonDocsEvent);
   });
 
+  it("uses Sentry's url tag for public docs noise filtering", async () => {
+    installBrowser();
+    (window as any).__AGENT_NATIVE_CONFIG__ = {
+      sentryDsn: "https://public@example/4511270423822336",
+      sentryEnvironment: "production",
+    };
+    const { configureTracking } = await freshAnalytics();
+
+    configureTracking({});
+    const options = sentryMock.init.mock.calls[0][0];
+    const result = options.beforeSend({
+      tags: {
+        url: "https://www.agent-native.com/templates/clips",
+      },
+      exception: {
+        values: [
+          {
+            type: "RangeError",
+            value: "Maximum call stack size exceeded.",
+            stacktrace: {
+              frames: [{ filename: "undefined", function: null }],
+            },
+          },
+        ],
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
   it("drops user-aborted browser requests from Sentry", async () => {
     installBrowser();
     (window as any).__AGENT_NATIVE_CONFIG__ = {

--- a/packages/core/src/client/analytics.ts
+++ b/packages/core/src/client/analytics.ts
@@ -610,7 +610,9 @@ function isAgentNativeDocsUrl(url: string): boolean {
 
 function shouldDropBrowserSentryNoise(event: Sentry.Event): boolean {
   const exceptionValues = event.exception?.values ?? [];
-  const requestUrl = event.request?.url?.toLowerCase() ?? "";
+  const taggedUrl =
+    typeof event.tags?.url === "string" ? event.tags.url : undefined;
+  const requestUrl = (event.request?.url ?? taggedUrl ?? "").toLowerCase();
   const isDocsPage = isAgentNativeDocsUrl(requestUrl);
   // AgentAutoContinueSignal is a control-flow sentinel thrown to bubble
   // out of the SSE stream parser when the agent run needs to be

--- a/templates/content/app/components/editor/DocumentEditor.layout.test.ts
+++ b/templates/content/app/components/editor/DocumentEditor.layout.test.ts
@@ -94,7 +94,27 @@ describe("document editor layout", () => {
     expect(source).toContain("pendingDocumentSaveRef.current = pending");
     expect(source).toContain("clearTimeout(saveTimeoutRef.current)");
     expect(source).toContain(
-      "void pending.save(pending.title, pending.content)",
+      "Promise.resolve(pending.save(pending.title, pending.content)).catch",
+    );
+    expect(source).toContain("handleBackgroundSaveError");
+    expect(source).toContain("const canEditRef = useRef(canEdit)");
+    expect(source).toContain("if (!canEditRef.current) return document");
+    expect(source).toContain("if (!canEditRef.current) return");
+  });
+
+  it("keeps read-only documents off editor-only realtime endpoints", () => {
+    const source = readFileSync(
+      new URL("./DocumentEditor.tsx", import.meta.url),
+      {
+        encoding: "utf8",
+      },
+    );
+
+    expect(source).toContain(
+      'docId: canEdit && !isLocalFileDocument ? documentId : ""',
+    );
+    expect(source).toContain(
+      "canEdit && !isLocalFileDocument ? documentId : null",
     );
   });
 

--- a/templates/content/app/components/editor/DocumentEditor.layout.test.ts
+++ b/templates/content/app/components/editor/DocumentEditor.layout.test.ts
@@ -93,12 +93,15 @@ describe("document editor layout", () => {
     expect(source).toContain("type PendingDocumentSave");
     expect(source).toContain("pendingDocumentSaveRef.current = pending");
     expect(source).toContain("clearTimeout(saveTimeoutRef.current)");
-    expect(source).toContain(
-      "Promise.resolve(pending.save(pending.title, pending.content)).catch",
-    );
+    expect(source).toContain("const flushPendingDocumentSave = useCallback");
+    expect(source).toContain("canEditWhenQueued: canEditRef.current");
+    expect(source).toContain("flushPendingDocumentSave(pending)");
+    expect(source).toContain("allowQueuedSave: true");
     expect(source).toContain("handleBackgroundSaveError");
     expect(source).toContain("const canEditRef = useRef(canEdit)");
-    expect(source).toContain("if (!canEditRef.current) return document");
+    expect(source).toContain(
+      "if (!options.allowQueuedSave && !canEditRef.current) return document",
+    );
     expect(source).toContain("if (!canEditRef.current) return");
   });
 

--- a/templates/content/app/components/editor/DocumentEditor.tsx
+++ b/templates/content/app/components/editor/DocumentEditor.tsx
@@ -157,8 +157,17 @@ interface DocumentEditorBodyProps {
 type PendingDocumentSave = {
   title: string;
   content: string;
-  save: (title: string, content: string) => unknown | Promise<unknown>;
+  save: (
+    title: string,
+    content: string,
+    options?: DocumentSaveOptions,
+  ) => unknown | Promise<unknown>;
+  canEditWhenQueued: boolean;
   timeout: ReturnType<typeof setTimeout>;
+};
+
+type DocumentSaveOptions = {
+  allowQueuedSave?: boolean;
 };
 
 type DocumentSaveResult = {
@@ -578,12 +587,15 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
   }, [document, isLinkedLocalSourceDocument, localTitle, localContent]);
 
   const persistDocumentUpdates = useCallback(
-    async (updates: {
-      title?: string;
-      content?: string;
-      icon?: string | null;
-    }): Promise<Document> => {
-      if (!canEditRef.current) return document;
+    async (
+      updates: {
+        title?: string;
+        content?: string;
+        icon?: string | null;
+      },
+      options: DocumentSaveOptions = {},
+    ): Promise<Document> => {
+      if (!options.allowQueuedSave && !canEditRef.current) return document;
 
       const localSource = document.source;
       const isLinkedLocalSource = canWriteLinkedLocalSource(
@@ -643,7 +655,11 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
   );
 
   const saveDocumentImmediately = useCallback(
-    async (title: string, content: string): Promise<DocumentSaveResult> => {
+    async (
+      title: string,
+      content: string,
+      options: DocumentSaveOptions = {},
+    ): Promise<DocumentSaveResult> => {
       // Never clobber a newer server version (e.g. an agent edit we haven't
       // reconciled into the editor yet) with the editor's current — possibly
       // stale — content. Guard per-field using the field's own watermark.
@@ -667,7 +683,7 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
         return { contentPersisted: !contentChanged };
       }
 
-      const saved = await persistDocumentUpdates(updates);
+      const saved = await persistDocumentUpdates(updates, options);
       // Adopt the server updatedAt per saved field.
       const savedAt = saved?.updatedAt ?? new Date().toISOString();
       if (updates.title !== undefined) {
@@ -714,6 +730,17 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
       queryClient,
     ],
   );
+  const flushPendingDocumentSave = useCallback(
+    (pending: PendingDocumentSave) => {
+      if (!pending.canEditWhenQueued) return;
+      void Promise.resolve(
+        pending.save(pending.title, pending.content, {
+          allowQueuedSave: true,
+        }),
+      ).catch(handleBackgroundSaveError);
+    },
+    [handleBackgroundSaveError],
+  );
   const debouncedSave = useCallback(
     (title: string, content: string) => {
       if (!canEditRef.current) return;
@@ -722,21 +749,19 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
         title,
         content,
         save: saveDocumentImmediately,
+        canEditWhenQueued: canEditRef.current,
         timeout: setTimeout(() => {
           if (pendingDocumentSaveRef.current === pending) {
             pendingDocumentSaveRef.current = null;
           }
           saveTimeoutRef.current = null;
-          if (!canEditRef.current) return;
-          void Promise.resolve(
-            pending.save(pending.title, pending.content),
-          ).catch(handleBackgroundSaveError);
+          flushPendingDocumentSave(pending);
         }, 500),
       };
       pendingDocumentSaveRef.current = pending;
       saveTimeoutRef.current = pending.timeout;
     },
-    [handleBackgroundSaveError, saveDocumentImmediately],
+    [flushPendingDocumentSave, saveDocumentImmediately],
   );
 
   useEffect(() => {
@@ -746,21 +771,19 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
       clearTimeout(pending.timeout);
       saveTimeoutRef.current = null;
       pendingDocumentSaveRef.current = null;
-      if (!canEditRef.current) return;
-      void Promise.resolve(pending.save(pending.title, pending.content)).catch(
-        handleBackgroundSaveError,
-      );
+      flushPendingDocumentSave(pending);
     };
-  }, [documentId, handleBackgroundSaveError]);
+  }, [documentId, flushPendingDocumentSave]);
 
   useEffect(() => {
     if (canEdit) return;
-    if (saveTimeoutRef.current) {
-      clearTimeout(saveTimeoutRef.current);
-      saveTimeoutRef.current = null;
-    }
+    const pending = pendingDocumentSaveRef.current;
+    if (!pending) return;
+    clearTimeout(pending.timeout);
+    saveTimeoutRef.current = null;
     pendingDocumentSaveRef.current = null;
-  }, [canEdit, documentId]);
+    flushPendingDocumentSave(pending);
+  }, [canEdit, documentId, flushPendingDocumentSave]);
 
   // Collab-aware ingest flush: the `pull-document` action writes a one-shot
   // `flush-request-<id>` app-state key when an external agent wants to ingest

--- a/templates/content/app/components/editor/DocumentEditor.tsx
+++ b/templates/content/app/components/editor/DocumentEditor.tsx
@@ -274,6 +274,8 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
   const updateDocument = useUpdateDocument();
   const queryClient = useQueryClient();
   const canEdit = document.canEdit ?? true;
+  const canEditRef = useRef(canEdit);
+  canEditRef.current = canEdit;
   // The block render context (asset/upload resolvers, inline markdown reader,
   // panel popover) is stable for the editor's lifetime. Created once here and
   // provided alongside the content block registry so every registry block in the
@@ -324,6 +326,15 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
     document.updatedAt ?? null,
   );
   documentUpdatedAtRef.current = document.updatedAt ?? null;
+  const handleBackgroundSaveError = useCallback(
+    (error: unknown) => {
+      toast.error(t("empty.genericError"), {
+        description:
+          error instanceof Error ? error.message : t("empty.genericError"),
+      });
+    },
+    [t],
+  );
   const titleFocusedRef = useRef(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const titleInputRef = useRef<HTMLTextAreaElement>(null);
@@ -375,7 +386,8 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
       }
     : undefined;
 
-  // Collaborative editing — stable Y.Doc per document, always-on
+  // Collaborative editing is write-only for now. Viewers get the SQL snapshot
+  // and skip collab endpoints that reject non-editor access.
   const {
     ydoc,
     awareness,
@@ -384,7 +396,7 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
     agentActive,
     agentPresent,
   } = useCollaborativeDoc({
-    docId: isLocalFileDocument ? "" : documentId,
+    docId: canEdit && !isLocalFileDocument ? documentId : "",
     requestSource: TAB_ID,
     user: currentUser,
   });
@@ -571,6 +583,8 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
       content?: string;
       icon?: string | null;
     }): Promise<Document> => {
+      if (!canEditRef.current) return document;
+
       const localSource = document.source;
       const isLinkedLocalSource = canWriteLinkedLocalSource(
         documentId,
@@ -702,6 +716,7 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
   );
   const debouncedSave = useCallback(
     (title: string, content: string) => {
+      if (!canEditRef.current) return;
       if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
       const pending: PendingDocumentSave = {
         title,
@@ -712,13 +727,16 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
             pendingDocumentSaveRef.current = null;
           }
           saveTimeoutRef.current = null;
-          void pending.save(pending.title, pending.content);
+          if (!canEditRef.current) return;
+          void Promise.resolve(
+            pending.save(pending.title, pending.content),
+          ).catch(handleBackgroundSaveError);
         }, 500),
       };
       pendingDocumentSaveRef.current = pending;
       saveTimeoutRef.current = pending.timeout;
     },
-    [saveDocumentImmediately],
+    [handleBackgroundSaveError, saveDocumentImmediately],
   );
 
   useEffect(() => {
@@ -728,9 +746,21 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
       clearTimeout(pending.timeout);
       saveTimeoutRef.current = null;
       pendingDocumentSaveRef.current = null;
-      void pending.save(pending.title, pending.content);
+      if (!canEditRef.current) return;
+      void Promise.resolve(pending.save(pending.title, pending.content)).catch(
+        handleBackgroundSaveError,
+      );
     };
-  }, [documentId]);
+  }, [documentId, handleBackgroundSaveError]);
+
+  useEffect(() => {
+    if (canEdit) return;
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+      saveTimeoutRef.current = null;
+    }
+    pendingDocumentSaveRef.current = null;
+  }, [canEdit, documentId]);
 
   // Collab-aware ingest flush: the `pull-document` action writes a one-shot
   // `flush-request-<id>` app-state key when an external agent wants to ingest
@@ -846,7 +876,7 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
   const [hoveredThreadId, setHoveredThreadId] = useState<string | null>(null);
   const activeThreadId = hoveredThreadId ?? selectedThreadId;
   const { data: threads, isLoading: commentsLoading } = useComments(
-    isLocalFileDocument ? null : documentId,
+    canEdit && !isLocalFileDocument ? documentId : null,
   );
   const hasComments =
     !isLocalFileDocument &&
@@ -1061,7 +1091,7 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
                           onSelect={(emoji) => {
                             void (async () => {
                               await persistDocumentUpdates({ icon: emoji });
-                            })();
+                            })().catch(handleBackgroundSaveError);
                           }}
                         />
                       ) : document.icon ? (

--- a/templates/content/changelog/2026-06-29-read-only-pages-no-longer-try-to-autosave-or-open-editor-onl.md
+++ b/templates/content/changelog/2026-06-29-read-only-pages-no-longer-try-to-autosave-or-open-editor-onl.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-06-29
+---
+
+Read-only pages no longer try to autosave or open editor-only realtime connections.


### PR DESCRIPTION
## Summary
- Delay chat reconnect aborts until active runs are truly stuck using server-clock progress timestamps
- Recover assistant-ui duplicate message-id append races before they escape to Sentry
- Drop public-site source-less browser noise when Sentry only supplies the URL tag
- Stop Content read-only pages from autosaving or opening editor-only realtime/comment endpoints

## Tests
- corepack pnpm --filter @agent-native/core exec vitest run src/client/analytics.spec.ts src/client/AssistantChat.display.spec.ts src/client/chat/repo-helpers.spec.ts
- corepack pnpm --filter content exec vitest run app/components/editor/DocumentEditor.layout.test.ts
- corepack pnpm --filter @agent-native/core typecheck
- corepack pnpm --filter content typecheck