### PR TITLE
Fix design system token preview crash

### DIFF
--- a/templates/design/app/lib/design-system-preview.test.ts
+++ b/templates/design/app/lib/design-system-preview.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatDesignTokenValue,
+  getCssColorToken,
+} from "./design-system-preview";
+
+describe("design-system preview helpers", () => {
+  it("formats responsive token objects instead of rendering raw objects", () => {
+    expect(
+      formatDesignTokenValue({
+        sm: "14px",
+        md: "16px",
+        lg: "18px",
+        xl: "20px",
+        "2xl": "24px",
+        "3xl": "30px",
+        "4xl": "36px",
+        "5xl": "48px",
+      }),
+    ).toBe(
+      "Sm: 14px, Md: 16px, Lg: 18px, Xl: 20px, 2xl: 24px, 3xl: 30px, 4xl: 36px, 5xl: 48px",
+    );
+  });
+
+  it("uses only strings as CSS color preview values", () => {
+    expect(getCssColorToken({ base: "#111827", hover: "#1f2937" })).toBe(
+      "#111827",
+    );
+    expect(getCssColorToken({ sm: { nested: true } })).toBeUndefined();
+  });
+});

--- a/templates/design/app/lib/design-system-preview.ts
+++ b/templates/design/app/lib/design-system-preview.ts
@@ -1,0 +1,69 @@
+const DEFAULT_OBJECT_ENTRY_LIMIT = 8;
+
+export function formatDesignTokenValue(value: unknown): string | undefined {
+  return formatTokenValue(value, new Set());
+}
+
+export function getCssColorToken(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  for (const nested of Object.values(value)) {
+    const candidate = getCssColorToken(nested);
+    if (candidate) return candidate;
+  }
+
+  return undefined;
+}
+
+function formatTokenValue(
+  value: unknown,
+  seenObjects: Set<object>,
+): string | undefined {
+  if (value === null || value === undefined) return undefined;
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    const parts = value
+      .map((item) => formatTokenValue(item, seenObjects))
+      .filter((item): item is string => Boolean(item));
+    return parts.length > 0 ? parts.join(", ") : undefined;
+  }
+
+  if (typeof value !== "object") return undefined;
+
+  if (seenObjects.has(value)) return undefined;
+  seenObjects.add(value);
+
+  const entries = Object.entries(value)
+    .map(([key, nestedValue]) => {
+      const formatted = formatTokenValue(nestedValue, seenObjects);
+      return formatted ? `${labelizeDesignTokenKey(key)}: ${formatted}` : null;
+    })
+    .filter((entry): entry is string => Boolean(entry))
+    .slice(0, DEFAULT_OBJECT_ENTRY_LIMIT);
+
+  seenObjects.delete(value);
+  return entries.length > 0 ? entries.join(", ") : undefined;
+}
+
+function labelizeDesignTokenKey(key: string) {
+  return key
+    .replace(/([A-Z])/g, " $1")
+    .replace(/[-_]/g, " ")
+    .replace(/^./, (char) => char.toUpperCase());
+}

