### PR TITLE
Claim background chat runs before setup

### DIFF
--- a/.changeset/early-background-run-claim.md
+++ b/.changeset/early-background-run-claim.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Claim durable background agent-chat runs before expensive worker setup so hosted apps stay on the 15-minute background-function path instead of falling back to 40-second inline chunks.

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -16,6 +16,7 @@ import { EngineError } from "./engine/types.js";
 import {
   AGENT_INTERNAL_CONTINUE_PROMPT,
   buildUserContentWithAttachments,
+  claimBackgroundWorkerRunEarly,
   createPlanModeActionRegistry,
   isPlanModeToolCallAllowed,
   isContextTooLongError,
@@ -4072,6 +4073,114 @@ describe("shouldChainBackgroundContinuation (server-driven background chain)", (
         continuationCount: MAX_BACKGROUND_RUN_CONTINUATIONS - 1,
       }),
     ).toBe(true);
+  });
+});
+
+describe("claimBackgroundWorkerRunEarly", () => {
+  function deps(claimResult = true) {
+    const calls: string[] = [];
+    return {
+      calls,
+      recordRunDiagnostic: vi.fn(async (_runId: string, stage: string) => {
+        calls.push(`record:${stage}`);
+      }),
+      insertRun: vi.fn(
+        async (
+          _runId: string,
+          _threadId: string,
+          _turnId: string,
+          _options?: { dispatchMode?: "foreground" | "background" },
+        ) => {
+          calls.push("insert");
+        },
+      ),
+      claimBackgroundRun: vi.fn(async (_runId: string) => {
+        calls.push("claim");
+        return claimResult;
+      }),
+      updateRunHeartbeat: vi.fn(async (_runId: string) => {
+        calls.push("heartbeat");
+      }),
+    };
+  }
+
+  it("claims the first background chunk before expensive setup can race foreground fallback", async () => {
+    const d = deps();
+
+    await expect(
+      claimBackgroundWorkerRunEarly({
+        runId: "run-bg",
+        threadId: "thread-bg",
+        markerTurnId: "turn-bg",
+        continuationCount: 0,
+        runsInBackgroundFunction: true,
+        deps: d,
+      }),
+    ).resolves.toEqual({ claimed: true });
+
+    expect(d.insertRun).not.toHaveBeenCalled();
+    expect(d.calls).toEqual([
+      "record:worker_entered",
+      "claim",
+      "record:worker_claimed",
+      "heartbeat",
+    ]);
+    expect(d.recordRunDiagnostic).toHaveBeenNthCalledWith(
+      1,
+      "run-bg",
+      "worker_entered",
+      "runsInBackgroundFunction=true continuationCount=0",
+    );
+  });
+
+  it("inserts a chained background continuation row before claiming it", async () => {
+    const d = deps();
+
+    await expect(
+      claimBackgroundWorkerRunEarly({
+        runId: "run-next",
+        threadId: "thread-next",
+        markerTurnId: "turn-next",
+        continuationCount: 2,
+        runsInBackgroundFunction: true,
+        deps: d,
+      }),
+    ).resolves.toEqual({ claimed: true });
+
+    expect(d.insertRun).toHaveBeenCalledWith(
+      "run-next",
+      "thread-next",
+      "turn-next",
+      { dispatchMode: "background" },
+    );
+    expect(d.calls).toEqual([
+      "record:worker_entered",
+      "insert",
+      "claim",
+      "record:worker_claimed",
+      "heartbeat",
+    ]);
+  });
+
+  it("records duplicate deliveries and does not heartbeat or execute the turn", async () => {
+    const d = deps(false);
+
+    await expect(
+      claimBackgroundWorkerRunEarly({
+        runId: "run-dupe",
+        threadId: "thread-dupe",
+        continuationCount: 0,
+        runsInBackgroundFunction: true,
+        deps: d,
+      }),
+    ).resolves.toEqual({ claimed: false, skipped: "already-claimed" });
+
+    expect(d.updateRunHeartbeat).not.toHaveBeenCalled();
+    expect(d.calls).toEqual([
+      "record:worker_entered",
+      "claim",
+      "record:worker_claim_lost",
+    ]);
   });
 });
 

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -4025,6 +4025,58 @@ export function shouldChainBackgroundContinuation(opts: {
   );
 }
 
