### PR TITLE
Fix dev file watching after watcher limit fallback

### DIFF
--- a/.changeset/nitro-watch-emfile-guard.md
+++ b/.changeset/nitro-watch-emfile-guard.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep Nitro/Vite dev servers responsive when native file watchers hit EMFILE or ENOSPC by falling back to polling instead of replacing failed watches with no-ops.

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "events";
 import fs from "fs";
 import type { IncomingMessage, ServerResponse } from "http";
 import { createRequire, syncBuiltinESMExports } from "module";
@@ -36,6 +37,137 @@ const require = createRequire(import.meta.url);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 let nitroFsWatchGuardInstalled = false;
 
+type FsWatchArgs = [fs.PathLike, ...any[]];
+
+function isFileWatchLimitError(
+  error: NodeJS.ErrnoException | undefined,
+): boolean {
+  return error?.code === "EMFILE" || error?.code === "ENOSPC";
+}
+
+function watchPollingIntervalMs(): number {
+  const raw = Number(process.env.CHOKIDAR_INTERVAL ?? 1000);
+  return Number.isFinite(raw) && raw > 0 ? raw : 1000;
+}
+
+function fsWatchListener(args: FsWatchArgs): fs.WatchListener<string> | null {
+  const maybeOptionsOrListener = args[1];
+  const maybeListener = args[2];
+  if (typeof maybeOptionsOrListener === "function")
+    return maybeOptionsOrListener as fs.WatchListener<string>;
+  if (typeof maybeListener === "function")
+    return maybeListener as fs.WatchListener<string>;
+  return null;
+}
+
+function fsWatchPersistent(args: FsWatchArgs): boolean {
+  const options = args[1];
+  if (!options || typeof options === "function") return true;
+  if (typeof options === "string" || Buffer.isBuffer(options)) return true;
+  return options.persistent !== false;
+}
+
+function directEntrySnapshot(
+  target: string,
+): Map<string, { mtimeMs: number; size: number; directory: boolean }> {
+  const snapshot = new Map<
+    string,
+    { mtimeMs: number; size: number; directory: boolean }
+  >();
+  const stat = fs.statSync(target);
+  if (!stat.isDirectory()) {
+    snapshot.set(path.basename(target), {
+      mtimeMs: stat.mtimeMs,
+      size: stat.size,
+      directory: false,
+    });
+    return snapshot;
+  }
+  for (const entry of fs.readdirSync(target, { withFileTypes: true })) {
+    const entryPath = path.join(target, entry.name);
+    try {
+      const entryStat = fs.statSync(entryPath);
+      snapshot.set(entry.name, {
+        mtimeMs: entryStat.mtimeMs,
+        size: entryStat.size,
+        directory: entryStat.isDirectory(),
+      });
+    } catch {
+      // The entry may have disappeared between readdir and stat.
+    }
+  }
+  return snapshot;
+}
+
+function createPollingFsWatcher(args: FsWatchArgs): fs.FSWatcher {
+  const target = String(args[0]);
+  const listener = fsWatchListener(args);
+  const emitter = new EventEmitter() as fs.FSWatcher;
+  let closed = false;
+  let previous = directEntrySnapshot(target);
+
+  if (listener) emitter.on("change", listener);
+
+  const emitChange = (eventName: "change" | "rename", filename: string) => {
+    emitter.emit("change", eventName, filename);
+  };
+
+  const timer = setInterval(() => {
+    if (closed) return;
+    let next: typeof previous;
+    try {
+      next = directEntrySnapshot(target);
+    } catch (error) {
+      emitter.emit("error", error);
+      return;
+    }
+
+    for (const [filename, current] of next) {
+      const old = previous.get(filename);
+      if (!old) {
+        emitChange("rename", filename);
+        continue;
+      }
+      if (
+        old.mtimeMs !== current.mtimeMs ||
+        old.size !== current.size ||
+        old.directory !== current.directory
+      ) {
+        emitChange("change", filename);
+      }
+    }
+    for (const filename of previous.keys()) {
+      if (!next.has(filename)) emitChange("rename", filename);
+    }
+    previous = next;
+  }, watchPollingIntervalMs());
+
+  if (!fsWatchPersistent(args)) timer.unref();
+
+  emitter.close = () => {
+    if (closed) return;
+    closed = true;
+    clearInterval(timer);
+    emitter.removeAllListeners();
+  };
+  emitter.ref = () => {
+    timer.ref();
+    return emitter;
+  };
+  emitter.unref = () => {
+    timer.unref();
+    return emitter;
+  };
+
+  return emitter;
+}
+
+function warnNitroFsWatchFallback(target: unknown, err: NodeJS.ErrnoException) {
+  console.warn(
+    `[agent-native] Falling back to polling Nitro fs.watch for ${String(target)}: ${err.message}`,
+  );
+}
+
 function installNitroFsWatchGuard(): void {
   if (nitroFsWatchGuardInstalled) return;
   nitroFsWatchGuardInstalled = true;
@@ -49,29 +181,32 @@ function installNitroFsWatchGuard(): void {
       watcher = originalWatch(...args);
     } catch (error) {
       const err = error as NodeJS.ErrnoException;
-      if (err.code !== "EMFILE" && err.code !== "ENOSPC") throw error;
-      console.warn(
-        `[agent-native] Disabled Nitro fs.watch for ${String(args[0])}: ${err.message}`,
-      );
-      return {
-        close() {},
-        on() {
-          return this as fs.FSWatcher;
-        },
-      } as unknown as fs.FSWatcher;
+      if (!isFileWatchLimitError(err)) throw error;
+      warnNitroFsWatchFallback(args[0], err);
+      return createPollingFsWatcher(args as FsWatchArgs);
     }
 
     const originalEmit = watcher.emit.bind(watcher);
+    const originalClose = watcher.close.bind(watcher);
+    let pollingFallback: fs.FSWatcher | undefined;
+
+    watcher.close = (() => {
+      pollingFallback?.close();
+      return originalClose();
+    }) as fs.FSWatcher["close"];
+
     watcher.emit = ((eventName: string | symbol, ...eventArgs: any[]) => {
       const err = eventArgs[0] as NodeJS.ErrnoException | undefined;
-      if (
-        eventName === "error" &&
-        (err?.code === "EMFILE" || err?.code === "ENOSPC")
-      ) {
-        console.warn(
-          `[agent-native] Disabled Nitro fs.watch for ${String(args[0])}: ${err.message}`,
-        );
+      if (eventName === "error" && isFileWatchLimitError(err) && err) {
+        warnNitroFsWatchFallback(args[0], err);
         watcher.close();
+        pollingFallback = createPollingFsWatcher(args as FsWatchArgs);
+        pollingFallback.on("change", (changeEvent, filename) => {
+          originalEmit("change", changeEvent, filename);
+        });
+        pollingFallback.on("error", (pollingError) => {
+          originalEmit("error", pollingError);
+        });
         return false;
       }
       return originalEmit(eventName, ...eventArgs);

--- a/scripts/dev-lazy.ts
+++ b/scripts/dev-lazy.ts
@@ -322,6 +322,7 @@ type PollingFileWatcherMode = "enable" | "disable-explicit" | "disable-default";
 function pollingFileWatcherMode(
   env: NodeJS.ProcessEnv,
   root: string,
+  options: { multiTemplateWatchLoad?: boolean } = {},
 ): PollingFileWatcherMode {
   const explicit =
     readBooleanEnv(env.AGENT_NATIVE_DEV_USE_POLLING) ??
@@ -341,12 +342,15 @@ function pollingFileWatcherMode(
     env.GITPOD_WORKSPACE_ID ||
     env.REMOTE_CONTAINERS ||
     env.DEVCONTAINER ||
-    root.startsWith("/root/app/"),
+    root.startsWith("/root/app/") ||
+    options.multiTemplateWatchLoad,
   );
   return autoEnable ? "enable" : "disable-default";
 }
 
-const pollingMode = pollingFileWatcherMode(process.env, ROOT);
+const pollingMode = pollingFileWatcherMode(process.env, ROOT, {
+  multiTemplateWatchLoad: apps.length > 1 && (eager || prewarmEnabled),
+});
 const usePollingFileWatcher = pollingMode === "enable";
 
 function devWatcherEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
@@ -1425,15 +1429,16 @@ execSync("node scripts/prebuild-workspace-packages.ts dev", {
 
 if (usePollingFileWatcher) {
   console.log(
-    `[dev-lazy] Using polling file watchers (${POLLING_WATCH_INTERVAL_MS}ms) to avoid remote-container inotify limits.`,
+    `[dev-lazy] Using polling file watchers (${POLLING_WATCH_INTERVAL_MS}ms) to avoid file watcher descriptor limits.`,
   );
 }
 
+const coreWatchCompiler = usePollingFileWatcher ? "tsc" : "tsgo";
 startBackgroundProcess("core", "pnpm", [
   "--filter",
   "@agent-native/core",
   "exec",
-  "tsgo",
+  coreWatchCompiler,
   "--watch",
   "--preserveWatchOutput",
 ]);


### PR DESCRIPTION
- enable polling watchers for multi-template `pnpm dev` runs that can exhaust native watcher limits
- fall back to polling when Nitro’s raw `fs.watch` hits `EMFILE`/`ENOSPC` instead of replacing it with a no-op watcher
- use `tsc --watch` for the core watcher in polling mode so file changes are actually detected
