### PR TITLE
Fix Design Studio overview canvas editing

### DIFF
--- a/templates/design/.generated/bridge/editor-chrome.generated.ts
+++ b/templates/design/.generated/bridge/editor-chrome.generated.ts
@@ -8,6 +8,7 @@ export const editorChromeBridgeScript: string = `"use strict";
   (function() {
     var readOnly = __READ_ONLY__;
     var textEditingEnabled = !readOnly && __TEXT_EDITING_ENABLED__;
+    var designCanvasScreenId = __DESIGN_CANVAS_SCREEN_ID__ || "";
     var scaleToolEnabled = false;
     var editorChromeScaleX = Math.max(
       0.05,
@@ -1876,6 +1877,32 @@ export const editorChromeBridgeScript: string = `"use strict";
       if (cs.position === "absolute" || cs.position === "fixed") return false;
       return true;
     }
+    function isOutsideIframeViewport(clientX, clientY) {
+      return clientX < 0 || clientY < 0 || clientX > window.innerWidth || clientY > window.innerHeight;
+    }
+    function postCrossScreenDrag(phase, el, ev) {
+      if (phase === "cancel") {
+        window.parent.postMessage(
+          { type: "agent-native:cross-screen-drag", phase: "cancel" },
+          "*"
+        );
+        return;
+      }
+      window.parent.postMessage(
+        {
+          type: "agent-native:cross-screen-drag",
+          phase,
+          screenId: designCanvasScreenId,
+          selector: getSelector(el ?? null),
+          sourceId: getSourceId(el ?? null),
+          iframeX: ev?.clientX ?? 0,
+          iframeY: ev?.clientY ?? 0,
+          viewportW: window.innerWidth,
+          viewportH: window.innerHeight
+        },
+        "*"
+      );
+    }
     var BRIDGE_CONTAINER_TAGS = [
       "div",
       "section",
@@ -2257,6 +2284,9 @@ export const editorChromeBridgeScript: string = `"use strict";
       }
       ensurePositionable(selectedEl);
       var cs = window.getComputedStyle(selectedEl);
+      var originalInlinePosition = selectedEl.style.position;
+      var originalInlineLeft = selectedEl.style.left;
+      var originalInlineTop = selectedEl.style.top;
       var originLeft = readPx(selectedEl.style.left || cs.left);
       var originTop = readPx(selectedEl.style.top || cs.top);
       var startX = e.clientX;
@@ -2264,6 +2294,9 @@ export const editorChromeBridgeScript: string = `"use strict";
       var dragEl = selectedEl;
       var moved = false;
       var DRAG_THRESHOLD = 3;
+      if (!duplicatedForDrag) {
+        postCrossScreenDrag("start", dragEl, e);
+      }
       function onMove(ev) {
         if (!moved && Math.hypot(ev.clientX - startX, ev.clientY - startY) > DRAG_THRESHOLD) {
           moved = true;
@@ -2272,18 +2305,37 @@ export const editorChromeBridgeScript: string = `"use strict";
         var nextTop = originTop + ev.clientY - startY;
         dragEl.style.left = Math.round(nextLeft) + "px";
         dragEl.style.top = Math.round(nextTop) + "px";
-        showTransformBadge(
-          "X " + Math.round(nextLeft) + "  Y " + Math.round(nextTop),
-          ev.clientX,
-          ev.clientY
-        );
+        if (!duplicatedForDrag) {
+          postCrossScreenDrag("move", dragEl, ev);
+        }
+        if (!duplicatedForDrag && isOutsideIframeViewport(ev.clientX, ev.clientY)) {
+          showTransformBadge("Move layer", ev.clientX, ev.clientY);
+        } else {
+          showTransformBadge(
+            "X " + Math.round(nextLeft) + "  Y " + Math.round(nextTop),
+            ev.clientX,
+            ev.clientY
+          );
+        }
         refreshOverlays();
       }
-      function onUp() {
+      function restoreSourceDragPosition() {
+        dragEl.style.position = originalInlinePosition;
+        dragEl.style.left = originalInlineLeft;
+        dragEl.style.top = originalInlineTop;
+        selectedEl = originalSelectedEl;
+        positionOverlay(selectionOverlay, selectedEl);
+      }
+      function onUp(ev) {
         document.removeEventListener(events.move, onMove, true);
         document.removeEventListener(events.up, onUp, true);
         hideTransformBadge();
         if (!dragEl) return;
+        if (ev && !duplicatedForDrag && isOutsideIframeViewport(ev.clientX, ev.clientY)) {
+          postCrossScreenDrag("end", dragEl, ev);
+          restoreSourceDragPosition();
+          return;
+        }
         if (duplicatedForDrag && !moved) {
           if (dragEl.parentElement) dragEl.parentElement.removeChild(dragEl);
           selectedEl = originalSelectedEl;
@@ -2310,6 +2362,7 @@ export const editorChromeBridgeScript: string = `"use strict";
             },
             "*"
           );
+          postCrossScreenDrag("cancel");
         }
       }
       document.addEventListener(events.move, onMove, true);
@@ -2492,6 +2545,12 @@ export const editorChromeBridgeScript: string = `"use strict";
         pendingShieldDrag.onUp,
         true
       );
+      if (pendingShieldDrag.pointerId !== void 0 && shieldOverlay.releasePointerCapture) {
+        try {
+          shieldOverlay.releasePointerCapture(pendingShieldDrag.pointerId);
+        } catch (_err) {
+        }
+      }
       pendingShieldDrag = null;
     }
     function beginPotentialShieldDrag(e) {
@@ -2505,6 +2564,15 @@ export const editorChromeBridgeScript: string = `"use strict";
       var clickTarget = selectionTargetForHit(hit);
       if (!dragTarget || dragTarget === document.body || dragTarget === document.documentElement || isLayerInteractionBlocked(dragTarget)) {
         return;
+      }
+      if (e.pointerId !== void 0 && shieldOverlay.setPointerCapture && !e.altKey) {
+        try {
+          shieldOverlay.setPointerCapture(e.pointerId);
+        } catch (_err) {
+        }
+      }
+      if (!e.altKey) {
+        postCrossScreenDrag("start", dragTarget, e);
       }
       var startX = e.clientX;
       var startY = e.clientY;
@@ -2528,6 +2596,9 @@ export const editorChromeBridgeScript: string = `"use strict";
       function onUp(ev) {
         clearPendingShieldDrag();
         if (didStartDrag) return;
+        if (!e.altKey) {
+          postCrossScreenDrag("cancel");
+        }
         if (ev) stopNativeInteraction(ev);
         selectTarget(clickTarget || dragTarget);
         suppressNextShieldClickBriefly();
@@ -2537,7 +2608,8 @@ export const editorChromeBridgeScript: string = `"use strict";
         move: events.move,
         up: events.up,
         onMove,
