### PR TITLE
Assets image generation: reliable long runs, embedded text + brand ty…

### DIFF
--- a/.changeset/long-image-reconnect-timeout.md
+++ b/.changeset/long-image-reconnect-timeout.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Stop chat reconnect from falsely reporting "stopped before finishing" on long but healthy runs. The active-run reconnect now treats the stuck threshold as an idle deadline that resets on every streamed event, instead of a one-shot cap on total reconnect duration — so a long-running tool (e.g. image generation) that keeps emitting activity heartbeats is never aborted with a no-progress error just for running longer than the threshold. Also surfaces active tool progress while reconnecting, and waits for interrupted write-tool results before re-running them so long-running tools do not appear stopped or duplicate work.

--- a/packages/core/src/agent/production-agent-ledger.spec.ts
+++ b/packages/core/src/agent/production-agent-ledger.spec.ts
@@ -229,6 +229,78 @@ describe("tool-call result ledger", () => {
     );
   });
 
+  it("waits briefly for a late zombie ledger result before re-executing", async () => {
+    readLedgerMock
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce("late zombie result");
+
+    const action = makeWriteAction();
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine: singleToolEngine("save-data", { content: "slow" }),
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [
+        { role: "user", content: [{ type: "text", text: "save this" }] },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              id: "orig-late",
+              name: "save-data",
+              input: { content: "slow" },
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "orig-late",
+              toolName: "save-data",
+              toolInput: '{"content":"slow"}',
+              content: "Interrupted before this tool returned a result.",
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: `${AGENT_INTERNAL_CONTINUE_PROMPT}\n\nInternal note: retry`,
+            },
+          ],
+        },
+      ],
+      actions: { "save-data": action },
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+      threadId: "thread-late-zombie",
+    });
+
+    expect(readLedgerMock).toHaveBeenCalledTimes(2);
+    expect(action.run).not.toHaveBeenCalled();
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "activity",
+        tool: "save-data",
+        label: "Waiting for previous save-data result.",
+      }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_done",
+        tool: "save-data",
+        result: expect.stringContaining("late zombie result"),
+      }),
+    );
+  });
+
   it("returns a completed journal result without re-executing a write tool", async () => {
     currentTurnEventsMock.mockResolvedValue([
       {

--- a/packages/core/src/agent/production-agent-ledger.spec.ts
+++ b/packages/core/src/agent/production-agent-ledger.spec.ts
@@ -301,6 +301,74 @@ describe("tool-call result ledger", () => {
     );
   });
 
+  it("does not re-execute a write tool when the run is aborted during the ledger wait", async () => {
+    // Regression: waitForInterruptedToolLedgerEntry returns null both when no
+    // entry exists AND when the run is aborted mid-wait. The caller must not
+    // treat an aborted wait as a cache miss and start a fresh execution — that
+    // would spawn a duplicate zombie side effect (e.g. a second image
+    // generation / double charge). Abort the run while the ledger is being
+    // polled and assert the action never runs.
+    const controller = new AbortController();
+    readLedgerMock.mockImplementation(async () => {
+      controller.abort();
+      return null;
+    });
+
+    const action = makeWriteAction();
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine: singleToolEngine("save-data", { content: "aborted" }),
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [
+        { role: "user", content: [{ type: "text", text: "save this" }] },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              id: "orig-abort",
+              name: "save-data",
+              input: { content: "aborted" },
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "orig-abort",
+              toolName: "save-data",
+              toolInput: '{"content":"aborted"}',
+              content: "Interrupted before this tool returned a result.",
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: `${AGENT_INTERNAL_CONTINUE_PROMPT}\n\nInternal note: retry`,
+            },
+          ],
+        },
+      ],
+      actions: { "save-data": action },
+      send: (event) => events.push(event),
+      signal: controller.signal,
+      threadId: "thread-aborted-wait",
+    }).catch(() => {
+      // An aborted run may surface as a rejection depending on loop teardown;
+      // the invariant under test is simply that the action never executed.
+    });
+
+    expect(action.run).not.toHaveBeenCalled();
+  });
+
   it("returns a completed journal result without re-executing a write tool", async () => {
     currentTurnEventsMock.mockResolvedValue([
       {

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -2173,8 +2173,6 @@ function toolCallCacheKey(toolName: string, input: unknown): string {
 
 const INTERRUPTED_TOOL_LEDGER_POLL_MS =
   process.env.NODE_ENV === "test" ? 0 : 2_000;
-const INTERRUPTED_TOOL_LEDGER_MAX_WAIT_MS =
-  process.env.NODE_ENV === "test" ? 1 : 5 * 60_000;
 
 async function waitForInterruptedToolLedgerEntry(opts: {
   threadId: string;
@@ -2185,10 +2183,17 @@ async function waitForInterruptedToolLedgerEntry(opts: {
   send: (event: AgentChatEvent) => void;
 }): Promise<string | null> {
   const pollMs = INTERRUPTED_TOOL_LEDGER_POLL_MS;
-  const maxWaitMs = Math.max(
-    0,
-    Math.min(opts.timeoutMs, INTERRUPTED_TOOL_LEDGER_MAX_WAIT_MS),
-  );
+  // Wait up to the tool's OWN declared timeout — the abandoned zombie can keep
+  // running that long (e.g. a 12-minute image generation, whose provider keeps
+  // generating after the run aborts), and giving up early re-runs the same
+  // write tool while the original is still in flight, duplicating work and
+  // double-charging. A flat sub-tool-timeout cap (previously 5 min) silently
+  // truncated long tools. The run's AbortSignal still bounds this to the run's
+  // remaining budget: when the run is cut off, the poll returns null and the
+  // re-dispatch hits the already-aborted signal instead of launching a real
+  // second call, so the wait never outlives the run.
+  const maxWaitMs =
+    process.env.NODE_ENV === "test" ? 1 : Math.max(0, opts.timeoutMs);
   const maxPolls =
     process.env.NODE_ENV === "test"
       ? 3

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -3433,6 +3433,25 @@ export async function runAgentLoop(opts: {
         }
       }
 
+      // Stop BEFORE emitting tool_start if the run was already aborted —
+      // typically because the ledger wait above polled for minutes and the soft
+      // timeout fired meanwhile. Emitting tool_start/tool_done here would leave a
+      // bogus interrupted pair in the transcript for a tool that never re-ran,
+      // and re-invoking would spawn a duplicate zombie. Return the interrupted
+      // marker (no events) so the next continuation recovers via the ledger.
+      // (A second guard inside the try below still covers an abort that lands in
+      // the tiny sync window between here and the action invocation.)
+      if (signal.aborted) {
+        recordToolResult(INTERRUPTED_TOOL_RESULT_MARKER, false);
+        return {
+          type: "tool-result" as const,
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+          toolInput: wireToolInput,
+          content: INTERRUPTED_TOOL_RESULT_MARKER,
+        };
+      }
+
       send({
         type: "tool_start",
         tool: toolCall.name,

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -3502,6 +3502,16 @@ export async function runAgentLoop(opts: {
         | import("../mcp-client/app-result.js").AgentMcpAppPayload
         | undefined;
       try {
+        // The run may have been aborted while we waited above for an
+        // interrupted tool's ledger result (the wait can poll for minutes).
+        // Re-check before invoking the action: starting it now would spawn a
+        // fresh zombie execution — a duplicate side effect / double charge —
+        // which the ledger-recovery path exists to prevent. The Promise.race
+        // "Run aborted" leg below only rejects AFTER the action is invoked, so
+        // it cannot guard this. Throw here instead, handled like any abort.
+        if (signal.aborted) {
+          throw new Error("Run aborted");
+        }
         const timeoutSignal = AbortSignal.timeout(toolTimeoutMs);
         const actionUserEmail = opts.ownerEmail ?? getRequestUserEmail();
         const actionOrgId = opts.orgId ?? getRequestOrgId() ?? null;

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -2171,6 +2171,58 @@ function toolCallCacheKey(toolName: string, input: unknown): string {
   return `${toolName}:${stableStringify(normalizeToolCallInputForHistory(input))}`;
 }
 
+const INTERRUPTED_TOOL_LEDGER_POLL_MS =
+  process.env.NODE_ENV === "test" ? 0 : 2_000;
+const INTERRUPTED_TOOL_LEDGER_MAX_WAIT_MS =
+  process.env.NODE_ENV === "test" ? 1 : 5 * 60_000;
+
+async function waitForInterruptedToolLedgerEntry(opts: {
+  threadId: string;
+  toolKey: string;
+  toolName: string;
+  timeoutMs: number;
+  signal: AbortSignal;
+  send: (event: AgentChatEvent) => void;
+}): Promise<string | null> {
+  const pollMs = INTERRUPTED_TOOL_LEDGER_POLL_MS;
+  const maxWaitMs = Math.max(
+    0,
+    Math.min(opts.timeoutMs, INTERRUPTED_TOOL_LEDGER_MAX_WAIT_MS),
+  );
+  const maxPolls =
+    process.env.NODE_ENV === "test"
+      ? 3
+      : Math.max(1, Math.ceil(maxWaitMs / Math.max(1, pollMs)) + 1);
+
+  for (let attempt = 0; attempt < maxPolls; attempt++) {
+    if (opts.signal.aborted) return null;
+    const ledgerResult = await readLedgerEntry(opts.threadId, opts.toolKey);
+    if (ledgerResult !== null) return ledgerResult;
+
+    if (attempt >= maxPolls - 1) break;
+    opts.send({
+      type: "activity",
+      tool: opts.toolName,
+      label: `Waiting for previous ${opts.toolName} result.`,
+    });
+    if (pollMs <= 0) continue;
+    await new Promise<void>((resolve) => {
+      let settled = false;
+      const done = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        opts.signal.removeEventListener("abort", done);
+        resolve();
+      };
+      const timer = setTimeout(done, pollMs);
+      opts.signal.addEventListener("abort", done, { once: true });
+    });
+  }
+
+  return null;
+}
+
 function normalizeToolErrorForBreaker(error: string): string {
   return error.replace(/\s+/g, " ").trim();
 }
@@ -3241,6 +3293,17 @@ export async function runAgentLoop(opts: {
         };
       }
 
+      const DEFAULT_TOOL_RESULT_CHARS = 50_000;
+      const DEFAULT_TOOL_TIMEOUT_MS = 60_000;
+      const toolTimeoutMs =
+        actionEntry.timeoutMs ??
+        opts.toolLimits?.timeoutMs ??
+        DEFAULT_TOOL_TIMEOUT_MS;
+      const toolMaxResultChars =
+        actionEntry.maxResultChars ??
+        opts.toolLimits?.maxResultChars ??
+        DEFAULT_TOOL_RESULT_CHARS;
+
       // TOOL-CALL JOURNAL HARD-BLOCK (resume safety, tool-layer enforcement).
       // The prompt-level resume journal already TELLS a resuming model not to
       // re-run completed tool calls; this enforces it at the tool layer so a
@@ -3291,17 +3354,23 @@ export async function runAgentLoop(opts: {
       // previous invocation's zombie actually completed and wrote its result to
       // the durable ledger. If so, return the ledger result without re-executing
       // (prevents the duplicate side effect) and skip counting it toward the
-      // interruption budget.
+      // interruption budget. A just-abandoned long tool may need a short grace
+      // period before its detached promise writes the ledger, so wait while the
+      // current run still has budget instead of immediately re-running it.
       if (!actionEntry.readOnly) {
         const writeCacheKey = toolCallCacheKey(toolCall.name, toolCall.input);
         const priorInterruptions =
           writeToolInterruptions.get(writeCacheKey) ?? 0;
 
         if (priorInterruptions > 0 && opts.threadId) {
-          const ledgerResult = await readLedgerEntry(
-            opts.threadId,
-            writeCacheKey,
-          );
+          const ledgerResult = await waitForInterruptedToolLedgerEntry({
+            threadId: opts.threadId,
+            toolKey: writeCacheKey,
+            toolName: toolCall.name,
+            timeoutMs: toolTimeoutMs,
+            signal,
+            send,
+          });
           if (ledgerResult !== null) {
             // Zombie completed — recover the real result without re-executing.
             const result =
@@ -3427,16 +3496,6 @@ export async function runAgentLoop(opts: {
         };
       }
 
-      const DEFAULT_TOOL_RESULT_CHARS = 50_000;
-      const DEFAULT_TOOL_TIMEOUT_MS = 60_000;
-      const toolTimeoutMs =
-        actionEntry.timeoutMs ??
-        opts.toolLimits?.timeoutMs ??
-        DEFAULT_TOOL_TIMEOUT_MS;
-      const toolMaxResultChars =
-        actionEntry.maxResultChars ??
-        opts.toolLimits?.maxResultChars ??
-        DEFAULT_TOOL_RESULT_CHARS;
       let result: string;
       let isError = false;
       let mcpApp:

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -151,7 +151,10 @@ describe("waitForThreadRunToClear", () => {
     expect(labelSource.indexOf("runningActivityLabel")).toBeLessThan(
       labelSource.indexOf("isReconnecting"),
     );
-    expect(labelSource).toContain('"Working"');
+    // A bare reconnect (no replayed content) must default to "Thinking", never a
+    // perpetual "Working" — that label was removed.
+    expect(labelSource).not.toContain('"Working"');
+    expect(labelSource).toContain('"Thinking"');
   });
 });
 

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -167,7 +167,11 @@ describe("reconnectProgressTimedOut", () => {
     let lastProgressAt = 0;
     for (let now = 0; now <= 300_000; now += 8_000) {
       expect(
-        reconnectProgressTimedOut({ lastProgressAt, now, thresholdMs: threshold }),
+        reconnectProgressTimedOut({
+          lastProgressAt,
+          now,
+          thresholdMs: threshold,
+        }),
       ).toBe(false);
       lastProgressAt = now; // event arrived → markReconnectProgress()
     }

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -26,6 +26,7 @@ import {
   isAssistantUiRecoverableRenderError,
   isAssistantUiStaleIndexError,
   latestNonRecoveryUserMessageText,
+  reconnectProgressTimedOut,
   resolveAssistantChatSubmitIntent,
 } from "./AssistantChat.js";
 
@@ -114,6 +115,80 @@ describe("waitForThreadRunToClear", () => {
     expect(end).toBeGreaterThan(start);
     expect(helperSource).toContain("activeRunLooksStale(info)");
     expect(helperSource).not.toContain("heartbeatAt");
+  });
+
+  it("aborts the reconnect on an idle gap, not a fixed total duration", () => {
+    const source = readFileSync("src/client/AssistantChat.tsx", {
+      encoding: "utf8",
+    });
+    const start = source.indexOf("const startReconnectToRun = useCallback");
+    const end = source.indexOf("const reconnectActiveRunForThread");
+    const helperSource = source.slice(start, end);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    // The no-progress decision must be a sliding idle deadline that resets on
+    // streamed events — never a one-shot `setTimeout(..., THRESHOLD)` that caps
+    // total reconnect duration and falsely fails a healthy long run.
+    expect(helperSource).toContain("markReconnectProgress");
+    expect(helperSource).toContain("reconnectProgressTimedOut");
+    expect(helperSource).not.toContain(
+      "setTimeout(() => {\n        reconnectTimedOut = true;",
+    );
+    expect(helperSource).not.toContain("20_000");
+  });
+
+  it("shows active tool activity before falling back to reconnecting", () => {
+    const source = readFileSync("src/client/AssistantChat.tsx", {
+      encoding: "utf8",
+    });
+    const start = source.indexOf("const runningStatusLabel =");
+    const end = source.indexOf("const lastBroadcastRunningRef");
+    const labelSource = source.slice(start, end);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    expect(labelSource.indexOf("runningActivityLabel")).toBeLessThan(
+      labelSource.indexOf("isReconnecting"),
+    );
+    expect(labelSource).toContain('"Working"');
+  });
+});
+
+describe("reconnectProgressTimedOut", () => {
+  const threshold = 90_000;
+
+  it("never times out a run that keeps streaming heartbeats", () => {
+    // Simulate a long image generation that emits an activity heartbeat every
+    // 8s over 5 minutes of reconnect wall-clock. Each event resets the idle
+    // deadline, so the gap is always 8s — far under the 90s stuck threshold.
+    // A one-shot total-duration cap (the prior behaviour) would have fired at
+    // 90s and falsely surfaced `reconnect_no_progress`.
+    let lastProgressAt = 0;
+    for (let now = 0; now <= 300_000; now += 8_000) {
+      expect(
+        reconnectProgressTimedOut({ lastProgressAt, now, thresholdMs: threshold }),
+      ).toBe(false);
+      lastProgressAt = now; // event arrived → markReconnectProgress()
+    }
+  });
+
+  it("times out only after true silence for the full threshold", () => {
+    const lastProgressAt = 1_000;
+    expect(
+      reconnectProgressTimedOut({
+        lastProgressAt,
+        now: lastProgressAt + threshold - 1,
+        thresholdMs: threshold,
+      }),
+    ).toBe(false);
+    expect(
+      reconnectProgressTimedOut({
+        lastProgressAt,
+        now: lastProgressAt + threshold,
+        thresholdMs: threshold,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -230,6 +230,12 @@ const PENDING_SELECTION_KEY = "pending-selection-context";
 const ACTIVE_RUN_CLEAR_TIMEOUT_MS = 5_000;
 const ACTIVE_RUN_STUCK_THRESHOLD_MS = 90_000;
 const ACTIVE_RUN_POLL_INTERVAL_MS = 150;
+// How long a single activity (model call, tool prep, long tool) must stay
+// in-flight before its label is surfaced in the running indicator. Below this
+// the indicator stays a steady "Thinking" so normal fast turns don't flicker
+// through transient labels ("Contacting model", "Preparing X action"); past it
+// the live label appears so a genuinely slow step reads as working, not hung.
+const ACTIVITY_LABEL_REVEAL_DELAY_MS = 6_000;
 const SUBMIT_ENGINE_STATUS_TIMEOUT_MS = 1000;
 
 type ActiveRunLookup = {
@@ -1344,6 +1350,21 @@ const AssistantChatInner = forwardRef<
   const [runningActivityLabel, setRunningActivityLabel] = useState<
     string | null
   >(null);
+  // Delayed-reveal state for the activity label (see ACTIVITY_LABEL_REVEAL_DELAY_MS).
+  // `latest` holds the most recent activity label; `surfaced` flips true once the
+  // reveal timer fires; `timer` is the pending one-shot reveal.
+  const activityLabelTimerRef = useRef<number | null>(null);
+  const latestActivityLabelRef = useRef<string | null>(null);
+  const activityLabelSurfacedRef = useRef(false);
+  const resetRunningActivity = useCallback(() => {
+    if (activityLabelTimerRef.current !== null) {
+      window.clearTimeout(activityLabelTimerRef.current);
+      activityLabelTimerRef.current = null;
+    }
+    latestActivityLabelRef.current = null;
+    activityLabelSurfacedRef.current = false;
+    setRunningActivityLabel(null);
+  }, []);
   const [reconnectContent, setReconnectContent] = useState<ContentPart[]>([]);
   // When stop is clicked during reconnect, keep content visible (don't wipe it)
   const [reconnectFrozen, setReconnectFrozen] = useState(false);
@@ -1362,15 +1383,19 @@ const AssistantChatInner = forwardRef<
   const textStreaming = isRunning || externalStreaming;
   // UI-only running state — drives the stop button and thinking indicator.
   const showRunningInUI = isRunning;
+  // A revealed activity label wins; otherwise stay a steady "Thinking" by
+  // default. We only surface "Reconnecting" while we are actively replaying
+  // recovered content (reconnectContent populated). A bare reconnect with no
+  // replayed content — e.g. a tail-resume after the serverless wall, where
+  // `scheduleUpdate` intentionally leaves reconnectContent empty — is normal
+  // ongoing work, so it must read as "Thinking", never a perpetual "Working".
   const runningStatusLabel = runningActivityLabel
     ? runningActivityLabel
     : isAutoResuming
       ? "Resuming"
       : isReconnecting && reconnectContent.length > 0
         ? "Reconnecting"
-        : isReconnecting
-          ? "Working"
-          : "Thinking";
+        : "Thinking";
   const lastBroadcastRunningRef = useRef(isRunning);
   const tiptapRef = useRef<TiptapComposerHandle>(null);
   // Stable ref to the "stop active run" action so addToQueue can abort
@@ -2302,15 +2327,33 @@ const AssistantChatInner = forwardRef<
       if (tabId && detail?.tabId && detail.tabId !== tabId) return;
       const label =
         typeof detail?.label === "string" ? detail.label.trim() : "";
-      if (label) {
-        setIsAutoResuming(false);
+      if (!label) return;
+      setIsAutoResuming(false);
+      latestActivityLabelRef.current = label;
+      // Already past the delay → keep the visible label current.
+      if (activityLabelSurfacedRef.current) {
         setRunningActivityLabel(label);
+        return;
+      }
+      // Not yet surfaced → arm a single reveal timer on the FIRST activity of
+      // this in-flight period. A burst of quick steps that all finish (clear)
+      // before the timer fires never surfaces anything, so normal fast turns
+      // stay a steady "Thinking". A step still in-flight at the deadline reveals
+      // the latest label so a slow operation reads as working, not hung.
+      if (activityLabelTimerRef.current === null) {
+        activityLabelTimerRef.current = window.setTimeout(() => {
+          activityLabelTimerRef.current = null;
+          activityLabelSurfacedRef.current = true;
+          if (latestActivityLabelRef.current) {
+            setRunningActivityLabel(latestActivityLabelRef.current);
+          }
+        }, ACTIVITY_LABEL_REVEAL_DELAY_MS);
       }
     };
     const clear = (e: Event) => {
       const detail = (e as CustomEvent).detail as { tabId?: string };
       if (tabId && detail?.tabId && detail.tabId !== tabId) return;
-      setRunningActivityLabel(null);
+      resetRunningActivity();
     };
     window.addEventListener("agent-chat:activity", handler);
     window.addEventListener("agent-chat:activity-clear", clear);
@@ -2318,7 +2361,7 @@ const AssistantChatInner = forwardRef<
       window.removeEventListener("agent-chat:activity", handler);
       window.removeEventListener("agent-chat:activity-clear", clear);
     };
-  }, [tabId]);
+  }, [resetRunningActivity, tabId]);
 
   // Show "Resuming…" during the adapter's auto-continuation window (the
   // ~250ms gap between the end of one serverless chunk and the POST for the
@@ -2338,9 +2381,9 @@ const AssistantChatInner = forwardRef<
   useEffect(() => {
     if (!isRunning) {
       setIsAutoResuming(false);
-      setRunningActivityLabel(null);
+      resetRunningActivity();
     }
-  }, [isRunning]);
+  }, [isRunning, resetRunningActivity]);
 
   // Auto-dequeue: when the agent is idle, send the next queued message. This
   // intentionally does not depend on observing the running -> idle transition:

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -254,6 +254,24 @@ function activeRunLooksStale(runInfo: ActiveRunLookup): boolean {
   );
 }
 
+/**
+ * Decide whether a reconnect should give up with "no progress". The signal is
+ * *time since the last streamed event*, NOT total reconnect duration: a healthy
+ * long-running tool (e.g. image generation, which emits `activity` heartbeats
+ * every few seconds) makes continuous progress and must never be aborted just
+ * for running longer than the threshold. Only genuine silence for the full
+ * stuck threshold counts as stuck. Pure + exported so the decision is unit
+ * testable without driving the whole reconnect lifecycle.
+ */
+export function reconnectProgressTimedOut(args: {
+  lastProgressAt: number;
+  now: number;
+  thresholdMs?: number;
+}): boolean {
+  const threshold = args.thresholdMs ?? ACTIVE_RUN_STUCK_THRESHOLD_MS;
+  return args.now - args.lastProgressAt >= threshold;
+}
+
 function isAssistantUiDuplicateMessageIdError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error ?? "");
   return (
@@ -1323,6 +1341,9 @@ const AssistantChatInner = forwardRef<
   // True during the 250ms continuation window and startup of the next chunk
   // (adapter's auto-continue delay before POSTing the next chunk).
   const [isAutoResuming, setIsAutoResuming] = useState(false);
+  const [runningActivityLabel, setRunningActivityLabel] = useState<
+    string | null
+  >(null);
   const [reconnectContent, setReconnectContent] = useState<ContentPart[]>([]);
   // When stop is clicked during reconnect, keep content visible (don't wipe it)
   const [reconnectFrozen, setReconnectFrozen] = useState(false);
@@ -1341,6 +1362,15 @@ const AssistantChatInner = forwardRef<
   const textStreaming = isRunning || externalStreaming;
   // UI-only running state — drives the stop button and thinking indicator.
   const showRunningInUI = isRunning;
+  const runningStatusLabel = runningActivityLabel
+    ? runningActivityLabel
+    : isAutoResuming
+      ? "Resuming"
+      : isReconnecting && reconnectContent.length > 0
+        ? "Reconnecting"
+        : isReconnecting
+          ? "Working"
+          : "Thinking";
   const lastBroadcastRunningRef = useRef(isRunning);
   const tiptapRef = useRef<TiptapComposerHandle>(null);
   // Stable ref to the "stop active run" action so addToQueue can abort
@@ -1608,11 +1638,32 @@ const AssistantChatInner = forwardRef<
       }, 1000);
 
       let reconnectTimedOut = false;
-      const maxReconnectTimer = setTimeout(() => {
+      // Idle deadline, NOT a total-duration cap. A long-but-healthy run (image
+      // generation emits `activity` heartbeats every few seconds) keeps
+      // advancing `lastReconnectProgressAt`, so it is never aborted for simply
+      // taking longer than the threshold. Only true silence for the full stuck
+      // threshold trips it — the same semantics as `activeRunLooksStale` and the
+      // SSE-level no-progress timeout. `markReconnectProgress` resets it on every
+      // streamed event (see the `onSeq` callback below, which fires for every
+      // event including activity, for both fresh and tail-resume reconnects).
+      let lastReconnectProgressAt = Date.now();
+      const markReconnectProgress = () => {
+        lastReconnectProgressAt = Date.now();
+      };
+      const idleCheck = setInterval(() => {
+        if (
+          !reconnectProgressTimedOut({
+            lastProgressAt: lastReconnectProgressAt,
+            now: Date.now(),
+          })
+        ) {
+          return;
+        }
         reconnectTimedOut = true;
         abortCtrl.abort();
         clearInterval(watchdog);
-      }, 20_000);
+        clearInterval(idleCheck);
+      }, 1000);
 
       const streamReconnect = async () => {
         let noProgressDuringReconnect = false;
@@ -1653,7 +1704,10 @@ const AssistantChatInner = forwardRef<
               toolCallCounter,
               tabId,
               scheduleUpdate,
-              (seq) => updateActiveRunSeq(seq),
+              (seq) => {
+                markReconnectProgress();
+                updateActiveRunSeq(seq);
+              },
             );
             if (afterSeq === 0) {
               setReconnectContent([...content]);
@@ -1677,7 +1731,7 @@ const AssistantChatInner = forwardRef<
             window.clearInterval(threadPollInterval);
           }
           clearInterval(watchdog);
-          clearTimeout(maxReconnectTimer);
+          clearInterval(idleCheck);
         }
 
         if (noProgressDuringReconnect && reconnectRunIdRef.current === runId) {
@@ -2235,11 +2289,9 @@ const AssistantChatInner = forwardRef<
     return () => window.removeEventListener("agent-chat:run-error", handler);
   }, [tabId]);
 
-  // Real activity means the next chunk has started — leave the auto-resume
-  // ("Resuming") state so the indicator settles back to "Thinking". The
-  // activity label itself is intentionally not surfaced: the running
-  // indicator stays a steady "Thinking" rather than flipping through
-  // transient step labels.
+  // Real activity means the next chunk has started. Surface longer-lived
+  // activity such as "Still generating image" so active-run reconnects do not
+  // look like failures while the server is still making progress.
   useEffect(() => {
     const handler = (e: Event) => {
       const detail = (e as CustomEvent).detail as {
@@ -2248,12 +2300,24 @@ const AssistantChatInner = forwardRef<
         tabId?: string;
       };
       if (tabId && detail?.tabId && detail.tabId !== tabId) return;
-      if (typeof detail?.label === "string" && detail.label.trim()) {
+      const label =
+        typeof detail?.label === "string" ? detail.label.trim() : "";
+      if (label) {
         setIsAutoResuming(false);
+        setRunningActivityLabel(label);
       }
     };
+    const clear = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { tabId?: string };
+      if (tabId && detail?.tabId && detail.tabId !== tabId) return;
+      setRunningActivityLabel(null);
+    };
     window.addEventListener("agent-chat:activity", handler);
-    return () => window.removeEventListener("agent-chat:activity", handler);
+    window.addEventListener("agent-chat:activity-clear", clear);
+    return () => {
+      window.removeEventListener("agent-chat:activity", handler);
+      window.removeEventListener("agent-chat:activity-clear", clear);
+    };
   }, [tabId]);
 
   // Show "Resuming…" during the adapter's auto-continuation window (the
@@ -2274,6 +2338,7 @@ const AssistantChatInner = forwardRef<
   useEffect(() => {
     if (!isRunning) {
       setIsAutoResuming(false);
+      setRunningActivityLabel(null);
     }
   }, [isRunning]);
 
@@ -3336,18 +3401,7 @@ const AssistantChatInner = forwardRef<
                           <ReconnectStreamMessage content={reconnectContent} />
                         )}
                       {showRunningInUI && (
-                        <RunningActivityStatus
-                          label={
-                            isReconnecting
-                              ? "Reconnecting"
-                              : isAutoResuming
-                                ? "Resuming"
-                                : // Keep a steady "Thinking" while the model works —
-                                  // never flip through transient activity labels
-                                  // (e.g. "Contacting model", "Preparing X action").
-                                  "Thinking"
-                          }
-                        />
+                        <RunningActivityStatus label={runningStatusLabel} />
                       )}
                       {queuedMessages.map((msg) => {
                         const displayText = msg.text

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -1137,3 +1137,69 @@ describe("SSE event processor tool id matching", () => {
     });
   });
 });
+
+describe("SSE event processor activity-label clearing", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const stubWindow = () => {
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+    return dispatchEvent;
+  };
+
+  it("clears the running activity label when a tool finishes", async () => {
+    const dispatchEvent = stubWindow();
+    await drain(
+      readSSEStream(
+        eventStream([
+          { type: "tool_start", tool: "generate-image", input: {} },
+          { type: "tool_done", tool: "generate-image", result: "ok" },
+          { type: "done" },
+        ]),
+        [],
+        { value: 0 },
+        "tab-clear-tool",
+      ),
+    );
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "agent-chat:activity-clear",
+        detail: { tabId: "tab-clear-tool" },
+      }),
+    );
+  });
+
+  it("clears the running activity label when visible text streams", async () => {
+    const dispatchEvent = stubWindow();
+    await drain(
+      readSSEStream(
+        eventStream([
+          { type: "text", text: "Here is your answer." },
+          { type: "done" },
+        ]),
+        [],
+        { value: 0 },
+        "tab-clear-text",
+      ),
+    );
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "agent-chat:activity-clear",
+        detail: { tabId: "tab-clear-text" },
+      }),
+    );
+  });
+});

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -352,6 +352,11 @@ export function processEvent(
   }
 
   if (ev.type === "text") {
+    // Visible output means the run is plainly not hanging — drop any running
+    // activity label so a transient "Contacting model" / "Still generating
+    // image" doesn't linger beside streamed text. Idempotent (clears once, then
+    // no-ops) so per-token text deltas stay cheap.
+    if (ev.text) dispatchActivityClear(tabId);
     const lastPart = content[content.length - 1];
     if (lastPart && lastPart.type === "text") {
       lastPart.text += ev.text ?? "";
@@ -492,6 +497,10 @@ export function processEvent(
         }),
       );
     }
+    // Clear any sticky running-activity label (e.g. "Still generating image"):
+    // the tool that was emitting activity heartbeats has finished, so the label
+    // must not linger while the model streams its follow-up text or reasoning.
+    dispatchActivityClear(tabId);
     // Use id-based lookup when available so parallel same-name tool calls
     // get their results correctly assigned; fall back to name-matching.
     const doneIdx = findPendingToolCallIndex(content, doneTool, ev.id);

--- a/templates/assets/.agents/skills/image-generation/SKILL.md
+++ b/templates/assets/.agents/skills/image-generation/SKILL.md
@@ -15,8 +15,15 @@ Use this skill before calling `generate-image`, `generate-image-batch`, or
   `presetId`, and `media-type` references choose image generation versus video
   generation. Call `view-screen` when the user says "this library" or "this
   image" and you need fresh IDs. The image model may default from the composer
-  image-model picker; all other generation settings should be explicit action
-  args, preset values, or action schema defaults.
+  image-model picker.
+- A tagged `@preset` (presetId) owns `aspectRatio`, `imageSize`, `model`,
+  `tier`, and `category`. When a preset is set, do NOT pass those args yourself —
+  leave them out so the preset's saved values are used. You cannot see the
+  preset's settings from the presetId, so passing your own guess silently
+  overrides the preset (this is the usual cause of a preset's aspect ratio being
+  ignored). Pass one of these args alongside a preset ONLY when the user
+  explicitly asks for a value that differs from the preset. When there is no
+  preset, set them explicitly or rely on the action schema defaults.
 - Use category-tagged references. Blog heroes should prefer `hero`; diagrams
   should prefer `diagram`; product imagery should include `product` and `logo`
   references.

--- a/templates/assets/AGENTS.md
+++ b/templates/assets/AGENTS.md
@@ -47,6 +47,10 @@ prompt, aspectRatio }`.
   composer is empty. The image model is the only remaining composer-side
   default; the image-model picker writes `imageGenerationModel`, which image
   generation actions may use when `model` is omitted.
+- For exact visible copy inside a generated image, pass `embeddedText` and
+  optional `textPlacement` to `generate-image` or each `generate-image-batch`
+  slot. Keep the general `prompt` for creative direction; the structured text
+  fields are what allow the pipeline to render copy instead of suppressing it.
 - `asset-variants` is the shared live generation tray state. New image
   candidates should appear there through `generate-image` or
   `generate-image-batch`; do not invent page-local progress surfaces.

--- a/templates/assets/actions/_tool-activity.spec.ts
+++ b/templates/assets/actions/_tool-activity.spec.ts
@@ -48,6 +48,31 @@ describe("withToolActivity", () => {
     expect(send).toHaveBeenCalledTimes(3);
   });
 
+  it("tags activity with the dispatched tool (actionName) when no tool is given", async () => {
+    // Regression: generate-image runs as a sub-step of generate-image-batch /
+    // rerun-generation-run, which forward their own context. With no explicit
+    // `tool`, the heartbeat must be tagged with the PARENT's actionName so it
+    // matches the real tool_start card instead of spawning an orphan
+    // "generate-image" activity card on the client.
+    const send = vi.fn();
+
+    await withToolActivity(
+      {
+        caller: "tool",
+        actionName: "generate-image-batch",
+        send,
+      },
+      { label: "Generating image." },
+      () => Promise.resolve("done"),
+    );
+
+    expect(send).toHaveBeenCalledWith({
+      type: "activity",
+      label: "Generating image.",
+      tool: "generate-image-batch",
+    });
+  });
+
   it("does not emit activity for frontend calls", async () => {
     const send = vi.fn();
 

--- a/templates/assets/actions/_tool-activity.spec.ts
+++ b/templates/assets/actions/_tool-activity.spec.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { withToolActivity } from "./_tool-activity.js";
+
+describe("withToolActivity", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("emits initial and periodic activity for agent tool calls", async () => {
+    vi.useFakeTimers();
+    const send = vi.fn();
+    const work = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          setTimeout(() => resolve("done"), 2_500);
+        }),
+    );
+
+    const resultPromise = withToolActivity(
+      {
+        caller: "tool",
+        actionName: "generate-image",
+        send,
+      },
+      {
+        label: "Generating image.",
+        ongoingLabel: "Still generating image.",
+        intervalMs: 1_000,
+      },
+      work,
+    );
+
+    expect(send).toHaveBeenCalledWith({
+      type: "activity",
+      label: "Generating image.",
+      tool: "generate-image",
+    });
+
+    await vi.advanceTimersByTimeAsync(2_500);
+    await expect(resultPromise).resolves.toBe("done");
+
+    expect(send).toHaveBeenCalledWith({
+      type: "activity",
+      label: "Still generating image.",
+      tool: "generate-image",
+    });
+    expect(send).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not emit activity for frontend calls", async () => {
+    const send = vi.fn();
+
+    await expect(
+      withToolActivity(
+        {
+          caller: "frontend",
+          send,
+        } as any,
+        { label: "Generating image.", intervalMs: 1 },
+        async () => "done",
+      ),
+    ).resolves.toBe("done");
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("emits default progress before chat reconnect can look idle", async () => {
+    vi.useFakeTimers();
+    const send = vi.fn();
+    const resultPromise = withToolActivity(
+      {
+        caller: "tool",
+        actionName: "generate-image",
+        send,
+      },
+      { label: "Generating image." },
+      () =>
+        new Promise<string>((resolve) => {
+          setTimeout(() => resolve("done"), 8_500);
+        }),
+    );
+
+    await vi.advanceTimersByTimeAsync(7_999);
+    expect(send).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(send).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(resultPromise).resolves.toBe("done");
+  });
+
+  it("keeps emitting progress after the run signal aborts", async () => {
+    vi.useFakeTimers();
+    const send = vi.fn();
+    const controller = new AbortController();
+    const resultPromise = withToolActivity(
+      {
+        caller: "tool",
+        actionName: "generate-image",
+        send,
+        signal: controller.signal,
+      },
+      { label: "Generating image.", intervalMs: 1_000 },
+      () =>
+        new Promise<string>((resolve) => {
+          setTimeout(() => resolve("done"), 1_500);
+        }),
+    );
+
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(send).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(resultPromise).resolves.toBe("done");
+  });
+});

--- a/templates/assets/actions/_tool-activity.ts
+++ b/templates/assets/actions/_tool-activity.ts
@@ -1,0 +1,46 @@
+import type { ActionRunContext } from "@agent-native/core/action";
+
+const DEFAULT_TOOL_ACTIVITY_INTERVAL_MS = 8_000;
+
+type ToolActivityOptions = {
+  label: string;
+  ongoingLabel?: string;
+  intervalMs?: number;
+  tool?: string;
+};
+
+function canEmitToolActivity(
+  context: ActionRunContext | undefined,
+): context is ActionRunContext & Required<Pick<ActionRunContext, "send">> {
+  return context?.caller === "tool" && typeof context.send === "function";
+}
+
+export async function withToolActivity<T>(
+  context: ActionRunContext | undefined,
+  options: ToolActivityOptions,
+  work: () => Promise<T>,
+): Promise<T> {
+  if (!canEmitToolActivity(context)) return work();
+
+  const tool = options.tool ?? context.actionName;
+  const sendActivity = (label: string) => {
+    context.send({
+      type: "activity",
+      label,
+      ...(tool ? { tool } : {}),
+    });
+  };
+
+  sendActivity(options.label);
+  const interval = setInterval(
+    () => sendActivity(options.ongoingLabel ?? options.label),
+    options.intervalMs ?? DEFAULT_TOOL_ACTIVITY_INTERVAL_MS,
+  );
+  interval.unref?.();
+
+  try {
+    return await work();
+  } finally {
+    clearInterval(interval);
+  }
+}

--- a/templates/assets/actions/generate-image-batch.spec.ts
+++ b/templates/assets/actions/generate-image-batch.spec.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const assertAccessMock = vi.hoisted(() => vi.fn());
 const requireGenerationSessionInLibraryMock = vi.hoisted(() => vi.fn());
-const readImageModelDefaultMock = vi.hoisted(() => vi.fn());
 const generateImageRunMock = vi.hoisted(() => vi.fn());
 const upsertVariantSlotMock = vi.hoisted(() => vi.fn());
 const getDbMock = vi.hoisted(() => vi.fn());
@@ -36,10 +35,6 @@ vi.mock("./_helpers.js", () => ({
   requireGenerationSessionInLibrary: requireGenerationSessionInLibraryMock,
 }));
 
-vi.mock("./_image-model-default.js", () => ({
-  readImageModelDefault: readImageModelDefaultMock,
-}));
-
 vi.mock("./generate-image.js", () => ({
   default: {
     run: generateImageRunMock,
@@ -66,7 +61,6 @@ describe("generate-image-batch", () => {
     requireGenerationSessionInLibraryMock.mockResolvedValue({
       id: "session-1",
     });
-    readImageModelDefaultMock.mockResolvedValue(undefined);
     generateImageRunMock.mockResolvedValue({ assetId: "asset-1" });
     upsertVariantSlotMock.mockResolvedValue(undefined);
     getDbMock.mockReturnValue(createDb());
@@ -157,6 +151,29 @@ describe("generate-image-batch", () => {
         variantScopeId: "picker:tab-1",
         dismissible: false,
         activateSessionAsset: false,
+      }),
+      undefined,
+    );
+  });
+
+  it("forwards exact embedded text controls per slot", async () => {
+    await action.run({
+      libraryId: "lib-1",
+      slots: [
+        {
+          slotId: "slot-1",
+          prompt: "Generate a cafe poster",
+          embeddedText: "Bean & Brew",
+          textPlacement: "centered headline",
+        },
+      ],
+    });
+
+    expect(generateImageRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        slotId: "slot-1",
+        embeddedText: "Bean & Brew",
+        textPlacement: "centered headline",
       }),
       undefined,
     );

--- a/templates/assets/actions/generate-image-batch.ts
+++ b/templates/assets/actions/generate-image-batch.ts
@@ -18,7 +18,6 @@ import {
   STYLE_STRENGTHS,
 } from "../shared/api.js";
 import { requireGenerationSessionInLibrary } from "./_helpers.js";
-import { readImageModelDefault } from "./_image-model-default.js";
 import generateImage from "./generate-image.js";
 import { upsertVariantSlot } from "./variant-slots.js";
 
@@ -35,14 +34,36 @@ export default defineAction({
         "Brand kit/library ID. Pass the refId from a brand-kit @mention, or choose a kit from view-screen/list-libraries.",
       ),
     collectionId: z.string().optional(),
-    presetId: z.string().optional(),
+    presetId: z
+      .string()
+      .optional()
+      .describe(
+        "Generation preset ID (from a @preset mention or list-generation-presets). The preset already defines aspectRatio, imageSize, model, tier, and category. When you set presetId, OMIT each slot's aspectRatio/imageSize and the top-level model/tier so the preset's values are used; only pass one when the user explicitly asks for a value that differs from the preset.",
+      ),
     sessionId: z.string().optional(),
     slots: z
       .array(
         z.object({
           slotId: z.string(),
           prompt: z.string().min(1),
-          aspectRatio: z.enum(ASPECT_RATIOS).optional(),
+          embeddedText: z
+            .string()
+            .optional()
+            .describe(
+              "Exact words to render inside the image, spelled exactly. When set, the image is allowed to contain this text; when omitted, the image avoids embedded text.",
+            ),
+          textPlacement: z
+            .string()
+            .optional()
+            .describe(
+              "Where/how the embedded text should appear, e.g. 'centered headline', 'lower-left label'.",
+            ),
+          aspectRatio: z
+            .enum(ASPECT_RATIOS)
+            .optional()
+            .describe(
+              "Slot aspect ratio. When a presetId is set, omit this — the preset's aspect ratio is used unless the user explicitly asks for a different ratio for this slot.",
+            ),
           imageSize: z.enum(IMAGE_SIZES).optional(),
           categories: z.array(z.enum(IMAGE_CATEGORIES)).optional(),
           referenceAssetIds: z.array(z.string()).optional(),
@@ -78,7 +99,6 @@ export default defineAction({
   parallelSafe: true,
   timeoutMs: IMAGE_GENERATION_TOOL_TIMEOUT_MS,
   run: async ({ slots, ...inputBase }, context?: ActionRunContext) => {
-    const imageModelDefault = await readImageModelDefault();
     const libraryId = inputBase.libraryId;
     if (!libraryId) {
       throw new Error(
@@ -88,7 +108,6 @@ export default defineAction({
     const base = {
       ...inputBase,
       libraryId,
-      model: inputBase.model ?? imageModelDefault,
     };
     await assertAccess("asset-library", base.libraryId, "editor");
     if (base.sessionId) {
@@ -123,6 +142,8 @@ export default defineAction({
               presetId: base.presetId,
               sessionId: base.sessionId,
               prompt: slot.prompt,
+              embeddedText: slot.embeddedText,
+              textPlacement: slot.textPlacement,
               aspectRatio: slot.aspectRatio,
               imageSize: slot.imageSize,
               model: base.model,

--- a/templates/assets/actions/generate-image.ts
+++ b/templates/assets/actions/generate-image.ts
@@ -21,6 +21,7 @@ import {
   DEFAULT_GENERATION_REFERENCE_LIMIT,
   generateWithManagedImageProvider,
   isImageGenerationSetupError,
+  resolveImageModelForRequest,
   selectReferences,
 } from "../server/lib/generation.js";
 import { compositeLogo } from "../server/lib/image-processing.js";
@@ -35,7 +36,6 @@ import {
   IMAGE_SIZES,
   STYLE_STRENGTHS,
   type ImageCategory,
-  type ImageModel,
   type ImageQualityTier,
   type StyleBrief,
 } from "../shared/api.js";
@@ -44,21 +44,10 @@ import {
   serializeAsset,
 } from "./_helpers.js";
 import { readImageModelDefault } from "./_image-model-default.js";
+import { withToolActivity } from "./_tool-activity.js";
 import { upsertVariantSlot, wasVariantSlotDismissed } from "./variant-slots.js";
 
 const IMAGE_GENERATION_TOOL_TIMEOUT_MS = 12 * 60_000;
-
-function resolveModelForTier(
-  tier: ImageQualityTier | undefined,
-  category: ImageCategory | undefined,
-): ImageModel | undefined {
-  if (!tier) return undefined;
-  if (tier === "fast") return "gemini-3.1-flash-image";
-  if (tier === "best") return "gemini-3-pro-image";
-  return ["hero", "landing", "logo", "campaign"].includes(category ?? "")
-    ? "gemini-3-pro-image"
-    : "gemini-3.1-flash-image";
-}
 
 export default defineAction({
   description:
@@ -71,11 +60,38 @@ export default defineAction({
         "Brand kit/library ID. Pass the refId from a brand-kit @mention, or choose a kit from view-screen/list-libraries.",
       ),
     collectionId: z.string().optional(),
-    presetId: z.string().optional(),
+    presetId: z
+      .string()
+      .optional()
+      .describe(
+        "Generation preset ID (from a @preset mention or list-generation-presets). A preset already defines aspectRatio, imageSize, model, tier, and category. When you set presetId, OMIT those args so the preset's values are used; only pass one of them when the user explicitly asks for a value that differs from the preset.",
+      ),
     sessionId: z.string().optional(),
     prompt: z.string().min(1),
-    aspectRatio: z.enum(ASPECT_RATIOS).optional(),
-    imageSize: z.enum(IMAGE_SIZES).optional(),
+    embeddedText: z
+      .string()
+      .optional()
+      .describe(
+        "Exact words to render inside the image, spelled exactly. When set, the image is allowed to contain this text; when omitted, the image avoids embedded text.",
+      ),
+    textPlacement: z
+      .string()
+      .optional()
+      .describe(
+        "Where/how the embedded text should appear, e.g. 'centered headline', 'lower-left label'.",
+      ),
+    aspectRatio: z
+      .enum(ASPECT_RATIOS)
+      .optional()
+      .describe(
+        "Image aspect ratio. When a presetId is set, omit this — the preset's aspect ratio is used. Pass a value only when there is no preset, or when the user explicitly asks for a ratio different from the preset's.",
+      ),
+    imageSize: z
+      .enum(IMAGE_SIZES)
+      .optional()
+      .describe(
+        "Output resolution tier. When a presetId is set, omit this — the preset's size is used unless the user explicitly requests a different one.",
+      ),
     model: z.enum(IMAGE_MODELS).optional(),
     tier: z.enum(IMAGE_QUALITY_TIERS).optional(),
     intent: z.enum(GENERATION_INTENTS).default("generate"),
@@ -251,11 +267,15 @@ export default defineAction({
     const category = (args.categories?.[0] ??
       preset?.category ??
       collection?.category) as ImageCategory | undefined;
-    const resolvedModel = (args.model ??
-      imageModelDefault ??
-      resolveModelForTier(resolvedTier, category) ??
-      preset?.model ??
-      "gemini-3.1-flash-image") as (typeof IMAGE_MODELS)[number];
+    const resolvedModel = resolveImageModelForRequest({
+      explicitModel: args.model,
+      imageModelDefault,
+      explicitTier: args.tier,
+      resolvedTier,
+      category,
+      presetModel: preset?.model as (typeof IMAGE_MODELS)[number] | undefined,
+      embeddedText: args.embeddedText,
+    }) as (typeof IMAGE_MODELS)[number];
     const resolvedCategories =
       args.categories ??
       (preset?.category ? ([preset.category] as any) : undefined);
@@ -297,6 +317,8 @@ export default defineAction({
         .filter((item) => item?.trim())
         .join("\n\n"),
       prompt: promptForRun,
+      embeddedText: args.embeddedText,
+      textPlacement: args.textPlacement,
       referenceCount: references.length,
       includeLogo: args.includeLogo,
       aspectRatio: resolvedAspectRatio,
@@ -346,6 +368,8 @@ export default defineAction({
       collectionId: resolvedCollectionId ?? null,
       presetId: preset?.id ?? null,
       sessionId: session?.id ?? null,
+      embeddedText: args.embeddedText ?? null,
+      textPlacement: args.textPlacement ?? null,
       customInstructions: library.customInstructions ?? "",
     };
     const dismissibleSlot = args.dismissible !== false && Boolean(slotId);
@@ -357,6 +381,8 @@ export default defineAction({
       dismissible: dismissibleSlot,
       sourceAssetId: args.sourceAssetId,
       subjectAssetId: args.subjectAssetId,
+      embeddedText: args.embeddedText,
+      textPlacement: args.textPlacement,
       intent: args.intent,
       styleStrength: args.styleStrength,
       tier: resolvedTier,
@@ -404,22 +430,31 @@ export default defineAction({
     });
 
     try {
-      const generated = await generateWithManagedImageProvider({
-        prompt: promptForRun,
-        compiledPrompt,
-        references,
-        model: resolvedModel,
-        aspectRatio: resolvedAspectRatio,
-        imageSize: resolvedImageSize,
-        groundingMode: args.groundingMode,
-        intent: args.intent,
-        styleStrength: args.styleStrength,
-        runId,
-        libraryId: args.libraryId,
-        collectionId: resolvedCollectionId ?? null,
-        source: args.source,
-        callerAppId: args.callerAppId,
-      });
+      const generated = await withToolActivity(
+        context,
+        {
+          label: "Generating image.",
+          ongoingLabel: "Still generating image.",
+          tool: "generate-image",
+        },
+        () =>
+          generateWithManagedImageProvider({
+            prompt: promptForRun,
+            compiledPrompt,
+            references,
+            model: resolvedModel,
+            aspectRatio: resolvedAspectRatio,
+            imageSize: resolvedImageSize,
+            groundingMode: args.groundingMode,
+            intent: args.intent,
+            styleStrength: args.styleStrength,
+            runId,
+            libraryId: args.libraryId,
+            collectionId: resolvedCollectionId ?? null,
+            source: args.source,
+            callerAppId: args.callerAppId,
+          }),
+      );
       await deleteAppState("image-generation-setup").catch(() => {});
       let image = generated.image;
       let mimeType = generated.mimeType;
@@ -468,37 +503,46 @@ export default defineAction({
           Artifacts: [],
         };
       }
-      const asset = await createAssetFromBuffer({
-        libraryId: args.libraryId,
-        collectionId: resolvedCollectionId ?? null,
-        buffer: image,
-        mimeType,
-        role: "generated",
-        status: "candidate",
-        prompt: args.prompt,
-        model: generated.model,
-        aspectRatio: resolvedAspectRatio,
-        imageSize: resolvedImageSize,
-        generationRunId: runId,
-        metadata: {
-          provider: generated.provider,
-          compiledPrompt,
-          referenceAssetIds: references.map((ref) => ref.id),
-          sourceAssetId: args.sourceAssetId,
-          subjectAssetId: args.subjectAssetId,
-          intent: args.intent,
-          styleStrength: args.styleStrength,
-          tier: resolvedTier,
-          includeLogo: args.includeLogo,
-          presetId: preset?.id,
-          sessionId: session?.id,
-          generated: true,
-          sourceUrl: generated.sourceUrl,
-          providerGenerationId: generated.providerGenerationId,
-          creditsCharged: generated.creditsCharged,
+      const asset = await withToolActivity(
+        context,
+        {
+          label: "Saving generated image.",
+          ongoingLabel: "Still saving generated image.",
+          tool: "generate-image",
         },
-        category,
-      });
+        () =>
+          createAssetFromBuffer({
+            libraryId: args.libraryId,
+            collectionId: resolvedCollectionId ?? null,
+            buffer: image,
+            mimeType,
+            role: "generated",
+            status: "candidate",
+            prompt: args.prompt,
+            model: generated.model,
+            aspectRatio: resolvedAspectRatio,
+            imageSize: resolvedImageSize,
+            generationRunId: runId,
+            metadata: {
+              provider: generated.provider,
+              compiledPrompt,
+              referenceAssetIds: references.map((ref) => ref.id),
+              sourceAssetId: args.sourceAssetId,
+              subjectAssetId: args.subjectAssetId,
+              intent: args.intent,
+              styleStrength: args.styleStrength,
+              tier: resolvedTier,
+              includeLogo: args.includeLogo,
+              presetId: preset?.id,
+              sessionId: session?.id,
+              generated: true,
+              sourceUrl: generated.sourceUrl,
+              providerGenerationId: generated.providerGenerationId,
+              creditsCharged: generated.creditsCharged,
+            },
+            category,
+          }),
+      );
       if (session) {
         const itemCreatedAt = nowIso();
         await db.insert(schema.assetGenerationSessionItems).values({

--- a/templates/assets/actions/generate-image.ts
+++ b/templates/assets/actions/generate-image.ts
@@ -435,7 +435,12 @@ export default defineAction({
         {
           label: "Generating image.",
           ongoingLabel: "Still generating image.",
-          tool: "generate-image",
+          // Intentionally no explicit `tool`: withToolActivity falls back to
+          // context.actionName, which is the ACTUAL dispatched tool. When this
+          // action is invoked directly that is "generate-image"; when it runs as
+          // a sub-step of generate-image-batch / rerun-generation-run it is the
+          // parent tool, so the activity event matches the real tool_start card
+          // instead of spawning an orphan "generate-image" activity card.
         },
         () =>
           generateWithManagedImageProvider({
@@ -508,7 +513,9 @@ export default defineAction({
         {
           label: "Saving generated image.",
           ongoingLabel: "Still saving generated image.",
-          tool: "generate-image",
+          // See above: omit `tool` so the activity is tagged with the real
+          // dispatched tool (context.actionName) rather than a hardcoded
+          // "generate-image" that orphans under batch/rerun.
         },
         () =>
           createAssetFromBuffer({

--- a/templates/assets/actions/rerun-generation-run.ts
+++ b/templates/assets/actions/rerun-generation-run.ts
@@ -1,4 +1,5 @@
 import { defineAction } from "@agent-native/core";
+import type { ActionRunContext } from "@agent-native/core/action";
 import { assertAccess } from "@agent-native/core/sharing";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
@@ -30,7 +31,10 @@ export default defineAction({
       ),
   }),
   parallelSafe: true,
-  run: async ({ runId, slotId, sessionId, source, callerAppId }) => {
+  run: async (
+    { runId, slotId, sessionId, source, callerAppId },
+    context?: ActionRunContext,
+  ) => {
     const db = getDb();
     const [run] = await db
       .select()
@@ -68,43 +72,48 @@ export default defineAction({
     const categories =
       metadata.settingsUsed?.categories ?? metadata.categories ?? undefined;
 
-    return generateImage.run({
-      libraryId: run.libraryId,
-      collectionId: run.collectionId ?? undefined,
-      presetId: run.presetId ?? undefined,
-      sessionId: resolvedSessionId,
-      prompt: run.prompt,
-      embeddedText:
-        metadata.settingsUsed?.embeddedText ??
-        metadata.embeddedText ??
-        undefined,
-      textPlacement:
-        metadata.settingsUsed?.textPlacement ??
-        metadata.textPlacement ??
-        undefined,
-      aspectRatio: run.aspectRatio as any,
-      imageSize: run.imageSize as any,
-      model: run.model as any,
-      tier: (metadata.settingsUsed?.tier ?? metadata.tier ?? undefined) as any,
-      intent: (metadata.settingsUsed?.intent ??
-        metadata.intent ??
-        "generate") as any,
-      styleStrength: (metadata.settingsUsed?.styleStrength ??
-        metadata.styleStrength ??
-        "balanced") as any,
-      categories: categories as any,
-      includeLogo: Boolean(
-        metadata.settingsUsed?.includeLogo ?? metadata.includeLogo,
-      ),
-      groundingMode: run.groundingMode as any,
-      sourceAssetId: metadata.sourceAssetId,
-      subjectAssetId:
-        metadata.settingsUsed?.subjectAssetId ??
-        metadata.subjectAssetId ??
-        undefined,
-      slotId,
-      source,
-      callerAppId,
-    });
+    return generateImage.run(
+      {
+        libraryId: run.libraryId,
+        collectionId: run.collectionId ?? undefined,
+        presetId: run.presetId ?? undefined,
+        sessionId: resolvedSessionId,
+        prompt: run.prompt,
+        embeddedText:
+          metadata.settingsUsed?.embeddedText ??
+          metadata.embeddedText ??
+          undefined,
+        textPlacement:
+          metadata.settingsUsed?.textPlacement ??
+          metadata.textPlacement ??
+          undefined,
+        aspectRatio: run.aspectRatio as any,
+        imageSize: run.imageSize as any,
+        model: run.model as any,
+        tier: (metadata.settingsUsed?.tier ??
+          metadata.tier ??
+          undefined) as any,
+        intent: (metadata.settingsUsed?.intent ??
+          metadata.intent ??
+          "generate") as any,
+        styleStrength: (metadata.settingsUsed?.styleStrength ??
+          metadata.styleStrength ??
+          "balanced") as any,
+        categories: categories as any,
+        includeLogo: Boolean(
+          metadata.settingsUsed?.includeLogo ?? metadata.includeLogo,
+        ),
+        groundingMode: run.groundingMode as any,
+        sourceAssetId: metadata.sourceAssetId,
+        subjectAssetId:
+          metadata.settingsUsed?.subjectAssetId ??
+          metadata.subjectAssetId ??
+          undefined,
+        slotId,
+        source,
+        callerAppId,
+      },
+      context,
+    );
   },
 });

--- a/templates/assets/actions/rerun-generation-run.ts
+++ b/templates/assets/actions/rerun-generation-run.ts
@@ -52,6 +52,8 @@ export default defineAction({
         intent?: string;
         styleStrength?: string;
         subjectAssetId?: string;
+        embeddedText?: string | null;
+        textPlacement?: string | null;
       };
       includeLogo?: boolean;
       categories?: string[];
@@ -60,6 +62,8 @@ export default defineAction({
       intent?: string;
       styleStrength?: string;
       tier?: string | null;
+      embeddedText?: string | null;
+      textPlacement?: string | null;
     }>(run.metadata, {});
     const categories =
       metadata.settingsUsed?.categories ?? metadata.categories ?? undefined;
@@ -70,6 +74,14 @@ export default defineAction({
       presetId: run.presetId ?? undefined,
       sessionId: resolvedSessionId,
       prompt: run.prompt,
+      embeddedText:
+        metadata.settingsUsed?.embeddedText ??
+        metadata.embeddedText ??
+        undefined,
+      textPlacement:
+        metadata.settingsUsed?.textPlacement ??
+        metadata.textPlacement ??
+        undefined,
       aspectRatio: run.aspectRatio as any,
       imageSize: run.imageSize as any,
       model: run.model as any,

--- a/templates/assets/changelog/2026-06-29-image-generation-can-now-render-requested-text-and-respect-b.md
+++ b/templates/assets/changelog/2026-06-29-image-generation-can-now-render-requested-text-and-respect-b.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-06-29
+---
+
+Image generation can now render requested text and respect brand fonts

--- a/templates/assets/changelog/2026-06-30-image-generation-no-longer-looks-stuck-while-the-provider-is-still-working.md
+++ b/templates/assets/changelog/2026-06-30-image-generation-no-longer-looks-stuck-while-the-provider-is-still-working.md
@@ -2,4 +2,5 @@
 type: fixed
 date: 2026-06-30
 ---
+
 Image generation no longer looks stuck while the provider is still creating and saving the asset.

--- a/templates/assets/changelog/2026-06-30-image-generation-no-longer-looks-stuck-while-the-provider-is-still-working.md
+++ b/templates/assets/changelog/2026-06-30-image-generation-no-longer-looks-stuck-while-the-provider-is-still-working.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+date: 2026-06-30
+---
+Image generation no longer looks stuck while the provider is still creating and saving the asset.

--- a/templates/assets/changelog/2026-06-30-tagged-presets-now-control-the-image-aspect-ratio.md
+++ b/templates/assets/changelog/2026-06-30-tagged-presets-now-control-the-image-aspect-ratio.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-06-30
+---
+
+Tagging a @preset now reliably uses its aspect ratio and other saved settings instead of a guessed one

--- a/templates/assets/server/lib/generation.test.ts
+++ b/templates/assets/server/lib/generation.test.ts
@@ -714,6 +714,30 @@ describe("resolveImageModelForRequest", () => {
       }),
     ).toBe("gemini-3-pro-image");
   });
+
+  it("keeps a preset's explicit model over its own drifted derived tier", () => {
+    // Preset saved model = Pro, but settings.tier drifted to `fast` (the two
+    // are separate fields and can be updated independently). With no explicit
+    // per-request tier, the explicit saved model must win.
+    expect(
+      resolveImageModelForRequest({
+        presetModel: "gemini-3-pro-image",
+        resolvedTier: "fast",
+      }),
+    ).toBe("gemini-3-pro-image");
+  });
+
+  it("lets an explicit per-request tier override the preset's saved model", () => {
+    // The caller deliberately requested `best` this turn, so it outranks the
+    // preset's saved Flash model.
+    expect(
+      resolveImageModelForRequest({
+        presetModel: "gemini-3.1-flash-image",
+        explicitTier: "best",
+        resolvedTier: "best",
+      }),
+    ).toBe("gemini-3-pro-image");
+  });
 });
 
 describe("compareReferenceCandidates", () => {

--- a/templates/assets/server/lib/generation.test.ts
+++ b/templates/assets/server/lib/generation.test.ts
@@ -663,6 +663,26 @@ describe("resolveImageModelForRequest", () => {
       }),
     ).toBe("gemini-3.1-flash-image");
   });
+
+  it("does not let embedded-text routing override a preset's saved model", () => {
+    expect(
+      resolveImageModelForRequest({
+        presetModel: "gemini-3.1-flash-image",
+        embeddedText: "Bean & Brew",
+      }),
+    ).toBe("gemini-3.1-flash-image");
+  });
+
+  it("does not let embedded-text routing override a preset-derived tier", () => {
+    // A preset that resolves to a `fast` tier (no explicit tier on the request)
+    // must keep its Flash model even when embedded text is requested.
+    expect(
+      resolveImageModelForRequest({
+        resolvedTier: "fast",
+        embeddedText: "Bean & Brew",
+      }),
+    ).toBe("gemini-3.1-flash-image");
+  });
 });
 
 describe("compareReferenceCandidates", () => {

--- a/templates/assets/server/lib/generation.test.ts
+++ b/templates/assets/server/lib/generation.test.ts
@@ -683,6 +683,37 @@ describe("resolveImageModelForRequest", () => {
       }),
     ).toBe("gemini-3.1-flash-image");
   });
+
+  it("does not let the composer default override a preset's saved model", () => {
+    // Sticky composer default differs from the tagged preset's saved model;
+    // the preset must win.
+    expect(
+      resolveImageModelForRequest({
+        imageModelDefault: "gemini-3.1-flash-image",
+        presetModel: "gemini-3-pro-image",
+      }),
+    ).toBe("gemini-3-pro-image");
+  });
+
+  it("does not let the composer default override a tier-derived model", () => {
+    // A `best` tier request must resolve to Pro even when the composer default
+    // is Flash.
+    expect(
+      resolveImageModelForRequest({
+        imageModelDefault: "gemini-3.1-flash-image",
+        explicitTier: "best",
+        resolvedTier: "best",
+      }),
+    ).toBe("gemini-3-pro-image");
+  });
+
+  it("still uses the composer default when nothing more specific applies", () => {
+    expect(
+      resolveImageModelForRequest({
+        imageModelDefault: "gemini-3-pro-image",
+      }),
+    ).toBe("gemini-3-pro-image");
+  });
 });
 
 describe("compareReferenceCandidates", () => {

--- a/templates/assets/server/lib/generation.test.ts
+++ b/templates/assets/server/lib/generation.test.ts
@@ -4,6 +4,8 @@ import {
   compareReferenceCandidates,
   compilePrompt,
   generateWithManagedImageProvider,
+  resolveImageModelForRequest,
+  sanitizeStyleBrief,
 } from "./generation.js";
 import type { GenerateProviderInput } from "./generation.js";
 
@@ -51,6 +53,8 @@ const baseInput: GenerateProviderInput = {
   imageSize: "2K",
   groundingMode: "auto",
 };
+const SUPPRESS_EMBEDDED_TEXT =
+  "Do not render headlines, body text, UI labels, or prompt wording inside the image unless the user explicitly asks for exact visible text.";
 
 function mockBuilderFailure(status: number, body: unknown) {
   const fetchMock = vi.fn(async () => {
@@ -543,6 +547,121 @@ describe("compilePrompt", () => {
     expect(prompt).toContain("Make the background navy");
     expect(prompt).toContain("Preserve all unchanged areas");
     expect(prompt).not.toContain("Style brief:");
+  });
+
+  it("quotes exact embedded text and removes the blanket text suppression", () => {
+    const prompt = compilePrompt({
+      libraryTitle: "Bean Brand",
+      styleBrief: {
+        description: "Warm editorial cafe photography.",
+        typographyPolicy: "Use refined display lettering.",
+      },
+      prompt: "Create a poster for the spring menu",
+      embeddedText: "Bean & Brew",
+      textPlacement: "centered headline",
+      referenceCount: 2,
+      includeLogo: false,
+      category: "campaign",
+    });
+
+    expect(prompt).toContain('"Bean & Brew"');
+    expect(prompt).toContain("Placement: centered headline.");
+    expect(prompt).toContain("Match the brand typography");
+    expect(prompt).not.toContain(SUPPRESS_EMBEDDED_TEXT);
+  });
+
+  it("keeps the embedded text suppression when no exact text is requested", () => {
+    const prompt = compilePrompt({
+      libraryTitle: "Bean Brand",
+      styleBrief: {
+        description: "Warm editorial cafe photography.",
+      },
+      prompt: "Create a poster for the spring menu",
+      referenceCount: 2,
+      includeLogo: false,
+      category: "campaign",
+    });
+
+    expect(prompt).toContain(SUPPRESS_EMBEDDED_TEXT);
+  });
+
+  it("renders structured brand typography in generation prompts", () => {
+    const prompt = compilePrompt({
+      libraryTitle: "Northstar",
+      styleBrief: {
+        description: "Clean editorial product photography.",
+        fontFamilies: ["Sohne", "Georgia"],
+        fontWeights: ["regular", "bold"],
+        letterforms: "geometric sans, high x-height, single-story a",
+        caseStyle: "ALL CAPS headlines, sentence-case body",
+        typographyPolicy: "Keep copy compact and premium.",
+      },
+      prompt: "A landing-page hero background",
+      referenceCount: 3,
+      includeLogo: false,
+      aspectRatio: "16:9",
+      imageSize: "2K",
+      category: "landing",
+    });
+
+    expect(prompt).toContain("Brand typography:");
+    expect(prompt).toContain("families Sohne, Georgia");
+    expect(prompt).toContain(
+      "letterforms: geometric sans, high x-height, single-story a",
+    );
+    expect(prompt).toContain("case: ALL CAPS headlines");
+    expect(prompt).toContain("Keep copy compact and premium.");
+  });
+});
+
+describe("sanitizeStyleBrief", () => {
+  it("round-trips structured typography fields and drops empty array entries", () => {
+    const brief = sanitizeStyleBrief({
+      fontFamilies: [" Sohne ", "", 42, "Georgia"],
+      fontWeights: ["regular", null, " bold "],
+      letterforms: " geometric sans, high x-height ",
+      caseStyle: " ALL CAPS headlines ",
+      typographyPolicy: " Keep display text tight. ",
+      doNot: [" blurry text ", false, "", "extra logos"],
+    });
+
+    expect(brief).toMatchObject({
+      fontFamilies: ["Sohne", "Georgia"],
+      fontWeights: ["regular", "bold"],
+      letterforms: "geometric sans, high x-height",
+      caseStyle: "ALL CAPS headlines",
+      typographyPolicy: "Keep display text tight.",
+      doNot: ["blurry text", "extra logos"],
+    });
+    expect(brief.description).toBeUndefined();
+  });
+});
+
+describe("resolveImageModelForRequest", () => {
+  it("prefers Gemini Pro for embedded text when no model or tier was explicit", () => {
+    expect(
+      resolveImageModelForRequest({
+        imageModelDefault: "gemini-3.1-flash-image",
+        embeddedText: "Bean & Brew",
+      }),
+    ).toBe("gemini-3-pro-image");
+  });
+
+  it("keeps explicit model and tier choices ahead of embedded-text routing", () => {
+    expect(
+      resolveImageModelForRequest({
+        explicitModel: "gemini-3.1-flash-image",
+        embeddedText: "Bean & Brew",
+      }),
+    ).toBe("gemini-3.1-flash-image");
+    expect(
+      resolveImageModelForRequest({
+        imageModelDefault: "gemini-3.1-flash-image",
+        explicitTier: "fast",
+        resolvedTier: "fast",
+        embeddedText: "Bean & Brew",
+      }),
+    ).toBe("gemini-3.1-flash-image");
   });
 });
 

--- a/templates/assets/server/lib/generation.ts
+++ b/templates/assets/server/lib/generation.ts
@@ -811,10 +811,17 @@ export function resolveImageModelForRequest(input: {
 }): ImageModel {
   if (input.explicitModel) return input.explicitModel;
 
-  // Exact embedded text is materially better on Gemini Pro. Only auto-upgrade
-  // when the caller did not pin a model or tier for this request.
+  // Exact embedded text is materially better on Gemini Pro, so upgrade to it by
+  // default for text requests — but never override a model or tier the caller
+  // or a tagged preset already chose (presets "own" model/tier per the action
+  // docs). Only auto-upgrade when there is no tier (explicit or preset-derived)
+  // and no preset model in play; this still upgrades a bare text request over
+  // the composer default.
   const textAccurateModel: ImageModel | undefined =
-    input.embeddedText?.trim() && !input.explicitTier
+    input.embeddedText?.trim() &&
+    !input.explicitTier &&
+    !input.resolvedTier &&
+    !input.presetModel
       ? "gemini-3-pro-image"
       : undefined;
 

--- a/templates/assets/server/lib/generation.ts
+++ b/templates/assets/server/lib/generation.ts
@@ -11,6 +11,7 @@ import type {
   GenerationIntent,
   ImageCategory,
   ImageModel,
+  ImageQualityTier,
   ImageSize,
   StyleStrength,
   StyleBrief,
@@ -564,7 +565,8 @@ export async function analyzeStyleWithGemini(input: {
       {
         text: [
           "Analyze these brand/style reference images for a reusable image generation style brief.",
-          "Return only compact JSON with keys: description, medium, mood, subjectMatter, texture, composition, lighting, typographyPolicy, doNot.",
+          "Return only compact JSON with keys: description, medium, mood, subjectMatter, texture, composition, lighting, fontFamilies, fontWeights, letterforms, caseStyle, typographyPolicy, doNot.",
+          "For typography, describe specific letterforms and font traits, not just broad sans/serif categories; omit any typography field you cannot determine confidently.",
           "Use specific trait-locking phrases that can be reused across future image prompts.",
           "Do not name brands, artists, studios, franchises, or copyrighted works unless they appear as user-provided brand identity.",
           "Keep doNot as an array of short constraints. Omit uncertain fields instead of guessing.",
@@ -608,16 +610,24 @@ function extractJsonObject(text: string): string {
   return "{}";
 }
 
-function sanitizeStyleBrief(value: Record<string, unknown>): StyleBrief {
+export function sanitizeStyleBrief(value: Record<string, unknown>): StyleBrief {
   const stringField = (key: string) => {
     const raw = value[key];
     return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
   };
-  const doNot = Array.isArray(value.doNot)
-    ? value.doNot.filter(
-        (item): item is string => typeof item === "string" && !!item.trim(),
-      )
-    : undefined;
+  const stringArrayField = (key: string) => {
+    const raw = value[key];
+    return Array.isArray(raw)
+      ? raw
+          .filter(
+            (item): item is string => typeof item === "string" && !!item.trim(),
+          )
+          .map((item) => item.trim())
+      : undefined;
+  };
+  const fontFamilies = stringArrayField("fontFamilies");
+  const fontWeights = stringArrayField("fontWeights");
+  const doNot = stringArrayField("doNot");
   return {
     description: stringField("description"),
     medium: stringField("medium"),
@@ -626,8 +636,12 @@ function sanitizeStyleBrief(value: Record<string, unknown>): StyleBrief {
     texture: stringField("texture"),
     composition: stringField("composition"),
     lighting: stringField("lighting"),
+    fontFamilies: fontFamilies?.length ? fontFamilies : undefined,
+    fontWeights: fontWeights?.length ? fontWeights : undefined,
+    letterforms: stringField("letterforms"),
+    caseStyle: stringField("caseStyle"),
     typographyPolicy: stringField("typographyPolicy"),
-    doNot: doNot?.length ? doNot.map((item) => item.trim()) : undefined,
+    doNot: doNot?.length ? doNot : undefined,
   };
 }
 
@@ -774,6 +788,45 @@ function toBuilderImageModel(model: ImageModel) {
   return model;
 }
 
+function resolveModelForTier(
+  tier: ImageQualityTier | undefined,
+  category: ImageCategory | undefined,
+): ImageModel | undefined {
+  if (!tier) return undefined;
+  if (tier === "fast") return "gemini-3.1-flash-image";
+  if (tier === "best") return "gemini-3-pro-image";
+  return ["hero", "landing", "logo", "campaign"].includes(category ?? "")
+    ? "gemini-3-pro-image"
+    : "gemini-3.1-flash-image";
+}
+
+export function resolveImageModelForRequest(input: {
+  explicitModel?: ImageModel;
+  imageModelDefault?: ImageModel;
+  explicitTier?: ImageQualityTier;
+  resolvedTier?: ImageQualityTier;
+  category?: ImageCategory;
+  presetModel?: ImageModel | null;
+  embeddedText?: string | null;
+}): ImageModel {
+  if (input.explicitModel) return input.explicitModel;
+
+  // Exact embedded text is materially better on Gemini Pro. Only auto-upgrade
+  // when the caller did not pin a model or tier for this request.
+  const textAccurateModel: ImageModel | undefined =
+    input.embeddedText?.trim() && !input.explicitTier
+      ? "gemini-3-pro-image"
+      : undefined;
+
+  return (
+    textAccurateModel ??
+    input.imageModelDefault ??
+    resolveModelForTier(input.resolvedTier, input.category) ??
+    input.presetModel ??
+    "gemini-3.1-flash-image"
+  );
+}
+
 function toBuilderReferenceRole(role: string) {
   switch (role) {
     case "style_reference":
@@ -799,6 +852,8 @@ export function compilePrompt(input: {
   styleBrief: StyleBrief;
   customInstructions?: string | null;
   prompt: string;
+  embeddedText?: string | null;
+  textPlacement?: string | null;
   referenceCount: number;
   includeLogo: boolean;
   aspectRatio?: AspectRatio;
@@ -815,6 +870,11 @@ export function compilePrompt(input: {
   const doNot = style.doNot?.length
     ? `\nAvoid: ${style.doNot.join("; ")}.`
     : "";
+  const typographyBlock = formatBrandTypography(style);
+  const requestedEmbeddedText = hasEmbeddedText(input.embeddedText);
+  const textInstruction = requestedEmbeddedText
+    ? formatEmbeddedTextInstruction(input.embeddedText, input.textPlacement)
+    : "Do not render headlines, body text, UI labels, or prompt wording inside the image unless the user explicitly asks for exact visible text.";
   const logoInstruction = input.includeLogo
     ? "\nLeave a clean uncluttered area in the upper-right for the real brand logo; do not draw or approximate the logo yourself."
     : "";
@@ -839,14 +899,24 @@ export function compilePrompt(input: {
           : "No reference images are attached for this run. Use the style brief and custom instructions as the source of truth.";
 
   if (intent === "edit") {
+    const editTypographyInstruction =
+      requestedEmbeddedText && typographyBlock ? `\n\n${typographyBlock}` : "";
+    const editTextInstruction = requestedEmbeddedText
+      ? `\n\n${formatEmbeddedTextInstruction(input.embeddedText, input.textPlacement)}`
+      : "";
+    const editConstraint = requestedEmbeddedText
+      ? "Do not reimagine the image, change its aspect ratio, or alter unrelated subjects. Do not add any other new text. Return the full image."
+      : "Do not reimagine the image, change its aspect ratio, add new text, or alter unrelated subjects. Return the full image.";
     return `Edit the attached image for the "${input.libraryTitle}" asset library.
 
 ${referenceInstruction}
