### PR TITLE
Improve Design editor robustness and QA coverage

### DIFF
--- a/.changeset/design-editor-robustness.md
+++ b/.changeset/design-editor-robustness.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Improve local SQLite collab write robustness for Design editor workflows.

--- a/packages/core/src/collab/storage.ts
+++ b/packages/core/src/collab/storage.ts
@@ -10,6 +10,41 @@ import { ensureTableExists, ensureColumnExists } from "../db/ddl-guard.js";
 
 let _initPromise: Promise<void> | undefined;
 
+type DbExecClient = ReturnType<typeof getDbExec>;
+type DbExecuteArg = Parameters<DbExecClient["execute"]>[0];
+type DbExecuteResult = Awaited<ReturnType<DbExecClient["execute"]>>;
+
+function isSqliteBusyError(error: unknown): boolean {
+  if (isPostgres()) return false;
+  const candidate = error as { code?: unknown; message?: unknown } | null;
+  return (
+    candidate?.code === "SQLITE_BUSY" ||
+    candidate?.code === "SQLITE_BUSY_RECOVERY" ||
+    (typeof candidate?.message === "string" &&
+      /database is locked|SQLITE_BUSY/i.test(candidate.message))
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function executeWithSqliteRetry(
+  client: DbExecClient,
+  statement: DbExecuteArg,
+): Promise<DbExecuteResult> {
+  const delays = [25, 75, 150, 300, 600];
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await client.execute(statement);
+    } catch (error) {
+      const delay = delays[attempt];
+      if (delay === undefined || !isSqliteBusyError(error)) throw error;
+      await sleep(delay);
+    }
+  }
+}
+
 async function ensureTable(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
@@ -97,7 +132,7 @@ export async function trySaveYDocState(
   const b64 = uint8ArrayToBase64(state);
   const nowExpr = isPostgres() ? "NOW()::text" : "datetime('now')";
   if (expectedVersion === null) {
-    const result = await client.execute({
+    const result = await executeWithSqliteRetry(client, {
       sql: isPostgres()
         ? `INSERT INTO _collab_docs (doc_id, yjs_state, text_snapshot, version, updated_at) VALUES (?, ?, ?, 0, ${nowExpr}) ON CONFLICT (doc_id) DO NOTHING`
         : `INSERT OR IGNORE INTO _collab_docs (doc_id, yjs_state, text_snapshot, version, updated_at) VALUES (?, ?, ?, 0, ${nowExpr})`,
@@ -106,7 +141,7 @@ export async function trySaveYDocState(
     return result.rowsAffected > 0;
   }
 
-  const result = await client.execute({
+  const result = await executeWithSqliteRetry(client, {
     sql: `UPDATE _collab_docs SET yjs_state = ?, text_snapshot = ?, version = version + 1, updated_at = ${nowExpr} WHERE doc_id = ? AND version = ?`,
     args: [b64, textSnapshot, docId, expectedVersion],
   });
@@ -123,13 +158,13 @@ export async function saveYDocState(
   const client = getDbExec();
   const b64 = uint8ArrayToBase64(state);
   const nowExpr = isPostgres() ? "NOW()::text" : "datetime('now')";
-  const updated = await client.execute({
+  const updated = await executeWithSqliteRetry(client, {
     sql: `UPDATE _collab_docs SET yjs_state = ?, text_snapshot = ?, version = version + 1, updated_at = ${nowExpr} WHERE doc_id = ?`,
     args: [b64, textSnapshot, docId],
   });
   if (updated.rowsAffected > 0) return;
 
-  const inserted = await client.execute({
+  const inserted = await executeWithSqliteRetry(client, {
     sql: isPostgres()
       ? `INSERT INTO _collab_docs (doc_id, yjs_state, text_snapshot, version, updated_at) VALUES (?, ?, ?, 0, ${nowExpr}) ON CONFLICT (doc_id) DO NOTHING`
       : `INSERT OR IGNORE INTO _collab_docs (doc_id, yjs_state, text_snapshot, version, updated_at) VALUES (?, ?, ?, 0, ${nowExpr})`,
@@ -137,7 +172,7 @@ export async function saveYDocState(
   });
   if (inserted.rowsAffected > 0) return;
 
-  await client.execute({
+  await executeWithSqliteRetry(client, {
     sql: `UPDATE _collab_docs SET yjs_state = ?, text_snapshot = ?, version = version + 1, updated_at = ${nowExpr} WHERE doc_id = ?`,
     args: [b64, textSnapshot, docId],
   });

--- a/templates/design/.generated/bridge/editor-chrome.generated.ts
+++ b/templates/design/.generated/bridge/editor-chrome.generated.ts
@@ -27,7 +27,7 @@ export const editorChromeBridgeScript: string = `"use strict";
         "data-agent-native-editor-chrome-style",
         ""
       );
-      chromeTransitionStyle.textContent = '[data-agent-native-edit-overlay="selection"]{transition:border-width 150ms ease-out}[data-agent-native-edge-handle],[data-agent-native-edit-handle],[data-agent-native-rotate-handle]{transition:width 150ms ease-out,height 150ms ease-out,border-width 150ms ease-out,top 150ms ease-out,bottom 150ms ease-out,left 150ms ease-out,right 150ms ease-out}[data-agent-native-spacing-line]{position:absolute;display:none;pointer-events:none;border-radius:999px}[data-agent-native-spacing-region]{position:absolute;display:none;box-sizing:border-box;pointer-events:auto;background-size:6px 6px}[data-agent-native-spacing-region][data-orientation="vertical"]{cursor:ew-resize}[data-agent-native-spacing-region][data-orientation="horizontal"]{cursor:ns-resize}';
+      chromeTransitionStyle.textContent = '[data-agent-native-edit-overlay="selection"]{transition:border-width 150ms ease-out}[data-agent-native-empty-text-editing="true"] [data-agent-native-edit-overlay="selection"]{display:none!important}[data-agent-native-text-editing]{outline:none!important;outline-offset:0!important}[data-agent-native-edge-handle],[data-agent-native-edit-handle],[data-agent-native-rotate-handle]{transition:width 150ms ease-out,height 150ms ease-out,border-width 150ms ease-out,top 150ms ease-out,bottom 150ms ease-out,left 150ms ease-out,right 150ms ease-out}[data-agent-native-spacing-line]{position:absolute;display:none;pointer-events:none;border-radius:999px}[data-agent-native-spacing-region]{position:absolute;display:none;box-sizing:border-box;pointer-events:auto;background-size:6px 6px}[data-agent-native-spacing-region][data-orientation="vertical"]{cursor:ew-resize}[data-agent-native-spacing-region][data-orientation="horizontal"]{cursor:ns-resize}';
       (document.head || document.documentElement).appendChild(
         chromeTransitionStyle
       );
@@ -1809,12 +1809,22 @@ export const editorChromeBridgeScript: string = `"use strict";
       }
     }
     function refreshOverlays() {
+      var textEditingEl = activeTextEditEl || document.querySelector(
+        "[data-agent-native-text-editing]"
+      );
       if (hoveredEl && hoveredEl !== selectedEl) {
         positionOverlay(highlightOverlay, hoveredEl);
       } else {
         highlightOverlay.style.display = "none";
       }
-      if (selectedEl) {
+      if (textEditingEl) {
+        if (activeTextEditEl === textEditingEl) {
+          updateTextEditingChrome(textEditingEl, "", "");
+        }
+        if (!hasTextCharacters(textEditingEl)) {
+          hideSelectionOverlay();
+        }
+      } else if (selectedEl) {
         positionOverlay(selectionOverlay, selectedEl);
       } else {
         hideParentAutoLayoutOverlay();
@@ -2118,9 +2128,15 @@ export const editorChromeBridgeScript: string = `"use strict";
       });
     }
     function updateTextEditingChrome(target, originalMinWidth, originalMinHeight) {
-      target.style.outline = "";
-      target.style.outlineOffset = "";
+      target.style.outline = "none";
+      target.style.outlineStyle = "none";
+      target.style.outlineWidth = "0px";
+      target.style.outlineColor = "transparent";
+      target.style.outlineOffset = "0px";
       if (hasTextCharacters(target)) {
+        document.documentElement.removeAttribute(
+          "data-agent-native-empty-text-editing"
+        );
         target.style.minWidth = originalMinWidth;
         target.style.minHeight = originalMinHeight;
         positionOverlay(selectionOverlay, target);
@@ -2129,6 +2145,10 @@ export const editorChromeBridgeScript: string = `"use strict";
       }
       target.style.minWidth = originalMinWidth || "1px";
       target.style.minHeight = originalMinHeight || "1em";
+      document.documentElement.setAttribute(
+        "data-agent-native-empty-text-editing",
+        "true"
+      );
       hideSelectionOverlay();
       setSelectionOverlayResizeChromeVisible(false);
     }
@@ -3882,24 +3902,34 @@ export const editorChromeBridgeScript: string = `"use strict";
       var target = findTextEditTarget(elementFromEditorPoint(e.clientX, e.clientY)) || findTextEditTarget(eventTarget) || eventTarget;
       if (!target || target.nodeType !== 1) return;
       selectedEl = selectionTargetForHit(target) || target;
+      var programmaticTextEdit = !!e && e.agentNativeProgrammaticTextEdit === true;
       var originalText = target.textContent || "";
       var originalHtml = target.innerHTML || "";
       var originalMinWidth = target.style.minWidth;
       var originalMinHeight = target.style.minHeight;
       var originalBorderColor = target.style.borderColor;
+      var originalOutline = target.style.outline;
+      var originalOutlineOffset = target.style.outlineOffset;
       var committed = false;
       activeTextEditEl = target;
       target.setAttribute("contenteditable", "true");
       target.setAttribute("data-agent-native-text-editing", "true");
       target.style.cursor = "text";
       target.style.borderColor = "transparent";
+      target.style.outline = "none";
+      target.style.outlineStyle = "none";
+      target.style.outlineWidth = "0px";
+      target.style.outlineColor = "transparent";
+      target.style.outlineOffset = "0px";
       setTextEditingPointerPassthrough(true);
       updateTextEditingChrome(target, originalMinWidth, originalMinHeight);
-      postElementSelect(target, e);
-      window.parent.postMessage(
-        { type: "element-dblclick-text", payload: getElementInfo(target) },
-        "*"
-      );
+      if (!programmaticTextEdit) {
+        postElementSelect(target, e);
+        window.parent.postMessage(
+          { type: "element-dblclick-text", payload: getElementInfo(target) },
+          "*"
+        );
+      }
       postTextEditingState(target, true);
       function finish(commit) {
         if (committed) return;
@@ -3913,9 +3943,12 @@ export const editorChromeBridgeScript: string = `"use strict";
         document.removeEventListener("selectionchange", onSelectionChange);
         target.removeAttribute("contenteditable");
         target.removeAttribute("data-agent-native-text-editing");
+        document.documentElement.removeAttribute(
+          "data-agent-native-empty-text-editing"
+        );
         target.style.cursor = "";
-        target.style.outline = "";
-        target.style.outlineOffset = "";
+        target.style.outline = originalOutline;
+        target.style.outlineOffset = originalOutlineOffset;
         target.style.minWidth = originalMinWidth;
         target.style.minHeight = originalMinHeight;
         target.style.borderColor = originalBorderColor;
@@ -3936,6 +3969,15 @@ export const editorChromeBridgeScript: string = `"use strict";
         }
       }
       function onBlur() {
+        if (programmaticTextEdit && !(target.textContent || "").trim()) {
+          window.setTimeout(function() {
+            if (committed || (target.textContent || "").trim()) return;
+            target.focus();
+            updateTextEditingChrome(target, originalMinWidth, originalMinHeight);
+            postTextEditingState(target, true);
+          }, 0);
+          return;
+        }
         finish(true);
       }
       function onKeyDown(ev) {
@@ -4127,6 +4169,7 @@ export const editorChromeBridgeScript: string = `"use strict";
             clientX: bteCenterX,
             clientY: bteCenterY,
             target: textTarget,
+            agentNativeProgrammaticTextEdit: true,
             preventDefault: function() {
             },
             stopPropagation: function() {

--- a/templates/design/actions/export-html.ts
+++ b/templates/design/actions/export-html.ts
@@ -9,6 +9,7 @@ import {
   exportFilename,
   trySaveExportFile,
 } from "../server/lib/design-export.js";
+import { isBoardFile } from "../shared/board-file.js";
 import "../server/db/index.js"; // ensure registerShareableResource runs
 
 export default defineAction({
@@ -31,12 +32,13 @@ export default defineAction({
       .select()
       .from(schema.designFiles)
       .where(eq(schema.designFiles.designId, id));
+    const exportFiles = files.filter((file) => !isBoardFile(file.filename));
 
-    const html = buildStandaloneHtml({ title: row.title, files });
+    const html = buildStandaloneHtml({ title: row.title, files: exportFiles });
 
     const filename = exportFilename(row.title, "html");
     const saveResult = await trySaveExportFile(filename, html);
 
-    return { html, filename, ...saveResult, fileCount: files.length };
+    return { html, filename, ...saveResult, fileCount: exportFiles.length };
   },
 });

--- a/templates/design/actions/export-pdf.ts
+++ b/templates/design/actions/export-pdf.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import { isBoardFile } from "../shared/board-file.js";
 import "../server/db/index.js"; // ensure registerShareableResource runs
 
 export default defineAction({
@@ -27,6 +28,7 @@ export default defineAction({
       .select()
       .from(schema.designFiles)
       .where(eq(schema.designFiles.designId, id));
+    const exportFiles = files.filter((file) => !isBoardFile(file.filename));
 
     return {
       id: row.id,
@@ -34,7 +36,7 @@ export default defineAction({
       description: row.description,
       projectType: row.projectType,
       data: row.data ?? null,
-      files: files.map((f) => ({
+      files: exportFiles.map((f) => ({
         id: f.id,
         filename: f.filename,
         fileType: f.fileType,

--- a/templates/design/actions/export-svg.ts
+++ b/templates/design/actions/export-svg.ts
@@ -10,6 +10,7 @@ import {
   exportFilename,
   trySaveExportFile,
 } from "../server/lib/design-export.js";
+import { isBoardFile } from "../shared/board-file.js";
 import "../server/db/index.js"; // ensure registerShareableResource runs
 
 export default defineAction({
@@ -45,8 +46,9 @@ export default defineAction({
       .select()
       .from(schema.designFiles)
       .where(eq(schema.designFiles.designId, id));
+    const exportFiles = files.filter((file) => !isBoardFile(file.filename));
 
-    const html = buildStandaloneHtml({ title: row.title, files });
+    const html = buildStandaloneHtml({ title: row.title, files: exportFiles });
     const svg = buildSvgForeignObject({
       html,
       width,
@@ -56,6 +58,6 @@ export default defineAction({
     const filename = exportFilename(row.title, "svg");
     const saveResult = await trySaveExportFile(filename, svg);
 
-    return { svg, filename, ...saveResult, fileCount: files.length };
+    return { svg, filename, ...saveResult, fileCount: exportFiles.length };
   },
 });

--- a/templates/design/actions/export-zip.ts
+++ b/templates/design/actions/export-zip.ts
@@ -8,6 +8,7 @@ import {
   exportFilename,
   trySaveExportFile,
 } from "../server/lib/design-export.js";
+import { isBoardFile } from "../shared/board-file.js";
 import "../server/db/index.js"; // ensure registerShareableResource runs
 
 const METADATA_ARCHIVE_DIR = "agent-native-metadata";
@@ -40,6 +41,7 @@ export default defineAction({
       .select()
       .from(schema.designFiles)
       .where(eq(schema.designFiles.designId, id));
+    const exportFiles = files.filter((file) => !isBoardFile(file.filename));
 
     // Dynamic import JSZip
     const JSZip = (await import("jszip")).default;
@@ -57,14 +59,14 @@ export default defineAction({
       "",
       "## Files",
       "",
-      ...files.map((f) => `- ${f.filename} (${f.fileType})`),
+      ...exportFiles.map((f) => `- ${f.filename} (${f.fileType})`),
     ].join("\n");
 
     zip.file(`${METADATA_ARCHIVE_DIR}/README.md`, readme);
 
     // Preserve design-relative paths so exported HTML keeps working with
     // sibling CSS/assets. Strip traversal segments defensively for legacy rows.
-    for (const [index, file] of files.entries()) {
+    for (const [index, file] of exportFiles.entries()) {
       const filename = safeArchivePath(
         file.filename,
         `design-file-${index + 1}.txt`,
@@ -84,6 +86,11 @@ export default defineAction({
     const filename = exportFilename(row.title, "zip");
     const saveResult = await trySaveExportFile(filename, zipBuffer);
 
-    return { zipBase64, filename, ...saveResult, fileCount: files.length };
+    return {
+      zipBase64,
+      filename,
+      ...saveResult,
+      fileCount: exportFiles.length,
+    };
   },
 });

--- a/templates/design/actions/update-file.ts
+++ b/templates/design/actions/update-file.ts
@@ -71,39 +71,36 @@ export default defineAction({
     await assertAccess("design", file.designId, "editor");
 
     // Reject a rename that would collide with an existing filename in the same
-    // design. The collision check and the write run in one transaction so they
-    // can't be interleaved by a concurrent rename. (A DB-level UNIQUE index on
-    // (designId, filename) would be the strongest guarantee but is a non-additive
-    // schema change on existing data, so it's deferred.)
-    await db.transaction(async (tx) => {
-      if (filename !== undefined) {
-        const [collision] = await tx
-          .select({ id: schema.designFiles.id })
-          .from(schema.designFiles)
-          .where(
-            and(
-              eq(schema.designFiles.designId, file.designId),
-              eq(schema.designFiles.filename, filename),
-            ),
-          )
-          .limit(1);
-        if (collision && collision.id !== id) {
-          throw new Error(
-            `File "${filename}" already exists in design ${file.designId}`,
-          );
-        }
+    // design. SQLite's local async transaction wrapper can fail under concurrent
+    // editor/collab writes; keep this action to direct statements until a DB-level
+    // UNIQUE index can enforce the invariant atomically.
+    if (filename !== undefined) {
+      const [collision] = await db
+        .select({ id: schema.designFiles.id })
+        .from(schema.designFiles)
+        .where(
+          and(
+            eq(schema.designFiles.designId, file.designId),
+            eq(schema.designFiles.filename, filename),
+          ),
+        )
+        .limit(1);
+      if (collision && collision.id !== id) {
+        throw new Error(
+          `File "${filename}" already exists in design ${file.designId}`,
+        );
       }
+    }
 
-      const updates: Record<string, unknown> = { updatedAt: now };
-      if (content !== undefined) updates.content = content;
-      if (filename !== undefined) updates.filename = filename;
-      if (fileType !== undefined) updates.fileType = fileType;
+    const updates: Record<string, unknown> = { updatedAt: now };
+    if (content !== undefined) updates.content = content;
+    if (filename !== undefined) updates.filename = filename;
+    if (fileType !== undefined) updates.fileType = fileType;
 
-      await tx
-        .update(schema.designFiles)
-        .set(updates)
-        .where(eq(schema.designFiles.id, id));
-    });
+    await db
+      .update(schema.designFiles)
+      .set(updates)
+      .where(eq(schema.designFiles.id, id));
 
     // Push content through the collab layer so live editors see the change
     if (content !== undefined && syncCollab) {

--- a/templates/design/actions/update-file.ts
+++ b/templates/design/actions/update-file.ts
@@ -4,6 +4,7 @@ import {
   applyText,
   seedFromText,
 } from "@agent-native/core/collab";
+import { isPostgres } from "@agent-native/core/db";
 import { accessFilter, assertAccess } from "@agent-native/core/sharing";
 import { and, eq, sql } from "drizzle-orm";
 import { z } from "zod";
@@ -86,42 +87,72 @@ export default defineAction({
     if (filename !== undefined) updates.filename = filename;
     if (fileType !== undefined) updates.fileType = fileType;
 
-    // Reject colliding renames as part of the write. SQLite's local async
-    // transaction wrapper can fail under concurrent editor/collab writes, so
-    // keep this to one guarded UPDATE instead of a SELECT-then-UPDATE window.
-    const updateWhere =
-      filename === undefined
-        ? eq(schema.designFiles.id, id)
-        : and(
-            eq(schema.designFiles.id, id),
-            sql`NOT EXISTS (
-              SELECT 1 FROM design_files AS sibling
-              WHERE sibling.design_id = ${file.designId}
-                AND sibling.filename = ${filename}
-                AND sibling.id <> ${id}
-            )`,
+    if (filename !== undefined && isPostgres()) {
+      await db.transaction(async (tx) => {
+        // Postgres evaluates concurrent NOT EXISTS updates under MVCC, so a
+        // guarded UPDATE alone can still race. Serialize design-file renames in
+        // this rare path without using SQLite's fragile async savepoint wrapper.
+        await (
+          tx as unknown as { execute: (query: unknown) => Promise<unknown> }
+        ).execute(sql`LOCK TABLE design_files IN SHARE ROW EXCLUSIVE MODE`);
+        const [collision] = await tx
+          .select({ id: schema.designFiles.id })
+          .from(schema.designFiles)
+          .where(
+            and(
+              eq(schema.designFiles.designId, file.designId),
+              eq(schema.designFiles.filename, filename),
+            ),
+          )
+          .limit(1);
+        if (collision && collision.id !== id) {
+          throw new Error(
+            `File "${filename}" already exists in design ${file.designId}`,
           );
+        }
+        await tx
+          .update(schema.designFiles)
+          .set(updates)
+          .where(eq(schema.designFiles.id, id));
+      });
+    } else {
+      // Reject colliding SQLite renames as part of the write. SQLite's local
+      // async transaction wrapper can fail under concurrent editor/collab writes,
+      // so keep this to one guarded UPDATE instead of a SELECT-then-UPDATE window.
+      const updateWhere =
+        filename === undefined
+          ? eq(schema.designFiles.id, id)
+          : and(
+              eq(schema.designFiles.id, id),
+              sql`NOT EXISTS (
+                SELECT 1 FROM design_files AS sibling
+                WHERE sibling.design_id = ${file.designId}
+                  AND sibling.filename = ${filename}
+                  AND sibling.id <> ${id}
+              )`,
+            );
 
-    const updateResult = await db
-      .update(schema.designFiles)
-      .set(updates)
-      .where(updateWhere);
+      const updateResult = await db
+        .update(schema.designFiles)
+        .set(updates)
+        .where(updateWhere);
 
-    if (filename !== undefined && rowsAffected(updateResult) === 0) {
-      const [collision] = await db
-        .select({ id: schema.designFiles.id })
-        .from(schema.designFiles)
-        .where(
-          and(
-            eq(schema.designFiles.designId, file.designId),
-            eq(schema.designFiles.filename, filename),
-          ),
-        )
-        .limit(1);
-      if (collision && collision.id !== id) {
-        throw new Error(
-          `File "${filename}" already exists in design ${file.designId}`,
-        );
+      if (filename !== undefined && rowsAffected(updateResult) === 0) {
+        const [collision] = await db
+          .select({ id: schema.designFiles.id })
+          .from(schema.designFiles)
+          .where(
+            and(
+              eq(schema.designFiles.designId, file.designId),
+              eq(schema.designFiles.filename, filename),
+            ),
+          )
+          .limit(1);
+        if (collision && collision.id !== id) {
+          throw new Error(
+            `File "${filename}" already exists in design ${file.designId}`,
+          );
+        }
       }
     }
 

--- a/templates/design/actions/update-file.ts
+++ b/templates/design/actions/update-file.ts
@@ -11,9 +11,11 @@ import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 
 function rowsAffected(result: unknown): number | undefined {
-  const candidate = result as
-    | { rowsAffected?: unknown; rowCount?: unknown; changes?: unknown }
-    | null;
+  const candidate = result as {
+    rowsAffected?: unknown;
+    rowCount?: unknown;
+    changes?: unknown;
+  } | null;
   const value =
     candidate?.rowsAffected ?? candidate?.rowCount ?? candidate?.changes;
   return typeof value === "number" ? value : undefined;

--- a/templates/design/actions/update-file.ts
+++ b/templates/design/actions/update-file.ts
@@ -5,10 +5,19 @@ import {
   seedFromText,
 } from "@agent-native/core/collab";
 import { accessFilter, assertAccess } from "@agent-native/core/sharing";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+
+function rowsAffected(result: unknown): number | undefined {
+  const candidate = result as
+    | { rowsAffected?: unknown; rowCount?: unknown; changes?: unknown }
+    | null;
+  const value =
+    candidate?.rowsAffected ?? candidate?.rowCount ?? candidate?.changes;
+  return typeof value === "number" ? value : undefined;
+}
 
 export default defineAction({
   description:
@@ -70,11 +79,33 @@ export default defineAction({
 
     await assertAccess("design", file.designId, "editor");
 
-    // Reject a rename that would collide with an existing filename in the same
-    // design. SQLite's local async transaction wrapper can fail under concurrent
-    // editor/collab writes; keep this action to direct statements until a DB-level
-    // UNIQUE index can enforce the invariant atomically.
-    if (filename !== undefined) {
+    const updates: Record<string, unknown> = { updatedAt: now };
+    if (content !== undefined) updates.content = content;
+    if (filename !== undefined) updates.filename = filename;
+    if (fileType !== undefined) updates.fileType = fileType;
+
+    // Reject colliding renames as part of the write. SQLite's local async
+    // transaction wrapper can fail under concurrent editor/collab writes, so
+    // keep this to one guarded UPDATE instead of a SELECT-then-UPDATE window.
+    const updateWhere =
+      filename === undefined
+        ? eq(schema.designFiles.id, id)
+        : and(
+            eq(schema.designFiles.id, id),
+            sql`NOT EXISTS (
+              SELECT 1 FROM design_files AS sibling
+              WHERE sibling.design_id = ${file.designId}
+                AND sibling.filename = ${filename}
+                AND sibling.id <> ${id}
+            )`,
+          );
+
+    const updateResult = await db
+      .update(schema.designFiles)
+      .set(updates)
+      .where(updateWhere);
+
+    if (filename !== undefined && rowsAffected(updateResult) === 0) {
       const [collision] = await db
         .select({ id: schema.designFiles.id })
         .from(schema.designFiles)
@@ -91,16 +122,6 @@ export default defineAction({
         );
       }
     }
-
-    const updates: Record<string, unknown> = { updatedAt: now };
-    if (content !== undefined) updates.content = content;
-    if (filename !== undefined) updates.filename = filename;
-    if (fileType !== undefined) updates.fileType = fileType;
-
-    await db
-      .update(schema.designFiles)
-      .set(updates)
-      .where(eq(schema.designFiles.id, id));
 
     // Push content through the collab layer so live editors see the change
     if (content !== undefined && syncCollab) {

--- a/templates/design/app/components/design/DesignCanvas.spacing-overlay.test.ts
+++ b/templates/design/app/components/design/DesignCanvas.spacing-overlay.test.ts
@@ -104,7 +104,9 @@ describe("DesignCanvas spacing overlay bridge", () => {
 describe("DesignCanvas text editing bridge", () => {
   it("uses selection chrome instead of double outlines while text is focused", () => {
     expect(source).toContain("function updateTextEditingChrome");
-    expect(source).toContain('target.style.outline = ""');
+    expect(source).toContain('target.style.outline = "none"');
+    expect(source).toContain('target.style.outlineStyle = "none"');
+    expect(source).toContain('target.style.outlineWidth = "0px"');
     expect(source).toContain('selectionOverlay.style.display = "none"');
     expect(source).toContain("setSelectionOverlayResizeChromeVisible(false)");
     expect(source).toContain('target.addEventListener("input", onInput');

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -1811,14 +1811,15 @@ export function DesignCanvas({
             : "allow-scripts allow-popups allow-popups-to-escape-sandbox allow-same-origin"
         }
         data-design-preview-iframe
-        data-screen-iframe-id={screenId ?? undefined}
+        data-screen-iframe-id={
+          boardSurface ? undefined : (screenId ?? undefined)
+        }
         data-design-source-type={
           sourceType ??
           (externalPreviewUrl
             ? "localhost" // inferred — content is a URL
             : "inline")
         }
-        allowTransparency={transparentBackground || undefined}
         className="block h-full w-full border-0 bg-transparent"
         style={{
           background: iframeBackgroundColor,

--- a/templates/design/app/components/design/EditPanel.tsx
+++ b/templates/design/app/components/design/EditPanel.tsx
@@ -138,7 +138,7 @@ import type { StatesPanelProps } from "./StatesPanel";
 import { TweaksPanelContent } from "./TweaksPanel";
 import type { ElementInfo } from "./types";
 
-export type InspectorTab = "design" | "tweaks";
+export type InspectorTab = "design" | "tweaks" | "extensions";
 
 const MIXED_VALUE = "Mixed";
 
@@ -216,6 +216,7 @@ interface EditPanelProps {
   tweakValues?: Record<string, string | number | boolean>;
   onTweakChange?: (id: string, value: string | number | boolean) => void;
   onRequestTweaks?: (anchor: HTMLElement) => void;
+  extensionsPanel?: ReactNode;
   onStyleChange: (property: string, value: string) => void;
   onStylesChange?: (styles: Record<string, string>) => void;
   onExport?: (settings: ExportSettingsValue[]) => void;
@@ -283,6 +284,8 @@ interface EditPanelProps {
   defaultComponentName?: string;
   /** Code-inspection data for the "Inspect code" popover. */
   inspectCode?: InspectCodeData;
+  /** Optional compact AI edit controls for selected/local source elements. */
+  aiActions?: ReactNode;
 }
 
 /**
@@ -2960,10 +2963,12 @@ function InspectorTabsHeader({
   activeTab,
   onActiveTabChange,
   trailing,
+  showExtensions,
 }: {
   activeTab: InspectorTab;
   onActiveTabChange: (tab: InspectorTab) => void;
   trailing?: ReactNode;
+  showExtensions?: boolean;
 }) {
   const t = useT();
 
@@ -2986,6 +2991,14 @@ function InspectorTabsHeader({
           >
             {t("designEditor.tweaks")}
           </TabsTrigger>
+          {showExtensions ? (
+            <TabsTrigger
+              value="extensions"
+              className="h-6 rounded-md px-1.5 !text-[11px] font-semibold text-muted-foreground shadow-none transition-colors hover:text-foreground data-[state=active]:bg-[var(--design-editor-panel-raised-bg)] data-[state=active]:text-foreground data-[state=active]:shadow-none"
+            >
+              {"Extensions" /* i18n-ignore design inspector tab */}
+            </TabsTrigger>
+          ) : null}
         </TabsList>
       </Tabs>
       {trailing ? <div className="shrink-0">{trailing}</div> : null}
@@ -3282,7 +3295,7 @@ function CornerRadiusControl({
         value={radius}
         onChange={commitRadius}
         min={0}
-        precision={1}
+        precision={0}
       />
       <Tooltip>
         <TooltipTrigger asChild>
@@ -3308,6 +3321,7 @@ function CornerRadiusControl({
         <>
           <AppearanceScrubField
             label={t("editPanel.labels.topLeft")}
+            ariaLabel="Top left"
             icon={IconRadiusTopLeft}
             value={corners.topLeft}
             onChange={(value) =>
@@ -3321,6 +3335,7 @@ function CornerRadiusControl({
           />
           <AppearanceScrubField
             label={t("editPanel.labels.topRight")}
+            ariaLabel="Top right"
             icon={IconRadiusTopRight}
             value={corners.topRight}
             onChange={(value) =>
@@ -3335,6 +3350,7 @@ function CornerRadiusControl({
           <span aria-hidden="true" />
           <AppearanceScrubField
             label={t("editPanel.labels.bottomLeft")}
+            ariaLabel="Bottom left"
             icon={IconRadiusBottomLeft}
             value={corners.bottomLeft}
             onChange={(value) =>
@@ -3348,6 +3364,7 @@ function CornerRadiusControl({
           />
           <AppearanceScrubField
             label={t("editPanel.labels.bottomRight")}
+            ariaLabel="Bottom right"
             icon={IconRadiusBottomRight}
             value={corners.bottomRight}
             onChange={(value) =>
@@ -3368,6 +3385,7 @@ function CornerRadiusControl({
 
 function AppearanceScrubField({
   label,
+  ariaLabel,
   icon,
   value,
   onChange,
@@ -3379,6 +3397,7 @@ function AppearanceScrubField({
   precision,
 }: {
   label: string;
+  ariaLabel?: string;
   icon: (props: { className?: string }) => ReactNode;
   value: number;
   onChange: (value: number) => void;
@@ -3392,7 +3411,7 @@ function AppearanceScrubField({
   return (
     <ScrubInput
       label={label}
-      ariaLabel={label}
+      ariaLabel={ariaLabel ?? label}
       icon={icon}
       value={value}
       onChange={onChange}
@@ -6842,6 +6861,7 @@ export function EditPanel({
   tweakValues = {},
   onTweakChange,
   onRequestTweaks,
+  extensionsPanel,
   onStyleChange,
   onStylesChange,
   onExport,
@@ -6858,6 +6878,7 @@ export function EditPanel({
   selectedElementAlreadyComponent = false,
   defaultComponentName = "Component",
   inspectCode,
+  aiActions,
 }: EditPanelProps) {
   const t = useT();
   const [createComponentOpen, setCreateComponentOpen] = useState(false);
@@ -6950,6 +6971,7 @@ export function EditPanel({
         activeTab={activeTab}
         onActiveTabChange={handleActiveTabChange}
         trailing={headerTrailing}
+        showExtensions={!!extensionsPanel}
       />
 
       {activeTab === "design" ? (
@@ -7057,6 +7079,12 @@ export function EditPanel({
                 sourceCapabilities={sourceCapabilities}
               />
             )}
+
+            {aiActions ? (
+              <div className="border-b border-[var(--design-editor-control-border)] px-2 py-1.5">
+                {aiActions}
+              </div>
+            ) : null}
 
             {!inspectorElement && (
               <PageProperties
@@ -7227,6 +7255,10 @@ export function EditPanel({
               className="px-3 py-3"
             />
           </div>
+        </div>
+      ) : activeTab === "extensions" && extensionsPanel ? (
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          {extensionsPanel}
         </div>
       ) : null}
     </div>

--- a/templates/design/app/components/design/MotionDock.tsx
+++ b/templates/design/app/components/design/MotionDock.tsx
@@ -117,6 +117,12 @@ export interface MotionDockProps {
   canvasIframeRef?: React.RefObject<HTMLIFrameElement | null>;
   /** Whether the parent autosave mutation is in flight. */
   applying?: boolean;
+  /** Controlled auto-keyframe state. */
+  autoKeyframe?: boolean;
+  /** Called when the auto-keyframe toggle changes. */
+  onAutoKeyframeChange?: (enabled: boolean) => void;
+  /** Called whenever the playhead moves. */
+  onPlayheadChange?: (t: number) => void;
   /**
    * The currently-selected canvas element, if any. Required to create the FIRST
    * track for a layer: the picker animates this node's
@@ -139,6 +145,9 @@ export function MotionDock({
   onDurationChange,
   canvasIframeRef,
   applying = false,
+  autoKeyframe: autoKeyframeProp,
+  onAutoKeyframeChange,
+  onPlayheadChange,
   selectedTarget = null,
 }: MotionDockProps) {
   // Controlled / uncontrolled open state.
@@ -158,8 +167,27 @@ export function MotionDock({
   const playRafRef = useRef<number | null>(null);
   const playStartRef = useRef<{ wallMs: number; startT: number } | null>(null);
 
-  // Auto-keyframe mode: clicking the canvas at a time scrubs without writing.
-  const [autoKeyframe, setAutoKeyframe] = useState(false);
+  // Auto-keyframe mode: inspector/style edits create keyframes at the playhead.
+  const [autoKeyframeInternal, setAutoKeyframeInternal] = useState(false);
+  const autoKeyframe = autoKeyframeProp ?? autoKeyframeInternal;
+  const setAutoKeyframe = useCallback(
+    (next: boolean | ((current: boolean) => boolean)) => {
+      const resolved =
+        typeof next === "function"
+          ? (next as (current: boolean) => boolean)(autoKeyframe)
+          : next;
+      setAutoKeyframeInternal(resolved);
+      onAutoKeyframeChange?.(resolved);
+    },
+    [autoKeyframe, onAutoKeyframeChange],
+  );
+  const setPlayheadValue = useCallback(
+    (next: number) => {
+      setPlayhead(next);
+      onPlayheadChange?.(next);
+    },
+    [onPlayheadChange],
+  );
 
   // Dock height (resizable via the top drag handle).
   const [dockHeight, setDockHeight] = useState(DEFAULT_DOCK_HEIGHT);
@@ -235,7 +263,7 @@ export function MotionDock({
       if (!playStartRef.current) return;
       const elapsed = now - playStartRef.current.wallMs;
       const t = Math.min(1, playStartRef.current.startT + elapsed / durationMs);
-      setPlayhead(t);
+      setPlayheadValue(t);
       sendPreview(t);
       if (t < 1) {
         playRafRef.current = requestAnimationFrame(tick);
@@ -244,7 +272,7 @@ export function MotionDock({
       }
     };
     playRafRef.current = requestAnimationFrame(tick);
-  }, [durationMs, playhead, sendPreview, stopPlayback]);
+  }, [durationMs, playhead, sendPreview, setPlayheadValue, stopPlayback]);
 
   useEffect(() => {
     return () => {
@@ -263,10 +291,10 @@ export function MotionDock({
       (e.target as HTMLElement).setPointerCapture(e.pointerId);
       const rect = trackAreaRef.current.getBoundingClientRect();
       const t = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
-      setPlayhead(t);
+      setPlayheadValue(t);
       sendPreview(t);
     },
-    [sendPreview, stopPlayback],
+    [sendPreview, setPlayheadValue, stopPlayback],
   );
 
   const handleRulerPointerMove = useCallback(
@@ -274,10 +302,10 @@ export function MotionDock({
       if (!isDraggingPlayhead.current || !trackAreaRef.current) return;
       const rect = trackAreaRef.current.getBoundingClientRect();
       const t = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
-      setPlayhead(t);
+      setPlayheadValue(t);
       sendPreview(t);
     },
-    [sendPreview],
+    [sendPreview, setPlayheadValue],
   );
 
   const handleRulerPointerUp = useCallback(() => {
@@ -493,7 +521,7 @@ export function MotionDock({
                   className="size-6 shrink-0"
                   onClick={() => {
                     stopPlayback();
-                    setPlayhead(0);
+                    setPlayheadValue(0);
                     sendPreview(0);
                   }}
                   aria-label="Reset playhead"

--- a/templates/design/app/components/design/MotionDock.tsx
+++ b/templates/design/app/components/design/MotionDock.tsx
@@ -121,6 +121,8 @@ export interface MotionDockProps {
   autoKeyframe?: boolean;
   /** Called when the auto-keyframe toggle changes. */
   onAutoKeyframeChange?: (enabled: boolean) => void;
+  /** Controlled playhead position, normalized to [0, 1]. */
+  playhead?: number;
   /** Called whenever the playhead moves. */
   onPlayheadChange?: (t: number) => void;
   /**
@@ -147,6 +149,7 @@ export function MotionDock({
   applying = false,
   autoKeyframe: autoKeyframeProp,
   onAutoKeyframeChange,
+  playhead: playheadProp,
   onPlayheadChange,
   selectedTarget = null,
 }: MotionDockProps) {
@@ -162,10 +165,14 @@ export function MotionDock({
   );
 
   // Playhead position: normalised [0, 1].
-  const [playhead, setPlayhead] = useState(0);
+  const [playhead, setPlayhead] = useState(playheadProp ?? 0);
   const [playing, setPlaying] = useState(false);
   const playRafRef = useRef<number | null>(null);
   const playStartRef = useRef<{ wallMs: number; startT: number } | null>(null);
+  useEffect(() => {
+    if (playheadProp === undefined) return;
+    setPlayhead(Math.max(0, Math.min(1, playheadProp)));
+  }, [playheadProp]);
 
   // Auto-keyframe mode: inspector/style edits create keyframes at the playhead.
   const [autoKeyframeInternal, setAutoKeyframeInternal] = useState(false);

--- a/templates/design/app/components/design/MultiScreenCanvas.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.tsx
@@ -1189,7 +1189,6 @@ export function MultiScreenCanvas({
   const dragState = useRef<DragState | null>(null);
   const dragCleanup = useRef<(() => void) | null>(null);
   const duplicateCleanup = useRef<(() => void) | null>(null);
-  const autoFittedInitialViewRef = useRef(false);
   const handledSelectAllRequestRef = useRef(selectAllRequest);
   const handledClearSelectionRequestRef = useRef(clearSelectionRequest);
   const [isDragging, setIsDragging] = useState(false);
@@ -1510,7 +1509,7 @@ export function MultiScreenCanvas({
     setTransformBadge(null);
   }, [clearSelectionRequest, updateSelectedDraftIds, updateSelectedIds]);
 
-  // Center the lineup on first mount so the user sees screens, not whitespace.
+  // Center the lineup when the screen footprint changes so new frames stay reachable.
   useEffect(() => {
     if (!surfaceRef.current || screens.length === 0) return;
     const rect = surfaceRef.current.getBoundingClientRect();
@@ -1542,16 +1541,13 @@ export function MultiScreenCanvas({
         : scale;
     const heightFitScale =
       totalHeight > 0 ? Math.max(0.1, (rect.height - 96) / totalHeight) : scale;
-    const nextScale = !autoFittedInitialViewRef.current
-      ? Math.min(scale, widthFitScale, heightFitScale)
-      : scale;
+    const nextScale = Math.min(scale, widthFitScale, heightFitScale);
     if (nextScale < scale) {
       const nextZoom = nextScale * 100;
       zoomRef.current = nextZoom;
       setCanvasZoom(nextZoom);
       onZoomChange?.(nextZoom);
     }
-    autoFittedInitialViewRef.current = true;
     const visualLeft = Math.max(24, (rect.width - totalWidth * nextScale) / 2);
     const visualTop = Math.max(24, (rect.height - totalHeight * nextScale) / 2);
     const nextPan = {

--- a/templates/design/app/components/design/MultiScreenCanvas.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.tsx
@@ -186,7 +186,11 @@ interface MultiScreenCanvasProps {
     screenId: string,
     primitive: CanvasPrimitiveInsert,
   ) => boolean | string;
-  onPrimitiveCreated?: (screenId: string, nodeId: string) => void;
+  onPrimitiveCreated?: (
+    screenId: string,
+    nodeId: string,
+    options?: { nextTool?: "move" | "pen" },
+  ) => void;
   onPrimitiveReparent?: (args: {
     sourceNodeId: string;
     sourceScreenId: string;
@@ -1185,6 +1189,7 @@ export function MultiScreenCanvas({
   const dragState = useRef<DragState | null>(null);
   const dragCleanup = useRef<(() => void) | null>(null);
   const duplicateCleanup = useRef<(() => void) | null>(null);
+  const autoFittedInitialViewRef = useRef(false);
   const handledSelectAllRequestRef = useRef(selectAllRequest);
   const handledClearSelectionRequestRef = useRef(clearSelectionRequest);
   const [isDragging, setIsDragging] = useState(false);
@@ -1529,11 +1534,29 @@ export function MultiScreenCanvas({
     );
     const totalWidth = bounds?.width ?? SCREEN_WIDTH;
     const totalHeight = bounds?.height ?? SCREEN_CARD_HEIGHT;
-    const visualLeft = Math.max(24, (rect.width - totalWidth * scale) / 2);
-    const visualTop = Math.max(24, (rect.height - totalHeight * scale) / 2);
+    // Leave a Figma-like board gutter beside the last frame for quick drops/draws,
+    // and fit tall single frames so lower canvas interactions remain reachable.
+    const widthFitScale =
+      screens.length > 1 && totalWidth > 0
+        ? Math.max(0.1, (rect.width - 180) / totalWidth)
+        : scale;
+    const heightFitScale =
+      totalHeight > 0 ? Math.max(0.1, (rect.height - 96) / totalHeight) : scale;
+    const nextScale = !autoFittedInitialViewRef.current
+      ? Math.min(scale, widthFitScale, heightFitScale)
+      : scale;
+    if (nextScale < scale) {
+      const nextZoom = nextScale * 100;
+      zoomRef.current = nextZoom;
+      setCanvasZoom(nextZoom);
+      onZoomChange?.(nextZoom);
+    }
+    autoFittedInitialViewRef.current = true;
+    const visualLeft = Math.max(24, (rect.width - totalWidth * nextScale) / 2);
+    const visualTop = Math.max(24, (rect.height - totalHeight * nextScale) / 2);
     const nextPan = {
-      x: visualLeft - SURFACE_PADDING * scale,
-      y: visualTop - SURFACE_PADDING * scale,
+      x: visualLeft - SURFACE_PADDING * nextScale,
+      y: visualTop - SURFACE_PADDING * nextScale,
     };
     panRef.current = nextPan;
     setPan(nextPan);
@@ -2517,9 +2540,11 @@ export function MultiScreenCanvas({
         updateSelectedIds(() => state.baseSelectedIds);
         updateSelectedDraftIds(() => state.baseSelectedDraftIds);
       } else if (state.type === "pen-node") {
-        setActivePenPath(
-          state.pathBefore ? clonePenPath(state.pathBefore) : null,
-        );
+        const restoredPath = state.pathBefore
+          ? clonePenPath(state.pathBefore)
+          : null;
+        activePenPathRef.current = restoredPath;
+        setActivePenPath(restoredPath);
         setPenGesturePreview(null);
         setPenPointer(null);
         setPenCloseHover(false);
@@ -2792,10 +2817,10 @@ export function MultiScreenCanvas({
           });
           const persisted = handler(boardPrimitive);
           if (!persisted) return null;
-          // Return a sentinel PersistedDraftPrimitive so the caller can remove
-          // the draft. The sentinel frameId "__board__" is detected downstream.
+          // Return the board file id so the caller can run the same selection
+          // and text-edit activation path used by regular screen primitives.
           return {
-            frameId: "__board__",
+            frameId: boardFileId ?? "__board__",
             nodeId:
               (typeof persisted === "string"
                 ? persisted
@@ -2836,6 +2861,7 @@ export function MultiScreenCanvas({
       };
     },
     [
+      boardFileId,
       getScreenMetadata,
       getTargetFrameForDraft,
       metadataById,
@@ -2845,7 +2871,11 @@ export function MultiScreenCanvas({
   );
 
   const commitDraftPrimitive = useCallback(
-    (nextDraft: DraftPrimitive, preferredFrameId?: string) => {
+    (
+      nextDraft: DraftPrimitive,
+      preferredFrameId?: string,
+      options?: { nextTool?: "move" | "pen" },
+    ) => {
       const persisted = persistDraftPrimitive(nextDraft, preferredFrameId);
       if (persisted) {
         updateDraftPrimitives((current) =>
@@ -2853,9 +2883,9 @@ export function MultiScreenCanvas({
         );
         updateSelectedDraftIds(() => []);
         updateSelectedIds(() => []);
-        if (persisted.frameId !== "__board__") {
-          onPrimitiveCreated?.(persisted.frameId, persisted.nodeId);
-        }
+        onPrimitiveCreated?.(persisted.frameId, persisted.nodeId, {
+          nextTool: options?.nextTool,
+        });
         return;
       }
 
@@ -2937,9 +2967,10 @@ export function MultiScreenCanvas({
           stroke: toolProps?.stroke,
           strokeWidth: toolProps?.strokeWidth,
         }),
+        undefined,
+        { nextTool: "pen" },
       );
       clearActivePenPath();
-      onActiveToolChange?.("pen");
     },
     [clearActivePenPath, commitDraftPrimitive, onActiveToolChange, toolProps],
   );
@@ -3041,9 +3072,10 @@ export function MultiScreenCanvas({
         pathBefore: pathSnapshot,
         hasMoved: false,
       };
-      setPenGesturePreview(
-        appendPenNode(pathSnapshot, createCornerNode(anchor)),
-      );
+      const initialPath = appendPenNode(pathSnapshot, createCornerNode(anchor));
+      activePenPathRef.current = initialPath;
+      setActivePenPath(initialPath);
+      setPenGesturePreview(initialPath);
       setPenPointer(null);
       setPenCloseHover(false);
       setIsDragging(true);
@@ -3071,7 +3103,10 @@ export function MultiScreenCanvas({
                 : handlePoint,
             )
           : createCornerNode(state.anchor);
-        setPenGesturePreview(appendPenNode(state.pathBefore, node));
+        const nextPath = appendPenNode(state.pathBefore, node);
+        activePenPathRef.current = nextPath;
+        setActivePenPath(nextPath);
+        setPenGesturePreview(nextPath);
       };
 
       const handleMouseUp = (ev: MouseEvent) => {
@@ -3090,7 +3125,9 @@ export function MultiScreenCanvas({
                 : handlePoint,
             )
           : createCornerNode(state.anchor);
-        setActivePenPath(appendPenNode(state.pathBefore, node));
+        const nextPath = appendPenNode(state.pathBefore, node);
+        activePenPathRef.current = nextPath;
+        setActivePenPath(nextPath);
         setPenGesturePreview(null);
         setPenPointer(null);
         setPenCloseHover(false);
@@ -3101,6 +3138,7 @@ export function MultiScreenCanvas({
       const cancelPenGesture = () => {
         const state = dragState.current;
         if (state?.type === "pen-node") {
+          activePenPathRef.current = state.pathBefore;
           setActivePenPath(state.pathBefore);
         }
         setPenGesturePreview(null);
@@ -4730,6 +4768,20 @@ export function MultiScreenCanvas({
         frameGeometry[screen.id] ?? getInitialFrameGeometry(index, metadata),
     };
   });
+  const topScreenId =
+    selectedIds.find((id) =>
+      canvasFrames.some(({ screen }) => screen.id === id),
+    ) ??
+    (activeId && canvasFrames.some(({ screen }) => screen.id === activeId)
+      ? activeId
+      : canvasFrames[0]?.screen.id);
+  const renderCanvasFrames =
+    topScreenId && canvasFrames.some(({ screen }) => screen.id === topScreenId)
+      ? [
+          ...canvasFrames.filter(({ screen }) => screen.id !== topScreenId),
+          ...canvasFrames.filter(({ screen }) => screen.id === topScreenId),
+        ]
+      : canvasFrames;
   const screenContentById = useMemo(() => {
     if (!renderScreenContent) return new Map<string, ReactNode>();
     return new Map(
@@ -4910,7 +4962,7 @@ export function MultiScreenCanvas({
             );
           })()}
 
-        {canvasFrames.map(({ screen, metadata, geometry }) => {
+        {renderCanvasFrames.map(({ screen, metadata, geometry }) => {
           return (
             <Screen
               key={screen.id}
@@ -7031,13 +7083,6 @@ function draftPrimitiveToInsert(
     x: Math.round((point.x - frameGeometry.x) * scaleX),
     y: Math.round((point.y - frameGeometry.y) * scaleY),
   });
-  const localGeometry = {
-    ...draft.geometry,
-    x: Math.round((draft.geometry.x - frameGeometry.x) * scaleX),
-    y: Math.round((draft.geometry.y - frameGeometry.y) * scaleY),
-    width: Math.max(1, Math.round(draft.geometry.width * scaleX)),
-    height: Math.max(1, Math.round(draft.geometry.height * scaleY)),
-  };
   const scaledPenPath = draft.penPath
     ? scalePenPathToGeometry(draft.penPath, frameGeometry, {
         x: 0,
@@ -7046,6 +7091,15 @@ function draftPrimitiveToInsert(
         height: metadata?.height ?? frameGeometry.height,
       })
     : undefined;
+  const localGeometry = scaledPenPath
+    ? getPenPathGeometry(scaledPenPath)
+    : {
+        ...draft.geometry,
+        x: Math.round((draft.geometry.x - frameGeometry.x) * scaleX),
+        y: Math.round((draft.geometry.y - frameGeometry.y) * scaleY),
+        width: Math.max(1, Math.round(draft.geometry.width * scaleX)),
+        height: Math.max(1, Math.round(draft.geometry.height * scaleY)),
+      };
   return {
     kind: draft.kind,
     nodeId: draft.id,

--- a/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
+++ b/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
@@ -58,6 +58,8 @@ declare var __DESIGN_CANVAS_BOARD_SURFACE__: boolean;
     );
     chromeTransitionStyle.textContent =
       '[data-agent-native-edit-overlay="selection"]{transition:border-width 150ms ease-out}' +
+      '[data-agent-native-empty-text-editing="true"] [data-agent-native-edit-overlay="selection"]{display:none!important}' +
+      "[data-agent-native-text-editing]{outline:none!important;outline-offset:0!important}" +
       "[data-agent-native-edge-handle],[data-agent-native-edit-handle],[data-agent-native-rotate-handle]{transition:width 150ms ease-out,height 150ms ease-out,border-width 150ms ease-out,top 150ms ease-out,bottom 150ms ease-out,left 150ms ease-out,right 150ms ease-out}" +
       "[data-agent-native-spacing-line]{position:absolute;display:none;pointer-events:none;border-radius:999px}" +
       "[data-agent-native-spacing-region]{position:absolute;display:none;box-sizing:border-box;pointer-events:auto;background-size:6px 6px}" +
@@ -2402,12 +2404,24 @@ declare var __DESIGN_CANVAS_BOARD_SURFACE__: boolean;
   }
 
   function refreshOverlays(): void {
+    var textEditingEl =
+      activeTextEditEl ||
+      (document.querySelector(
+        "[data-agent-native-text-editing]",
+      ) as HTMLElement | null);
     if (hoveredEl && hoveredEl !== selectedEl) {
       positionOverlay(highlightOverlay, hoveredEl);
     } else {
       highlightOverlay.style.display = "none";
     }
-    if (selectedEl) {
+    if (textEditingEl) {
+      if (activeTextEditEl === textEditingEl) {
+        updateTextEditingChrome(textEditingEl, "", "");
+      }
+      if (!hasTextCharacters(textEditingEl)) {
+        hideSelectionOverlay();
+      }
+    } else if (selectedEl) {
       positionOverlay(selectionOverlay, selectedEl);
     } else {
       hideParentAutoLayoutOverlay();
@@ -2819,9 +2833,15 @@ declare var __DESIGN_CANVAS_BOARD_SURFACE__: boolean;
     originalMinWidth: string,
     originalMinHeight: string,
   ): void {
-    target.style.outline = "";
-    target.style.outlineOffset = "";
+    target.style.outline = "none";
+    target.style.outlineStyle = "none";
+    target.style.outlineWidth = "0px";
+    target.style.outlineColor = "transparent";
+    target.style.outlineOffset = "0px";
     if (hasTextCharacters(target)) {
+      document.documentElement.removeAttribute(
+        "data-agent-native-empty-text-editing",
+      );
       target.style.minWidth = originalMinWidth;
       target.style.minHeight = originalMinHeight;
       positionOverlay(selectionOverlay, target);
@@ -2830,6 +2850,10 @@ declare var __DESIGN_CANVAS_BOARD_SURFACE__: boolean;
     }
     target.style.minWidth = originalMinWidth || "1px";
     target.style.minHeight = originalMinHeight || "1em";
+    document.documentElement.setAttribute(
+      "data-agent-native-empty-text-editing",
+      "true",
+    );
     hideSelectionOverlay();
     setSelectionOverlayResizeChromeVisible(false);
   }
@@ -5021,24 +5045,37 @@ declare var __DESIGN_CANVAS_BOARD_SURFACE__: boolean;
     // code-layer node rather than a runtime-only descendant (which would emit a
     // brittle body > div:nth-of-type(...) selector that never resolves).
     selectedEl = selectionTargetForHit(target) || target;
+    var programmaticTextEdit =
+      !!e &&
+      (e as unknown as { agentNativeProgrammaticTextEdit?: boolean })
+        .agentNativeProgrammaticTextEdit === true;
     var originalText = target.textContent || "";
     var originalHtml = target.innerHTML || "";
     var originalMinWidth = target.style.minWidth;
     var originalMinHeight = target.style.minHeight;
     var originalBorderColor = target.style.borderColor;
+    var originalOutline = target.style.outline;
+    var originalOutlineOffset = target.style.outlineOffset;
     var committed = false;
     activeTextEditEl = target;
     target.setAttribute("contenteditable", "true");
     target.setAttribute("data-agent-native-text-editing", "true");
     target.style.cursor = "text";
     target.style.borderColor = "transparent";
+    target.style.outline = "none";
+    target.style.outlineStyle = "none";
+    target.style.outlineWidth = "0px";
+    target.style.outlineColor = "transparent";
+    target.style.outlineOffset = "0px";
     setTextEditingPointerPassthrough(true);
     updateTextEditingChrome(target, originalMinWidth, originalMinHeight);
-    postElementSelect(target, e);
-    (window.parent as Window).postMessage(
-      { type: "element-dblclick-text", payload: getElementInfo(target) },
-      "*",
-    );
+    if (!programmaticTextEdit) {
+      postElementSelect(target, e);
+      (window.parent as Window).postMessage(
+        { type: "element-dblclick-text", payload: getElementInfo(target) },
+        "*",
+      );
+    }
     postTextEditingState(target, true);
 
     function finish(commit) {
@@ -5053,9 +5090,12 @@ declare var __DESIGN_CANVAS_BOARD_SURFACE__: boolean;
       document.removeEventListener("selectionchange", onSelectionChange);
       target.removeAttribute("contenteditable");
       target.removeAttribute("data-agent-native-text-editing");
+      document.documentElement.removeAttribute(
+        "data-agent-native-empty-text-editing",
+      );
       target.style.cursor = "";
-      target.style.outline = "";
-      target.style.outlineOffset = "";
+      target.style.outline = originalOutline;
+      target.style.outlineOffset = originalOutlineOffset;
       target.style.minWidth = originalMinWidth;
       target.style.minHeight = originalMinHeight;
       target.style.borderColor = originalBorderColor;
@@ -5077,6 +5117,15 @@ declare var __DESIGN_CANVAS_BOARD_SURFACE__: boolean;
     }
 
     function onBlur() {
+      if (programmaticTextEdit && !(target.textContent || "").trim()) {
+        window.setTimeout(function () {
+          if (committed || (target.textContent || "").trim()) return;
+          target.focus();
+          updateTextEditingChrome(target, originalMinWidth, originalMinHeight);
+          postTextEditingState(target, true);
+        }, 0);
+        return;
+      }
       finish(true);
     }
 
@@ -5302,6 +5351,7 @@ declare var __DESIGN_CANVAS_BOARD_SURFACE__: boolean;
           clientX: bteCenterX,
           clientY: bteCenterY,
           target: textTarget,
+          agentNativeProgrammaticTextEdit: true,
           preventDefault: function () {},
           stopPropagation: function () {},
           stopImmediatePropagation: function () {},

--- a/templates/design/app/components/design/canvas-primitive-style.ts
+++ b/templates/design/app/components/design/canvas-primitive-style.ts
@@ -248,6 +248,8 @@ export function canvasPrimitiveReactStyle(
   // For text kind, clear fill-as-background since text uses `color`
   if (kind === "text") {
     style.background = "transparent";
+    style.outline = "none";
+    style.outlineOffset = 0;
   }
 
   return style;

--- a/templates/design/app/components/design/inspector/InspectorAiActions.tsx
+++ b/templates/design/app/components/design/inspector/InspectorAiActions.tsx
@@ -25,6 +25,8 @@ export interface InspectorAiActionsProps {
   fileId?: string;
   /** Active file name (e.g. "index.html"). */
   filename?: string;
+  /** Localhost-backed source file, when the selected screen comes from a local app. */
+  routeSourceFile?: string;
   /** The design id. */
   designId?: string;
   /** When false, the controls are disabled. */
@@ -43,6 +45,7 @@ export function InspectorAiActions({
   sourceId,
   fileId,
   filename,
+  routeSourceFile,
   designId,
   canEdit,
 }: InspectorAiActionsProps) {
@@ -57,6 +60,7 @@ export function InspectorAiActions({
     sourceId,
     fileId,
     filename,
+    routeSourceFile,
     designId,
   };
   const disabled = !canEdit || !request.trim();

--- a/templates/design/app/hooks/useAgentEditRequest.test.ts
+++ b/templates/design/app/hooks/useAgentEditRequest.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { buildEditContext, buildFullPrompt } from "./useAgentEditRequest";
+
+describe("useAgentEditRequest prompt context", () => {
+  it("includes localhost route source files for local visual-edit handoff", () => {
+    const context = buildEditContext({
+      message: "Make this button primary",
+      designId: "design-123",
+      fileId: "file-abc",
+      filename: "/pricing",
+      selector: '[data-agent-native-node-id="cta"]',
+      sourceId: "cta",
+      routeSourceFile: "src/routes/pricing.tsx",
+    });
+
+    expect(context).toContain('Design id: "design-123".');
+    expect(context).toContain(
+      'Localhost source file to route edits through: "src/routes/pricing.tsx".',
+    );
+    expect(context).toContain(
+      "Route edits through the agent code editing surface",
+    );
+
+    expect(
+      buildFullPrompt({
+        message: "Make this button primary",
+        routeSourceFile: "src/routes/pricing.tsx",
+      }),
+    ).toContain("src/routes/pricing.tsx");
+  });
+});

--- a/templates/design/app/hooks/useAgentEditRequest.ts
+++ b/templates/design/app/hooks/useAgentEditRequest.ts
@@ -26,7 +26,7 @@ export interface AgentEditRequestArgs {
  * same pattern used by the tweaks panel (DesignEditor.tsx ~5293) and the
  * extensions panel context builder (DesignExtensionsPanel.tsx ~120-131).
  */
-function buildEditContext(args: AgentEditRequestArgs): string {
+export function buildEditContext(args: AgentEditRequestArgs): string {
   const lines: string[] = [];
 
   if (args.designId) {
@@ -77,7 +77,7 @@ function buildEditContext(args: AgentEditRequestArgs): string {
  * Builds the full pasteable prompt string (visible message + context block)
  * for use in the "Copy prompt" flow.
  */
-function buildFullPrompt(args: AgentEditRequestArgs): string {
+export function buildFullPrompt(args: AgentEditRequestArgs): string {
   const context = buildEditContext(args);
   return `${args.message}\n\n---\n${context}`;
 }

--- a/templates/design/app/i18n-data.ts
+++ b/templates/design/app/i18n-data.ts
@@ -291,7 +291,7 @@ const enUS = {
     clickToRename: "Click to rename",
     collaborators: "Collaborators",
     share: "Share",
-    signUpToSave: "Sign up to save",
+    signUpToSave: "Sign up free to save",
     signUpToSaveDescription:
       "Sign up for a free account to save designs, screen layouts, and generate new ones.",
     signUpToShare: "Sign up to share",

--- a/templates/design/app/pages/DesignEditor.selection.test.ts
+++ b/templates/design/app/pages/DesignEditor.selection.test.ts
@@ -37,6 +37,7 @@ import {
   sortCodeLayerIdsByTreeOrder,
   formatPendingVisualStylePrompt,
   mergePendingVisualStyleEdit,
+  upsertMotionStyleKeyframes,
 } from "./DesignEditor";
 
 describe("DesignEditor overview selection state", () => {
@@ -399,6 +400,70 @@ describe("DesignEditor motion timeline hydration", () => {
           { t: 1, value: "1" },
         ],
       },
+    ]);
+  });
+
+  it("creates style-keyframe tracks at the current playhead", () => {
+    expect(
+      upsertMotionStyleKeyframes({
+        tracks: [],
+        targetNodeId: "e2e-alpha-button",
+        label: "Alpha Button",
+        styles: { opacity: "0.25", backgroundColor: "rgb(255, 0, 0)" },
+        computedStyles: {
+          opacity: "1",
+          backgroundColor: "rgb(34, 197, 94)",
+        },
+        playhead: 0.5,
+      }),
+    ).toEqual([
+      {
+        targetNodeId: "e2e-alpha-button",
+        label: "Alpha Button",
+        property: "opacity",
+        keyframes: [
+          { t: 0, value: "1", ease: "ease" },
+          { t: 0.5, value: "0.25", ease: "ease" },
+          { t: 1, value: "1", ease: "ease" },
+        ],
+      },
+      {
+        targetNodeId: "e2e-alpha-button",
+        label: "Alpha Button",
+        property: "background-color",
+        keyframes: [
+          { t: 0, value: "rgb(34, 197, 94)", ease: "ease" },
+          { t: 0.5, value: "rgb(255, 0, 0)", ease: "ease" },
+          { t: 1, value: "rgb(34, 197, 94)", ease: "ease" },
+        ],
+      },
+    ]);
+  });
+
+  it("replaces an existing keyframe at the same playhead", () => {
+    const next = upsertMotionStyleKeyframes({
+      tracks: [
+        {
+          targetNodeId: "e2e-alpha-button",
+          label: "Alpha Button",
+          property: "opacity",
+          keyframes: [
+            { t: 0, value: "1" },
+            { t: 0.5, value: "0.5" },
+            { t: 1, value: "0" },
+          ],
+        },
+      ],
+      targetNodeId: "e2e-alpha-button",
+      label: "Alpha Button",
+      styles: { opacity: "0.2" },
+      playhead: 0.501,
+    });
+
+    expect(next[0]?.keyframes).toEqual([
+      { t: 0, value: "1" },
+      { t: 0.501, value: "0.2", ease: "ease" },
+      { t: 1, value: "0" },
     ]);
   });
 });
@@ -1010,6 +1075,16 @@ describe("DesignEditor undo order helpers", () => {
     ).toEqual([
       { fileId: "screen-a", before: "<a>old</a>", after: "<a>new</a>" },
     ]);
+  });
+
+  it("does not treat a stale active file id as available after deletion", () => {
+    expect(
+      getAvailableContentHistoryChanges(
+        { fileId: "deleted-screen", before: "<b>old</b>", after: "<b>new</b>" },
+        ["screen-a"],
+        "deleted-screen",
+      ),
+    ).toEqual([]);
   });
 
   it("keeps active content and grouped file-content stacks distinct", () => {

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -165,6 +165,7 @@ import {
   type InspectorTab,
 } from "@/components/design/EditPanel";
 import type { ExportSettingsValue } from "@/components/design/inspector";
+import { InspectorAiActions } from "@/components/design/inspector/InspectorAiActions";
 import {
   LayersPanel,
   type LayersPanelFile,
@@ -1093,6 +1094,120 @@ export function hydrateMotionDockTracks(
   }));
 }
 
+const MOTION_KEYFRAME_TIME_EPSILON = 0.002;
+
+function motionCssPropertyName(property: string): string | null {
+  const trimmed = property.trim();
+  if (!trimmed || trimmed.startsWith("--")) return null;
+  const cssName = trimmed
+    .replace(/^css/, "")
+    .replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`)
+    .toLowerCase();
+  return /^-?[a-z][a-z0-9-]*$/i.test(cssName) ? cssName : null;
+}
+
+function camelStyleProperty(property: string): string {
+  return property.replace(/-([a-z])/g, (_, letter: string) =>
+    letter.toUpperCase(),
+  );
+}
+
+function computedMotionStyleValue(
+  computedStyles: Record<string, string> | undefined,
+  property: string,
+): string | undefined {
+  if (!computedStyles) return undefined;
+  return (
+    computedStyles[property] ??
+    computedStyles[camelStyleProperty(property)] ??
+    computedStyles[
+      property.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`)
+    ]
+  );
+}
+
+function defaultMotionBaseValue(property: string, nextValue: string): string {
+  if (property === "opacity") return "1";
+  if (property === "transform" || property === "filter") return "none";
+  return nextValue;
+}
+
+export function upsertMotionStyleKeyframes(args: {
+  tracks: MotionDockTrack[];
+  targetNodeId: string;
+  label: string;
+  styles: Record<string, string>;
+  computedStyles?: Record<string, string>;
+  playhead: number;
+  defaultEase?: string;
+}): MotionDockTrack[] {
+  const t = Math.max(0, Math.min(1, args.playhead));
+  const ease = args.defaultEase ?? "ease";
+  let nextTracks = args.tracks;
+
+  for (const [rawProperty, rawValue] of Object.entries(args.styles)) {
+    if (rawValue === undefined) continue;
+    const value = String(rawValue).trim();
+    if (!value) continue;
+    const property = motionCssPropertyName(rawProperty);
+    if (!property) continue;
+
+    const existingIndex = nextTracks.findIndex(
+      (track) =>
+        track.targetNodeId === args.targetNodeId && track.property === property,
+    );
+
+    if (existingIndex >= 0) {
+      nextTracks = nextTracks.map((track, index) => {
+        if (index !== existingIndex) return track;
+        const withoutCurrentTime = track.keyframes.filter(
+          (keyframe) => Math.abs(keyframe.t - t) > MOTION_KEYFRAME_TIME_EPSILON,
+        );
+        return {
+          ...track,
+          label: track.label || args.label,
+          keyframes: [...withoutCurrentTime, { t, value, ease }].sort(
+            (a, b) => a.t - b.t,
+          ),
+        };
+      });
+      continue;
+    }
+
+    const baseValue =
+      computedMotionStyleValue(args.computedStyles, property) ??
+      computedMotionStyleValue(args.computedStyles, rawProperty) ??
+      defaultMotionBaseValue(property, value);
+    const keyframes =
+      t <= MOTION_KEYFRAME_TIME_EPSILON
+        ? [
+            { t: 0, value, ease },
+            { t: 1, value: baseValue, ease },
+          ]
+        : t >= 1 - MOTION_KEYFRAME_TIME_EPSILON
+          ? [
+              { t: 0, value: baseValue, ease },
+              { t: 1, value, ease },
+            ]
+          : [
+              { t: 0, value: baseValue, ease },
+              { t, value, ease },
+              { t: 1, value: baseValue, ease },
+            ];
+    nextTracks = [
+      ...nextTracks,
+      {
+        targetNodeId: args.targetNodeId,
+        property,
+        keyframes,
+        label: args.label,
+      },
+    ];
+  }
+
+  return nextTracks;
+}
+
 export function motionTimelineFingerprint(
   fileId: string,
   timeline: MotionTimelineRow | null | undefined,
@@ -1114,6 +1229,8 @@ function buildSignInHrefForDesignIntent(intent: PostAuthDesignIntent): string {
   if (typeof window === "undefined") return base;
 
   const returnUrl = new URL(window.location.href);
+  returnUrl.search = "";
+  returnUrl.hash = "";
   returnUrl.searchParams.set("intent", intent);
   const ret = returnUrl.pathname + returnUrl.search + returnUrl.hash;
   return `${base}?return=${encodeURIComponent(ret)}`;
@@ -1174,8 +1291,11 @@ export function getAvailableContentHistoryChanges(
   activeFileId?: string | null,
 ): ContentHistoryChange[] {
   const fileIds = new Set(availableFileIds);
+  const activeFileIsAvailable = !!activeFileId && fileIds.has(activeFileId);
   return getContentHistoryChanges(entry).filter(
-    (change) => change.fileId === activeFileId || fileIds.has(change.fileId),
+    (change) =>
+      fileIds.has(change.fileId) ||
+      (activeFileIsAvailable && change.fileId === activeFileId),
   );
 }
 
@@ -1871,6 +1991,14 @@ function appendCanvasPrimitiveToHtml(
       const explicitPathData = primitive.pathData?.trim()
         ? primitive.pathData
         : null;
+      const pathViewBoxLeft = options?.preserveNegativePosition
+        ? geometry.x
+        : Math.max(0, geometry.x);
+      const pathViewBoxTop = options?.preserveNegativePosition
+        ? geometry.y
+        : Math.max(0, geometry.y);
+      const pathViewBoxWidth = Math.max(1, geometry.width);
+      const pathViewBoxHeight = Math.max(1, geometry.height);
       const points = primitive.points?.length
         ? primitive.points
         : [
@@ -1935,7 +2063,7 @@ function appendCanvasPrimitiveToHtml(
       svg.setAttribute(
         "viewBox",
         explicitPathData
-          ? `${left} ${top} ${width} ${height}`
+          ? `${pathViewBoxLeft} ${pathViewBoxTop} ${pathViewBoxWidth} ${pathViewBoxHeight}`
           : `0 0 ${width} ${height}`,
       );
       svg.setAttribute(
@@ -2340,7 +2468,7 @@ function extractLayerPosition(
 function postBeginTextEditToPreviewIframes(
   screenId: string | null,
   nodeId: string,
-): boolean {
+): "active" | "done" | false {
   if (typeof document === "undefined" || !nodeId) return false;
   const iframes = Array.from(
     document.querySelectorAll<HTMLIFrameElement>(
@@ -2352,16 +2480,18 @@ function postBeginTextEditToPreviewIframes(
   );
   const orderedIframes = targetIframes.length > 0 ? targetIframes : iframes;
   const selector = `[data-agent-native-node-id="${nodeId.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"][data-agent-native-text-editing]`;
-  if (
-    orderedIframes.some((iframe) => {
-      try {
-        return iframe.contentDocument?.querySelector(selector);
-      } catch {
-        return false;
-      }
-    })
-  ) {
-    return true;
+  for (const iframe of orderedIframes) {
+    try {
+      const doc = iframe.contentDocument;
+      const node = doc?.querySelector<HTMLElement>(
+        `[data-agent-native-node-id="${nodeId.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"]`,
+      );
+      const editing = doc?.querySelector(selector);
+      if (editing && doc?.activeElement === editing) return "active";
+      if (node && (node.textContent ?? "").trim().length > 0) return "done";
+    } catch {
+      // Keep retrying other iframes.
+    }
   }
   orderedIframes.forEach((iframe) => {
     iframe.contentWindow?.postMessage(
@@ -2377,13 +2507,29 @@ function scheduleBeginTextEditForScreen(
   nodeId: string,
 ) {
   if (typeof window === "undefined") return;
-  let sawEditing = false;
-  [50, 150, 300, 600, 900, 1200, 1800, 2400, 3200, 4200].forEach((delay) => {
+  let finished = false;
+  [180, 300, 600, 900, 1200, 1800, 2400, 3200, 4200].forEach((delay) => {
     window.setTimeout(() => {
-      if (sawEditing) return;
-      sawEditing = postBeginTextEditToPreviewIframes(screenId, nodeId);
+      if (finished) return;
+      finished = postBeginTextEditToPreviewIframes(screenId, nodeId) === "done";
     }, delay);
   });
+}
+
+function postShaderFillPreviewClearToPreviewIframes() {
+  if (typeof document === "undefined") return;
+  document
+    .querySelectorAll<HTMLIFrameElement>("iframe[data-design-preview-iframe]")
+    .forEach((iframe) => {
+      try {
+        iframe.contentWindow?.postMessage(
+          { type: "shader-fill-preview-clear" },
+          "*",
+        );
+      } catch {
+        // Ignore inaccessible iframe windows; same-origin previews handle this.
+      }
+    });
 }
 
 function removeElementFromHtml(
@@ -4335,6 +4481,9 @@ export default function DesignEditor() {
   const [motionTimelineId, setMotionTimelineId] = useState<string | null>(null);
   const [motionTracks, setMotionTracks] = useState<MotionDockTrack[]>([]);
   const [motionDurationMs, setMotionDurationMs] = useState(1000);
+  const [motionPlayhead, setMotionPlayhead] = useState(0);
+  const [motionAutoKeyframeEnabled, setMotionAutoKeyframeEnabled] =
+    useState(false);
   const [motionTracksDirty, setMotionTracksDirty] = useState(false);
   const [motionAutosaveRevision, setMotionAutosaveRevision] = useState(0);
   const [motionHydrationFingerprint, setMotionHydrationFingerprint] = useState<
@@ -4402,6 +4551,10 @@ export default function DesignEditor() {
     nodeId?: string;
     css: string;
   } | null>(null);
+  const clearShaderFillPreview = useCallback(() => {
+    setShaderFillPreview(null);
+    postShaderFillPreviewClearToPreviewIframes();
+  }, []);
 
   // ── Breakpoint preview state (§6.4) ─────────────────────────────────────────
   // Active breakpoint width for the current design (pixels). Controls which
@@ -5647,9 +5800,14 @@ export default function DesignEditor() {
         : undefined;
 
     // Exclude the board file — it is rendered by its own DesignCanvas instance
-    // in MultiScreenCanvas and must not appear as a screen frame.
+    // in MultiScreenCanvas and must not appear as a screen frame.  Support files
+    // such as CSS are editable files, not visual screens.
     return files
-      .filter((file) => !isBoardFile(file.filename))
+      .filter(
+        (file) =>
+          normalizedDesignFileType(file.fileType) === "html" &&
+          !isBoardFile(file.filename),
+      )
       .map((file) => {
         const metadata = getDesignDataRecord(metadataByFileId, file.id);
         const stringValue = (key: string) =>
@@ -5990,14 +6148,29 @@ export default function DesignEditor() {
     };
   }, []);
 
-  // Set active file to first file when data loads
-  useEffect(() => {
-    if (files.length > 0 && !activeFileId) {
-      setActiveFileId(files[0].id);
-    }
-  }, [files, activeFileId]);
+  const defaultActiveFile =
+    files.find(
+      (file) =>
+        normalizedDesignFileType(file.fileType) === "html" &&
+        !isBoardFile(file.filename) &&
+        file.filename.toLowerCase() === "index.html",
+    ) ??
+    files.find(
+      (file) =>
+        normalizedDesignFileType(file.fileType) === "html" &&
+        !isBoardFile(file.filename),
+    ) ??
+    files[0];
 
-  const activeFile = files.find((f) => f.id === activeFileId) ?? files[0];
+  // Set active file to the primary screen when data loads.
+  useEffect(() => {
+    if (defaultActiveFile && !activeFileId) {
+      setActiveFileId(defaultActiveFile.id);
+    }
+  }, [activeFileId, defaultActiveFile]);
+
+  const activeFile =
+    files.find((f) => f.id === activeFileId) ?? defaultActiveFile;
   activeFileIdForUndoRef.current = activeFile?.id ?? null;
   const motionTimelineQueryParams =
     id && activeFile?.id
@@ -6143,9 +6316,13 @@ export default function DesignEditor() {
       if (target && !targetFile) return false;
 
       const inspectorTab =
-        command.inspectorTab === "design" || command.inspectorTab === "tweaks"
+        command.inspectorTab === "design" ||
+        command.inspectorTab === "tweaks" ||
+        command.inspectorTab === "extensions"
           ? command.inspectorTab
-          : command.inspector === "design" || command.inspector === "tweaks"
+          : command.inspector === "design" ||
+              command.inspector === "tweaks" ||
+              command.inspector === "extensions"
             ? command.inspector
             : undefined;
       if (inspectorTab) setActiveInspectorTab(inspectorTab);
@@ -6973,12 +7150,22 @@ export default function DesignEditor() {
   const canvasIframeRef = useMemo<React.RefObject<HTMLIFrameElement | null>>(
     () => ({
       get current() {
-        return document.querySelector<HTMLIFrameElement>(
-          "iframe[data-design-preview-iframe]",
+        const iframes = Array.from(
+          document.querySelectorAll<HTMLIFrameElement>(
+            "iframe[data-design-preview-iframe]",
+          ),
+        );
+        if (!activeFile?.id) return iframes[0] ?? null;
+        return (
+          iframes.find(
+            (iframe) => iframe.dataset.screenIframeId === activeFile.id,
+          ) ??
+          iframes[0] ??
+          null
         );
       },
     }),
-    [],
+    [activeFile?.id],
   );
 
   const handleEditorDragStateChange = useCallback((active: boolean) => {
@@ -7370,6 +7557,8 @@ export default function DesignEditor() {
     setMotionTimelineId(null);
     setMotionTracks([]);
     setMotionDurationMs(1000);
+    setMotionPlayhead(0);
+    setMotionAutoKeyframeEnabled(false);
     setMotionTracksDirty(false);
     setMotionAutosaveRevision(0);
     setMotionHydrationFingerprint(null);
@@ -7511,8 +7700,36 @@ export default function DesignEditor() {
   }, [selectedCodeLayerNode, selectedElement]);
 
   useEffect(() => {
-    setShaderFillPreview(null);
-  }, [activeFile?.id, selectedElement?.selector, selectedElement?.sourceId]);
+    clearShaderFillPreview();
+  }, [
+    activeFile?.id,
+    clearShaderFillPreview,
+    selectedElement?.selector,
+    selectedElement?.sourceId,
+  ]);
+  useEffect(() => {
+    const urlParams = new URLSearchParams(location.search);
+    const urlKeepsExtensionsInspector =
+      urlParams.get("inspector") === "extensions" ||
+      urlParams.get("inspectorTab") === "extensions";
+    if (activeInspectorTab === "extensions" && urlKeepsExtensionsInspector) {
+      return;
+    }
+    clearShaderFillPreview();
+  }, [
+    activeInspectorTab,
+    clearShaderFillPreview,
+    location.pathname,
+    location.search,
+  ]);
+  useEffect(() => {
+    window.addEventListener("pagehide", clearShaderFillPreview);
+    window.addEventListener("beforeunload", clearShaderFillPreview);
+    return () => {
+      window.removeEventListener("pagehide", clearShaderFillPreview);
+      window.removeEventListener("beforeunload", clearShaderFillPreview);
+    };
+  }, [clearShaderFillPreview]);
 
   // A friendly default name for the create-component dialog, derived from the
   // selected element's layer name / tag.
@@ -7589,6 +7806,56 @@ export default function DesignEditor() {
     if (!motionDockOpen || motionTracks.length === 0) return [];
     return motionTracks.map(({ label: _label, ...track }) => track);
   }, [motionDockOpen, motionTracks]);
+
+  const upsertMotionKeyframesFromStyles = useCallback(
+    (
+      styles: Record<string, string>,
+      elementInfo?: ElementInfo,
+      selector?: string,
+    ) => {
+      if (!motionDockOpen || !motionAutoKeyframeEnabled) return;
+      const info = elementInfo ?? selectedElement ?? undefined;
+      const targetNode = info
+        ? resolveCodeLayerNodeFromElementInfo(activeCodeLayerProjection, info)
+        : selector
+          ? resolveCodeLayerNodeFromBridge(activeCodeLayerProjection, selector)
+          : selectedCodeLayerNode;
+      const targetNodeId =
+        targetNode?.dataAttributes["data-agent-native-node-id"]?.trim() ??
+        info?.sourceId ??
+        selectedCodeLayerNode?.dataAttributes[
+          "data-agent-native-node-id"
+        ]?.trim();
+      if (!targetNodeId) return;
+
+      const label =
+        targetNode?.layerName ||
+        selectedCodeLayerNode?.layerName ||
+        info?.tagName ||
+        "Selected element";
+      setMotionTracks((current) => {
+        return upsertMotionStyleKeyframes({
+          tracks: current,
+          targetNodeId,
+          label,
+          styles,
+          computedStyles:
+            info?.computedStyles ?? selectedElement?.computedStyles,
+          playhead: motionPlayhead,
+        });
+      });
+      markMotionTracksDirty();
+    },
+    [
+      activeCodeLayerProjection,
+      markMotionTracksDirty,
+      motionAutoKeyframeEnabled,
+      motionDockOpen,
+      motionPlayhead,
+      selectedCodeLayerNode,
+      selectedElement,
+    ],
+  );
 
   const inspectCodeData = useMemo<InspectCodeData | undefined>(() => {
     if (!selectedElement) return undefined;
@@ -8258,7 +8525,11 @@ export default function DesignEditor() {
   );
 
   const handlePrimitiveCreated = useCallback(
-    (screenId: string, nodeId: string, options?: { selectFrame?: boolean }) => {
+    (
+      screenId: string,
+      nodeId: string,
+      options?: { selectFrame?: boolean; nextTool?: "move" | "pen" },
+    ) => {
       // B2/B4 fix: stay in overview mode after drawing a primitive.  The user
       // drew a shape on the board — they should remain on the board with the
       // new primitive selected, matching Figma behaviour.  We activate the
@@ -8277,7 +8548,7 @@ export default function DesignEditor() {
         setOverviewSelectedScreenIds(
           options?.selectFrame === false ? [] : [screenId],
         );
-        setActiveTool("move");
+        setActiveTool(options?.nextTool ?? "move");
         setMode("edit");
       });
       // viewMode stays at "overview" — no setViewMode("single") call here.
@@ -8775,7 +9046,7 @@ export default function DesignEditor() {
           css,
         });
       },
-      onShaderFillPreviewClear: () => setShaderFillPreview(null),
+      onShaderFillPreviewClear: clearShaderFillPreview,
       onShaderFillApplied: (fileId, content, updatedAt) => {
         applyFileContentUpdate(fileId, content, {
           refreshPreview: fileId === activeFile?.id,
@@ -8792,6 +9063,7 @@ export default function DesignEditor() {
       activeFile?.updatedAt,
       activeTool,
       applyFileContentUpdate,
+      clearShaderFillPreview,
       design?.title,
       files,
       id,
@@ -9097,6 +9369,7 @@ export default function DesignEditor() {
         ([, value]) => value !== undefined,
       );
       if (entries.length === 0) return;
+      upsertMotionKeyframesFromStyles(styles, options.elementInfo, selector);
       // Base every patch off the freshest known content, not the closed-over
       // render value. Handlers that fire several onStyleChange calls in one
       // synchronous user action (e.g. fixed-size text → width+height+whiteSpace,
@@ -9413,6 +9686,7 @@ export default function DesignEditor() {
       selectedElement,
       t,
       updateLiveScreenSnapshotContent,
+      upsertMotionKeyframesFromStyles,
       ydoc,
       isSynced,
     ],
@@ -9599,8 +9873,13 @@ export default function DesignEditor() {
         styles,
         elementInfo,
       );
+      upsertMotionKeyframesFromStyles(styles, elementInfo, selector);
     },
-    [activeFile?.id, recordPendingVisualStyleEdit],
+    [
+      activeFile?.id,
+      recordPendingVisualStyleEdit,
+      upsertMotionKeyframesFromStyles,
+    ],
   );
 
   const handleVisualStructureChange = useCallback(
@@ -9918,8 +10197,15 @@ export default function DesignEditor() {
       elementInfo?: ElementInfo,
     ) => {
       recordPendingVisualStyleEdit(screenId, selector, styles, elementInfo);
+      if (screenId === activeFile?.id) {
+        upsertMotionKeyframesFromStyles(styles, elementInfo, selector);
+      }
     },
-    [recordPendingVisualStyleEdit],
+    [
+      activeFile?.id,
+      recordPendingVisualStyleEdit,
+      upsertMotionKeyframesFromStyles,
+    ],
   );
 
   const handleScreenVisualStructureChange = useCallback(
@@ -10418,16 +10704,15 @@ export default function DesignEditor() {
           ? boardFileId
           : activeFile?.id;
       if (!targetFileId || !canEditDesign || entries.length === 0) return;
-      const targetIsBoard = targetFileId === boardFileId;
       const baseContent =
         targetFileId === activeFile?.id
           ? getFreshActiveContent()
           : (getScreenContent(targetFileId) ?? "");
       if (!baseContent && targetFileId !== boardFileId) return;
       const layerHtmls = entries.map((entry) => entry.html);
-      const styleSnapshots = targetIsBoard
-        ? entries.map((entry) => entry.portableStyleSnapshot)
-        : undefined;
+      const styleSnapshots = entries.map(
+        (entry) => entry.portableStyleSnapshot,
+      );
       const applyPasteContentUpdate = (nextContent: string) => {
         if (targetFileId === activeFile?.id) {
           applyLocalContentUpdate(nextContent, {
@@ -10446,7 +10731,11 @@ export default function DesignEditor() {
       // in normal document flow instead of being an absolutely-positioned body
       // child.  Fall back to the old position-based clone when nothing is
       // selected or a "Paste here" position is provided.
-      if (!position && !targetIsBoard && selectedElement?.selector) {
+      if (
+        !position &&
+        targetFileId !== boardFileId &&
+        selectedElement?.selector
+      ) {
         const selector = selectedCanvasSelector ?? selectedElement.selector;
         const result = insertClonedHtmlLayers(baseContent, layerHtmls, {
           targetSelectors: [selector],
@@ -10533,7 +10822,6 @@ export default function DesignEditor() {
     const baseContent = getFreshActiveContent();
     if (selectedElement?.boundingRect) {
       const { x, y } = selectedElement.boundingRect;
-      const targetIsBoard = activeFile.id === boardFileId;
       const result = insertClonedHtmlLayers(
         baseContent,
         entries.map((entry) => entry.html),
@@ -10542,9 +10830,7 @@ export default function DesignEditor() {
             x: x + index * 16,
             y: y + index * 16,
           })),
-          styleSnapshots: targetIsBoard
-            ? entries.map((entry) => entry.portableStyleSnapshot)
-            : undefined,
+          styleSnapshots: entries.map((entry) => entry.portableStyleSnapshot),
         },
       );
       if (!result) return;
@@ -11187,14 +11473,11 @@ export default function DesignEditor() {
       // there is no anchor, preserve absolute mode and rebase left/top to the
       // release point so screen↔board moves behave like Figma absolute layers.
       const destNodeAttrId = result.movedNodeId ?? nodeAttrId;
-      const stylePreservedDest =
-        targetScreenId === boardFileId
-          ? applyPortableStyleSnapshotToHtml(
-              result.destHtml,
-              destNodeAttrId,
-              styleSnapshot,
-            )
-          : result.destHtml;
+      const stylePreservedDest = applyPortableStyleSnapshotToHtml(
+        result.destHtml,
+        destNodeAttrId,
+        styleSnapshot,
+      );
       const nextDestContent = targetAnchorAttrId
         ? targetDropMode === "absolute-container"
           ? targetLocalPoint && targetAnchorRect
@@ -11345,6 +11628,59 @@ export default function DesignEditor() {
         removedGeometryRedoEntries,
       );
 
+      const nextContentUndoStack: ContentHistoryEntry[] = [];
+      let removedContentUndoEntries = 0;
+      contentUndoStackRef.current.forEach((entry) => {
+        const remainingChanges = getContentHistoryChanges(entry).filter(
+          (change) => !deleteIds.has(change.fileId),
+        );
+        if (remainingChanges.length === 0) {
+          removedContentUndoEntries += 1;
+          return;
+        }
+        nextContentUndoStack.push(
+          remainingChanges.length === 1
+            ? remainingChanges[0]
+            : { changes: remainingChanges },
+        );
+      });
+      contentUndoStackRef.current = nextContentUndoStack;
+      historyOrderRef.current = removeRecentUndoRedoOrderKinds(
+        historyOrderRef.current,
+        "file-content",
+        removedContentUndoEntries,
+      );
+      const nextContentRedoStack: ContentHistoryEntry[] = [];
+      let removedContentRedoEntries = 0;
+      contentRedoStackRef.current.forEach((entry) => {
+        const remainingChanges = getContentHistoryChanges(entry).filter(
+          (change) => !deleteIds.has(change.fileId),
+        );
+        if (remainingChanges.length === 0) {
+          removedContentRedoEntries += 1;
+          return;
+        }
+        nextContentRedoStack.push(
+          remainingChanges.length === 1
+            ? remainingChanges[0]
+            : { changes: remainingChanges },
+        );
+      });
+      contentRedoStackRef.current = nextContentRedoStack;
+      redoOrderRef.current = removeRecentUndoRedoOrderKinds(
+        redoOrderRef.current,
+        "file-content",
+        removedContentRedoEntries,
+      );
+      localContentUndoStackRef.current =
+        localContentUndoStackRef.current.filter(
+          (change) => !deleteIds.has(change.fileId),
+        );
+      localContentRedoStackRef.current =
+        localContentRedoStackRef.current.filter(
+          (change) => !deleteIds.has(change.fileId),
+        );
+
       writeFrameGeometrySnapshot(nextGeometry);
       queryClient.setQueryData(["action", "get-design", { id }], (old: any) => {
         if (!old || typeof old !== "object" || !Array.isArray(old.files)) {
@@ -11488,7 +11824,7 @@ export default function DesignEditor() {
     if (!canEditDesign) return;
     const um = undoManagerRef.current;
     const canUseOverviewHistory = viewModeRef.current === "overview";
-    let prunedUndoHistory = false;
+    let prunedUndoHistory = 0;
     const undoContent = (scope: "any" | "local" | "global" = "any") => {
       if (scope !== "global" && um?.canUndo()) {
         um.undo();
@@ -11570,7 +11906,7 @@ export default function DesignEditor() {
       );
       if (changes.length === 0) {
         contentUndoStackRef.current.pop();
-        prunedUndoHistory = true;
+        prunedUndoHistory += 1;
         return false;
       }
       contentUndoStackRef.current.pop();
@@ -11638,14 +11974,24 @@ export default function DesignEditor() {
       return true;
     };
 
-    const undoByOrder = (preferred?: UndoRedoOrderKind) =>
-      preferred === "geometry"
-        ? undoGeometry() || undoContent()
-        : preferred === "file-content"
-          ? undoContent("global") || undoGeometry()
-          : preferred === "content"
-            ? undoContent("local") || undoContent("global") || undoGeometry()
-            : undoContent() || undoGeometry();
+    const undoByOrder = (preferred?: UndoRedoOrderKind) => {
+      if (preferred === "geometry") return undoGeometry() || undoContent();
+      if (preferred === "file-content") {
+        const prunedBefore = prunedUndoHistory;
+        if (undoContent("global")) return true;
+        if (prunedUndoHistory > prunedBefore) return false;
+        return undoGeometry();
+      }
+      if (preferred === "content") {
+        const prunedBefore = prunedUndoHistory;
+        return (
+          undoContent("local") ||
+          undoContent("global") ||
+          (prunedUndoHistory > prunedBefore ? false : undoGeometry())
+        );
+      }
+      return undoContent() || undoGeometry();
+    };
     let didUndo = false;
     if (canUseOverviewHistory) {
       while (!didUndo) {
@@ -11656,7 +12002,7 @@ export default function DesignEditor() {
     } else {
       didUndo = undoContent("local");
     }
-    if (didUndo || prunedUndoHistory) {
+    if (didUndo || prunedUndoHistory > 0) {
       syncUndoRedoState();
     }
   }, [
@@ -13180,7 +13526,7 @@ ${serializedHtml}
   };
 
   useEffect(() => {
-    if (viewMode === "overview") return;
+    if (viewMode === "overview" && !motionDockOpen) return;
     if (!activeFile || !activeContent.trim()) return;
     const stamped = ensureCodeLayerNodeIdsInHtml(activeContent, {
       source: {
@@ -13192,7 +13538,14 @@ ${serializedHtml}
     });
     if (!stamped.changed || stamped.content === activeContent) return;
     applyLocalContentUpdate(stamped.content, { recordHistory: false });
-  }, [activeContent, activeFile, applyLocalContentUpdate, id, viewMode]);
+  }, [
+    activeContent,
+    activeFile,
+    applyLocalContentUpdate,
+    id,
+    motionDockOpen,
+    viewMode,
+  ]);
   const activeCodeLayerTree = useMemo(
     () => buildCodeLayerTree(activeCodeLayerProjection),
     [activeCodeLayerProjection],
@@ -13984,9 +14337,7 @@ ${serializedHtml}
 
   // Detect if the active screen is a localhost/local source so we can show a banner.
   const activeScreenIsLocalSource =
-    viewMode === "single" &&
-    Boolean(activeFile) &&
-    activeOverviewScreen?.sourceType === "localhost";
+    Boolean(activeFile) && activeOverviewScreen?.sourceType === "localhost";
   const activeScreenRouteSourceFile = activeScreenIsLocalSource
     ? getLocalhostRouteSourceFile({
         sourceFile: activeOverviewScreen?.sourceFile,
@@ -15303,12 +15654,8 @@ ${serializedHtml}
             className="h-8 cursor-pointer gap-1.5 rounded-md bg-[var(--design-editor-panel-raised-bg)] px-3 text-sm shadow-none"
             aria-label={t("designEditor.signUpToSave")}
           >
-            <a
-              href={signInToSaveHref}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <span>{t("home.save")}</span>
+            <a href={signInToSaveHref} role="button">
+              <span>{t("designEditor.signUpToSave")}</span>
             </a>
           </Button>
         </TooltipTrigger>
@@ -15321,13 +15668,9 @@ ${serializedHtml}
             variant="default"
             size="sm"
             className="h-8 cursor-pointer gap-1.5 rounded-md !border-[var(--design-editor-accent-color)] !bg-[var(--design-editor-accent-color)] px-3 text-sm !text-[var(--design-editor-accent-contrast-color)] shadow-none hover:!border-[var(--design-editor-accent-hover-color)] hover:!bg-[var(--design-editor-accent-hover-color)] hover:!text-[var(--design-editor-accent-contrast-color)] focus-visible:ring-[var(--design-editor-accent-color)]"
-            aria-label={t("designEditor.signUpToShare")}
+            aria-label={t("designEditor.share")}
           >
-            <a
-              href={signInToShareHref}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+            <a href={signInToShareHref} role="button">
               <span>{t("designEditor.share")}</span>
             </a>
           </Button>
@@ -15964,20 +16307,22 @@ ${serializedHtml}
                   activeLeftPanel === "agent" ? "flex" : "hidden",
                 )}
               >
-                <AgentChatSurface
-                  mode="panel"
-                  className="min-h-0 flex-1 border-0 bg-transparent shadow-none"
-                  storageKey={DESIGN_CHAT_STORAGE_KEY}
-                  emptyStateText={t("chat.emptyState")}
-                  suggestions={[
-                    t("chat.suggestionLandingPage"),
-                    t("chat.suggestionBrandMatch"),
-                    t("chat.suggestionMobile"),
-                  ]}
-                  scope={designChatScope}
-                  showScopeBadge={false}
-                  browserTabId={browserTabId}
-                />
+                {canEditDesign ? (
+                  <AgentChatSurface
+                    mode="panel"
+                    className="min-h-0 flex-1 border-0 bg-transparent shadow-none"
+                    storageKey={DESIGN_CHAT_STORAGE_KEY}
+                    emptyStateText={t("chat.emptyState")}
+                    suggestions={[
+                      t("chat.suggestionLandingPage"),
+                      t("chat.suggestionBrandMatch"),
+                      t("chat.suggestionMobile"),
+                    ]}
+                    scope={designChatScope}
+                    showScopeBadge={false}
+                    browserTabId={browserTabId}
+                  />
+                ) : null}
               </div>
               <div
                 className={cn(
@@ -16521,6 +16866,9 @@ ${serializedHtml}
                             }
                             fusionUrl={designFusionUrl}
                             onComponentSourceJump={handleComponentSourceJump}
+                            motionTracks={
+                              screenIsActive ? motionTracksWire : []
+                            }
                             embeddedFrame={{
                               viewportWidth: Math.max(
                                 1,
@@ -16902,6 +17250,13 @@ ${serializedHtml}
                     })
                   }
                   onRequestTweaks={handleRequestTweaks}
+                  extensionsPanel={
+                    <DesignExtensionsPanel
+                      context={designExtensionContext}
+                      hideAssetLibrary
+                      title={t("designEditor.extensions")}
+                    />
+                  }
                   onStyleChange={handleStyleChange}
                   onStylesChange={handleStylesChange}
                   onExport={handleInspectorExport}
@@ -16920,6 +17275,21 @@ ${serializedHtml}
                   }
                   defaultComponentName={defaultComponentName}
                   inspectCode={inspectCodeData}
+                  aiActions={
+                    selectedElement && selectedInspectorElements.length <= 1 ? (
+                      <InspectorAiActions
+                        selector={
+                          selectedCanvasSelector ?? selectedElement.selector
+                        }
+                        sourceId={selectedElement.sourceId}
+                        fileId={activeFile?.id}
+                        filename={activeFile?.filename}
+                        routeSourceFile={activeScreenRouteSourceFile}
+                        designId={id}
+                        canEdit={canEditDesign}
+                      />
+                    ) : undefined
+                  }
                   statesPanelProps={
                     id
                       ? {
@@ -17022,6 +17392,9 @@ ${serializedHtml}
           onTracksChange={handleMotionTracksChange}
           onDurationChange={handleMotionDurationChange}
           canvasIframeRef={canvasIframeRef}
+          autoKeyframe={motionAutoKeyframeEnabled}
+          onAutoKeyframeChange={setMotionAutoKeyframeEnabled}
+          onPlayheadChange={setMotionPlayhead}
           selectedTarget={motionSelectedTarget}
           applying={motionAutosavePending}
         />

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -12024,7 +12024,7 @@ export default function DesignEditor() {
     if (!canEditDesign) return;
     const um = undoManagerRef.current;
     const canUseOverviewHistory = viewModeRef.current === "overview";
-    let prunedRedoHistory = false;
+    let prunedRedoHistory = 0;
     const redoContent = (scope: "any" | "local" | "global" = "any") => {
       if (scope !== "global" && um?.canRedo()) {
         um.redo();
@@ -12106,7 +12106,7 @@ export default function DesignEditor() {
       );
       if (changes.length === 0) {
         contentRedoStackRef.current.pop();
-        prunedRedoHistory = true;
+        prunedRedoHistory += 1;
         return false;
       }
       contentRedoStackRef.current.pop();
@@ -12174,14 +12174,24 @@ export default function DesignEditor() {
       return true;
     };
 
-    const redoByOrder = (preferred?: UndoRedoOrderKind) =>
-      preferred === "geometry"
-        ? redoGeometry() || redoContent()
-        : preferred === "file-content"
-          ? redoContent("global") || redoGeometry()
-          : preferred === "content"
-            ? redoContent("local") || redoContent("global") || redoGeometry()
-            : redoContent() || redoGeometry();
+    const redoByOrder = (preferred?: UndoRedoOrderKind) => {
+      if (preferred === "geometry") return redoGeometry() || redoContent();
+      if (preferred === "file-content") {
+        const prunedBefore = prunedRedoHistory;
+        if (redoContent("global")) return true;
+        if (prunedRedoHistory > prunedBefore) return false;
+        return redoGeometry();
+      }
+      if (preferred === "content") {
+        const prunedBefore = prunedRedoHistory;
+        return (
+          redoContent("local") ||
+          redoContent("global") ||
+          (prunedRedoHistory > prunedBefore ? false : redoGeometry())
+        );
+      }
+      return redoContent() || redoGeometry();
+    };
     let didRedo = false;
     if (canUseOverviewHistory) {
       while (!didRedo) {
@@ -12192,7 +12202,7 @@ export default function DesignEditor() {
     } else {
       didRedo = redoContent("local");
     }
-    if (didRedo || prunedRedoHistory) {
+    if (didRedo || prunedRedoHistory > 0) {
       syncUndoRedoState();
     }
   }, [
@@ -17394,6 +17404,7 @@ ${serializedHtml}
           canvasIframeRef={canvasIframeRef}
           autoKeyframe={motionAutoKeyframeEnabled}
           onAutoKeyframeChange={setMotionAutoKeyframeEnabled}
+          playhead={motionPlayhead}
           onPlayheadChange={setMotionPlayhead}
           selectedTarget={motionSelectedTarget}
           applying={motionAutosavePending}

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -8558,7 +8558,7 @@ export default function DesignEditor() {
       // inserted HTML over separate renders, so post directly to the target
       // iframe with a few short retries instead of relying on a single global
       // bridge callback.
-      const textNodeId = pendingTextEditNodeIdRef.current ?? nodeId;
+      const textNodeId = pendingTextEditNodeIdRef.current;
       pendingTextEditNodeIdRef.current = null;
       if (textNodeId) {
         scheduleBeginTextEditForScreen(screenId, textNodeId);

--- a/templates/design/app/pages/VisualEdit.tsx
+++ b/templates/design/app/pages/VisualEdit.tsx
@@ -20,8 +20,6 @@ export default function VisualEditPage() {
   const { session } = useSession();
   const hasSession = Boolean(session?.email);
   const primaryHref = hasSession ? "/" : buildSignInHref();
-  const primaryTarget = hasSession ? undefined : "_blank";
-  const primaryRel = hasSession ? undefined : "noopener noreferrer";
   const primaryAriaLabel = hasSession
     ? t("visualEdit.openDesign")
     : t("designEditor.signUpToSave");
@@ -37,15 +35,10 @@ export default function VisualEditPage() {
             {t("navigation.brand")}
           </Link>
           <Button asChild variant="outline" size="sm">
-            <a
-              href={primaryHref}
-              target={primaryTarget}
-              rel={primaryRel}
-              aria-label={primaryAriaLabel}
-            >
+            <a href={primaryHref} aria-label={primaryAriaLabel}>
               {hasSession
                 ? t("visualEdit.openDesign")
-                : t("visualEdit.saveCta")}
+                : t("designEditor.signUpToSave")}
               <IconArrowUpRight className="size-4" />
             </a>
           </Button>
@@ -65,16 +58,11 @@ export default function VisualEditPage() {
             </p>
             <div className="mt-7 flex flex-wrap items-center gap-3">
               <Button asChild size="lg" className="gap-2">
-                <a
-                  href={primaryHref}
-                  target={primaryTarget}
-                  rel={primaryRel}
-                  aria-label={primaryAriaLabel}
-                >
+                <a href={primaryHref} aria-label={primaryAriaLabel}>
                   <IconDeviceFloppy className="size-4" />
                   {hasSession
                     ? t("visualEdit.openDesign")
-                    : t("visualEdit.saveCta")}
+                    : t("designEditor.signUpToSave")}
                 </a>
               </Button>
             </div>

--- a/templates/design/e2e/canvas-tools.spec.ts
+++ b/templates/design/e2e/canvas-tools.spec.ts
@@ -1592,6 +1592,18 @@ test("overview undo skips deleted screen content history", async ({ page }) => {
       (file) => file.id === aboutFile.id,
     ),
   ).toBe(false);
+
+  await pressPrimaryShortcut(page, "z", { shift: true });
+  await expect
+    .poll(() => primitiveCount(page, "index.html", "rectangle"), {
+      timeout: 20_000,
+    })
+    .toBe(homeRectanglesBefore + 1);
+  expect(
+    htmlScreenFiles(await designFiles(page)).some(
+      (file) => file.id === aboutFile.id,
+    ),
+  ).toBe(false);
 });
 
 test("overview undo does not restore ghost geometry for deleted screens", async ({

--- a/templates/design/e2e/code-native-pr-surfaces.spec.ts
+++ b/templates/design/e2e/code-native-pr-surfaces.spec.ts
@@ -343,6 +343,39 @@ test("Motion dock autosaves track edits to CSS and reopens them", async ({
     )
     .toContain("e2e-alpha-button");
 
+  const overviewMotionButton = page.getByRole("button", {
+    name: "Motion",
+    exact: true,
+  });
+  await expect(overviewMotionButton).toBeVisible();
+  await overviewMotionButton.click();
+  await expect(
+    motionDock.getByRole("button", { name: "Alpha Button" }),
+  ).toBeVisible();
+
+  const durationInput = motionDock.getByLabel("Duration in ms");
+  await durationInput.fill("4000");
+  await durationInput.press("Tab");
+  await motionDock.getByRole("button", { name: "Play", exact: true }).click();
+  await expect
+    .poll(
+      () =>
+        designFrame(page)
+          .locator('[data-agent-native-node-id="e2e-alpha-button"]')
+          .evaluate((el) =>
+            Number.parseFloat(window.getComputedStyle(el).opacity),
+          ),
+      { timeout: 2_000, intervals: [50, 100, 150, 250, 500] },
+    )
+    .toBeLessThan(0.95);
+  await motionDock
+    .getByRole("button", { name: "Reset playhead", exact: true })
+    .click();
+  await motionDock
+    .getByRole("button", { name: "Collapse motion dock", exact: true })
+    .click();
+  await expect(page.locator('[aria-label="Motion dock"]')).toHaveCount(0);
+
   const reopenMotionDockButton = page.getByRole("button", {
     name: "Motion",
     exact: true,

--- a/templates/design/e2e/editor-keyboard-layers.spec.ts
+++ b/templates/design/e2e/editor-keyboard-layers.spec.ts
@@ -499,43 +499,22 @@ async function pressPrimaryShortcut(
   key: string,
   options: { shift?: boolean } = {},
 ): Promise<void> {
-  await page.evaluate(
-    ({ key, primary, shift }) => {
-      const isLetter = /^[a-z]$/i.test(key);
-      const eventKey = isLetter
-        ? shift
-          ? key.toUpperCase()
-          : key.toLowerCase()
-        : key;
-      const eventInit: KeyboardEventInit = {
-        key: eventKey,
-        code: isLetter ? `Key${key.toUpperCase()}` : key,
-        bubbles: true,
-        cancelable: true,
-        composed: true,
-        metaKey: primary === "Meta",
-        ctrlKey: primary === "Control",
-        shiftKey: shift,
-      };
-      window.dispatchEvent(new KeyboardEvent("keydown", eventInit));
-      window.dispatchEvent(new KeyboardEvent("keyup", eventInit));
-    },
-    { key, primary: PRIMARY, shift: options.shift ?? false },
-  );
+  await page.evaluate(() => {
+    document.body.setAttribute("tabindex", "-1");
+    document.body.focus();
+  });
+  const parts = [PRIMARY];
+  if (options.shift) parts.push("Shift");
+  parts.push(key.length === 1 ? key.toUpperCase() : key);
+  await page.keyboard.press(parts.join("+"));
 }
 
 async function pressEditorKey(page: Page, key: string): Promise<void> {
-  await page.evaluate((key) => {
-    const eventInit: KeyboardEventInit = {
-      key,
-      code: key,
-      bubbles: true,
-      cancelable: true,
-      composed: true,
-    };
-    window.dispatchEvent(new KeyboardEvent("keydown", eventInit));
-    window.dispatchEvent(new KeyboardEvent("keyup", eventInit));
-  }, key);
+  await page.evaluate(() => {
+    document.body.setAttribute("tabindex", "-1");
+    document.body.focus();
+  });
+  await page.keyboard.press(key);
 }
 
 function count(value: string, needle: string): number {

--- a/templates/design/e2e/editor.spec.ts
+++ b/templates/design/e2e/editor.spec.ts
@@ -319,7 +319,21 @@ test("spacing handles stay visible at rest and remain draggable", async ({
   const box = await container.boundingBox();
   if (!box) throw new Error("missing fixture container bounds");
 
-  await page.mouse.click(box.x + 12, box.y + 12);
+  const frameBox = await page
+    .locator("iframe[data-design-preview-iframe]")
+    .last()
+    .boundingBox();
+  if (!frameBox) throw new Error("missing design iframe bounds");
+  await designFrame(page)
+    .locator('[data-agent-native-edit-overlay="shield"]')
+    .first()
+    .dispatchEvent("click", {
+      bubbles: true,
+      cancelable: true,
+      clientX: box.x - frameBox.x + 12,
+      clientY: box.y - frameBox.y + 12,
+      detail: 1,
+    });
   const selected = await waitForBridge(page, "element-select");
   expect(
     (selected?.payload?.tagName ?? selected?.tagName ?? "").toUpperCase(),

--- a/templates/design/e2e/helpers.ts
+++ b/templates/design/e2e/helpers.ts
@@ -221,7 +221,7 @@ export async function enterDirectMode(page: Page): Promise<void> {
     .then(() => true)
     .catch(() => false);
   if (fullViewVisible) {
-    await fullView.first().click();
+    await fullView.last().click();
     await expect(fullView).toHaveCount(0);
   }
   await expect
@@ -267,7 +267,7 @@ export async function bridgeMessages(page: Page): Promise<any[]> {
 export async function waitForBridge(
   page: Page,
   type: string,
-  timeout = 8_000,
+  timeout = 15_000,
 ): Promise<any> {
   const handle = await page.waitForFunction(
     (t) =>


### PR DESCRIPTION
## Summary
- Stabilizes Design canvas editing, pen/text primitives, overview history, shader previews, exports, and signed-out visual-edit flows.
- Restores inspector/tool surfaces for shader fills and component props while improving local visual-edit handoff context.
- Adds SQLite/collab and update-file robustness fixes plus expanded unit/E2E regression coverage.

## Test plan
- `pnpm --dir templates/design run typecheck`
- `pnpm --dir templates/design exec vitest run app/pages/DesignEditor.selection.test.ts app/hooks/useAgentEditRequest.test.ts`
- `E2E_BASE_URL=http://127.0.0.1:8080 pnpm --dir templates/design exec playwright test --reporter=line` (71 passed)


Made with [Cursor](https://cursor.com)