### PR TITLE
Fix background markers and analytics freshness

### DIFF
--- a/.changeset/tidy-background-markers.md
+++ b/.changeset/tidy-background-markers.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep background chat continuation markers and database pool detection aligned with the actual background function dispatch path.

--- a/packages/core/src/agent/durable-background.spec.ts
+++ b/packages/core/src/agent/durable-background.spec.ts
@@ -8,6 +8,7 @@ import {
   AGENT_CHAT_BACKGROUND_RUN_FIELD,
   backgroundRuntimeDiagnosticDetail,
   backgroundRunMarkerExpectsBackgroundRuntime,
+  dispatchPathTargetsNetlifyBackgroundFunction,
   extractProcessRunId,
   isAgentChatDurableBackgroundEnabled,
   isHostedRuntimeForDurableBackground,
@@ -196,6 +197,19 @@ describe("isInBackgroundFunctionRuntime (real -background function guard)", () =
 });
 
 describe("background runtime marker fallback", () => {
+  it("derives marker expectation from the concrete dispatch path", () => {
+    expect(
+      dispatchPathTargetsNetlifyBackgroundFunction(
+        "/.netlify/functions/design-agent-background",
+      ),
+    ).toBe(true);
+    expect(
+      dispatchPathTargetsNetlifyBackgroundFunction(
+        "/_agent-native/agent-chat/_process-run",
+      ),
+    ).toBe(false);
+  });
+
   it("uses the long background timeout when the authenticated dispatch marker proves the Netlify background function URL was targeted", () => {
     const marker = { backgroundFunctionRuntimeExpected: true };
 

--- a/packages/core/src/agent/durable-background.ts
+++ b/packages/core/src/agent/durable-background.ts
@@ -149,6 +149,12 @@ export function resolveAgentChatProcessRunDispatchPath(): string {
   return AGENT_CHAT_PROCESS_RUN_PATH;
 }
 
+export function dispatchPathTargetsNetlifyBackgroundFunction(
+  dispatchPath: string,
+): boolean {
+  return dispatchPath.startsWith("/.netlify/functions/");
+}
+
 /**
  * Env flag for durable background runs. DEFAULT-OFF (opt-in): unset means
  * disabled; an app opts IN with an explicit truthy value (`true`/`1`/`yes`/`on`).

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -54,6 +54,7 @@ import { computeProtectedSegmentIds } from "./context-xray/segments.js";
 import {
   AGENT_CHAT_BACKGROUND_RUN_FIELD,
   backgroundRuntimeDiagnosticDetail,
+  dispatchPathTargetsNetlifyBackgroundFunction,
   isAgentChatDurableBackgroundEnabled,
   resolveAgentChatProcessRunDispatchPath,
   shouldUseBackgroundFunctionTimeoutForWorker,
@@ -5017,7 +5018,7 @@ export function createProductionAgentHandler(
       let dispatched = false;
       const backgroundDispatchPath = resolveAgentChatProcessRunDispatchPath();
       const expectsNetlifyBackgroundFunction =
-        backgroundDispatchPath.startsWith("/.netlify/functions/");
+        dispatchPathTargetsNetlifyBackgroundFunction(backgroundDispatchPath);
       try {
         await fireInternalDispatch({
           event,
@@ -5313,6 +5314,12 @@ export function createProductionAgentHandler(
                 // its seq log starts clean; same turnId folds the assistant
                 // message across chunks.
                 const nextRunId = generateRunId();
+                const continuationDispatchPath =
+                  resolveAgentChatProcessRunDispatchPath();
+                const continuationExpectsNetlifyBackgroundFunction =
+                  dispatchPathTargetsNetlifyBackgroundFunction(
+                    continuationDispatchPath,
+                  );
                 try {
                   await fireInternalDispatch({
                     event,
@@ -5322,7 +5329,7 @@ export function createProductionAgentHandler(
                     // background:true; never shadowed because /.netlify/* is
                     // excluded from the /* catch-all) so each chunk keeps the
                     // 15-min budget; off-Netlify the in-process framework route.
-                    path: resolveAgentChatProcessRunDispatchPath(),
+                    path: continuationDispatchPath,
                     taskId: nextRunId,
                     body: {
                       ...body,
@@ -5332,7 +5339,7 @@ export function createProductionAgentHandler(
                         turnId: effectiveTurnId,
                         continuationCount: backgroundContinuationCount + 1,
                         backgroundFunctionRuntimeExpected:
-                          runsInBackgroundFunction,
+                          continuationExpectsNetlifyBackgroundFunction,
                       },
                     },
                   });

--- a/packages/core/src/db/client.spec.ts
+++ b/packages/core/src/db/client.spec.ts
@@ -13,6 +13,14 @@ describe("db/client dialect detection", () => {
 
   afterEach(() => {
     process.env = originalEnv;
+    Reflect.deleteProperty(
+      globalThis as Record<string, unknown>,
+      "__AGENT_NATIVE_BACKGROUND_RUNTIME__",
+    );
+    Reflect.deleteProperty(
+      globalThis as Record<string, unknown>,
+      "__AGENT_NATIVE_BACKGROUND_RUNTIME_EXPECTED__",
+    );
     vi.resetModules();
   });
 
@@ -79,6 +87,28 @@ describe("db/client dialect detection", () => {
     vi.stubEnv("NETLIFY_DATABASE_URL", "postgres://netlify.example/db");
     const { getDatabaseUrl } = await import("./client.js");
     expect(getDatabaseUrl()).toBe("postgres://plan.example/db");
+  });
+
+  it("keeps the Neon foreground pool small on serverless", async () => {
+    vi.stubEnv("NETLIFY", "true");
+    const { neonPoolMax, isBackgroundFunctionPoolContext } =
+      await import("./client.js");
+
+    expect(isBackgroundFunctionPoolContext()).toBe(false);
+    expect(neonPoolMax()).toBe(2);
+  });
+
+  it("uses the background Neon pool when the verified process-run marker expects a background function", async () => {
+    vi.stubEnv("NETLIFY", "true");
+    (
+      globalThis as Record<string, unknown>
+    ).__AGENT_NATIVE_BACKGROUND_RUNTIME_EXPECTED__ = true;
+
+    const { neonPoolMax, isBackgroundFunctionPoolContext } =
+      await import("./client.js");
+
+    expect(isBackgroundFunctionPoolContext()).toBe(true);
+    expect(neonPoolMax()).toBe(8);
   });
 });
 

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -837,10 +837,19 @@ export function neonPoolMax(): number {
  * (agent/durable-background.ts), replicated here to avoid a `db` → `agent`
  * import cycle. Keep the signals in sync with that function.
  */
-function isBackgroundFunctionPoolContext(): boolean {
+export function isBackgroundFunctionPoolContext(): boolean {
   if (
     (globalThis as Record<string, unknown>)
       .__AGENT_NATIVE_BACKGROUND_RUNTIME__ === true
+  ) {
+    return true;
+  }
+  // Set by the HMAC-authenticated agent-chat `_process-run` route before it
+  // re-enters the normal chat handler. This mirrors the marker-only runtime
+  // proof used by durable-background.ts without importing agent code into db/.
+  if (
+    (globalThis as Record<string, unknown>)
+      .__AGENT_NATIVE_BACKGROUND_RUNTIME_EXPECTED__ === true
   ) {
     return true;
   }

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -34,8 +34,9 @@ import {
 } from "../agent/app-model-defaults.js";
 import { DEFAULT_ANTHROPIC_MODEL } from "../agent/default-model.js";
 import {
+  AGENT_CHAT_BACKGROUND_RUN_FIELD,
   AGENT_CHAT_PROCESS_RUN_PATH,
-  extractProcessRunId,
+  backgroundRunMarkerExpectsBackgroundRuntime,
   isInBackgroundFunctionRuntime,
   prepareProcessRunRequest,
 } from "../agent/durable-background.js";
@@ -7993,18 +7994,6 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
             setResponseStatus(event, 405);
             return { error: "Method not allowed" };
           }
-          // DIAGNOSTIC: load the run-store diagnostic recorder. Each stage we
-          // reach is written onto the run row (diag_stage) so a silent failure
-          // INSIDE the Netlify background function — whose logs we cannot read —
-          // is still diagnosable from the client via /runs/active. Best-effort:
-          // the import + every record call is wrapped so diagnostics can never
-          // break the worker path.
-          const diag = await import("../agent/run-store.js")
-            .then((m) => ({
-              record: m.recordRunDiagnostic,
-              stages: m.RUN_DIAG_STAGE,
-            }))
-            .catch(() => null);
 
           // Consume the body ONCE (h3 v2's web Request stream is single-use).
           let processBody: any;
@@ -8013,18 +8002,6 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
           } catch {
             setResponseStatus(event, 400);
             return { error: "Invalid request body" };
-          }
-
-          // Record "the route handler was entered" against the run BEFORE auth
-          // runs. This is the proof the bg-fn invocation actually reached Nitro
-          // (vs. dying at the function entry / never being invoked). The runId
-          // is parsed without authenticating so we can attach it even on a
-          // subsequent auth failure.
-          const diagRunId = extractProcessRunId(processBody);
-          if (diag && diagRunId) {
-            await diag
-              .record(diagRunId, diag.stages.routeEntered)
-              .catch(() => {});
           }
 
           // Validate + HMAC-authenticate the self-dispatch and prepare the
@@ -8041,6 +8018,12 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
             // bypassing session auth) inside the unreadable bg function would
             // leave the run to time out with NO clue. The detail carries the
             // status + whether A2A_SECRET is even present in this isolate.
+            const diag = await import("../agent/run-store.js")
+              .then((m) => ({
+                record: m.recordRunDiagnostic,
+                stages: m.RUN_DIAG_STAGE,
+              }))
+              .catch(() => null);
             if (diag && prepared.runId) {
               const a2aPresent = Boolean(
                 process.env.A2A_SECRET && process.env.A2A_SECRET.length > 0,
@@ -8057,27 +8040,58 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
             return { error: prepared.error };
           }
 
-          // DIAGNOSTIC: auth + body validation passed. Reaching here proves the
-          // request was authenticated and we are about to invoke the worker.
-          if (diag) {
-            await diag
-              .record(prepared.runId, diag.stages.authPassed)
-              .catch(() => {});
+          const preparedMarker = (prepared.body as Record<string, unknown>)[
+            AGENT_CHAT_BACKGROUND_RUN_FIELD
+          ];
+          const expectsBackgroundRuntime =
+            backgroundRunMarkerExpectsBackgroundRuntime(preparedMarker);
+          const runtimeGlobals = globalThis as Record<string, unknown>;
+          const hadExpectedRuntimeMarker = Object.prototype.hasOwnProperty.call(
+            runtimeGlobals,
+            "__AGENT_NATIVE_BACKGROUND_RUNTIME_EXPECTED__",
+          );
+          const previousExpectedRuntimeMarker =
+            runtimeGlobals.__AGENT_NATIVE_BACKGROUND_RUNTIME_EXPECTED__;
+          if (expectsBackgroundRuntime) {
+            runtimeGlobals.__AGENT_NATIVE_BACKGROUND_RUNTIME_EXPECTED__ = true;
           }
 
-          // Stash the verified+augmented body for the handler — the body stream
-          // is already consumed, so the handler reads this instead.
-          (event as any).context = (event as any).context ?? {};
-          (event as any).context.__agentChatBackgroundBody = prepared.body;
-
-          // Durable owner context: this self-dispatch is cookieless (HMAC-only).
-          // Resolve the owner from the persisted run row, never the request body,
-          // then invoke the normal handler. The shared agent-run context helper
-          // expands that owner into the same user/org AsyncLocalStorage context the
-          // foreground request uses, so credential and data scoping stay aligned.
-          await seedBackgroundAgentRunOwnerContext(event, prepared.runId);
-
           try {
+            // DIAGNOSTIC: load the run-store diagnostic recorder only after the
+            // authenticated marker has been mirrored into globalThis. run-store
+            // can initialize the DB pool; the pool must see the same background
+            // proof as the agent timeout logic before that happens.
+            const diag = await import("../agent/run-store.js")
+              .then((m) => ({
+                record: m.recordRunDiagnostic,
+                stages: m.RUN_DIAG_STAGE,
+              }))
+              .catch(() => null);
+
+            // Record "the route handler was entered" against the run after auth
+            // succeeds. This is the proof the bg-fn invocation actually reached
+            // Nitro (vs. dying at the function entry / never being invoked).
+            if (diag) {
+              await diag
+                .record(prepared.runId, diag.stages.routeEntered)
+                .catch(() => {});
+              await diag
+                .record(prepared.runId, diag.stages.authPassed)
+                .catch(() => {});
+            }
+
+            // Stash the verified+augmented body for the handler — the body stream
+            // is already consumed, so the handler reads this instead.
+            (event as any).context = (event as any).context ?? {};
+            (event as any).context.__agentChatBackgroundBody = prepared.body;
+
+            // Durable owner context: this self-dispatch is cookieless (HMAC-only).
+            // Resolve the owner from the persisted run row, never the request
+            // body, then invoke the normal handler. The shared agent-run context
+            // helper expands that owner into the same user/org AsyncLocalStorage
+            // context the foreground request uses, so credential and data scoping
+            // stay aligned.
+            await seedBackgroundAgentRunOwnerContext(event, prepared.runId);
             return await invokeAgentChatHandler(event);
           } catch (err: any) {
             console.error("[agent-chat] _process-run failed:", err);
@@ -8099,6 +8113,18 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
             );
             setResponseStatus(event, 500);
             return { error: "process-run failed" };
+          } finally {
+            if (expectsBackgroundRuntime) {
+              if (hadExpectedRuntimeMarker) {
+                runtimeGlobals.__AGENT_NATIVE_BACKGROUND_RUNTIME_EXPECTED__ =
+                  previousExpectedRuntimeMarker;
+              } else {
+                Reflect.deleteProperty(
+                  runtimeGlobals,
+                  "__AGENT_NATIVE_BACKGROUND_RUNTIME_EXPECTED__",
+                );
+              }
+            }
           }
         }),
       );

--- a/templates/analytics/actions/compose-dashboard.spec.ts
+++ b/templates/analytics/actions/compose-dashboard.spec.ts
@@ -205,6 +205,7 @@ describe("compose-dashboard", () => {
       expect(panel.sql).toContain("event_date");
       expect(panel.sql).not.toContain("substr(timestamp, 1, 10)");
       expect(panel.sql).toContain("CURRENT_DATE");
+      expect(panel.sql).toContain("<= to_char(CURRENT_DATE, 'YYYY-MM-DD')");
       expect(panel.sql).not.toContain("AT TIME ZONE");
       expect(panel.sql).not.toContain("now() AT TIME ZONE");
     }

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/DashboardFilterBar.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/DashboardFilterBar.tsx
@@ -228,18 +228,25 @@ export function DashboardFilterBar({
       <Collapsible
         open={filtersOpen}
         onOpenChange={setFiltersOpen}
-        className="group rounded-lg border border-border bg-card p-3"
+        className="group rounded-lg border border-border bg-card px-3 py-2"
       >
-        <div className="flex items-center justify-between gap-3">
-          <div className="flex items-baseline gap-2">
-            <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-              {t("sqlDashboard.filters")}
-            </h3>
-            <span className="text-[10px] text-muted-foreground/60">
-              {t("sqlDashboard.autoApplied")}
-            </span>
-          </div>
-          <div className="flex items-center gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 group-data-[state=closed]:opacity-100">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <CollapsibleContent className="min-w-0 flex-1">
+            <div className="flex flex-wrap gap-3 items-end">
+              {uniqueFilters.map((f) => (
+                <FilterControl
+                  key={f.id}
+                  filter={f}
+                  vars={vars}
+                  hasParam={(key) =>
+                    searchParams.has(FILTER_PARAM_PREFIX + key)
+                  }
+                  setValue={(updates) => setParam(updates)}
+                />
+              ))}
+            </div>
+          </CollapsibleContent>
+          <div className="flex shrink-0 items-center gap-1 self-center opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 group-data-[state=closed]:opacity-100">
             {onSaveView && filtersActive && (
               <Button
                 variant="ghost"
@@ -284,19 +291,6 @@ export function DashboardFilterBar({
             </CollapsibleTrigger>
           </div>
         </div>
-        <CollapsibleContent className="pt-3">
-          <div className="flex flex-wrap gap-3 items-end">
-            {uniqueFilters.map((f) => (
-              <FilterControl
-                key={f.id}
-                filter={f}
-                vars={vars}
-                hasParam={(key) => searchParams.has(FILTER_PARAM_PREFIX + key)}
-                setValue={(updates) => setParam(updates)}
-              />
-            ))}
-          </div>
-        </CollapsibleContent>
       </Collapsible>
 
       <Dialog open={saveDialogOpen} onOpenChange={setSaveDialogOpen}>

--- a/templates/analytics/changelog/2026-07-01-dashboard-charts-no-longer-show-future-dates-when-clients-se.md
+++ b/templates/analytics/changelog/2026-07-01-dashboard-charts-no-longer-show-future-dates-when-clients-se.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-01
+---
+
+Dashboard charts no longer show future dates when clients send bad event timestamps.

--- a/templates/analytics/changelog/2026-07-01-dashboard-filters-take-less-space-and-keep-view-actions-tucked.md
+++ b/templates/analytics/changelog/2026-07-01-dashboard-filters-take-less-space-and-keep-view-actions-tucked.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-01
+---
+
+Dashboard filters take less space and keep view actions tucked to the side.

--- a/templates/analytics/server/lib/first-party-analytics.spec.ts
+++ b/templates/analytics/server/lib/first-party-analytics.spec.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  normalizeAnalyticsTimestamp,
   resolveAnalyticsEventDimensions,
+  scopedAnalyticsSql,
   validateFirstPartyAnalyticsSql,
 } from "./first-party-analytics";
 
@@ -55,7 +57,7 @@ describe("validateFirstPartyAnalyticsSql", () => {
   it("allows scoped session recording summary queries", () => {
     expect(() =>
       validateFirstPartyAnalyticsSql(
-        "SELECT app, COUNT(*) AS recordings FROM session_recordings GROUP BY app",
+        "SELECT app, COUNT(*) AS recordings FROM session_recordings WHERE owner_email = 'alice@example.com' GROUP BY app",
       ),
     ).not.toThrow();
   });
@@ -74,5 +76,55 @@ describe("validateFirstPartyAnalyticsSql", () => {
         "WITH session_replay_chunks AS (SELECT id FROM analytics_events) SELECT COUNT(*) FROM session_replay_chunks",
       ),
     ).toThrow("session replay chunks");
+  });
+});
+
+describe("normalizeAnalyticsTimestamp", () => {
+  it("clamps future client timestamps to the server receive time", () => {
+    expect(
+      normalizeAnalyticsTimestamp(
+        "2026-07-05T12:00:00.000Z",
+        "2026-07-01T13:00:00.000Z",
+      ),
+    ).toBe("2026-07-01T13:00:00.000Z");
+  });
+
+  it("keeps valid past timestamps", () => {
+    expect(
+      normalizeAnalyticsTimestamp(
+        "2026-06-30T12:00:00.000Z",
+        "2026-07-01T13:00:00.000Z",
+      ),
+    ).toBe("2026-06-30T12:00:00.000Z");
+  });
+});
+
+describe("scopedAnalyticsSql", () => {
+  it("adds tenant and freshness guards around analytics event reads", () => {
+    const scoped = scopedAnalyticsSql(
+      "SELECT event_date, COUNT(*) AS count FROM analytics_events GROUP BY event_date",
+      { userEmail: "alice@example.com", orgId: "org_123" },
+      "2026-07-01",
+    );
+
+    expect(scoped.sql).toContain("FROM analytics_events WHERE");
+    expect(scoped.sql).toContain(
+      "(org_id = ? OR (org_id IS NULL AND owner_email = ?))",
+    );
+    expect(scoped.sql).toContain(
+      "COALESCE(NULLIF(event_date, ''), substr(timestamp, 1, 10)) <= ?",
+    );
+    expect(scoped.args).toEqual(["org_123", "alice@example.com", "2026-07-01"]);
+  });
+
+  it("adds freshness guards around session recording reads", () => {
+    const scoped = scopedAnalyticsSql(
+      "SELECT COUNT(*) AS recordings FROM session_recordings",
+      { userEmail: "alice@example.com", orgId: null },
+      "2026-07-01",
+    );
+
+    expect(scoped.sql).toContain("substr(started_at, 1, 10) <= ?");
+    expect(scoped.args).toEqual(["alice@example.com", "2026-07-01"]);
   });
 });

--- a/templates/analytics/server/lib/first-party-analytics.ts
+++ b/templates/analytics/server/lib/first-party-analytics.ts
@@ -50,6 +50,10 @@ function nowIso(): string {
   return new Date().toISOString();
 }
 
+function todayIsoDate(): string {
+  return nowIso().slice(0, 10);
+}
+
 function randomHex(bytes: number): string {
   const arr = new Uint8Array(bytes);
   if (!globalThis.crypto?.getRandomValues) {
@@ -204,17 +208,30 @@ function asString(value: unknown): string | null {
   return null;
 }
 
-function normalizeTimestamp(value: unknown): string {
-  if (value instanceof Date) return value.toISOString();
+export function normalizeAnalyticsTimestamp(
+  value: unknown,
+  receivedAt = nowIso(),
+): string {
+  const fallback = (() => {
+    const date = new Date(receivedAt);
+    return Number.isNaN(date.getTime()) ? nowIso() : date.toISOString();
+  })();
+  const fallbackTime = new Date(fallback).getTime();
+  const normalize = (date: Date) => {
+    if (Number.isNaN(date.getTime())) return fallback;
+    return date.getTime() > fallbackTime ? fallback : date.toISOString();
+  };
+
+  if (value instanceof Date) return normalize(value);
   if (typeof value === "number") {
     const d = new Date(value);
-    return Number.isNaN(d.getTime()) ? nowIso() : d.toISOString();
+    return normalize(d);
   }
   if (typeof value === "string" && value.trim()) {
     const d = new Date(value);
-    return Number.isNaN(d.getTime()) ? nowIso() : d.toISOString();
+    return normalize(d);
   }
-  return nowIso();
+  return fallback;
 }
 
 function eventDateFromTimestamp(timestamp: string): string {
@@ -362,7 +379,7 @@ export async function recordAnalyticsEvents(
       asString((properties as any).anonymousId) ??
       asString((properties as any).distinctId);
     const userKey = userId || anonymousId;
-    const timestamp = normalizeTimestamp(event.timestamp);
+    const timestamp = normalizeAnalyticsTimestamp(event.timestamp, receivedAt);
 
     return {
       id: id("evt"),
@@ -516,9 +533,17 @@ function scopeClause(scope: AnalyticsScope): {
   };
 }
 
-function scopedAnalyticsSql(
+function freshnessClause(tableName: string): string {
+  if (tableName === "analytics_events") {
+    return "(COALESCE(NULLIF(event_date, ''), substr(timestamp, 1, 10)) <= ?)";
+  }
+  return "(substr(started_at, 1, 10) <= ?)";
+}
+
+export function scopedAnalyticsSql(
   sql: string,
   scope: AnalyticsScope,
+  today = todayIsoDate(),
 ): { sql: string; args: Array<string | null> } {
   const args: Array<string | null> = [];
   const aliasRe =
@@ -536,8 +561,8 @@ function scopedAnalyticsSql(
           ? aliasPart
           : ` AS ${normalizedTable}`;
       const scopeDef = scopeClause(scope);
-      args.push(...scopeDef.args);
-      return `${keyword} (SELECT * FROM ${normalizedTable} WHERE ${scopeDef.sql})${usableAlias}`;
+      args.push(...scopeDef.args, today);
+      return `${keyword} (SELECT * FROM ${normalizedTable} WHERE ${scopeDef.sql} AND ${freshnessClause(normalizedTable)})${usableAlias}`;
     },
   );
   return { sql: rewritten, args };

--- a/templates/analytics/server/lib/first-party-metric-catalog.ts
+++ b/templates/analytics/server/lib/first-party-metric-catalog.ts
@@ -128,6 +128,10 @@ function daysAgoSql(days: number): string {
   return `to_char(CURRENT_DATE - INTERVAL '${days} ${unit}', 'YYYY-MM-DD')`;
 }
 
+function todaySql(): string {
+  return "to_char(CURRENT_DATE, 'YYYY-MM-DD')";
+}
+
 function windowStartFilter(days: number): string {
   return `${EVENT_DATE_SQL} >= ${daysAgoSql(days)}`;
 }
@@ -140,14 +144,14 @@ function rollingWindowStartSql(
 }
 
 function dashboardTimeRangeFilter(dateExpr = EVENT_DATE_FILTER_SQL): string {
-  return `('{{timeRange}}' IN ('', 'all') OR ('{{timeRange}}' = '7d' AND ${dateExpr} >= ${daysAgoSql(7)}) OR ('{{timeRange}}' = '30d' AND ${dateExpr} >= ${daysAgoSql(30)}) OR ('{{timeRange}}' = '90d' AND ${dateExpr} >= ${daysAgoSql(90)}) OR ('{{timeRange}}' = '180d' AND ${dateExpr} >= ${daysAgoSql(180)}) OR ('{{timeRange}}' = '365d' AND ${dateExpr} >= ${daysAgoSql(365)}))`;
+  return `(${dateExpr} <= ${todaySql()} AND ('{{timeRange}}' IN ('', 'all') OR ('{{timeRange}}' = '7d' AND ${dateExpr} >= ${daysAgoSql(7)}) OR ('{{timeRange}}' = '30d' AND ${dateExpr} >= ${daysAgoSql(30)}) OR ('{{timeRange}}' = '90d' AND ${dateExpr} >= ${daysAgoSql(90)}) OR ('{{timeRange}}' = '180d' AND ${dateExpr} >= ${daysAgoSql(180)}) OR ('{{timeRange}}' = '365d' AND ${dateExpr} >= ${daysAgoSql(365)})))`;
 }
 
 function dashboardLookbackTimeRangeFilter(
   dateExpr = EVENT_DATE_FILTER_SQL,
   lookbackDays = 0,
 ): string {
-  return `('{{timeRange}}' IN ('', 'all') OR ('{{timeRange}}' = '7d' AND ${dateExpr} >= ${daysAgoSql(7 + lookbackDays)}) OR ('{{timeRange}}' = '30d' AND ${dateExpr} >= ${daysAgoSql(30 + lookbackDays)}) OR ('{{timeRange}}' = '90d' AND ${dateExpr} >= ${daysAgoSql(90 + lookbackDays)}) OR ('{{timeRange}}' = '180d' AND ${dateExpr} >= ${daysAgoSql(180 + lookbackDays)}) OR ('{{timeRange}}' = '365d' AND ${dateExpr} >= ${daysAgoSql(365 + lookbackDays)}))`;
+  return `(${dateExpr} <= ${todaySql()} AND ('{{timeRange}}' IN ('', 'all') OR ('{{timeRange}}' = '7d' AND ${dateExpr} >= ${daysAgoSql(7 + lookbackDays)}) OR ('{{timeRange}}' = '30d' AND ${dateExpr} >= ${daysAgoSql(30 + lookbackDays)}) OR ('{{timeRange}}' = '90d' AND ${dateExpr} >= ${daysAgoSql(90 + lookbackDays)}) OR ('{{timeRange}}' = '180d' AND ${dateExpr} >= ${daysAgoSql(180 + lookbackDays)}) OR ('{{timeRange}}' = '365d' AND ${dateExpr} >= ${daysAgoSql(365 + lookbackDays)})))`;
 }
 
 const DASHBOARD_TIME_RANGE_FILTER = dashboardTimeRangeFilter();

--- a/templates/analytics/server/lib/session-replay.spec.ts
+++ b/templates/analytics/server/lib/session-replay.spec.ts
@@ -679,6 +679,43 @@ describe("session replay ingest parsing", () => {
     });
   }
 
+  it("clamps future replay recording times before inserting rows", async () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    putPrivateBlobMock.mockResolvedValue(null);
+    const { db, inserts } = createReplayDbMock(replayIngestKeyDbResults(null));
+    getDbMock.mockReturnValue(db);
+    const input = parseSessionReplayIngestPayload({
+      publicKey: "anpk_test",
+      replayId: "recording_1",
+      sessionId: "session_1",
+      userId: "dev@example.com",
+      anonymousId: "anon_1",
+      sequence: 0,
+      timestamp: "2026-07-05T12:00:00.000Z",
+      events: [{ type: 4, timestamp: Date.parse("2026-07-05T12:00:01.000Z") }],
+    });
+
+    try {
+      await recordSessionReplayChunks(input, {
+        origin: "https://app.example.com",
+        requestBytes: 100,
+        now: new Date("2026-07-01T13:00:00.000Z"),
+      }).catch(() => {});
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+
+    const recordingInsert = inserts.find(
+      (entry) =>
+        typeof (entry.values as { clientRecordingId?: unknown })
+          ?.clientRecordingId === "string",
+    );
+    expect((recordingInsert?.values as { startedAt: string }).startedAt).toBe(
+      "2026-07-01T13:00:00.000Z",
+    );
+  });
+
   it("uploads replay chunks in the public key owner's org scope (anonymous ingest)", async () => {
     // The ingest endpoint is anonymous + cross-origin (no session). Without the
     // runWithRequestContext wrap, resolveBuilderPrivateKey()/S3 scoped-secret

--- a/templates/analytics/server/lib/session-replay.ts
+++ b/templates/analytics/server/lib/session-replay.ts
@@ -275,6 +275,53 @@ function replayMaxIso(values: Array<string | null | undefined>): string | null {
   return present.reduce((max, value) => (value > max ? value : max));
 }
 
+function replayClampIso(
+  value: string | null | undefined,
+  latestIso: string,
+): string | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  const latest = Date.parse(latestIso);
+  if (!Number.isFinite(parsed)) return null;
+  if (!Number.isFinite(latest)) return value;
+  return parsed > latest ? latestIso : value;
+}
+
+function clampReplayChunkTiming(
+  chunk: NormalizedSessionReplayChunk,
+  latestIso: string,
+): NormalizedSessionReplayChunk {
+  const startedAt = replayClampIso(chunk.startedAt, latestIso);
+  let endedAt = replayClampIso(chunk.endedAt, latestIso);
+  if (startedAt && endedAt && endedAt < startedAt) {
+    endedAt = startedAt;
+  }
+  return { ...chunk, startedAt, endedAt };
+}
+
+function clampReplayIngestTiming(
+  input: ParsedSessionReplayIngest,
+  latestIso: string,
+): ParsedSessionReplayIngest {
+  const chunks = input.chunks.map((chunk) =>
+    clampReplayChunkTiming(chunk, latestIso),
+  );
+  const startedAt =
+    replayMinIso([
+      replayClampIso(input.startedAt, latestIso),
+      ...chunks.map((chunk) => chunk.startedAt),
+    ]) ?? latestIso;
+  let endedAt = replayMaxIso([
+    replayClampIso(input.endedAt, latestIso),
+    ...chunks.map((chunk) => chunk.endedAt),
+  ]);
+  if (endedAt && endedAt < startedAt) endedAt = startedAt;
+  const durationMs = endedAt
+    ? Math.max(0, Date.parse(endedAt) - Date.parse(startedAt))
+    : input.durationMs;
+  return { ...input, startedAt, endedAt, durationMs, chunks };
+}
+
 function normalizeReplayUrl(url: string | null): {
   url: string | null;
   path: string | null;
@@ -1101,7 +1148,8 @@ export async function recordSessionReplayChunks(
 }> {
   const key = await resolveReplayPublicKey(input.publicKey, context);
   const db = getDb() as any;
-  const ingestedAt = replayNowIso();
+  const ingestedAt = replayTimestamp(context.now) ?? replayNowIso();
+  const clampedInput = clampReplayIngestTiming(input, ingestedAt);
 
   let [recording] = await db
     .select()
@@ -1109,7 +1157,10 @@ export async function recordSessionReplayChunks(
     .where(
       and(
         eq(schema.sessionRecordings.publicKeyId, key.id),
-        eq(schema.sessionRecordings.clientRecordingId, input.clientRecordingId),
+        eq(
+          schema.sessionRecordings.clientRecordingId,
+          clampedInput.clientRecordingId,
+        ),
       ),
     )
     .limit(1);
@@ -1121,27 +1172,27 @@ export async function recordSessionReplayChunks(
       .values({
         id: newRecordingId,
         publicKeyId: key.id,
-        clientRecordingId: input.clientRecordingId,
-        sessionId: input.sessionId,
-        userId: input.userId,
-        anonymousId: input.anonymousId,
-        userKey: input.userKey,
-        startedAt: input.startedAt,
-        endedAt: input.endedAt,
-        durationMs: input.durationMs,
-        pageCount: input.pageCount,
-        errorCount: input.errorCount,
-        rageClickCount: input.rageClickCount,
-        privacyMode: input.privacyMode,
-        firstUrl: input.url,
-        lastUrl: input.url,
-        path: input.path,
-        hostname: input.hostname,
-        referrer: input.referrer,
-        app: input.app,
-        template: input.template,
-        status: input.status,
-        metadata: JSON.stringify(input.metadata),
+        clientRecordingId: clampedInput.clientRecordingId,
+        sessionId: clampedInput.sessionId,
+        userId: clampedInput.userId,
+        anonymousId: clampedInput.anonymousId,
+        userKey: clampedInput.userKey,
+        startedAt: clampedInput.startedAt,
+        endedAt: clampedInput.endedAt,
+        durationMs: clampedInput.durationMs,
+        pageCount: clampedInput.pageCount,
+        errorCount: clampedInput.errorCount,
+        rageClickCount: clampedInput.rageClickCount,
+        privacyMode: clampedInput.privacyMode,
+        firstUrl: clampedInput.url,
+        lastUrl: clampedInput.url,
+        path: clampedInput.path,
+        hostname: clampedInput.hostname,
+        referrer: clampedInput.referrer,
+        app: clampedInput.app,
+        template: clampedInput.template,
+        status: clampedInput.status,
+        metadata: JSON.stringify(clampedInput.metadata),
         lastIngestedAt: ingestedAt,
         ownerEmail: key.ownerEmail,
         orgId: key.orgId,
@@ -1162,7 +1213,7 @@ export async function recordSessionReplayChunks(
           eq(schema.sessionRecordings.publicKeyId, key.id),
           eq(
             schema.sessionRecordings.clientRecordingId,
-            input.clientRecordingId,
+            clampedInput.clientRecordingId,
           ),
         ),
       )
@@ -1193,7 +1244,7 @@ export async function recordSessionReplayChunks(
     existingChunks.length === 0;
 
   try {
-    for (const rawChunk of input.chunks) {
+    for (const rawChunk of clampedInput.chunks) {
       const existing = existingBySeq.get(rawChunk.seq);
       if (existing) {
         if (existing.checksum !== rawChunk.checksum) {
@@ -1272,13 +1323,15 @@ export async function recordSessionReplayChunks(
     id: replayId("sri"),
     publicKeyId: key.id,
     recordingId: recording.id,
-    byteLength: replayIngestByteLength(input, context),
+    byteLength: replayIngestByteLength(clampedInput, context),
     createdAt: ingestedAt,
     ownerEmail: key.ownerEmail,
     orgId: key.orgId,
   });
 
-  const allChunks = [...existingChunks, ...rowsToInsert];
+  const allChunks = [...existingChunks, ...rowsToInsert].map((chunk: any) =>
+    clampReplayChunkTiming(chunk, ingestedAt),
+  );
   const chunkCount = allChunks.length;
   const eventCount = allChunks.reduce(
     (sum, chunk: any) => sum + Number(chunk.eventCount ?? 0),
@@ -1291,57 +1344,63 @@ export async function recordSessionReplayChunks(
   const startedAt =
     replayMinIso([
       recording.startedAt,
-      input.startedAt,
+      clampedInput.startedAt,
       ...allChunks.map((chunk: any) => chunk.startedAt),
-    ]) ?? input.startedAt;
+    ]) ?? clampedInput.startedAt;
   const endedAt =
     replayMaxIso([
       recording.endedAt,
-      input.endedAt,
+      clampedInput.endedAt,
       ...allChunks.map((chunk: any) => chunk.endedAt),
     ]) ?? null;
   const durationMs =
-    input.durationMs ??
+    clampedInput.durationMs ??
     (endedAt
       ? Math.max(0, Date.parse(endedAt) - Date.parse(startedAt))
       : (recording.durationMs ?? null));
   const metadata = mergeReplayMetadata(
     parseRecordingMetadata(recording),
-    input.metadata,
+    clampedInput.metadata,
   );
 
   await db
     .update(schema.sessionRecordings)
     .set({
-      sessionId: input.sessionId,
-      userId: input.userId ?? recording.userId ?? null,
-      anonymousId: input.anonymousId ?? recording.anonymousId ?? null,
-      userKey: input.userKey ?? recording.userKey ?? null,
+      sessionId: clampedInput.sessionId,
+      userId: clampedInput.userId ?? recording.userId ?? null,
+      anonymousId: clampedInput.anonymousId ?? recording.anonymousId ?? null,
+      userKey: clampedInput.userKey ?? recording.userKey ?? null,
       startedAt,
       endedAt,
       durationMs,
       chunkCount,
       eventCount,
       totalBytes,
-      pageCount: Math.max(Number(recording.pageCount ?? 0), input.pageCount),
-      errorCount: Math.max(Number(recording.errorCount ?? 0), input.errorCount),
+      pageCount: Math.max(
+        Number(recording.pageCount ?? 0),
+        clampedInput.pageCount,
+      ),
+      errorCount: Math.max(
+        Number(recording.errorCount ?? 0),
+        clampedInput.errorCount,
+      ),
       rageClickCount: Math.max(
         Number(recording.rageClickCount ?? 0),
-        input.rageClickCount,
+        clampedInput.rageClickCount,
       ),
       privacyMode:
-        input.privacyMode !== "unknown"
-          ? input.privacyMode
+        clampedInput.privacyMode !== "unknown"
+          ? clampedInput.privacyMode
           : (recording.privacyMode ?? "unknown"),
-      firstUrl: recording.firstUrl ?? input.url,
-      lastUrl: input.url ?? recording.lastUrl ?? null,
-      path: input.path ?? recording.path ?? null,
-      hostname: input.hostname ?? recording.hostname ?? null,
-      referrer: input.referrer ?? recording.referrer ?? null,
-      app: input.app ?? recording.app ?? null,
-      template: input.template ?? recording.template ?? null,
+      firstUrl: recording.firstUrl ?? clampedInput.url,
+      lastUrl: clampedInput.url ?? recording.lastUrl ?? null,
+      path: clampedInput.path ?? recording.path ?? null,
+      hostname: clampedInput.hostname ?? recording.hostname ?? null,
+      referrer: clampedInput.referrer ?? recording.referrer ?? null,
+      app: clampedInput.app ?? recording.app ?? null,
+      template: clampedInput.template ?? recording.template ?? null,
       status:
-        input.status === "completed" || recording.status === "completed"
+        clampedInput.status === "completed" || recording.status === "completed"
           ? "completed"
           : "active",
       metadata: JSON.stringify(metadata),
@@ -1364,7 +1423,7 @@ export async function recordSessionReplayChunks(
 
   return {
     recordingId: recording.id,
-    sessionId: input.sessionId,
+    sessionId: clampedInput.sessionId,
     acceptedChunks: rowsToInsert.length,
     duplicateChunks,
     chunkCount,

--- a/templates/analytics/server/plugins/db.ts
+++ b/templates/analytics/server/plugins/db.ts
@@ -492,6 +492,27 @@ export default runMigrations(
       version: 71,
       sql: `CREATE INDEX IF NOT EXISTS session_replay_ingests_recording_idx ON session_replay_ingests (recording_id)`,
     },
+    {
+      version: 72,
+      sql: {
+        postgres: `UPDATE analytics_events SET timestamp = COALESCE(NULLIF(received_at, ''), to_char(CURRENT_TIMESTAMP AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')), event_date = substr(COALESCE(NULLIF(received_at, ''), to_char(CURRENT_TIMESTAMP AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')), 1, 10) WHERE COALESCE(NULLIF(event_date, ''), substr(timestamp, 1, 10)) > to_char(CURRENT_DATE, 'YYYY-MM-DD')`,
+        sqlite: `UPDATE analytics_events SET timestamp = COALESCE(NULLIF(received_at, ''), datetime('now')), event_date = substr(COALESCE(NULLIF(received_at, ''), date('now')), 1, 10) WHERE COALESCE(NULLIF(event_date, ''), substr(timestamp, 1, 10)) > date('now')`,
+      },
+    },
+    {
+      version: 73,
+      sql: {
+        postgres: `UPDATE session_recordings SET started_at = CASE WHEN substr(started_at, 1, 10) > to_char(CURRENT_DATE, 'YYYY-MM-DD') THEN LEAST(COALESCE(NULLIF(last_ingested_at, ''), NULLIF(updated_at, ''), NULLIF(created_at, ''), to_char(CURRENT_TIMESTAMP AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')), to_char(CURRENT_TIMESTAMP AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')) ELSE started_at END, ended_at = CASE WHEN ended_at IS NOT NULL AND substr(ended_at, 1, 10) > to_char(CURRENT_DATE, 'YYYY-MM-DD') THEN LEAST(COALESCE(NULLIF(last_ingested_at, ''), NULLIF(updated_at, ''), NULLIF(created_at, ''), to_char(CURRENT_TIMESTAMP AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')), to_char(CURRENT_TIMESTAMP AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')) ELSE ended_at END WHERE (owner_email IS NOT NULL OR org_id IS NOT NULL) AND (substr(started_at, 1, 10) > to_char(CURRENT_DATE, 'YYYY-MM-DD') OR (ended_at IS NOT NULL AND substr(ended_at, 1, 10) > to_char(CURRENT_DATE, 'YYYY-MM-DD')))`,
+        sqlite: `UPDATE session_recordings SET started_at = CASE WHEN substr(started_at, 1, 10) > date('now') THEN min(COALESCE(NULLIF(last_ingested_at, ''), NULLIF(updated_at, ''), NULLIF(created_at, ''), datetime('now')), datetime('now')) ELSE started_at END, ended_at = CASE WHEN ended_at IS NOT NULL AND substr(ended_at, 1, 10) > date('now') THEN min(COALESCE(NULLIF(last_ingested_at, ''), NULLIF(updated_at, ''), NULLIF(created_at, ''), datetime('now')), datetime('now')) ELSE ended_at END WHERE (owner_email IS NOT NULL OR org_id IS NOT NULL) AND (substr(started_at, 1, 10) > date('now') OR (ended_at IS NOT NULL AND substr(ended_at, 1, 10) > date('now')))`,
+      },
+    },
+    {
+      version: 74,
+      sql: {
+        postgres: `UPDATE session_replay_chunks SET started_at = CASE WHEN started_at IS NOT NULL AND substr(started_at, 1, 10) > to_char(CURRENT_DATE, 'YYYY-MM-DD') THEN LEAST(COALESCE(NULLIF(created_at, ''), to_char(CURRENT_TIMESTAMP AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')), to_char(CURRENT_TIMESTAMP AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')) ELSE started_at END, ended_at = CASE WHEN ended_at IS NOT NULL AND substr(ended_at, 1, 10) > to_char(CURRENT_DATE, 'YYYY-MM-DD') THEN LEAST(COALESCE(NULLIF(created_at, ''), to_char(CURRENT_TIMESTAMP AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')), to_char(CURRENT_TIMESTAMP AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')) ELSE ended_at END WHERE (started_at IS NOT NULL AND substr(started_at, 1, 10) > to_char(CURRENT_DATE, 'YYYY-MM-DD')) OR (ended_at IS NOT NULL AND substr(ended_at, 1, 10) > to_char(CURRENT_DATE, 'YYYY-MM-DD'))`,
+        sqlite: `UPDATE session_replay_chunks SET started_at = CASE WHEN started_at IS NOT NULL AND substr(started_at, 1, 10) > date('now') THEN min(COALESCE(NULLIF(created_at, ''), datetime('now')), datetime('now')) ELSE started_at END, ended_at = CASE WHEN ended_at IS NOT NULL AND substr(ended_at, 1, 10) > date('now') THEN min(COALESCE(NULLIF(created_at, ''), datetime('now')), datetime('now')) ELSE ended_at END WHERE (started_at IS NOT NULL AND substr(started_at, 1, 10) > date('now')) OR (ended_at IS NOT NULL AND substr(ended_at, 1, 10) > date('now'))`,
+      },
+    },
   ],
   { table: "analytics_migrations" },
 );

--- a/templates/clips/chrome-extension/public/manifest.json
+++ b/templates/clips/chrome-extension/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Agent-Native Clips",
   "short_name": "Clips",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Start Clips recordings from Chrome, capture optional diagnostics, and preview Clips links on GitHub.",
   "minimum_chrome_version": "116",
   "action": {


### PR DESCRIPTION
## Summary
- keep background-runtime markers aligned with the exact dispatch path used for initial and continuation agent-chat runs
- mirror authenticated background-run markers before DB/run-store initialization so hosted background workers get the expected pool behavior
- clamp future Analytics event/replay timestamps, keep scoped SQL fresh through today, compact dashboard filters, and bump the Clips extension manifest

## Validation
- corepack pnpm prep