+${editTypographyInstruction}
 
 Make only this change:
 ${input.prompt}
+${editTextInstruction}
 
-Do not reimagine the image, change its aspect ratio, add new text, or alter unrelated subjects. Return the full image.`;
+${editConstraint}`;
   }
 
   return `Create a brand-consistent image for the "${input.libraryTitle}" asset library.
@@ -861,13 +931,46 @@ ${style.subjectMatter ? `\nSubject matter: ${style.subjectMatter}.` : ""}
 ${style.texture ? `\nTexture/material treatment: ${style.texture}.` : ""}
 ${style.composition ? `\nComposition: ${style.composition}.` : ""}
 ${style.lighting ? `\nLighting: ${style.lighting}.` : ""}
-${style.typographyPolicy ? `\nTypography policy: ${style.typographyPolicy}.` : ""}${frameInstruction}
+${typographyBlock ? `\n${typographyBlock}` : ""}${frameInstruction}
 ${doNot}${logoInstruction}${diagramInstruction}${customInstructions}
 
-Do not render headlines, body text, UI labels, or prompt wording inside the image unless the user explicitly asks for exact visible text.
+${textInstruction}
 
 User request:
 ${input.prompt}`;
+}
+
+function hasEmbeddedText(value?: string | null): boolean {
+  return typeof value === "string" && !!value.trim();
+}
+
+function formatEmbeddedTextInstruction(
+  embeddedText?: string | null,
+  textPlacement?: string | null,
+): string {
+  const placement = textPlacement?.trim();
+  return [
+    `Render this text exactly, spelled correctly, inside the image: ${JSON.stringify(embeddedText ?? "")}.`,
+    placement ? `Placement: ${placement}.` : "",
+    "Match the brand typography described above where specified; keep it legible and well-kerned.",
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+function formatBrandTypography(style: StyleBrief): string {
+  const parts = [
+    style.fontFamilies?.length
+      ? `families ${style.fontFamilies.join(", ")}`
+      : "",
+    style.fontWeights?.length ? `weights ${style.fontWeights.join(", ")}` : "",
+    style.letterforms ? `letterforms: ${style.letterforms}` : "",
+    style.caseStyle ? `case: ${style.caseStyle}` : "",
+    style.typographyPolicy,
+  ].filter((part): part is string => typeof part === "string" && !!part.trim());
+
+  if (!parts.length) return "";
+  return `Brand typography: ${parts.join("; ")}. Match these for any rendered text.`;
 }
 
 // A content-only reference is an image the user attached as subject/content for

--- a/templates/assets/server/lib/generation.ts
+++ b/templates/assets/server/lib/generation.ts
@@ -826,16 +826,23 @@ export function resolveImageModelForRequest(input: {
       : undefined;
 
   // Precedence: explicit per-request model (handled above) > embedded-text
-  // upgrade > the tier-derived model (an explicit or preset-derived tier) >
-  // the preset's saved model > the sticky composer default > the floor. The
-  // composer default ranks LAST of the real signals: it is a global stored
-  // preference, so it must not silently defeat a tagged preset's model or a
-  // tier-only request (the preset/tier "own" the model unless the caller
-  // explicitly overrides them).
+  // upgrade > an EXPLICIT per-request tier > the preset's saved model > the
+  // preset-DERIVED tier mapping > the sticky composer default > the floor.
+  //
+  // Two subtleties:
+  //   - An explicit per-request tier outranks the preset's saved model (the
+  //     caller is deliberately overriding the preset this turn).
+  //   - The preset's explicit saved model outranks its OWN derived tier: a
+  //     preset's `model` column and `settings.tier` can drift out of sync
+  //     (update-generation-preset can change one without the other), and the
+  //     explicitly saved model is the authoritative choice.
+  //   - The composer default ranks LAST of the real signals: it is a global
+  //     stored preference and must not defeat a tagged preset or a tier request.
   return (
     textAccurateModel ??
-    resolveModelForTier(input.resolvedTier, input.category) ??
+    resolveModelForTier(input.explicitTier, input.category) ??
     input.presetModel ??
+    resolveModelForTier(input.resolvedTier, input.category) ??
     input.imageModelDefault ??
     "gemini-3.1-flash-image"
   );

--- a/templates/assets/server/lib/generation.ts
+++ b/templates/assets/server/lib/generation.ts
@@ -825,11 +825,18 @@ export function resolveImageModelForRequest(input: {
       ? "gemini-3-pro-image"
       : undefined;
 
+  // Precedence: explicit per-request model (handled above) > embedded-text
+  // upgrade > the tier-derived model (an explicit or preset-derived tier) >
+  // the preset's saved model > the sticky composer default > the floor. The
+  // composer default ranks LAST of the real signals: it is a global stored
+  // preference, so it must not silently defeat a tagged preset's model or a
+  // tier-only request (the preset/tier "own" the model unless the caller
+  // explicitly overrides them).
   return (
     textAccurateModel ??
-    input.imageModelDefault ??
     resolveModelForTier(input.resolvedTier, input.category) ??
     input.presetModel ??
+    input.imageModelDefault ??
     "gemini-3.1-flash-image"
   );
 }

--- a/templates/assets/shared/api.ts
+++ b/templates/assets/shared/api.ts
@@ -112,6 +112,10 @@ export interface StyleBrief {
   texture?: string;
   composition?: string;
   lighting?: string;
+  fontFamilies?: string[];
+  fontWeights?: string[];
+  letterforms?: string;
+  caseStyle?: string;
   typographyPolicy?: string;
   doNot?: string[];
 }


### PR DESCRIPTION
…pography, and preset-respecting settings

## Summary

Hardens Assets image generation across reliability and output quality. Long synchronous image runs no longer look stopped or duplicate work, generated images can render exact requested copy in brand-consistent type, and a tagged `@preset` now actually controls aspect ratio and its other saved settings.

## Reliability — long-running tool handoff

- **Reconnect no longer false-fails healthy long runs.** The active-run reconnect treated the stuck threshold as a one-shot cap on *total* reconnect duration, so a long generation that kept streaming activity heartbeats was aborted at the threshold and mislabeled `reconnect_no_progress`. It's now a sliding idle deadline that resets on every streamed event — only true silence trips it. (`AssistantChat.tsx`, exported `reconnectProgressTimedOut` helper.)
- **Activity is visible while reconnecting.** Surfaces the live tool label (e.g. "Still generating image") instead of a bare "Reconnecting".
- **Interrupted write tools wait for their result instead of re-running.** When a chunk is cut off mid-tool, the continuation waits for the prior invocation's result via the durable ledger before re-dispatching, so a slow image action recovers its real result instead of duplicating work. (`production-agent.ts` `waitForInterruptedToolLedgerEntry`.)
- `generate-image` now emits activity heartbeats around the provider call and the asset save (`_tool-activity.ts`).

> Note: on the production background-function path, the image run gets the ~13-min soft-timeout ceiling, so the first call runs uninterrupted; the chunk/recover behavior above is the correct hosted fallback, not a duplicate.

## Embedded text + brand typography

- New `embeddedText` / `textPlacement` args on `generate-image` and each `generate-image-batch` slot render exact copy inside the image instead of suppressing all text.
- Style-brief analysis now captures `fontFamilies`, `fontWeights`, `letterforms`, and `caseStyle`; prompt compilation emits a brand-typography block and auto-upgrades to the Pro image model when exact text is requested and no model/tier was pinned.
- `rerun-generation-run` carries `embeddedText`/`textPlacement` through reruns.

## Presets control their settings

- A tagged `@preset` already defines aspect ratio, size, model, tier, and category, but `presetId` is opaque to the agent, so it filled in its own `aspectRatio` and silently overrode the preset. Schema `describe()`s on `presetId`/`aspectRatio`/`imageSize` now tell the agent to omit those when a preset is set (unless the user explicitly overrides), and the image-generation skill's misleading "settings should be explicit action args" line is replaced with an explicit preset-precedence rule.

## Tests

- Core: reconnect idle-deadline behavior (`AssistantChat.display.spec.ts`), ledger wait (`production-agent-ledger.spec.ts`), tool-activity (`_tool-activity.spec.ts`).
- Assets: batch + generation specs (`generate-image-batch.spec.ts`, `generation.test.ts`).
