### PR TITLE
Pin nf3 for Node 22 hosted builds

### DIFF
--- a/.changeset/pin-nf3-node22-builds.md
+++ b/.changeset/pin-nf3-node22-builds.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Pin Nitro's `nf3` tracer dependency to a Node 22-compatible release so downstream package updates continue to build hosted apps.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -257,6 +257,7 @@
     "minimatch": "^10.0.0",
     "nanoid": "^5.1.9",
     "next-themes": "^0.4.6",
+    "nf3": "0.3.17",
     "nitro": "3.0.260415-beta",
     "p-limit": "^7.3.0",
     "prettier": "^3.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,6 +368,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      nf3:
+        specifier: 0.3.17
+        version: 0.3.17
       nitro:
         specifier: 3.0.260415-beta
         version: 3.0.260415-beta(@libsql/client@0.15.15)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(kysely@0.28.17)(postgres@3.4.9))(jiti@2.6.1)(lru-cache@11.5.1)(rollup@4.62.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.81.0)


### PR DESCRIPTION
## Summary
- pin `nf3` to `0.3.17` as a direct `@agent-native/core` dependency so Nitro resolves the Node 22-compatible tracer
- add a patch changeset for `@agent-native/core`

## Verification
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter @agent-native/core typecheck`
- `git diff --check`
- Node 22 consumer simulation resolving `nf3@0.3.17` and importing `dist/_chunks/trace.mjs` successfully

This unblocks the downstream builder workspace package updater failure where `nf3@0.3.18` imported `nodeFileTrace` from `@vercel/nft` under Node 22.