--- a/templates/design/app/pages/DesignSystems.tsx
+++ b/templates/design/app/pages/DesignSystems.tsx
@@ -65,6 +65,10 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  formatDesignTokenValue,
+  getCssColorToken,
+} from "@/lib/design-system-preview";
 
 interface DesignSystem {
   id: string;
@@ -83,25 +87,25 @@ interface DesignSystem {
 
 interface DesignSystemData {
   colors?: {
-    primary?: string;
-    secondary?: string;
-    accent?: string;
-    background?: string;
-    surface?: string;
-    text?: string;
-    textMuted?: string;
+    primary?: unknown;
+    secondary?: unknown;
+    accent?: unknown;
+    background?: unknown;
+    surface?: unknown;
+    text?: unknown;
+    textMuted?: unknown;
   };
   typography?: {
-    headingFont?: string;
-    bodyFont?: string;
-    headingWeight?: string;
-    bodyWeight?: string;
+    headingFont?: unknown;
+    bodyFont?: unknown;
+    headingWeight?: unknown;
+    bodyWeight?: unknown;
   };
-  spacing?: Record<string, string | undefined>;
-  borders?: Record<string, string | undefined>;
+  spacing?: Record<string, unknown>;
+  borders?: Record<string, unknown>;
   logos?: Array<{ url?: string; name?: string; variant?: string }>;
-  defaults?: Record<string, string | undefined>;
-  notes?: string;
+  defaults?: Record<string, unknown>;
+  notes?: unknown;
 }
 
 export default function DesignSystems() {
@@ -474,6 +478,12 @@ export default function DesignSystems() {
                 {designSystems.map((ds) => {
                   const parsed = parseData(ds.data);
                   const colors = parsed?.colors;
+                  const primaryColor = getCssColorToken(colors?.primary);
+                  const secondaryColor = getCssColorToken(colors?.secondary);
+                  const accentColor = getCssColorToken(colors?.accent);
+                  const headingFont = formatDesignTokenValue(
+                    parsed?.typography?.headingFont,
+                  );
                   const isSelected = selectedSystemIds.has(ds.id);
                   return (
                     <div
@@ -498,29 +508,27 @@ export default function DesignSystems() {
                       >
                         {/* Color preview */}
                         <div className="aspect-video bg-muted/50 flex items-center justify-center gap-2 p-4">
-                          {colors?.primary && (
+                          {primaryColor && (
                             <div
                               className="w-10 h-10 rounded-lg"
-                              style={{ backgroundColor: colors.primary }}
+                              style={{ backgroundColor: primaryColor }}
                             />
                           )}
-                          {colors?.secondary && (
+                          {secondaryColor && (
                             <div
                               className="w-10 h-10 rounded-lg"
-                              style={{ backgroundColor: colors.secondary }}
+                              style={{ backgroundColor: secondaryColor }}
                             />
                           )}
-                          {colors?.accent && (
+                          {accentColor && (
                             <div
                               className="w-10 h-10 rounded-lg"
-                              style={{ backgroundColor: colors.accent }}
+                              style={{ backgroundColor: accentColor }}
                             />
                           )}
-                          {!colors?.primary &&
-                            !colors?.secondary &&
-                            !colors?.accent && (
-                              <IconPalette className="w-8 h-8 text-muted-foreground/40" />
-                            )}
+                          {!primaryColor && !secondaryColor && !accentColor && (
+                            <IconPalette className="w-8 h-8 text-muted-foreground/40" />
+                          )}
                         </div>
                         <div className="p-4 pb-3">
                           <div className="flex items-center gap-2 mb-1">
@@ -533,9 +541,9 @@ export default function DesignSystems() {
                               </span>
                             )}
                           </div>
-                          {parsed?.typography?.headingFont && (
+                          {headingFont && (
                             <div className="text-xs text-muted-foreground/70">
-                              {parsed.typography.headingFont}
+                              {headingFont}
                             </div>
                           )}
                         </div>
@@ -885,10 +893,12 @@ function TokenPreview({
                 key={color.label}
                 className="flex min-w-0 items-center gap-3 rounded-lg border border-border bg-muted/30 p-2"
               >
-                <div
-                  className="h-9 w-9 shrink-0 rounded-md border border-border"
-                  style={{ backgroundColor: color.value }}
-                />
+                {color.swatch ? (
+                  <div
+                    className="h-9 w-9 shrink-0 rounded-md border border-border"
+                    style={{ backgroundColor: color.swatch }}
+                  />
+                ) : null}
                 <div className="min-w-0">
                   <div className="text-xs font-medium text-foreground">
                     {color.label}
@@ -1001,34 +1011,47 @@ function getColorTokens(data: DesignSystemData | null, t: DesignT) {
   return [
     {
       label: t("designSystems.tokenPreview.colorLabels.primary"),
-      value: colors.primary,
+      value: formatDesignTokenValue(colors.primary),
+      swatch: getCssColorToken(colors.primary),
     },
     {
       label: t("designSystems.tokenPreview.colorLabels.secondary"),
-      value: colors.secondary,
+      value: formatDesignTokenValue(colors.secondary),
+      swatch: getCssColorToken(colors.secondary),
     },
     {
       label: t("designSystems.tokenPreview.colorLabels.accent"),
-      value: colors.accent,
+      value: formatDesignTokenValue(colors.accent),
+      swatch: getCssColorToken(colors.accent),
     },
     {
       label: t("designSystems.tokenPreview.colorLabels.background"),
-      value: colors.background,
+      value: formatDesignTokenValue(colors.background),
+      swatch: getCssColorToken(colors.background),
     },
     {
       label: t("designSystems.tokenPreview.colorLabels.surface"),
-      value: colors.surface,
+      value: formatDesignTokenValue(colors.surface),
+      swatch: getCssColorToken(colors.surface),
     },
     {
       label: t("designSystems.tokenPreview.colorLabels.text"),
-      value: colors.text,
+      value: formatDesignTokenValue(colors.text),
+      swatch: getCssColorToken(colors.text),
     },
     {
       label: t("designSystems.tokenPreview.colorLabels.mutedText"),
-      value: colors.textMuted,
+      value: formatDesignTokenValue(colors.textMuted),
+      swatch: getCssColorToken(colors.textMuted),
     },
-  ].filter((item): item is { label: string; value: string } =>
-    Boolean(item.value),
+  ].filter(
+    (
+      item,
+    ): item is {
+      label: string;
+      value: string;
+      swatch: string | undefined;
+    } => Boolean(item.value),
   );
 }
 
@@ -1038,19 +1061,19 @@ function getTypographyTokens(data: DesignSystemData | null, t: DesignT) {
   return [
     {
       label: t("designSystems.tokenPreview.typeLabels.headingFont"),
-      value: typography.headingFont,
+      value: formatDesignTokenValue(typography.headingFont),
     },
     {
       label: t("designSystems.tokenPreview.typeLabels.bodyFont"),
-      value: typography.bodyFont,
+      value: formatDesignTokenValue(typography.bodyFont),
     },
     {
       label: t("designSystems.tokenPreview.typeLabels.headingWeight"),
-      value: typography.headingWeight,
+      value: formatDesignTokenValue(typography.headingWeight),
     },
     {
       label: t("designSystems.tokenPreview.typeLabels.bodyWeight"),
-      value: typography.bodyWeight,
+      value: formatDesignTokenValue(typography.bodyWeight),
     },
   ].filter((item): item is { label: string; value: string } =>
     Boolean(item.value),
@@ -1089,12 +1112,10 @@ function getDetailTokens(
   ].filter((item): item is { label: string; value: string } => Boolean(item));
 }
 
-function objectPreviewItems(
-  prefix: string,
-  values: Record<string, string | undefined>,
-) {
+function objectPreviewItems(prefix: string, values: Record<string, unknown>) {
   return Object.entries(values)
-    .filter((entry): entry is [string, string] => Boolean(entry[1]))
+    .map(([key, value]) => [key, formatDesignTokenValue(value)] as const)
+    .filter((entry): entry is readonly [string, string] => Boolean(entry[1]))
     .slice(0, 4)
     .map(([key, value]) => ({
       label: `${prefix}: ${labelizeKey(key)}`,

--- a/templates/design/changelog/2026-07-01-design-systems-no-longer-crash-on-responsive-tokens.md
+++ b/templates/design/changelog/2026-07-01-design-systems-no-longer-crash-on-responsive-tokens.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-01
+---
+
+Design systems no longer crash when imported tokens include responsive values.


### PR DESCRIPTION
## Summary
- Format imported design-system token values before rendering previews
- Keep color swatches/style values string-only when imported tokens are responsive maps
- Add a regression test for responsive token objects

## Validation
- corepack pnpm exec oxfmt templates/design/app/pages/DesignSystems.tsx templates/design/app/lib/design-system-preview.ts templates/design/app/lib/design-system-preview.test.ts templates/design/changelog/2026-07-01-design-systems-no-longer-crash-on-responsive-tokens.md
- corepack pnpm --filter design exec vitest run app/lib/design-system-preview.test.ts
- corepack pnpm --filter design typecheck