### PR TITLE
Improve agent timeout recovery and Design sharing

### DIFF
--- a/.changeset/clear-agent-timeout-recovery.md
+++ b/.changeset/clear-agent-timeout-recovery.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Improve agent-chat timeout recovery so completed tool actions end with a clear saved-result note instead of a generic connection failure, and bound repeated no-progress tool stalls.

--- a/.changeset/quiet-share-panel-controls.md
+++ b/.changeset/quiet-share-panel-controls.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow share panels to hide copyable link fields, omit the bottom Done action, and render compact host-provided footer actions.

--- a/.changeset/share-popover-nested-menus.md
+++ b/.changeset/share-popover-nested-menus.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Stack nested share popover menus above their parent panel so users can change visibility.

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -3330,7 +3330,10 @@ export async function runAgentLoop(opts: {
       }
 
       const DEFAULT_TOOL_RESULT_CHARS = 50_000;
-      const DEFAULT_TOOL_TIMEOUT_MS = 60_000;
+      // Default action tools should not undercut durable/background runs. The
+      // run-manager still aborts foreground hosted runs around 40s, while
+      // background runs get nearly the full 15-minute function budget.
+      const DEFAULT_TOOL_TIMEOUT_MS = 12 * 60_000;
       const toolTimeoutMs =
         actionEntry.timeoutMs ??
         opts.toolLimits?.timeoutMs ??

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -3801,7 +3801,11 @@ export async function runAgentLoop(opts: {
         input: toolCall.input as Record<string, unknown>,
         result,
         ...(isError ? { isError: true } : {}),
-        ...(isError ? { completedSideEffect: false } : {}),
+        ...(isError
+          ? { completedSideEffect: false }
+          : actionEntry.readOnly !== true
+            ? { completedSideEffect: true }
+            : {}),
         ...(mcpApp ? { mcpApp } : {}),
         ...(actionEntry.chatUI ? { chatUI: actionEntry.chatUI } : {}),
       });

--- a/packages/core/src/agent/run-loop-with-resume.spec.ts
+++ b/packages/core/src/agent/run-loop-with-resume.spec.ts
@@ -391,7 +391,7 @@ describe("runAgentLoopDirectWithSoftTimeout", () => {
     expect(err.errorCode).toBe(RUN_BUDGET_EXHAUSTED_ERROR_CODE);
     expect(err.error).toBe(RUN_BUDGET_EXHAUSTED_MESSAGE);
     expect(err.error).toContain("stopped");
-    expect(err.error).toContain("nothing was partially saved");
+    expect(err.error).toContain("Check any completed tool cards");
     expect(err.recoverable).toBe(true);
     // The unfinished partial text must be cleared before the terminal so it
     // stands alone instead of trailing a half sentence.
@@ -399,6 +399,66 @@ describe("runAgentLoopDirectWithSoftTimeout", () => {
     const errorIndex = sentEvents.findIndex((e) => e.type === "error");
     expect(clearIndex).toBeGreaterThanOrEqual(0);
     expect(clearIndex).toBeLessThan(errorIndex);
+  });
+
+  it("preserves completed tool cards when the continuation budget is exhausted after a side effect", async () => {
+    const sentEvents: AgentChatEvent[] = [];
+    let attempts = 0;
+    mockGetCurrentTurnEventsForThread.mockResolvedValue([
+      { type: "tool_start", tool: "generate-design", input: { id: "d1" } },
+      {
+        type: "tool_done",
+        tool: "generate-design",
+        input: { id: "d1" },
+        result: '{"designId":"d1"}',
+        completedSideEffect: true,
+      },
+    ]);
+    mockRunAgentLoop.mockImplementation(async (opts) => {
+      attempts++;
+      if (attempts === 1) {
+        opts.send({
+          type: "tool_start",
+          tool: "generate-design",
+          input: { id: "d1" },
+        });
+        opts.send({
+          type: "tool_done",
+          tool: "generate-design",
+          input: { id: "d1" },
+          result: '{"designId":"d1"}',
+          completedSideEffect: true,
+        });
+      }
+      throw new Error("socket hang up");
+    });
+
+    await runAgentLoopDirectWithSoftTimeout(
+      makeOpts(
+        [{ role: "user", content: [{ type: "text", text: "go" }] }],
+        new AbortController().signal,
+        (event) => sentEvents.push(event),
+        "thread-1",
+      ),
+      60_000,
+    );
+
+    expect(attempts).toBe(MAX_RUN_LOOP_CONTINUATIONS);
+    const terminal = sentEvents.find((e) => e.type === "error");
+    expect(terminal).toMatchObject({
+      type: "error",
+      errorCode: RUN_BUDGET_EXHAUSTED_ERROR_CODE,
+    });
+    expect(sentEvents.some((event) => event.type === "clear")).toBe(false);
+    expect(sentEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "tool_done",
+          tool: "generate-design",
+          completedSideEffect: true,
+        }),
+      ]),
+    );
   });
 
   it("does NOT emit a give-up terminal when the turn finishes cleanly", async () => {

--- a/packages/core/src/agent/run-loop-with-resume.ts
+++ b/packages/core/src/agent/run-loop-with-resume.ts
@@ -79,6 +79,24 @@ async function appendToolCallJournalNote(
   }
 }
 
+async function hasCompletedSideEffectToolCallInCurrentTurn(
+  threadId: string | undefined,
+): Promise<boolean> {
+  if (!threadId) return false;
+  try {
+    const events = await getCurrentTurnEventsForThread(threadId);
+    if (events.length === 0) return false;
+    return events.some(
+      (event) =>
+        event.type === "tool_done" &&
+        event.completedSideEffect === true &&
+        event.isError !== true,
+    );
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Cap on continuation iterations inside a single
  * `runAgentLoopDirectWithSoftTimeout` invocation. The host's hard function
@@ -102,12 +120,12 @@ export const RUN_BUDGET_EXHAUSTED_ERROR_CODE = "run_budget_exhausted";
  * exhausts its in-invocation continuation budget without finishing. Generic and
  * framework-level (not app-specific). Mirrors the `reliable-mutations` skill's
  * "fail loud, retry as a single bulk action" guidance so the user understands
- * the turn stopped before finishing and was not partially saved by the run
- * itself. */
+ * the turn stopped before finishing without implying that earlier completed
+ * tool calls did not persist. */
 export const RUN_BUDGET_EXHAUSTED_MESSAGE =
-  "I ran out of time before finishing this step (hosted runs have a ~40s budget). " +
-  "I stopped rather than leave things half-done — nothing was partially saved by me here. " +
-  "Please retry, ideally as a single bulk action.";
+  "I ran out of time before finishing this step. " +
+  "I stopped rather than keep retrying silently. " +
+  "Check any completed tool cards above before retrying, ideally as one smaller follow-up.";
 
 /**
  * Internal entry point used by the agent-chat plugin's run handler. Wraps
@@ -189,7 +207,11 @@ export async function runAgentLoopDirectWithSoftTimeout(
         // Clear partial text the client received before the abort so the
         // resumed model doesn't re-emit it and produce duplicated output.
         lastAttemptWasUnfinishedContinuation = true;
-        opts.send({ type: "clear" });
+        if (
+          !(await hasCompletedSideEffectToolCallInCurrentTurn(opts.threadId))
+        ) {
+          opts.send({ type: "clear" });
+        }
         appendAgentLoopContinuation(opts.messages, "run_timeout");
         await appendToolCallJournalNote(opts.messages, opts.threadId);
         continue;
@@ -209,7 +231,11 @@ export async function runAgentLoopDirectWithSoftTimeout(
       // the in-memory messages array, so the next attempt re-emits it).
       if (!upstreamSignal.aborted && isResumableEngineError(err)) {
         lastAttemptWasUnfinishedContinuation = true;
-        opts.send({ type: "clear" });
+        if (
+          !(await hasCompletedSideEffectToolCallInCurrentTurn(opts.threadId))
+        ) {
+          opts.send({ type: "clear" });
+        }
         appendAgentLoopContinuation(
           opts.messages,
           continuationReasonForResumableError(err),
@@ -234,7 +260,11 @@ export async function runAgentLoopDirectWithSoftTimeout(
   if (!upstreamSignal.aborted && lastAttemptWasUnfinishedContinuation) {
     // Discard any partial text already streamed for the unfinished attempt so
     // the terminal message stands alone instead of trailing a half sentence.
-    opts.send({ type: "clear" });
+    // Preserve completed tool cards: they are the user's only durable proof
+    // that a side effect landed before the final assistant note timed out.
+    if (!(await hasCompletedSideEffectToolCallInCurrentTurn(opts.threadId))) {
+      opts.send({ type: "clear" });
+    }
     opts.send({
       type: "error",
       error: RUN_BUDGET_EXHAUSTED_MESSAGE,

--- a/packages/core/src/agent/thread-data-builder.ts
+++ b/packages/core/src/agent/thread-data-builder.ts
@@ -18,6 +18,8 @@ interface ContentPart {
   argsText?: string;
   args?: Record<string, string>;
   result?: string;
+  isError?: boolean;
+  completedSideEffect?: boolean;
   mcpApp?: AgentMcpAppPayload;
   chatUI?: ActionChatUIConfig;
 }
@@ -159,6 +161,10 @@ export function buildAssistantMessage(
           part.result === undefined
         ) {
           part.result = event.result ?? "";
+          if (event.isError !== undefined) part.isError = event.isError;
+          if (event.completedSideEffect !== undefined) {
+            part.completedSideEffect = event.completedSideEffect;
+          }
           if (event.mcpApp) part.mcpApp = event.mcpApp;
           if (event.chatUI) part.chatUI = event.chatUI;
           break;

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -2381,6 +2381,89 @@ describe("createAgentChatAdapter", () => {
     expect(secondBody.message).not.toContain("compact working v1");
   });
 
+  it("does not treat completed tool activity as unfinished action preparation", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let postCount = 0;
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/_agent-native/agent-chat" && init?.method === "POST") {
+        postCount += 1;
+        return postCount === 1
+          ? sseResponse([
+              {
+                type: "activity",
+                label: "Preparing generate-design action",
+                tool: "generate-design",
+              },
+              {
+                type: "tool_start",
+                tool: "generate-design",
+                input: { designId: "design_1" },
+              },
+              {
+                type: "tool_done",
+                tool: "generate-design",
+                result: '{"designId":"design_1"}',
+                completedSideEffect: true,
+              },
+              { type: "auto_continue", reason: "run_timeout" },
+            ])
+          : sseResponse([
+              { type: "text", text: "saved the design" },
+              { type: "done" },
+            ]);
+      }
+      if (url.includes("/runs/")) {
+        return jsonResponse({ active: false, status: "idle" });
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-design-completed-tool-timeout",
+      threadId: "thread-design-completed-tool-timeout",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Generate a todo app design" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+
+    expect(postCount).toBe(2);
+    const chatPosts = fetchSpy.mock.calls.filter(
+      ([url, init]) =>
+        url === "/_agent-native/agent-chat" && init?.method === "POST",
+    );
+    const secondBody = JSON.parse(chatPosts[1][1].body);
+    expect(secondBody.message).not.toContain(
+      "preparing the `generate-design` action input",
+    );
+    expect(secondBody.message).not.toContain("before the action could finish");
+  });
+
   it("nudges Design variant generation to save compact screens before refining", async () => {
     vi.useFakeTimers();
     vi.stubGlobal("window", { dispatchEvent: vi.fn() });
@@ -3583,6 +3666,90 @@ describe("createAgentChatAdapter", () => {
     expect(last?.content?.at(-1)?.text).toBe("done");
   });
 
+  it("bails when the same in-flight tool repeatedly stops producing progress", async () => {
+    vi.useFakeTimers();
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let chatPostCount = 0;
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/_agent-native/agent-chat" && init?.method === "POST") {
+        chatPostCount += 1;
+        return sseResponse(
+          [
+            {
+              type: "tool_start",
+              tool: "generate-design",
+              input: { designId: "design_1" },
+            },
+            { type: "auto_continue", reason: "no_progress" },
+          ],
+          `run-no-progress-${chatPostCount}`,
+        );
+      }
+      if (url.includes("/abort") && init?.method === "POST") {
+        return jsonResponse({ ok: true });
+      }
+      if (url.includes("/runs/")) {
+        return jsonResponse({ active: false, status: "idle" });
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-inflight-no-progress",
+      threadId: "thread-inflight-no-progress",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "generate design" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    const results = await promise;
+
+    expect(chatPostCount).toBe(4);
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "agent-chat:run-error",
+        detail: expect.objectContaining({
+          errorCode: "connection_error",
+          message: expect.stringContaining("same tool"),
+        }),
+      }),
+    );
+    const last = results.at(-1) as any;
+    expect(last.status).toEqual({ type: "incomplete", reason: "error" });
+    const toolCards = last.content.filter(
+      (part: any) =>
+        part.type === "tool-call" && part.toolName === "generate-design",
+    );
+    expect(toolCards.length).toBeGreaterThan(0);
+    expect(toolCards.every((part: any) => part.result !== undefined)).toBe(
+      true,
+    );
+  });
+
   it("preserves large create-extension input verbatim in continuation history", async () => {
     // Large-input tools carry the artifact itself as their input. Lossy
     // truncation to an `{ __agentNativeTruncated }` placeholder would strand
@@ -3925,6 +4092,239 @@ describe("createAgentChatAdapter", () => {
     );
     const last = results.at(-1) as any;
     expect(last.status).toEqual({ type: "incomplete", reason: "error" });
+  });
+
+  it("finishes with a saved note when final text times out after a completed side-effect tool", async () => {
+    vi.useFakeTimers();
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let postCount = 0;
+    const fetchSpy = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.method !== "POST") {
+        return jsonResponse({ active: false, status: "idle" });
+      }
+      postCount += 1;
+      return postCount === 1
+        ? sseResponse([
+            { type: "text", text: "Building it now!" },
+            {
+              type: "tool_start",
+              tool: "generate-design",
+              input: { designId: "design_1" },
+            },
+            {
+              type: "tool_done",
+              tool: "generate-design",
+              result: '{"designId":"design_1","urlPath":"/design/design_1"}',
+              completedSideEffect: true,
+            },
+            { type: "auto_continue", reason: "run_timeout" },
+          ])
+        : sseResponse([{ type: "auto_continue", reason: "run_timeout" }]);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-completed-side-effect",
+      threadId: "thread-completed-side-effect",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "create a dark todo app" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    const results = await promise;
+
+    expect(postCount).toBe(2);
+    expect(dispatchEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "agent-chat:run-error",
+      }),
+    );
+    const last = results.at(-1) as any;
+    expect(last.status).toEqual({ type: "complete", reason: "stop" });
+    expect(last.metadata.custom.runWarning).toMatchObject({
+      errorCode: "final_response_timeout_after_tool",
+      recoverable: true,
+    });
+    expect(last.content.at(-1).text).toContain("The design was saved");
+  });
+
+  it("reconnects to a newer background continuation after run_timeout before self-posting", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let postCount = 0;
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/_agent-native/agent-chat" && init?.method === "POST") {
+        postCount += 1;
+        return sseResponse(
+          [
+            { type: "text", text: "Working" },
+            { type: "auto_continue", reason: "run_timeout" },
+          ],
+          "run-first",
+        );
+      }
+      if (url.includes("/runs/active")) {
+        return jsonResponse({
+          active: true,
+          runId: "run-bg-next",
+          threadId: "thread-bg-next",
+          status: "running",
+          dispatchMode: "background-function",
+          heartbeatAt: Date.now(),
+          lastProgressAt: Date.now(),
+        });
+      }
+      if (url.includes("/runs/run-bg-next/events")) {
+        return sseResponse(
+          [{ type: "text", text: " and done" }, { type: "done" }],
+          "run-bg-next",
+        );
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-bg-next",
+      threadId: "thread-bg-next",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "do a long background task" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(2000);
+    const results = await promise;
+
+    expect(postCount).toBe(1);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining("/runs/run-bg-next/events"),
+      expect.any(Object),
+    );
+    const last = results.at(-1) as any;
+    expect(last.content.at(-1).text).toContain("Working and done");
+  });
+
+  it("does not adopt a foreground active run after run_timeout", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let postCount = 0;
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/_agent-native/agent-chat" && init?.method === "POST") {
+        postCount += 1;
+        return postCount === 1
+          ? sseResponse(
+              [
+                { type: "text", text: "Working" },
+                { type: "auto_continue", reason: "run_timeout" },
+              ],
+              "run-first",
+            )
+          : sseResponse(
+              [{ type: "text", text: " continued" }, { type: "done" }],
+              "run-self-continuation",
+            );
+      }
+      if (url.includes("/runs/active")) {
+        return jsonResponse({
+          active: true,
+          runId: "run-foreground-other",
+          threadId: "thread-bg-foreground",
+          status: "running",
+          dispatchMode: "foreground",
+          heartbeatAt: Date.now(),
+          lastProgressAt: Date.now(),
+        });
+      }
+      if (url.includes("/runs/run-foreground-other/events")) {
+        return jsonResponse({ error: "should not reconnect foreground" }, 500);
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-bg-foreground",
+      threadId: "thread-bg-foreground",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "do a long foreground task" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(2000);
+    const results = await promise;
+
+    expect(postCount).toBe(2);
+    expect(fetchSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("/runs/run-foreground-other/events"),
+      expect.any(Object),
+    );
+    const last = results.at(-1) as any;
+    expect(last.content.at(-1).text).toContain("Working continued");
   });
 
   it("gives up quickly when the model repeats the same narration without finishing", async () => {

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -2381,6 +2381,81 @@ describe("createAgentChatAdapter", () => {
     expect(secondBody.message).not.toContain("compact working v1");
   });
 
+  it("nudges Design variant generation to save compact screens before refining", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let postCount = 0;
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/_agent-native/agent-chat" && init?.method === "POST") {
+        postCount += 1;
+        return postCount === 1
+          ? sseResponse([
+              {
+                type: "activity",
+                label: "Preparing present-design-variants action",
+                tool: "present-design-variants",
+              },
+              { type: "auto_continue", reason: "run_timeout" },
+            ])
+          : sseResponse([
+              { type: "text", text: "saved compact variant screens" },
+              { type: "done" },
+            ]);
+      }
+      if (url.includes("/runs/")) {
+        return jsonResponse({ active: false, status: "idle" });
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-design-variants-input-timeout",
+      threadId: "thread-design-variants-input-timeout",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Generate three todo variants" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+
+    expect(postCount).toBe(2);
+    const chatPosts = fetchSpy.mock.calls.filter(
+      ([url, init]) =>
+        url === "/_agent-native/agent-chat" && init?.method === "POST",
+    );
+    const secondBody = JSON.parse(chatPosts[1][1].body);
+    expect(secondBody.message).toContain(
+      "preparing the `present-design-variants` action input",
+    );
+    expect(secondBody.message).toContain(
+      "compact but complete variant screens",
+    );
+    expect(secondBody.message).toContain("edit-design");
+  });
+
   it("surfaces a startup timeout when the POST never becomes an SSE stream", async () => {
     vi.useFakeTimers();
     const dispatchEvent = vi.fn();

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -697,6 +697,41 @@ function hasContinuationProgress(content: ContentPart[]): boolean {
   );
 }
 
+function lastCompletedSideEffectTool(
+  content: ContentPart[],
+): Extract<ContentPart, { type: "tool-call" }> | undefined {
+  for (let i = content.length - 1; i >= 0; i--) {
+    const part = content[i];
+    if (
+      part.type === "tool-call" &&
+      part.activity !== true &&
+      part.result !== undefined &&
+      part.isError !== true &&
+      part.completedSideEffect === true
+    ) {
+      return part;
+    }
+  }
+  return undefined;
+}
+
+function humanizeActionName(toolName: string): string {
+  return toolName
+    .replace(/^agent:/, "")
+    .replace(/[-_]+/g, " ")
+    .trim();
+}
+
+function completedToolTimeoutMessage(toolName: string): string {
+  if (toolName === "generate-design" || toolName === "update-design") {
+    return "The design was saved, but the assistant timed out before sending its final note. You can open the generated design from the completed tool card above.";
+  }
+  if (toolName === "present-design-variants") {
+    return "The design variants were saved, but the assistant timed out before sending its final note. You can review the completed variants from the tool card above.";
+  }
+  return `The ${humanizeActionName(toolName)} action completed, but the assistant timed out before sending its final response. The saved result is in the completed tool card above.`;
+}
+
 /**
  * Signature of the *unique* sentence-like segments in a continuation's newly
  * streamed text, used to detect a degenerate repetition loop. A stuck model
@@ -785,6 +820,8 @@ function toolContinuationKey(
     stableJson(part.args),
     part.result === undefined ? "pending" : "done",
     part.result ?? "",
+    part.isError === true ? "error" : "",
+    part.completedSideEffect === true ? "side-effect" : "",
     part.activity === true ? "activity" : "tool",
     part.mcpApp ? "mcp-app" : "",
   ].join("\u0000");
@@ -1351,6 +1388,7 @@ export function createAgentChatAdapter(
       // its own budget rather than inheriting the prior payload's.
       let lastInFlightToolSignature: string | undefined;
       let repeatedInFlightToolCount = 0;
+      let recoveryGaveUpOnInFlightTool = false;
       const MAX_REPEATED_INFLIGHT_TOOL_STALLS = 3;
       const continuationHistoryFragments: string[] = [];
       const structuredContinuationFragments: AgentChatStructuredMessage[] = [];
@@ -1392,6 +1430,9 @@ export function createAgentChatAdapter(
       };
 
       const exhaustedRecoveryMessage = (reason?: string): string => {
+        if (recoveryGaveUpOnInFlightTool) {
+          return "The agent got stuck waiting for the same tool to finish, so I stopped the automatic retries. The tool did not report a completed result.";
+        }
         if (recoveryGaveUpOnRepetition) {
           return "The agent got stuck repeating the same response without finishing, so I stopped the automatic retries. This often happens when it tries to re-type a large pasted file into one action — starting a new chat, or asking for a smaller first step, usually gets it unstuck.";
         }
@@ -1676,6 +1717,83 @@ export function createAgentChatAdapter(
           return false;
         };
 
+        const reconnectBackgroundContinuationForRunTimeout =
+          async function* (): AsyncGenerator<
+            ChatModelRunResult,
+            boolean,
+            unknown
+          > {
+            if (!threadId || !runId) return false;
+            const interruptedRunId = runId;
+            const interruptedLastSeq = lastSeq;
+            let lastActiveRunError: unknown = null;
+            for (let attempt = 0; attempt < 3; attempt++) {
+              if (attempt > 0) {
+                await delay(500, abortSignal);
+              }
+              if (abortSignal.aborted) return true;
+              try {
+                const activeRes = await fetch(
+                  `${apiUrl}/runs/active?threadId=${encodeURIComponent(threadId)}`,
+                  { signal: abortSignal },
+                );
+                if (!activeRes.ok) {
+                  if (activeRes.status === 404) return false;
+                  lastActiveRunError = new Error(
+                    `Active run lookup failed: ${activeRes.status}`,
+                  );
+                  continue;
+                }
+                const active = await activeRes.json();
+                if (!active?.active || !active.runId) return false;
+                const activeRunId = String(active.runId);
+                const dispatchMode =
+                  typeof active.dispatchMode === "string"
+                    ? active.dispatchMode
+                    : "";
+                if (activeRunId === interruptedRunId) {
+                  if (dispatchMode.startsWith("background")) continue;
+                  return false;
+                }
+                const activeTurnId =
+                  typeof active.turnId === "string" ? active.turnId : "";
+                const activeStatus =
+                  typeof active.status === "string" ? active.status : "";
+                if (!dispatchMode.startsWith("background")) return false;
+                if (activeTurnId && activeTurnId !== turnId) return false;
+                if (activeStatus !== "running" && activeStatus !== "starting") {
+                  return false;
+                }
+                runId = activeRunId;
+                if (!attemptedRunIds.includes(activeRunId)) {
+                  attemptedRunIds.push(activeRunId);
+                }
+                lastSeq = -1;
+                setActiveRun({ threadId, runId: activeRunId, lastSeq: -1 });
+                const reconnected = yield* reconnectCurrentRun();
+                if (reconnected) return true;
+              } catch (activeErr: unknown) {
+                if (
+                  activeErr instanceof Error &&
+                  activeErr.name === "AbortError"
+                ) {
+                  clearActiveRun();
+                  return true;
+                }
+                lastActiveRunError = activeErr;
+              }
+            }
+            if (lastActiveRunError) {
+              captureChatClientError(
+                lastActiveRunError,
+                "reconnect-background-continuation-failed",
+              );
+            }
+            runId = interruptedRunId;
+            lastSeq = interruptedLastSeq;
+            return false;
+          };
+
         const visibleContentForContinuation = (): ContentPart[] => {
           return contentAfterContinuationPrefix(
             content,
@@ -1685,7 +1803,11 @@ export function createAgentChatAdapter(
 
         const prepareAutoContinuation = (
           signal: AgentAutoContinueSignal,
-        ): { ok: boolean; resetVisibleContent: boolean } => {
+        ): {
+          ok: boolean;
+          resetVisibleContent: boolean;
+          completedToolName?: string;
+        } => {
           lastAutoContinueReason = signal.reason;
           if (signal.errorInfo) {
             lastRecoverableRunError = signal.errorInfo;
@@ -1705,6 +1827,7 @@ export function createAgentChatAdapter(
           // before tool_start; treating it as progress caused silent retry
           // loops when the LLM timed out while assembling a large tool input.
           const hasInFlightTool = hasInFlightToolCall(visibleContent);
+          const completedSideEffectTool = lastCompletedSideEffectTool(content);
           // Either real output or an actively-running tool counts as progress
           // for the stalled/empty caps.
           const madeProgress = madeContentProgress || hasInFlightTool;
@@ -1719,11 +1842,11 @@ export function createAgentChatAdapter(
           // MAX_REPEATED_INFLIGHT_TOOL_STALLS consecutive stream_ended events,
           // bail with a clear message.
           //
-          // Only count stream_ended (connection drop / reconnect failed), NOT
-          // run_timeout (server legitimately still executing a slow tool). A
-          // run_timeout with an in-flight tool means the server is actively
-          // working and reconnection may still recover the result; a repeated
-          // stream_ended means the connection keeps breaking under that payload.
+          // Count broken streams (connection drop / reconnect failed) and
+          // no_progress stalls (the client aborts a stream that stayed open but
+          // stopped producing events). Do NOT count run_timeout: with an
+          // in-flight tool that means the server is still actively executing a
+          // slow action and reconnection may recover the result.
           const currentInFlightToolPart = visibleContent.find(
             (p): p is Extract<ContentPart, { type: "tool-call" }> =>
               p.type === "tool-call" &&
@@ -1734,8 +1857,9 @@ export function createAgentChatAdapter(
           const currentInFlightToolSignature = currentInFlightToolPart
             ? inFlightToolInputSignature(currentInFlightToolPart)
             : undefined;
-          const isConnectionDrop = signal.reason === "stream_ended";
-          if (currentInFlightToolName && isConnectionDrop) {
+          const isBrokenInFlightTool =
+            signal.reason === "stream_ended" || signal.reason === "no_progress";
+          if (currentInFlightToolName && isBrokenInFlightTool) {
             if (
               currentInFlightToolName === lastInFlightToolName &&
               currentInFlightToolSignature === lastInFlightToolSignature
@@ -1774,13 +1898,31 @@ export function createAgentChatAdapter(
             emptyTransientContinuationAttempts = 0;
           } else {
             totalTransientContinuationAttempts += 1;
+            // If a mutating action already completed, do not turn a missing
+            // closing sentence into a scary connection failure. Give the model
+            // one continuation opportunity (the completed tool itself counts
+            // as progress on the first timeout); if the follow-up produces no
+            // new content, stop locally with a clear "saved, final note timed
+            // out" message.
+            if (
+              completedSideEffectTool &&
+              !hasInFlightToolCall(content) &&
+              !madeContentProgress &&
+              !hasInFlightTool
+            ) {
+              return {
+                ok: false,
+                resetVisibleContent: false,
+                completedToolName: completedSideEffectTool.toolName,
+              };
+            }
             // Bail when the same write tool is stuck in-flight across too many
             // consecutive continuations. Checked before the text-repeat guard
             // because hasInFlightTool=true would mask the repeat as progress.
             if (
               repeatedInFlightToolCount >= MAX_REPEATED_INFLIGHT_TOOL_STALLS
             ) {
-              recoveryGaveUpOnRepetition = true;
+              recoveryGaveUpOnInFlightTool = true;
               return { ok: false, resetVisibleContent: false };
             }
             // Bail fast on a non-advancing repetition loop, well before the
@@ -2177,6 +2319,11 @@ export function createAgentChatAdapter(
               if (err.reason === "no_progress") {
                 await abortCurrentRun();
               }
+              if (err.reason === "run_timeout" && !err.errorInfo) {
+                const reconnected =
+                  yield* reconnectBackgroundContinuationForRunTimeout();
+                if (reconnected) return;
+              }
               if (err.reason === "stream_ended") {
                 const reconnected = yield* reconnectCurrentRun();
                 if (reconnected) return;
@@ -2185,6 +2332,31 @@ export function createAgentChatAdapter(
               }
               const continuation = prepareAutoContinuation(err);
               if (!continuation.ok) {
+                if (continuation.completedToolName) {
+                  const message = completedToolTimeoutMessage(
+                    continuation.completedToolName,
+                  );
+                  content.push({ type: "text", text: message });
+                  yield {
+                    content: [...content],
+                    status: {
+                      type: "complete" as const,
+                      reason: "stop" as const,
+                    },
+                    metadata: {
+                      custom: {
+                        ...(runId ? { runId } : {}),
+                        runWarning: {
+                          message,
+                          errorCode: "final_response_timeout_after_tool",
+                          recoverable: true,
+                        },
+                      },
+                    },
+                  };
+                  clearActiveRun();
+                  return;
+                }
                 const preservedError =
                   err.errorInfo ?? lastRecoverableRunError ?? null;
                 const message =
@@ -2357,6 +2529,31 @@ export function createAgentChatAdapter(
                 new AgentAutoContinueSignal({ reason: "stream_ended" }),
               );
               if (!continuation.ok) {
+                if (continuation.completedToolName) {
+                  const message = completedToolTimeoutMessage(
+                    continuation.completedToolName,
+                  );
+                  content.push({ type: "text", text: message });
+                  yield {
+                    content: [...content],
+                    status: {
+                      type: "complete" as const,
+                      reason: "stop" as const,
+                    },
+                    metadata: {
+                      custom: {
+                        ...(runId ? { runId } : {}),
+                        runWarning: {
+                          message,
+                          errorCode: "final_response_timeout_after_tool",
+                          recoverable: true,
+                        },
+                      },
+                    },
+                  };
+                  clearActiveRun();
+                  return;
+                }
                 const message = exhaustedRecoveryMessage("stream_ended");
                 captureChatClientError(err, "recovery-exhausted");
                 const runError = {

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -851,6 +851,8 @@ function incrementalActionGuidance(tool: string): string | undefined {
     case "generate-design":
     case "update-design":
       return "persist a minimal first version (fewer files) with `generate-design`, then refine individual files with `edit-design` search/replace instead of resending everything";
+    case "present-design-variants":
+      return "save compact but complete variant screens with `present-design-variants` first, keeping each HTML direction focused enough to finish, then refine the chosen direction with `generate-design` or `edit-design`";
     case "create-visual-plan":
     case "create-ui-plan":
     case "create-plan-design":

--- a/packages/core/src/client/sharing/ShareButton.spec.tsx
+++ b/packages/core/src/client/sharing/ShareButton.spec.tsx
@@ -9,6 +9,15 @@ import { ShareButton } from "./ShareButton.js";
 const shareMutate = vi.hoisted(() => vi.fn());
 const otherMutate = vi.hoisted(() => vi.fn());
 const refetchShares = vi.hoisted(() => vi.fn(async () => undefined));
+const popoverInteractOutsideHandlers = vi.hoisted(
+  () =>
+    [] as Array<
+      (event: {
+        detail: { originalEvent: { target: EventTarget | null } };
+        preventDefault: () => void;
+      }) => void
+    >,
+);
 const sharesData = vi.hoisted(() => ({
   current: {
     ownerEmail: "owner@example.com",
@@ -39,9 +48,29 @@ vi.mock("../components/ui/popover.js", () => ({
   PopoverAnchor: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),
-  PopoverContent: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
+  PopoverContent: ({
+    children,
+    onInteractOutside,
+    onOpenAutoFocus: _onOpenAutoFocus,
+    align: _align,
+    sideOffset: _sideOffset,
+    ...props
+  }: {
+    children: React.ReactNode;
+    onInteractOutside?: (event: {
+      detail: { originalEvent: { target: EventTarget | null } };
+      preventDefault: () => void;
+    }) => void;
+    onOpenAutoFocus?: unknown;
+    align?: unknown;
+    sideOffset?: unknown;
+    [key: string]: unknown;
+  }) => {
+    if (onInteractOutside) {
+      popoverInteractOutsideHandlers.push(onInteractOutside);
+    }
+    return <div {...props}>{children}</div>;
+  },
 }));
 
 function setInputValue(input: HTMLInputElement, value: string) {
@@ -74,6 +103,7 @@ describe("ShareButton", () => {
     shareMutate.mockReset();
     otherMutate.mockReset();
     refetchShares.mockClear();
+    popoverInteractOutsideHandlers.length = 0;
     sharesData.current = {
       ownerEmail: "owner@example.com",
       orgId: null,
@@ -332,6 +362,74 @@ describe("ShareButton", () => {
     expect(text.indexOf("Public response link")).toBeLessThan(
       text.indexOf("People with editing access"),
     );
+  });
+
+  it("can hide copyable share links and the done button", async () => {
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <ShareButton
+            resourceType="design"
+            resourceId="design-1"
+            shareUrl="https://design.agent-native.com/design/design-1"
+            shareUrlLabel="Design editor link"
+            showShareLinks={false}
+            showDoneButton={false}
+            shareFooterContent={<button type="button">Copy share link</button>}
+          />
+        </QueryClientProvider>,
+      );
+    });
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("People with access");
+    expect(text).toContain("General access");
+    expect(text).toContain("Copy share link");
+    expect(text).not.toContain("Design editor link");
+    expect(text).not.toContain("Done");
+  });
+
+  it("keeps the share popover open for nested portaled share menus", async () => {
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <ShareButton
+            resourceType="design"
+            resourceId="design-1"
+            shareUrl="https://design.agent-native.com/design/design-1"
+          />
+        </QueryClientProvider>,
+      );
+    });
+
+    const handler =
+      popoverInteractOutsideHandlers[popoverInteractOutsideHandlers.length - 1];
+    if (!handler) throw new Error("share popover outside handler not found");
+
+    const nestedOverlay = document.createElement("div");
+    nestedOverlay.setAttribute("data-agent-native-share-overlay", "");
+    const nestedItem = document.createElement("button");
+    nestedOverlay.appendChild(nestedItem);
+    document.body.appendChild(nestedOverlay);
+    const outside = document.createElement("button");
+    document.body.appendChild(outside);
+
+    const preventNestedDismiss = vi.fn();
+    handler({
+      detail: { originalEvent: { target: nestedItem } },
+      preventDefault: preventNestedDismiss,
+    });
+    expect(preventNestedDismiss).toHaveBeenCalledOnce();
+
+    const preventOutsideDismiss = vi.fn();
+    handler({
+      detail: { originalEvent: { target: outside } },
+      preventDefault: preventOutsideDismiss,
+    });
+    expect(preventOutsideDismiss).not.toHaveBeenCalled();
+
+    nestedOverlay.remove();
+    outside.remove();
   });
 
   it("renders optional share tabs and switches to custom tab content", async () => {

--- a/packages/core/src/client/sharing/ShareButton.tsx
+++ b/packages/core/src/client/sharing/ShareButton.tsx
@@ -15,6 +15,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import {
   useCallback,
+  type ComponentPropsWithoutRef,
   useEffect,
   useId,
   useMemo,
@@ -69,6 +70,10 @@ export interface ShareButtonProps {
   /** Where to render share links in the popover. Defaults to the bottom,
    *  matching the historical Google-Docs-style share dialog. */
   shareUrlPlacement?: "top" | "bottom";
+  /** Whether to render copyable share URL fields. Defaults to true. */
+  showShareLinks?: boolean;
+  /** Whether to render the bottom Done button. Defaults to true. */
+  showDoneButton?: boolean;
   /** Optional placeholder shown in the share-URL slot when `shareUrl` is
    *  undefined. Use this to explain *why* there's no link yet (e.g. "Publish
    *  this form to get a public response link") instead of leaving the slot
@@ -99,6 +104,8 @@ export interface ShareButtonProps {
   generalAccessLabel?: ReactNode;
   /** Optional note rendered between general access and the copyable link. */
   accessNote?: ReactNode;
+  /** Optional host-rendered footer for compact app-specific share actions. */
+  shareFooterContent?: ReactNode;
   /** Optional Notion-style organization access control. When present, the
    *  share panel exposes a "Hide in search" switch under Advanced for org
    *  visibility. */
@@ -171,6 +178,8 @@ const BUTTON_GHOST_ICON = cn(
 );
 const SHARE_POPOVER_SURFACE =
   "border border-border bg-popover text-popover-foreground";
+const SHARE_NESTED_OVERLAY_ATTR = "data-agent-native-share-overlay";
+const SHARE_NESTED_OVERLAY_Z = "z-[100020]";
 const MEMBER_SUGGESTION_LIMIT = 25;
 const MEMBER_SEARCH_DEBOUNCE_MS = 140;
 
@@ -218,6 +227,28 @@ const ROLE_OPTIONS: Array<{ value: Role; label: string; description: string }> =
       description: "Can edit and manage access",
     },
   ];
+
+type SharePopoverInteractOutsideEvent = Parameters<
+  NonNullable<
+    ComponentPropsWithoutRef<typeof PopoverContent>["onInteractOutside"]
+  >
+>[0];
+
+function isShareNestedOverlayTarget(target: EventTarget | null): boolean {
+  return (
+    target instanceof Element &&
+    target.closest(`[${SHARE_NESTED_OVERLAY_ATTR}]`) !== null
+  );
+}
+
+function handleSharePopoverInteractOutside(
+  event: SharePopoverInteractOutsideEvent,
+) {
+  const originalTarget = event.detail.originalEvent.target;
+  if (isShareNestedOverlayTarget(originalTarget)) {
+    event.preventDefault();
+  }
+}
 
 /**
  * Framework share control. Renders a shadcn-outline-styled trigger that
@@ -344,12 +375,14 @@ export function ShareButton(props: ShareButtonProps) {
       <PopoverContent
         align="end"
         sideOffset={6}
+        data-agent-native-share-overlay=""
         className={cn(
           "z-[2000] w-[min(460px,92vw)] rounded-lg p-4 shadow-lg",
           SHARE_POPOVER_SURFACE,
           props.popoverClassName,
         )}
         onOpenAutoFocus={(e) => e.preventDefault()}
+        onInteractOutside={handleSharePopoverInteractOutside}
       >
         <SharePanel
           {...props}
@@ -622,9 +655,11 @@ function SharePanel(
     </>
   );
   const showShareLinks =
-    Boolean(props.shareUrl) ||
-    Boolean(props.shareUrlPlaceholder) ||
-    Boolean(props.secondaryShareUrl);
+    (props.showShareLinks ?? true) &&
+    (Boolean(props.shareUrl) ||
+      Boolean(props.shareUrlPlaceholder) ||
+      Boolean(props.secondaryShareUrl));
+  const showDoneButton = props.showDoneButton ?? true;
   const shareUrlPlacement = props.shareUrlPlacement ?? "bottom";
   const extraTabs = props.shareTabs?.tabs ?? [];
   const hasTabs = extraTabs.length > 0;
@@ -821,11 +856,13 @@ function SharePanel(
       <div className="mb-4 h-7 rounded-md bg-muted animate-pulse" />
       <div className="mb-2 text-sm font-semibold">{generalAccessLabel}</div>
       <div className="mb-4 h-9 rounded-md bg-muted animate-pulse" />
-      <div className="mt-2 flex justify-end">
-        <button type="button" onClick={onClose} className={BUTTON_PRIMARY_SM}>
-          Done
-        </button>
-      </div>
+      {showDoneButton ? (
+        <div className="mt-2 flex justify-end">
+          <button type="button" onClick={onClose} className={BUTTON_PRIMARY_SM}>
+            Done
+          </button>
+        </div>
+      ) : null}
     </div>
   ) : (
     <div>
@@ -990,15 +1027,19 @@ function SharePanel(
 
       {showShareLinks && shareUrlPlacement === "bottom" ? shareLinks : null}
 
-      <div className="mt-2 flex justify-end">
-        <button
-          type="button"
-          onClick={handleDone}
-          className={BUTTON_PRIMARY_SM}
-        >
-          Done
-        </button>
-      </div>
+      {props.shareFooterContent}
+
+      {showDoneButton ? (
+        <div className="mt-2 flex justify-end">
+          <button
+            type="button"
+            onClick={handleDone}
+            className={BUTTON_PRIMARY_SM}
+          >
+            Done
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 
@@ -1076,8 +1117,13 @@ function AdvancedAccessPopover({
       <PopoverContent
         align="start"
         sideOffset={6}
+        data-agent-native-share-overlay=""
         onOpenAutoFocus={(event) => event.preventDefault()}
-        className={cn("z-[2300] w-72 p-3 shadow-lg", SHARE_POPOVER_SURFACE)}
+        className={cn(
+          SHARE_NESTED_OVERLAY_Z,
+          "w-72 p-3 shadow-lg",
+          SHARE_POPOVER_SURFACE,
+        )}
       >
         <div className="space-y-3">
           <div>
@@ -1291,9 +1337,11 @@ function MemberAutocomplete({
       <PopoverContent
         align="start"
         sideOffset={4}
+        data-agent-native-share-overlay=""
         onOpenAutoFocus={(event) => event.preventDefault()}
         className={cn(
-          "z-[2200] w-[var(--radix-popper-anchor-width)] min-w-[18rem] rounded-md p-1 shadow-lg",
+          SHARE_NESTED_OVERLAY_Z,
+          "w-[var(--radix-popper-anchor-width)] min-w-[18rem] rounded-md p-1 shadow-lg",
           SHARE_POPOVER_SURFACE,
         )}
       >
@@ -1441,8 +1489,7 @@ function CopyLinkField({
 // Radix Select wrappers styled like shadcn Select (no native <select> anywhere)
 // ---------------------------------------------------------------------------
 
-const selectContentClass =
-  "z-[2100] min-w-[12rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0";
+const selectContentClass = `${SHARE_NESTED_OVERLAY_Z} min-w-[12rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0`;
 const selectItemClass =
   "relative flex w-full cursor-pointer select-none items-start gap-2 rounded-sm py-2 ps-8 pe-3 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50";
 
@@ -1517,6 +1564,7 @@ function RoleSelect(props: {
       </Select.Trigger>
       <Select.Portal>
         <Select.Content
+          data-agent-native-share-overlay=""
           className={selectContentClass}
           position="popper"
           sideOffset={4}
@@ -1563,6 +1611,7 @@ function VisibilitySelect(props: {
       </Select.Trigger>
       <Select.Portal>
         <Select.Content
+          data-agent-native-share-overlay=""
           className={selectContentClass}
           position="popper"
           sideOffset={4}

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -959,7 +959,7 @@ describe("SSE event processor error classification", () => {
     );
 
     const giveUpMessage =
-      "I ran out of time before finishing this step (hosted runs have a ~40s budget). " +
+      "I ran out of time before finishing this step. " +
       "I stopped rather than leave things half-done — nothing was partially saved by me here. " +
       "Please retry, ideally as a single bulk action.";
 

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -18,6 +18,8 @@ export type ContentPart =
       argsText: string;
       args: Record<string, string>;
       result?: string;
+      isError?: boolean;
+      completedSideEffect?: boolean;
       mcpApp?: AgentMcpAppPayload;
       chatUI?: ActionChatUIConfig;
       activity?: boolean;
@@ -45,6 +47,8 @@ export interface SSEEvent {
   label?: string;
   input?: Record<string, string>;
   result?: string;
+  isError?: boolean;
+  completedSideEffect?: boolean;
   mcpApp?: AgentMcpAppPayload;
   chatUI?: ActionChatUIConfig;
   /** Stable key the client echoes back in `approvedToolCalls` to approve a
@@ -525,6 +529,10 @@ export function processEvent(
       const part = content[doneIdx];
       if (part.type === "tool-call") {
         part.result = ev.result ?? "";
+        if (ev.isError !== undefined) part.isError = ev.isError;
+        if (ev.completedSideEffect !== undefined) {
+          part.completedSideEffect = ev.completedSideEffect;
+        }
         if (ev.mcpApp) part.mcpApp = ev.mcpApp;
         if (ev.chatUI) part.chatUI = ev.chatUI;
       }
@@ -851,6 +859,13 @@ export async function* readSSEStream(
             label: runningToolLabel(tool),
             tool,
           });
+        } else if (ev.type === "tool_done") {
+          const tool = ev.tool ?? "unknown";
+          for (let i = activityTrail.length - 1; i >= 0; i--) {
+            if (activityTrail[i]?.tool === tool) {
+              activityTrail.splice(i, 1);
+            }
+          }
         }
 
         const { action, result, autoContinue } = processEvent(

--- a/packages/core/src/server/agent-chat-plugin.a2a.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin.a2a.spec.ts
@@ -81,8 +81,7 @@ describe("assembleA2AFinalResponse", () => {
           { type: "clear" },
           {
             type: "error",
-            error:
-              "I ran out of time before finishing this step (hosted runs have a ~40s budget).",
+            error: "I ran out of time before finishing this step.",
             errorCode: "run_budget_exhausted",
             recoverable: true,
           },

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -137,7 +137,7 @@ details live in `.agents/skills/`.
   name the metrics and the server generates the validated SQL/config for every
   panel in ONE fast call. Do NOT hand-author big `update-dashboard` configs
   panel-by-panel or loop `update-dashboard` — streaming a giant multi-panel
-  argument inside the ~40s budget fails and thrashes. Unknown metric keys are
+  argument across timeout boundaries fails and thrashes. Unknown metric keys are
   skipped and reported; per-panel SQL validates independently; existing
   dashboards append by default (`overwrite: true` replaces). Report the returned
   `panelCount` as proof-of-done.

--- a/templates/design/app/pages/DesignEditor.selection.test.ts
+++ b/templates/design/app/pages/DesignEditor.selection.test.ts
@@ -34,6 +34,7 @@ import {
   shouldEscapeToOverview,
   shouldIgnoreOverviewLayerCreationEcho,
   shouldBlockPendingVisualStyleNavigation,
+  shouldShowPendingVisualStyleApply,
   sortCodeLayerIdsByTreeOrder,
   formatPendingVisualStylePrompt,
   mergePendingVisualStyleEdit,
@@ -170,6 +171,52 @@ describe("DesignEditor pending visual style edits", () => {
         hasPendingVisualStyleEdits: false,
         currentPathname: "/design/design-1",
         nextPathname: "/",
+      }),
+    ).toBe(false);
+  });
+
+  it("shows the apply styles affordance for localhost-backed visual edits", () => {
+    expect(
+      shouldShowPendingVisualStyleApply({
+        edits: [
+          {
+            screenId: "local-home",
+            filename: "localhost-home.html",
+            screenName: "Home",
+            selector: ".hero",
+            classes: [],
+            styles: { color: "rgb(37, 99, 235)" },
+            updatedAt: 1,
+          },
+        ],
+        screenSourceTypes: new Map([["local-home", "localhost"]]),
+      }),
+    ).toBe(true);
+  });
+
+  it("hides the apply styles affordance for non-localhost visual edits", () => {
+    const edits = [
+      {
+        screenId: "generated-home",
+        filename: "home.html",
+        screenName: "Home",
+        selector: ".hero",
+        classes: [],
+        styles: { color: "rgb(37, 99, 235)" },
+        updatedAt: 1,
+      },
+    ];
+
+    expect(
+      shouldShowPendingVisualStyleApply({
+        edits,
+        screenSourceTypes: new Map([["generated-home", "inline"]]),
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowPendingVisualStyleApply({
+        edits,
+        screenSourceTypes: new Map([["generated-home", "fusion"]]),
       }),
     ).toBe(false);
   });

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -117,6 +117,7 @@ import {
   IconExternalLink,
   IconCircleCheck,
   IconTerminal2,
+  IconLink,
 } from "@tabler/icons-react";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -214,7 +215,6 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -245,7 +245,6 @@ import {
 } from "@/components/ui/popover";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Textarea } from "@/components/ui/textarea";
 import {
   Tooltip,
   TooltipContent,
@@ -994,6 +993,22 @@ export function formatPendingVisualStylePrompt(args: {
   ]
     .filter((line) => line !== "")
     .join("\n");
+}
+
+export function shouldShowPendingVisualStyleApply(args: {
+  edits: readonly PendingVisualStyleEdit[];
+  screenSourceTypes: ReadonlyMap<string, unknown>;
+  fallbackSourceType?: unknown;
+}): boolean {
+  return (
+    args.edits.length > 0 &&
+    args.edits.every(
+      (edit) =>
+        normalizeDesignSourceType(
+          args.screenSourceTypes.get(edit.screenId) ?? args.fallbackSourceType,
+        ) === "localhost",
+    )
+  );
 }
 
 interface DesignData {
@@ -5155,8 +5170,8 @@ export default function DesignEditor() {
     null,
   );
   const [codingHandoffLoading, setCodingHandoffLoading] = useState(false);
-  const [downloadZipInstead, setDownloadZipInstead] = useState(false);
-  const [codingHandoffDetail, setCodingHandoffDetail] = useState("");
+  const [shareLinkCopied, setShareLinkCopied] = useState(false);
+  const shareLinkCopiedResetRef = useRef<number | null>(null);
   const [, setPatchProof] = useState<PatchProofState | null>(null);
   const pendingFileSavesRef = useRef<Record<string, FileContentSaveRequest>>(
     {},
@@ -5351,6 +5366,13 @@ export default function DesignEditor() {
     if (!id || typeof window === "undefined") return undefined;
     return getDesignEditorShareUrl(id, window.location.origin, appBasePath());
   }, [id]);
+  useEffect(() => {
+    return () => {
+      if (shareLinkCopiedResetRef.current !== null) {
+        window.clearTimeout(shareLinkCopiedResetRef.current);
+      }
+    };
+  }, []);
   const {
     designSystems,
     defaultSystem,
@@ -12530,17 +12552,13 @@ export default function DesignEditor() {
 
   const getCodingHandoffClipboardText = useCallback(
     (result: CodingHandoffResult | null) => {
-      const base =
-        typeof result?.clipboardText === "string"
-          ? result.clipboardText
-          : typeof result?.prompt === "string"
-            ? result.prompt
-            : "";
-      const detail = codingHandoffDetail.trim();
-      if (!base || !detail) return base;
-      return `${base}\n\nAdditional implementation detail:\n${detail}`;
+      return typeof result?.clipboardText === "string"
+        ? result.clipboardText
+        : typeof result?.prompt === "string"
+          ? result.prompt
+          : "";
     },
-    [codingHandoffDetail],
+    [],
   );
 
   const handleCopyCodingHandoff = useCallback(async () => {
@@ -12557,6 +12575,24 @@ export default function DesignEditor() {
       toast.error(t("designEditor.toasts.clipboardBlocked"));
     }
   }, [ensureCodingHandoff, getCodingHandoffClipboardText, t]);
+
+  const handleCopyShareLink = useCallback(async () => {
+    if (!editorShareUrl) return;
+    try {
+      await navigator.clipboard.writeText(editorShareUrl);
+      setShareLinkCopied(true);
+      if (shareLinkCopiedResetRef.current !== null) {
+        window.clearTimeout(shareLinkCopiedResetRef.current);
+      }
+      shareLinkCopiedResetRef.current = window.setTimeout(() => {
+        setShareLinkCopied(false);
+        shareLinkCopiedResetRef.current = null;
+      }, 1400);
+      toast.success("Share link copied" /* i18n-ignore share copy toast */);
+    } catch {
+      toast.error(t("designEditor.toasts.clipboardBlocked"));
+    }
+  }, [editorShareUrl, t]);
 
   const hasPendingVisualStyleEdits = pendingVisualStyleEdits.length > 0;
   useBeforeUnload(
@@ -12596,6 +12632,29 @@ export default function DesignEditor() {
   const pendingVisualStylePropertyCount = useMemo(
     () => getPendingVisualStylePropertyCount(pendingVisualStyleEdits),
     [pendingVisualStyleEdits],
+  );
+  const pendingVisualStyleScreenSourceTypes = useMemo(
+    () =>
+      new Map<string, unknown>(
+        overviewScreens.map((screen) => [
+          screen.id,
+          screen.sourceType ?? designSourceType,
+        ]),
+      ),
+    [designSourceType, overviewScreens],
+  );
+  const showPendingVisualStyleApply = useMemo(
+    () =>
+      shouldShowPendingVisualStyleApply({
+        edits: pendingVisualStyleEdits,
+        screenSourceTypes: pendingVisualStyleScreenSourceTypes,
+        fallbackSourceType: designSourceType,
+      }),
+    [
+      designSourceType,
+      pendingVisualStyleEdits,
+      pendingVisualStyleScreenSourceTypes,
+    ],
   );
   const pendingVisualStylePrompt = useMemo(
     () =>
@@ -12702,22 +12761,6 @@ export default function DesignEditor() {
       },
     });
   }, [exportZipMutation, fallbackExportName, id, t, triggerBlobDownload]);
