### PR TITLE
Improve visual editor editing reliability

### DIFF
--- a/.changeset/design-connect-provenance-contract.md
+++ b/.changeset/design-connect-provenance-contract.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Design connect: document the per-element provenance contract (`data-source-file` / `data-source-line` / `data-source-column` / `data-component-name`, plus `data-loc` shorthand) used to map a selected element back to its source location, and surface it in `design connect --help`. The `resolveNodeToFile` bridge capability now carries a reason string describing this contract.

--- a/.changeset/visual-plan-install-feedback.md
+++ b/.changeset/visual-plan-install-feedback.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Harden the app-backed skill installer for visual-plan feedback: built-in skill folders now stage writes before replacing existing installs, include first-time install command metadata, and make `skills update` point first-time users to `skills add` for setup and MCP registration.

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -12,6 +12,26 @@
       "autoPort": true
     },
     {
+      "name": "design-review-verify",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": [
+        "-c",
+        "NODE_ENV=development APP_NAME=design AGENT_USER_EMAIL=dev@local.test DESIGN_DATABASE_URL=file:/tmp/design-review-verify.db pnpm --filter design exec agent-native dev"
+      ],
+      "port": 8080,
+      "autoPort": true
+    },
+    {
+      "name": "design-review-verify-fixed",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": [
+        "-c",
+        "NODE_ENV=development APP_NAME=design APP_URL=http://localhost:8093 AGENT_USER_EMAIL=dev@local.test DESIGN_DATABASE_URL=file:/tmp/design-review-verify.db PORT=8093 pnpm --filter design exec agent-native dev"
+      ],
+      "port": 8093,
+      "autoPort": false
+    },
+    {
       "name": "dev",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["dev:lazy", "--", "--all"],

--- a/packages/core/src/cli/design-connect.ts
+++ b/packages/core/src/cli/design-connect.ts
@@ -367,7 +367,14 @@ export async function prepareDesignConnectManifest(
       reason:
         operation === "writeFile"
           ? "The bridge advertises the contract before enabling local file writes."
-          : undefined,
+          : operation === "resolveNodeToFile"
+            ? // resolveNodeToFile maps a runtime DOM node id (from the editor's
+              // 'select' payload) to { file, line, component } provenance.  The
+              // bridge endpoint exists; per-element provenance data must be
+              // emitted by the connected app at build time — see the provenance
+              // note in the help text below.
+              "Requires the connected app to emit data-source-file / data-source-line / data-component-name attributes (e.g. via @vitejs/plugin-react jsxDEV or a Babel source plugin)."
+            : undefined,
     })),
   };
 }
@@ -442,7 +449,26 @@ Options:
   --route-manifest <path> Non-destructive route manifest output path
   --json                  Print the manifest JSON and exit
   --once                  Prepare/scaffold the manifest and exit
-  --dry-run               Print what would be exposed without writing files`);
+  --dry-run               Print what would be exposed without writing files
+
+Element provenance (resolveNodeToFile):
+  The design editor can map a selected DOM element back to its source file,
+  line, and React component name when the connected app emits provenance
+  attributes at build time.  Add one of the following to your app's build:
+
+  • @vitejs/plugin-react with jsxDEV enabled (development mode default):
+      Sets data-source-file and data-source-line on each JSX element
+      automatically when using the Babel transform.
+
+  • A Babel source plugin (e.g. babel-plugin-react-source or a custom plugin):
+      Emits data-source-file="src/Button.tsx" data-source-line="12"
+      data-source-column="4" data-component-name="Button" on each element.
+
+  • data-loc="src/Button.tsx:12:4" shorthand attribute (Babel source convention):
+      The bridge parses this as { sourceFile, line, column } automatically.
+
+  Without these attributes the editor still works; provenance is simply absent.
+  Cross-origin localhost iframes cannot be read regardless of attributes (CSP).`);
 }
 
 export async function runDesign(argv: string[]) {

--- a/packages/core/src/cli/skills.spec.ts
+++ b/packages/core/src/cli/skills.spec.ts
@@ -1056,6 +1056,94 @@ describe("agent-native skills", () => {
     ).toBe("https://assets.agent-native.com/_agent-native/mcp");
   });
 
+  it("installs visual-plan into Claude Code user skills idempotently", async () => {
+    const root = tmpDir();
+    const home = path.join(root, "home");
+    const skillDir = path.join(home, ".claude", "skills", "visual-plan");
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, "old.txt"), "stale copy\n");
+    fs.writeFileSync(path.join(skillDir, "SKILL.md"), "old visual plan\n");
+    const previousHome = process.env.HOME;
+    process.env.HOME = home;
+
+    try {
+      const result = await addAgentNativeSkill(
+        parseSkillsArgs([
+          "add",
+          "visual-plan",
+          "--client",
+          "claude-code",
+          "--scope",
+          "user",
+          "--no-connect",
+        ]),
+        { baseDir: root, runCommand: async () => 0 },
+      );
+
+      expect(result.skillNames).toEqual(["visual-plan"]);
+      expect(result.planMode).toBe("hosted");
+      expect(result.mcpUrl).toBe(
+        "https://plan.agent-native.com/_agent-native/mcp",
+      );
+      expect(result.written).toContain(skillDir);
+      expect(fs.existsSync(path.join(skillDir, "old.txt"))).toBe(false);
+      expect(
+        fs.readFileSync(path.join(skillDir, "SKILL.md"), "utf-8"),
+      ).toContain("# Agent-Native Plans");
+      const metadata = JSON.parse(
+        fs.readFileSync(
+          path.join(skillDir, AGENT_NATIVE_SKILL_METADATA_FILE),
+          "utf-8",
+        ),
+      );
+      expect(metadata).toMatchObject({
+        source: "agent-native",
+        appSkillId: "visual-plans",
+        skillName: "visual-plan",
+        mcpUrl: "https://plan.agent-native.com/_agent-native/mcp",
+        planMode: "hosted",
+        installCommand: "npx @agent-native/core@latest skills add visual-plan",
+        updateCommand:
+          "npx @agent-native/core@latest skills update visual-plan",
+      });
+      expect(
+        fs.existsSync(path.join(home, ".claude", "commands", "visual-plan.md")),
+      ).toBe(true);
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+    }
+  });
+
+  it("fails loudly when the target skill folder cannot be written", async () => {
+    const root = tmpDir();
+    const home = path.join(root, "home");
+    fs.mkdirSync(home, { recursive: true });
+    fs.writeFileSync(path.join(home, ".claude"), "not a directory\n");
+    const previousHome = process.env.HOME;
+    process.env.HOME = home;
+
+    try {
+      await expect(
+        addAgentNativeSkill(
+          parseSkillsArgs([
+            "add",
+            "visual-plan",
+            "--client",
+            "claude-code",
+            "--scope",
+            "user",
+            "--no-mcp",
+          ]),
+          { baseDir: root, runCommand: async () => 0 },
+        ),
+      ).rejects.toThrow(/Cannot write Agent Native skill folder .*visual-plan/);
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+    }
+  });
+
   it("delegates plain GitHub skill repos to @agent-native/skills", async () => {
     const root = tmpDir();
     const commands: { cmd: string; args: string[]; stdio?: string }[] = [];
@@ -1962,6 +2050,37 @@ describe("agent-native skills", () => {
       status: "stale",
       managed: true,
     });
+  });
+
+  it("explains that update is not the first-time visual-plan installer", async () => {
+    const root = tmpDir();
+    const home = path.join(root, "home");
+    fs.mkdirSync(home, { recursive: true });
+    const previousHome = process.env.HOME;
+    process.env.HOME = home;
+    const stdout: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+
+    try {
+      await runSkills(
+        ["update", "visual-plan", "--client", "claude-code", "--scope", "user"],
+        { baseDir: root, runCommand: async () => 0 },
+      );
+
+      expect(stdout.join("")).toContain(
+        "The update command only refreshes skill folders that already exist",
+      );
+      expect(stdout.join("")).toContain(
+        "npx @agent-native/core@latest skills add visual-plan",
+      );
+      expect(stdout.join("")).toContain("MCP registration");
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+    }
   });
 
   it("updates managed copied skill folders in place", async () => {

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -3073,6 +3073,7 @@ interface SkillInstallMetadata {
   contentHash: string;
   mcpUrl: string;
   installedAt: string;
+  installCommand: string;
   updateCommand: string;
   planMode?: PlanInstallMode;
 }
@@ -3489,30 +3490,48 @@ function writeSkillFolder(
   bundle: SkillFolderBundle,
   installedAt = new Date().toISOString(),
 ): void {
-  fs.rmSync(dir, { recursive: true, force: true });
-  fs.mkdirSync(dir, { recursive: true });
-  for (const [rel, content] of Object.entries(bundle.files)) {
-    const target = path.join(dir, rel);
-    fs.mkdirSync(path.dirname(target), { recursive: true });
-    fs.writeFileSync(target, content, "utf-8");
-  }
-  const metadata: SkillInstallMetadata = {
-    schemaVersion: 1,
-    source: "agent-native",
-    appSkillId: bundle.appSkillId,
-    displayName: bundle.displayName,
-    skillName: bundle.skillName,
-    contentHash: bundle.contentHash,
-    mcpUrl: bundle.mcpUrl,
-    installedAt,
-    updateCommand: `npx @agent-native/core@latest skills update ${bundle.skillName}`,
-    ...(bundle.planMode ? { planMode: bundle.planMode } : {}),
-  };
-  fs.writeFileSync(
-    path.join(dir, AGENT_NATIVE_SKILL_METADATA_FILE),
-    `${JSON.stringify(metadata, null, 2)}\n`,
-    "utf-8",
+  const parent = path.dirname(dir);
+  const tempDir = path.join(
+    parent,
+    `.${path.basename(dir)}.${process.pid}.${Date.now()}.tmp`,
   );
+  try {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    fs.mkdirSync(tempDir, { recursive: true });
+    for (const [rel, content] of Object.entries(bundle.files)) {
+      const target = path.join(tempDir, rel);
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, content, "utf-8");
+    }
+    const metadata: SkillInstallMetadata = {
+      schemaVersion: 1,
+      source: "agent-native",
+      appSkillId: bundle.appSkillId,
+      displayName: bundle.displayName,
+      skillName: bundle.skillName,
+      contentHash: bundle.contentHash,
+      mcpUrl: bundle.mcpUrl,
+      installedAt,
+      installCommand: `npx @agent-native/core@latest skills add ${bundle.skillName}`,
+      updateCommand: `npx @agent-native/core@latest skills update ${bundle.skillName}`,
+      ...(bundle.planMode ? { planMode: bundle.planMode } : {}),
+    };
+    fs.writeFileSync(
+      path.join(tempDir, AGENT_NATIVE_SKILL_METADATA_FILE),
+      `${JSON.stringify(metadata, null, 2)}\n`,
+      "utf-8",
+    );
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.renameSync(tempDir, dir);
+  } catch (error: any) {
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch {}
+    throw new Error(
+      `Cannot write Agent Native skill folder ${dir}: ${error?.message ?? error}`,
+      { cause: error },
+    );
+  }
 }
 
 function isJsonRecord(value: unknown): value is Record<string, unknown> {
@@ -6228,7 +6247,9 @@ function runSkillsStatusOrUpdate(
     const target = parsed.target ? ` for ${parsed.target}` : "";
     const hint = isScaffoldGuidanceTarget(parsed.target)
       ? `Run this from a generated Agent Native app or workspace root.\n`
-      : `Run "npx @agent-native/core@latest skills add ${parsed.target ?? "visual-plan"}" to install one.\n`;
+      : update
+        ? `The update command only refreshes skill folders that already exist; it does not do first-time install, MCP registration, or auth. Run "npx @agent-native/core@latest skills add ${parsed.target ?? "visual-plan"}" for one-step setup.\n`
+        : `Run "npx @agent-native/core@latest skills add ${parsed.target ?? "visual-plan"}" to install one.\n`;
     process.stdout.write(
       `No installed Agent Native skill copies found${target}.\n${hint}`,
     );

--- a/templates/design/actions/add-localhost-screens.ts
+++ b/templates/design/actions/add-localhost-screens.ts
@@ -30,6 +30,7 @@ const routeInputSchema = z.object({
   path: z.string().optional(),
   url: z.string().optional(),
   title: z.string().optional(),
+  sourceFile: z.string().optional(),
   width: z.number().positive().optional(),
   height: z.number().positive().optional(),
   x: z.number().optional(),
@@ -307,6 +308,7 @@ export default defineAction({
       path: string;
       url: string;
       routeId: string;
+      sourceFile?: string;
       width: number;
       height: number;
     }> = [];
@@ -330,6 +332,7 @@ export default defineAction({
         input.routeId ?? manifestRoute?.id ?? makeLocalhostRouteId(path);
       const title =
         input.title ?? manifestRoute?.title ?? titleFromRoutePath(path);
+      const sourceFile = input.sourceFile ?? manifestRoute?.sourceFile;
       const width = input.width ?? defaultWidth;
       const height = input.height ?? defaultHeight;
       const preferredFilename = `localhost-${slugForPath(path)}.html`;
@@ -369,6 +372,7 @@ export default defineAction({
         path,
         url,
         routeId,
+        sourceFile,
         width,
         height,
       });
@@ -406,6 +410,7 @@ export default defineAction({
         previewUrl: screen.url,
         connectionId: connection.id,
         routeId: screen.routeId,
+        sourceFile: screen.sourceFile,
         path: screen.path,
         bridgeUrl: connection.bridgeUrl ?? undefined,
       };

--- a/templates/design/actions/apply-visual-edit.ts
+++ b/templates/design/actions/apply-visual-edit.ts
@@ -15,8 +15,11 @@ import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import {
   applyVisualEdit,
+  type AutoLayoutEditIntent,
   type CodeLayerSource,
   type EditIntent,
+  type UnwrapEditIntent,
+  type WrapNodesEditIntent,
 } from "../shared/code-layer.js";
 
 type VisualEditActionSource = CodeLayerSource & { html?: string };
@@ -110,6 +113,50 @@ const intentSchema = z.preprocess(
       anchor: targetSchema,
       placement: z.enum(["before", "after", "inside"]),
     }),
+    z.object({
+      kind: z.literal("wrapNodes"),
+      targetIds: z
+        .array(z.string())
+        .min(1)
+        .describe(
+          "data-agent-native-node-id values of sibling nodes to group. All must share a common parent.",
+        ),
+      autoLayout: z
+        .boolean()
+        .optional()
+        .describe(
+          "When true the wrapper gets display:flex; flex-direction:column; gap:8px and absolute positioning is stripped from each wrapped child.",
+        ),
+    }) satisfies z.ZodType<WrapNodesEditIntent>,
+    z.object({
+      kind: z.literal("unwrap"),
+      targetId: z
+        .string()
+        .describe(
+          "data-agent-native-node-id of the wrapper to remove, promoting its children to the wrapper's parent.",
+        ),
+    }) satisfies z.ZodType<UnwrapEditIntent>,
+    z.object({
+      kind: z.literal("autoLayout"),
+      targetId: z
+        .string()
+        .describe(
+          "data-agent-native-node-id of the container to convert to/from auto-layout.",
+        ),
+      enabled: z
+        .boolean()
+        .describe(
+          "true = enable auto-layout (display:flex + direction + gap, strip absolute positioning from direct children); false = set display:block.",
+        ),
+      direction: z
+        .enum(["row", "column"])
+        .optional()
+        .describe("Flex direction when enabling. Defaults to column."),
+      gap: z
+        .string()
+        .optional()
+        .describe("Gap value when enabling. Defaults to 8px."),
+    }) satisfies z.ZodType<AutoLayoutEditIntent>,
   ]),
 );
 

--- a/templates/design/app/components/design/DesignCanvas.spacing-overlay.test.ts
+++ b/templates/design/app/components/design/DesignCanvas.spacing-overlay.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(
+  fileURLToPath(new URL("./DesignCanvas.tsx", import.meta.url)),
+  "utf8",
+);
+
+describe("DesignCanvas spacing overlay bridge", () => {
+  it("injects editable spacing chrome instead of the old passive padding inset", () => {
+    expect(source).toContain("data-agent-native-spacing-overlay");
+    expect(source).toContain("data-agent-native-spacing-region");
+    expect(source).toContain("data-agent-native-spacing-badge");
+    expect(source).not.toContain("data-agent-native-padding-overlay");
+  });
+
+  it("persists dragged padding and gap values through visual style changes", () => {
+    expect(source).toContain("function startSpacingDrag");
+    expect(source).toContain("styles[handle.property] = finalValue + 'px'");
+    expect(source).toContain(
+      "styles[handle.oppositeProperty] = finalValue + 'px'",
+    );
+    expect(source).toContain("addAxisGaps('x', 'columnGap'");
+    expect(source).toContain("addAxisGaps('y', 'rowGap'");
+  });
+
+  it("shows spacing affordances when hovering the selected element or its children", () => {
+    expect(source).toContain("selectedSpacingHovered = Boolean");
+    expect(source).toContain("hoveredEl === selectedEl");
+    expect(source).toContain("selectedEl.contains(hoveredEl)");
+  });
+});

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -260,7 +260,11 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
     var chromeTransitionStyle = document.createElement('style');
     chromeTransitionStyle.textContent =
       '[data-agent-native-edit-overlay="selection"]{transition:border-width 150ms ease-out}' +
-      '[data-agent-native-edge-handle],[data-agent-native-edit-handle],[data-agent-native-rotate-handle]{transition:width 150ms ease-out,height 150ms ease-out,border-width 150ms ease-out,top 150ms ease-out,bottom 150ms ease-out,left 150ms ease-out,right 150ms ease-out}';
+      '[data-agent-native-edge-handle],[data-agent-native-edit-handle],[data-agent-native-rotate-handle]{transition:width 150ms ease-out,height 150ms ease-out,border-width 150ms ease-out,top 150ms ease-out,bottom 150ms ease-out,left 150ms ease-out,right 150ms ease-out}' +
+      '[data-agent-native-spacing-line]{position:absolute;display:none;pointer-events:none;border-radius:999px}' +
+      '[data-agent-native-spacing-region]{position:absolute;display:none;box-sizing:border-box;pointer-events:auto;background-size:6px 6px}' +
+      '[data-agent-native-spacing-region][data-orientation="vertical"]{cursor:ew-resize}' +
+      '[data-agent-native-spacing-region][data-orientation="horizontal"]{cursor:ns-resize}';
     (document.head || document.documentElement).appendChild(chromeTransitionStyle);
   })();
 
@@ -484,6 +488,40 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
         reason: 'Parent layout context decides whether movement means gap, order, alignment, or wrapper structure.',
       });
     }
+    // --- provenance: read source-location attributes when present ---
+    // These are emitted by connected apps via @vitejs/plugin-react jsxDEV or a
+    // Babel source plugin.  Cross-origin localhost iframes cannot be read (CSP /
+    // same-origin policy), so this will be undefined in that case — expected.
+    var provenance = undefined;
+    var dataSourceFile = el.getAttribute('data-source-file');
+    var dataSourceLine = el.getAttribute('data-source-line');
+    var dataSourceColumn = el.getAttribute('data-source-column');
+    var dataComponentName = el.getAttribute('data-component-name');
+    var dataLoc = el.getAttribute('data-loc');
+    // data-loc may encode "file:line:col" (Babel source plugin convention).
+    // Only parse it when data-source-file is absent, to avoid double-reads.
+    if (!dataSourceFile && dataLoc) {
+      var locParts = dataLoc.split(':');
+      // Expect at least "file:line" or "file:line:col"; guard against bare ids.
+      if (locParts.length >= 2) {
+        var maybeFile = locParts[0];
+        var maybeLine = Number(locParts[locParts.length >= 3 ? locParts.length - 2 : locParts.length - 1]);
+        var maybeCol = locParts.length >= 3 ? Number(locParts[locParts.length - 1]) : undefined;
+        // Only treat as provenance when file part looks path-like.
+        if (maybeFile && maybeFile.length > 0 && !isNaN(maybeLine)) {
+          dataSourceFile = maybeFile;
+          dataSourceLine = String(maybeLine);
+          if (maybeCol !== undefined && !isNaN(maybeCol)) dataSourceColumn = String(maybeCol);
+        }
+      }
+    }
+    if (dataSourceFile || dataSourceLine || dataSourceColumn || dataComponentName) {
+      provenance = {};
+      if (dataSourceFile) provenance.sourceFile = dataSourceFile;
+      if (dataSourceLine) { var ln = parseInt(dataSourceLine, 10); if (!isNaN(ln)) provenance.line = ln; }
+      if (dataSourceColumn) { var col = parseInt(dataSourceColumn, 10); if (!isNaN(col)) provenance.column = col; }
+      if (dataComponentName) provenance.component = dataComponentName;
+    }
     return {
       tagName: el.tagName.toLowerCase(),
       id: el.id || undefined,
@@ -559,6 +597,7 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
       confidence: capabilities.reduce(function(best, item) {
         return Math.max(best, item.confidence || 0);
       }, 0),
+      provenance: provenance,
     };
   }
 
@@ -635,16 +674,21 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
     if (pos.indexOf('e') !== -1) rotate.style.right = '-26px';
     selectionOverlay.appendChild(rotate);
   });
-  var paddingOverlay = document.createElement('div');
-  paddingOverlay.setAttribute('data-agent-native-padding-overlay', '');
-  paddingOverlay.style.cssText = 'position:absolute;border:1px dashed var(--design-editor-accent-strong-color);border-radius:2px;pointer-events:none;';
-  selectionOverlay.appendChild(paddingOverlay);
+  var spacingOverlay = document.createElement('div');
+  spacingOverlay.setAttribute('data-agent-native-spacing-overlay', '');
+  spacingOverlay.style.cssText = 'position:absolute;inset:0;display:none;pointer-events:none;';
+  selectionOverlay.appendChild(spacingOverlay);
   document.body.appendChild(selectionOverlay);
 
   var transformBadge = document.createElement('div');
   transformBadge.setAttribute('data-agent-native-transform-badge', '');
   transformBadge.style.cssText = 'position:fixed;z-index:100000;display:none;pointer-events:none;border:1px solid hsl(var(--border));border-radius:4px;background:hsl(var(--background) / 0.96);color:hsl(var(--foreground));font:11px/1.4 ui-monospace,SFMono-Regular,Menlo,monospace;padding:3px 5px;box-shadow:0 8px 20px color-mix(in srgb, hsl(var(--foreground)) 16%, transparent);';
   document.body.appendChild(transformBadge);
+
+  var spacingBadge = document.createElement('div');
+  spacingBadge.setAttribute('data-agent-native-spacing-badge', '');
+  spacingBadge.style.cssText = 'position:fixed;z-index:100000;display:none;pointer-events:none;border-radius:3px;color:white;font:10px/1.2 ui-monospace,SFMono-Regular,Menlo,monospace;font-weight:700;padding:2px 4px;box-shadow:0 4px 14px rgba(0,0,0,0.18);';
+  document.body.appendChild(spacingBadge);
 
   var insertionGuide = document.createElement('div');
   insertionGuide.setAttribute('data-agent-native-insertion-guide', '');
@@ -661,14 +705,26 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
 	  var activeTextEditEl = null;
 	  var textEditPointerState = null;
 	  var pendingStructureMove = null;
+  var pendingShieldDrag = null;
+  var suppressNextShieldClick = false;
+  var suppressNextShieldClickTimer = null;
+  var selectedSpacingHovered = false;
+  var hoveredSpacingHandleKey = '';
+  var spacingHandleStateByKey = {};
+  var spacingHandleNodesByKey = {};
+  var spacingDrag = null;
 	  var lockedSelectors = [];
 	  var hiddenSelectors = [];
 
   function clearRuntimeSelection() {
     selectedEl = null;
     hoveredEl = null;
+    selectedSpacingHovered = false;
+    hoveredSpacingHandleKey = '';
+    spacingDrag = null;
     selectionOverlay.style.display = 'none';
     highlightOverlay.style.display = 'none';
+    hideSpacingOverlay();
     hideMeasurements();
   }
 
@@ -849,22 +905,365 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
     refreshOverlays();
   }
 
-  function updatePaddingOverlay(el) {
-    if (!el) {
-      paddingOverlay.style.display = 'none';
+  function hideSpacingOverlay() {
+    spacingOverlay.style.display = 'none';
+    spacingOverlay.innerHTML = '';
+    spacingHandleStateByKey = {};
+    spacingHandleNodesByKey = {};
+    if (!spacingDrag) spacingBadge.style.display = 'none';
+  }
+
+  function visibleLayoutChildren(el) {
+    if (!el || !el.children) return [];
+    return Array.prototype.slice.call(el.children).filter(function(child) {
+      if (!child || child.nodeType !== 1 || isOverlayElement(child) || isLayerInteractionBlocked(child)) return false;
+      var cs = window.getComputedStyle(child);
+      if (cs.display === 'none' || cs.visibility === 'hidden' || cs.position === 'fixed') return false;
+      var rect = child.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    });
+  }
+
+  function spacingColor(kind) {
+    return kind === 'gap' ? '#ff4fd8' : 'var(--design-editor-accent-color)';
+  }
+
+  function spacingFill(kind, orientation) {
+    var tint = kind === 'gap' ? 'rgba(255, 79, 216, 0.28)' : 'rgba(46, 168, 255, 0.24)';
+    var stripe = kind === 'gap' ? 'rgba(255, 79, 216, 0.58)' : 'rgba(46, 168, 255, 0.52)';
+    var angle = orientation === 'vertical' ? '135deg' : '45deg';
+    return 'repeating-linear-gradient(' + angle + ', ' + stripe + ' 0 1px, ' + tint + ' 1px 4px, transparent 4px 7px)';
+  }
+
+  function clampSpacingValue(value) {
+    var rounded = Math.round(value);
+    if (!Number.isFinite(rounded)) return 0;
+    return Math.max(0, Math.min(999, rounded));
+  }
+
+  function makeSpacingHandle(config) {
+    var region = config.region;
+    if (!region || region.width <= 0 || region.height <= 0) return null;
+    return {
+      key: config.key,
+      groupKey: config.groupKey || config.key,
+      kind: config.kind,
+      property: config.property,
+      oppositeProperty: config.oppositeProperty || '',
+      side: config.side || '',
+      orientation: config.orientation,
+      value: clampSpacingValue(config.value),
+      region: {
+        x: Math.round(region.x),
+        y: Math.round(region.y),
+        width: Math.max(1, Math.round(region.width)),
+        height: Math.max(1, Math.round(region.height)),
+      },
+      line: config.line,
+    };
+  }
+
+  function childLocalRect(child, containerRect) {
+    var rect = child.getBoundingClientRect();
+    return {
+      left: rect.left - containerRect.left,
+      top: rect.top - containerRect.top,
+      right: rect.right - containerRect.left,
+      bottom: rect.bottom - containerRect.top,
+      width: rect.width,
+      height: rect.height,
+    };
+  }
+
+  function childRectsOverlap(a, b, axis) {
+    if (axis === 'x') {
+      return Math.max(a.top, b.top) < Math.min(a.bottom, b.bottom);
+    }
+    return Math.max(a.left, b.left) < Math.min(a.right, b.right);
+  }
+
+  function buildPaddingSpacingHandles(el, rect, cs) {
+    var handles = [];
+    var borderTop = readPx(cs.borderTopWidth);
+    var borderRight = readPx(cs.borderRightWidth);
+    var borderBottom = readPx(cs.borderBottomWidth);
+    var borderLeft = readPx(cs.borderLeftWidth);
+    var paddingTop = readPx(cs.paddingTop);
+    var paddingRight = readPx(cs.paddingRight);
+    var paddingBottom = readPx(cs.paddingBottom);
+    var paddingLeft = readPx(cs.paddingLeft);
+    var sx = chromeScaleX();
+    var sy = chromeScaleY();
+    var line = Math.max(1, chromeLineScale());
+    var hLineWidth = Math.max(8, Math.min(24, rect.width * 0.18)) * sx;
+    var vLineHeight = Math.max(8, Math.min(24, rect.height * 0.18)) * sy;
+    var innerLeft = borderLeft;
+    var innerTop = borderTop;
+    var innerWidth = Math.max(1, rect.width - borderLeft - borderRight);
+    var innerHeight = Math.max(1, rect.height - borderTop - borderBottom);
+    if (paddingTop > 0) {
+      handles.push(makeSpacingHandle({
+        key: 'padding:top',
+        kind: 'padding',
+        property: 'paddingTop',
+        oppositeProperty: 'paddingBottom',
+        side: 'top',
+        orientation: 'horizontal',
+        value: paddingTop,
+        region: { x: innerLeft, y: innerTop, width: innerWidth, height: paddingTop },
+        line: {
+          x: rect.width / 2 - hLineWidth / 2,
+          y: innerTop + paddingTop / 2 - line / 2,
+          width: hLineWidth,
+          height: line,
+        },
+      }));
+    }
+    if (paddingBottom > 0) {
+      handles.push(makeSpacingHandle({
+        key: 'padding:bottom',
+        kind: 'padding',
+        property: 'paddingBottom',
+        oppositeProperty: 'paddingTop',
+        side: 'bottom',
+        orientation: 'horizontal',
+        value: paddingBottom,
+        region: { x: innerLeft, y: rect.height - borderBottom - paddingBottom, width: innerWidth, height: paddingBottom },
+        line: {
+          x: rect.width / 2 - hLineWidth / 2,
+          y: rect.height - borderBottom - paddingBottom / 2 - line / 2,
+          width: hLineWidth,
+          height: line,
+        },
+      }));
+    }
+    if (paddingLeft > 0) {
+      handles.push(makeSpacingHandle({
+        key: 'padding:left',
+        kind: 'padding',
+        property: 'paddingLeft',
+        oppositeProperty: 'paddingRight',
+        side: 'left',
+        orientation: 'vertical',
+        value: paddingLeft,
+        region: { x: innerLeft, y: innerTop, width: paddingLeft, height: innerHeight },
+        line: {
+          x: innerLeft + paddingLeft / 2 - line / 2,
+          y: rect.height / 2 - vLineHeight / 2,
+          width: line,
+          height: vLineHeight,
+        },
+      }));
+    }
+    if (paddingRight > 0) {
+      handles.push(makeSpacingHandle({
+        key: 'padding:right',
+        kind: 'padding',
+        property: 'paddingRight',
+        oppositeProperty: 'paddingLeft',
+        side: 'right',
+        orientation: 'vertical',
+        value: paddingRight,
+        region: { x: rect.width - borderRight - paddingRight, y: innerTop, width: paddingRight, height: innerHeight },
+        line: {
+          x: rect.width - borderRight - paddingRight / 2 - line / 2,
+          y: rect.height / 2 - vLineHeight / 2,
+          width: line,
+          height: vLineHeight,
+        },
+      }));
+    }
+    return handles.filter(Boolean);
+  }
+
+  function buildGapSpacingHandles(el, rect, cs) {
+    var children = visibleLayoutChildren(el);
+    if (children.length < 2) return [];
+    var handles = [];
+    var sx = chromeScaleX();
+    var sy = chromeScaleY();
+    var line = Math.max(1, chromeLineScale());
+    var hLineWidth = 10 * sx;
+    var vLineHeight = 10 * sy;
+    var isFlex = cs.display === 'flex' || cs.display === 'inline-flex';
+    var isGrid = cs.display === 'grid' || cs.display === 'inline-grid';
+    if (!isFlex && !isGrid) return handles;
+    var primaryAxis = isFlex && cs.flexDirection && cs.flexDirection.indexOf('column') === 0 ? 'y' : 'x';
+    var childRects = children.map(function(child) {
+      return childLocalRect(child, rect);
+    });
+
+    function addAxisGaps(axis, property, groupKey) {
+      var cssGap = readPx(cs[property]);
+      if (cssGap <= 0) return;
+      var sorted = childRects.slice().sort(function(a, b) {
+        return axis === 'x' ? a.left - b.left : a.top - b.top;
+      });
+      var count = 0;
+      for (var i = 0; i < sorted.length - 1; i += 1) {
+        var a = sorted[i];
+        var b = sorted[i + 1];
+        if (!childRectsOverlap(a, b, axis)) continue;
+        var gap = axis === 'x' ? b.left - a.right : b.top - a.bottom;
+        if (gap <= 1) continue;
+        if (axis === 'x') {
+          var top = Math.max(a.top, b.top);
+          var bottom = Math.min(a.bottom, b.bottom);
+          var height = Math.max(1, bottom - top);
+          handles.push(makeSpacingHandle({
+            key: groupKey + ':' + count,
+            groupKey: groupKey,
+            kind: 'gap',
+            property: property,
+            orientation: 'vertical',
+            value: cssGap,
+            region: { x: a.right, y: top, width: gap, height: height },
+            line: {
+              x: a.right + gap / 2 - line / 2,
+              y: top + height / 2 - vLineHeight / 2,
+              width: line,
+              height: vLineHeight,
+            },
+          }));
+        } else {
+          var left = Math.max(a.left, b.left);
+          var right = Math.min(a.right, b.right);
+          var width = Math.max(1, right - left);
+          handles.push(makeSpacingHandle({
+            key: groupKey + ':' + count,
+            groupKey: groupKey,
+            kind: 'gap',
+            property: property,
+            orientation: 'horizontal',
+            value: cssGap,
+            region: { x: left, y: a.bottom, width: width, height: gap },
+            line: {
+              x: left + width / 2 - hLineWidth / 2,
+              y: a.bottom + gap / 2 - line / 2,
+              width: hLineWidth,
+              height: line,
+            },
+          }));
+        }
+        count += 1;
+      }
+    }
+
+    if (primaryAxis === 'x') {
+      addAxisGaps('x', 'columnGap', 'gap:column');
+      if (isGrid) addAxisGaps('y', 'rowGap', 'gap:row');
+    } else {
+      addAxisGaps('y', 'rowGap', 'gap:row');
+      if (isGrid) addAxisGaps('x', 'columnGap', 'gap:column');
+    }
+    return handles.filter(Boolean);
+  }
+
+  function buildSpacingHandles(el) {
+    if (!el || !document.documentElement.contains(el)) return [];
+    if (Math.abs(currentRotation(el)) > 0.01) return [];
+    var children = visibleLayoutChildren(el);
+    if (children.length === 0) return [];
+    var rect = el.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return [];
+    var cs = window.getComputedStyle(el);
+    return buildPaddingSpacingHandles(el, rect, cs).concat(buildGapSpacingHandles(el, rect, cs));
+  }
+
+  function showSpacingBadgeForHandle(handle, value) {
+    if (!selectedEl || !handle) {
+      spacingBadge.style.display = 'none';
       return;
     }
-    var cs = window.getComputedStyle(el);
-    var top = readPx(cs.paddingTop) + readPx(cs.borderTopWidth);
-    var right = readPx(cs.paddingRight) + readPx(cs.borderRightWidth);
-    var bottom = readPx(cs.paddingBottom) + readPx(cs.borderBottomWidth);
-    var left = readPx(cs.paddingLeft) + readPx(cs.borderLeftWidth);
-    var hasPadding = top > 0 || right > 0 || bottom > 0 || left > 0;
-    paddingOverlay.style.display = hasPadding ? 'block' : 'none';
-    paddingOverlay.style.top = top + 'px';
-    paddingOverlay.style.right = right + 'px';
-    paddingOverlay.style.bottom = bottom + 'px';
-    paddingOverlay.style.left = left + 'px';
+    var rect = selectedEl.getBoundingClientRect();
+    var x = rect.left + handle.region.x + handle.region.width / 2;
+    var y = rect.top + handle.region.y + handle.region.height / 2;
+    spacingBadge.textContent = String(clampSpacingValue(value));
+    spacingBadge.style.display = 'block';
+    spacingBadge.style.background = spacingColor(handle.kind);
+    spacingBadge.style.left = x + 'px';
+    spacingBadge.style.top = y + 'px';
+    spacingBadge.style.transform = 'translate(-50%, -50%)';
+  }
+
+  function renderSpacingHandle(handle, activeGroupKey) {
+    if (!handle) return;
+    spacingHandleStateByKey[handle.key] = handle;
+    var highlighted = Boolean(activeGroupKey && handle.groupKey === activeGroupKey);
+    var lineNode = document.createElement('span');
+    lineNode.setAttribute('data-agent-native-spacing-line', handle.kind);
+    lineNode.style.display = 'block';
+    lineNode.style.left = handle.line.x + 'px';
+    lineNode.style.top = handle.line.y + 'px';
+    lineNode.style.width = Math.max(1, handle.line.width) + 'px';
+    lineNode.style.height = Math.max(1, handle.line.height) + 'px';
+    lineNode.style.background = spacingColor(handle.kind);
+    spacingOverlay.appendChild(lineNode);
+
+    var regionNode = document.createElement('span');
+    regionNode.setAttribute('data-agent-native-spacing-region', handle.kind);
+    regionNode.setAttribute('data-orientation', handle.orientation);
+    regionNode.setAttribute('data-spacing-key', handle.key);
+    regionNode.style.display = 'block';
+    regionNode.style.left = handle.region.x + 'px';
+    regionNode.style.top = handle.region.y + 'px';
+    regionNode.style.width = handle.region.width + 'px';
+    regionNode.style.height = handle.region.height + 'px';
+    regionNode.style.background = highlighted ? spacingFill(handle.kind, handle.orientation) : 'transparent';
+    regionNode.style.outline = highlighted ? '1px solid ' + spacingColor(handle.kind) : '0';
+    regionNode.style.outlineOffset = '-1px';
+    regionNode.addEventListener('mouseenter', function() {
+      hoveredSpacingHandleKey = handle.key;
+      selectedSpacingHovered = true;
+      updateSpacingOverlay(selectedEl);
+    });
+    regionNode.addEventListener('mouseleave', function() {
+      if (spacingDrag) return;
+      hoveredSpacingHandleKey = '';
+      updateSpacingOverlay(selectedEl);
+    });
+    regionNode.addEventListener('mousedown', function(event) {
+      startSpacingDrag(handle.key, event);
+    }, true);
+    spacingHandleNodesByKey[handle.key] = regionNode;
+    spacingOverlay.appendChild(regionNode);
+  }
+
+  function updateSpacingOverlay(el) {
+    if (el && el !== selectedEl) {
+      hideSpacingOverlay();
+      return;
+    }
+    if (!selectedEl || !document.documentElement.contains(selectedEl)) {
+      hideSpacingOverlay();
+      return;
+    }
+    if (!selectedSpacingHovered && !hoveredSpacingHandleKey && !spacingDrag) {
+      hideSpacingOverlay();
+      return;
+    }
+    var handles = buildSpacingHandles(selectedEl);
+    if (handles.length === 0) {
+      hideSpacingOverlay();
+      return;
+    }
+    spacingOverlay.style.display = 'block';
+    spacingOverlay.innerHTML = '';
+    spacingHandleStateByKey = {};
+    spacingHandleNodesByKey = {};
+    var activeHandle =
+      (spacingDrag && spacingDrag.handle) ||
+      handles.find(function(handle) { return handle.key === hoveredSpacingHandleKey; }) ||
+      null;
+    var activeGroupKey = activeHandle ? activeHandle.groupKey : '';
+    handles.forEach(function(handle) {
+      renderSpacingHandle(handle, activeGroupKey);
+    });
+    if (activeHandle) {
+      showSpacingBadgeForHandle(activeHandle, spacingDrag ? spacingDrag.currentValue : activeHandle.value);
+    } else {
+      spacingBadge.style.display = 'none';
+    }
   }
 
   function applyEditorChromeScale() {
@@ -874,7 +1273,7 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
     var line = chromeLineScale();
     highlightOverlay.style.borderWidth = (1.5 * line) + 'px';
     selectionOverlay.style.borderWidth = (1.5 * line) + 'px';
-    paddingOverlay.style.borderWidth = Math.max(1, 1 * line) + 'px';
+    if (selectedEl) updateSpacingOverlay(selectedEl);
 
     selectionOverlay.querySelectorAll('[data-agent-native-edge-handle]').forEach(function(edge) {
       var pos = edge.getAttribute('data-agent-native-edge-handle');
@@ -936,7 +1335,7 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
         overlay.style.height = elH + 'px';
         overlay.style.transform = 'rotate(' + elRot + 'deg)';
         overlay.style.transformOrigin = '0 0';
-        updatePaddingOverlay(el);
+        updateSpacingOverlay(el);
         return;
       }
     }
@@ -947,7 +1346,7 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
     overlay.style.width = rect.width + 'px';
     overlay.style.height = rect.height + 'px';
     overlay.style.transform = '';
-    if (overlay === selectionOverlay) updatePaddingOverlay(el);
+    if (overlay === selectionOverlay) updateSpacingOverlay(el);
   }
 
   function refreshOverlays() {
@@ -1024,6 +1423,13 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
         hoverRect.top + hoverRect.height / 2 - (selectedRect.top + selectedRect.height / 2)
       )) + 'px'
     );
+  }
+
+  function dragEventNames(e) {
+    var pointerGesture = e && e.type && e.type.indexOf('pointer') === 0;
+    return pointerGesture
+      ? { move: 'pointermove', up: 'pointerup' }
+      : { move: 'mousemove', up: 'mouseup' };
   }
 
   function elementFromEditorPoint(clientX, clientY) {
@@ -1190,6 +1596,14 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
   function selectElementAtEvent(e) {
     stopNativeInteraction(e);
     blurActiveTextEditor();
+    if (suppressNextShieldClick) {
+      suppressNextShieldClick = false;
+      if (suppressNextShieldClickTimer !== null) {
+        clearTimeout(suppressNextShieldClickTimer);
+        suppressNextShieldClickTimer = null;
+      }
+      return;
+    }
     // Suppress the first click in a double-click sequence — the dblclick
     // handler (beginTextEditingFromEvent) will fire immediately after and a
     // spurious element-select would cause inspector flicker.
@@ -1197,15 +1611,27 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
     var target = elementFromEditorPoint(e.clientX, e.clientY);
     if (!target || target === document.body || target === document.documentElement) {
       // Click on empty canvas: clear the current selection (matches Figma).
-      selectedEl = null;
-      selectionOverlay.style.display = 'none';
+      clearRuntimeSelection();
       window.parent.postMessage({ type: 'clear-selection' }, '*');
       return;
     }
+    selectedSpacingHovered = false;
+    hoveredSpacingHandleKey = '';
     selectedEl = selectionTargetForHit(target);
     var info = getElementInfo(selectedEl);
     positionOverlay(selectionOverlay, selectedEl);
     window.parent.postMessage({ type: 'element-select', payload: info }, '*');
+  }
+
+  function suppressNextShieldClickBriefly() {
+    suppressNextShieldClick = true;
+    if (suppressNextShieldClickTimer !== null) {
+      clearTimeout(suppressNextShieldClickTimer);
+    }
+    suppressNextShieldClickTimer = setTimeout(function() {
+      suppressNextShieldClick = false;
+      suppressNextShieldClickTimer = null;
+    }, 250);
   }
 
   function openContextMenuAtEvent(e) {
@@ -1214,6 +1640,8 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
     var target = elementFromEditorPoint(e.clientX, e.clientY);
     var info = null;
     if (target) {
+      selectedSpacingHovered = false;
+      hoveredSpacingHandleKey = '';
       selectedEl = selectionTargetForHit(target);
       info = getElementInfo(selectedEl);
       positionOverlay(selectionOverlay, selectedEl);
@@ -1319,6 +1747,81 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
     }, '*');
   }
 
+  function spacingValueFromPointer(handle, originValue, startX, startY, clientX, clientY) {
+    var delta =
+      handle.orientation === 'vertical' ? clientX - startX : clientY - startY;
+    if (handle.kind === 'padding' && (handle.side === 'right' || handle.side === 'bottom')) {
+      delta = -delta;
+    }
+    return clampSpacingValue(originValue + delta);
+  }
+
+  function applySpacingDragValue(target, handle, value, mirrorOpposite) {
+    if (!target || !handle) return;
+    target.style[handle.property] = value + 'px';
+    if (handle.kind === 'padding' && mirrorOpposite && handle.oppositeProperty) {
+      target.style[handle.oppositeProperty] = value + 'px';
+    }
+  }
+
+  function startSpacingDrag(key, e) {
+    var handle = spacingHandleStateByKey[key];
+    if (!selectedEl || !handle || isLayerInteractionBlocked(selectedEl)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.stopImmediatePropagation) e.stopImmediatePropagation();
+    var events = dragEventNames(e);
+    var dragEl = selectedEl;
+    var originValue = handle.value;
+    var startX = e.clientX;
+    var startY = e.clientY;
+    hoveredSpacingHandleKey = key;
+    selectedSpacingHovered = true;
+    spacingDrag = {
+      handle: handle,
+      currentValue: originValue,
+      mirrorOpposite: !!e.altKey,
+    };
+    showSpacingBadgeForHandle(handle, originValue);
+
+    function onMove(ev) {
+      if (!dragEl || !document.documentElement.contains(dragEl)) return;
+      var nextValue = spacingValueFromPointer(handle, originValue, startX, startY, ev.clientX, ev.clientY);
+      spacingDrag = {
+        handle: handle,
+        currentValue: nextValue,
+        mirrorOpposite: !!ev.altKey,
+      };
+      applySpacingDragValue(dragEl, handle, nextValue, !!ev.altKey);
+      positionOverlay(selectionOverlay, dragEl);
+      showSpacingBadgeForHandle(handle, nextValue);
+    }
+
+    function onUp(ev) {
+      document.removeEventListener(events.move, onMove, true);
+      document.removeEventListener(events.up, onUp, true);
+      if (!dragEl || !document.documentElement.contains(dragEl)) {
+        spacingDrag = null;
+        return;
+      }
+      var finalValue = spacingDrag ? spacingDrag.currentValue : originValue;
+      var mirrorOpposite = spacingDrag ? spacingDrag.mirrorOpposite : !!ev.altKey;
+      applySpacingDragValue(dragEl, handle, finalValue, mirrorOpposite);
+      selectedEl = dragEl;
+      spacingDrag = null;
+      var styles = {};
+      styles[handle.property] = finalValue + 'px';
+      if (handle.kind === 'padding' && mirrorOpposite && handle.oppositeProperty) {
+        styles[handle.oppositeProperty] = finalValue + 'px';
+      }
+      postVisualStyleChange(styles);
+      positionOverlay(selectionOverlay, dragEl);
+    }
+
+    document.addEventListener(events.move, onMove, true);
+    document.addEventListener(events.up, onUp, true);
+  }
+
 	  function postTextContentChange(el, value, html) {
 	    window.parent.postMessage({
 	      type: 'text-content-change',
@@ -1404,7 +1907,14 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
   }
 
   function isOverlayElement(el) {
-    return Boolean(el && el.getAttribute && el.getAttribute('data-agent-native-edit-overlay'));
+    // Use closest() so that children of overlay elements (e.g. spacing-region
+    // spans inside selectionOverlay that have pointer-events:auto via a CSS rule
+    // and can therefore still be returned by elementFromPoint even when the
+    // parent overlay has pointer-events:none set inline) are also treated as
+    // overlay elements and never used as drag-drop anchor targets.
+    return Boolean(
+      el && el.closest && el.closest('[data-agent-native-edit-overlay]')
+    );
   }
 
   function draggableElementChildren(parent) {
@@ -1418,9 +1928,40 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
     if (el === document.body || el === document.documentElement) return false;
     var cs = window.getComputedStyle(el);
     if (cs.position === 'absolute' || cs.position === 'fixed') return false;
-    var parent = el.parentElement;
-    if (parent === document.body && draggableElementChildren(parent).length <= 2) return false;
-    return draggableElementChildren(parent).filter(function(child) { return child !== el; }).length > 0;
+    return true;
+  }
+
+  // keep in sync with EditPanel.tsx CONTAINER_TAGS/LEAF_TAGS (~line 1574)
+  var BRIDGE_CONTAINER_TAGS = ['div', 'section', 'main', 'header', 'footer', 'nav', 'article', 'aside', 'form', 'ul', 'ol', 'figure', 'fieldset', 'details', 'dialog', 'blockquote', 'table', 'tbody', 'thead', 'tr'];
+  var BRIDGE_LEAF_TAGS = ['img', 'video', 'picture', 'audio', 'canvas', 'svg', 'path', 'input', 'textarea', 'select', 'br', 'hr', 'iframe'];
+  var BRIDGE_TEXT_TAGS = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'span', 'a', 'strong', 'em', 'label', 'li'];
+
+  function isContainerDropTarget(el) {
+    if (!el || el === document.documentElement) return false;
+    if (isOverlayElement(el) || isLayerInteractionBlocked(el)) return false;
+    if (el === document.body) return true;
+    var tag = (el.tagName || '').toLowerCase();
+    // Reject leaf/text tags — they cannot accept children
+    if (BRIDGE_LEAF_TAGS.indexOf(tag) !== -1 || BRIDGE_TEXT_TAGS.indexOf(tag) !== -1) return false;
+    var cs = window.getComputedStyle(el);
+    if (
+      cs.display === 'flex' ||
+      cs.display === 'inline-flex' ||
+      cs.display === 'grid' ||
+      cs.display === 'inline-grid'
+    ) {
+      return true;
+    }
+    return BRIDGE_CONTAINER_TAGS.indexOf(tag) !== -1;
+  }
+
+  function edgePlacementForRect(rect, axis, clientX, clientY) {
+    var size = axis === 'x' ? rect.width : rect.height;
+    if (!size) return null;
+    var offset = axis === 'x' ? clientX - rect.left : clientY - rect.top;
+    if (offset < size * 0.22) return 'before';
+    if (offset > size * 0.78) return 'after';
+    return null;
   }
 
   function parentFlowAxis(parent) {
@@ -1445,18 +1986,19 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
     var hit = elementFromEditorPoint(clientX, clientY);
     if (
       hit &&
-      hit !== document.body &&
       hit !== document.documentElement &&
       hit !== el &&
       !el.contains(hit) &&
-      !hit.contains(el) &&
       !isOverlayElement(hit)
     ) {
-      var hitChildren = draggableElementChildren(hit).filter(function(child) {
-        return child !== el;
-      });
-      if (hitChildren.length === 0) {
-        return { anchor: hit, placement: 'inside', axis: parentFlowAxis(hit) };
+      if (isContainerDropTarget(hit)) {
+        var containerRect = hit.getBoundingClientRect();
+        var edgeAxis = hit.parentElement ? parentFlowAxis(hit.parentElement) : parentFlowAxis(hit);
+        var edgePlacement = edgePlacementForRect(containerRect, edgeAxis, clientX, clientY);
+        if (!edgePlacement) {
+          return { anchor: hit, placement: 'inside', axis: parentFlowAxis(hit) };
+        }
+        return { anchor: hit, placement: edgePlacement, axis: edgeAxis };
       }
       var hitParent = hit.parentElement;
       if (hitParent) {
@@ -1503,6 +2045,7 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
     insertionGuide.style.display = 'block';
     insertionGuide.style.background = 'var(--design-editor-accent-color)';
     insertionGuide.style.border = '0';
+    insertionGuide.style.borderRadius = '999px';
     insertionGuide.style.boxShadow = '0 0 0 1px var(--design-editor-accent-color)';
     if (target.placement === 'inside') {
       insertionGuide.style.left = rect.left + 'px';
@@ -1511,6 +2054,7 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
       insertionGuide.style.height = rect.height + 'px';
       insertionGuide.style.background = 'color-mix(in srgb, var(--design-editor-accent-color) 14%, transparent)';
       insertionGuide.style.border = '2px solid var(--design-editor-accent-color)';
+      insertionGuide.style.borderRadius = '4px';
       insertionGuide.style.boxShadow = 'none';
       return;
     }
@@ -1578,6 +2122,8 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
     if (isLayerInteractionBlocked(selectedEl)) return;
     e.preventDefault();
     e.stopPropagation();
+    if (e.stopImmediatePropagation) e.stopImmediatePropagation();
+    var events = dragEventNames(e);
     var originalSelectedEl = selectedEl;
     var duplicatedForDrag = false;
     if (e.altKey && selectedEl !== document.body && selectedEl !== document.documentElement) {
@@ -1601,8 +2147,8 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
         showTransformBadge(currentTarget ? 'Move layer' : 'Move', ev.clientX, ev.clientY);
       }
       function onReorderUp() {
-        document.removeEventListener('mousemove', onReorderMove, true);
-        document.removeEventListener('mouseup', onReorderUp, true);
+        document.removeEventListener(events.move, onReorderMove, true);
+        document.removeEventListener(events.up, onReorderUp, true);
 	        hideTransformBadge();
 	        hideInsertionGuide();
 	        if (!currentTarget) {
@@ -1630,9 +2176,9 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
 	          applyRuntimeReorder(reorderEl, currentTarget);
 	          postVisualStructureChange(reorderEl, currentTarget, { prevParent: prevParent, prevNextSibling: prevNextSibling });
 	        }
-	      }
-      document.addEventListener('mousemove', onReorderMove, true);
-      document.addEventListener('mouseup', onReorderUp, true);
+      }
+      document.addEventListener(events.move, onReorderMove, true);
+      document.addEventListener(events.up, onReorderUp, true);
       return;
     }
     ensurePositionable(selectedEl);
@@ -1659,8 +2205,8 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
       refreshOverlays();
     }
     function onUp() {
-      document.removeEventListener('mousemove', onMove, true);
-      document.removeEventListener('mouseup', onUp, true);
+      document.removeEventListener(events.move, onMove, true);
+      document.removeEventListener(events.up, onUp, true);
       hideTransformBadge();
       if (!dragEl) return;
       if (duplicatedForDrag && !moved) {
@@ -1686,8 +2232,8 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
         }, '*');
       }
     }
-    document.addEventListener('mousemove', onMove, true);
-    document.addEventListener('mouseup', onUp, true);
+    document.addEventListener(events.move, onMove, true);
+    document.addEventListener(events.up, onUp, true);
   }
 
   function startResize(handle, e) {
@@ -1864,7 +2410,68 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
     document.addEventListener('mouseup', onUp, true);
   }
 
+  function clearPendingShieldDrag() {
+    if (!pendingShieldDrag) return;
+    document.removeEventListener(pendingShieldDrag.move, pendingShieldDrag.onMove, true);
+    document.removeEventListener(pendingShieldDrag.up, pendingShieldDrag.onUp, true);
+    pendingShieldDrag = null;
+  }
+
+  function beginPotentialShieldDrag(e) {
+    stopNativeInteraction(e);
+    if (e.button !== 0 || activeTextEditEl) return;
+    var events = dragEventNames(e);
+    var hit = elementFromEditorPoint(e.clientX, e.clientY);
+    if (!hit || hit === document.body || hit === document.documentElement) return;
+    var dragTarget =
+      selectedEl &&
+      document.documentElement.contains(selectedEl) &&
+      selectedEl.contains(hit)
+        ? selectedEl
+        : selectionTargetForHit(hit);
+    if (
+      !dragTarget ||
+      dragTarget === document.body ||
+      dragTarget === document.documentElement ||
+      isLayerInteractionBlocked(dragTarget)
+    ) {
+      return;
+    }
+    var startX = e.clientX;
+    var startY = e.clientY;
+    var didStartDrag = false;
+    function selectDragTarget() {
+      selectedEl = dragTarget;
+      positionOverlay(selectionOverlay, selectedEl);
+      window.parent.postMessage({ type: 'element-select', payload: getElementInfo(selectedEl) }, '*');
+    }
+    function onMove(ev) {
+      if (Math.hypot(ev.clientX - startX, ev.clientY - startY) <= 3) return;
+      clearPendingShieldDrag();
+      didStartDrag = true;
+      selectDragTarget();
+      suppressNextShieldClickBriefly();
+      startMove(ev);
+    }
+    function onUp(ev) {
+      clearPendingShieldDrag();
+      if (didStartDrag) return;
+      if (ev) stopNativeInteraction(ev);
+      selectDragTarget();
+      suppressNextShieldClickBriefly();
+    }
+    clearPendingShieldDrag();
+    pendingShieldDrag = { move: events.move, up: events.up, onMove: onMove, onUp: onUp };
+    document.addEventListener(events.move, onMove, true);
+    document.addEventListener(events.up, onUp, true);
+  }
+
   selectionOverlay.addEventListener('mousedown', function(e) {
+    var spacingKey = e.target && e.target.getAttribute && e.target.getAttribute('data-spacing-key');
+    if (spacingKey) {
+      startSpacingDrag(spacingKey, e);
+      return;
+    }
     var resizeHandle = e.target && e.target.getAttribute && e.target.getAttribute('data-agent-native-edit-handle');
     if (!resizeHandle && e.target && e.target.getAttribute) {
       resizeHandle = e.target.getAttribute('data-agent-native-edge-handle');
@@ -1880,6 +2487,8 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
     }
     startMove(e);
   }, true);
+
+  shieldOverlay.addEventListener('pointerdown', beginPotentialShieldDrag, true);
 
   ['pointerdown','pointerup','mousedown','mouseup','auxclick'].forEach(function(type) {
     shieldOverlay.addEventListener(type, stopNativeInteraction, true);
@@ -2050,10 +2659,25 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
     hoveredEl = elementFromEditorPoint(e.clientX, e.clientY);
     if (!hoveredEl) {
       highlightOverlay.style.display = 'none';
+      if (!spacingDrag) {
+        selectedSpacingHovered = false;
+        hoveredSpacingHandleKey = '';
+        updateSpacingOverlay(selectedEl);
+      }
       hideMeasurements();
       return;
     }
     if (hoveredEl && hoveredEl.closest('[data-agent-native-text-editing]')) return;
+    if (!spacingDrag) {
+      selectedSpacingHovered = Boolean(
+        selectedEl &&
+          hoveredEl &&
+          (hoveredEl === selectedEl ||
+            (selectedEl.contains && selectedEl.contains(hoveredEl))),
+      );
+      if (!selectedSpacingHovered) hoveredSpacingHandleKey = '';
+      updateSpacingOverlay(selectedEl);
+    }
     if (hoveredEl === selectedEl) {
       highlightOverlay.style.display = 'none';
     } else {
@@ -2071,6 +2695,11 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
   shieldOverlay.addEventListener('pointerleave', function(e) {
     stopNativeInteraction(e);
     hoveredEl = null;
+    if (!spacingDrag) {
+      selectedSpacingHovered = false;
+      hoveredSpacingHandleKey = '';
+      updateSpacingOverlay(selectedEl);
+    }
     highlightOverlay.style.display = 'none';
     hideMeasurements();
     window.parent.postMessage({ type: 'element-hover', payload: null }, '*');
@@ -2130,6 +2759,8 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
         } catch (_err) {}
       }
       if (!target) return;
+      selectedSpacingHovered = false;
+      hoveredSpacingHandleKey = '';
       selectedEl = target;
       positionOverlay(selectionOverlay, target);
       if (hoveredEl === selectedEl) highlightOverlay.style.display = 'none';
@@ -2540,9 +3171,15 @@ export function DesignCanvas({
         const placement = String(e.data.placement || "after");
         const requestId =
           typeof e.data.requestId === "string" ? e.data.requestId : undefined;
+        const sourceId =
+          typeof e.data.sourceId === "string" ? e.data.sourceId : undefined;
+        const anchorSourceId =
+          typeof e.data.anchorSourceId === "string"
+            ? e.data.anchorSourceId
+            : undefined;
         if (
-          selector &&
-          anchorSelector &&
+          (selector || sourceId) &&
+          (anchorSelector || anchorSourceId) &&
           (placement === "before" ||
             placement === "after" ||
             placement === "inside")
@@ -2554,14 +3191,8 @@ export function DesignCanvas({
             e.data.payload,
             {
               requestId,
-              sourceId:
-                typeof e.data.sourceId === "string"
-                  ? e.data.sourceId
-                  : undefined,
-              anchorSourceId:
-                typeof e.data.anchorSourceId === "string"
-                  ? e.data.anchorSourceId
-                  : undefined,
+              sourceId,
+              anchorSourceId,
             },
           );
           if (requestId) {

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -2263,7 +2263,7 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
     return true;
   }
 
-  // keep in sync with EditPanel.tsx CONTAINER_TAGS/LEAF_TAGS (~line 1574)
+  // keep in sync with EditPanel.tsx CONTAINER_TAGS/LEAF_TAGS (~line 1679)
   var BRIDGE_CONTAINER_TAGS = ['div', 'section', 'main', 'header', 'footer', 'nav', 'article', 'aside', 'form', 'ul', 'ol', 'figure', 'fieldset', 'details', 'dialog', 'blockquote', 'table', 'tbody', 'thead', 'tr'];
   var BRIDGE_LEAF_TAGS = ['img', 'video', 'picture', 'audio', 'canvas', 'svg', 'path', 'input', 'textarea', 'select', 'br', 'hr', 'iframe'];
   var BRIDGE_TEXT_TAGS = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'span', 'a', 'strong', 'em', 'label', 'li'];
@@ -2473,16 +2473,96 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
       var reorderEl = selectedEl;
       var currentTarget = reorderTargetForPoint(reorderEl, e.clientX, e.clientY);
       showInsertionGuideFor(currentTarget);
+      // Cross-screen drag state: true when the pointer is outside this iframe's
+      // viewport bounds.  The host frame renders the ghost + highlight and owns
+      // the drop when this is true; the bridge suppresses its in-iframe reorder.
+      var pointerOutsideIframe = false;
+      var reorderSelector = getSelector(reorderEl);
+      var reorderSourceId = getSourceId(reorderEl);
       function onReorderMove(ev) {
-        currentTarget = reorderTargetForPoint(reorderEl, ev.clientX, ev.clientY);
-        showInsertionGuideFor(currentTarget);
-        showTransformBadge(currentTarget ? 'Move layer' : 'Move', ev.clientX, ev.clientY);
+        var vw = window.innerWidth;
+        var vh = window.innerHeight;
+        var cx = ev.clientX;
+        var cy = ev.clientY;
+        var outside = cx < 0 || cy < 0 || cx > vw || cy > vh;
+        pointerOutsideIframe = outside;
+        // Always notify the host frame so it can track the cursor position,
+        // render the ghost, and highlight the target screen.
+        window.parent.postMessage({
+          type: 'agent-native:cross-screen-drag',
+          phase: 'move',
+          selector: reorderSelector,
+          sourceId: reorderSourceId,
+          iframeX: cx,
+          iframeY: cy,
+          viewportW: vw,
+          viewportH: vh,
+        }, '*');
+        if (outside) {
+          // Cursor left this iframe — hide the in-iframe insertion guide so
+          // it does not render while the host shows a cross-screen drop target.
+          hideInsertionGuide();
+          showTransformBadge('Move layer', cx, cy);
+        } else {
+          // Cursor is inside this iframe — use existing in-iframe behavior.
+          currentTarget = reorderTargetForPoint(reorderEl, cx, cy);
+          showInsertionGuideFor(currentTarget);
+          showTransformBadge(currentTarget ? 'Move layer' : 'Move', cx, cy);
+        }
       }
-      function onReorderUp() {
+      function onReorderEscape() {
         document.removeEventListener(events.move, onReorderMove, true);
         document.removeEventListener(events.up, onReorderUp, true);
+        document.removeEventListener('keydown', onReorderKeyDown, true);
+        hideTransformBadge();
+        hideInsertionGuide();
+        window.parent.postMessage({ type: 'agent-native:cross-screen-drag', phase: 'cancel' }, '*');
+        // Revert any clone that was inserted for alt-drag.
+        if (duplicatedForDrag && reorderEl && reorderEl !== originalSelectedEl) {
+          if (reorderEl.parentElement) reorderEl.parentElement.removeChild(reorderEl);
+          selectedEl = originalSelectedEl;
+          positionOverlay(selectionOverlay, selectedEl);
+          window.parent.postMessage({ type: 'element-select', payload: getElementInfo(selectedEl) }, '*');
+        }
+      }
+      function onReorderKeyDown(ev) {
+        if (ev.key === 'Escape') {
+          ev.preventDefault();
+          ev.stopPropagation();
+          if (ev.stopImmediatePropagation) ev.stopImmediatePropagation();
+          onReorderEscape();
+        }
+      }
+      function onReorderUp(ev) {
+        document.removeEventListener(events.move, onReorderMove, true);
+        document.removeEventListener(events.up, onReorderUp, true);
+        document.removeEventListener('keydown', onReorderKeyDown, true);
 	        hideTransformBadge();
 	        hideInsertionGuide();
+        var vw = window.innerWidth;
+        var vh = window.innerHeight;
+        var cx = ev ? ev.clientX : 0;
+        var cy = ev ? ev.clientY : 0;
+        var outsideOnDrop = cx < 0 || cy < 0 || cx > vw || cy > vh;
+        // Post the end message so the host can finalize a cross-screen drop.
+        window.parent.postMessage({
+          type: 'agent-native:cross-screen-drag',
+          phase: 'end',
+          selector: reorderSelector,
+          sourceId: reorderSourceId,
+          iframeX: cx,
+          iframeY: cy,
+          viewportW: vw,
+          viewportH: vh,
+        }, '*');
+        // When the pointer is outside this iframe at release, the host owns the
+        // move (cross-screen drop).  Do NOT apply the in-iframe reorder so we
+        // avoid a ghost element left in screen A's DOM.
+        // Use outsideOnDrop only — pointerOutsideIframe is stale when the user
+        // briefly exits the iframe and re-enters before releasing.  The host
+        // already clears cross-screen state on re-entry so checking the
+        // momentary excursion flag here would wrongly drop the element nowhere.
+        if (outsideOnDrop) return;
 	        if (!currentTarget) {
 	          // No valid drop target — clean up the clone if one was inserted so
 	          // no ghost element is left in the DOM.
@@ -2511,6 +2591,7 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
       }
       document.addEventListener(events.move, onReorderMove, true);
       document.addEventListener(events.up, onReorderUp, true);
+      document.addEventListener('keydown', onReorderKeyDown, true);
       return;
     }
     ensurePositionable(selectedEl);

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -744,18 +744,16 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
     // data-loc may encode "file:line:col" (Babel source plugin convention).
     // Only parse it when data-source-file is absent, to avoid double-reads.
     if (!dataSourceFile && dataLoc) {
-      var locParts = dataLoc.split(':');
-      // Expect at least "file:line" or "file:line:col"; guard against bare ids.
-      if (locParts.length >= 2) {
-        var maybeFile = locParts[0];
-        var maybeLine = Number(locParts[locParts.length >= 3 ? locParts.length - 2 : locParts.length - 1]);
-        var maybeCol = locParts.length >= 3 ? Number(locParts[locParts.length - 1]) : undefined;
-        // Only treat as provenance when file part looks path-like.
-        if (maybeFile && maybeFile.length > 0 && !isNaN(maybeLine)) {
-          dataSourceFile = maybeFile;
-          dataSourceLine = String(maybeLine);
-          if (maybeCol !== undefined && !isNaN(maybeCol)) dataSourceColumn = String(maybeCol);
-        }
+      var lastColonIndex = dataLoc.lastIndexOf(':');
+      var lastPart = lastColonIndex >= 0 ? dataLoc.slice(lastColonIndex + 1) : '';
+      if (lastColonIndex >= 0 && /^\\d+$/.test(lastPart)) {
+        var beforeLastPart = dataLoc.slice(0, lastColonIndex);
+        var previousColonIndex = beforeLastPart.lastIndexOf(':');
+        var previousPart = previousColonIndex >= 0 ? beforeLastPart.slice(previousColonIndex + 1) : '';
+        var hasColumn = /^\\d+$/.test(previousPart);
+        dataSourceFile = hasColumn ? beforeLastPart.slice(0, previousColonIndex) : beforeLastPart;
+        dataSourceLine = hasColumn ? previousPart : lastPart;
+        if (hasColumn) dataSourceColumn = lastPart;
       }
     }
     if (dataSourceFile || dataSourceLine || dataSourceColumn || dataComponentName) {

--- a/templates/design/app/components/design/EditPanel.tsx
+++ b/templates/design/app/components/design/EditPanel.tsx
@@ -59,6 +59,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { useParams } from "react-router";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -117,6 +118,7 @@ import {
 } from "./inspector";
 import { IconLayoutSettings } from "./inspector/design-icons";
 import type { DesignPaintType } from "./inspector/DesignColorPicker";
+import { InspectorAiActions } from "./inspector/InspectorAiActions";
 import { TweaksPanelContent } from "./TweaksPanel";
 import type { ElementInfo } from "./types";
 
@@ -137,9 +139,17 @@ interface EditPanelProps {
   onRequestTweaks?: (anchor: HTMLElement) => void;
   onStyleChange: (property: string, value: string) => void;
   onStylesChange?: (styles: Record<string, string>) => void;
+  onAutoLayoutConvert?: (
+    targetNodeId: string,
+    opts?: { direction?: "row" | "column"; gap?: string },
+  ) => void;
   onExport?: (settings: ExportSettingsValue[]) => void;
   exporting?: boolean;
   readOnly?: boolean;
+  /** Active file id — forwarded to InspectorAiActions for agent context. */
+  fileId?: string;
+  /** Active file name (e.g. "index.html") — forwarded to InspectorAiActions. */
+  filename?: string;
 }
 
 /**
@@ -2959,10 +2969,15 @@ function FlexContainerControls({
   element,
   onStyleChange,
   onStylesChange,
+  onAutoLayoutConvert,
 }: {
   element: ElementInfo;
   onStyleChange: (property: string, value: string) => void;
   onStylesChange?: (styles: Record<string, string>) => void;
+  onAutoLayoutConvert?: (
+    targetNodeId: string,
+    opts?: { direction?: "row" | "column"; gap?: string },
+  ) => void;
 }) {
   const t = useT();
   const styles = element.computedStyles;
@@ -2982,6 +2997,47 @@ function FlexContainerControls({
   // alone is a no-op against a block element.
   const ensureFlex = () => {
     if (!isFlex) onStyleChange("display", "flex");
+  };
+
+  /**
+   * Handle the Flow control switching between flex and normal-flow (block).
+   *
+   * For 'flex': ensures display:flex is set (ensureFlex path).
+   * For 'block': sets display:block and leaves children unchanged — mirrors
+   * the { kind:"autoLayout", enabled:false } substrate intent exactly.
+   */
+  const handleDisplayChange = (nextDisplay: "flex" | "block") => {
+    if (nextDisplay === "flex") {
+      ensureFlex();
+      return;
+    }
+    // Turn auto-layout off: set display:block, leaving children unchanged.
+    // This is the direct equivalent of the autoLayout substrate with enabled:false.
+    onStyleChange("display", "block");
+  };
+
+  /**
+   * "Convert to auto layout" — enables flex on a non-flex container and strips
+   * position:absolute from direct children (full reflow via the autoLayout
+   * substrate intent). Falls back to a style-only patch when no substrate
+   * handler is wired (e.g. read-only or non-editable contexts).
+   */
+  const handleConvertToAutoLayout = () => {
+    if (onAutoLayoutConvert && element.sourceId) {
+      onAutoLayoutConvert(element.sourceId, { direction: "row", gap: "8px" });
+      return;
+    }
+    // Fallback: set display:flex on the parent only (no child strip).
+    commitStylePatch(
+      {
+        display: "flex",
+        flexDirection: "row",
+        gap: "8px",
+        alignItems: "flex-start",
+      },
+      onStyleChange,
+      onStylesChange,
+    );
   };
   const padding = {
     top: parseNumericValue(styles.paddingTop || "0"),
@@ -3029,8 +3085,22 @@ function FlexContainerControls({
 
   return (
     <div className="space-y-2">
+      {/* Convert to auto layout — shown when the container is not yet flex */}
+      {!isFlex ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 w-full gap-1.5 text-[11px]"
+          onClick={handleConvertToAutoLayout}
+        >
+          <IconLayoutSettings className="size-3.5 shrink-0" />
+          {"Convert to auto layout" /* i18n-ignore design inspector action */}
+        </Button>
+      ) : null}
       <AutoLayoutMatrix
         value={autoLayoutValue}
+        onDisplayChange={handleDisplayChange}
         onDirectionChange={(direction) => {
           ensureFlex();
           onStyleChange(
@@ -3214,10 +3284,15 @@ function LayoutContextProperties({
   element,
   onStyleChange,
   onStylesChange,
+  onAutoLayoutConvert,
 }: {
   element: ElementInfo;
   onStyleChange: (property: string, value: string) => void;
   onStylesChange?: (styles: Record<string, string>) => void;
+  onAutoLayoutConvert?: (
+    targetNodeId: string,
+    opts?: { direction?: "row" | "column"; gap?: string },
+  ) => void;
 }) {
   const t = useT();
   const flexChild = isParentFlex(element);
@@ -3310,6 +3385,7 @@ function LayoutContextProperties({
         element={element}
         onStyleChange={onStyleChange}
         onStylesChange={onStylesChange}
+        onAutoLayoutConvert={onAutoLayoutConvert}
       />
       {childControls}
     </PanelSection>
@@ -4671,11 +4747,17 @@ export function EditPanel({
   onRequestTweaks,
   onStyleChange,
   onStylesChange,
+  onAutoLayoutConvert,
   onExport,
   exporting = false,
   readOnly = false,
+  fileId,
+  filename,
 }: EditPanelProps) {
   const t = useT();
+  // Source designId from the URL so we don't need to thread it as a prop
+  // through DesignEditor. The design editor always mounts under /design/:id.
+  const { id: designId } = useParams<{ id: string }>();
   const [exportSettings, setExportSettings] = useState<ExportSettingsValue>(
     DEFAULT_EXPORT_SETTINGS,
   );
@@ -4846,6 +4928,7 @@ export function EditPanel({
                   element={selectedElement}
                   onStyleChange={onStyleChange}
                   onStylesChange={onStylesChange}
+                  onAutoLayoutConvert={onAutoLayoutConvert}
                 />
                 <AppearanceProperties
                   element={selectedElement}
@@ -4882,6 +4965,17 @@ export function EditPanel({
                     onStyleChange={onStyleChange}
                   />
                 ) : null}
+                {/* AI edit request block — collapsible, collapsed by default */}
+                <section className="shrink-0 border-t border-[var(--design-editor-control-border)]">
+                  <InspectorAiActions
+                    selector={selectedElement.selector}
+                    sourceId={selectedElement.sourceId}
+                    designId={designId}
+                    fileId={fileId}
+                    filename={filename}
+                    canEdit={!readOnly}
+                  />
+                </section>
               </>
             )}
             {onExport ? (

--- a/templates/design/app/components/design/LocalSourceEditBanner.tsx
+++ b/templates/design/app/components/design/LocalSourceEditBanner.tsx
@@ -1,0 +1,157 @@
+import { useT } from "@agent-native/core/client";
+import {
+  IconInfoCircle,
+  IconMessageBolt,
+  IconClipboard,
+  IconX,
+} from "@tabler/icons-react";
+import { useState } from "react";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { useAgentEditRequest } from "@/hooks/useAgentEditRequest";
+
+export interface LocalSourceEditBannerProps {
+  /** The design id for agent context. */
+  designId: string;
+  /** The active file id for agent context, if known. */
+  fileId?: string;
+  /** Path to the localhost source file that should receive edits, if known. */
+  routeSourceFile?: string;
+  /** Called when the user dismisses the banner. */
+  onDismiss?: () => void;
+}
+
+/**
+ * Dismissible informational banner shown for screens connected to a local
+ * source (localhost / React dev server). Explains that edits are routed
+ * through the AI agent rather than applied directly, and provides quick
+ * "Ask AI to edit" and "Copy prompt" affordances.
+ */
+export function LocalSourceEditBanner({
+  designId,
+  fileId,
+  routeSourceFile,
+  onDismiss,
+}: LocalSourceEditBannerProps) {
+  const t = useT();
+  const { sendEdit, copyPrompt } = useAgentEditRequest();
+  const [promptOpen, setPromptOpen] = useState(false);
+  const [request, setRequest] = useState("");
+
+  const baseArgs = { designId, fileId, routeSourceFile };
+  const submitArgs = { ...baseArgs, message: request };
+  const trimmed = request.trim();
+
+  return (
+    <>
+      <Alert className="relative flex items-start gap-2 rounded-none border-x-0 border-t-0 py-2 px-3 text-xs">
+        <IconInfoCircle className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+        <AlertDescription className="flex flex-1 flex-col gap-1.5 text-xs leading-snug">
+          <span>{t("designEditor.localSourceEdit.bannerNotice")}</span>
+          <div className="flex flex-wrap gap-1.5">
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-6 gap-1 px-2 text-[11px]"
+              onClick={() => setPromptOpen(true)}
+            >
+              <IconMessageBolt className="size-3 shrink-0" />
+              {t("designEditor.localSourceEdit.askAiToEdit")}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-6 gap-1 px-2 text-[11px] text-muted-foreground"
+              onClick={() => {
+                void copyPrompt({
+                  ...baseArgs,
+                  message: routeSourceFile
+                    ? `Edit the connected source file "${routeSourceFile}" as requested.`
+                    : "Edit the connected source code as requested.",
+                });
+              }}
+            >
+              <IconClipboard className="size-3 shrink-0" />
+              {t("designEditor.localSourceEdit.copyPrompt")}
+            </Button>
+          </div>
+        </AlertDescription>
+        {onDismiss && (
+          <button
+            type="button"
+            aria-label={t("designEditor.dismiss")}
+            onClick={onDismiss}
+            className="absolute end-2 top-2 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+          >
+            <IconX className="size-3.5" />
+          </button>
+        )}
+      </Alert>
+
+      <Dialog open={promptOpen} onOpenChange={setPromptOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {t("designEditor.localSourceEdit.dialogTitle")}
+            </DialogTitle>
+            <DialogDescription>
+              {routeSourceFile
+                ? t("designEditor.localSourceEdit.dialogDescriptionFile", {
+                    file: routeSourceFile,
+                  })
+                : t("designEditor.localSourceEdit.dialogDescription")}
+            </DialogDescription>
+          </DialogHeader>
+          <Textarea
+            autoFocus
+            value={request}
+            onChange={(e) => setRequest(e.target.value)}
+            placeholder={t("designEditor.localSourceEdit.requestPlaceholder")}
+            className="min-h-[96px] resize-none"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && trimmed) {
+                e.preventDefault();
+                void sendEdit(submitArgs);
+                setRequest("");
+                setPromptOpen(false);
+              }
+            }}
+          />
+          <DialogFooter className="gap-2">
+            <Button
+              variant="ghost"
+              onClick={() => {
+                void copyPrompt(submitArgs);
+              }}
+              disabled={!trimmed}
+            >
+              <IconClipboard className="size-4" />
+              {t("designEditor.localSourceEdit.copyPrompt")}
+            </Button>
+            <Button
+              onClick={() => {
+                void sendEdit(submitArgs);
+                setRequest("");
+                setPromptOpen(false);
+              }}
+              disabled={!trimmed}
+            >
+              <IconMessageBolt className="size-4" />
+              {t("designEditor.localSourceEdit.askAiToEdit")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/templates/design/app/components/design/MultiScreenCanvas.primitives.test.ts
+++ b/templates/design/app/components/design/MultiScreenCanvas.primitives.test.ts
@@ -41,11 +41,22 @@ function primEntry(
   };
 }
 
+/** Mirror the djb2-variant hash used by parsePrimitivesFromScreen.
+ *  Keep in sync with the `hashString` helper in MultiScreenCanvas.tsx. */
+function hashString(s: string): string {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) {
+    h = ((h << 5) + h) ^ s.charCodeAt(i);
+    h = h >>> 0;
+  }
+  return h.toString(16);
+}
+
 /** Inject pre-built primitives into the module cache so tests don't need
  *  DOMParser (unavailable in jsdom-less vitest). */
 function seedCache(screen: ScreenStub, prims: ParsedScreenPrimitive[]) {
-  // Cache key mirrors the fixed implementation: id:length:prefix48
-  const key = `${screen.id}:${screen.content.length}:${screen.content.slice(0, 48)}`;
+  // Cache key mirrors the implementation: id:length:hash(content)
+  const key = `${screen.id}:${screen.content.length}:${hashString(screen.content)}`;
   primitiveParseCache.set(key, prims);
 }
 
@@ -114,8 +125,13 @@ describe("primitiveLocalToBoardRect", () => {
 // ---------------------------------------------------------------------------
 // parsePrimitivesFromScreen cache key: regression for equal-length edits
 // ---------------------------------------------------------------------------
+/** Mirror parsePrimitivesFromScreen's cache key formula exactly. */
+function makeCacheKey(screen: { id: string; content: string }): string {
+  return `${screen.id}:${screen.content.length}:${hashString(screen.content)}`;
+}
+
 describe("parsePrimitivesFromScreen cache key", () => {
-  it("uses a different cache key when content changes with equal length (regression)", () => {
+  it("uses a different cache key when content changes with equal length, prefix differs", () => {
     const screenId = "cache-test";
     // Two different contents of the same length whose first 48 chars differ
     const contentA = "A".repeat(80);
@@ -136,9 +152,34 @@ describe("parsePrimitivesFromScreen cache key", () => {
     expect(contentA.length).toBe(contentB.length);
 
     // But the cache keys must differ (prefix differs)
-    const keyA = `${screenA.id}:${screenA.content.length}:${screenA.content.slice(0, 48)}`;
-    const keyB = `${screenB.id}:${screenB.content.length}:${screenB.content.slice(0, 48)}`;
-    expect(keyA).not.toBe(keyB);
+    expect(makeCacheKey(screenA)).not.toBe(makeCacheKey(screenB));
+  });
+
+  it("regression: different key when content differs only after position 48 (same prefix, same length)", () => {
+    // This is the collision the old prefix-only key failed to catch:
+    // same screenId, same length, same first 48 chars, but different body content.
+    // Real scenario: agent replaces a node-id at position 50 in the HTML.
+    const screenId = "cache-test";
+    const sharedPrefix = "X".repeat(48); // exactly 48 chars — prefix identical
+    const contentA = sharedPrefix + "A".repeat(52); // 100 chars total
+    const contentB = sharedPrefix + "B".repeat(52); // 100 chars total
+
+    const screenA: ScreenStub = {
+      id: screenId,
+      filename: "f.html",
+      content: contentA,
+    };
+    const screenB: ScreenStub = {
+      id: screenId,
+      filename: "f.html",
+      content: contentB,
+    };
+
+    expect(contentA.length).toBe(contentB.length);
+    expect(contentA.slice(0, 48)).toBe(contentB.slice(0, 48)); // confirms old formula collides
+
+    // New formula (prefix48 + suffix48) must produce different keys
+    expect(makeCacheKey(screenA)).not.toBe(makeCacheKey(screenB));
   });
 
   it("same content always produces same cache key", () => {
@@ -147,9 +188,39 @@ describe("parsePrimitivesFromScreen cache key", () => {
       filename: "a.html",
       content: "<div>",
     };
-    const key1 = `${screen.id}:${screen.content.length}:${screen.content.slice(0, 48)}`;
-    const key2 = `${screen.id}:${screen.content.length}:${screen.content.slice(0, 48)}`;
-    expect(key1).toBe(key2);
+    expect(makeCacheKey(screen)).toBe(makeCacheKey(screen));
+  });
+
+  it("regression: different key when edit is deep in the middle of a large HTML file", () => {
+    // The old prefix48+suffix48 formula collided when changes were in the middle
+    // zone [48..len-49].  Real case: an agent rewrites a node-id at character 200
+    // of a 2000-char HTML file.  The new hash-based key must differentiate these.
+    const screenId = "long-screen";
+    const prefix = "P".repeat(48);
+    const suffix = "S".repeat(48);
+    const middleA = "M".repeat(200); // change only in this middle zone
+    const middleB = "N".repeat(200);
+    const contentA = prefix + middleA + suffix; // 296 chars
+    const contentB = prefix + middleB + suffix;
+
+    const screenA: ScreenStub = {
+      id: screenId,
+      filename: "long.html",
+      content: contentA,
+    };
+    const screenB: ScreenStub = {
+      id: screenId,
+      filename: "long.html",
+      content: contentB,
+    };
+
+    // Confirm this is the scenario the old formula failed on:
+    expect(contentA.length).toBe(contentB.length);
+    expect(contentA.slice(0, 48)).toBe(contentB.slice(0, 48));
+    expect(contentA.slice(-48)).toBe(contentB.slice(-48));
+
+    // New hash-based formula must produce different keys:
+    expect(makeCacheKey(screenA)).not.toBe(makeCacheKey(screenB));
   });
 });
 
@@ -363,5 +434,48 @@ describe("resolveNodeScreenId", () => {
     ]);
 
     expect(resolveNodeScreenId("shared", [s1, s2])).toBe("s1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-screen coord translation: board coords from iframe coords
+// The cross-screen drag receiver uses the same formula as primitiveLocalToBoardRect
+// (boardX = frame.x + iframeX * (frame.width / metadata.width)).  Verify they
+// round-trip correctly and are consistent with each other.
+// ---------------------------------------------------------------------------
+describe("cross-screen coord translation (iframeX → boardX consistency)", () => {
+  it("board coords from iframe coords match primitiveLocalToBoardRect inversion", () => {
+    // Frame placed at (100, 200) on the board, 320×640 px.
+    // Logical design dimensions (metadata): 390×844 (iPhone-like).
+    const frameGeom = makeGeom(100, 200, 320, 640);
+    const meta = { width: 390, height: 844 };
+
+    // Suppose a primitive lives at local (localLeft=78, localTop=168) in the
+    // design's logical space.  Its board rect from primitiveLocalToBoardRect:
+    const boardRect = primitiveLocalToBoardRect(78, 168, 1, 1, frameGeom, meta);
+
+    // The cross-screen drag receiver computes:
+    //   scaleX = frame.width / metadata.width
+    //   boardX = frame.x + iframeX * scaleX
+    // If the pointer is at iframeX=78, iframeY=168 (same as the local coords):
+    const scaleX = frameGeom.width / Math.max(1, meta.width);
+    const scaleY = frameGeom.height / Math.max(1, meta.height);
+    const receiverBoardX = frameGeom.x + 78 * scaleX;
+    const receiverBoardY = frameGeom.y + 168 * scaleY;
+
+    // Both should land at the same board coordinates:
+    expect(receiverBoardX).toBeCloseTo(boardRect.x, 5);
+    expect(receiverBoardY).toBeCloseTo(boardRect.y, 5);
+  });
+
+  it("iframe pointer at (0,0) maps to frame origin on the board", () => {
+    const frameGeom = makeGeom(50, 80, 320, 640);
+    const meta = { width: 320, height: 640 };
+    const scaleX = frameGeom.width / Math.max(1, meta.width);
+    const scaleY = frameGeom.height / Math.max(1, meta.height);
+    const boardX = frameGeom.x + 0 * scaleX;
+    const boardY = frameGeom.y + 0 * scaleY;
+    expect(boardX).toBe(50);
+    expect(boardY).toBe(80);
   });
 });

--- a/templates/design/app/components/design/MultiScreenCanvas.primitives.test.ts
+++ b/templates/design/app/components/design/MultiScreenCanvas.primitives.test.ts
@@ -1,0 +1,367 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  getPrimitiveDropTargetForPoint,
+  ParsedScreenPrimitive,
+  primitiveLocalToBoardRect,
+  primitiveParseCache,
+  resolveNodeScreenId,
+  type FrameGeometry,
+} from "./MultiScreenCanvas";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type ScreenStub = { id: string; filename: string; content: string };
+
+function makeGeom(x: number, y: number, w: number, h: number): FrameGeometry {
+  return { x, y, width: w, height: h };
+}
+
+function primEntry(
+  nodeId: string,
+  screenId: string,
+  opts: {
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+    isContainer?: boolean;
+  },
+): ParsedScreenPrimitive {
+  return {
+    nodeId,
+    screenId,
+    localLeft: opts.left,
+    localTop: opts.top,
+    localWidth: opts.width,
+    localHeight: opts.height,
+    isContainer: opts.isContainer ?? true,
+  };
+}
+
+/** Inject pre-built primitives into the module cache so tests don't need
+ *  DOMParser (unavailable in jsdom-less vitest). */
+function seedCache(screen: ScreenStub, prims: ParsedScreenPrimitive[]) {
+  // Cache key mirrors the fixed implementation: id:length:prefix48
+  const key = `${screen.id}:${screen.content.length}:${screen.content.slice(0, 48)}`;
+  primitiveParseCache.set(key, prims);
+}
+
+// ---------------------------------------------------------------------------
+// Setup: clear the module-level cache before every test so tests are isolated
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  primitiveParseCache.clear();
+});
+
+// ---------------------------------------------------------------------------
+// primitiveLocalToBoardRect
+// ---------------------------------------------------------------------------
+describe("primitiveLocalToBoardRect", () => {
+  it("correctly converts screen-local coords to board coords at 4× scale", () => {
+    // Board frame: 320×640 at (100,200). Metadata: 1280×2560 (4× larger).
+    const result = primitiveLocalToBoardRect(
+      640,
+      1280,
+      256,
+      512,
+      makeGeom(100, 200, 320, 640),
+      { width: 1280, height: 2560 },
+    );
+    expect(result.x).toBeCloseTo(260);
+    expect(result.y).toBeCloseTo(520);
+    expect(result.width).toBeCloseTo(64);
+    expect(result.height).toBeCloseTo(128);
+  });
+
+  it("is a no-op when metadata size equals frame size", () => {
+    const result = primitiveLocalToBoardRect(
+      50,
+      100,
+      80,
+      160,
+      makeGeom(0, 0, 400, 800),
+      { width: 400, height: 800 },
+    );
+    expect(result).toEqual({ x: 50, y: 100, width: 80, height: 160 });
+  });
+
+  it("clamps width/height to minimum 1 for tiny local sizes", () => {
+    const result = primitiveLocalToBoardRect(
+      0,
+      0,
+      0.1,
+      0.1,
+      makeGeom(0, 0, 320, 640),
+      { width: 320, height: 640 },
+    );
+    expect(result.width).toBeGreaterThanOrEqual(1);
+    expect(result.height).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not throw on zero metadata dimensions", () => {
+    expect(() =>
+      primitiveLocalToBoardRect(0, 0, 10, 10, makeGeom(0, 0, 320, 640), {
+        width: 0,
+        height: 0,
+      }),
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parsePrimitivesFromScreen cache key: regression for equal-length edits
+// ---------------------------------------------------------------------------
+describe("parsePrimitivesFromScreen cache key", () => {
+  it("uses a different cache key when content changes with equal length (regression)", () => {
+    const screenId = "cache-test";
+    // Two different contents of the same length whose first 48 chars differ
+    const contentA = "A".repeat(80);
+    const contentB = "B".repeat(80);
+
+    const screenA: ScreenStub = {
+      id: screenId,
+      filename: "f.html",
+      content: contentA,
+    };
+    const screenB: ScreenStub = {
+      id: screenId,
+      filename: "f.html",
+      content: contentB,
+    };
+
+    // Content lengths are equal
+    expect(contentA.length).toBe(contentB.length);
+
+    // But the cache keys must differ (prefix differs)
+    const keyA = `${screenA.id}:${screenA.content.length}:${screenA.content.slice(0, 48)}`;
+    const keyB = `${screenB.id}:${screenB.content.length}:${screenB.content.slice(0, 48)}`;
+    expect(keyA).not.toBe(keyB);
+  });
+
+  it("same content always produces same cache key", () => {
+    const screen: ScreenStub = {
+      id: "s1",
+      filename: "a.html",
+      content: "<div>",
+    };
+    const key1 = `${screen.id}:${screen.content.length}:${screen.content.slice(0, 48)}`;
+    const key2 = `${screen.id}:${screen.content.length}:${screen.content.slice(0, 48)}`;
+    expect(key1).toBe(key2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPrimitiveDropTargetForPoint
+// ---------------------------------------------------------------------------
+describe("getPrimitiveDropTargetForPoint", () => {
+  const screenA: ScreenStub = { id: "sA", filename: "a.html", content: "" };
+  const screenB: ScreenStub = { id: "sB", filename: "b.html", content: "" };
+  const frames = {
+    sA: makeGeom(0, 0, 320, 640),
+    sB: makeGeom(400, 0, 320, 640),
+  };
+  const getMeta = () => ({ width: 320, height: 640 });
+
+  it("returns last DOM-order container under the point (topmost visually)", () => {
+    seedCache(screenA, [
+      primEntry("outer", "sA", { left: 0, top: 0, width: 320, height: 640 }),
+      primEntry("inner", "sA", {
+        left: 100,
+        top: 100,
+        width: 120,
+        height: 120,
+      }),
+    ]);
+    seedCache(screenB, []);
+
+    const result = getPrimitiveDropTargetForPoint(
+      { x: 150, y: 150 },
+      null,
+      [screenA, screenB],
+      frames,
+      getMeta,
+    );
+    expect(result?.nodeId).toBe("inner");
+  });
+
+  it("returns outer when point inside outer but not inner", () => {
+    seedCache(screenA, [
+      primEntry("outer", "sA", { left: 0, top: 0, width: 320, height: 640 }),
+      primEntry("inner", "sA", {
+        left: 100,
+        top: 100,
+        width: 120,
+        height: 120,
+      }),
+    ]);
+    seedCache(screenB, []);
+
+    const result = getPrimitiveDropTargetForPoint(
+      { x: 20, y: 20 },
+      null,
+      [screenA, screenB],
+      frames,
+      getMeta,
+    );
+    expect(result?.nodeId).toBe("outer");
+  });
+
+  it("excludes the exact dragged node and returns another screen's container", () => {
+    seedCache(screenA, [
+      primEntry("outer", "sA", { left: 0, top: 0, width: 320, height: 640 }),
+    ]);
+    // screenB has its own container at board (400,0,320,640)
+    seedCache(screenB, [
+      primEntry("other-screen-container", "sB", {
+        left: 0,
+        top: 0,
+        width: 320,
+        height: 640,
+      }),
+    ]);
+
+    // Dragging 'outer' (on screenA); point at (500, 100) is inside screenB's container
+    const result = getPrimitiveDropTargetForPoint(
+      { x: 500, y: 100 },
+      "outer",
+      [screenA, screenB],
+      frames,
+      getMeta,
+    );
+    expect(result?.nodeId).toBe("other-screen-container");
+  });
+
+  it("regression: excludes geometric descendants of the dragged node", () => {
+    // BUG was: dragging 'outer' (0,0,320,640) let 'inner' (100,100,120,120)
+    // be highlighted as a drop target, creating a circular parent→child move.
+    seedCache(screenA, [
+      primEntry("outer", "sA", { left: 0, top: 0, width: 320, height: 640 }),
+      primEntry("inner", "sA", {
+        left: 100,
+        top: 100,
+        width: 120,
+        height: 120,
+      }),
+    ]);
+    seedCache(screenB, []);
+
+    const result = getPrimitiveDropTargetForPoint(
+      { x: 150, y: 150 },
+      "outer",
+      [screenA, screenB],
+      frames,
+      getMeta,
+    );
+    // 'inner' is fully enclosed by 'outer' → should be excluded
+    // Nothing else at this point → null
+    expect(result).toBeNull();
+  });
+
+  it("does not exclude a sibling that overlaps but is not enclosed by the dragged node", () => {
+    seedCache(screenA, [
+      // dragged: occupies left half of screen
+      primEntry("left-half", "sA", {
+        left: 0,
+        top: 0,
+        width: 160,
+        height: 640,
+      }),
+      // sibling: occupies right half (not enclosed by left-half)
+      primEntry("right-half", "sA", {
+        left: 160,
+        top: 0,
+        width: 160,
+        height: 640,
+      }),
+    ]);
+    seedCache(screenB, []);
+
+    const result = getPrimitiveDropTargetForPoint(
+      { x: 250, y: 300 }, // inside right-half board rect
+      "left-half",
+      [screenA, screenB],
+      frames,
+      getMeta,
+    );
+    expect(result?.nodeId).toBe("right-half");
+  });
+
+  it("returns null when point outside all frames", () => {
+    seedCache(screenA, [
+      primEntry("p", "sA", { left: 0, top: 0, width: 320, height: 640 }),
+    ]);
+    seedCache(screenB, []);
+
+    const result = getPrimitiveDropTargetForPoint(
+      { x: 999, y: 999 },
+      null,
+      [screenA, screenB],
+      frames,
+      getMeta,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("skips non-container (leaf) primitives", () => {
+    seedCache(screenA, [
+      primEntry("leaf", "sA", {
+        left: 0,
+        top: 0,
+        width: 320,
+        height: 640,
+        isContainer: false,
+      }),
+    ]);
+    seedCache(screenB, []);
+
+    const result = getPrimitiveDropTargetForPoint(
+      { x: 50, y: 50 },
+      null,
+      [screenA, screenB],
+      frames,
+      getMeta,
+    );
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveNodeScreenId
+// ---------------------------------------------------------------------------
+describe("resolveNodeScreenId", () => {
+  const s1: ScreenStub = { id: "s1", filename: "a.html", content: "" };
+  const s2: ScreenStub = { id: "s2", filename: "b.html", content: "" };
+
+  it("returns the correct screen id when node is found", () => {
+    seedCache(s1, [
+      primEntry("alpha", "s1", { left: 0, top: 0, width: 100, height: 100 }),
+    ]);
+    seedCache(s2, [
+      primEntry("beta", "s2", { left: 0, top: 0, width: 100, height: 100 }),
+    ]);
+
+    expect(resolveNodeScreenId("alpha", [s1, s2])).toBe("s1");
+    expect(resolveNodeScreenId("beta", [s1, s2])).toBe("s2");
+  });
+
+  it("returns null when nodeId is not in any screen", () => {
+    seedCache(s1, []);
+    seedCache(s2, []);
+
+    expect(resolveNodeScreenId("ghost", [s1, s2])).toBeNull();
+  });
+
+  it("returns the first screen when nodeId appears in multiple screens", () => {
+    seedCache(s1, [
+      primEntry("shared", "s1", { left: 0, top: 0, width: 100, height: 100 }),
+    ]);
+    seedCache(s2, [
+      primEntry("shared", "s2", { left: 0, top: 0, width: 100, height: 100 }),
+    ]);
+
+    expect(resolveNodeScreenId("shared", [s1, s2])).toBe("s1");
+  });
+});

--- a/templates/design/app/components/design/MultiScreenCanvas.transition.test.ts
+++ b/templates/design/app/components/design/MultiScreenCanvas.transition.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   getChromeBorderTransition,
+  getPreviewDeviceFrameGeometry,
   getSelectionBoxTransition,
   isDirectScreenHoverTarget,
 } from "./MultiScreenCanvas";
@@ -32,5 +33,25 @@ describe("MultiScreenCanvas selection chrome transitions", () => {
 
     expect(isDirectScreenHoverTarget(frame, frame)).toBe(true);
     expect(isDirectScreenHoverTarget(screenContentChild, frame)).toBe(false);
+  });
+
+  it("updates both dimensions when switching to a concrete device preview", () => {
+    expect(
+      getPreviewDeviceFrameGeometry({
+        currentGeometry: { x: 12, y: 24, width: 320, height: 640, z: 4 },
+        metadata: { width: 390, height: 844 },
+        previewDeviceFrame: "mobile",
+      }),
+    ).toEqual({ x: 12, y: 24, width: 390, height: 844, z: 4 });
+  });
+
+  it("keeps responsive preview width flexible while matching source aspect", () => {
+    expect(
+      getPreviewDeviceFrameGeometry({
+        currentGeometry: { x: 0, y: 0, width: 640, height: 640 },
+        metadata: { width: 1280, height: 800 },
+        previewDeviceFrame: "none",
+      }),
+    ).toEqual({ x: 0, y: 0, width: 640, height: 400 });
   });
 });

--- a/templates/design/app/components/design/MultiScreenCanvas.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.tsx
@@ -200,6 +200,19 @@ interface MultiScreenCanvasProps {
     widthPx: number | undefined,
   ) => void;
   onSelectionChange?: (selectedIds: string[]) => void;
+  /**
+   * Called when the user drags an element out of the active screen's iframe
+   * and drops it onto a different screen.  The bridge in the source iframe
+   * posts { type:"agent-native:cross-screen-drag" } messages; the host
+   * translates them to board coords, finds the target frame, and calls this
+   * prop with the resolved ids.
+   */
+  onCrossScreenElementDrop?: (args: {
+    sourceSelector: string;
+    sourceNodeId?: string;
+    sourceScreenId: string;
+    targetScreenId: string;
+  }) => void;
 }
 
 /**
@@ -541,6 +554,7 @@ export function MultiScreenCanvas({
   onAddBreakpoint,
   onActiveBreakpointChange,
   onSelectionChange,
+  onCrossScreenElementDrop,
 }: MultiScreenCanvasProps) {
   const t = useT();
   const surfaceRef = useRef<HTMLDivElement>(null);
@@ -591,6 +605,30 @@ export function MultiScreenCanvas({
     useState<PrimitiveDropTarget | null>(null);
   const primitiveDropTargetRef = useRef<PrimitiveDropTarget | null>(null);
   const onPrimitiveReparentRef = useRef(onPrimitiveReparent);
+
+  // Cross-screen element drag state — driven by postMessage from the source iframe.
+  interface CrossScreenDragGhost {
+    /** Board-space point where the ghost is shown (follows the cursor). */
+    boardX: number;
+    boardY: number;
+  }
+  interface CrossScreenDragTarget {
+    /** The screen frame that is the candidate drop target. */
+    id: string;
+    geometry: FrameGeometry;
+  }
+  const [crossScreenGhost, setCrossScreenGhost] =
+    useState<CrossScreenDragGhost | null>(null);
+  const [crossScreenTarget, setCrossScreenTarget] =
+    useState<CrossScreenDragTarget | null>(null);
+  /** Ref kept in sync with state so the message handler can read without closures. */
+  const crossScreenTargetRef = useRef<CrossScreenDragTarget | null>(null);
+  /** The most-recent drag message payload — kept for use in the "end" handler. */
+  const crossScreenDragMsgRef = useRef<{
+    selector: string;
+    sourceId?: string;
+  } | null>(null);
+  const onCrossScreenElementDropRef = useRef(onCrossScreenElementDrop);
   const suppressNextPick = useRef(false);
   const feedbackTimerRef = useRef<number | null>(null);
   const pendingWheelGestureRef = useRef<PendingWheelGesture | null>(null);
@@ -625,6 +663,10 @@ export function MultiScreenCanvas({
   useEffect(() => {
     onPrimitiveReparentRef.current = onPrimitiveReparent;
   }, [onPrimitiveReparent]);
+
+  useEffect(() => {
+    onCrossScreenElementDropRef.current = onCrossScreenElementDrop;
+  }, [onCrossScreenElementDrop]);
 
   useEffect(() => {
     screensRef.current = screens;
@@ -960,6 +1002,155 @@ export function MultiScreenCanvas({
         )[0],
     [getCurrentFrameEntries],
   );
+
+  // ── Cross-screen element drag receiver ────────────────────────────────────
+  // The source iframe (the active interactive screen) posts
+  // { type: "agent-native:cross-screen-drag", phase, selector, sourceId,
+  //   iframeX, iframeY, viewportW, viewportH }
+  // during element drags that the bridge wants the host to handle.
+  useEffect(() => {
+    if (!onCrossScreenElementDrop) return;
+
+    const clearCrossScreenDrag = () => {
+      setCrossScreenGhost(null);
+      setCrossScreenTarget(null);
+      crossScreenTargetRef.current = null;
+      crossScreenDragMsgRef.current = null;
+    };
+
+    const handleMessage = (event: MessageEvent) => {
+      if (!event.data || event.data.type !== "agent-native:cross-screen-drag") {
+        return;
+      }
+      const msg = event.data as {
+        type: string;
+        phase: "move" | "end" | "cancel";
+        selector?: string;
+        sourceId?: string;
+        iframeX?: number;
+        iframeY?: number;
+        viewportW?: number;
+        viewportH?: number;
+      };
+
+      if (msg.phase === "cancel") {
+        clearCrossScreenDrag();
+        return;
+      }
+
+      // The drag originates from the active screen (only the active screen has
+      // a live interactive iframe posting these messages).
+      const sourceScreenId = activeId;
+      if (!sourceScreenId) {
+        // Always clear visual state (ghost + highlight) when we have no active
+        // screen to attribute the drag to — regardless of the phase. Without
+        // this, a "move" message arriving after activeId became null would leave
+        // stale ghost/target state visible on the canvas.
+        clearCrossScreenDrag();
+        return;
+      }
+
+      if (msg.phase === "move") {
+        const { iframeX, iframeY, viewportW, viewportH, selector, sourceId } =
+          msg;
+        if (
+          iframeX === undefined ||
+          iframeY === undefined ||
+          viewportW === undefined ||
+          viewportH === undefined
+        ) {
+          return;
+        }
+
+        // Remember the latest drag payload for use on "end".
+        crossScreenDragMsgRef.current = {
+          selector: selector ?? "",
+          sourceId,
+        };
+
+        // Pointer is inside the source iframe — let the bridge handle it.
+        if (
+          iframeX >= 0 &&
+          iframeY >= 0 &&
+          iframeX <= viewportW &&
+          iframeY <= viewportH
+        ) {
+          clearCrossScreenDrag();
+          return;
+        }
+
+        // Translate iframe coords → board coords using source frame geometry.
+        // Board math mirrors primitiveLocalToBoardRect:
+        //   boardX = frame.x + iframeX * (frame.width / metadata.width)
+        //   boardY = frame.y + iframeY * (frame.height / metadata.height)
+        const sourceScreen = screensRef.current.find(
+          (s) => s.id === sourceScreenId,
+        );
+        const sourceGeometry = frameGeometryRef.current[sourceScreenId];
+        if (!sourceScreen || !sourceGeometry) {
+          clearCrossScreenDrag();
+          return;
+        }
+        const sourceMetadata = getResolvedMetadata(sourceScreen);
+        const scaleX = sourceGeometry.width / Math.max(1, sourceMetadata.width);
+        const scaleY =
+          sourceGeometry.height / Math.max(1, sourceMetadata.height);
+        const boardX = sourceGeometry.x + iframeX * scaleX;
+        const boardY = sourceGeometry.y + iframeY * scaleY;
+        const boardPoint = { x: boardX, y: boardY };
+
+        setCrossScreenGhost({ boardX, boardY });
+
+        // Find which screen frame the board point falls in.
+        const target = getFrameEntryAtPoint(boardPoint);
+        if (target && target.id !== sourceScreenId) {
+          const nextTarget = { id: target.id, geometry: target.geometry };
+          crossScreenTargetRef.current = nextTarget;
+          setCrossScreenTarget(nextTarget);
+        } else {
+          crossScreenTargetRef.current = null;
+          setCrossScreenTarget(null);
+        }
+        return;
+      }
+
+      if (msg.phase === "end") {
+        const candidate = crossScreenTargetRef.current;
+        // Use the saved payload from the last "move" as the primary source of
+        // truth; fall back to the "end" message's own fields in case the ref
+        // was cleared (e.g. a brief re-entry into the source iframe nulled it
+        // via clearCrossScreenDrag while pointerOutsideIframe remained true).
+        const payload = crossScreenDragMsgRef.current ?? {
+          selector: msg.selector ?? "",
+          sourceId: msg.sourceId,
+        };
+        clearCrossScreenDrag();
+        // Guard: require at least one stable identifier (selector or sourceId)
+        // so the drop handler in DesignEditor can resolve the node. An empty
+        // selector AND a missing sourceId would produce nodeAttrId="" and
+        // moveNodeBetweenDocuments would fail with a generic error toast.
+        const hasIdentifier = !!(payload.selector || payload.sourceId);
+        if (candidate && hasIdentifier && sourceScreenId) {
+          onCrossScreenElementDropRef.current?.({
+            sourceSelector: payload.selector,
+            sourceNodeId: payload.sourceId,
+            sourceScreenId,
+            targetScreenId: candidate.id,
+          });
+        }
+      }
+    };
+
+    window.addEventListener("message", handleMessage);
+    return () => {
+      window.removeEventListener("message", handleMessage);
+    };
+  }, [
+    activeId,
+    getFrameEntryAtPoint,
+    getResolvedMetadata,
+    onCrossScreenElementDrop,
+  ]);
 
   const deleteSelectedItems = useCallback(() => {
     const frameIds = selectedIdsRef.current.filter(
@@ -3464,6 +3655,46 @@ export function MultiScreenCanvas({
           {transformBadge.text}
         </div>
       ) : null}
+
+      {/* Cross-screen element drag: highlight the candidate target screen frame.
+          Uses the same style as the primitiveDropTarget overlay (2px accent border
+          + 14% accent fill) so it is visually consistent. */}
+      {crossScreenTarget ? (
+        <span
+          data-cross-screen-drop-target
+          className="pointer-events-none absolute z-40 rounded-sm"
+          style={{
+            // Surface position = pan + (SURFACE_PADDING + canvasCoord) * scale
+            left:
+              pan.x + (SURFACE_PADDING + crossScreenTarget.geometry.x) * scale,
+            top:
+              pan.y + (SURFACE_PADDING + crossScreenTarget.geometry.y) * scale,
+            width: Math.max(1, crossScreenTarget.geometry.width * scale),
+            height: Math.max(1, crossScreenTarget.geometry.height * scale),
+            border: "2px solid var(--design-editor-accent-color)",
+            background:
+              "color-mix(in srgb, var(--design-editor-accent-color) 14%, transparent)",
+          }}
+        />
+      ) : null}
+
+      {/* Cross-screen element drag: small ghost following the board-space cursor. */}
+      {crossScreenGhost ? (
+        <span
+          data-cross-screen-drag-ghost
+          className="pointer-events-none absolute z-50 rounded border border-[var(--design-editor-accent-color)] bg-[var(--design-editor-accent-color)]/20 shadow"
+          style={{
+            // A fixed-size ghost (16×16 canvas-px) centred on the board point.
+            // Surface position = pan + (SURFACE_PADDING + canvasCoord) * scale
+            left:
+              pan.x + (SURFACE_PADDING + crossScreenGhost.boardX) * scale - 8,
+            top:
+              pan.y + (SURFACE_PADDING + crossScreenGhost.boardY) * scale - 8,
+            width: 16,
+            height: 16,
+          }}
+        />
+      ) : null}
     </div>
   );
 }
@@ -5569,17 +5800,32 @@ export interface ParsedScreenPrimitive {
   isContainer: boolean;
 }
 
+/** Fast djb2-variant hash of a string. Runs in O(n) but is inlined for the
+ *  JIT — no allocations, no imports.  Produces a 32-bit unsigned integer as a
+ *  hex string.  Used only for cache-key disambiguation, not cryptography. */
+function hashString(s: string): string {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) {
+    // h = h * 33 ^ charCode  (djb2 xor variant)
+    h = ((h << 5) + h) ^ s.charCodeAt(i);
+    h = h >>> 0; // keep as unsigned 32-bit
+  }
+  return h.toString(16);
+}
+
 /** Simple LRU-style cache to avoid re-parsing the same screen HTML on every
- *  mousemove frame.  Keyed by `screenId:contentLength:prefix48` so that edits
- *  that keep the same character count (e.g. agent replacing one node-id with
- *  another of equal length) still invalidate the entry. */
+ *  mousemove frame.  Keyed by `screenId:contentLength:hash` so that ANY edit
+ *  (including changes deep in the middle of a large HTML document) invalidates
+ *  the entry.  A length:hash pair eliminates the collision zone that existed
+ *  when only prefix48+suffix48 were used — edits in `content[48..len-49]` would
+ *  produce the same key even though the content differed. */
 export const primitiveParseCache = new Map<string, ParsedScreenPrimitive[]>();
 const PRIMITIVE_PARSE_CACHE_MAX = 64;
 
 export function parsePrimitivesFromScreen(
   screen: ScreenFile,
 ): ParsedScreenPrimitive[] {
-  const cacheKey = `${screen.id}:${screen.content.length}:${screen.content.slice(0, 48)}`;
+  const cacheKey = `${screen.id}:${screen.content.length}:${hashString(screen.content)}`;
   const cached = primitiveParseCache.get(cacheKey);
   if (cached) return cached;
 

--- a/templates/design/app/components/design/MultiScreenCanvas.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.tsx
@@ -135,6 +135,7 @@ interface MultiScreenCanvasProps {
   zoom: number;
   activeId?: string | null;
   selectedScreenIds?: string[];
+  fullViewScreenIds?: string[];
   activeScreenHasHoveredChild?: boolean;
   hoveredChildScreenId?: string | null;
   directlyHoveredScreenId?: string | null;
@@ -158,6 +159,13 @@ interface MultiScreenCanvasProps {
     primitive: CanvasPrimitiveInsert,
   ) => boolean | string;
   onPrimitiveCreated?: (screenId: string, nodeId: string) => void;
+  onPrimitiveReparent?: (args: {
+    sourceNodeId: string;
+    sourceScreenId: string;
+    targetNodeId: string;
+    targetScreenId: string;
+    placement: "inside";
+  }) => void;
   onCreateScreenFrame?: (geometry: FrameGeometry) => void;
   onDeleteSelection?: (ids: string[]) => boolean | void;
   onZoomChange?: (zoom: number) => void;
@@ -482,6 +490,7 @@ export function MultiScreenCanvas({
   zoom,
   activeId,
   selectedScreenIds,
+  fullViewScreenIds,
   activeScreenHasHoveredChild = false,
   hoveredChildScreenId,
   directlyHoveredScreenId,
@@ -499,6 +508,7 @@ export function MultiScreenCanvas({
   onGeometryCommit,
   onCreatePrimitive,
   onPrimitiveCreated,
+  onPrimitiveReparent,
   onCreateScreenFrame,
   onDeleteSelection,
   onZoomChange,
@@ -518,6 +528,7 @@ export function MultiScreenCanvas({
   const frameGeometryRef = useRef(frameGeometry);
   const onGeometryChangeRef = useRef(onGeometryChange);
   const onGeometryCommitRef = useRef(onGeometryCommit);
+  const screensRef = useRef(screens);
   const [draftPrimitives, setDraftPrimitives] = useState<DraftPrimitive[]>([]);
   const draftPrimitivesRef = useRef(draftPrimitives);
   const [selectedDraftIds, setSelectedDraftIds] = useState<string[]>([]);
@@ -552,6 +563,10 @@ export function MultiScreenCanvas({
     null,
   );
   const [dragCursor, setDragCursor] = useState<string | null>(null);
+  const [primitiveDropTarget, setPrimitiveDropTarget] =
+    useState<PrimitiveDropTarget | null>(null);
+  const primitiveDropTargetRef = useRef<PrimitiveDropTarget | null>(null);
+  const onPrimitiveReparentRef = useRef(onPrimitiveReparent);
   const suppressNextPick = useRef(false);
   const feedbackTimerRef = useRef<number | null>(null);
   const pendingWheelGestureRef = useRef<PendingWheelGesture | null>(null);
@@ -582,6 +597,14 @@ export function MultiScreenCanvas({
   useEffect(() => {
     onGeometryCommitRef.current = onGeometryCommit;
   }, [onGeometryCommit]);
+
+  useEffect(() => {
+    onPrimitiveReparentRef.current = onPrimitiveReparent;
+  }, [onPrimitiveReparent]);
+
+  useEffect(() => {
+    screensRef.current = screens;
+  }, [screens]);
 
   useEffect(() => {
     activePenPathRef.current = activePenPath;
@@ -734,15 +757,13 @@ export function MultiScreenCanvas({
         const metadata = getResolvedMetadata(screen);
         const currentGeometry =
           current[screen.id] ?? getInitialFrameGeometry(index, metadata);
-        const nextHeight = getOverviewFrameHeight(
-          currentGeometry.width,
+        const nextGeometry = getPreviewDeviceFrameGeometry({
+          currentGeometry,
           metadata,
-        );
-        if (currentGeometry.height === nextHeight) return;
-        next[screen.id] = {
-          ...currentGeometry,
-          height: nextHeight,
-        };
+          previewDeviceFrame,
+        });
+        if (sameFrameGeometry(currentGeometry, nextGeometry)) return;
+        next[screen.id] = nextGeometry;
         changed = true;
       });
 
@@ -787,9 +808,17 @@ export function MultiScreenCanvas({
     if (!surfaceRef.current || screens.length === 0) return;
     const rect = surfaceRef.current.getBoundingClientRect();
     const scale = zoomRef.current / 100;
-    const frames = screens.map((screen, index) =>
-      getInitialFrameGeometry(index, getResolvedMetadata(screen)),
-    );
+    const frames = screens.map((screen, index) => {
+      const metadata = getResolvedMetadata(screen);
+      const currentGeometry =
+        frameGeometryRef.current[screen.id] ??
+        getInitialFrameGeometry(index, metadata);
+      return getPreviewDeviceFrameGeometry({
+        currentGeometry,
+        metadata,
+        previewDeviceFrame,
+      });
+    });
     const bounds = getFrameGroupBounds(
       frames.map((geometry, index) => ({
         id: screens[index]?.id ?? String(index),
@@ -1036,6 +1065,31 @@ export function MultiScreenCanvas({
     [],
   );
 
+  const updatePrimitiveDropTarget = useCallback(
+    (target: PrimitiveDropTarget | null) => {
+      primitiveDropTargetRef.current = target;
+      setPrimitiveDropTarget(target);
+    },
+    [],
+  );
+
+  const findPrimitiveDropTarget = useCallback(
+    (
+      point: Point,
+      draggedNodeId: string | null,
+    ): PrimitiveDropTarget | null => {
+      if (!onPrimitiveReparentRef.current) return null;
+      return getPrimitiveDropTargetForPoint(
+        point,
+        draggedNodeId,
+        screensRef.current,
+        frameGeometryRef.current,
+        getResolvedMetadata,
+      );
+    },
+    [getResolvedMetadata],
+  );
+
   const finishDrag = useCallback(() => {
     if (feedbackTimerRef.current !== null) {
       window.clearTimeout(feedbackTimerRef.current);
@@ -1049,6 +1103,8 @@ export function MultiScreenCanvas({
     setAlignmentGuides([]);
     setTransformBadge(null);
     setDragCursor(null);
+    primitiveDropTargetRef.current = null;
+    setPrimitiveDropTarget(null);
     dragCleanup.current?.();
   }, []);
 
@@ -1773,40 +1829,94 @@ export function MultiScreenCanvas({
           ev.clientX,
           ev.clientY,
         );
+
+        // Primitive drop-into-container detection: check if the dragged draft
+        // is hovering over a committed container primitive on any screen.
+        const canvasPoint = getCanvasPoint(ev.clientX, ev.clientY);
+        const primitiveTarget = findPrimitiveDropTarget(canvasPoint, null);
+        updatePrimitiveDropTarget(primitiveTarget);
       };
 
       const handleMouseUp = () => {
         const state = dragState.current;
+        const dropTarget = primitiveDropTargetRef.current;
         if (state?.type === "draft-move" && state.hasMoved) {
-          const persisted: Array<{
-            draftId: string;
-            frameId: string;
-            nodeId: string;
-          }> = [];
-          draftPrimitivesRef.current.forEach((draft) => {
-            if (!state.targetIds.includes(draft.id)) return;
-            const result = persistDraftPrimitive(draft);
-            if (result) {
-              persisted.push({
-                draftId: draft.id,
-                frameId: result.frameId,
-                nodeId: result.nodeId,
-              });
-            }
-          });
+          if (dropTarget) {
+            // Drop into a container primitive: persist the draft into the
+            // target's screen, then call onPrimitiveReparent to nest it.
+            const persisted: Array<{
+              draftId: string;
+              frameId: string;
+              nodeId: string;
+            }> = [];
+            draftPrimitivesRef.current.forEach((draft) => {
+              if (!state.targetIds.includes(draft.id)) return;
+              // Persist into the target's screen (not just any containing frame)
+              const result = persistDraftPrimitive(draft, dropTarget.screenId);
+              if (result) {
+                persisted.push({
+                  draftId: draft.id,
+                  frameId: result.frameId,
+                  nodeId: result.nodeId,
+                });
+              }
+            });
 
-          if (persisted.length > 0) {
-            const persistedDraftIds = new Set(
-              persisted.map((entry) => entry.draftId),
-            );
-            updateDraftPrimitives((current) =>
-              current.filter((draft) => !persistedDraftIds.has(draft.id)),
-            );
-            updateSelectedDraftIds((current) =>
-              current.filter((draftId) => !persistedDraftIds.has(draftId)),
-            );
-            const lastNodeId = persisted[persisted.length - 1]?.nodeId;
-            if (lastNodeId) updateSelectedIds(() => [lastNodeId]);
+            if (persisted.length > 0) {
+              const persistedDraftIds = new Set(
+                persisted.map((entry) => entry.draftId),
+              );
+              updateDraftPrimitives((current) =>
+                current.filter((draft) => !persistedDraftIds.has(draft.id)),
+              );
+              updateSelectedDraftIds((current) =>
+                current.filter((draftId) => !persistedDraftIds.has(draftId)),
+              );
+              // Reparent each persisted node into the container primitive.
+              persisted.forEach((entry) => {
+                onPrimitiveReparentRef.current?.({
+                  sourceNodeId: entry.nodeId,
+                  sourceScreenId: entry.frameId,
+                  targetNodeId: dropTarget.nodeId,
+                  targetScreenId: dropTarget.screenId,
+                  placement: "inside",
+                });
+              });
+              const lastNodeId = persisted[persisted.length - 1]?.nodeId;
+              if (lastNodeId) updateSelectedIds(() => [lastNodeId]);
+            }
+          } else {
+            // Normal drop: persist into whichever screen contains the draft.
+            const persisted: Array<{
+              draftId: string;
+              frameId: string;
+              nodeId: string;
+            }> = [];
+            draftPrimitivesRef.current.forEach((draft) => {
+              if (!state.targetIds.includes(draft.id)) return;
+              const result = persistDraftPrimitive(draft);
+              if (result) {
+                persisted.push({
+                  draftId: draft.id,
+                  frameId: result.frameId,
+                  nodeId: result.nodeId,
+                });
+              }
+            });
+
+            if (persisted.length > 0) {
+              const persistedDraftIds = new Set(
+                persisted.map((entry) => entry.draftId),
+              );
+              updateDraftPrimitives((current) =>
+                current.filter((draft) => !persistedDraftIds.has(draft.id)),
+              );
+              updateSelectedDraftIds((current) =>
+                current.filter((draftId) => !persistedDraftIds.has(draftId)),
+              );
+              const lastNodeId = persisted[persisted.length - 1]?.nodeId;
+              if (lastNodeId) updateSelectedIds(() => [lastNodeId]);
+            }
           }
         }
         finishDrag();
@@ -1815,12 +1925,15 @@ export function MultiScreenCanvas({
       installDragListeners(handleMouseMove, handleMouseUp);
     },
     [
+      findPrimitiveDropTarget,
       finishDrag,
+      getCanvasPoint,
       getCurrentCanvasEntries,
       installDragListeners,
       persistDraftPrimitive,
       showTransformFeedback,
       updateDraftPrimitives,
+      updatePrimitiveDropTarget,
       updateSelectedDraftIds,
       updateSelectedIds,
     ],
@@ -2068,11 +2181,51 @@ export function MultiScreenCanvas({
           ev.clientX,
           ev.clientY,
         );
+
+        // When all dragged ids are committed primitive nodeIds (not screen
+        // frames), check for a container primitive drop target to highlight.
+        const currentFrameIds = Object.keys(frameGeometryRef.current);
+        const allCommitted = state.targetIds.every(
+          (targetId) => !currentFrameIds.includes(targetId),
+        );
+        if (allCommitted) {
+          const canvasPoint = getCanvasPoint(ev.clientX, ev.clientY);
+          updatePrimitiveDropTarget(
+            findPrimitiveDropTarget(canvasPoint, state.primaryId),
+          );
+        }
       };
 
       const handleMouseUp = () => {
         const state = dragState.current;
+        const dropTarget = primitiveDropTargetRef.current;
         if (state?.type === "move" && state.hasMoved) {
+          // If all dragged ids are committed primitive nodeIds (not screen
+          // frames), attempt a primitive reparent on drop.
+          const currentFrameIds = Object.keys(frameGeometryRef.current);
+          const allCommitted = state.targetIds.every(
+            (targetId) => !currentFrameIds.includes(targetId),
+          );
+          if (allCommitted && dropTarget) {
+            const sourceScreenId = resolveNodeScreenId(
+              state.primaryId,
+              screensRef.current,
+            );
+            if (sourceScreenId) {
+              onPrimitiveReparentRef.current?.({
+                sourceNodeId: state.primaryId,
+                sourceScreenId,
+                targetNodeId: dropTarget.nodeId,
+                targetScreenId: dropTarget.screenId,
+                placement: "inside",
+              });
+              suppressNextPick.current = true;
+              finishDrag();
+              return;
+            }
+          }
+
+          // Normal screen-frame geometry commit.
           const after = cloneFrameGeometryById(frameGeometryRef.current);
           onGeometryCommitRef.current?.(
             frameGeometryWithOverrides(after, state.originFrames),
@@ -2087,12 +2240,15 @@ export function MultiScreenCanvas({
     },
     [
       activeId,
+      findPrimitiveDropTarget,
       finishDrag,
+      getCanvasPoint,
       getCurrentFrameEntries,
       installDragListeners,
       onPick,
       showTransformFeedback,
       updateFrameGeometry,
+      updatePrimitiveDropTarget,
       updateSelectedDraftIds,
       updateSelectedIds,
     ],
@@ -2957,6 +3113,7 @@ export function MultiScreenCanvas({
         : appendPenNode(activePenPath, createCornerNode(penPointer))
       : activePenPath;
   const selectedIdSet = new Set(selectedIds);
+  const fullViewIdSet = new Set(fullViewScreenIds ?? []);
   const selectedDraftIdSet = new Set(selectedDraftIds);
   const surfaceCursor = isPanning
     ? "grabbing"
@@ -3063,6 +3220,7 @@ export function MultiScreenCanvas({
               screenContent={screenContentById.get(screen.id)}
               isActive={screen.id === activeId}
               isSelected={selectedIdSet.has(screen.id)}
+              showFullView={fullViewIdSet.has(screen.id)}
               isDirectlyHovered={screen.id === directlyHoveredScreenId}
               hasHoveredChild={
                 (screen.id === activeId && activeScreenHasHoveredChild) ||
@@ -3199,6 +3357,29 @@ export function MultiScreenCanvas({
             top: pan.y + (SURFACE_PADDING + marquee.y) * scale,
             width: Math.max(1, marquee.width * scale),
             height: Math.max(1, marquee.height * scale),
+          }}
+        />
+      ) : null}
+
+      {primitiveDropTarget ? (
+        <span
+          data-primitive-drop-target
+          className="pointer-events-none absolute z-40 rounded-sm"
+          style={{
+            // Surface position = pan + (SURFACE_PADDING + canvasCoord) * scale
+            left:
+              pan.x +
+              (SURFACE_PADDING + primitiveDropTarget.boardRect.x) * scale,
+            top:
+              pan.y +
+              (SURFACE_PADDING + primitiveDropTarget.boardRect.y) * scale,
+            width: Math.max(1, primitiveDropTarget.boardRect.width * scale),
+            height: Math.max(1, primitiveDropTarget.boardRect.height * scale),
+            // Match the in-screen inside-guide style: 2px accent border + 14%
+            // accent fill. Uses the same CSS variable as the DesignCanvas guide.
+            border: "2px solid var(--design-editor-accent-color)",
+            background:
+              "color-mix(in srgb, var(--design-editor-accent-color) 14%, transparent)",
           }}
         />
       ) : null}
@@ -3573,6 +3754,7 @@ interface ScreenProps {
   geometry: FrameGeometry;
   isActive: boolean;
   isSelected: boolean;
+  showFullView: boolean;
   isDirectlyHovered: boolean;
   hasHoveredChild: boolean;
   groupSelected: boolean;
@@ -3605,6 +3787,7 @@ const Screen = memo(function Screen({
   geometry,
   isActive,
   isSelected,
+  showFullView,
   isDirectlyHovered,
   hasHoveredChild,
   groupSelected,
@@ -3633,6 +3816,7 @@ const Screen = memo(function Screen({
     !creationToolActive &&
     !canvasGestureActive;
   const emphasized = isSelected || frameDirectlyHovered;
+  const fullViewVisible = emphasized || showFullView;
   const activeOrEmphasized = isActive || emphasized;
   const selectionOutlined = isSelected && !groupSelected;
   const showHoverChrome =
@@ -3760,7 +3944,7 @@ const Screen = memo(function Screen({
           className={cn(
             "absolute top-1/2 z-40 flex h-5 shrink-0 items-center gap-1 overflow-hidden rounded-md border border-border bg-background/95 px-1.5 text-[10px] font-medium text-foreground opacity-0 shadow-sm transition-opacity",
             "hover:bg-accent hover:text-accent-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-            emphasized && "opacity-100",
+            fullViewVisible && "opacity-100",
             fullViewOutsideFrame ? "left-full" : "right-1",
           )}
           style={{
@@ -3858,26 +4042,12 @@ const Screen = memo(function Screen({
         }}
       >
         <span
-          data-screen-hover-outline
-          className={cn(
-            "pointer-events-none absolute border transition-opacity",
-            showHoverChrome
-              ? "border-[var(--design-editor-accent-color)] opacity-100"
-              : "border-transparent opacity-0",
-          )}
-          style={{
-            inset: -5 * chromeScale,
-            borderRadius: 13 * chromeScale,
-            borderWidth: 1.5 * chromeScale,
-            transition: getChromeBorderTransition(chromeSettling),
-          }}
-        />
-        <span
           data-screen-content
           className={cn(
             "relative block h-full w-full overflow-hidden rounded-lg border bg-white shadow-2xl transition-colors",
-            "border-border",
-            showHoverChrome && "border-muted-foreground/60",
+            showHoverChrome
+              ? "border-[var(--design-editor-accent-color)]"
+              : "border-border",
           )}
           style={{ pointerEvents: screenContentInteractive ? "auto" : "none" }}
         >
@@ -3954,6 +4124,7 @@ function areScreenPropsEqual(prev: ScreenProps, next: ScreenProps) {
     sameFrameGeometry(prev.geometry, next.geometry) &&
     prev.isActive === next.isActive &&
     prev.isSelected === next.isSelected &&
+    prev.showFullView === next.showFullView &&
     prev.isDirectlyHovered === next.isDirectlyHovered &&
     prev.hasHoveredChild === next.hasHoveredChild &&
     prev.groupSelected === next.groupSelected &&
@@ -4276,6 +4447,30 @@ function getOverviewFrameHeight(width: number, metadata?: ScreenViewportSize) {
   const sourceHeight =
     metadata?.height && metadata.height > 0 ? metadata.height : 2560;
   return Math.max(80, Math.round((width * sourceHeight) / sourceWidth));
+}
+
+export function getPreviewDeviceFrameGeometry({
+  currentGeometry,
+  metadata,
+  previewDeviceFrame,
+}: {
+  currentGeometry: FrameGeometry;
+  metadata?: { width: number; height: number };
+  previewDeviceFrame: DeviceFrameType;
+}): FrameGeometry {
+  if (previewDeviceFrame === "none") {
+    return {
+      ...currentGeometry,
+      height: getOverviewFrameHeight(currentGeometry.width, metadata),
+    };
+  }
+
+  const viewport = DEVICE_FRAME_VIEWPORTS[previewDeviceFrame];
+  return {
+    ...currentGeometry,
+    width: Math.max(1, Math.round(metadata?.width ?? viewport.width)),
+    height: Math.max(1, Math.round(metadata?.height ?? viewport.height)),
+  };
 }
 
 function getScreenPreviewViewport(
@@ -5084,4 +5279,258 @@ function getUrl(value: string | undefined) {
 
 function clampNumber(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value));
+}
+
+// ---------------------------------------------------------------------------
+// Primitive-into-primitive drop target detection
+// ---------------------------------------------------------------------------
+
+/** A committed container primitive that can accept a dropped primitive. */
+export interface PrimitiveDropTarget {
+  /** The node's data-agent-native-node-id value. */
+  nodeId: string;
+  /** The screen frame id (ScreenFile.id) that owns this primitive. */
+  screenId: string;
+  /** The primitive's bounding rect in board/canvas space. */
+  boardRect: FrameGeometry;
+}
+
+/**
+ * Parsed representation of a committed primitive found in a screen's HTML.
+ * Geometry is in screen-local CSS pixels (as written by appendCanvasPrimitiveToHtml).
+ */
+export interface ParsedScreenPrimitive {
+  nodeId: string;
+  screenId: string;
+  /** Position relative to screen body (CSS px). */
+  localLeft: number;
+  localTop: number;
+  localWidth: number;
+  localHeight: number;
+  isContainer: boolean;
+}
+
+/** Simple LRU-style cache to avoid re-parsing the same screen HTML on every
+ *  mousemove frame.  Keyed by `screenId:contentLength:prefix48` so that edits
+ *  that keep the same character count (e.g. agent replacing one node-id with
+ *  another of equal length) still invalidate the entry. */
+export const primitiveParseCache = new Map<string, ParsedScreenPrimitive[]>();
+const PRIMITIVE_PARSE_CACHE_MAX = 64;
+
+export function parsePrimitivesFromScreen(
+  screen: ScreenFile,
+): ParsedScreenPrimitive[] {
+  const cacheKey = `${screen.id}:${screen.content.length}:${screen.content.slice(0, 48)}`;
+  const cached = primitiveParseCache.get(cacheKey);
+  if (cached) return cached;
+
+  const result: ParsedScreenPrimitive[] = [];
+  if (typeof DOMParser === "undefined" || !screen.content) {
+    return result;
+  }
+
+  try {
+    const doc = new DOMParser().parseFromString(screen.content, "text/html");
+    const nodes = doc.querySelectorAll("[data-agent-native-node-id]");
+    nodes.forEach((el) => {
+      const nodeId = el.getAttribute("data-agent-native-node-id");
+      if (!nodeId) return;
+
+      const htmlEl = el as HTMLElement;
+      const style = htmlEl.style;
+      const tag = el.tagName.toLowerCase();
+
+      // Only block elements with explicit absolute positioning are considered
+      // positioned primitives drawn by appendCanvasPrimitiveToHtml.
+      if (style.position !== "absolute") return;
+
+      const left = parseFloat(style.left) || 0;
+      const top = parseFloat(style.top) || 0;
+      const width = parseFloat(style.width) || 0;
+      const height = parseFloat(style.height) || 0;
+
+      // Validity: must have non-zero size
+      if (width <= 0 || height <= 0) return;
+
+      // Container check:
+      //   - Must be a div (not svg/path/circle/polygon/etc.)
+      //   - Must NOT be an ellipse (border-radius:50%)
+      //   - NOT a text primitive (but text divs could be containers in principle;
+      //     we exclude them by checking for display:inline-block autoSize pattern)
+      const isDiv = tag === "div";
+      const isEllipse =
+        style.borderRadius === "50%" ||
+        style.borderRadius === "50% 50% 50% 50%";
+      const isTextAutoSize = style.display === "inline-block";
+      const isContainer = isDiv && !isEllipse && !isTextAutoSize;
+
+      result.push({
+        nodeId,
+        screenId: screen.id,
+        localLeft: left,
+        localTop: top,
+        localWidth: width,
+        localHeight: height,
+        isContainer,
+      });
+    });
+  } catch {
+    // Silently ignore parse errors
+  }
+
+  if (primitiveParseCache.size >= PRIMITIVE_PARSE_CACHE_MAX) {
+    // Evict the oldest entry
+    const firstKey = primitiveParseCache.keys().next().value;
+    if (firstKey !== undefined) primitiveParseCache.delete(firstKey);
+  }
+  primitiveParseCache.set(cacheKey, result);
+  return result;
+}
+
+/**
+ * Convert a screen-local primitive rect to board/canvas coordinates.
+ *
+ * appendCanvasPrimitiveToHtml stores positions in screen-local CSS pixels
+ * scaled from the board draft geometry:
+ *   localX = (boardX - frame.x) * (metadata.width / frame.width)
+ * Inverting:
+ *   boardX = frame.x + localX * (frame.width / metadata.width)
+ */
+export function primitiveLocalToBoardRect(
+  localLeft: number,
+  localTop: number,
+  localWidth: number,
+  localHeight: number,
+  frameGeometry: FrameGeometry,
+  metadata: { width: number; height: number },
+): FrameGeometry {
+  const scaleX = frameGeometry.width / Math.max(1, metadata.width);
+  const scaleY = frameGeometry.height / Math.max(1, metadata.height);
+  return {
+    x: frameGeometry.x + localLeft * scaleX,
+    y: frameGeometry.y + localTop * scaleY,
+    width: Math.max(1, localWidth * scaleX),
+    height: Math.max(1, localHeight * scaleY),
+  };
+}
+
+/**
+ * Find the topmost committed container primitive at `point` (canvas coords),
+ * excluding `draggedNodeId` and any of its descendants.
+ *
+ * Descendants are detected geometrically: a primitive whose board rect is
+ * fully enclosed by the dragged node's board rect is treated as a descendant
+ * and excluded. This avoids a circular parent-child relationship on drop.
+ *
+ * Returns null if no valid target found.
+ */
+export function getPrimitiveDropTargetForPoint(
+  point: Point,
+  draggedNodeId: string | null,
+  screens: ScreenFile[],
+  frameGeometryById: FrameGeometryById,
+  getMetadata: (screen: ScreenFile) => { width: number; height: number },
+): PrimitiveDropTarget | null {
+  // Pre-compute the dragged node's board rect so we can exclude its descendants.
+  let draggedBoardRect: FrameGeometry | null = null;
+  if (draggedNodeId) {
+    outer: for (const screen of screens) {
+      const frameGeometry = frameGeometryById[screen.id];
+      if (!frameGeometry) continue;
+      const metadata = getMetadata(screen);
+      const primitives = parsePrimitivesFromScreen(screen);
+      for (const prim of primitives) {
+        if (prim.nodeId === draggedNodeId) {
+          draggedBoardRect = primitiveLocalToBoardRect(
+            prim.localLeft,
+            prim.localTop,
+            prim.localWidth,
+            prim.localHeight,
+            frameGeometry,
+            metadata,
+          );
+          break outer;
+        }
+      }
+    }
+  }
+
+  let best: PrimitiveDropTarget | null = null;
+
+  for (const screen of screens) {
+    const frameGeometry = frameGeometryById[screen.id];
+    if (!frameGeometry) continue;
+
+    const frameBounds = {
+      left: frameGeometry.x,
+      top: frameGeometry.y,
+      right: frameGeometry.x + frameGeometry.width,
+      bottom: frameGeometry.y + frameGeometry.height,
+    };
+    if (!rectContainsPoint(frameBounds, point)) {
+      continue;
+    }
+
+    const metadata = getMetadata(screen);
+    const primitives = parsePrimitivesFromScreen(screen);
+
+    for (const prim of primitives) {
+      if (!prim.isContainer) continue;
+      if (draggedNodeId && prim.nodeId === draggedNodeId) continue;
+
+      const boardRect = primitiveLocalToBoardRect(
+        prim.localLeft,
+        prim.localTop,
+        prim.localWidth,
+        prim.localHeight,
+        frameGeometry,
+        metadata,
+      );
+
+      // Exclude geometric descendants: a primitive whose board rect is fully
+      // contained within the dragged node's board rect is a child/descendant
+      // and cannot be a valid reparent target (would create a cycle).
+      if (
+        draggedBoardRect &&
+        boardRect.x >= draggedBoardRect.x &&
+        boardRect.y >= draggedBoardRect.y &&
+        boardRect.x + boardRect.width <=
+          draggedBoardRect.x + draggedBoardRect.width &&
+        boardRect.y + boardRect.height <=
+          draggedBoardRect.y + draggedBoardRect.height
+      ) {
+        continue;
+      }
+
+      if (
+        point.x >= boardRect.x &&
+        point.x <= boardRect.x + boardRect.width &&
+        point.y >= boardRect.y &&
+        point.y <= boardRect.y + boardRect.height
+      ) {
+        // Later in the DOM = higher paint order = topmost visually.
+        // We take the last match within each screen (DOM order).
+        best = { nodeId: prim.nodeId, screenId: screen.id, boardRect };
+      }
+    }
+  }
+
+  return best;
+}
+
+/**
+ * Resolve which screen (ScreenFile.id) owns a committed primitive nodeId by
+ * scanning all screen HTML for the given data-agent-native-node-id value.
+ */
+export function resolveNodeScreenId(
+  nodeId: string,
+  screens: ScreenFile[],
+): string | null {
+  for (const screen of screens) {
+    const primitives = parsePrimitivesFromScreen(screen);
+    if (primitives.some((p) => p.nodeId === nodeId)) {
+      return screen.id;
+    }
+  }
+  return null;
 }

--- a/templates/design/app/components/design/inspector/InspectorAiActions.tsx
+++ b/templates/design/app/components/design/inspector/InspectorAiActions.tsx
@@ -1,0 +1,145 @@
+import { useT } from "@agent-native/core/client";
+import {
+  IconClipboard,
+  IconChevronDown,
+  IconSparkles,
+} from "@tabler/icons-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Textarea } from "@/components/ui/textarea";
+import { useAgentEditRequest } from "@/hooks/useAgentEditRequest";
+import { cn } from "@/lib/utils";
+
+export interface InspectorAiActionsProps {
+  /** CSS selector for the currently-selected element, if any. */
+  selector?: string;
+  /** Source id (data-code-layer-id) of the selected element, if any. */
+  sourceId?: string;
+  /** Active file id. */
+  fileId?: string;
+  /** Active file name (e.g. "index.html"). */
+  filename?: string;
+  /** The design id. */
+  designId?: string;
+  /** When false, the controls are disabled. */
+  canEdit: boolean;
+}
+
+/**
+ * Compact inspector block that lets the user type a freeform AI edit request
+ * and either route it to the agent chat sidebar ("Apply with AI") or copy the
+ * prompt to the clipboard ("Copy prompt").
+ *
+ * Collapsed by default to keep the inspector clean.
+ */
+export function InspectorAiActions({
+  selector,
+  sourceId,
+  fileId,
+  filename,
+  designId,
+  canEdit,
+}: InspectorAiActionsProps) {
+  const t = useT();
+  const { sendEdit, copyPrompt } = useAgentEditRequest();
+  const [open, setOpen] = useState(false);
+  const [request, setRequest] = useState("");
+
+  const args = {
+    message: request,
+    selector,
+    sourceId,
+    fileId,
+    filename,
+    designId,
+  };
+  const disabled = !canEdit || !request.trim();
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="w-full">
+      <CollapsibleTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "flex w-full items-center justify-between gap-1 rounded px-2 py-1.5 text-xs font-medium text-muted-foreground hover:bg-accent hover:text-foreground transition-colors",
+          )}
+        >
+          <span className="flex items-center gap-1.5">
+            <IconSparkles className="size-3.5 shrink-0" />
+            {t("designEditor.localSourceEdit.askAi")}
+          </span>
+          <IconChevronDown
+            className={cn(
+              "size-3.5 shrink-0 transition-transform duration-150",
+              open && "rotate-180",
+            )}
+          />
+        </button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-none">
+        <div className="flex flex-col gap-2 px-1 pb-2 pt-1">
+          <Textarea
+            value={request}
+            onChange={(e) => setRequest(e.target.value)}
+            placeholder={
+              selector
+                ? t("designEditor.localSourceEdit.describeElementChange")
+                : t("designEditor.localSourceEdit.describeChange")
+            }
+            className="min-h-[64px] resize-none text-xs"
+            disabled={!canEdit}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && !disabled) {
+                e.preventDefault();
+                void sendEdit(args);
+                setRequest("");
+                setOpen(false);
+              }
+            }}
+          />
+          <div className="flex gap-1.5">
+            <Button
+              size="sm"
+              variant="default"
+              className="flex-1 gap-1.5 text-xs"
+              disabled={disabled}
+              onClick={() => {
+                void sendEdit(args);
+                setRequest("");
+                setOpen(false);
+              }}
+            >
+              <IconSparkles className="size-3.5 shrink-0" />
+              {t("designEditor.localSourceEdit.applyWithAi")}
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              className="gap-1.5 text-xs"
+              disabled={disabled}
+              onClick={() => {
+                void copyPrompt(args);
+              }}
+              title={t("designEditor.localSourceEdit.copyPromptTooltip")}
+            >
+              <IconClipboard className="size-3.5 shrink-0" />
+              {t("designEditor.localSourceEdit.copyPrompt")}
+            </Button>
+          </div>
+          {selector && (
+            <p className="text-[10px] leading-tight text-muted-foreground truncate">
+              {t("designEditor.localSourceEdit.targeting")}{" "}
+              <code className="font-mono">{selector}</code>
+            </p>
+          )}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/templates/design/app/components/design/inspector/SHADER_INTEGRATION.md
+++ b/templates/design/app/components/design/inspector/SHADER_INTEGRATION.md
@@ -26,7 +26,7 @@ card's **Apply fill** button persists that fill via the `apply-shader-fill` acti
   `shared/shader-fill.ts` so `descriptor.colors` can never inject CSS.
 
 Sections (a), (b), (d), and (f) below remain optional ways to surface shaders in
-*other* inspector seams (the colour picker fill type, the effects panel, the
+_other_ inspector seams (the colour picker fill type, the effects panel, the
 artboard WebGL bridge, design-system tokens) and are not required for the
 card-based apply path that ships today.
 

--- a/templates/design/app/hooks/useAgentEditRequest.ts
+++ b/templates/design/app/hooks/useAgentEditRequest.ts
@@ -1,0 +1,131 @@
+import { sendToAgentChat, useT } from "@agent-native/core/client";
+import { useCallback } from "react";
+import { toast } from "sonner";
+
+export interface AgentEditRequestArgs {
+  /** Freeform user message describing the edit to make. */
+  message: string;
+  /** CSS selector or data-agent-native-node-id identifying the target element. */
+  selector?: string;
+  /** Source id (data-code-layer-id) of the target element. */
+  sourceId?: string;
+  /** The design file id (screen / file row id) being edited. */
+  fileId?: string;
+  /** The design id (row id of the design). */
+  designId?: string;
+  /** For localhost-connected screens: the source file path to route edits through. */
+  routeSourceFile?: string;
+  /** Human-readable filename for context (e.g. "index.html"). */
+  filename?: string;
+}
+
+/**
+ * Builds the hidden agent context string for an edit request, following the
+ * same pattern used by the tweaks panel (DesignEditor.tsx ~5293) and the
+ * extensions panel context builder (DesignExtensionsPanel.tsx ~120-131).
+ */
+function buildEditContext(args: AgentEditRequestArgs): string {
+  const lines: string[] = [];
+
+  if (args.designId) {
+    lines.push(`Design id: "${args.designId}".`);
+  }
+  if (args.fileId) {
+    lines.push(
+      args.filename
+        ? `Active file: "${args.filename}" (file id: "${args.fileId}").`
+        : `Active file id: "${args.fileId}".`,
+    );
+  } else if (args.filename) {
+    lines.push(`Active file: "${args.filename}".`);
+  }
+  if (args.selector) {
+    lines.push(`Selected element CSS selector: "${args.selector}".`);
+  }
+  if (args.sourceId) {
+    lines.push(
+      `Selected element source id (data-code-layer-id): "${args.sourceId}".`,
+    );
+  }
+  if (args.routeSourceFile) {
+    lines.push(
+      `Localhost source file to route edits through: "${args.routeSourceFile}".`,
+    );
+  }
+
+  lines.push("");
+  lines.push("Agent instructions:");
+  lines.push(
+    "1. Call view-screen first to see the current state of the design.",
+  );
+  lines.push(
+    "2. For style, class, text, or positional changes on the selected element, prefer apply-visual-edit — it is deterministic and does not require a full regeneration.",
+  );
+  lines.push(
+    "3. For structural changes, new sections, or multi-element edits, use edit-design (search/replace) for small targeted changes or generate-design for full rewrites.",
+  );
+  lines.push(
+    "4. If a routeSourceFile is provided, the design screen is connected to localhost source code. Route edits through the agent code editing surface for that file rather than modifying the inline HTML prototype.",
+  );
+
+  return lines.join("\n");
+}
+
+/**
+ * Builds the full pasteable prompt string (visible message + context block)
+ * for use in the "Copy prompt" flow.
+ */
+function buildFullPrompt(args: AgentEditRequestArgs): string {
+  const context = buildEditContext(args);
+  return `${args.message}\n\n---\n${context}`;
+}
+
+export interface UseAgentEditRequestReturn {
+  /**
+   * Routes the edit request directly to the agent chat sidebar.
+   * The message is shown in the chat; the context is hidden.
+   */
+  sendEdit: (args: AgentEditRequestArgs) => Promise<void>;
+  /**
+   * Builds the same prompt+context as a single string and copies it to the
+   * clipboard. Toasts success or blocked per the pattern in DesignEditor.tsx ~7608.
+   */
+  copyPrompt: (args: AgentEditRequestArgs) => Promise<void>;
+}
+
+/**
+ * Shared hook for routing AI edit requests from the inspector and the
+ * local-source banner. Reuses sendToAgentChat from @agent-native/core/client
+ * and the clipboard+toast pattern established in DesignEditor.tsx.
+ */
+export function useAgentEditRequest(): UseAgentEditRequestReturn {
+  const t = useT();
+
+  const sendEdit = useCallback(
+    async (args: AgentEditRequestArgs): Promise<void> => {
+      const context = buildEditContext(args);
+      sendToAgentChat({
+        message: args.message,
+        context,
+        submit: true,
+        openSidebar: true,
+      });
+    },
+    [],
+  );
+
+  const copyPrompt = useCallback(
+    async (args: AgentEditRequestArgs): Promise<void> => {
+      const text = buildFullPrompt(args);
+      try {
+        await navigator.clipboard.writeText(text);
+        toast.success(t("designEditor.toasts.codingHandoffCopied"));
+      } catch {
+        toast.error(t("designEditor.toasts.clipboardBlocked"));
+      }
+    },
+    [t],
+  );
+
+  return { sendEdit, copyPrompt };
+}

--- a/templates/design/app/hooks/useDesignHotkeys.ts
+++ b/templates/design/app/hooks/useDesignHotkeys.ts
@@ -307,7 +307,9 @@ function handleDesignHotkey(
   if (primary && key === "d") return run(props.onDuplicate);
   if (primary && key === "r") return run(props.onRename);
   if (primary && key === "g") {
-    return event.shiftKey ? run(props.onUngroup) : run(props.onGroup);
+    // Figma uses ⇧⌘G for ungroup; also support ⌥⌘G as an alias.
+    if (event.shiftKey || event.altKey) return run(props.onUngroup);
+    return run(props.onGroup);
   }
 
   if (primary && (key === "=" || key === "+")) return run(props.onZoomIn);

--- a/templates/design/app/i18n-data.ts
+++ b/templates/design/app/i18n-data.ts
@@ -427,6 +427,25 @@ const enUS = {
       duplicateElementFailed: "Could not duplicate that element",
       saveCopyError: "Could not save a copy of this design",
     },
+    localSourceEdit: {
+      bannerNotice:
+        "Edits to connected local code are applied by the AI agent, not written directly.",
+      askAiToEdit: "Ask AI to edit",
+      copyPrompt: "Copy prompt",
+      dialogTitle: "Ask AI to edit connected source",
+      requestPlaceholder:
+        "Change the button color to blue, update the heading text…",
+      askAi: "Ask AI",
+      applyWithAi: "Apply with AI",
+      copyPromptTooltip: "Copy prompt to clipboard",
+      targeting: "Targeting:",
+      describeElementChange: "Describe the change for this element…",
+      describeChange: "Describe what you want to change…",
+      dialogDescription:
+        "Describe what you want to change. The agent will call view-screen first, then apply edits through the code editor.",
+      dialogDescriptionFile:
+        'Describe what you want to change in "{{file}}". The agent will call view-screen first, then apply edits through the code editor.',
+    },
   },
   layersPanel: {
     title: "Layers",
@@ -9323,6 +9342,232 @@ const designVisualEditOverrides = {
   },
 } satisfies Record<Exclude<LocaleCode, "en-US">, PartialMessages>;
 
+const designLocalSourceEditOverrides = {
+  "zh-TW": {
+    designEditor: {
+      localSourceEdit: {
+        bannerNotice: "對已連結本機程式碼的編輯由 AI 代理套用，不會直接寫入。",
+        askAiToEdit: "請 AI 編輯",
+        copyPrompt: "複製提示",
+        dialogTitle: "請 AI 編輯已連結的來源",
+        requestPlaceholder: "將按鈕顏色改成藍色、更新標題文字…",
+        askAi: "詢問 AI",
+        applyWithAi: "用 AI 套用",
+        copyPromptTooltip: "將提示複製到剪貼簿",
+        targeting: "目標：",
+        describeElementChange: "描述要對此元素進行的更改…",
+        describeChange: "描述您想要更改的內容…",
+        dialogDescription:
+          "描述您想要更改的內容。代理會先呼叫 view-screen，再透過程式碼編輯器套用編輯。",
+        dialogDescriptionFile:
+          "描述您想在「{{file}}」中更改的內容。代理會先呼叫 view-screen，再透過程式碼編輯器套用編輯。",
+      },
+    },
+  },
+  "zh-CN": {
+    designEditor: {
+      localSourceEdit: {
+        bannerNotice: "对已连接本地代码的编辑由 AI 代理应用，不会直接写入。",
+        askAiToEdit: "请 AI 编辑",
+        copyPrompt: "复制提示",
+        dialogTitle: "请 AI 编辑已连接的源码",
+        requestPlaceholder: "将按钮颜色改成蓝色、更新标题文字…",
+        askAi: "询问 AI",
+        applyWithAi: "用 AI 应用",
+        copyPromptTooltip: "将提示复制到剪贴板",
+        targeting: "目标：",
+        describeElementChange: "描述要对此元素进行的更改…",
+        describeChange: "描述您想要更改的内容…",
+        dialogDescription:
+          "描述您想要更改的内容。代理会先调用 view-screen，再通过代码编辑器应用编辑。",
+        dialogDescriptionFile:
+          "描述您想在“{{file}}”中更改的内容。代理会先调用 view-screen，再通过代码编辑器应用编辑。",
+      },
+    },
+  },
+  "es-ES": {
+    designEditor: {
+      localSourceEdit: {
+        bannerNotice:
+          "Las ediciones del código local conectado las aplica el agente de IA, no se escriben directamente.",
+        askAiToEdit: "Pedir edición a la IA",
+        copyPrompt: "Copiar prompt",
+        dialogTitle: "Pedir a la IA que edite el código conectado",
+        requestPlaceholder:
+          "Cambia el color del botón a azul, actualiza el texto del título…",
+        askAi: "Preguntar a la IA",
+        applyWithAi: "Aplicar con IA",
+        copyPromptTooltip: "Copiar prompt al portapapeles",
+        targeting: "Objetivo:",
+        describeElementChange: "Describe el cambio para este elemento…",
+        describeChange: "Describe lo que quieres cambiar…",
+        dialogDescription:
+          "Describe lo que quieres cambiar. El agente llamará a view-screen primero y luego aplicará los cambios a través del editor de código.",
+        dialogDescriptionFile:
+          'Describe lo que quieres cambiar en "{{file}}". El agente llamará a view-screen primero y luego aplicará los cambios a través del editor de código.',
+      },
+    },
+  },
+  "fr-FR": {
+    designEditor: {
+      localSourceEdit: {
+        bannerNotice:
+          "Les modifications du code local connecté sont appliquées par l'agent IA, pas écrites directement.",
+        askAiToEdit: "Demander à l'IA de modifier",
+        copyPrompt: "Copier le prompt",
+        dialogTitle: "Demander à l'IA de modifier la source connectée",
+        requestPlaceholder:
+          "Change la couleur du bouton en bleu, mets à jour le titre…",
+        askAi: "Demander à l'IA",
+        applyWithAi: "Appliquer avec l'IA",
+        copyPromptTooltip: "Copier le prompt dans le presse-papiers",
+        targeting: "Cible :",
+        describeElementChange: "Décrivez la modification pour cet élément…",
+        describeChange: "Décrivez ce que vous voulez changer…",
+        dialogDescription:
+          "Décrivez ce que vous voulez changer. L'agent appellera d'abord view-screen, puis appliquera les modifications via l'éditeur de code.",
+        dialogDescriptionFile:
+          "Décrivez ce que vous voulez changer dans \"{{file}}\". L'agent appellera d'abord view-screen, puis appliquera les modifications via l'éditeur de code.",
+      },
+    },
+  },
+  "de-DE": {
+    designEditor: {
+      localSourceEdit: {
+        bannerNotice:
+          "Änderungen am verbundenen lokalen Code werden vom KI-Agenten angewendet, nicht direkt geschrieben.",
+        askAiToEdit: "KI um Änderung bitten",
+        copyPrompt: "Prompt kopieren",
+        dialogTitle: "KI um Bearbeitung der verbundenen Quelle bitten",
+        requestPlaceholder:
+          "Ändere die Button-Farbe in Blau, aktualisiere den Überschriftstext…",
+        askAi: "KI fragen",
+        applyWithAi: "Mit KI anwenden",
+        copyPromptTooltip: "Prompt in die Zwischenablage kopieren",
+        targeting: "Ziel:",
+        describeElementChange: "Beschreibe die Änderung für dieses Element…",
+        describeChange: "Beschreibe, was du ändern möchtest…",
+        dialogDescription:
+          "Beschreibe, was du ändern möchtest. Der Agent ruft zuerst view-screen auf und wendet die Änderungen dann über den Code-Editor an.",
+        dialogDescriptionFile:
+          'Beschreibe, was du in "{{file}}" ändern möchtest. Der Agent ruft zuerst view-screen auf und wendet die Änderungen dann über den Code-Editor an.',
+      },
+    },
+  },
+  "ja-JP": {
+    designEditor: {
+      localSourceEdit: {
+        bannerNotice:
+          "接続済みローカルコードの編集は AI エージェントが適用し、直接は書き込みません。",
+        askAiToEdit: "AI に編集を依頼",
+        copyPrompt: "プロンプトをコピー",
+        dialogTitle: "接続済みソースの編集を AI に依頼",
+        requestPlaceholder: "ボタンの色を青に変更、見出しテキストを更新…",
+        askAi: "AI に質問",
+        applyWithAi: "AI で適用",
+        copyPromptTooltip: "プロンプトをクリップボードにコピー",
+        targeting: "対象：",
+        describeElementChange: "この要素への変更を説明してください…",
+        describeChange: "変更したい内容を説明してください…",
+        dialogDescription:
+          "変更したい内容を説明してください。エージェントはまず view-screen を呼び出し、その後コードエディターで編集を適用します。",
+        dialogDescriptionFile:
+          "「{{file}}」で変更したい内容を説明してください。エージェントはまず view-screen を呼び出し、その後コードエディターで編集を適用します。",
+      },
+    },
+  },
+  "ko-KR": {
+    designEditor: {
+      localSourceEdit: {
+        bannerNotice:
+          "연결된 로컬 코드 편집은 AI 에이전트가 적용하며 직접 작성하지 않습니다.",
+        askAiToEdit: "AI에 편집 요청",
+        copyPrompt: "프롬프트 복사",
+        dialogTitle: "연결된 소스 편집을 AI에 요청",
+        requestPlaceholder:
+          "버튼 색상을 파란색으로 변경, 제목 텍스트 업데이트…",
+        askAi: "AI에 질문",
+        applyWithAi: "AI로 적용",
+        copyPromptTooltip: "프롬프트를 클립보드에 복사",
+        targeting: "대상:",
+        describeElementChange: "이 요소에 대한 변경 사항을 설명하세요…",
+        describeChange: "변경하려는 내용을 설명하세요…",
+        dialogDescription:
+          "변경하려는 내용을 설명하세요. 에이전트가 먼저 view-screen을 호출한 다음 코드 편집기로 편집을 적용합니다.",
+        dialogDescriptionFile:
+          "“{{file}}”에서 변경하려는 내용을 설명하세요. 에이전트가 먼저 view-screen을 호출한 다음 코드 편집기로 편집을 적용합니다.",
+      },
+    },
+  },
+  "pt-BR": {
+    designEditor: {
+      localSourceEdit: {
+        bannerNotice:
+          "As edições do código local conectado são aplicadas pelo agente de IA, não escritas diretamente.",
+        askAiToEdit: "Pedir edição à IA",
+        copyPrompt: "Copiar prompt",
+        dialogTitle: "Pedir à IA para editar a fonte conectada",
+        requestPlaceholder:
+          "Mude a cor do botão para azul, atualize o texto do título…",
+        askAi: "Perguntar à IA",
+        applyWithAi: "Aplicar com IA",
+        copyPromptTooltip: "Copiar prompt para a área de transferência",
+        targeting: "Alvo:",
+        describeElementChange: "Descreva a alteração para este elemento…",
+        describeChange: "Descreva o que você quer mudar…",
+        dialogDescription:
+          "Descreva o que você quer mudar. O agente chamará view-screen primeiro e depois aplicará as edições pelo editor de código.",
+        dialogDescriptionFile:
+          'Descreva o que você quer mudar em "{{file}}". O agente chamará view-screen primeiro e depois aplicará as edições pelo editor de código.',
+      },
+    },
+  },
+  "hi-IN": {
+    designEditor: {
+      localSourceEdit: {
+        bannerNotice:
+          "जुड़े हुए local code में बदलाव AI agent लागू करता है, सीधे नहीं लिखे जाते।",
+        askAiToEdit: "AI से edit करने को कहें",
+        copyPrompt: "Prompt कॉपी करें",
+        dialogTitle: "जुड़े हुए source को edit करने के लिए AI से कहें",
+        requestPlaceholder: "बटन का रंग नीला करें, heading text अपडेट करें…",
+        askAi: "AI से पूछें",
+        applyWithAi: "AI से लागू करें",
+        copyPromptTooltip: "Prompt को clipboard पर कॉपी करें",
+        targeting: "लक्ष्य:",
+        describeElementChange: "इस element के लिए बदलाव बताएं…",
+        describeChange: "आप क्या बदलना चाहते हैं, बताएं…",
+        dialogDescription:
+          "आप क्या बदलना चाहते हैं, बताएं। Agent पहले view-screen को call करेगा, फिर code editor से बदलाव लागू करेगा।",
+        dialogDescriptionFile:
+          '"{{file}}" में आप क्या बदलना चाहते हैं, बताएं। Agent पहले view-screen को call करेगा, फिर code editor से बदलाव लागू करेगा।',
+      },
+    },
+  },
+  "ar-SA": {
+    designEditor: {
+      localSourceEdit: {
+        bannerNotice:
+          "يطبّق وكيل الذكاء الاصطناعي التعديلات على الكود المحلي المتصل، ولا تُكتب مباشرة.",
+        askAiToEdit: "اطلب من الذكاء الاصطناعي التعديل",
+        copyPrompt: "نسخ الموجّه",
+        dialogTitle: "اطلب من الذكاء الاصطناعي تعديل المصدر المتصل",
+        requestPlaceholder: "غيّر لون الزر إلى الأزرق، وحدّث نص العنوان…",
+        askAi: "اسأل الذكاء الاصطناعي",
+        applyWithAi: "تطبيق بالذكاء الاصطناعي",
+        copyPromptTooltip: "نسخ الموجّه إلى الحافظة",
+        targeting: "الهدف:",
+        describeElementChange: "صف التغيير المطلوب على هذا العنصر…",
+        describeChange: "صف ما تريد تغييره…",
+        dialogDescription:
+          "صف ما تريد تغييره. سيستدعي الوكيل view-screen أولاً ثم يطبّق التعديلات عبر محرر الكود.",
+        dialogDescriptionFile:
+          'صف ما تريد تغييره في "{{file}}". سيستدعي الوكيل view-screen أولاً ثم يطبّق التعديلات عبر محرر الكود.',
+      },
+    },
+  },
+} satisfies Record<Exclude<LocaleCode, "en-US">, PartialMessages>;
+
 export const messagesByLocale = {
   "en-US": enUS,
   "zh-TW": mergeMessages(
@@ -9332,6 +9577,7 @@ export const messagesByLocale = {
       designShapeToolOverrides["zh-TW"],
       designPublicShareOverrides["zh-TW"],
       designVisualEditOverrides["zh-TW"],
+      designLocalSourceEditOverrides["zh-TW"],
     ),
   ),
   "zh-CN": mergeMessages(
@@ -9344,6 +9590,7 @@ export const messagesByLocale = {
       designShapeToolOverrides["zh-CN"],
       designPublicShareOverrides["zh-CN"],
       designVisualEditOverrides["zh-CN"],
+      designLocalSourceEditOverrides["zh-CN"],
       {
         root: {
           commandActions: "操作",
@@ -9395,6 +9642,7 @@ export const messagesByLocale = {
       designShapeToolOverrides["es-ES"],
       designPublicShareOverrides["es-ES"],
       designVisualEditOverrides["es-ES"],
+      designLocalSourceEditOverrides["es-ES"],
       {
         root: {
           commandActions: "Acciones",
@@ -9446,6 +9694,7 @@ export const messagesByLocale = {
       designShapeToolOverrides["fr-FR"],
       designPublicShareOverrides["fr-FR"],
       designVisualEditOverrides["fr-FR"],
+      designLocalSourceEditOverrides["fr-FR"],
       {
         root: {
           commandActions: "Actions",
@@ -9497,6 +9746,7 @@ export const messagesByLocale = {
       designShapeToolOverrides["de-DE"],
       designPublicShareOverrides["de-DE"],
       designVisualEditOverrides["de-DE"],
+      designLocalSourceEditOverrides["de-DE"],
       {
         root: {
           commandActions: "Aktionen",
@@ -9548,6 +9798,7 @@ export const messagesByLocale = {
       designShapeToolOverrides["ja-JP"],
       designPublicShareOverrides["ja-JP"],
       designVisualEditOverrides["ja-JP"],
+      designLocalSourceEditOverrides["ja-JP"],
       {
         root: {
           commandActions: "操作",
@@ -9600,6 +9851,7 @@ export const messagesByLocale = {
       designShapeToolOverrides["ko-KR"],
       designPublicShareOverrides["ko-KR"],
       designVisualEditOverrides["ko-KR"],
+      designLocalSourceEditOverrides["ko-KR"],
       {
         root: {
           commandActions: "작업",
@@ -9650,6 +9902,7 @@ export const messagesByLocale = {
       designShapeToolOverrides["pt-BR"],
       designPublicShareOverrides["pt-BR"],
       designVisualEditOverrides["pt-BR"],
+      designLocalSourceEditOverrides["pt-BR"],
       {
         root: {
           commandActions: "Ações",
@@ -9701,6 +9954,7 @@ export const messagesByLocale = {
       designShapeToolOverrides["hi-IN"],
       designPublicShareOverrides["hi-IN"],
       designVisualEditOverrides["hi-IN"],
+      designLocalSourceEditOverrides["hi-IN"],
       {
         root: {
           commandActions: "क्रियाएं",
@@ -9752,6 +10006,7 @@ export const messagesByLocale = {
       designShapeToolOverrides["ar-SA"],
       designPublicShareOverrides["ar-SA"],
       designVisualEditOverrides["ar-SA"],
+      designLocalSourceEditOverrides["ar-SA"],
       {
         root: {
           commandActions: "الإجراءات",

--- a/templates/design/app/i18n/zh-TW.ts
+++ b/templates/design/app/i18n/zh-TW.ts
@@ -412,6 +412,23 @@ const messages = {
       duplicateElementFailed: "無法複製該元素",
       saveCopyError: "無法儲存這個設計的副本",
     },
+    localSourceEdit: {
+      bannerNotice: "對已連結本機程式碼的編輯由 AI 代理套用，不會直接寫入。",
+      askAiToEdit: "請 AI 編輯",
+      copyPrompt: "複製提示",
+      dialogTitle: "請 AI 編輯已連結的來源",
+      requestPlaceholder: "將按鈕顏色改成藍色、更新標題文字…",
+      askAi: "詢問 AI",
+      applyWithAi: "用 AI 套用",
+      copyPromptTooltip: "將提示複製到剪貼簿",
+      targeting: "目標：",
+      describeElementChange: "描述要對此元素進行的變更…",
+      describeChange: "描述您想要變更的內容…",
+      dialogDescription:
+        "描述您想要變更的內容。代理會先呼叫 view-screen，再透過程式碼編輯器套用編輯。",
+      dialogDescriptionFile:
+        "描述您想在「{{file}}」中變更的內容。代理會先呼叫 view-screen，再透過程式碼編輯器套用編輯。",
+    },
     inspectorLockedTitle: "產生中，檢查器已鎖定",
     inspectorLockedDescription: "第一個畫面準備好後即可使用控制項。",
   },

--- a/templates/design/app/pages/DesignEditor.selection.test.ts
+++ b/templates/design/app/pages/DesignEditor.selection.test.ts
@@ -4,6 +4,8 @@ import { buildCodeLayerProjection } from "../../shared/code-layer";
 import {
   buildActiveFileNodeIdSet,
   getDesignEditorShareUrl,
+  getLayerMoveSourceContent,
+  getLocalhostRouteSourceFile,
   getOverviewCanvasZoom,
   getOverviewDisplayZoom,
   getOverviewEnterTarget,
@@ -175,6 +177,63 @@ describe("DesignEditor share URLs", () => {
     expect(
       getDesignEditorShareUrl("design-123", "https://builder.example"),
     ).toBe("https://builder.example/design/design-123");
+  });
+});
+
+describe("DesignEditor localhost route source", () => {
+  it("prefers explicit route metadata sourceFile for local handoff", () => {
+    expect(
+      getLocalhostRouteSourceFile({
+        sourceFile: "app/routes/home.tsx",
+        source: '{"file":"legacy.tsx"}',
+      }),
+    ).toBe("app/routes/home.tsx");
+  });
+
+  it("falls back to legacy source metadata shapes", () => {
+    expect(
+      getLocalhostRouteSourceFile({
+        source: '{"file":"app/routes/settings.tsx"}',
+      }),
+    ).toBe("app/routes/settings.tsx");
+    expect(
+      getLocalhostRouteSourceFile({ source: "app/routes/plain.tsx" }),
+    ).toBe("app/routes/plain.tsx");
+  });
+});
+
+describe("DesignEditor layer move source snapshots", () => {
+  it("uses the progressive source snapshot before active file content", () => {
+    expect(
+      getLayerMoveSourceContent({
+        sourceFileId: "active",
+        activeFileId: "active",
+        activeContent: "original active",
+        sourceFileContent: "stale file",
+        sourceContentMap: new Map([["active", "after first move"]]),
+      }),
+    ).toBe("after first move");
+  });
+
+  it("falls back to active content or source file content for first move", () => {
+    expect(
+      getLayerMoveSourceContent({
+        sourceFileId: "active",
+        activeFileId: "active",
+        activeContent: "original active",
+        sourceFileContent: "stale file",
+        sourceContentMap: new Map(),
+      }),
+    ).toBe("original active");
+    expect(
+      getLayerMoveSourceContent({
+        sourceFileId: "other",
+        activeFileId: "active",
+        activeContent: "original active",
+        sourceFileContent: "other file",
+        sourceContentMap: new Map(),
+      }),
+    ).toBe("other file");
   });
 });
 

--- a/templates/design/app/pages/DesignEditor.selection.test.ts
+++ b/templates/design/app/pages/DesignEditor.selection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { buildCodeLayerProjection } from "../../shared/code-layer";
 import {
+  buildActiveFileNodeIdSet,
   getDesignEditorShareUrl,
   getOverviewCanvasZoom,
   getOverviewDisplayZoom,
@@ -344,5 +345,68 @@ describe("DesignEditor element canonicalization", () => {
     });
 
     expect(node).toBeNull();
+  });
+});
+
+describe("buildActiveFileNodeIdSet (group/ungroup stale-id filter)", () => {
+  it("includes both projection ids and data-agent-native-node-id attr values", () => {
+    const html = `<!DOCTYPE html><html><body>
+      <div data-agent-native-node-id="node-a">A</div>
+      <div data-agent-native-node-id="node-b">B</div>
+    </body></html>`;
+    const projection = buildCodeLayerProjection(html);
+    const idSet = buildActiveFileNodeIdSet(projection);
+
+    // Projection ids (internal) should be present.
+    for (const n of projection.nodes) {
+      expect(idSet.has(n.id)).toBe(true);
+    }
+    // data-agent-native-node-id attr values should be present.
+    expect(idSet.has("node-a")).toBe(true);
+    expect(idSet.has("node-b")).toBe(true);
+  });
+
+  it("excludes ids that belong to nodes outside the active file", () => {
+    const activeHtml = `<!DOCTYPE html><html><body>
+      <div data-agent-native-node-id="active-node-1">A</div>
+      <div data-agent-native-node-id="active-node-2">B</div>
+    </body></html>`;
+    const activeProjection = buildCodeLayerProjection(activeHtml);
+    const activeNodeIdSet = buildActiveFileNodeIdSet(activeProjection);
+
+    // Ids from a second (non-active) file are NOT in the active set.
+    expect(activeNodeIdSet.has("other-file-node")).toBe(false);
+
+    // simulated selectedLayerIdsState that mixes active + stale ids
+    const files = [{ id: "file-a" }, { id: "file-b" }];
+    const fileIds = new Set(files.map((f) => f.id));
+    const allLayerIds = [
+      "active-node-1",
+      "active-node-2",
+      "other-file-node", // stale id from non-active file
+      "file-a", // file-row id — should be excluded by fileIds filter
+    ];
+
+    const filteredNodeIds = allLayerIds.filter(
+      (id) =>
+        !id.startsWith("__") && !fileIds.has(id) && activeNodeIdSet.has(id),
+    );
+
+    // Only the two active-file node attr ids pass through.
+    expect(filteredNodeIds).toEqual(["active-node-1", "active-node-2"]);
+  });
+
+  it("handles nodes without data-agent-native-node-id (only projection id exposed)", () => {
+    const html = `<!DOCTYPE html><html><body>
+      <div class="plain">No node id attr</div>
+    </body></html>`;
+    const projection = buildCodeLayerProjection(html);
+    const idSet = buildActiveFileNodeIdSet(projection);
+
+    // At least one projection id is present.
+    expect(idSet.size).toBeGreaterThan(0);
+    for (const n of projection.nodes) {
+      expect(idSet.has(n.id)).toBe(true);
+    }
   });
 });

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -162,6 +162,7 @@ import {
   type CanvasPrimitiveInsert,
 } from "@/components/design/MultiScreenCanvas";
 import { QuestionFlow } from "@/components/design/QuestionFlow";
+import type { ReviewPanelProps } from "@/components/design/ReviewPanel";
 import type { ElementInfo, DeviceFrameType } from "@/components/design/types";
 import {
   DEVICE_FRAME_VIEWPORTS,
@@ -221,6 +222,8 @@ import {
 } from "@/lib/pending-generation";
 import { prettyScreenName } from "@/lib/screen-names";
 import { cn } from "@/lib/utils";
+
+import type { A11yFinding } from "../../shared/design-review.js";
 
 const TAB_ID = generateTabId();
 
@@ -423,6 +426,27 @@ export function shouldEscapeToOverview(args: {
     mode === "edit" &&
     activeTool === "move"
   );
+}
+
+/**
+ * Build the set of all node ids (both projection ids and data-agent-native-node-id
+ * attribute values) that exist in the given projection. Used by handleGroupSelection
+ * and handleUngroupSelection to filter selectedLayerIdsState to the active file's
+ * nodes before passing them to wrapNodes / unwrap, preventing cross-file stale ids
+ * from causing spurious "conflict" errors.
+ *
+ * Exported for unit testing.
+ */
+export function buildActiveFileNodeIdSet(
+  projection: CodeLayerProjection,
+): Set<string> {
+  const ids = new Set<string>();
+  for (const n of projection.nodes) {
+    ids.add(n.id);
+    const attrId = n.dataAttributes["data-agent-native-node-id"];
+    if (attrId) ids.add(attrId);
+  }
+  return ids;
 }
 
 let html2CanvasColorContext: CanvasRenderingContext2D | null | undefined;
@@ -4362,6 +4386,65 @@ export default function DesignEditor() {
     generating,
     pendingGenerationActive,
   });
+
+  // §6.5 Review panel — lazy, on-demand accessibility audit for the active
+  // file. The audit walks the file's rendered HTML, so it must never run on
+  // editor load: it is gated behind `auditRequested` (flipped by the panel's
+  // "Run" button) and reset whenever the active file changes so each file is
+  // audited explicitly. The ReviewPanel itself owns the apply-a11y-fix mutation
+  // behind its inline "Fix" button; we just supply the active design source and
+  // refetch on apply so a resolved finding drops out of the list.
+  const [auditRequested, setAuditRequested] = useState(false);
+  useEffect(() => {
+    setAuditRequested(false);
+  }, [activeFile?.id]);
+
+  const auditQuery = useActionQuery<{
+    auditedAt: string;
+    findings: A11yFinding[];
+  }>(
+    "run-design-audit",
+    { designId: id ?? "", fileId: activeFile?.id },
+    {
+      enabled: auditRequested && !!id && !!activeFile?.id,
+      refetchOnWindowFocus: false,
+    },
+  );
+
+  const reviewPanelProps = useMemo<
+    Omit<ReviewPanelProps, "className"> | undefined
+  >(() => {
+    if (!id || !activeFile) return undefined;
+    const audit = auditRequested ? auditQuery.data : undefined;
+    return {
+      findings: audit?.findings ?? [],
+      auditLoading: auditRequested && auditQuery.isFetching,
+      auditedAt: audit?.auditedAt ?? null,
+      auditError:
+        auditRequested && auditQuery.isError
+          ? auditQuery.error?.message ||
+            "Audit failed. Try again." /* i18n-ignore design review fallback */
+          : null,
+      onRunAudit: () => {
+        // First run flips the gate (the query auto-fetches); later runs refetch.
+        if (auditRequested) {
+          void auditQuery.refetch();
+        } else {
+          setAuditRequested(true);
+        }
+      },
+      fixSource: {
+        designId: id,
+        fileId: activeFile.id,
+        filename: activeFile.filename,
+      },
+      onFixApplied: () => {
+        // Re-run the audit so the resolved finding drops out of the list.
+        void auditQuery.refetch();
+      },
+    };
+  }, [id, activeFile, auditRequested, auditQuery]);
+
   const selectedScreenIds = useMemo(
     () =>
       getSelectedScreenIdsForEditorState({
@@ -7517,9 +7600,19 @@ export default function DesignEditor() {
   const handleGroupSelection = useCallback(() => {
     if (!canEditDesign || !activeFile) return;
     // Collect the DOM-node layer ids that belong to the active screen.
+    // Build a set of ids present in the active content so stale ids from
+    // other files (which can persist in selectedLayerIdsState after a
+    // cross-screen layers-panel selection) are excluded before wrapNodes
+    // runs against activeContent. Without this filter, cross-file ids
+    // cause wrapNodes to return "conflict" even for a valid same-file
+    // selection.
     const fileIds = new Set(files.map((f) => f.id));
+    const activeNodeIdSet = buildActiveFileNodeIdSet(
+      buildCodeLayerProjection(activeContent),
+    );
     const nodeIds = selectedLayerIdsState.filter(
-      (id) => !id.startsWith("__") && !fileIds.has(id),
+      (id) =>
+        !id.startsWith("__") && !fileIds.has(id) && activeNodeIdSet.has(id),
     );
     if (nodeIds.length < 2) return;
     const patch = applyVisualEdit(activeContent, {
@@ -7563,9 +7656,16 @@ export default function DesignEditor() {
   // Unwrap the currently selected single-container layer.
   const handleUngroupSelection = useCallback(() => {
     if (!canEditDesign || !activeFile) return;
+    // Filter to active-file nodes only (mirrors handleGroupSelection fix).
+    // A stale id from another file must not be passed to unwrap or it will
+    // fail with "conflict" even though the actual selection is valid.
     const fileIds = new Set(files.map((f) => f.id));
+    const activeNodeIdSet = buildActiveFileNodeIdSet(
+      buildCodeLayerProjection(activeContent),
+    );
     const nodeIds = selectedLayerIdsState.filter(
-      (id) => !id.startsWith("__") && !fileIds.has(id),
+      (id) =>
+        !id.startsWith("__") && !fileIds.has(id) && activeNodeIdSet.has(id),
     );
     const targetId = nodeIds[0];
     if (!targetId) return;
@@ -7762,16 +7862,13 @@ export default function DesignEditor() {
       // Use removeAbsolutePositioningFromNodeInHtml (DOM-based) because
       // applyVisualEdit({kind:"style",value:""}) is a silent no-op (the
       // substrate rejects empty-string values in isSafeStyleValue). Use
-      // nodeAttrId as the lookup key — after moveNodeBetweenDocuments the
-      // node retains that id in the destination unless it collided, in which
-      // case the DOM query by the original id falls through gracefully and
-      // skips the strip (the node stays absolute, which is better than
-      // corrupting an unrelated node). The `n.id === sourceNodeId` fallback
-      // that was here before is wrong: projection ids in the destination
-      // document are freshly assigned and will never equal a source projection id.
+      // result.movedNodeId (the final id in destHtml, which may differ from
+      // nodeAttrId when a collision triggered an id re-stamp) so the strip and
+      // re-selection always find the correct element.
+      const destNodeAttrId = result.movedNodeId ?? nodeAttrId;
       const strippedDest = removeAbsolutePositioningFromNodeInHtml(
         result.destHtml,
-        nodeAttrId,
+        destNodeAttrId,
       );
 
       applyFileContentUpdate(sourceScreenId, result.sourceHtml, {
@@ -7784,7 +7881,108 @@ export default function DesignEditor() {
       // Re-select the moved node in the destination.
       const finalProjection = buildCodeLayerProjection(strippedDest);
       const movedNodeFinal = finalProjection.nodes.find(
-        (n) => n.dataAttributes["data-agent-native-node-id"] === nodeAttrId,
+        (n) => n.dataAttributes["data-agent-native-node-id"] === destNodeAttrId,
+      );
+      if (movedNodeFinal) {
+        setSelectedLayerIdsState([movedNodeFinal.id]);
+        setSelectedElement(elementInfoFromCodeLayerNode(movedNodeFinal));
+      }
+    },
+    [applyFileContentUpdate, canEditDesign, getScreenContent, t],
+  );
+
+  /**
+   * Cross-screen element drag-drop handler (CONTRACT: onCrossScreenElementDrop
+   * prop on MultiScreenCanvas).
+   *
+   * The bridge in the source screen's iframe posts phase:"end" with the
+   * selector / sourceNodeId of the dragged element.  MultiScreenCanvas maps
+   * the board point to a target screen and calls this handler.  We resolve
+   * both screens' content, identify the node by its data-agent-native-node-id
+   * (falling back to a projection lookup by selector when only the selector is
+   * available), call moveNodeBetweenDocuments to move it into the target
+   * screen's <body>, persist both files, switch the active screen to the
+   * target, and select the moved node — keeping viewMode "overview" throughout.
+   */
+  const handleCrossScreenElementDrop = useCallback(
+    ({
+      sourceSelector,
+      sourceNodeId,
+      sourceScreenId,
+      targetScreenId,
+    }: {
+      sourceSelector: string;
+      sourceNodeId?: string;
+      sourceScreenId: string;
+      targetScreenId: string;
+    }) => {
+      if (!canEditDesign) return;
+      if (sourceScreenId === targetScreenId) return;
+
+      const sourceContent = getScreenContent(sourceScreenId);
+      const destContent = getScreenContent(targetScreenId);
+      if (!sourceContent || !destContent) return;
+
+      // Resolve the data-agent-native-node-id that moveNodeBetweenDocuments
+      // uses as a stable key.  Prefer the bridge-supplied sourceNodeId when it
+      // looks like a node-attr id; otherwise look up via selector projection.
+      const sourceProjection = buildCodeLayerProjection(sourceContent);
+      const resolvedSourceNode = sourceNodeId
+        ? (sourceProjection.nodes.find(
+            (n) =>
+              n.dataAttributes["data-agent-native-node-id"] === sourceNodeId ||
+              n.id === sourceNodeId,
+          ) ??
+          resolveCodeLayerNodeFromBridge(
+            sourceProjection,
+            sourceSelector,
+            sourceNodeId,
+          ))
+        : resolveCodeLayerNodeFromBridge(sourceProjection, sourceSelector);
+      const nodeAttrId =
+        resolvedSourceNode?.dataAttributes["data-agent-native-node-id"] ??
+        sourceNodeId ??
+        sourceSelector;
+
+      const result = moveNodeBetweenDocuments(sourceContent, destContent, {
+        nodeId: nodeAttrId,
+        placement: "inside",
+      });
+      if (result.status !== "applied") {
+        toast.error(
+          codeLayerPatchMessage(
+            result.message,
+            t("designEditor.toasts.layerMoveFailed"),
+          ),
+          { duration: 4000 },
+        );
+        return;
+      }
+
+      // Strip absolute positioning from the moved node in the destination so
+      // it flows naturally as a body child (mirrors handleOverviewPrimitiveReparent).
+      // Use result.movedNodeId (the final id in destHtml, which may differ from
+      // nodeAttrId when a collision triggered an id re-stamp) so the strip and
+      // re-selection always find the correct element.
+      const destNodeAttrId = result.movedNodeId ?? nodeAttrId;
+      const strippedDest = removeAbsolutePositioningFromNodeInHtml(
+        result.destHtml,
+        destNodeAttrId,
+      );
+
+      applyFileContentUpdate(sourceScreenId, result.sourceHtml, {
+        refreshPreview: true,
+      });
+      applyFileContentUpdate(targetScreenId, strippedDest, {
+        refreshPreview: true,
+      });
+
+      // Switch active screen to the target and select the moved node; viewMode
+      // stays "overview" (no setViewMode call).
+      setActiveFileId(targetScreenId);
+      const finalProjection = buildCodeLayerProjection(strippedDest);
+      const movedNodeFinal = finalProjection.nodes.find(
+        (n) => n.dataAttributes["data-agent-native-node-id"] === destNodeAttrId,
       );
       if (movedNodeFinal) {
         setSelectedLayerIdsState([movedNodeFinal.id]);
@@ -11408,6 +11606,7 @@ ${serializedHtml}
                       onCreatePrimitive={handleCreatePrimitive}
                       onPrimitiveCreated={handlePrimitiveCreated}
                       onPrimitiveReparent={handleOverviewPrimitiveReparent}
+                      onCrossScreenElementDrop={handleCrossScreenElementDrop}
                       onCreateScreenFrame={handleCreateScreenFrame}
                       onDeleteSelection={handleDeleteOverviewSelection}
                       onSelectionChange={setOverviewSelectedScreenIds}
@@ -11879,6 +12078,7 @@ ${serializedHtml}
                         }
                       : undefined
                   }
+                  reviewPanelProps={reviewPanelProps}
                 />
               </div>
             ) : (

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -3432,7 +3432,10 @@ export default function DesignEditor() {
   const canEditDesign = canShareDesign || designAccessRole === "editor";
   const canEditDesignRef = useRef(canEditDesign);
   const pendingLocalFileContentsRef = useRef<
-    Map<string, { content: string; startedAt: number }>
+    Map<
+      string,
+      { content: string; startedAt: number; baseUpdatedAt?: string | null }
+    >
   >(new Map());
   const [
     pendingLocalFileContentsRevision,
@@ -3440,12 +3443,25 @@ export default function DesignEditor() {
   ] = useState(0);
 
   const markPendingLocalFileContent = useCallback(
-    (fileId: string, content: string) => {
+    (fileId: string, content: string, baseUpdatedAt?: string | null) => {
       const current = pendingLocalFileContentsRef.current.get(fileId);
-      if (current?.content === content) return;
+      if (current?.content === content) {
+        if (
+          baseUpdatedAt !== undefined &&
+          current.baseUpdatedAt === undefined
+        ) {
+          pendingLocalFileContentsRef.current.set(fileId, {
+            ...current,
+            baseUpdatedAt,
+          });
+          setPendingLocalFileContentsRevision((revision) => revision + 1);
+        }
+        return;
+      }
       pendingLocalFileContentsRef.current.set(fileId, {
         content,
         startedAt: Date.now(),
+        baseUpdatedAt,
       });
       setPendingLocalFileContentsRevision((revision) => revision + 1);
     },
@@ -3908,6 +3924,12 @@ export default function DesignEditor() {
     for (const file of serverFiles) {
       const pending = pendingLocalFileContentsRef.current.get(file.id);
       if (pending && (file.content ?? "") === pending.content) {
+        if (
+          pending.baseUpdatedAt !== undefined &&
+          file.updatedAt === pending.baseUpdatedAt
+        ) {
+          continue;
+        }
         pendingLocalFileContentsRef.current.delete(file.id);
         changed = true;
       }
@@ -5500,7 +5522,11 @@ export default function DesignEditor() {
         redoOrderRef.current = [];
         syncUndoRedoState();
       }
-      markPendingLocalFileContent(activeFile.id, nextContent);
+      markPendingLocalFileContent(
+        activeFile.id,
+        nextContent,
+        activeFile.updatedAt,
+      );
       setCollabContent(nextContent);
       setCollabContentFileId(activeFile.id);
       lastLocalContentRef.current = nextContent;
@@ -5574,7 +5600,8 @@ export default function DesignEditor() {
         applyLocalContentUpdate(nextContent, options);
         return;
       }
-      markPendingLocalFileContent(fileId, nextContent);
+      const previousFile = files.find((file) => file.id === fileId);
+      markPendingLocalFileContent(fileId, nextContent, previousFile?.updatedAt);
       queryClient.setQueryData(["action", "get-design", { id }], (old: any) => {
         if (!old || typeof old !== "object" || !Array.isArray(old.files)) {
           return old;
@@ -5595,6 +5622,7 @@ export default function DesignEditor() {
     [
       activeFile?.id,
       applyLocalContentUpdate,
+      files,
       id,
       markPendingLocalFileContent,
       queryClient,
@@ -7863,7 +7891,11 @@ export default function DesignEditor() {
         um.undo();
         if (ydoc && activeFile) {
           const next = ydoc.getText("content").toString();
-          markPendingLocalFileContent(activeFile.id, next);
+          markPendingLocalFileContent(
+            activeFile.id,
+            next,
+            activeFile.updatedAt,
+          );
           lastLocalContentRef.current = next;
           queueFileContentSave(activeFile.id, next, {
             syncCollab: !(ydoc && isSynced),
@@ -7969,7 +8001,11 @@ export default function DesignEditor() {
         um.redo();
         if (ydoc && activeFile) {
           const next = ydoc.getText("content").toString();
-          markPendingLocalFileContent(activeFile.id, next);
+          markPendingLocalFileContent(
+            activeFile.id,
+            next,
+            activeFile.updatedAt,
+          );
           lastLocalContentRef.current = next;
           queueFileContentSave(activeFile.id, next, {
             syncCollab: !(ydoc && isSynced),

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -47,6 +47,7 @@ import {
   moveNodeBetweenDocuments,
   removeCodeLayerNodeFromHtml,
   type CodeLayerNode,
+  type CodeLayerProjection,
   type CodeLayerTreeNode,
 } from "@shared/code-layer";
 import { componentNameFor, isComponentInstance } from "@shared/component-model";
@@ -2029,6 +2030,48 @@ function collectCodeLayerAncestors(
     if (match.length > 0) return match;
   }
   return [];
+}
+
+function findCodeLayerNodeInProjection(
+  projection: CodeLayerProjection,
+  previousNode: CodeLayerNode,
+): CodeLayerNode | null {
+  const stableSourceIds = [
+    previousNode.dataAttributes["data-agent-native-node-id"],
+    previousNode.dataAttributes["data-code-layer-id"],
+    previousNode.dataAttributes["data-layer-id"],
+    previousNode.dataAttributes["data-builder-id"],
+    previousNode.dataAttributes["data-loc"],
+    typeof previousNode.attributes.id === "string"
+      ? previousNode.attributes.id
+      : undefined,
+  ].filter((id): id is string => Boolean(id));
+
+  for (const sourceId of stableSourceIds) {
+    const stableMatch = projection.nodes.find(
+      (node) =>
+        node.dataAttributes["data-agent-native-node-id"] === sourceId ||
+        node.dataAttributes["data-code-layer-id"] === sourceId ||
+        node.dataAttributes["data-layer-id"] === sourceId ||
+        node.dataAttributes["data-builder-id"] === sourceId ||
+        node.dataAttributes["data-loc"] === sourceId ||
+        node.attributes.id === sourceId,
+    );
+    if (stableMatch) return stableMatch;
+  }
+
+  const exactMatch = projection.nodes.find(
+    (node) => node.id === previousNode.id,
+  );
+  if (exactMatch) return exactMatch;
+
+  const fallbackMatches = projection.nodes.filter(
+    (node) =>
+      node.tag === previousNode.tag &&
+      node.layerName === previousNode.layerName &&
+      (node.textSnippet ?? "") === (previousNode.textSnippet ?? ""),
+  );
+  return fallbackMatches.length === 1 ? (fallbackMatches[0] ?? null) : null;
 }
 
 function AgentNativeMenuMark({ className }: { className?: string }) {
@@ -9804,6 +9847,7 @@ ${serializedHtml}
       const sameFileDragIds: string[] = [];
       const crossFileDrags: Array<{ draggedId: string; sourceFileId: string }> =
         [];
+      const movedNodeSnapshots = new Map<string, CodeLayerNode>();
       for (const draggedId of intent.draggedIds) {
         const draggedOwner = codeLayerOwnerByNodeId.get(draggedId);
         if (
@@ -9814,6 +9858,7 @@ ${serializedHtml}
         ) {
           continue;
         }
+        movedNodeSnapshots.set(draggedId, draggedOwner.node);
         if (draggedOwner.fileId === targetOwner.fileId) {
           sameFileDragIds.push(draggedId);
         } else {
@@ -9896,6 +9941,40 @@ ${serializedHtml}
       }
 
       if (!moved) return;
+
+      const finalDestProjection =
+        nextDestContent !== destContent
+          ? buildCodeLayerProjection(nextDestContent)
+          : null;
+      const finalDestTree = finalDestProjection
+        ? buildCodeLayerTree(finalDestProjection)
+        : [];
+      const movedNodesAfterMove = intent.draggedIds
+        .map((draggedId) => movedNodeSnapshots.get(draggedId))
+        .map((node) =>
+          node && finalDestProjection
+            ? findCodeLayerNodeInProjection(finalDestProjection, node)
+            : null,
+        )
+        .filter((node): node is CodeLayerNode => Boolean(node));
+
+      if (movedNodesAfterMove.length > 0) {
+        setSelectedLayerIdsState(movedNodesAfterMove.map((node) => node.id));
+        const lastMovedNode =
+          movedNodesAfterMove[movedNodesAfterMove.length - 1];
+        if (lastMovedNode && targetOwner.fileId === activeFile?.id) {
+          setSelectedElement(elementInfoFromCodeLayerNode(lastMovedNode));
+        }
+        const movedAncestorIds = movedNodesAfterMove.flatMap((node) =>
+          collectCodeLayerAncestors(finalDestTree, node.id),
+        );
+        setExpandedLayerIds((current) => {
+          const next = new Set(current);
+          next.add(targetOwner.fileId);
+          movedAncestorIds.forEach((ancestorId) => next.add(ancestorId));
+          return next.size === current.length ? current : Array.from(next);
+        });
+      }
 
       // Persist source files that changed.
       for (const [sourceFileId, newSourceContent] of sourceContentMap) {

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -43,6 +43,7 @@ import {
   buildCodeLayerProjection,
   buildCodeLayerTree,
   ensureCodeLayerNodeIdsInHtml,
+  moveNodeBetweenDocuments,
   removeCodeLayerNodeFromHtml,
   type CodeLayerNode,
   type CodeLayerTreeNode,
@@ -132,6 +133,7 @@ import {
   type LayersPanelMoveIntent,
   type LayersPanelNode,
 } from "@/components/design/LayersPanel";
+import { LocalSourceEditBanner } from "@/components/design/LocalSourceEditBanner";
 import {
   MultiScreenCanvas,
   OVERVIEW_FRAME_WIDTH,
@@ -629,6 +631,12 @@ interface GeometryHistoryEntry {
   after: CanvasFrameGeometryById;
 }
 
+interface ContentHistoryEntry {
+  fileId: string;
+  before: string;
+  after: string;
+}
+
 type PatchProofStatus =
   | "runtime"
   | "queued"
@@ -844,6 +852,44 @@ function escapeHtmlAttributeValue(value: string): string {
     .replace(/"/g, "&quot;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
+}
+
+const ABS_POSITION_PROPS = [
+  "position",
+  "left",
+  "top",
+  "right",
+  "bottom",
+] as const;
+
+/**
+ * Remove absolute-positioning style properties from the element identified by
+ * `data-agent-native-node-id` so that it becomes a flow child after being
+ * reparented into a container. Returns the updated HTML, or the original HTML
+ * if the node cannot be found or parsing is unavailable.
+ *
+ * Uses DOMParser + CSSStyleDeclaration.removeProperty() rather than
+ * applyVisualEdit({kind:"style",value:""}) because the substrate rejects
+ * empty-string values in isSafeStyleValue, making that approach a silent no-op.
+ */
+function removeAbsolutePositioningFromNodeInHtml(
+  content: string,
+  nodeAttrId: string,
+): string {
+  if (typeof window === "undefined") return content;
+  try {
+    const doc = new DOMParser().parseFromString(content, "text/html");
+    const element = doc.querySelector(
+      `[data-agent-native-node-id="${CSS.escape(nodeAttrId)}"]`,
+    ) as HTMLElement | null;
+    if (!element) return content;
+    for (const prop of ABS_POSITION_PROPS) {
+      element.style.removeProperty(prop);
+    }
+    return `<!DOCTYPE html>\n${doc.documentElement.outerHTML}`;
+  } catch {
+    return content;
+  }
 }
 
 function escapeHtmlText(value: string): string {
@@ -2981,6 +3027,9 @@ export default function DesignEditor() {
   const [canUndo, setCanUndo] = useState(false);
   const [canRedo, setCanRedo] = useState(false);
   const undoManagerRef = useRef<Y.UndoManager | null>(null);
+  const contentUndoStackRef = useRef<ContentHistoryEntry[]>([]);
+  const contentRedoStackRef = useRef<ContentHistoryEntry[]>([]);
+  const suppressContentHistoryRef = useRef(false);
   const geometryUndoStackRef = useRef<GeometryHistoryEntry[]>([]);
   const geometryRedoStackRef = useRef<GeometryHistoryEntry[]>([]);
   const historyOrderRef = useRef<Array<"content" | "geometry">>([]);
@@ -2989,10 +3038,12 @@ export default function DesignEditor() {
     const undoManager = undoManagerRef.current;
     setCanUndo(
       Boolean(undoManager?.canUndo()) ||
+        contentUndoStackRef.current.length > 0 ||
         geometryUndoStackRef.current.length > 0,
     );
     setCanRedo(
       Boolean(undoManager?.canRedo()) ||
+        contentRedoStackRef.current.length > 0 ||
         geometryRedoStackRef.current.length > 0,
     );
   }, []);
@@ -3000,6 +3051,9 @@ export default function DesignEditor() {
   const designSelectionOwnerIdRef = useRef(`${TAB_ID}:${generateTabId()}`);
   const frameGeometrySaveTimerRef = useRef<number | null>(null);
   const [tweakSaveActive, setTweakSaveActive] = useState(false);
+  // Dismissible localhost-source banner (reset per session).
+  const [localSourceBannerDismissed, setLocalSourceBannerDismissed] =
+    useState(false);
   // Shared visual-editor annotate overlays. drawMode owns the send toolbar,
   // while pinMode temporarily routes canvas clicks to comment pins that queue
   // into the same agent submission.
@@ -3318,6 +3372,42 @@ export default function DesignEditor() {
     designAccessRole === "owner" || designAccessRole === "admin";
   const canEditDesign = canShareDesign || designAccessRole === "editor";
   const canEditDesignRef = useRef(canEditDesign);
+  const pendingLocalFileContentsRef = useRef<
+    Map<string, { content: string; startedAt: number }>
+  >(new Map());
+  const [
+    pendingLocalFileContentsRevision,
+    setPendingLocalFileContentsRevision,
+  ] = useState(0);
+
+  const markPendingLocalFileContent = useCallback(
+    (fileId: string, content: string) => {
+      const current = pendingLocalFileContentsRef.current.get(fileId);
+      if (current?.content === content) return;
+      pendingLocalFileContentsRef.current.set(fileId, {
+        content,
+        startedAt: Date.now(),
+      });
+      setPendingLocalFileContentsRevision((revision) => revision + 1);
+    },
+    [],
+  );
+
+  const clearPendingLocalFileContent = useCallback(
+    (fileId: string, expectedContent?: string) => {
+      const current = pendingLocalFileContentsRef.current.get(fileId);
+      if (!current) return;
+      if (
+        expectedContent !== undefined &&
+        current.content !== expectedContent
+      ) {
+        return;
+      }
+      pendingLocalFileContentsRef.current.delete(fileId);
+      setPendingLocalFileContentsRevision((revision) => revision + 1);
+    },
+    [],
+  );
 
   useEffect(() => {
     canEditDesignRef.current = canEditDesign;
@@ -3382,6 +3472,7 @@ export default function DesignEditor() {
   const saveFileContent = useCallback(
     (pending: FileContentSaveRequest) => {
       if (!canEditDesignRef.current) return;
+      markPendingLocalFileContent(pending.id, pending.content);
       latestFileSaveForUnloadRef.current[pending.id] = pending;
       const previous =
         fileSaveChainsRef.current[pending.id] ?? Promise.resolve();
@@ -3400,6 +3491,7 @@ export default function DesignEditor() {
                 : prev,
             );
           } catch (error) {
+            clearPendingLocalFileContent(pending.id, pending.content);
             setPatchProof((prev) =>
               prev && prev.fileId === pending.id && prev.status === "queued"
                 ? {
@@ -3421,7 +3513,12 @@ export default function DesignEditor() {
         }
       });
     },
-    [t, updateFileMutation],
+    [
+      clearPendingLocalFileContent,
+      markPendingLocalFileContent,
+      t,
+      updateFileMutation,
+    ],
   );
 
   const queueFileContentSave = useCallback(
@@ -3436,6 +3533,7 @@ export default function DesignEditor() {
         content,
         syncCollab: options.syncCollab ?? true,
       };
+      markPendingLocalFileContent(fileId, content);
       latestFileSaveForUnloadRef.current[fileId] = pending;
       if (options.immediate) {
         const timer = fileSaveTimersRef.current[fileId];
@@ -3460,7 +3558,7 @@ export default function DesignEditor() {
         saveFileContent(pending);
       }, 400);
     },
-    [saveFileContent],
+    [markPendingLocalFileContent, saveFileContent],
   );
 
   useEffect(() => {
@@ -3705,7 +3803,32 @@ export default function DesignEditor() {
     updateDesignMutation,
   ]);
 
-  const files = design?.files ?? [];
+  const serverFiles = design?.files ?? [];
+  useEffect(() => {
+    if (pendingLocalFileContentsRef.current.size === 0) return;
+    let changed = false;
+    for (const file of serverFiles) {
+      const pending = pendingLocalFileContentsRef.current.get(file.id);
+      if (pending && (file.content ?? "") === pending.content) {
+        pendingLocalFileContentsRef.current.delete(file.id);
+        changed = true;
+      }
+    }
+    if (changed) {
+      setPendingLocalFileContentsRevision((revision) => revision + 1);
+    }
+  }, [serverFiles]);
+  const pendingLocalFileContentsSnapshot = useMemo(
+    () => new Map(pendingLocalFileContentsRef.current),
+    [pendingLocalFileContentsRevision],
+  );
+  const files = useMemo(() => {
+    if (pendingLocalFileContentsSnapshot.size === 0) return serverFiles;
+    return serverFiles.map((file) => {
+      const pending = pendingLocalFileContentsSnapshot.get(file.id);
+      return pending ? { ...file, content: pending.content } : file;
+    });
+  }, [pendingLocalFileContentsSnapshot, serverFiles]);
   const designDataJson = useMemo(
     () => parseDesignDataJson(design?.data),
     [design?.data],
@@ -4409,7 +4532,10 @@ export default function DesignEditor() {
       setCollabContentFileId(null);
       lastAppliedFileUpdatedAtRef.current = null;
       lastLocalContentRef.current = null;
+      contentUndoStackRef.current = [];
+      contentRedoStackRef.current = [];
       clearStaleAgentCollabRecovery();
+      syncUndoRedoState();
       return;
     }
     if (activeFileId !== prevActiveFileIdRef.current) {
@@ -4418,9 +4544,17 @@ export default function DesignEditor() {
       setCollabContentFileId(null);
       lastAppliedFileUpdatedAtRef.current = null;
       lastLocalContentRef.current = null;
+      contentUndoStackRef.current = [];
+      contentRedoStackRef.current = [];
       clearStaleAgentCollabRecovery();
+      syncUndoRedoState();
     }
-  }, [activeFileId, clearStaleAgentCollabRecovery, viewMode]);
+  }, [
+    activeFileId,
+    clearStaleAgentCollabRecovery,
+    syncUndoRedoState,
+    viewMode,
+  ]);
 
   useEffect(() => {
     return clearStaleAgentCollabRecovery;
@@ -4432,6 +4566,19 @@ export default function DesignEditor() {
     const fileId = activeFileId;
     const ytext = ydoc.getText("content");
     const text = ytext.toString();
+    const pendingLocalContent =
+      pendingLocalFileContentsRef.current.get(fileId)?.content;
+    if (pendingLocalContent && text !== pendingLocalContent) {
+      setCollabContent(pendingLocalContent);
+      setCollabContentFileId(fileId);
+      lastLocalContentRef.current = pendingLocalContent;
+      setContentRenderRevision((revision) => revision + 1);
+      ydoc.transact(() => {
+        ytext.delete(0, ytext.length);
+        ytext.insert(0, pendingLocalContent);
+      }, TAB_ID);
+      return;
+    }
     if (text.length > 0) {
       const storedContent = activeFile?.content ?? "";
       if (
@@ -4458,7 +4605,14 @@ export default function DesignEditor() {
       setCollabContentFileId(fileId);
       setContentRenderRevision((revision) => revision + 1);
     }
-  }, [ydoc, isSynced, activeFileId, activeFile?.content, activeFile?.fileType]);
+  }, [
+    ydoc,
+    isSynced,
+    activeFileId,
+    activeFile?.content,
+    activeFile?.fileType,
+    pendingLocalFileContentsRevision,
+  ]);
 
   // Keep the freshest DB `updatedAt` in a ref the observe handler can read.
   useEffect(() => {
@@ -4479,14 +4633,27 @@ export default function DesignEditor() {
     const ytext = ydoc.getText("content");
     const handler = (_event: unknown, transaction?: { origin?: unknown }) => {
       const next = ytext.toString();
-      setCollabContent(next);
-      setCollabContentFileId(fileId);
       // UndoManager fires with itself as the origin; treat those as local too
       // so the reconcile watermark and stale-selection fix are consistent.
       const isLocalEdit =
         transaction?.origin === TAB_ID ||
         transaction?.origin === LOCAL_EDIT_ORIGIN ||
         transaction?.origin === undoManagerRef.current;
+      const pendingLocalContent =
+        pendingLocalFileContentsRef.current.get(fileId)?.content;
+      if (pendingLocalContent && next !== pendingLocalContent && !isLocalEdit) {
+        setCollabContent(pendingLocalContent);
+        setCollabContentFileId(fileId);
+        lastLocalContentRef.current = pendingLocalContent;
+        setContentRenderRevision((revision) => revision + 1);
+        ydoc.transact(() => {
+          ytext.delete(0, ytext.length);
+          ytext.insert(0, pendingLocalContent);
+        }, TAB_ID);
+        return;
+      }
+      setCollabContent(next);
+      setCollabContentFileId(fileId);
       if (isLocalEdit) {
         lastLocalContentRef.current = next;
       } else {
@@ -4829,12 +4996,16 @@ export default function DesignEditor() {
   // file switch can render one frame with the previous file's Yjs text.
   const activeCollabFileReady =
     viewMode === "single" && activeFileId === prevActiveFileIdRef.current;
+  const pendingActiveFileContent = activeFile?.id
+    ? pendingLocalFileContentsSnapshot.get(activeFile.id)?.content
+    : undefined;
   const activeContent =
-    activeCollabFileReady &&
+    pendingActiveFileContent ??
+    (activeCollabFileReady &&
     collabContentFileId === activeFile?.id &&
     collabContent !== null
       ? collabContent
-      : (activeFile?.content ?? "");
+      : (activeFile?.content ?? ""));
   const fileContentById = useMemo(() => {
     const map = new Map<string, string>();
     for (const file of files) {
@@ -4949,6 +5120,36 @@ export default function DesignEditor() {
       } = {},
     ) => {
       if (!activeFile || !canEditDesignRef.current) return;
+      const previousContent =
+        collabContentFileIdRef.current === activeFile.id &&
+        typeof collabContentRef.current === "string"
+          ? collabContentRef.current
+          : (activeFile.content ?? "");
+      const yjsHistoryAvailable = Boolean(
+        ydoc && isSynced && undoManagerRef.current,
+      );
+      if (
+        !suppressContentHistoryRef.current &&
+        !yjsHistoryAvailable &&
+        previousContent !== nextContent
+      ) {
+        contentUndoStackRef.current = [
+          ...contentUndoStackRef.current.slice(-(MAX_DESIGN_UNDO_STACK - 1)),
+          {
+            fileId: activeFile.id,
+            before: previousContent,
+            after: nextContent,
+          },
+        ];
+        contentRedoStackRef.current = [];
+        historyOrderRef.current = [
+          ...historyOrderRef.current.slice(-(MAX_DESIGN_UNDO_STACK - 1)),
+          "content",
+        ];
+        redoOrderRef.current = [];
+        syncUndoRedoState();
+      }
+      markPendingLocalFileContent(activeFile.id, nextContent);
       setCollabContent(nextContent);
       setCollabContentFileId(activeFile.id);
       lastLocalContentRef.current = nextContent;
@@ -5002,9 +5203,11 @@ export default function DesignEditor() {
       activeFile,
       id,
       isSynced,
+      markPendingLocalFileContent,
       queryClient,
       queueFileContentSave,
       replacePreviewContent,
+      syncUndoRedoState,
       ydoc,
     ],
   );
@@ -5020,6 +5223,7 @@ export default function DesignEditor() {
         applyLocalContentUpdate(nextContent, options);
         return;
       }
+      markPendingLocalFileContent(fileId, nextContent);
       queryClient.setQueryData(["action", "get-design", { id }], (old: any) => {
         if (!old || typeof old !== "object" || !Array.isArray(old.files)) {
           return old;
@@ -5037,7 +5241,14 @@ export default function DesignEditor() {
         syncCollab: true,
       });
     },
-    [activeFile?.id, applyLocalContentUpdate, id, queryClient, saveFileContent],
+    [
+      activeFile?.id,
+      applyLocalContentUpdate,
+      id,
+      markPendingLocalFileContent,
+      queryClient,
+      saveFileContent,
+    ],
   );
 
   const handleCreatePrimitive = useCallback(
@@ -6516,7 +6727,6 @@ export default function DesignEditor() {
     setHasCanvasClipboard(true);
     try {
       await navigator.clipboard.writeText(html);
-      toast.success(t("designEditor.toasts.copied"));
     } catch {
       toast.error(t("designEditor.toasts.clipboardBlocked"));
     }
@@ -6545,9 +6755,8 @@ export default function DesignEditor() {
       if (!nextContent) return;
       if (!position) pasteCascadeRef.current += 1;
       applyLocalContentUpdate(nextContent);
-      toast.success(t("designEditor.toasts.pasted"), { duration: 3000 });
     },
-    [activeContent, activeFile, applyLocalContentUpdate, canEditDesign, t],
+    [activeContent, activeFile, applyLocalContentUpdate, canEditDesign],
   );
 
   const handlePasteOverSelection = useCallback(() => {
@@ -6561,7 +6770,6 @@ export default function DesignEditor() {
       );
       if (!nextContent) return;
       applyLocalContentUpdate(nextContent);
-      toast.success(t("designEditor.toasts.pasted"));
     } else {
       handlePasteSelection();
     }
@@ -6571,7 +6779,6 @@ export default function DesignEditor() {
     applyLocalContentUpdate,
     handlePasteSelection,
     selectedElement,
-    t,
   ]);
 
   const handleDuplicateSelection = useCallback(() => {
@@ -6664,6 +6871,287 @@ export default function DesignEditor() {
     selectedElement,
     selectedLayerIdsState,
   ]);
+
+  // Wrap the current multi-layer selection into a new group container.
+  const handleGroupSelection = useCallback(() => {
+    if (!canEditDesign || !activeFile) return;
+    // Collect the DOM-node layer ids that belong to the active screen.
+    const fileIds = new Set(files.map((f) => f.id));
+    const nodeIds = selectedLayerIdsState.filter(
+      (id) => !id.startsWith("__") && !fileIds.has(id),
+    );
+    if (nodeIds.length < 2) return;
+    const patch = applyVisualEdit(activeContent, {
+      kind: "wrapNodes",
+      targetIds: nodeIds,
+      autoLayout: false,
+    });
+    if (patch.result.status !== "applied") {
+      toast.error(
+        codeLayerPatchMessage(
+          patch.result.message,
+          t("designEditor.toasts.layerMoveFailed"),
+        ),
+        { duration: 4000 },
+      );
+      return;
+    }
+    applyLocalContentUpdate(patch.content, { skipPreview: true });
+    // Select the new wrapper node if the substrate reported its id.
+    const wrapperId = patch.result.wrapperNodeId;
+    if (wrapperId) {
+      // Find the projection node whose data-agent-native-node-id matches.
+      const wrapperNode = patch.projection.nodes.find(
+        (n) => n.dataAttributes["data-agent-native-node-id"] === wrapperId,
+      );
+      if (wrapperNode) {
+        setSelectedLayerIdsState([wrapperNode.id]);
+        setSelectedElement(elementInfoFromCodeLayerNode(wrapperNode));
+      }
+    }
+  }, [
+    activeContent,
+    activeFile,
+    applyLocalContentUpdate,
+    canEditDesign,
+    files,
+    selectedLayerIdsState,
+    t,
+  ]);
+
+  // Unwrap the currently selected single-container layer.
+  const handleUngroupSelection = useCallback(() => {
+    if (!canEditDesign || !activeFile) return;
+    const fileIds = new Set(files.map((f) => f.id));
+    const nodeIds = selectedLayerIdsState.filter(
+      (id) => !id.startsWith("__") && !fileIds.has(id),
+    );
+    const targetId = nodeIds[0];
+    if (!targetId) return;
+    const patch = applyVisualEdit(activeContent, {
+      kind: "unwrap",
+      targetId,
+    });
+    if (patch.result.status !== "applied") {
+      toast.error(
+        codeLayerPatchMessage(
+          patch.result.message,
+          t("designEditor.toasts.layerMoveFailed"),
+        ),
+        { duration: 4000 },
+      );
+      return;
+    }
+    applyLocalContentUpdate(patch.content, { skipPreview: true });
+    setSelectedElement(null);
+    setSelectedLayerIdsState([]);
+  }, [
+    activeContent,
+    activeFile,
+    applyLocalContentUpdate,
+    canEditDesign,
+    files,
+    selectedLayerIdsState,
+    t,
+  ]);
+
+  /**
+   * Convert the selected container to full auto-layout. Applies the
+   * { kind: "autoLayout", enabled: true } substrate intent which sets
+   * display:flex on the target AND strips position:absolute/left/top/right/bottom
+   * from its direct children so they become flow children.
+   */
+  const handleAutoLayoutConvert = useCallback(
+    (
+      targetNodeId: string,
+      opts?: { direction?: "row" | "column"; gap?: string },
+    ) => {
+      if (!canEditDesign || !activeFile) return;
+      const patch = applyVisualEdit(activeContent, {
+        kind: "autoLayout",
+        targetId: targetNodeId,
+        enabled: true,
+        direction: opts?.direction ?? "row",
+        gap: opts?.gap ?? "8px",
+      });
+      if (patch.result.status !== "applied") {
+        toast.error(
+          codeLayerPatchMessage(
+            patch.result.message,
+            t("designEditor.toasts.layerMoveFailed"),
+          ),
+          { duration: 4000 },
+        );
+        return;
+      }
+      applyLocalContentUpdate(patch.content, { skipPreview: true });
+      // Re-select the container so the inspector refreshes its layout state.
+      const containerNode = patch.projection.nodes.find(
+        (n) =>
+          n.dataAttributes["data-agent-native-node-id"] === targetNodeId ||
+          n.id === targetNodeId,
+      );
+      if (containerNode) {
+        setSelectedLayerIdsState([containerNode.id]);
+        setSelectedElement(elementInfoFromCodeLayerNode(containerNode));
+      }
+    },
+    [activeContent, activeFile, applyLocalContentUpdate, canEditDesign, t],
+  );
+
+  /**
+   * Handle a primitive being drag-dropped onto another primitive in the
+   * MultiScreenCanvas overview (CONTRACT: onPrimitiveReparent prop).
+   *
+   * Same-screen: applies a moveNode intent then strips the moved node's
+   * absolute positioning so it becomes a flow child of the container.
+   * Cross-screen: uses moveNodeBetweenDocuments and persists both files.
+   */
+  const handleOverviewPrimitiveReparent = useCallback(
+    ({
+      sourceNodeId,
+      sourceScreenId,
+      targetNodeId,
+      targetScreenId,
+    }: {
+      sourceNodeId: string;
+      sourceScreenId: string;
+      targetNodeId: string;
+      targetScreenId: string;
+      placement: "inside";
+    }) => {
+      if (!canEditDesign) return;
+
+      if (sourceScreenId === targetScreenId) {
+        // --- Same-screen reparent ---
+        const baseContent = getScreenContent(sourceScreenId);
+        if (!baseContent) return;
+
+        // 1. Move the node inside the target container.
+        const movePatch = applyVisualEdit(baseContent, {
+          kind: "moveNode",
+          target: { nodeId: sourceNodeId },
+          anchor: { nodeId: targetNodeId },
+          placement: "inside",
+        });
+        if (movePatch.result.status !== "applied") {
+          toast.error(
+            codeLayerPatchMessage(
+              movePatch.result.message,
+              t("designEditor.toasts.layerMoveFailed"),
+            ),
+            { duration: 4000 },
+          );
+          return;
+        }
+
+        // 2. Strip absolute positioning from the moved node so it flows naturally.
+        // Use removeAbsolutePositioningFromNodeInHtml (DOM-based) because the
+        // applyVisualEdit substrate rejects empty-string values in isSafeStyleValue,
+        // making applyVisualEdit({kind:"style",value:""}) a silent no-op.
+        const movedNodeAttrId =
+          movePatch.projection.nodes.find(
+            (n) =>
+              n.dataAttributes["data-agent-native-node-id"] === sourceNodeId ||
+              n.id === sourceNodeId,
+          )?.dataAttributes["data-agent-native-node-id"] ?? sourceNodeId;
+        const strippedContent = removeAbsolutePositioningFromNodeInHtml(
+          movePatch.content,
+          movedNodeAttrId,
+        );
+
+        applyFileContentUpdate(sourceScreenId, strippedContent, {
+          skipPreview: true,
+        });
+
+        // Re-select the moved node.
+        const nextProjection = buildCodeLayerProjection(strippedContent);
+        const movedNodeAfter = nextProjection.nodes.find(
+          (n) =>
+            n.dataAttributes["data-agent-native-node-id"] === sourceNodeId ||
+            n.id === sourceNodeId,
+        );
+        if (movedNodeAfter) {
+          setSelectedLayerIdsState([movedNodeAfter.id]);
+          setSelectedElement(elementInfoFromCodeLayerNode(movedNodeAfter));
+        }
+        return;
+      }
+
+      // --- Cross-screen reparent ---
+      const sourceContent = getScreenContent(sourceScreenId);
+      const destContent = getScreenContent(targetScreenId);
+      if (!sourceContent || !destContent) return;
+
+      // Resolve data-agent-native-node-id attributes for moveNodeBetweenDocuments.
+      const sourceProjection = buildCodeLayerProjection(sourceContent);
+      const destProjection = buildCodeLayerProjection(destContent);
+      const sourceNode = sourceProjection.nodes.find(
+        (n) =>
+          n.dataAttributes["data-agent-native-node-id"] === sourceNodeId ||
+          n.id === sourceNodeId,
+      );
+      const anchorNode = destProjection.nodes.find(
+        (n) =>
+          n.dataAttributes["data-agent-native-node-id"] === targetNodeId ||
+          n.id === targetNodeId,
+      );
+      const nodeAttrId =
+        sourceNode?.dataAttributes["data-agent-native-node-id"] ?? sourceNodeId;
+      const anchorAttrId =
+        anchorNode?.dataAttributes["data-agent-native-node-id"] ?? targetNodeId;
+
+      const result = moveNodeBetweenDocuments(sourceContent, destContent, {
+        nodeId: nodeAttrId,
+        anchorNodeId: anchorAttrId,
+        placement: "inside",
+      });
+      if (result.status !== "applied") {
+        toast.error(
+          codeLayerPatchMessage(
+            result.message,
+            t("designEditor.toasts.layerMoveFailed"),
+          ),
+          { duration: 4000 },
+        );
+        return;
+      }
+
+      // Strip absolute positioning from the moved node in the destination.
+      // Use removeAbsolutePositioningFromNodeInHtml (DOM-based) because
+      // applyVisualEdit({kind:"style",value:""}) is a silent no-op (the
+      // substrate rejects empty-string values in isSafeStyleValue). Use
+      // nodeAttrId as the lookup key — after moveNodeBetweenDocuments the
+      // node retains that id in the destination unless it collided, in which
+      // case the DOM query by the original id falls through gracefully and
+      // skips the strip (the node stays absolute, which is better than
+      // corrupting an unrelated node). The `n.id === sourceNodeId` fallback
+      // that was here before is wrong: projection ids in the destination
+      // document are freshly assigned and will never equal a source projection id.
+      const strippedDest = removeAbsolutePositioningFromNodeInHtml(
+        result.destHtml,
+        nodeAttrId,
+      );
+
+      applyFileContentUpdate(sourceScreenId, result.sourceHtml, {
+        refreshPreview: true,
+      });
+      applyFileContentUpdate(targetScreenId, strippedDest, {
+        refreshPreview: true,
+      });
+
+      // Re-select the moved node in the destination.
+      const finalProjection = buildCodeLayerProjection(strippedDest);
+      const movedNodeFinal = finalProjection.nodes.find(
+        (n) => n.dataAttributes["data-agent-native-node-id"] === nodeAttrId,
+      );
+      if (movedNodeFinal) {
+        setSelectedLayerIdsState([movedNodeFinal.id]);
+        setSelectedElement(elementInfoFromCodeLayerNode(movedNodeFinal));
+      }
+    },
+    [applyFileContentUpdate, canEditDesign, getScreenContent, t],
+  );
 
   const handleCutSelection = useCallback(async () => {
     if (!selectedElement?.selector) return;
@@ -6763,8 +7251,7 @@ export default function DesignEditor() {
       textAlign: selectedElement.computedStyles.textAlign,
     };
     setHasPropsClipboard(true);
-    toast.success(t("designEditor.toasts.propsCopied"));
-  }, [selectedElement, t]);
+  }, [selectedElement]);
 
   const handlePasteProps = useCallback(() => {
     if (!canEditDesign) return;
@@ -6775,8 +7262,7 @@ export default function DesignEditor() {
       ),
     );
     commitVisualStyles(selectedElement.selector, styles);
-    toast.success(t("designEditor.toasts.propsPasted"));
-  }, [canEditDesign, commitVisualStyles, selectedElement, t]);
+  }, [canEditDesign, commitVisualStyles, selectedElement]);
 
   const changeSelectedZIndex = useCallback(
     (mode: "forward" | "front" | "backward" | "back") => {
@@ -6836,31 +7322,63 @@ export default function DesignEditor() {
     if (!canEditDesign) return;
     const um = undoManagerRef.current;
     const undoContent = () => {
-      if (!um || !um.canUndo()) return false;
-      um.undo();
-      if (ydoc && activeFile) {
-        const next = ydoc.getText("content").toString();
-        lastLocalContentRef.current = next;
-        queueFileContentSave(activeFile.id, next, {
-          syncCollab: !(ydoc && isSynced),
-        });
-        if (!replacePreviewContent(next)) {
-          setContentRenderRevision((revision) => revision + 1);
+      if (um?.canUndo()) {
+        um.undo();
+        if (ydoc && activeFile) {
+          const next = ydoc.getText("content").toString();
+          markPendingLocalFileContent(activeFile.id, next);
+          lastLocalContentRef.current = next;
+          queueFileContentSave(activeFile.id, next, {
+            syncCollab: !(ydoc && isSynced),
+          });
+          if (!replacePreviewContent(next)) {
+            setContentRenderRevision((revision) => revision + 1);
+          }
+          // Clear stale selection if the undo removed the selected element.
+          setSelectedElement((prev) => {
+            if (!prev) return prev;
+            return elementInfoExistsInContent(next, prev) ? prev : null;
+          });
+          setHoveredElement((prev) => {
+            if (!prev) return prev;
+            return elementInfoExistsInContent(next, prev) ? prev : null;
+          });
         }
-        // Clear stale selection if the undo removed the selected element.
-        setSelectedElement((prev) => {
-          if (!prev) return prev;
-          return elementInfoExistsInContent(next, prev) ? prev : null;
-        });
-        setHoveredElement((prev) => {
-          if (!prev) return prev;
-          return elementInfoExistsInContent(next, prev) ? prev : null;
-        });
+        redoOrderRef.current = [
+          ...redoOrderRef.current.slice(-(MAX_DESIGN_UNDO_STACK - 1)),
+          "content",
+        ];
+        return true;
       }
+
+      if (!activeFile) return false;
+      const entry = contentUndoStackRef.current.pop();
+      if (!entry || entry.fileId !== activeFile.id) return false;
+      contentRedoStackRef.current = [
+        ...contentRedoStackRef.current.slice(-(MAX_DESIGN_UNDO_STACK - 1)),
+        entry,
+      ];
       redoOrderRef.current = [
         ...redoOrderRef.current.slice(-(MAX_DESIGN_UNDO_STACK - 1)),
         "content",
       ];
+      suppressContentHistoryRef.current = true;
+      try {
+        applyLocalContentUpdate(entry.before, {
+          refreshPreview: false,
+          immediateSave: true,
+        });
+      } finally {
+        suppressContentHistoryRef.current = false;
+      }
+      setSelectedElement((prev) => {
+        if (!prev) return prev;
+        return elementInfoExistsInContent(entry.before, prev) ? prev : null;
+      });
+      setHoveredElement((prev) => {
+        if (!prev) return prev;
+        return elementInfoExistsInContent(entry.before, prev) ? prev : null;
+      });
       return true;
     };
     const undoGeometry = () => {
@@ -6896,8 +7414,10 @@ export default function DesignEditor() {
   }, [
     ydoc,
     activeFile,
+    applyLocalContentUpdate,
     canEditDesign,
     isSynced,
+    markPendingLocalFileContent,
     queueFileContentSave,
     replacePreviewContent,
     syncUndoRedoState,
@@ -6908,31 +7428,63 @@ export default function DesignEditor() {
     if (!canEditDesign) return;
     const um = undoManagerRef.current;
     const redoContent = () => {
-      if (!um || !um.canRedo()) return false;
-      um.redo();
-      if (ydoc && activeFile) {
-        const next = ydoc.getText("content").toString();
-        lastLocalContentRef.current = next;
-        queueFileContentSave(activeFile.id, next, {
-          syncCollab: !(ydoc && isSynced),
-        });
-        if (!replacePreviewContent(next)) {
-          setContentRenderRevision((revision) => revision + 1);
+      if (um?.canRedo()) {
+        um.redo();
+        if (ydoc && activeFile) {
+          const next = ydoc.getText("content").toString();
+          markPendingLocalFileContent(activeFile.id, next);
+          lastLocalContentRef.current = next;
+          queueFileContentSave(activeFile.id, next, {
+            syncCollab: !(ydoc && isSynced),
+          });
+          if (!replacePreviewContent(next)) {
+            setContentRenderRevision((revision) => revision + 1);
+          }
+          // Clear stale selection if the redo removed the selected element.
+          setSelectedElement((prev) => {
+            if (!prev) return prev;
+            return elementInfoExistsInContent(next, prev) ? prev : null;
+          });
+          setHoveredElement((prev) => {
+            if (!prev) return prev;
+            return elementInfoExistsInContent(next, prev) ? prev : null;
+          });
         }
-        // Clear stale selection if the redo removed the selected element.
-        setSelectedElement((prev) => {
-          if (!prev) return prev;
-          return elementInfoExistsInContent(next, prev) ? prev : null;
-        });
-        setHoveredElement((prev) => {
-          if (!prev) return prev;
-          return elementInfoExistsInContent(next, prev) ? prev : null;
-        });
+        historyOrderRef.current = [
+          ...historyOrderRef.current.slice(-(MAX_DESIGN_UNDO_STACK - 1)),
+          "content",
+        ];
+        return true;
       }
+
+      if (!activeFile) return false;
+      const entry = contentRedoStackRef.current.pop();
+      if (!entry || entry.fileId !== activeFile.id) return false;
+      contentUndoStackRef.current = [
+        ...contentUndoStackRef.current.slice(-(MAX_DESIGN_UNDO_STACK - 1)),
+        entry,
+      ];
       historyOrderRef.current = [
         ...historyOrderRef.current.slice(-(MAX_DESIGN_UNDO_STACK - 1)),
         "content",
       ];
+      suppressContentHistoryRef.current = true;
+      try {
+        applyLocalContentUpdate(entry.after, {
+          refreshPreview: false,
+          immediateSave: true,
+        });
+      } finally {
+        suppressContentHistoryRef.current = false;
+      }
+      setSelectedElement((prev) => {
+        if (!prev) return prev;
+        return elementInfoExistsInContent(entry.after, prev) ? prev : null;
+      });
+      setHoveredElement((prev) => {
+        if (!prev) return prev;
+        return elementInfoExistsInContent(entry.after, prev) ? prev : null;
+      });
       return true;
     };
     const redoGeometry = () => {
@@ -6968,8 +7520,10 @@ export default function DesignEditor() {
   }, [
     ydoc,
     activeFile,
+    applyLocalContentUpdate,
     canEditDesign,
     isSynced,
+    markPendingLocalFileContent,
     queueFileContentSave,
     replacePreviewContent,
     syncUndoRedoState,
@@ -7408,6 +7962,8 @@ export default function DesignEditor() {
       setTitleDraft(design?.title ?? "");
       setTitleEditing(true);
     },
+    onGroup: canEditDesign ? handleGroupSelection : undefined,
+    onUngroup: canEditDesign ? handleUngroupSelection : undefined,
     onSelectAll: handleSelectAllFrames,
     onUndo: canEditDesign ? handleUndo : undefined,
     onRedo: canEditDesign ? handleRedo : undefined,
@@ -8505,12 +9061,67 @@ ${serializedHtml}
     selectedElementLayerId ??
     activeFile?.id ??
     "";
+  const selectedElementFullViewScreenId =
+    viewMode === "overview" && selectedElement
+      ? selectedElementLayerId
+        ? (codeLayerOwnerByNodeId.get(selectedElementLayerId)?.fileId ??
+          activeFileId)
+        : activeFileId
+      : null;
+  const fullViewScreenIds = selectedElementFullViewScreenId
+    ? [selectedElementFullViewScreenId]
+    : [];
   const activeLayerLocked = Boolean(
     activeLayerId && effectiveCodeLayerState.lockedIds.has(activeLayerId),
   );
   const activeLayerHidden = Boolean(
     activeLayerId && effectiveCodeLayerState.hiddenIds.has(activeLayerId),
   );
+
+  // Detect if the active screen is a localhost/local source so we can show a banner.
+  const activeScreenIsLocalSource =
+    viewMode === "single" &&
+    Boolean(activeFile) &&
+    activeOverviewScreen?.sourceType === "localhost";
+  // `source` in screen metadata may be a JSON object with a `file` field; try to
+  // extract it as the routeSourceFile for the banner.
+  const activeScreenRouteSourceFile = (() => {
+    if (!activeScreenIsLocalSource) return undefined;
+    const raw = activeOverviewScreen?.source;
+    if (!raw) return undefined;
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      if (
+        parsed &&
+        typeof parsed === "object" &&
+        "file" in parsed &&
+        typeof (parsed as Record<string, unknown>).file === "string"
+      ) {
+        return (parsed as Record<string, string>).file;
+      }
+    } catch {
+      // If source is a plain string path, use it directly.
+      if (typeof raw === "string" && raw.length > 0) return raw;
+    }
+    return undefined;
+  })();
+
+  // canGroup: 2+ DOM-node layers selected in the active screen (not file rows).
+  const fileIdSet = new Set(files.map((f) => f.id));
+  const selectedDomLayerIds = selectedLayerIds.filter(
+    (id) => !id.startsWith("__") && !fileIdSet.has(id),
+  );
+  const canGroup =
+    canEditDesign &&
+    viewMode === "single" &&
+    Boolean(activeFile) &&
+    selectedDomLayerIds.length >= 2;
+  // canUngroup: exactly one DOM-node layer selected.
+  const canUngroup =
+    canEditDesign &&
+    viewMode === "single" &&
+    Boolean(activeFile) &&
+    selectedDomLayerIds.length === 1;
 
   const canMoveLayer = useCallback(
     (intent: LayersPanelMoveIntent) => {
@@ -8524,17 +9135,24 @@ ${serializedHtml}
       }
       return intent.draggedIds.some((draggedId) => {
         const draggedOwner = codeLayerOwnerByNodeId.get(draggedId);
-        return (
-          draggedId !== intent.targetId &&
-          !!draggedOwner &&
-          draggedOwner.fileId === targetOwner.fileId &&
-          !collectCodeLayerAncestors(
+        if (
+          draggedId === intent.targetId ||
+          !draggedOwner ||
+          effectiveCodeLayerState.lockedIds.has(draggedId) ||
+          effectiveCodeLayerState.hiddenIds.has(draggedId)
+        ) {
+          return false;
+        }
+        // Same-file move: also exclude ancestor drags (would orphan the node).
+        if (draggedOwner.fileId === targetOwner.fileId) {
+          return !collectCodeLayerAncestors(
             targetOwner.tree,
             intent.targetId,
-          ).includes(draggedId) &&
-          !effectiveCodeLayerState.lockedIds.has(draggedId) &&
-          !effectiveCodeLayerState.hiddenIds.has(draggedId)
-        );
+          ).includes(draggedId);
+        }
+        // Cross-file move: allowed as long as neither side is locked/hidden
+        // (already checked above). File-row ids are excluded by the owner check.
+        return true;
       });
     },
     [codeLayerOwnerByNodeId, effectiveCodeLayerState],
@@ -8552,26 +9170,43 @@ ${serializedHtml}
       ) {
         return;
       }
-      const sourceFile = files.find((file) => file.id === targetOwner.fileId);
-      const sourceContent =
+      const destFile = files.find((file) => file.id === targetOwner.fileId);
+      const destContent =
         targetOwner.fileId === activeFile?.id
           ? activeContent
-          : (sourceFile?.content ?? "");
-      if (!sourceContent) return;
-      let nextContent = sourceContent;
-      let moved = false;
+          : (destFile?.content ?? "");
+      if (!destContent) return;
+
+      // Group dragged ids by source file so we can handle same-file and
+      // cross-file moves independently.
+      const sameFileDragIds: string[] = [];
+      const crossFileDrags: Array<{ draggedId: string; sourceFileId: string }> =
+        [];
       for (const draggedId of intent.draggedIds) {
         const draggedOwner = codeLayerOwnerByNodeId.get(draggedId);
         if (
           draggedId === intent.targetId ||
           !draggedOwner ||
-          draggedOwner.fileId !== targetOwner.fileId ||
           effectiveCodeLayerState.lockedIds.has(draggedId) ||
           effectiveCodeLayerState.hiddenIds.has(draggedId)
         ) {
           continue;
         }
-        const patch = applyVisualEdit(nextContent, {
+        if (draggedOwner.fileId === targetOwner.fileId) {
+          sameFileDragIds.push(draggedId);
+        } else {
+          crossFileDrags.push({
+            draggedId,
+            sourceFileId: draggedOwner.fileId,
+          });
+        }
+      }
+
+      // --- Same-file moves (existing path) ---
+      let nextDestContent = destContent;
+      let moved = false;
+      for (const draggedId of sameFileDragIds) {
+        const patch = applyVisualEdit(nextDestContent, {
           kind: "moveNode",
           target: { nodeId: draggedId },
           anchor: { nodeId: intent.targetId },
@@ -8587,13 +9222,72 @@ ${serializedHtml}
           );
           continue;
         }
-        nextContent = patch.content;
+        nextDestContent = patch.content;
         moved = true;
       }
-      if (!moved || nextContent === sourceContent) return;
-      applyFileContentUpdate(targetOwner.fileId, nextContent, {
-        refreshPreview: true,
-      });
+
+      // --- Cross-file moves: use moveNodeBetweenDocuments ---
+      // Group by source file so multiple nodes from the same source are
+      // applied sequentially against the running source content.
+      const sourceContentMap = new Map<string, string>();
+      for (const { draggedId, sourceFileId } of crossFileDrags) {
+        const srcFile = files.find((f) => f.id === sourceFileId);
+        if (!srcFile) continue;
+        const currentSourceContent =
+          sourceFileId === activeFile?.id
+            ? activeContent
+            : (sourceContentMap.get(sourceFileId) ?? srcFile.content ?? "");
+
+        // The dragged node's data-agent-native-node-id is the node id tracked
+        // by code-layer. Look up the actual attribute value from the owner.
+        const draggedOwner = codeLayerOwnerByNodeId.get(draggedId);
+        const nodeAttrId =
+          draggedOwner?.node.dataAttributes["data-agent-native-node-id"] ??
+          draggedId;
+        const anchorAttrId =
+          codeLayerOwnerByNodeId.get(intent.targetId)?.node.dataAttributes[
+            "data-agent-native-node-id"
+          ] ?? intent.targetId;
+
+        const result = moveNodeBetweenDocuments(
+          currentSourceContent,
+          nextDestContent,
+          {
+            nodeId: nodeAttrId,
+            anchorNodeId: anchorAttrId,
+            placement: intent.placement,
+          },
+        );
+        if (result.status !== "applied") {
+          toast.error(
+            codeLayerPatchMessage(
+              result.message,
+              t("designEditor.toasts.layerMoveFailed"),
+            ),
+            { duration: 4000 },
+          );
+          continue;
+        }
+        sourceContentMap.set(sourceFileId, result.sourceHtml);
+        nextDestContent = result.destHtml;
+        moved = true;
+      }
+
+      if (!moved) return;
+
+      // Persist source files that changed.
+      for (const [sourceFileId, newSourceContent] of sourceContentMap) {
+        applyFileContentUpdate(sourceFileId, newSourceContent, {
+          refreshPreview: false,
+        });
+      }
+
+      // Persist dest file (which may also be the active file).
+      if (nextDestContent !== destContent) {
+        applyFileContentUpdate(targetOwner.fileId, nextDestContent, {
+          refreshPreview: false,
+        });
+      }
     },
     [
       activeContent,
@@ -9827,7 +10521,9 @@ ${serializedHtml}
               canEditDesign && hasPropsClipboard && Boolean(selectedElement)
             }
             canCopyAsCode={Boolean(selectedElement?.selector)}
-            hiddenActions={["group", "ungroup", "rename"]}
+            canGroup={canGroup}
+            canUngroup={canUngroup}
+            hiddenActions={["rename"]}
             getCanvasPoint={getContextCanvasPoint}
             onPasteHere={(details) =>
               handlePasteSelection(
@@ -9859,310 +10555,332 @@ ${serializedHtml}
                 handleToggleLayerHidden(activeLayerId, !activeLayerHidden);
               }
             }}
+            onGroup={canGroup ? handleGroupSelection : undefined}
+            onUngroup={canUngroup ? handleUngroupSelection : undefined}
             onCopyProps={handleCopyProps}
             onPasteProps={handlePasteProps}
             onCopyAsCode={handleCopySelection}
           >
             {activeFile ? (
-              <div
-                ref={canvasContainerRef}
-                className="relative mx-1 h-full min-w-0 flex-1 overflow-hidden rounded-xl bg-[var(--design-editor-canvas-bg)]"
-                onPointerMove={handleCanvasPointerMove}
-              >
-                {/* Transparent shield that blocks pointer events reaching the
+              <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+                {/* Banner for screens connected to a local dev server: edits
+                    route through the agent rather than being applied inline. */}
+                {activeScreenIsLocalSource &&
+                  !localSourceBannerDismissed &&
+                  id && (
+                    <LocalSourceEditBanner
+                      designId={id}
+                      fileId={activeFile.id}
+                      routeSourceFile={activeScreenRouteSourceFile}
+                      onDismiss={() => setLocalSourceBannerDismissed(true)}
+                    />
+                  )}
+                <div
+                  ref={canvasContainerRef}
+                  className="relative mx-1 min-w-0 flex-1 overflow-hidden rounded-xl bg-[var(--design-editor-canvas-bg)]"
+                  onPointerMove={handleCanvasPointerMove}
+                >
+                  {/* Transparent shield that blocks pointer events reaching the
                     iframe when a portaled Radix popover (e.g. color picker) is
                     open. The iframe has its own event context so it receives
                     pointer events even when visually covered by the popover. */}
-                {inspectorPopoverOpen && (
-                  <div
-                    aria-hidden="true"
-                    style={{
-                      position: "absolute",
-                      inset: 0,
-                      zIndex: 10,
-                      pointerEvents: "auto",
-                    }}
-                  />
-                )}
-                {viewMode === "overview" ? (
-                  <MultiScreenCanvas
-                    screens={overviewScreens}
-                    zoom={overviewCanvasZoom}
-                    onZoomChange={setOverviewCanvasZoom}
-                    activeId={activeFileId}
-                    selectedScreenIds={overviewSelectedScreenIds}
-                    activeScreenHasHoveredChild={
-                      Boolean(hoveredElement) &&
-                      !hoveredElementIsScreenRoot &&
-                      hoveredElementScreenId === activeFileId
-                    }
-                    hoveredChildScreenId={hoveredChildScreenId}
-                    directlyHoveredScreenId={hoveredScreenRootId}
-                    previewDeviceFrame={deviceFrame}
-                    activeTool={activeTool}
-                    onActiveToolChange={(tool) =>
-                      setActiveTool(tool === "rectangle" ? "rect" : tool)
-                    }
-                    selectAllRequest={overviewSelectAllRequest}
-                    clearSelectionRequest={overviewClearSelectionRequest}
-                    onScreenSelectionChange={
-                      handleOverviewScreenSelectionChange
-                    }
-                    geometryById={canvasFrameGeometryById}
-                    onGeometryChange={queueFrameGeometrySave}
-                    onGeometryCommit={handleGeometryCommit}
-                    onCreatePrimitive={handleCreatePrimitive}
-                    onPrimitiveCreated={handlePrimitiveCreated}
-                    onCreateScreenFrame={handleCreateScreenFrame}
-                    onDeleteSelection={handleDeleteOverviewSelection}
-                    onSelectionChange={setOverviewSelectedScreenIds}
-                    onPick={(id) => {
-                      pendingOverviewScreenSelectionRef.current = null;
-                      setSelectedElement(null);
-                      setHoveredElement(null);
-                      setSelectedLayerIdsState([id]);
-                      setActiveFileId(id);
-                      setActiveTool("move");
-                      setMode("edit");
-                    }}
-                    onEdit={enterSingleScreen}
-                    onDuplicate={handleDuplicateScreen}
-                    renderScreenContent={(screen, metadata, geometry) => {
-                      const screenIsActive = screen.id === activeFile?.id;
-                      const screenContent = getScreenContent(screen.id);
-                      const screenContentKey = [
-                        screen.id,
-                        screen.updatedAt ?? "",
-                        getContentSignature(screenContent),
-                        screenIsActive ? contentRenderRevision : 0,
-                      ].join(":");
+                  {inspectorPopoverOpen && (
+                    <div
+                      aria-hidden="true"
+                      style={{
+                        position: "absolute",
+                        inset: 0,
+                        zIndex: 10,
+                        pointerEvents: "auto",
+                      }}
+                    />
+                  )}
+                  {viewMode === "overview" ? (
+                    <MultiScreenCanvas
+                      screens={overviewScreens}
+                      zoom={overviewCanvasZoom}
+                      onZoomChange={setOverviewCanvasZoom}
+                      activeId={activeFileId}
+                      selectedScreenIds={overviewSelectedScreenIds}
+                      fullViewScreenIds={fullViewScreenIds}
+                      activeScreenHasHoveredChild={
+                        Boolean(hoveredElement) &&
+                        !hoveredElementIsScreenRoot &&
+                        hoveredElementScreenId === activeFileId
+                      }
+                      hoveredChildScreenId={hoveredChildScreenId}
+                      directlyHoveredScreenId={hoveredScreenRootId}
+                      previewDeviceFrame={deviceFrame}
+                      activeTool={activeTool}
+                      onActiveToolChange={(tool) =>
+                        setActiveTool(tool === "rectangle" ? "rect" : tool)
+                      }
+                      selectAllRequest={overviewSelectAllRequest}
+                      clearSelectionRequest={overviewClearSelectionRequest}
+                      onScreenSelectionChange={
+                        handleOverviewScreenSelectionChange
+                      }
+                      geometryById={canvasFrameGeometryById}
+                      onGeometryChange={queueFrameGeometrySave}
+                      onGeometryCommit={handleGeometryCommit}
+                      onCreatePrimitive={handleCreatePrimitive}
+                      onPrimitiveCreated={handlePrimitiveCreated}
+                      onPrimitiveReparent={handleOverviewPrimitiveReparent}
+                      onCreateScreenFrame={handleCreateScreenFrame}
+                      onDeleteSelection={handleDeleteOverviewSelection}
+                      onSelectionChange={setOverviewSelectedScreenIds}
+                      onPick={(id) => {
+                        pendingOverviewScreenSelectionRef.current = null;
+                        setSelectedElement(null);
+                        setHoveredElement(null);
+                        setSelectedLayerIdsState([id]);
+                        setActiveFileId(id);
+                        setActiveTool("move");
+                        setMode("edit");
+                      }}
+                      onEdit={enterSingleScreen}
+                      onDuplicate={handleDuplicateScreen}
+                      renderScreenContent={(screen, metadata, geometry) => {
+                        const screenIsActive = screen.id === activeFile?.id;
+                        const screenContent = getScreenContent(screen.id);
+                        const screenContentKey = screenIsActive
+                          ? [screen.id, contentRenderRevision].join(":")
+                          : [
+                              screen.id,
+                              screen.updatedAt ?? "",
+                              getContentSignature(screenContent),
+                              0,
+                            ].join(":");
 
-                      return (
-                        <DesignCanvas
-                          content={screenContent}
-                          contentKey={screenContentKey}
-                          zoom={100}
-                          deviceFrame="none"
-                          embeddedFrame={{
-                            viewportWidth: Math.max(
-                              1,
-                              Math.round(geometry.width),
-                            ),
-                            viewportHeight: Math.max(
-                              1,
-                              Math.round(geometry.height),
-                            ),
-                            displayWidth: Math.max(
-                              1,
-                              Math.round(geometry.width),
-                            ),
-                            displayHeight: Math.max(
-                              1,
-                              Math.round(geometry.height),
-                            ),
-                            fluid: true,
-                          }}
-                          editorChromeScaleX={overviewCanvasZoom / 100}
-                          editorChromeScaleY={overviewCanvasZoom / 100}
-                          editMode={mode === "edit"}
-                          interactMode={false}
-                          readOnly={!canEditDesign}
-                          scaleMode={screenIsActive && activeTool === "scale"}
-                          clearSelectionRequest={overviewClearSelectionRequest}
-                          registerRuntimeBridge={screenIsActive}
-                          selectedSelector={
-                            screenIsActive ? selectedCanvasSelector : null
-                          }
-                          selectedSelectorCandidates={
-                            screenIsActive
-                              ? selectedCanvasSelectorCandidates
-                              : []
-                          }
-                          hoveredSelector={
-                            hoveredElementScreenId === screen.id
-                              ? hoveredCanvasSelector
-                              : null
-                          }
-                          hoveredSelectorCandidates={
-                            hoveredElementScreenId === screen.id
-                              ? hoveredCanvasSelectorCandidates
-                              : []
-                          }
-                          lockedSelectors={getLayerSelectorsForFile(
-                            screen.id,
-                            lockedLayerIds,
-                          )}
-                          hiddenSelectors={getLayerSelectorsForFile(
-                            screen.id,
-                            hiddenLayerIds,
-                          )}
-                          onElementSelect={(info) =>
-                            handleScreenElementSelect(screen.id, info)
-                          }
-                          onElementHover={(info) =>
-                            handleScreenElementHover(screen.id, info)
-                          }
-                          onClearSelection={() =>
-                            handleScreenElementClear(screen.id)
-                          }
-                          onIframeHotkey={handleIframeHotkey}
-                          onIframeContextMenu={handleIframeContextMenu}
-                          onVisualStyleChange={(selector, styles, info) =>
-                            handleScreenVisualStyleChange(
+                        return (
+                          <DesignCanvas
+                            content={screenContent}
+                            contentKey={screenContentKey}
+                            zoom={100}
+                            deviceFrame="none"
+                            embeddedFrame={{
+                              viewportWidth: Math.max(
+                                1,
+                                Math.round(geometry.width),
+                              ),
+                              viewportHeight: Math.max(
+                                1,
+                                Math.round(geometry.height),
+                              ),
+                              displayWidth: Math.max(
+                                1,
+                                Math.round(geometry.width),
+                              ),
+                              displayHeight: Math.max(
+                                1,
+                                Math.round(geometry.height),
+                              ),
+                              fluid: true,
+                            }}
+                            editorChromeScaleX={overviewCanvasZoom / 100}
+                            editorChromeScaleY={overviewCanvasZoom / 100}
+                            editMode={mode === "edit"}
+                            interactMode={false}
+                            readOnly={!canEditDesign}
+                            scaleMode={screenIsActive && activeTool === "scale"}
+                            clearSelectionRequest={
+                              overviewClearSelectionRequest
+                            }
+                            registerRuntimeBridge={screenIsActive}
+                            selectedSelector={
+                              screenIsActive ? selectedCanvasSelector : null
+                            }
+                            selectedSelectorCandidates={
+                              screenIsActive
+                                ? selectedCanvasSelectorCandidates
+                                : []
+                            }
+                            hoveredSelector={
+                              hoveredElementScreenId === screen.id
+                                ? hoveredCanvasSelector
+                                : null
+                            }
+                            hoveredSelectorCandidates={
+                              hoveredElementScreenId === screen.id
+                                ? hoveredCanvasSelectorCandidates
+                                : []
+                            }
+                            lockedSelectors={getLayerSelectorsForFile(
                               screen.id,
-                              selector,
-                              styles,
-                              info,
-                            )
-                          }
-                          onVisualStructureChange={(
-                            selector,
-                            anchorSelector,
-                            placement,
-                            info,
-                            details,
-                          ) =>
-                            handleScreenVisualStructureChange(
+                              lockedLayerIds,
+                            )}
+                            hiddenSelectors={getLayerSelectorsForFile(
                               screen.id,
+                              hiddenLayerIds,
+                            )}
+                            onElementSelect={(info) =>
+                              handleScreenElementSelect(screen.id, info)
+                            }
+                            onElementHover={(info) =>
+                              handleScreenElementHover(screen.id, info)
+                            }
+                            onClearSelection={() =>
+                              handleScreenElementClear(screen.id)
+                            }
+                            onIframeHotkey={handleIframeHotkey}
+                            onIframeContextMenu={handleIframeContextMenu}
+                            onVisualStyleChange={(selector, styles, info) =>
+                              handleScreenVisualStyleChange(
+                                screen.id,
+                                selector,
+                                styles,
+                                info,
+                              )
+                            }
+                            onVisualStructureChange={(
                               selector,
                               anchorSelector,
                               placement,
                               info,
                               details,
-                            )
-                          }
-                          onVisualDuplicateChange={(
-                            selector,
-                            cloneHtml,
-                            info,
-                            details,
-                          ) =>
-                            handleScreenVisualDuplicateChange(
-                              screen.id,
+                            ) =>
+                              handleScreenVisualStructureChange(
+                                screen.id,
+                                selector,
+                                anchorSelector,
+                                placement,
+                                info,
+                                details,
+                              )
+                            }
+                            onVisualDuplicateChange={(
                               selector,
                               cloneHtml,
                               info,
                               details,
-                            )
-                          }
-                          onTextContentChange={(
-                            selector,
-                            value,
-                            info,
-                            details,
-                          ) =>
-                            handleScreenTextContentChange(
-                              screen.id,
+                            ) =>
+                              handleScreenVisualDuplicateChange(
+                                screen.id,
+                                selector,
+                                cloneHtml,
+                                info,
+                                details,
+                              )
+                            }
+                            onTextContentChange={(
                               selector,
                               value,
                               info,
                               details,
-                            )
-                          }
-                          onTextEditingStateChange={setTextEditingState}
-                          onElementDblClickText={(info) =>
-                            handleScreenElementDblClickText(screen.id, info)
-                          }
-                          tweakValues={cssVarValues}
-                          drawMode={false}
-                          pinMode={false}
-                          designId={id}
-                          designTitle={design?.title}
-                          commentContextId={`${id}:${screen.id}`}
-                          commentContextLabel={`${design?.title ?? t("navigation.brand")} / ${prettyScreenName(screen.filename)}`}
-                        />
-                      );
-                    }}
-                  />
-                ) : (
-                  <>
-                    <DesignCanvas
-                      content={activeContent}
-                      contentKey={`${activeFile.id}:${contentRenderRevision}`}
-                      zoom={zoom}
-                      onZoomChange={setZoom}
-                      deviceFrame={deviceFrame}
-                      editMode={mode === "edit"}
-                      interactMode={mode === "interact"}
-                      readOnly={!canEditDesign}
-                      scaleMode={activeTool === "scale"}
-                      clearSelectionRequest={overviewClearSelectionRequest}
-                      selectedSelector={selectedCanvasSelector}
-                      selectedSelectorCandidates={
-                        selectedCanvasSelectorCandidates
-                      }
-                      hoveredSelector={hoveredCanvasSelector}
-                      hoveredSelectorCandidates={
-                        hoveredCanvasSelectorCandidates
-                      }
-                      lockedSelectors={lockedLayerSelectors}
-                      hiddenSelectors={hiddenLayerSelectors}
-                      onElementSelect={handleElementSelect}
-                      onElementHover={handleElementHover}
-                      onClearSelection={() => {
-                        setSelectedElement(null);
-                        setHoveredElement(null);
-                        setHoveredElementScreenId(null);
-                        setSelectedLayerIdsState([]);
-                      }}
-                      onIframeHotkey={handleIframeHotkey}
-                      onIframeContextMenu={handleIframeContextMenu}
-                      onVisualStyleChange={handleVisualStyleChange}
-                      onVisualStructureChange={handleVisualStructureChange}
-                      onVisualDuplicateChange={handleVisualDuplicateChange}
-                      onTextContentChange={handleTextContentChange}
-                      onTextEditingStateChange={setTextEditingState}
-                      onElementDblClickText={handleElementDblClickText}
-                      tweakValues={cssVarValues}
-                      drawMode={drawMode}
-                      onExitDrawMode={() => {
-                        setDrawMode(false);
-                        setPinMode(false);
-                        setActiveTool("move");
-                        setMode("edit");
-                      }}
-                      pinMode={pinMode}
-                      onExitPinMode={() => {
-                        setPinMode(false);
-                        if (mode === "annotate") {
-                          setActiveTool("draw");
-                        }
-                      }}
-                      designId={id}
-                      designTitle={design?.title}
-                      commentContextId={`${id}:${activeFile.id}`}
-                      commentContextLabel={`${design?.title ?? t("navigation.brand")} / ${prettyScreenName(activeFile.filename)}`}
-                      onPrototypeNavigate={(screen) => {
-                        if (!screen) return;
-                        const norm = (s: string) =>
-                          s
-                            .replace(/^\.?\//, "")
-                            .replace(/\.html?$/i, "")
-                            .toLowerCase();
-                        const target = norm(screen);
-                        if (!target) return;
-                        // Exact (normalized) filename match only — a substring match
-                        // could send "board" to "dashboard.html".
-                        const match = files.find(
-                          (f) => norm(f.filename) === target,
+                            ) =>
+                              handleScreenTextContentChange(
+                                screen.id,
+                                selector,
+                                value,
+                                info,
+                                details,
+                              )
+                            }
+                            onTextEditingStateChange={setTextEditingState}
+                            onElementDblClickText={(info) =>
+                              handleScreenElementDblClickText(screen.id, info)
+                            }
+                            tweakValues={cssVarValues}
+                            drawMode={false}
+                            pinMode={false}
+                            designId={id}
+                            designTitle={design?.title}
+                            commentContextId={`${id}:${screen.id}`}
+                            commentContextLabel={`${design?.title ?? t("navigation.brand")} / ${prettyScreenName(screen.filename)}`}
+                          />
                         );
-                        if (match) {
-                          viewModeRef.current = "single";
-                          setScreenZoom(FOCUSED_SCREEN_ZOOM);
-                          setViewMode("single");
-                          setActiveFileId(match.id);
-                        }
                       }}
                     />
-                    {/* Presence: live cursor overlay for remote participants */}
-                    {others.length > 0 && (
-                      <LiveCursorOverlay
-                        others={others}
-                        containerRef={canvasContainerRef}
+                  ) : (
+                    <>
+                      <DesignCanvas
+                        content={activeContent}
+                        contentKey={`${activeFile.id}:${contentRenderRevision}`}
+                        zoom={zoom}
+                        onZoomChange={setZoom}
+                        deviceFrame={deviceFrame}
+                        editMode={mode === "edit"}
+                        interactMode={mode === "interact"}
+                        readOnly={!canEditDesign}
+                        scaleMode={activeTool === "scale"}
+                        clearSelectionRequest={overviewClearSelectionRequest}
+                        selectedSelector={selectedCanvasSelector}
+                        selectedSelectorCandidates={
+                          selectedCanvasSelectorCandidates
+                        }
+                        hoveredSelector={hoveredCanvasSelector}
+                        hoveredSelectorCandidates={
+                          hoveredCanvasSelectorCandidates
+                        }
+                        lockedSelectors={lockedLayerSelectors}
+                        hiddenSelectors={hiddenLayerSelectors}
+                        onElementSelect={handleElementSelect}
+                        onElementHover={handleElementHover}
+                        onClearSelection={() => {
+                          setSelectedElement(null);
+                          setHoveredElement(null);
+                          setHoveredElementScreenId(null);
+                          setSelectedLayerIdsState([]);
+                        }}
+                        onIframeHotkey={handleIframeHotkey}
+                        onIframeContextMenu={handleIframeContextMenu}
+                        onVisualStyleChange={handleVisualStyleChange}
+                        onVisualStructureChange={handleVisualStructureChange}
+                        onVisualDuplicateChange={handleVisualDuplicateChange}
+                        onTextContentChange={handleTextContentChange}
+                        onTextEditingStateChange={setTextEditingState}
+                        onElementDblClickText={handleElementDblClickText}
+                        tweakValues={cssVarValues}
+                        drawMode={drawMode}
+                        onExitDrawMode={() => {
+                          setDrawMode(false);
+                          setPinMode(false);
+                          setActiveTool("move");
+                          setMode("edit");
+                        }}
+                        pinMode={pinMode}
+                        onExitPinMode={() => {
+                          setPinMode(false);
+                          if (mode === "annotate") {
+                            setActiveTool("draw");
+                          }
+                        }}
+                        designId={id}
+                        designTitle={design?.title}
+                        commentContextId={`${id}:${activeFile.id}`}
+                        commentContextLabel={`${design?.title ?? t("navigation.brand")} / ${prettyScreenName(activeFile.filename)}`}
+                        onPrototypeNavigate={(screen) => {
+                          if (!screen) return;
+                          const norm = (s: string) =>
+                            s
+                              .replace(/^\.?\//, "")
+                              .replace(/\.html?$/i, "")
+                              .toLowerCase();
+                          const target = norm(screen);
+                          if (!target) return;
+                          // Exact (normalized) filename match only — a substring match
+                          // could send "board" to "dashboard.html".
+                          const match = files.find(
+                            (f) => norm(f.filename) === target,
+                          );
+                          if (match) {
+                            viewModeRef.current = "single";
+                            setScreenZoom(FOCUSED_SCREEN_ZOOM);
+                            setViewMode("single");
+                            setActiveFileId(match.id);
+                          }
+                        }}
                       />
-                    )}
-                  </>
-                )}
+                      {/* Presence: live cursor overlay for remote participants */}
+                      {others.length > 0 && (
+                        <LiveCursorOverlay
+                          others={others}
+                          containerRef={canvasContainerRef}
+                        />
+                      )}
+                    </>
+                  )}
+                </div>
               </div>
             ) : (
               <div className="flex flex-1 items-center justify-center">
@@ -10181,7 +10899,7 @@ ${serializedHtml}
                       </p>
                       {retryablePrompt ? (
                         <p className="mx-auto mb-4 max-w-sm text-xs italic text-muted-foreground/70">
-                          "{retryablePrompt.prompt}"
+                          {`"${retryablePrompt.prompt}"`}
                         </p>
                       ) : null}
                       <div className="flex items-center justify-center gap-2">
@@ -10258,6 +10976,7 @@ ${serializedHtml}
                   onRequestTweaks={handleRequestTweaks}
                   onStyleChange={handleStyleChange}
                   onStylesChange={handleStylesChange}
+                  onAutoLayoutConvert={handleAutoLayoutConvert}
                   onExport={handleInspectorExport}
                   exporting={pngExporting || svgExporting}
                 />

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -395,6 +395,45 @@ export function getDesignEditorShareUrl(
   return new URL(pathname, origin).toString();
 }
 
+export function getLocalhostRouteSourceFile(args: {
+  sourceFile?: string;
+  source?: string;
+}): string | undefined {
+  if (args.sourceFile?.trim()) return args.sourceFile;
+  const raw = args.source;
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      "file" in parsed &&
+      typeof (parsed as Record<string, unknown>).file === "string"
+    ) {
+      return (parsed as Record<string, string>).file;
+    }
+  } catch {
+    if (raw.length > 0) return raw;
+  }
+  return undefined;
+}
+
+export function getLayerMoveSourceContent(args: {
+  sourceFileId: string;
+  activeFileId?: string | null;
+  activeContent: string;
+  sourceFileContent?: string;
+  sourceContentMap: ReadonlyMap<string, string>;
+}) {
+  return (
+    args.sourceContentMap.get(args.sourceFileId) ??
+    (args.sourceFileId === args.activeFileId
+      ? args.activeContent
+      : args.sourceFileContent) ??
+    ""
+  );
+}
+
 function resolveZoomUpdate(update: SetStateAction<number>, current: number) {
   return typeof update === "function" ? update(current) : update;
 }
@@ -4085,6 +4124,7 @@ export default function DesignEditor() {
         updatedAt: file.updatedAt,
         sourceType: stringValue("sourceType"),
         source: stringValue("source"),
+        sourceFile: stringValue("sourceFile"),
         lod: stringValue("lod"),
         previewState: stringValue("previewState"),
         status: stringValue("status"),
@@ -9979,28 +10019,12 @@ ${serializedHtml}
     viewMode === "single" &&
     Boolean(activeFile) &&
     activeOverviewScreen?.sourceType === "localhost";
-  // `source` in screen metadata may be a JSON object with a `file` field; try to
-  // extract it as the routeSourceFile for the banner.
-  const activeScreenRouteSourceFile = (() => {
-    if (!activeScreenIsLocalSource) return undefined;
-    const raw = activeOverviewScreen?.source;
-    if (!raw) return undefined;
-    try {
-      const parsed = JSON.parse(raw) as unknown;
-      if (
-        parsed &&
-        typeof parsed === "object" &&
-        "file" in parsed &&
-        typeof (parsed as Record<string, unknown>).file === "string"
-      ) {
-        return (parsed as Record<string, string>).file;
-      }
-    } catch {
-      // If source is a plain string path, use it directly.
-      if (typeof raw === "string" && raw.length > 0) return raw;
-    }
-    return undefined;
-  })();
+  const activeScreenRouteSourceFile = activeScreenIsLocalSource
+    ? getLocalhostRouteSourceFile({
+        sourceFile: activeOverviewScreen?.sourceFile,
+        source: activeOverviewScreen?.source,
+      })
+    : undefined;
 
   // canGroup: 2+ DOM-node layers selected in the active screen (not file rows).
   const fileIdSet = new Set(files.map((f) => f.id));
@@ -10131,10 +10155,13 @@ ${serializedHtml}
       for (const { draggedId, sourceFileId } of crossFileDrags) {
         const srcFile = files.find((f) => f.id === sourceFileId);
         if (!srcFile) continue;
-        const currentSourceContent =
-          sourceFileId === activeFile?.id
-            ? activeContent
-            : (sourceContentMap.get(sourceFileId) ?? srcFile.content ?? "");
+        const currentSourceContent = getLayerMoveSourceContent({
+          sourceFileId,
+          activeFileId: activeFile?.id,
+          activeContent,
+          sourceFileContent: srcFile.content,
+          sourceContentMap,
+        });
 
         // The dragged node's data-agent-native-node-id is the node id tracked
         // by code-layer. Look up the actual attribute value from the owner.

--- a/templates/design/changelog/2026-06-29-added-a-review-panel-in-the-design-editor-s-inspector-with-a.md
+++ b/templates/design/changelog/2026-06-29-added-a-review-panel-in-the-design-editor-s-inspector-with-a.md
@@ -1,0 +1,6 @@
+---
+type: added
+date: 2026-06-29
+---
+
+Added a Review panel in the design editor's inspector with an on-demand accessibility audit and one-click inline fixes for contrast, tap-target, and focus issues

--- a/templates/design/changelog/2026-06-29-copying-and-pasting-layers-no-longer-shows-success-notificat.md
+++ b/templates/design/changelog/2026-06-29-copying-and-pasting-layers-no-longer-shows-success-notificat.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-06-29
+---
+
+Copying and pasting layers no longer shows success notifications.

--- a/templates/design/changelog/2026-06-29-device-presets-in-all-screens-view-resize-the-selected-previ.md
+++ b/templates/design/changelog/2026-06-29-device-presets-in-all-screens-view-resize-the-selected-previ.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-06-29
+---
+
+Device presets in all-screens view resize the selected preview width and height together.

--- a/templates/design/changelog/2026-06-29-layer-and-canvas-drags-keep-the-layer-list-stable-while-chan.md
+++ b/templates/design/changelog/2026-06-29-layer-and-canvas-drags-keep-the-layer-list-stable-while-chan.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-06-29
+---
+
+Layer and canvas drags keep the layer list stable while changes save.

--- a/templates/design/changelog/2026-06-29-layer-moves-can-be-undone-and-redone-without-flashing-the-ca.md
+++ b/templates/design/changelog/2026-06-29-layer-moves-can-be-undone-and-redone-without-flashing-the-ca.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-06-29
+---
+
+Layer moves can be undone and redone without flashing the canvas preview.

--- a/templates/design/changelog/2026-06-29-screen-previews-use-a-single-blue-hover-border-in-all-screen.md
+++ b/templates/design/changelog/2026-06-29-screen-previews-use-a-single-blue-hover-border-in-all-screen.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-06-29
+---
+
+Screen previews use a single blue hover border in all-screens view.

--- a/templates/design/changelog/2026-06-29-selected-containers-show-draggable-padding-and-gap-guides-on.md
+++ b/templates/design/changelog/2026-06-29-selected-containers-show-draggable-padding-and-gap-guides-on.md
@@ -1,0 +1,6 @@
+---
+type: added
+date: 2026-06-29
+---
+
+Selected containers show draggable padding and gap guides on hover.

--- a/templates/design/e2e/editor.spec.ts
+++ b/templates/design/e2e/editor.spec.ts
@@ -43,13 +43,21 @@ test("editor renders the toolbar and the design iframe content", async ({
 test("screen overview resizes previews from the device selector", async ({
   page,
 }) => {
+  const firstScreenCard = page.locator("[data-screen-card]").first();
+  await expect(firstScreenCard).toBeVisible();
+
   await page.getByRole("button", { name: "Device preview" }).first().click();
   await page.getByRole("menuitemradio", { name: "Desktop" }).click();
   await expect(page.getByText("1280 x 800").first()).toBeVisible();
+  const desktopBox = await firstScreenCard.boundingBox();
+  if (!desktopBox) throw new Error("missing desktop screen card bounds");
 
   await page.getByRole("button", { name: "Device preview" }).first().click();
   await page.getByRole("menuitemradio", { name: "Mobile" }).click();
   await expect(page.getByText("390 x 844").first()).toBeVisible();
+  await expect
+    .poll(async () => (await firstScreenCard.boundingBox())?.width ?? 0)
+    .toBeLessThan(desktopBox.width - 1);
 });
 
 test("screen overview keeps the name readable when frame header space is tight", async ({
@@ -115,6 +123,7 @@ test("screen overview lets users select elements inside the active screen", asyn
     .filter({ has: activeScreenCard })
     .first();
   const frameTitle = activeScreenShell.locator("[data-frame-title]");
+  const fullViewButton = activeScreenShell.locator("[data-frame-full-view]");
   const accentColor = await activeScreenCard.evaluate(() => {
     const probe = document.createElement("span");
     probe.style.color = "var(--design-editor-accent-color)";
@@ -162,6 +171,11 @@ test("screen overview lets users select elements inside the active screen", asyn
   const payload = selected?.payload ?? selected;
   expect(payload?.textContent ?? "").toContain("E2E Hero Heading");
   await expect(page.locator("[data-frame-selection-box]")).toHaveCount(0);
+  await expect
+    .poll(() =>
+      fullViewButton.evaluate((el) => window.getComputedStyle(el).opacity),
+    )
+    .toBe("1");
   await expect
     .poll(() =>
       designFrame(page)
@@ -324,13 +338,10 @@ test("deeply nested layer rows keep a clickable hit target", async ({
 test("dragging an element on the canvas drives the bridge (move/reorder)", async ({
   page,
 }) => {
-  // Best-effort: real pointer drag through the editor. We assert the drag
-  // produced bridge activity (and capture which messages fired). A committed
-  // reorder emits `visual-structure-change`; if the gesture only re-selects we
-  // still prove pointer events reach the in-iframe bridge.
+  // Real pointer drag through the editor: this must reach the structural
+  // move path, not just the hover/select bridge messages.
   const fired = await dragCanvasByText(page, "Alpha Button", 0, 90);
-  expect(fired.length).toBeGreaterThan(0);
-  expect(fired.some((t) => /^(element-|visual-)/.test(t))).toBe(true);
+  expect(fired).toContain("visual-structure-change");
 });
 
 test("can capture a screenshot of the editor via CDP", async ({

--- a/templates/design/shared/code-layer.test.ts
+++ b/templates/design/shared/code-layer.test.ts
@@ -852,6 +852,17 @@ describe("wrapNodes", () => {
     expect(patch.content).toBe(html);
   });
 
+  it("returns unsupported when selected siblings are not contiguous", () => {
+    const html = `<main><div data-agent-native-node-id="a">A</div><div data-agent-native-node-id="b">B</div><div data-agent-native-node-id="c">C</div></main>`;
+    const patch = applyVisualEdit(html, {
+      kind: "wrapNodes",
+      targetIds: ["a", "c"],
+    });
+
+    expect(patch.result.status).toBe("unsupported");
+    expect(patch.content).toBe(html);
+  });
+
   it("returns conflict when a target node id is not found", () => {
     const html = `<main><div data-agent-native-node-id="a">A</div></main>`;
     const patch = applyVisualEdit(html, {

--- a/templates/design/shared/code-layer.test.ts
+++ b/templates/design/shared/code-layer.test.ts
@@ -1180,4 +1180,33 @@ describe("autoLayout (regression)", () => {
     // Grandchild positioning is NOT touched by wrapNodes autoLayout (only direct-child strip)
     expect(patch.content).toContain("top: 3px");
   });
+
+  it("applies all three flex styles when element has no stable data attributes and no HTML id", () => {
+    // Regression: previously only the first style property (display:flex) was applied because
+    // re-parsing after each individual mutation could not re-locate the target element when
+    // it carried no data-agent-native-node-id, data-code-layer-id, or HTML id.  All three
+    // setContainerStyle calls after the first returned silently with no-op.
+    const html = `<div class="container"><span style="position: absolute; left: 5px">X</span></div>`;
+    const projection = buildCodeLayerProjection(html);
+    const box = projection.nodes.find((n) => n.tag === "div");
+
+    expect(box?.dataAttributes["data-agent-native-node-id"]).toBeUndefined();
+    expect(box?.attributes["id"]).toBeUndefined();
+
+    const patch = applyVisualEdit(html, {
+      kind: "autoLayout",
+      targetId: box!.id,
+      enabled: true,
+      direction: "row",
+      gap: "12px",
+    });
+
+    expect(patch.result.status).toBe("applied");
+    expect(patch.content).toContain("display: flex");
+    expect(patch.content).toContain("flex-direction: row");
+    expect(patch.content).toContain("gap: 12px");
+    // Child absolute positioning is also stripped
+    expect(patch.content).not.toContain("position: absolute");
+    expect(patch.content).not.toContain("left: 5px");
+  });
 });

--- a/templates/design/shared/code-layer.test.ts
+++ b/templates/design/shared/code-layer.test.ts
@@ -5,6 +5,7 @@ import {
   buildCodeLayerProjection,
   buildCodeLayerTree,
   ensureCodeLayerNodeIdsInHtml,
+  moveNodeBetweenDocuments,
   removeCodeLayerNodeFromHtml,
   type EditIntent,
 } from "./code-layer";
@@ -728,5 +729,393 @@ describe("applyVisualEdit", () => {
 
     expect(patch.result.status).toBe("unsupported");
     expect(patch.content).toBe(html);
+  });
+});
+
+describe("wrapNodes", () => {
+  it("wraps sibling nodes in a new div wrapper at first target position", () => {
+    const html = `<main><div data-agent-native-node-id="a">A</div><div data-agent-native-node-id="b">B</div><div data-agent-native-node-id="c">C</div></main>`;
+    const patch = applyVisualEdit(html, {
+      kind: "wrapNodes",
+      targetIds: ["a", "b"],
+    });
+
+    expect(patch.result.status).toBe("applied");
+    expect(patch.result.changed).toBe(true);
+    expect(patch.result.wrapperNodeId).toBeTruthy();
+    // Wrapper should contain both targets
+    expect(patch.content).toContain(
+      `data-agent-native-node-id="${patch.result.wrapperNodeId}"`,
+    );
+    expect(patch.content).toContain(`data-agent-native-layer-name="Group"`);
+    expect(patch.content).toContain(`data-agent-native-node-id="a"`);
+    expect(patch.content).toContain(`data-agent-native-node-id="b"`);
+    // Wrapper should appear before c
+    const wrapperIdx = patch.content.indexOf(
+      `data-agent-native-layer-name="Group"`,
+    );
+    const cIdx = patch.content.indexOf(`data-agent-native-node-id="c"`);
+    expect(wrapperIdx).toBeLessThan(cIdx);
+    // c is still a direct child of main, not inside the wrapper
+    expect(patch.content).toMatch(/<\/div><div data-agent-native-node-id="c">/);
+  });
+
+  it("adds autoLayout styles to wrapper and strips absolute positioning from wrapped children", () => {
+    const html = `<main><div data-agent-native-node-id="x" style="position: absolute; left: 10px; top: 20px">X</div><div data-agent-native-node-id="y" style="position: absolute; right: 5px">Y</div></main>`;
+    const patch = applyVisualEdit(html, {
+      kind: "wrapNodes",
+      targetIds: ["x", "y"],
+      autoLayout: true,
+    });
+
+    expect(patch.result.status).toBe("applied");
+    expect(patch.content).toContain("display: flex");
+    expect(patch.content).toContain("flex-direction: column");
+    expect(patch.content).toContain("gap: 8px");
+    // Absolute positioning should be stripped from children
+    expect(patch.content).not.toContain("position: absolute");
+    expect(patch.content).not.toContain("left: 10px");
+    expect(patch.content).not.toContain("top: 20px");
+    expect(patch.content).not.toContain("right: 5px");
+  });
+
+  it("returns unsupported when targets don't share a parent", () => {
+    const html = `<main><section><div data-agent-native-node-id="a">A</div></section><div data-agent-native-node-id="b">B</div></main>`;
+    const patch = applyVisualEdit(html, {
+      kind: "wrapNodes",
+      targetIds: ["a", "b"],
+    });
+
+    expect(patch.result.status).toBe("unsupported");
+    expect(patch.content).toBe(html);
+  });
+
+  it("returns conflict when a target node id is not found", () => {
+    const html = `<main><div data-agent-native-node-id="a">A</div></main>`;
+    const patch = applyVisualEdit(html, {
+      kind: "wrapNodes",
+      targetIds: ["a", "does-not-exist"],
+    });
+
+    expect(patch.result.status).toBe("conflict");
+    expect(patch.content).toBe(html);
+  });
+});
+
+describe("unwrap", () => {
+  it("replaces a wrapper with its children at the wrapper's parent position", () => {
+    const html = `<main><div data-agent-native-node-id="wrapper"><span data-agent-native-node-id="a">A</span><span data-agent-native-node-id="b">B</span></div><p>after</p></main>`;
+    const patch = applyVisualEdit(html, {
+      kind: "unwrap",
+      targetId: "wrapper",
+    });
+
+    expect(patch.result.status).toBe("applied");
+    expect(patch.content).not.toContain(`data-agent-native-node-id="wrapper"`);
+    expect(patch.content).toContain(`data-agent-native-node-id="a"`);
+    expect(patch.content).toContain(`data-agent-native-node-id="b"`);
+    expect(patch.content).toContain("<p>after</p>");
+    // Children appear before <p>after</p>
+    const aIdx = patch.content.indexOf(`data-agent-native-node-id="a"`);
+    const pIdx = patch.content.indexOf("<p>after</p>");
+    expect(aIdx).toBeLessThan(pIdx);
+  });
+
+  it("round-trips through wrapNodes: wrapping then unwrapping returns equivalent content", () => {
+    const original = `<main><div data-agent-native-node-id="a">A</div><div data-agent-native-node-id="b">B</div></main>`;
+    const wrapped = applyVisualEdit(original, {
+      kind: "wrapNodes",
+      targetIds: ["a", "b"],
+    });
+    expect(wrapped.result.status).toBe("applied");
+    const wrapperId = wrapped.result.wrapperNodeId!;
+
+    const unwrapped = applyVisualEdit(wrapped.content, {
+      kind: "unwrap",
+      targetId: wrapperId,
+    });
+    expect(unwrapped.result.status).toBe("applied");
+    // After round-trip, both original nodes are direct children of <main> again.
+    expect(unwrapped.content).toContain(`data-agent-native-node-id="a"`);
+    expect(unwrapped.content).toContain(`data-agent-native-node-id="b"`);
+    expect(unwrapped.content).not.toContain(
+      `data-agent-native-node-id="${wrapperId}"`,
+    );
+  });
+
+  it("returns conflict when the targetId is not found", () => {
+    const html = `<main><div data-agent-native-node-id="a">A</div></main>`;
+    const patch = applyVisualEdit(html, {
+      kind: "unwrap",
+      targetId: "not-here",
+    });
+
+    expect(patch.result.status).toBe("conflict");
+    expect(patch.content).toBe(html);
+  });
+});
+
+describe("autoLayout", () => {
+  it("enables auto-layout on a container with display:flex + direction + gap", () => {
+    const html = `<div data-agent-native-node-id="box"><span>A</span><span>B</span></div>`;
+    const patch = applyVisualEdit(html, {
+      kind: "autoLayout",
+      targetId: "box",
+      enabled: true,
+      direction: "row",
+      gap: "16px",
+    });
+
+    expect(patch.result.status).toBe("applied");
+    expect(patch.content).toContain("display: flex");
+    expect(patch.content).toContain("flex-direction: row");
+    expect(patch.content).toContain("gap: 16px");
+  });
+
+  it("uses column and 8px defaults when direction and gap are omitted", () => {
+    const html = `<div data-agent-native-node-id="box"><span>A</span></div>`;
+    const patch = applyVisualEdit(html, {
+      kind: "autoLayout",
+      targetId: "box",
+      enabled: true,
+    });
+
+    expect(patch.result.status).toBe("applied");
+    expect(patch.content).toContain("flex-direction: column");
+    expect(patch.content).toContain("gap: 8px");
+  });
+
+  it("strips absolute positioning from direct children when enabling", () => {
+    const html = `<div data-agent-native-node-id="container"><div data-agent-native-node-id="child" style="position: absolute; left: 0; top: 0; right: 0; bottom: 0">Child</div></div>`;
+    const patch = applyVisualEdit(html, {
+      kind: "autoLayout",
+      targetId: "container",
+      enabled: true,
+    });
+
+    expect(patch.result.status).toBe("applied");
+    // Container is now flex
+    expect(patch.content).toContain("display: flex");
+    // Child's absolute positioning is stripped
+    expect(patch.content).not.toContain("position: absolute");
+    expect(patch.content).not.toContain("left: 0");
+    expect(patch.content).not.toContain("top: 0");
+    expect(patch.content).not.toContain("right: 0");
+    expect(patch.content).not.toContain("bottom: 0");
+  });
+
+  it("disables auto-layout by setting display:block", () => {
+    const html = `<div data-agent-native-node-id="box" style="display: flex; flex-direction: column; gap: 8px"><span>A</span></div>`;
+    const patch = applyVisualEdit(html, {
+      kind: "autoLayout",
+      targetId: "box",
+      enabled: false,
+    });
+
+    expect(patch.result.status).toBe("applied");
+    expect(patch.content).toContain("display: block");
+  });
+
+  it("returns conflict when targetId is not found", () => {
+    const html = `<div data-agent-native-node-id="box">A</div>`;
+    const patch = applyVisualEdit(html, {
+      kind: "autoLayout",
+      targetId: "missing",
+      enabled: true,
+    });
+
+    expect(patch.result.status).toBe("conflict");
+    expect(patch.content).toBe(html);
+  });
+});
+
+describe("moveNodeBetweenDocuments", () => {
+  it("removes the node from sourceHtml and inserts it into destHtml body", () => {
+    const sourceHtml = `<body><div data-agent-native-node-id="keep">Keep</div><div data-agent-native-node-id="move-me">Move</div></body>`;
+    const destHtml = `<body><div data-agent-native-node-id="anchor">Anchor</div></body>`;
+
+    const result = moveNodeBetweenDocuments(sourceHtml, destHtml, {
+      nodeId: "move-me",
+    });
+
+    expect(result.status).toBe("applied");
+    // Node is gone from source
+    expect(result.sourceHtml).not.toContain(
+      `data-agent-native-node-id="move-me"`,
+    );
+    expect(result.sourceHtml).toContain(`data-agent-native-node-id="keep"`);
+    // Node landed in dest
+    expect(result.destHtml).toContain(`data-agent-native-node-id="move-me"`);
+    expect(result.destHtml).toContain("Move");
+  });
+
+  it("inserts before anchor when placement is before", () => {
+    const sourceHtml = `<body><div data-agent-native-node-id="node">Node</div></body>`;
+    const destHtml = `<body><div data-agent-native-node-id="anchor">Anchor</div></body>`;
+
+    const result = moveNodeBetweenDocuments(sourceHtml, destHtml, {
+      nodeId: "node",
+      anchorNodeId: "anchor",
+      placement: "before",
+    });
+
+    expect(result.status).toBe("applied");
+    const nodeIdx = result.destHtml.indexOf(`data-agent-native-node-id="node"`);
+    const anchorIdx = result.destHtml.indexOf(
+      `data-agent-native-node-id="anchor"`,
+    );
+    expect(nodeIdx).toBeLessThan(anchorIdx);
+  });
+
+  it("inserts after anchor when placement is after", () => {
+    const sourceHtml = `<body><div data-agent-native-node-id="node">Node</div></body>`;
+    const destHtml = `<body><div data-agent-native-node-id="anchor">Anchor</div></body>`;
+
+    const result = moveNodeBetweenDocuments(sourceHtml, destHtml, {
+      nodeId: "node",
+      anchorNodeId: "anchor",
+      placement: "after",
+    });
+
+    expect(result.status).toBe("applied");
+    const anchorIdx = result.destHtml.indexOf(
+      `data-agent-native-node-id="anchor"`,
+    );
+    const nodeIdx = result.destHtml.indexOf(`data-agent-native-node-id="node"`);
+    expect(anchorIdx).toBeLessThan(nodeIdx);
+  });
+
+  it("re-stamps colliding node ids in the moved subtree to be unique in dest", () => {
+    const sourceHtml = `<body><div data-agent-native-node-id="dup"><span data-agent-native-node-id="child-dup">Child</span></div></body>`;
+    const destHtml = `<body><div data-agent-native-node-id="dup">Existing dup in dest</div></body>`;
+
+    const result = moveNodeBetweenDocuments(sourceHtml, destHtml, {
+      nodeId: "dup",
+    });
+
+    expect(result.status).toBe("applied");
+    // Collect all ids in destHtml
+    const allIds = Array.from(
+      result.destHtml.matchAll(/data-agent-native-node-id="([^"]+)"/g),
+      (m) => m[1],
+    );
+    // All ids must be unique
+    expect(new Set(allIds).size).toBe(allIds.length);
+    // The original "dup" from dest must still be present
+    expect(allIds).toContain("dup");
+  });
+
+  it("returns unsupported when the node is not found in sourceHtml", () => {
+    const result = moveNodeBetweenDocuments(
+      `<body><div data-agent-native-node-id="a">A</div></body>`,
+      `<body></body>`,
+      { nodeId: "does-not-exist" },
+    );
+
+    expect(result.status).toBe("unsupported");
+    expect(result.message).toContain("does-not-exist");
+  });
+
+  it("returns unsupported when anchor is not found in destHtml", () => {
+    const result = moveNodeBetweenDocuments(
+      `<body><div data-agent-native-node-id="node">Node</div></body>`,
+      `<body><div data-agent-native-node-id="existing">X</div></body>`,
+      { nodeId: "node", anchorNodeId: "not-here" },
+    );
+
+    expect(result.status).toBe("unsupported");
+    expect(result.message).toContain("not-here");
+  });
+
+  it("re-stamps ALL colliding ids in a deeply-nested moved subtree", () => {
+    const sourceHtml = `<body><div data-agent-native-node-id="root"><div data-agent-native-node-id="l1"><span data-agent-native-node-id="l3">Deep</span></div></div></body>`;
+    const destHtml = `<body><div data-agent-native-node-id="l1">Existing l1</div><span data-agent-native-node-id="l3">Existing l3</span></body>`;
+
+    const result = moveNodeBetweenDocuments(sourceHtml, destHtml, {
+      nodeId: "root",
+    });
+
+    expect(result.status).toBe("applied");
+    const allIds = Array.from(
+      result.destHtml.matchAll(/data-agent-native-node-id="([^"]+)"/g),
+      (m) => m[1],
+    );
+    expect(new Set(allIds).size).toBe(allIds.length);
+    // Original ids preserved
+    expect(allIds).toContain("l1");
+    expect(allIds).toContain("l3");
+    // No duplicate l1 or l3
+    expect(allIds.filter((id) => id === "l1")).toHaveLength(1);
+    expect(allIds.filter((id) => id === "l3")).toHaveLength(1);
+    // Moved content is present
+    expect(result.destHtml).toContain("Deep");
+  });
+});
+
+describe("autoLayout (regression)", () => {
+  it("applies flex styles when target is resolved by projection hash, not data-agent-native-node-id", () => {
+    // Regression: setContainerStyle previously searched only by data-agent-native-node-id,
+    // silently returning without applying any styles when the node had no such attribute.
+    // Now it uses any stable identifier (data-code-layer-id, data-layer-id, HTML id, etc.).
+    const html = `<div id="my-box"><span style="position: absolute; left: 5px">X</span></div>`;
+    const projection = buildCodeLayerProjection(html);
+    const box = projection.nodes.find((n) => n.tag === "div");
+
+    expect(box?.dataAttributes["data-agent-native-node-id"]).toBeUndefined();
+
+    const patch = applyVisualEdit(html, {
+      kind: "autoLayout",
+      targetId: box!.id,
+      enabled: true,
+    });
+
+    expect(patch.result.status).toBe("applied");
+    expect(patch.content).toContain("display: flex");
+    expect(patch.content).toContain("flex-direction: column");
+    expect(patch.content).toContain("gap: 8px");
+    // Child absolute positioning is stripped
+    expect(patch.content).not.toContain("position: absolute");
+    expect(patch.content).not.toContain("left: 5px");
+  });
+
+  it("strips absolute positioning from multiple direct children when targeting by HTML id", () => {
+    const html = `<div id="container"><div style="position: absolute; left: 0; top: 0">A</div><div style="position: absolute; left: 100px; top: 0">B</div></div>`;
+    const projection = buildCodeLayerProjection(html);
+    const container = projection.nodes.find(
+      (n) => n.tag === "div" && !n.parentId,
+    );
+    expect(container).toBeTruthy();
+
+    const patch = applyVisualEdit(html, {
+      kind: "autoLayout",
+      targetId: container!.id,
+      enabled: true,
+      direction: "row",
+      gap: "16px",
+    });
+
+    expect(patch.result.status).toBe("applied");
+    expect(patch.content).toContain("display: flex");
+    expect(patch.content).toContain("flex-direction: row");
+    expect(patch.content).toContain("gap: 16px");
+    expect(patch.content).not.toContain("position: absolute");
+    expect(patch.content).not.toContain("left: 0");
+    expect(patch.content).not.toContain("left: 100px");
+  });
+
+  it("wrapNodes with autoLayout correctly strips each child's own positioning only", () => {
+    // Each wrapped child's own absolute positioning is stripped; grandchild positioning is untouched.
+    const html = `<main><div data-agent-native-node-id="a" style="position: absolute; left: 10px"><span style="position: absolute; top: 3px">GC</span></div><div data-agent-native-node-id="b" style="position: absolute; right: 5px">B</div></main>`;
+    const patch = applyVisualEdit(html, {
+      kind: "wrapNodes",
+      targetIds: ["a", "b"],
+      autoLayout: true,
+    });
+
+    expect(patch.result.status).toBe("applied");
+    expect(patch.content).not.toContain("left: 10px");
+    expect(patch.content).not.toContain("right: 5px");
+    // Grandchild positioning is NOT touched by wrapNodes autoLayout (only direct-child strip)
+    expect(patch.content).toContain("top: 3px");
   });
 });

--- a/templates/design/shared/code-layer.ts
+++ b/templates/design/shared/code-layer.ts
@@ -2824,10 +2824,19 @@ function applyWrapNodes(
   // All targets must share the same parent.
   const parentIndexes = new Set(targetElements.map((el) => el.parentIndex));
   if (parentIndexes.size !== 1) return "unsupported";
-  const sharedParentIndex = [...parentIndexes][0];
 
   // Sort targets by their source position (ascending).
   targetElements.sort((a, b) => a.start - b.start);
+
+  const siblingIndexes = targetElements
+    .map((el) => el.siblingIndex)
+    .sort((a, b) => a - b);
+  const firstSiblingIndex = siblingIndexes[0];
+  if (firstSiblingIndex === undefined) return "unsupported";
+  const targetsAreContiguous = siblingIndexes.every(
+    (siblingIndex, index) => siblingIndex === firstSiblingIndex + index,
+  );
+  if (!targetsAreContiguous) return "unsupported";
 
   // Collect existing node ids so we can generate a unique one.
   const usedIds = new Set(

--- a/templates/design/shared/code-layer.ts
+++ b/templates/design/shared/code-layer.ts
@@ -324,11 +324,55 @@ export interface MoveNodeEditIntent {
   placement: "before" | "after" | "inside";
 }
 
+/**
+ * GROUP: wrap sibling nodes sharing a parent inside a new <div> wrapper.
+ * The wrapper is inserted at the position of the first target; targets are
+ * reparented into it in source order. The new wrapper gets a fresh
+ * data-agent-native-node-id and data-agent-native-layer-name="Group".
+ *
+ * When autoLayout is true the wrapper also receives
+ * `display:flex; flex-direction:column; gap:8px` and
+ * position/left/top/right/bottom are stripped from each wrapped child.
+ *
+ * Returns "unsupported" if the targets don't share a common parent.
+ */
+export interface WrapNodesEditIntent {
+  kind: "wrapNodes";
+  targetIds: string[];
+  autoLayout?: boolean;
+}
+
+/**
+ * UNGROUP: replace the wrapper node with its children, spliced into the
+ * wrapper's parent at the wrapper's position, then remove the wrapper.
+ */
+export interface UnwrapEditIntent {
+  kind: "unwrap";
+  targetId: string;
+}
+
+/**
+ * CONVERT an existing container to/from auto-layout.
+ * When enabled, sets display:flex (+ flex-direction, gap) on the target and
+ * strips position:absolute/left/top/right/bottom from its DIRECT children.
+ * When !enabled, sets display:block (turns auto-layout off).
+ */
+export interface AutoLayoutEditIntent {
+  kind: "autoLayout";
+  targetId: string;
+  enabled: boolean;
+  direction?: "row" | "column";
+  gap?: string;
+}
+
 export type EditIntent =
   | StyleEditIntent
   | ClassEditIntent
   | TextEditIntent
-  | MoveNodeEditIntent;
+  | MoveNodeEditIntent
+  | WrapNodesEditIntent
+  | UnwrapEditIntent
+  | AutoLayoutEditIntent;
 
 export interface EditIntentResolution {
   status: "resolved" | "conflict" | "unsupported";
@@ -372,6 +416,8 @@ export interface PatchResult {
   after?: PatchNodeSummary;
   changed: boolean;
   message?: string;
+  /** For wrapNodes: the data-agent-native-node-id of the newly created wrapper. */
+  wrapperNodeId?: string;
 }
 
 export interface ApplyVisualEditResult {
@@ -2393,6 +2439,374 @@ function applyMoveNodeEdit(
   };
 }
 
+/** Generate a fresh unique data-agent-native-node-id value not already in the set. */
+function freshNodeId(usedIds: Set<string>, basis: string): string {
+  const base = `an-${hashStable(basis)}`;
+  let value = base;
+  let suffix = 1;
+  while (usedIds.has(value)) {
+    value = `an-${hashStable(`${base}:${suffix}`)}`;
+    suffix += 1;
+  }
+  usedIds.add(value);
+  return value;
+}
+
+/**
+ * Strip the given CSS property names from an inline style attribute value.
+ * Returns the new style string (may be empty if all declarations were removed).
+ */
+function stripStyleProperties(
+  styleValue: string | null,
+  propertiesToRemove: string[],
+): string {
+  if (!styleValue) return "";
+  const toRemove = new Set(propertiesToRemove.map((p) => p.toLowerCase()));
+  const remaining = parseStyleDeclarations(styleValue).filter(
+    (decl) => !toRemove.has(decl.property),
+  );
+  return serializeStyleDeclarations(remaining);
+}
+
+/** Absolute-positioning properties stripped when converting a child to auto-layout flow. */
+const AUTO_LAYOUT_STRIP_PROPS = [
+  "position",
+  "left",
+  "top",
+  "right",
+  "bottom",
+] as const;
+
+/**
+ * Apply display:flex + direction + gap to a raw open-tag string and return it.
+ * Only touches the style attribute.
+ */
+function addAutoLayoutStyleToOpenTag(
+  openTag: string,
+  element: ParsedElement,
+  html: string,
+  direction: "row" | "column",
+  gap: string,
+): string {
+  const currentStyle = attributeValue(element, "style");
+  let declarations = parseStyleDeclarations(currentStyle);
+  const setOrReplace = (prop: string, val: string) => {
+    const existing = declarations.find((d) => d.property === prop);
+    if (existing) {
+      existing.value = val;
+    } else {
+      declarations.push({ property: prop, value: val });
+    }
+  };
+  setOrReplace("display", "flex");
+  setOrReplace("flex-direction", direction);
+  setOrReplace("gap", gap);
+  const nextStyle = serializeStyleDeclarations(declarations);
+  // We work on a scratch copy relative to element boundaries
+  const attr = getAttribute(element, "style");
+  if (attr) {
+    return `${openTag.slice(0, attr.start - element.start)}${attr.name}="${escapeHtmlAttribute(nextStyle)}"${openTag.slice(attr.end - element.start)}`;
+  }
+  // Insert before closing >
+  const closeChar = openTag.endsWith("/>")
+    ? openTag.length - 2
+    : openTag.length - 1;
+  return `${openTag.slice(0, closeChar)} style="${escapeHtmlAttribute(nextStyle)}"${openTag.slice(closeChar)}`;
+}
+
+/**
+ * Strip absolute-positioning properties from a child's inline style, applying
+ * the edit directly to the html string at the child element's source spans.
+ * Returns the updated html string.
+ */
+function stripAbsolutePositioningFromChild(
+  html: string,
+  child: ParsedElement,
+): string {
+  const currentStyle = attributeValue(child, "style");
+  if (!currentStyle) return html;
+  const nextStyle = stripStyleProperties(currentStyle, [
+    ...AUTO_LAYOUT_STRIP_PROPS,
+  ]);
+  return replaceOrInsertAttribute(html, child, "style", nextStyle);
+}
+
+/**
+ * GROUP: wrap targetted sibling elements (sharing a common parent) in a new
+ * <div> wrapper. Targets must all share the same parent element.
+ */
+function applyWrapNodes(
+  html: string,
+  build: ProjectionBuild,
+  intent: WrapNodesEditIntent,
+):
+  | { content: string; capability: EditCapability; wrapperNodeId: string }
+  | PatchResultStatus {
+  const { targetIds, autoLayout = false } = intent;
+  if (targetIds.length === 0) return "unsupported";
+
+  // Resolve all target nodes via nodeId attribute matching.
+  const targetElements: ParsedElement[] = [];
+  for (const id of targetIds) {
+    const node = build.projection.nodes.find(
+      (n) =>
+        n.dataAttributes["data-agent-native-node-id"] === id || n.id === id,
+    );
+    if (!node) return "conflict";
+    const el = build.elementByNodeId.get(node.id);
+    if (!el) return "conflict";
+    targetElements.push(el);
+  }
+
+  // All targets must share the same parent.
+  const parentIndexes = new Set(targetElements.map((el) => el.parentIndex));
+  if (parentIndexes.size !== 1) return "unsupported";
+  const sharedParentIndex = [...parentIndexes][0];
+
+  // Sort targets by their source position (ascending).
+  targetElements.sort((a, b) => a.start - b.start);
+
+  // Collect existing node ids so we can generate a unique one.
+  const usedIds = new Set(
+    build.projection.nodes.flatMap((n) => {
+      const id = n.dataAttributes["data-agent-native-node-id"];
+      return id ? [id] : [];
+    }),
+  );
+
+  const wrapperNodeId = freshNodeId(
+    usedIds,
+    `wrap:${targetElements.map((el) => el.start).join(":")}`,
+  );
+
+  // Collect the source fragments for all targets.
+  const fragments = targetElements.map((el) => {
+    let frag = html.slice(el.start, el.end);
+    // If autoLayout, strip positioning from each wrapped child.
+    if (autoLayout) {
+      // We need a ParsedElement that reflects the fragment's own positions.
+      // Re-parse the fragment to find the root element and strip its style.
+      const fragElements = parseHtmlElements(frag);
+      const root = fragElements.find((fe) => fe.parentIndex === undefined);
+      if (root) {
+        frag = stripAbsolutePositioningFromChild(frag, root);
+      }
+    }
+    return frag;
+  });
+
+  const autoLayoutStyle = autoLayout
+    ? ` style="display: flex; flex-direction: column; gap: 8px"`
+    : "";
+  const wrapperOpen = `<div data-agent-native-node-id="${escapeHtmlAttribute(wrapperNodeId)}" data-agent-native-layer-name="Group"${autoLayoutStyle}>`;
+  const wrapperClose = `</div>`;
+  const wrapperContent = `${wrapperOpen}${fragments.join("")}${wrapperClose}`;
+
+  // Build the replacement: remove all targets from html (back to front) then
+  // insert the wrapper at the first target's position.
+  // Sort by position descending to remove safely.
+  const sorted = [...targetElements].sort((a, b) => b.start - a.start);
+
+  // Remove all targets from the html (back to front).
+  let result = html;
+  let firstTargetStart = targetElements[0]!.start;
+
+  for (const el of sorted) {
+    const start = el.start;
+    const end = el.end;
+    if (start < firstTargetStart) {
+      firstTargetStart = start;
+    }
+    result = `${result.slice(0, start)}${result.slice(end)}`;
+  }
+
+  // Re-compute firstTargetStart relative to the modified string: all removals
+  // before it shift it. Count how many bytes were removed before firstTargetStart.
+  let bytesRemovedBefore = 0;
+  for (const el of targetElements) {
+    if (el.start < targetElements[0]!.start) {
+      bytesRemovedBefore += el.end - el.start;
+    }
+  }
+  const insertAt = firstTargetStart - bytesRemovedBefore;
+
+  result = `${result.slice(0, insertAt)}${wrapperContent}${result.slice(insertAt)}`;
+
+  return {
+    content: result,
+    capability: {
+      kind: "structure",
+      operations: ["moveNode"],
+      confidence: 0.82,
+    },
+    wrapperNodeId,
+  };
+}
+
+/**
+ * UNGROUP: replace the wrapper node with its children, spliced into the
+ * wrapper's parent at the wrapper's position, then remove the wrapper.
+ */
+function applyUnwrap(
+  html: string,
+  build: ProjectionBuild,
+  intent: UnwrapEditIntent,
+): { content: string; capability: EditCapability } | PatchResultStatus {
+  const { targetId } = intent;
+  const node = build.projection.nodes.find(
+    (n) =>
+      n.dataAttributes["data-agent-native-node-id"] === targetId ||
+      n.id === targetId,
+  );
+  if (!node) return "conflict";
+  if (!node.source) return "needsAgent";
+
+  const element = build.elementByNodeId.get(node.id);
+  if (!element) return "conflict";
+  if (element.selfClosing || element.contentStart >= element.contentEnd) {
+    // Nothing to unwrap from an empty/void element.
+    return "unsupported";
+  }
+
+  // The children's source content is the element's inner HTML.
+  const innerContent = html.slice(element.contentStart, element.contentEnd);
+
+  // Replace the whole element (start..end) with its inner content.
+  const result = `${html.slice(0, element.start)}${innerContent}${html.slice(element.end)}`;
+
+  return {
+    content: result,
+    capability: {
+      kind: "structure",
+      operations: ["moveNode"],
+      confidence: 0.82,
+    },
+  };
+}
+
+/**
+ * CONVERT: toggle auto-layout (display:flex) on an existing container.
+ */
+function applyAutoLayout(
+  html: string,
+  build: ProjectionBuild,
+  intent: AutoLayoutEditIntent,
+): { content: string; capability: EditCapability } | PatchResultStatus {
+  const { targetId, enabled, direction = "column", gap = "8px" } = intent;
+  const node = build.projection.nodes.find(
+    (n) =>
+      n.dataAttributes["data-agent-native-node-id"] === targetId ||
+      n.id === targetId,
+  );
+  if (!node) return "conflict";
+  if (!node.source) return "needsAgent";
+
+  const element = build.elementByNodeId.get(node.id);
+  if (!element) return "conflict";
+
+  if (!enabled) {
+    // Turn off auto-layout: set display:block.
+    const currentStyle = attributeValue(element, "style");
+    let declarations = parseStyleDeclarations(currentStyle);
+    const displayDecl = declarations.find((d) => d.property === "display");
+    if (displayDecl) {
+      displayDecl.value = "block";
+    } else {
+      declarations.push({ property: "display", value: "block" });
+    }
+    const nextStyle = serializeStyleDeclarations(declarations);
+    return {
+      content: replaceOrInsertAttribute(html, element, "style", nextStyle),
+      capability: {
+        kind: "style",
+        properties: ["display"],
+        confidence: 0.9,
+      },
+    };
+  }
+
+  // Enable auto-layout: set display:flex + direction + gap on the container.
+  let result = html;
+
+  // Build a stable element finder for `element` that survives re-parses after
+  // style mutations. We collect all stable identifier attribute values present
+  // on the initial element (STABLE_NODE_ID_ATTRIBUTES + HTML id), then match
+  // any of them in subsequent parses. This handles the case where the node has
+  // no data-agent-native-node-id attribute and was resolved by its projection
+  // hash id — a data-attribute-only search would silently miss it.
+  const stableAttrPairs: Array<[string, string]> = [];
+  for (const attrName of STABLE_NODE_ID_ATTRIBUTES) {
+    const v = attributeValue(element, attrName);
+    if (v) stableAttrPairs.push([attrName, v]);
+  }
+  const htmlIdValue = attributeValue(element, "id");
+  const findElementInParsed = (
+    elements: ParsedElement[],
+  ): ParsedElement | undefined => {
+    for (const attrPair of stableAttrPairs) {
+      const found = elements.find(
+        (fe) => attributeValue(fe, attrPair[0]) === attrPair[1],
+      );
+      if (found) return found;
+    }
+    if (htmlIdValue) {
+      return elements.find((fe) => attributeValue(fe, "id") === htmlIdValue);
+    }
+    return undefined;
+  };
+
+  // Set container styles.
+  const setContainerStyle = (prop: VisualStyleProperty, val: string): void => {
+    // Re-parse after each mutation so attribute positions stay valid.
+    const elements = parseHtmlElements(result);
+    const el = findElementInParsed(elements);
+    if (!el) return;
+    const currentStyle2 = attributeValue(el, "style");
+    let declarations2 = parseStyleDeclarations(currentStyle2);
+    const existing = declarations2.find((d) => d.property === prop);
+    if (existing) {
+      existing.value = val;
+    } else {
+      declarations2.push({ property: prop, value: val });
+    }
+    result = replaceOrInsertAttribute(
+      result,
+      el,
+      "style",
+      serializeStyleDeclarations(declarations2),
+    );
+  };
+
+  setContainerStyle("display", "flex");
+  setContainerStyle("flex-direction", direction);
+  setContainerStyle("gap", gap);
+
+  // Strip absolute positioning from direct children.
+  // Re-parse to get up-to-date child positions.
+  const updatedElements = parseHtmlElements(result);
+  // Find the target element again using the same stable-attribute strategy.
+  const updatedTarget = findElementInParsed(updatedElements);
+
+  if (updatedTarget) {
+    // Process children in reverse order so offsets stay valid.
+    const childIndexes = [...updatedTarget.childIndexes].reverse();
+    for (const childIndex of childIndexes) {
+      const child = updatedElements[childIndex];
+      if (!child) continue;
+      result = stripAbsolutePositioningFromChild(result, child);
+    }
+  }
+
+  return {
+    content: result,
+    capability: {
+      kind: "style",
+      properties: ["display", "flex-direction", "gap"],
+      confidence: 0.88,
+    },
+  };
+}
+
 function findAfterNode(
   projection: CodeLayerProjection,
   before: CodeLayerNode,
@@ -2436,6 +2850,121 @@ export function applyVisualEdit(
   }
 
   const initial = buildProjection(html, source);
+
+  // --- Structural intents that don't resolve a single target node ---
+
+  if (intent.kind === "wrapNodes") {
+    const wrapEdit = applyWrapNodes(html, initial, intent);
+    if (typeof wrapEdit === "string") {
+      return {
+        content: html,
+        projection: initial.projection,
+        result: {
+          ...patchResult(
+            wrapEdit,
+            source,
+            intent,
+            false,
+            wrapEdit === "unsupported"
+              ? "wrapNodes requires all targets to share a common parent element."
+              : "Could not resolve one or more target nodes for wrapNodes.",
+          ),
+        },
+      };
+    }
+    const nextProjection = buildCodeLayerProjection(wrapEdit.content, {
+      source,
+    });
+    return {
+      content: wrapEdit.content,
+      projection: nextProjection,
+      result: {
+        ...patchResult(
+          "applied",
+          source,
+          intent,
+          wrapEdit.content !== html,
+          wrapEdit.content === html
+            ? "No source change was needed."
+            : "Nodes wrapped.",
+        ),
+        wrapperNodeId: wrapEdit.wrapperNodeId,
+      },
+    };
+  }
+
+  if (intent.kind === "unwrap") {
+    const unwrapEdit = applyUnwrap(html, initial, intent);
+    if (typeof unwrapEdit === "string") {
+      return {
+        content: html,
+        projection: initial.projection,
+        result: patchResult(
+          unwrapEdit,
+          source,
+          intent,
+          false,
+          unwrapEdit === "conflict"
+            ? `Could not resolve unwrap target "${intent.targetId}".`
+            : "Cannot unwrap a self-closing or empty element.",
+        ),
+      };
+    }
+    const nextProjection = buildCodeLayerProjection(unwrapEdit.content, {
+      source,
+    });
+    return {
+      content: unwrapEdit.content,
+      projection: nextProjection,
+      result: patchResult(
+        "applied",
+        source,
+        intent,
+        unwrapEdit.content !== html,
+        unwrapEdit.content === html
+          ? "No source change was needed."
+          : "Node unwrapped.",
+      ),
+    };
+  }
+
+  if (intent.kind === "autoLayout") {
+    const alEdit = applyAutoLayout(html, initial, intent);
+    if (typeof alEdit === "string") {
+      return {
+        content: html,
+        projection: initial.projection,
+        result: patchResult(
+          alEdit,
+          source,
+          intent,
+          false,
+          alEdit === "conflict"
+            ? `Could not resolve autoLayout target "${intent.targetId}".`
+            : "Cannot apply autoLayout to this element.",
+        ),
+      };
+    }
+    const nextProjection = buildCodeLayerProjection(alEdit.content, { source });
+    return {
+      content: alEdit.content,
+      projection: nextProjection,
+      result: patchResult(
+        "applied",
+        source,
+        intent,
+        alEdit.content !== html,
+        alEdit.content === html
+          ? "No source change was needed."
+          : intent.enabled
+            ? "Auto-layout enabled."
+            : "Auto-layout disabled.",
+      ),
+    };
+  }
+
+  // --- Target-resolved intents (style / class / textContent / moveNode) ---
+
   const resolution = resolveTarget(initial, intent.target);
   if (resolution.status !== "resolved" || !resolution.node) {
     return {
@@ -2570,5 +3099,142 @@ export function applyVisualEdit(
       before,
       after,
     ),
+  };
+}
+
+export interface MoveNodeBetweenDocumentsOptions {
+  nodeId: string;
+  anchorNodeId?: string;
+  placement?: "before" | "after" | "inside";
+}
+
+export interface MoveNodeBetweenDocumentsResult {
+  sourceHtml: string;
+  destHtml: string;
+  status: "applied" | "unsupported";
+  message?: string;
+}
+
+/**
+ * Move a node (by data-agent-native-node-id) from sourceHtml into destHtml.
+ * The node's serialized subtree is removed from sourceHtml and inserted into
+ * destHtml relative to anchorNodeId (default: append to <body> or end of doc).
+ * Any node ids in the moved subtree that already exist in destHtml are
+ * re-stamped to stay unique. No external dependencies.
+ */
+export function moveNodeBetweenDocuments(
+  sourceHtml: string,
+  destHtml: string,
+  opts: MoveNodeBetweenDocumentsOptions,
+): MoveNodeBetweenDocumentsResult {
+  const { nodeId, anchorNodeId, placement = "inside" } = opts;
+
+  // --- Locate the node in sourceHtml ---
+  const sourceElements = parseHtmlElements(sourceHtml);
+  const sourceTarget = sourceElements.find(
+    (el) => attributeValue(el, "data-agent-native-node-id") === nodeId,
+  );
+  if (!sourceTarget) {
+    return {
+      sourceHtml,
+      destHtml,
+      status: "unsupported",
+      message: `Node with data-agent-native-node-id="${nodeId}" not found in sourceHtml.`,
+    };
+  }
+
+  // --- Extract the subtree fragment ---
+  let fragment = sourceHtml.slice(sourceTarget.start, sourceTarget.end);
+
+  // --- Collect all existing node ids in destHtml to avoid collisions ---
+  const destElements = parseHtmlElements(destHtml);
+  const destUsedIds = new Set<string>(
+    destElements
+      .map((el) => attributeValue(el, "data-agent-native-node-id"))
+      .filter((v): v is string => v !== null),
+  );
+
+  // --- Re-stamp any colliding node ids in the fragment ---
+  // We do this by parsing the fragment as its own HTML and replacing ids.
+  const fragElements = parseHtmlElements(fragment);
+  // Build replacement map: old id → new id
+  const idRemap = new Map<string, string>();
+  for (const fragEl of fragElements) {
+    const existingId = attributeValue(fragEl, "data-agent-native-node-id");
+    if (!existingId) continue;
+    if (destUsedIds.has(existingId)) {
+      const newId = freshNodeId(
+        destUsedIds,
+        `moved:${existingId}:${fragEl.start}`,
+      );
+      idRemap.set(existingId, newId);
+    } else {
+      destUsedIds.add(existingId);
+    }
+  }
+
+  // Apply id remaps to the fragment (back to front by attribute position).
+  if (idRemap.size > 0) {
+    const remapEdits: Array<{ start: number; end: number; value: string }> = [];
+    for (const fragEl of fragElements) {
+      const attr = getAttribute(fragEl, "data-agent-native-node-id");
+      if (!attr || typeof attr.value !== "string") continue;
+      const newId = idRemap.get(attr.value);
+      if (!newId) continue;
+      remapEdits.push({
+        start: attr.start,
+        end: attr.end,
+        value: `data-agent-native-node-id="${escapeHtmlAttribute(newId)}"`,
+      });
+    }
+    // Apply back to front.
+    remapEdits.sort((a, b) => b.start - a.start);
+    for (const edit of remapEdits) {
+      fragment = `${fragment.slice(0, edit.start)}${edit.value}${fragment.slice(edit.end)}`;
+    }
+  }
+
+  // --- Remove node from sourceHtml ---
+  const nextSourceHtml = `${sourceHtml.slice(0, sourceTarget.start)}${sourceHtml.slice(sourceTarget.end)}`;
+
+  // --- Insert fragment into destHtml ---
+  let nextDestHtml: string;
+
+  if (anchorNodeId) {
+    const anchor = destElements.find(
+      (el) => attributeValue(el, "data-agent-native-node-id") === anchorNodeId,
+    );
+    if (!anchor) {
+      return {
+        sourceHtml,
+        destHtml,
+        status: "unsupported",
+        message: `Anchor node with data-agent-native-node-id="${anchorNodeId}" not found in destHtml.`,
+      };
+    }
+    const insertAt =
+      placement === "before"
+        ? anchor.start
+        : placement === "after"
+          ? anchor.end
+          : anchor.selfClosing
+            ? anchor.end
+            : anchor.contentEnd;
+    nextDestHtml = `${destHtml.slice(0, insertAt)}${fragment}${destHtml.slice(insertAt)}`;
+  } else {
+    // Default: find <body> and append inside it, or append at end of doc.
+    const bodyEl = destElements.find((el) => el.tag === "body");
+    const insertAt = bodyEl
+      ? bodyEl.selfClosing
+        ? bodyEl.end
+        : bodyEl.contentEnd
+      : destHtml.length;
+    nextDestHtml = `${destHtml.slice(0, insertAt)}${fragment}${destHtml.slice(insertAt)}`;
+  }
+
+  return {
+    sourceHtml: nextSourceHtml,
+    destHtml: nextDestHtml,
+    status: "applied",
   };
 }

--- a/templates/design/shared/code-layer.ts
+++ b/templates/design/shared/code-layer.ts
@@ -2737,6 +2737,7 @@ const AUTO_LAYOUT_STRIP_PROPS = [
   "top",
   "right",
   "bottom",
+  "inset",
 ] as const;
 
 /**
@@ -2988,14 +2989,38 @@ function applyAutoLayout(
   }
 
   // Enable auto-layout: set display:flex + direction + gap on the container.
-  let result = html;
+  // Apply all three style properties in a single mutation against the already-
+  // resolved element so that elements with no stable data attributes or HTML id
+  // are handled correctly.  Re-parsing after each individual property write
+  // caused a silent no-op for those elements because the re-parse-based element
+  // finder could not locate them after the first write changed the style attr.
+  const currentStyle = attributeValue(element, "style");
+  let declarations = parseStyleDeclarations(currentStyle);
+  const setOrReplace = (prop: string, val: string) => {
+    const existing = declarations.find((d) => d.property === prop);
+    if (existing) {
+      existing.value = val;
+    } else {
+      declarations.push({ property: prop, value: val });
+    }
+  };
+  setOrReplace("display", "flex");
+  setOrReplace("flex-direction", direction);
+  setOrReplace("gap", gap);
+  let result = replaceOrInsertAttribute(
+    html,
+    element,
+    "style",
+    serializeStyleDeclarations(declarations),
+  );
 
-  // Build a stable element finder for `element` that survives re-parses after
-  // style mutations. We collect all stable identifier attribute values present
-  // on the initial element (STABLE_NODE_ID_ATTRIBUTES + HTML id), then match
-  // any of them in subsequent parses. This handles the case where the node has
-  // no data-agent-native-node-id attribute and was resolved by its projection
-  // hash id — a data-attribute-only search would silently miss it.
+  // Strip absolute positioning from direct children.
+  // Re-parse to get up-to-date child element positions after the style mutation.
+  const updatedElements = parseHtmlElements(result);
+  // Locate the target element in the updated parse.  Prefer stable data
+  // attributes and HTML id; fall back to matching by original source position
+  // (safe because the container open-tag length only changed by the style attr
+  // rewrite, which shifts nothing before element.start).
   const stableAttrPairs: Array<[string, string]> = [];
   for (const attrName of STABLE_NODE_ID_ATTRIBUTES) {
     const v = attributeValue(element, attrName);
@@ -3014,39 +3039,10 @@ function applyAutoLayout(
     if (htmlIdValue) {
       return elements.find((fe) => attributeValue(fe, "id") === htmlIdValue);
     }
-    return undefined;
+    // Fallback: match by original start position.  The container's start offset
+    // is unchanged because only its open-tag content (style attr) was modified.
+    return elements.find((fe) => fe.start === element.start);
   };
-
-  // Set container styles.
-  const setContainerStyle = (prop: VisualStyleProperty, val: string): void => {
-    // Re-parse after each mutation so attribute positions stay valid.
-    const elements = parseHtmlElements(result);
-    const el = findElementInParsed(elements);
-    if (!el) return;
-    const currentStyle2 = attributeValue(el, "style");
-    let declarations2 = parseStyleDeclarations(currentStyle2);
-    const existing = declarations2.find((d) => d.property === prop);
-    if (existing) {
-      existing.value = val;
-    } else {
-      declarations2.push({ property: prop, value: val });
-    }
-    result = replaceOrInsertAttribute(
-      result,
-      el,
-      "style",
-      serializeStyleDeclarations(declarations2),
-    );
-  };
-
-  setContainerStyle("display", "flex");
-  setContainerStyle("flex-direction", direction);
-  setContainerStyle("gap", gap);
-
-  // Strip absolute positioning from direct children.
-  // Re-parse to get up-to-date child positions.
-  const updatedElements = parseHtmlElements(result);
-  // Find the target element again using the same stable-attribute strategy.
   const updatedTarget = findElementInParsed(updatedElements);
 
   if (updatedTarget) {
@@ -3377,6 +3373,12 @@ export interface MoveNodeBetweenDocumentsResult {
   destHtml: string;
   status: "applied" | "unsupported";
   message?: string;
+  /**
+   * The data-agent-native-node-id of the moved node in destHtml.
+   * May differ from the original nodeId when a collision caused a re-stamp.
+   * Only present when status is "applied".
+   */
+  movedNodeId?: string;
 }
 
 /**
@@ -3496,9 +3498,13 @@ export function moveNodeBetweenDocuments(
     nextDestHtml = `${destHtml.slice(0, insertAt)}${fragment}${destHtml.slice(insertAt)}`;
   }
 
+  // The moved node keeps its original id unless it collided and was re-stamped.
+  const movedNodeId = idRemap.get(nodeId) ?? nodeId;
+
   return {
     sourceHtml: nextSourceHtml,
     destHtml: nextDestHtml,
     status: "applied",
+    movedNodeId,
   };
 }

--- a/templates/design/shared/source-mode.test.ts
+++ b/templates/design/shared/source-mode.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   makeLocalhostRouteId,
   normalizeDesignSourceType,
+  parseDataLocProvenance,
   titleFromRoutePath,
 } from "./source-mode";
 
@@ -31,5 +32,19 @@ describe("source mode helpers", () => {
     expect(makeLocalhostRouteId("/*")).toBe("route-wildcard");
     expect(titleFromRoutePath("/design/:id")).toBe("Design Id");
     expect(titleFromRoutePath("/*")).toBe("Wildcard");
+  });
+
+  it("parses data-loc provenance from the right so Windows paths survive", () => {
+    expect(parseDataLocProvenance("C:/src/App.tsx:12:3")).toEqual({
+      sourceFile: "C:/src/App.tsx",
+      line: 12,
+      column: 3,
+    });
+    expect(parseDataLocProvenance("/src/App.tsx:12")).toEqual({
+      sourceFile: "/src/App.tsx",
+      line: 12,
+      column: undefined,
+    });
+    expect(parseDataLocProvenance("not-a-location")).toBeNull();
   });
 });

--- a/templates/design/shared/source-mode.ts
+++ b/templates/design/shared/source-mode.ts
@@ -63,6 +63,30 @@ export interface ElementProvenance {
   component?: string;
 }
 
+export function parseDataLocProvenance(
+  dataLoc: string,
+): Pick<ElementProvenance, "sourceFile" | "line" | "column"> | null {
+  const lastColonIndex = dataLoc.lastIndexOf(":");
+  if (lastColonIndex < 0) return null;
+  const lastPart = dataLoc.slice(lastColonIndex + 1);
+  if (!/^\d+$/.test(lastPart)) return null;
+
+  const beforeLastPart = dataLoc.slice(0, lastColonIndex);
+  const previousColonIndex = beforeLastPart.lastIndexOf(":");
+  const previousPart =
+    previousColonIndex >= 0 ? beforeLastPart.slice(previousColonIndex + 1) : "";
+  const hasColumn = /^\d+$/.test(previousPart);
+  const sourceFile = (
+    hasColumn ? beforeLastPart.slice(0, previousColonIndex) : beforeLastPart
+  ).trim();
+  const line = Number(hasColumn ? previousPart : lastPart);
+  const column = hasColumn ? Number(lastPart) : undefined;
+
+  if (!sourceFile || !Number.isFinite(line)) return null;
+  if (column !== undefined && !Number.isFinite(column)) return null;
+  return { sourceFile, line, column };
+}
+
 export type DesignSourceType = (typeof DESIGN_SOURCE_TYPES)[number];
 
 export const DESIGN_BRIDGE_OPERATIONS = [

--- a/templates/design/shared/source-mode.ts
+++ b/templates/design/shared/source-mode.ts
@@ -1,5 +1,25 @@
 export const DESIGN_SOURCE_TYPES = ["inline", "localhost", "fusion"] as const;
 
+/**
+ * Source-level provenance for a selected DOM element, populated from
+ * data attributes emitted by the connected app's build-time transform
+ * (e.g. @vitejs/plugin-react jsxDEV source maps or a Babel source plugin).
+ *
+ * - data-source-file / data-loc "file:line:col" → sourceFile
+ * - data-source-line / data-loc                 → line
+ * - data-source-column / data-loc               → column
+ * - data-component-name                         → component
+ *
+ * All fields are optional because cross-origin localhost iframes cannot be
+ * read (same-origin policy), and inline screens may not carry these attrs.
+ */
+export interface ElementProvenance {
+  sourceFile?: string;
+  line?: number;
+  column?: number;
+  component?: string;
+}
+
 export type DesignSourceType = (typeof DESIGN_SOURCE_TYPES)[number];
 
 export const DESIGN_BRIDGE_OPERATIONS = [

--- a/templates/plan/app/components/plan/CanvasArea.tsx
+++ b/templates/plan/app/components/plan/CanvasArea.tsx
@@ -14,6 +14,7 @@ import { IconMinus, IconPlus } from "@tabler/icons-react";
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -28,6 +29,9 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 
 import { Wireframe, type DesignElementSelection } from "./wireframe/Wireframe";
+
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 /* -------------------------------------------------------------------------- */
 /* Pan / zoom feel — recovered from the on-main hardcoded renderer            */
@@ -313,7 +317,7 @@ export function CanvasArea({
     canvas.viewport?.pan?.x ?? ""
   }:${canvas.viewport?.pan?.y ?? ""}`;
   const lastAppliedSavedViewportKeyRef = useRef<string | null>(null);
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!hasSavedViewport) return;
     if (lastAppliedSavedViewportKeyRef.current === savedViewportKey) return;
     lastAppliedSavedViewportKeyRef.current = savedViewportKey;
@@ -344,7 +348,7 @@ export function CanvasArea({
   boardRef.current = board;
 
   const lastAutoFitKeyRef = useRef<string | null>(null);
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (hasSavedViewport) return;
     if (lastAutoFitKeyRef.current === frameLayoutKey) return;
     const element = viewportRef.current;

--- a/templates/plan/changelog/2026-06-29-plan-canvases-open-without-an-initial-pan-and-zoom-flicker.md
+++ b/templates/plan/changelog/2026-06-29-plan-canvases-open-without-an-initial-pan-and-zoom-flicker.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-06-29
+---
+
+Plan canvases open without an initial pan-and-zoom flicker while the first view settles.


### PR DESCRIPTION
## Summary
- Restore reliable same-screen canvas and layer drag/drop behavior, including child drops without oversized rounded insertion guides.
- Make layer move undo/redo avoid preview iframe reloads and keep local content history usable when Yjs history is unavailable.
- Add visual editor tests/changelog coverage plus related design-connect and plan polish already present on the branch.

## Validation
- corepack pnpm --filter design typecheck
- corepack pnpm --filter design exec vitest run app/pages/DesignEditor.selection.test.ts app/components/design/MultiScreenCanvas.transition.test.ts shared/code-layer.test.ts --reporter=dot
- corepack pnpm --filter content exec vitest run server/agent-card.test.ts
- corepack pnpm exec tsx scripts/guard-i18n-catalogs.ts
- templates/design E2E: dragging an element on the canvas drives the bridge (move/reorder)
- Browser probes for direct canvas selection and layer move undo/redo preview reloads
- corepack pnpm prep