### PR TITLE
Send replay gzip uploads as binary

### DIFF
--- a/.changeset/quiet-replay-gzip-bytes.md
+++ b/.changeset/quiet-replay-gzip-bytes.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Send compressed session replay uploads as binary payloads so Netlify preserves gzip bytes.

--- a/packages/core/src/client/session-replay.spec.ts
+++ b/packages/core/src/client/session-replay.spec.ts
@@ -465,7 +465,9 @@ describe("session replay", () => {
 
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("/api/analytics/replay");
-    expect(headerValue(init.headers, "content-type")).toBe("application/json");
+    expect(headerValue(init.headers, "content-type")).toBe(
+      "application/octet-stream",
+    );
     expect(headerValue(init.headers, "content-encoding")).toBe("gzip");
     expect(headerValue(init.headers, "x-agent-native-analytics-key")).toBe(
       "anpk_test",

--- a/packages/core/src/client/session-replay.ts
+++ b/packages/core/src/client/session-replay.ts
@@ -761,7 +761,7 @@ async function gzipReplayBody(body: string): Promise<Blob | null> {
       .stream()
       .pipeThrough(new CompressionStream("gzip"));
     const compressed = await new Response(stream).arrayBuffer();
-    return new Blob([compressed], { type: "application/json" });
+    return new Blob([compressed], { type: "application/octet-stream" });
   } catch {
     return null;
   }
@@ -774,7 +774,7 @@ async function buildReplayUploadBody(body: string): Promise<ReplayUploadBody> {
       body: compressed,
       compressed: true,
       headers: {
-        "Content-Type": "application/json",
+        "Content-Type": "application/octet-stream",
         "Content-Encoding": "gzip",
       },
     };


### PR DESCRIPTION
## Summary
- send compressed session replay uploads with application/octet-stream so Netlify preserves gzip bytes
- keep uncompressed replay uploads as text/plain
- add a core changeset for the client upload fix

## Testing
- corepack pnpm --filter @agent-native/core exec vitest run src/client/session-replay.spec.ts
- corepack pnpm --filter @agent-native/core typecheck
- git diff --check