### PR TITLE
Reduce AI request polling in Clips

### DIFF
--- a/templates/clips/actions/list-ai-requests.ts
+++ b/templates/clips/actions/list-ai-requests.ts
@@ -1,0 +1,57 @@
+/**
+ * List pending clips AI requests for the current user.
+ *
+ * Collapses the per-recording `clips-ai-request-<id>` polling done by the
+ * auto-title bridge into a single call. Application state is already
+ * session-scoped, and we additionally filter the referenced recordings through
+ * `accessFilter` so we never return a request for a recording the user can't
+ * access.
+ */
+
+import { defineAction } from "@agent-native/core";
+import { listAppState } from "@agent-native/core/application-state";
+import { accessFilter } from "@agent-native/core/sharing";
+import { and, inArray } from "drizzle-orm";
+import { z } from "zod";
+
+import { getDb, schema } from "../server/db/index.js";
+
+const REQUEST_PREFIX = "clips-ai-request-";
+
+export default defineAction({
+  description:
+    "List pending clips AI requests (regenerate-title, summary, chapters, etc.) for recordings the current user can access.",
+  schema: z.object({}),
+  http: { method: "GET" },
+  run: async () => {
+    const entries = await listAppState(REQUEST_PREFIX);
+
+    const requests = entries
+      .map((e) => e.value as Record<string, unknown>)
+      .filter(
+        (v): v is Record<string, unknown> & { recordingId: string } =>
+          !!v && typeof v.recordingId === "string" && v.recordingId.length > 0,
+      );
+
+    if (requests.length === 0) return { requests: [] };
+
+    const recordingIds = [...new Set(requests.map((r) => r.recordingId))];
+
+    const db = getDb();
+    const accessible = await db
+      .select({ id: schema.recordings.id })
+      .from(schema.recordings)
+      .where(
+        and(
+          accessFilter(schema.recordings, schema.recordingShares),
+          inArray(schema.recordings.id, recordingIds),
+        ),
+      );
+
+    const accessibleIds = new Set(accessible.map((r) => r.id));
+
+    return {
+      requests: requests.filter((r) => accessibleIds.has(r.recordingId)),
+    };
+  },
+});

--- a/templates/clips/actions/list-ai-requests.ts
+++ b/templates/clips/actions/list-ai-requests.ts
@@ -5,13 +5,15 @@
  * auto-title bridge into a single call. Application state is already
  * session-scoped, and we additionally filter the referenced recordings through
  * `accessFilter` so we never return a request for a recording the user can't
- * access.
+ * access. Only requests for `status = "ready"` recordings are returned — the
+ * bridge ignores non-ready recordings, so excluding them avoids sending large
+ * transcript blobs for recordings the hook will skip this tick.
  */
 
 import { defineAction } from "@agent-native/core";
 import { listAppState } from "@agent-native/core/application-state";
 import { accessFilter } from "@agent-native/core/sharing";
-import { and, inArray } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
@@ -45,6 +47,7 @@ export default defineAction({
         and(
           accessFilter(schema.recordings, schema.recordingShares),
           inArray(schema.recordings.id, recordingIds),
+          eq(schema.recordings.status, "ready"),
         ),
       );
 

--- a/templates/clips/app/hooks/use-auto-title.ts
+++ b/templates/clips/app/hooks/use-auto-title.ts
@@ -1,8 +1,9 @@
 /**
  * Clips AI request bridge
  *
- * Watches the `clips-ai-request-:id` application_state queue. The bridge sends
- * queued recording work to the agent chat exactly once per
+ * Polls the `list-ai-requests` action — a single access-scoped call that returns
+ * every pending `clips-ai-request-*` entry for recordings the user can access.
+ * The bridge sends queued recording work to the agent chat exactly once per
  * (recordingId, kind, requestedAt).
  *
  * Once handled we DELETE the request entry so the next page load / tab switch
@@ -21,6 +22,7 @@ import { useRecordings, type RecordingSummary } from "./use-library";
 
 const DEFAULT_TITLE = "Untitled recording";
 const POLL_INTERVAL_MS = 3000;
+const TWO_MINUTES_MS = 2 * 60 * 1000;
 
 /** True when `title` is blank or equal to the server-seeded default. */
 export function isDefaultTitle(title: string | null | undefined): boolean {
@@ -62,22 +64,21 @@ const DISPATCHABLE_REQUESTS = new Set([
   "generate-workflow",
 ]);
 
-async function readRequest(recordingId: string): Promise<AiRequest | null> {
-  const url = agentNativePath(
-    `/_agent-native/application-state/${encodeURIComponent(
-      `clips-ai-request-${recordingId}`,
-    )}`,
-  );
+async function listRequests(): Promise<Map<string, AiRequest>> {
   try {
-    const res = await fetch(url);
-    if (!res.ok) return null;
-    const payload = await res.json().catch(() => null);
-    if (!payload || typeof payload !== "object") return null;
-    // The application-state endpoint wraps stored values under `.value`.
-    const value = (payload as any).value ?? payload;
-    return value as AiRequest;
+    const result = (await callAction("list-ai-requests", {} as any, {
+      method: "GET",
+    })) as { requests?: AiRequest[] } | null | undefined;
+    return new Map(
+      (result?.requests ?? [])
+        .filter(
+          (r): r is AiRequest & { recordingId: string } => !!r?.recordingId,
+        )
+        .map((r) => [r.recordingId, r]),
+    );
   } catch {
-    return null;
+    // Swallow — the next tick retries.
+    return new Map();
   }
 }
 
@@ -120,16 +121,15 @@ export function useAutoTitleBridge(): void {
       if (cancelled || inflight.current) return;
       inflight.current = true;
       try {
+        const requestsById = await listRequests();
+        if (cancelled) return;
+
         for (const rec of readyRecordings) {
           if (cancelled) return;
 
-          const request = await readRequest(rec.id);
+          const request = requestsById.get(rec.id) ?? null;
 
-          if (
-            request?.kind &&
-            DISPATCHABLE_REQUESTS.has(request.kind) &&
-            request.recordingId === rec.id
-          ) {
+          if (request?.kind && DISPATCHABLE_REQUESTS.has(request.kind)) {
             // Server queued a delegation — use the full context it provided.
             // Key includes requestedAt so each distinct server request fires
             // exactly once, independent of any prior fallback dispatch.
@@ -164,9 +164,8 @@ export function useAutoTitleBridge(): void {
               continue;
             }
 
-            const ageMs = Date.now() - new Date(rec.createdAt).getTime();
-            const TWO_MINUTES_MS = 2 * 60 * 1000;
-            if (ageMs < TWO_MINUTES_MS) continue;
+            if (Date.now() - new Date(rec.createdAt).getTime() < TWO_MINUTES_MS)
+              continue;
 
             // Use a dedicated key so a later server-queued request (e.g. from
             // a long transcription that finishes after the 2-min window) is


### PR DESCRIPTION
Every 3 seconds, the Clips app checks whether the server has queued any AI work for a recording (generating a title, summary, chapters, etc.). Before this PR, it did that by firing one HTTP request per ready recording — so if you had N ready recordings, that was N requests every 3 seconds.

This PR replaces that with a single request that returns all pending AI work at once. A new action, `list-ai-requests`, reads all pending `clips-ai-request-*` entries from app state and filters them down to only the recordings the current user can actually access. The hook then looks up each recording's entry from that single result instead of fetching them one by one.