+export async function claimBackgroundWorkerRunEarly(opts: {
+  runId: string;
+  threadId?: string | null;
+  markerTurnId?: string | null;
+  requestTurnId?: string | null;
+  continuationCount: number;
+  runsInBackgroundFunction: boolean;
+  deps?: {
+    recordRunDiagnostic?: typeof recordRunDiagnostic;
+    insertRun?: typeof insertRun;
+    claimBackgroundRun?: typeof claimBackgroundRun;
+    updateRunHeartbeat?: typeof updateRunHeartbeat;
+  };
+}): Promise<{ claimed: true } | { claimed: false; skipped: string }> {
+  const record = opts.deps?.recordRunDiagnostic ?? recordRunDiagnostic;
+  const insert = opts.deps?.insertRun ?? insertRun;
+  const claim = opts.deps?.claimBackgroundRun ?? claimBackgroundRun;
+  const heartbeat = opts.deps?.updateRunHeartbeat ?? updateRunHeartbeat;
+  const threadId =
+    typeof opts.threadId === "string" && opts.threadId.trim()
+      ? opts.threadId.trim()
+      : opts.runId;
+  const turnId =
+    typeof opts.markerTurnId === "string" && opts.markerTurnId.trim()
+      ? opts.markerTurnId.trim()
+      : typeof opts.requestTurnId === "string" && opts.requestTurnId.trim()
+        ? opts.requestTurnId.trim()
+        : opts.runId;
+
+  await record(
+    opts.runId,
+    RUN_DIAG_STAGE.workerEntered,
+    `runsInBackgroundFunction=${opts.runsInBackgroundFunction} continuationCount=${opts.continuationCount}`,
+  ).catch(() => {});
+
+  if (opts.continuationCount > 0) {
+    await insert(opts.runId, threadId, turnId, {
+      dispatchMode: "background",
+    }).catch(() => {});
+  }
+
+  const won = await claim(opts.runId);
+  if (!won) {
+    await record(opts.runId, RUN_DIAG_STAGE.workerClaimLost).catch(() => {});
+    return { claimed: false, skipped: "already-claimed" };
+  }
+
+  await record(opts.runId, RUN_DIAG_STAGE.workerClaimed).catch(() => {});
+  await heartbeat(opts.runId).catch(() => {});
+  return { claimed: true };
+}
+
 function progressStepFromAgentChatEvent(event: AgentChatEvent): string | null {
   switch (event.type) {
     case "activity":
@@ -4175,6 +4227,24 @@ export function createProductionAgentHandler(
       Number.isFinite(backgroundRunMarker.continuationCount)
         ? Math.max(0, Math.floor(backgroundRunMarker.continuationCount))
         : 0;
+    let backgroundRunClaimedEarly = false;
+    if (isBackgroundWorker && bgRunId) {
+      const earlyClaim = await claimBackgroundWorkerRunEarly({
+        runId: bgRunId,
+        threadId,
+        markerTurnId:
+          typeof backgroundRunMarker?.turnId === "string"
+            ? backgroundRunMarker.turnId
+            : null,
+        requestTurnId,
+        continuationCount: backgroundContinuationCount,
+        runsInBackgroundFunction,
+      });
+      if (!earlyClaim.claimed) {
+        return { ok: true, skipped: earlyClaim.skipped };
+      }
+      backgroundRunClaimedEarly = true;
+    }
     // The foreground POST decides whether to dispatch into a background
     // function. The background worker itself never re-dispatches.
     const dispatchToBackground =
@@ -5254,48 +5324,37 @@ export function createProductionAgentHandler(
           }
         : undefined;
 
-    // Background worker: claim the pre-inserted run idempotently before
-    // executing. A duplicate Netlify delivery loses the claim and no-ops here,
-    // so the run can never be double-executed. Bump the heartbeat immediately
-    // on entry so a slow cold-start doesn't leave the row looking stale to the
-    // reaper before startRun's 1.5s heartbeat timer takes over.
+    // Background worker: the run was claimed immediately after the authenticated
+    // `_process-run` body was parsed, before owner/model/prompt/tool setup. That
+    // early claim is what lets the foreground subscribe to the real background
+    // worker instead of racing slow setup and falling back to the 40s inline
+    // path. This late block is a defensive fallback for older/custom callers
+    // that somehow reach here without the early claim.
     if (isBackgroundWorker) {
-      // DIAGNOSTIC: the re-entered handler recognized itself as the background
-      // worker. Record the runtime regime too — `isInBackgroundFunctionRuntime()`
-      // reads a globalThis marker set by the bg-fn entry, which may NOT be set in
-      // this isolate; recording the ACTUAL resolved value reveals whether the
-      // worker is on the 13-min `-background` budget or the 40s clamp. This is
-      // the proof the worker reached its own code (vs. dying at auth before it).
-      await recordRunDiagnostic(
-        runId,
-        RUN_DIAG_STAGE.workerEntered,
-        `runsInBackgroundFunction=${runsInBackgroundFunction} continuationCount=${backgroundContinuationCount}`,
-      ).catch(() => {});
-      // A chained continuation chunk's runId was minted by the prior chunk and
-      // never inserted, so insert its background row now (idempotently — a
-      // duplicate Netlify delivery that already inserted it just PK-collides and
-      // the claim below dedups). The first chunk's row was inserted by the
-      // foreground, so skip the insert there.
-      if (isChainedBackgroundContinuation) {
-        await insertRun(runId, effectiveThreadId, effectiveTurnId, {
-          dispatchMode: "background",
-        }).catch(() => {});
-      }
-      const won = await claimBackgroundRun(runId);
-      if (!won) {
-        // Already claimed by an earlier delivery — return a benign ack so
-        // Netlify doesn't retry a successful handoff.
-        await recordRunDiagnostic(runId, RUN_DIAG_STAGE.workerClaimLost).catch(
+      if (!backgroundRunClaimedEarly) {
+        await recordRunDiagnostic(
+          runId,
+          RUN_DIAG_STAGE.workerEntered,
+          `runsInBackgroundFunction=${runsInBackgroundFunction} continuationCount=${backgroundContinuationCount}`,
+        ).catch(() => {});
+        if (isChainedBackgroundContinuation) {
+          await insertRun(runId, effectiveThreadId, effectiveTurnId, {
+            dispatchMode: "background",
+          }).catch(() => {});
+        }
+        const won = await claimBackgroundRun(runId);
+        if (!won) {
+          await recordRunDiagnostic(
+            runId,
+            RUN_DIAG_STAGE.workerClaimLost,
+          ).catch(() => {});
+          return { ok: true, skipped: "already-claimed" };
+        }
+        await recordRunDiagnostic(runId, RUN_DIAG_STAGE.workerClaimed).catch(
           () => {},
         );
-        return { ok: true, skipped: "already-claimed" };
+        await updateRunHeartbeat(runId).catch(() => {});
       }
-      // DIAGNOSTIC: this worker won the claim and now OWNS the run. If a run
-      // ever stalls at this stage it means the loop below failed to start.
-      await recordRunDiagnostic(runId, RUN_DIAG_STAGE.workerClaimed).catch(
-        () => {},
-      );
-      await updateRunHeartbeat(runId).catch(() => {});
     }
 
     // DIAGNOSTIC-ONLY: build the pre-startRun setup-timing breakdown now (so the

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -65,6 +65,23 @@ export const UNCLAIMED_BACKGROUND_RUN_ERROR_EVENT = {
 } as const;
 
 /**
+ * Terminal error for a background worker that DID claim the run, then failed
+ * during route/handler setup before `startRun` could emit its own error event.
+ * Claimed runs are no longer eligible for foreground inline recovery, so the
+ * route boundary must fail them loudly instead of leaving subscribers to wait
+ * for stale-run recovery.
+ */
+export const CLAIMED_BACKGROUND_WORKER_FAILED_ERROR_EVENT = {
+  type: "error",
+  error:
+    "The background agent worker stopped before it could start the turn. You can retry from the preserved chat context.",
+  errorCode: "background_worker_failed",
+  recoverable: true,
+  details:
+    "The durable background worker claimed the run but threw during setup before it could emit agent events.",
+} as const;
+
+/**
  * Grace period before a never-claimed background run (dispatch_mode still
  * 'background', no worker claim) is treated as a dead handoff and reaped.
  *

--- a/packages/core/src/server/agent-chat-plugin.shared.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin.shared.spec.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { AgentRunSummary } from "../agent/run-store.js";
+import { CLAIMED_BACKGROUND_WORKER_FAILED_ERROR_EVENT } from "../agent/run-store.js";
 import type { ChatThread } from "../chat-threads/store.js";
 import {
+  finalizeClaimedAgentChatProcessRunFailure,
   handleSharedThreadRequest,
   shouldDisableRecurringJobsRuntime,
 } from "./agent-chat-plugin.js";
@@ -140,6 +142,73 @@ describe("recurring jobs runtime startup", () => {
         AGENT_NATIVE_ENABLE_LOCAL_RECURRING_JOBS: "1",
       }),
     ).toBe(true);
+  });
+});
+
+describe("agent chat process-run failure finalization", () => {
+  function deps(dispatchMode: string | null) {
+    return {
+      readBackgroundRunClaim: vi.fn(async () => ({
+        dispatchMode,
+        status: "running",
+      })),
+      recordRunDiagnostic: vi.fn(async () => {}),
+      setRunError: vi.fn(async () => {}),
+      updateRunStatusIfRunning: vi.fn(async () => true),
+      ensureTerminalRunEvent: vi.fn(async () => {}),
+    };
+  }
+
+  it("marks claimed background worker setup failures terminal immediately", async () => {
+    const d = deps("background-processing");
+
+    await expect(
+      finalizeClaimedAgentChatProcessRunFailure(
+        "run-claimed",
+        new Error("setup exploded"),
+        d,
+      ),
+    ).resolves.toBe(true);
+
+    expect(d.recordRunDiagnostic).toHaveBeenCalledWith(
+      "run-claimed",
+      "route_threw",
+      "setup exploded",
+    );
+    expect(d.setRunError).toHaveBeenCalledWith(
+      "run-claimed",
+      "background_worker_failed",
+      expect.stringContaining("setup exploded"),
+    );
+    expect(d.updateRunStatusIfRunning).toHaveBeenCalledWith(
+      "run-claimed",
+      "errored",
+    );
+    expect(d.ensureTerminalRunEvent).toHaveBeenCalledWith(
+      "run-claimed",
+      CLAIMED_BACKGROUND_WORKER_FAILED_ERROR_EVENT,
+    );
+  });
+
+  it("leaves unclaimed worker failures recoverable by foreground inline fallback", async () => {
+    const d = deps("background");
+
+    await expect(
+      finalizeClaimedAgentChatProcessRunFailure(
+        "run-unclaimed",
+        new Error("pre-claim failure"),
+        d,
+      ),
+    ).resolves.toBe(false);
+
+    expect(d.recordRunDiagnostic).toHaveBeenCalledWith(
+      "run-unclaimed",
+      "route_threw",
+      "pre-claim failure",
+    );
+    expect(d.setRunError).not.toHaveBeenCalled();
+    expect(d.updateRunStatusIfRunning).not.toHaveBeenCalled();
+    expect(d.ensureTerminalRunEvent).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -62,7 +62,15 @@ import {
 import { runAgentLoopDirectWithSoftTimeout } from "../agent/run-loop-with-resume.js";
 import { callerOwnsRun, callerOwnsThread } from "../agent/run-ownership.js";
 import type { AgentRunSummary } from "../agent/run-store.js";
-import { readBackgroundRunClaim } from "../agent/run-store.js";
+import {
+  CLAIMED_BACKGROUND_WORKER_FAILED_ERROR_EVENT,
+  ensureTerminalRunEvent,
+  readBackgroundRunClaim,
+  recordRunDiagnostic,
+  RUN_DIAG_STAGE,
+  setRunError,
+  updateRunStatusIfRunning,
+} from "../agent/run-store.js";
 import { buildRuntimeContextPrompt } from "../agent/runtime-context.js";
 import {
   buildAssistantMessage,
@@ -3862,6 +3870,50 @@ export function shouldDisableRecurringJobsRuntime(
   }
 
   return isLocalRuntime;
+}
+
+type AgentChatProcessRunFailureDeps = {
+  readBackgroundRunClaim?: typeof readBackgroundRunClaim;
+  recordRunDiagnostic?: typeof recordRunDiagnostic;
+  setRunError?: typeof setRunError;
+  updateRunStatusIfRunning?: typeof updateRunStatusIfRunning;
+  ensureTerminalRunEvent?: typeof ensureTerminalRunEvent;
+};
+
+export async function finalizeClaimedAgentChatProcessRunFailure(
+  runId: string,
+  err: unknown,
+  deps: AgentChatProcessRunFailureDeps = {},
+): Promise<boolean> {
+  const readClaim = deps.readBackgroundRunClaim ?? readBackgroundRunClaim;
+  const record = deps.recordRunDiagnostic ?? recordRunDiagnostic;
+  const setError = deps.setRunError ?? setRunError;
+  const updateStatus =
+    deps.updateRunStatusIfRunning ?? updateRunStatusIfRunning;
+  const ensureTerminal = deps.ensureTerminalRunEvent ?? ensureTerminalRunEvent;
+  const message = err instanceof Error ? err.message : String(err);
+
+  await record(runId, RUN_DIAG_STAGE.routeThrew, message).catch(() => {});
+
+  const claim = await readClaim(runId).catch(() => null);
+  if (
+    claim?.status !== "running" ||
+    claim.dispatchMode !== "background-processing"
+  ) {
+    return false;
+  }
+
+  await setError(
+    runId,
+    CLAIMED_BACKGROUND_WORKER_FAILED_ERROR_EVENT.errorCode,
+    `${CLAIMED_BACKGROUND_WORKER_FAILED_ERROR_EVENT.details} setupError=${message}`,
+  ).catch(() => {});
+  await updateStatus(runId, "errored").catch(() => {});
+  await ensureTerminal(
+    runId,
+    CLAIMED_BACKGROUND_WORKER_FAILED_ERROR_EVENT,
+  ).catch(() => {});
+  return true;
 }
 
 export function createAgentChatPlugin(
@@ -8030,17 +8082,10 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
                 runId: prepared.runId,
               },
             });
-            // DIAGNOSTIC: the worker invocation threw at the route boundary —
-            // record the message so the failure cause is readable client-side.
-            if (diag) {
-              await diag
-                .record(
-                  prepared.runId,
-                  diag.stages.routeThrew,
-                  err instanceof Error ? err.message : String(err),
-                )
-                .catch(() => {});
-            }
+            await finalizeClaimedAgentChatProcessRunFailure(
+              prepared.runId,
+              err,
+            );
             setResponseStatus(event, 500);
             return { error: "process-run failed" };
           }


### PR DESCRIPTION
## Summary
- claim durable background agent-chat runs immediately after the signed worker marker is parsed
- insert chained continuation rows before claiming so foreground subscription no longer races worker setup
- keep duplicate background deliveries idempotent and covered by focused tests

## Tests
- corepack pnpm --dir packages/core exec vitest --run src/agent/production-agent.spec.ts src/agent/run-manager.spec.ts src/agent/durable-background.spec.ts src/agent/run-store.durable-background.spec.ts src/client/agent-chat-adapter.spec.ts src/client/sse-event-processor.spec.ts
- corepack pnpm --filter @agent-native/core typecheck
- CI=true corepack pnpm guards