### PR TITLE
Upload while recording

### DIFF
--- a/.changeset/file-upload-resumable-capability.md
+++ b/.changeset/file-upload-resumable-capability.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": minor
+---
+
+Add optional `resumable` capability to `FileUploadProvider` for streaming uploads. Providers that implement `startSession`, `relayChunk`, and `completeSession` can receive video chunks during recording instead of waiting for a fully assembled file after stop. The Builder.io provider implements this via the GCS resumable upload protocol. Also exports `ResumableUploadSession` and `ResumableChunkResult` types.

--- a/packages/core/src/file-upload/builder.ts
+++ b/packages/core/src/file-upload/builder.ts
@@ -2,6 +2,8 @@ import type {
   FileUploadProvider,
   FileUploadInput,
   FileUploadResult,
+  ResumableUploadSession,
+  ResumableChunkResult,
 } from "./types.js";
 
 const DEFAULT_BUILDER_APP_HOST = "https://builder.io";
@@ -46,8 +48,6 @@ async function uploadLargeFileViaSignedUrl(
   bareMimeType: string,
   bytes: Uint8Array,
 ): Promise<FileUploadResult> {
-  const host = builderUploadHost();
-  const authHeader = { Authorization: `Bearer ${privateKey}` };
   const name = input.filename ?? "upload";
   const mb = (bytes.byteLength / (1024 * 1024)).toFixed(1);
 
@@ -57,32 +57,12 @@ async function uploadLargeFileViaSignedUrl(
 
   // Step 1 — request a signed URL.
   console.log(`[builder-upload] step 1: requesting signed URL`);
-  const step1Res = await fetchWithTimeout(
-    new URL("/api/v1/upload/signed-url", host).toString(),
-    {
-      method: "POST",
-      headers: { ...authHeader, "Content-Type": "application/json" },
-      body: JSON.stringify({
-        fileName: name,
-        contentType: bareMimeType,
-        size: bytes.byteLength,
-      }),
-    },
+  const { uploadUrl, assetId, requiredHeaders } = await requestBuilderSignedUrl(
+    privateKey,
+    name,
+    bareMimeType,
+    bytes.byteLength,
   );
-  await assertOk(step1Res, "Builder.io signed-URL request failed");
-
-  const step1Json = (await step1Res.json()) as {
-    uploadUrl?: string;
-    assetId?: string;
-    expiresAt?: string;
-    requiredHeaders?: Record<string, string>;
-  };
-  const { uploadUrl, assetId, requiredHeaders } = step1Json;
-  if (!uploadUrl || !assetId || !requiredHeaders) {
-    throw new Error(
-      `Builder.io signed-URL response missing required fields: ${JSON.stringify(Object.keys(step1Json))}`,
-    );
-  }
   console.log(`[builder-upload] step 1 ok: assetId=${assetId}`);
 
   // Step 2 — PUT bytes directly to GCS. Only requiredHeaders; no Authorization
@@ -102,21 +82,80 @@ async function uploadLargeFileViaSignedUrl(
   console.log(
     `[builder-upload] step 3: registering asset - ${assetId}, ${input.filename}`,
   );
-  const step3Res = await fetchWithTimeout(
+  const { url, id } = await completeBuilderUpload(
+    privateKey,
+    assetId,
+    input.filename,
+  );
+  console.log(`[builder-upload] done [${assetId}]: ${url}`);
+  return { url, id, provider: "builder" };
+}
+
+async function requestBuilderSignedUrl(
+  privateKey: string,
+  filename: string,
+  mimeType: string,
+  size: number,
+  resumable = false,
+): Promise<{
+  uploadUrl: string;
+  assetId: string;
+  requiredHeaders: Record<string, string>;
+}> {
+  const host = builderUploadHost();
+  const url = new URL("/api/v1/upload/signed-url", host);
+  const res = await fetchWithTimeout(url.toString(), {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${privateKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      fileName: filename,
+      contentType: mimeType,
+      size,
+      resumable,
+    }),
+  });
+  await assertOk(res, "Builder.io signed-URL request failed");
+  const json = (await res.json()) as {
+    uploadUrl?: string;
+    assetId?: string;
+    requiredHeaders?: Record<string, string>;
+  };
+  if (!json.uploadUrl || !json.assetId || !json.requiredHeaders) {
+    throw new Error(
+      `Builder.io signed-URL response missing required fields: ${JSON.stringify(Object.keys(json))}`,
+    );
+  }
+  return {
+    uploadUrl: json.uploadUrl,
+    assetId: json.assetId,
+    requiredHeaders: json.requiredHeaders,
+  };
+}
+
+async function completeBuilderUpload(
+  privateKey: string,
+  assetId: string,
+  filename: string | undefined,
+): Promise<{ url: string; id?: string }> {
+  const host = builderUploadHost();
+  const res = await fetchWithTimeout(
     new URL("/api/v1/upload/complete", host).toString(),
     {
       method: "POST",
-      headers: { ...authHeader, "Content-Type": "application/json" },
-      body: JSON.stringify({ assetId, name: input.filename }),
+      headers: {
+        Authorization: `Bearer ${privateKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ assetId, name: filename }),
     },
   );
-  await assertOk(step3Res, "Builder.io upload complete failed");
-
-  const { url, id } = (await step3Res.json()) as { url?: string; id?: string };
-  if (!url) throw new Error("Builder.io upload/complete returned no URL");
-
-  console.log(`[builder-upload] done [${assetId}]: ${url}`);
-  return { url, id, provider: "builder" };
+  await assertOk(res, "Builder.io upload complete failed");
+  const json = (await res.json()) as { url?: string; id?: string };
+  if (!json.url) throw new Error("Builder.io upload/complete returned no URL");
+  return { url: json.url, id: json.id };
 }
 
 // Retry transient 5xx once with backoff. Builder.io's upload service
@@ -220,5 +259,128 @@ export const builderFileUploadProvider: FileUploadProvider = {
 
     console.log(`[builder-upload] done: ${json.url}`);
     return { url: json.url, id: json.id, provider: "builder" };
+  },
+
+  resumable: {
+    async startSession(filename, mimeType, maxBytes) {
+      const { resolveBuilderPrivateKey } =
+        await import("../server/credential-provider.js");
+      const privateKey = await resolveBuilderPrivateKey();
+      if (!privateKey) throw new Error("BUILDER_PRIVATE_KEY is not set");
+
+      console.log(
+        `[builder-resumable] starting session: ${filename} ${mimeType} ${maxBytes} bytes`,
+      );
+      const { uploadUrl, assetId, requiredHeaders } =
+        await requestBuilderSignedUrl(
+          privateKey,
+          filename,
+          mimeType,
+          maxBytes,
+          true,
+        );
+      console.log(`[builder-resumable] session step 1 ok: assetId=${assetId}`);
+
+      const initHeaders: Record<string, string> = {
+        "Content-Type": mimeType,
+        "x-goog-resumable": "start",
+      };
+      const contentLengthRange =
+        requiredHeaders?.["x-goog-content-length-range"];
+      if (contentLengthRange)
+        initHeaders["x-goog-content-length-range"] = contentLengthRange;
+
+      console.log(`[builder-resumable] session step 2: initiating GCS session`);
+      const initRes = await fetchWithTimeout(uploadUrl, {
+        method: "POST",
+        headers: initHeaders,
+        body: new Uint8Array(0),
+      });
+      if (!initRes.ok) {
+        const body = await initRes.text().catch(() => "");
+        throw new Error(
+          `GCS resumable session initiation failed (${initRes.status}): ${body}`,
+        );
+      }
+      const sessionUri = initRes.headers.get("location");
+      if (!sessionUri)
+        throw new Error(
+          "GCS did not return a Location header for the resumable session",
+        );
+
+      console.log(`[builder-resumable] session ready: assetId=${assetId}`);
+      return {
+        sessionId: sessionUri,
+        meta: { assetId, filename, mimeType },
+      } satisfies ResumableUploadSession;
+    },
+
+    async relayChunk(session, contentRange, bytes, options) {
+      const sessionUri = session.sessionId;
+      const MAX_ATTEMPTS = 4;
+      const RETRYABLE = new Set([408, 429, 500, 502, 503, 504]);
+      const delayMs = (attempt: number) =>
+        Math.min(2000, 300 * 2 ** (attempt - 1));
+
+      let lastError: unknown = null;
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        try {
+          const headers: Record<string, string> = {
+            "Content-Range": contentRange,
+          };
+          if (options?.mimeType) headers["Content-Type"] = options.mimeType;
+          const res = await fetch(sessionUri, {
+            method: "PUT",
+            headers,
+            body: bytes as unknown as BodyInit,
+          });
+          if (res.status === 308 || res.ok)
+            return {
+              ok: true,
+              status: res.status,
+            } satisfies ResumableChunkResult;
+          if (RETRYABLE.has(res.status) && attempt < MAX_ATTEMPTS) {
+            await res.text().catch(() => "");
+            console.warn(
+              `[builder-resumable] transient ${res.status} on attempt ${attempt}, retrying`,
+            );
+            await new Promise((r) => setTimeout(r, delayMs(attempt)));
+            continue;
+          }
+          return {
+            ok: false,
+            status: res.status,
+          } satisfies ResumableChunkResult;
+        } catch (err) {
+          lastError = err;
+          if (attempt >= MAX_ATTEMPTS) break;
+          console.warn(
+            `[builder-resumable] network error on attempt ${attempt}:`,
+            err instanceof Error ? err.message : String(err),
+          );
+          await new Promise((r) => setTimeout(r, delayMs(attempt)));
+        }
+      }
+      throw lastError instanceof Error
+        ? lastError
+        : new Error("GCS PUT failed after retries");
+    },
+
+    async completeSession(session, filename) {
+      const { resolveBuilderPrivateKey } =
+        await import("../server/credential-provider.js");
+      const privateKey = await resolveBuilderPrivateKey();
+      if (!privateKey) throw new Error("BUILDER_PRIVATE_KEY is not set");
+
+      const assetId = session.meta.assetId as string;
+      console.log(`[builder-resumable] completing upload: assetId=${assetId}`);
+      const { url } = await completeBuilderUpload(
+        privateKey,
+        assetId,
+        filename,
+      );
+      console.log(`[builder-resumable] upload complete: ${url}`);
+      return url;
+    },
   },
 };

--- a/packages/core/src/file-upload/index.ts
+++ b/packages/core/src/file-upload/index.ts
@@ -2,6 +2,8 @@ export type {
   FileUploadInput,
   FileUploadProvider,
   FileUploadResult,
+  ResumableUploadSession,
+  ResumableChunkResult,
 } from "./types.js";
 export {
   registerFileUploadProvider,

--- a/packages/core/src/file-upload/types.ts
+++ b/packages/core/src/file-upload/types.ts
@@ -27,6 +27,22 @@ export interface FileUploadResult {
   provider: string;
 }
 
+/** Opaque session handle returned by {@link FileUploadProvider.resumable.startSession}.
+ * `sessionId` is provider-specific (GCS Location URI, S3 UploadId, etc.).
+ * `meta` holds any provider state needed for subsequent relay and complete calls. */
+export interface ResumableUploadSession {
+  sessionId: string;
+  meta: Record<string, unknown>;
+}
+
+export interface ResumableChunkResult {
+  ok: boolean;
+  status: number;
+  /** Providers that need per-chunk state (e.g. S3 ETags) return updated meta
+   * here; the chunk route merges it back into the stored session. */
+  updatedMeta?: Record<string, unknown>;
+}
+
 export interface FileUploadProvider {
   /** Unique id, e.g. "builder", "s3". */
   id: string;
@@ -41,4 +57,14 @@ export interface FileUploadProvider {
   isConfiguredForRequest?: () => Promise<boolean>;
   /** Upload a file and return a URL. Throw on failure. */
   upload: (input: FileUploadInput) => Promise<FileUploadResult>;
+  /**
+   * Optional resumable/streaming upload capability.
+   * When present, create-recording will initialise a session and stream chunks
+   * during recording instead of assembling the full blob after stop().
+   */
+  resumable?: {
+    startSession(filename: string, mimeType: string, maxBytes: number): Promise<ResumableUploadSession>;
+    relayChunk(session: ResumableUploadSession, contentRange: string, bytes: Uint8Array, options?: { mimeType?: string }): Promise<ResumableChunkResult>;
+    completeSession(session: ResumableUploadSession, filename: string): Promise<string>;
+  };
 }

--- a/packages/core/src/file-upload/types.ts
+++ b/packages/core/src/file-upload/types.ts
@@ -63,8 +63,20 @@ export interface FileUploadProvider {
    * during recording instead of assembling the full blob after stop().
    */
   resumable?: {
-    startSession(filename: string, mimeType: string, maxBytes: number): Promise<ResumableUploadSession>;
-    relayChunk(session: ResumableUploadSession, contentRange: string, bytes: Uint8Array, options?: { mimeType?: string }): Promise<ResumableChunkResult>;
-    completeSession(session: ResumableUploadSession, filename: string): Promise<string>;
+    startSession(
+      filename: string,
+      mimeType: string,
+      maxBytes: number,
+    ): Promise<ResumableUploadSession>;
+    relayChunk(
+      session: ResumableUploadSession,
+      contentRange: string,
+      bytes: Uint8Array,
+      options?: { mimeType?: string },
+    ): Promise<ResumableChunkResult>;
+    completeSession(
+      session: ResumableUploadSession,
+      filename: string,
+    ): Promise<string>;
   };
 }

--- a/templates/clips/actions/create-recording.ts
+++ b/templates/clips/actions/create-recording.ts
@@ -12,6 +12,8 @@
 import { defineAction } from "@agent-native/core";
 import { writeAppState } from "@agent-native/core/application-state";
 import { getActiveFileUploadProviderForRequest } from "@agent-native/core/file-upload";
+import type { UploadMode } from "@shared/recording-core.js";
+import { MAX_UPLOAD_BYTES } from "@shared/upload-limits.js";
 
 import { getDb, schema } from "../server/db/index.js";
 import {
@@ -23,8 +25,6 @@ import {
 import { setResumableSession } from "../server/lib/resumable-session.js";
 import { createRecordingSchema } from "./lib/create-recording-schema.js";
 import { DEFAULT_RECORDING_TITLE } from "./lib/title-source.js";
-import { MAX_UPLOAD_BYTES } from "@shared/upload-limits.js";
-import type { UploadMode } from "@shared/recording-core.js";
 
 export default defineAction({
   description:

--- a/templates/clips/actions/create-recording.ts
+++ b/templates/clips/actions/create-recording.ts
@@ -11,6 +11,7 @@
 
 import { defineAction } from "@agent-native/core";
 import { writeAppState } from "@agent-native/core/application-state";
+import { getActiveFileUploadProviderForRequest } from "@agent-native/core/file-upload";
 
 import { getDb, schema } from "../server/db/index.js";
 import {
@@ -19,8 +20,11 @@ import {
   requireOrganizationAccess,
   stringifySpaceIds,
 } from "../server/lib/recordings.js";
+import { setResumableSession } from "../server/lib/resumable-session.js";
 import { createRecordingSchema } from "./lib/create-recording-schema.js";
 import { DEFAULT_RECORDING_TITLE } from "./lib/title-source.js";
+import { MAX_UPLOAD_BYTES } from "@shared/upload-limits.js";
+import type { UploadMode } from "@shared/recording-core.js";
 
 export default defineAction({
   description:
@@ -76,6 +80,45 @@ export default defineAction({
 
     console.log(`Created recording "${title}" (${id})`);
 
+    // Initialize a resumable upload session so chunks are streamed to the
+    // provider during recording (no post-stop assembly). Falls back gracefully
+    // to the SQL chunk path when no provider supports resumable uploads or the
+    // init fails.
+    let uploadMode: UploadMode = "buffered";
+    const uploadProvider = await getActiveFileUploadProviderForRequest();
+    if (args.requestStreaming && uploadProvider?.resumable) {
+      try {
+        const recordingMimeType =
+          args.mimeType?.split(";")[0]?.trim() || "video/webm";
+        const ext = /mp4|quicktime/i.test(recordingMimeType) ? "mp4" : "webm";
+        const filename = `${id}.${ext}`;
+        console.log(
+          `[create-recording] starting resumable session: provider=${uploadProvider.id} mimeType=${recordingMimeType}`,
+        );
+        const session = await uploadProvider.resumable.startSession(
+          filename,
+          recordingMimeType,
+          MAX_UPLOAD_BYTES,
+        );
+        await setResumableSession(id, {
+          providerId: uploadProvider.id,
+          sessionId: session.sessionId,
+          meta: session.meta,
+          bytesUploaded: 0,
+          lastCommittedIndex: -1,
+        });
+        uploadMode = "streaming";
+        console.log(
+          `[create-recording] resumable session ready for ${id}: provider=${uploadProvider.id}`,
+        );
+      } catch (err) {
+        console.warn(
+          `[create-recording] resumable session init failed, falling back to buffered:`,
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
+
     return {
       id,
       organizationId,
@@ -84,6 +127,7 @@ export default defineAction({
       abortUrl: `/api/uploads/${id}/abort`,
       // Frontend substitutes {index}/{total}/{isFinal}
       uploadChunkUrlTemplate: `/api/uploads/${id}/chunk?index={index}&total={total}&isFinal={isFinal}`,
+      uploadMode,
     };
   },
 });

--- a/templates/clips/actions/finalize-recording.ts
+++ b/templates/clips/actions/finalize-recording.ts
@@ -161,7 +161,12 @@ async function markRecordingReady(params: {
       uploadProgress: 100,
       updatedAt: now,
     })
-    .where(eq(schema.recordings.id, id));
+    .where(
+      and(
+        eq(schema.recordings.id, id),
+        ownerEmailMatches(schema.recordings.ownerEmail, ownerEmail),
+      ),
+    );
 
   const [existingTranscript] = await db
     .select({ recordingId: schema.recordingTranscripts.recordingId })

--- a/templates/clips/actions/finalize-recording.ts
+++ b/templates/clips/actions/finalize-recording.ts
@@ -251,10 +251,6 @@ export default defineAction({
       .string()
       .optional()
       .describe("MIME type of the assembled blob (e.g. video/webm)"),
-    videoSizeBytes: z
-      .number()
-      .optional()
-      .describe("Byte size of the uploaded video file"),
   }),
   run: async (args) => {
     const db = getDb();
@@ -375,13 +371,18 @@ export default defineAction({
               ? resumableSession.meta.filename
               : "",
           );
-          await deleteResumableSession(id);
           debugLog("[finalize] resumable upload completed", { id, videoUrl });
-          return markRecordingReady({
+          const result = await markRecordingReady({
             ...readyParams,
             videoUrl,
-            videoSizeBytes: args.videoSizeBytes ?? 0,
+            videoSizeBytes: resumableSession.bytesUploaded,
           });
+          // Delete only after durable state is written — so a retry before
+          // this point can still find the session and re-enter this path.
+          deleteResumableSession(id).catch((err) =>
+            console.warn("[finalize] failed to delete resumable session:", err),
+          );
+          return result;
         } catch (err) {
           console.error("[finalize] resumable complete failed:", err);
           throw new Error(

--- a/templates/clips/actions/finalize-recording.ts
+++ b/templates/clips/actions/finalize-recording.ts
@@ -16,7 +16,10 @@ import {
   deleteAppState,
 } from "@agent-native/core/application-state";
 import { emit } from "@agent-native/core/event-bus";
-import { uploadFile } from "@agent-native/core/file-upload";
+import {
+  getActiveFileUploadProvider,
+  uploadFile,
+} from "@agent-native/core/file-upload";
 import { captureRouteError } from "@agent-native/core/server";
 import { MAX_UPLOAD_BYTES as MAX_RECORDING_UPLOAD_BYTES } from "@shared/upload-limits.js";
 import { and, eq } from "drizzle-orm";
@@ -32,6 +35,10 @@ import {
   getCurrentOwnerEmail,
   ownerEmailMatches,
 } from "../server/lib/recordings.js";
+import {
+  deleteResumableSession,
+  getResumableSession,
+} from "../server/lib/resumable-session.js";
 import {
   requiresConfiguredVideoStorage,
   STORAGE_SETUP_REQUIRED_REASON,
@@ -107,6 +114,115 @@ const cliBoolean = z.preprocess((value) => {
   return value;
 }, z.boolean());
 
+// Flip recording to 'ready', seed transcript row, fire background transcript,
+// emit clip.created. Used by both the resumable and buffered upload paths.
+async function markRecordingReady(params: {
+  id: string;
+  ownerEmail: string;
+  videoUrl: string;
+  videoSizeBytes: number;
+  videoFormat: "webm" | "mp4";
+  finalDurationMs: number;
+  finalWidth: number;
+  finalHeight: number;
+  finalHasAudio: boolean;
+  finalHasCamera: boolean;
+  existingTitle: string;
+}) {
+  const {
+    id,
+    ownerEmail,
+    videoUrl,
+    videoSizeBytes,
+    videoFormat,
+    finalDurationMs,
+    finalWidth,
+    finalHeight,
+    finalHasAudio,
+    finalHasCamera,
+    existingTitle,
+  } = params;
+  const db = getDb();
+  const now = new Date().toISOString();
+
+  await db
+    .update(schema.recordings)
+    .set({
+      status: "ready",
+      videoUrl,
+      videoFormat,
+      videoSizeBytes,
+      durationMs: finalDurationMs,
+      width: finalWidth,
+      height: finalHeight,
+      hasAudio: finalHasAudio,
+      hasCamera: finalHasCamera,
+      failureReason: null,
+      uploadProgress: 100,
+      updatedAt: now,
+    })
+    .where(eq(schema.recordings.id, id));
+
+  const [existingTranscript] = await db
+    .select({ recordingId: schema.recordingTranscripts.recordingId })
+    .from(schema.recordingTranscripts)
+    .where(eq(schema.recordingTranscripts.recordingId, id));
+  if (!existingTranscript) {
+    await db.insert(schema.recordingTranscripts).values({
+      recordingId: id,
+      ownerEmail,
+      status: "pending",
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  await writeAppState(`recording-upload-${id}`, {
+    recordingId: id,
+    status: "ready",
+    progress: 100,
+    videoUrl,
+    finishedAt: now,
+  });
+  await writeAppState("refresh-signal", { ts: Date.now() });
+
+  // Kick off transcription in the background — fire-and-forget so the chunk
+  // endpoint gets a quick response. The request context (user email via
+  // AsyncLocalStorage) carries through to async continuations.
+  void Promise.resolve(
+    requestTranscript.run({ recordingId: id, force: true }),
+  ).catch((err: unknown) => {
+    console.error("[finalize] background transcript failed", {
+      id,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
+
+  try {
+    emit(
+      "clip.created",
+      {
+        clipId: id,
+        title: existingTitle,
+        createdBy: ownerEmail,
+        duration: finalDurationMs,
+        url: videoUrl,
+      },
+      { owner: ownerEmail },
+    );
+  } catch (err) {
+    console.warn("[finalize] clip.created emit failed:", err);
+  }
+
+  return {
+    id,
+    status: "ready" as const,
+    videoUrl,
+    videoSizeBytes,
+    durationMs: finalDurationMs,
+  };
+}
+
 export default defineAction({
   description:
     "Assemble recorded chunks into a final video blob, upload it to the configured storage provider, update the recording row (videoUrl, durationMs, width/height/hasAudio/hasCamera), flip status to 'ready', and trigger the agent to produce a title, summary, transcript, and chapters in the background.",
@@ -130,6 +246,10 @@ export default defineAction({
       .string()
       .optional()
       .describe("MIME type of the assembled blob (e.g. video/webm)"),
+    videoSizeBytes: z
+      .number()
+      .optional()
+      .describe("Byte size of the uploaded video file"),
   }),
   run: async (args) => {
     const db = getDb();
@@ -163,6 +283,21 @@ export default defineAction({
         // Still purge chunks for this id — it's orphaned.
         chunkKeysToPurge = await listRecordingChunkKeys(ownerEmail, id);
         throw new Error(`Recording not found: ${id}`);
+      }
+
+      // Idempotency guard: finalize can be re-invoked when a client retries the
+      // final chunk after a lost response. If already 'ready' return the existing
+      // result instead of re-running the complete/assembly path (session and
+      // chunks are gone by then).
+      if (existing.status === "ready" && existing.videoUrl) {
+        debugLog("[finalize] already finalized, returning existing", { id });
+        return {
+          id,
+          status: "ready" as const,
+          videoUrl: existing.videoUrl,
+          videoSizeBytes: existing.videoSizeBytes ?? 0,
+          durationMs: existing.durationMs ?? 0,
+        };
       }
 
       const uploadStateRaw = await readAppState(`recording-upload-${id}`);
@@ -200,6 +335,57 @@ export default defineAction({
         typeof args.hasCamera === "boolean"
           ? args.hasCamera
           : (stateBoolean(uploadState, "hasCamera") ?? existing.hasCamera);
+
+      const readyParams = {
+        id,
+        ownerEmail,
+        videoFormat,
+        finalDurationMs,
+        finalWidth,
+        finalHeight,
+        finalHasAudio,
+        finalHasCamera,
+        existingTitle: existing.title,
+      };
+
+      // Resumable path: create-recording initialized a session and chunk.post.ts
+      // forwarded all chunks to the provider. Complete the session to get the CDN URL.
+      const resumableSession = await getResumableSession(id);
+      if (resumableSession) {
+        debugLog("[finalize] resumable session found, completing upload", {
+          id,
+          providerId: resumableSession.providerId,
+        });
+        try {
+          const uploadProvider = getActiveFileUploadProvider();
+          if (!uploadProvider?.resumable) {
+            throw new Error("No resumable upload provider configured");
+          }
+          const videoUrl = await uploadProvider.resumable.completeSession(
+            {
+              sessionId: resumableSession.sessionId,
+              meta: resumableSession.meta,
+            },
+            typeof resumableSession.meta.filename === "string"
+              ? resumableSession.meta.filename
+              : "",
+          );
+          await deleteResumableSession(id);
+          debugLog("[finalize] resumable upload completed", { id, videoUrl });
+          return markRecordingReady({
+            ...readyParams,
+            videoUrl,
+            videoSizeBytes: args.videoSizeBytes ?? 0,
+          });
+        } catch (err) {
+          console.error("[finalize] resumable complete failed:", err);
+          throw new Error(
+            `Upload completion failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+
+      // Buffered path — assemble chunks from application_state, then upload.
 
       // The recorder stashes compression metadata at
       // `recording-compression-{id}` when its browser-side ffmpeg.wasm
@@ -525,99 +711,17 @@ export default defineAction({
         }
         throw err;
       }
-      const videoUrl = upload.url;
-
-      // Update the recording row with final metadata and flip to 'ready'.
-      await db
-        .update(schema.recordings)
-        .set({
-          status: "ready",
-          videoUrl,
-          videoFormat,
-          videoSizeBytes: assembled.byteLength,
-          durationMs: finalDurationMs,
-          width: finalWidth,
-          height: finalHeight,
-          hasAudio: finalHasAudio,
-          hasCamera: finalHasCamera,
-          failureReason: null,
-          uploadProgress: 100,
-          updatedAt: new Date().toISOString(),
-        })
-        .where(eq(schema.recordings.id, id));
-
-      // Seed a pending transcript row so the agent background task has a place
-      // to write results.
-      const [existingTranscript] = await db
-        .select({ recordingId: schema.recordingTranscripts.recordingId })
-        .from(schema.recordingTranscripts)
-        .where(eq(schema.recordingTranscripts.recordingId, id));
-      if (!existingTranscript) {
-        await db.insert(schema.recordingTranscripts).values({
-          recordingId: id,
-          ownerEmail,
-          status: "pending",
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-        });
-      }
-
-      await writeAppState(`recording-upload-${id}`, {
-        recordingId: id,
-        status: "ready",
-        progress: 100,
-        videoUrl,
-        finishedAt: new Date().toISOString(),
-      });
-
-      await writeAppState("refresh-signal", { ts: Date.now() });
-
-      // Kick off transcription in the background. Native web/macOS speech rows
-      // are preserved first; cloud transcription only fills gaps/refines when
-      // needed. The chunk endpoint already awaits this finalize call, so we
-      // fire-and-forget — the request context (user email via AsyncLocalStorage)
-      // carries through to async continuations started before this run()
-      // returns. Without this the transcript row stays in `pending` forever and
-      // the UI shows an infinite "Transcribing…" spinner.
-      void Promise.resolve(
-        requestTranscript.run({ recordingId: id, force: true }),
-      ).catch((err: unknown) => {
-        console.error("[finalize] background transcript failed", {
-          id,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      });
-
-      // Emit clip.created event — best-effort, never block the main flow.
-      try {
-        emit(
-          "clip.created",
-          {
-            clipId: id,
-            title: existing.title,
-            createdBy: ownerEmail,
-            duration: finalDurationMs,
-            url: videoUrl,
-          },
-          { owner: ownerEmail },
-        );
-      } catch (err) {
-        console.warn("[finalize] clip.created emit failed:", err);
-      }
 
       debugLog("[finalize] done", {
         id,
-        videoUrl,
+        videoUrl: upload.url,
         bytes: assembled.byteLength,
       });
-
-      return {
-        id,
-        status: "ready" as const,
-        videoUrl,
+      return markRecordingReady({
+        ...readyParams,
+        videoUrl: upload.url,
         videoSizeBytes: assembled.byteLength,
-        durationMs: finalDurationMs,
-      };
+      });
     } finally {
       // Unconditional chunk scratch-space cleanup. Runs on success AND on
       // error — a throw during uploadFile / drizzle update / anything else

--- a/templates/clips/actions/lib/create-recording-schema.ts
+++ b/templates/clips/actions/lib/create-recording-schema.ts
@@ -64,4 +64,16 @@ export const createRecordingSchema = z.object({
     .enum(["private", "org", "public"])
     .optional()
     .describe("Initial share visibility for the recording"),
+  mimeType: z
+    .string()
+    .optional()
+    .describe(
+      "MIME type the browser will record (e.g. video/webm, video/mp4). Used to initialize the resumable session with the correct content type.",
+    ),
+  requestStreaming: z
+    .boolean()
+    .optional()
+    .describe(
+      "Opt in to the resumable streaming upload path. Only send this when the caller can produce 256 KiB-aligned chunks (GCS requirement). Defaults to false — callers that omit this always get the buffered path.",
+    ),
 });

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -11,6 +11,7 @@ import {
   chunkUploadUrl,
   pickMimeType,
   pickMimeTypeCandidates,
+  type UploadMode,
 } from "@shared/recording-core";
 
 import {
@@ -95,6 +96,13 @@ export interface RecorderEngineOptions {
   uploadUrl?: string;
   /** Abort URL. Default `/api/uploads/:id/abort`. */
   abortUrl?: string;
+  /**
+   * Upload strategy returned by create-recording.
+   * `"streaming"` — server has a resumable session; engine flushes aligned
+   * chunks during recording. `"buffered"` — blob assembled after stop() and
+   * uploaded in slices via the SQL chunk path.
+   */
+  uploadMode?: UploadMode;
   /** Fired whenever the state machine transitions. */
   onState?: (state: RecorderState, detail?: Record<string, unknown>) => void;
   /** Fired on each uploaded chunk (for progress UI). */
@@ -183,6 +191,11 @@ interface CompressionUploadMeta {
 }
 
 const DEFAULT_CHUNK_MS = 1000;
+// GCS resumable uploads require every non-final chunk to be a multiple of
+// 256 KiB. MediaRecorder emits arbitrary blob sizes, so on the streaming path
+// we buffer raw blobs and only PUT aligned slices. ~4 MiB per streamed chunk.
+const GCS_CHUNK_ALIGN_BYTES = 256 * 1024;
+const STREAM_CHUNK_BYTES = 15 * GCS_CHUNK_ALIGN_BYTES; // 3.75 MiB
 const CHUNK_UPLOAD_MAX_ATTEMPTS = 3;
 const RETRYABLE_CHUNK_UPLOAD_STATUSES = new Set([
   408, 425, 429, 500, 502, 503, 504,
@@ -430,7 +443,15 @@ export class RecorderEngine {
    * fetch quietly complete and the recording finalise server-side.
    */
   private uploadAbort: AbortController | null = null;
-  private streamChunksDuringRecording = false;
+  private uploadMode: UploadMode = "buffered";
+  /**
+   * Streaming-path buffer. MediaRecorder blobs accumulate here until at least
+   * STREAM_CHUNK_BYTES is available, then a 256 KiB-aligned slice is PUT to API
+   * as a non-final chunk. The unaligned remainder is held and uploaded as the
+   * final chunk on stop().
+   */
+  private pendingStreamBlobs: Blob[] = [];
+  private pendingStreamBytes = 0;
   /**
    * One-shot guards so a camera/mic disconnect warning fires at most once even
    * when a device exposes multiple tracks that each emit `ended`.
@@ -806,10 +827,12 @@ export class RecorderEngine {
     recordingId: string;
     uploadUrl: string;
     abortUrl: string;
+    uploadMode?: UploadMode;
   }): void {
     this.opts.recordingId = target.recordingId;
     this.opts.uploadUrl = target.uploadUrl;
     this.opts.abortUrl = target.abortUrl;
+    this.opts.uploadMode = target.uploadMode ?? "buffered";
   }
 
   // -------------------------------------------------------------------------
@@ -884,7 +907,9 @@ export class RecorderEngine {
     this.totalRecordedBytes = 0;
     this.lastFinalizeMeta = null;
     this.uploadAbort = new AbortController();
-    this.streamChunksDuringRecording = false;
+    this.uploadMode = this.opts.uploadMode ?? "buffered";
+    this.pendingStreamBlobs = [];
+    this.pendingStreamBytes = 0;
     this.cameraDisconnectNotified = false;
     this.micDisconnectNotified = false;
     const useTimeslicedLocalChunks = canUseTimeslicedRecorderChunks(
@@ -901,9 +926,10 @@ export class RecorderEngine {
       // whether this recording needs compression.
       this.localChunks.push(blob);
       this.totalRecordedBytes += blob.size;
-      if (this.streamChunksDuringRecording) {
-        const index = this.chunkIndex++;
-        this.queueChunk(blob, index, /* isFinal */ false);
+      if (this.uploadMode === "streaming") {
+        this.pendingStreamBlobs.push(blob);
+        this.pendingStreamBytes += blob.size;
+        this.flushAlignedStreamChunks();
       }
     });
 
@@ -1071,12 +1097,13 @@ export class RecorderEngine {
     try {
       if (
         COMPRESSION_ENABLED &&
-        this.totalRecordedBytes > COMPRESS_THRESHOLD_BYTES
+        this.totalRecordedBytes > COMPRESS_THRESHOLD_BYTES &&
+        this.opts.uploadMode !== "streaming"
       ) {
         // Compress before the first server upload so large recordings don't
         // stage their uncompressed source in SQL.
         result = await this.compressAndReupload(finalizeMeta);
-      } else if (!this.streamChunksDuringRecording) {
+      } else if (this.uploadMode !== "streaming") {
         this.transition("uploading", { progress: 0 });
         const assembled = new Blob(this.localChunks, { type: this.mimeType });
         result = await this.uploadBlobInSlices(
@@ -1086,26 +1113,28 @@ export class RecorderEngine {
           this.uploadAbort?.signal,
         );
       } else {
-        // Send a 0-byte isFinal sentinel — the actual final-chunk bytes
-        // were already uploaded by the start()-time listener as a
-        // regular (non-final) chunk. Mirroring the auto-stop path so
-        // both branches share one code shape.
+        // Streaming path: all 256 KiB-aligned chunks were queued during
+        // recording. Whatever bytes remain become the
+        // final chunk. If the recording happened to end exactly
+        // on a boundary the remainder is empty, which the server treats as a
+        // close sentinel.
         this.transition("uploading", { progress: 100 });
-        result = await this.uploadChunk(
-          new Blob([], { type: this.mimeType }),
-          this.chunkIndex++,
-          {
-            isFinal: true,
-            total: this.chunkIndex,
-            mimeType: this.mimeType,
-            durationMs,
-            width: dimensions.width,
-            height: dimensions.height,
-            hasAudio,
-            hasCamera,
-            signal: this.uploadAbort?.signal,
-          },
-        );
+        const remainder = new Blob(this.pendingStreamBlobs, {
+          type: this.mimeType,
+        });
+        this.pendingStreamBlobs = [];
+        this.pendingStreamBytes = 0;
+        result = await this.uploadChunk(remainder, this.chunkIndex++, {
+          isFinal: true,
+          total: this.chunkIndex,
+          mimeType: this.mimeType,
+          durationMs,
+          width: dimensions.width,
+          height: dimensions.height,
+          hasAudio,
+          hasCamera,
+          signal: this.uploadAbort?.signal,
+        });
       }
       this.transition("complete");
       completed = true;
@@ -1523,6 +1552,30 @@ export class RecorderEngine {
     }
   }
 
+  /**
+   * Drain the streaming buffer in 256 KiB-aligned chunks.
+   * GCS rejects non-final resumable chunks that are not a multiple of 256 KiB,
+   * so we slice on STREAM_CHUNK_BYTES boundaries and carry the remainder. The
+   * leftover is uploaded as the final chunk on stop().
+   */
+  private flushAlignedStreamChunks(): void {
+    while (this.pendingStreamBytes >= STREAM_CHUNK_BYTES) {
+      const combined = new Blob(this.pendingStreamBlobs, {
+        type: this.mimeType,
+      });
+      const head = combined.slice(0, STREAM_CHUNK_BYTES, this.mimeType);
+      const tail = combined.slice(
+        STREAM_CHUNK_BYTES,
+        combined.size,
+        this.mimeType,
+      );
+      this.pendingStreamBlobs = tail.size > 0 ? [tail] : [];
+      this.pendingStreamBytes = tail.size;
+      const index = this.chunkIndex++;
+      this.queueChunk(head, index, /* isFinal */ false);
+    }
+  }
+
   private queueChunk(blob: Blob, index: number, isFinal: boolean): void {
     this.chunkQueue = this.chunkQueue.then(async () => {
       if (this.uploadFailure) return;
@@ -1660,8 +1713,10 @@ export class RecorderEngine {
           signal: extra.signal,
         });
       } catch (err) {
+        // The final chunk is safe to retry on a network error: finalize is
+        // idempotent server-side (a recording already 'ready' returns its
+        // existing result), so a lost response won't double-finalize.
         if (
-          extra.isFinal ||
           attempt >= CHUNK_UPLOAD_MAX_ATTEMPTS ||
           (err as { name?: string } | null)?.name === "AbortError"
         ) {
@@ -1673,7 +1728,6 @@ export class RecorderEngine {
 
       if (
         !res.ok &&
-        !extra.isFinal &&
         attempt < CHUNK_UPLOAD_MAX_ATTEMPTS &&
         isRetryableChunkUploadStatus(res.status)
       ) {

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -33,7 +33,7 @@ import {
 
 // Re-exported for existing callers; the canonical impls live in
 // @shared/recording-core and are shared with the Chrome extension recorder.
-export { pickMimeType, pickMimeTypeCandidates };
+export { pickMimeType, pickMimeTypeCandidates, canUseTimeslicedRecorderChunks };
 
 export type RecordingMode = "screen" | "camera" | "screen+camera";
 export type DisplaySurface = "monitor" | "window" | "browser";

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -7,7 +7,11 @@ import {
 } from "@agent-native/core/client";
 import { useLiveTranscription } from "@agent-native/core/client/transcription/use-live-transcription";
 import type { BrowserDiagnosticsData } from "@shared/browser-diagnostics";
-import { chunkUploadUrl, pickMimeType, type UploadMode } from "@shared/recording-core";
+import {
+  chunkUploadUrl,
+  pickMimeType,
+  type UploadMode,
+} from "@shared/recording-core";
 import {
   IconAlertTriangle,
   IconArrowLeft,

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -7,7 +7,7 @@ import {
 } from "@agent-native/core/client";
 import { useLiveTranscription } from "@agent-native/core/client/transcription/use-live-transcription";
 import type { BrowserDiagnosticsData } from "@shared/browser-diagnostics";
-import { chunkUploadUrl } from "@shared/recording-core";
+import { chunkUploadUrl, pickMimeType, type UploadMode } from "@shared/recording-core";
 import {
   IconAlertTriangle,
   IconArrowLeft,
@@ -567,6 +567,7 @@ interface PendingRecording {
   id: string;
   uploadChunkUrl: string;
   abortUrl: string;
+  uploadMode?: UploadMode;
 }
 
 function PreRecordPanelSkeleton() {
@@ -1194,6 +1195,8 @@ export default function RecordRoute() {
               visibility: reportContext ? "org" : "public",
               spaceIds: spaceIdFromUrl ? [spaceIdFromUrl] : undefined,
               folderId: folderIdFromUrl ?? undefined,
+              mimeType: pickMimeType() || undefined,
+              requestStreaming: true,
             }),
           },
         );
@@ -1213,10 +1216,12 @@ export default function RecordRoute() {
             id: string;
             uploadChunkUrl: string;
             abortUrl: string;
+            uploadMode?: UploadMode;
           };
           id?: string;
           uploadChunkUrl?: string;
           abortUrl?: string;
+          uploadMode?: UploadMode;
         };
         const info = created.result ?? (created as PendingRecording);
         if (!info?.id) {
@@ -1244,6 +1249,7 @@ export default function RecordRoute() {
           recordingId: info.id,
           uploadUrl: uploadChunkUrl,
           abortUrl,
+          uploadMode: info.uploadMode,
         });
         await saveBugReportContextRef.current(info.id);
 

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -99,6 +99,7 @@ import { CountdownOverlay } from "@/components/recorder/countdown-overlay";
 import { PreRecordPanel } from "@/components/recorder/pre-record-panel";
 import {
   RecorderEngine,
+  canUseTimeslicedRecorderChunks,
   NO_MIC_DEVICE_ID,
   type DisplaySurface,
   type RecorderFinalizeResult,
@@ -1200,7 +1201,7 @@ export default function RecordRoute() {
               spaceIds: spaceIdFromUrl ? [spaceIdFromUrl] : undefined,
               folderId: folderIdFromUrl ?? undefined,
               mimeType: pickMimeType() || undefined,
-              requestStreaming: true,
+              requestStreaming: canUseTimeslicedRecorderChunks(pickMimeType()),
             }),
           },
         );

--- a/templates/clips/server/lib/resumable-session.ts
+++ b/templates/clips/server/lib/resumable-session.ts
@@ -26,7 +26,10 @@ export async function setResumableSession(
   recordingId: string,
   session: StoredResumableSession,
 ): Promise<void> {
-  await writeAppState(key(recordingId), session as unknown as Record<string, unknown>);
+  await writeAppState(
+    key(recordingId),
+    session as unknown as Record<string, unknown>,
+  );
 }
 
 export async function deleteResumableSession(

--- a/templates/clips/server/lib/resumable-session.ts
+++ b/templates/clips/server/lib/resumable-session.ts
@@ -1,0 +1,36 @@
+import {
+  deleteAppState,
+  readAppState,
+  writeAppState,
+} from "@agent-native/core/application-state";
+
+export interface StoredResumableSession {
+  providerId: string;
+  sessionId: string;
+  meta: Record<string, unknown>;
+  bytesUploaded: number;
+  lastCommittedIndex?: number;
+}
+
+const key = (recordingId: string) => `resumable-session-${recordingId}`;
+
+export async function getResumableSession(
+  recordingId: string,
+): Promise<StoredResumableSession | null> {
+  const raw = await readAppState(key(recordingId));
+  if (!raw || typeof raw !== "object") return null;
+  return raw as unknown as StoredResumableSession;
+}
+
+export async function setResumableSession(
+  recordingId: string,
+  session: StoredResumableSession,
+): Promise<void> {
+  await writeAppState(key(recordingId), session as unknown as Record<string, unknown>);
+}
+
+export async function deleteResumableSession(
+  recordingId: string,
+): Promise<void> {
+  await deleteAppState(key(recordingId));
+}

--- a/templates/clips/server/routes/api/uploads/[recordingId]/abort.post.ts
+++ b/templates/clips/server/routes/api/uploads/[recordingId]/abort.post.ts
@@ -24,7 +24,7 @@ import {
   getEventOwnerContext,
   ownerEmailMatches,
 } from "../../../../lib/recordings.js";
-import { deleteResumableSession } from "../../../lib/resumable-session.js";
+import { deleteResumableSession } from "../../../../lib/resumable-session.js";
 
 export default defineEventHandler(async (event: H3Event) => {
   const recordingId = getRouterParam(event, "recordingId");

--- a/templates/clips/server/routes/api/uploads/[recordingId]/abort.post.ts
+++ b/templates/clips/server/routes/api/uploads/[recordingId]/abort.post.ts
@@ -10,6 +10,7 @@ import {
   deleteAppStateByPrefix,
 } from "@agent-native/core/application-state";
 import { runWithRequestContext } from "@agent-native/core/server";
+import { deleteResumableSession } from "../../../lib/resumable-session.js";
 import { and, eq } from "drizzle-orm";
 import {
   defineEventHandler,
@@ -62,6 +63,7 @@ export default defineEventHandler(async (event: H3Event) => {
     const cleared = await deleteAppStateByPrefix(
       `recording-chunks-${recordingId}-`,
     );
+    await deleteResumableSession(recordingId).catch(() => {});
 
     const now = new Date().toISOString();
     await db

--- a/templates/clips/server/routes/api/uploads/[recordingId]/abort.post.ts
+++ b/templates/clips/server/routes/api/uploads/[recordingId]/abort.post.ts
@@ -10,7 +10,6 @@ import {
   deleteAppStateByPrefix,
 } from "@agent-native/core/application-state";
 import { runWithRequestContext } from "@agent-native/core/server";
-import { deleteResumableSession } from "../../../lib/resumable-session.js";
 import { and, eq } from "drizzle-orm";
 import {
   defineEventHandler,
@@ -25,6 +24,7 @@ import {
   getEventOwnerContext,
   ownerEmailMatches,
 } from "../../../../lib/recordings.js";
+import { deleteResumableSession } from "../../../lib/resumable-session.js";
 
 export default defineEventHandler(async (event: H3Event) => {
   const recordingId = getRouterParam(event, "recordingId");

--- a/templates/clips/server/routes/api/uploads/[recordingId]/chunk.post.ts
+++ b/templates/clips/server/routes/api/uploads/[recordingId]/chunk.post.ts
@@ -213,6 +213,12 @@ export default defineEventHandler(async (event: H3Event) => {
       );
     }
 
+    // Already finalized — retried final chunk after session was deleted. Skip
+    // buffered path writes so recording-upload-* state stays correct.
+    if (existing.status === "ready") {
+      return { ok: true, finalized: true };
+    }
+
     // Store chunks in application_state, assemble on finalize.
     if (await shouldRejectVideoUploadWithoutStorage()) {
       const now = new Date().toISOString();

--- a/templates/clips/server/routes/api/uploads/[recordingId]/chunk.post.ts
+++ b/templates/clips/server/routes/api/uploads/[recordingId]/chunk.post.ts
@@ -18,6 +18,7 @@ import {
   readAppState,
   writeAppState,
 } from "@agent-native/core/application-state";
+import { getActiveFileUploadProvider } from "@agent-native/core/file-upload";
 import { runWithRequestContext } from "@agent-native/core/server";
 import { normalizeChunkUploadNumber } from "@shared/recording-core.js";
 import { MAX_UPLOAD_BYTES as MAX_RECORDING_UPLOAD_BYTES } from "@shared/upload-limits.js";
@@ -41,10 +42,21 @@ import {
   ownerEmailMatches,
 } from "../../../../lib/recordings.js";
 import {
+  getResumableSession,
+  setResumableSession,
+  type StoredResumableSession,
+} from "../../../../lib/resumable-session.js";
+import {
   shouldRejectVideoUploadWithoutStorage,
   STORAGE_SETUP_REQUIRED_REASON,
 } from "../../../../lib/video-storage.js";
+
 const RECORDING_TOO_LARGE_REASON = `Recording exceeds the ${Math.round(MAX_RECORDING_UPLOAD_BYTES / (1024 * 1024))} MB size limit. Please record a shorter clip.`;
+
+// Netlify functions have a 6 MB buffered request cap, but binary requests
+// are base64 encoded by the gateway and effectively cap out around 4.5 MB.
+// Keep our own cap lower so dev/local failures match production.
+const MAX_CHUNK_BYTES = 4 * 1024 * 1024;
 
 const ALLOWED_RECORDING_MIME_TYPES = new Set([
   "video/webm",
@@ -123,10 +135,6 @@ export default defineEventHandler(async (event: H3Event) => {
     throw createError({ statusCode: 400, message: "Invalid chunk index" });
   }
 
-  // Netlify functions have a 6 MB buffered request cap, but binary requests
-  // are base64 encoded by the gateway and effectively cap out around 4.5 MB.
-  // Keep our own cap lower so dev/local failures match production.
-  const MAX_CHUNK_BYTES = 4 * 1024 * 1024;
   const contentLength = Number(getHeader(event, "content-length") || 0);
   if (contentLength > MAX_CHUNK_BYTES) {
     setResponseStatus(event, 413);
@@ -172,6 +180,20 @@ export default defineEventHandler(async (event: H3Event) => {
       throw createError({ statusCode: 404, message: "Recording not found" });
     }
 
+    // Resumable streaming path — forward chunks directly to the provider.
+    const resumableSession = await getResumableSession(recordingId);
+    if (resumableSession) {
+      return handleResumableChunk(
+        event,
+        resumableSession,
+        recordingId,
+        index,
+        isFinal,
+        mimeType,
+        query,
+      );
+    }
+
     const failedUploadResponse = (reason: string, bytes?: number) => {
       setResponseStatus(
         event,
@@ -191,6 +213,7 @@ export default defineEventHandler(async (event: H3Event) => {
       );
     }
 
+    // Store chunks in application_state, assemble on finalize.
     if (await shouldRejectVideoUploadWithoutStorage()) {
       const now = new Date().toISOString();
       await db
@@ -367,10 +390,7 @@ export default defineEventHandler(async (event: H3Event) => {
 
       await db
         .update(schema.recordings)
-        .set({
-          uploadProgress: progress,
-          updatedAt: new Date().toISOString(),
-        })
+        .set({ uploadProgress: progress, updatedAt: new Date().toISOString() })
         .where(
           and(
             eq(schema.recordings.id, recordingId),
@@ -404,21 +424,9 @@ export default defineEventHandler(async (event: H3Event) => {
       if (failedResponse) return failedResponse;
       debugLog("[chunk] isFinal — invoking finalize", { recordingId });
       try {
-        const result = await finalizeRecording.run({
-          id: recordingId,
-          durationMs: normalizeChunkUploadNumber(query.durationMs),
-          width: normalizeChunkUploadNumber(query.width),
-          height: normalizeChunkUploadNumber(query.height),
-          hasAudio:
-            query.hasAudio === undefined
-              ? undefined
-              : query.hasAudio === "1" || query.hasAudio === "true",
-          hasCamera:
-            query.hasCamera === undefined
-              ? undefined
-              : query.hasCamera === "1" || query.hasCamera === "true",
-          mimeType,
-        });
+        const result = await finalizeRecording.run(
+          buildFinalizeArgs(recordingId, mimeType, query),
+        );
         debugLog("[chunk] finalize ok", {
           recordingId,
           videoUrl: (result as any)?.videoUrl,
@@ -460,11 +468,154 @@ export default defineEventHandler(async (event: H3Event) => {
       }
     }
 
-    return {
-      ok: true,
-      finalized: false,
-      index,
-      bytes: bytes.byteLength,
-    };
+    return { ok: true, finalized: false, index, bytes: bytes.byteLength };
   });
 });
+
+function buildFinalizeArgs(
+  recordingId: string,
+  mimeType: string,
+  query: Record<string, unknown>,
+) {
+  return {
+    id: recordingId,
+    durationMs: normalizeChunkUploadNumber(query.durationMs),
+    width: normalizeChunkUploadNumber(query.width),
+    height: normalizeChunkUploadNumber(query.height),
+    hasAudio:
+      query.hasAudio === undefined
+        ? undefined
+        : query.hasAudio === "1" || query.hasAudio === "true",
+    hasCamera:
+      query.hasCamera === undefined
+        ? undefined
+        : query.hasCamera === "1" || query.hasCamera === "true",
+    mimeType,
+  };
+}
+
+// Resumable streaming path: each chunk is forwarded directly to the upload
+// provider. Always returns a response — never falls through to the buffered path.
+async function handleResumableChunk(
+  event: H3Event,
+  session: StoredResumableSession,
+  recordingId: string,
+  index: number,
+  isFinal: boolean,
+  mimeType: string,
+  query: Record<string, unknown>,
+) {
+  const uploadProvider = getActiveFileUploadProvider();
+  console.log(
+    `[resumable-chunk-${recordingId}] resumable session exists - bytesUploaded=${session.bytesUploaded} index=${index} isFinal=${isFinal}`,
+  );
+
+  const raw = await readRawBody(event, false);
+  const bytes: Uint8Array = raw ?? new Uint8Array(0);
+
+  if (!isFinal && bytes.byteLength === 0) {
+    throw createError({ statusCode: 400, message: "Empty chunk body" });
+  }
+
+  if (isFinal && bytes.byteLength === 0) {
+    // 0-byte sentinel from the recorder after stop(). All data chunks have
+    // already been PUT to the provider; send Content-Range: bytes */<total>
+    // to close the session before handing off to finalize-recording.
+    const closeRes = await uploadProvider!.resumable!.relayChunk(
+      { sessionId: session.sessionId, meta: session.meta },
+      `bytes */${session.bytesUploaded}`,
+      new Uint8Array(0),
+    );
+    if (!closeRes.ok) {
+      console.error(
+        `[resumable-chunk-${recordingId}] session close failed (${closeRes.status})`,
+      );
+      setResponseStatus(event, 502);
+      return {
+        ok: false,
+        error: `Resumable session close failed (${closeRes.status})`,
+      };
+    }
+  } else {
+    // Idempotent replay guard: a client retry (after a lost response) can
+    // re-send a chunk we already committed. Re-PUTing it at the new offset
+    // would corrupt the file — detect the duplicate by index and skip the PUT.
+    // Chunks are strictly sequential, so any index <= last committed is a replay.
+    // A replayed non-final is acked here; a replayed final falls through to
+    // finalize, which is idempotent.
+    const isReplay = index <= (session.lastCommittedIndex ?? -1);
+    if (isReplay) {
+      console.warn(
+        `[resumable-chunk-${recordingId}] duplicate chunk ${index}, acking without re-upload`,
+      );
+      if (!isFinal) {
+        return {
+          ok: true,
+          finalized: false,
+          index,
+          bytes: bytes.byteLength,
+          duplicate: true,
+        };
+      }
+    } else {
+      // Forward the data chunk to the provider and advance offsets only after
+      // the provider confirms receipt (308 Resume Incomplete for non-final, 2xx for final).
+      const start = session.bytesUploaded;
+      const end = start + bytes.byteLength - 1;
+      const contentRange = isFinal
+        ? `bytes ${start}-${end}/${start + bytes.byteLength}`
+        : `bytes ${start}-${end}/*`;
+
+      const putT0 = Date.now();
+      const putResult = await uploadProvider!.resumable!.relayChunk(
+        { sessionId: session.sessionId, meta: session.meta },
+        contentRange,
+        bytes,
+        { mimeType: mimeType.split(";")[0].trim() },
+      );
+      console.log(
+        `[resumable-chunk-${recordingId}] PUT ${Date.now() - putT0}ms status=${putResult.status} range="${contentRange}"`,
+      );
+
+      const resultOk = isFinal
+        ? putResult.ok && putResult.status !== 308
+        : putResult.ok;
+      if (!resultOk) {
+        setResponseStatus(event, 502);
+        return {
+          ok: false,
+          error: `Chunk upload failed (${putResult.status})`,
+        };
+      }
+
+      await setResumableSession(recordingId, {
+        ...session,
+        ...(putResult.updatedMeta
+          ? { meta: { ...session.meta, ...putResult.updatedMeta } }
+          : {}),
+        bytesUploaded: start + bytes.byteLength,
+        lastCommittedIndex: index,
+      });
+
+      if (!isFinal) {
+        return { ok: true, finalized: false, index, bytes: bytes.byteLength };
+      }
+    }
+  }
+
+  // isFinal — delegate to finalize-recording, which reads the resumable
+  // session and calls provider.resumable.completeSession.
+  try {
+    const result = await finalizeRecording.run(
+      buildFinalizeArgs(recordingId, mimeType, query),
+    );
+    return { ok: true, finalized: true, ...result };
+  } catch (err) {
+    console.error(`[resumable-chunk-${recordingId}] finalize failed:`, err);
+    setResponseStatus(event, 500);
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "Finalize failed",
+    };
+  }
+}

--- a/templates/clips/server/routes/api/uploads/[recordingId]/reset-chunks.post.ts
+++ b/templates/clips/server/routes/api/uploads/[recordingId]/reset-chunks.post.ts
@@ -44,6 +44,7 @@ import {
   getEventOwnerContext,
   ownerEmailMatches,
 } from "../../../../lib/recordings.js";
+import { deleteResumableSession } from "../../../../lib/resumable-session.js";
 
 interface CompressionMeta {
   originalBytes?: number;
@@ -112,6 +113,9 @@ export default defineEventHandler(async (event: H3Event) => {
     const cleared = await deleteAppStateByPrefix(
       `recording-chunks-${recordingId}-`,
     );
+    // Clear any stale resumable session so a buffered retry does not
+    // accidentally route through handleResumableChunk with stale offsets.
+    await deleteResumableSession(recordingId).catch(() => {});
 
     // Reset the per-recording upload progress so the UI poller sees the
     // re-upload restart from 0 and doesn't briefly show "100% then

--- a/templates/clips/shared/recording-core.ts
+++ b/templates/clips/shared/recording-core.ts
@@ -46,6 +46,11 @@ export function pickMimeType(): string {
   return "";
 }
 
+/** How the client delivers recorded data to the server.
+ *  - `"streaming"` — chunks are flushed to GCS during recording via a resumable session
+ *  - `"buffered"`  — full blob assembled after stop() and uploaded in slices */
+export type UploadMode = "streaming" | "buffered";
+
 /** Query params understood by the chunk-upload route
  * (`/api/uploads/:id/chunk`). This is the on-the-wire contract — the route in
  * `server/routes/api/uploads/[recordingId]/chunk.post.ts` reads exactly these. */


### PR DESCRIPTION
Previously, Clips buffered all video chunks in the database and assembled them into a file only after the user stopped recording. This PR changes the default to stream chunks directly to storage during recording, so the upload is nearly complete by the time the user hits stop.

## What changed

**Streaming upload path.** When a storage provider supports it, `create-recording` now opens a resumable upload session upfront. Each chunk the browser records is forwarded to the provider immediately. When recording stops, only the final "seal" call is needed — there is no post-stop assembly or upload wait.

**Provider-agnostic design.** The `FileUploadProvider` interface gained an optional `resumable` capability with three methods: start a session, relay a chunk, complete the session. Builder.io implements this via GCS resumable uploads. Other providers can opt in by implementing the same interface.

**Explicit opt-in per caller.** `create-recording` accepts a new `requestStreaming` flag. Only callers that produce 256 KiB-aligned chunks (which GCS requires) should set this. This PR enables streaming only in the web app. The Chrome extension and desktop app continue using the buffered path unchanged and will be migrated in follow-up PRs. If streaming is requested but no provider supports it, the action throws before creating any database rows.

**Browser picks the video codec.** The web recorder now sends the `mimeType` it selected to `create-recording`, so the resumable session is opened with the correct content type. Previously the server hardcoded `video/webm`, which broke Safari where the browser records in MP4.

**Session state is stored in `application_state`.** Between chunks, the session URI, bytes uploaded so far, and provider metadata are persisted so the server can resume correctly after a function restart or retry. A new `StoredResumableSession` helper centralises the read/write/delete calls in one place.

**Duplicate chunk protection.** If the browser retries a chunk after a lost response, the server detects the duplicate by index and acknowledges it without re-uploading to GCS, preventing data corruption.

**Streaming chunk size reduced to 3.75 MiB** (from 4 MiB) to stay safely under the server's 4 MiB per-chunk limit.