-        onUp
+        onUp,
+        pointerId: e.pointerId
       };
       document.addEventListener(events.move, onMove, true);
       document.addEventListener(events.up, onUp, true);

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -596,7 +596,11 @@ export function DesignCanvas({
         )
           .replace("__TEXT_EDITING_ENABLED__", editMode ? "true" : "false")
           .replace("__EDITOR_CHROME_SCALE_X__", String(editorChromeScaleX))
-          .replace("__EDITOR_CHROME_SCALE_Y__", String(editorChromeScaleY));
+          .replace("__EDITOR_CHROME_SCALE_Y__", String(editorChromeScaleY))
+          .replace(
+            "__DESIGN_CANVAS_SCREEN_ID__",
+            JSON.stringify(screenId ?? contentKey ?? ""),
+          );
     const embeddedWheelBridge = EMBEDDED_WHEEL_BRIDGE_SCRIPT.replace(
       "__EMBEDDED_WHEEL_FORWARDING_ENABLED__",
       isEmbeddedFrame ? "true" : "false",

--- a/templates/design/app/components/design/MultiScreenCanvas.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.tsx
@@ -749,6 +749,7 @@ export function MultiScreenCanvas({
     selector: string;
     sourceId?: string;
   } | null>(null);
+  const crossScreenParentDragCleanupRef = useRef<(() => void) | null>(null);
   /** Board-space point from the last cross-screen-drag "move" message. */
   const crossScreenLastBoardPointRef = useRef<{ x: number; y: number } | null>(
     null,
@@ -1144,11 +1145,122 @@ export function MultiScreenCanvas({
   useEffect(() => {
     if (!onCrossScreenElementDrop) return;
 
+    const stopParentCrossScreenDrag = () => {
+      crossScreenParentDragCleanupRef.current?.();
+      crossScreenParentDragCleanupRef.current = null;
+    };
+
     const clearCrossScreenDrag = () => {
+      stopParentCrossScreenDrag();
       setCrossScreenGhost(null);
       setCrossScreenTarget(null);
       crossScreenTargetRef.current = null;
       crossScreenDragMsgRef.current = null;
+    };
+
+    const updateCrossScreenTargetFromBoardPoint = (
+      boardPoint: Point,
+      sourceScreenId: string,
+    ) => {
+      crossScreenLastBoardPointRef.current = boardPoint;
+      setCrossScreenGhost({ boardX: boardPoint.x, boardY: boardPoint.y });
+      const target = getFrameEntryAtPoint(boardPoint);
+      if (target && target.id !== sourceScreenId) {
+        const nextTarget = { id: target.id, geometry: target.geometry };
+        crossScreenTargetRef.current = nextTarget;
+        setCrossScreenTarget(nextTarget);
+      } else {
+        crossScreenTargetRef.current = null;
+        setCrossScreenTarget(null);
+      }
+    };
+
+    const finalizeCrossScreenDrop = (
+      sourceScreenId: string,
+      candidate: CrossScreenDragTarget | null,
+      payload: { selector: string; sourceId?: string },
+      lastBoardPoint: Point | null,
+    ) => {
+      clearCrossScreenDrag();
+      crossScreenLastBoardPointRef.current = null;
+      const hasIdentifier = !!(payload.selector || payload.sourceId);
+      if (!candidate || !hasIdentifier || !sourceScreenId) return;
+
+      const runHitTest = (): Promise<{
+        anchorNodeId?: string;
+        placement?: "before" | "after" | "inside";
+      }> => {
+        if (!lastBoardPoint) return Promise.resolve({});
+        const targetScreen = screensRef.current.find(
+          (s) => s.id === candidate.id,
+        );
+        if (!targetScreen) return Promise.resolve({});
+        const targetGeometry = candidate.geometry;
+        const targetIframe =
+          surfaceRef.current?.querySelector<HTMLIFrameElement>(
+            `[data-screen-iframe-id="${CSS.escape(candidate.id)}"]`,
+          );
+        const targetContentWindow = targetIframe?.contentWindow;
+        if (!targetContentWindow) return Promise.resolve({});
+        const targetViewportWidth =
+          targetIframe.clientWidth || getResolvedMetadata(targetScreen).width;
+        const targetViewportHeight =
+          targetIframe.clientHeight || getResolvedMetadata(targetScreen).height;
+        const scaleX = targetViewportWidth / Math.max(1, targetGeometry.width);
+        const scaleY =
+          targetViewportHeight / Math.max(1, targetGeometry.height);
+        const localX = (lastBoardPoint.x - targetGeometry.x) * scaleX;
+        const localY = (lastBoardPoint.y - targetGeometry.y) * scaleY;
+
+        const correlationId = `hit-${Date.now()}-${Math.random()
+          .toString(36)
+          .slice(2, 6)}`;
+
+        return new Promise((resolve) => {
+          const timer = window.setTimeout(() => {
+            window.removeEventListener("message", hitListener);
+            resolve({});
+          }, 50);
+
+          const hitListener = (ev: MessageEvent) => {
+            if (
+              !ev.data ||
+              ev.data.type !== "agent-native:hit-test-result" ||
+              ev.data.correlationId !== correlationId
+            ) {
+              return;
+            }
+            window.clearTimeout(timer);
+            window.removeEventListener("message", hitListener);
+            resolve({
+              anchorNodeId: ev.data.anchorNodeId ?? undefined,
+              placement: ev.data.placement ?? undefined,
+            });
+          };
+          window.addEventListener("message", hitListener);
+
+          targetContentWindow.postMessage(
+            {
+              type: "agent-native:hit-test",
+              correlationId,
+              x: localX,
+              y: localY,
+            },
+            "*",
+          );
+        });
+      };
+
+      void runHitTest().then(({ anchorNodeId, placement }) => {
+        onCrossScreenElementDropRef.current?.({
+          sourceSelector: payload.selector,
+          sourceNodeId: payload.sourceId,
+          sourceScreenId,
+          targetScreenId: candidate.id,
+          targetAnchorNodeId: anchorNodeId,
+          targetAnchorPlacement: placement,
+        });
+      });
     };
 
     const handleMessage = (event: MessageEvent) => {
@@ -1157,7 +1269,8 @@ export function MultiScreenCanvas({
       }
       const msg = event.data as {
         type: string;
-        phase: "move" | "end" | "cancel";
+        phase: "start" | "move" | "end" | "cancel";
+        screenId?: string;
         selector?: string;
         sourceId?: string;
         iframeX?: number;
@@ -1171,15 +1284,71 @@ export function MultiScreenCanvas({
         return;
       }
 
-      // The drag originates from the active screen (only the active screen has
-      // a live interactive iframe posting these messages).
-      const sourceScreenId = activeId;
+      // Prefer the iframe-supplied source id. In overview, activeId can point
+      // at a different screen than the layer currently being dragged.
+      const sourceScreenId =
+        msg.screenId &&
+        (msg.screenId === boardFileId || frameGeometryRef.current[msg.screenId])
+          ? msg.screenId
+          : activeId;
       if (!sourceScreenId) {
         // Always clear visual state (ghost + highlight) when we have no active
         // screen to attribute the drag to — regardless of the phase. Without
         // this, a "move" message arriving after activeId became null would leave
         // stale ghost/target state visible on the canvas.
         clearCrossScreenDrag();
+        return;
+      }
+
+      if (msg.phase === "start") {
+        crossScreenDragMsgRef.current = {
+          selector: msg.selector ?? "",
+          sourceId: msg.sourceId,
+        };
+        stopParentCrossScreenDrag();
+        let restorePreviewPointerEvents: (() => void) | null = null;
+        const activateParentDrag = (ev: MouseEvent) => {
+          if (!restorePreviewPointerEvents) {
+            restorePreviewPointerEvents = mutePreviewIframePointerEvents(
+              surfaceRef.current,
+            );
+          }
+          ev.preventDefault();
+          updateCrossScreenTargetFromBoardPoint(
+            getCanvasPoint(ev.clientX, ev.clientY),
+            sourceScreenId,
+          );
+        };
+        const handleParentMouseMove = (ev: MouseEvent) => {
+          activateParentDrag(ev);
+        };
+        const handleParentMouseUp = (ev: MouseEvent) => {
+          activateParentDrag(ev);
+          const candidate = crossScreenTargetRef.current;
+          const payload = crossScreenDragMsgRef.current ?? {
+            selector: msg.selector ?? "",
+            sourceId: msg.sourceId,
+          };
+          const lastBoardPoint = crossScreenLastBoardPointRef.current;
+          finalizeCrossScreenDrop(
+            sourceScreenId,
+            candidate,
+            payload,
+            lastBoardPoint,
+          );
+        };
+        const cleanup = () => {
+          window.removeEventListener("mousemove", handleParentMouseMove, true);
+          window.removeEventListener("mouseup", handleParentMouseUp, true);
+          restorePreviewPointerEvents?.();
+          restorePreviewPointerEvents = null;
+          if (crossScreenParentDragCleanupRef.current === cleanup) {
+            crossScreenParentDragCleanupRef.current = null;
+          }
+        };
+        crossScreenParentDragCleanupRef.current = cleanup;
+        window.addEventListener("mousemove", handleParentMouseMove, true);
+        window.addEventListener("mouseup", handleParentMouseUp, true);
         return;
       }
 
@@ -1208,14 +1377,16 @@ export function MultiScreenCanvas({
           iframeX <= viewportW &&
           iframeY <= viewportH
         ) {
-          clearCrossScreenDrag();
+          setCrossScreenGhost(null);
+          setCrossScreenTarget(null);
+          crossScreenTargetRef.current = null;
+          crossScreenLastBoardPointRef.current = null;
           return;
         }
 
-        // Translate iframe coords → board coords using source frame geometry.
-        // Board math mirrors primitiveLocalToBoardRect:
-        //   boardX = frame.x + iframeX * (frame.width / metadata.width)
-        //   boardY = frame.y + iframeY * (frame.height / metadata.height)
+        // Translate iframe coords → board coords using the live embedded
+        // viewport from the bridge. In overview, the iframe viewport may be the
+        // frame geometry rather than the screen metadata width.
 
         let boardX: number;
         let boardY: number;
@@ -1234,31 +1405,13 @@ export function MultiScreenCanvas({
             clearCrossScreenDrag();
             return;
           }
-          const sourceMetadata = getResolvedMetadata(sourceScreen);
-          const scaleX =
-            sourceGeometry.width / Math.max(1, sourceMetadata.width);
-          const scaleY =
-            sourceGeometry.height / Math.max(1, sourceMetadata.height);
+          const scaleX = sourceGeometry.width / Math.max(1, viewportW);
+          const scaleY = sourceGeometry.height / Math.max(1, viewportH);
           boardX = sourceGeometry.x + iframeX * scaleX;
           boardY = sourceGeometry.y + iframeY * scaleY;
         }
         const boardPoint = { x: boardX, y: boardY };
-
-        // Remember the latest board-space position for use in the "end" handler.
-        crossScreenLastBoardPointRef.current = boardPoint;
-
-        setCrossScreenGhost({ boardX, boardY });
-
-        // Find which screen frame the board point falls in.
-        const target = getFrameEntryAtPoint(boardPoint);
-        if (target && target.id !== sourceScreenId) {
-          const nextTarget = { id: target.id, geometry: target.geometry };
-          crossScreenTargetRef.current = nextTarget;
-          setCrossScreenTarget(nextTarget);
-        } else {
-          crossScreenTargetRef.current = null;
-          setCrossScreenTarget(null);
-        }
+        updateCrossScreenTargetFromBoardPoint(boardPoint, sourceScreenId);
         return;
       }
 
@@ -1273,97 +1426,18 @@ export function MultiScreenCanvas({
           sourceId: msg.sourceId,
         };
         const lastBoardPoint = crossScreenLastBoardPointRef.current;
-        clearCrossScreenDrag();
-        crossScreenLastBoardPointRef.current = null;
-        // Guard: require at least one stable identifier (selector or sourceId)
-        // so the drop handler in DesignEditor can resolve the node. An empty
-        // selector AND a missing sourceId would produce nodeAttrId="" and
-        // moveNodeBetweenDocuments would fail with a generic error toast.
-        const hasIdentifier = !!(payload.selector || payload.sourceId);
-        if (candidate && hasIdentifier && sourceScreenId) {
-          // Translate the board-space drop point to the target iframe's local
-          // coordinate space, then run a lightweight hit-test (postMessage +
-          // 50 ms timeout) to find the deepest container at the drop site.
-          const runHitTest = (): Promise<{
-            anchorNodeId?: string;
-            placement?: "before" | "after" | "inside";
-          }> => {
-            if (!lastBoardPoint) return Promise.resolve({});
-            const targetScreen = screensRef.current.find(
-              (s) => s.id === candidate.id,
-            );
-            if (!targetScreen) return Promise.resolve({});
-            const targetGeometry = candidate.geometry;
-            const targetMetadata = getResolvedMetadata(targetScreen);
-            // Board → target iframe local coords
-            const scaleX =
-              targetMetadata.width / Math.max(1, targetGeometry.width);
-            const scaleY =
-              targetMetadata.height / Math.max(1, targetGeometry.height);
-            const localX = (lastBoardPoint.x - targetGeometry.x) * scaleX;
-            const localY = (lastBoardPoint.y - targetGeometry.y) * scaleY;
-
-            const targetIframe =
-              surfaceRef.current?.querySelector<HTMLIFrameElement>(
-                `[data-screen-iframe-id="${CSS.escape(candidate.id)}"]`,
-              );
-            const targetContentWindow = targetIframe?.contentWindow;
-            if (!targetContentWindow) return Promise.resolve({});
-
-            const correlationId = `hit-${Date.now()}-${Math.random()
-              .toString(36)
-              .slice(2, 6)}`;
-
-            return new Promise((resolve) => {
-              const timer = window.setTimeout(() => {
-                window.removeEventListener("message", hitListener);
-                resolve({});
-              }, 50);
-
-              const hitListener = (ev: MessageEvent) => {
-                if (
-                  !ev.data ||
-                  ev.data.type !== "agent-native:hit-test-result" ||
-                  ev.data.correlationId !== correlationId
-                )
-                  return;
-                window.clearTimeout(timer);
-                window.removeEventListener("message", hitListener);
-                resolve({
-                  anchorNodeId: ev.data.anchorNodeId ?? undefined,
-                  placement: ev.data.placement ?? undefined,
-                });
-              };
-              window.addEventListener("message", hitListener);
-
-              targetContentWindow.postMessage(
-                {
-                  type: "agent-native:hit-test",
-                  correlationId,
-                  x: localX,
-                  y: localY,
-                },
-                "*",
-              );
-            });
-          };
-
-          void runHitTest().then(({ anchorNodeId, placement }) => {
-            onCrossScreenElementDropRef.current?.({
-              sourceSelector: payload.selector,
-              sourceNodeId: payload.sourceId,
-              sourceScreenId,
-              targetScreenId: candidate.id,
-              targetAnchorNodeId: anchorNodeId,
-              targetAnchorPlacement: placement,
-            });
-          });
-        }
+        finalizeCrossScreenDrop(
+          sourceScreenId,
+          candidate,
+          payload,
+          lastBoardPoint,
+        );
       }
     };
 
     window.addEventListener("message", handleMessage);
     return () => {
+      stopParentCrossScreenDrag();
       window.removeEventListener("message", handleMessage);
     };
   }, [
@@ -1371,6 +1445,7 @@ export function MultiScreenCanvas({
     boardFileId,
     boardFrameGeometry,
     getFrameEntryAtPoint,
+    getCanvasPoint,
     getResolvedMetadata,
     onCrossScreenElementDrop,
   ]);
@@ -1940,6 +2015,7 @@ export function MultiScreenCanvas({
   }, [frameGeometry, retryPersistedDraftPrimitives, screens]);
 
   const clearActivePenPath = useCallback(() => {
+    activePenPathRef.current = null;
     setActivePenPath(null);
     setPenGesturePreview(null);
     setPenPointer(null);
@@ -1964,6 +2040,25 @@ export function MultiScreenCanvas({
     },
     [clearActivePenPath, commitDraftPrimitive, onActiveToolChange, toolProps],
   );
+
+  const undoActivePenPathSegment = useCallback(() => {
+    const path = activePenPathRef.current;
+    if (!path) return false;
+
+    const remainingNodes = path.nodes.slice(0, -1);
+    if (remainingNodes.length === 0) {
+      clearActivePenPath();
+      return true;
+    }
+
+    const nextPath: PenPath = { nodes: remainingNodes, closed: false };
+    activePenPathRef.current = nextPath;
+    setActivePenPath(nextPath);
+    setPenGesturePreview(null);
+    setPenPointer(null);
+    setPenCloseHover(false);
+    return true;
+  }, [clearActivePenPath]);
 
   const getPenAnchorPoint = useCallback(
     (
@@ -3615,14 +3710,20 @@ export function MultiScreenCanvas({
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       const path = activePenPathRef.current;
-      if (
-        !path ||
-        event.metaKey ||
-        event.ctrlKey ||
-        isEditableHotkeyTarget(event.target)
-      ) {
+      if (!path || isEditableHotkeyTarget(event.target)) {
         return;
       }
+
+      const primaryKey = event.metaKey || event.ctrlKey;
+      if (primaryKey && !event.shiftKey && event.key.toLowerCase() === "z") {
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+        undoActivePenPathSegment();
+        return;
+      }
+
+      if (primaryKey) return;
 
       if (event.key === "Enter") {
         event.preventDefault();
@@ -3644,14 +3745,7 @@ export function MultiScreenCanvas({
         event.preventDefault();
         event.stopPropagation();
         event.stopImmediatePropagation();
-        const remainingNodes = path.nodes.slice(0, -1);
-        if (remainingNodes.length === 0) {
-          clearActivePenPath();
-          return;
-        }
-        setActivePenPath({ nodes: remainingNodes, closed: false });
-        setPenPointer(null);
-        setPenCloseHover(false);
+        undoActivePenPathSegment();
       }
     };
 
@@ -3659,7 +3753,7 @@ export function MultiScreenCanvas({
     return () => {
       window.removeEventListener("keydown", handleKeyDown, true);
     };
-  }, [clearActivePenPath, finishPenPath]);
+  }, [clearActivePenPath, finishPenPath, undoActivePenPathSegment]);
 
   useEffect(() => {
     const tool = normalizeCanvasTool(activeTool ?? localActiveTool);

--- a/templates/design/app/components/design/MultiScreenCanvas.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.tsx
@@ -1306,13 +1306,11 @@ export function MultiScreenCanvas({
           sourceId: msg.sourceId,
         };
         stopParentCrossScreenDrag();
-        let restorePreviewPointerEvents: (() => void) | null = null;
+        const restorePreviewPointerEvents = mutePreviewIframePointerEvents(
+          surfaceRef.current,
+        );
+        let didCleanup = false;
         const activateParentDrag = (ev: MouseEvent) => {
-          if (!restorePreviewPointerEvents) {
-            restorePreviewPointerEvents = mutePreviewIframePointerEvents(
-              surfaceRef.current,
-            );
-          }
           ev.preventDefault();
           updateCrossScreenTargetFromBoardPoint(
             getCanvasPoint(ev.clientX, ev.clientY),
@@ -1337,11 +1335,16 @@ export function MultiScreenCanvas({
             lastBoardPoint,
           );
         };
+        const handleParentWindowBlur = () => {
+          clearCrossScreenDrag();
+        };
         const cleanup = () => {
+          if (didCleanup) return;
+          didCleanup = true;
           window.removeEventListener("mousemove", handleParentMouseMove, true);
           window.removeEventListener("mouseup", handleParentMouseUp, true);
-          restorePreviewPointerEvents?.();
-          restorePreviewPointerEvents = null;
+          window.removeEventListener("blur", handleParentWindowBlur, true);
+          restorePreviewPointerEvents();
           if (crossScreenParentDragCleanupRef.current === cleanup) {
             crossScreenParentDragCleanupRef.current = null;
           }
@@ -1349,6 +1352,7 @@ export function MultiScreenCanvas({
         crossScreenParentDragCleanupRef.current = cleanup;
         window.addEventListener("mousemove", handleParentMouseMove, true);
         window.addEventListener("mouseup", handleParentMouseUp, true);
+        window.addEventListener("blur", handleParentWindowBlur, true);
         return;
       }
 

--- a/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
+++ b/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
@@ -11,6 +11,7 @@
  *   __TEXT_EDITING_ENABLED__   — boolean literal "true"/"false"
  *   __EDITOR_CHROME_SCALE_X__  — number string, e.g. "1.5"
  *   __EDITOR_CHROME_SCALE_Y__  — number string, e.g. "1.5"
+ *   __DESIGN_CANVAS_SCREEN_ID__ — string literal for the owning screen/file id
  *
  * Rules:
  *   • No import/require of any module (DOM globals only).
@@ -24,10 +25,12 @@ declare var __READ_ONLY__: boolean;
 declare var __TEXT_EDITING_ENABLED__: boolean;
 declare var __EDITOR_CHROME_SCALE_X__: string;
 declare var __EDITOR_CHROME_SCALE_Y__: string;
+declare var __DESIGN_CANVAS_SCREEN_ID__: string;
 
 (function () {
   var readOnly = __READ_ONLY__;
   var textEditingEnabled = !readOnly && __TEXT_EDITING_ENABLED__;
+  var designCanvasScreenId = __DESIGN_CANVAS_SCREEN_ID__ || "";
   var scaleToolEnabled = false;
   var editorChromeScaleX = Math.max(
     0.05,
@@ -2533,6 +2536,43 @@ declare var __EDITOR_CHROME_SCALE_Y__: string;
     return true;
   }
 
+  function isOutsideIframeViewport(clientX: number, clientY: number): boolean {
+    return (
+      clientX < 0 ||
+      clientY < 0 ||
+      clientX > window.innerWidth ||
+      clientY > window.innerHeight
+    );
+  }
+
+  function postCrossScreenDrag(
+    phase: "start" | "move" | "end" | "cancel",
+    el?: Element | null,
+    ev?: { clientX?: number; clientY?: number } | null,
+  ): void {
+    if (phase === "cancel") {
+      (window.parent as Window).postMessage(
+        { type: "agent-native:cross-screen-drag", phase: "cancel" },
+        "*",
+      );
+      return;
+    }
+    (window.parent as Window).postMessage(
+      {
+        type: "agent-native:cross-screen-drag",
+        phase,
+        screenId: designCanvasScreenId,
+        selector: getSelector(el ?? null),
+        sourceId: getSourceId(el ?? null),
+        iframeX: ev?.clientX ?? 0,
+        iframeY: ev?.clientY ?? 0,
+        viewportW: window.innerWidth,
+        viewportH: window.innerHeight,
+      },
+      "*",
+    );
+  }
+
   // keep in sync with EditPanel.tsx CONTAINER_TAGS/LEAF_TAGS (~line 1679)
   var BRIDGE_CONTAINER_TAGS = [
     "div",
@@ -3000,6 +3040,9 @@ declare var __EDITOR_CHROME_SCALE_Y__: string;
     }
     ensurePositionable(selectedEl);
     var cs = window.getComputedStyle(selectedEl);
+    var originalInlinePosition = (selectedEl as HTMLElement).style.position;
+    var originalInlineLeft = (selectedEl as HTMLElement).style.left;
+    var originalInlineTop = (selectedEl as HTMLElement).style.top;
     var originLeft = readPx((selectedEl as HTMLElement).style.left || cs.left);
     var originTop = readPx(selectedEl.style.top || cs.top);
     var startX = e.clientX;
@@ -3010,6 +3053,9 @@ declare var __EDITOR_CHROME_SCALE_Y__: string;
     var dragEl = selectedEl;
     var moved = false;
     var DRAG_THRESHOLD = 3;
+    if (!duplicatedForDrag) {
+      postCrossScreenDrag("start", dragEl, e);
+    }
     function onMove(ev) {
       if (
         !moved &&
@@ -3021,18 +3067,44 @@ declare var __EDITOR_CHROME_SCALE_Y__: string;
       var nextTop = originTop + ev.clientY - startY;
       (dragEl as HTMLElement).style.left = Math.round(nextLeft) + "px";
       (dragEl as HTMLElement).style.top = Math.round(nextTop) + "px";
-      showTransformBadge(
-        "X " + Math.round(nextLeft) + "  Y " + Math.round(nextTop),
-        ev.clientX,
-        ev.clientY,
-      );
+      if (!duplicatedForDrag) {
+        postCrossScreenDrag("move", dragEl, ev);
+      }
+      if (
+        !duplicatedForDrag &&
+        isOutsideIframeViewport(ev.clientX, ev.clientY)
+      ) {
+        showTransformBadge("Move layer", ev.clientX, ev.clientY);
+      } else {
+        showTransformBadge(
+          "X " + Math.round(nextLeft) + "  Y " + Math.round(nextTop),
+          ev.clientX,
+          ev.clientY,
+        );
+      }
       refreshOverlays();
     }
-    function onUp() {
+    function restoreSourceDragPosition(): void {
+      (dragEl as HTMLElement).style.position = originalInlinePosition;
+      (dragEl as HTMLElement).style.left = originalInlineLeft;
+      (dragEl as HTMLElement).style.top = originalInlineTop;
+      selectedEl = originalSelectedEl;
+      positionOverlay(selectionOverlay, selectedEl);
+    }
+    function onUp(ev) {
       document.removeEventListener(events.move, onMove, true);
       document.removeEventListener(events.up, onUp, true);
       hideTransformBadge();
       if (!dragEl) return;
+      if (
+        ev &&
+        !duplicatedForDrag &&
+        isOutsideIframeViewport(ev.clientX, ev.clientY)
+      ) {
+        postCrossScreenDrag("end", dragEl, ev);
+        restoreSourceDragPosition();
+        return;
+      }
       if (duplicatedForDrag && !moved) {
         // Alt-click with no real drag — remove the premature clone and restore the original selection.
         if (dragEl.parentElement) dragEl.parentElement.removeChild(dragEl);
@@ -3060,6 +3132,7 @@ declare var __EDITOR_CHROME_SCALE_Y__: string;
           },
           "*",
         );
+        postCrossScreenDrag("cancel");
       }
     }
     document.addEventListener(events.move, onMove, true);
@@ -3274,6 +3347,14 @@ declare var __EDITOR_CHROME_SCALE_Y__: string;
       pendingShieldDrag.onUp,
       true,
     );
+    if (
+      pendingShieldDrag.pointerId !== undefined &&
+      shieldOverlay.releasePointerCapture
+    ) {
+      try {
+        shieldOverlay.releasePointerCapture(pendingShieldDrag.pointerId);
+      } catch (_err) {}
+    }
     pendingShieldDrag = null;
   }
 
@@ -3299,6 +3380,18 @@ declare var __EDITOR_CHROME_SCALE_Y__: string;
     ) {
       return;
     }
+    if (
+      e.pointerId !== undefined &&
+      shieldOverlay.setPointerCapture &&
+      !e.altKey
+    ) {
+      try {
+        shieldOverlay.setPointerCapture(e.pointerId);
+      } catch (_err) {}
+    }
+    if (!e.altKey) {
+      postCrossScreenDrag("start", dragTarget, e);
+    }
     var startX = e.clientX;
     var startY = e.clientY;
     var didStartDrag = false;
@@ -3321,6 +3414,9 @@ declare var __EDITOR_CHROME_SCALE_Y__: string;
     function onUp(ev) {
       clearPendingShieldDrag();
       if (didStartDrag) return;
+      if (!e.altKey) {
+        postCrossScreenDrag("cancel");
+      }
       if (ev) stopNativeInteraction(ev);
       selectTarget(clickTarget || dragTarget);
       suppressNextShieldClickBriefly();
@@ -3331,6 +3427,7 @@ declare var __EDITOR_CHROME_SCALE_Y__: string;
       up: events.up,
       onMove: onMove,
       onUp: onUp,
+      pointerId: e.pointerId,
     };
     document.addEventListener(events.move, onMove, true);
     document.addEventListener(events.up, onUp, true);

--- a/templates/design/app/hooks/useDesignHotkeys.ts
+++ b/templates/design/app/hooks/useDesignHotkeys.ts
@@ -1,4 +1,7 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
+
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 export type DesignHotkeyTool =
   | "move"
@@ -166,9 +169,9 @@ function isFocusableChromeTarget(target: EventTarget | null) {
 export function useDesignHotkeys(props: UseDesignHotkeysProps) {
   const propsRef = useRef(props);
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     propsRef.current = props;
-  }, [props]);
+  });
 
   useEffect(() => {
     const eventTarget =

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -497,12 +497,6 @@ export function removeUndoRedoOrderKind<T extends string>(
 
 type UndoRedoOrderKind = "content" | "file-content" | "geometry";
 
-function isContentUndoRedoOrderKind(
-  kind: UndoRedoOrderKind | undefined,
-): kind is "content" | "file-content" {
-  return kind === "content" || kind === "file-content";
-}
-
 function resolveZoomUpdate(update: SetStateAction<number>, current: number) {
   return typeof update === "function" ? update(current) : update;
 }
@@ -909,6 +903,17 @@ export function getAvailableContentHistoryChanges(
   return getContentHistoryChanges(entry).filter(
     (change) => change.fileId === activeFileId || fileIds.has(change.fileId),
   );
+}
+
+function findLastContentHistoryChangeIndex(
+  stack: ContentHistoryChange[],
+  fileId?: string | null,
+) {
+  if (!fileId) return -1;
+  for (let index = stack.length - 1; index >= 0; index -= 1) {
+    if (stack[index]?.fileId === fileId) return index;
+  }
+  return -1;
 }
 
 type PatchProofStatus =
@@ -3978,6 +3983,9 @@ export default function DesignEditor() {
   const undoManagerRef = useRef<Y.UndoManager | null>(null);
   const contentUndoStackRef = useRef<ContentHistoryEntry[]>([]);
   const contentRedoStackRef = useRef<ContentHistoryEntry[]>([]);
+  const localContentUndoStackRef = useRef<ContentHistoryChange[]>([]);
+  const localContentRedoStackRef = useRef<ContentHistoryChange[]>([]);
+  const activeFileIdForUndoRef = useRef<string | null>(null);
   const suppressContentHistoryRef = useRef(false);
   const geometryUndoStackRef = useRef<GeometryHistoryEntry[]>([]);
   const geometryRedoStackRef = useRef<GeometryHistoryEntry[]>([]);
@@ -3985,21 +3993,40 @@ export default function DesignEditor() {
   const redoOrderRef = useRef<UndoRedoOrderKind[]>([]);
   const clearRedoStacks = useCallback(() => {
     contentRedoStackRef.current = [];
+    localContentRedoStackRef.current = [];
     geometryRedoStackRef.current = [];
     redoOrderRef.current = [];
     undoManagerRef.current?.clear(false, true);
   }, []);
   const syncUndoRedoState = useCallback(() => {
     const undoManager = undoManagerRef.current;
+    const canUseOverviewHistory = viewModeRef.current === "overview";
+    const activeHistoryFileId = activeFileIdForUndoRef.current;
+    const hasLocalUndo =
+      !canUseOverviewHistory &&
+      findLastContentHistoryChangeIndex(
+        localContentUndoStackRef.current,
+        activeHistoryFileId,
+      ) !== -1;
+    const hasLocalRedo =
+      !canUseOverviewHistory &&
+      findLastContentHistoryChangeIndex(
+        localContentRedoStackRef.current,
+        activeHistoryFileId,
+      ) !== -1;
     setCanUndo(
       Boolean(undoManager?.canUndo()) ||
-        contentUndoStackRef.current.length > 0 ||
-        geometryUndoStackRef.current.length > 0,
+        hasLocalUndo ||
+        (canUseOverviewHistory &&
+          (contentUndoStackRef.current.length > 0 ||
+            geometryUndoStackRef.current.length > 0)),
     );
     setCanRedo(
       Boolean(undoManager?.canRedo()) ||
-        contentRedoStackRef.current.length > 0 ||
-        geometryRedoStackRef.current.length > 0,
+        hasLocalRedo ||
+        (canUseOverviewHistory &&
+          (contentRedoStackRef.current.length > 0 ||
+            geometryRedoStackRef.current.length > 0)),
     );
   }, []);
   const recordContentHistoryEntry = useCallback(
@@ -4021,9 +4048,23 @@ export default function DesignEditor() {
     },
     [clearRedoStacks, syncUndoRedoState],
   );
+  const recordLocalContentHistoryEntry = useCallback(
+    (change: ContentHistoryChange) => {
+      if (change.before === change.after) return;
+      localContentUndoStackRef.current = [
+        ...localContentUndoStackRef.current.slice(-(MAX_DESIGN_UNDO_STACK - 1)),
+        change,
+      ];
+      clearRedoStacks();
+      syncUndoRedoState();
+    },
+    [clearRedoStacks, syncUndoRedoState],
+  );
   const clearLocalUndoRedoStacks = useCallback(() => {
     contentUndoStackRef.current = [];
     contentRedoStackRef.current = [];
+    localContentUndoStackRef.current = [];
+    localContentRedoStackRef.current = [];
     geometryUndoStackRef.current = [];
     geometryRedoStackRef.current = [];
     historyOrderRef.current = [];
@@ -5363,6 +5404,7 @@ export default function DesignEditor() {
   }, [files, activeFileId]);
 
   const activeFile = files.find((f) => f.id === activeFileId) ?? files[0];
+  activeFileIdForUndoRef.current = activeFile?.id ?? null;
   const motionTimelineQueryParams =
     id && activeFile?.id
       ? { designId: id, sourceRef: activeFile.id }
@@ -6901,6 +6943,7 @@ export default function DesignEditor() {
         immediateSave?: boolean;
         persist?: boolean;
         recordHistory?: boolean;
+        historyBeforeContent?: string;
         updatedAt?: string;
       } = {},
     ) => {
@@ -6908,10 +6951,12 @@ export default function DesignEditor() {
       const shouldRecordHistory =
         options.recordHistory !== false && !options.updatedAt;
       const previousContent =
-        collabContentFileIdRef.current === activeFile.id &&
-        typeof collabContentRef.current === "string"
-          ? collabContentRef.current
-          : (activeFile.content ?? "");
+        typeof options.historyBeforeContent === "string"
+          ? options.historyBeforeContent
+          : collabContentFileIdRef.current === activeFile.id &&
+              typeof collabContentRef.current === "string"
+            ? collabContentRef.current
+            : (activeFile.content ?? "");
       const yjsHistoryAvailable = Boolean(
         shouldRecordHistory &&
         viewModeRef.current !== "overview" &&
@@ -6925,11 +6970,16 @@ export default function DesignEditor() {
         !yjsHistoryAvailable &&
         previousContent !== nextContent
       ) {
-        recordContentHistoryEntry({
+        const change = {
           fileId: activeFile.id,
           before: previousContent,
           after: nextContent,
-        });
+        };
+        if (viewModeRef.current === "overview") {
+          recordContentHistoryEntry(change);
+        } else {
+          recordLocalContentHistoryEntry(change);
+        }
       }
       if (options.updatedAt) {
         clearPendingLocalFileContent(activeFile.id);
@@ -7014,6 +7064,7 @@ export default function DesignEditor() {
       queueFileContentSave,
       replacePreviewContent,
       recordContentHistoryEntry,
+      recordLocalContentHistoryEntry,
       syncUndoRedoState,
       ydoc,
     ],
@@ -7307,7 +7358,10 @@ export default function DesignEditor() {
         : null;
 
       if (targetFile.id === activeFile?.id) {
-        applyLocalContentUpdate(nextContent, { immediateSave: true });
+        applyLocalContentUpdate(nextContent, {
+          historyBeforeContent: baseContent,
+          immediateSave: true,
+        });
       } else {
         recordContentHistoryEntry({
           fileId: targetFile.id,
@@ -8401,11 +8455,16 @@ export default function DesignEditor() {
         !suppressContentHistoryRef.current &&
         baseContent !== resolvedNextContent
       ) {
-        recordContentHistoryEntry({
+        const change = {
           fileId: activeFile.id,
           before: baseContent,
           after: resolvedNextContent,
-        });
+        };
+        if (viewModeRef.current === "overview") {
+          recordContentHistoryEntry(change);
+        } else {
+          recordLocalContentHistoryEntry(change);
+        }
       }
 
       setCollabContent(resolvedNextContent);
@@ -8470,6 +8529,7 @@ export default function DesignEditor() {
       canEditDesign,
       queueFileContentSave,
       recordContentHistoryEntry,
+      recordLocalContentHistoryEntry,
       replacePreviewContent,
       selectedElement,
       t,
@@ -10009,14 +10069,24 @@ export default function DesignEditor() {
         resolvedSourceNode?.dataAttributes["data-agent-native-node-id"] ??
         sourceNodeId ??
         sourceSelector;
+      const destProjection = buildCodeLayerProjection(destContent);
+      const resolvedTargetAnchor = targetAnchorNodeId
+        ? resolveCodeLayerNodeFromBridge(
+            destProjection,
+            undefined,
+            targetAnchorNodeId,
+          )
+        : null;
+      const targetAnchorAttrId =
+        resolvedTargetAnchor?.dataAttributes["data-agent-native-node-id"];
 
       // Use hit-test anchor when the canvas supplied one; fall back to
       // top-level body append ("inside" with no anchor = existing behaviour).
       const result = moveNodeBetweenDocuments(sourceContent, destContent, {
         nodeId: nodeAttrId,
-        ...(targetAnchorNodeId
+        ...(targetAnchorAttrId
           ? {
-              anchorNodeId: targetAnchorNodeId,
+              anchorNodeId: targetAnchorAttrId,
               placement: targetAnchorPlacement ?? "inside",
             }
           : { placement: "inside" }),
@@ -10260,8 +10330,10 @@ export default function DesignEditor() {
   const handleUndo = useCallback(() => {
     if (!canEditDesign) return;
     const um = undoManagerRef.current;
-    const undoContent = () => {
-      if (um?.canUndo()) {
+    const canUseOverviewHistory = viewModeRef.current === "overview";
+    let prunedUndoHistory = false;
+    const undoContent = (scope: "any" | "local" | "global" = "any") => {
+      if (scope !== "global" && um?.canUndo()) {
         um.undo();
         if (ydoc && activeFile) {
           const next = ydoc.getText("content").toString();
@@ -10294,6 +10366,43 @@ export default function DesignEditor() {
         return true;
       }
 
+      if (!canUseOverviewHistory && scope !== "global" && activeFile?.id) {
+        const localIndex = findLastContentHistoryChangeIndex(
+          localContentUndoStackRef.current,
+          activeFile.id,
+        );
+        if (localIndex !== -1) {
+          const [entry] = localContentUndoStackRef.current.splice(
+            localIndex,
+            1,
+          );
+          if (entry) {
+            localContentRedoStackRef.current = [
+              ...localContentRedoStackRef.current.slice(
+                -(MAX_DESIGN_UNDO_STACK - 1),
+              ),
+              entry,
+            ];
+            applyLocalContentUpdate(entry.before, {
+              refreshPreview: false,
+              immediateSave: true,
+              recordHistory: false,
+            });
+            setSelectedElement((prev) => {
+              if (!prev) return prev;
+              return refreshElementInfoFromContent(entry.before, prev);
+            });
+            setHoveredElement((prev) => {
+              if (!prev) return prev;
+              return refreshElementInfoFromContent(entry.before, prev);
+            });
+            return true;
+          }
+        }
+      }
+
+      if (scope === "local") return false;
+      if (!canUseOverviewHistory) return false;
       const entry =
         contentUndoStackRef.current[contentUndoStackRef.current.length - 1];
       if (!entry) return false;
@@ -10302,7 +10411,11 @@ export default function DesignEditor() {
         files.map((file) => file.id),
         activeFile?.id,
       );
-      if (changes.length === 0) return false;
+      if (changes.length === 0) {
+        contentUndoStackRef.current.pop();
+        prunedUndoHistory = true;
+        return false;
+      }
       contentUndoStackRef.current.pop();
       contentRedoStackRef.current = [
         ...contentRedoStackRef.current.slice(-(MAX_DESIGN_UNDO_STACK - 1)),
@@ -10347,6 +10460,7 @@ export default function DesignEditor() {
       return true;
     };
     const undoGeometry = () => {
+      if (!canUseOverviewHistory) return false;
       const entry = geometryUndoStackRef.current.pop();
       if (!entry) return false;
       geometryRedoStackRef.current = [
@@ -10366,14 +10480,25 @@ export default function DesignEditor() {
       return true;
     };
 
-    const preferred = historyOrderRef.current.pop();
-    const didUndo =
+    const undoByOrder = (preferred?: UndoRedoOrderKind) =>
       preferred === "geometry"
         ? undoGeometry() || undoContent()
-        : isContentUndoRedoOrderKind(preferred)
-          ? undoContent() || undoGeometry()
-          : undoContent() || undoGeometry();
-    if (didUndo) {
+        : preferred === "file-content"
+          ? undoContent("global") || undoGeometry()
+          : preferred === "content"
+            ? undoContent("local") || undoContent("global") || undoGeometry()
+            : undoContent() || undoGeometry();
+    let didUndo = false;
+    if (canUseOverviewHistory) {
+      while (!didUndo) {
+        const preferred = historyOrderRef.current.pop();
+        didUndo = undoByOrder(preferred);
+        if (didUndo || preferred === undefined) break;
+      }
+    } else {
+      didUndo = undoContent("local");
+    }
+    if (didUndo || prunedUndoHistory) {
       syncUndoRedoState();
     }
   }, [
@@ -10394,8 +10519,10 @@ export default function DesignEditor() {
   const handleRedo = useCallback(() => {
     if (!canEditDesign) return;
     const um = undoManagerRef.current;
-    const redoContent = () => {
-      if (um?.canRedo()) {
+    const canUseOverviewHistory = viewModeRef.current === "overview";
+    let prunedRedoHistory = false;
+    const redoContent = (scope: "any" | "local" | "global" = "any") => {
+      if (scope !== "global" && um?.canRedo()) {
         um.redo();
         if (ydoc && activeFile) {
           const next = ydoc.getText("content").toString();
@@ -10428,6 +10555,43 @@ export default function DesignEditor() {
         return true;
       }
 
+      if (!canUseOverviewHistory && scope !== "global" && activeFile?.id) {
+        const localIndex = findLastContentHistoryChangeIndex(
+          localContentRedoStackRef.current,
+          activeFile.id,
+        );
+        if (localIndex !== -1) {
+          const [entry] = localContentRedoStackRef.current.splice(
+            localIndex,
+            1,
+          );
+          if (entry) {
+            localContentUndoStackRef.current = [
+              ...localContentUndoStackRef.current.slice(
+                -(MAX_DESIGN_UNDO_STACK - 1),
+              ),
+              entry,
+            ];
+            applyLocalContentUpdate(entry.after, {
+              refreshPreview: false,
+              immediateSave: true,
+              recordHistory: false,
+            });
+            setSelectedElement((prev) => {
+              if (!prev) return prev;
+              return refreshElementInfoFromContent(entry.after, prev);
+            });
+            setHoveredElement((prev) => {
+              if (!prev) return prev;
+              return refreshElementInfoFromContent(entry.after, prev);
+            });
+            return true;
+          }
+        }
+      }
+
+      if (scope === "local") return false;
+      if (!canUseOverviewHistory) return false;
       const entry =
         contentRedoStackRef.current[contentRedoStackRef.current.length - 1];
       if (!entry) return false;
@@ -10436,7 +10600,11 @@ export default function DesignEditor() {
         files.map((file) => file.id),
         activeFile?.id,
       );
-      if (changes.length === 0) return false;
+      if (changes.length === 0) {
+        contentRedoStackRef.current.pop();
+        prunedRedoHistory = true;
+        return false;
+      }
       contentRedoStackRef.current.pop();
       contentUndoStackRef.current = [
         ...contentUndoStackRef.current.slice(-(MAX_DESIGN_UNDO_STACK - 1)),
@@ -10481,6 +10649,7 @@ export default function DesignEditor() {
       return true;
     };
     const redoGeometry = () => {
+      if (!canUseOverviewHistory) return false;
       const entry = geometryRedoStackRef.current.pop();
       if (!entry) return false;
       geometryUndoStackRef.current = [
@@ -10500,14 +10669,25 @@ export default function DesignEditor() {
       return true;
     };
 
-    const preferred = redoOrderRef.current.pop();
-    const didRedo =
+    const redoByOrder = (preferred?: UndoRedoOrderKind) =>
       preferred === "geometry"
         ? redoGeometry() || redoContent()
-        : isContentUndoRedoOrderKind(preferred)
-          ? redoContent() || redoGeometry()
-          : redoContent() || redoGeometry();
-    if (didRedo) {
+        : preferred === "file-content"
+          ? redoContent("global") || redoGeometry()
+          : preferred === "content"
+            ? redoContent("local") || redoContent("global") || redoGeometry()
+            : redoContent() || redoGeometry();
+    let didRedo = false;
+    if (canUseOverviewHistory) {
+      while (!didRedo) {
+        const preferred = redoOrderRef.current.pop();
+        didRedo = redoByOrder(preferred);
+        if (didRedo || preferred === undefined) break;
+      }
+    } else {
+      didRedo = redoContent("local");
+    }
+    if (didRedo || prunedRedoHistory) {
       syncUndoRedoState();
     }
   }, [
@@ -11772,7 +11952,7 @@ ${serializedHtml}
       },
     });
     if (!stamped.changed || stamped.content === activeContent) return;
-    applyLocalContentUpdate(stamped.content);
+    applyLocalContentUpdate(stamped.content, { recordHistory: false });
   }, [activeContent, activeFile, applyLocalContentUpdate, id, viewMode]);
   const activeCodeLayerTree = useMemo(
     () => buildCodeLayerTree(activeCodeLayerProjection),

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -876,6 +876,32 @@ interface GeometryHistoryEntry {
   after: CanvasFrameGeometryById;
 }
 
+function geometryHistoryEntryTouchesFrameIds(
+  entry: GeometryHistoryEntry,
+  frameIds: Set<string>,
+) {
+  for (const frameId of frameIds) {
+    if (entry.before[frameId] || entry.after[frameId]) return true;
+  }
+  return false;
+}
+
+function removeRecentUndoRedoOrderKinds<T extends string>(
+  order: T[],
+  kind: T,
+  count: number,
+): T[] {
+  if (count <= 0) return order;
+  const next = [...order];
+  let remaining = count;
+  for (let index = next.length - 1; index >= 0 && remaining > 0; index -= 1) {
+    if (next[index] !== kind) continue;
+    next.splice(index, 1);
+    remaining -= 1;
+  }
+  return next;
+}
+
 export interface ContentHistoryChange {
   fileId: string;
   before: string;
@@ -4035,6 +4061,29 @@ export default function DesignEditor() {
         (change) => change.before !== change.after,
       );
       if (changes.length === 0) return;
+      const activeHistoryFileId = activeFileIdForUndoRef.current;
+      if (
+        activeHistoryFileId &&
+        changes.some((change) => change.fileId === activeHistoryFileId)
+      ) {
+        undoManagerRef.current?.clear(true, false);
+        localContentUndoStackRef.current =
+          localContentUndoStackRef.current.filter(
+            (change) => change.fileId !== activeHistoryFileId,
+          );
+        localContentRedoStackRef.current =
+          localContentRedoStackRef.current.filter(
+            (change) => change.fileId !== activeHistoryFileId,
+          );
+        historyOrderRef.current = removeUndoRedoOrderKind(
+          historyOrderRef.current,
+          "content",
+        );
+        redoOrderRef.current = removeUndoRedoOrderKind(
+          redoOrderRef.current,
+          "content",
+        );
+      }
       contentUndoStackRef.current = [
         ...contentUndoStackRef.current.slice(-(MAX_DESIGN_UNDO_STACK - 1)),
         changes.length === 1 ? changes[0] : { changes },
@@ -10190,6 +10239,38 @@ export default function DesignEditor() {
         delete nextGeometry[file.id];
       });
 
+      const nextGeometryUndoStack: GeometryHistoryEntry[] = [];
+      let removedGeometryUndoEntries = 0;
+      geometryUndoStackRef.current.forEach((entry) => {
+        if (geometryHistoryEntryTouchesFrameIds(entry, deleteIds)) {
+          removedGeometryUndoEntries += 1;
+          return;
+        }
+        nextGeometryUndoStack.push(entry);
+      });
+      geometryUndoStackRef.current = nextGeometryUndoStack;
+      historyOrderRef.current = removeRecentUndoRedoOrderKinds(
+        historyOrderRef.current,
+        "geometry",
+        removedGeometryUndoEntries,
+      );
+
+      const nextGeometryRedoStack: GeometryHistoryEntry[] = [];
+      let removedGeometryRedoEntries = 0;
+      geometryRedoStackRef.current.forEach((entry) => {
+        if (geometryHistoryEntryTouchesFrameIds(entry, deleteIds)) {
+          removedGeometryRedoEntries += 1;
+          return;
+        }
+        nextGeometryRedoStack.push(entry);
+      });
+      geometryRedoStackRef.current = nextGeometryRedoStack;
+      redoOrderRef.current = removeRecentUndoRedoOrderKinds(
+        redoOrderRef.current,
+        "geometry",
+        removedGeometryRedoEntries,
+      );
+
       writeFrameGeometrySnapshot(nextGeometry);
       queryClient.setQueryData(["action", "get-design", { id }], (old: any) => {
         if (!old || typeof old !== "object" || !Array.isArray(old.files)) {
@@ -10226,6 +10307,7 @@ export default function DesignEditor() {
       // are hard-deleted, so suppress MultiScreenCanvas' local frame-history
       // entry; otherwise undo would restore geometry for files that no longer
       // exist.
+      syncUndoRedoState();
       return false;
     },
     [
@@ -10236,6 +10318,7 @@ export default function DesignEditor() {
       files,
       id,
       queryClient,
+      syncUndoRedoState,
       t,
       writeFrameGeometrySnapshot,
     ],

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -1457,14 +1457,19 @@ function primitiveLayerName(primitive: CanvasPrimitiveInsert): string {
 function appendCanvasPrimitiveToHtml(
   content: string,
   primitive: CanvasPrimitiveInsert,
+  options?: { preserveNegativePosition?: boolean },
 ): string | null {
   if (typeof window === "undefined") return null;
   try {
     const doc = new DOMParser().parseFromString(content, "text/html");
     if (!doc.body) return null;
     const geometry = primitive.geometry;
-    const left = Math.max(0, Math.round(geometry.x));
-    const top = Math.max(0, Math.round(geometry.y));
+    const left = options?.preserveNegativePosition
+      ? Math.round(geometry.x)
+      : Math.max(0, Math.round(geometry.x));
+    const top = options?.preserveNegativePosition
+      ? Math.round(geometry.y)
+      : Math.max(0, Math.round(geometry.y));
     const width = Math.max(1, Math.round(geometry.width));
     const height = Math.max(1, Math.round(geometry.height));
     const nodeId = primitive.nodeId ?? uniqueLayerId(primitive.kind);
@@ -3978,6 +3983,12 @@ export default function DesignEditor() {
   const geometryRedoStackRef = useRef<GeometryHistoryEntry[]>([]);
   const historyOrderRef = useRef<UndoRedoOrderKind[]>([]);
   const redoOrderRef = useRef<UndoRedoOrderKind[]>([]);
+  const clearRedoStacks = useCallback(() => {
+    contentRedoStackRef.current = [];
+    geometryRedoStackRef.current = [];
+    redoOrderRef.current = [];
+    undoManagerRef.current?.clear(false, true);
+  }, []);
   const syncUndoRedoState = useCallback(() => {
     const undoManager = undoManagerRef.current;
     setCanUndo(
@@ -4001,15 +4012,14 @@ export default function DesignEditor() {
         ...contentUndoStackRef.current.slice(-(MAX_DESIGN_UNDO_STACK - 1)),
         changes.length === 1 ? changes[0] : { changes },
       ];
-      contentRedoStackRef.current = [];
+      clearRedoStacks();
       historyOrderRef.current = [
         ...historyOrderRef.current.slice(-(MAX_DESIGN_UNDO_STACK - 1)),
         "file-content",
       ];
-      redoOrderRef.current = [];
       syncUndoRedoState();
     },
-    [syncUndoRedoState],
+    [clearRedoStacks, syncUndoRedoState],
   );
   const clearLocalUndoRedoStacks = useCallback(() => {
     contentUndoStackRef.current = [];
@@ -5160,14 +5170,11 @@ export default function DesignEditor() {
           after: afterSnapshot,
         },
       ];
-      geometryRedoStackRef.current = [];
-      contentRedoStackRef.current = [];
-      undoManagerRef.current?.clear(false, true);
+      clearRedoStacks();
       historyOrderRef.current = [
         ...historyOrderRef.current.slice(-(MAX_DESIGN_UNDO_STACK - 1)),
         "geometry",
       ];
-      redoOrderRef.current = [];
       const resizedFrameIds = viewportChangedFrameIds(
         beforeSnapshot,
         afterSnapshot,
@@ -5180,7 +5187,7 @@ export default function DesignEditor() {
       );
       syncUndoRedoState();
     },
-    [syncUndoRedoState, writeFrameGeometrySnapshot],
+    [clearRedoStacks, syncUndoRedoState, writeFrameGeometrySnapshot],
   );
 
   // §6.6 — "Make this a real app" handler.
@@ -5862,6 +5869,7 @@ export default function DesignEditor() {
   const [collabContentFileId, setCollabContentFileId] = useState<string | null>(
     null,
   );
+  const previousDesignIdForHistoryRef = useRef<string | null>(null);
   const prevActiveFileIdRef = useRef<string | null>(null);
   // `updatedAt` of the DB content this preview currently reflects. A poll that
   // returns an older-or-equal value is a stale snapshot and is ignored; a newer
@@ -5907,7 +5915,16 @@ export default function DesignEditor() {
     };
   }, [awareness, ydoc]);
 
-  // Reset per-file reconcile state when switching files
+  useEffect(() => {
+    if (previousDesignIdForHistoryRef.current === id) return;
+    previousDesignIdForHistoryRef.current = id ?? null;
+    clearLocalUndoRedoStacks();
+    syncUndoRedoState();
+  }, [clearLocalUndoRedoStacks, id, syncUndoRedoState]);
+
+  // Reset per-file reconcile state when switching files.
+  // Keep undo/redo content + geometry stacks intact: overview mode needs one
+  // chronological history across all screens, board edits, and frame geometry.
   useEffect(() => {
     if (viewMode === "overview") {
       prevActiveFileIdRef.current = activeFileId;
@@ -5916,9 +5933,7 @@ export default function DesignEditor() {
       lastAppliedFileUpdatedAtRef.current = null;
       lastLocalContentRef.current = null;
       latestActiveContentRef.current = null;
-      clearLocalUndoRedoStacks();
       clearStaleAgentCollabRecovery();
-      syncUndoRedoState();
       return;
     }
     if (activeFileId !== prevActiveFileIdRef.current) {
@@ -5928,17 +5943,9 @@ export default function DesignEditor() {
       lastAppliedFileUpdatedAtRef.current = null;
       lastLocalContentRef.current = null;
       latestActiveContentRef.current = null;
-      clearLocalUndoRedoStacks();
       clearStaleAgentCollabRecovery();
-      syncUndoRedoState();
     }
-  }, [
-    activeFileId,
-    clearLocalUndoRedoStacks,
-    clearStaleAgentCollabRecovery,
-    syncUndoRedoState,
-    viewMode,
-  ]);
+  }, [activeFileId, clearStaleAgentCollabRecovery, viewMode]);
 
   useEffect(() => {
     return clearStaleAgentCollabRecovery;
@@ -6102,12 +6109,19 @@ export default function DesignEditor() {
     });
 
     const syncState = () => syncUndoRedoState();
-    const handleStackItemAdded = () => {
+    const handleStackItemAdded = (event: {
+      origin?: unknown;
+      type?: "undo" | "redo";
+    }) => {
+      if (event.origin !== LOCAL_EDIT_ORIGIN || event.type !== "undo") {
+        syncUndoRedoState();
+        return;
+      }
       historyOrderRef.current = [
         ...historyOrderRef.current.slice(-(MAX_DESIGN_UNDO_STACK - 1)),
         "content",
       ];
-      redoOrderRef.current = [];
+      clearRedoStacks();
       syncUndoRedoState();
     };
     um.on("stack-item-added", handleStackItemAdded);
@@ -6135,7 +6149,7 @@ export default function DesignEditor() {
       );
       syncUndoRedoState();
     };
-  }, [ydoc, isSynced, syncUndoRedoState]);
+  }, [clearRedoStacks, ydoc, isSynced, syncUndoRedoState]);
 
   // Reconcile authoritative external DB content (agent edit / peer-via-SQL) into
   // the live preview. This is the robustness fallback the Yjs observe path can't
@@ -6899,7 +6913,11 @@ export default function DesignEditor() {
           ? collabContentRef.current
           : (activeFile.content ?? "");
       const yjsHistoryAvailable = Boolean(
-        shouldRecordHistory && ydoc && isSynced && undoManagerRef.current,
+        shouldRecordHistory &&
+        viewModeRef.current !== "overview" &&
+        ydoc &&
+        isSynced &&
+        undoManagerRef.current,
       );
       if (
         !suppressContentHistoryRef.current &&
@@ -6972,7 +6990,7 @@ export default function DesignEditor() {
               ytext.delete(0, ytext.length);
               ytext.insert(0, nextContent);
             },
-            shouldRecordHistory ? LOCAL_EDIT_ORIGIN : TAB_ID,
+            yjsHistoryAvailable ? LOCAL_EDIT_ORIGIN : TAB_ID,
           );
         }
       }
@@ -7273,7 +7291,9 @@ export default function DesignEditor() {
                 : storedContent;
             })()
           : storedContent);
-      const nextContent = appendCanvasPrimitiveToHtml(baseContent, primitive);
+      const nextContent = appendCanvasPrimitiveToHtml(baseContent, primitive, {
+        preserveNegativePosition: targetFile.id === boardFileId,
+      });
       if (!nextContent) {
         toast.error(t("designEditor.toasts.primitiveInsertFailed"));
         return false;
@@ -7335,6 +7355,7 @@ export default function DesignEditor() {
       activeContent,
       activeFile?.id,
       applyLocalContentUpdate,
+      boardFileId,
       canEditDesign,
       files,
       id,
@@ -8369,6 +8390,23 @@ export default function DesignEditor() {
             );
           })
         : null;
+      const yjsHistoryAvailable = Boolean(
+        viewModeRef.current !== "overview" &&
+        ydoc &&
+        isSynced &&
+        undoManagerRef.current,
+      );
+      if (
+        !yjsHistoryAvailable &&
+        !suppressContentHistoryRef.current &&
+        baseContent !== resolvedNextContent
+      ) {
+        recordContentHistoryEntry({
+          fileId: activeFile.id,
+          before: baseContent,
+          after: resolvedNextContent,
+        });
+      }
 
       setCollabContent(resolvedNextContent);
       setCollabContentFileId(activeFile.id);
@@ -8381,14 +8419,18 @@ export default function DesignEditor() {
       latestActiveContentRef.current = resolvedNextContent;
       // Write the edit into the shared Y.Doc so other open clients see it live
       // through Yjs (not only via the slower update-file → applyText round-trip).
-      // Use LOCAL_EDIT_ORIGIN so the UndoManager captures this transaction.
+      // Single-screen edits use the active-file UndoManager. Overview edits are
+      // tracked in the global file-content stack so all screens share one order.
       if (ydoc && isSynced) {
         const ytext = ydoc.getText("content");
         if (ytext.toString() !== resolvedNextContent) {
-          ydoc.transact(() => {
-            ytext.delete(0, ytext.length);
-            ytext.insert(0, resolvedNextContent);
-          }, LOCAL_EDIT_ORIGIN);
+          ydoc.transact(
+            () => {
+              ytext.delete(0, ytext.length);
+              ytext.insert(0, resolvedNextContent);
+            },
+            yjsHistoryAvailable ? LOCAL_EDIT_ORIGIN : TAB_ID,
+          );
         }
       }
       queueFileContentSave(activeFile.id, resolvedNextContent, {
@@ -8427,6 +8469,7 @@ export default function DesignEditor() {
       activeBreakpointWidthState,
       canEditDesign,
       queueFileContentSave,
+      recordContentHistoryEntry,
       replacePreviewContent,
       selectedElement,
       t,
@@ -10109,7 +10152,11 @@ export default function DesignEditor() {
         });
       });
 
-      return true;
+      // File-backed screen deletion is not a geometry-only edit. The screen rows
+      // are hard-deleted, so suppress MultiScreenCanvas' local frame-history
+      // entry; otherwise undo would restore geometry for files that no longer
+      // exist.
+      return false;
     },
     [
       activeFile,

--- a/templates/design/changelog/2026-06-30-canvas-editing-now-keeps-undo-redo-and-cross-screen-layer-mo.md
+++ b/templates/design/changelog/2026-06-30-canvas-editing-now-keeps-undo-redo-and-cross-screen-layer-mo.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-06-30
+---
+
+Canvas editing now keeps undo/redo and cross-screen layer moves reliable in All screens mode.

--- a/templates/design/e2e/canvas-tools.spec.ts
+++ b/templates/design/e2e/canvas-tools.spec.ts
@@ -1282,6 +1282,163 @@ test("overview undo and redo stay global across screen content and canvas geomet
     .toBeGreaterThan(20);
 });
 
+test("single-screen undo does not consume overview history", async ({
+  page,
+}) => {
+  await postAction(page.request, "create-file", {
+    designId,
+    filename: "about.html",
+    content: FIXTURE_HTML.replace("E2E Fixture", "E2E Second Fixture"),
+    fileType: "html",
+  });
+  await gotoEditor(page, designId);
+  await expect(screenShell(page, "About")).toBeVisible();
+
+  const aboutShell = screenShell(page, "About");
+  const aboutCard = aboutShell.locator("[data-screen-card]");
+  const aboutCardBox = await aboutCard.boundingBox();
+  if (!aboutCardBox) throw new Error("no about card box");
+  const aboutRectanglesBefore = await primitiveCount(
+    page,
+    "about.html",
+    "rectangle",
+  );
+
+  await createDraftPrimitive(page, "Rectangle", "Rectangle", {
+    start: {
+      x: aboutCardBox.x + aboutCardBox.width * 0.12,
+      y: aboutCardBox.y + aboutCardBox.height * 0.12,
+    },
+    end: {
+      x: aboutCardBox.x + aboutCardBox.width * 0.22,
+      y: aboutCardBox.y + aboutCardBox.height * 0.22,
+    },
+  });
+  await expect
+    .poll(() => primitiveCount(page, "about.html", "rectangle"), {
+      timeout: 20_000,
+    })
+    .toBe(aboutRectanglesBefore + 1);
+
+  const sidebar = page.locator("aside").first();
+  const allScreens = sidebar.getByRole("button", { name: "All screens" });
+  const homeScreen = sidebar
+    .getByRole("button", { name: "Home", exact: true })
+    .first();
+  await homeScreen.click();
+  await expect(homeScreen).toHaveAttribute("aria-current", "page");
+
+  await pressPrimaryShortcut(page, "z");
+  await page.waitForTimeout(300);
+  expect(await primitiveCount(page, "about.html", "rectangle")).toBe(
+    aboutRectanglesBefore + 1,
+  );
+
+  await allScreens.click();
+  await expect(allScreens).toHaveAttribute("aria-current", "page");
+  await expect(screenShell(page, "About")).toBeVisible();
+  await pressPrimaryShortcut(page, "z");
+  await expect
+    .poll(() => primitiveCount(page, "about.html", "rectangle"), {
+      timeout: 20_000,
+    })
+    .toBe(aboutRectanglesBefore);
+});
+
+test("overview undo skips deleted screen content history", async ({ page }) => {
+  await postAction(page.request, "create-file", {
+    designId,
+    filename: "about.html",
+    content: FIXTURE_HTML.replace("E2E Fixture", "E2E Second Fixture"),
+    fileType: "html",
+  });
+  await gotoEditor(page, designId);
+  await expect(screenShell(page, "About")).toBeVisible();
+
+  const aboutFile = (await designFiles(page)).find(
+    (file) => file.filename === "about.html",
+  );
+  if (!aboutFile) throw new Error("about.html was not created");
+
+  const homeShell = screenShell(page, "Home");
+  const aboutShell = screenShell(page, "About");
+  const homeCardBox = await homeShell
+    .locator("[data-screen-card]")
+    .boundingBox();
+  const aboutCardBox = await aboutShell
+    .locator("[data-screen-card]")
+    .boundingBox();
+  if (!homeCardBox || !aboutCardBox) throw new Error("missing screen card box");
+  const homeRectanglesBefore = await primitiveCount(
+    page,
+    "index.html",
+    "rectangle",
+  );
+  const aboutRectanglesBefore = await primitiveCount(
+    page,
+    "about.html",
+    "rectangle",
+  );
+
+  await createDraftPrimitive(page, "Rectangle", "Rectangle", {
+    start: {
+      x: homeCardBox.x + homeCardBox.width * 0.16,
+      y: homeCardBox.y + homeCardBox.height * 0.18,
+    },
+    end: {
+      x: homeCardBox.x + homeCardBox.width * 0.3,
+      y: homeCardBox.y + homeCardBox.height * 0.3,
+    },
+  });
+  await expect
+    .poll(() => primitiveCount(page, "index.html", "rectangle"), {
+      timeout: 20_000,
+    })
+    .toBe(homeRectanglesBefore + 1);
+
+  await createDraftPrimitive(page, "Rectangle", "Rectangle", {
+    start: {
+      x: aboutCardBox.x + aboutCardBox.width * 0.16,
+      y: aboutCardBox.y + aboutCardBox.height * 0.18,
+    },
+    end: {
+      x: aboutCardBox.x + aboutCardBox.width * 0.3,
+      y: aboutCardBox.y + aboutCardBox.height * 0.3,
+    },
+  });
+  await expect
+    .poll(() => primitiveCount(page, "about.html", "rectangle"), {
+      timeout: 20_000,
+    })
+    .toBe(aboutRectanglesBefore + 1);
+
+  const aboutBox = await aboutShell.boundingBox();
+  if (!aboutBox) throw new Error("no about shell box");
+  await page.mouse.click(aboutBox.x + aboutBox.width * 0.3, aboutBox.y + 12);
+  await page.keyboard.press("Delete");
+  await expect
+    .poll(
+      async () =>
+        htmlScreenFiles(await designFiles(page)).some(
+          (file) => file.id === aboutFile.id,
+        ),
+      { timeout: 20_000 },
+    )
+    .toBe(false);
+
+  await pressPrimaryShortcut(page, "z");
+  await expect
+    .poll(() => primitiveCount(page, "index.html", "rectangle"), {
+      timeout: 20_000,
+    })
+    .toBe(homeRectanglesBefore);
+  expect(
+    htmlScreenFiles(await designFiles(page)).some(
+      (file) => file.id === aboutFile.id,
+    ),
+  ).toBe(false);
+});
+
 test("overview undo does not restore ghost geometry for deleted screens", async ({
   page,
 }) => {

--- a/templates/design/e2e/canvas-tools.spec.ts
+++ b/templates/design/e2e/canvas-tools.spec.ts
@@ -1457,6 +1457,23 @@ test("overview undo does not restore ghost geometry for deleted screens", async 
   if (!aboutFile) throw new Error("about.html was not created");
 
   const aboutShell = screenShell(page, "About");
+  const aboutBoxBeforeMove = await aboutShell.boundingBox();
+  if (!aboutBoxBeforeMove) throw new Error("no about shell before move");
+  await dragBetween(
+    page,
+    {
+      x: aboutBoxBeforeMove.x + aboutBoxBeforeMove.width * 0.34,
+      y: aboutBoxBeforeMove.y + 12,
+    },
+    {
+      x: aboutBoxBeforeMove.x + aboutBoxBeforeMove.width * 0.34 + 80,
+      y: aboutBoxBeforeMove.y + 12 + 36,
+    },
+  );
+  const movedAboutBox = await aboutShell.boundingBox();
+  if (!movedAboutBox) throw new Error("no moved about shell box");
+  expect(movedAboutBox.x).toBeGreaterThan(aboutBoxBeforeMove.x + 20);
+
   const aboutBox = await aboutShell.boundingBox();
   if (!aboutBox) throw new Error("no about shell box");
   await page.mouse.click(aboutBox.x + aboutBox.width * 0.3, aboutBox.y + 12);

--- a/templates/design/e2e/canvas-tools.spec.ts
+++ b/templates/design/e2e/canvas-tools.spec.ts
@@ -16,6 +16,7 @@ interface DesignFileRecord {
   id: string;
   filename: string;
   content: string;
+  fileType?: string;
 }
 
 interface TextPrimitiveSummary {
@@ -113,7 +114,7 @@ test.afterEach(async ({ page }) => {
 });
 
 function toolButton(page: Page, name: string): Locator {
-  return page.getByRole("button", { name, exact: true });
+  return page.locator(`button[aria-label="${name}"]`).first();
 }
 
 function selectedLayerRow(page: Page): Locator {
@@ -174,6 +175,7 @@ async function designFiles(page: Page): Promise<DesignFileRecord[]> {
     id: String(file.id ?? ""),
     filename: String(file.filename ?? ""),
     content: String(file.content ?? ""),
+    fileType: typeof file.fileType === "string" ? file.fileType : undefined,
   }));
 }
 
@@ -183,6 +185,97 @@ async function fileContent(page: Page, filename: string): Promise<string> {
   );
   if (!file) throw new Error(`File not found: ${filename}`);
   return file.content;
+}
+
+async function designData(page: Page): Promise<Record<string, any>> {
+  const result = await getAction(page.request, "get-design", { id: designId });
+  if (typeof result.data !== "string") return {};
+  return JSON.parse(result.data || "{}");
+}
+
+function htmlScreenFiles(files: DesignFileRecord[]): DesignFileRecord[] {
+  return files.filter(
+    (file) => file.fileType === "html" && file.filename !== "__board__.html",
+  );
+}
+
+async function primitiveCount(
+  page: Page,
+  filename: string,
+  kind: string,
+): Promise<number> {
+  const content = await fileContent(page, filename);
+  return page.evaluate(
+    ({ html, primitiveKind }) => {
+      const doc = new DOMParser().parseFromString(html, "text/html");
+      return doc.querySelectorAll(`[data-an-primitive="${primitiveKind}"]`)
+        .length;
+    },
+    { html: content, primitiveKind: kind },
+  );
+}
+
+async function primitiveNodeIds(
+  page: Page,
+  filename: string,
+  kind: string,
+): Promise<string[]> {
+  const content = await fileContent(page, filename);
+  return page.evaluate(
+    ({ html, primitiveKind }) => {
+      const doc = new DOMParser().parseFromString(html, "text/html");
+      return Array.from(
+        doc.querySelectorAll<HTMLElement>(
+          `[data-an-primitive="${primitiveKind}"]`,
+        ),
+      )
+        .map((element) => element.dataset.agentNativeNodeId ?? "")
+        .filter(Boolean);
+    },
+    { html: content, primitiveKind: kind },
+  );
+}
+
+async function primitiveLeftPositions(
+  page: Page,
+  filename: string,
+  kind: string,
+): Promise<number[]> {
+  const content = await fileContent(page, filename);
+  return page.evaluate(
+    ({ html, primitiveKind }) => {
+      const doc = new DOMParser().parseFromString(html, "text/html");
+      return Array.from(
+        doc.querySelectorAll<HTMLElement>(
+          `[data-an-primitive="${primitiveKind}"]`,
+        ),
+      )
+        .map((element) => Number.parseFloat(element.style.left))
+        .filter((value) => Number.isFinite(value));
+    },
+    { html: content, primitiveKind: kind },
+  );
+}
+
+async function dragInEmptyCanvasLeftOf(
+  page: Page,
+  shellName: string,
+  options?: { width?: number; height?: number; topOffset?: number },
+): Promise<void> {
+  const card = screenShell(page, shellName).locator("[data-screen-card]");
+  const cardBox = await card.boundingBox();
+  if (!cardBox) throw new Error(`no ${shellName} screen card box`);
+
+  const width = options?.width ?? 96;
+  const height = options?.height ?? 96;
+  const start = {
+    x: cardBox.x - 12,
+    y: cardBox.y + (options?.topOffset ?? 120),
+  };
+  await dragBetween(page, start, {
+    x: start.x - width,
+    y: start.y + height,
+  });
 }
 
 async function textPrimitiveSummaries(
@@ -257,6 +350,7 @@ async function replaceActiveText(page: Page, text: string): Promise<void> {
   await page.keyboard.press(selectAllShortcut);
   await page.keyboard.type(text);
   await page.keyboard.press("Enter");
+  await page.waitForTimeout(150);
 }
 
 async function insertTextByClick(
@@ -307,6 +401,40 @@ async function insertTextByDrag(
 
 function countOccurrences(content: string, text: string): number {
   return content.split(text).length - 1;
+}
+
+async function pressPrimaryShortcut(
+  page: Page,
+  key: string,
+  options: { shift?: boolean } = {},
+): Promise<void> {
+  await page.evaluate(
+    ({ key, primary, shift }) => {
+      const isLetter = /^[a-z]$/i.test(key);
+      const eventKey = isLetter
+        ? shift
+          ? key.toUpperCase()
+          : key.toLowerCase()
+        : key;
+      const eventInit: KeyboardEventInit = {
+        key: eventKey,
+        code: isLetter ? `Key${key.toUpperCase()}` : key,
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        metaKey: primary === "Meta",
+        ctrlKey: primary === "Control",
+        shiftKey: shift,
+      };
+      window.dispatchEvent(new KeyboardEvent("keydown", eventInit));
+      window.dispatchEvent(new KeyboardEvent("keyup", eventInit));
+    },
+    {
+      key,
+      primary: process.platform === "darwin" ? "Meta" : "Control",
+      shift: options.shift ?? false,
+    },
+  );
 }
 
 async function vectorPrimitiveSummaries(
@@ -413,6 +541,20 @@ async function screenIframeViewportSize(shell: Locator): Promise<{
     width: (element as HTMLIFrameElement).clientWidth,
     height: (element as HTMLIFrameElement).clientHeight,
   }));
+}
+
+async function primitiveViewportBox(
+  shell: Locator,
+  nodeId: string,
+): Promise<{ x: number; y: number; width: number; height: number }> {
+  const iframe = shell.locator("iframe[data-design-preview-iframe]").first();
+  await expect(iframe).toBeVisible();
+  const box = await iframe
+    .contentFrame()
+    .locator(`[data-agent-native-node-id="${nodeId}"]`)
+    .boundingBox();
+  if (!box) throw new Error(`primitive not found: ${nodeId}`);
+  return box;
 }
 
 function expectCloseToFrameSize(
@@ -537,6 +679,7 @@ test("copy and paste duplicates selected text", async ({ page }) => {
   const text = `Copied text ${Date.now()}`;
   await insertTextByClick(page, screenShell(page), text);
   await waitForTextPrimitive(page, "index.html", text);
+  await selectedLayerRow(page).click();
 
   const copyShortcut = process.platform === "darwin" ? "Meta+C" : "Control+C";
   const pasteShortcut = process.platform === "darwin" ? "Meta+V" : "Control+V";
@@ -571,6 +714,97 @@ test("rectangle insertion keeps the new primitive selected", async ({
   await restoreHome(page);
 });
 
+test("dragging a rectangle between screens moves it across files", async ({
+  page,
+}) => {
+  await postAction(page.request, "create-file", {
+    designId,
+    filename: "about.html",
+    content: FIXTURE_HTML.replace("E2E Fixture", "E2E Second Fixture"),
+    fileType: "html",
+  });
+  await gotoEditor(page, designId);
+  await expect(screenShell(page, "About")).toBeVisible();
+
+  const homeShell = screenShell(page, "Home");
+  const aboutShell = screenShell(page, "About");
+  const homeCard = homeShell.locator("[data-screen-card]");
+  const aboutCard = aboutShell.locator("[data-screen-card]");
+  const homeCardBox = await homeCard.boundingBox();
+  const aboutCardBox = await aboutCard.boundingBox();
+  if (!homeCardBox || !aboutCardBox) throw new Error("missing screen card box");
+
+  const homeIdsBefore = await primitiveNodeIds(page, "index.html", "rectangle");
+  const aboutIdsBefore = await primitiveNodeIds(
+    page,
+    "about.html",
+    "rectangle",
+  );
+  const drawStart = {
+    x: homeCardBox.x + homeCardBox.width * 0.1,
+    y: homeCardBox.y + homeCardBox.height * 0.06,
+  };
+  const drawEnd = {
+    x: homeCardBox.x + homeCardBox.width * 0.2,
+    y: homeCardBox.y + homeCardBox.height * 0.14,
+  };
+
+  await createDraftPrimitive(page, "Rectangle", "Rectangle", {
+    start: drawStart,
+    end: drawEnd,
+  });
+  await expect
+    .poll(() => primitiveNodeIds(page, "index.html", "rectangle"), {
+      timeout: 20_000,
+    })
+    .toHaveLength(homeIdsBefore.length + 1);
+  const homeIdsAfterCreate = await primitiveNodeIds(
+    page,
+    "index.html",
+    "rectangle",
+  );
+  const movedId = homeIdsAfterCreate.find((id) => !homeIdsBefore.includes(id));
+  if (!movedId) throw new Error("new rectangle id was not found");
+  const movedBox = await primitiveViewportBox(homeShell, movedId);
+
+  await dragBetween(
+    page,
+    {
+      x: movedBox.x + movedBox.width / 2,
+      y: movedBox.y + movedBox.height / 2,
+    },
+    {
+      x: aboutCardBox.x + aboutCardBox.width * 0.38,
+      y: aboutCardBox.y + aboutCardBox.height * 0.16,
+    },
+  );
+
+  await expect
+    .poll(
+      async () => {
+        const homeIds = await primitiveNodeIds(page, "index.html", "rectangle");
+        const aboutIds = await primitiveNodeIds(
+          page,
+          "about.html",
+          "rectangle",
+        );
+        return {
+          aboutHasMoved: aboutIds.includes(movedId),
+          aboutCount: aboutIds.length,
+          homeHasMoved: homeIds.includes(movedId),
+          homeCount: homeIds.length,
+        };
+      },
+      { timeout: 20_000 },
+    )
+    .toEqual({
+      aboutHasMoved: true,
+      aboutCount: aboutIdsBefore.length + 1,
+      homeHasMoved: false,
+      homeCount: homeIdsBefore.length,
+    });
+});
+
 test("frame insertion creates a new screen and can return to Home", async ({
   page,
 }) => {
@@ -602,6 +836,95 @@ test("frame insertion creates a new screen and can return to Home", async ({
   );
   await expect(selectedLayerRow(page)).toContainText("Screen 2");
   await restoreHome(page);
+});
+
+test("frame drawn left of the first screen creates a new screen", async ({
+  page,
+}) => {
+  await postAction(page.request, "create-file", {
+    designId,
+    filename: "about.html",
+    content: FIXTURE_HTML.replace("E2E Fixture", "E2E Second Fixture"),
+    fileType: "html",
+  });
+  await gotoEditor(page, designId);
+  await expect(screenShell(page, "About")).toBeVisible();
+
+  const filesBeforeFrame = await designFiles(page);
+  const screenCountBeforeFrame = htmlScreenFiles(filesBeforeFrame).length;
+
+  await toolButton(page, "Frame").click();
+  await expect(toolButton(page, "Frame")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await dragInEmptyCanvasLeftOf(page, "Home", { width: 112, height: 132 });
+
+  await expect(toolButton(page, "Move")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await expect
+    .poll(async () => htmlScreenFiles(await designFiles(page)).length, {
+      timeout: 20_000,
+    })
+    .toBe(screenCountBeforeFrame + 1);
+
+  const filesAfterFrame = await designFiles(page);
+  const newScreen = htmlScreenFiles(filesAfterFrame).find(
+    (file) => !filesBeforeFrame.some((before) => before.id === file.id),
+  );
+  if (!newScreen) throw new Error("new screen file was not created");
+
+  const frameData = await designData(page);
+  const newFrameGeometry = frameData.canvasFrames?.[newScreen.id];
+  expect(newFrameGeometry?.x).toBeLessThan(0);
+});
+
+test("rectangle drawn left of the first screen persists on the board", async ({
+  page,
+}) => {
+  await postAction(page.request, "create-file", {
+    designId,
+    filename: "about.html",
+    content: FIXTURE_HTML.replace("E2E Fixture", "E2E Second Fixture"),
+    fileType: "html",
+  });
+  await gotoEditor(page, designId);
+  await expect(screenShell(page, "About")).toBeVisible();
+
+  const boardRectanglesBefore = await primitiveCount(
+    page,
+    "__board__.html",
+    "rectangle",
+  );
+
+  await toolButton(page, "Rectangle").click();
+  await expect(toolButton(page, "Rectangle")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await dragInEmptyCanvasLeftOf(page, "Home", {
+    width: 84,
+    height: 76,
+    topOffset: 300,
+  });
+
+  await expect
+    .poll(() => primitiveCount(page, "__board__.html", "rectangle"), {
+      timeout: 20_000,
+    })
+    .toBe(boardRectanglesBefore + 1);
+  await expect
+    .poll(async () => {
+      const positions = await primitiveLeftPositions(
+        page,
+        "__board__.html",
+        "rectangle",
+      );
+      return Math.min(...positions);
+    })
+    .toBeLessThan(0);
 });
 
 test("pen escape cancels the in-progress path and enter commits vector art", async ({
@@ -638,6 +961,78 @@ test("pen escape cancels the in-progress path and enter commits vector art", asy
   await expect(selectedLayerRow(page)).toContainText("Vector");
 
   await restoreHome(page);
+});
+
+test("primary undo removes active pen segments without undoing committed vectors", async ({
+  page,
+}) => {
+  const card = await homeScreenCard(page);
+  const cardBox = await card.boundingBox();
+  if (!cardBox) throw new Error("no home screen card box");
+
+  await toolButton(page, "Pen").click();
+  await expect(toolButton(page, "Pen")).toHaveAttribute("aria-pressed", "true");
+  await page.waitForTimeout(150);
+
+  await page.mouse.click(
+    cardBox.x + cardBox.width * 0.26,
+    cardBox.y + cardBox.height * 0.3,
+  );
+  await page.mouse.click(
+    cardBox.x + cardBox.width * 0.42,
+    cardBox.y + cardBox.height * 0.38,
+  );
+  await expect(page.locator("[data-pen-path-overlay]")).toHaveCount(1);
+  await page.keyboard.press("Enter");
+  await expect(page.locator("[data-pen-path-overlay]")).toHaveCount(0);
+  await expect(selectedLayerRow(page)).toContainText("Vector");
+
+  const committedVector = await waitForVectorPrimitive(
+    page,
+    "index.html",
+    /\bL\b/,
+  );
+
+  await page.mouse.click(
+    cardBox.x + cardBox.width * 0.52,
+    cardBox.y + cardBox.height * 0.32,
+  );
+  await page.mouse.click(
+    cardBox.x + cardBox.width * 0.72,
+    cardBox.y + cardBox.height * 0.48,
+  );
+  await page.mouse.click(
+    cardBox.x + cardBox.width * 0.62,
+    cardBox.y + cardBox.height * 0.64,
+  );
+  await expect(page.locator("[data-pen-path-overlay]")).toHaveCount(1);
+  await expect(page.locator("[data-pen-anchor]")).toHaveCount(3);
+
+  const undoShortcut = process.platform === "darwin" ? "Meta+Z" : "Control+Z";
+  await page.keyboard.press(undoShortcut);
+  await expect(page.locator("[data-pen-path-overlay]")).toHaveCount(1);
+  await expect(page.locator("[data-pen-anchor]")).toHaveCount(2);
+  await page.waitForTimeout(500);
+
+  const vectorsAfterSegmentUndo = await vectorPrimitiveSummaries(
+    page,
+    "index.html",
+  );
+  expect(vectorsAfterSegmentUndo).toHaveLength(1);
+  expect(vectorsAfterSegmentUndo[0]?.d).toBe(committedVector.d);
+
+  await page.keyboard.press(undoShortcut);
+  await expect(page.locator("[data-pen-anchor]")).toHaveCount(1);
+  await page.keyboard.press(undoShortcut);
+  await expect(page.locator("[data-pen-path-overlay]")).toHaveCount(0);
+  await page.waitForTimeout(500);
+
+  const vectorsAfterClearingPath = await vectorPrimitiveSummaries(
+    page,
+    "index.html",
+  );
+  expect(vectorsAfterClearingPath).toHaveLength(1);
+  expect(vectorsAfterClearingPath[0]?.d).toBe(committedVector.d);
 });
 
 test("pen Bezier vector stays visible and persists through reload", async ({
@@ -754,6 +1149,188 @@ test("dragging the Home screen shell moves it", async ({ page }) => {
   if (!movedBack) throw new Error("no restored shell box");
   expect(Math.abs(movedBack.x - before.x)).toBeLessThan(6);
   expect(Math.abs(movedBack.y - before.y)).toBeLessThan(6);
+});
+
+test("overview undo and redo stay global across screen content and canvas geometry", async ({
+  page,
+}) => {
+  await postAction(page.request, "create-file", {
+    designId,
+    filename: "about.html",
+    content: FIXTURE_HTML.replace("E2E Fixture", "E2E Second Fixture"),
+    fileType: "html",
+  });
+  await gotoEditor(page, designId);
+  await expect(screenShell(page, "About")).toBeVisible();
+
+  const homeShell = screenShell(page, "Home");
+  const beforeMove = await homeShell.boundingBox();
+  if (!beforeMove) throw new Error("no home shell before move");
+  const aboutShell = screenShell(page, "About");
+  const aboutCard = aboutShell.locator("[data-screen-card]");
+  const aboutCardBox = await aboutCard.boundingBox();
+  if (!aboutCardBox) throw new Error("no about card box");
+  const homeCard = homeShell.locator("[data-screen-card]");
+  const homeCardBox = await homeCard.boundingBox();
+  if (!homeCardBox) throw new Error("no home card box");
+  const homeRectanglesBefore = await primitiveCount(
+    page,
+    "index.html",
+    "rectangle",
+  );
+  const aboutRectanglesBefore = await primitiveCount(
+    page,
+    "about.html",
+    "rectangle",
+  );
+
+  await createDraftPrimitive(page, "Rectangle", "Rectangle", {
+    start: {
+      x: homeCardBox.x + homeCardBox.width * 0.16,
+      y: homeCardBox.y + homeCardBox.height * 0.18,
+    },
+    end: {
+      x: homeCardBox.x + homeCardBox.width * 0.32,
+      y: homeCardBox.y + homeCardBox.height * 0.3,
+    },
+  });
+  await expect
+    .poll(() => primitiveCount(page, "index.html", "rectangle"), {
+      timeout: 20_000,
+    })
+    .toBe(homeRectanglesBefore + 1);
+
+  await createDraftPrimitive(page, "Rectangle", "Rectangle", {
+    start: {
+      x: aboutCardBox.x + aboutCardBox.width * 0.18,
+      y: aboutCardBox.y + aboutCardBox.height * 0.2,
+    },
+    end: {
+      x: aboutCardBox.x + aboutCardBox.width * 0.34,
+      y: aboutCardBox.y + aboutCardBox.height * 0.32,
+    },
+  });
+  await expect
+    .poll(() => primitiveCount(page, "about.html", "rectangle"), {
+      timeout: 20_000,
+    })
+    .toBe(aboutRectanglesBefore + 1);
+
+  await dragBetween(
+    page,
+    { x: beforeMove.x + beforeMove.width * 0.34, y: beforeMove.y + 12 },
+    {
+      x: beforeMove.x + beforeMove.width * 0.34 + 72,
+      y: beforeMove.y + 12 + 32,
+    },
+  );
+  const moved = await homeShell.boundingBox();
+  if (!moved) throw new Error("no moved home shell");
+  expect(moved.x).toBeGreaterThan(beforeMove.x + 20);
+
+  await pressPrimaryShortcut(page, "z");
+  await expect
+    .poll(async () => {
+      const current = await homeShell.boundingBox();
+      return current
+        ? Math.abs(current.x - beforeMove.x)
+        : Number.POSITIVE_INFINITY;
+    })
+    .toBeLessThan(6);
+  expect(await primitiveCount(page, "index.html", "rectangle")).toBe(
+    homeRectanglesBefore + 1,
+  );
+  expect(await primitiveCount(page, "about.html", "rectangle")).toBe(
+    aboutRectanglesBefore + 1,
+  );
+
+  await pressPrimaryShortcut(page, "z");
+  await expect
+    .poll(() => primitiveCount(page, "about.html", "rectangle"), {
+      timeout: 20_000,
+    })
+    .toBe(aboutRectanglesBefore);
+  expect(await primitiveCount(page, "index.html", "rectangle")).toBe(
+    homeRectanglesBefore + 1,
+  );
+
+  await pressPrimaryShortcut(page, "z");
+  await expect
+    .poll(() => primitiveCount(page, "index.html", "rectangle"), {
+      timeout: 20_000,
+    })
+    .toBe(homeRectanglesBefore);
+
+  await pressPrimaryShortcut(page, "z", { shift: true });
+  await expect
+    .poll(() => primitiveCount(page, "index.html", "rectangle"), {
+      timeout: 20_000,
+    })
+    .toBe(homeRectanglesBefore + 1);
+  await pressPrimaryShortcut(page, "z", { shift: true });
+  await expect
+    .poll(() => primitiveCount(page, "about.html", "rectangle"), {
+      timeout: 20_000,
+    })
+    .toBe(aboutRectanglesBefore + 1);
+  await pressPrimaryShortcut(page, "z", { shift: true });
+  await expect
+    .poll(async () => {
+      const current = await homeShell.boundingBox();
+      return current ? current.x - beforeMove.x : 0;
+    })
+    .toBeGreaterThan(20);
+});
+
+test("overview undo does not restore ghost geometry for deleted screens", async ({
+  page,
+}) => {
+  await postAction(page.request, "create-file", {
+    designId,
+    filename: "about.html",
+    content: FIXTURE_HTML.replace("E2E Fixture", "E2E Second Fixture"),
+    fileType: "html",
+  });
+  await gotoEditor(page, designId);
+  await expect(screenShell(page, "About")).toBeVisible();
+
+  const aboutFile = (await designFiles(page)).find(
+    (file) => file.filename === "about.html",
+  );
+  if (!aboutFile) throw new Error("about.html was not created");
+
+  const aboutShell = screenShell(page, "About");
+  const aboutBox = await aboutShell.boundingBox();
+  if (!aboutBox) throw new Error("no about shell box");
+  await page.mouse.click(aboutBox.x + aboutBox.width * 0.3, aboutBox.y + 12);
+  await page.keyboard.press("Delete");
+
+  await expect
+    .poll(
+      async () =>
+        htmlScreenFiles(await designFiles(page)).some(
+          (file) => file.id === aboutFile.id,
+        ),
+      { timeout: 20_000 },
+    )
+    .toBe(false);
+
+  await pressPrimaryShortcut(page, "z");
+  await page.waitForTimeout(300);
+
+  const dataAfterUndo = await designData(page);
+  expect(
+    Boolean(
+      dataAfterUndo.canvasFrames &&
+      typeof dataAfterUndo.canvasFrames === "object" &&
+      dataAfterUndo.canvasFrames[aboutFile.id],
+    ),
+  ).toBe(false);
+  expect(
+    htmlScreenFiles(await designFiles(page)).some(
+      (file) => file.id === aboutFile.id,
+    ),
+  ).toBe(false);
 });
 
 test("Escape cancels an in-progress overview screen drag", async ({ page }) => {


### PR DESCRIPTION
## Summary
- make All screens undo/redo use a reliable global history across screen content and canvas geometry
- fix overview cross-screen layer drag persistence by passing the source screen id through the iframe bridge and using live iframe viewport coordinates
- cover Figma-like canvas edge cases for cross-screen layer moves, off-screen creation, pen undo, and screen deletion undo

## Validation
- E2E_BASE_URL=http://127.0.0.1:9344 E2E_BROWSER_CHANNEL=chrome corepack pnpm --filter design e2e e2e/canvas-tools.spec.ts --project=chromium-chrome --grep "dragging a rectangle between screens|overview undo|left of the first screen|primary undo" (6 passed)
- E2E_BASE_URL=http://127.0.0.1:9344 E2E_BROWSER_CHANNEL=chrome corepack pnpm --filter design e2e e2e/canvas-tools.spec.ts --project=chromium-chrome (19 passed)
- corepack pnpm --filter design typecheck
- git diff --check