### PR TITLE
Fix Design editor drag and undo reliability

### DIFF
--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -2384,7 +2384,7 @@ const EDITOR_CHROME_BRIDGE_SCRIPT = `
       insertionGuide.style.height = rect.height + 'px';
       insertionGuide.style.background = 'color-mix(in srgb, var(--design-editor-accent-color) 14%, transparent)';
       insertionGuide.style.border = '2px solid var(--design-editor-accent-color)';
-      insertionGuide.style.borderRadius = '4px';
+      insertionGuide.style.borderRadius = '2px';
       insertionGuide.style.boxShadow = 'none';
       return;
     }

--- a/templates/design/app/components/design/LayersPanel.test.ts
+++ b/templates/design/app/components/design/LayersPanel.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getDraggedLayerIdsForRows,
+  getLayerSelectionAnchorFromExternalSelection,
+  getTreeOrderedLayerIds,
+  shouldResyncLayerSelectionAnchor,
+  type FlatLayerRow,
+} from "./LayersPanel";
+
+function row(
+  id: string,
+  ancestorIds: string[] = [],
+  selectable = true,
+): FlatLayerRow {
+  return {
+    node: { id, name: id, selectable },
+    rowKey: id,
+    depth: ancestorIds.length,
+    ancestorIds,
+    hasChildren: false,
+    canAcceptChildren: false,
+  };
+}
+
+describe("LayersPanel selection anchors", () => {
+  it("uses the latest externally selected visible layer as the shift anchor", () => {
+    expect(
+      getLayerSelectionAnchorFromExternalSelection({
+        selectedIds: ["panel-old", "__header", "canvas-current"],
+        selectableVisibleIds: ["panel-old", "canvas-current"],
+      }),
+    ).toBe("canvas-current");
+  });
+
+  it("clears the range anchor when external selection is no longer visible", () => {
+    expect(
+      getLayerSelectionAnchorFromExternalSelection({
+        selectedIds: ["hidden-layer"],
+        selectableVisibleIds: ["visible-layer"],
+      }),
+    ).toBeNull();
+  });
+
+  it("resyncs when filtering hides the existing range anchor", () => {
+    expect(
+      shouldResyncLayerSelectionAnchor({
+        selectionSignature: "same-selection",
+        lastPanelSelectionSignature: "same-selection",
+        currentAnchor: "filtered-out",
+        selectableVisibleIds: ["still-visible"],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("LayersPanel drag payload ordering", () => {
+  const rows = [
+    row("__code_section__", [], false),
+    row("parent"),
+    row("first", ["parent"]),
+    row("second", ["parent"]),
+    row("third", ["parent"]),
+  ];
+
+  it("normalizes multi-drag payloads to visible tree order", () => {
+    expect(getTreeOrderedLayerIds(["third", "first"], rows)).toEqual([
+      "first",
+      "third",
+    ]);
+  });
+
+  it("drops selected descendants when their ancestor is dragged", () => {
+    expect(
+      getDraggedLayerIdsForRows({
+        selectedIds: ["third", "parent", "first"],
+        nodeId: "parent",
+        visibleRows: rows,
+      }),
+    ).toEqual(["parent"]);
+  });
+});

--- a/templates/design/app/components/design/LayersPanel.tsx
+++ b/templates/design/app/components/design/LayersPanel.tsx
@@ -170,7 +170,7 @@ export interface LayersPanelProps {
   canMoveLayer?: (intent: LayersPanelMoveIntent) => boolean;
 }
 
-interface FlatLayerRow {
+export interface FlatLayerRow {
   node: LayersPanelNode;
   rowKey: string;
   depth: number;
@@ -412,6 +412,65 @@ function collectAncestorIds(
   return Array.from(ancestors);
 }
 
+export function getLayerSelectionAnchorFromExternalSelection(args: {
+  selectedIds: readonly string[];
+  selectableVisibleIds: readonly string[];
+}): string | null {
+  const selectableVisibleIdSet = new Set(args.selectableVisibleIds);
+  return (
+    [...args.selectedIds]
+      .reverse()
+      .find((id) => selectableVisibleIdSet.has(id)) ?? null
+  );
+}
+
+export function getTreeOrderedLayerIds(
+  ids: readonly string[],
+  visibleRows: readonly FlatLayerRow[],
+): string[] {
+  const idSet = new Set(ids.filter((id) => id && !id.startsWith("__")));
+  const orderedIds = visibleRows
+    .map((row) => row.node.id)
+    .filter((id) => idSet.has(id));
+  const orderedIdSet = new Set(orderedIds);
+  return [
+    ...orderedIds,
+    ...ids.filter((id) => id && !id.startsWith("__") && !orderedIdSet.has(id)),
+  ];
+}
+
+export function getDraggedLayerIdsForRows(args: {
+  selectedIds: readonly string[];
+  nodeId: string;
+  visibleRows: readonly FlatLayerRow[];
+}): string[] {
+  const rawDraggedIds = args.selectedIds.includes(args.nodeId)
+    ? getTreeOrderedLayerIds(args.selectedIds, args.visibleRows)
+    : [args.nodeId];
+  const draggedIdSet = new Set(rawDraggedIds);
+  return rawDraggedIds.filter((id) => {
+    const rowForId = args.visibleRows.find((row) => row.node.id === id);
+    return !rowForId?.ancestorIds.some((ancestorId) =>
+      draggedIdSet.has(ancestorId),
+    );
+  });
+}
+
+export function shouldResyncLayerSelectionAnchor(args: {
+  selectionSignature: string;
+  lastPanelSelectionSignature: string;
+  currentAnchor: string | null;
+  selectableVisibleIds: readonly string[];
+}) {
+  const anchorStillVisible =
+    args.currentAnchor !== null &&
+    args.selectableVisibleIds.includes(args.currentAnchor);
+  return (
+    args.selectionSignature !== args.lastPanelSelectionSignature ||
+    !anchorStillVisible
+  );
+}
+
 function layerCanShowBadge(node: LayersPanelNode) {
   return (
     node.type === "file" ||
@@ -451,6 +510,7 @@ export function LayersPanel({
   const labels = useMemo(() => mergeLabels(labelsProp, t), [labelsProp, t]);
   const selectedIdSet = useMemo(() => new Set(selectedIds), [selectedIds]);
   const selectedIdsRef = useRef<readonly string[]>(selectedIds);
+  const lastPanelSelectionSignatureRef = useRef(selectedIds.join("\0"));
   const expandedIdSet = useMemo(() => new Set(expandedIds), [expandedIds]);
   const lastSelectionAnchorRef = useRef<string | null>(selectedIds[0] ?? null);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -486,9 +546,35 @@ export function LayersPanel({
     [roots, selectedIdSet],
   );
 
+  const selectableVisibleIds = useMemo(
+    () =>
+      visibleRows
+        .map(({ node }) => node)
+        .filter((node) => node.selectable !== false)
+        .map((node) => node.id),
+    [visibleRows],
+  );
+
   useLayoutEffect(() => {
     selectedIdsRef.current = selectedIds;
-  }, [selectedIds]);
+    const signature = selectedIds.join("\0");
+    if (
+      !shouldResyncLayerSelectionAnchor({
+        selectionSignature: signature,
+        lastPanelSelectionSignature: lastPanelSelectionSignatureRef.current,
+        currentAnchor: lastSelectionAnchorRef.current,
+        selectableVisibleIds,
+      })
+    ) {
+      return;
+    }
+    lastPanelSelectionSignatureRef.current = signature;
+    lastSelectionAnchorRef.current =
+      getLayerSelectionAnchorFromExternalSelection({
+        selectedIds,
+        selectableVisibleIds,
+      });
+  }, [selectableVisibleIds, selectedIds]);
 
   useEffect(() => {
     if (selectedAncestorIds.length === 0) return;
@@ -521,15 +607,6 @@ export function LayersPanel({
     });
     return () => window.cancelAnimationFrame(frame);
   }, [selectedScrollRowKey]);
-
-  const selectableVisibleIds = useMemo(
-    () =>
-      visibleRows
-        .map(({ node }) => node)
-        .filter((node) => node.selectable !== false)
-        .map((node) => node.id),
-    [visibleRows],
-  );
 
   const selectNode = useCallback(
     (
@@ -582,6 +659,7 @@ export function LayersPanel({
       if (!options.range) {
         lastSelectionAnchorRef.current = id;
       }
+      lastPanelSelectionSignatureRef.current = nextIds.join("\0");
       onSelectionChange(nextIds, { id, selectedIds: nextIds, ...options });
     },
     [onSelectionChange, selectableVisibleIds],
@@ -948,12 +1026,15 @@ function LayerRow({
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
-    const focusVisibleButton = (nextIndex: number) => {
+    const getFocusableButtons = () => {
       const tree = event.currentTarget.closest('[role="tree"]');
-      if (!tree) return false;
-      const buttons = Array.from(
+      if (!tree) return [];
+      return Array.from(
         tree.querySelectorAll<HTMLButtonElement>("[data-layer-row-button]"),
       ).filter((button) => !button.disabled);
+    };
+    const focusVisibleButton = (nextIndex: number) => {
+      const buttons = getFocusableButtons();
       const target =
         buttons[Math.max(0, Math.min(buttons.length - 1, nextIndex))];
       target?.focus();
@@ -971,6 +1052,8 @@ function LayerRow({
     const currentIndex = visibleRows.findIndex(
       (visibleRow) => visibleRow.rowKey === row.rowKey,
     );
+    const focusableButtons = getFocusableButtons();
+    const currentFocusableIndex = focusableButtons.indexOf(event.currentTarget);
 
     if (event.key === "Enter" || event.key === " " || event.key === "Space") {
       event.preventDefault();
@@ -990,12 +1073,12 @@ function LayerRow({
     }
     if (event.key === "ArrowDown") {
       event.preventDefault();
-      focusVisibleButton(currentIndex + 1);
+      focusVisibleButton(currentFocusableIndex + 1);
       return;
     }
     if (event.key === "ArrowUp") {
       event.preventDefault();
-      focusVisibleButton(currentIndex - 1);
+      focusVisibleButton(currentFocusableIndex - 1);
       return;
     }
     if (event.key === "Home") {
@@ -1005,7 +1088,7 @@ function LayerRow({
     }
     if (event.key === "End") {
       event.preventDefault();
-      focusVisibleButton(visibleRows.length - 1);
+      focusVisibleButton(focusableButtons.length - 1);
       return;
     }
     if (event.key === "ArrowRight" && hasChildren && !isExpanded) {
@@ -1015,9 +1098,13 @@ function LayerRow({
     }
     if (event.key === "ArrowRight" && hasChildren && isExpanded) {
       event.preventDefault();
-      const child = visibleRows[currentIndex + 1];
+      const nextButton = focusableButtons[currentFocusableIndex + 1];
+      const childId = nextButton?.dataset.layerNodeId;
+      const child = childId
+        ? visibleRows.find((visibleRow) => visibleRow.node.id === childId)
+        : null;
       if (child?.ancestorIds.includes(node.id)) {
-        focusVisibleButton(currentIndex + 1);
+        focusVisibleButton(currentFocusableIndex + 1);
       }
       return;
     }
@@ -1038,17 +1125,10 @@ function LayerRow({
       event.preventDefault();
       return;
     }
-    const rawDraggedIds = selectedIds.includes(node.id)
-      ? selectedIds.filter((id) => !id.startsWith("__"))
-      : [node.id];
-    // Remove any node whose ancestor is also being dragged to avoid double-moves.
-    // When a parent is moved, its children move with it automatically.
-    const draggedIdSet = new Set(rawDraggedIds);
-    const draggedIds = rawDraggedIds.filter((id) => {
-      const rowForId = visibleRows.find((r) => r.node.id === id);
-      return !rowForId?.ancestorIds.some((ancestorId) =>
-        draggedIdSet.has(ancestorId),
-      );
+    const draggedIds = getDraggedLayerIdsForRows({
+      selectedIds,
+      nodeId: node.id,
+      visibleRows,
     });
     event.dataTransfer.effectAllowed = "move";
     event.dataTransfer.setData("application/x-design-layer-id", node.id);

--- a/templates/design/app/pages/DesignEditor.selection.test.ts
+++ b/templates/design/app/pages/DesignEditor.selection.test.ts
@@ -4,7 +4,9 @@ import { buildCodeLayerProjection } from "../../shared/code-layer";
 import {
   buildActiveFileNodeIdSet,
   getFreshActiveFileContent,
+  getFreshScreenContent,
   getDesignEditorShareUrl,
+  getLayerMoveIterationOrder,
   getLayerMoveSourceContent,
   getLocalhostRouteSourceFile,
   getOverviewCanvasZoom,
@@ -284,6 +286,50 @@ describe("DesignEditor layer move source snapshots", () => {
     expect(
       sortCodeLayerIdsByTreeOrder(["caption", "heading", "missing"], tree),
     ).toEqual(["heading", "caption", "missing"]);
+  });
+
+  it("iterates after-drops in reverse so same-anchor inserts keep tree order", () => {
+    expect(getLayerMoveIterationOrder(["a", "b", "c"], "after")).toEqual([
+      "c",
+      "b",
+      "a",
+    ]);
+
+    expect(getLayerMoveIterationOrder(["a", "b", "c"], "before")).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+    expect(getLayerMoveIterationOrder(["a", "b", "c"], "inside")).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+
+  it("uses the fresh active snapshot when resolving overview screen content", () => {
+    const fileContentById = new Map([
+      ["active", "stale persisted active"],
+      ["other", "other screen content"],
+    ]);
+
+    expect(
+      getFreshScreenContent({
+        screenId: "active",
+        activeFileId: "active",
+        freshActiveContent: "fresh active content",
+        fileContentById,
+      }),
+    ).toBe("fresh active content");
+
+    expect(
+      getFreshScreenContent({
+        screenId: "other",
+        activeFileId: "active",
+        freshActiveContent: "fresh active content",
+        fileContentById,
+      }),
+    ).toBe("other screen content");
   });
 });
 

--- a/templates/design/app/pages/DesignEditor.selection.test.ts
+++ b/templates/design/app/pages/DesignEditor.selection.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { buildCodeLayerProjection } from "../../shared/code-layer";
 import {
   buildActiveFileNodeIdSet,
+  getFreshActiveFileContent,
   getDesignEditorShareUrl,
   getLayerMoveSourceContent,
   getLocalhostRouteSourceFile,
@@ -17,6 +18,7 @@ import {
   getSelectedScreenIdsForEditorState,
   shouldLockInspectorForInitialGeneration,
   shouldEscapeToOverview,
+  sortCodeLayerIdsByTreeOrder,
 } from "./DesignEditor";
 
 describe("DesignEditor overview selection state", () => {
@@ -203,6 +205,32 @@ describe("DesignEditor localhost route source", () => {
 });
 
 describe("DesignEditor layer move source snapshots", () => {
+  it("prefers the latest local active content snapshot during rapid edits", () => {
+    expect(
+      getFreshActiveFileContent({
+        activeContent: "stale react content",
+        latestContent: null,
+        lastLocalContent: "fresh local content",
+      }),
+    ).toBe("fresh local content");
+
+    expect(
+      getFreshActiveFileContent({
+        activeContent: "stale react content",
+        latestContent: "remote or local latest content",
+        lastLocalContent: "older local content",
+      }),
+    ).toBe("remote or local latest content");
+
+    expect(
+      getFreshActiveFileContent({
+        activeContent: "current react content",
+        latestContent: null,
+        lastLocalContent: null,
+      }),
+    ).toBe("current react content");
+  });
+
   it("uses the progressive source snapshot before active file content", () => {
     expect(
       getLayerMoveSourceContent({
@@ -234,6 +262,28 @@ describe("DesignEditor layer move source snapshots", () => {
         sourceContentMap: new Map(),
       }),
     ).toBe("other file");
+  });
+
+  it("orders same-file multi-layer moves by tree order", () => {
+    const tree = [
+      {
+        id: "parent",
+        children: [
+          { id: "heading", children: [] },
+          {
+            id: "content",
+            children: [
+              { id: "button", children: [] },
+              { id: "caption", children: [] },
+            ],
+          },
+        ],
+      },
+    ] as any;
+
+    expect(
+      sortCodeLayerIdsByTreeOrder(["caption", "heading", "missing"], tree),
+    ).toEqual(["heading", "caption", "missing"]);
   });
 });
 

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -442,6 +442,24 @@ export function getFreshActiveFileContent(args: {
   return args.latestContent ?? args.lastLocalContent ?? args.activeContent;
 }
 
+export function getFreshScreenContent(args: {
+  screenId: string;
+  activeFileId?: string | null;
+  freshActiveContent: string;
+  fileContentById: ReadonlyMap<string, string>;
+}) {
+  return args.screenId === args.activeFileId
+    ? args.freshActiveContent
+    : (args.fileContentById.get(args.screenId) ?? "");
+}
+
+export function getLayerMoveIterationOrder<T>(
+  orderedIds: readonly T[],
+  placement: "before" | "after" | "inside",
+): T[] {
+  return placement === "after" ? [...orderedIds].reverse() : [...orderedIds];
+}
+
 function resolveZoomUpdate(update: SetStateAction<number>, current: number) {
   return typeof update === "function" ? update(current) : update;
 }
@@ -5479,9 +5497,16 @@ export default function DesignEditor() {
   }, [files]);
   const getScreenContent = useCallback(
     (screenId: string) =>
-      screenId === activeFile?.id
-        ? activeContent
-        : (fileContentById.get(screenId) ?? ""),
+      getFreshScreenContent({
+        screenId,
+        activeFileId: activeFile?.id,
+        freshActiveContent: getFreshActiveFileContent({
+          activeContent,
+          latestContent: latestActiveContentRef.current,
+          lastLocalContent: lastLocalContentRef.current,
+        }),
+        fileContentById,
+      }),
     [activeContent, activeFile?.id, fileContentById],
   );
   const pageStyles = useMemo(
@@ -10246,7 +10271,10 @@ ${serializedHtml}
       // --- Same-file moves (existing path) ---
       let nextDestContent = destContent;
       let moved = false;
-      for (const draggedId of orderedSameFileDragIds) {
+      for (const draggedId of getLayerMoveIterationOrder(
+        orderedSameFileDragIds,
+        intent.placement,
+      )) {
         const patch = applyVisualEdit(nextDestContent, {
           kind: "moveNode",
           target: { nodeId: draggedId },

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -434,6 +434,14 @@ export function getLayerMoveSourceContent(args: {
   );
 }
 
+export function getFreshActiveFileContent(args: {
+  activeContent: string;
+  latestContent?: string | null;
+  lastLocalContent?: string | null;
+}) {
+  return args.latestContent ?? args.lastLocalContent ?? args.activeContent;
+}
+
 function resolveZoomUpdate(update: SetStateAction<number>, current: number) {
   return typeof update === "function" ? update(current) : update;
 }
@@ -2096,6 +2104,36 @@ function collectCodeLayerAncestors(
   return [];
 }
 
+export function sortCodeLayerIdsByTreeOrder(
+  ids: readonly string[],
+  tree: readonly CodeLayerTreeNode[],
+): string[] {
+  const treeOrder = new Map<string, number>();
+  let index = 0;
+  const visit = (nodes: readonly CodeLayerTreeNode[]) => {
+    for (const node of nodes) {
+      treeOrder.set(node.id, index);
+      index += 1;
+      visit(node.children);
+    }
+  };
+  visit(tree);
+
+  const originalOrder = new Map(
+    ids.map((id, originalIndex) => [id, originalIndex]),
+  );
+  return [...ids].sort((a, b) => {
+    const aOrder = treeOrder.get(a);
+    const bOrder = treeOrder.get(b);
+    if (aOrder === undefined && bOrder === undefined) {
+      return (originalOrder.get(a) ?? 0) - (originalOrder.get(b) ?? 0);
+    }
+    if (aOrder === undefined) return 1;
+    if (bOrder === undefined) return -1;
+    return aOrder - bOrder;
+  });
+}
+
 function findCodeLayerNodeInProjection(
   projection: CodeLayerProjection,
   previousNode: CodeLayerNode,
@@ -3212,6 +3250,14 @@ export default function DesignEditor() {
         contentRedoStackRef.current.length > 0 ||
         geometryRedoStackRef.current.length > 0,
     );
+  }, []);
+  const clearLocalUndoRedoStacks = useCallback(() => {
+    contentUndoStackRef.current = [];
+    contentRedoStackRef.current = [];
+    geometryUndoStackRef.current = [];
+    geometryRedoStackRef.current = [];
+    historyOrderRef.current = [];
+    redoOrderRef.current = [];
   }, []);
   const persistedSelectionStateRef = useRef<string | null>(null);
   const designSelectionOwnerIdRef = useRef(`${TAB_ID}:${generateTabId()}`);
@@ -4873,6 +4919,7 @@ export default function DesignEditor() {
   // The last content this client itself wrote into the Y.Doc (inline-style
   // edits) — so the reconcile/observe doesn't treat our own echo as external.
   const lastLocalContentRef = useRef<string | null>(null);
+  const latestActiveContentRef = useRef<string | null>(null);
   // Freshest known DB `updatedAt` for the active file, kept in a ref so the
   // Yjs observe handler can advance the reconcile watermark without re-subscribing.
   const documentFileUpdatedAtRef = useRef<string | null>(null);
@@ -4916,8 +4963,8 @@ export default function DesignEditor() {
       setCollabContentFileId(null);
       lastAppliedFileUpdatedAtRef.current = null;
       lastLocalContentRef.current = null;
-      contentUndoStackRef.current = [];
-      contentRedoStackRef.current = [];
+      latestActiveContentRef.current = null;
+      clearLocalUndoRedoStacks();
       clearStaleAgentCollabRecovery();
       syncUndoRedoState();
       return;
@@ -4928,13 +4975,14 @@ export default function DesignEditor() {
       setCollabContentFileId(null);
       lastAppliedFileUpdatedAtRef.current = null;
       lastLocalContentRef.current = null;
-      contentUndoStackRef.current = [];
-      contentRedoStackRef.current = [];
+      latestActiveContentRef.current = null;
+      clearLocalUndoRedoStacks();
       clearStaleAgentCollabRecovery();
       syncUndoRedoState();
     }
   }, [
     activeFileId,
+    clearLocalUndoRedoStacks,
     clearStaleAgentCollabRecovery,
     syncUndoRedoState,
     viewMode,
@@ -4956,6 +5004,7 @@ export default function DesignEditor() {
       setCollabContent(pendingLocalContent);
       setCollabContentFileId(fileId);
       lastLocalContentRef.current = pendingLocalContent;
+      latestActiveContentRef.current = pendingLocalContent;
       setContentRenderRevision((revision) => revision + 1);
       ydoc.transact(() => {
         ytext.delete(0, ytext.length);
@@ -4975,6 +5024,7 @@ export default function DesignEditor() {
         setCollabContent(storedContent);
         setCollabContentFileId(fileId);
         lastLocalContentRef.current = storedContent;
+        latestActiveContentRef.current = storedContent;
         setContentRenderRevision((revision) => revision + 1);
         ydoc.transact(() => {
           ytext.delete(0, ytext.length);
@@ -4987,6 +5037,7 @@ export default function DesignEditor() {
       // confirms or applies the current DB content.
       setCollabContent(text);
       setCollabContentFileId(fileId);
+      latestActiveContentRef.current = text;
       setContentRenderRevision((revision) => revision + 1);
     }
   }, [
@@ -5029,6 +5080,7 @@ export default function DesignEditor() {
         setCollabContent(pendingLocalContent);
         setCollabContentFileId(fileId);
         lastLocalContentRef.current = pendingLocalContent;
+        latestActiveContentRef.current = pendingLocalContent;
         setContentRenderRevision((revision) => revision + 1);
         ydoc.transact(() => {
           ytext.delete(0, ytext.length);
@@ -5038,6 +5090,7 @@ export default function DesignEditor() {
       }
       setCollabContent(next);
       setCollabContentFileId(fileId);
+      latestActiveContentRef.current = next;
       if (isLocalEdit) {
         lastLocalContentRef.current = next;
       } else {
@@ -5142,6 +5195,7 @@ export default function DesignEditor() {
       setCollabContent(dbContent);
       setCollabContentFileId(activeFile.id);
       lastLocalContentRef.current = dbContent;
+      latestActiveContentRef.current = dbContent;
       if (dbUpdatedAt) lastAppliedFileUpdatedAtRef.current = dbUpdatedAt;
       setContentRenderRevision((revision) => revision + 1);
 
@@ -5195,6 +5249,7 @@ export default function DesignEditor() {
             setCollabContent(expectedContent);
             setCollabContentFileId(expectedFileId);
             lastLocalContentRef.current = expectedContent;
+            latestActiveContentRef.current = expectedContent;
             lastAppliedFileUpdatedAtRef.current = expectedUpdatedAt;
             setContentRenderRevision((revision) => revision + 1);
 
@@ -5220,6 +5275,7 @@ export default function DesignEditor() {
     setCollabContent(dbContent);
     setCollabContentFileId(activeFile.id);
     lastLocalContentRef.current = dbContent;
+    latestActiveContentRef.current = dbContent;
     if (dbUpdatedAt) lastAppliedFileUpdatedAtRef.current = dbUpdatedAt;
     setContentRenderRevision((revision) => revision + 1);
 
@@ -5411,6 +5467,9 @@ export default function DesignEditor() {
       : (activeFile?.content ?? ""));
   const activeContent =
     typeof activeContentSource === "string" ? activeContentSource : "";
+  useLayoutEffect(() => {
+    latestActiveContentRef.current = activeContent;
+  }, [activeContent]);
   const fileContentById = useMemo(() => {
     const map = new Map<string, string>();
     for (const file of files) {
@@ -5729,6 +5788,7 @@ export default function DesignEditor() {
       setCollabContent(nextContent);
       setCollabContentFileId(activeFile.id);
       lastLocalContentRef.current = nextContent;
+      latestActiveContentRef.current = nextContent;
       if (id) {
         queryClient.setQueryData(
           ["action", "get-design", { id }],
@@ -6557,7 +6617,10 @@ export default function DesignEditor() {
       // advance lastLocalContentRef.current to resolvedNextContent below, the
       // next synchronous call reads the previous call's result and the patches
       // compose. Falls back to activeContent when the ref is unset (file switch).
-      const baseContent = lastLocalContentRef.current ?? activeContent;
+      const baseContent =
+        latestActiveContentRef.current ??
+        lastLocalContentRef.current ??
+        activeContent;
       const [firstProperty, firstValue] = entries[0];
       const projection = buildCodeLayerProjection(baseContent);
       const targetInfo = options.elementInfo ?? selectedElement;
@@ -6744,6 +6807,7 @@ export default function DesignEditor() {
       // Mark as our own write so the get-design reconcile + Yjs observe don't
       // treat the echo as an external edit and fight the live value.
       lastLocalContentRef.current = resolvedNextContent;
+      latestActiveContentRef.current = resolvedNextContent;
       // Write the edit into the shared Y.Doc so other open clients see it live
       // through Yjs (not only via the slower update-file → applyText round-trip).
       // Use LOCAL_EDIT_ORIGIN so the UndoManager captures this transaction.
@@ -6830,6 +6894,16 @@ export default function DesignEditor() {
     [commitVisualStyles, selectedElement?.selector],
   );
 
+  const getFreshActiveContent = useCallback(
+    () =>
+      getFreshActiveFileContent({
+        activeContent,
+        latestContent: latestActiveContentRef.current,
+        lastLocalContent: lastLocalContentRef.current,
+      }),
+    [activeContent],
+  );
+
   const handleVisualStyleChange = useCallback(
     (
       selector: string,
@@ -6858,7 +6932,8 @@ export default function DesignEditor() {
     ) => {
       if (!canEditDesign) return false;
       if (!activeFile) return false;
-      const projection = buildCodeLayerProjection(activeContent);
+      const baseContent = getFreshActiveContent();
+      const projection = buildCodeLayerProjection(baseContent);
       const resolveBridgeNode = (targetSelector: string, sourceId?: string) =>
         resolveCodeLayerNodeFromBridge(projection, targetSelector, sourceId);
       const targetInfo = elementInfo
@@ -6875,7 +6950,7 @@ export default function DesignEditor() {
         anchorSelector,
         details?.anchorSourceId,
       );
-      const patch = applyVisualEdit(activeContent, {
+      const patch = applyVisualEdit(baseContent, {
         kind: "moveNode",
         target: targetNode ? { nodeId: targetNode.id } : { selector },
         anchor: anchorNode
@@ -6923,7 +6998,13 @@ export default function DesignEditor() {
       }
       return true;
     },
-    [activeContent, activeFile, applyLocalContentUpdate, canEditDesign, t],
+    [
+      activeFile,
+      applyLocalContentUpdate,
+      canEditDesign,
+      getFreshActiveContent,
+      t,
+    ],
   );
 
   const handleVisualDuplicateChange = useCallback(
@@ -6940,7 +7021,8 @@ export default function DesignEditor() {
     ) => {
       if (!canEditDesign) return false;
       if (!activeFile) return false;
-      const projection = buildCodeLayerProjection(activeContent);
+      const baseContent = getFreshActiveContent();
+      const projection = buildCodeLayerProjection(baseContent);
       const targetInfo = elementInfo
         ? {
             ...elementInfo,
@@ -6960,7 +7042,7 @@ export default function DesignEditor() {
         details?.anchorSelector,
         details?.anchorSourceId,
       );
-      const nextContent = insertClonedHtmlLayer(activeContent, cloneHtml, {
+      const nextContent = insertClonedHtmlLayer(baseContent, cloneHtml, {
         targetSelectors: targetNode
           ? codeLayerSelectorAliases(targetNode)
           : [selector],
@@ -6994,7 +7076,13 @@ export default function DesignEditor() {
       }
       return true;
     },
-    [activeContent, activeFile, applyLocalContentUpdate, canEditDesign, t],
+    [
+      activeFile,
+      applyLocalContentUpdate,
+      canEditDesign,
+      getFreshActiveContent,
+      t,
+    ],
   );
 
   const handleTextContentChange = useCallback(
@@ -7006,7 +7094,8 @@ export default function DesignEditor() {
     ) => {
       if (!canEditDesign) return;
       if (!activeFile) return;
-      const projection = buildCodeLayerProjection(activeContent);
+      const baseContent = getFreshActiveContent();
+      const projection = buildCodeLayerProjection(baseContent);
       const targetInfo = elementInfo ? { ...elementInfo, selector } : null;
       const targetNode = targetInfo
         ? resolveCodeLayerNodeFromElementInfo(projection, targetInfo)
@@ -7014,10 +7103,10 @@ export default function DesignEditor() {
       const isEmpty = value.trim().length === 0;
       const removedContent =
         isEmpty && targetNode
-          ? removeCodeLayerNodeFromHtml(activeContent, targetNode)
+          ? removeCodeLayerNodeFromHtml(baseContent, targetNode)
           : null;
       const patch = !removedContent
-        ? applyVisualEdit(activeContent, {
+        ? applyVisualEdit(baseContent, {
             kind: "textContent",
             target: targetNode ? { nodeId: targetNode.id } : { selector },
             value,
@@ -7027,12 +7116,7 @@ export default function DesignEditor() {
       const nextContent =
         removedContent ??
         (patch?.result.status === "applied" ? patch.content : null) ??
-        updateElementContentInHtml(
-          activeContent,
-          selector,
-          value,
-          details?.html,
-        );
+        updateElementContentInHtml(baseContent, selector, value, details?.html);
       if (!nextContent) {
         toast.error(
           codeLayerPatchMessage(
@@ -7081,7 +7165,13 @@ export default function DesignEditor() {
           : previous;
       });
     },
-    [activeContent, activeFile, applyLocalContentUpdate, canEditDesign, t],
+    [
+      activeFile,
+      applyLocalContentUpdate,
+      canEditDesign,
+      getFreshActiveContent,
+      t,
+    ],
   );
 
   const handleScreenVisualStyleChange = useCallback(
@@ -7402,7 +7492,10 @@ export default function DesignEditor() {
 
   const handleCopySelection = useCallback(async () => {
     if (!selectedElement?.selector) return;
-    const html = getElementOuterHtml(activeContent, selectedElement.selector);
+    const html = getElementOuterHtml(
+      getFreshActiveContent(),
+      selectedElement.selector,
+    );
     if (!html) return;
     copiedLayerHtmlRef.current = html;
     pasteCascadeRef.current = 0;
@@ -7412,11 +7505,12 @@ export default function DesignEditor() {
     } catch {
       toast.error(t("designEditor.toasts.clipboardBlocked"));
     }
-  }, [activeContent, selectedElement, t]);
+  }, [getFreshActiveContent, selectedElement, t]);
 
   const handlePasteSelection = useCallback(
     (position?: { x: number; y: number }) => {
       if (!activeFile || !canEditDesign || !copiedLayerHtmlRef.current) return;
+      const baseContent = getFreshActiveContent();
 
       // B7 fix: when an element is selected and no explicit canvas position was
       // given, insert the clone as an in-flow sibling right AFTER the selected
@@ -7451,7 +7545,7 @@ export default function DesignEditor() {
           }
         })();
 
-        const nextContent = insertClonedHtmlLayer(activeContent, strippedHtml, {
+        const nextContent = insertClonedHtmlLayer(baseContent, strippedHtml, {
           targetSelectors: [selector],
           placement: "after",
         });
@@ -7476,7 +7570,7 @@ export default function DesignEditor() {
             : { x: 120 + offset, y: 120 + offset };
         })();
       const nextContent = cloneHtmlLayerAtPosition(
-        activeContent,
+        baseContent,
         copiedLayerHtmlRef.current,
         targetPosition,
       );
@@ -7485,10 +7579,10 @@ export default function DesignEditor() {
       applyLocalContentUpdate(nextContent);
     },
     [
-      activeContent,
       activeFile,
       applyLocalContentUpdate,
       canEditDesign,
+      getFreshActiveContent,
       selectedCanvasSelector,
       selectedElement,
     ],
@@ -7496,10 +7590,11 @@ export default function DesignEditor() {
 
   const handlePasteOverSelection = useCallback(() => {
     if (!activeFile || !copiedLayerHtmlRef.current) return;
+    const baseContent = getFreshActiveContent();
     if (selectedElement?.boundingRect) {
       const { x, y } = selectedElement.boundingRect;
       const nextContent = cloneHtmlLayerAtPosition(
-        activeContent,
+        baseContent,
         copiedLayerHtmlRef.current,
         { x, y },
       );
@@ -7509,9 +7604,9 @@ export default function DesignEditor() {
       handlePasteSelection();
     }
   }, [
-    activeContent,
     activeFile,
     applyLocalContentUpdate,
+    getFreshActiveContent,
     handlePasteSelection,
     selectedElement,
   ]);
@@ -7519,7 +7614,8 @@ export default function DesignEditor() {
   const handleDuplicateSelection = useCallback(() => {
     if (!canEditDesign) return;
     if (selectedElement?.selector) {
-      const html = getElementOuterHtml(activeContent, selectedElement.selector);
+      const baseContent = getFreshActiveContent();
+      const html = getElementOuterHtml(baseContent, selectedElement.selector);
       if (!html) {
         toast.error(t("designEditor.toasts.duplicateElementFailed"));
         return;
@@ -7550,7 +7646,7 @@ export default function DesignEditor() {
           return html;
         }
       })();
-      const nextContent = insertClonedHtmlLayer(activeContent, strippedHtml, {
+      const nextContent = insertClonedHtmlLayer(baseContent, strippedHtml, {
         targetSelectors: [selector],
         placement: "after",
       });
@@ -7563,10 +7659,10 @@ export default function DesignEditor() {
     }
     if (activeFile) handleDuplicateScreen(activeFile.id);
   }, [
-    activeContent,
     activeFile,
     applyLocalContentUpdate,
     canEditDesign,
+    getFreshActiveContent,
     handleDuplicateScreen,
     selectedCanvasSelector,
     selectedElement,
@@ -7575,6 +7671,7 @@ export default function DesignEditor() {
 
   const handleDeleteSelection = useCallback(() => {
     if (!canEditDesign) return;
+    const baseContent = getFreshActiveContent();
     // Multi-select delete: when several DOM/code layers are selected in the
     // panel, remove all of them — not just the single focused element. Compose
     // the removals against the running content (re-projecting each pass) so
@@ -7586,7 +7683,7 @@ export default function DesignEditor() {
         !files.some((file) => file.id === layerId),
     );
     if (candidateIds.length > 1) {
-      let content = activeContent;
+      let content = baseContent;
       const removedSelectors: string[] = [];
       for (const layerId of candidateIds) {
         const projection = buildCodeLayerProjection(content);
@@ -7600,7 +7697,7 @@ export default function DesignEditor() {
         if (selector) removedSelectors.push(selector);
         content = next;
       }
-      if (content !== activeContent) {
+      if (content !== baseContent) {
         removedSelectors.forEach((selector) => deleteRuntimeElement(selector));
         applyLocalContentUpdate(content, { refreshPreview: false });
         setSelectedElement(null);
@@ -7611,27 +7708,26 @@ export default function DesignEditor() {
     }
 
     if (!selectedElement?.selector) return;
-    const projection = buildCodeLayerProjection(activeContent);
+    const projection = buildCodeLayerProjection(baseContent);
     const targetNode = resolveCodeLayerNodeFromElementInfo(
       projection,
       selectedElement,
     );
     const nextContent =
       (targetNode
-        ? removeCodeLayerNodeFromHtml(activeContent, targetNode)
-        : null) ??
-      removeElementFromHtml(activeContent, selectedElement.selector);
+        ? removeCodeLayerNodeFromHtml(baseContent, targetNode)
+        : null) ?? removeElementFromHtml(baseContent, selectedElement.selector);
     if (!nextContent) return;
     deleteRuntimeElement(selectedElement.selector);
     applyLocalContentUpdate(nextContent, { refreshPreview: false });
     setSelectedElement(null);
     setSelectedLayerIdsState([]);
   }, [
-    activeContent,
     applyLocalContentUpdate,
     canEditDesign,
     deleteRuntimeElement,
     files,
+    getFreshActiveContent,
     selectedElement,
     selectedLayerIdsState,
   ]);
@@ -7639,6 +7735,7 @@ export default function DesignEditor() {
   // Wrap the current multi-layer selection into a new group container.
   const handleGroupSelection = useCallback(() => {
     if (!canEditDesign || !activeFile) return;
+    const baseContent = getFreshActiveContent();
     // Collect the DOM-node layer ids that belong to the active screen.
     // Build a set of ids present in the active content so stale ids from
     // other files (which can persist in selectedLayerIdsState after a
@@ -7648,14 +7745,14 @@ export default function DesignEditor() {
     // selection.
     const fileIds = new Set(files.map((f) => f.id));
     const activeNodeIdSet = buildActiveFileNodeIdSet(
-      buildCodeLayerProjection(activeContent),
+      buildCodeLayerProjection(baseContent),
     );
     const nodeIds = selectedLayerIdsState.filter(
       (id) =>
         !id.startsWith("__") && !fileIds.has(id) && activeNodeIdSet.has(id),
     );
     if (nodeIds.length < 2) return;
-    const patch = applyVisualEdit(activeContent, {
+    const patch = applyVisualEdit(baseContent, {
       kind: "wrapNodes",
       targetIds: nodeIds,
       autoLayout: false,
@@ -7684,11 +7781,11 @@ export default function DesignEditor() {
       }
     }
   }, [
-    activeContent,
     activeFile,
     applyLocalContentUpdate,
     canEditDesign,
     files,
+    getFreshActiveContent,
     selectedLayerIdsState,
     t,
   ]);
@@ -7696,12 +7793,13 @@ export default function DesignEditor() {
   // Unwrap the currently selected single-container layer.
   const handleUngroupSelection = useCallback(() => {
     if (!canEditDesign || !activeFile) return;
+    const baseContent = getFreshActiveContent();
     // Filter to active-file nodes only (mirrors handleGroupSelection fix).
     // A stale id from another file must not be passed to unwrap or it will
     // fail with "conflict" even though the actual selection is valid.
     const fileIds = new Set(files.map((f) => f.id));
     const activeNodeIdSet = buildActiveFileNodeIdSet(
-      buildCodeLayerProjection(activeContent),
+      buildCodeLayerProjection(baseContent),
     );
     const nodeIds = selectedLayerIdsState.filter(
       (id) =>
@@ -7709,7 +7807,7 @@ export default function DesignEditor() {
     );
     const targetId = nodeIds[0];
     if (!targetId) return;
-    const patch = applyVisualEdit(activeContent, {
+    const patch = applyVisualEdit(baseContent, {
       kind: "unwrap",
       targetId,
     });
@@ -7727,11 +7825,11 @@ export default function DesignEditor() {
     setSelectedElement(null);
     setSelectedLayerIdsState([]);
   }, [
-    activeContent,
     activeFile,
     applyLocalContentUpdate,
     canEditDesign,
     files,
+    getFreshActiveContent,
     selectedLayerIdsState,
     t,
   ]);
@@ -7748,7 +7846,8 @@ export default function DesignEditor() {
       opts?: { direction?: "row" | "column"; gap?: string },
     ) => {
       if (!canEditDesign || !activeFile) return;
-      const patch = applyVisualEdit(activeContent, {
+      const baseContent = getFreshActiveContent();
+      const patch = applyVisualEdit(baseContent, {
         kind: "autoLayout",
         targetId: targetNodeId,
         enabled: true,
@@ -7777,7 +7876,13 @@ export default function DesignEditor() {
         setSelectedElement(elementInfoFromCodeLayerNode(containerNode));
       }
     },
-    [activeContent, activeFile, applyLocalContentUpdate, canEditDesign, t],
+    [
+      activeFile,
+      applyLocalContentUpdate,
+      canEditDesign,
+      getFreshActiveContent,
+      t,
+    ],
   );
 
   /**
@@ -10090,10 +10195,11 @@ ${serializedHtml}
       ) {
         return;
       }
+      const freshActiveContent = getFreshActiveContent();
       const destFile = files.find((file) => file.id === targetOwner.fileId);
       const destContent =
         targetOwner.fileId === activeFile?.id
-          ? activeContent
+          ? freshActiveContent
           : (destFile?.content ?? "");
       if (!destContent) return;
 
@@ -10124,10 +10230,23 @@ ${serializedHtml}
         }
       }
 
+      const targetTreeForMove =
+        targetOwner.fileId === activeFile?.id
+          ? buildCodeLayerTree(buildCodeLayerProjection(freshActiveContent))
+          : targetOwner.tree;
+      const orderedSameFileDragIds = sortCodeLayerIdsByTreeOrder(
+        sameFileDragIds,
+        targetTreeForMove,
+      );
+      const movedIdOrder = [
+        ...orderedSameFileDragIds,
+        ...crossFileDrags.map((drag) => drag.draggedId),
+      ];
+
       // --- Same-file moves (existing path) ---
       let nextDestContent = destContent;
       let moved = false;
-      for (const draggedId of sameFileDragIds) {
+      for (const draggedId of orderedSameFileDragIds) {
         const patch = applyVisualEdit(nextDestContent, {
           kind: "moveNode",
           target: { nodeId: draggedId },
@@ -10158,7 +10277,7 @@ ${serializedHtml}
         const currentSourceContent = getLayerMoveSourceContent({
           sourceFileId,
           activeFileId: activeFile?.id,
-          activeContent,
+          activeContent: freshActiveContent,
           sourceFileContent: srcFile.content,
           sourceContentMap,
         });
@@ -10207,7 +10326,7 @@ ${serializedHtml}
       const finalDestTree = finalDestProjection
         ? buildCodeLayerTree(finalDestProjection)
         : [];
-      const movedNodesAfterMove = intent.draggedIds
+      const movedNodesAfterMove = movedIdOrder
         .map((draggedId) => movedNodeSnapshots.get(draggedId))
         .map((node) =>
           node && finalDestProjection
@@ -10249,14 +10368,14 @@ ${serializedHtml}
       }
     },
     [
-      activeContent,
       activeFile?.id,
       applyFileContentUpdate,
       canEditDesign,
       canMoveLayer,
       codeLayerOwnerByNodeId,
-      files,
       effectiveCodeLayerState,
+      files,
+      getFreshActiveContent,
       t,
     ],
   );
@@ -10406,7 +10525,7 @@ ${serializedHtml}
       const sourceFile = files.find((file) => file.id === owner.fileId);
       const sourceContent =
         owner.fileId === activeFile?.id
-          ? activeContent
+          ? getFreshActiveContent()
           : (sourceFile?.content ?? "");
       if (!sourceContent) return;
       const nextContent = setCodeLayerAttributeInHtml(
@@ -10422,12 +10541,12 @@ ${serializedHtml}
       setSelectedLayerIdsState([layerId]);
     },
     [
-      activeContent,
       activeFile?.id,
       applyFileContentUpdate,
       canEditDesign,
       codeLayerOwnerByNodeId,
       files,
+      getFreshActiveContent,
       queryClient,
       t,
       updateFileMutation,
@@ -10455,7 +10574,7 @@ ${serializedHtml}
       const sourceFile = files.find((file) => file.id === owner.fileId);
       const sourceContent =
         owner.fileId === activeFile?.id
-          ? activeContent
+          ? getFreshActiveContent()
           : (sourceFile?.content ?? "");
       if (!sourceContent) return;
       const nextContent = setCodeLayerAttributeInHtml(
@@ -10471,12 +10590,12 @@ ${serializedHtml}
       applyLockedState();
     },
     [
-      activeContent,
       activeFile?.id,
       applyFileContentUpdate,
       canEditDesign,
       codeLayerOwnerByNodeId,
       files,
+      getFreshActiveContent,
     ],
   );
 
@@ -10501,7 +10620,7 @@ ${serializedHtml}
       const sourceFile = files.find((file) => file.id === owner.fileId);
       const sourceContent =
         owner.fileId === activeFile?.id
-          ? activeContent
+          ? getFreshActiveContent()
           : (sourceFile?.content ?? "");
       if (!sourceContent) return;
       const nextContent = setCodeLayerAttributeInHtml(
@@ -10517,12 +10636,12 @@ ${serializedHtml}
       applyHiddenState();
     },
     [
-      activeContent,
       activeFile?.id,
       applyFileContentUpdate,
       canEditDesign,
       codeLayerOwnerByNodeId,
       files,
+      getFreshActiveContent,
     ],
   );
 


### PR DESCRIPTION
## Summary
- base rapid visual edits and layer moves on the freshest active HTML so drag/drop, duplicate, text, group, paste, and layer actions do not clobber each other
- reset content and geometry undo/redo stacks together when switching file/overview state
- fix Layers panel range anchors, keyboard traversal, and multi-layer drag ordering; sharpen inside-drop highlight corners

## Testing
- corepack pnpm --filter design exec vitest run app/pages/DesignEditor.selection.test.ts app/pages/undo-manager.test.ts app/components/design/LayersPanel.test.ts app/components/design/MultiScreenCanvas.primitives.test.ts app/components/design/DesignCanvas.spacing-overlay.test.ts app/components/design/EditPanel.gradient.test.ts app/components/design/inspector/fill-serialization.test.ts app/components/design/inspector/DesignColorPicker.modes.test.ts shared/code-layer.test.ts shared/pen-path.test.ts --reporter=dot
- corepack pnpm --filter design typecheck
- corepack pnpm --filter @agent-native/core exec vitest run src/server/auth.spec.ts --reporter=dot
- corepack pnpm prep

## Notes
- Narrow Design Playwright e2e was attempted, but the local Design dev server timed out during startup with Nitro/Vite dependency warnings before tests could run. The full prep gate passed afterward.