### PR TITLE
Fix Design Studio canvas layer editing

### DIFF
--- a/templates/design/.generated/bridge/editor-chrome.generated.ts
+++ b/templates/design/.generated/bridge/editor-chrome.generated.ts
@@ -2658,17 +2658,16 @@ export const editorChromeBridgeScript: string = `"use strict";
         }
       }
     }
-    function beginTextEditingFromEvent(e) {
+    function beginTextEditingFromEvent(e, forceTextEditing) {
       if (activeTextEditEl && e.target && activeTextEditEl.contains(e.target))
         return;
-      if (!textEditingEnabled) {
+      if (!textEditingEnabled && !forceTextEditing) {
         stopNativeInteraction(e);
         return;
       }
       stopNativeInteraction(e);
-      var target = findTextEditTarget(
-        elementFromEditorPoint(e.clientX, e.clientY)
-      );
+      var eventTarget = e && e.target && e.target.nodeType === 1 ? e.target : null;
+      var target = findTextEditTarget(elementFromEditorPoint(e.clientX, e.clientY)) || findTextEditTarget(eventTarget) || eventTarget;
       if (!target || target.nodeType !== 1) return;
       selectedEl = selectionTargetForHit(target) || target;
       var originalText = target.textContent || "";
@@ -2886,7 +2885,8 @@ export const editorChromeBridgeScript: string = `"use strict";
         return;
       }
       if (e.data.type === "begin-text-edit") {
-        if (readOnly || !textEditingEnabled) return;
+        var forceBeginTextEdit = e.data.force === true;
+        if ((readOnly || !textEditingEnabled) && !forceBeginTextEdit) return;
         var nodeId = typeof e.data.nodeId === "string" ? e.data.nodeId : "";
         if (!nodeId) return;
         var nodeTarget = document.querySelector(
@@ -2899,17 +2899,20 @@ export const editorChromeBridgeScript: string = `"use strict";
         var bteRect = textTarget.getBoundingClientRect();
         var bteCenterX = bteRect.right - 2;
         var bteCenterY = bteRect.top + bteRect.height / 2;
-        beginTextEditingFromEvent({
-          clientX: bteCenterX,
-          clientY: bteCenterY,
-          target: textTarget,
-          preventDefault: function() {
+        beginTextEditingFromEvent(
+          {
+            clientX: bteCenterX,
+            clientY: bteCenterY,
+            target: textTarget,
+            preventDefault: function() {
+            },
+            stopPropagation: function() {
+            },
+            stopImmediatePropagation: function() {
+            }
           },
-          stopPropagation: function() {
-          },
-          stopImmediatePropagation: function() {
-          }
-        });
+          forceBeginTextEdit
+        );
         return;
       }
       if (e.data.type === "set-editor-chrome-scale") {

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -374,6 +374,8 @@ interface DesignCanvasProps {
   designTitle?: string;
   /** Stable id for comment pins, usually scoped to the active screen. */
   commentContextId?: string;
+  /** Stable id of the screen containing this canvas when rendered in overview. */
+  screenId?: string;
   /** Human-readable label for comment-pin prompts. */
   commentContextLabel?: string;
   /**
@@ -506,6 +508,7 @@ export function DesignCanvas({
   designId,
   designTitle,
   commentContextId,
+  screenId,
   commentContextLabel,
   onPrototypeNavigate,
   motionTracks,
@@ -1098,7 +1101,10 @@ export function DesignCanvas({
   const beginTextEdit = useCallback((nodeId: string) => {
     const iframe = iframeRef.current;
     if (!iframe?.contentWindow || !nodeId) return;
-    iframe.contentWindow.postMessage({ type: "begin-text-edit", nodeId }, "*");
+    iframe.contentWindow.postMessage(
+      { type: "begin-text-edit", nodeId, force: true },
+      "*",
+    );
   }, []);
 
   const sendStyleChange = useCallback(
@@ -1342,6 +1348,7 @@ export function DesignCanvas({
             : "allow-scripts allow-popups allow-popups-to-escape-sandbox allow-same-origin"
         }
         data-design-preview-iframe
+        data-screen-iframe-id={screenId ?? undefined}
         data-design-source-type={
           sourceType ??
           (externalPreviewUrl

--- a/templates/design/app/components/design/LayersPanel.tsx
+++ b/templates/design/app/components/design/LayersPanel.tsx
@@ -1000,7 +1000,11 @@ function LayerRow({
   const hideable = node.hideable !== false && Boolean(onToggleHidden);
   const dragEligible = selectable && !node.locked && !node.hidden;
   const draggable = dragEligible && Boolean(onMoveLayer);
-  const canDropInside = layerCanDropInside(node, hasChildren);
+  const canDropInside = layerCanDropInside(
+    node,
+    hasChildren,
+    canAcceptChildren,
+  );
   const activeDrop =
     dropIndicator?.targetId === node.id ? dropIndicator.placement : null;
   // Tracks whether the user pressed Escape to cancel rename so that the
@@ -1868,9 +1872,14 @@ function ElementLayerGlyph({ className }: { className?: string }) {
   );
 }
 
-function layerCanDropInside(node: LayersPanelNode, hasChildren: boolean) {
+function layerCanDropInside(
+  node: LayersPanelNode,
+  hasChildren: boolean,
+  canAcceptChildren: boolean,
+) {
   return (
     hasChildren ||
+    canAcceptChildren ||
     Boolean(node.layout?.isFlexContainer || node.layout?.isGridContainer) ||
     node.type === "file" ||
     node.type === "screen" ||

--- a/templates/design/app/components/design/MultiScreenCanvas.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.tsx
@@ -3365,15 +3365,26 @@ export function MultiScreenCanvas({
     [flushPendingWheelGesture],
   );
 
-  const handleWheelEvent = useCallback(
-    (event: WheelEvent) => {
+  const enqueueWheelGestureFromClient = useCallback(
+    (args: {
+      deltaX: number;
+      deltaY: number;
+      deltaMode: number;
+      clientX: number;
+      clientY: number;
+      ctrlKey: boolean;
+      metaKey: boolean;
+      shiftKey: boolean;
+    }) => {
       const rect = surfaceRef.current?.getBoundingClientRect();
       if (!rect) return;
-      event.preventDefault();
-      event.stopPropagation();
-      const delta = getWheelDelta(event);
+      const delta = getWheelDeltaFromValues(
+        args.deltaX,
+        args.deltaY,
+        args.deltaMode,
+      );
 
-      if (event.ctrlKey || event.metaKey) {
+      if (args.ctrlKey || args.metaKey) {
         const zoomDeltaY = clamp(
           delta.y,
           -MAX_WHEEL_ZOOM_DELTA,
@@ -3382,26 +3393,47 @@ export function MultiScreenCanvas({
         enqueueWheelGesture({
           mode: "zoom",
           deltaY: zoomDeltaY,
-          cursor: { x: event.clientX - rect.left, y: event.clientY - rect.top },
-          clientX: event.clientX,
-          clientY: event.clientY,
+          cursor: {
+            x: args.clientX - rect.left,
+            y: args.clientY - rect.top,
+          },
+          clientX: args.clientX,
+          clientY: args.clientY,
         });
         return;
       }
 
       const deltaX = clamp(
-        event.shiftKey && delta.x === 0 ? delta.y : delta.x,
+        args.shiftKey && delta.x === 0 ? delta.y : delta.x,
         -MAX_WHEEL_PAN_DELTA,
         MAX_WHEEL_PAN_DELTA,
       );
       const deltaY = clamp(
-        event.shiftKey && delta.x === 0 ? 0 : delta.y,
+        args.shiftKey && delta.x === 0 ? 0 : delta.y,
         -MAX_WHEEL_PAN_DELTA,
         MAX_WHEEL_PAN_DELTA,
       );
       enqueueWheelGesture({ mode: "pan", deltaX, deltaY });
     },
     [enqueueWheelGesture],
+  );
+
+  const handleWheelEvent = useCallback(
+    (event: WheelEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      enqueueWheelGestureFromClient({
+        deltaX: event.deltaX,
+        deltaY: event.deltaY,
+        deltaMode: event.deltaMode,
+        clientX: event.clientX,
+        clientY: event.clientY,
+        ctrlKey: event.ctrlKey,
+        metaKey: event.metaKey,
+        shiftKey: event.shiftKey,
+      });
+    },
+    [enqueueWheelGestureFromClient],
   );
 
   useEffect(() => {
@@ -3417,6 +3449,44 @@ export function MultiScreenCanvas({
       });
     };
   }, [handleWheelEvent]);
+
+  useEffect(() => {
+    const handleEmbeddedWheelMessage = (event: MessageEvent) => {
+      if (!event.data || event.data.type !== "embedded-canvas-wheel") return;
+      const surface = surfaceRef.current;
+      if (!surface) return;
+      const sourceIframe = Array.from(
+        surface.querySelectorAll<HTMLIFrameElement>(
+          "iframe[data-design-preview-iframe]",
+        ),
+      ).find((iframe) => iframe.contentWindow === event.source);
+      if (!sourceIframe) return;
+
+      const rect = sourceIframe.getBoundingClientRect();
+      const scaleX =
+        sourceIframe.clientWidth > 0
+          ? rect.width / sourceIframe.clientWidth
+          : 1;
+      const scaleY =
+        sourceIframe.clientHeight > 0
+          ? rect.height / sourceIframe.clientHeight
+          : 1;
+      enqueueWheelGestureFromClient({
+        deltaX: Number(event.data.deltaX) || 0,
+        deltaY: Number(event.data.deltaY) || 0,
+        deltaMode: Number(event.data.deltaMode) || WheelEvent.DOM_DELTA_PIXEL,
+        clientX: rect.left + (Number(event.data.clientX) || 0) * scaleX,
+        clientY: rect.top + (Number(event.data.clientY) || 0) * scaleY,
+        ctrlKey: Boolean(event.data.ctrlKey),
+        metaKey: Boolean(event.data.metaKey),
+        shiftKey: Boolean(event.data.shiftKey),
+      });
+    };
+
+    window.addEventListener("message", handleEmbeddedWheelMessage);
+    return () =>
+      window.removeEventListener("message", handleEmbeddedWheelMessage);
+  }, [enqueueWheelGestureFromClient]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -6060,12 +6130,15 @@ function getSelectableBounds(geometry: FrameGeometry): BoundsRect {
   };
 }
 
-function getWheelDelta(event: WheelEvent) {
-  const multiplier =
-    event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? 800 : 1;
+function getWheelDeltaFromValues(
+  deltaX: number,
+  deltaY: number,
+  deltaMode: number,
+) {
+  const multiplier = deltaMode === 1 ? 16 : deltaMode === 2 ? 800 : 1;
   return {
-    x: event.deltaX * multiplier,
-    y: event.deltaY * multiplier,
+    x: deltaX * multiplier,
+    y: deltaY * multiplier,
   };
 }
 

--- a/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
+++ b/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
@@ -3468,17 +3468,20 @@ declare var __EDITOR_CHROME_SCALE_Y__: string;
     }
   }
 
-  function beginTextEditingFromEvent(e) {
+  function beginTextEditingFromEvent(e, forceTextEditing) {
     if (activeTextEditEl && e.target && activeTextEditEl.contains(e.target))
       return;
-    if (!textEditingEnabled) {
+    if (!textEditingEnabled && !forceTextEditing) {
       stopNativeInteraction(e);
       return;
     }
     stopNativeInteraction(e);
-    var target = findTextEditTarget(
-      elementFromEditorPoint(e.clientX, e.clientY),
-    );
+    var eventTarget =
+      e && e.target && e.target.nodeType === 1 ? e.target : null;
+    var target =
+      findTextEditTarget(elementFromEditorPoint(e.clientX, e.clientY)) ||
+      findTextEditTarget(eventTarget) ||
+      eventTarget;
     if (!target || target.nodeType !== 1) return;
     // Anchor the selection identity to the nearest source-backed element. Text
     // editing still operates on the actual target text node, but a later
@@ -3725,7 +3728,8 @@ declare var __EDITOR_CHROME_SCALE_Y__: string;
     // text-element creation so the user can type right away and the autosize
     // CSS (width:max-content or similar) takes effect from the first keystroke.
     if (e.data.type === "begin-text-edit") {
-      if (readOnly || !textEditingEnabled) return;
+      var forceBeginTextEdit = e.data.force === true;
+      if ((readOnly || !textEditingEnabled) && !forceBeginTextEdit) return;
       var nodeId: string =
         typeof e.data.nodeId === "string" ? e.data.nodeId : "";
       if (!nodeId) return;
@@ -3749,14 +3753,17 @@ declare var __EDITOR_CHROME_SCALE_Y__: string;
       var bteCenterY = bteRect.top + bteRect.height / 2;
       // Delegate to the canonical path so all state, events, and postMessages
       // stay consistent with a normal double-click text edit.
-      beginTextEditingFromEvent({
-        clientX: bteCenterX,
-        clientY: bteCenterY,
-        target: textTarget,
-        preventDefault: function () {},
-        stopPropagation: function () {},
-        stopImmediatePropagation: function () {},
-      } as unknown as MouseEvent);
+      beginTextEditingFromEvent(
+        {
+          clientX: bteCenterX,
+          clientY: bteCenterY,
+          target: textTarget,
+          preventDefault: function () {},
+          stopPropagation: function () {},
+          stopImmediatePropagation: function () {},
+        } as unknown as MouseEvent,
+        forceBeginTextEdit,
+      );
       return;
     }
     if (e.data.type === "set-editor-chrome-scale") {

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -778,6 +778,18 @@ interface CodingHandoffResult {
   fileCount?: number;
 }
 
+interface CanvasLayerClipboardEntry {
+  html: string;
+  rootNodeId?: string;
+  sourceFileId: string;
+}
+
+interface SelectedCanvasLayerSnapshot extends CanvasLayerClipboardEntry {
+  node: CodeLayerNode;
+  sourceIndex: number;
+  tree: CodeLayerTreeNode[];
+}
+
 export interface MotionTimelineRow {
   id: string | null;
   designId: string;
@@ -1328,7 +1340,12 @@ function normalizedDesignFileType(
 
 function nextBlankScreenFilename(files: DesignFile[]): string {
   const existing = new Set(files.map((file) => file.filename));
-  let index = files.length + 1;
+  const screenCount = files.filter(
+    (file) =>
+      normalizedDesignFileType(file.fileType) === "html" &&
+      !isBoardFile(file.filename),
+  ).length;
+  let index = screenCount + 1;
   let candidate = `screen-${index}.html`;
   while (existing.has(candidate)) {
     index += 1;
@@ -1438,6 +1455,9 @@ function appendCanvasPrimitiveToHtml(
       const svg = doc.createElementNS("http://www.w3.org/2000/svg", "svg");
       const path = doc.createElementNS("http://www.w3.org/2000/svg", "path");
       const markerId = `${nodeId}-arrow`;
+      const explicitPathData = primitive.pathData?.trim()
+        ? primitive.pathData
+        : null;
       const points = primitive.points?.length
         ? primitive.points
         : [
@@ -1448,7 +1468,7 @@ function appendCanvasPrimitiveToHtml(
       const originY = Math.min(...points.map((point) => point.y));
       path.setAttribute(
         "d",
-        primitive.pathData ??
+        explicitPathData ??
           points
             .map((point, index) => {
               const command = index === 0 ? "M" : "L";
@@ -1495,7 +1515,13 @@ function appendCanvasPrimitiveToHtml(
       }
       svg.setAttribute("data-agent-native-node-id", nodeId);
       svg.setAttribute("data-agent-native-layer-name", layerName);
-      svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+      svg.setAttribute("data-an-primitive", primitive.kind);
+      svg.setAttribute(
+        "viewBox",
+        explicitPathData
+          ? `${left} ${top} ${width} ${height}`
+          : `0 0 ${width} ${height}`,
+      );
       svg.setAttribute(
         "style",
         [
@@ -1667,44 +1693,126 @@ function cloneHtmlLayerAtPosition(
   layerHtml: string,
   position: { x: number; y: number },
 ): string | null {
-  if (typeof window === "undefined") return null;
-  try {
-    const doc = new DOMParser().parseFromString(content, "text/html");
-    const layerDoc = new DOMParser().parseFromString(
-      `<template>${layerHtml}</template>`,
-      "text/html",
-    );
-    const source =
-      layerDoc.querySelector("template")?.content.firstElementChild ??
-      layerDoc.body.firstElementChild;
-    if (!source || !doc.body) return null;
-    const clone = doc.importNode(source, true) as HTMLElement | SVGElement;
-    const clonedNodes = [
-      clone,
-      ...Array.from(clone.querySelectorAll("[data-agent-native-node-id]")),
-    ] as Array<HTMLElement | SVGElement>;
-    clonedNodes.forEach((node, index) => {
+  return (
+    insertClonedHtmlLayers(content, [layerHtml], {
+      positions: [position],
+    })?.content ?? null
+  );
+}
+
+function styleHost(element: Element): (HTMLElement | SVGElement) | null {
+  return element instanceof HTMLElement || element instanceof SVGElement
+    ? element
+    : null;
+}
+
+function clearRootLayerPosition(element: Element) {
+  const host = styleHost(element);
+  if (!host) return;
+  host.style.position = "";
+  host.style.left = "";
+  host.style.top = "";
+  host.style.right = "";
+  host.style.bottom = "";
+}
+
+function setRootLayerPosition(
+  element: Element,
+  position: { x: number; y: number },
+) {
+  const host = styleHost(element);
+  if (!host) return;
+  // Use explicit style property assignments rather than prepending a raw
+  // string. Prepending creates duplicate CSS properties in the same style
+  // attribute, and in CSS the LAST occurrence wins, so existing left/top
+  // values from the cloned element would override the new position.
+  host.style.position = "absolute";
+  host.style.left = `${Math.max(0, Math.round(position.x))}px`;
+  host.style.top = `${Math.max(0, Math.round(position.y))}px`;
+  host.style.right = "";
+  host.style.bottom = "";
+}
+
+function prepareClonedHtmlLayer(
+  doc: Document,
+  layerHtml: string,
+): { element: Element; rootNodeId: string } | null {
+  const layerDoc = new DOMParser().parseFromString(
+    `<template>${layerHtml}</template>`,
+    "text/html",
+  );
+  const source =
+    layerDoc.querySelector("template")?.content.firstElementChild ??
+    layerDoc.body.firstElementChild;
+  if (!source) return null;
+  const clone = doc.importNode(source, true) as Element;
+  const rootNodeId = uniqueLayerId("copy");
+  clone.setAttribute("data-agent-native-node-id", rootNodeId);
+  Array.from(clone.querySelectorAll("[data-agent-native-node-id]")).forEach(
+    (node) => {
       node.setAttribute(
         "data-agent-native-node-id",
-        uniqueLayerId(index === 0 ? "copy" : "copy-child"),
+        uniqueLayerId("copy-child"),
       );
+    },
+  );
+  return { element: clone, rootNodeId };
+}
+
+function insertClonedHtmlLayers(
+  content: string,
+  layerHtmls: string[],
+  options: {
+    targetSelectors?: string[];
+    anchorSelectors?: string[];
+    placement?: "before" | "after" | "inside";
+    stripRootPosition?: boolean;
+    positions?: Array<{ x: number; y: number } | null | undefined>;
+  } = {},
+): { content: string; rootNodeIds: string[] } | null {
+  if (typeof window === "undefined" || layerHtmls.length === 0) return null;
+  try {
+    const doc = new DOMParser().parseFromString(content, "text/html");
+    if (!doc.body) return null;
+    const fragment = doc.createDocumentFragment();
+    const rootNodeIds: string[] = [];
+    layerHtmls.forEach((layerHtml, index) => {
+      const prepared = prepareClonedHtmlLayer(doc, layerHtml);
+      if (!prepared) return;
+      const position = options.positions?.[index];
+      if (position) {
+        setRootLayerPosition(prepared.element, position);
+      } else if (options.stripRootPosition) {
+        clearRootLayerPosition(prepared.element);
+      }
+      rootNodeIds.push(prepared.rootNodeId);
+      fragment.appendChild(prepared.element);
     });
-    if (clone instanceof HTMLElement || clone instanceof SVGElement) {
-      // Use explicit style property assignments rather than prepending a raw
-      // string. Prepending creates duplicate CSS properties in the same style
-      // attribute, and in CSS the LAST occurrence wins, so existing left/top
-      // values from the cloned element would override the new position.
-      const cloneStyle = (clone as HTMLElement | SVGElement).style;
-      cloneStyle.position = "absolute";
-      cloneStyle.left = `${Math.max(0, Math.round(position.x))}px`;
-      cloneStyle.top = `${Math.max(0, Math.round(position.y))}px`;
-      // Clear conflicting properties that could shift the element away from
-      // the intended position.
-      cloneStyle.right = "";
-      cloneStyle.bottom = "";
+    if (rootNodeIds.length === 0) return null;
+
+    const target = queryFirstSelector(doc, options.targetSelectors ?? []);
+    const anchor =
+      queryFirstSelector(doc, options.anchorSelectors ?? []) ?? target;
+    const placement = options.placement ?? "after";
+    if (!anchor) {
+      doc.body.appendChild(fragment);
+    } else if (placement === "inside") {
+      anchor.appendChild(fragment);
+    } else if (placement === "before") {
+      if (anchor.parentElement)
+        anchor.parentElement.insertBefore(fragment, anchor);
+      else doc.body.appendChild(fragment);
+    } else {
+      if (anchor.parentElement) {
+        anchor.parentElement.insertBefore(fragment, anchor.nextSibling);
+      } else {
+        doc.body.appendChild(fragment);
+      }
     }
-    doc.body.appendChild(clone);
-    return `<!DOCTYPE html>\n${doc.documentElement.outerHTML}`;
+    return {
+      content: `<!DOCTYPE html>\n${doc.documentElement.outerHTML}`,
+      rootNodeIds,
+    };
   } catch {
     return null;
   }
@@ -1748,52 +1856,13 @@ function insertClonedHtmlLayer(
     placement?: "before" | "after" | "inside";
   },
 ): string | null {
-  if (typeof window === "undefined") return null;
-  try {
-    const doc = new DOMParser().parseFromString(content, "text/html");
-    const layerDoc = new DOMParser().parseFromString(
-      `<template>${cloneHtml}</template>`,
-      "text/html",
-    );
-    const source =
-      layerDoc.querySelector("template")?.content.firstElementChild ??
-      layerDoc.body.firstElementChild;
-    if (!source || !doc.body) return null;
-    const clone = doc.importNode(source, true) as HTMLElement | SVGElement;
-    const clonedNodes = [
-      clone,
-      ...Array.from(clone.querySelectorAll("[data-agent-native-node-id]")),
-    ] as Array<HTMLElement | SVGElement>;
-    clonedNodes.forEach((node, index) => {
-      node.setAttribute(
-        "data-agent-native-node-id",
-        uniqueLayerId(index === 0 ? "copy" : "copy-child"),
-      );
-    });
-
-    const target = queryFirstSelector(doc, options.targetSelectors);
-    const anchor =
-      queryFirstSelector(doc, options.anchorSelectors ?? []) ?? target;
-    const placement = options.placement ?? "after";
-    if (!anchor) {
-      doc.body.appendChild(clone);
-    } else if (placement === "inside") {
-      anchor.appendChild(clone);
-    } else if (placement === "before") {
-      if (anchor.parentElement)
-        anchor.parentElement.insertBefore(clone, anchor);
-      else doc.body.appendChild(clone);
-    } else {
-      if (anchor.parentElement) {
-        anchor.parentElement.insertBefore(clone, anchor.nextSibling);
-      } else {
-        doc.body.appendChild(clone);
-      }
-    }
-    return `<!DOCTYPE html>\n${doc.documentElement.outerHTML}`;
-  } catch {
-    return null;
-  }
+  return (
+    insertClonedHtmlLayers(content, [cloneHtml], {
+      targetSelectors: options.targetSelectors,
+      anchorSelectors: options.anchorSelectors,
+      placement: options.placement,
+    })?.content ?? null
+  );
 }
 
 function getElementOuterHtml(content: string, selector: string): string | null {
@@ -1833,6 +1902,55 @@ function extractLayerPosition(
   } catch {
     return null;
   }
+}
+
+function postBeginTextEditToPreviewIframes(
+  screenId: string | null,
+  nodeId: string,
+): boolean {
+  if (typeof document === "undefined" || !nodeId) return false;
+  const iframes = Array.from(
+    document.querySelectorAll<HTMLIFrameElement>(
+      "iframe[data-design-preview-iframe]",
+    ),
+  );
+  const targetIframes = iframes.filter(
+    (iframe) => screenId && iframe.dataset.screenIframeId === screenId,
+  );
+  const orderedIframes = targetIframes.length > 0 ? targetIframes : iframes;
+  const selector = `[data-agent-native-node-id="${nodeId.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"][data-agent-native-text-editing]`;
+  if (
+    orderedIframes.some((iframe) => {
+      try {
+        return iframe.contentDocument?.querySelector(selector);
+      } catch {
+        return false;
+      }
+    })
+  ) {
+    return true;
+  }
+  orderedIframes.forEach((iframe) => {
+    iframe.contentWindow?.postMessage(
+      { type: "begin-text-edit", nodeId, force: true },
+      "*",
+    );
+  });
+  return false;
+}
+
+function scheduleBeginTextEditForScreen(
+  screenId: string | null,
+  nodeId: string,
+) {
+  if (typeof window === "undefined") return;
+  let sawEditing = false;
+  [50, 150, 300, 600, 900, 1200, 1800, 2400, 3200, 4200].forEach((delay) => {
+    window.setTimeout(() => {
+      if (sawEditing) return;
+      sawEditing = postBeginTextEditToPreviewIframes(screenId, nodeId);
+    }, delay);
+  });
 }
 
 function removeElementFromHtml(
@@ -3616,6 +3734,7 @@ export default function DesignEditor() {
     useState(0);
   const [hasCanvasClipboard, setHasCanvasClipboard] = useState(false);
   const [hasPropsClipboard, setHasPropsClipboard] = useState(false);
+  const copiedLayerEntriesRef = useRef<CanvasLayerClipboardEntry[]>([]);
   const copiedLayerHtmlRef = useRef<string | null>(null);
   // Cascade offset for repeated keyboard pastes so successive clones don't stack
   // pixel-perfectly on top of each other. Reset on each fresh copy/cut.
@@ -7146,9 +7265,7 @@ export default function DesignEditor() {
       // enter text-edit mode — fixing the "click to add text should let me
       // type immediately" bug. The ref is read once and cleared.
       if (primitive.kind === "text") {
-        const textNodeId =
-          typeof result === "string" ? result : (primitive.nodeId ?? null);
-        pendingTextEditNodeIdRef.current = textNodeId;
+        pendingTextEditNodeIdRef.current = primitive.nodeId ?? null;
       } else {
         pendingTextEditNodeIdRef.current = null;
       }
@@ -7193,17 +7310,15 @@ export default function DesignEditor() {
       });
       // viewMode stays at "overview" — no setViewMode("single") call here.
 
-      // Immediately enter text-editing for newly created TEXT primitives so the
-      // user can start typing without a second click (fixes auto-size flow too).
-      // We read-and-clear the ref set by handleCreatePrimitive just above. The
-      // 50 ms delay gives React a tick to commit the new content into the active
-      // screen's iframe before the bridge tries to find the element by nodeId.
-      const textNodeId = pendingTextEditNodeIdRef.current;
+      // Immediately enter text-editing for newly created TEXT primitives. In
+      // overview mode the target iframe may become active and receive the
+      // inserted HTML over separate renders, so post directly to the target
+      // iframe with a few short retries instead of relying on a single global
+      // bridge callback.
+      const textNodeId = pendingTextEditNodeIdRef.current ?? nodeId;
       pendingTextEditNodeIdRef.current = null;
       if (textNodeId) {
-        setTimeout(() => {
-          (window as any).__designCanvasBeginTextEdit?.(textNodeId);
-        }, 50);
+        scheduleBeginTextEditForScreen(screenId, textNodeId);
       }
     },
     [clearPendingOverviewLayerSelectionTimer],
@@ -7222,28 +7337,14 @@ export default function DesignEditor() {
       if (!result) return false;
 
       // For TEXT primitives drawn on the board surface, immediately enter
-      // text-editing mode via begin-text-edit.  The board DesignCanvas uses
-      // registerRuntimeBridge=false so window.__designCanvasBeginTextEdit is
-      // not set; instead we broadcast the message to all preview iframes — the
-      // one that contains the new nodeId will handle it, others ignore it.
-      // The 50 ms delay lets the board iframe receive its content update first.
+      // text-editing mode via begin-text-edit. The target is the board file,
+      // so use the same iframe-targeted retry path as screen primitives.
       if (primitive.kind === "text") {
         const textNodeId =
           pendingTextEditNodeIdRef.current ?? primitive.nodeId ?? null;
         pendingTextEditNodeIdRef.current = null;
         if (textNodeId) {
-          setTimeout(() => {
-            document
-              .querySelectorAll<HTMLIFrameElement>(
-                "iframe[data-design-preview-iframe]",
-              )
-              .forEach((iframe) => {
-                iframe.contentWindow?.postMessage(
-                  { type: "begin-text-edit", nodeId: textNodeId },
-                  "*",
-                );
-              });
-          }, 50);
+          scheduleBeginTextEditForScreen(boardFileId, textNodeId);
         }
       }
 
@@ -8935,27 +9036,167 @@ export default function DesignEditor() {
     ],
   );
 
-  const handleCopySelection = useCallback(async () => {
-    if (!selectedElement?.selector) return;
-    const html = getElementOuterHtml(
-      getFreshActiveContent(),
-      selectedElement.selector,
+  const getSelectedLayerSnapshots = useCallback(() => {
+    const fileIds = new Set(files.map((file) => file.id));
+    const candidateIds = selectedLayerIdsState.filter(
+      (layerId) =>
+        layerId && !layerId.startsWith("__") && !fileIds.has(layerId),
     );
-    if (!html) return;
-    copiedLayerHtmlRef.current = html;
+    if (
+      selectedElementLayerId &&
+      !candidateIds.includes(selectedElementLayerId)
+    ) {
+      candidateIds.push(selectedElementLayerId);
+    }
+
+    const snapshots: SelectedCanvasLayerSnapshot[] = [];
+    for (const file of files) {
+      const content = getScreenContent(file.id);
+      if (!content) continue;
+      const projection = buildCodeLayerProjection(content);
+      const tree = buildCodeLayerTree(projection);
+      for (const layerId of candidateIds) {
+        const node = projection.nodes.find(
+          (candidate) =>
+            candidate.id === layerId ||
+            candidate.dataAttributes["data-agent-native-node-id"] === layerId,
+        );
+        if (!node?.source) continue;
+        snapshots.push({
+          html: content.slice(node.source.start, node.source.end),
+          rootNodeId:
+            node.dataAttributes["data-agent-native-node-id"] ?? node.id,
+          sourceFileId: file.id,
+          node,
+          sourceIndex: node.source.start,
+          tree,
+        });
+      }
+    }
+
+    if (snapshots.length === 0 && activeFile && selectedElement?.selector) {
+      const content = getFreshActiveContent();
+      const projection = buildCodeLayerProjection(content);
+      const tree = buildCodeLayerTree(projection);
+      const node = resolveCodeLayerNodeFromElementInfo(
+        projection,
+        selectedElement,
+      );
+      const html = node?.source
+        ? content.slice(node.source.start, node.source.end)
+        : getElementOuterHtml(content, selectedElement.selector);
+      if (html && node) {
+        snapshots.push({
+          html,
+          rootNodeId:
+            node.dataAttributes["data-agent-native-node-id"] ??
+            selectedElement.sourceId ??
+            selectedElement.id,
+          sourceFileId: activeFile.id,
+          node,
+          sourceIndex: node.source?.start ?? Number.MAX_SAFE_INTEGER,
+          tree,
+        });
+      }
+    }
+
+    const selectedKeys = new Set(
+      snapshots.map(
+        (snapshot) => `${snapshot.sourceFileId}:${snapshot.node.id}`,
+      ),
+    );
+    const topLevelSnapshots = snapshots.filter(
+      (snapshot) =>
+        !collectCodeLayerAncestors(snapshot.tree, snapshot.node.id).some(
+          (ancestorId) =>
+            selectedKeys.has(`${snapshot.sourceFileId}:${ancestorId}`),
+        ),
+    );
+    const fileOrder = new Map(files.map((file, index) => [file.id, index]));
+    return topLevelSnapshots.sort((a, b) => {
+      const fileDelta =
+        (fileOrder.get(a.sourceFileId) ?? 0) -
+        (fileOrder.get(b.sourceFileId) ?? 0);
+      if (fileDelta !== 0) return fileDelta;
+      return a.sourceIndex - b.sourceIndex;
+    });
+  }, [
+    activeFile,
+    files,
+    getFreshActiveContent,
+    getScreenContent,
+    selectedElement,
+    selectedElementLayerId,
+    selectedLayerIdsState,
+  ]);
+
+  const getCanvasClipboardEntries = useCallback(() => {
+    if (copiedLayerEntriesRef.current.length > 0) {
+      return copiedLayerEntriesRef.current;
+    }
+    return copiedLayerHtmlRef.current
+      ? [
+          {
+            html: copiedLayerHtmlRef.current,
+            sourceFileId: activeFile?.id ?? "",
+          },
+        ]
+      : [];
+  }, [activeFile?.id]);
+
+  const selectInsertedLayers = useCallback(
+    (screenId: string, content: string, rootNodeIds: string[]) => {
+      const projection = buildCodeLayerProjection(content);
+      const insertedNodes = rootNodeIds
+        .map((rootNodeId) =>
+          projection.nodes.find(
+            (node) =>
+              node.id === rootNodeId ||
+              node.dataAttributes["data-agent-native-node-id"] === rootNodeId,
+          ),
+        )
+        .filter((node): node is CodeLayerNode => Boolean(node));
+      if (insertedNodes.length === 0) return;
+      setActiveFileId(screenId);
+      setSelectedLayerIdsState(insertedNodes.map((node) => node.id));
+      const lastNode = insertedNodes[insertedNodes.length - 1];
+      setSelectedElement(
+        lastNode ? elementInfoFromCodeLayerNode(lastNode) : null,
+      );
+      setActiveTool("move");
+      setMode("edit");
+      if (viewModeRef.current === "overview") {
+        setOverviewSelectedScreenIds([screenId]);
+      }
+    },
+    [],
+  );
+
+  const handleCopySelection = useCallback(async () => {
+    const entries = getSelectedLayerSnapshots().map((snapshot) => ({
+      html: snapshot.html,
+      rootNodeId: snapshot.rootNodeId,
+      sourceFileId: snapshot.sourceFileId,
+    }));
+    if (entries.length === 0) return;
+    const clipboardText = entries.map((entry) => entry.html).join("\n");
+    copiedLayerEntriesRef.current = entries;
+    copiedLayerHtmlRef.current = clipboardText;
     pasteCascadeRef.current = 0;
     setHasCanvasClipboard(true);
     try {
-      await navigator.clipboard.writeText(html);
+      await navigator.clipboard.writeText(clipboardText);
     } catch {
       toast.error(t("designEditor.toasts.clipboardBlocked"));
     }
-  }, [getFreshActiveContent, selectedElement, t]);
+  }, [getSelectedLayerSnapshots, t]);
 
   const handlePasteSelection = useCallback(
     (position?: { x: number; y: number }) => {
-      if (!activeFile || !canEditDesign || !copiedLayerHtmlRef.current) return;
+      const entries = getCanvasClipboardEntries();
+      if (!activeFile || !canEditDesign || entries.length === 0) return;
       const baseContent = getFreshActiveContent();
+      const layerHtmls = entries.map((entry) => entry.html);
 
       // B7 fix: when an element is selected and no explicit canvas position was
       // given, insert the clone as an in-flow sibling right AFTER the selected
@@ -8965,38 +9206,19 @@ export default function DesignEditor() {
       // selected or a "Paste here" position is provided.
       if (!position && selectedElement?.selector) {
         const selector = selectedCanvasSelector ?? selectedElement.selector;
-        // Strip position properties from the pasted clone so it becomes an
-        // in-flow sibling (not absolute).
-        const strippedHtml = (() => {
-          try {
-            const parser = new DOMParser();
-            const tmp = parser.parseFromString(
-              `<template>${copiedLayerHtmlRef.current!}</template>`,
-              "text/html",
-            );
-            const root =
-              tmp.querySelector("template")?.content.firstElementChild ??
-              tmp.body.firstElementChild;
-            if (root && root instanceof HTMLElement) {
-              root.style.position = "";
-              root.style.left = "";
-              root.style.top = "";
-              root.style.right = "";
-              root.style.bottom = "";
-            }
-            return root?.outerHTML ?? copiedLayerHtmlRef.current!;
-          } catch {
-            return copiedLayerHtmlRef.current!;
-          }
-        })();
-
-        const nextContent = insertClonedHtmlLayer(baseContent, strippedHtml, {
+        const result = insertClonedHtmlLayers(baseContent, layerHtmls, {
           targetSelectors: [selector],
           placement: "after",
+          stripRootPosition: true,
         });
-        if (nextContent) {
+        if (result) {
           pasteCascadeRef.current += 1;
-          applyLocalContentUpdate(nextContent);
+          applyLocalContentUpdate(result.content);
+          selectInsertedLayers(
+            activeFile.id,
+            result.content,
+            result.rootNodeIds,
+          );
           return;
         }
         // Fall through to position-based clone if insert failed.
@@ -9005,59 +9227,154 @@ export default function DesignEditor() {
       // Explicit positions (e.g. "Paste here" at the cursor) are honored as-is.
       // Keyboard pastes land near the source layer and cascade so repeats don't
       // stack exactly.
-      const targetPosition =
-        position ??
-        (() => {
-          const src = extractLayerPosition(copiedLayerHtmlRef.current!);
-          const offset = pasteCascadeRef.current * 16;
-          return src
-            ? { x: src.x + 10 + offset, y: src.y + 10 + offset }
-            : { x: 120 + offset, y: 120 + offset };
-        })();
-      const nextContent = cloneHtmlLayerAtPosition(
-        baseContent,
-        copiedLayerHtmlRef.current,
-        targetPosition,
+      const sourcePositions = entries.map((entry) =>
+        extractLayerPosition(entry.html),
       );
-      if (!nextContent) return;
+      const positionedSources = sourcePositions.filter(
+        (source): source is { x: number; y: number } => Boolean(source),
+      );
+      const minSourceX = positionedSources.length
+        ? Math.min(...positionedSources.map((source) => source.x))
+        : 0;
+      const minSourceY = positionedSources.length
+        ? Math.min(...positionedSources.map((source) => source.y))
+        : 0;
+      const cascadeOffset = pasteCascadeRef.current * 16;
+      const positions = entries.map((_, index) => {
+        const source = sourcePositions[index];
+        if (position) {
+          return source && positionedSources.length
+            ? {
+                x: position.x + source.x - minSourceX,
+                y: position.y + source.y - minSourceY,
+              }
+            : { x: position.x + index * 16, y: position.y + index * 16 };
+        }
+        return source
+          ? {
+              x: source.x + 10 + cascadeOffset,
+              y: source.y + 10 + cascadeOffset,
+            }
+          : {
+              x: 120 + cascadeOffset + index * 16,
+              y: 120 + cascadeOffset + index * 16,
+            };
+      });
+      const result = insertClonedHtmlLayers(baseContent, layerHtmls, {
+        positions,
+      });
+      if (!result) return;
       if (!position) pasteCascadeRef.current += 1;
-      applyLocalContentUpdate(nextContent);
+      applyLocalContentUpdate(result.content);
+      selectInsertedLayers(activeFile.id, result.content, result.rootNodeIds);
     },
     [
       activeFile,
       applyLocalContentUpdate,
       canEditDesign,
+      getCanvasClipboardEntries,
       getFreshActiveContent,
+      selectInsertedLayers,
       selectedCanvasSelector,
       selectedElement,
     ],
   );
 
   const handlePasteOverSelection = useCallback(() => {
-    if (!activeFile || !copiedLayerHtmlRef.current) return;
+    const entries = getCanvasClipboardEntries();
+    if (!activeFile || entries.length === 0) return;
     const baseContent = getFreshActiveContent();
     if (selectedElement?.boundingRect) {
       const { x, y } = selectedElement.boundingRect;
-      const nextContent = cloneHtmlLayerAtPosition(
+      const result = insertClonedHtmlLayers(
         baseContent,
-        copiedLayerHtmlRef.current,
-        { x, y },
+        entries.map((entry) => entry.html),
+        {
+          positions: entries.map((_, index) => ({
+            x: x + index * 16,
+            y: y + index * 16,
+          })),
+        },
       );
-      if (!nextContent) return;
-      applyLocalContentUpdate(nextContent);
+      if (!result) return;
+      applyLocalContentUpdate(result.content);
+      selectInsertedLayers(activeFile.id, result.content, result.rootNodeIds);
     } else {
       handlePasteSelection();
     }
   }, [
     activeFile,
     applyLocalContentUpdate,
+    getCanvasClipboardEntries,
     getFreshActiveContent,
     handlePasteSelection,
+    selectInsertedLayers,
     selectedElement,
   ]);
 
   const handleDuplicateSelection = useCallback(() => {
     if (!canEditDesign) return;
+    const snapshots = getSelectedLayerSnapshots();
+    if (snapshots.length > 0) {
+      const selectedIds: string[] = [];
+      const selectedScreenIds: string[] = [];
+      let lastActiveNode: CodeLayerNode | null = null;
+
+      for (const file of files) {
+        const group = snapshots.filter(
+          (snapshot) => snapshot.sourceFileId === file.id,
+        );
+        if (group.length === 0) continue;
+        let content = getScreenContent(file.id);
+        const insertedRootNodeIds: string[] = [];
+        for (const snapshot of [...group].sort(
+          (a, b) => b.sourceIndex - a.sourceIndex,
+        )) {
+          const projection = buildCodeLayerProjection(content);
+          const anchorNode =
+            projection.nodes.find(
+              (node) =>
+                node.id === snapshot.node.id ||
+                node.dataAttributes["data-agent-native-node-id"] ===
+                  snapshot.rootNodeId,
+            ) ?? snapshot.node;
+          const result = insertClonedHtmlLayers(content, [snapshot.html], {
+            targetSelectors: codeLayerSelectorAliases(anchorNode),
+            placement: "after",
+            stripRootPosition: true,
+          });
+          if (!result) continue;
+          content = result.content;
+          insertedRootNodeIds.unshift(...result.rootNodeIds);
+        }
+        if (insertedRootNodeIds.length === 0) continue;
+        applyFileContentUpdate(file.id, content, { refreshPreview: false });
+        selectedScreenIds.push(file.id);
+        const finalProjection = buildCodeLayerProjection(content);
+        insertedRootNodeIds.forEach((rootNodeId) => {
+          const insertedNode = finalProjection.nodes.find(
+            (node) =>
+              node.id === rootNodeId ||
+              node.dataAttributes["data-agent-native-node-id"] === rootNodeId,
+          );
+          if (!insertedNode) return;
+          selectedIds.push(insertedNode.id);
+          if (file.id === activeFile?.id) lastActiveNode = insertedNode;
+        });
+      }
+
+      if (selectedIds.length > 0) {
+        setSelectedLayerIdsState(selectedIds);
+        setSelectedElement(
+          lastActiveNode ? elementInfoFromCodeLayerNode(lastActiveNode) : null,
+        );
+        if (viewModeRef.current === "overview") {
+          setOverviewSelectedScreenIds(selectedScreenIds);
+        }
+        return;
+      }
+    }
+
     if (selectedElement?.selector) {
       const baseContent = getFreshActiveContent();
       const html = getElementOuterHtml(baseContent, selectedElement.selector);
@@ -9105,9 +9422,13 @@ export default function DesignEditor() {
     if (activeFile) handleDuplicateScreen(activeFile.id);
   }, [
     activeFile,
+    applyFileContentUpdate,
     applyLocalContentUpdate,
     canEditDesign,
+    files,
     getFreshActiveContent,
+    getScreenContent,
+    getSelectedLayerSnapshots,
     handleDuplicateScreen,
     selectedCanvasSelector,
     selectedElement,
@@ -9116,65 +9437,89 @@ export default function DesignEditor() {
 
   const handleDeleteSelection = useCallback(() => {
     if (!canEditDesign) return;
-    const baseContent = getFreshActiveContent();
-    // Multi-select delete: when several DOM/code layers are selected in the
-    // panel, remove all of them — not just the single focused element. Compose
-    // the removals against the running content (re-projecting each pass) so
-    // nested selections resolve correctly and earlier removals aren't clobbered.
-    const candidateIds = selectedLayerIdsState.filter(
-      (layerId) =>
-        layerId &&
-        !layerId.startsWith("__") &&
-        !files.some((file) => file.id === layerId),
-    );
-    if (candidateIds.length > 1) {
-      let content = baseContent;
-      const removedSelectors: string[] = [];
-      for (const layerId of candidateIds) {
+    const snapshots = getSelectedLayerSnapshots();
+    if (snapshots.length > 0) {
+      const activeRuntimeSelectors: string[] = [];
+      let didDelete = false;
+      for (const file of files) {
+        const group = snapshots.filter(
+          (snapshot) => snapshot.sourceFileId === file.id,
+        );
+        if (group.length === 0) continue;
+        const originalContent = getScreenContent(file.id);
+        let content = originalContent;
         const projection = buildCodeLayerProjection(content);
-        const node =
-          projection.nodes.find((candidate) => candidate.id === layerId) ??
-          resolveCodeLayerNodeFromBridge(projection, layerId, layerId);
-        if (!node) continue;
-        const next = removeCodeLayerNodeFromHtml(content, node);
-        if (!next) continue;
-        const selector = preferredCodeLayerSelector(node);
-        if (selector) removedSelectors.push(selector);
-        content = next;
+        const tree = buildCodeLayerTree(projection);
+        const selectedNodeIds = new Set(
+          group.map((snapshot) => snapshot.node.id),
+        );
+        const nodes = group
+          .map((snapshot) =>
+            projection.nodes.find(
+              (node) =>
+                node.id === snapshot.node.id ||
+                node.dataAttributes["data-agent-native-node-id"] ===
+                  snapshot.rootNodeId,
+            ),
+          )
+          .filter((node): node is CodeLayerNode => Boolean(node?.source))
+          .filter(
+            (node) =>
+              !collectCodeLayerAncestors(tree, node.id).some((ancestorId) =>
+                selectedNodeIds.has(ancestorId),
+              ),
+          )
+          .sort((a, b) => (b.source?.start ?? 0) - (a.source?.start ?? 0));
+        if (nodes.length === 0) continue;
+        const removedSelectors: string[] = [];
+        for (const node of nodes) {
+          const next = removeCodeLayerNodeFromHtml(content, node);
+          if (!next) continue;
+          const selector = preferredCodeLayerSelector(node);
+          if (selector) removedSelectors.push(selector);
+          content = next;
+        }
+        if (content === originalContent) continue;
+        if (file.id === activeFile?.id) {
+          activeRuntimeSelectors.push(...removedSelectors);
+        }
+        didDelete = true;
+        applyFileContentUpdate(file.id, content, { refreshPreview: false });
       }
-      if (content !== baseContent) {
-        removedSelectors.forEach((selector) => deleteRuntimeElement(selector));
-        applyLocalContentUpdate(content, { refreshPreview: false });
-        setSelectedElement(null);
-        setSelectedLayerIdsState([]);
-        return;
+      if (!didDelete) return;
+      activeRuntimeSelectors.forEach((selector) =>
+        deleteRuntimeElement(selector),
+      );
+      setSelectedElement(null);
+      setSelectedLayerIdsState([]);
+      if (viewModeRef.current === "overview") {
+        setOverviewSelectedScreenIds([]);
       }
-      // Nothing resolved (stale ids) — fall through to the single path.
+      return;
     }
 
     if (!selectedElement?.selector) return;
-    const projection = buildCodeLayerProjection(baseContent);
-    const targetNode = resolveCodeLayerNodeFromElementInfo(
-      projection,
-      selectedElement,
+    const baseContent = getFreshActiveContent();
+    const nextContent = removeElementFromHtml(
+      baseContent,
+      selectedElement.selector,
     );
-    const nextContent =
-      (targetNode
-        ? removeCodeLayerNodeFromHtml(baseContent, targetNode)
-        : null) ?? removeElementFromHtml(baseContent, selectedElement.selector);
     if (!nextContent) return;
     deleteRuntimeElement(selectedElement.selector);
     applyLocalContentUpdate(nextContent, { refreshPreview: false });
     setSelectedElement(null);
     setSelectedLayerIdsState([]);
   }, [
+    activeFile?.id,
+    applyFileContentUpdate,
     applyLocalContentUpdate,
     canEditDesign,
     deleteRuntimeElement,
     files,
     getFreshActiveContent,
+    getScreenContent,
+    getSelectedLayerSnapshots,
     selectedElement,
-    selectedLayerIdsState,
   ]);
 
   // Wrap the current multi-layer selection into a new group container.
@@ -14113,6 +14458,7 @@ ${serializedHtml}
                           <DesignCanvas
                             content={screenContent}
                             contentKey={screenContentKey}
+                            screenId={screen.id}
                             zoom={100}
                             deviceFrame="none"
                             sourceType={designSourceType}

--- a/templates/design/changelog/2026-06-30-design-studio-canvas-layers-can-be-copied-pasted-and-reparen.md
+++ b/templates/design/changelog/2026-06-30-design-studio-canvas-layers-can-be-copied-pasted-and-reparen.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-06-30
+---
+
+Design Studio canvas layers can be copied, pasted, and reparented more reliably across screens.

--- a/templates/design/e2e/canvas-tools.spec.ts
+++ b/templates/design/e2e/canvas-tools.spec.ts
@@ -12,6 +12,26 @@ import { gotoEditor } from "./helpers";
 let designId: string;
 let baseURLForActions: string;
 
+interface DesignFileRecord {
+  id: string;
+  filename: string;
+  content: string;
+}
+
+interface TextPrimitiveSummary {
+  text: string;
+  style: string;
+  display: string;
+  width: string;
+  height: string;
+}
+
+interface VectorPrimitiveSummary {
+  d: string;
+  viewBox: string;
+  style: string;
+}
+
 async function postAction(
   request: APIRequestContext,
   actionName: string,
@@ -32,11 +52,40 @@ async function postAction(
   return response.json();
 }
 
-test.beforeEach(async ({ page, request }, workerInfo) => {
+async function getAction(
+  request: APIRequestContext,
+  actionName: string,
+  input: Record<string, unknown>,
+): Promise<any> {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(input)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item != null) params.append(`${key}[]`, String(item));
+      }
+      continue;
+    }
+    if (value != null) params.append(key, String(value));
+  }
+  const response = await request.get(
+    `${baseURLForActions}/_agent-native/actions/${actionName}?${params}`,
+    {
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+  if (!response.ok()) {
+    throw new Error(
+      `${actionName} failed: ${response.status()} ${await response.text()}`,
+    );
+  }
+  return response.json();
+}
+
+test.beforeEach(async ({ page }, workerInfo) => {
   baseURLForActions =
     (workerInfo.project.use.baseURL as string | undefined) ??
     "http://127.0.0.1:9333";
-  const created = await postAction(request, "create-design", {
+  const created = await postAction(page.request, "create-design", {
     title: "E2E Canvas Tools",
     projectType: "prototype",
   });
@@ -44,7 +93,7 @@ test.beforeEach(async ({ page, request }, workerInfo) => {
   if (!designId) {
     throw new Error(`create-design did not return an id: ${created}`);
   }
-  await postAction(request, "create-file", {
+  await postAction(page.request, "create-file", {
     designId,
     filename: "index.html",
     content: FIXTURE_HTML,
@@ -55,9 +104,12 @@ test.beforeEach(async ({ page, request }, workerInfo) => {
 
 test.use({ viewport: { width: 1440, height: 1000 } });
 
-test.afterEach(async ({ request }) => {
+test.afterEach(async ({ page }) => {
   if (!designId) return;
-  await postAction(request, "delete-design", { id: designId }).catch(() => {});
+  await postAction(page.request, "delete-design", { id: designId }).catch(
+    () => {},
+  );
+  designId = "";
 });
 
 function toolButton(page: Page, name: string): Locator {
@@ -114,6 +166,211 @@ async function createDraftPrimitive(
     "true",
   );
   await expect(selectedLayerRow(page)).toContainText(selectionLabel);
+}
+
+async function designFiles(page: Page): Promise<DesignFileRecord[]> {
+  const result = await getAction(page.request, "get-design", { id: designId });
+  return (result.files ?? []).map((file: any) => ({
+    id: String(file.id ?? ""),
+    filename: String(file.filename ?? ""),
+    content: String(file.content ?? ""),
+  }));
+}
+
+async function fileContent(page: Page, filename: string): Promise<string> {
+  const file = (await designFiles(page)).find(
+    (candidate) => candidate.filename === filename,
+  );
+  if (!file) throw new Error(`File not found: ${filename}`);
+  return file.content;
+}
+
+async function textPrimitiveSummaries(
+  page: Page,
+  filename: string,
+): Promise<TextPrimitiveSummary[]> {
+  const content = await fileContent(page, filename);
+  return page.evaluate((html) => {
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    return Array.from(doc.querySelectorAll('[data-an-primitive="text"]')).map(
+      (element) => {
+        const host = element as HTMLElement;
+        return {
+          text: host.textContent ?? "",
+          style: host.getAttribute("style") ?? "",
+          display: host.style.display,
+          width: host.style.width,
+          height: host.style.height,
+        };
+      },
+    );
+  }, content);
+}
+
+async function waitForTextPrimitive(
+  page: Page,
+  filename: string,
+  text: string,
+): Promise<TextPrimitiveSummary> {
+  await expect
+    .poll(
+      async () =>
+        (await textPrimitiveSummaries(page, filename)).find((primitive) =>
+          primitive.text.includes(text),
+        ) ?? null,
+      { timeout: 20_000 },
+    )
+    .not.toBeNull();
+  const primitive = (await textPrimitiveSummaries(page, filename)).find(
+    (candidate) => candidate.text.includes(text),
+  );
+  if (!primitive) throw new Error(`Text primitive not found: ${text}`);
+  return primitive;
+}
+
+async function waitForTextEditing(page: Page): Promise<void> {
+  await expect
+    .poll(
+      async () =>
+        page
+          .locator("iframe[data-design-preview-iframe]")
+          .evaluateAll((iframes) =>
+            iframes.reduce((count, iframe) => {
+              const frame = iframe as HTMLIFrameElement;
+              return (
+                count +
+                (frame.contentDocument?.querySelectorAll(
+                  "[data-agent-native-text-editing]",
+                ).length ?? 0)
+              );
+            }, 0),
+          ),
+      { timeout: 10_000 },
+    )
+    .toBeGreaterThan(0);
+}
+
+async function replaceActiveText(page: Page, text: string): Promise<void> {
+  await waitForTextEditing(page);
+  const selectAllShortcut =
+    process.platform === "darwin" ? "Meta+A" : "Control+A";
+  await page.keyboard.press(selectAllShortcut);
+  await page.keyboard.type(text);
+  await page.keyboard.press("Enter");
+}
+
+async function insertTextByClick(
+  page: Page,
+  shell: Locator,
+  text: string,
+): Promise<void> {
+  const card = shell.locator("[data-screen-card]");
+  const cardBox = await card.boundingBox();
+  if (!cardBox) throw new Error("no screen card box");
+
+  await toolButton(page, "Text").click();
+  await expect(toolButton(page, "Text")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await page.mouse.click(cardBox.x + cardBox.width * 0.32, cardBox.y + 120);
+  await replaceActiveText(page, text);
+}
+
+async function insertTextByDrag(
+  page: Page,
+  shell: Locator,
+  text: string,
+): Promise<void> {
+  const card = shell.locator("[data-screen-card]");
+  const cardBox = await card.boundingBox();
+  if (!cardBox) throw new Error("no screen card box");
+
+  await toolButton(page, "Text").click();
+  await expect(toolButton(page, "Text")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await dragBetween(
+    page,
+    {
+      x: cardBox.x + cardBox.width * 0.28,
+      y: cardBox.y + cardBox.height * 0.28,
+    },
+    {
+      x: cardBox.x + cardBox.width * 0.64,
+      y: cardBox.y + cardBox.height * 0.38,
+    },
+  );
+  await replaceActiveText(page, text);
+}
+
+function countOccurrences(content: string, text: string): number {
+  return content.split(text).length - 1;
+}
+
+async function vectorPrimitiveSummaries(
+  page: Page,
+  filename: string,
+): Promise<VectorPrimitiveSummary[]> {
+  const content = await fileContent(page, filename);
+  return page.evaluate((html) => {
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    return Array.from(
+      doc.querySelectorAll('svg[data-agent-native-layer-name="Vector"]'),
+    ).map((element) => {
+      const svg = element as SVGElement;
+      return {
+        d: svg.querySelector("path")?.getAttribute("d") ?? "",
+        viewBox: svg.getAttribute("viewBox") ?? "",
+        style: svg.getAttribute("style") ?? "",
+      };
+    });
+  }, content);
+}
+
+async function waitForVectorPrimitive(
+  page: Page,
+  filename: string,
+  pathPattern: RegExp,
+): Promise<VectorPrimitiveSummary> {
+  await expect
+    .poll(
+      async () =>
+        (await vectorPrimitiveSummaries(page, filename)).find((primitive) =>
+          pathPattern.test(primitive.d),
+        ) ?? null,
+      { timeout: 20_000 },
+    )
+    .not.toBeNull();
+  const primitive = (await vectorPrimitiveSummaries(page, filename)).find(
+    (candidate) => pathPattern.test(candidate.d),
+  );
+  if (!primitive) {
+    throw new Error(`Vector primitive not found in ${filename}`);
+  }
+  return primitive;
+}
+
+function expectPathStartsInsideViewBox(vector: VectorPrimitiveSummary): void {
+  const viewBox = vector.viewBox
+    .split(/\s+/)
+    .map(Number)
+    .filter((value) => Number.isFinite(value));
+  const start = vector.d.match(/M\s+(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)/);
+  if (viewBox.length !== 4 || !start) {
+    throw new Error(
+      `Could not inspect vector geometry: viewBox=${vector.viewBox} d=${vector.d}`,
+    );
+  }
+
+  const [x, y, width, height] = viewBox;
+  const startX = Number(start[1]);
+  const startY = Number(start[2]);
+  expect(startX).toBeGreaterThanOrEqual(x - 0.1);
+  expect(startX).toBeLessThanOrEqual(x + width + 0.1);
+  expect(startY).toBeGreaterThanOrEqual(y - 0.1);
+  expect(startY).toBeLessThanOrEqual(y + height + 0.1);
 }
 
 async function restoreHome(page: Page): Promise<void> {
@@ -227,6 +484,73 @@ test("text insertion keeps the new primitive selected", async ({ page }) => {
   await restoreHome(page);
 });
 
+test("click text creates auto-width text and survives reload", async ({
+  page,
+}) => {
+  const text = `Auto width text ${Date.now()}`;
+
+  await insertTextByClick(page, screenShell(page), text);
+
+  const primitive = await waitForTextPrimitive(page, "index.html", text);
+  expect(primitive.display).toBe("inline-block");
+  expect(primitive.width).toBe("");
+  expect(primitive.height).toBe("");
+  expect(primitive.style).not.toMatch(/(^|;)\s*width\s*:/);
+  expect(primitive.style).not.toMatch(/(^|;)\s*height\s*:/);
+
+  await gotoEditor(page, designId);
+  await expect
+    .poll(async () => fileContent(page, "index.html"), { timeout: 20_000 })
+    .toContain(text);
+});
+
+test("drag text creates bounded text", async ({ page }) => {
+  const text = `Bounded text ${Date.now()}`;
+
+  await insertTextByDrag(page, screenShell(page), text);
+
+  const primitive = await waitForTextPrimitive(page, "index.html", text);
+  expect(primitive.display).toBe("flex");
+  expect(primitive.width).toMatch(/px$/);
+  expect(primitive.height).toMatch(/px$/);
+});
+
+test("text insertion targets the clicked screen in all-screens canvas", async ({
+  page,
+}) => {
+  const text = `Second screen text ${Date.now()}`;
+  await postAction(page.request, "create-file", {
+    designId,
+    filename: "about.html",
+    content: FIXTURE_HTML.replace("E2E Fixture", "E2E Second Fixture"),
+    fileType: "html",
+  });
+  await gotoEditor(page, designId);
+
+  await insertTextByClick(page, screenShell(page, "About"), text);
+
+  await waitForTextPrimitive(page, "about.html", text);
+  expect(await fileContent(page, "index.html")).not.toContain(text);
+});
+
+test("copy and paste duplicates selected text", async ({ page }) => {
+  const text = `Copied text ${Date.now()}`;
+  await insertTextByClick(page, screenShell(page), text);
+  await waitForTextPrimitive(page, "index.html", text);
+
+  const copyShortcut = process.platform === "darwin" ? "Meta+C" : "Control+C";
+  const pasteShortcut = process.platform === "darwin" ? "Meta+V" : "Control+V";
+  await page.keyboard.press(copyShortcut);
+  await page.keyboard.press(pasteShortcut);
+
+  await expect
+    .poll(
+      async () => countOccurrences(await fileContent(page, "index.html"), text),
+      { timeout: 20_000 },
+    )
+    .toBeGreaterThanOrEqual(2);
+});
+
 test("rectangle insertion keeps the new primitive selected", async ({
   page,
 }) => {
@@ -314,6 +638,93 @@ test("pen escape cancels the in-progress path and enter commits vector art", asy
   await expect(selectedLayerRow(page)).toContainText("Vector");
 
   await restoreHome(page);
+});
+
+test("pen Bezier vector stays visible and persists through reload", async ({
+  page,
+}) => {
+  await postAction(page.request, "create-file", {
+    designId,
+    filename: "about.html",
+    content: FIXTURE_HTML.replace("E2E Fixture", "E2E Second Fixture"),
+    fileType: "html",
+  });
+  await gotoEditor(page, designId);
+  await expect(screenShell(page, "About")).toBeVisible();
+
+  const card = screenShell(page, "About").locator("[data-screen-card]");
+  const cardBox = await card.boundingBox();
+  if (!cardBox) throw new Error("no about screen card box");
+
+  await toolButton(page, "Pen").click();
+  await expect(toolButton(page, "Pen")).toHaveAttribute("aria-pressed", "true");
+  await page.waitForTimeout(150);
+
+  const start = {
+    x: cardBox.x + cardBox.width * 0.68,
+    y: cardBox.y + cardBox.height * 0.3,
+  };
+  await page.mouse.move(start.x, start.y);
+  await page.mouse.down();
+  await page.mouse.move(start.x + 92, start.y - 52, { steps: 10 });
+  await page.mouse.up();
+  await expect(page.locator("[data-pen-path-overlay]")).toHaveCount(1);
+
+  const end = {
+    x: cardBox.x + cardBox.width * 0.84,
+    y: cardBox.y + cardBox.height * 0.48,
+  };
+  await page.mouse.move(end.x, end.y);
+  await page.mouse.down();
+  await page.mouse.move(end.x - 84, end.y + 68, { steps: 10 });
+  await page.mouse.up();
+  await expect(page.locator("[data-pen-handle]")).toHaveCount(4);
+
+  await page.keyboard.press("Enter");
+  await expect(page.locator("[data-pen-path-overlay]")).toHaveCount(0);
+  await expect(selectedLayerRow(page)).toContainText("Vector");
+
+  const vector = await waitForVectorPrimitive(page, "about.html", /\bC\b/);
+  expect(vector.style).toContain("position:absolute");
+  expectPathStartsInsideViewBox(vector);
+  expect(await fileContent(page, "index.html")).not.toContain(vector.d);
+
+  await gotoEditor(page, designId);
+  const reloaded = await waitForVectorPrimitive(page, "about.html", /\bC\b/);
+  expect(reloaded.d).toBe(vector.d);
+  expectPathStartsInsideViewBox(reloaded);
+});
+
+test("pen closes a vector path by clicking the first anchor", async ({
+  page,
+}) => {
+  const card = await homeScreenCard(page);
+  const cardBox = await card.boundingBox();
+  if (!cardBox) throw new Error("no home screen card box");
+
+  const first = {
+    x: cardBox.x + cardBox.width * 0.46,
+    y: cardBox.y + cardBox.height * 0.36,
+  };
+  const second = {
+    x: cardBox.x + cardBox.width * 0.64,
+    y: cardBox.y + cardBox.height * 0.52,
+  };
+
+  await toolButton(page, "Pen").click();
+  await expect(toolButton(page, "Pen")).toHaveAttribute("aria-pressed", "true");
+  await page.waitForTimeout(150);
+  await page.mouse.click(first.x, first.y);
+  await page.mouse.click(second.x, second.y);
+  await expect(page.locator("[data-pen-path-overlay]")).toHaveCount(1);
+
+  await page.mouse.click(first.x, first.y);
+  await expect(page.locator("[data-pen-path-overlay]")).toHaveCount(0);
+  await expect(selectedLayerRow(page)).toContainText("Vector");
+
+  const vector = await waitForVectorPrimitive(page, "index.html", /\bZ$/);
+  expect(vector.d).toContain(" Z");
+  expectPathStartsInsideViewBox(vector);
 });
 
 test("dragging the Home screen shell moves it", async ({ page }) => {

--- a/templates/design/e2e/editor-keyboard-layers.spec.ts
+++ b/templates/design/e2e/editor-keyboard-layers.spec.ts
@@ -1,0 +1,538 @@
+import {
+  expect,
+  test,
+  type APIRequestContext,
+  type Page,
+} from "@playwright/test";
+
+import { designFrame, enterDirectMode, gotoEditor } from "./helpers";
+
+const SOURCE_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Keyboard Source</title>
+  </head>
+  <body style="margin:0;font-family:system-ui,sans-serif;background:#111827;color:#f9fafb">
+    <main data-agent-native-node-id="source-root" data-agent-native-layer-name="Source Root" style="position:relative;min-height:560px;padding:48px">
+      <section data-agent-native-node-id="source-card" data-agent-native-layer-name="Copy Card" style="position:absolute;left:40px;top:60px;width:260px;padding:20px;border-radius:16px;background:#1f2937">
+        <h2 data-agent-native-node-id="source-card-title" data-agent-native-layer-name="Copy Card Title" style="margin:0 0 12px;font-size:24px">Copy Card Title</h2>
+        <button data-agent-native-node-id="source-card-child" data-agent-native-layer-name="Nested CTA" style="padding:10px 16px;border:0;border-radius:10px;background:#38bdf8;color:#082f49">Nested CTA</button>
+      </section>
+      <button data-agent-native-node-id="source-peer" data-agent-native-layer-name="Source Peer" style="position:absolute;left:340px;top:80px;padding:12px 18px;border:0;border-radius:10px;background:#a78bfa;color:#1f1147">Source Peer</button>
+    </main>
+  </body>
+</html>`;
+
+const TARGET_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Keyboard Target</title>
+  </head>
+  <body style="margin:0;font-family:system-ui,sans-serif;background:#f8fafc;color:#0f172a">
+    <main data-agent-native-node-id="target-root" data-agent-native-layer-name="Target Root" style="position:relative;min-height:560px;padding:48px">
+      <h1 data-agent-native-node-id="target-heading" data-agent-native-layer-name="Target Heading" style="margin:0;font-size:32px">Target Screen</h1>
+    </main>
+  </body>
+</html>`;
+
+const PRIMARY = process.platform === "darwin" ? "Meta" : "Control";
+
+test.describe("editor keyboard layer clipboard", () => {
+  let designId: string;
+
+  test.afterEach(async ({ request, baseURL }) => {
+    if (!designId) return;
+    await postAction(request, baseURL, "delete-design", { id: designId }).catch(
+      () => {},
+    );
+    designId = "";
+  });
+
+  test("pastes a nested selected layer on the same screen and another screen with fresh ids after reload", async ({
+    page,
+    request,
+    baseURL,
+  }) => {
+    designId = await createKeyboardDesign(
+      request,
+      baseURL,
+      "E2E Keyboard Paste",
+    );
+    await gotoEditor(page, designId);
+
+    await selectLayerRow(page, "Copy Card");
+    await pressPrimaryShortcut(page, "c");
+    await pressPrimaryShortcut(page, "v");
+
+    await expectFileContent(
+      request,
+      baseURL,
+      designId,
+      "source.html",
+      (html) => {
+        expect(count(html, 'data-agent-native-layer-name="Copy Card"')).toBe(2);
+        expect(count(html, ">Nested CTA<")).toBe(2);
+        expect(count(html, 'data-agent-native-node-id="source-card"')).toBe(1);
+        expect(
+          count(html, 'data-agent-native-node-id="source-card-child"'),
+        ).toBe(1);
+        expect(allNodeIdsAreUnique(html)).toBe(true);
+      },
+    );
+
+    await selectScreenRow(page, "Target");
+    await pressPrimaryShortcut(page, "v");
+
+    await expectFileContent(
+      request,
+      baseURL,
+      designId,
+      "target.html",
+      (html) => {
+        expect(count(html, 'data-agent-native-layer-name="Copy Card"')).toBe(1);
+        expect(count(html, ">Nested CTA<")).toBe(1);
+        expect(html).not.toContain('data-agent-native-node-id="source-card"');
+        expect(html).not.toContain(
+          'data-agent-native-node-id="source-card-child"',
+        );
+        expect(allNodeIdsAreUnique(html)).toBe(true);
+      },
+    );
+
+    await gotoEditor(page, designId);
+    await selectScreenRow(page, "Target");
+    await enterDirectMode(page);
+    await expect(
+      designFrame(page).getByRole("heading", { name: "Target Screen" }),
+    ).toBeVisible();
+    await expect(
+      designFrame(page).getByRole("button", { name: "Nested CTA" }),
+    ).toBeVisible();
+  });
+
+  test("pastes a multi-selection across screens with each layer and child id regenerated", async ({
+    page,
+    request,
+    baseURL,
+  }) => {
+    designId = await createKeyboardDesign(
+      request,
+      baseURL,
+      "E2E Keyboard Multi Paste",
+    );
+    await gotoEditor(page, designId);
+
+    await selectLayerRow(page, "Copy Card");
+    await additiveSelectLayerRow(page, "Source Peer");
+    await expect.poll(() => selectedRowCount(page)).toBe(2);
+
+    await pressPrimaryShortcut(page, "c");
+    await selectScreenRow(page, "Target");
+    await pressPrimaryShortcut(page, "v");
+
+    await expectFileContent(
+      request,
+      baseURL,
+      designId,
+      "target.html",
+      (html) => {
+        expect(count(html, 'data-agent-native-layer-name="Copy Card"')).toBe(1);
+        expect(count(html, 'data-agent-native-layer-name="Source Peer"')).toBe(
+          1,
+        );
+        expect(count(html, ">Nested CTA<")).toBe(1);
+        expect(html).not.toContain('data-agent-native-node-id="source-card"');
+        expect(html).not.toContain(
+          'data-agent-native-node-id="source-card-child"',
+        );
+        expect(html).not.toContain('data-agent-native-node-id="source-peer"');
+        expect(allNodeIdsAreUnique(html)).toBe(true);
+      },
+    );
+  });
+
+  test("duplicates, deletes, cuts, undoes, and redoes selected layers from the keyboard", async ({
+    page,
+    request,
+    baseURL,
+  }) => {
+    designId = await createKeyboardDesign(
+      request,
+      baseURL,
+      "E2E Keyboard Layer Edits",
+    );
+    await gotoEditor(page, designId);
+    await selectScreenRow(page, "Source");
+    await enterDirectMode(page);
+
+    await selectLayerRow(page, "Source Peer");
+    await pressPrimaryShortcut(page, "d");
+    await expectFileContent(
+      request,
+      baseURL,
+      designId,
+      "source.html",
+      (html) => {
+        expect(count(html, 'data-agent-native-layer-name="Source Peer"')).toBe(
+          2,
+        );
+        expect(count(html, 'data-agent-native-node-id="source-peer"')).toBe(1);
+        expect(allNodeIdsAreUnique(html)).toBe(true);
+      },
+    );
+
+    await pressEditorKey(page, "Delete");
+    await expectFileContent(
+      request,
+      baseURL,
+      designId,
+      "source.html",
+      (html) => {
+        expect(count(html, 'data-agent-native-layer-name="Source Peer"')).toBe(
+          1,
+        );
+      },
+    );
+
+    await pressPrimaryShortcut(page, "z");
+    await expectFileContent(
+      request,
+      baseURL,
+      designId,
+      "source.html",
+      (html) => {
+        expect(count(html, 'data-agent-native-layer-name="Source Peer"')).toBe(
+          2,
+        );
+      },
+    );
+
+    await pressPrimaryShortcut(page, "z", { shift: true });
+    await expectFileContent(
+      request,
+      baseURL,
+      designId,
+      "source.html",
+      (html) => {
+        expect(count(html, 'data-agent-native-layer-name="Source Peer"')).toBe(
+          1,
+        );
+      },
+    );
+
+    await selectLayerRow(page, "Copy Card");
+    await pressPrimaryShortcut(page, "x");
+    await expectFileContent(
+      request,
+      baseURL,
+      designId,
+      "source.html",
+      (html) => {
+        expect(count(html, 'data-agent-native-layer-name="Copy Card"')).toBe(0);
+        expect(count(html, ">Nested CTA<")).toBe(0);
+      },
+    );
+
+    await selectScreenRow(page, "Target");
+    await pressPrimaryShortcut(page, "v");
+    await expectFileContent(
+      request,
+      baseURL,
+      designId,
+      "target.html",
+      (html) => {
+        expect(count(html, 'data-agent-native-layer-name="Copy Card"')).toBe(1);
+        expect(count(html, ">Nested CTA<")).toBe(1);
+        expect(html).not.toContain('data-agent-native-node-id="source-card"');
+        expect(allNodeIdsAreUnique(html)).toBe(true);
+      },
+    );
+  });
+});
+
+async function createKeyboardDesign(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  title: string,
+): Promise<string> {
+  const created = await postAction(request, baseURL, "create-design", {
+    title,
+    projectType: "prototype",
+  });
+  const id: string | undefined =
+    created?.id ?? created?.data?.id ?? created?.design?.id;
+  if (!id) throw new Error(`create-design did not return id: ${created}`);
+
+  await postAction(request, baseURL, "create-file", {
+    designId: id,
+    filename: "source.html",
+    fileType: "html",
+    content: SOURCE_HTML,
+  });
+  await postAction(request, baseURL, "create-file", {
+    designId: id,
+    filename: "target.html",
+    fileType: "html",
+    content: TARGET_HTML,
+  });
+  return id;
+}
+
+async function postAction(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  name: string,
+  input: Record<string, unknown>,
+): Promise<any> {
+  const res = await request.post(
+    `${actionBaseUrl(baseURL)}/_agent-native/actions/${name}`,
+    {
+      data: input,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+  if (!res.ok()) {
+    throw new Error(
+      `action ${name} failed: ${res.status()} ${await res.text()}`,
+    );
+  }
+  return res.json();
+}
+
+function actionBaseUrl(baseURL: string | undefined): string {
+  return (
+    baseURL ??
+    process.env.E2E_BASE_URL ??
+    `http://127.0.0.1:${process.env.E2E_PORT ?? "9333"}`
+  ).replace(/\/$/, "");
+}
+
+async function getDesign(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  id: string,
+): Promise<any> {
+  const params = new URLSearchParams({ id });
+  const res = await request.get(
+    `${actionBaseUrl(baseURL)}/_agent-native/actions/get-design?${params}`,
+    {
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+  if (!res.ok()) {
+    throw new Error(
+      `action get-design failed: ${res.status()} ${await res.text()}`,
+    );
+  }
+  const result = await res.json();
+  if (hasFiles(result)) return result;
+  if (hasFiles(result?.result)) return result.result;
+  if (hasFiles(result?.design)) return result.design;
+  if (hasFiles(result?.data)) return result.data;
+  return result;
+}
+
+async function expectFileContent(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  designId: string,
+  filename: string,
+  assertContent: (html: string) => void,
+) {
+  await expect
+    .poll(
+      async () => {
+        const design = await getDesign(request, baseURL, designId);
+        const files = Array.isArray(design?.files) ? design.files : [];
+        const file = files.find(
+          (candidate: { filename?: string }) => candidate.filename === filename,
+        );
+        if (!file) {
+          return {
+            ok: false,
+            message: `missing file "${filename}"; saw files: ${files
+              .map((candidate: { filename?: string }) => candidate.filename)
+              .filter(Boolean)
+              .join(", ")}`,
+          };
+        }
+        if (typeof file.content !== "string") {
+          return {
+            ok: false,
+            message: `file "${filename}" has no string content`,
+          };
+        }
+        try {
+          assertContent(file.content);
+          return { ok: true, message: "" };
+        } catch (error) {
+          return {
+            ok: false,
+            message: error instanceof Error ? error.message : String(error),
+          };
+        }
+      },
+      { timeout: 15_000 },
+    )
+    .toEqual({ ok: true, message: "" });
+}
+
+function hasFiles(value: any): value is { files: any[] } {
+  return !!value && typeof value === "object" && Array.isArray(value.files);
+}
+
+function layerTree(page: Page) {
+  return page.getByRole("tree", { name: "Layers" });
+}
+
+function layerRowButton(page: Page, name: string) {
+  return layerTree(page)
+    .locator("[data-layer-row-button][data-layer-node-id]")
+    .filter({ has: page.locator(`span[title="${cssString(name)}"]`) })
+    .first();
+}
+
+function layerRow(page: Page, name: string) {
+  return layerRowButton(page, name).locator(
+    'xpath=ancestor::*[@role="treeitem"][1]',
+  );
+}
+
+function screenButton(page: Page, name: string) {
+  return page
+    .locator("button:not([data-layer-row-button])")
+    .filter({ hasText: new RegExp(`^\\s*${escapeRegExp(name)}\\s*$`) })
+    .first();
+}
+
+async function selectLayerRow(page: Page, name: string): Promise<void> {
+  await openLayerSearch(page, name);
+  const button = layerRowButton(page, name);
+  await expect(button).toBeVisible();
+  await button.click({ force: true });
+  await expect(layerRow(page, name)).toHaveAttribute("aria-selected", "true");
+}
+
+async function additiveSelectLayerRow(page: Page, name: string): Promise<void> {
+  await openLayerSearch(page, "");
+  const button = layerRowButton(page, name);
+  await expect(button).toBeVisible();
+  await button.click({
+    force: true,
+    modifiers: [process.platform === "darwin" ? "Meta" : "Control"],
+  });
+  await expect(layerRow(page, name)).toHaveAttribute("aria-selected", "true");
+}
+
+async function selectScreenRow(page: Page, name: string): Promise<void> {
+  await openLayerSearch(page, "");
+  const button = screenButton(page, name);
+  await expect(button).toBeVisible();
+  await button.click();
+  await expect(button).toHaveAttribute("aria-current", "page");
+}
+
+async function selectedRowCount(page: Page): Promise<number> {
+  return layerTree(page)
+    .locator('[role="treeitem"][aria-selected="true"]')
+    .count();
+}
+
+async function openLayerSearch(page: Page, query: string): Promise<void> {
+  const normalized = query.trim().toLowerCase();
+  const input = page.getByPlaceholder("Search layers...");
+  if (!(await input.isVisible().catch(() => false))) {
+    await page
+      .getByRole("button", { name: "Search layers...", exact: true })
+      .click();
+    await expect(input).toBeVisible();
+  }
+  await input.fill(query);
+  await expect(input).toHaveValue(query);
+  await expect
+    .poll(
+      async () => {
+        const names = await visibleLayerNames(page);
+        return normalized
+          ? names.some((name) => name.toLowerCase().includes(normalized))
+          : names.length > 0;
+      },
+      { timeout: 10_000 },
+    )
+    .toBe(true);
+}
+
+async function visibleLayerNames(page: Page): Promise<string[]> {
+  return await layerTree(page)
+    .locator("[data-layer-row-button][data-layer-node-id]")
+    .evaluateAll((nodes) =>
+      nodes
+        .map((node) => (node.textContent ?? "").trim())
+        .filter((name) => name.length > 0),
+    );
+}
+
+async function pressPrimaryShortcut(
+  page: Page,
+  key: string,
+  options: { shift?: boolean } = {},
+): Promise<void> {
+  await page.evaluate(
+    ({ key, primary, shift }) => {
+      const isLetter = /^[a-z]$/i.test(key);
+      const eventKey = isLetter
+        ? shift
+          ? key.toUpperCase()
+          : key.toLowerCase()
+        : key;
+      const eventInit: KeyboardEventInit = {
+        key: eventKey,
+        code: isLetter ? `Key${key.toUpperCase()}` : key,
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        metaKey: primary === "Meta",
+        ctrlKey: primary === "Control",
+        shiftKey: shift,
+      };
+      window.dispatchEvent(new KeyboardEvent("keydown", eventInit));
+      window.dispatchEvent(new KeyboardEvent("keyup", eventInit));
+    },
+    { key, primary: PRIMARY, shift: options.shift ?? false },
+  );
+}
+
+async function pressEditorKey(page: Page, key: string): Promise<void> {
+  await page.evaluate((key) => {
+    const eventInit: KeyboardEventInit = {
+      key,
+      code: key,
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    };
+    window.dispatchEvent(new KeyboardEvent("keydown", eventInit));
+    window.dispatchEvent(new KeyboardEvent("keyup", eventInit));
+  }, key);
+}
+
+function count(value: string, needle: string): number {
+  return value.split(needle).length - 1;
+}
+
+function allNodeIdsAreUnique(html: string): boolean {
+  const ids = Array.from(
+    html.matchAll(/data-agent-native-node-id="([^"]+)"/g),
+  ).map((match) => match[1]);
+  return ids.length === new Set(ids).size;
+}
+
+function cssString(value: string) {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/templates/design/e2e/editor.spec.ts
+++ b/templates/design/e2e/editor.spec.ts
@@ -102,6 +102,9 @@ test("screen overview resizes previews from the device selector", async ({
   await expect
     .poll(async () => (await firstScreenCard.boundingBox())?.width ?? 0)
     .toBeLessThan(desktopBox.width - 1);
+
+  await page.getByRole("button", { name: "Device preview" }).first().click();
+  await page.getByRole("menuitemradio", { name: "Responsive" }).click();
 });
 
 test("screen overview keeps the name readable when frame header space is tight", async ({

--- a/templates/design/e2e/global-setup.ts
+++ b/templates/design/e2e/global-setup.ts
@@ -16,7 +16,9 @@ export const E2E_EMAIL = "e2e@local.test";
 export const E2E_PASSWORD = "password-e2e-1234";
 export const SEED_TITLE = "E2E Seed Design";
 
-const AUTH_DIR = path.join(import.meta.dirname, ".auth");
+const AUTH_DIR = process.env.E2E_AUTH_DIR
+  ? path.resolve(process.env.E2E_AUTH_DIR)
+  : path.join(import.meta.dirname, ".auth");
 const STATE_PATH = path.join(AUTH_DIR, "state.json");
 const SEED_PATH = path.join(AUTH_DIR, "seed.json");
 const BROWSER_CHANNEL = process.env.E2E_BROWSER_CHANNEL;

--- a/templates/design/e2e/helpers.ts
+++ b/templates/design/e2e/helpers.ts
@@ -25,7 +25,10 @@ import { FIXTURE_HTML, SEED_TITLE } from "./global-setup";
  */
 
 export async function readSeedDesignId(): Promise<string> {
-  const seedPath = path.join(import.meta.dirname, ".auth", "seed.json");
+  const authDir = process.env.E2E_AUTH_DIR
+    ? path.resolve(process.env.E2E_AUTH_DIR)
+    : path.join(import.meta.dirname, ".auth");
+  const seedPath = path.join(authDir, "seed.json");
   const raw = await readFile(seedPath, "utf8");
   const { designId } = JSON.parse(raw) as { designId: string };
   if (!designId) throw new Error("no seeded designId - global-setup failed");

--- a/templates/design/e2e/layers-reparent.spec.ts
+++ b/templates/design/e2e/layers-reparent.spec.ts
@@ -133,6 +133,55 @@ test.describe.serial("layers menu structure operations", () => {
     }
   });
 
+  test("dragging onto an empty container reparents inside and persists after reload", async ({
+    page,
+  }) => {
+    await clickLayerRow(page, "Alpha Button");
+    await openLayerSearch(page, "");
+    const containerLevel = await rowLevel(page, "E2E Token Sample");
+
+    await layerRow(page, "Alpha Button").dragTo(
+      layerRow(page, "E2E Token Sample"),
+      {
+        targetPosition: { x: 96, y: 16 },
+      },
+    );
+
+    await expect(layerRow(page, "E2E Token Sample")).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+    await expect
+      .poll(async () => rowLevel(page, "Alpha Button"))
+      .toBe(containerLevel + 1);
+    await expect
+      .poll(async () => {
+        const names = await visibleLayerNames(page);
+        return (
+          names.indexOf("E2E Token Sample") < names.indexOf("Alpha Button")
+        );
+      })
+      .toBe(true);
+
+    await gotoEditor(page, designId);
+    await revealLayerRow(page, "E2E Token Sample");
+    const persistedContainerLevel = await rowLevel(page, "E2E Token Sample");
+    await expandLayerRow(page, "E2E Token Sample");
+    await expect(layerRow(page, "Alpha Button")).toBeVisible();
+    await expect
+      .poll(async () => {
+        const names = await visibleLayerNames(page);
+        return (
+          names.indexOf("E2E Token Sample") >= 0 &&
+          names.indexOf("E2E Token Sample") < names.indexOf("Alpha Button")
+        );
+      })
+      .toBe(true);
+    await expect
+      .poll(async () => rowLevel(page, "Alpha Button"))
+      .toBe(persistedContainerLevel + 1);
+  });
+
   test("locking a layer keeps panel selection but blocks canvas selection", async ({
     page,
   }) => {
@@ -256,8 +305,19 @@ async function waitForLayerRowButton(page: Page, name: string) {
 
 async function expandLayerRow(page: Page, name: string): Promise<void> {
   const row = layerRow(page, name);
+  await expect(row).toBeVisible();
   if ((await row.getAttribute("aria-expanded")) === "true") return;
-  await row.getByRole("button", { name: "Expand layer" }).click();
+  const toggle = row.getByRole("button", { name: "Expand layer" });
+  await expect(toggle).toBeVisible();
+  await toggle.click({ force: true });
+  await expect(row).toHaveAttribute("aria-expanded", "true");
+}
+
+async function revealLayerRow(page: Page, name: string): Promise<void> {
+  await openLayerSearch(page, name);
+  await clickLayerRow(page, name);
+  await openLayerSearch(page, "");
+  await expect(layerRow(page, name)).toBeVisible();
 }
 
 async function additiveSelectLayerRow(page: Page, name: string): Promise<void> {

--- a/templates/design/playwright.config.ts
+++ b/templates/design/playwright.config.ts
@@ -15,6 +15,9 @@ import { defineConfig, devices } from "@playwright/test";
  */
 const PORT = Number(process.env.E2E_PORT ?? 9333);
 const BASE_URL = process.env.E2E_BASE_URL ?? `http://127.0.0.1:${PORT}`;
+const AUTH_DIR = process.env.E2E_AUTH_DIR
+  ? path.resolve(process.env.E2E_AUTH_DIR)
+  : path.join(import.meta.dirname, "e2e", ".auth");
 const E2E_DATABASE_URL = `file:${path.join(
   import.meta.dirname,
   "data",
@@ -34,7 +37,7 @@ export default defineConfig({
   globalSetup: path.join(import.meta.dirname, "e2e", "global-setup.ts"),
   use: {
     baseURL: BASE_URL,
-    storageState: path.join(import.meta.dirname, "e2e", ".auth", "state.json"),
+    storageState: path.join(AUTH_DIR, "state.json"),
     trace: "on-first-retry",
     actionTimeout: 15_000,
     navigationTimeout: 30_000,


### PR DESCRIPTION
## Summary
- Fix Design Studio all-screens layer copy/paste, layer reparenting, text-edit entry, and vector persistence behaviors
- Add focused Chrome E2E coverage for layer clipboard, text primitives, pen paths, and layer reparenting
- Add a Design changelog note for canvas layer editing reliability

## Validation
- pnpm --filter design typecheck
- Chrome E2E: e2e/layers-reparent.spec.ts (6 passed)
- Chrome E2E: e2e/canvas-tools.spec.ts --grep 'pen|Vector' (3 passed)
- Chrome E2E: e2e/canvas-tools.spec.ts --grep text (4 passed, 1 assertion fixed after rerun)
- Subagent Chrome E2E: e2e/editor-keyboard-layers.spec.ts (3 passed)
- git diff --check