### PR TITLE
Fix Design visual editor interaction regressions

### DIFF
--- a/templates/design/actions/apply-visual-edit.test.ts
+++ b/templates/design/actions/apply-visual-edit.test.ts
@@ -121,4 +121,60 @@ describe("apply-visual-edit", () => {
     expect(mocks.applyVisualEdit).not.toHaveBeenCalled();
     expect(mocks.assertAccess).not.toHaveBeenCalled();
   });
+
+  it("allows fileId-only edits against non-index design files", async () => {
+    mocks.selectChain.limit.mockResolvedValueOnce([
+      {
+        id: "file_details",
+        designId: "design_123",
+        filename: "details.html",
+        fileType: "html",
+        content: "<main>Details</main>",
+      },
+    ]);
+    mocks.applyVisualEdit.mockReturnValueOnce({
+      result: { status: "applied", changed: false },
+      projection: { nodes: [] },
+      content: "<main>Updated details</main>",
+    });
+
+    await expect(
+      action.run({
+        source: {
+          kind: "design-file",
+          fileId: "file_details",
+        },
+        intent: {
+          kind: "style",
+          target: { selector: "main" },
+          property: "color",
+          value: "red",
+        },
+      }),
+    ).resolves.toMatchObject({
+      designId: "design_123",
+      fileId: "file_details",
+      filename: "details.html",
+      persisted: false,
+    });
+
+    expect(mocks.applyVisualEdit).toHaveBeenCalledWith(
+      "<main>Details</main>",
+      expect.any(Object),
+      {
+        source: {
+          kind: "design-file",
+          designId: "design_123",
+          fileId: "file_details",
+          filename: "details.html",
+          revision: undefined,
+        },
+      },
+    );
+    expect(mocks.assertAccess).toHaveBeenCalledWith(
+      "design",
+      "design_123",
+      "editor",
+    );
+  });
 });

--- a/templates/design/actions/apply-visual-edit.ts
+++ b/templates/design/actions/apply-visual-edit.ts
@@ -39,7 +39,7 @@ const sourceSchema = z.preprocess(
         .default("design-file"),
       designId: z.string().optional(),
       fileId: z.string().optional(),
-      filename: z.string().optional().default("index.html"),
+      filename: z.string().optional(),
       path: z.string().optional(),
       url: z.string().optional(),
       revision: z.string().optional(),
@@ -183,7 +183,7 @@ async function resolveEditableDesignFile(
       `source.designId "${source.designId}" does not match file "${file.id}"`,
     );
   }
