### PR TITLE
Add close button to agent pane and hide toggle when open

### DIFF
--- a/.changeset/agent-toggle-close-icon.md
+++ b/.changeset/agent-toggle-close-icon.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Add a close (X) button to the left of the Chat tab in the agent pane header that closes the agent chat. The button used to open the agent is unchanged.
+Add a close (X) button to the left of the Chat tab in the agent pane header that closes the agent chat, and hide the open-agent button while the agent pane is open.

--- a/.changeset/agent-toggle-close-icon.md
+++ b/.changeset/agent-toggle-close-icon.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-The agent toggle button now shows a close (X) icon and closes the agent chat when the panel is open, instead of always showing the chat icon.
+Add a close (X) button to the left of the Chat tab in the agent pane header that closes the agent chat. The button used to open the agent is unchanged.

--- a/.changeset/agent-toggle-close-icon.md
+++ b/.changeset/agent-toggle-close-icon.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+The agent toggle button now shows a close (X) icon and closes the agent chat when the panel is open, instead of always showing the chat icon.

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -85,8 +85,6 @@ import {
   getInitialAgentSidebarOpen,
   setAgentSidebarOpenPreference,
   subscribeAgentSidebarUrlChanges,
-  SIDEBAR_STATE_CHANGE_EVENT,
-  type AgentSidebarStateChangeDetail,
 } from "./agent-sidebar-state.js";
 import { trackEvent } from "./analytics.js";
 import { agentNativePath } from "./api-path.js";
