### PR TITLE
Stabilize prep under full test load

### DIFF
--- a/.changeset/prep-stability-core.md
+++ b/.changeset/prep-stability-core.md
@@ -1,5 +1,6 @@
 ---
 "@agent-native/core": patch
+"@agent-native/dispatch": patch
 ---
 
-Avoid unsupported array helpers in Builder engine message caching.
+Avoid unsupported array helpers in Builder engine message caching and stabilize prep-load tests.

--- a/.changeset/prep-stability-core.md
+++ b/.changeset/prep-stability-core.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Avoid unsupported array helpers in Builder engine message caching.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -184,7 +184,7 @@
     "build": "tsgo && tsgo -p tsconfig.cli.json && node scripts/finalize-build.mjs && node scripts/check-dist-imports.mjs",
     "dev": "tsgo --watch",
     "typecheck": "tsgo --noEmit",
-    "test": "vitest --run src",
+    "test": "vitest --run src --maxWorkers=25%",
     "prepack": "tsx ../../scripts/sync-workspace-core-skills.ts --check && npm run build && cp ../../README.md ./README.md",
     "prepublishOnly": "npm run build"
   },

--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -193,9 +193,13 @@ class BuilderEngine implements AgentEngine {
     // content block so the entire conversation prefix is cached.
     let cachedMessages = messages;
     if (cacheEnabled && messages.length > 0) {
-      const lastUserIdx = [...messages].findLastIndex(
-        (m: any) => m.role === "user",
-      );
+      let lastUserIdx = -1;
+      for (let i = messages.length - 1; i >= 0; i -= 1) {
+        if ((messages[i] as any).role === "user") {
+          lastUserIdx = i;
+          break;
+        }
+      }
       if (lastUserIdx >= 0) {
         cachedMessages = [...messages];
         const lastMsg = { ...cachedMessages[lastUserIdx] } as any;

--- a/packages/core/src/scripts/runner.spec.ts
+++ b/packages/core/src/scripts/runner.spec.ts
@@ -52,7 +52,7 @@ const tsxCli = resolveTsxCli();
 const tsxIsBinShim = !tsxCli.endsWith(".mjs") && !tsxCli.endsWith(".js");
 const tsxCommand = tsxIsBinShim ? tsxCli : process.execPath;
 const tsxLeadingArgs = tsxIsBinShim ? [] : [tsxCli];
-const spawnTimeoutMs = 15_000;
+const spawnTimeoutMs = 30_000;
 
 describe("runScript package actions", () => {
   let tmpDir: string;
@@ -107,7 +107,7 @@ describe("runScript package actions", () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("Fixture package actions:");
     expect(result.stdout).toContain("package-action");
-  }, 20_000);
+  }, 40_000);
 
   it("runs a package action when no local action exists", () => {
     const result = spawnSync(
@@ -148,7 +148,7 @@ describe("runScript package actions", () => {
       sourceIds: ["mail", "calendar"],
       limit: "8",
     });
-  }, 20_000);
+  }, 40_000);
 
   it("runs a package action with a positional JSON object", () => {
     const result = spawnSync(
@@ -187,7 +187,7 @@ describe("runScript package actions", () => {
       cursors: { slack: "next-page" },
       sourceIds: ["mail", "calendar"],
     });
-  }, 20_000);
+  }, 40_000);
 
   it("lets explicit flags override positional JSON object keys", () => {
     const result = spawnSync(
@@ -226,7 +226,7 @@ describe("runScript package actions", () => {
       limit: "12",
       cursors: { slack: "next-page" },
     });
-  }, 20_000);
+  }, 40_000);
 
   it("reports invalid positional JSON object input", () => {
     const result = spawnSync(
@@ -245,7 +245,7 @@ describe("runScript package actions", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("Invalid positional JSON argument");
-  }, 20_000);
+  }, 40_000);
 
   it("preserves empty package action arguments", () => {
     const result = spawnSync(
@@ -268,5 +268,5 @@ describe("runScript package actions", () => {
         fs.readFileSync(path.join(tmpDir, "package-output.json"), "utf8"),
       ),
     ).toEqual({ label: "" });
-  }, 20_000);
+  }, 40_000);
 });

--- a/packages/core/src/server/agent-teams.spec.ts
+++ b/packages/core/src/server/agent-teams.spec.ts
@@ -59,7 +59,7 @@ describe("agent teams message queue", () => {
         key.startsWith("task-message:task-1:"),
       ),
     ).toHaveLength(2);
-  }, 15_000);
+  }, 30_000);
 
   it("drains queued messages into the next tool result once", async () => {
     const { sendToTask, _agentTeamsQueueForTests } =
@@ -90,7 +90,7 @@ describe("agent teams message queue", () => {
       "change direction",
     );
     await expect(actions["do-work"].run({})).resolves.toBe("tool result");
-  });
+  }, 30_000);
 
   it("uses the final response guard to deliver queued messages before completion", async () => {
     const { sendToTask, _agentTeamsQueueForTests } =

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -47,7 +47,7 @@ describe("server/auth", () => {
 
       vi.stubEnv("NODE_ENV", "test");
       expect(shouldSkipEmailVerification()).toBe(true);
-    });
+    }, 15_000);
 
     it("is disabled by default in production", async () => {
       vi.stubEnv("NODE_ENV", "production");
@@ -55,7 +55,7 @@ describe("server/auth", () => {
         await import("./better-auth-instance.js");
 
       expect(shouldSkipEmailVerification()).toBe(false);
-    });
+    }, 15_000);
 
     it("is enabled by AUTH_SKIP_EMAIL_VERIFICATION=1", async () => {
       vi.stubEnv("AUTH_SKIP_EMAIL_VERIFICATION", "1");
@@ -63,7 +63,7 @@ describe("server/auth", () => {
         await import("./better-auth-instance.js");
 
       expect(shouldSkipEmailVerification()).toBe(true);
-    });
+    }, 15_000);
 
     it("treats blank, false, and 0 as disabled", async () => {
       const { shouldSkipEmailVerification } =
@@ -77,7 +77,7 @@ describe("server/auth", () => {
 
       vi.stubEnv("AUTH_SKIP_EMAIL_VERIFICATION", "0");
       expect(shouldSkipEmailVerification()).toBe(false);
-    });
+    }, 15_000);
   });
 
   describe("resolveSignupTrackingIdentity", () => {

--- a/packages/dispatch/src/server/lib/workspace-resource-approval-lifecycle.spec.ts
+++ b/packages/dispatch/src/server/lib/workspace-resource-approval-lifecycle.spec.ts
@@ -223,5 +223,5 @@ describe("workspace resource approval lifecycle", () => {
         personalOverride.layers.find((layer) => layer.scope === "personal"),
       ).toMatchObject({ exists: true, effective: true });
     });
-  }, 30_000);
+  }, 60_000);
 });


### PR DESCRIPTION
## Summary
- Avoid `Array.findLastIndex` in the Builder engine cache breakpoint path so core typecheck works with the current TS lib target.
- Lower core Vitest worker pressure and raise targeted integration-test timeouts that were being killed under full concurrent `pnpm run prep` load.
- Add a patch changeset for the core compatibility fix.

## Test plan
- `pnpm --dir packages/core run typecheck`
- `pnpm --dir packages/core run test`
- `pnpm --dir templates/assets run typecheck`
- `pnpm run prep`


Made with [Cursor](https://cursor.com)