### PR TITLE
Fix background chat run diagnostics

### DIFF
--- a/.changeset/bright-runs-explain.md
+++ b/.changeset/bright-runs-explain.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Persist terminal reasons for agent runs and classify recoverable run-timeout continuations separately in traces.

--- a/.changeset/fresh-runs-debug-context.md
+++ b/.changeset/fresh-runs-debug-context.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Improve agent run diagnostics by recording terminal continuation reasons and adding safe run context to copied recovery debug details.

--- a/.changeset/wrapped-diagram-labels.md
+++ b/.changeset/wrapped-diagram-labels.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep visual plan and recap diagram labels wrapped inside their boxes instead of overflowing authored diagram shapes.

--- a/packages/core/src/agent/durable-background.spec.ts
+++ b/packages/core/src/agent/durable-background.spec.ts
@@ -242,6 +242,17 @@ describe("resolveAgentChatProcessRunDispatchPath (default function url on hosted
     );
   });
 
+  it("dispatches to the function's DEFAULT url in deployed Netlify Lambda runtime even when NETLIFY is absent", () => {
+    // Production Functions do not always preserve the build-time NETLIFY env
+    // flag, but they do expose AWS_LAMBDA_FUNCTION_NAME. The durable dispatcher
+    // must still target the emitted Netlify background function so the marker
+    // unlocks the 15-minute worker budget.
+    process.env.AWS_LAMBDA_FUNCTION_NAME = "agent-native-design-server";
+    expect(resolveAgentChatProcessRunDispatchPath()).toBe(
+      AGENT_BACKGROUND_FUNCTION_URL_PATH,
+    );
+  });
+
   it("dispatches to the PER-APP default url on hosted Netlify (workspace)", () => {
     // Workspace deploy emits one background fn per app named <app>-agent-background
     // reachable at its default url. The foreground reads the workspace app id from
@@ -250,6 +261,15 @@ describe("resolveAgentChatProcessRunDispatchPath (default function url on hosted
     process.env.AGENT_NATIVE_WORKSPACE_APP_ID = "plan";
     expect(resolveAgentChatProcessRunDispatchPath()).toBe(
       "/.netlify/functions/plan-agent-background",
+    );
+    Reflect.deleteProperty(process.env, "AGENT_NATIVE_WORKSPACE_APP_ID");
+  });
+
+  it("dispatches to the PER-APP default url in workspace Lambda runtime even when NETLIFY is absent", () => {
+    process.env.AWS_LAMBDA_FUNCTION_NAME = "agent-native-workspace-design";
+    process.env.AGENT_NATIVE_WORKSPACE_APP_ID = "design";
+    expect(resolveAgentChatProcessRunDispatchPath()).toBe(
+      "/.netlify/functions/design-agent-background",
     );
     Reflect.deleteProperty(process.env, "AGENT_NATIVE_WORKSPACE_APP_ID");
   });
@@ -275,6 +295,7 @@ describe("resolveAgentChatProcessRunDispatchPath (default function url on hosted
     // `netlify dev` runs in-process; the same in-process catch-all handles it.
     process.env.NETLIFY = "true";
     process.env.NETLIFY_LOCAL = "true";
+    process.env.AWS_LAMBDA_FUNCTION_NAME = "agent-native-design-server";
     expect(resolveAgentChatProcessRunDispatchPath()).toBe(
       AGENT_CHAT_PROCESS_RUN_PATH,
     );
@@ -282,6 +303,7 @@ describe("resolveAgentChatProcessRunDispatchPath (default function url on hosted
 
   it("returns the framework path when NETLIFY is explicitly false", () => {
     process.env.NETLIFY = "false";
+    process.env.AWS_LAMBDA_FUNCTION_NAME = "agent-native-design-server";
     expect(resolveAgentChatProcessRunDispatchPath()).toBe(
       AGENT_CHAT_PROCESS_RUN_PATH,
     );

--- a/packages/core/src/agent/durable-background.ts
+++ b/packages/core/src/agent/durable-background.ts
@@ -97,6 +97,17 @@ function resolveWorkspaceBackgroundFunctionUrlPath(): string | null {
   return `/.netlify/functions/${candidate}-agent-background`;
 }
 
+function isNetlifyHostedRuntimeForDispatch(): boolean {
+  if (process.env.NETLIFY_LOCAL === "true") return false;
+  if (process.env.NETLIFY === "false") return false;
+  if (process.env.NETLIFY && process.env.NETLIFY !== "false") return true;
+  // Netlify sets AWS Lambda runtime env on deployed Functions, but the build-time
+  // NETLIFY flag is not always present in the runtime isolate. Treat Lambda as
+  // Netlify here unless Netlify was explicitly disabled above; non-Netlify AWS
+  // falls back inline if the /.netlify/functions dispatch fast-fails.
+  return Boolean(process.env.AWS_LAMBDA_FUNCTION_NAME);
+}
+
 /**
  * Resolve the path the foreground POST should self-dispatch the chat background
  * worker to.
@@ -129,11 +140,7 @@ function resolveWorkspaceBackgroundFunctionUrlPath(): string | null {
  * to shadow because `/.netlify/*` is already excluded from the `server` catch-all.
  */
 export function resolveAgentChatProcessRunDispatchPath(): string {
-  if (
-    process.env.NETLIFY &&
-    process.env.NETLIFY !== "false" &&
-    process.env.NETLIFY_LOCAL !== "true"
-  ) {
+  if (isNetlifyHostedRuntimeForDispatch()) {
     return (
       resolveWorkspaceBackgroundFunctionUrlPath() ??
       AGENT_BACKGROUND_FUNCTION_URL_PATH

--- a/packages/core/src/agent/production-agent-journal-hard-block.spec.ts
+++ b/packages/core/src/agent/production-agent-journal-hard-block.spec.ts
@@ -32,6 +32,7 @@ vi.mock("./run-store.js", () => ({
   bumpRunProgress: vi.fn(),
   ensureTerminalRunEvent: vi.fn(),
   setRunError: vi.fn(),
+  setRunTerminalReason: vi.fn(),
 }));
 
 // Keep OM out of the way. It's gated on ownerEmail anyway, but mock it so the

--- a/packages/core/src/agent/production-agent-ledger.spec.ts
+++ b/packages/core/src/agent/production-agent-ledger.spec.ts
@@ -44,6 +44,7 @@ vi.mock("./run-store.js", () => ({
   bumpRunProgress: vi.fn(),
   ensureTerminalRunEvent: vi.fn(),
   setRunError: vi.fn(),
+  setRunTerminalReason: vi.fn(),
   STALE_RUN_ERROR_EVENT: {
     type: "error",
     error: "stale",

--- a/packages/core/src/agent/production-agent-observational-memory.spec.ts
+++ b/packages/core/src/agent/production-agent-observational-memory.spec.ts
@@ -29,6 +29,7 @@ vi.mock("./run-store.js", () => ({
   bumpRunProgress: vi.fn(),
   ensureTerminalRunEvent: vi.fn(),
   setRunError: vi.fn(),
+  setRunTerminalReason: vi.fn(),
 }));
 
 // Mock the OM module: assert producer + drive the consumer.

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -124,6 +124,7 @@ import {
   insertRun,
   updateRunHeartbeat,
   updateRunStatusIfRunning,
+  setRunTerminalReason,
   claimBackgroundRun,
   readBackgroundRunClaim,
   recordRunDiagnostic,
@@ -5089,7 +5090,17 @@ export function createProductionAgentHandler(
         }
         // A background worker owns this run but we cannot subscribe — surface an
         // error rather than risk a double-run by falling through to inline.
-        await updateRunStatusIfRunning(runId, "errored").catch(() => {});
+        const terminalReason =
+          backgroundOutcome.action === "stream"
+            ? "background_subscribe_failed"
+            : "background_dispatch_failed";
+        const statusUpdated = await updateRunStatusIfRunning(
+          runId,
+          "errored",
+        ).catch(() => false);
+        if (statusUpdated) {
+          await setRunTerminalReason(runId, terminalReason).catch(() => {});
+        }
         setResponseStatus(event, 500);
         return {
           error:
@@ -5333,9 +5344,16 @@ export function createProductionAgentHandler(
                     "[agent-chat] background continuation dispatch failed:",
                     chainErr instanceof Error ? chainErr.message : chainErr,
                   );
-                  await updateRunStatusIfRunning(runId, "errored").catch(
-                    () => {},
-                  );
+                  const statusUpdated = await updateRunStatusIfRunning(
+                    runId,
+                    "errored",
+                  ).catch(() => false);
+                  if (statusUpdated) {
+                    await setRunTerminalReason(
+                      runId,
+                      "background_continuation_dispatch_failed",
+                    ).catch(() => {});
+                  }
                 }
               }
             } finally {
@@ -5766,6 +5784,22 @@ export function createProductionAgentHandler(
               threadId: threadId ?? null,
               userId: ownerEmail,
               config: obsConfig,
+              classifyError: () => {
+                if (
+                  agentLoopOpts.signal.aborted &&
+                  agentLoopOpts.signal.reason === "run_timeout"
+                ) {
+                  return {
+                    status: "success",
+                    errorMessage: null,
+                    metadata: {
+                      terminalReason: "run_timeout",
+                      recoverableContinuation: true,
+                    },
+                  };
+                }
+                return null;
+              },
             });
           }
         } catch (err) {

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -26,6 +26,7 @@ vi.mock("./run-store.js", () => ({
   reapUnclaimedBackgroundRun: vi.fn(() => Promise.resolve(false)),
   ensureTerminalRunEvent: vi.fn(() => Promise.resolve()),
   setRunError: vi.fn(() => Promise.resolve()),
+  setRunTerminalReason: vi.fn(() => Promise.resolve()),
   STALE_RUN_ERROR_EVENT: {
     type: "error",
     error:
@@ -69,6 +70,7 @@ import {
   ensureTerminalRunEvent,
   cleanupOldRuns,
   setRunError,
+  setRunTerminalReason,
   reapIfStale,
   reapUnclaimedBackgroundRun,
 } from "./run-store.js";
@@ -149,6 +151,7 @@ describe("run manager soft timeout", () => {
     vi.mocked(updateRunStatusIfRunning).mockResolvedValue(true);
     vi.mocked(cleanupOldRuns).mockClear();
     vi.mocked(setRunError).mockClear();
+    vi.mocked(setRunTerminalReason).mockClear();
     vi.mocked(reapUnclaimedBackgroundRun).mockReset();
     vi.mocked(reapUnclaimedBackgroundRun).mockResolvedValue(false);
     vi.mocked(reapIfStale).mockReset();
@@ -163,6 +166,7 @@ describe("run manager soft timeout", () => {
   it("emits an internal continuation signal and aborts the run chunk", async () => {
     const events: AgentChatEvent[] = [];
     let aborted = false;
+    let abortReason: unknown;
 
     const run = startRun(
       "run-soft-timeout",
@@ -171,6 +175,7 @@ describe("run manager soft timeout", () => {
         await new Promise<void>((resolve) => {
           signal.addEventListener("abort", () => {
             aborted = true;
+            abortReason = signal.reason;
             resolve();
           });
         });
@@ -183,6 +188,7 @@ describe("run manager soft timeout", () => {
     await vi.advanceTimersByTimeAsync(11);
 
     expect(aborted).toBe(true);
+    expect(abortReason).toBe("run_timeout");
     expect(events).toContainEqual(
       expect.objectContaining({
         type: "auto_continue",
@@ -190,6 +196,12 @@ describe("run manager soft timeout", () => {
       }),
     );
     expect(run.status).toBe("completed");
+    await vi.waitFor(() =>
+      expect(setRunTerminalReason).toHaveBeenCalledWith(
+        "run-soft-timeout",
+        "run_timeout",
+      ),
+    );
   });
 
   it("persists the terminal auto_continue with a unique seq when the run emits events after the soft timeout", async () => {

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -18,6 +18,7 @@ import {
   reapUnclaimedBackgroundRun,
   ensureTerminalRunEvent,
   setRunError,
+  setRunTerminalReason,
   STALE_RUN_ERROR_EVENT,
 } from "./run-store.js";
 import type { AgentChatEvent, RunEvent, RunStatus } from "./types.js";
@@ -293,6 +294,26 @@ function isTerminalRunEvent(event: AgentChatEvent): boolean {
   );
 }
 
+function terminalReasonForRun(
+  finalStatus: "completed" | "errored" | "aborted",
+  terminalEvent: AgentChatEvent | null,
+  abortReason: string | undefined,
+  completionError: unknown,
+): string {
+  if (terminalEvent?.type === "auto_continue") {
+    return terminalEvent.reason || "auto_continue";
+  }
+  if (terminalEvent?.type === "loop_limit") return "loop_limit";
+  if (terminalEvent?.type === "missing_api_key") return "missing_api_key";
+  if (terminalEvent?.type === "error") {
+    return `error:${terminalEvent.errorCode || "unknown"}`;
+  }
+  if (finalStatus === "aborted") return `aborted:${abortReason ?? "user"}`;
+  if (completionError) return "completion_error";
+  if (finalStatus === "errored") return "error:unknown";
+  return "done";
+}
+
 function abortInMemoryRun(run: ActiveRun, reason: string = "user") {
   run.abortReason = reason;
   run.status = "aborted";
@@ -459,7 +480,7 @@ export function startRun(
             type: "auto_continue",
             reason: "run_timeout",
           });
-          abort.abort();
+          abort.abort("run_timeout");
         }, softTimeoutMs)
       : null;
   let pendingTerminalEvent: RunEvent | null = null;
@@ -634,6 +655,12 @@ export function startRun(
           : run.status === "errored" || completionError
             ? "errored"
             : "completed";
+      const terminalReason = terminalReasonForRun(
+        finalStatus,
+        pendingTerminalEvent?.event ?? null,
+        run.abortReason,
+        completionError,
+      );
 
       // 3. Emit the terminal event only after thread_data is durable. Live
       //    SSE clients close on this event and usually fetch thread_data
@@ -706,7 +733,13 @@ export function startRun(
       try {
         await insertRunPromise;
         if (!terminalPersistenceError) {
-          await updateRunStatusIfRunning(runId, finalStatus);
+          const statusUpdated = await updateRunStatusIfRunning(
+            runId,
+            finalStatus,
+          );
+          if (statusUpdated) {
+            await setRunTerminalReason(runId, terminalReason);
+          }
         }
       } catch {
         // Best-effort — reapIfStale will eventually clean this up via
@@ -1077,6 +1110,8 @@ export async function getActiveRunForThreadAsync(threadId: string): Promise<{
   lastProgressAt: number | null;
   /** How the run was dispatched (NULL/foreground, background, background-processing). */
   dispatchMode?: string | null;
+  /** Compact terminal classification, e.g. done, run_timeout, stale_run. */
+  terminalReason?: string | null;
   /**
    * Last reached `_process-run` worker stage as a JSON string
    * `{stage,detail?,at}`. Surfaced so a silent background-worker death is
@@ -1143,6 +1178,7 @@ export async function getActiveRunForThreadAsync(threadId: string): Promise<{
         heartbeatAt: sqlRun.heartbeatAt ?? sqlRun.startedAt,
         lastProgressAt: sqlRun.lastProgressAt,
         dispatchMode: sqlRun.dispatchMode,
+        terminalReason: sqlRun.terminalReason,
         diagStage: sqlRun.diagStage,
       };
     }
@@ -1170,6 +1206,7 @@ export async function getActiveRunForThreadAsync(threadId: string): Promise<{
         heartbeatAt: sqlRun.heartbeatAt ?? sqlRun.startedAt,
         lastProgressAt: sqlRun.lastProgressAt,
         dispatchMode: sqlRun.dispatchMode,
+        terminalReason: sqlRun.terminalReason,
         diagStage: sqlRun.diagStage,
       };
     }

--- a/packages/core/src/agent/run-store.durable-background.spec.ts
+++ b/packages/core/src/agent/run-store.durable-background.spec.ts
@@ -24,6 +24,7 @@ interface RunRow {
   completed_at: number | null;
   error_code: string | null;
   error_detail: string | null;
+  terminal_reason: string | null;
   diag_stage: string | null;
 }
 
@@ -85,6 +86,7 @@ const mockDb = {
         completed_at: null,
         error_code: null,
         error_detail: null,
+        terminal_reason: null,
         diag_stage: null,
       });
       return { rows: [], rowsAffected: 1 };
@@ -109,8 +111,8 @@ const mockDb = {
       /WHERE id = \?/i.test(sql)
     ) {
       const completedAt = args[0] as number;
-      const id = args[3] as string;
-      const cutoff = args[4] as number;
+      const id = args[4] as string;
+      const cutoff = args[5] as number;
       const row = rows.find(
         (r) =>
           r.id === id &&
@@ -123,6 +125,7 @@ const mockDb = {
         row.completed_at = completedAt;
         row.error_code = args[1] as string;
         row.error_detail = args[2] as string;
+        row.terminal_reason = args[3] as string;
         return { rows: [], rowsAffected: 1 };
       }
       return { rows: [], rowsAffected: 0 };
@@ -152,8 +155,8 @@ const mockDb = {
       /WHERE id = \?/i.test(sql)
     ) {
       const completedAt = args[0] as number;
-      const id = args[3] as string;
-      const lastBound = args[4] as number;
+      const id = args[4] as string;
+      const lastBound = args[5] as number;
       // Default path inlines the background-aware CASE and binds `now`; the
       // explicit-maxStaleMs path inlines a plain `?` and binds a pre-computed
       // cutoff. Distinguish by the SQL fragment, not the arg type.
@@ -169,6 +172,7 @@ const mockDb = {
         row.completed_at = completedAt;
         row.error_code = args[1] as string;
         row.error_detail = args[2] as string;
+        row.terminal_reason = args[3] as string;
         return { rows: [], rowsAffected: 1 };
       }
       return { rows: [], rowsAffected: 0 };

--- a/packages/core/src/agent/run-store.spec.ts
+++ b/packages/core/src/agent/run-store.spec.ts
@@ -176,7 +176,8 @@ describe("run store", () => {
       /UPDATE agent_runs SET status = 'aborted'/i.test(call.sql),
     );
     expect(update?.args[0]).toBe("user");
-    expect(update?.args[2]).toBe("run-abort");
+    expect(update?.args[2]).toBe("aborted:user");
+    expect(update?.args[3]).toBe("run-abort");
 
     const insert = execCalls.find((call) =>
       /INSERT INTO agent_run_events/i.test(call.sql),
@@ -241,9 +242,11 @@ describe("run store", () => {
     );
     expect(update?.sql).toContain("error_code = ?");
     expect(update?.sql).toContain("error_detail = ?");
+    expect(update?.sql).toContain("terminal_reason = ?");
     expect(update?.args[1]).toBe(STALE_RUN_ERROR_EVENT.errorCode);
     expect(update?.args[2]).toBe(STALE_RUN_ERROR_EVENT.details);
-    expect(update?.args[3]).toBe("run-stale");
+    expect(update?.args[3]).toBe(STALE_RUN_ERROR_EVENT.errorCode);
+    expect(update?.args[4]).toBe("run-stale");
 
     const insert = execCalls.find((call) =>
       /INSERT INTO agent_run_events/i.test(call.sql),
@@ -316,12 +319,14 @@ describe("run store", () => {
         /UPDATE agent_runs/i.test(call.sql) &&
         /SET status = 'errored'/i.test(call.sql) &&
         /error_code = \?/i.test(call.sql) &&
-        /error_detail = \?/i.test(call.sql),
+        /error_detail = \?/i.test(call.sql) &&
+        /terminal_reason = \?/i.test(call.sql),
     );
     expect(staleUpdates.length).toBeGreaterThanOrEqual(3);
     for (const update of staleUpdates) {
       expect(update.args[1]).toBe(STALE_RUN_ERROR_EVENT.errorCode);
       expect(update.args[2]).toBe(STALE_RUN_ERROR_EVENT.details);
+      expect(update.args[3]).toBe(STALE_RUN_ERROR_EVENT.errorCode);
     }
   });
 

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -116,6 +116,7 @@ async function ensureRunTables(): Promise<void> {
           turn_id TEXT,
           error_code TEXT,
           error_detail TEXT,
+          terminal_reason TEXT,
           dispatch_mode TEXT,
           diag_stage TEXT
         )
@@ -187,6 +188,7 @@ async function ensureRunTables(): Promise<void> {
           ["turn_id", "TEXT"],
           ["error_code", "TEXT"],
           ["error_detail", "TEXT"],
+          ["terminal_reason", "TEXT"],
           ["dispatch_mode", "TEXT"],
           ["diag_stage", "TEXT"],
           ["worker_stage", "TEXT"],
@@ -264,6 +266,7 @@ async function ensureRunTables(): Promise<void> {
         "turn_id",
         "error_code",
         "error_detail",
+        "terminal_reason",
         "dispatch_mode",
         "diag_stage",
         "worker_stage",
@@ -622,6 +625,28 @@ export async function setRunError(
 }
 
 /**
+ * Record why a run reached its terminal status. Unlike error_code/error_detail,
+ * this is set for successful checkpoint boundaries too (for example
+ * status='completed' + terminal_reason='run_timeout').
+ */
+export async function setRunTerminalReason(
+  runId: string,
+  terminalReason: string | undefined,
+): Promise<void> {
+  if (!terminalReason) return;
+  try {
+    await ensureRunTables();
+    const client = getDbExec();
+    await client.execute({
+      sql: `UPDATE agent_runs SET terminal_reason = ? WHERE id = ?`,
+      args: [terminalReason.slice(0, 200), runId],
+    });
+  } catch {
+    // Diagnostics are best-effort; never let them break completion.
+  }
+}
+
+/**
  * Diagnostic stage names recorded onto a background run as it moves through the
  * `_process-run` worker pipeline. Each value is the LAST stage successfully
  * reached, so a stuck run's `diag_stage` reveals exactly where it died. Ordered
@@ -765,7 +790,8 @@ export async function reapIfStale(
           SET status = 'errored',
               completed_at = ?,
               error_code = ?,
-              error_detail = ?
+              error_detail = ?,
+              terminal_reason = ?
           WHERE id = ?
             AND status = 'running'
             AND ${staleClause}`,
@@ -773,6 +799,7 @@ export async function reapIfStale(
       completedAt,
       STALE_RUN_ERROR_EVENT.errorCode,
       STALE_RUN_ERROR_EVENT.details,
+      STALE_RUN_ERROR_EVENT.errorCode,
       runId,
       ...staleArgs,
     ],
@@ -821,7 +848,8 @@ export async function reapUnclaimedBackgroundRun(
           SET status = 'errored',
               completed_at = ?,
               error_code = ?,
-              error_detail = ?
+              error_detail = ?,
+              terminal_reason = ?
           WHERE id = ?
             AND status = 'running'
             AND dispatch_mode = 'background'
@@ -830,6 +858,7 @@ export async function reapUnclaimedBackgroundRun(
       completedAt,
       UNCLAIMED_BACKGROUND_RUN_ERROR_EVENT.errorCode,
       UNCLAIMED_BACKGROUND_RUN_ERROR_EVENT.details,
+      UNCLAIMED_BACKGROUND_RUN_ERROR_EVENT.errorCode,
       runId,
       cutoff,
     ],
@@ -902,8 +931,8 @@ export async function markRunAborted(
   await ensureRunTables();
   const client = getDbExec();
   await client.execute({
-    sql: `UPDATE agent_runs SET status = 'aborted', abort_reason = ?, completed_at = ? WHERE id = ?`,
-    args: [reason ?? "user", Date.now(), runId],
+    sql: `UPDATE agent_runs SET status = 'aborted', abort_reason = ?, completed_at = ?, terminal_reason = ? WHERE id = ?`,
+    args: [reason ?? "user", Date.now(), `aborted:${reason ?? "user"}`, runId],
   });
   await safeAppendTerminalRunEvent(runId, { type: "done" }, "mark-aborted");
 }
@@ -1005,13 +1034,14 @@ export async function getRunByThread(
   completedAt: number | null;
   lastProgressAt: number | null;
   dispatchMode: string | null;
+  terminalReason: string | null;
   diagStage: string | null;
 } | null> {
   await ensureRunTables();
   const client = getDbExec();
   const sql = options?.includeTerminal
-    ? `SELECT id, thread_id, turn_id, status, started_at, heartbeat_at, completed_at, last_progress_at, dispatch_mode, diag_stage FROM agent_runs WHERE thread_id = ? ORDER BY started_at DESC LIMIT 1`
-    : `SELECT id, thread_id, turn_id, status, started_at, heartbeat_at, completed_at, last_progress_at, dispatch_mode, diag_stage FROM agent_runs WHERE thread_id = ? AND status = 'running' ORDER BY started_at DESC LIMIT 1`;
+    ? `SELECT id, thread_id, turn_id, status, started_at, heartbeat_at, completed_at, last_progress_at, dispatch_mode, terminal_reason, diag_stage FROM agent_runs WHERE thread_id = ? ORDER BY started_at DESC LIMIT 1`
+    : `SELECT id, thread_id, turn_id, status, started_at, heartbeat_at, completed_at, last_progress_at, dispatch_mode, terminal_reason, diag_stage FROM agent_runs WHERE thread_id = ? AND status = 'running' ORDER BY started_at DESC LIMIT 1`;
   const { rows } = await client.execute({ sql, args: [threadId] });
   if (rows.length === 0) return null;
   const r = rows[0] as {
@@ -1024,6 +1054,7 @@ export async function getRunByThread(
     completed_at: number | string | null;
     last_progress_at: number | string | null;
     dispatch_mode?: string | null;
+    terminal_reason?: string | null;
     diag_stage?: string | null;
   };
   return {
@@ -1037,6 +1068,7 @@ export async function getRunByThread(
     lastProgressAt:
       r.last_progress_at == null ? null : Number(r.last_progress_at),
     dispatchMode: r.dispatch_mode ?? null,
+    terminalReason: r.terminal_reason ?? null,
     diagStage: r.diag_stage ?? null,
   };
 }
@@ -1053,6 +1085,7 @@ export interface AgentRunSummary {
   errorCode: string | null;
   abortReason: string | null;
   dispatchMode: string | null;
+  terminalReason: string | null;
   /** Last reached `_process-run` worker stage (JSON `{stage,detail?,at}`). */
   diagStage: string | null;
 }
@@ -1065,7 +1098,7 @@ export async function listRunsForThread(
   const limit = Math.min(Math.max(options.limit ?? 10, 1), 50);
   const client = getDbExec();
   const { rows } = await client.execute({
-    sql: `SELECT id, thread_id, turn_id, status, started_at, heartbeat_at, completed_at, last_progress_at, error_code, abort_reason, dispatch_mode, diag_stage
+    sql: `SELECT id, thread_id, turn_id, status, started_at, heartbeat_at, completed_at, last_progress_at, error_code, abort_reason, dispatch_mode, terminal_reason, diag_stage
           FROM agent_runs
           WHERE thread_id = ?
           ORDER BY started_at DESC
@@ -1085,6 +1118,7 @@ export async function listRunsForThread(
       error_code?: string | null;
       abort_reason?: string | null;
       dispatch_mode?: string | null;
+      terminal_reason?: string | null;
       diag_stage?: string | null;
     };
     return {
@@ -1100,6 +1134,7 @@ export async function listRunsForThread(
       errorCode: row.error_code ?? null,
       abortReason: row.abort_reason ?? null,
       dispatchMode: row.dispatch_mode ?? null,
+      terminalReason: row.terminal_reason ?? null,
       diagStage: row.diag_stage ?? null,
     };
   });
@@ -1183,13 +1218,15 @@ export async function reapAllStaleRuns(): Promise<number> {
           SET status = 'errored',
               completed_at = ?,
               error_code = ?,
-              error_detail = ?
+              error_detail = ?,
+              terminal_reason = ?
           WHERE status = 'running'
             AND ${livenessBasisSql()} < ${backgroundAwareStaleCutoffSql()}`,
     args: [
       completedAt,
       STALE_RUN_ERROR_EVENT.errorCode,
       STALE_RUN_ERROR_EVENT.details,
+      STALE_RUN_ERROR_EVENT.errorCode,
       completedAt,
     ],
   });
@@ -1241,12 +1278,14 @@ export async function cleanupOldRuns(
           SET status = 'errored',
               completed_at = ?,
               error_code = ?,
-              error_detail = ?
+              error_detail = ?,
+              terminal_reason = ?
           WHERE status = 'running' AND started_at < ?`,
     args: [
       completedAt,
       STALE_RUN_ERROR_EVENT.errorCode,
       STALE_RUN_ERROR_EVENT.details,
+      STALE_RUN_ERROR_EVENT.errorCode,
       cutoff,
     ],
   });
@@ -1257,13 +1296,15 @@ export async function cleanupOldRuns(
           SET status = 'errored',
               completed_at = ?,
               error_code = ?,
-              error_detail = ?
+              error_detail = ?,
+              terminal_reason = ?
           WHERE status = 'running'
             AND ${livenessBasisSql()} < ${backgroundAwareStaleCutoffSql()}`,
     args: [
       completedAt,
       STALE_RUN_ERROR_EVENT.errorCode,
       STALE_RUN_ERROR_EVENT.details,
+      STALE_RUN_ERROR_EVENT.errorCode,
       completedAt,
     ],
   });
@@ -1312,6 +1353,7 @@ export async function listErroredRuns(options?: {
     status: string;
     errorCode: string | null;
     errorDetail: string | null;
+    terminalReason: string | null;
     startedAt: number;
     completedAt: number | null;
     durationMs: number | null;
@@ -1323,7 +1365,7 @@ export async function listErroredRuns(options?: {
   const since =
     options?.sinceMs && options.sinceMs > 0 ? Date.now() - options.sinceMs : 0;
   const { rows } = await client.execute({
-    sql: `SELECT id, thread_id, turn_id, status, error_code, error_detail, started_at, completed_at
+    sql: `SELECT id, thread_id, turn_id, status, error_code, error_detail, terminal_reason, started_at, completed_at
           FROM agent_runs
           WHERE status IN ('errored', 'aborted')
             AND COALESCE(completed_at, started_at) >= ?
@@ -1339,6 +1381,7 @@ export async function listErroredRuns(options?: {
       status: string;
       error_code: string | null;
       error_detail: string | null;
+      terminal_reason: string | null;
       started_at: number | string;
       completed_at: number | string | null;
     };
@@ -1352,6 +1395,7 @@ export async function listErroredRuns(options?: {
       status: row.status,
       errorCode: row.error_code ?? null,
       errorDetail: row.error_detail ?? null,
+      terminalReason: row.terminal_reason ?? null,
       startedAt,
       completedAt,
       durationMs: completedAt == null ? null : completedAt - startedAt,

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -2634,6 +2634,19 @@ describe("createAgentChatAdapter", () => {
       ([event]) => event?.type === "agent-chat:run-error",
     )?.[0] as CustomEvent<{ details?: string }> | undefined;
     expect(dispatchedRunError?.detail.details).toContain(
+      "api_url: /_agent-native/agent-chat",
+    );
+    expect(dispatchedRunError?.detail.details).toContain(
+      "tab_id: chat-repeated-prep",
+    );
+    expect(dispatchedRunError?.detail.details).toContain(
+      "thread_id: thread-repeated-prep",
+    );
+    expect(dispatchedRunError?.detail.details).toContain("current_run: run-qa");
+    expect(dispatchedRunError?.detail.details).toContain(
+      "attempted_runs: run-qa",
+    );
+    expect(dispatchedRunError?.detail.details).toContain(
       "last_preparing_tool: present-design-variants",
     );
     const last = results.at(-1) as any;

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -1461,8 +1461,29 @@ export function createAgentChatAdapter(
       const nextContinuationToolCallId = () =>
         `continuation_tc_${++continuationToolCallCounter}`;
 
+      const runDebugContextDetails = (): string => {
+        const pageOrigin =
+          typeof window !== "undefined" && window.location?.origin
+            ? window.location.origin
+            : "";
+        return [
+          `api_url: ${apiUrl}`,
+          pageOrigin ? `page_origin: ${pageOrigin}` : "",
+          tabId ? `tab_id: ${tabId}` : "",
+          threadId ? `thread_id: ${threadId}` : "",
+          `turn_id: ${turnId}`,
+          runId ? `current_run: ${runId}` : "",
+          attemptedRunIds.length > 0
+            ? `attempted_runs: ${attemptedRunIds.join(", ")}`
+            : "",
+        ]
+          .filter(Boolean)
+          .join("\n");
+      };
+
       const connectionRecoveryDetails = (): string => {
         return [
+          runDebugContextDetails(),
           lastAutoContinueReason
             ? `last_auto_continue_reason: ${lastAutoContinueReason}`
             : "",
@@ -1488,9 +1509,6 @@ export function createAgentChatAdapter(
             ? `activity_trail: ${formatActivityTrail(lastActivityTrail)}`
             : "",
           `total_transient_continuations: ${totalTransientContinuationAttempts}`,
-          attemptedRunIds.length > 0
-            ? `attempted_runs: ${attemptedRunIds.join(", ")}`
-            : "",
         ]
           .filter(Boolean)
           .join("\n");

--- a/packages/core/src/client/blocks/library/diagram.spec.tsx
+++ b/packages/core/src/client/blocks/library/diagram.spec.tsx
@@ -137,6 +137,20 @@ describe("DiagramBlock expand affordance", () => {
     );
   });
 
+  it("forces html diagram primitive labels to wrap inside their boxes", () => {
+    const css = readFileSync("src/styles/blocks.css", "utf8");
+
+    expect(css).toMatch(
+      /\.plan-diagram-frame\s+:is\(\s*\.diagram-panel,[^}]*\[class\*="box"\]\s*\)\s*{[^}]*overflow-wrap:\s*anywhere !important;[^}]*white-space:\s*normal !important;/s,
+    );
+    expect(css).toMatch(
+      /\.plan-diagram-frame\s+:is\(\s*\.diagram-panel,[^}]*\)\s+:is\(h1,\s*h2,\s*h3,\s*p,\s*small,\s*strong,\s*span,\s*li\)\s*{[^}]*overflow-wrap:\s*anywhere !important;[^}]*white-space:\s*normal !important;/s,
+    );
+    expect(css).toMatch(
+      /\.plan-diagram-frame\s+:is\(\.diagram-pill,[^}]*\)\s*{[^}]*flex-wrap:\s*wrap;[^}]*white-space:\s*normal !important;/s,
+    );
+  });
+
   it("renders the expand control for the legacy node-graph variant", () => {
     act(() => {
       root.render(
@@ -156,6 +170,38 @@ describe("DiagramBlock expand affordance", () => {
 
     expect(expandButton()).toBeTruthy();
     expect(styleButton()).toBeNull();
+  });
+
+  it("lets long legacy sequence edge labels wrap instead of truncating", () => {
+    act(() => {
+      root.render(
+        <DiagramRead
+          blockId="diagram-sequence-wrap"
+          ctx={{}}
+          data={{
+            nodes: [
+              { id: "start", label: "Authenticated shell" },
+              { id: "guard", label: "Sign-in guard" },
+            ],
+            edges: [
+              {
+                from: "start",
+                to: "guard",
+                label: "already on /_agent-native/sign-in",
+              },
+            ],
+          }}
+        />,
+      );
+    });
+
+    const label = Array.from(container.querySelectorAll("span")).find((node) =>
+      node.textContent?.includes("/_agent-native/sign-in"),
+    );
+
+    expect(label?.className).toContain("whitespace-normal");
+    expect(label?.className).toContain("[overflow-wrap:anywhere]");
+    expect(label?.className).not.toContain("truncate");
   });
 
   it("opens a lightbox on click and closes it on Escape", () => {

--- a/packages/core/src/client/blocks/library/diagram.tsx
+++ b/packages/core/src/client/blocks/library/diagram.tsx
@@ -291,7 +291,7 @@ function PositionedDiagram({
               return (
                 <span
                   key={`${edge.from}-${edge.to}-${index}-label`}
-                  className="absolute z-10 max-w-[130px] -translate-x-1/2 -translate-y-1/2 rounded-full border border-border bg-background px-2 py-0.5 text-center text-[11px] font-semibold text-muted-foreground shadow-sm"
+                  className="absolute z-10 max-w-[130px] -translate-x-1/2 -translate-y-1/2 break-words rounded-full border border-border bg-background px-2 py-0.5 text-center text-[11px] font-semibold text-muted-foreground shadow-sm [overflow-wrap:anywhere]"
                   style={{
                     left: `${(from.displayX + to.displayX) / 2}%`,
                     top: `${(from.displayY + to.displayY) / 2}%`,
@@ -305,7 +305,7 @@ function PositionedDiagram({
           {displayNodesForDirection.map((node, index) => (
             <article
               key={node.id}
-              className="absolute z-20 -translate-x-1/2 -translate-y-1/2 rounded-xl border-2 border-border bg-background p-3 text-foreground shadow-sm"
+              className="absolute z-20 -translate-x-1/2 -translate-y-1/2 break-words rounded-xl border-2 border-border bg-background p-3 text-foreground shadow-sm [overflow-wrap:anywhere]"
               style={{
                 left: `${node.displayX}%`,
                 top: `${node.displayY}%`,
@@ -485,7 +485,7 @@ function SequenceDiagram({
               {next && (
                 <div className="grid min-w-[72px] justify-items-center gap-1 text-muted-foreground">
                   {edge?.label && (
-                    <span className="max-w-[96px] truncate rounded-full border border-border px-2 py-0.5 text-[11px] font-semibold">
+                    <span className="max-w-[96px] whitespace-normal break-words rounded-full border border-border px-2 py-0.5 text-center text-[11px] font-semibold [overflow-wrap:anywhere]">
                       {edge.label}
                     </span>
                   )}

--- a/packages/core/src/client/chat/message-components.spec.tsx
+++ b/packages/core/src/client/chat/message-components.spec.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
+  assistantMessageHasUnresolvedTool,
   shouldShowAssistantMessageFooter,
   ThinkingIndicator,
 } from "./message-components.js";
@@ -78,6 +79,18 @@ describe("shouldShowAssistantMessageFooter", () => {
     ).toBe(true);
   });
 
+  it("hides controls for the current assistant response while a tool is unresolved", () => {
+    expect(
+      shouldShowAssistantMessageFooter({
+        isLast: true,
+        chatRunning: false,
+        hasRenderableContent: true,
+        statusIsTerminal: true,
+        hasUnresolvedTool: true,
+      }),
+    ).toBe(false);
+  });
+
   it("keeps completed historical assistant messages actionable", () => {
     expect(
       shouldShowAssistantMessageFooter({
@@ -87,5 +100,37 @@ describe("shouldShowAssistantMessageFooter", () => {
         statusIsTerminal: true,
       }),
     ).toBe(true);
+  });
+});
+
+describe("assistantMessageHasUnresolvedTool", () => {
+  it("detects unresolved running and activity tool parts", () => {
+    expect(
+      assistantMessageHasUnresolvedTool([
+        {
+          type: "tool-call",
+          toolName: "edit-design",
+          toolCallId: "tc_1",
+          argsText: "",
+          args: {},
+          activity: true,
+        },
+      ]),
+    ).toBe(true);
+  });
+
+  it("ignores completed tool parts", () => {
+    expect(
+      assistantMessageHasUnresolvedTool([
+        {
+          type: "tool-call",
+          toolName: "edit-design",
+          toolCallId: "tc_1",
+          argsText: "{}",
+          args: {},
+          result: "{}",
+        },
+      ]),
+    ).toBe(false);
   });
 });

--- a/packages/core/src/client/chat/message-components.tsx
+++ b/packages/core/src/client/chat/message-components.tsx
@@ -784,19 +784,31 @@ function assistantMessageStatusIsTerminal(message: {
   return statusType === "complete" || statusType === "incomplete";
 }
 
+export function assistantMessageHasUnresolvedTool(content: unknown): boolean {
+  if (!Array.isArray(content)) return false;
+  return content.some((part): boolean => {
+    if (!part || typeof part !== "object") return false;
+    const record = part as { type?: unknown; result?: unknown };
+    return record.type === "tool-call" && record.result === undefined;
+  });
+}
+
 export function shouldShowAssistantMessageFooter({
   isLast,
   chatRunning,
   hasRenderableContent,
   statusIsTerminal,
+  hasUnresolvedTool,
 }: {
   isLast: boolean;
   chatRunning: boolean;
   hasRenderableContent: boolean;
   statusIsTerminal: boolean;
+  hasUnresolvedTool?: boolean;
 }): boolean {
   if (!hasRenderableContent) return false;
   if (!isLast) return true;
+  if (hasUnresolvedTool) return false;
   return !chatRunning && statusIsTerminal;
 }
 
@@ -813,11 +825,13 @@ export function AssistantMessage() {
     thread.messages.length > 0 &&
     thread.messages[thread.messages.length - 1].id === msg.id;
   const hasRenderableContent = assistantMessageHasRenderableContent(msg);
+  const hasUnresolvedTool = assistantMessageHasUnresolvedTool(msg.content);
   const isComplete = shouldShowAssistantMessageFooter({
     isLast,
     chatRunning,
     hasRenderableContent,
     statusIsTerminal: assistantMessageStatusIsTerminal(msg),
+    hasUnresolvedTool,
   });
   const cpCtx = React.useContext(CheckpointContext);
 
@@ -906,6 +920,9 @@ export function AssistantMessage() {
         />
         {isComplete && hasCodeAgentTools && msgContent && (
           <FilesChangedSummary parts={msgContent} />
+        )}
+        {isLast && hasUnresolvedTool && !chatRunning && (
+          <RunningActivityStatus label="Thinking" />
         )}
       </div>
       {isComplete && (

--- a/packages/core/src/observability/traces.spec.ts
+++ b/packages/core/src/observability/traces.spec.ts
@@ -296,4 +296,48 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
 
     expect(usage.model).toBe("claude-test");
   });
+
+  it("allows recoverable run-timeout aborts to be classified as successful run spans", async () => {
+    const { tracer, spans } = createRecordingTracer();
+    __setAgentTracerForTests(tracer as any);
+    const controller = new AbortController();
+
+    const loopOpts: any = {
+      engine: {},
+      model: "claude-test",
+      systemPrompt: "",
+      tools: [],
+      messages: [],
+      actions: {},
+      send: () => {},
+      signal: controller.signal,
+    };
+
+    await expect(
+      instrumentAgentLoop({
+        runAgentLoop: async () => {
+          controller.abort("run_timeout");
+          throw new Error("This operation was aborted");
+        },
+        loopOpts,
+        runId: "run-timeout-classified",
+        threadId: "thread-1",
+        userId: "user@example.com",
+        config: { ...DEFAULT_OBSERVABILITY_CONFIG, enabled: true },
+        classifyError: () => ({
+          status: "success",
+          errorMessage: null,
+          metadata: {
+            terminalReason: "run_timeout",
+            recoverableContinuation: true,
+          },
+        }),
+      }),
+    ).rejects.toThrow("This operation was aborted");
+
+    const runSpan = spans.find((span) => span.name === "agent.run");
+    expect(runSpan?.status?.code).toBe(SPAN_STATUS_OK);
+    expect(runSpan?.status?.message).toBeUndefined();
+    expect(runSpan?.ended).toBe(true);
+  });
 });

--- a/packages/core/src/observability/traces.ts
+++ b/packages/core/src/observability/traces.ts
@@ -89,6 +89,14 @@ export async function instrumentAgentLoop(opts: {
    *  reads. */
   userId: string | null;
   config: ObservabilityConfig;
+  classifyError?: (error: unknown) =>
+    | {
+        status?: "success" | "error";
+        errorMessage?: string | null;
+        metadata?: Record<string, unknown> | null;
+      }
+    | null
+    | undefined;
 }): Promise<AgentLoopUsage> {
   const { runAgentLoop, loopOpts, runId, threadId, userId, config } = opts;
   const runStart = Date.now();
@@ -260,11 +268,17 @@ export async function instrumentAgentLoop(opts: {
   let usage: AgentLoopUsage | undefined;
   let runStatus: "success" | "error" = "success";
   let errorMessage: string | null = null;
+  let runMetadata: Record<string, unknown> | null = null;
   try {
     usage = await runAgentLoop({ ...loopOpts, send: instrumentedSend });
   } catch (err: any) {
-    runStatus = "error";
-    errorMessage = err?.message ?? String(err);
+    const classification = opts.classifyError?.(err) ?? null;
+    runStatus = classification?.status ?? "error";
+    errorMessage =
+      classification?.errorMessage === undefined
+        ? (err?.message ?? String(err))
+        : classification.errorMessage;
+    runMetadata = classification?.metadata ?? null;
     throw err;
   } finally {
     const runEnd = Date.now();
@@ -325,7 +339,7 @@ export async function instrumentAgentLoop(opts: {
       durationMs: totalDurationMs,
       status: runStatus,
       errorMessage,
-      metadata: null,
+      metadata: runMetadata,
       createdAt: runStart,
     };
     spans.push(parentSpan);

--- a/packages/core/src/server/agent-chat-plugin.shared.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin.shared.spec.ts
@@ -92,6 +92,9 @@ const run: AgentRunSummary = {
   lastProgressAt: 150,
   errorCode: null,
   abortReason: null,
+  dispatchMode: null,
+  terminalReason: "done",
+  diagStage: null,
 };
 
 describe("recurring jobs runtime startup", () => {
@@ -154,6 +157,7 @@ describe("agent chat process-run failure finalization", () => {
       })),
       recordRunDiagnostic: vi.fn(async () => {}),
       setRunError: vi.fn(async () => {}),
+      setRunTerminalReason: vi.fn(async () => {}),
       updateRunStatusIfRunning: vi.fn(async () => true),
       ensureTerminalRunEvent: vi.fn(async () => {}),
     };
@@ -184,6 +188,10 @@ describe("agent chat process-run failure finalization", () => {
       "run-claimed",
       "errored",
     );
+    expect(d.setRunTerminalReason).toHaveBeenCalledWith(
+      "run-claimed",
+      "background_worker_failed",
+    );
     expect(d.ensureTerminalRunEvent).toHaveBeenCalledWith(
       "run-claimed",
       CLAIMED_BACKGROUND_WORKER_FAILED_ERROR_EVENT,
@@ -207,6 +215,7 @@ describe("agent chat process-run failure finalization", () => {
       "pre-claim failure",
     );
     expect(d.setRunError).not.toHaveBeenCalled();
+    expect(d.setRunTerminalReason).not.toHaveBeenCalled();
     expect(d.updateRunStatusIfRunning).not.toHaveBeenCalled();
     expect(d.ensureTerminalRunEvent).not.toHaveBeenCalled();
   });

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -69,6 +69,7 @@ import {
   recordRunDiagnostic,
   RUN_DIAG_STAGE,
   setRunError,
+  setRunTerminalReason,
   updateRunStatusIfRunning,
 } from "../agent/run-store.js";
 import { buildRuntimeContextPrompt } from "../agent/runtime-context.js";
@@ -3876,6 +3877,7 @@ type AgentChatProcessRunFailureDeps = {
   readBackgroundRunClaim?: typeof readBackgroundRunClaim;
   recordRunDiagnostic?: typeof recordRunDiagnostic;
   setRunError?: typeof setRunError;
+  setRunTerminalReason?: typeof setRunTerminalReason;
   updateRunStatusIfRunning?: typeof updateRunStatusIfRunning;
   ensureTerminalRunEvent?: typeof ensureTerminalRunEvent;
 };
@@ -3888,6 +3890,7 @@ export async function finalizeClaimedAgentChatProcessRunFailure(
   const readClaim = deps.readBackgroundRunClaim ?? readBackgroundRunClaim;
   const record = deps.recordRunDiagnostic ?? recordRunDiagnostic;
   const setError = deps.setRunError ?? setRunError;
+  const setTerminalReason = deps.setRunTerminalReason ?? setRunTerminalReason;
   const updateStatus =
     deps.updateRunStatusIfRunning ?? updateRunStatusIfRunning;
   const ensureTerminal = deps.ensureTerminalRunEvent ?? ensureTerminalRunEvent;
@@ -3908,7 +3911,13 @@ export async function finalizeClaimedAgentChatProcessRunFailure(
     CLAIMED_BACKGROUND_WORKER_FAILED_ERROR_EVENT.errorCode,
     `${CLAIMED_BACKGROUND_WORKER_FAILED_ERROR_EVENT.details} setupError=${message}`,
   ).catch(() => {});
-  await updateStatus(runId, "errored").catch(() => {});
+  const statusUpdated = await updateStatus(runId, "errored").catch(() => false);
+  if (statusUpdated) {
+    await setTerminalReason(
+      runId,
+      CLAIMED_BACKGROUND_WORKER_FAILED_ERROR_EVENT.errorCode,
+    ).catch(() => {});
+  }
   await ensureTerminal(
     runId,
     CLAIMED_BACKGROUND_WORKER_FAILED_ERROR_EVENT,
@@ -7400,6 +7409,7 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
               // unreadable Netlify background-function logs — read
               // `/runs/active?threadId=...` and inspect `diagStage`.
               dispatchMode: run.dispatchMode ?? null,
+              terminalReason: run.terminalReason ?? null,
               diagStage: run.diagStage ?? null,
               workerStage: workerClaim?.workerStage ?? null,
               // Server clock so the client computes "stuck" elapsed time

--- a/packages/core/src/styles/blocks.css
+++ b/packages/core/src/styles/blocks.css
@@ -1355,8 +1355,37 @@
   color: var(--wf-ink) !important;
 }
 
-.plan-diagram-frame :is(.diagram-node, .diagram-box, .diagram-card) {
+.plan-diagram-frame
+  :is(
+    .diagram-panel,
+    .diagram-card,
+    .diagram-node,
+    .diagram-box,
+    [class*="card"],
+    [class*="panel"],
+    [class*="box"]
+  ) {
   max-width: 100%;
+  overflow-wrap: anywhere !important;
+  word-break: break-word;
+  white-space: normal !important;
+}
+
+.plan-diagram-frame
+  :is(
+    .diagram-panel,
+    .diagram-card,
+    .diagram-node,
+    .diagram-box,
+    [class*="card"],
+    [class*="panel"],
+    [class*="box"]
+  )
+  :is(h1, h2, h3, p, small, strong, span, li) {
+  max-width: 100%;
+  overflow-wrap: anywhere !important;
+  word-break: break-word;
+  white-space: normal !important;
 }
 
 /* Base padding so primitive text never touches the box edge, even when an author
@@ -1422,6 +1451,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  flex-wrap: wrap;
   /* A pill hugs its label. `fit-content` is a definite cross size, so a flex
    * column with the default `align-items: stretch` no longer blows the pill out
    * to full width (the number chips and short status labels stay pill-shaped).
@@ -1434,6 +1464,19 @@
   padding: 3px 11px;
   color: var(--wf-ink);
   background: var(--wf-paper);
+  overflow-wrap: anywhere !important;
+  text-align: center;
+  white-space: normal !important;
+  word-break: break-word;
+}
+
+.plan-diagram-frame
+  :is(.diagram-pill, [class*="pill"], [class*="badge"], [class*="chip"])
+  > * {
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere !important;
+  white-space: normal !important;
 }
 
 .plan-diagram-frame :is(.diagram-accent, .diagram-pill.accent) {

--- a/templates/clips/changelog/2026-07-01-chrome-extension-recordings-stream-uploads-while-recording.md
+++ b/templates/clips/changelog/2026-07-01-chrome-extension-recordings-stream-uploads-while-recording.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-01
+---
+
+Chrome extension recordings now stream uploads while recording so saving is less likely to time out.

--- a/templates/clips/chrome-extension/src/background.ts
+++ b/templates/clips/chrome-extension/src/background.ts
@@ -32,6 +32,7 @@ const UNQUOTED_SECRET_VALUE_RE = new RegExp(
 type CaptureSurface = "browser" | "window" | "monitor" | "camera";
 type ConsoleLevel = "debug" | "log" | "info" | "warn" | "error";
 type NetworkType = "fetch" | "xhr";
+type UploadMode = "streaming" | "buffered";
 
 type ExtensionSettings = {
   clipsBaseUrl: string;
@@ -134,6 +135,7 @@ type NativeRecording = {
   recordingId: string;
   clipsBaseUrl: string;
   uploadUrl: string;
+  uploadMode: UploadMode;
   targetTabId: number;
   targetTitle: string | null;
   targetUrl: string | null;
@@ -1049,6 +1051,7 @@ async function armRecording(args: {
     id?: string;
     uploadChunkUrl?: string;
     abortUrl?: string;
+    uploadMode?: UploadMode;
   };
   let created: CreatedRecording;
   try {
@@ -1061,6 +1064,8 @@ async function armRecording(args: {
       hasAudio:
         settings.includeMicrophone || settings.captureSurface !== "camera",
       visibility: "public",
+      mimeType: "video/webm",
+      requestStreaming: true,
     });
   } catch (err) {
     captureExtensionError(err, {
@@ -1091,6 +1096,7 @@ async function armRecording(args: {
     recordingId: created.id,
     clipsBaseUrl: settings.clipsBaseUrl,
     uploadUrl,
+    uploadMode: created.uploadMode ?? "buffered",
     targetTabId: tab.id as number,
     targetTitle: tab.title?.trim() || null,
     targetUrl: tab.url?.trim() || null,
@@ -1122,6 +1128,7 @@ async function armRecording(args: {
       sessionId,
       recordingId: created.id,
       uploadUrl,
+      uploadMode: created.uploadMode ?? "buffered",
       hasCamera: cameraInvolved,
       startDelayMs,
       authToken,
@@ -1274,6 +1281,7 @@ async function handleOverlayRestart() {
       sessionId: recording.sessionId,
       recordingId: recording.recordingId,
       uploadUrl: recording.uploadUrl,
+      uploadMode: recording.uploadMode ?? "buffered",
       hasCamera:
         recording.captureSurface === "camera" || recording.includeCamera,
       startDelayMs: COUNTDOWN_SECONDS * 1000,

--- a/templates/clips/chrome-extension/src/offscreen.ts
+++ b/templates/clips/chrome-extension/src/offscreen.ts
@@ -17,7 +17,11 @@
 // app recorder via @shared/recording-core so the server contract can't drift.
 
 import { scheduleReadyChime } from "@shared/recording-audio";
-import { chunkUploadUrl, pickMimeType } from "@shared/recording-core";
+import {
+  chunkUploadUrl,
+  pickMimeType,
+  type UploadMode,
+} from "@shared/recording-core";
 import { MAX_UPLOAD_BYTES } from "@shared/upload-limits";
 
 import { waitForReadyRecordingAfterFinalizeError } from "./finalize-recovery";
@@ -63,6 +67,7 @@ type BeginMessage = {
   sessionId: string;
   recordingId: string;
   uploadUrl: string;
+  uploadMode?: UploadMode;
   hasCamera?: boolean;
   // Pre-roll countdown delay, owned here in the offscreen document (a reliable
   // context) rather than the service worker (which can suspend and drop timers).
@@ -114,6 +119,7 @@ type ActiveRecording = {
   sessionId: string;
   recordingId: string;
   uploadUrl: string;
+  uploadMode: UploadMode;
   authToken: string | null;
   mode: CaptureMode;
   startedAtMs: number;
@@ -134,6 +140,8 @@ type ActiveRecording = {
   // Set if the recording grew past the buffer ceiling and we stopped retaining
   // — at that point a local save can't be guaranteed, so we don't promise one.
   localBufferOverflow: boolean;
+  pendingStreamBlobs: Blob[];
+  pendingStreamBytes: number;
   cancelled: boolean;
   // Set when the recorder is being torn down to start over on the same source
   // streams, so the stop handler skips the usual track cleanup.
@@ -155,6 +163,8 @@ type ActiveRecording = {
   rejectStopped: (error: Error) => void;
 };
 
+const GCS_CHUNK_ALIGN_BYTES = 256 * 1024;
+const STREAM_CHUNK_BYTES = 15 * GCS_CHUNK_ALIGN_BYTES; // 3.75 MiB
 const UPLOAD_SLICE_BYTES = 3 * 1024 * 1024;
 
 // Don't retain more than the upload ceiling — past it the server rejects the
@@ -578,6 +588,32 @@ async function uploadBlobInSlices(
   }
 }
 
+async function uploadStreamingBlob(
+  recording: ActiveRecording,
+  blob: Blob,
+): Promise<void> {
+  if (blob.size === 0) return;
+  recording.pendingStreamBlobs.push(blob);
+  recording.pendingStreamBytes += blob.size;
+
+  while (recording.pendingStreamBytes >= STREAM_CHUNK_BYTES) {
+    if (recording.cancelled || recording.uploadFailure) return;
+    const combined = new Blob(recording.pendingStreamBlobs, {
+      type: recording.mimeType,
+    });
+    const head = combined.slice(0, STREAM_CHUNK_BYTES, recording.mimeType);
+    const tail = combined.slice(
+      STREAM_CHUNK_BYTES,
+      undefined,
+      recording.mimeType,
+    );
+    recording.pendingStreamBlobs = tail.size > 0 ? [tail] : [];
+    recording.pendingStreamBytes = tail.size;
+    const index = recording.chunkIndex++;
+    await uploadChunk(recording, head, index);
+  }
+}
+
 function stopStreams(streams: (MediaStream | null)[]): void {
   for (const stream of streams) {
     if (!stream) continue;
@@ -744,6 +780,7 @@ async function begin(message: BeginMessage): Promise<{
     sessionId: ready.sessionId,
     recordingId: message.recordingId,
     uploadUrl: message.uploadUrl,
+    uploadMode: message.uploadMode ?? "buffered",
     authToken: message.authToken ?? null,
     mode: ready.mode,
     startedAtMs: 0,
@@ -763,6 +800,8 @@ async function begin(message: BeginMessage): Promise<{
     recordedBlobs: [],
     recordedBytes: 0,
     localBufferOverflow: false,
+    pendingStreamBlobs: [],
+    pendingStreamBytes: 0,
     cancelled: false,
     restarting: false,
     startTimer: null,
@@ -798,7 +837,11 @@ async function begin(message: BeginMessage): Promise<{
     // rejected promise that surfaces as an "Uncaught (in promise)" error (bad
     // look in a Chrome Web Store review). finalizeStop reads recording.upload-
     // Failure and surfaces it through the normal error path instead.
-    const upload = uploadBlobInSlices(recording, event.data).catch((err) => {
+    const upload = (
+      recording.uploadMode === "streaming"
+        ? uploadStreamingBlob(recording, event.data)
+        : uploadBlobInSlices(recording, event.data)
+    ).catch((err) => {
       recording.uploadFailure =
         err instanceof Error ? err : new Error(String(err));
       captureExtensionError(recording.uploadFailure, {
@@ -1001,20 +1044,22 @@ async function finalizeStop(recording: ActiveRecording): Promise<void> {
     }
     let result: UploadResult;
     try {
-      result = await uploadChunk(
-        recording,
-        new Blob([], { type: recording.mimeType }),
-        recording.chunkIndex,
-        {
-          isFinal: true,
-          total: recording.chunkIndex,
-          durationMs,
-          width: recording.dimensions.width,
-          height: recording.dimensions.height,
-          hasAudio: recording.hasAudio,
-          hasCamera: recording.hasCamera,
-        },
-      );
+      const finalBlob =
+        recording.uploadMode === "streaming"
+          ? new Blob(recording.pendingStreamBlobs, { type: recording.mimeType })
+          : new Blob([], { type: recording.mimeType });
+      recording.pendingStreamBlobs = [];
+      recording.pendingStreamBytes = 0;
+      const finalIndex = recording.chunkIndex;
+      result = await uploadChunk(recording, finalBlob, finalIndex, {
+        isFinal: true,
+        total: finalIndex + (finalBlob.size > 0 ? 1 : 0),
+        durationMs,
+        width: recording.dimensions.width,
+        height: recording.dimensions.height,
+        hasAudio: recording.hasAudio,
+        hasCamera: recording.hasCamera,
+      });
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
       (error as { finalUpload?: boolean }).finalUpload = true;

--- a/templates/plan/app/components/plan/wireframe/html-artboard.css
+++ b/templates/plan/app/components/plan/wireframe/html-artboard.css
@@ -405,8 +405,37 @@
   color: var(--wf-ink) !important;
 }
 
-.plan-diagram-frame :is(.diagram-node, .diagram-box, .diagram-card) {
+.plan-diagram-frame
+  :is(
+    .diagram-panel,
+    .diagram-card,
+    .diagram-node,
+    .diagram-box,
+    [class*="card"],
+    [class*="panel"],
+    [class*="box"]
+  ) {
   max-width: 100%;
+  overflow-wrap: anywhere !important;
+  word-break: break-word;
+  white-space: normal !important;
+}
+
+.plan-diagram-frame
+  :is(
+    .diagram-panel,
+    .diagram-card,
+    .diagram-node,
+    .diagram-box,
+    [class*="card"],
+    [class*="panel"],
+    [class*="box"]
+  )
+  :is(h1, h2, h3, p, small, strong, span, li) {
+  max-width: 100%;
+  overflow-wrap: anywhere !important;
+  word-break: break-word;
+  white-space: normal !important;
 }
 
 /* Base padding so primitive text never touches the box edge, even when an author
@@ -472,6 +501,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  flex-wrap: wrap;
   /* A pill hugs its label. `fit-content` is a definite cross size, so a flex
    * column with the default `align-items: stretch` no longer blows the pill out
    * to full width (the number chips and short status labels stay pill-shaped).
@@ -484,6 +514,19 @@
   padding: 3px 11px;
   color: var(--wf-ink);
   background: var(--wf-paper);
+  overflow-wrap: anywhere !important;
+  text-align: center;
+  white-space: normal !important;
+  word-break: break-word;
+}
+
+.plan-diagram-frame
+  :is(.diagram-pill, [class*="pill"], [class*="badge"], [class*="chip"])
+  > * {
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere !important;
+  white-space: normal !important;
 }
 
 .plan-diagram-frame :is(.diagram-accent, .diagram-pill.accent) {

--- a/templates/plan/app/components/plan/wireframe/rough.spec.ts
+++ b/templates/plan/app/components/plan/wireframe/rough.spec.ts
@@ -31,4 +31,21 @@ describe("HTML wireframe rough overlay defaults", () => {
     expect(hideRule).not.toContain(".wf-card");
     expect(hideRule).not.toContain(".wf-box");
   });
+
+  it("keeps diagram primitive text contained inside boxes", () => {
+    const css = readFileSync(
+      join(process.cwd(), "app/components/plan/wireframe/html-artboard.css"),
+      "utf8",
+    );
+
+    expect(css).toMatch(
+      /\.plan-diagram-frame\s+:is\(\s*\.diagram-panel,[^}]*\[class\*="box"\]\s*\)\s*{[^}]*overflow-wrap:\s*anywhere !important;[^}]*white-space:\s*normal !important;/s,
+    );
+    expect(css).toMatch(
+      /\.plan-diagram-frame\s+:is\(\s*\.diagram-panel,[^}]*\)\s+:is\(h1,\s*h2,\s*h3,\s*p,\s*small,\s*strong,\s*span,\s*li\)\s*{[^}]*overflow-wrap:\s*anywhere !important;[^}]*white-space:\s*normal !important;/s,
+    );
+    expect(css).toMatch(
+      /\.plan-diagram-frame\s+:is\(\.diagram-pill,[^}]*\)\s*{[^}]*flex-wrap:\s*wrap;[^}]*white-space:\s*normal !important;/s,
+    );
+  });
 });

--- a/templates/plan/changelog/2026-07-01-visual-plan-and-recap-diagram-labels-now-wrap-inside-their-b.md
+++ b/templates/plan/changelog/2026-07-01-visual-plan-and-recap-diagram-labels-now-wrap-inside-their-b.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-01
+---
+
+Visual plan and recap diagram labels now wrap inside their boxes instead of spilling outside.


### PR DESCRIPTION
## Summary
- route deployed Lambda function runtimes to the emitted Netlify background function even when the build-only NETLIFY flag is absent
- persist agent run terminal reasons and improve recovery/debug details so soft continuations do not look like generic aborted failures
- keep unresolved activity-only tool cards visibly running, wrap diagram labels, and include the Clips streaming upload side change from the shared branch

## Validation
- corepack pnpm prep
- verified Netlify runtime assumptions against current Netlify/AWS docs and Netlify forum guidance
- reproduced prod Design failure on run chain run-1782912802856-lgqs25 through run-1782913073810-3rn8tn before this fix: dispatch_mode=background-processing still used 40s chunks because markerExpected/runtimeDetected were false

## Notes
- production verification still needs this PR merged and released so Design can prove long-budget workers on a fresh run
