### PR TITLE
Fix infinite sign-in redirect loop under base-path deploys

### DIFF
--- a/.changeset/signin-redirect-loop-guard.md
+++ b/.changeset/signin-redirect-loop-guard.md
@@ -1,0 +1,12 @@
+---
+"@agent-native/core": patch
+---
+
+Fix an infinite sign-in redirect loop under base-path deploys. When the
+authenticated app shell (wrapped in `RequireSession`) was served at the sign-in
+path — e.g. `/<app>/_agent-native/sign-in` on a path-prefixed deploy — the gate
+redirected to the sign-in page from the sign-in page, nesting and re-encoding the
+current URL as a fresh `?return=` on every hop (`…sign-in?return=%252F…sign-in%253Freturn…`).
+`RequireSession` now refuses to redirect when already on the sign-in entry point
+(new exported `isOnSignInPage` helper), and `safeReturnPath` collapses any
+`return` that resolves back to `…/_agent-native/sign-in` to `/`.

--- a/packages/core/src/client/require-session.spec.tsx
+++ b/packages/core/src/client/require-session.spec.tsx
@@ -98,6 +98,32 @@ describe("RequireSession", () => {
     expect(href).toContain(encodeURIComponent("/inbox?label=important"));
   });
 
+  it("never redirects when already on the sign-in page (no infinite loop)", () => {
+    // Simulates the base-path deploy case where the app shell is served at the
+    // sign-in path. Redirecting here would nest the sign-in URL as a fresh
+    // `?return=` and loop forever — the gate must not redirect to itself.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        pathname: "/_agent-native/sign-in",
+        search: "?return=%2Finbox",
+        hash: "",
+        origin: "https://mail.example.com",
+        href: "https://mail.example.com/_agent-native/sign-in?return=%2Finbox",
+        replace: replaceMock,
+        assign: vi.fn(),
+      },
+    });
+    useSessionMock.mockReturnValue({ session: null, isLoading: false });
+    render(
+      <RequireSession>
+        <Child />
+      </RequireSession>,
+    );
+    expect(replaceMock).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-testid="protected"]')).toBeNull();
+  });
+
   it("does not redirect twice across re-renders", () => {
     useSessionMock.mockReturnValue({ session: null, isLoading: false });
     render(

--- a/packages/core/src/client/require-session.tsx
+++ b/packages/core/src/client/require-session.tsx
@@ -70,6 +70,24 @@ export function buildSignInReturnHref(): string {
   return `${base}?return=${encodeURIComponent(ret)}`;
 }
 
+/**
+ * True when the browser is already sitting on the framework sign-in entry
+ * point. Redirecting to sign-in from here would append the current sign-in
+ * URL as a fresh `?return=`, re-encode it, and navigate again — an infinite
+ * loop of ever-growing `…sign-in?return=%252F…sign-in%253Freturn%253D…` URLs.
+ *
+ * This happens when the authenticated app shell (wrapped in `RequireSession`)
+ * is served at the sign-in path instead of the framework login HTML — e.g.
+ * under a base-path deploy where the SPA shell answers `/<app>/_agent-native/
+ * sign-in`. The sign-in page is the framework's job, not the gate's: never
+ * redirect to ourselves. Compared against `agentNativePath(...)` so it matches
+ * whether or not the app is mounted under a base path.
+ */
+export function isOnSignInPage(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.location.pathname === agentNativePath("/_agent-native/sign-in");
+}
+
 export function RequireSession({
   children,
   fallback,
@@ -83,7 +101,8 @@ export function RequireSession({
   // flight is harmless but noisy.
   const redirectedRef = useRef(false);
 
-  const mustRedirect = !bypass && !isLoading && !session && redirect;
+  const mustRedirect =
+    !bypass && !isLoading && !session && redirect && !isOnSignInPage();
 
   useEffect(() => {
     if (!mustRedirect) return;

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -2855,6 +2855,27 @@ describe("server/auth", () => {
       // the parsed segments.)
       expect(safeReturnPath("/foo?bar=1#baz")).toBe("/foo?bar=1#baz");
     });
+
+    it("collapses a return that points back at the sign-in page (loop guard)", async () => {
+      const safeReturnPath = await load();
+      // A `return` resolving to the sign-in entry point would re-enter the
+      // redirect loop — collapse to "/". Covers root and base-path mounts,
+      // and a nested already-encoded loop URL.
+      expect(safeReturnPath("/_agent-native/sign-in")).toBe("/");
+      expect(safeReturnPath("/_agent-native/sign-in?return=%2Finbox")).toBe(
+        "/",
+      );
+      expect(safeReturnPath("/mail/_agent-native/sign-in")).toBe("/");
+      expect(
+        safeReturnPath(
+          "/mail/_agent-native/sign-in?return=%252Fmail%252F_agent-native%252Fsign-in",
+        ),
+      ).toBe("/");
+      // A normal app path that merely contains the words is unaffected.
+      expect(safeReturnPath("/mail/inbox?label=important")).toBe(
+        "/mail/inbox?label=important",
+      );
+    });
   });
 
   describe("OAuth return URLs", () => {

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -542,6 +542,12 @@ export function safeReturnPath(raw: string | null | undefined): string {
   try {
     const parsed = new URL(raw, "http://safe-base.invalid");
     if (parsed.origin !== "http://safe-base.invalid") return "/";
+    // Never return to the sign-in entry point itself. A `return` that resolves
+    // back to `…/_agent-native/sign-in` re-enters the redirect loop — each hop
+    // nests the prior sign-in URL as a fresh `?return=`. Collapse it to "/" so
+    // the post-sign-in 302 lands on the app, not another sign-in page. Matches
+    // with or without an app base-path prefix (`/<app>/_agent-native/sign-in`).
+    if (parsed.pathname.endsWith("/_agent-native/sign-in")) return "/";
     return parsed.pathname + parsed.search + parsed.hash;
   } catch {
     return "/";


### PR DESCRIPTION
## Problem
`RequireSession` had no guard against redirecting to the sign-in page **from** the sign-in page. When the authenticated app shell (wrapped in `RequireSession`) is served at the sign-in path — e.g. a base-path deploy where the SPA answers `/<app>/_agent-native/sign-in` with no client-resolvable session — it redirected sign-in → sign-in, nesting and re-encoding the current URL as a fresh `?return=` on every hop:

```
/<app>/_agent-native/sign-in?return=%2F<app>%2F_agent-native%2Fsign-in%3Freturn%3D%252F<app>%252F…
```

…growing without bound. Hit in production behind a `/<app>` path prefix once a session cookie existed but the client session check couldn't resolve it.

## Fix
- **`RequireSession`**: new exported `isOnSignInPage()`; never redirect when `window.location.pathname` already equals `agentNativePath("/_agent-native/sign-in")` (matches with or without an app base path). Falls through to the loading fallback.
- **`safeReturnPath`** (server): collapse any `return` that resolves back to `…/_agent-native/sign-in` to `/`, so the post-sign-in 302 can't re-enter the loop either.

Tests for both paths + changeset.