-
-  const handleDownloadHandoffZip = useCallback(async () => {
-    const result = await ensureCodingHandoff();
-    if (!result?.zipUrl) {
-      toast.error(t("designEditor.toasts.zipCreateError"));
-      return;
-    }
-    const a = document.createElement("a");
-    a.href = result.zipUrl;
-    a.download = fallbackExportName("zip", "agent-handoff");
-    a.rel = "noopener";
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    toast.success(t("designEditor.toasts.zipDownloaded"));
-  }, [ensureCodingHandoff, fallbackExportName, t]);
 
   const handleDownloadPng = useCallback(
     async (settings?: Partial<ExportSettingsValue>) => {
@@ -12925,14 +12968,6 @@ ${serializedHtml}
     [handleDownloadPng, handleDownloadSvg],
   );
 
-  const handleSendToPrimaryAction = useCallback(() => {
-    if (downloadZipInstead) {
-      void handleDownloadHandoffZip();
-      return;
-    }
-    void handleCopyCodingHandoff();
-  }, [downloadZipInstead, handleCopyCodingHandoff, handleDownloadHandoffZip]);
-
   const shareExportOptions: Array<{
     value: ShareExportFormat;
     title: string;
@@ -13096,84 +13131,72 @@ ${serializedHtml}
       <div className="flex flex-wrap items-center gap-2">
         <Button
           type="button"
-          onClick={handleSendToPrimaryAction}
-          disabled={
-            downloadZipInstead
-              ? !activeFile || codingHandoffLoading
-              : codingHandoffLoading
-          }
+          onClick={() => void handleCopyCodingHandoff()}
+          disabled={codingHandoffLoading}
           className="h-8 gap-1.5 rounded-md px-3 text-[12px]"
         >
-          {downloadZipInstead ? (
-            <IconArchive className="size-3.5" />
-          ) : (
-            <IconClipboard className="size-3.5" />
-          )}
-          {
-            downloadZipInstead
-              ? t("designEditor.downloadZip")
-              : "Copy agent prompt" /* i18n-ignore share send action */
-          }
+          <IconClipboard className="size-3.5" />
+          {"Copy agent prompt" /* i18n-ignore share send action */}
         </Button>
-      </div>
-
-      <div className="space-y-3">
-        <div className="flex items-start gap-2.5">
-          <Checkbox
-            checked={downloadZipInstead}
-            onCheckedChange={(checked) =>
-              setDownloadZipInstead(checked === true)
-            }
-            className="mt-0.5"
-          />
-          <div className="min-w-0">
-            <div className="text-[12px] font-medium text-foreground">
-              {"Download zip instead" /* i18n-ignore share send option */}
-            </div>
-            <div className="mt-0.5 !text-[11px] leading-4 text-muted-foreground">
-              {
-                "For agents without the Design connector, drop the bundle into your agent's chat manually." /* i18n-ignore share send option description */
-              }
-            </div>
-          </div>
-        </div>
-
-        <div className="space-y-1.5">
-          <label className="text-[12px] font-medium text-foreground">
-            {
-              "Give the agent more detail on what to implement" /* i18n-ignore share send detail label */
-            }{" "}
-            <span className="font-normal text-muted-foreground">
-              {"(optional)" /* i18n-ignore optional label */}
-            </span>
-          </label>
-          <Textarea
-            value={codingHandoffDetail}
-            onChange={(event) => setCodingHandoffDetail(event.target.value)}
-            placeholder={activeFile?.filename ?? "Add implementation notes..."}
-            className="min-h-20 resize-none rounded-md bg-[var(--design-editor-control-bg)] text-[12px]"
-          />
-        </div>
       </div>
     </div>
   );
+  const shareLinkFooter = (
+    <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-[var(--design-editor-panel-divider-color)] pt-3">
+      <Button
+        type="button"
+        onClick={() => void handleCopyShareLink()}
+        disabled={!editorShareUrl}
+        className="h-8 min-w-[8.75rem] gap-1.5 rounded-md px-3 text-[12px]"
+      >
+        {shareLinkCopied ? (
+          <IconCheck className="size-3.5" />
+        ) : (
+          <IconClipboard className="size-3.5" />
+        )}
+        {
+          shareLinkCopied
+            ? "Copied" /* i18n-ignore share copy action copied */
+            : "Copy share link" /* i18n-ignore share copy action */
+        }
+      </Button>
+    </div>
+  );
+  const designShareTabLabelClassName =
+    "inline-flex items-center justify-center gap-1.5";
   const designSharePopoverClassName =
     "z-[100010] !w-[min(620px,calc(100vw-32px))] !p-3 " +
-    "[&_[role=tablist]]:!inline-flex [&_[role=tablist]]:!w-fit [&_[role=tablist]]:!self-start [&_[role=tablist]]:justify-start [&_[role=tablist]]:gap-0.5 [&_[role=tablist]]:rounded-none [&_[role=tablist]]:bg-transparent [&_[role=tablist]]:p-0 " +
-    "[&_[role=tab]]:!h-6 [&_[role=tab]]:!flex-none [&_[role=tab]]:rounded-md [&_[role=tab]]:px-2 [&_[role=tab]]:!text-[11px] [&_[role=tab]]:font-semibold [&_[role=tab]]:shadow-none [&_[role=tab]]:ring-0 " +
-    "[&_[role=tab]:hover]:bg-[var(--design-editor-panel-raised-bg)] [&_[role=tab]:hover]:text-foreground [&_[role=tab][aria-selected=true]]:bg-[var(--design-editor-panel-raised-bg)] [&_[role=tab][aria-selected=true]]:text-foreground [&_[role=tab][aria-selected=true]]:ring-0";
+    "[&_[role=tablist]]:!inline-flex [&_[role=tablist]]:!w-fit [&_[role=tablist]]:!self-start [&_[role=tablist]]:justify-start [&_[role=tablist]]:gap-1 [&_[role=tablist]]:rounded-lg [&_[role=tablist]]:border [&_[role=tablist]]:border-[var(--design-editor-panel-divider-color)] [&_[role=tablist]]:bg-[var(--design-editor-panel-raised-bg)] [&_[role=tablist]]:p-1 " +
+    "[&_[role=tab]]:!h-8 [&_[role=tab]]:!flex-none [&_[role=tab]]:rounded-md [&_[role=tab]]:px-3 [&_[role=tab]]:!text-[12px] [&_[role=tab]]:font-semibold [&_[role=tab]]:shadow-none [&_[role=tab]]:ring-0 " +
+    "[&_[role=tab]:hover]:bg-white/70 dark:[&_[role=tab]:hover]:bg-[var(--design-editor-control-bg)] [&_[role=tab]:hover]:text-foreground " +
+    "[&_[role=tab][aria-selected=true]]:bg-white dark:[&_[role=tab][aria-selected=true]]:bg-[var(--design-editor-control-bg)] [&_[role=tab][aria-selected=true]]:text-foreground [&_[role=tab][aria-selected=true]]:shadow-sm [&_[role=tab][aria-selected=true]]:ring-1 [&_[role=tab][aria-selected=true]]:ring-[var(--design-editor-control-border)]";
   const designShareTabs = {
-    shareLabel: "Share link" /* i18n-ignore share tab label */,
+    shareLabel: (
+      <span className={designShareTabLabelClassName}>
+        <IconLink className="size-3.5" />
+        {"Share link" /* i18n-ignore share tab label */}
+      </span>
+    ),
     defaultValue: "share",
     tabs: [
       {
         value: "export",
-        label: t("designEditor.export"),
+        label: (
+          <span className={designShareTabLabelClassName}>
+            <IconFileExport className="size-3.5" />
+            {t("designEditor.export")}
+          </span>
+        ),
         content: shareExportTab,
       },
       {
         value: "send",
-        label: "Send to agent" /* i18n-ignore share tab label */,
+        label: (
+          <span className={designShareTabLabelClassName}>
+            <IconTerminal2 className="size-3.5" />
+            {"Send to agent" /* i18n-ignore share tab label */}
+          </span>
+        ),
         content: shareSendToTab,
       },
     ],
@@ -15480,6 +15503,9 @@ ${serializedHtml}
               shareUrl={editorShareUrl}
               shareUrlLabel={t("designEditor.shareEditorLink")}
               shareUrlDescription={t("designEditor.shareEditorLinkDescription")}
+              showShareLinks={false}
+              showDoneButton={false}
+              shareFooterContent={shareLinkFooter}
               shareTabs={designShareTabs}
               popoverClassName={designSharePopoverClassName}
               triggerClassName="h-8 rounded-md !border-[var(--design-editor-accent-color)] !bg-[var(--design-editor-accent-color)] px-3 text-sm !text-[var(--design-editor-accent-contrast-color)] shadow-none hover:!border-[var(--design-editor-accent-hover-color)] hover:!bg-[var(--design-editor-accent-hover-color)] hover:!text-[var(--design-editor-accent-contrast-color)] focus-visible:ring-[var(--design-editor-accent-color)] [&_svg]:!text-[var(--design-editor-accent-contrast-color)]"
@@ -15879,6 +15905,9 @@ ${serializedHtml}
                 shareUrlDescription={t(
                   "designEditor.shareEditorLinkDescription",
                 )}
+                showShareLinks={false}
+                showDoneButton={false}
+                shareFooterContent={shareLinkFooter}
                 shareTabs={designShareTabs}
                 popoverClassName={designSharePopoverClassName}
                 triggerClassName="h-8 rounded-md !border-[var(--design-editor-accent-color)] !bg-[var(--design-editor-accent-color)] px-3 !text-[var(--design-editor-accent-contrast-color)] shadow-none hover:!border-[var(--design-editor-accent-hover-color)] hover:!bg-[var(--design-editor-accent-hover-color)] hover:!text-[var(--design-editor-accent-contrast-color)] focus-visible:ring-[var(--design-editor-accent-color)] [&_svg]:!text-[var(--design-editor-accent-contrast-color)]"
@@ -16196,7 +16225,7 @@ ${serializedHtml}
                       }}
                     />
                   )}
