### PR TITLE
fix: able to inline edit text when ai is working or after that

### DIFF
--- a/.changeset/inline-text-edit-focus.md
+++ b/.changeset/inline-text-edit-focus.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add an optional `focus` flag to `setAgentChatContextItem` (and thread it through to the composer). Callers that mirror ambient UI state into chat context — such as a design canvas element selection — can now pass `focus: false` to stage the context chip without moving keyboard focus into the composer. This stops passive context staging from blurring and tearing down an in-progress inline text editor in the Design canvas (which re-fires on every selection and on each get-design poll during an agent run). Focus stays enabled by default, so existing callers are unchanged.

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -623,8 +623,15 @@ export interface AssistantChatHandle {
   ): void;
   /** Programmatically prefill the composer without submitting. */
   prefillMessage(text: string): void;
-  /** Add or replace keyed context for the next composer submission. */
-  setComposerContextItem(item: AgentChatContextItem): void;
+  /**
+   * Add or replace keyed context for the next composer submission.
+   * Focuses the composer by default; pass `{ focus: false }` for passive
+   * context mirroring (e.g. canvas selection) that must not steal focus.
+   */
+  setComposerContextItem(
+    item: AgentChatContextItem,
+    options?: { focus?: boolean },
+  ): void;
   /** Remove a keyed context item from the composer. */
   removeComposerContextItem(key: string): void;
   /** Clear all staged context items from the composer. */
@@ -2927,9 +2934,17 @@ const AssistantChatInner = forwardRef<
         tiptapRef.current?.setText(text);
         tiptapRef.current?.focus();
       },
