### PR TITLE
Fix durable agent run recovery

### DIFF
--- a/.changeset/durable-background-terminal-recovery.md
+++ b/.changeset/durable-background-terminal-recovery.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep durable background agent runs from being reported as stale after a terminal event was already persisted, and show tool activity during tail reconnects.

--- a/packages/core/src/agent/run-store.durable-background.spec.ts
+++ b/packages/core/src/agent/run-store.durable-background.spec.ts
@@ -33,7 +33,7 @@ let rows: RunRow[] = [];
 // Mirror the two constants used by `backgroundAwareStaleCutoffSql`. The SQL
 // inlines them as literals, so we evaluate the CASE in JS to decide reaping.
 const RUN_STALE_MS = 15_000;
-const BACKGROUND_RUN_STALE_MS = 16 * 60_000;
+const BACKGROUND_RUN_STALE_MS = 90_000;
 
 function rowStaleWindow(row: RunRow): number {
   return row.dispatch_mode && row.dispatch_mode.startsWith("background")
@@ -251,9 +251,9 @@ describe("run-store durable background", () => {
     vi.clearAllMocks();
   });
 
-  it("exports the tight foreground + durable background stale windows", () => {
+  it("exports the tight foreground + wide background stale windows", () => {
     expect(STORE_RUN_STALE_MS).toBe(15_000);
-    expect(STORE_BACKGROUND_RUN_STALE_MS).toBe(16 * 60_000);
+    expect(STORE_BACKGROUND_RUN_STALE_MS).toBe(90_000);
     expect(STORE_BACKGROUND_RUN_STALE_MS).toBeGreaterThan(STORE_RUN_STALE_MS);
   });
 
@@ -296,8 +296,8 @@ describe("run-store durable background", () => {
     const now = Date.now();
     await insertRun("r-live-bg", "t1", "turn", { dispatchMode: "background" });
     const row = rows.find((r) => r.id === "r-live-bg")!;
-    // Heartbeat 30s ago: past the 15s foreground window, but well within the
-    // durable background window — must NOT be reaped.
+    // Heartbeat 30s ago: past the 15s foreground window, but within the 90s
+    // background window — must NOT be reaped.
     row.heartbeat_at = now - 30_000;
 
     const reaped = await reapIfStale("r-live-bg");
@@ -305,11 +305,11 @@ describe("run-store durable background", () => {
     expect(await getRunStatus("r-live-bg")).toBe("running");
   });
 
-  it("stale reaper reaps a background run only after the durable background window", async () => {
+  it("stale reaper reaps a background run only after the wide 90s window", async () => {
     const now = Date.now();
     await insertRun("r-dead-bg", "t1", "turn", { dispatchMode: "background" });
     const row = rows.find((r) => r.id === "r-dead-bg")!;
-    row.heartbeat_at = now - (16 * 60_000 + 1_000);
+    row.heartbeat_at = now - 120_000; // > 90s — genuinely dead worker.
 
     const reaped = await reapIfStale("r-dead-bg");
     expect(reaped).toBe(true);

--- a/packages/core/src/agent/run-store.durable-background.spec.ts
+++ b/packages/core/src/agent/run-store.durable-background.spec.ts
@@ -209,7 +209,9 @@ const mockDb = {
     }
 
     // append-terminal-event read / insert paths used by safeAppendTerminalRunEvent
-    if (/SELECT seq, event_data FROM agent_run_events/i.test(sql)) {
+    if (
+      /SELECT seq, event_data(?:, event_at)? FROM agent_run_events/i.test(sql)
+    ) {
       return { rows: [], rowsAffected: 0 };
     }
     if (/INSERT INTO agent_run_events/i.test(sql)) {

--- a/packages/core/src/agent/run-store.durable-background.spec.ts
+++ b/packages/core/src/agent/run-store.durable-background.spec.ts
@@ -33,7 +33,7 @@ let rows: RunRow[] = [];
 // Mirror the two constants used by `backgroundAwareStaleCutoffSql`. The SQL
 // inlines them as literals, so we evaluate the CASE in JS to decide reaping.
 const RUN_STALE_MS = 15_000;
-const BACKGROUND_RUN_STALE_MS = 90_000;
+const BACKGROUND_RUN_STALE_MS = 16 * 60_000;
 
 function rowStaleWindow(row: RunRow): number {
   return row.dispatch_mode && row.dispatch_mode.startsWith("background")
@@ -251,9 +251,9 @@ describe("run-store durable background", () => {
     vi.clearAllMocks();
   });
 
-  it("exports the tight foreground + wide background stale windows", () => {
+  it("exports the tight foreground + durable background stale windows", () => {
     expect(STORE_RUN_STALE_MS).toBe(15_000);
-    expect(STORE_BACKGROUND_RUN_STALE_MS).toBe(90_000);
+    expect(STORE_BACKGROUND_RUN_STALE_MS).toBe(16 * 60_000);
     expect(STORE_BACKGROUND_RUN_STALE_MS).toBeGreaterThan(STORE_RUN_STALE_MS);
   });
 
@@ -297,7 +297,7 @@ describe("run-store durable background", () => {
     await insertRun("r-live-bg", "t1", "turn", { dispatchMode: "background" });
     const row = rows.find((r) => r.id === "r-live-bg")!;
     // Heartbeat 30s ago: past the 15s foreground window, but well within the
-    // 90s background window — must NOT be reaped.
+    // durable background window — must NOT be reaped.
     row.heartbeat_at = now - 30_000;
 
     const reaped = await reapIfStale("r-live-bg");
@@ -305,11 +305,11 @@ describe("run-store durable background", () => {
     expect(await getRunStatus("r-live-bg")).toBe("running");
   });
 
-  it("stale reaper reaps a background run only after the wide 90s window", async () => {
+  it("stale reaper reaps a background run only after the durable background window", async () => {
     const now = Date.now();
     await insertRun("r-dead-bg", "t1", "turn", { dispatchMode: "background" });
     const row = rows.find((r) => r.id === "r-dead-bg")!;
-    row.heartbeat_at = now - 120_000; // > 90s — genuinely dead worker.
+    row.heartbeat_at = now - (16 * 60_000 + 1_000);
 
     const reaped = await reapIfStale("r-dead-bg");
     expect(reaped).toBe(true);
@@ -390,7 +390,7 @@ describe("run-store durable background", () => {
 
   // ─── FALLBACK HARDENING: reapUnclaimedBackgroundRun ────────────────────────
   describe("reapUnclaimedBackgroundRun (202-acked but worker never started)", () => {
-    it("exports a grace MUCH tighter than the 90s claimed-worker window", () => {
+    it("exports a grace MUCH tighter than the claimed-worker window", () => {
       expect(UNCLAIMED_BACKGROUND_RUN_GRACE_MS).toBe(25_000);
       expect(UNCLAIMED_BACKGROUND_RUN_GRACE_MS).toBeLessThan(
         STORE_BACKGROUND_RUN_STALE_MS,

--- a/packages/core/src/agent/run-store.spec.ts
+++ b/packages/core/src/agent/run-store.spec.ts
@@ -256,6 +256,31 @@ describe("run store", () => {
     expect(JSON.parse(eventJson)).toEqual(STALE_RUN_ERROR_EVENT);
   });
 
+  it("reconciles a persisted terminal event instead of stale-reaping the run", async () => {
+    latestEventRows = [
+      { seq: 9, event_data: JSON.stringify({ type: "done" }) },
+    ];
+
+    const reaped = await reapIfStale("run-done-event");
+
+    expect(reaped).toBe(false);
+    const repair = execCalls.find(
+      (call) =>
+        /UPDATE agent_runs/i.test(call.sql) &&
+        /SET status = \?/i.test(call.sql),
+    );
+    expect(repair?.args[0]).toBe("completed");
+    expect(repair?.args[6]).toBe("done");
+    expect(repair?.args[7]).toBe("run-done-event");
+    expect(
+      execCalls.some(
+        (call) =>
+          /UPDATE agent_runs[\s\S]*SET status = 'errored'/i.test(call.sql) &&
+          call.args.includes("run-done-event"),
+      ),
+    ).toBe(false);
+  });
+
   it("reapIfStale honors last_progress_at as liveness so a progressing run is not reaped mid-tool", async () => {
     await reapIfStale("run-progressing");
 

--- a/packages/core/src/agent/run-store.spec.ts
+++ b/packages/core/src/agent/run-store.spec.ts
@@ -6,7 +6,11 @@ interface ExecCall {
 }
 
 const execCalls: ExecCall[] = [];
-let latestEventRows: Array<{ seq: number; event_data: string }> = [];
+let latestEventRows: Array<{
+  seq: number;
+  event_at?: number | null;
+  event_data: string;
+}> = [];
 let staleSelectRows: Array<{ id: string }> = [];
 let claimSlotRows: Array<{ id: string }> = [];
 let runStatusRows: Array<{ status: string }> = [];
@@ -26,7 +30,11 @@ const mockDb = {
     const args = typeof sql === "string" ? [] : (sql.args ?? []);
     execCalls.push({ sql: rawSql, args });
 
-    if (/SELECT seq, event_data FROM agent_run_events/i.test(rawSql)) {
+    if (
+      /SELECT seq, event_data(?:, event_at)? FROM agent_run_events/i.test(
+        rawSql,
+      )
+    ) {
       return { rows: latestEventRows, rowsAffected: 0 };
     }
     // tryClaimRunSlot: SELECT id FROM agent_runs WHERE thread_id = ? AND ...
@@ -182,7 +190,10 @@ describe("run store", () => {
     const insert = execCalls.find((call) =>
       /INSERT INTO agent_run_events/i.test(call.sql),
     );
-    expect(insert?.args).toEqual(["run-abort", 0, '{"type":"done"}']);
+    expect(insert?.args[0]).toBe("run-abort");
+    expect(insert?.args[1]).toBe(0);
+    expect(typeof insert?.args[2]).toBe("number");
+    expect(insert?.args[3]).toBe('{"type":"done"}');
   });
 
   it("does not append another terminal event after auto_continue", async () => {
@@ -252,13 +263,18 @@ describe("run store", () => {
       /INSERT INTO agent_run_events/i.test(call.sql),
     );
     expect(insert?.args[0]).toBe("run-stale");
-    const eventJson = insert?.args[2] as string;
+    expect(typeof insert?.args[2]).toBe("number");
+    const eventJson = insert?.args[3] as string;
     expect(JSON.parse(eventJson)).toEqual(STALE_RUN_ERROR_EVENT);
   });
 
   it("reconciles a persisted terminal event instead of stale-reaping the run", async () => {
     latestEventRows = [
-      { seq: 9, event_data: JSON.stringify({ type: "done" }) },
+      {
+        seq: 9,
+        event_at: 123_456,
+        event_data: JSON.stringify({ type: "done" }),
+      },
     ];
 
     const reaped = await reapIfStale("run-done-event");
@@ -270,6 +286,7 @@ describe("run store", () => {
         /SET status = \?/i.test(call.sql),
     );
     expect(repair?.args[0]).toBe("completed");
+    expect(repair?.args[1]).toBe(123_456);
     expect(repair?.args[6]).toBe("done");
     expect(repair?.args[7]).toBe("run-done-event");
     expect(
@@ -279,6 +296,25 @@ describe("run store", () => {
           call.args.includes("run-done-event"),
       ),
     ).toBe(false);
+  });
+
+  it("reconciles legacy terminal events without stamping repair time", async () => {
+    latestEventRows = [
+      { seq: 9, event_data: JSON.stringify({ type: "done" }) },
+    ];
+
+    await reapIfStale("run-legacy-done-event");
+
+    const repair = execCalls.find(
+      (call) =>
+        /UPDATE agent_runs/i.test(call.sql) &&
+        /SET status = \?/i.test(call.sql),
+    );
+    expect(repair?.sql).toContain("completed_at = COALESCE");
+    expect(repair?.sql).toContain("last_progress_at");
+    expect(repair?.sql).toContain("heartbeat_at");
+    expect(repair?.args[0]).toBe("completed");
+    expect(repair?.args[1]).toBeNull();
   });
 
   it("reapIfStale honors last_progress_at as liveness so a progressing run is not reaped mid-tool", async () => {
@@ -330,7 +366,7 @@ describe("run store", () => {
       /INSERT INTO agent_run_events/i.test(call.sql),
     );
     expect(insert?.args[0]).toBe("old-but-heartbeating-run");
-    expect(insert?.args[2] as string).toContain('"errorCode":"stale_run"');
+    expect(insert?.args[3] as string).toContain('"errorCode":"stale_run"');
   });
 
   it("persists stale error diagnostics for all stale-run reap paths", async () => {

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -1154,8 +1154,8 @@ export async function getRunByThread(
   await ensureRunTables();
   const client = getDbExec();
   const sql = options?.includeTerminal
-    ? `SELECT id, thread_id, turn_id, status, started_at, heartbeat_at, completed_at, last_progress_at, dispatch_mode, terminal_reason, diag_stage FROM agent_runs WHERE thread_id = ? ORDER BY started_at DESC LIMIT 1`
-    : `SELECT id, thread_id, turn_id, status, started_at, heartbeat_at, completed_at, last_progress_at, dispatch_mode, terminal_reason, diag_stage FROM agent_runs WHERE thread_id = ? AND status = 'running' ORDER BY started_at DESC LIMIT 1`;
+    ? `SELECT id, thread_id, turn_id, status, started_at, heartbeat_at, completed_at, last_progress_at, dispatch_mode, terminal_reason, diag_stage, error_code FROM agent_runs WHERE thread_id = ? ORDER BY started_at DESC LIMIT 1`
+    : `SELECT id, thread_id, turn_id, status, started_at, heartbeat_at, completed_at, last_progress_at, dispatch_mode, terminal_reason, diag_stage, error_code FROM agent_runs WHERE thread_id = ? AND status = 'running' ORDER BY started_at DESC LIMIT 1`;
   const { rows } = await client.execute({ sql, args: [threadId] });
   if (rows.length === 0) return null;
   const r = rows[0] as {
@@ -1170,8 +1170,13 @@ export async function getRunByThread(
     dispatch_mode?: string | null;
     terminal_reason?: string | null;
     diag_stage?: string | null;
+    error_code?: string | null;
   };
-  if (r.status === "running" && (await reconcileTerminalRunFromEvents(r.id))) {
+  const canReconcileFromEvents =
+    r.status === "running" ||
+    (r.status === "errored" &&
+      r.error_code === STALE_RUN_ERROR_EVENT.errorCode);
+  if (canReconcileFromEvents && (await reconcileTerminalRunFromEvents(r.id))) {
     return getRunByThread(threadId, options);
   }
   return {
@@ -1326,7 +1331,6 @@ export async function reapAllStaleRuns(): Promise<number> {
   const stale = await client.execute({
     sql: `SELECT id FROM agent_runs
           WHERE status = 'running'
-            AND ${terminalRunEventExclusionSql()}
             AND ${livenessBasisSql()} < ${backgroundAwareStaleCutoffSql()}`,
     args: [now],
   });
@@ -1391,7 +1395,6 @@ export async function cleanupOldRuns(
   const stale = await client.execute({
     sql: `SELECT id FROM agent_runs
           WHERE status = 'running'
-            AND ${terminalRunEventExclusionSql()}
             AND (
               ${livenessBasisSql()} < ${backgroundAwareStaleCutoffSql()}
               OR started_at < ?

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -27,14 +27,15 @@ export const RUN_STALE_MS = 15_000;
  * inserts the `running` row, then `fireInternalDispatch` returns 202 and the
  * background function may take >15s to cold-start and emit its first heartbeat.
  * With the normal 15s window the reaper would falsely kill that freshly-
- * inserted-but-not-yet-heartbeaten row. Once claimed, background workers can
- * legitimately run against Netlify's 15-minute background execution budget, so
- * the stale watchdog must not become a shorter de-facto run timeout.
+ * inserted-but-not-yet-heartbeaten row. 90s tolerates a slow background
+ * cold-start while still reaping a genuinely dead background worker promptly.
+ * Claimed background workers heartbeat during long work; the stale watchdog is a
+ * liveness timeout, not the Netlify background-function execution budget.
  *
  * Only applied to rows explicitly marked background-dispatched; ordinary
  * foreground runs keep the tight 15s window unchanged.
  */
-export const BACKGROUND_RUN_STALE_MS = 16 * 60_000;
+export const BACKGROUND_RUN_STALE_MS = 90_000;
 
 export const STALE_RUN_ERROR_EVENT = {
   type: "error",
@@ -86,10 +87,11 @@ export const CLAIMED_BACKGROUND_WORKER_FAILED_ERROR_EVENT = {
  * Grace period before a never-claimed background run (dispatch_mode still
  * 'background', no worker claim) is treated as a dead handoff and reaped.
  *
- * This is intentionally MUCH tighter than `BACKGROUND_RUN_STALE_MS`. The wide
- * durable-worker window exists ONLY to protect a CLAIMED worker whose heartbeat
- * lags during long background work. A run that is still `dispatch_mode = 'background'`
- * has, by definition, NO worker — nothing to protect — so once a Netlify
+ * This is intentionally tighter than `BACKGROUND_RUN_STALE_MS`. That wider
+ * window protects cold-starting or temporarily delayed background dispatches,
+ * while claimed workers stay alive by heartbeat/progress updates. A run that is
+ * still `dispatch_mode = 'background'` has, by definition, NO worker — nothing
+ * to protect — so once a Netlify
  * background function has had a reasonable cold-start window to claim it and
  * hasn't, the handoff is dead and should surface promptly instead of leaving
  * the user staring at a spinner for the durable-worker window. 25s comfortably exceeds a normal

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -128,6 +128,7 @@ async function ensureRunTables(): Promise<void> {
         CREATE TABLE IF NOT EXISTS agent_run_events (
           run_id TEXT NOT NULL,
           seq ${intType()} NOT NULL,
+          event_at ${intType()},
           event_data TEXT NOT NULL,
           PRIMARY KEY (run_id, seq)
         )
@@ -203,6 +204,11 @@ async function ensureRunTables(): Promise<void> {
           );
         }
         await ensureTableExists("agent_run_events", agentRunEventsCreateSql);
+        await ensureColumnExists(
+          "agent_run_events",
+          "event_at",
+          `ALTER TABLE agent_run_events ADD COLUMN IF NOT EXISTS event_at ${intType()}`,
+        );
         await ensureTableExists("agent_tool_ledger", agentToolLedgerCreateSql);
         // Widen millisecond-timestamp columns that older deployments created as
         // 32-bit `INTEGER`. `insertRun()` writes `Date.now()` into `started_at`
@@ -216,6 +222,7 @@ async function ensureRunTables(): Promise<void> {
           "heartbeat_at",
           "last_progress_at",
         ]);
+        await widenIntColumnsToBigInt("agent_run_events", ["event_at"]);
         await widenIntColumnsToBigInt("agent_tool_ledger", ["completed_at"]);
         return;
       }
@@ -281,6 +288,13 @@ async function ensureRunTables(): Promise<void> {
         }
       }
       await client.execute(agentRunEventsCreateSql);
+      try {
+        await client.execute(
+          `ALTER TABLE agent_run_events ADD COLUMN event_at ${intType()}`,
+        );
+      } catch {
+        // Column already exists — ignore
+      }
       await client.execute(agentToolLedgerCreateSql);
       // Widen millisecond-timestamp columns that older deployments created as
       // 32-bit `INTEGER`. `insertRun()` writes `Date.now()` into `started_at`
@@ -294,6 +308,7 @@ async function ensureRunTables(): Promise<void> {
         "heartbeat_at",
         "last_progress_at",
       ]);
+      await widenIntColumnsToBigInt("agent_run_events", ["event_at"]);
       await widenIntColumnsToBigInt("agent_tool_ledger", ["completed_at"]);
     })().catch((err) => {
       // Retry init on the next call after a failed startup.
@@ -689,18 +704,29 @@ function terminalReasonForEvent(event: AgentChatEvent): string | null {
   return null;
 }
 
-async function getLatestRunEvent(
-  runId: string,
-): Promise<AgentChatEvent | null> {
+async function getLatestRunEvent(runId: string): Promise<{
+  event: AgentChatEvent;
+  eventAt: number | null;
+} | null> {
   const client = getDbExec();
   const { rows } = await client.execute({
-    sql: `SELECT seq, event_data FROM agent_run_events WHERE run_id = ? ORDER BY seq DESC LIMIT 1`,
+    sql: `SELECT seq, event_data, event_at FROM agent_run_events WHERE run_id = ? ORDER BY seq DESC LIMIT 1`,
     args: [runId],
   });
-  const raw = (rows[0] as { event_data?: string } | undefined)?.event_data;
+  const row = rows[0] as
+    | {
+        event_at?: number | string | null;
+        event_data?: string;
+      }
+    | undefined;
+  const raw = row?.event_data;
   if (!raw) return null;
   try {
-    return JSON.parse(raw) as AgentChatEvent;
+    const eventAt = row.event_at == null ? NaN : Number(row.event_at);
+    return {
+      event: JSON.parse(raw) as AgentChatEvent,
+      eventAt: Number.isFinite(eventAt) && eventAt > 0 ? eventAt : null,
+    };
   } catch {
     return null;
   }
@@ -719,23 +745,24 @@ export async function reconcileTerminalRunFromEvents(
   runId: string,
 ): Promise<boolean> {
   await ensureRunTables();
-  const event = await getLatestRunEvent(runId);
-  if (!event) return false;
-  const status = terminalStatusForEvent(event);
-  const terminalReason = terminalReasonForEvent(event);
+  const latest = await getLatestRunEvent(runId);
+  if (!latest) return false;
+  const status = terminalStatusForEvent(latest.event);
+  const terminalReason = terminalReasonForEvent(latest.event);
   if (!status || !terminalReason) return false;
 
   const client = getDbExec();
-  const completedAt = Date.now();
-  const errorCode = event.type === "error" ? (event.errorCode ?? null) : null;
+  const errorCode =
+    latest.event.type === "error" ? (latest.event.errorCode ?? null) : null;
   const errorDetail =
-    event.type === "error"
-      ? (event.details || event.error || "").slice(0, 2000) || null
+    latest.event.type === "error"
+      ? (latest.event.details || latest.event.error || "").slice(0, 2000) ||
+        null
       : null;
   const { rowsAffected } = await client.execute({
     sql: `UPDATE agent_runs
           SET status = ?,
-              completed_at = COALESCE(completed_at, ?),
+              completed_at = COALESCE(completed_at, ?, ${livenessBasisSql()}),
               error_code = CASE WHEN ? IS NOT NULL THEN ? ELSE error_code END,
               error_detail = CASE WHEN ? IS NOT NULL THEN ? ELSE error_detail END,
               terminal_reason = COALESCE(terminal_reason, ?)
@@ -746,7 +773,7 @@ export async function reconcileTerminalRunFromEvents(
             )`,
     args: [
       status,
-      completedAt,
+      latest.eventAt,
       errorCode,
       errorCode,
       errorDetail,
@@ -1089,8 +1116,8 @@ export async function insertRunEvent(
   // run aborts at the same time the producer emits its final event.
   // Treat the second write as a no-op so the run completes cleanly.
   await client.execute({
-    sql: `INSERT INTO agent_run_events (run_id, seq, event_data) VALUES (?, ?, ?) ON CONFLICT (run_id, seq) DO NOTHING`,
-    args: [runId, seq, eventData],
+    sql: `INSERT INTO agent_run_events (run_id, seq, event_at, event_data) VALUES (?, ?, ?, ?) ON CONFLICT (run_id, seq) DO NOTHING`,
+    args: [runId, seq, Date.now(), eventData],
   });
 }
 
@@ -1633,7 +1660,7 @@ async function appendTerminalRunEvent(
   }
   const nextSeq = last ? Number(last.seq ?? -1) + 1 : 0;
   await client.execute({
-    sql: `INSERT INTO agent_run_events (run_id, seq, event_data) VALUES (?, ?, ?) ON CONFLICT (run_id, seq) DO NOTHING`,
-    args: [runId, nextSeq, JSON.stringify(event)],
+    sql: `INSERT INTO agent_run_events (run_id, seq, event_at, event_data) VALUES (?, ?, ?, ?) ON CONFLICT (run_id, seq) DO NOTHING`,
+    args: [runId, nextSeq, Date.now(), JSON.stringify(event)],
   });
 }

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -27,13 +27,14 @@ export const RUN_STALE_MS = 15_000;
  * inserts the `running` row, then `fireInternalDispatch` returns 202 and the
  * background function may take >15s to cold-start and emit its first heartbeat.
  * With the normal 15s window the reaper would falsely kill that freshly-
- * inserted-but-not-yet-heartbeaten row. 90s tolerates a slow background
- * cold-start while still reaping a genuinely dead background worker promptly.
+ * inserted-but-not-yet-heartbeaten row. Once claimed, background workers can
+ * legitimately run against Netlify's 15-minute background execution budget, so
+ * the stale watchdog must not become a shorter de-facto run timeout.
  *
  * Only applied to rows explicitly marked background-dispatched; ordinary
  * foreground runs keep the tight 15s window unchanged.
  */
-export const BACKGROUND_RUN_STALE_MS = 90_000;
+export const BACKGROUND_RUN_STALE_MS = 16 * 60_000;
 
 export const STALE_RUN_ERROR_EVENT = {
   type: "error",
@@ -85,13 +86,13 @@ export const CLAIMED_BACKGROUND_WORKER_FAILED_ERROR_EVENT = {
  * Grace period before a never-claimed background run (dispatch_mode still
  * 'background', no worker claim) is treated as a dead handoff and reaped.
  *
- * This is intentionally MUCH tighter than `BACKGROUND_RUN_STALE_MS` (90s). The
- * wide 90s window exists ONLY to protect a CLAIMED worker whose heartbeat lags
- * during a slow cold start. A run that is still `dispatch_mode = 'background'`
+ * This is intentionally MUCH tighter than `BACKGROUND_RUN_STALE_MS`. The wide
+ * durable-worker window exists ONLY to protect a CLAIMED worker whose heartbeat
+ * lags during long background work. A run that is still `dispatch_mode = 'background'`
  * has, by definition, NO worker — nothing to protect — so once a Netlify
  * background function has had a reasonable cold-start window to claim it and
  * hasn't, the handoff is dead and should surface promptly instead of leaving
- * the user staring at a spinner for 90s. 25s comfortably exceeds a normal
+ * the user staring at a spinner for the durable-worker window. 25s comfortably exceeds a normal
  * Netlify Lambda cold start while still failing fast on a silent worker death.
  */
 export const UNCLAIMED_BACKGROUND_RUN_GRACE_MS = 25_000;
@@ -431,6 +432,20 @@ function backgroundAwareStaleCutoffSql(): string {
   return `(CAST(? AS BIGINT) - CASE WHEN dispatch_mode LIKE 'background%' THEN ${BACKGROUND_RUN_STALE_MS} ELSE ${RUN_STALE_MS} END)`;
 }
 
+function terminalRunEventExclusionSql(runIdColumn = "id"): string {
+  return `NOT EXISTS (
+    SELECT 1 FROM agent_run_events terminal_events
+    WHERE terminal_events.run_id = agent_runs.${runIdColumn}
+      AND (
+        terminal_events.event_data LIKE '{"type":"done"%'
+        OR terminal_events.event_data LIKE '{"type":"error"%'
+        OR terminal_events.event_data LIKE '{"type":"missing_api_key"%'
+        OR terminal_events.event_data LIKE '{"type":"loop_limit"%'
+        OR terminal_events.event_data LIKE '{"type":"auto_continue"%'
+      )
+  )`;
+}
+
 /**
  * Liveness basis for the stale reapers: the MOST RECENT of `heartbeat_at`
  * ("process is up", bumped on a 1.5s timer) and `last_progress_at` ("real work
@@ -573,6 +588,7 @@ export async function tryClaimRunSlot(
       sql: `SELECT id FROM agent_runs
             WHERE thread_id = ?
               AND status = 'running'
+              AND ${terminalRunEventExclusionSql()}
               AND COALESCE(heartbeat_at, started_at) >= ?
             ORDER BY started_at DESC LIMIT 1`,
       args: [threadId, heartbeatCutoff],
@@ -586,6 +602,7 @@ export async function tryClaimRunSlot(
     sql: `SELECT id FROM agent_runs
           WHERE thread_id = ?
             AND status = 'running'
+            AND ${terminalRunEventExclusionSql()}
             AND COALESCE(heartbeat_at, started_at) >= ${backgroundAwareStaleCutoffSql()}
           ORDER BY started_at DESC LIMIT 1`,
     args: [threadId, now],
@@ -644,6 +661,100 @@ export async function setRunTerminalReason(
   } catch {
     // Diagnostics are best-effort; never let them break completion.
   }
+}
+
+function terminalStatusForEvent(
+  event: AgentChatEvent,
+): "completed" | "errored" | null {
+  if (event.type === "error") return "errored";
+  if (
+    event.type === "done" ||
+    event.type === "missing_api_key" ||
+    event.type === "loop_limit" ||
+    event.type === "auto_continue"
+  ) {
+    return "completed";
+  }
+  return null;
+}
+
+function terminalReasonForEvent(event: AgentChatEvent): string | null {
+  if (event.type === "auto_continue") return event.reason || "auto_continue";
+  if (event.type === "loop_limit") return "loop_limit";
+  if (event.type === "missing_api_key") return "missing_api_key";
+  if (event.type === "error") return `error:${event.errorCode || "unknown"}`;
+  if (event.type === "done") return "done";
+  return null;
+}
+
+async function getLatestRunEvent(
+  runId: string,
+): Promise<AgentChatEvent | null> {
+  const client = getDbExec();
+  const { rows } = await client.execute({
+    sql: `SELECT seq, event_data FROM agent_run_events WHERE run_id = ? ORDER BY seq DESC LIMIT 1`,
+    args: [runId],
+  });
+  const raw = (rows[0] as { event_data?: string } | undefined)?.event_data;
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as AgentChatEvent;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Repair a run whose terminal event was durably appended but whose final
+ * `agent_runs.status` write lost a race with reconnect/reaper code.
+ *
+ * The event ledger is the durable transcript users see. If its latest event is
+ * terminal, the run is no longer alive and must not be converted into a stale
+ * error later. This keeps `agent_runs` and `agent_run_events` from telling two
+ * different stories after delayed DB writes or background function teardown.
+ */
+export async function reconcileTerminalRunFromEvents(
+  runId: string,
+): Promise<boolean> {
+  await ensureRunTables();
+  const event = await getLatestRunEvent(runId);
+  if (!event) return false;
+  const status = terminalStatusForEvent(event);
+  const terminalReason = terminalReasonForEvent(event);
+  if (!status || !terminalReason) return false;
+
+  const client = getDbExec();
+  const completedAt = Date.now();
+  const errorCode = event.type === "error" ? (event.errorCode ?? null) : null;
+  const errorDetail =
+    event.type === "error"
+      ? (event.details || event.error || "").slice(0, 2000) || null
+      : null;
+  const { rowsAffected } = await client.execute({
+    sql: `UPDATE agent_runs
+          SET status = ?,
+              completed_at = COALESCE(completed_at, ?),
+              error_code = CASE WHEN ? IS NOT NULL THEN ? ELSE error_code END,
+              error_detail = CASE WHEN ? IS NOT NULL THEN ? ELSE error_detail END,
+              terminal_reason = COALESCE(terminal_reason, ?)
+          WHERE id = ?
+            AND (
+              status = 'running'
+              OR (status = 'errored' AND error_code = ?)
+            )`,
+    args: [
+      status,
+      completedAt,
+      errorCode,
+      errorCode,
+      errorDetail,
+      errorDetail,
+      terminalReason,
+      runId,
+      STALE_RUN_ERROR_EVENT.errorCode,
+    ],
+  });
+  return (rowsAffected ?? 0) > 0;
 }
 
 /**
@@ -774,6 +885,7 @@ export async function reapIfStale(
   maxStaleMs?: number,
 ): Promise<boolean> {
   await ensureRunTables();
+  if (await reconcileTerminalRunFromEvents(runId)) return false;
   const client = getDbExec();
   const completedAt = Date.now();
   // Background-dispatched runs get the wider stale window so a slow cold-start
@@ -794,6 +906,7 @@ export async function reapIfStale(
               terminal_reason = ?
           WHERE id = ?
             AND status = 'running'
+            AND ${terminalRunEventExclusionSql()}
             AND ${staleClause}`,
     args: [
       completedAt,
@@ -805,6 +918,7 @@ export async function reapIfStale(
     ],
   });
   const reaped = (rowsAffected ?? 0) > 0;
+  if (!reaped && (await reconcileTerminalRunFromEvents(runId))) return false;
   if (reaped) {
     await safeAppendTerminalRunEvent(
       runId,
@@ -823,7 +937,7 @@ export async function reapIfStale(
  * before it can claim), the row stays `background`, never heartbeats again, and
  * — because dispatch returned 202 — the foreground already returned the SSE
  * stream, so the existing fast-fail inline fallback never engaged. The run would
- * otherwise hang for the full 90s background window and then error opaquely.
+ * otherwise hang for the full durable background window and then error opaquely.
  *
  * This reaps such a run EARLY and DISTINCTLY: a row that is still unclaimed
  * (`dispatch_mode = 'background'`) past the tight `UNCLAIMED_BACKGROUND_RUN_GRACE_MS`
@@ -1057,6 +1171,9 @@ export async function getRunByThread(
     terminal_reason?: string | null;
     diag_stage?: string | null;
   };
+  if (r.status === "running" && (await reconcileTerminalRunFromEvents(r.id))) {
+    return getRunByThread(threadId, options);
+  }
   return {
     id: r.id,
     threadId: r.thread_id,
@@ -1209,9 +1326,16 @@ export async function reapAllStaleRuns(): Promise<number> {
   const stale = await client.execute({
     sql: `SELECT id FROM agent_runs
           WHERE status = 'running'
+            AND ${terminalRunEventExclusionSql()}
             AND ${livenessBasisSql()} < ${backgroundAwareStaleCutoffSql()}`,
     args: [now],
   });
+  for (const row of stale.rows) {
+    const id = (row as { id?: unknown }).id;
+    if (typeof id === "string") {
+      await reconcileTerminalRunFromEvents(id);
+    }
+  }
   const completedAt = Date.now();
   const { rowsAffected } = await client.execute({
     sql: `UPDATE agent_runs
@@ -1221,6 +1345,7 @@ export async function reapAllStaleRuns(): Promise<number> {
               error_detail = ?,
               terminal_reason = ?
           WHERE status = 'running'
+            AND ${terminalRunEventExclusionSql()}
             AND ${livenessBasisSql()} < ${backgroundAwareStaleCutoffSql()}`,
     args: [
       completedAt,
@@ -1266,12 +1391,19 @@ export async function cleanupOldRuns(
   const stale = await client.execute({
     sql: `SELECT id FROM agent_runs
           WHERE status = 'running'
+            AND ${terminalRunEventExclusionSql()}
             AND (
               ${livenessBasisSql()} < ${backgroundAwareStaleCutoffSql()}
               OR started_at < ?
     )`,
     args: [now, cutoff],
   });
+  for (const row of stale.rows) {
+    const id = (row as { id?: unknown }).id;
+    if (typeof id === "string") {
+      await reconcileTerminalRunFromEvents(id);
+    }
+  }
   const completedAt = Date.now();
   await client.execute({
     sql: `UPDATE agent_runs
@@ -1280,7 +1412,9 @@ export async function cleanupOldRuns(
               error_code = ?,
               error_detail = ?,
               terminal_reason = ?
-          WHERE status = 'running' AND started_at < ?`,
+          WHERE status = 'running'
+            AND ${terminalRunEventExclusionSql()}
+            AND started_at < ?`,
     args: [
       completedAt,
       STALE_RUN_ERROR_EVENT.errorCode,
@@ -1299,6 +1433,7 @@ export async function cleanupOldRuns(
               error_detail = ?,
               terminal_reason = ?
           WHERE status = 'running'
+            AND ${terminalRunEventExclusionSql()}
             AND ${livenessBasisSql()} < ${backgroundAwareStaleCutoffSql()}`,
     args: [
       completedAt,

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -26,6 +26,7 @@ import {
   isAssistantUiRecoverableRenderError,
   isAssistantUiStaleIndexError,
   latestNonRecoveryUserMessageText,
+  reconnectActivityFallbackContent,
   reconnectProgressTimedOut,
   resolveAssistantChatRunningState,
   resolveAssistantChatSubmitIntent,
@@ -182,6 +183,19 @@ describe("waitForThreadRunToClear", () => {
     // perpetual "Working" — that label was removed.
     expect(labelSource).not.toContain('"Working"');
     expect(labelSource).toContain('"Thinking"');
+  });
+
+  it("builds a running tool card for tail-reconnect activity", () => {
+    expect(reconnectActivityFallbackContent(" generate-design ")).toEqual([
+      expect.objectContaining({
+        type: "tool-call",
+        toolName: "generate-design",
+        argsText: "",
+        args: {},
+        activity: true,
+      }),
+    ]);
+    expect(reconnectActivityFallbackContent("")).toEqual([]);
   });
 });
 

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -197,6 +197,23 @@ describe("waitForThreadRunToClear", () => {
     ]);
     expect(reconnectActivityFallbackContent("")).toEqual([]);
   });
+
+  it("rehydrates reconnect activity from active-run state", () => {
+    const source = readFileSync("src/client/AssistantChat.tsx", {
+      encoding: "utf8",
+    });
+    const start = source.indexOf("const startReconnectToRun = useCallback");
+    const end = source.indexOf("const reconnectActiveRunForThread");
+    const helperSource = source.slice(start, end);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    expect(helperSource).toContain("getActiveRunActivityTool(threadId, runId)");
+    expect(helperSource).toContain(
+      "setRunningActivityTool(storedActivityTool)",
+    );
+    expect(helperSource).toContain("activityTool: storedActivityTool");
+  });
 });
 
 describe("reconnectProgressTimedOut", () => {

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -553,6 +553,23 @@ function reconnectContentFollowKey(content: ContentPart[]): string {
   return content.map(contentPartFollowKey).join("|");
 }
 
+export function reconnectActivityFallbackContent(
+  toolName: string | null | undefined,
+): ContentPart[] {
+  const tool = toolName?.trim();
+  if (!tool) return [];
+  return [
+    {
+      type: "tool-call",
+      toolCallId: `reconnect-activity:${tool}`,
+      toolName: tool,
+      argsText: "",
+      args: {},
+      activity: true,
+    },
+  ];
+}
+
 const RECOVERY_USER_MESSAGE_PREFIXES = [
   "Continue from where you left off",
   "Continue from where you stopped",
@@ -1395,6 +1412,9 @@ const AssistantChatInner = forwardRef<
   const [runningActivityLabel, setRunningActivityLabel] = useState<
     string | null
   >(null);
+  const [runningActivityTool, setRunningActivityTool] = useState<string | null>(
+    null,
+  );
   // Delayed-reveal state for the activity label (see ACTIVITY_LABEL_REVEAL_DELAY_MS).
   // `latest` holds the most recent activity label; `surfaced` flips true once the
   // reveal timer fires; `timer` is the pending one-shot reveal.
@@ -1409,6 +1429,7 @@ const AssistantChatInner = forwardRef<
     latestActivityLabelRef.current = null;
     activityLabelSurfacedRef.current = false;
     setRunningActivityLabel(null);
+    setRunningActivityTool(null);
   }, []);
   const [reconnectContent, setReconnectContent] = useState<ContentPart[]>([]);
   // When stop is clicked during reconnect, keep content visible (don't wipe it)
@@ -1445,6 +1466,18 @@ const AssistantChatInner = forwardRef<
       : isReconnecting && reconnectContent.length > 0
         ? "Reconnecting"
         : "Thinking";
+  const reconnectActivityContent = useMemo(
+    () =>
+      (isReconnecting || reconnectFrozen) && reconnectContent.length === 0
+        ? reconnectActivityFallbackContent(runningActivityTool)
+        : [],
+    [
+      isReconnecting,
+      reconnectFrozen,
+      reconnectContent.length,
+      runningActivityTool,
+    ],
+  );
   const lastBroadcastRunningRef = useRef(isRunning);
   const tiptapRef = useRef<TiptapComposerHandle>(null);
   // Stable ref to the "stop active run" action so addToQueue can abort
@@ -2407,7 +2440,9 @@ const AssistantChatInner = forwardRef<
       const label =
         typeof detail?.label === "string" ? detail.label.trim() : "";
       if (!label) return;
+      const tool = typeof detail?.tool === "string" ? detail.tool.trim() : "";
       setIsAutoResuming(false);
+      setRunningActivityTool(tool || null);
       latestActivityLabelRef.current = label;
       // Already past the delay → keep the visible label current.
       if (activityLabelSurfacedRef.current) {
@@ -3548,6 +3583,13 @@ const AssistantChatInner = forwardRef<
                         reconnectAfterSeq === 0 &&
                         reconnectContent.length > 0 && (
                           <ReconnectStreamMessage content={reconnectContent} />
+                        )}
+                      {(isReconnecting || reconnectFrozen) &&
+                        reconnectAfterSeq > 0 &&
+                        reconnectActivityContent.length > 0 && (
+                          <ReconnectStreamMessage
+                            content={reconnectActivityContent}
+                          />
                         )}
                       {showRunningInUI && (
                         <RunningActivityStatus label={runningStatusLabel} />

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -37,9 +37,11 @@ import React, {
 import { LLM_MISSING_CREDENTIALS_MESSAGE } from "../agent/engine/credential-errors.js";
 import type { ReasoningEffort } from "../shared/reasoning-effort.js";
 import {
+  getActiveRunActivityTool,
   getActiveRun,
   resolveReconnectAfterSeq,
   setActiveRun,
+  updateActiveRunActivity,
   updateActiveRunSeq,
 } from "./active-run-state.js";
 import {
@@ -1430,6 +1432,7 @@ const AssistantChatInner = forwardRef<
     activityLabelSurfacedRef.current = false;
     setRunningActivityLabel(null);
     setRunningActivityTool(null);
+    updateActiveRunActivity(null);
   }, []);
   const [reconnectContent, setReconnectContent] = useState<ContentPart[]>([]);
   // When stop is clicked during reconnect, keep content visible (don't wipe it)
@@ -1733,11 +1736,14 @@ const AssistantChatInner = forwardRef<
 
       reconnectRunIdRef.current = runId;
       const afterSeq = resolveReconnectAfterSeq(threadId, runId);
+      const storedActivityTool = getActiveRunActivityTool(threadId, runId);
+      setRunningActivityTool(storedActivityTool);
       setReconnectAfterSeq(afterSeq);
       setActiveRun({
         threadId,
         runId,
         lastSeq: afterSeq > 0 ? afterSeq - 1 : -1,
+        ...(storedActivityTool ? { activityTool: storedActivityTool } : {}),
       });
       setIsReconnecting(true);
       setReconnectFrozen(false);
@@ -2443,6 +2449,7 @@ const AssistantChatInner = forwardRef<
       const tool = typeof detail?.tool === "string" ? detail.tool.trim() : "";
       setIsAutoResuming(false);
       setRunningActivityTool(tool || null);
+      updateActiveRunActivity(tool || null);
       latestActivityLabelRef.current = label;
       // Already past the delay → keep the visible label current.
       if (activityLabelSurfacedRef.current) {

--- a/packages/core/src/client/active-run-state.spec.ts
+++ b/packages/core/src/client/active-run-state.spec.ts
@@ -2,8 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   clearActiveRun,
+  getActiveRun,
+  getActiveRunActivityTool,
   resolveReconnectAfterSeq,
   setActiveRun,
+  updateActiveRunActivity,
+  updateActiveRunSeq,
 } from "./active-run-state.js";
 
 function createMemoryStorage(): Storage {
@@ -51,5 +55,31 @@ describe("resolveReconnectAfterSeq", () => {
     expect(resolveReconnectAfterSeq("thread-2", "run-1")).toBe(0);
     clearActiveRun();
     expect(resolveReconnectAfterSeq("thread-1", "run-1")).toBe(0);
+  });
+
+  it("persists the current activity tool for refresh-time reconnects", () => {
+    setActiveRun({ threadId: "thread-1", runId: "run-1", lastSeq: 10 });
+
+    updateActiveRunActivity(" generate-design ");
+    expect(getActiveRunActivityTool("thread-1", "run-1")).toBe(
+      "generate-design",
+    );
+    expect(getActiveRunActivityTool("thread-1", "run-2")).toBeNull();
+
+    updateActiveRunSeq(12);
+    expect(getActiveRun()).toMatchObject({
+      threadId: "thread-1",
+      runId: "run-1",
+      lastSeq: 12,
+      activityTool: "generate-design",
+    });
+
+    updateActiveRunActivity("");
+    expect(getActiveRun()).toMatchObject({
+      threadId: "thread-1",
+      runId: "run-1",
+      lastSeq: 12,
+    });
+    expect(getActiveRun()?.activityTool).toBeUndefined();
   });
 });

--- a/packages/core/src/client/active-run-state.ts
+++ b/packages/core/src/client/active-run-state.ts
@@ -4,6 +4,13 @@ export interface ActiveRunState {
   threadId: string;
   runId: string;
   lastSeq: number;
+  activityTool?: string | null;
+}
+
+function normalizeActivityTool(toolName: unknown): string | null {
+  if (typeof toolName !== "string") return null;
+  const tool = toolName.trim();
+  return tool || null;
 }
 
 export function setActiveRun(state: ActiveRunState): void {
@@ -28,6 +35,29 @@ export function updateActiveRunSeq(seq: number): void {
     state.lastSeq = seq;
     setActiveRun(state);
   }
+}
+
+export function updateActiveRunActivity(
+  toolName: string | null | undefined,
+): void {
+  const state = getActiveRun();
+  if (!state) return;
+  const activityTool = normalizeActivityTool(toolName);
+  if (activityTool) {
+    setActiveRun({ ...state, activityTool });
+    return;
+  }
+  const { activityTool: _activityTool, ...nextState } = state;
+  setActiveRun(nextState);
+}
+
+export function getActiveRunActivityTool(
+  threadId: string,
+  runId: string,
+): string | null {
+  const stored = getActiveRun();
+  if (stored?.threadId !== threadId || stored.runId !== runId) return null;
+  return normalizeActivityTool(stored.activityTool);
 }
 
 export function clearActiveRun(): void {

--- a/templates/clips/changelog/2026-07-01-chrome-recording-uploads-now-serialize-chunks-to-avoid-resum.md
+++ b/templates/clips/changelog/2026-07-01-chrome-recording-uploads-now-serialize-chunks-to-avoid-resum.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-01
+---
+
+Chrome recording uploads now serialize chunks to avoid resumable upload offset races.

--- a/templates/clips/chrome-extension/public/manifest.json
+++ b/templates/clips/chrome-extension/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Agent-Native Clips",
   "short_name": "Clips",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Start Clips recordings from Chrome, capture optional diagnostics, and preview Clips links on GitHub.",
   "minimum_chrome_version": "116",
   "action": {

--- a/templates/clips/chrome-extension/src/offscreen.ts
+++ b/templates/clips/chrome-extension/src/offscreen.ts
@@ -129,6 +129,7 @@ type ActiveRecording = {
   sourceStreams: MediaStream[];
   audioContext: AudioContext | null;
   chunkIndex: number;
+  uploadChain: Promise<void>;
   uploadPromises: Promise<unknown>[];
   uploadFailure: Error | null;
   // Local safety buffer: every recorded blob is kept here (browser-managed,
@@ -795,6 +796,7 @@ async function begin(message: BeginMessage): Promise<{
     ],
     audioContext: mixedAudio.audioContext,
     chunkIndex: 0,
+    uploadChain: Promise.resolve(),
     uploadPromises: [],
     uploadFailure: null,
     recordedBlobs: [],
@@ -837,30 +839,35 @@ async function begin(message: BeginMessage): Promise<{
     // rejected promise that surfaces as an "Uncaught (in promise)" error (bad
     // look in a Chrome Web Store review). finalizeStop reads recording.upload-
     // Failure and surfaces it through the normal error path instead.
-    const upload = (
-      recording.uploadMode === "streaming"
-        ? uploadStreamingBlob(recording, event.data)
-        : uploadBlobInSlices(recording, event.data)
-    ).catch((err) => {
-      recording.uploadFailure =
-        err instanceof Error ? err : new Error(String(err));
-      captureExtensionError(recording.uploadFailure, {
-        tags: {
-          surface: "offscreen",
-          recordingStep: "dataavailable-upload",
-        },
-        extra: {
-          recordingId: recording.recordingId,
-          blobBytes: event.data.size,
-          chunkIndex: recording.chunkIndex,
-          mimeType: event.data.type || recording.mimeType,
-        },
+    const upload = recording.uploadChain
+      .then(() =>
+        recording.cancelled || recording.uploadFailure
+          ? undefined
+          : recording.uploadMode === "streaming"
+            ? uploadStreamingBlob(recording, event.data)
+            : uploadBlobInSlices(recording, event.data),
+      )
+      .catch((err) => {
+        recording.uploadFailure =
+          err instanceof Error ? err : new Error(String(err));
+        captureExtensionError(recording.uploadFailure, {
+          tags: {
+            surface: "offscreen",
+            recordingStep: "dataavailable-upload",
+          },
+          extra: {
+            recordingId: recording.recordingId,
+            blobBytes: event.data.size,
+            chunkIndex: recording.chunkIndex,
+            mimeType: event.data.type || recording.mimeType,
+          },
+        });
+        reportStatus(recording.sessionId, "error", {
+          error: recording.uploadFailure.message,
+        });
+        if (recorder.state !== "inactive") recorder.stop();
       });
-      reportStatus(recording.sessionId, "error", {
-        error: recording.uploadFailure.message,
-      });
-      if (recorder.state !== "inactive") recorder.stop();
-    });
+    recording.uploadChain = upload.then(() => undefined);
     recording.uploadPromises.push(upload);
   });
 


### PR DESCRIPTION
## Summary
- reconcile agent run rows from persisted terminal events so durable background runs do not later surface as stale errors
- extend claimed background stale protection to the 15-minute background-function budget while keeping unclaimed handoffs fast-failing
- show a running tool card during tail reconnect activity and serialize Clips extension chunk uploads

## Validation
- corepack pnpm prep
- corepack pnpm --filter @agent-native/core build
- corepack pnpm typecheck