### PR TITLE
Surface unfinished agent tool actions

### DIFF
--- a/.agents/plugins/agent-native-design/.codex-plugin/plugin.json
+++ b/.agents/plugins/agent-native-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-native-design",
-  "version": "1.0.0+codex.4d6c28e750db",
+  "version": "1.0.0+codex.62831ce71a2d",
   "description": "Explore, compare, iterate, and export interactive UI design prototypes from the Design app.",
   "author": { "name": "Agent-Native", "url": "https://agent-native.com" },
   "homepage": "https://design.agent-native.com",

--- a/.agents/plugins/agent-native-design/skills/design-exploration/SKILL.md
+++ b/.agents/plugins/agent-native-design/skills/design-exploration/SKILL.md
@@ -17,11 +17,13 @@ iteration, or a human-in-the-loop choice among design directions.
 
 - Use `create-design` first to create a project shell. Do not report the
   design as ready until it has renderable HTML.
-- For open-ended UX exploration, generate distinct, complete HTML directions
-  (2-5, three by default) and call `present-design-variants`. Design saves
-  every option as a normal screen on the overview board and renders an inline
-  chat choice with one button per screen name. After the user picks, delete the
-  unchosen variant screens and continue from the kept screen.
+- For open-ended UX exploration, generate distinct, compact, complete HTML
+  directions (2-5, three by default) and call `present-design-variants`. Each
+  direction should be one representative screen or directional snapshot, not a
+  full app per variant. Design saves every option as a normal screen on the
+  overview board and renders an inline chat choice with one button per screen
+  name. After the user picks, delete the unchosen variant screens and continue
+  from the kept screen.
 - If the chat choice buttons are not available in the host, ask the user to
   tell you the screen name they prefer. The variants are already real screens
   on the board, so do not ask them to paste HTML or copy a generated handoff
@@ -38,8 +40,8 @@ iteration, or a human-in-the-loop choice among design directions.
 1. Default to three variants unless the user asks for a different count
    (`present-design-variants` accepts 2-5; three is the sweet spot).
 2. Make variants structurally and stylistically distinct, not just color swaps.
-3. Each variant must be a complete standalone HTML document that renders
-   without a build step.
+3. Each variant must be a compact, complete standalone HTML document that
+   renders without a build step.
 4. For product UI redesigns, prefer cleaner hierarchy, progressive disclosure,
    and realistic controls over decorative mockups.
 5. After `present-design-variants`, wait for the user's pick before

--- a/.changeset/loud-unstarted-tool-actions.md
+++ b/.changeset/loud-unstarted-tool-actions.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Surface an explicit chat error when an agent stops before a displayed tool action starts or returns a result, and keep Design variant generation prompts compact enough to finish.

--- a/.changeset/pin-nf3-node22-builds.md
+++ b/.changeset/pin-nf3-node22-builds.md
@@ -1,5 +1,0 @@
----
-"@agent-native/core": patch
----
-
-Pin Nitro's `nf3` tracer dependency to a Node 22-compatible release so downstream package updates continue to build hosted apps.

--- a/.changeset/pin-nf3-node22-builds.md
+++ b/.changeset/pin-nf3-node22-builds.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Pin Nitro's `nf3` tracer dependency to a Node 22-compatible release so downstream package updates continue to build hosted apps.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @agent-native/core
 
+## 0.84.4
+
+### Patch Changes
+
+- 61715b4: Pin Nitro's `nf3` tracer dependency to a Node 22-compatible release so downstream package updates continue to build hosted apps.
+
 ## 0.84.3
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.84.3",
+  "version": "0.84.4",
   "description": "Framework for agent-native application development — where AI agents and UI share SQL state, actions, and context",
   "homepage": "https://github.com/BuilderIO/agent-native#readme",
   "bugs": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -257,6 +257,7 @@
     "minimatch": "^10.0.0",
     "nanoid": "^5.1.9",
     "next-themes": "^0.4.6",