-      setComposerContextItem(item: AgentChatContextItem) {
+      setComposerContextItem(
+        item: AgentChatContextItem,
+        options?: { focus?: boolean },
+      ) {
         stageComposerContextItem(item);
-        tiptapRef.current?.focus();
+        // Only pull focus into the composer for explicit user gestures.
+        // Passive context mirroring (e.g. a canvas selection staged with
+        // openSidebar:false) must not steal focus — doing so blurs an active
+        // inline text editor living in the design canvas iframe and tears it
+        // down the instant it opens.
+        if (options?.focus !== false) tiptapRef.current?.focus();
       },
       removeComposerContextItem(key: string) {
         removeComposerContextItem(key);

--- a/packages/core/src/client/MultiTabAssistantChat.spec.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.spec.tsx
@@ -320,11 +320,14 @@ describe("MultiTabAssistantChat postMessage bridge", () => {
         ([event]) => event.type === "agent-panel:open",
       ),
     ).toBe(true);
-    expect(chatHandleMocks.setComposerContextItem).toHaveBeenCalledWith({
-      key: "selected-element",
-      title: "Selected Element",
-      context: "<button>Buy</button>",
-    });
+    expect(chatHandleMocks.setComposerContextItem).toHaveBeenCalledWith(
+      {
+        key: "selected-element",
+        title: "Selected Element",
+        context: "<button>Buy</button>",
+      },
+      { focus: true },
+    );
     expect(chatHandleMocks.sendMessage).not.toHaveBeenCalled();
     expect(chatHandleMocks.prefillMessage).not.toHaveBeenCalled();
     dispatchEventSpy.mockRestore();
@@ -354,14 +357,53 @@ describe("MultiTabAssistantChat postMessage bridge", () => {
         ([event]) => event.type === "agent-panel:open",
       ),
     ).toBe(false);
-    expect(chatHandleMocks.setComposerContextItem).toHaveBeenCalledWith({
-      key: "selected-element",
-      title: "Selected Element",
-      context: "<button>Buy</button>",
-    });
+    // openSidebar:false keeps the sidebar closed, but focus is independent —
+    // by default staging still focuses the composer (unchanged behavior).
+    expect(chatHandleMocks.setComposerContextItem).toHaveBeenCalledWith(
+      {
+        key: "selected-element",
+        title: "Selected Element",
+        context: "<button>Buy</button>",
+      },
+      { focus: true },
+    );
     expect(chatHandleMocks.sendMessage).not.toHaveBeenCalled();
     expect(chatHandleMocks.prefillMessage).not.toHaveBeenCalled();
     dispatchEventSpy.mockRestore();
+  });
+
+  it("stages keyed context without focus when focus is false", () => {
+    // Passive context mirroring (e.g. a canvas element selection) must stage
+    // the chip without stealing focus, so an in-progress inline text editor in
+    // the design canvas iframe is not blurred and torn down.
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: {
+            type: "agentNative.setChatContext",
+            data: {
+              key: "selected-element",
+              title: "Selected Element",
+              context: "<button>Buy</button>",
+              openSidebar: false,
+              focus: false,
+            },
+          },
+          origin: window.location.origin,
+        }),
+      );
+    });
+
+    expect(chatHandleMocks.setComposerContextItem).toHaveBeenCalledWith(
+      {
+        key: "selected-element",
+        title: "Selected Element",
+        context: "<button>Buy</button>",
+      },
+      { focus: false },
+    );
+    expect(chatHandleMocks.sendMessage).not.toHaveBeenCalled();
+    expect(chatHandleMocks.prefillMessage).not.toHaveBeenCalled();
   });
 
   it("removes keyed context from the active composer", () => {

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -1118,10 +1118,14 @@ export function MultiTabAssistantChat({
   const postMessageSubmissionsDisabled = props.composerDisabled === true;
 
   const setContextInTab = useCallback(
-    (threadId: string, item: AgentChatContextItem) => {
+    (
+      threadId: string,
+      item: AgentChatContextItem,
+      options?: { focus?: boolean },
+    ) => {
       const ref = chatRefs.current.get(threadId);
       if (ref) {
-        ref.setComposerContextItem(item);
+        ref.setComposerContextItem(item, options);
         return;
       }
       const existing = pendingContextItems.current.get(threadId) ?? [];
@@ -1712,7 +1716,11 @@ export function MultiTabAssistantChat({
         if (postMessageSubmissionsDisabled) return;
         const currentTabId = activeThreadIdRef.current;
         if (!currentTabId) return;
-        setContextInTab(currentTabId, item);
+        // Focus defaults to true; a caller opts out with `focus: false` for
+        // passive context (e.g. a canvas selection) so staging never steals
+        // focus from an in-progress inline editor.
+        const focus = (event.data.data?.focus as boolean | undefined) !== false;
+        setContextInTab(currentTabId, item, { focus });
         return;
       }
       if (event.data?.type === AGENT_CHAT_REMOVE_CONTEXT_MESSAGE_TYPE) {

--- a/packages/core/src/client/agent-chat.ts
+++ b/packages/core/src/client/agent-chat.ts
@@ -113,6 +113,13 @@ export interface AgentChatContextSetOptions extends AgentChatContextItem {
    * Defaults to true so the user can see the staged context.
    */
   openSidebar?: boolean;
+  /**
+   * Whether to move keyboard focus into the composer when staging the item.
+   * Defaults to true. Pass `false` for context that mirrors ambient UI state
+   * (e.g. a canvas element selection) so staging never steals focus from an
+   * unrelated editor — such as an inline text editor in a design canvas.
+   */
+  focus?: boolean;
 }
 
 /** @deprecated Use `AgentChatContextSetOptions` instead. */
@@ -865,9 +872,17 @@ export function setAgentChatContextItem(
   publishAgentChatContextItems(
     withReplacedAgentChatContextItem(agentChatContextState.items, item),
   );
-  postAgentChatContextMessage(AGENT_CHAT_SET_CONTEXT_MESSAGE_TYPE, item, {
-    openSidebar: opts.openSidebar !== false,
-  });
+  // Forward an explicit `focus: false` so the receiving composer can stage the
+  // chip without stealing focus. Focus stays enabled by default (field omitted)
+  // for every existing caller.
+  const messageData = opts.focus === false ? { ...item, focus: false } : item;
+  postAgentChatContextMessage(
+    AGENT_CHAT_SET_CONTEXT_MESSAGE_TYPE,
+    messageData,
+    {
+      openSidebar: opts.openSidebar !== false,
+    },
+  );
 }
 
 /** @deprecated Use `setAgentChatContextItem` instead. */

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -8797,6 +8797,11 @@ export default function DesignEditor() {
       title: shortLabel,
       context: contextLines.join("\n"),
       openSidebar: false,
+      // Mirror the selection into chat context without stealing focus: this
+      // effect re-fires on every selection change and on each get-design poll
+      // during an agent run, and focusing the composer here would blur (and
+      // tear down) an in-progress inline text edit on the canvas.
+      focus: false,
     });
   }, [activeFile, design?.title, id, selectedCodeLayerNode, selectedElement]);
 

--- a/templates/design/e2e/canvas-tools.spec.ts
+++ b/templates/design/e2e/canvas-tools.spec.ts
@@ -7,7 +7,12 @@ import {
 } from "@playwright/test";
 
 import { FIXTURE_HTML } from "./global-setup";
-import { gotoEditor, installBridge } from "./helpers";
+import {
+  designFrame,
+  enterDirectMode,
+  gotoEditor,
+  installBridge,
+} from "./helpers";
 
 let designId: string;
 let baseURLForActions: string;
@@ -691,6 +696,89 @@ test("toolbar modes toggle the editor mode buttons", async ({ page }) => {
     "aria-pressed",
     "true",
   );
+});
+
+async function textEditingCount(page: Page): Promise<number> {
+  return page
+    .locator("iframe[data-design-preview-iframe]")
+    .evaluateAll((iframes) =>
+      iframes.reduce((count, iframe) => {
+        const frame = iframe as HTMLIFrameElement;
+        return (
+          count +
+          (frame.contentDocument?.querySelectorAll(
+            "[data-agent-native-text-editing]",
+          ).length ?? 0)
+        );
+      }, 0),
+    );
+}
+
+async function dblClickText(page: Page, text: string): Promise<void> {
+  const target = designFrame(page).getByText(text).first();
+  await target.waitFor({ state: "visible", timeout: 10_000 });
+  const box = await target.boundingBox();
+  if (!box) throw new Error(`no bounding box for text: ${text}`);
+  await page.mouse.dblclick(box.x + box.width / 2, box.y + box.height / 2);
+}
+
+test("double-click existing text starts inline editing and stays open (overview)", async ({
+  page,
+}) => {
+  await installBridge(page);
+
+  await dblClickText(page, "E2E Hero Heading");
+
+  // Inline editing must begin — the iframe stamps the contenteditable target.
+  await waitForTextEditing(page);
+
+  // ...and must stay open. The reported bug tears it down within ~1 frame
+  // (the caret "blinks" then focus jumps to the chat composer), so wait a beat
+  // and confirm we are still editing with focus.
+  await page.waitForTimeout(800);
+  const summary = await textEditingChromeSummary(page);
+  expect(summary?.editing, "still in inline text-editing mode").toBe(true);
+  expect(summary?.active, "editable still holds focus").toBe(true);
+  expect(await textEditingCount(page), "exactly one editor open").toBe(1);
+
+  // Typing replaces the text inline (no AI round-trip). Verify by observing
+  // the committed text in the iframe DOM rather than a bridge payload shape.
+  const selectAll = process.platform === "darwin" ? "Meta+A" : "Control+A";
+  await page.keyboard.press(selectAll);
+  await page.keyboard.type("Edited Inline");
+  await page.keyboard.press("Enter");
+  await expect
+    .poll(
+      async () =>
+        page
+          .locator("iframe[data-design-preview-iframe]")
+          .evaluateAll((iframes) =>
+            iframes.some((iframe) =>
+              (
+                (iframe as HTMLIFrameElement).contentDocument?.body
+                  ?.textContent ?? ""
+              ).includes("Edited Inline"),
+            ),
+          ),
+      { timeout: 10_000 },
+    )
+    .toBe(true);
+});
+
+test("double-click existing text starts inline editing and stays open (full view)", async ({
+  page,
+}) => {
+  await installBridge(page);
+  await enterDirectMode(page);
+
+  await dblClickText(page, "E2E Hero Heading");
+
+  await waitForTextEditing(page);
+
+  await page.waitForTimeout(800);
+  const summary = await textEditingChromeSummary(page);
+  expect(summary?.editing, "still in inline text-editing mode").toBe(true);
+  expect(summary?.active, "editable still holds focus").toBe(true);
 });
 
 test("text insertion keeps the new primitive selected", async ({ page }) => {


### PR DESCRIPTION
local clip: [clip-2026-07-01_13-28-33.webm](https://github.com/user-attachments/assets/e1791f57-910c-4382-9c5a-c7e78f23a196)
