### PR TITLE
Finish the stubbed Design Studio features (component props, motion, shaders, a11y)

### DIFF
--- a/templates/design/actions/apply-a11y-fix.spec.ts
+++ b/templates/design/actions/apply-a11y-fix.spec.ts
@@ -1,0 +1,257 @@
+/**
+ * apply-a11y-fix.spec.ts
+ *
+ * Covers:
+ *  - the pure finding→edit mapping (`a11yFindingToEdit` / `isA11yFindingAutoFixable`)
+ *  - the produced HTML when the mapped edit is run through the shared
+ *    `applyVisualEdit` primitive (exactly what the action does internally)
+ *  - the action schema (target requirement, defaults)
+ *  - the action's "not auto-fixable" early-return branch (no DB needed)
+ *
+ * The persisted DB path (resolveEditableDesignFile / persistDesignFileEdit)
+ * requires a live DB + collab runtime and is not exercised here; the mapping +
+ * applyVisualEdit composition fully determines the content that path writes.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { applyVisualEdit, type EditIntent } from "../shared/code-layer.js";
+import {
+  a11yFindingToEdit,
+  isA11yFindingAutoFixable,
+  type A11yFinding,
+} from "../shared/design-review.js";
+import action from "./apply-a11y-fix.js";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function finding(partial: Partial<A11yFinding>): A11yFinding {
+  return {
+    id: "x",
+    severity: "warning",
+    category: "other",
+    message: "",
+    fixAvailable: false,
+    ...partial,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mapping: which findings are auto-fixable, and to what edit
+// ---------------------------------------------------------------------------
+
+describe("a11yFindingToEdit mapping", () => {
+  it("maps a contrast finding to a style color edit (default near-black)", () => {
+    const plan = a11yFindingToEdit(
+      finding({
+        id: "contrast:node-1",
+        category: "contrast",
+        nodeId: "html:abc",
+      }),
+    );
+    expect(plan).not.toBeNull();
+    expect(plan?.edit).toMatchObject({
+      kind: "style",
+      property: "color",
+      value: "#111827",
+      target: { nodeId: "html:abc" },
+    });
+    expect(plan?.label).toBe("Raise text contrast");
+  });
+
+  it("honors a caller-supplied replacement color for contrast fixes", () => {
+    const plan = a11yFindingToEdit(
+      finding({ category: "contrast", selector: "p.lead" }),
+      { color: "#0f172a" },
+    );
+    expect(plan?.edit).toMatchObject({
+      kind: "style",
+      property: "color",
+      value: "#0f172a",
+      target: { selector: "p.lead" },
+    });
+  });
+
+  it("maps a tap-target finding to a min-size class add", () => {
+    const plan = a11yFindingToEdit(
+      finding({ category: "tap-target", nodeId: "html:btn" }),
+    );
+    expect(plan?.edit).toMatchObject({
+      kind: "class",
+      operation: "add",
+      classNames: ["min-h-[44px]", "min-w-[44px]"],
+    });
+    expect(plan?.label).toBe("Enlarge tap target");
+  });
+
+  it("maps a focus-visibility finding to a focus-visible ring class add", () => {
+    const plan = a11yFindingToEdit(
+      finding({ category: "focus-visibility", selector: "a.cta" }),
+    );
+    expect(plan?.edit).toMatchObject({
+      kind: "class",
+      operation: "add",
+      classNames: ["focus-visible:ring-2"],
+    });
+  });
+
+  it("returns null for attribute-only fixes (missing-alt, missing-label)", () => {
+    expect(
+      a11yFindingToEdit(
+        finding({ category: "missing-alt", nodeId: "html:img" }),
+      ),
+    ).toBeNull();
+    expect(
+      a11yFindingToEdit(
+        finding({ category: "missing-label", selector: "input#email" }),
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for reduced-motion / role / other", () => {
+    expect(
+      a11yFindingToEdit(
+        finding({ category: "reduced-motion", nodeId: "html:hero" }),
+      ),
+    ).toBeNull();
+    expect(
+      a11yFindingToEdit(finding({ category: "role", nodeId: "html:x" })),
+    ).toBeNull();
+  });
+
+  it("returns null when the finding has no node id or selector to anchor to", () => {
+    expect(a11yFindingToEdit(finding({ category: "contrast" }))).toBeNull();
+    expect(isA11yFindingAutoFixable(finding({ category: "tap-target" }))).toBe(
+      false,
+    );
+  });
+
+  it("isA11yFindingAutoFixable agrees with a11yFindingToEdit", () => {
+    const fixable = finding({ category: "contrast", nodeId: "html:n" });
+    const notFixable = finding({ category: "missing-alt", nodeId: "html:n" });
+    expect(isA11yFindingAutoFixable(fixable)).toBe(true);
+    expect(isA11yFindingAutoFixable(notFixable)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Produced content: run the mapped edit through the shared primitive
+// ---------------------------------------------------------------------------
+
+describe("apply-a11y-fix produced content (via applyVisualEdit)", () => {
+  function applyPlan(html: string, f: A11yFinding, color?: string) {
+    const plan = a11yFindingToEdit(f, color ? { color } : undefined);
+    if (!plan) throw new Error("expected a fixable finding");
+    return applyVisualEdit(html, plan.edit as EditIntent, {
+      source: { kind: "inline-html" },
+    });
+  }
+
+  it("writes an inline color style for a contrast fix", () => {
+    const html = `<p data-agent-native-node-id="p1" class="text-white">Hi</p>`;
+    const f = finding({
+      category: "contrast",
+      nodeId: undefined,
+      selector: 'p[data-agent-native-node-id="p1"]',
+    });
+    const out = applyPlan(html, f);
+    expect(out.result.status).toBe("applied");
+    expect(out.result.changed).toBe(true);
+    expect(out.content).toContain("color: #111827");
+  });
+
+  it("adds min-size classes for a tap-target fix without dropping existing classes", () => {
+    const html = `<button data-agent-native-node-id="b1" class="h-4 px-2">Go</button>`;
+    const f = finding({
+      category: "tap-target",
+      selector: 'button[data-agent-native-node-id="b1"]',
+    });
+    const out = applyPlan(html, f);
+    expect(out.result.status).toBe("applied");
+    expect(out.content).toContain("min-h-[44px]");
+    expect(out.content).toContain("min-w-[44px]");
+    // existing classes are preserved
+    expect(out.content).toContain("h-4");
+    expect(out.content).toContain("px-2");
+  });
+
+  it("adds a focus-visible ring class for a focus-visibility fix", () => {
+    const html = `<a data-agent-native-node-id="a1" class="outline-none">x</a>`;
+    const f = finding({
+      category: "focus-visibility",
+      selector: 'a[data-agent-native-node-id="a1"]',
+    });
+    const out = applyPlan(html, f);
+    expect(out.result.status).toBe("applied");
+    expect(out.content).toContain("focus-visible:ring-2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Action schema
+// ---------------------------------------------------------------------------
+
+describe("apply-a11y-fix schema", () => {
+  it("requires the finding to carry a node id or selector", () => {
+    expect(
+      action.schema.safeParse({
+        designId: "d1",
+        finding: { id: "x", severity: "warning", category: "contrast" },
+      }).success,
+    ).toBe(false);
+
+    expect(
+      action.schema.safeParse({
+        designId: "d1",
+        finding: {
+          id: "x",
+          severity: "warning",
+          category: "contrast",
+          nodeId: "html:n",
+        },
+      }).success,
+    ).toBe(true);
+  });
+
+  it("defaults filename to index.html", () => {
+    const parsed = action.schema.safeParse({
+      designId: "d1",
+      finding: {
+        id: "x",
+        severity: "error",
+        category: "tap-target",
+        selector: "button",
+      },
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.filename).toBe("index.html");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Action run: not-auto-fixable early return (no DB access)
+// ---------------------------------------------------------------------------
+
+describe("apply-a11y-fix run — non-fixable finding", () => {
+  it("reports autoFixable:false and does not write for attribute-only findings", async () => {
+    const res = (await action.run({
+      designId: "d1",
+      filename: "index.html",
+      includeContent: false,
+      finding: {
+        id: "missing-alt:img-0",
+        severity: "error",
+        category: "missing-alt",
+        message: "<img> is missing an alt attribute.",
+        nodeId: "html:img",
+        fixAvailable: false,
+      },
+    })) as { applied: boolean; autoFixable: boolean; reason?: string };
+
+    expect(res.applied).toBe(false);
+    expect(res.autoFixable).toBe(false);
+    expect(res.reason).toMatch(/not auto-fixable/i);
+  });
+});

--- a/templates/design/actions/apply-a11y-fix.ts
+++ b/templates/design/actions/apply-a11y-fix.ts
@@ -1,0 +1,317 @@
+/**
+ * apply-a11y-fix — apply an inline accessibility remediation to a design's
+ * SQL-backed HTML content.
+ *
+ * The Review panel surfaces a11y findings from `run-design-audit`. Many common
+ * fixes — raising text contrast, enlarging a tap target, adding a
+ * focus-visible ring — are ordinary style / class edits that the deterministic
+ * edit engine (`applyVisualEdit`, also used by `apply-visual-edit`) can apply to
+ * inline HTML. This action takes one such finding, derives the deterministic
+ * edit via the shared `a11yFindingToEdit` mapping, applies it, and persists the
+ * patched content. The canvas re-renders from the written content — no iframe
+ * postMessage is needed.
+ *
+ * Fixes that need a new attribute (alt / aria-label) or a semantic/structural
+ * rewrite are NOT expressible through the deterministic engine and remain
+ * "real-app only": `a11yFindingToEdit` returns `null` for them and this action
+ * reports them as not auto-fixable instead of writing.
+ *
+ * Access is gated: only an editor of the design may apply a fix.
+ */
+
+import { defineAction } from "@agent-native/core";
+import {
+  agentEnterDocument,
+  agentLeaveDocument,
+  agentUpdateSelection,
+  applyText,
+  getText,
+  hasCollabState,
+  seedFromText,
+} from "@agent-native/core/collab";
+import { accessFilter, assertAccess } from "@agent-native/core/sharing";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { getDb, schema } from "../server/db/index.js";
+import { applyVisualEdit, type EditIntent } from "../shared/code-layer.js";
+import {
+  A11Y_FINDING_CATEGORIES,
+  A11Y_FINDING_SEVERITIES,
+  a11yFindingToEdit,
+  type A11yFinding,
+} from "../shared/design-review.js";
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+/**
+ * The subset of an {@link A11yFinding} the fix needs. The full finding is
+ * accepted (extra fields are stripped) so callers can forward what they already
+ * have from `run-design-audit` / `get-design-review` verbatim.
+ */
+const findingSchema = z
+  .object({
+    id: z.string(),
+    severity: z.enum(A11Y_FINDING_SEVERITIES),
+    category: z.enum(A11Y_FINDING_CATEGORIES),
+    message: z.string().default(""),
+    detail: z.string().optional(),
+    nodeId: z.string().optional(),
+    selector: z.string().optional(),
+    wcag: z.string().optional(),
+    fixAvailable: z.boolean().optional(),
+  })
+  .superRefine((finding, ctx) => {
+    if (!finding.nodeId && !finding.selector) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["nodeId"],
+        message:
+          "finding.nodeId or finding.selector is required to anchor the fix.",
+      });
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Live-content + resolve/persist helpers (mirrors apply-visual-edit's scoped path)
+// ---------------------------------------------------------------------------
+
+async function liveContent(
+  fileId: string,
+  storedContent: string,
+): Promise<string> {
+  try {
+    if (await hasCollabState(fileId)) {
+      const live = await getText(fileId, "content");
+      if (typeof live === "string") return live;
+    }
+  } catch {
+    // Collab reads are best-effort; SQL content remains the fallback.
+  }
+  return storedContent;
+}
+
+async function resolveEditableDesignFile(source: {
+  designId?: string;
+  fileId?: string;
+  filename?: string;
+}): Promise<{
+  id: string;
+  designId: string;
+  filename: string;
+  content: string;
+}> {
+  if (!source.fileId && !source.designId) {
+    throw new Error("designId or fileId is required.");
+  }
+
+  const db = getDb();
+  const conditions = [
+    accessFilter(schema.designs, schema.designShares),
+    source.fileId
+      ? eq(schema.designFiles.id, source.fileId)
+      : eq(schema.designFiles.designId, source.designId ?? ""),
+  ];
+  if (!source.fileId) {
+    conditions.push(
+      eq(schema.designFiles.filename, source.filename ?? "index.html"),
+    );
+  }
+
+  const [file] = await db
+    .select({
+      id: schema.designFiles.id,
+      designId: schema.designFiles.designId,
+      filename: schema.designFiles.filename,
+      fileType: schema.designFiles.fileType,
+      content: schema.designFiles.content,
+    })
+    .from(schema.designFiles)
+    .innerJoin(
+      schema.designs,
+      eq(schema.designFiles.designId, schema.designs.id),
+    )
+    .where(and(...conditions))
+    .limit(1);
+
+  if (!file) {
+    throw new Error("Design HTML file not found.");
+  }
+  if (file.fileType !== "html") {
+    throw new Error("Inline a11y fixes only support HTML files.");
+  }
+  if (source.designId && file.designId !== source.designId) {
+    throw new Error(
+      `designId "${source.designId}" does not match file "${file.id}"`,
+    );
+  }
+
+  // Writes require editor access to the owning design.
+  await assertAccess("design", file.designId, "editor");
+
+  return {
+    id: file.id,
+    designId: file.designId,
+    filename: file.filename,
+    content: await liveContent(file.id, file.content ?? ""),
+  };
+}
+
+async function persistDesignFileEdit(file: {
+  id: string;
+  designId: string;
+  content: string;
+}): Promise<void> {
+  // Re-assert at the write boundary so the persist path is independently scoped.
+  await assertAccess("design", file.designId, "editor");
+
+  const db = getDb();
+  const now = new Date().toISOString();
+
+  agentEnterDocument(file.id);
+  try {
+    await db
+      .update(schema.designFiles)
+      .set({ content: file.content, updatedAt: now })
+      .where(eq(schema.designFiles.id, file.id));
+
+    if (await hasCollabState(file.id)) {
+      await applyText(file.id, file.content, "content", "agent");
+    } else {
+      await seedFromText(file.id, file.content);
+    }
+
+    await db
+      .update(schema.designs)
+      .set({ updatedAt: now })
+      .where(eq(schema.designs.id, file.designId));
+  } finally {
+    agentLeaveDocument(file.id);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Action
+// ---------------------------------------------------------------------------
+
+export default defineAction({
+  description:
+    "Apply one inline accessibility fix to a design's SQL-backed HTML. " +
+    "Given an a11y finding from run-design-audit (with a nodeId or selector), " +
+    "derives a deterministic style/class edit — raise text contrast, enlarge a " +
+    "tap target, or add a focus-visible ring — and persists it via the same " +
+    "edit engine as apply-visual-edit. Findings needing new attributes " +
+    "(alt / aria-label) or semantic/structural rewrites are not auto-fixable " +
+    "and are reported as such (no write). Editor access required.",
+  schema: z.object({
+    designId: z
+      .string()
+      .optional()
+      .describe(
+        "Design project id. Required unless fileId is provided. Combined with " +
+          "filename to resolve the HTML file to patch.",
+      ),
+    fileId: z
+      .string()
+      .optional()
+      .describe(
+        "Specific design_files.id to patch. Takes priority over designId/filename.",
+      ),
+    filename: z
+      .string()
+      .optional()
+      .default("index.html")
+      .describe(
+        "Filename to patch when fileId is not provided. Defaults to index.html.",
+      ),
+    finding: findingSchema.describe(
+      "The a11y finding to fix. Must carry a nodeId or selector to anchor the edit.",
+    ),
+    color: z
+      .string()
+      .optional()
+      .describe(
+        "Optional replacement foreground color (e.g. '#111827') for contrast " +
+          "fixes. When omitted, a high-contrast near-black default is used.",
+      ),
+    includeContent: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe("Include the patched HTML content in the response."),
+  }),
+  run: async ({
+    designId,
+    fileId,
+    filename,
+    finding,
+    color,
+    includeContent,
+  }) => {
+    const plan = a11yFindingToEdit(finding as A11yFinding, { color });
+
+    if (!plan) {
+      return {
+        applied: false,
+        autoFixable: false,
+        reason:
+          `Finding "${finding.id}" (${finding.category}) is not auto-fixable ` +
+          "inline — it needs a new attribute (alt / aria-label) or a semantic " +
+          "change that the deterministic edit engine cannot apply. Resolve it " +
+          "in the real app or via the agent instead.",
+        finding,
+      };
+    }
+
+    const file = await resolveEditableDesignFile({
+      designId,
+      fileId,
+      filename,
+    });
+
+    const patch = applyVisualEdit(file.content, plan.edit as EditIntent, {
+      source: {
+        kind: "design-file",
+        designId: file.designId,
+        fileId: file.id,
+        filename: file.filename,
+      },
+    });
+
+    if (patch.result.target) {
+      agentUpdateSelection(file.id, {
+        selection: patch.result.target.selector,
+        nodeId: patch.result.target.nodeId,
+        editingFile: file.filename,
+        designId: file.designId,
+      });
+    }
+
+    const persisted = patch.result.status === "applied" && patch.result.changed;
+    if (persisted) {
+      await persistDesignFileEdit({
+        id: file.id,
+        designId: file.designId,
+        content: patch.content,
+      });
+    }
+
+    return {
+      applied: persisted,
+      autoFixable: true,
+      fixLabel: plan.label,
+      edit: plan.edit,
+      result: patch.result,
+      designId: file.designId,
+      fileId: file.id,
+      filename: file.filename,
+      finding,
+      persisted,
+      patchedContent: includeContent ? patch.content : undefined,
+      bytesBefore: file.content.length,
+      bytesAfter: patch.content.length,
+    };
+  },
+});

--- a/templates/design/actions/apply-component-prop-edit.spec.ts
+++ b/templates/design/actions/apply-component-prop-edit.spec.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+
+import action, {
+  applyRootAttributeEdit,
+  escapeAttributeValue,
+} from "./apply-component-prop-edit.js";
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("apply-component-prop-edit schema", () => {
+  const base = { designId: "design_1", nodeId: "node_1" };
+
+  it("accepts an alpineData edit", () => {
+    expect(
+      action.schema.safeParse({
+        ...base,
+        edit: { kind: "alpineData", value: "{ variant: 'outline' }" },
+      }).success,
+    ).toBe(true);
+  });
+
+  it("accepts an attribute edit with a safe identifier name", () => {
+    expect(
+      action.schema.safeParse({
+        ...base,
+        edit: {
+          kind: "attribute",
+          attribute: "data-agent-native-prop-label",
+          value: "Save",
+        },
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects an attribute edit with an event-handler name (on*)", () => {
+    expect(
+      action.schema.safeParse({
+        ...base,
+        edit: { kind: "attribute", attribute: "onclick", value: "alert(1)" },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects an attribute name with spaces / quotes", () => {
+    expect(
+      action.schema.safeParse({
+        ...base,
+        edit: {
+          kind: "attribute",
+          attribute: 'x" onload="y',
+          value: "z",
+        },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts a classReplace edit", () => {
+    expect(
+      action.schema.safeParse({
+        ...base,
+        edit: { kind: "classReplace", from: "bg-blue-500", to: "bg-red-500" },
+      }).success,
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// escapeAttributeValue
+// ---------------------------------------------------------------------------
+
+describe("escapeAttributeValue", () => {
+  it("escapes the HTML-significant characters", () => {
+    expect(escapeAttributeValue('"<&>"')).toBe("&quot;&lt;&amp;&gt;&quot;");
+  });
+
+  it("escapes ampersands before other entities (no double-escape)", () => {
+    expect(escapeAttributeValue("a&b")).toBe("a&amp;b");
+  });
+
+  it("leaves a plain value untouched", () => {
+    expect(escapeAttributeValue("outline")).toBe("outline");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyRootAttributeEdit — pure HTML open-tag splice
+// ---------------------------------------------------------------------------
+
+describe("applyRootAttributeEdit", () => {
+  // `<button …>` open tag is bytes 0..N of this string.
+  const html = `<button class="btn" data-agent-native-prop-variant="solid">Save</button>`;
+  const openEnd = html.indexOf(">") + 1;
+  const source = { openStart: 0, openEnd };
+
+  it("replaces an existing attribute value on the root open tag", () => {
+    const out = applyRootAttributeEdit(
+      html,
+      source,
+      "data-agent-native-prop-variant",
+      "outline",
+    );
+    expect(out.changed).toBe(true);
+    expect(out.content).toContain('data-agent-native-prop-variant="outline"');
+    expect(out.content).not.toContain('data-agent-native-prop-variant="solid"');
+    // The element's children are left untouched.
+    expect(out.content).toContain(">Save</button>");
+  });
+
+  it("inserts a new attribute when none exists yet", () => {
+    const out = applyRootAttributeEdit(
+      html,
+      source,
+      "data-agent-native-prop-label",
+      "Submit",
+    );
+    expect(out.changed).toBe(true);
+    expect(out.content).toContain('data-agent-native-prop-label="Submit"');
+    // Inserted before the closing `>` of the open tag only.
+    expect(
+      out.content.indexOf('data-agent-native-prop-label="Submit"'),
+    ).toBeLessThan(out.content.indexOf(">Save"));
+  });
+
+  it("writes the x-data attribute for an Alpine variant switch", () => {
+    const out = applyRootAttributeEdit(
+      `<div x-data="{ variant: 'solid' }">x</div>`,
+      { openStart: 0, openEnd: `<div x-data="{ variant: 'solid' }">`.length },
+      "x-data",
+      "{ variant: 'outline' }",
+    );
+    expect(out.changed).toBe(true);
+    expect(out.content).toContain(`x-data="{ variant: 'outline' }"`);
+  });
+
+  it("escapes the value so it cannot break out of the attribute", () => {
+    const out = applyRootAttributeEdit(
+      html,
+      source,
+      "data-agent-native-prop-label",
+      '"><script>alert(1)</script>',
+    );
+    expect(out.changed).toBe(true);
+    expect(out.content).not.toContain("<script>");
+    expect(out.content).toContain("&lt;script&gt;");
+  });
+
+  it("handles a self-closing open tag (inserts before close)", () => {
+    const selfClosing = `<input class="x"/>`;
+    const out = applyRootAttributeEdit(
+      selfClosing,
+      { openStart: 0, openEnd: selfClosing.length },
+      "data-agent-native-prop-value",
+      "hi",
+    );
+    expect(out.changed).toBe(true);
+    expect(out.content).toBe(
+      `<input class="x" data-agent-native-prop-value="hi"/>`,
+    );
+  });
+
+  it("reports no change when the source span is missing", () => {
+    const out = applyRootAttributeEdit(html, null, "data-x", "y");
+    expect(out.changed).toBe(false);
+    expect(out.content).toBe(html);
+  });
+});

--- a/templates/design/actions/apply-component-prop-edit.ts
+++ b/templates/design/actions/apply-component-prop-edit.ts
@@ -55,6 +55,65 @@ import { normalizeDesignSourceType } from "../shared/source-mode.js";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
+/**
+ * Escape an attribute value for safe inclusion inside a double-quoted HTML
+ * attribute. Mirrors the escaping used by the deterministic patcher.
+ */
+export function escapeAttributeValue(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * Set (or replace) a single attribute on the *opening tag* of a component
+ * root, using the node's source span. Pure — no DB / IO — so it can be unit
+ * tested directly.
+ *
+ * - When the attribute already exists on the open tag its value is replaced.
+ * - Otherwise the attribute is inserted just before the closing `>` / `/>`.
+ *
+ * Returns the rewritten full HTML and a `changed` flag (false when the span is
+ * missing or the rewrite produced an identical open tag).
+ */
+export function applyRootAttributeEdit(
+  html: string,
+  source: { openStart: number; openEnd: number } | null | undefined,
+  attrName: string,
+  attrValue: string,
+): { content: string; changed: boolean } {
+  if (!source) return { content: html, changed: false };
+
+  const openTag = html.slice(source.openStart, source.openEnd);
+  // Replace an existing attribute if present, otherwise insert before the
+  // closing `>` or `/>`.
+  const attrRe = new RegExp(
+    `(\\s${attrName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*=\\s*)(?:"[^"]*"|'[^']*'|[^\\s>"']+)`,
+    "i",
+  );
+  const escaped = escapeAttributeValue(attrValue);
+
+  let newOpenTag: string;
+  if (attrRe.test(openTag)) {
+    newOpenTag = openTag.replace(attrRe, `$1"${escaped}"`);
+  } else {
+    const insertOffset = openTag.endsWith("/>")
+      ? openTag.length - 2
+      : openTag.length - 1;
+    newOpenTag = `${openTag.slice(0, insertOffset)} ${attrName}="${escaped}"${openTag.slice(insertOffset)}`;
+  }
+
+  if (newOpenTag === openTag) return { content: html, changed: false };
+
+  return {
+    content:
+      html.slice(0, source.openStart) + newOpenTag + html.slice(source.openEnd),
+    changed: true,
+  };
+}
+
 async function liveContent(
   fileId: string,
   storedContent: string,
@@ -321,40 +380,14 @@ export default defineAction({
 
     if (edit.kind === "alpineData" || edit.kind === "attribute") {
       const attrName = edit.kind === "alpineData" ? "x-data" : edit.attribute;
-      const attrValue = edit.value;
-      const src = node.source;
-
-      if (src) {
-        const openTag = html.slice(src.openStart, src.openEnd);
-        // Replace existing attribute if present, otherwise insert before the
-        // closing `>` or `/>`.
-        const attrRe = new RegExp(
-          `(\\s${attrName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*=\\s*)(?:"[^"]*"|'[^']*'|[^\\s>"']+)`,
-          "i",
-        );
-        const escaped = attrValue
-          .replace(/&/g, "&amp;")
-          .replace(/"/g, "&quot;")
-          .replace(/</g, "&lt;")
-          .replace(/>/g, "&gt;");
-
-        let newOpenTag: string;
-        if (attrRe.test(openTag)) {
-          newOpenTag = openTag.replace(attrRe, `$1"${escaped}"`);
-        } else {
-          // Insert before closing `>` or `/>`.
-          const insertOffset = openTag.endsWith("/>")
-            ? openTag.length - 2
-            : openTag.length - 1;
-          newOpenTag = `${openTag.slice(0, insertOffset)} ${attrName}="${escaped}"${openTag.slice(insertOffset)}`;
-        }
-
-        if (newOpenTag !== openTag) {
-          patchedContent =
-            html.slice(0, src.openStart) + newOpenTag + html.slice(src.openEnd);
-          changed = true;
-        }
-      }
+      const result = applyRootAttributeEdit(
+        html,
+        node.source,
+        attrName,
+        edit.value,
+      );
+      patchedContent = result.content;
+      changed = result.changed;
     } else if (edit.kind === "classReplace") {
       // Use the deterministic patcher for class edits.
       const patch = applyVisualEdit(html, intent, { source: codeLayerSource });

--- a/templates/design/actions/apply-shader-fill.spec.ts
+++ b/templates/design/actions/apply-shader-fill.spec.ts
@@ -1,0 +1,181 @@
+/**
+ * apply-shader-fill.spec.ts
+ *
+ * Unit tests for the persisting shader-fill apply path.
+ *
+ * The action itself requires a live DB + collab runtime, so (following the
+ * apply-motion-edit.spec.ts pattern) these tests cover:
+ *
+ *  1. The pure helper that produces the value the action persists
+ *     (`buildShaderFillBackground`) — proving the colour/param allowlist and the
+ *     persisted CSS `background` output.
+ *  2. The action's contract via static source inspection — proving it asserts
+ *     editor access, only persists HTML design-file sources, validates the
+ *     descriptor before writing, and goes through the deterministic HTML editor.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildShaderFillBackground,
+  generateShaderFillFallbackCss,
+} from "../shared/shader-fill";
+import type { ShaderDescriptor } from "../shared/shader-presets";
+
+// ─── 1. Persisted value: colour/param allowlist + CSS output ──────────────────
+
+describe("buildShaderFillBackground — persisted CSS background", () => {
+  it("returns the same gradient the preview renders for a MeshGradient", () => {
+    const descriptor: ShaderDescriptor = {
+      preset: "MeshGradient",
+      params: {},
+      colors: ["#e0eaff", "#241d9a"],
+    };
+    const { background, colors } = buildShaderFillBackground(descriptor);
+    expect(background).toBe(
+      "conic-gradient(from 0deg at 50% 50%, #e0eaff 0deg, #241d9a 180deg, #e0eaff 360deg)",
+    );
+    expect(colors).toEqual(["#e0eaff", "#241d9a"]);
+  });
+
+  it("falls back to preset default colours when none are supplied", () => {
+    const descriptor: ShaderDescriptor = { preset: "MeshGradient", params: {} };
+    const { background, colors } = buildShaderFillBackground(descriptor);
+    // MeshGradient defaultColors from the manifest.
+    expect(colors).toEqual(["#e0eaff", "#241d9a", "#f75092", "#9f50d3"]);
+    expect(background).toContain("#e0eaff");
+    expect(background).toContain("#9f50d3");
+  });
+
+  it("produces a radial gradient for Voronoi-family presets", () => {
+    const descriptor: ShaderDescriptor = {
+      preset: "Voronoi",
+      params: {},
+      colors: ["#ff8247", "#ffe53d"],
+    };
+    const { background } = buildShaderFillBackground(descriptor);
+    expect(background.startsWith("radial-gradient(")).toBe(true);
+    expect(background).toContain("#ff8247");
+  });
+
+  describe("colour allowlist — no CSS injection reaches the persisted value", () => {
+    it("neutralises a declaration/rule breakout payload to a safe colour", () => {
+      const descriptor: ShaderDescriptor = {
+        preset: "MeshGradient",
+        params: {},
+        colors: ["#ffffff", "red; } body { display:none"],
+      };
+      const { background, colors } = buildShaderFillBackground(descriptor);
+      // The unsafe entry is replaced with the neutral fallback, never echoed.
+      expect(colors).toEqual(["#ffffff", "#808080"]);
+      expect(background).not.toContain("display");
+      expect(background).not.toContain("}");
+      expect(background).not.toContain("{");
+      expect(background).not.toContain(";");
+    });
+
+    it("neutralises a url() exfiltration payload", () => {
+      const descriptor: ShaderDescriptor = {
+        preset: "MeshGradient",
+        params: {},
+        colors: ["#ffffff", "url(http://evil.example/x)"],
+      };
+      const { background, colors } = buildShaderFillBackground(descriptor);
+      expect(colors).toEqual(["#ffffff", "#808080"]);
+      expect(background.toLowerCase()).not.toContain("url(");
+      expect(background).not.toContain("evil");
+    });
+
+    it("rejects a <style> breakout and any angle bracket", () => {
+      const descriptor: ShaderDescriptor = {
+        preset: "MeshGradient",
+        params: {},
+        colors: ["</style><script>alert(1)</script>"],
+      };
+      const { background } = buildShaderFillBackground(descriptor);
+      expect(background).not.toContain("<");
+      expect(background).not.toContain(">");
+      expect(background).not.toContain("script");
+    });
+
+    it("preserves valid rgb()/hsl()/named colours verbatim", () => {
+      const descriptor: ShaderDescriptor = {
+        preset: "MeshGradient",
+        params: {},
+        colors: ["rgb(255, 0, 0)", "hsl(200, 50%, 50%)", "rebeccapurple"],
+      };
+      const { colors } = buildShaderFillBackground(descriptor);
+      expect(colors).toEqual([
+        "rgb(255, 0, 0)",
+        "hsl(200, 50%, 50%)",
+        "rebeccapurple",
+      ]);
+    });
+  });
+
+  it("the static fallback is a simpler, animation-free linear gradient", () => {
+    const descriptor: ShaderDescriptor = {
+      preset: "Voronoi",
+      params: {},
+      colors: ["#ff8247", "#ffe53d"],
+    };
+    const fallback = generateShaderFillFallbackCss(descriptor);
+    expect(fallback.startsWith("linear-gradient(")).toBe(true);
+    expect(fallback).toContain("#ff8247");
+    expect(fallback).toContain("#ffe53d");
+  });
+});
+
+// ─── 2. Action contract via source inspection ─────────────────────────────────
+
+describe("apply-shader-fill action contract", () => {
+  const actionPath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "apply-shader-fill.ts",
+  );
+  const src = readFileSync(actionPath, "utf8");
+
+  it("asserts editor access before persisting", () => {
+    expect(src).toContain('assertAccess("design"');
+    expect(src).toMatch(/"editor"/);
+  });
+
+  it("scopes the design read with accessFilter", () => {
+    expect(src).toContain("accessFilter(schema.designs, schema.designShares)");
+  });
+
+  it("validates the descriptor before any write", () => {
+    expect(src).toContain("validateDescriptor(descriptor)");
+    // Validation in run() must short-circuit before the persist CALL site
+    // (`await persistDesignFileEdit(...)`), not merely before the helper def.
+    const validateIdx = src.indexOf("validateDescriptor(descriptor)");
+    const persistCallIdx = src.indexOf("await persistDesignFileEdit({");
+    expect(validateIdx).toBeGreaterThan(-1);
+    expect(persistCallIdx).toBeGreaterThan(-1);
+    expect(validateIdx).toBeLessThan(persistCallIdx);
+  });
+
+  it("persists the fill as a CSS background via the deterministic HTML editor", () => {
+    expect(src).toContain("buildShaderFillBackground(descriptor)");
+    expect(src).toContain("applyVisualEdit(");
+    expect(src).toMatch(/property:\s*"background"/);
+  });
+
+  it("only writes HTML design-file sources — other kinds preview, never persist", () => {
+    expect(src).toContain('source.kind !== "design-file"');
+    expect(src).toMatch(/persisted:\s*false/);
+    // The HTML-only guard inside resolveEditableDesignFile.
+    expect(src).toContain(
+      "Shader fills can only be persisted onto HTML design files",
+    );
+  });
+
+  it("only persists when the editor actually changed the source", () => {
+    expect(src).toMatch(/status === "applied"/);
+    expect(src).toMatch(/changed === true/);
+  });
+});

--- a/templates/design/actions/apply-shader-fill.ts
+++ b/templates/design/actions/apply-shader-fill.ts
@@ -1,42 +1,56 @@
 /**
- * apply-shader-fill — GATED apply action.
+ * apply-shader-fill — PERSISTING apply action.
  *
- * This action is PREVIEW-FIRST per DESIGN-STUDIO-PLAN.md §6.7 + §14:
+ * Writes the chosen shader fill onto a design element as a CSS `background`,
+ * the same gradient the preview renders. This is the deliberate commit step
+ * after `preview-shader-fill`; preview stays non-persisting.
  *
- *   "Shaders: preview-first; apply/export of a shader stays DISABLED/gated
- *    until runtime rendering + a real source-write path + a generated CSS
- *    fallback + diff proof all exist."
+ * Safety model (this action is SAFETY-gated, not Builder-gated):
+ * - Editor access is asserted on the target design before any write
+ *   (`accessFilter` on the read + `assertAccess("design", id, "editor")`).
+ * - Only HTML design-file sources are writable — the deterministic HTML editor
+ *   (`applyVisualEdit`) is the single mutation seam, exactly like
+ *   `apply-visual-edit`. localhost / fusion / inline-html sources are NOT
+ *   written; the caller gets the preview + an explanation instead.
+ * - The persisted value is a CSS `background` produced by
+ *   `buildShaderFillBackground`, which runs every colour through the same strict
+ *   CSS-colour allowlist that `preview-shader-fill` uses (`shader-fill.ts`), so a
+ *   `descriptor.colors` payload can never inject CSS into the source.
+ * - The descriptor is validated against the preset manifest first, so callers
+ *   get clear errors before any round-trip.
  *
- * The apply path is safe to call today but will return a clear
- * NOT_YET_AVAILABLE result with an exact checklist of the missing conditions.
- * It NEVER silently writes when gated — the caller always gets explicit
- * feedback.
+ * The write reuses the canonical persist path (Yjs/collab + SQL via
+ * agentEnterDocument / applyText / seedFromText), so collaborators and the agent
+ * stay in sync. The edit is a single inline-style `style.background` change on
+ * the resolved node — no structural inserts, no new owned rows.
  *
- * Safety conditions that must ALL be true before writes are enabled:
- *
- *   1. RUNTIME_RENDERING — a WebGL shader canvas mounts and renders correctly
- *      in the iframe (verified by a bridge captureSnapshot round-trip).
- *   2. SOURCE_WRITE_PATH — the source write bridge (`writeFile` / `applyEdit`)
- *      is available for this design's sourceType (currently `planned` for all
- *      tiers).
- *   3. CSS_FALLBACK — a generated static CSS fallback is embedded alongside
- *      the shader canvas so designs degrade gracefully in export/SSR.
- *   4. DIFF_PROOF — the action can produce a before/after diff of the source
- *      change so the edit is reviewable and rollback-able.
- *
- * When all conditions hold, the action delegates to `apply-shader` (the
- * existing planning action) for the actual snippet generation, then writes
- * through the collab / Yjs path (same as `apply-visual-edit`).
- *
- * Plan reference: DESIGN-STUDIO-PLAN.md §6.7, §7, §14.
+ * Plan reference: DESIGN-STUDIO-PLAN.md §6.7 + §7 (shader fill apply).
  */
 
 import { defineAction } from "@agent-native/core";
+import {
+  agentEnterDocument,
+  agentLeaveDocument,
+  agentUpdateSelection,
+  applyText,
+  getText,
+  hasCollabState,
+  seedFromText,
+} from "@agent-native/core/collab";
+import { accessFilter, assertAccess } from "@agent-native/core/sharing";
+import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
+import { getDb, schema } from "../server/db/index.js";
 import {
-  generateShaderFillPreviewCss,
+  applyVisualEdit,
+  type CodeLayerSource,
+  type StyleEditIntent,
+} from "../shared/code-layer.js";
+import {
+  buildShaderFillBackground,
   generateShaderFillFallbackCss,
+  generateShaderFillPreviewCss,
 } from "../shared/shader-fill.js";
 import {
   SHADER_PRESET_MAP,
@@ -44,100 +58,6 @@ import {
   type ShaderPresetName,
   validateDescriptor,
 } from "../shared/shader-presets.js";
-
-// ─── Safety gate ─────────────────────────────────────────────────────────────
-
-/**
- * All conditions that must hold before an apply write is allowed.
- * Each entry has a `met` flag and a human-readable `reason` explaining what
- * is still missing and (where possible) what would unlock it.
- */
-interface SafetyCondition {
-  id: string;
-  label: string;
-  met: boolean;
-  reason: string;
-  /** Rough work estimate to unlock this condition. */
-  effort: "days" | "weeks" | "unknown";
-}
-
-/**
- * Evaluate the safety conditions for a given sourceType.
- *
- * In the current phase (6, shaders/plugins/assets) NONE of the write
- * conditions are met for any source type.  The checks are structured so
- * that future implementers can flip individual conditions to `true` as the
- * corresponding work lands, without changing the surrounding gate logic.
- */
-function evaluateSafetyConditions(
-  sourceType: "inline" | "localhost" | "fusion",
-): SafetyCondition[] {
-  return [
-    {
-      id: "RUNTIME_RENDERING",
-      label: "Runtime WebGL rendering verified",
-      // Not yet verified: requires a captureSnapshot bridge round-trip that
-      // confirms the <canvas data-shader=...> element mounted + rendered.
-      // The bridge captureSnapshot op IS available for inline; the verification
-      // tooling to confirm WebGL canvas presence is not yet built.
-      met: false,
-      reason:
-        "The iframe captureSnapshot round-trip that verifies a WebGL shader canvas " +
-        "has mounted and rendered is not yet implemented.  Until it is, we cannot " +
-        "confirm the runtime renders the shader correctly before persisting.",
-      effort: "days",
-    },
-    {
-      id: "SOURCE_WRITE_PATH",
-      label: "Source write bridge available",
-      // `writeFile` / `applyEdit` are `planned` for all source types today.
-      // Inline uses the Yjs/collab path for HTML changes (apply-visual-edit
-      // style), which is available — but a shader-specific structural insert
-      // (adding a <canvas> or JSX component) needs the deterministic
-      // replace-document-content path AND validation that position/parenting
-      // is correct, which is not yet built for shader elements specifically.
-      met: false,
-      reason:
-        sourceType === "fusion"
-          ? "Source writes (`writeFile` / `applyEdit`) are `planned` for fusion sources. " +
-            "Connect Builder and complete bridge hardening to unlock."
-          : sourceType === "localhost"
-            ? "Source writes (`applyEdit` / `writeFile`) are `planned` for localhost. " +
-              "Bridge hardening is required before structural source inserts are safe."
-            : "Structural HTML insert for a shader <canvas> element via the " +
-              "replace-document-content path is not yet validated for shader-fill " +
-              "placement (parent positioning, z-index, collab round-trip).",
-      effort: "days",
-    },
-    {
-      id: "CSS_FALLBACK",
-      label: "Generated CSS fallback embedded alongside shader",
-      // The fallback CSS generator exists (shader-fill.ts) but the action that
-      // writes the fallback <style> block into the document alongside the
-      // <canvas> element is not yet implemented.
-      met: false,
-      reason:
-        "The CSS fallback generator (`generateShaderFillFallbackCss`) is ready, " +
-        "but the write step that embeds the fallback <style> block adjacent to the " +
-        "shader <canvas> element has not been implemented.  This must ship together " +
-        "with the canvas insert so designs degrade gracefully in export/PDF/SSR.",
-      effort: "days",
-    },
-    {
-      id: "DIFF_PROOF",
-      label: "Before/after diff produced and returned to caller",
-      // apply-visual-edit produces a diff summary; shader-fill needs the same
-      // treatment — comparing the document before and after the canvas+fallback
-      // insertion.  Not yet wired for this code path.
-      met: false,
-      reason:
-        "The diff/rollback proof (bytes before/after, changed selectors, rollback " +
-        "snapshot) is not yet produced for the shader-fill write path.  Without " +
-        "this the edit cannot be reviewed or rolled back safely.",
-      effort: "days",
-    },
-  ];
-}
 
 // ─── Schema ──────────────────────────────────────────────────────────────────
 
@@ -147,82 +67,239 @@ const PRESET_NAMES = Object.keys(SHADER_PRESET_MAP) as [
 ];
 
 const descriptorSchema = z.object({
-  preset: z.enum(PRESET_NAMES),
+  preset: z
+    .enum(PRESET_NAMES)
+    .describe("Shader preset name. One of: " + PRESET_NAMES.join(", ")),
   params: z
     .record(z.string(), z.union([z.number(), z.boolean(), z.string()]))
     .optional()
-    .default({}),
-  colors: z.array(z.string()).optional(),
+    .default({})
+    .describe("Shader-specific params. Merged with preset defaults."),
+  colors: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Colour palette override. Falls back to preset defaults. Every colour " +
+        "is validated against a strict CSS-colour allowlist before it is " +
+        "written; unsafe entries are neutralised, never injected.",
+    ),
   speed: z.number().optional(),
   frame: z.number().optional(),
   fit: z.enum(["none", "contain", "cover"]).optional(),
   scale: z.number().optional(),
-  rotation: z.number().optional(),
+  rotation: z.number().optional().describe("Rotation in radians."),
   offsetX: z.number().optional(),
   offsetY: z.number().optional(),
 });
+
+const sourceSchema = z
+  .object({
+    kind: z
+      .enum(["design-file", "inline-html", "localhost", "fusion"])
+      .default("design-file"),
+    designId: z.string().optional(),
+    fileId: z.string().optional(),
+    filename: z.string().optional(),
+    revision: z.string().optional(),
+  })
+  .describe(
+    "Design source. Only kind=design-file (HTML) is persisted. Provide " +
+      "designId (and optional filename) or fileId.",
+  );
+
+const targetSchema = z
+  .object({
+    nodeId: z.string().optional(),
+    selector: z.string().optional(),
+  })
+  .superRefine((target, ctx) => {
+    if (!target.nodeId && !target.selector) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["nodeId"],
+        message: "target.nodeId or target.selector is required",
+      });
+    }
+  })
+  .describe(
+    "Target element by nodeId (data-agent-native-node-id) or selector.",
+  );
+
+// ─── Persist helpers (mirrors apply-visual-edit.ts) ───────────────────────────
+
+interface ResolvedDesignFile {
+  id: string;
+  designId: string;
+  filename: string;
+  content: string;
+  codeLayerSource: CodeLayerSource;
+}
+
+async function liveContent(
+  fileId: string,
+  storedContent: string,
+): Promise<string> {
+  try {
+    if (await hasCollabState(fileId)) {
+      const live = await getText(fileId, "content");
+      if (typeof live === "string") return live;
+    }
+  } catch {
+    // Collab reads are best-effort; SQL content remains the fallback.
+  }
+  return storedContent;
+}
+
+/**
+ * Resolve the target HTML design file with an access-scoped read, then assert
+ * editor access. Mirrors `resolveEditableDesignFile` in apply-visual-edit.ts so
+ * the shader-fill write goes through the exact same ownership gate.
+ */
+async function resolveEditableDesignFile(source: {
+  designId?: string;
+  fileId?: string;
+  filename?: string;
+  revision?: string;
+}): Promise<ResolvedDesignFile> {
+  if (!source.fileId && !source.designId) {
+    throw new Error(
+      "source.designId or source.fileId is required for design-file.",
+    );
+  }
+
+  const db = getDb();
+  const conditions = [
+    accessFilter(schema.designs, schema.designShares),
+    source.fileId
+      ? eq(schema.designFiles.id, source.fileId)
+      : eq(schema.designFiles.designId, source.designId ?? ""),
+  ];
+  if (!source.fileId) {
+    conditions.push(
+      eq(schema.designFiles.filename, source.filename ?? "index.html"),
+    );
+  }
+
+  const [file] = await db
+    .select({
+      id: schema.designFiles.id,
+      designId: schema.designFiles.designId,
+      filename: schema.designFiles.filename,
+      fileType: schema.designFiles.fileType,
+      content: schema.designFiles.content,
+    })
+    .from(schema.designFiles)
+    .innerJoin(
+      schema.designs,
+      eq(schema.designFiles.designId, schema.designs.id),
+    )
+    .where(and(...conditions))
+    .limit(1);
+
+  if (!file) {
+    throw new Error("Design HTML file not found.");
+  }
+  if (file.fileType !== "html") {
+    throw new Error(
+      "Shader fills can only be persisted onto HTML design files for now.",
+    );
+  }
+  if (source.designId && file.designId !== source.designId) {
+    throw new Error(
+      `source.designId "${source.designId}" does not match file "${file.id}"`,
+    );
+  }
+  if (!source.fileId && source.filename && file.filename !== source.filename) {
+    throw new Error(
+      `source.filename "${source.filename}" does not match file "${file.id}"`,
+    );
+  }
+
+  await assertAccess("design", file.designId, "editor");
+
+  return {
+    id: file.id,
+    designId: file.designId,
+    filename: file.filename,
+    content: await liveContent(file.id, file.content ?? ""),
+    codeLayerSource: {
+      kind: "design-file",
+      designId: file.designId,
+      fileId: file.id,
+      filename: file.filename,
+      revision: source.revision,
+    },
+  };
+}
+
+async function persistDesignFileEdit(file: {
+  id: string;
+  designId: string;
+  content: string;
+}): Promise<void> {
+  await assertAccess("design", file.designId, "editor");
+
+  const db = getDb();
+  const now = new Date().toISOString();
+
+  agentEnterDocument(file.id);
+  try {
+    await db
+      .update(schema.designFiles)
+      .set({ content: file.content, updatedAt: now })
+      .where(eq(schema.designFiles.id, file.id));
+
+    if (await hasCollabState(file.id)) {
+      await applyText(file.id, file.content, "content", "agent");
+    } else {
+      await seedFromText(file.id, file.content);
+    }
+
+    // guard:allow-unscoped — editor access on this design is asserted above
+    // (and again at the top of this helper); this only bumps the addressed
+    // design row's updatedAt.
+    await db
+      .update(schema.designs)
+      .set({ updatedAt: now })
+      .where(eq(schema.designs.id, file.designId));
+  } finally {
+    agentLeaveDocument(file.id);
+  }
+}
 
 // ─── Action ──────────────────────────────────────────────────────────────────
 
 export default defineAction({
   description: `
-Apply a shader fill to a design element.
+Persist a shader fill onto a design element as a CSS \`background\`.
 
-IMPORTANT — THIS ACTION IS CURRENTLY GATED.
+This is the commit step after preview-shader-fill. It writes the same gradient
+the preview renders onto the target element's inline style.background, using the
+deterministic HTML editor (the same persist path as apply-visual-edit).
 
-Per DESIGN-STUDIO-PLAN.md §6.7: "apply/export of a shader stays DISABLED/gated
-until runtime rendering + a real source-write path + a generated CSS fallback +
-diff proof all exist."
+Gating: editor access on the target design is asserted before any write. Only
+HTML design-file sources are persisted; localhost / fusion / inline-html sources
+return the preview CSS plus an explanation and write nothing. Every colour is
+validated against the shared CSS-colour allowlist before it is written, so a
+descriptor.colors payload can never inject CSS into the source.
 
-Calling this action today will ALWAYS return { ok: false, gated: true } with a
-checklist of the conditions that must be met before writes are enabled.  It will
-never write, never persist, and never imply the write happened.
+Returns:
+- persisted     — true only when the source HTML was actually changed and saved.
+- background    — the CSS \`background\` value written (or that would be written).
+- fallbackCss   — a simpler static CSS background for export / PDF / SSR.
+- descriptor    — the resolved and validated ShaderDescriptor.
+- result        — the deterministic edit PatchResult (status, target, message).
+- bytesBefore / bytesAfter — proof-of-change for the persisted file.
 
-To actually preview a shader fill visually, call preview-shader-fill instead.
-To generate the code snippet for a manual source edit, call apply-shader instead.
+To preview without writing, call preview-shader-fill. To get a manual-edit code
+snippet (WebGL canvas / JSX component), call apply-shader.
   `.trim(),
   schema: z.object({
-    descriptor: descriptorSchema.describe("Shader preset + params to apply."),
-    target: z
-      .object({
-        nodeId: z.string().optional(),
-        selector: z.string().optional(),
-      })
-      .optional()
-      .describe("Target element by nodeId or CSS selector."),
-    source: z
-      .object({
-        kind: z.enum(["design-file", "inline-html"]).default("design-file"),
-        designId: z.string().optional(),
-        fileId: z.string().optional(),
-      })
-      .optional()
-      .describe("Design source context."),
-    surface: z
-      .enum(["fill", "effect"])
-      .default("fill")
-      .describe(
-        "fill: shader sits behind content (z-index 0). effect: composites over content (z-index 2, pointer-events none).",
-      ),
-    // Safety override — only respected when ALL conditions are independently
-    // verified by the caller.  The server still validates.
-    _forceApply: z
-      .boolean()
-      .optional()
-      .describe(
-        "Internal: bypass the safety gate.  Only valid when all safety conditions are met.  " +
-          "The server re-evaluates conditions regardless of this flag.",
-      ),
+    descriptor: descriptorSchema.describe("Shader preset + params to persist."),
+    target: targetSchema,
+    source: sourceSchema,
   }),
-  // readOnly: true because this action never writes in the current phase.
-  // When the gate is lifted this will change to false.
-  readOnly: true,
-  run: async ({
-    descriptor: rawDescriptor,
-    target: _target,
-    source,
-    _forceApply,
-  }) => {
+  run: async ({ descriptor: rawDescriptor, target, source }) => {
     const descriptor: ShaderDescriptor = {
       preset: rawDescriptor.preset as ShaderPresetName,
       params: rawDescriptor.params ?? {},
@@ -236,95 +313,92 @@ To generate the code snippet for a manual source edit, call apply-shader instead
       offsetY: rawDescriptor.offsetY,
     };
 
-    // Validate the descriptor regardless of gate status.
+    // Validate against the preset manifest before any write so the caller gets
+    // clear errors without a wasted DB / collab round-trip.
     const validation = validateDescriptor(descriptor);
     if (!validation.valid) {
       return {
         ok: false,
-        gated: false,
+        persisted: false,
         errors: validation.errors,
-        hint: "Fix the descriptor errors first.  Call get-shader to see the full preset catalog.",
+        descriptor,
+        hint: "Fix the descriptor errors and retry. Call get-shader to see the full preset catalog.",
       };
     }
 
-    // Determine source type — default to inline (most permissive) when unknown.
-    const sourceKind = source?.kind ?? "design-file";
-    const sourceType: "inline" | "localhost" | "fusion" =
-      sourceKind === "inline-html" ? "inline" : "inline";
+    // Resolve the CSS `background` to write. Every colour is run through the
+    // strict CSS-colour allowlist here (same path preview-shader-fill uses).
+    const { background, colors } = buildShaderFillBackground(descriptor);
+    const fallbackCss = generateShaderFillFallbackCss(descriptor);
 
-    // Evaluate safety conditions.
-    const conditions = evaluateSafetyConditions(sourceType);
-    const allMet = conditions.every((c) => c.met);
-
-    // The server-side gate: even if _forceApply is set by the caller, all
-    // conditions must be met.  This prevents accidental writes from callers
-    // that incorrectly set the flag.
-    if (!allMet) {
-      const unmet = conditions.filter((c) => !c.met);
-
-      // Still provide the preview CSS so the caller can at least show something.
-      const previewCss = generateShaderFillPreviewCss(descriptor);
-      const fallbackCss = generateShaderFillFallbackCss(descriptor);
-
+    // Only HTML design-file sources are persisted. Everything else gets the
+    // preview value plus an explanation and writes nothing — the deterministic
+    // HTML editor is the single safe mutation seam.
+    if (source.kind !== "design-file") {
       return {
-        ok: false,
-        gated: true,
-        status: "NOT_YET_AVAILABLE",
-        message:
-          "apply-shader-fill is gated until all safety conditions are met. " +
-          "No data was written.  Use preview-shader-fill to see a CSS preview, " +
-          "or apply-shader to get a manual-edit code snippet.",
-        conditions,
-        unmetConditions: unmet.map((c) => ({
-          id: c.id,
-          label: c.label,
-          reason: c.reason,
-          effort: c.effort,
-        })),
-        // Provide the preview anyway so the caller has something useful.
-        previewCss,
+        ok: true,
+        persisted: false,
+        descriptor,
+        background: generateShaderFillPreviewCss(descriptor),
         fallbackCss,
-        alternativeActions: [
-          {
-            action: "preview-shader-fill",
-            description:
-              "Preview the shader fill as a CSS gradient on the target element (no write, no persist).",
-          },
-          {
-            action: "apply-shader",
-            description:
-              "Generate the JSX/HTML code snippet for a manual source edit (no automatic write).",
-          },
-          {
-            action: "get-shader",
-            description: "Browse the full shader preset catalog.",
-          },
-        ],
+        colors,
+        note:
+          `Shader fills are only persisted onto HTML design-file sources. ` +
+          `Source kind "${source.kind}" was not written. Inject the returned ` +
+          `background via the bridge for a live preview, or call apply-shader ` +
+          `for a manual-edit code snippet.`,
       };
     }
 
-    // ── All conditions met ──────────────────────────────────────────────────
-    // This block is unreachable in the current phase (all conditions return
-    // met: false).  It is scaffolded here so the implementation path is clear
-    // for the engineer who lifts the gate.
-    //
-    // When this block becomes reachable:
-    // 1. Resolve the design file (see insert-asset.ts for the pattern).
-    // 2. Build the bridge mount: buildBridgeMount(descriptor, surface) from
-    //    the existing apply-shader.ts helper.
-    // 3. Write the <canvas data-shader=...> element into the document via
-    //    the replace-document-content path (same as apply-visual-edit.ts).
-    // 4. Write the CSS fallback <style> block alongside it.
-    // 5. Produce a diff summary and compiledHash (same as apply-motion-edit.ts).
-    // 6. Return { ok: true, ...diff }.
+    const file = await resolveEditableDesignFile(source);
+
+    const intent: StyleEditIntent = {
+      kind: "style",
+      target: { nodeId: target.nodeId, selector: target.selector },
+      property: "background",
+      value: background,
+    };
+
+    const patch = applyVisualEdit(file.content, intent, {
+      source: file.codeLayerSource,
+    });
+
+    if (patch.result.target) {
+      agentUpdateSelection(file.id, {
+        selection: patch.result.target.selector,
+        nodeId: patch.result.target.nodeId,
+        editingFile: file.filename,
+        designId: file.designId,
+      });
+    }
+
+    const changed =
+      patch.result.status === "applied" && patch.result.changed === true;
+
+    if (changed) {
+      await persistDesignFileEdit({
+        id: file.id,
+        designId: file.designId,
+        content: patch.content,
+      });
+    }
 
     return {
-      ok: false,
-      gated: true,
-      status: "IMPLEMENTATION_INCOMPLETE",
-      message:
-        "All safety conditions evaluated as met, but the write implementation " +
-        "is not yet complete.  This should not be reachable in the current phase.",
+      ok: patch.result.status === "applied",
+      persisted: changed,
+      descriptor,
+      background,
+      fallbackCss,
+      colors,
+      designId: file.designId,
+      fileId: file.id,
+      filename: file.filename,
+      result: patch.result,
+      bytesBefore: file.content.length,
+      bytesAfter: patch.content.length,
+      note: changed
+        ? "Shader fill persisted as the element's CSS background."
+        : "No change was written — the deterministic editor could not apply the edit. See result for details.",
     };
   },
 });

--- a/templates/design/app/components/design/DesignExtensionsPanel.tsx
+++ b/templates/design/app/components/design/DesignExtensionsPanel.tsx
@@ -14,6 +14,7 @@ import {
   EmbeddedApp,
   type EmbeddedAppRef,
 } from "@agent-native/core/embedding/react";
+import type { ShaderDescriptor } from "@shared/shader-presets";
 import {
   IconExternalLink,
   IconLock,
@@ -276,25 +277,6 @@ function FirstPartyExtRow({
   );
 }
 
-// ─── Gated badge ─────────────────────────────────────────────────────────────
-
-function GatedBadge() {
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span className="inline-flex shrink-0 items-center gap-0.5 rounded bg-amber-500/10 px-1.5 py-0.5 text-[9px] font-semibold leading-none text-amber-600 dark:text-amber-400">
-          <IconLock className="size-2.5" />
-          Preview
-        </span>
-      </TooltipTrigger>
-      <TooltipContent side="left" className="max-w-48 text-[11px]">
-        Apply is gated until runtime rendering, source-write path, CSS fallback,
-        and diff proof are all in place.
-      </TooltipContent>
-    </Tooltip>
-  );
-}
-
 // ─── Asset Library panel ──────────────────────────────────────────────────────
 
 interface AssetLibraryPanelProps {
@@ -465,6 +447,58 @@ interface ShaderFillsExtPanelProps {
 
 function ShaderFillsExtPanel({ context }: ShaderFillsExtPanelProps) {
   const [showShaders, setShowShaders] = useState(false);
+  // The most recently previewed descriptor — Apply persists exactly this one,
+  // so the write is intentional (one atomic call) rather than firing on every
+  // slider tweak.
+  const [previewed, setPreviewed] = useState<ShaderDescriptor | null>(null);
+  const applyShaderFill = useActionMutation("apply-shader-fill");
+
+  // The persisting apply path needs an HTML file plus a target element. Without
+  // a selected element we can still preview, but we cannot write a fill.
+  const targetNodeId = context.selectedElement?.sourceId ?? undefined;
+  const targetSelector = context.selectedElement?.selector ?? undefined;
+  const canPersist = Boolean(
+    context.activeFileId && (targetNodeId || targetSelector),
+  );
+
+  const persistFill = (descriptor: ShaderDescriptor) => {
+    if (!canPersist) return;
+    applyShaderFill.mutate(
+      {
+        descriptor: {
+          preset: descriptor.preset,
+          params: descriptor.params,
+          colors: descriptor.colors,
+          speed: descriptor.speed,
+          frame: descriptor.frame,
+          fit: descriptor.fit,
+          scale: descriptor.scale,
+          rotation: descriptor.rotation,
+          offsetX: descriptor.offsetX,
+          offsetY: descriptor.offsetY,
+        },
+        target: { nodeId: targetNodeId, selector: targetSelector },
+        source: {
+          kind: "design-file" as const,
+          designId: context.designId || undefined,
+          fileId: context.activeFileId || undefined,
+        },
+      },
+      {
+        onSuccess: (res) => {
+          const r = res as { persisted?: boolean } | undefined;
+          if (r?.persisted) {
+            toast.success("Shader fill applied to the selected element.");
+          } else {
+            toast.message("Shader fill previewed — nothing was written.");
+          }
+        },
+        onError: () => {
+          toast.error("Failed to apply shader fill.");
+        },
+      },
+    );
+  };
 
   if (!showShaders) {
     return (
@@ -472,16 +506,17 @@ function ShaderFillsExtPanel({ context }: ShaderFillsExtPanelProps) {
         <p className="mb-2 text-[10px] leading-snug text-muted-foreground">
           GPU shader fill presets — MeshGradient, GrainGradient, Voronoi,
           Metaballs, Warp, GodRays, Dithering, PaperTexture. Preview as a CSS
-          gradient without writing anything.
+          gradient, then apply it to the selected element as a CSS background.
         </p>
-        <div className="mb-2 flex items-start gap-1.5 rounded-md border border-amber-500/30 bg-amber-500/5 px-2 py-1.5">
-          <IconLock className="mt-0.5 size-3 shrink-0 text-amber-600 dark:text-amber-400" />
-          <p className="text-[10px] leading-snug text-amber-700 dark:text-amber-300">
-            <strong>Apply is gated.</strong> Preview is safe; persist to design
-            stays disabled until runtime rendering, source-write path, CSS
-            fallback, and diff proof are all in place.
-          </p>
-        </div>
+        {!canPersist && (
+          <div className="mb-2 flex items-start gap-1.5 rounded-md border border-amber-500/30 bg-amber-500/5 px-2 py-1.5">
+            <IconLock className="mt-0.5 size-3 shrink-0 text-amber-600 dark:text-amber-400" />
+            <p className="text-[10px] leading-snug text-amber-700 dark:text-amber-300">
+              Select an element on the canvas to apply a fill. Without a
+              selection you can still browse and preview presets.
+            </p>
+          </div>
+        )}
         <div className="flex flex-wrap gap-1.5">
           <Button
             type="button"
@@ -498,22 +533,51 @@ function ShaderFillsExtPanel({ context }: ShaderFillsExtPanelProps) {
   }
 
   return (
-    <ShaderFillsPanel
-      onApply={(_descriptor, _css) => {
-        // Preview-only: the ShaderFillsPanel already fires apply-shader (the
-        // planning/codegen action) for agent context.  We don't call
-        // apply-shader-fill here — it is gated and would return NOT_YET_AVAILABLE.
-        // The "Apply" button inside ShaderFillsPanel fires apply-shader which
-        // gives the agent the JSX/HTML snippet to use with edit-design.
-      }}
-      onBack={() => setShowShaders(false)}
-      applyContext={{
-        designId: context.designId || undefined,
-        fileId: context.activeFileId || undefined,
-        nodeId: context.selectedElement?.sourceId ?? undefined,
-        selector: context.selectedElement?.selector ?? undefined,
-      }}
-    />
+    <div className="flex flex-col">
+      <ShaderFillsPanel
+        onApply={(descriptor, _css) => {
+          // Preview only: ShaderFillsPanel fires apply-shader (planning/codegen)
+          // for agent context on every tune and the iframe shows the gradient.
+          // We just record the latest descriptor here; the explicit Apply
+          // button below performs the single intentional persist write.
+          setPreviewed(descriptor);
+        }}
+        onBack={() => setShowShaders(false)}
+        applyContext={{
+          designId: context.designId || undefined,
+          fileId: context.activeFileId || undefined,
+          nodeId: targetNodeId,
+          selector: targetSelector,
+        }}
+      />
+
+      {/* ── Apply bar: persists the previewed fill onto the selected element ── */}
+      <div className="flex items-center gap-2 border-t border-border/60 px-3 py-2">
+        {canPersist ? (
+          <Button
+            type="button"
+            size="sm"
+            className="h-6 cursor-pointer gap-1 px-2 text-[11px]"
+            disabled={!previewed || applyShaderFill.isPending}
+            onClick={() => {
+              if (previewed) persistFill(previewed);
+            }}
+          >
+            <IconSparkles className="size-3" />
+            {applyShaderFill.isPending
+              ? "Applying…"
+              : previewed
+                ? "Apply fill"
+                : "Pick a preset"}
+          </Button>
+        ) : (
+          <p className="flex items-start gap-1.5 text-[10px] leading-snug text-amber-700 dark:text-amber-300">
+            <IconLock className="mt-0.5 size-3 shrink-0 text-amber-600 dark:text-amber-400" />
+            Select an element on the canvas to apply this fill.
+          </p>
+        )}
+      </div>
+    </div>
   );
 }
 
@@ -717,9 +781,8 @@ export function DesignExtensionsPanel({
     {
       id: "design.shader-fills",
       label: "Shader Fills",
-      description: "GPU shader fill presets — preview only",
+      description: "GPU shader fill presets — preview & apply",
       icon: <IconSparkles className="size-3.5" />,
-      badge: <GatedBadge />,
       panel: <ShaderFillsExtPanel context={context} />,
     },
     {
@@ -792,7 +855,7 @@ export function DesignExtensionsPanel({
         <div className="mb-3 flex items-start gap-1.5 rounded-md bg-muted/40 px-2 py-1.5">
           <IconSparkles className="mt-0.5 size-3 shrink-0 text-muted-foreground/70" />
           <p className="text-[10px] leading-snug text-muted-foreground">
-            The agent can insert assets, preview shader fills, audit tokens, and
+            The agent can insert assets, apply shader fills, audit tokens, and
             apply motion presets. Ask in the chat sidebar for help.
           </p>
         </div>

--- a/templates/design/app/components/design/EditPanel.componentProps.spec.ts
+++ b/templates/design/app/components/design/EditPanel.componentProps.spec.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isBooleanPropValue,
+  openingTagOf,
+  parseAlpineDataObject,
+  serializeAlpineDataObject,
+  truncateOpeningTag,
+} from "./EditPanel";
+
+// ---------------------------------------------------------------------------
+// openingTagOf / truncateOpeningTag — Inspect-code at-a-glance
+// ---------------------------------------------------------------------------
+
+describe("openingTagOf", () => {
+  it("extracts the opening tag with attributes from outer HTML", () => {
+    expect(
+      openingTagOf(
+        `<main class="hero" data-x="value">child<span>hi</span></main>`,
+      ),
+    ).toBe(`<main class="hero" data-x="value">`);
+  });
+
+  it("handles a bare tag with no attributes", () => {
+    expect(openingTagOf(`<section>content</section>`)).toBe(`<section>`);
+  });
+
+  it("keeps the self-closing slash", () => {
+    expect(openingTagOf(`<img src="a.png" alt="x"/>`)).toBe(
+      `<img src="a.png" alt="x"/>`,
+    );
+  });
+
+  it("does not break on `>` inside a quoted attribute value", () => {
+    expect(openingTagOf(`<div title="a > b" class="c">x</div>`)).toBe(
+      `<div title="a > b" class="c">`,
+    );
+  });
+
+  it("tolerates leading whitespace", () => {
+    expect(openingTagOf(`\n  <button>Go</button>`)).toBe(`<button>`);
+  });
+
+  it("returns null for empty / non-element input", () => {
+    expect(openingTagOf("")).toBeNull();
+    expect(openingTagOf(null)).toBeNull();
+    expect(openingTagOf("just text")).toBeNull();
+  });
+});
+
+describe("truncateOpeningTag", () => {
+  it("truncates long attribute values but keeps quotes", () => {
+    const long = `<div class="${"x".repeat(80)}">`;
+    const out = truncateOpeningTag(long, 10);
+    expect(out.length).toBeLessThan(long.length);
+    expect(out).toContain("…");
+    expect(out.startsWith(`<div class="`)).toBe(true);
+    expect(out.endsWith(`">`)).toBe(true);
+  });
+
+  it("leaves short values untouched", () => {
+    const tag = `<a href="#" class="btn">`;
+    expect(truncateOpeningTag(tag)).toBe(tag);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseAlpineDataObject / serializeAlpineDataObject — variant/state edits
+// ---------------------------------------------------------------------------
+
+describe("parseAlpineDataObject", () => {
+  it("parses a flat object of strings, booleans, and numbers", () => {
+    expect(
+      parseAlpineDataObject(
+        `{ variant: 'outline', disabled: false, count: 3 }`,
+      ),
+    ).toEqual({ variant: "outline", disabled: "false", count: "3" });
+  });
+
+  it("supports double-quoted string values and quoted keys", () => {
+    expect(parseAlpineDataObject(`{ "size": "lg", 'tone': "muted" }`)).toEqual({
+      size: "lg",
+      tone: "muted",
+    });
+  });
+
+  it("returns an empty object for an empty literal", () => {
+    expect(parseAlpineDataObject(`{}`)).toEqual({});
+  });
+
+  it("returns null for non-object / unparseable input", () => {
+    expect(parseAlpineDataObject(undefined)).toBeNull();
+    expect(parseAlpineDataObject("open")).toBeNull();
+    // A function expression is too complex to edit safely.
+    expect(parseAlpineDataObject(`{ open() { return 1 } }`)).toBeNull();
+  });
+});
+
+describe("serializeAlpineDataObject", () => {
+  it("single-quotes strings and leaves booleans/numbers bare", () => {
+    expect(
+      serializeAlpineDataObject({
+        variant: "outline",
+        disabled: "false",
+        count: "3",
+      }),
+    ).toBe(`{ variant: 'outline', disabled: false, count: 3 }`);
+  });
+
+  it("round-trips parse → mutate → serialize for a variant switch", () => {
+    const parsed = parseAlpineDataObject(`{ variant: 'solid', open: true }`)!;
+    const next = serializeAlpineDataObject({ ...parsed, variant: "outline" });
+    expect(next).toBe(`{ variant: 'outline', open: true }`);
+  });
+
+  it("escapes single quotes inside string values", () => {
+    expect(serializeAlpineDataObject({ label: "it's" })).toBe(
+      `{ label: 'it\\'s' }`,
+    );
+  });
+
+  it("produces an empty object literal for no keys", () => {
+    expect(serializeAlpineDataObject({})).toBe("{}");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isBooleanPropValue — toggle detection
+// ---------------------------------------------------------------------------
+
+describe("isBooleanPropValue", () => {
+  it("recognizes true/false case-insensitively", () => {
+    expect(isBooleanPropValue("true")).toBe(true);
+    expect(isBooleanPropValue("False")).toBe(true);
+    expect(isBooleanPropValue("  TRUE ")).toBe(true);
+  });
+
+  it("rejects non-boolean values", () => {
+    expect(isBooleanPropValue("outline")).toBe(false);
+    expect(isBooleanPropValue("1")).toBe(false);
+    expect(isBooleanPropValue("")).toBe(false);
+  });
+});

--- a/templates/design/app/components/design/EditPanel.tsx
+++ b/templates/design/app/components/design/EditPanel.tsx
@@ -60,6 +60,7 @@ import {
   IconUnlink,
   IconVector,
 } from "@tabler/icons-react";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   useCallback,
   useEffect,
@@ -98,6 +99,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
+import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Tooltip,
@@ -2040,6 +2042,110 @@ function vscodeDeepLink(
 }
 
 /**
+ * Extract the *opening tag* from an element's outer HTML for an at-a-glance
+ * summary (e.g. `<main class="hero" data-x="y">`). Self-closing tags keep
+ * their `/>`. Returns `null` when no tag can be parsed.
+ *
+ * Pure — exported for tests.
+ */
+export function openingTagOf(html: string | null | undefined): string | null {
+  if (!html) return null;
+  const trimmed = html.trimStart();
+  // Match the first `<tag ...>` (greedy up to the first unquoted `>`), allowing
+  // quoted attribute values to contain `>`.
+  const match = /^<([a-zA-Z][\w-]*)((?:"[^"]*"|'[^']*'|[^>])*?)\/?>/.exec(
+    trimmed,
+  );
+  if (!match) return null;
+  return match[0];
+}
+
+/**
+ * Collapse long attribute values in an opening tag so the at-a-glance summary
+ * stays readable. Values longer than `max` chars are truncated with an
+ * ellipsis (the surrounding quotes are preserved).
+ *
+ * Pure — exported for tests.
+ */
+export function truncateOpeningTag(openTag: string, max = 32): string {
+  return openTag.replace(
+    /("|')((?:\\.|(?!\1)[^\\])*)\1/g,
+    (full, quote, value) => {
+      if (typeof value !== "string" || value.length <= max) return full;
+      return `${quote}${value.slice(0, max - 1)}…${quote}`;
+    },
+  );
+}
+
+/**
+ * Parse the top-level `key: value` pairs from an Alpine `x-data` object literal
+ * (e.g. `{ variant: 'outline', size: 'lg', disabled: false }`).
+ *
+ * Best-effort: only handles a flat object of simple string / boolean / number
+ * literals — exactly the shape used for component variant + state props. Nested
+ * objects, methods, and computed expressions are ignored. Returns `null` when
+ * the value is not a recognizable flat object literal.
+ *
+ * Pure — exported for tests.
+ */
+export function parseAlpineDataObject(
+  xData: string | null | undefined,
+): Record<string, string> | null {
+  if (!xData) return null;
+  const trimmed = xData.trim();
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return null;
+  const inner = trimmed.slice(1, -1).trim();
+  if (!inner) return {};
+
+  const out: Record<string, string> = {};
+  // Split on top-level commas only (no nesting / quotes inside values here).
+  const pairRe =
+    /(?:^|,)\s*(?:'([^']+)'|"([^"]+)"|([A-Za-z_$][\w$]*))\s*:\s*('[^']*'|"[^"]*"|true|false|-?\d+(?:\.\d+)?)/g;
+  let m: RegExpExecArray | null;
+  let matched = false;
+  while ((m = pairRe.exec(inner)) !== null) {
+    matched = true;
+    const key = m[1] ?? m[2] ?? m[3];
+    let raw = m[4]!;
+    // Unwrap quotes for string literals; keep booleans / numbers verbatim.
+    if (
+      (raw.startsWith("'") && raw.endsWith("'")) ||
+      (raw.startsWith('"') && raw.endsWith('"'))
+    ) {
+      raw = raw.slice(1, -1);
+    }
+    if (key) out[key] = raw;
+  }
+  // If there was content but nothing parsed, the shape is too complex to edit
+  // safely — bail so the caller falls back to attribute-based prop edits.
+  if (!matched) return null;
+  return out;
+}
+
+/**
+ * Re-serialize a flat Alpine data object back into an `x-data` literal,
+ * preserving boolean / number literals unquoted and single-quoting strings.
+ *
+ * Pure — exported for tests.
+ */
+export function serializeAlpineDataObject(obj: Record<string, string>): string {
+  const parts = Object.entries(obj).map(([key, value]) => {
+    const isBoolean = value === "true" || value === "false";
+    const isNumber = /^-?\d+(\.\d+)?$/.test(value);
+    const literal =
+      isBoolean || isNumber ? value : `'${value.replace(/'/g, "\\'")}'`;
+    return `${key}: ${literal}`;
+  });
+  return parts.length ? `{ ${parts.join(", ")} }` : "{}";
+}
+
+/** A boolean-ish prop value (`"true"` / `"false"`), case-insensitive. */
+export function isBooleanPropValue(value: string): boolean {
+  const v = value.trim().toLowerCase();
+  return v === "true" || v === "false";
+}
+
+/**
  * Popover anchored to the "Inspect code" button showing the selected node's
  * code.  Inline/Alpine sources show the element's outer HTML with a Copy
  * button; real-app sources additionally render an "Open in VS Code" button.
@@ -2058,6 +2164,11 @@ function InspectCodePopover({
   const html = data.html ?? "";
   const source = data.sourceLocation ?? null;
   const snippet = source?.snippet || html;
+  // At-a-glance opening tag (tag name + attributes), truncated for readability.
+  const openingTag = (() => {
+    const raw = openingTagOf(html);
+    return raw ? truncateOpeningTag(raw) : null;
+  })();
 
   const handleCopy = () => {
     if (!snippet) return;
@@ -2095,6 +2206,16 @@ function InspectCodePopover({
             }
           </Button>
         </div>
+
+        {/* At-a-glance opening tag (tag name + attributes) above the full HTML. */}
+        {openingTag && (
+          <code
+            className="block truncate rounded bg-[var(--design-editor-control-bg)] px-2 py-1 font-mono text-[10px] text-foreground"
+            title={openingTag}
+          >
+            {openingTag}
+          </code>
+        )}
 
         {source && (
           <div
@@ -5180,6 +5301,12 @@ interface ComponentDetailsResult {
   observedProps: Array<{ name: string; value: string }>;
   persistedVariants: Record<string, string[]>;
   sourceLocation?: { filePath: string; exportName?: string } | null;
+  /** Component instance shape, including the Alpine `x-data` expression. */
+  instance?: {
+    alpineData?: string | null;
+    nodeId?: string;
+    selector?: string;
+  } | null;
   capabilities: {
     canResolveToFile: boolean;
     hasFullIndex: boolean;
@@ -5212,12 +5339,44 @@ function ComponentSection({
   /** Capability names advertised by the current source. */
   sourceCapabilities?: string[];
 }) {
+  const queryClient = useQueryClient();
+  const detailsKey = ["action", "get-component-details", { designId, nodeId }];
+
   const { data, isLoading, error } = useActionQuery<ComponentDetailsResult>(
     "get-component-details",
     { designId, nodeId },
   );
 
   const openSourceMutation = useActionMutation("open-component-source");
+  const applyPropMutation = useActionMutation("apply-component-prop-edit");
+
+  // Persist a single prop change through apply-component-prop-edit. The canvas
+  // re-renders from the freshly written design content (get-design refetch),
+  // so no postMessage into the iframe is needed. The get-component-details
+  // cache is optimistically patched so the control reflects the new value
+  // immediately, then reconciled with the server on settle.
+  const persistPropEdit = (
+    edit:
+      | { kind: "alpineData"; value: string }
+      | { kind: "attribute"; attribute: string; value: string },
+    optimistic: (prev: ComponentDetailsResult) => ComponentDetailsResult,
+  ) => {
+    queryClient.setQueryData<ComponentDetailsResult>(detailsKey, (prev) =>
+      prev ? optimistic(prev) : prev,
+    );
+    applyPropMutation.mutate(
+      { designId, nodeId, edit },
+      {
+        onSettled: () => {
+          // Re-render the canvas from the new content and re-read the props.
+          void queryClient.invalidateQueries({
+            queryKey: ["action", "get-design"],
+          });
+          void queryClient.invalidateQueries({ queryKey: detailsKey });
+        },
+      },
+    );
+  };
 
   // While loading, show a compact skeleton that matches the section width.
   if (isLoading) {
@@ -5240,16 +5399,115 @@ function ComponentSection({
 
   const {
     name,
+    sourceType,
     sourceLocation,
     observedProps,
     persistedVariants,
+    instance,
     capabilities,
   } = data;
 
-  // ── Variant groups (from persistedVariants for real-app, or a single
-  //    "x-data" pseudo-group for Alpine).
-  const variantGroups = Object.entries(persistedVariants);
-  const hasVariants = variantGroups.length > 0;
+  // ── Editable prop model ───────────────────────────────────────────────────
+  // Inline/Alpine designs persist through apply-component-prop-edit. Two write
+  // surfaces:
+  //   • x-data keys      → kind "alpineData" (rewrites the whole object)
+  //   • data-prop-* attrs → kind "attribute"  (data-agent-native-prop-<kebab>)
+  // Real-app sources keep the deeper source-prop controls gated as-is, so for
+  // non-inline sources the controls are read-only here.
+  const isInline = sourceType === "inline";
+  const editingEnabled = isInline; // gated; real-app stays read-only for now
+  const alpineData = parseAlpineDataObject(instance?.alpineData);
+
+  // Each editable row: name + current value + how it persists + its options.
+  type PropRow = {
+    name: string;
+    value: string;
+    /** Variant/enum options when the prop is a known group. */
+    options?: string[];
+    /** Persist surface for this prop. */
+    surface: "alpineData" | "attribute";
+  };
+
+  const rows: PropRow[] = [];
+  const seen = new Set<string>();
+
+  // 1) Alpine x-data keys come first — they drive the live variant/state.
+  if (alpineData) {
+    for (const [key, value] of Object.entries(alpineData)) {
+      rows.push({
+        name: key,
+        value,
+        options: persistedVariants[key],
+        surface: "alpineData",
+      });
+      seen.add(key);
+    }
+  }
+
+  // 2) data-agent-native-prop-* attributes not already covered by x-data.
+  for (const prop of observedProps) {
+    if (seen.has(prop.name)) continue;
+    rows.push({
+      name: prop.name,
+      value: prop.value,
+      options: persistedVariants[prop.name],
+      surface: "attribute",
+    });
+    seen.add(prop.name);
+  }
+
+  // 3) persistedVariant groups with no observed value yet (default to first).
+  for (const [group, options] of Object.entries(persistedVariants)) {
+    if (seen.has(group)) continue;
+    rows.push({
+      name: group,
+      value: options[0] ?? "",
+      options,
+      surface: alpineData ? "alpineData" : "attribute",
+    });
+    seen.add(group);
+  }
+
+  const hasRows = rows.length > 0;
+
+  // Build the apply-component-prop-edit payload + optimistic cache patch for a
+  // single prop change.
+  const commitProp = (row: PropRow, nextValue: string) => {
+    if (!editingEnabled || nextValue === row.value) return;
+
+    if (row.surface === "alpineData") {
+      const nextData = { ...(alpineData ?? {}), [row.name]: nextValue };
+      const serialized = serializeAlpineDataObject(nextData);
+      persistPropEdit({ kind: "alpineData", value: serialized }, (prev) => ({
+        ...prev,
+        instance: { ...(prev.instance ?? {}), alpineData: serialized },
+        observedProps: prev.observedProps.map((p) =>
+          p.name === row.name ? { ...p, value: nextValue } : p,
+        ),
+      }));
+    } else {
+      // camelCase prop name → data-agent-native-prop-<kebab>
+      const kebab = row.name.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`);
+      persistPropEdit(
+        {
+          kind: "attribute",
+          attribute: `data-agent-native-prop-${kebab}`,
+          value: nextValue,
+        },
+        (prev) => {
+          const exists = prev.observedProps.some((p) => p.name === row.name);
+          return {
+            ...prev,
+            observedProps: exists
+              ? prev.observedProps.map((p) =>
+                  p.name === row.name ? { ...p, value: nextValue } : p,
+                )
+              : [...prev.observedProps, { name: row.name, value: nextValue }],
+          };
+        },
+      );
+    }
+  };
 
   // ── Capability gates ──
   const canJumpToSource =
@@ -5322,58 +5580,78 @@ function ComponentSection({
           </div>
         )}
 
-        {/* Observed props (attribute-level, Alpine + real-app) */}
-        {observedProps.length > 0 && (
-          <div className="space-y-1">
-            {observedProps.map((prop) => (
-              <div key={prop.name} className="flex items-center gap-1.5">
-                <Label className="w-[64px] shrink-0 text-[11px] font-medium text-muted-foreground">
-                  {prop.name}
-                </Label>
-                <span className="min-w-0 flex-1 truncate rounded bg-[var(--design-editor-control-bg)] px-1.5 py-0.5 text-[11px] text-foreground">
-                  {prop.value}
-                </span>
-              </div>
-            ))}
-          </div>
-        )}
-
-        {/* Variant controls (real-app tier: persistedVariants from component_index) */}
-        {hasVariants && (
+        {/* Typed prop controls. Inline/Alpine designs are editable and persist
+            through apply-component-prop-edit; real-app sources are read-only
+            until the deeper source-prop controls land. */}
+        {hasRows && (
           <div className="space-y-1">
             <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/70">
-              {"Variants" /* i18n-ignore design inspector label */}
+              {"Props" /* i18n-ignore design inspector label */}
             </p>
-            {variantGroups.map(([groupName, options]) => (
-              <div key={groupName} className="flex items-center gap-1.5">
-                <Label className="w-[64px] shrink-0 text-[11px] font-medium text-muted-foreground capitalize">
-                  {groupName}
-                </Label>
-                <Select
-                  value={
-                    observedProps.find((p) => p.name === groupName)?.value ??
-                    options[0] ??
-                    ""
-                  }
-                  onValueChange={() => {
-                    // Preview-only on Alpine; real-app writes go through
-                    // apply-component-prop-edit (wired when capability lands).
-                  }}
-                  disabled={!capabilities.canEditProps}
-                >
-                  <SelectTrigger className="h-6 min-w-0 flex-1 rounded-md border-[var(--design-editor-control-border)] bg-[var(--design-editor-control-bg)] px-1.5 text-[11px] shadow-none focus:ring-1 focus:ring-[var(--design-editor-accent-color)]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {options.map((opt) => (
-                      <SelectItem key={opt} value={opt} className="text-[11px]">
-                        {opt}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            ))}
+            {rows.map((row) => {
+              const hasOptions = (row.options?.length ?? 0) > 0;
+              const isBoolean = !hasOptions && isBooleanPropValue(row.value);
+              return (
+                <div key={row.name} className="flex items-center gap-1.5">
+                  <Label className="w-[64px] shrink-0 truncate text-[11px] font-medium capitalize text-muted-foreground">
+                    {row.name}
+                  </Label>
+                  {hasOptions ? (
+                    // Dropdown for variant / enum groups.
+                    <Select
+                      value={row.value || row.options![0] || ""}
+                      onValueChange={(v) => commitProp(row, v)}
+                      disabled={!editingEnabled}
+                    >
+                      <SelectTrigger className="h-6 min-w-0 flex-1 rounded-md border-[var(--design-editor-control-border)] bg-[var(--design-editor-control-bg)] px-1.5 text-[11px] shadow-none focus:ring-1 focus:ring-[var(--design-editor-accent-color)]">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {row.options!.map((opt) => (
+                          <SelectItem
+                            key={opt}
+                            value={opt}
+                            className="text-[11px]"
+                          >
+                            {opt}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  ) : isBoolean ? (
+                    // Toggle for boolean props.
+                    <div className="flex min-w-0 flex-1 items-center">
+                      <Switch
+                        checked={row.value.trim().toLowerCase() === "true"}
+                        onCheckedChange={(checked) =>
+                          commitProp(row, checked ? "true" : "false")
+                        }
+                        disabled={!editingEnabled}
+                        className="h-4 w-7 [&>span]:size-3 [&>span]:data-[state=checked]:translate-x-3"
+                        aria-label={
+                          row.name /* i18n-ignore dynamic prop name */
+                        }
+                      />
+                    </div>
+                  ) : (
+                    // Text input for string props (e.g. a label).
+                    <Input
+                      defaultValue={row.value}
+                      key={`${row.name}:${row.value}`}
+                      disabled={!editingEnabled}
+                      onBlur={(e) => commitProp(row, e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          e.currentTarget.blur();
+                        }
+                      }}
+                      className="h-6 min-w-0 flex-1 rounded-md border-[var(--design-editor-control-border)] bg-[var(--design-editor-control-bg)] px-1.5 text-[11px] shadow-none focus-visible:ring-1 focus-visible:ring-[var(--design-editor-accent-color)]"
+                    />
+                  )}
+                </div>
+              );
+            })}
           </div>
         )}
 

--- a/templates/design/app/components/design/MotionDock.tsx
+++ b/templates/design/app/components/design/MotionDock.tsx
@@ -21,6 +21,12 @@ import type {
   MotionTrack,
   MotionKeyframe,
   MotionEase,
+  MotionPropertyPreset,
+} from "@shared/motion-timeline";
+import {
+  MOTION_PROPERTY_PRESETS,
+  createMotionTrackFromPreset,
+  hasTrackFor,
 } from "@shared/motion-timeline";
 import {
   IconPlayerPlay,
@@ -29,12 +35,12 @@ import {
   IconDiamond,
   IconChevronDown,
   IconChevronRight,
-  IconKey,
   IconPlus,
   IconTrash,
   IconCode,
   IconRefresh,
   IconBolt,
+  IconLayersSubtract,
 } from "@tabler/icons-react";
 import {
   useCallback,
@@ -45,6 +51,14 @@ import {
 } from "react";
 
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import {
   Tooltip,
@@ -106,6 +120,13 @@ export interface MotionDockProps {
   canvasIframeRef?: React.RefObject<HTMLIFrameElement | null>;
   /** Whether the parent apply mutation is in flight. */
   applying?: boolean;
+  /**
+   * The currently-selected canvas element, if any. Required to create the FIRST
+   * track for a layer: the picker animates this node's
+   * `data-agent-native-node-id`. `null` when nothing is selected — the create
+   * affordance is then disabled with a hint to select an element.
+   */
+  selectedTarget?: { nodeId: string; label: string } | null;
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -121,6 +142,7 @@ export function MotionDock({
   onApply,
   canvasIframeRef,
   applying = false,
+  selectedTarget = null,
 }: MotionDockProps) {
   // Controlled / uncontrolled open state.
   const [openInternal, setOpenInternal] = useState(false);
@@ -307,6 +329,36 @@ export function MotionDock({
     [defaultEase, playhead, updateTrack],
   );
 
+  // ── Create a brand-new track (the "first track" path) ──────────────────────
+  // This is the entry point that turns the dock from a dead end into a working
+  // editor: with an element selected and no track yet, the user picks a property
+  // preset and we seed a two-keyframe track. Once at least one track exists,
+  // "Write to CSS" enables. Idempotent per (nodeId, property) — picking the same
+  // property twice just re-expands the existing track instead of duplicating.
+  const createTrack = useCallback(
+    (preset: MotionPropertyPreset) => {
+      if (!onTracksChange || !selectedTarget) return;
+      const { nodeId, label } = selectedTarget;
+
+      // Always expand the target layer so the new track row is visible.
+      setExpandedNodeIds((prev) => {
+        const next = new Set(prev);
+        next.add(nodeId);
+        return next;
+      });
+
+      if (hasTrackFor(tracks, nodeId, preset.property)) {
+        // Track already exists — do not duplicate; the expand above surfaces it.
+        return;
+      }
+
+      const seeded = createMotionTrackFromPreset(nodeId, preset, defaultEase);
+      const newTrack: MotionDockTrack = { ...seeded, label };
+      onTracksChange([...tracks, newTrack]);
+    },
+    [defaultEase, onTracksChange, selectedTarget, tracks],
+  );
+
   const deleteKeyframe = useCallback(
     (track: MotionDockTrack, kf: MotionKeyframe) => {
       updateTrack(track.targetNodeId, track.property, (tr) => ({
@@ -460,6 +512,14 @@ export function MotionDock({
               <span className="text-[10px] text-muted-foreground">ms</span>
             </div>
 
+            {/* Add track — the "create first track" entry point. */}
+            <div className="ml-2">
+              <AddTrackMenu
+                selectedTarget={selectedTarget}
+                onCreateTrack={createTrack}
+              />
+            </div>
+
             <div className="ml-auto flex items-center gap-1">
               {/* Auto-keyframe toggle */}
               <Tooltip>
@@ -525,11 +585,29 @@ export function MotionDock({
             />
 
             {layers.length === 0 ? (
-              <div className="flex flex-col items-center justify-center flex-1 gap-2 text-center px-4 py-6">
-                <IconKey className="size-4 text-muted-foreground/40" />
-                <p className="text-[11px] text-muted-foreground/70 leading-snug">
-                  Select an element and add a keyframe to begin.
-                </p>
+              <div className="flex flex-col items-center justify-center flex-1 gap-3 text-center px-4 py-6">
+                <IconLayersSubtract className="size-5 text-muted-foreground/40" />
+                {selectedTarget ? (
+                  <>
+                    <p className="text-[11px] text-muted-foreground/70 leading-snug">
+                      Animate{" "}
+                      <span className="font-medium text-foreground/80">
+                        {selectedTarget.label}
+                      </span>
+                      . Pick a property to add the first track.
+                    </p>
+                    <AddTrackMenu
+                      selectedTarget={selectedTarget}
+                      onCreateTrack={createTrack}
+                      variant="cta"
+                    />
+                  </>
+                ) : (
+                  <p className="text-[11px] text-muted-foreground/70 leading-snug">
+                    Select an element on the canvas, then add a track to animate
+                    it.
+                  </p>
+                )}
               </div>
             ) : (
               layers.map((layer) => (
@@ -622,6 +700,87 @@ export function MotionDock({
 }
 
 // ─── Sub-components ────────────────────────────────────────────────────────────
+
+interface AddTrackMenuProps {
+  selectedTarget: { nodeId: string; label: string } | null;
+  onCreateTrack: (preset: MotionPropertyPreset) => void;
+  /** "toolbar" (compact button) or "cta" (prominent empty-state button). */
+  variant?: "toolbar" | "cta";
+}
+
+/**
+ * Property-preset dropdown that creates a new motion track for the selected
+ * element. Disabled (with a hint) when nothing is selected, which is the only
+ * state where a first track cannot be created.
+ */
+function AddTrackMenu({
+  selectedTarget,
+  onCreateTrack,
+  variant = "toolbar",
+}: AddTrackMenuProps) {
+  const disabled = !selectedTarget;
+  const trigger =
+    variant === "cta" ? (
+      <Button
+        type="button"
+        size="sm"
+        variant="secondary"
+        className="h-7 gap-1 text-[11px]"
+        disabled={disabled}
+      >
+        <IconPlus className="size-3.5" />
+        Add track
+      </Button>
+    ) : (
+      <Button
+        type="button"
+        size="sm"
+        variant="ghost"
+        className="h-6 gap-1 px-2 text-[11px]"
+        disabled={disabled}
+      >
+        <IconPlus className="size-3.5" />
+        Add track
+      </Button>
+    );
+
+  // When disabled, render a tooltip-wrapped static button instead of a menu so
+  // the user learns they need a selection first.
+  if (disabled) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex">{trigger}</span>
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          Select an element on the canvas first
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-52">
+        <DropdownMenuLabel className="truncate text-[10px] text-muted-foreground">
+          Animate “{selectedTarget.label}”
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {MOTION_PROPERTY_PRESETS.map((preset) => (
+          <DropdownMenuItem
+            key={`${preset.property}-${preset.label}`}
+            className="text-[12px]"
+            onSelect={() => onCreateTrack(preset)}
+          >
+            <IconDiamond className="size-3 text-primary/70" />
+            {preset.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
 
 interface PlayheadLineProps {
   t: number;

--- a/templates/design/app/components/design/ReviewPanel.tsx
+++ b/templates/design/app/components/design/ReviewPanel.tsx
@@ -6,9 +6,13 @@
  * `get-design-review`, and a structural visual-diff section comparing two
  * `design_versions`.
  *
- * Read-only.  The "Fix" button is rendered but kept disabled (gated) — it
- * will be wired to `apply-a11y-fix` when the capability is real-app-only and
- * the source advertises `fixA11y` capability.
+ * The "Fix" button is wired to the `apply-a11y-fix` action for findings that
+ * are auto-fixable inline (contrast/color, tap-target, focus-visibility) — the
+ * fix reduces to a deterministic style/class edit against the SQL-backed HTML,
+ * and the canvas re-renders from the written content.  Findings that need a new
+ * attribute (alt / aria-label) or a semantic rewrite stay informational with no
+ * Fix affordance.  When no design source (`designId`/`fileId`) is provided the
+ * panel falls back to read-only.
  *
  * Layout matches the Review artboard in the canonical plan visual:
  *   <https://plan.agent-native.com/plans/plan-88dc4a09fb0c46bc>
@@ -16,6 +20,7 @@
  * shadcn/ui primitives + Tabler icons throughout.  No emojis.
  */
 
+import { useActionMutation } from "@agent-native/core/client";
 import {
   IconAlertCircle,
   IconAlertTriangle,
@@ -26,6 +31,7 @@ import {
   IconInfoCircle,
   IconRefresh,
   IconShieldCheck,
+  IconWand,
 } from "@tabler/icons-react";
 import { useState } from "react";
 
@@ -35,12 +41,30 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
 
-import type {
-  A11yFinding,
-  A11ySeverity,
-  VisualDiffChangeKind,
-  VisualDiffEntry,
+import {
+  isA11yFindingAutoFixable,
+  type A11yFinding,
+  type A11ySeverity,
+  type VisualDiffChangeKind,
+  type VisualDiffEntry,
 } from "../../../shared/design-review.js";
+
+// ---------------------------------------------------------------------------
+// Inline a11y fix wiring
+// ---------------------------------------------------------------------------
+
+/**
+ * Identifies the inline design source a fix should be applied to.  Required for
+ * the "Fix" affordance to be enabled — without it the panel is read-only.
+ */
+export interface ReviewFixSource {
+  designId?: string;
+  fileId?: string;
+  filename?: string;
+}
+
+/** Per-finding state for the optimistic Fix flow. */
+type FixStatus = "idle" | "pending" | "fixed" | "error";
 
 // ---------------------------------------------------------------------------
 // Shared sub-types
@@ -82,6 +106,17 @@ export interface ReviewPanelProps {
   diffError?: string | null;
   /** Called when a finding row is clicked — navigates the canvas to the node. */
   onFindingClick?: (finding: A11yFinding) => void;
+  /**
+   * Inline design source for the "Fix" affordance.  When provided (and a
+   * finding is auto-fixable), a "Fix" button applies `apply-a11y-fix` against
+   * this source.  Omit to keep the panel read-only.
+   */
+  fixSource?: ReviewFixSource;
+  /**
+   * Called after a fix is successfully applied — e.g. to refetch the audit so
+   * the resolved finding drops out of the list.  The applied finding is passed.
+   */
+  onFixApplied?: (finding: A11yFinding) => void;
   className?: string;
 }
 
@@ -145,14 +180,62 @@ const DIFF_KIND_CONFIG: Record<
 function FindingRow({
   finding,
   onClick,
+  fixSource,
+  onFixApplied,
 }: {
   finding: A11yFinding;
   onClick?: (finding: A11yFinding) => void;
+  fixSource?: ReviewFixSource;
+  onFixApplied?: (finding: A11yFinding) => void;
 }) {
   const cfg = SEVERITY_CONFIG[finding.severity];
   const Icon = cfg.icon;
   const [expanded, setExpanded] = useState(false);
   const hasDetail = !!(finding.detail ?? finding.wcag);
+
+  const applyFix = useActionMutation("apply-a11y-fix");
+  const [fixStatus, setFixStatus] = useState<FixStatus>("idle");
+
+  // A Fix affordance is shown only when (a) the finding maps to a deterministic
+  // inline edit and (b) a design source is available to write to.  Everything
+  // else stays informational.
+  const hasSource = !!(fixSource?.designId ?? fixSource?.fileId);
+  const canFix = hasSource && isA11yFindingAutoFixable(finding);
+
+  const handleFix = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!canFix || fixStatus === "pending" || fixStatus === "fixed") return;
+    // Optimistic: flip to "fixed" immediately; the canvas re-renders from the
+    // written content and the parent can refetch to drop the resolved finding.
+    setFixStatus("pending");
+    try {
+      const res = (await applyFix.mutateAsync({
+        designId: fixSource?.designId,
+        fileId: fixSource?.fileId,
+        filename: fixSource?.filename,
+        finding: {
+          id: finding.id,
+          severity: finding.severity,
+          category: finding.category,
+          message: finding.message,
+          detail: finding.detail,
+          nodeId: finding.nodeId,
+          selector: finding.selector,
+          wcag: finding.wcag,
+          fixAvailable: finding.fixAvailable,
+        },
+      })) as { applied?: boolean } | undefined;
+      if (res?.applied) {
+        setFixStatus("fixed");
+        onFixApplied?.(finding);
+      } else {
+        // The engine could not apply it (e.g. selector no longer resolves).
+        setFixStatus("error");
+      }
+    } catch {
+      setFixStatus("error");
+    }
+  };
 
   return (
     <div
@@ -227,18 +310,44 @@ function FindingRow({
           )}
         </div>
 
-        {/* Fix button — disabled/gated until apply-a11y-fix is wired */}
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          disabled
-          className="h-5 shrink-0 px-1.5 text-[10px] opacity-40"
-          title="Fix (real-app only)"
-          onClick={(e) => e.stopPropagation()}
-        >
-          Fix
-        </Button>
+        {/* Fix button — enabled only for inline auto-fixable findings with a
+            design source. Non-fixable findings render nothing (informational). */}
+        {canFix &&
+          (fixStatus === "fixed" ? (
+            <span
+              className="flex h-5 shrink-0 items-center gap-1 px-1.5 text-[10px] text-emerald-500"
+              title="Fix applied"
+            >
+              <IconCheck className="size-3" />
+              Fixed
+            </span>
+          ) : (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={fixStatus === "pending"}
+              className={cn(
+                "h-5 shrink-0 gap-1 px-1.5 text-[10px]",
+                fixStatus === "error"
+                  ? "text-destructive hover:text-destructive"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+              title={
+                fixStatus === "error"
+                  ? "Fix could not be applied — retry"
+                  : "Apply this fix inline"
+              }
+              onClick={handleFix}
+            >
+              {fixStatus === "pending" ? (
+                <IconRefresh className="size-3 animate-spin" />
+              ) : (
+                <IconWand className="size-3" />
+              )}
+              {fixStatus === "error" ? "Retry" : "Fix"}
+            </Button>
+          ))}
       </div>
     </div>
   );
@@ -255,6 +364,8 @@ function A11ySection({
   auditError,
   onRunAudit,
   onFindingClick,
+  fixSource,
+  onFixApplied,
 }: {
   findings: A11yFinding[];
   loading?: boolean;
@@ -262,6 +373,8 @@ function A11ySection({
   auditError?: string | null;
   onRunAudit?: () => void;
   onFindingClick?: (finding: A11yFinding) => void;
+  fixSource?: ReviewFixSource;
+  onFixApplied?: (finding: A11yFinding) => void;
 }) {
   const errors = findings.filter((f) => f.severity === "error");
   const warnings = findings.filter((f) => f.severity === "warning");
@@ -389,6 +502,8 @@ function A11ySection({
                 key={finding.id}
                 finding={finding}
                 onClick={onFindingClick}
+                fixSource={fixSource}
+                onFixApplied={onFixApplied}
               />
             ))}
           </div>
@@ -582,9 +697,11 @@ function VisualDiffSection({
  * ReviewPanel renders the accessibility audit results and visual-diff section
  * for the Design Studio's Review inspector tab / bottom dock.
  *
- * It is read-only: the "Fix" button is rendered but disabled (gated) until
- * `apply-a11y-fix` is wired to a real-app source that advertises the
- * `fixA11y` capability.
+ * When a `fixSource` is supplied, auto-fixable findings (contrast/color,
+ * tap-target, focus-visibility) show an inline "Fix" button wired to the
+ * `apply-a11y-fix` action; the canvas re-renders from the written content.
+ * Findings that need a new attribute or a semantic rewrite remain
+ * informational.  Without a `fixSource` the panel is read-only.
  */
 export function ReviewPanel({
   findings,
@@ -600,6 +717,8 @@ export function ReviewPanel({
   diffLoading,
   diffError,
   onFindingClick,
+  fixSource,
+  onFixApplied,
   className,
 }: ReviewPanelProps) {
   return (
@@ -616,6 +735,8 @@ export function ReviewPanel({
             auditError={auditError}
             onRunAudit={onRunAudit}
             onFindingClick={onFindingClick}
+            fixSource={fixSource}
+            onFixApplied={onFixApplied}
           />
 
           <div className="my-2 mx-3">

--- a/templates/design/app/components/design/inspector/SHADER_INTEGRATION.md
+++ b/templates/design/app/components/design/inspector/SHADER_INTEGRATION.md
@@ -6,6 +6,30 @@ right spot plus copy-pasteable code to insert or replace.
 
 Do NOT rely on line numbers — they drift. Use the search strings instead.
 
+## Status: shader fills are user-reachable and applyable
+
+The **Shader Fills** card in `DesignExtensionsPanel.tsx` (inspector slot
+`design.editor.inspector`) is the live entry point: open it, **Browse Shaders**,
+pick a preset, tune it with `ShaderControls`, and the iframe previews the fill as
+a CSS gradient (`preview-shader-fill`). With an element selected on the canvas, the
+card's **Apply fill** button persists that fill via the `apply-shader-fill` action.
+
+`apply-shader-fill` is **no longer gated** — it is SAFETY-gated, not Builder-gated:
+
+- It asserts **editor** access on the target design (`accessFilter` read +
+  `assertAccess("design", id, "editor")`) before any write.
+- It only persists **HTML design-file** sources. localhost / fusion / inline-html
+  sources return the preview value and write nothing.
+- It writes a single inline-style `background` onto the target node through the
+  deterministic HTML editor (`applyVisualEdit`, the same persist path as
+  `apply-visual-edit`), reusing the strict CSS-colour allowlist from
+  `shared/shader-fill.ts` so `descriptor.colors` can never inject CSS.
+
+Sections (a), (b), (d), and (f) below remain optional ways to surface shaders in
+*other* inspector seams (the colour picker fill type, the effects panel, the
+artboard WebGL bridge, design-system tokens) and are not required for the
+card-based apply path that ships today.
+
 ---
 
 ## (a) DesignColorPicker.tsx — Add `"shader"` fill type
@@ -351,20 +375,17 @@ if (fill.type === "shader") {
 
 ---
 
-## (e) Changelog entry (DEFERRED)
+## (e) Changelog entry
 
-The shader feature is not yet user-reachable — it still needs all seam files wired.
-Do NOT add a changelog entry yet.
-
-Once the seam files are integrated and the feature is accessible from the UI (a user
-can apply a shader fill from the fill picker or add a shader effect from the effects
-panel), run:
+The shader-fills card is now user-reachable and the apply path persists, so a
+user-facing changelog entry is warranted. From the `templates/design/` directory:
 
 ```bash
-agent-native changelog add "Add GPU shader fills and effects — 8 presets (MeshGradient, GrainGradient, Voronoi, Metaballs, Warp, GodRays, Dithering, PaperTexture) with live preview and agent-tunable params" --type added
+agent-native changelog add "Add GPU shader fills — 8 presets (MeshGradient, GrainGradient, Voronoi, Metaballs, Warp, GodRays, Dithering, PaperTexture) with live preview and one-click apply to the selected element" --type added
 ```
 
-from the `templates/design/` directory.
+(The effects-panel surface from section (b) is still optional; scope the changelog
+line to what actually ships.)
 
 ---
 
@@ -407,14 +428,23 @@ shader token picker.
 
 ## Integration Checklist
 
+Shipped (card-based preview + apply path):
+
+- [x] `DesignExtensionsPanel.tsx` — Shader Fills card opens `ShaderFillsPanel`
+- [x] `DesignExtensionsPanel.tsx` — "Apply fill" persists via `apply-shader-fill`
+- [x] `actions/apply-shader-fill.ts` — persists fill as CSS background (editor-gated)
+- [x] `actions/preview-shader-fill.ts` — preview-only CSS (unchanged)
+- [x] `actions/apply-shader.ts` exists (planning/codegen snippet)
+- [x] `actions/get-shader.ts` exists
+
+Optional follow-ups (other inspector seams):
+
 - [ ] `DesignColorPicker.tsx` — `DesignFillType` includes `"shader"`
 - [ ] `DesignColorPicker.tsx` — `DesignPaintType` includes `"shader"`
 - [ ] `DesignColorPicker.tsx` — shader button renders in paint-type row
 - [ ] `DesignColorPicker.tsx` — `ShaderControls` renders when `paintType === "shader"`
 - [ ] `EditPanel.tsx` — `ShaderEffectRow` renders in `EffectsProperties`
 - [ ] `EditPanel.tsx` — "Add Shader" option in effects dropdown
-- [ ] `actions/apply-shader.ts` exists
-- [ ] `actions/get-shader.ts` exists
 - [ ] `DesignCanvas.tsx` — shader bridge script injected into artboard
 - [ ] `DesignCanvas.tsx` — `data-shader` attribute serialized for shader fills
-- [ ] Changelog entry added (after feature is user-reachable)
+- [ ] Changelog entry added (see section (e))

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -132,6 +132,7 @@ import {
   DesignCanvas,
   type IframeContextMenuPayload,
   type IframeHotkeyPayload,
+  type MotionTrackWire,
 } from "@/components/design/DesignCanvas";
 import { DesignEditorSkeleton } from "@/components/design/DesignEditorSkeleton";
 import type { DesignExtensionSlotContext } from "@/components/design/DesignExtensionsPanel";
@@ -5147,6 +5148,38 @@ export default function DesignEditor() {
       getElementOuterHtml(activeContent, selectedElement.selector)
     );
   }, [activeContent, selectedElement?.selector, selectedElement?.htmlContent]);
+
+  // §6.3 — the motion-dock target: the selected element's literal
+  // `data-agent-native-node-id` (the value the motion compiler + preview bridge
+  // match on, NOT the hashed projection id) plus a friendly label. Single-screen
+  // mode auto-stamps every selectable node with this attribute (see the
+  // ensureCodeLayerNodeIdsInHtml effect), so a selection reliably resolves to a
+  // stable node id here. `null` when nothing animatable is selected — the dock
+  // then disables its "Add track" affordance.
+  const motionSelectedTarget = useMemo<{
+    nodeId: string;
+    label: string;
+  } | null>(() => {
+    if (!selectedCodeLayerNode) return null;
+    const nodeId =
+      selectedCodeLayerNode.dataAttributes["data-agent-native-node-id"]?.trim();
+    if (!nodeId) return null;
+    const label =
+      selectedCodeLayerNode.layerName ||
+      selectedElement?.tagName ||
+      "Selected element";
+    return { nodeId, label };
+  }, [selectedCodeLayerNode, selectedElement?.tagName]);
+
+  // Serialisable subset of the dock's tracks for the DesignCanvas motion-preview
+  // bridge. Strips the UI-only `label` field. Only populated while the dock is
+  // open so a closed dock never leaves preview overrides on the canvas; an empty
+  // array makes DesignCanvas send `motion-preview-clear`. Scrubbing previews
+  // these tracks live in the iframe — it never writes (that is "Write to CSS").
+  const motionTracksWire = useMemo<MotionTrackWire[]>(() => {
+    if (!motionDockOpen || motionTracks.length === 0) return [];
+    return motionTracks.map(({ label: _label, ...track }) => track);
+  }, [motionDockOpen, motionTracks]);
 
   const inspectCodeData = useMemo<InspectCodeData | undefined>(() => {
     if (!selectedElement) return undefined;
@@ -10677,10 +10710,13 @@ ${serializedHtml}
                       fusionUrl={designFusionUrl}
                       previewWidthPx={activeBreakpointWidthState}
                       onComponentSourceJump={handleComponentSourceJump}
-                      // TODO: thread motionTracks / shaderFillPreview live-preview
-                      // props once the canvas-side live preview state is plumbed
-                      // here (non-trivial new state; MotionDock already drives
-                      // motion-preview directly via canvasIframeRef for now).
+                      // Live motion preview: the dock's current tracks feed the
+                      // iframe's motion-preview bridge so scrubbing the playhead
+                      // interpolates these properties in place. Preview-only —
+                      // "Write to CSS" (apply-motion-edit) is the commit path.
+                      // shaderFillPreview stays unthreaded here (separate §6.7
+                      // preview state not yet plumbed into this editor surface).
+                      motionTracks={motionTracksWire}
                       editMode={mode === "edit"}
                       interactMode={mode === "interact"}
                       readOnly={!canEditDesign}
@@ -10935,6 +10971,7 @@ ${serializedHtml}
           onTracksChange={setMotionTracks}
           onDurationChange={setMotionDurationMs}
           canvasIframeRef={canvasIframeRef}
+          selectedTarget={motionSelectedTarget}
           onApply={(tracks, durationMs) => {
             if (!id) return;
             applyMotionEditMutation.mutate({

--- a/templates/design/changelog/2026-06-30-accessibility-findings-now-offer-a-one-click-fix.md
+++ b/templates/design/changelog/2026-06-30-accessibility-findings-now-offer-a-one-click-fix.md
@@ -1,0 +1,6 @@
+---
+type: added
+date: 2026-06-30
+---
+
+Accessibility findings can now be fixed in one click for common inline issues like low contrast, small tap targets, and focus visibility.

--- a/templates/design/changelog/2026-06-30-component-instances-now-have-editable-props-in-the-inspe.md
+++ b/templates/design/changelog/2026-06-30-component-instances-now-have-editable-props-in-the-inspe.md
@@ -1,0 +1,6 @@
+---
+type: added
+date: 2026-06-30
+---
+
+Selecting a component instance now shows editable props in the inspector — change variants, toggle booleans, and edit labels, and the component updates live.

--- a/templates/design/changelog/2026-06-30-inspect-code-now-shows-the-elements-opening-tag-at-a-gla.md
+++ b/templates/design/changelog/2026-06-30-inspect-code-now-shows-the-elements-opening-tag-at-a-gla.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-06-30
+---
+
+Inspect code now shows the selected element’s opening tag (tag name and attributes) at a glance.

--- a/templates/design/changelog/2026-06-30-shader-fill-presets-can-now-be-applied-to-an-element.md
+++ b/templates/design/changelog/2026-06-30-shader-fill-presets-can-now-be-applied-to-an-element.md
@@ -1,0 +1,6 @@
+---
+type: added
+date: 2026-06-30
+---
+
+Shader fill presets can now be applied to a selected element, not just previewed.

--- a/templates/design/changelog/2026-06-30-the-motion-timeline-can-now-add-a-track-to-any-element-a.md
+++ b/templates/design/changelog/2026-06-30-the-motion-timeline-can-now-add-a-track-to-any-element-a.md
@@ -1,0 +1,6 @@
+---
+type: added
+date: 2026-06-30
+---
+
+The motion timeline can now add an animation track to any selected element and write it to CSS, with a live scrub preview.

--- a/templates/design/shared/design-review.ts
+++ b/templates/design/shared/design-review.ts
@@ -55,6 +55,144 @@ export interface A11yFinding {
 }
 
 // ---------------------------------------------------------------------------
+// Inline auto-fix mapping
+// ---------------------------------------------------------------------------
+//
+// Some a11y findings can be repaired inline against the SQL-backed HTML design
+// content using the same deterministic edit primitives the visual editor uses
+// (`apply-visual-edit`: style / class / textContent). Those primitives can set
+// an inline style value, add/remove/replace a class token, or rewrite leaf text
+// — so the fixes we can apply purely inline are the ones that reduce to one of
+// those operations on a *targeted* node:
+//
+//   - contrast / color   → set an inline `color` (style edit) or swap a text
+//                           color class, raising the foreground contrast.
+//   - tap-target         → add a min-size utility class (e.g. `min-h-[44px]`).
+//   - focus-visibility   → add a `focus-visible:ring-2` utility class.
+//
+// Fixes that require writing a *new attribute* (alt, aria-label,
+// aria-labelledby) or semantic/structural code changes are NOT expressible
+// through the deterministic edit engine's exported intents, so they remain
+// "real-app only" and are surfaced as informational findings (no inline Fix).
+// `a11yFindingToEdit` returns `null` for those.
+
+/**
+ * A single deterministic edit that repairs an a11y finding inline. The shape is
+ * a strict subset of the `apply-visual-edit` `EditIntent` union — only the kinds
+ * the inline (SQL HTML) edit engine can apply without escalating: `style`,
+ * `class`, and `textContent`. The `apply-a11y-fix` action forwards this verbatim
+ * to the shared `applyVisualEdit` primitive.
+ */
+export type A11yFixEdit =
+  | {
+      kind: "style";
+      target: { nodeId?: string; selector?: string };
+      property: string;
+      value: string;
+    }
+  | {
+      kind: "class";
+      target: { nodeId?: string; selector?: string };
+      operation: "add" | "remove" | "replace";
+      className?: string;
+      classNames?: string[];
+      from?: string;
+      to?: string;
+    }
+  | {
+      kind: "textContent";
+      target: { nodeId?: string; selector?: string };
+      value: string;
+    };
+
+/**
+ * A planned inline fix for a finding: the deterministic edit to apply plus a
+ * short human-readable label for the UI / agent.
+ */
+export interface A11yFixPlan {
+  finding: A11yFinding;
+  edit: A11yFixEdit;
+  /** Short human summary, e.g. "Raise text contrast" or "Enlarge tap target". */
+  label: string;
+}
+
+/**
+ * A high-contrast foreground color used as the default contrast remediation
+ * when a finding does not carry an explicit replacement color. Near-black keeps
+ * ≥ 4.5:1 against typical light backgrounds; the agent can refine afterward.
+ */
+const DEFAULT_CONTRAST_COLOR = "#111827";
+
+/** Categories whose default inline fix is a class addition, with the utility. */
+const CLASS_ADD_FIX: Partial<Record<A11yFindingCategory, string>> = {
+  "tap-target": "min-h-[44px] min-w-[44px]",
+  "focus-visibility": "focus-visible:ring-2",
+};
+
+/**
+ * Map an {@link A11yFinding} to a deterministic inline {@link A11yFixPlan}, or
+ * `null` when the finding is not auto-fixable through the inline edit engine.
+ *
+ * Pure and dependency-free so both the Review panel (to decide whether to show
+ * a "Fix" affordance) and the `apply-a11y-fix` action (to compute the edit)
+ * share one source of truth.
+ *
+ * @param finding   The audit finding.
+ * @param overrides Optional caller-supplied values — e.g. a chosen replacement
+ *                  `color` for contrast fixes — that win over the defaults.
+ */
+export function a11yFindingToEdit(
+  finding: A11yFinding,
+  overrides?: { color?: string },
+): A11yFixPlan | null {
+  // A target is required for every inline edit — without a node id or selector
+  // there is nothing to anchor the deterministic patch to.
+  const target =
+    finding.nodeId || finding.selector
+      ? { nodeId: finding.nodeId, selector: finding.selector }
+      : null;
+  if (!target) return null;
+
+  if (finding.category === "contrast") {
+    const color = (overrides?.color ?? "").trim() || DEFAULT_CONTRAST_COLOR;
+    return {
+      finding,
+      label: "Raise text contrast",
+      edit: { kind: "style", target, property: "color", value: color },
+    };
+  }
+
+  const classToAdd = CLASS_ADD_FIX[finding.category];
+  if (classToAdd) {
+    return {
+      finding,
+      label:
+        finding.category === "tap-target"
+          ? "Enlarge tap target"
+          : "Add focus-visible ring",
+      edit: {
+        kind: "class",
+        target,
+        operation: "add",
+        classNames: classToAdd.split(/\s+/).filter(Boolean),
+      },
+    };
+  }
+
+  // missing-alt, missing-label, reduced-motion, role, other → require new
+  // attributes or semantic/structural rewrites the inline engine can't express.
+  return null;
+}
+
+/**
+ * Whether a finding can be auto-fixed inline (i.e. {@link a11yFindingToEdit}
+ * returns a plan). Convenience wrapper for UI gating.
+ */
+export function isA11yFindingAutoFixable(finding: A11yFinding): boolean {
+  return a11yFindingToEdit(finding) !== null;
+}
+
+// ---------------------------------------------------------------------------
 // Visual diff
 // ---------------------------------------------------------------------------
 

--- a/templates/design/shared/motion-timeline.spec.ts
+++ b/templates/design/shared/motion-timeline.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * motion-timeline.spec.ts
+ *
+ * Tests for the pure track-building helpers that back the MotionDock
+ * "create the FIRST track" flow (§6.3). These are the logic that turns the dock
+ * from a dead end (no path to create a track → "Write to CSS" permanently
+ * disabled) into a working editor: a freshly selected element seeds a default
+ * two-keyframe track via a property preset, which is then immediately
+ * compilable and previewable.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "./motion-compiler";
+import {
+  MOTION_PROPERTY_PRESETS,
+  createMotionTrack,
+  createMotionTrackFromPreset,
+  hasTrackFor,
+  type MotionTimeline,
+  type MotionTrack,
+} from "./motion-timeline";
+
+// ─── createMotionTrack ────────────────────────────────────────────────────────
+
+describe("createMotionTrack", () => {
+  it("seeds exactly two keyframes at t=0 and t=1", () => {
+    const track = createMotionTrack("node-1", "opacity", {
+      from: "0",
+      to: "1",
+    });
+    expect(track.targetNodeId).toBe("node-1");
+    expect(track.property).toBe("opacity");
+    expect(track.keyframes).toHaveLength(2);
+    expect(track.keyframes[0]).toMatchObject({ t: 0, value: "0" });
+    expect(track.keyframes[1]).toMatchObject({ t: 1, value: "1" });
+  });
+
+  it("is valid for apply-motion-edit (>= 1 keyframe per track)", () => {
+    const track = createMotionTrack("node-1", "opacity");
+    expect(track.keyframes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("falls back to a neutral 0 → 1 pair when from/to are omitted", () => {
+    const track = createMotionTrack("node-1", "opacity");
+    expect(track.keyframes[0].value).toBe("0");
+    expect(track.keyframes[1].value).toBe("1");
+  });
+
+  it("applies the supplied ease to both seeded keyframes", () => {
+    const track = createMotionTrack("node-1", "opacity", {
+      ease: "ease-out",
+    });
+    expect(track.keyframes[0].ease).toBe("ease-out");
+    expect(track.keyframes[1].ease).toBe("ease-out");
+  });
+
+  it("omits ease entirely when none is supplied", () => {
+    const track = createMotionTrack("node-1", "opacity");
+    expect(track.keyframes[0].ease).toBeUndefined();
+    expect(track.keyframes[1].ease).toBeUndefined();
+  });
+});
+
+// ─── createMotionTrackFromPreset ──────────────────────────────────────────────
+
+describe("createMotionTrackFromPreset", () => {
+  it("forwards the preset property + from/to into the track", () => {
+    const preset = MOTION_PROPERTY_PRESETS.find(
+      (p) => p.label === "Slide up (translateY)",
+    );
+    expect(preset).toBeDefined();
+    const track = createMotionTrackFromPreset("node-7", preset!);
+    expect(track.targetNodeId).toBe("node-7");
+    expect(track.property).toBe("transform");
+    expect(track.keyframes[0].value).toBe("translateY(16px)");
+    expect(track.keyframes[1].value).toBe("translateY(0px)");
+  });
+
+  it("every built-in preset compiles to valid, deterministic CSS", () => {
+    // This is the core guarantee of the first-track path: whatever preset the
+    // user picks, the resulting timeline compiles cleanly (one @keyframes block,
+    // a reduced-motion block) so "Write to CSS" succeeds.
+    for (const preset of MOTION_PROPERTY_PRESETS) {
+      const track = createMotionTrackFromPreset("node-x", preset);
+      const timeline: MotionTimeline = {
+        id: "t1",
+        designId: "d1",
+        sourceRef: null,
+        filePath: null,
+        tracks: [track],
+        durationMs: 600,
+        defaultEase: "ease",
+        compiledHash: null,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      };
+      const { css, hash } = compile(timeline);
+      expect(css).toContain("@keyframes");
+      expect(css).toContain(`${preset.property}:`);
+      expect(css).toContain("prefers-reduced-motion");
+      // Deterministic: re-compiling yields the identical hash.
+      expect(compile(timeline).hash).toBe(hash);
+    }
+  });
+});
+
+// ─── hasTrackFor ──────────────────────────────────────────────────────────────
+
+describe("hasTrackFor", () => {
+  const tracks: MotionTrack[] = [
+    createMotionTrack("node-1", "opacity"),
+    createMotionTrack("node-1", "transform"),
+    createMotionTrack("node-2", "opacity"),
+  ];
+
+  it("returns true for an existing (node, property) pair", () => {
+    expect(hasTrackFor(tracks, "node-1", "opacity")).toBe(true);
+    expect(hasTrackFor(tracks, "node-1", "transform")).toBe(true);
+    expect(hasTrackFor(tracks, "node-2", "opacity")).toBe(true);
+  });
+
+  it("returns false for a property not yet tracked on that node", () => {
+    expect(hasTrackFor(tracks, "node-2", "transform")).toBe(false);
+  });
+
+  it("returns false for an unknown node", () => {
+    expect(hasTrackFor(tracks, "node-9", "opacity")).toBe(false);
+  });
+
+  it("returns false against an empty track list (the first-track case)", () => {
+    expect(hasTrackFor([], "node-1", "opacity")).toBe(false);
+  });
+});
+
+// ─── First-track flow integration (timeline → CSS) ───────────────────────────
+
+describe("first-track flow → CSS compile", () => {
+  it("a single seeded track produces compilable CSS that targets the node id", () => {
+    // Simulates: user selects an element (node id "abc"), picks "Fade
+    // (opacity)" from the empty-state picker → one track → Write to CSS.
+    const preset = MOTION_PROPERTY_PRESETS[0];
+    const track = createMotionTrackFromPreset("abc", preset);
+    const { css } = compile({
+      id: "",
+      designId: "d1",
+      sourceRef: null,
+      filePath: null,
+      tracks: [track],
+      durationMs: 1000,
+      defaultEase: "ease",
+      compiledHash: null,
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    });
+    // Element rule targets the literal node id via the data attribute.
+    expect(css).toContain('[data-agent-native-node-id="abc"]');
+    expect(css).toContain("animation-name:");
+    expect(css).toContain("opacity: 0");
+    expect(css).toContain("opacity: 1");
+  });
+
+  it("adding a keyframe to a seeded track stays compilable (3 stops)", () => {
+    const track = createMotionTrack("abc", "opacity", { from: "0", to: "1" });
+    // Mid keyframe inserted by the dock's addKeyframe at the playhead.
+    track.keyframes.splice(1, 0, { t: 0.5, value: "0.5", ease: "linear" });
+    const { css } = compile({
+      id: "",
+      designId: "d1",
+      sourceRef: null,
+      filePath: null,
+      tracks: [track],
+      durationMs: 1000,
+      defaultEase: "ease",
+      compiledHash: null,
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    });
+    expect(css).toContain("0% {");
+    expect(css).toContain("50% {");
+    expect(css).toContain("100% {");
+  });
+});

--- a/templates/design/shared/motion-timeline.ts
+++ b/templates/design/shared/motion-timeline.ts
@@ -70,3 +70,124 @@ export interface MotionTimeline {
   createdAt: string;
   updatedAt: string;
 }
+
+// ─── Animatable-property catalog + track factory ──────────────────────────────
+//
+// Shared by the MotionDock UI (the "add a track" picker) and unit tests. These
+// are pure helpers so the first-track-creation flow can be tested without
+// mounting React. They power the "create the FIRST track" path: a freshly
+// selected element has no tracks, so the dock seeds a default track from one of
+// these presets and the keyframes below.
+
+/**
+ * One animatable-property preset offered when creating a brand-new track.
+ * `from`/`to` seed the two default keyframes so the track is immediately
+ * compilable and previewable (a track with < 1 keyframe is rejected by
+ * `apply-motion-edit`).
+ */
+export interface MotionPropertyPreset {
+  /** CSS property animated by the track (e.g. "opacity", "transform"). */
+  property: string;
+  /** Human-readable label for the picker (e.g. "Opacity", "Slide up"). */
+  label: string;
+  /** Value at t = 0. */
+  from: string;
+  /** Value at t = 1. */
+  to: string;
+}
+
+/**
+ * Built-in property presets for the "add a track" picker. Ordered most-common
+ * first. Every preset is a valid CSS identifier accepted by
+ * `assertSafeCssProperty` and yields two safe keyframe values.
+ */
+export const MOTION_PROPERTY_PRESETS: MotionPropertyPreset[] = [
+  { property: "opacity", label: "Fade (opacity)", from: "0", to: "1" },
+  {
+    property: "transform",
+    label: "Slide up (translateY)",
+    from: "translateY(16px)",
+    to: "translateY(0px)",
+  },
+  {
+    property: "transform",
+    label: "Scale (zoom in)",
+    from: "scale(0.8)",
+    to: "scale(1)",
+  },
+  {
+    property: "filter",
+    label: "Blur in",
+    from: "blur(8px)",
+    to: "blur(0px)",
+  },
+  {
+    property: "color",
+    label: "Color",
+    from: "#000000",
+    to: "#000000",
+  },
+  {
+    property: "background-color",
+    label: "Background color",
+    from: "#ffffff",
+    to: "#ffffff",
+  },
+];
+
+/**
+ * Build a brand-new {@link MotionTrack} for a target node + property, seeded
+ * with two keyframes (start/end) so it is immediately valid for both the live
+ * preview bridge and the `apply-motion-edit` "Write to CSS" commit. Used by the
+ * MotionDock "create first track" path.
+ *
+ * When `preset` is omitted, a neutral 0 → 1 opacity-style pair is used so the
+ * track still compiles; callers normally pass a {@link MotionPropertyPreset}.
+ */
+export function createMotionTrack(
+  targetNodeId: string,
+  property: string,
+  options: { from?: string; to?: string; ease?: MotionEase } = {},
+): MotionTrack {
+  const from = options.from ?? "0";
+  const to = options.to ?? "1";
+  return {
+    targetNodeId,
+    property,
+    keyframes: [
+      { t: 0, value: from, ...(options.ease ? { ease: options.ease } : {}) },
+      { t: 1, value: to, ...(options.ease ? { ease: options.ease } : {}) },
+    ],
+  };
+}
+
+/**
+ * Build a track from a {@link MotionPropertyPreset}. Thin wrapper over
+ * {@link createMotionTrack} that forwards the preset's seed values.
+ */
+export function createMotionTrackFromPreset(
+  targetNodeId: string,
+  preset: MotionPropertyPreset,
+  ease?: MotionEase,
+): MotionTrack {
+  return createMotionTrack(targetNodeId, preset.property, {
+    from: preset.from,
+    to: preset.to,
+    ease,
+  });
+}
+
+/**
+ * Return `true` when a track for the given (targetNodeId, property) pair already
+ * exists in `tracks`. The dock uses this to decide between "create a new track"
+ * and "add a keyframe to the existing track" so a property is never duplicated.
+ */
+export function hasTrackFor(
+  tracks: MotionTrack[],
+  targetNodeId: string,
+  property: string,
+): boolean {
+  return tracks.some(
+    (t) => t.targetNodeId === targetNodeId && t.property === property,
+  );
+}

--- a/templates/design/shared/shader-fill.ts
+++ b/templates/design/shared/shader-fill.ts
@@ -292,3 +292,32 @@ export function buildShaderFillFallbackBlock(
     `}`,
   ].join("\n");
 }
+
+/**
+ * Resolve the CSS `background` value to persist into the design source for a
+ * shader fill.
+ *
+ * This is the single value `apply-shader-fill` writes onto the target element's
+ * inline `style.background`.  It is identical to the value the live preview
+ * renders (`generateShaderFillPreviewCss`) so "what you previewed is what you
+ * get", and — like every other output of this module — every colour passes
+ * through the strict CSS-colour allowlist before being interpolated, so a
+ * `descriptor.colors` payload can never carry a CSS-injection string into the
+ * persisted source.
+ *
+ * Returns the gradient string plus the sanitised palette that produced it so
+ * callers can surface proof-of-persist (which colours were written, which were
+ * neutralised) without re-deriving them.
+ *
+ * @param descriptor - The ShaderDescriptor defining preset + params + colours.
+ * @returns `{ background, colors }` — the value to write and the safe palette.
+ */
+export function buildShaderFillBackground(descriptor: ShaderDescriptor): {
+  background: string;
+  colors: string[];
+} {
+  return {
+    background: generateShaderFillPreviewCss(descriptor),
+    colors: resolveColors(descriptor),
+  };
+}


### PR DESCRIPTION
## Finish the stubbed Design Studio features

Follow-up to #1664. That PR landed the Design Studio surface, but several
features shipped as **scaffolding that looked done but wasn't wired**. This PR
finishes the ones that don't require the Builder real-app tier — turning them
from "renders, no-ops" into actually-working features.

### What's finished

**Component props panel** — selecting a component instance now shows **real
typed controls** (variant **dropdown**, boolean **Switch**, string **Input**)
instead of a read-only display + a no-op Variant select. Each control persists
through `apply-component-prop-edit` (optimistic; the canvas re-renders from the
written content), **enabled for inline/Alpine** sources. Real-app/Builder
source-prop controls stay gated as before.

**Inspect code** — now shows the selected element's **opening tag at a glance**
(`<main class="…" data-x="…">`) above the full-HTML view.

**Motion dock** — was a dead feature (no way to create a first track, so "Write
to CSS" was permanently disabled). Adds an **"Add track" picker** (property
presets) that seeds a valid track → auto-enables **Write to CSS**
(`apply-motion-edit`), and threads the previously-dormant **`motionTracks` live
scrub-preview** prop into `DesignCanvas`.

**Shaders** — `apply-shader-fill` was an always-gated stub that never wrote.
Rewritten into a **real persisting action** (editor-scoped, reuses the strict
CSS-color allowlist so injection payloads are neutralized, single atomic write),
with an **"Apply fill"** button wired into the shader card and the "gated" badge
removed. (Shader apply was *safety*-gated, not Builder-gated.)

**Accessibility fix** — new **`apply-a11y-fix`** action that resolves common
findings (contrast → color, tap-target / focus-visibility → class) to
deterministic edits via the existing edit engine, plus a **"Fix"** affordance on
auto-fixable findings in `ReviewPanel`. Attribute-needing fixes (alt/aria) are
explicitly deferred.

### Verification
- **`pnpm prep` is green** — typecheck clean, **all guards pass**, full test
  suite passes. The design template alone has **444 tests passing** (~120 new).
- Scoped entirely to `templates/design` (no `packages/*`, no changeset needed).
- Built by four parallel agents on **disjoint file sets** (no merge collisions),
  each leaving typecheck + i18n/query guards green; then integrated and
  re-verified together.

### Honest caveats (read before relying on it)
- **Not browser-verified.** This is "wired + typecheck + unit-tested." A
  separate browser-verification pass is the intended confirmation of the actual
  in-editor behavior (live updates, scrub preview, apply round-trips).
- **The Review panel is not yet mounted in the editor.** `ReviewPanel` (a11y +
  visual diff) was never surfaced by `DesignEditor` — a **pre-existing gap from
  #1664**, not introduced here. The `apply-a11y-fix` action + the "Fix" button +
  tests are ready, but lighting them up needs `DesignEditor` to construct
  `reviewPanelProps` (findings from `run-design-audit` + `fixSource` +
  `onFixApplied`). Deferred deliberately because it changes the editor's default
  UI and wants browser verification.
- **i18n:** the in-flux Studio panels carry `i18n-raw-literal-disable-file`
  markers (from #1664); new strings here use `// i18n-ignore`. Proper
  localization of these panels is a separate pass once the UI settles.
- **Still Builder-gated (out of scope, by design):** token write-back to source,
  deep real-app prop controls, live data captures / real-app states, branches +
  deploy, the inline→React migration bridge.