-                  {pendingVisualStyleEdits.length > 0 ? (
+                  {showPendingVisualStyleApply ? (
                     <div className="pointer-events-none absolute bottom-5 right-5 z-[70] flex items-end">
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>

--- a/templates/design/changelog/2026-06-30-agent-chat-now-reports-saved-design-generations-clearly-when.md
+++ b/templates/design/changelog/2026-06-30-agent-chat-now-reports-saved-design-generations-clearly-when.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-06-30
+---
+
+Agent chat now reports saved Design generations clearly when only the final assistant note times out.

--- a/templates/design/changelog/2026-06-30-apply-styles-now-appears-only-for-localhost-visual-edit-scre.md
+++ b/templates/design/changelog/2026-06-30-apply-styles-now-appears-only-for-localhost-visual-edit-scre.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-06-30
+---
+
+Apply styles now appears only for localhost visual-edit screens.

--- a/templates/design/changelog/2026-06-30-share-options-now-make-export-and-agent-handoff-easier-to-no.md
+++ b/templates/design/changelog/2026-06-30-share-options-now-make-export-and-agent-handoff-easier-to-no.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-06-30
+---
+
+Share options now make link sharing, export, and agent handoff easier to notice while keeping the dialog cleaner.

--- a/templates/design/changelog/2026-07-01-share-general-access-menu-stays-open-when-choosing-organization.md
+++ b/templates/design/changelog/2026-07-01-share-general-access-menu-stays-open-when-choosing-organization.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-01
+---
+
+Share general access options now appear above the dialog when switching a design from private to organization access.

--- a/templates/design/e2e/editor.spec.ts
+++ b/templates/design/e2e/editor.spec.ts
@@ -82,6 +82,28 @@ test("share dialog uses compact editor panel chrome", async ({
     650,
   );
 
+  await page.getByRole("tab", { name: "Share link" }).click();
+  await page.getByRole("button", { name: "General access" }).click();
+  await expect(
+    page.getByRole("option", { name: /Organization/ }),
+  ).toBeVisible();
+  await expect(shareOptions).toBeVisible();
+  const accessMenu = page
+    .locator("[data-radix-popper-content-wrapper]")
+    .filter({ has: page.getByRole("option", { name: /Organization/ }) })
+    .last();
+  await expect(accessMenu).toBeVisible();
+  const sharePopoverZ = Number.parseInt(
+    (await popover.evaluate((node) => getComputedStyle(node).zIndex)) || "0",
+    10,
+  );
+  const accessMenuZ = Number.parseInt(
+    (await accessMenu.evaluate((node) => getComputedStyle(node).zIndex)) || "0",
+    10,
+  );
+  expect(accessMenuZ).toBeGreaterThan(sharePopoverZ);
+  await page.keyboard.press("Escape");
+
   await cdpScreenshot(page, testInfo.outputPath("share-dialog-compact.png"));
 });
 


### PR DESCRIPTION
## Summary
- mark completed mutating tool calls so timeout recovery can distinguish saved side effects from failed work
- keep completed tool cards visible, remove stale 40s timeout copy, and show clear saved-result warnings instead of silent connection failures
- tighten Design share panel controls and nested share menu stacking

## Validation
- corepack pnpm --filter @agent-native/core exec vitest run src/agent/run-loop-with-resume.spec.ts src/client/agent-chat-adapter.spec.ts src/client/sse-event-processor.spec.ts
- corepack pnpm --filter @agent-native/core exec vitest run src/agent/production-agent.spec.ts src/agent/run-manager.spec.ts src/server/agent-chat-plugin.a2a.spec.ts src/client/sharing/ShareButton.spec.tsx
- corepack pnpm --filter @agent-native/core typecheck
- corepack pnpm --filter design exec vitest run app/pages/DesignEditor.selection.test.ts
- corepack pnpm --filter design typecheck
- git diff --check

Note: local Design Playwright smoke was attempted after repairing a corrupted node_modules install, but the dev server hung during cold boot after a transient Nitro 503. Production verification will be the decisive check for the reported hosted failure.