@@ -971,6 +969,22 @@ function AgentPanelInner({
     (activeMode: PanelMode) => (
       <TooltipProvider delayDuration={200}>
         <div className="flex shrink-0 items-center gap-1">
+          {onCollapse && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={onCollapse}
+                  aria-label={t("agentPanel.collapseSidebar")}
+                  className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                  style={AGENT_PANEL_CONTROL_STYLE}
+                >
+                  <IconX size={16} />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>{t("agentPanel.collapseSidebar")}</TooltipContent>
+            </Tooltip>
+          )}
           <Tooltip>
             <TooltipTrigger asChild>
               <button
@@ -1037,7 +1051,7 @@ function AgentPanelInner({
         </div>
       </TooltipProvider>
     ),
-    [codeAccessEnabled, codeUnavailableDescription, showCliMode, t],
+    [codeAccessEnabled, codeUnavailableDescription, onCollapse, showCliMode, t],
   );
 
   const [headerMenuOpen, setHeaderMenuOpen] = useState(false);
@@ -3029,43 +3043,25 @@ export function focusAgentChat() {
  * Dispatches a custom event that AgentSidebar listens for.
  */
 export function AgentToggleButton({ className }: { className?: string }) {
-  const [open, setOpen] = useState(false);
-  useEffect(() => {
-    const handler = (event: Event) => {
-      const detail = (event as CustomEvent<AgentSidebarStateChangeDetail>)
-        .detail;
-      if (detail && typeof detail.open === "boolean") setOpen(detail.open);
-    };
-    window.addEventListener(SIDEBAR_STATE_CHANGE_EVENT, handler);
-    return () =>
-      window.removeEventListener(SIDEBAR_STATE_CHANGE_EVENT, handler);
-  }, []);
-  const label = open ? "Close agent" : "Toggle agent";
   return (
     <TooltipProvider delayDuration={200}>
       <Tooltip>
         <TooltipTrigger asChild>
           <button
             type="button"
-            aria-label={label}
+            aria-label="Toggle agent"
             onClick={() =>
-              window.dispatchEvent(
-                new Event(open ? "agent-panel:close" : "agent-panel:toggle"),
-              )
+              window.dispatchEvent(new Event("agent-panel:toggle"))
             }
             className={cn(
               "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent/40 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
               className,
             )}
           >
-            {open ? (
-              <IconX size={20} aria-hidden />
-            ) : (
-              <IconMessageDots size={20} aria-hidden />
-            )}
+            <IconMessageDots size={20} aria-hidden />
           </button>
         </TooltipTrigger>
-        <TooltipContent>{label}</TooltipContent>
+        <TooltipContent>Toggle agent</TooltipContent>
       </Tooltip>
     </TooltipProvider>
   );

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -85,6 +85,8 @@ import {
   getInitialAgentSidebarOpen,
   setAgentSidebarOpenPreference,
   subscribeAgentSidebarUrlChanges,
+  SIDEBAR_STATE_CHANGE_EVENT,
+  type AgentSidebarStateChangeDetail,
 } from "./agent-sidebar-state.js";
 import { trackEvent } from "./analytics.js";
 import { agentNativePath } from "./api-path.js";
@@ -3027,25 +3029,43 @@ export function focusAgentChat() {
  * Dispatches a custom event that AgentSidebar listens for.
  */
 export function AgentToggleButton({ className }: { className?: string }) {
+  const [open, setOpen] = useState(false);
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<AgentSidebarStateChangeDetail>)
+        .detail;
+      if (detail && typeof detail.open === "boolean") setOpen(detail.open);
+    };
+    window.addEventListener(SIDEBAR_STATE_CHANGE_EVENT, handler);
+    return () =>
+      window.removeEventListener(SIDEBAR_STATE_CHANGE_EVENT, handler);
+  }, []);
+  const label = open ? "Close agent" : "Toggle agent";
   return (
     <TooltipProvider delayDuration={200}>
       <Tooltip>
         <TooltipTrigger asChild>
           <button
             type="button"
-            aria-label="Toggle agent"
+            aria-label={label}
             onClick={() =>
-              window.dispatchEvent(new Event("agent-panel:toggle"))
+              window.dispatchEvent(
+                new Event(open ? "agent-panel:close" : "agent-panel:toggle"),
+              )
             }
             className={cn(
               "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent/40 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
               className,
             )}
           >
-            <IconMessageDots size={20} aria-hidden />
+            {open ? (
+              <IconX size={20} aria-hidden />
+            ) : (
+              <IconMessageDots size={20} aria-hidden />
+            )}
           </button>
         </TooltipTrigger>
-        <TooltipContent>Toggle agent</TooltipContent>
+        <TooltipContent>{label}</TooltipContent>
       </Tooltip>
     </TooltipProvider>
   );

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -85,6 +85,8 @@ import {
   getInitialAgentSidebarOpen,
   setAgentSidebarOpenPreference,
   subscribeAgentSidebarUrlChanges,
+  SIDEBAR_STATE_CHANGE_EVENT,
+  type AgentSidebarStateChangeDetail,
 } from "./agent-sidebar-state.js";
 import { trackEvent } from "./analytics.js";
 import { agentNativePath } from "./api-path.js";
@@ -3043,6 +3045,20 @@ export function focusAgentChat() {
  * Dispatches a custom event that AgentSidebar listens for.
  */
 export function AgentToggleButton({ className }: { className?: string }) {
+  const [open, setOpen] = useState(false);
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<AgentSidebarStateChangeDetail>)
+        .detail;
+      if (detail && typeof detail.open === "boolean") setOpen(detail.open);
+    };
+    window.addEventListener(SIDEBAR_STATE_CHANGE_EVENT, handler);
+    return () =>
+      window.removeEventListener(SIDEBAR_STATE_CHANGE_EVENT, handler);
+  }, []);
+  // Hide the open-agent button while the agent pane is open; the pane has its
+  // own close button.
+  if (open) return null;
   return (
     <TooltipProvider delayDuration={200}>
       <Tooltip>


### PR DESCRIPTION
### Summary
Adds a close (X) button to the left of the Chat tab in the agent pane header, and hides the open-agent toggle button while the agent pane is already open.

### Problem
Previously, there was no dedicated close button inside the agent pane itself — users had to rely on the same toggle button in the toolbar to close it. This made the UI less intuitive, and the open-agent button remained visible even when the pane was already open, creating redundancy.

### Solution
A close button using `IconX` is rendered inside the agent pane's tab header (left of the Chat tab) when an `onCollapse` handler is available. The `AgentToggleButton` now listens for sidebar state change events and returns `null` (hides itself) while the agent pane is open.

### Key Changes
- **Close button in agent pane header**: Added an `IconX` button to the left of the Chat tab in `AgentPanelInner`'s tab bar, visible when `onCollapse` is provided; includes tooltip using the `agentPanel.collapseSidebar` translation key.
- **Hide toggle button when pane is open**: `AgentToggleButton` now subscribes to `SIDEBAR_STATE_CHANGE_EVENT` via a `useEffect` and tracks open state; returns `null` when the sidebar is open.
- **Imports**: Added `SIDEBAR_STATE_CHANGE_EVENT` and `AgentSidebarStateChangeDetail` imports from `agent-sidebar-state`.
- **Changeset**: Added a patch-level changeset entry for `@agent-native/core`.


https://github.com/user-attachments/assets/29f7fddd-67d0-4f0d-b239-00d43ccf985b



---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/chrome-blend-w5j7izet"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-chrome-blend-w5j7izet.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1681`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>chrome-blend-w5j7izet</branchName>-->