-  if (source.filename && file.filename !== source.filename) {
+  if (!source.fileId && source.filename && file.filename !== source.filename) {
     throw new Error(
       `source.filename "${source.filename}" does not match file "${file.id}"`,
     );

--- a/templates/design/app/components/design/DrawOverlay.tsx
+++ b/templates/design/app/components/design/DrawOverlay.tsx
@@ -274,7 +274,7 @@ export function DrawOverlay({ visible, onQueue, onSend }: DrawOverlayProps) {
       )}
 
       {/* Bottom toolbar */}
-      <div className="absolute bottom-4 left-1/2 z-30 flex -translate-x-1/2 items-center gap-2 rounded-xl border border-border bg-card px-3 py-2 shadow-2xl backdrop-blur-sm">
+      <div className="absolute bottom-16 left-1/2 z-30 flex max-w-[calc(100%-1rem)] -translate-x-1/2 flex-wrap items-center justify-center gap-2 rounded-xl border border-border bg-card px-3 py-2 shadow-2xl backdrop-blur-sm sm:bottom-20">
         {/* Color picker */}
         <div className="flex gap-1">
           {PRESET_COLORS.map((preset) => (

--- a/templates/design/app/components/design/EditPanel.tsx
+++ b/templates/design/app/components/design/EditPanel.tsx
@@ -574,7 +574,7 @@ function ColorInput({
       onImageFillChange={onImageFillChange}
       blendMode={blendMode}
       onBlendModeChange={onBlendModeChange}
-      showBlendMode={supportsLayeredFills}
+      showBlendMode={Boolean(onBlendModeChange)}
       fillRows={fillRows}
       selectedFillId={selectedFillId}
       onFillSelect={supportsLayeredFills ? setSelectedFillId : undefined}

--- a/templates/design/app/components/design/EditPanel.tsx
+++ b/templates/design/app/components/design/EditPanel.tsx
@@ -2975,6 +2975,8 @@ function FlexContainerControls({
   const isFlex = display.includes("flex");
   const flexDirection: AutoLayoutMatrixValue["direction"] =
     styles.flexDirection?.includes("column") ? "vertical" : "horizontal";
+  const mainGapAxis =
+    flexDirection === "horizontal" ? "horizontal" : "vertical";
   // When the element is in normal flow (not flex yet), picking any flow option
   // must first turn it into a flex container; otherwise setting flex-direction
   // alone is a no-op against a block element.
@@ -3022,6 +3024,7 @@ function FlexContainerControls({
     // optional contract field consumed by AutoLayoutMatrix; harmless when the
     // matrix ignores it.
     ...({ display } as Partial<AutoLayoutMatrixValue>),
+    spaceBetween: styles.justifyContent === "space-between",
   };
 
   return (
@@ -3079,15 +3082,19 @@ function FlexContainerControls({
           onStyleChange("overflow", clipContent ? "hidden" : "visible")
         }
         onDistribute={(axis) => {
-          const mainAxis =
-            autoLayoutValue.direction === "horizontal"
-              ? "horizontal"
-              : "vertical";
-          if (axis === mainAxis) {
+          if (axis === mainGapAxis) {
             onStyleChange("justifyContent", "space-between");
           } else if (autoLayoutValue.wrap === "wrap") {
             onStyleChange("alignContent", "space-between");
           }
+        }}
+        onGapModeChange={(gapMode, axis) => {
+          if (axis !== mainGapAxis) return;
+          ensureFlex();
+          onStyleChange(
+            "justifyContent",
+            gapMode === "auto" ? "space-between" : "flex-start",
+          );
         }}
         availableChildSizing={availableSizingForElement(element)}
         onChildSizingChange={(axis, sizing) => {

--- a/templates/design/app/components/design/LayersPanel.tsx
+++ b/templates/design/app/components/design/LayersPanel.tsx
@@ -909,7 +909,8 @@ function LayerRow({
   const selectable = node.selectable !== false;
   const lockable = node.lockable !== false && Boolean(onToggleLocked);
   const hideable = node.hideable !== false && Boolean(onToggleHidden);
-  const draggable = selectable && Boolean(onMoveLayer);
+  const dragEligible = selectable && !node.locked && !node.hidden;
+  const draggable = dragEligible && Boolean(onMoveLayer);
   const canDropInside = layerCanDropInside(node, hasChildren);
   const activeDrop =
     dropIndicator?.targetId === node.id ? dropIndicator.placement : null;
@@ -1061,7 +1062,7 @@ function LayerRow({
   };
 
   const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
-    if (!onMoveLayer || !selectable) return;
+    if (!onMoveLayer || !dragEligible) return;
     // dataTransfer.getData() always returns "" during dragover per spec.
     // Read from the module-level activeDragState set in handleDragStart instead.
     if (!activeDragState) return;
@@ -1084,7 +1085,7 @@ function LayerRow({
   };
 
   const handleDrop = (event: DragEvent<HTMLDivElement>) => {
-    if (!onMoveLayer || !selectable) {
+    if (!onMoveLayer || !dragEligible) {
       onDropIndicatorChange(null);
       return;
     }

--- a/templates/design/app/components/design/inspector/AutoLayoutMatrix.tsx
+++ b/templates/design/app/components/design/inspector/AutoLayoutMatrix.tsx
@@ -147,6 +147,7 @@ export interface AutoLayoutMatrixProps {
   onPaddingLinkedChange: (linked: boolean) => void;
   onClipContentChange?: (clipContent: boolean) => void;
   onDistribute?: (axis: DistributionAxis) => void;
+  onGapModeChange?: (mode: "fixed" | "auto", axis: DistributionAxis) => void;
   onChildSizingChange: (
     axis: AutoLayoutSizingAxis,
     sizing: AutoLayoutSizing,
@@ -246,6 +247,7 @@ export function AutoLayoutMatrix({
   onPaddingLinkedChange,
   onClipContentChange,
   onDistribute,
+  onGapModeChange,
   onChildSizingChange,
   onChildMinMaxChange,
   onApplyVariable,
@@ -455,6 +457,7 @@ export function AutoLayoutMatrix({
                 value={value.gap}
                 onGapChange={onGapChange}
                 onDistribute={onDistribute}
+                onGapModeChange={onGapModeChange}
                 label={copy.gap}
                 disabled={disabled}
                 direction={value.direction}
@@ -858,6 +861,7 @@ function GapField({
   value,
   onGapChange,
   onDistribute,
+  onGapModeChange,
   label,
   disabled,
   direction,
@@ -866,6 +870,7 @@ function GapField({
   value: number;
   onGapChange: (gap: number) => void;
   onDistribute?: (axis: DistributionAxis) => void;
+  onGapModeChange?: (mode: "fixed" | "auto", axis: DistributionAxis) => void;
   label: string;
   disabled: boolean;
   direction: AutoLayoutDirection;
@@ -928,16 +933,20 @@ function GapField({
               <DropdownMenuCheckboxItem
                 checked={gapMode !== "auto"}
                 className="text-[12px]"
-                onSelect={() => {
-                  /* Fixed gap: keep current numeric value (already numeric). */
-                }}
+                onSelect={() => onGapModeChange?.("fixed", direction)}
               >
                 {"Fixed" /* i18n-ignore design gap mode label */}
               </DropdownMenuCheckboxItem>
               <DropdownMenuCheckboxItem
                 checked={gapMode === "auto"}
                 className="text-[12px]"
-                onSelect={() => onDistribute(direction)}
+                onSelect={() => {
+                  if (onGapModeChange) {
+                    onGapModeChange("auto", direction);
+                    return;
+                  }
+                  onDistribute?.(direction);
+                }}
               >
                 {"Auto" /* i18n-ignore design gap mode label */}
               </DropdownMenuCheckboxItem>
@@ -1227,9 +1236,9 @@ export function SizingField({
               tooltipLabel={`${axis} size`}
               icon={null}
               value={Math.round(resolvedSize ?? 0)}
-              onChange={(next) => onSizeChange!(Math.max(1, Math.round(next)))}
+              onChange={(next) => onSizeChange!(Math.max(0, Math.round(next)))}
               unit="px"
-              min={1}
+              min={0}
               step={1}
               precision={0}
               disabled={disabled}

--- a/templates/design/app/components/design/inspector/DesignColorPicker.tsx
+++ b/templates/design/app/components/design/inspector/DesignColorPicker.tsx
@@ -29,6 +29,13 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -651,6 +658,24 @@ const NOISE_FALLBACK_CSS =
   "repeating-conic-gradient(#0000 0% 25%, #00000010 0% 50%) 0 0 / 6px 6px, #8a8a8a";
 const PATTERN_FALLBACK_CSS =
   "repeating-linear-gradient(45deg, #00000014 0 6px, #ffffff14 6px 12px), #9aa0a6";
+const BLEND_MODE_OPTIONS = [
+  { value: "normal", label: "Normal" },
+  { value: "multiply", label: "Multiply" },
+  { value: "screen", label: "Screen" },
+  { value: "overlay", label: "Overlay" },
+  { value: "darken", label: "Darken" },
+  { value: "lighten", label: "Lighten" },
+  { value: "color-dodge", label: "Color dodge" }, // i18n-ignore design blend mode label
+  { value: "color-burn", label: "Color burn" }, // i18n-ignore design blend mode label
+  { value: "hard-light", label: "Hard light" }, // i18n-ignore design blend mode label
+  { value: "soft-light", label: "Soft light" }, // i18n-ignore design blend mode label
+  { value: "difference", label: "Difference" },
+  { value: "exclusion", label: "Exclusion" },
+  { value: "hue", label: "Hue" },
+  { value: "saturation", label: "Saturation" },
+  { value: "color", label: "Color" },
+  { value: "luminosity", label: "Luminosity" },
+] as const;
 
 // ─── Main component ────────────────────────────────────────────────────────────
 
@@ -662,9 +687,9 @@ export function DesignColorPicker({
   label: _label,
   opacity,
   onOpacityChange,
-  blendMode: _blendMode,
-  onBlendModeChange: _onBlendModeChange,
-  showBlendMode: _showBlendMode,
+  blendMode,
+  onBlendModeChange,
+  showBlendMode = false,
   fillRows: _fillRows,
   selectedFillId: _selectedFillId,
   onFillSelect: _onFillSelect,
@@ -693,6 +718,11 @@ export function DesignColorPicker({
   const hsv = rgbaToHsv(color);
   const hsl = rgbaToHsl(color);
   const effectiveOpacity = opacity ?? alphaToOpacity(color.a);
+  const blendModeValue = BLEND_MODE_OPTIONS.some(
+    (option) => option.value === blendMode,
+  )
+    ? blendMode
+    : "normal";
 
   const [mode, setMode] = useState<DesignColorMode>("hex");
   const [hexDraft, setHexDraft] = useState(() => toDisplayHex(color));
@@ -1502,6 +1532,39 @@ export function DesignColorPicker({
                           %
                         </span>
                       </div>
+                    </div>
+                  </div>
+                )}
+
+                {showBlendMode && onBlendModeChange && (
+                  <div className="border-t border-border/70 px-3 py-2.5">
+                    <div className="flex items-center gap-1.5">
+                      <span className="min-w-0 flex-1 text-[11px] text-muted-foreground">
+                        {copy.blendMode}
+                      </span>
+                      <Select
+                        value={blendModeValue}
+                        disabled={disabled}
+                        onValueChange={onBlendModeChange}
+                      >
+                        <SelectTrigger
+                          aria-label={copy.blendMode}
+                          className="h-6 min-w-0 flex-1 rounded-md border-[var(--design-editor-control-border)] bg-[var(--design-editor-control-bg)] px-1.5 text-[11px] shadow-none focus:ring-1 focus:ring-[var(--design-editor-accent-color)]"
+                        >
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {BLEND_MODE_OPTIONS.map((option) => (
+                            <SelectItem
+                              key={option.value}
+                              value={option.value}
+                              className="text-[11px]"
+                            >
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
                     </div>
                   </div>
                 )}

--- a/templates/design/app/components/visual-editor/DrawOverlay.tsx
+++ b/templates/design/app/components/visual-editor/DrawOverlay.tsx
@@ -453,7 +453,7 @@ export function DrawOverlay({
   const toolbar = (
     <div
       data-draw-toolbar
-      className="pointer-events-auto fixed bottom-4 left-1/2 z-[110] flex -translate-x-1/2 items-center gap-2 rounded-xl border border-border bg-popover px-3 py-2 shadow-2xl"
+      className="pointer-events-auto fixed bottom-20 left-1/2 z-[110] flex max-w-[calc(100vw-1rem)] -translate-x-1/2 flex-wrap items-center justify-center gap-2 rounded-xl border border-border bg-popover px-3 py-2 shadow-2xl"
     >
       {/* Color picker */}
       <div className="flex gap-1">

--- a/templates/design/app/pages/DesignEditor.selection.test.ts
+++ b/templates/design/app/pages/DesignEditor.selection.test.ts
@@ -6,6 +6,7 @@ import {
   getOverviewCanvasZoom,
   getOverviewDisplayZoom,
   getOverviewEnterTarget,
+  getOverviewScreenIdsFromLayerSelection,
   getOverviewZoomScale,
   getSidebarCodeLayerSelectionState,
   isScreenRootElementInfo,
@@ -34,6 +35,35 @@ describe("DesignEditor overview selection state", () => {
         viewMode: "single",
       }),
     ).toEqual(["screen-active"]);
+  });
+});
+
+describe("DesignEditor overview layer selection", () => {
+  it("extracts selected screen ids from file layer rows", () => {
+    expect(
+      getOverviewScreenIdsFromLayerSelection({
+        fileIds: ["screen-a", "screen-b"],
+        layerIds: ["screen-a", "screen-b"],
+      }),
+    ).toEqual(["screen-a", "screen-b"]);
+  });
+
+  it("supports code-prefixed screen row ids and keeps selection order", () => {
+    expect(
+      getOverviewScreenIdsFromLayerSelection({
+        fileIds: ["screen-a", "screen-b"],
+        layerIds: ["code:screen-b", "screen-a", "code:screen-b"],
+      }),
+    ).toEqual(["screen-b", "screen-a"]);
+  });
+
+  it("ignores nested element layer ids when syncing screen selection", () => {
+    expect(
+      getOverviewScreenIdsFromLayerSelection({
+        fileIds: ["screen-a", "screen-b"],
+        layerIds: ["hero-title", "element:runtime", "screen-b"],
+      }),
+    ).toEqual(["screen-b"]);
   });
 });
 

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -263,6 +263,32 @@ export function getSelectedScreenIdsForEditorState(args: {
   return activeFileId ? [activeFileId] : [];
 }
 
+function fileIdFromLayerSelectionId(
+  layerId: string,
+  fileIds: Set<string>,
+): string | null {
+  const normalized = layerId.startsWith("code:")
+    ? layerId.slice("code:".length)
+    : layerId;
+  return fileIds.has(normalized) ? normalized : null;
+}
+
+export function getOverviewScreenIdsFromLayerSelection(args: {
+  fileIds: string[];
+  layerIds: string[];
+}) {
+  const fileIds = new Set(args.fileIds);
+  const seen = new Set<string>();
+  const selectedScreenIds: string[] = [];
+  args.layerIds.forEach((layerId) => {
+    const fileId = fileIdFromLayerSelectionId(layerId, fileIds);
+    if (!fileId || seen.has(fileId)) return;
+    seen.add(fileId);
+    selectedScreenIds.push(fileId);
+  });
+  return selectedScreenIds;
+}
+
 export function getOverviewEnterTarget(args: {
   activeFileId: string | null | undefined;
   overviewSelectedScreenIds: string[];
@@ -8616,6 +8642,21 @@ ${serializedHtml}
           ? currentLayerIds.filter((layerId) => layerId !== intent.id)
           : [...currentLayerIds, intent.id];
         setSelectedLayerIdsState(additiveLayerIds);
+        if (viewModeRef.current === "overview") {
+          const fileIds = files.map((file) => file.id);
+          const selectedScreenIds = getOverviewScreenIdsFromLayerSelection({
+            fileIds,
+            layerIds: additiveLayerIds,
+          });
+          const toggledScreen =
+            getOverviewScreenIdsFromLayerSelection({
+              fileIds,
+              layerIds: [intent.id],
+            }).length > 0;
+          if (toggledScreen || selectedScreenIds.length > 0) {
+            setOverviewSelectedScreenIds(selectedScreenIds);
+          }
+        }
         setSelectedElement(null);
         focusDesignInspectorForSelection();
         setActiveTool("move");

--- a/templates/design/changelog/2026-06-30-visual-editor-selection-layer-paint-and-drawing-controls-are-more-reliable.md
+++ b/templates/design/changelog/2026-06-30-visual-editor-selection-layer-paint-and-drawing-controls-are-more-reliable.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-06-30
+---
+
+Visual editor selection, layer dragging, paint blend modes, and drawing controls are more reliable.

--- a/templates/design/e2e/helpers.ts
+++ b/templates/design/e2e/helpers.ts
@@ -25,8 +25,10 @@ export async function readSeedDesignId(): Promise<string> {
   return designId;
 }
 
+const DESIGN_PREVIEW_IFRAME_SELECTOR = "iframe[data-design-preview-iframe]";
+
 export function designFrame(page: Page): FrameLocator {
-  return page.frameLocator("iframe[data-design-preview-iframe]");
+  return page.locator(DESIGN_PREVIEW_IFRAME_SELECTOR).first().contentFrame();
 }
 
 /** Open the editor for a design and wait for the toolbar + iframe to be ready. */
@@ -40,7 +42,7 @@ export async function gotoEditor(page: Page, designId: string): Promise<void> {
 
 async function waitForDesignBridgeReady(page: Page): Promise<void> {
   await expect(
-    page.locator("iframe[data-design-preview-iframe]"),
+    page.locator(DESIGN_PREVIEW_IFRAME_SELECTOR).first(),
   ).toBeVisible();
   await expect(
     designFrame(page).locator('[data-agent-native-edit-overlay="shield"]'),
@@ -71,8 +73,12 @@ export async function enterDirectMode(page: Page): Promise<void> {
   await expect
     .poll(
       async () =>
-        (await page.locator("iframe[data-design-preview-iframe]").boundingBox())
-          ?.width ?? 0,
+        (
+          await page
+            .locator(DESIGN_PREVIEW_IFRAME_SELECTOR)
+            .first()
+            .boundingBox()
+        )?.width ?? 0,
       { timeout: 10_000 },
     )
     .toBeGreaterThan(600);


### PR DESCRIPTION
## Summary
- Fix visual-edit fileId-only edits against non-index design files
- Sync additive overview screen selection from the Layers panel
- Make locked/hidden layer rows non-draggable and avoid stale drop affordances
- Restore blend mode editing in the color picker and fix Auto/Fixed gap switching
- Move draw toolbars above the bottom editor toolbar and make E2E iframe helpers tolerate multiple previews

## Validation
- corepack pnpm --filter design exec vitest run actions/apply-visual-edit.test.ts app/pages/DesignEditor.selection.test.ts --reporter=dot
- corepack pnpm --filter design typecheck
- git diff --check

## Notes
- A targeted Playwright smoke for the Annotate/Edit toolbar flow was attempted with `corepack pnpm --filter design exec playwright test e2e/canvas-tools.spec.ts --grep "toolbar modes toggle the editor mode buttons"`, but the local dev server/test did not complete after startup and was interrupted. CI should run the full browser matrix on this PR.