### PR TITLE
Handle text-wrapped Analytics replay gzip bodies

### DIFF
--- a/templates/analytics/server/handlers/session-replay.spec.ts
+++ b/templates/analytics/server/handlers/session-replay.spec.ts
@@ -38,6 +38,23 @@ describe("session replay ingest handler", () => {
     expect(decoded.body).toEqual(payload);
   });
 
+  it("recovers text-wrapped binary gzip bodies from Netlify", () => {
+    const payload = {
+      publicKey: "anpk_test",
+      replayId: "recording_1",
+      sessionId: "session_1",
+      events: [{ type: 4, data: { href: "/inbox" } }],
+    };
+    const compressed = gzipSync(Buffer.from(JSON.stringify(payload), "utf8"));
+    const textWrapped = Buffer.from(compressed.toString("latin1"), "utf8");
+
+    const decoded = decodeSessionReplayRequestBody(textWrapped, "gzip");
+
+    expect(textWrapped.byteLength).toBeGreaterThan(compressed.byteLength);
+    expect(decoded.requestBytes).toBe(compressed.byteLength);
+    expect(decoded.body).toEqual(payload);
+  });
+
   it("still rejects malformed gzip replay request bodies", () => {
     expect(() =>
       decodeSessionReplayRequestBody(Buffer.from("not gzip"), "gzip"),

--- a/templates/analytics/server/handlers/session-replay.ts
+++ b/templates/analytics/server/handlers/session-replay.ts
@@ -87,11 +87,31 @@ function looksLikeDecodedJson(bytes: Buffer): boolean {
   return first === "{" || first === "[";
 }
 
+function tryGunzip(bytes: Buffer): Buffer | null {
+  try {
+    return gunzipSync(bytes);
+  } catch {
+    return null;
+  }
+}
+
+function decodeTextWrappedGzip(
+  bytes: Buffer,
+): { decoded: Buffer; requestBytes: number } | null {
+  const text = bytes.toString("utf8");
+  const binaryStringBytes = Buffer.from(text, "latin1");
+  if (binaryStringBytes.equals(bytes)) return null;
+  const decoded = tryGunzip(binaryStringBytes);
+  return decoded
+    ? { decoded, requestBytes: binaryStringBytes.byteLength }
+    : null;
+}
+
 export function decodeSessionReplayRequestBody(
   rawBody: Buffer | Uint8Array | string | undefined,
   contentEncoding?: string | null,
 ): { body: unknown; requestBytes: number } {
-  const requestBytes =
+  let requestBytes =
     typeof rawBody === "string"
       ? Buffer.byteLength(rawBody, "utf8")
       : (rawBody?.byteLength ?? 0);
@@ -104,15 +124,25 @@ export function decodeSessionReplayRequestBody(
   let decoded = bytes;
 
   if (encoding === "gzip" || encoding === "x-gzip") {
-    try {
-      decoded = gunzipSync(bytes);
-    } catch {
+    const gunzipped = tryGunzip(bytes);
+    if (gunzipped) {
+      decoded = gunzipped;
+    } else {
       // Netlify may hand Nitro an already-decoded body while preserving the
       // original browser Content-Encoding header.
       if (looksLikeDecodedJson(bytes)) {
         decoded = bytes;
       } else {
-        throw statusError("Invalid gzip-compressed replay body", 400);
+        // Some Netlify paths wrap binary request bodies in a JS string before
+        // Nitro reads them back as UTF-8. Reinterpret that text as one-byte
+        // binary data so real browser CompressionStream uploads survive.
+        const textWrappedGzip = decodeTextWrappedGzip(bytes);
+        if (textWrappedGzip) {
+          decoded = textWrappedGzip.decoded;
+          requestBytes = textWrappedGzip.requestBytes;
+        } else {
+          throw statusError("Invalid gzip-compressed replay body", 400);
+        }
       }
     }
   } else if (encoding && encoding !== "identity") {


### PR DESCRIPTION
## Summary
- recover gzip replay uploads that arrive as UTF-8 text-wrapped binary bytes in Netlify/Nitro
- keep accepting already-decoded JSON bodies with preserved gzip headers
- add a regression test for the text-wrapped gzip body shape

## Testing
- corepack pnpm --filter analytics exec vitest run server/handlers/session-replay.spec.ts
- corepack pnpm --filter analytics typecheck
- git diff --check