### PR TITLE
Fix Analytics session replay gzip ingest

### DIFF
--- a/templates/analytics/changelog/2026-07-01-session-replay-recordings-upload-reliably-in-production.md
+++ b/templates/analytics/changelog/2026-07-01-session-replay-recordings-upload-reliably-in-production.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+date: 2026-07-01
+---
+Session replay recordings upload reliably in production.

--- a/templates/analytics/changelog/2026-07-01-session-replay-recordings-upload-reliably-in-production.md
+++ b/templates/analytics/changelog/2026-07-01-session-replay-recordings-upload-reliably-in-production.md
@@ -2,4 +2,5 @@
 type: fixed
 date: 2026-07-01
 ---
+
 Session replay recordings upload reliably in production.

--- a/templates/analytics/server/handlers/session-replay.spec.ts
+++ b/templates/analytics/server/handlers/session-replay.spec.ts
@@ -20,6 +20,30 @@ describe("session replay ingest handler", () => {
     expect(decoded.body).toEqual(payload);
   });
 
+  it("accepts decoded JSON bodies when the gzip header is preserved", () => {
+    const payload = {
+      publicKey: "anpk_test",
+      replayId: "recording_1",
+      sessionId: "session_1",
+      events: [{ type: 4, data: { href: "/inbox" } }],
+    };
+    const decoded = decodeSessionReplayRequestBody(
+      Buffer.from(JSON.stringify(payload), "utf8"),
+      "gzip",
+    );
+
+    expect(decoded.requestBytes).toBe(
+      Buffer.byteLength(JSON.stringify(payload), "utf8"),
+    );
+    expect(decoded.body).toEqual(payload);
+  });
+
+  it("still rejects malformed gzip replay request bodies", () => {
+    expect(() =>
+      decodeSessionReplayRequestBody(Buffer.from("not gzip"), "gzip"),
+    ).toThrow("Invalid gzip-compressed replay body");
+  });
+
   it("rejects unsupported replay request encodings", () => {
     expect(() =>
       decodeSessionReplayRequestBody(Buffer.from("{}"), "br"),

--- a/templates/analytics/server/handlers/session-replay.ts
+++ b/templates/analytics/server/handlers/session-replay.ts
@@ -82,6 +82,11 @@ function statusError(message: string, statusCode: number): Error {
   return Object.assign(new Error(message), { statusCode });
 }
 
+function looksLikeDecodedJson(bytes: Buffer): boolean {
+  const first = bytes.toString("utf8").trimStart()[0];
+  return first === "{" || first === "[";
+}
+
 export function decodeSessionReplayRequestBody(
   rawBody: Buffer | Uint8Array | string | undefined,
   contentEncoding?: string | null,
@@ -102,7 +107,13 @@ export function decodeSessionReplayRequestBody(
     try {
       decoded = gunzipSync(bytes);
     } catch {
-      throw statusError("Invalid gzip-compressed replay body", 400);
+      // Netlify may hand Nitro an already-decoded body while preserving the
+      // original browser Content-Encoding header.
+      if (looksLikeDecodedJson(bytes)) {
+        decoded = bytes;
+      } else {
+        throw statusError("Invalid gzip-compressed replay body", 400);
+      }
     }
   } else if (encoding && encoding !== "identity") {
     throw statusError(


### PR DESCRIPTION
## Summary
- tolerate already-decoded replay JSON when production preserves the gzip content-encoding header
- keep malformed gzip replay bodies rejected
- add Analytics changelog entry for the production replay upload fix

## Tests
- corepack pnpm --filter analytics exec vitest run server/handlers/session-replay.spec.ts
- corepack pnpm --filter analytics typecheck
- git diff --check