+    "nf3": "0.3.17",
     "nitro": "3.0.260415-beta",
     "p-limit": "^7.3.0",
     "prettier": "^3.8.3",

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -322,11 +322,13 @@ iteration, or a human-in-the-loop choice among design directions.
 
 - Use \`create-design\` first to create a project shell. Do not report the
   design as ready until it has renderable HTML.
-- For open-ended UX exploration, generate distinct, complete HTML directions
-  (2-5, three by default) and call \`present-design-variants\`. Design saves
-  every option as a normal screen on the overview board and renders an inline
-  chat choice with one button per screen name. After the user picks, delete the
-  unchosen variant screens and continue from the kept screen.
+- For open-ended UX exploration, generate distinct, compact, complete HTML
+  directions (2-5, three by default) and call \`present-design-variants\`. Each
+  direction should be one representative screen or directional snapshot, not a
+  full app per variant. Design saves every option as a normal screen on the
+  overview board and renders an inline chat choice with one button per screen
+  name. After the user picks, delete the unchosen variant screens and continue
+  from the kept screen.
 - If the chat choice buttons are not available in the host, ask the user to
   tell you the screen name they prefer. The variants are already real screens
   on the board, so do not ask them to paste HTML or copy a generated handoff
@@ -343,8 +345,8 @@ iteration, or a human-in-the-loop choice among design directions.
 1. Default to three variants unless the user asks for a different count
    (\`present-design-variants\` accepts 2-5; three is the sweet spot).
 2. Make variants structurally and stylistically distinct, not just color swaps.
-3. Each variant must be a complete standalone HTML document that renders
-   without a build step.
+3. Each variant must be a compact, complete standalone HTML document that
+   renders without a build step.
 4. For product UI redesigns, prefer cleaner hierarchy, progressive disclosure,
    and realistic controls over decorative mockups.
 5. After \`present-design-variants\`, wait for the user's pick before

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -1814,7 +1814,7 @@ export function createAgentChatAdapter(
           }
           const isTransient = signal.reason !== "loop_limit";
           const visibleContent = visibleContentForContinuation();
-          const currentPartialHistory =
+          let currentPartialHistory =
             contentToContinuationHistory(visibleContent);
           // Real, content-weight progress: streamed text or a completed tool
           // result. Used to reset the stalled/empty counters so trivial
@@ -1983,6 +1983,18 @@ export function createAgentChatAdapter(
                 MAX_TOTAL_TRANSIENT_CONTINUATIONS
             ) {
               return { ok: false, resetVisibleContent: false };
+            }
+          }
+
+          if (isTransient) {
+            const settledInterruptedTools = settleInterruptedToolCalls(
+              visibleContent,
+              undefined,
+              { includeActivity: true },
+            );
+            if (settledInterruptedTools) {
+              currentPartialHistory =
+                contentToContinuationHistory(visibleContent);
             }
           }
 

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -563,7 +563,7 @@ describe("SSE event processor error classification", () => {
     );
   });
 
-  it("renders tool-scoped activity as a pending tool call", async () => {
+  it("errors when a terminal stream leaves tool-scoped activity unresolved", async () => {
     const dispatchEvent = vi.fn();
     vi.stubGlobal("window", { dispatchEvent });
     vi.stubGlobal(
@@ -625,8 +625,17 @@ describe("SSE event processor error classification", () => {
             argsText: "",
             args: {},
             activity: true,
+            result: "Stopped before this action started.",
           }),
+          {
+            type: "text",
+            text: "Error: The agent stopped before starting the create document action. No tool result was returned, so the requested changes were not made.",
+          },
         ],
+        status: {
+          type: "incomplete",
+          reason: "error",
+        },
         metadata: {
           custom: {
             activityTrail: [
@@ -635,6 +644,13 @@ describe("SSE event processor error classification", () => {
                 tool: "create-document",
               },
             ],
+            runError: {
+              message:
+                "The agent stopped before starting the create document action. No tool result was returned, so the requested changes were not made.",
+              details: "interrupted_actions: create-document",
+              errorCode: "action_not_started",
+              recoverable: true,
+            },
           },
         },
       },
@@ -697,6 +713,11 @@ describe("SSE event processor error classification", () => {
             tool: "generate-design",
             input: { designId: "design-1" },
           },
+          {
+            type: "tool_done",
+            tool: "generate-design",
+            result: '{"saved":true}',
+          },
           { type: "done" },
         ]),
         [],
@@ -722,6 +743,89 @@ describe("SSE event processor error classification", () => {
         args: { designId: "design-1" },
       }),
     ]);
+    expect(results[2].content).toEqual([
+      expect.objectContaining({
+        type: "tool-call",
+        toolName: "generate-design",
+        result: '{"saved":true}',
+      }),
+    ]);
+  });
+
+  it("errors when a terminal stream leaves a started tool unresolved", async () => {
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+    const results = await drain(
+      readSSEStream(
+        eventStream([
+          {
+            type: "tool_start",
+            tool: "present-design-variants",
+            input: { designId: "design-1" },
+          },
+          { type: "done" },
+        ]),
+        [],
+        { value: 0 },
+        "tab-unfinished-tool",
+      ),
+    );
+
+    expect(results.at(-1)).toEqual({
+      content: [
+        expect.objectContaining({
+          type: "tool-call",
+          toolName: "present-design-variants",
+          result: "Interrupted before this tool returned a result.",
+        }),
+        {
+          type: "text",
+          text: "Error: The agent stopped before the present design variants action returned a result. The requested changes may not have been made.",
+        },
+      ],
+      status: {
+        type: "incomplete",
+        reason: "error",
+      },
+      metadata: {
+        custom: {
+          activityTrail: [
+            {
+              label: "Running present design variants",
+              tool: "present-design-variants",
+            },
+          ],
+          runError: {
+            message:
+              "The agent stopped before the present design variants action returned a result. The requested changes may not have been made.",
+            details: "interrupted_actions: present-design-variants",
+            errorCode: "action_not_started",
+            recoverable: true,
+          },
+        },
+      },
+    });
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "agent-chat:run-error",
+        detail: expect.objectContaining({
+          errorCode: "action_not_started",
+          tabId: "tab-unfinished-tool",
+        }),
+      }),
+    );
   });
 
   it("clears visible activity when the server clears a corrective draft", async () => {

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -7,7 +7,11 @@ import {
 } from "../agent/engine/credential-errors.js";
 import type { AgentMcpAppPayload } from "../mcp-client/app-result.js";
 import { formatChatErrorText, normalizeChatError } from "./error-format.js";
-import { humanizeToolLabelText, runningToolLabel } from "./tool-display.js";
+import {
+  humanizeToolLabelText,
+  humanizeToolName,
+  runningToolLabel,
+} from "./tool-display.js";
 
 export type ContentPart =
   | { type: "text"; text: string }
@@ -339,6 +343,42 @@ function dispatchActivityClear(tabId: string | undefined) {
       detail: { tabId },
     }),
   );
+}
+
+function pendingToolNames(content: ContentPart[]): {
+  activity: string[];
+  running: string[];
+} {
+  const activity = new Set<string>();
+  const running = new Set<string>();
+  for (const part of content) {
+    if (part.type === "tool-call" && part.result === undefined) {
+      if (part.activity === true) {
+        activity.add(part.toolName);
+      } else {
+        running.add(part.toolName);
+      }
+    }
+  }
+  return { activity: [...activity], running: [...running] };
+}
+
+function formatToolNames(tools: string[]): string {
+  const names = tools.map(humanizeToolName);
+  if (names.length === 0) return "the promised action";
+  if (names.length === 1) return `the ${names[0]} action`;
+  return `these actions: ${names.join(", ")}`;
+}
+
+function interruptedToolMessage(pending: {
+  activity: string[];
+  running: string[];
+}): string {
+  if (pending.running.length > 0) {
+    return `The agent stopped before ${formatToolNames(pending.running)} returned a result. The requested changes may not have been made.`;
+  }
+  const actionLabel = formatToolNames(pending.activity);
+  return `The agent stopped before starting ${actionLabel}. No tool result was returned, so the requested changes were not made.`;
 }
 
 /**
@@ -751,6 +791,40 @@ export function processEvent(
   }
 
   if (ev.type === "done") {
+    const interruptedTools = pendingToolNames(content);
+    const allInterruptedTools = [
+      ...interruptedTools.running,
+      ...interruptedTools.activity,
+    ];
+    if (allInterruptedTools.length > 0) {
+      settleInterruptedToolCalls(content, undefined, { includeActivity: true });
+      const message = interruptedToolMessage(interruptedTools);
+      const runError = {
+        message,
+        details: `interrupted_actions: ${allInterruptedTools.join(", ")}`,
+        errorCode: "action_not_started",
+        recoverable: true,
+      };
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(
+          new CustomEvent("agent-chat:run-error", {
+            detail: { ...runError, tabId },
+          }),
+        );
+      }
+      content.push({
+        type: "text",
+        text: formatChatErrorText(message, undefined, runError.errorCode),
+      });
+      return {
+        action: "error",
+        result: {
+          content: [...content],
+          status: { type: "incomplete" as const, reason: "error" as const },
+          metadata: { custom: { runError } },
+        } as ChatModelRunResult,
+      };
+    }
     return {
       action: "done",
       result: { content: [...content] } as ChatModelRunResult,

--- a/packages/skills/CHANGELOG.md
+++ b/packages/skills/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @agent-native/skills
 
+## 0.2.178
+
+### Patch Changes
+
+- Updated dependencies [61715b4]
+  - @agent-native/core@0.84.4
+
 ## 0.2.177
 
 ### Patch Changes

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/skills",
-  "version": "0.2.177",
+  "version": "0.2.178",
   "description": "Install BuilderIO skills for coding agents.",
   "homepage": "https://github.com/BuilderIO/agent-native#readme",
   "bugs": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,6 +368,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      nf3:
+        specifier: 0.3.17
+        version: 0.3.17
       nitro:
         specifier: 3.0.260415-beta
         version: 3.0.260415-beta(@libsql/client@0.15.15)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(kysely@0.28.17)(postgres@3.4.9))(jiti@2.6.1)(lru-cache@11.5.1)(rollup@4.62.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.81.0)

--- a/skills/design-exploration/SKILL.md
+++ b/skills/design-exploration/SKILL.md
@@ -17,11 +17,13 @@ iteration, or a human-in-the-loop choice among design directions.
 
 - Use `create-design` first to create a project shell. Do not report the
   design as ready until it has renderable HTML.
-- For open-ended UX exploration, generate distinct, complete HTML directions
-  (2-5, three by default) and call `present-design-variants`. Design saves
-  every option as a normal screen on the overview board and renders an inline
-  chat choice with one button per screen name. After the user picks, delete the
-  unchosen variant screens and continue from the kept screen.
+- For open-ended UX exploration, generate distinct, compact, complete HTML
+  directions (2-5, three by default) and call `present-design-variants`. Each
+  direction should be one representative screen or directional snapshot, not a
+  full app per variant. Design saves every option as a normal screen on the
+  overview board and renders an inline chat choice with one button per screen
+  name. After the user picks, delete the unchosen variant screens and continue
+  from the kept screen.
 - If the chat choice buttons are not available in the host, ask the user to
   tell you the screen name they prefer. The variants are already real screens
   on the board, so do not ask them to paste HTML or copy a generated handoff
@@ -38,8 +40,8 @@ iteration, or a human-in-the-loop choice among design directions.
 1. Default to three variants unless the user asks for a different count
    (`present-design-variants` accepts 2-5; three is the sweet spot).
 2. Make variants structurally and stylistically distinct, not just color swaps.
-3. Each variant must be a complete standalone HTML document that renders
-   without a build step.
+3. Each variant must be a compact, complete standalone HTML document that
+   renders without a build step.
 4. For product UI redesigns, prefer cleaner hierarchy, progressive disclosure,
    and realistic controls over decorative mockups.
 5. After `present-design-variants`, wait for the user's pick before

--- a/templates/design/AGENTS.md
+++ b/templates/design/AGENTS.md
@@ -133,8 +133,9 @@ patterns live in `.agents/skills/`.
   write-back remains a localhost/fusion follow-up capability.
 - For multi-variant work, use `present-design-variants` so every candidate is
   saved as a normal overview-board screen and the user gets one inline chat
-  button per screen name. After the user picks, delete the unchosen variant
-  screens before continuing from the kept screen.
+  button per screen name. Keep each variant compact: one representative screen
+  or directional snapshot, not a full app per variant. After the user picks,
+  delete the unchosen variant screens before continuing from the kept screen.
 - Use framework sharing actions for design and design-system visibility/grants.
 - `/visual-edit` is a public entry route and public `/design/:id` links may
   render read-only public designs without a session. Do not open anonymous write
@@ -217,10 +218,10 @@ patterns live in `.agents/skills/`.
   register that manifest with `connect-localhost`, call `add-localhost-screens`,
   and open the editor in overview mode.
 - For human-in-the-loop UI exploration, create a design shell, call
-  `present-design-variants` with 2-5 complete HTML directions (three by
-  default), wait for the user to pick one in chat, delete the other generated
-  variant screens with `delete-file`, then use `get-design-snapshot` and
-  `generate-design` or `edit-design` for follow-up refinements.
+  `present-design-variants` with 2-5 compact, complete HTML directions (three
+  by default), wait for the user to pick one in chat, delete the other
+  generated variant screens with `delete-file`, then use `get-design-snapshot`
+  and `generate-design` or `edit-design` for follow-up refinements.
 - If inline chat choice buttons are unavailable, the user can tell you the
   preferred screen name. Do not show a separate variant picker or ask them to
   paste a copyable handoff summary.

--- a/templates/design/actions/present-design-variants.ts
+++ b/templates/design/actions/present-design-variants.ts
@@ -52,7 +52,7 @@ const variantSchema = z.object({
     .string()
     .min(1)
     .describe(
-      "Complete self-contained HTML document for this variant. Inline the CSS needed for the preview; avoid relying on external CSS/script CDNs because app sandboxes may block them.",
+      "Complete self-contained HTML document for this variant. Keep it compact: one representative screen or directional snapshot, not a full multi-screen app. Inline the CSS needed for the preview; avoid relying on external CSS/script CDNs because app sandboxes may block them.",
     ),
   width: z
     .number()
@@ -227,7 +227,9 @@ export default defineAction({
     "Provide 2-5 variants (3 is the sweet spot). Use this for design " +
     "exploration before follow-up refinement. After the user's choice, keep " +
     "the chosen screen, delete the other generated variant screens, and " +
-    "continue from the kept screen.",
+    "continue from the kept screen. For complex apps, make each variant a " +
+    "compact but complete representative screen; expand the chosen direction " +
+    "after the user picks.",
   schema: z.object({
     designId: z.string().describe("Design project ID to show variants for"),
     prompt: z

--- a/templates/design/app/hooks/use-question-flow.ts
+++ b/templates/design/app/hooks/use-question-flow.ts
@@ -41,7 +41,7 @@ export function useQuestionFlow(
         formattedAnswers,
         "",
         designId
-          ? "Now continue the design. Honor any answer about variations: if the user asked to explore options, call present-design-variants with 2-5 complete HTML directions, wait for their chat pick, delete the unchosen variant screens, then continue from the kept screen; otherwise call generate-design with one complete, renderable index.html first. Do not ask another question unless a required decision is still genuinely missing."
+          ? "Now continue the design. Honor any answer about variations: if the user asked to explore options, call present-design-variants with 2-5 compact, complete HTML directions - one representative screen per direction, not a full app per variant - wait for their chat pick, delete the unchosen variant screens, then continue from the kept screen; otherwise call generate-design with one complete, renderable index.html first. Do not ask another question unless a required decision is still genuinely missing."
           : "Now continue the design. Honor any answer about variations: use variants only if requested; otherwise generate one polished direction.",
       ]
         .filter(Boolean)
@@ -79,7 +79,7 @@ export function useQuestionFlow(
         formattedAnswers,
         "",
         designId
-          ? "Now continue the design. Honor any answer about variations: if the user asked to explore options, call present-design-variants with 2-5 complete HTML directions, wait for their chat pick, delete the unchosen variant screens, then continue from the kept screen; otherwise call generate-design with one complete, renderable index.html first. Do not ask another question unless a required decision is still genuinely missing."
+          ? "Now continue the design. Honor any answer about variations: if the user asked to explore options, call present-design-variants with 2-5 compact, complete HTML directions - one representative screen per direction, not a full app per variant - wait for their chat pick, delete the unchosen variant screens, then continue from the kept screen; otherwise call generate-design with one complete, renderable index.html first. Do not ask another question unless a required decision is still genuinely missing."
           : "Now continue the design. Honor any answer about variations: use variants only if requested; otherwise generate one polished direction.",
       ]
         .filter(Boolean)

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -1309,7 +1309,7 @@ function designGenerationDirectives(
   return [
     `Use the \`generate-design --designId="${designId}"\` action with exactly one complete, renderable \`index.html\` file first. The design already exists - DO NOT call create-design.`,
     ...designSystemGenerationDirectives(designSystemId),
-    "If the user asked to explore variations, call `present-design-variants` with 2-5 complete HTML directions, wait for their chat pick, delete the unchosen variant screens, then continue from the kept screen. Otherwise generate one polished first direction.",
+    "If the user asked to explore variations, call `present-design-variants` with 2-5 compact, complete HTML directions: one representative screen per direction, not a full app per variant. Wait for their chat pick, delete the unchosen variant screens, then continue from the kept screen. Otherwise generate one polished first direction.",
     "Keep the first pass bounded enough to finish quickly: one self-contained Alpine.js + Tailwind CDN HTML document, polished but concise. Add 3-6 tweaks only when they naturally fit the design.",
     "After generate-design succeeds, stop and summarize what was created.",
   ];


### PR DESCRIPTION
## Summary
- fail terminal agent streams loudly when a displayed tool action never starts or never returns a result
- settle interrupted tool cards before auto-continuing so later successful continuations are not poisoned by old pending cards
- guide Design variant generation toward compact representative screens so multi-variant tool calls are more likely to finish before refinement

## Validation
- corepack pnpm --dir packages/core exec vitest --run src/client/sse-event-processor.spec.ts src/client/agent-chat-adapter.spec.ts
- corepack pnpm --filter @agent-native/core typecheck
- corepack pnpm --dir templates/design exec vitest --run actions/present-design-variants.spec.ts
- corepack pnpm exec oxfmt --check templates/design/actions/present-design-variants.ts templates/design/app/pages/DesignEditor.tsx templates/design/app/hooks/use-question-flow.ts packages/core/src/client/agent-chat-adapter.ts packages/core/src/client/sse-event-processor.ts packages/core/src/client/sse-event-processor.spec.ts
- git diff --check