### PR TITLE
Add Builder source component mapping foundation

### DIFF
--- a/templates/content/AGENTS.md
+++ b/templates/content/AGENTS.md
@@ -223,6 +223,9 @@ Content has two file workflows:
   mapping metadata, or marker ids unless a dedicated provider conversion
   workflow exists. Guarded Builder write-back refuses missing, tampered, or
   structurally moved markers so source-native components are not lost.
+  Readable bodies hydrated before source-component mapping may need a fresh
+  Builder body hydration pass before guarded push, because newly preserved
+  markers are intentionally treated as structure changes.
 - **Picked folders and components:** browser-picked folders can be the
   source of truth for `.md`/`.mdx` files, but the browser does not expose an
   absolute path that Vite can compile. Component previews from a picked

--- a/templates/content/AGENTS.md
+++ b/templates/content/AGENTS.md
@@ -213,12 +213,16 @@ Content has two file workflows:
   retargeting workflow is added.
 - **Builder source components:** Builder CMS database body hydration renders
   unsupported provider-native body blocks as `<SourceComponent ... />` markers.
-  Treat these as read-only preservation anchors, not editable local blocks.
-  Agents may edit surrounding prose, but must not delete, duplicate, move, or
-  rewrite `rawRef`, `rawHash`, or marker ids unless a dedicated provider
-  conversion workflow exists. Guarded Builder write-back refuses missing,
-  tampered, or structurally moved markers so source-native components are not
-  lost.
+  These markers include `mappingStatus` and `sourceEditState`: `mapped` /
+  `safe-to-edit` content has an explicit Markdown/NFM mapper, `preserved` /
+  `needs-review` content keeps a known Builder/source component intact for
+  review, and `unknown` / `preserved-only` content is an unmapped provider block
+  that must round-trip as-is. Treat source-component markers as read-only
+  preservation anchors, not editable local blocks. Agents may edit surrounding
+  prose, but must not delete, duplicate, move, or rewrite `rawRef`, `rawHash`,
+  mapping metadata, or marker ids unless a dedicated provider conversion
+  workflow exists. Guarded Builder write-back refuses missing, tampered, or
+  structurally moved markers so source-native components are not lost.
 - **Picked folders and components:** browser-picked folders can be the
   source of truth for `.md`/`.mdx` files, but the browser does not expose an
   absolute path that Vite can compile. Component previews from a picked

--- a/templates/content/app/blocks/SourceComponentBlock.tsx
+++ b/templates/content/app/blocks/SourceComponentBlock.tsx
@@ -5,6 +5,7 @@ import {
   type SourceComponentData,
 } from "@shared/source-component-block";
 import {
+  IconAlertTriangle,
   IconBox,
   IconDatabase,
   IconExternalLink,
@@ -16,6 +17,19 @@ import {
 function providerLabel(provider: string) {
   if (provider === "builder") return "Builder";
   return provider.trim() || "Source";
+}
+
+function sourceEditStateLabel(
+  state: SourceComponentData["sourceEditState"] | undefined,
+  t: ReturnType<typeof useT>,
+) {
+  if (state === "needs-review") {
+    return t("editor.sourceComponent.needsAttention");
+  }
+  if (state === "safe-to-edit") {
+    return t("editor.sourceComponent.previewAvailable");
+  }
+  return t("editor.properties.readOnly");
 }
 
 function safeHttpUrl(value: string | undefined) {
@@ -226,6 +240,9 @@ export function SourceComponentRead({
       : status === "warning"
         ? t("editor.sourceComponent.needsAttention")
         : t("editor.sourceComponent.previewUnavailable");
+  const sourceStateLabel = sourceEditStateLabel(data.sourceEditState, t);
+  const needsReview =
+    data.sourceEditState === "needs-review" || data.mappingStatus === "unknown";
 
   return (
     <section
@@ -252,13 +269,24 @@ export function SourceComponentRead({
             </div>
           </div>
         </div>
-        <span className="shrink-0 rounded-full border bg-background px-2 py-0.5 text-[11px] text-muted-foreground">
-          {statusLabel}
-        </span>
+        <div className="flex shrink-0 flex-col items-end gap-1">
+          <span className="rounded-full border bg-background px-2 py-0.5 text-[11px] text-muted-foreground">
+            {sourceStateLabel}
+          </span>
+          <span className="inline-flex items-center gap-1 rounded-full border bg-background px-2 py-0.5 text-[11px] text-muted-foreground">
+            {needsReview ? <IconAlertTriangle className="size-3" /> : null}
+            {statusLabel}
+          </span>
+        </div>
       </div>
       {data.summary ? (
         <div className="mt-2 text-sm leading-6 text-muted-foreground">
           {data.summary}
+        </div>
+      ) : null}
+      {data.mappingReason ? (
+        <div className="mt-2 text-xs leading-5 text-muted-foreground">
+          {data.mappingReason}
         </div>
       ) : null}
       <SourceComponentPreview data={data} />

--- a/templates/content/changelog/2026-07-01-builder-source-components-show-preservation-and-review-states.md
+++ b/templates/content/changelog/2026-07-01-builder-source-components-show-preservation-and-review-states.md
@@ -3,4 +3,4 @@ type: improved
 date: 2026-07-01
 ---
 
-Builder source components now show clearer preservation and review states during readable body sync.
+Builder source components now show clearer preservation and review states during readable body sync; previously hydrated Builder bodies may need refresh before guarded push.

--- a/templates/content/changelog/2026-07-01-builder-source-components-show-preservation-and-review-states.md
+++ b/templates/content/changelog/2026-07-01-builder-source-components-show-preservation-and-review-states.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-01
+---
+
+Builder source components now show clearer preservation and review states during readable body sync.

--- a/templates/content/shared/builder-mdx.test.ts
+++ b/templates/content/shared/builder-mdx.test.ts
@@ -174,6 +174,17 @@ describe("Builder MDX conversion", () => {
     expect(builderSourceComponentMappingFor("PricingTable")).toMatchObject({
       id: "builder-table-preserved",
     });
+    expect(builderSourceComponentMappingFor("Portable Text")).toMatchObject({
+      id: "builder-unknown-preserved",
+    });
+    expect(builderSourceComponentMappingFor("Timetable Widget")).toMatchObject({
+      id: "builder-unknown-preserved",
+    });
+    expect(builderSourceComponentMappingFor("Preferences Panel")).toMatchObject(
+      {
+        id: "builder-unknown-preserved",
+      },
+    );
     expect(
       builderSourceComponentMappingFor("Internal Reference"),
     ).toMatchObject({
@@ -1173,6 +1184,44 @@ describe("Builder MDX conversion", () => {
 
     expect(result.warnings).toEqual([]);
     expect(result.blocks).toEqual(lossless.blocks);
+  });
+
+  it("does not label mapped-name variants as safe-to-edit markers", async () => {
+    const article: BuilderContentEntry = {
+      id: "article-mapped-name-variant",
+      model: "blog-article",
+      name: "Article Mapped Name Variant",
+      data: {
+        title: "Article Mapped Name Variant",
+        blocks: [
+          {
+            "@type": "@builder.io/sdk:Element",
+            "@version": 2,
+            id: "lowercase-text-1",
+            component: {
+              name: "text",
+              options: { text: "<p>Lowercase mapped name.</p>" },
+            },
+          },
+        ],
+      },
+    };
+
+    const readable = await builderEntryToReadableMdxBundle(article);
+    const marker = readable.mdx.body
+      .split("\n\n")
+      .find((unit) => unit.includes("<SourceComponent"));
+    expect(marker).toBeDefined();
+    const parsedMarker = await parseRegistryBlockData(marker!);
+    expect(parsedMarker?.data).toMatchObject({
+      provider: "builder",
+      componentName: "text",
+      mappingId: "builder-unknown-preserved",
+      mappingStatus: "unknown",
+      sourceEditState: "preserved-only",
+      previewStatus: "warning",
+      title: "Builder text",
+    });
   });
 
   it("renders Builder Material Table components as structured source table previews", async () => {

--- a/templates/content/shared/builder-mdx.test.ts
+++ b/templates/content/shared/builder-mdx.test.ts
@@ -8,6 +8,7 @@ import {
   builderMdxToBuilderBlocks,
   type BuilderContentEntry,
 } from "./builder-mdx";
+import { builderSourceComponentMappingFor } from "./builder-source-component-registry";
 import { parseRegistryBlockData } from "./nfm-registry";
 
 const entry: BuilderContentEntry = {
@@ -154,6 +155,88 @@ function testBlocks(entry: BuilderContentEntry): unknown[] {
 }
 
 describe("Builder MDX conversion", () => {
+  it("classifies Builder source components through an explicit mapping registry", () => {
+    expect(builderSourceComponentMappingFor("Text")).toMatchObject({
+      id: "builder-text-markdown",
+      readableMode: "editable-markdown",
+      mappingStatus: "mapped",
+      sourceEditState: "safe-to-edit",
+    });
+    expect(builderSourceComponentMappingFor("Material Table")).toMatchObject({
+      id: "builder-table-preserved",
+      readableMode: "source-component",
+      mappingStatus: "preserved",
+      sourceEditState: "needs-review",
+    });
+    expect(builderSourceComponentMappingFor(" material_table ")).toMatchObject({
+      id: "builder-table-preserved",
+    });
+    expect(builderSourceComponentMappingFor("PricingTable")).toMatchObject({
+      id: "builder-table-preserved",
+    });
+    expect(
+      builderSourceComponentMappingFor("Internal Reference"),
+    ).toMatchObject({
+      id: "builder-reference-preserved",
+      readableMode: "source-component",
+      mappingStatus: "preserved",
+      sourceEditState: "needs-review",
+    });
+    expect(
+      builderSourceComponentMappingFor("CustomerOnlyWidget"),
+    ).toMatchObject({
+      id: "builder-unknown-preserved",
+      readableMode: "source-component",
+      mappingStatus: "unknown",
+      sourceEditState: "preserved-only",
+    });
+    expect(builderSourceComponentMappingFor(null)).toMatchObject({
+      id: "builder-nameless-preserved",
+      mappingStatus: "unknown",
+      sourceEditState: "preserved-only",
+    });
+  });
+
+  it("parses legacy and malformed source-component mapping attrs safely", async () => {
+    const legacy = await parseRegistryBlockData(
+      '<SourceComponent id="legacy-source-component" provider="builder" componentName="LegacyWidget" rawRef="content/builder/.raw/legacy.json" rawHash="legacy-hash" />',
+    );
+    expect(legacy?.data).toMatchObject({
+      provider: "builder",
+      componentName: "LegacyWidget",
+      rawRef: "content/builder/.raw/legacy.json",
+      rawHash: "legacy-hash",
+    });
+    expect(
+      (legacy?.data as { mappingStatus?: unknown }).mappingStatus,
+    ).toBeUndefined();
+    expect(
+      (legacy?.data as { sourceEditState?: unknown }).sourceEditState,
+    ).toBeUndefined();
+
+    const malformed = await parseRegistryBlockData(
+      '<SourceComponent id="bad-source-component" provider="builder" componentName="BadWidget" rawRef="content/builder/.raw/bad.json" rawHash="bad-hash" mappingStatus="delete-me" sourceEditState="editable-maybe" previewStatus="fine" previewKind="thing" />',
+    );
+    expect(malformed?.data).toMatchObject({
+      provider: "builder",
+      componentName: "BadWidget",
+      rawRef: "content/builder/.raw/bad.json",
+      rawHash: "bad-hash",
+    });
+    expect(
+      (malformed?.data as { mappingStatus?: unknown }).mappingStatus,
+    ).toBeUndefined();
+    expect(
+      (malformed?.data as { sourceEditState?: unknown }).sourceEditState,
+    ).toBeUndefined();
+    expect(
+      (malformed?.data as { previewStatus?: unknown }).previewStatus,
+    ).toBeUndefined();
+    expect(
+      (malformed?.data as { previewKind?: unknown }).previewKind,
+    ).toBeUndefined();
+  });
+
   it("pulls Builder blocks into .builder.mdx with raw sidecars", async () => {
     const bundle = await builderEntryToMdxBundle(entry);
 
@@ -468,6 +551,80 @@ describe("Builder MDX conversion", () => {
     expect(bundle.mdx.body).not.toContain("<BuilderRawBlock");
   });
 
+  it("preserves known Builder reference blocks instead of flattening nested children", async () => {
+    const article: BuilderContentEntry = {
+      id: "article-reference-block",
+      model: "blog-article",
+      name: "Article Reference Block",
+      data: {
+        title: "Article Reference Block",
+        blocks: [
+          {
+            "@type": "@builder.io/sdk:Element",
+            "@version": 2,
+            id: "reference-1",
+            component: {
+              name: "Reference Block",
+              options: {
+                entry: "shared-doc",
+                model: "docs-content",
+              },
+            },
+            children: [
+              {
+                "@type": "@builder.io/sdk:Element",
+                "@version": 2,
+                id: "reference-child-text",
+                component: {
+                  name: "Text",
+                  options: {
+                    text: "<p>This child text belongs to the source reference.</p>",
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const [readable, lossless] = await Promise.all([
+      builderEntryToReadableMdxBundle(article),
+      builderEntryToMdxBundle(article),
+    ]);
+
+    expect(readable.mdx.body).toContain("<SourceComponent");
+    expect(readable.mdx.body).toContain('componentName="Reference Block"');
+    expect(readable.mdx.body).not.toContain(
+      "This child text belongs to the source reference.",
+    );
+    const marker = readable.mdx.body
+      .split("\n\n")
+      .find((unit) => unit.includes("<SourceComponent"));
+    expect(marker).toBeDefined();
+    const parsedMarker = await parseRegistryBlockData(marker!);
+    expect(parsedMarker?.data).toMatchObject({
+      provider: "builder",
+      componentName: "Reference Block",
+      mappingId: "builder-reference-preserved",
+      mappingStatus: "preserved",
+      sourceEditState: "needs-review",
+    });
+    const sidecars = Object.fromEntries(
+      Object.entries(lossless.files).filter(
+        ([path]) => path !== lossless.mdx.path,
+      ),
+    );
+
+    const result = await builderReadableBodyToBuilderBlocks({
+      localContent: readable.mdx.body,
+      losslessContent: lossless.mdx.body,
+      sidecars,
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.blocks).toEqual(lossless.blocks);
+  });
+
   it("hydrates database bodies as clean readable markdown", async () => {
     const bundle = await builderEntryToReadableMdxBundle(entry);
 
@@ -475,6 +632,18 @@ describe("Builder MDX conversion", () => {
     expect(bundle.mdx.body).toContain("Welcome to docs.");
     expect(bundle.mdx.body).toContain("<SourceComponent");
     expect(bundle.mdx.body).toContain('componentName="Symbol"');
+    const marker = bundle.mdx.body
+      .split("\n\n")
+      .find((unit) => unit.includes('componentName="Symbol"'));
+    expect(marker).toBeDefined();
+    const parsedMarker = await parseRegistryBlockData(marker!);
+    expect(parsedMarker?.data).toMatchObject({
+      componentName: "Symbol",
+      mappingId: "builder-symbol-preserved",
+      mappingStatus: "preserved",
+      sourceEditState: "needs-review",
+      previewKind: "symbol",
+    });
     expect(bundle.mdx.body).not.toContain("<BuilderText");
     expect(bundle.mdx.body).not.toContain("<BuilderRawBlock");
   });
@@ -632,6 +801,9 @@ describe("Builder MDX conversion", () => {
     expect(parsedMarker?.data).toMatchObject({
       provider: "builder",
       componentName: "Embed",
+      mappingId: "builder-embed-preserved",
+      mappingStatus: "preserved",
+      sourceEditState: "needs-review",
       previewStatus: "available",
       previewKind: "embed",
       previewUrl: "https://example.com/embed",
@@ -976,9 +1148,13 @@ describe("Builder MDX conversion", () => {
     expect(parsedMarker?.data).toMatchObject({
       provider: "builder",
       componentName: "CustomerOnlyWidget",
+      mappingId: "builder-unknown-preserved",
+      mappingStatus: "unknown",
+      sourceEditState: "preserved-only",
+      previewStatus: "warning",
       previewKind: "component",
       preview: {
-        status: "available",
+        status: "warning",
         kind: "component",
         label: "Builder CustomerOnlyWidget",
       },
@@ -1075,6 +1251,9 @@ describe("Builder MDX conversion", () => {
     expect(parsedTable?.data).toMatchObject({
       provider: "builder",
       componentName: "Material Table",
+      mappingId: "builder-table-preserved",
+      mappingStatus: "preserved",
+      sourceEditState: "needs-review",
       previewKind: "table",
       previewItems: ["1 row", "2 columns"],
       preview: {
@@ -1099,6 +1278,9 @@ describe("Builder MDX conversion", () => {
     const parsedNameless = await parseRegistryBlockData(markers[1]!);
     expect(parsedNameless?.data).toMatchObject({
       componentName: "Builder component",
+      mappingId: "builder-nameless-preserved",
+      mappingStatus: "unknown",
+      sourceEditState: "preserved-only",
       previewStatus: "unavailable",
     });
     const sidecars = Object.fromEntries(

--- a/templates/content/shared/builder-mdx.ts
+++ b/templates/content/shared/builder-mdx.ts
@@ -10,6 +10,7 @@ import type {
 import {
   builderSourceComponentMappingFor,
   type BuilderSourceComponentMapping,
+  unknownBuilderSourceComponentMappingFor,
 } from "./builder-source-component-registry";
 import {
   parseRegistryBlockData,
@@ -841,7 +842,7 @@ function builderSourceComponentPreview(
       summary,
     };
   }
-  if (name === "Table" || name?.toLowerCase().includes("table")) {
+  if (mapping.id === "builder-table-preserved") {
     const shape = tableShapeFromOptions(options);
     const items = shape
       ? [pluralize(shape.rows, "row"), pluralize(shape.columns, "column")]
@@ -1176,9 +1177,14 @@ async function builderBlockToReadableMdx(
     if (childBody) return childBody;
   }
 
+  const markerMapping =
+    mapping.readableMode === "editable-markdown"
+      ? unknownBuilderSourceComponentMappingFor(name)
+      : mapping;
+
   if (name) {
     ctx.warnings.push(
-      `${mapping.label} is preserved in the Builder raw sidecar and shown as a read-only source component.`,
+      `${markerMapping.label} is preserved in the Builder raw sidecar and shown as a read-only source component.`,
     );
   }
   const data: SourceComponentData = {
@@ -1187,20 +1193,20 @@ async function builderBlockToReadableMdx(
     rawRef,
     rawHash: stableHash(block),
     sourceLabel: "Builder body",
-    mappingId: mapping.id,
-    mappingStatus: mapping.mappingStatus,
-    mappingReason: mapping.reason,
-    sourceEditState: mapping.sourceEditState,
+    mappingId: markerMapping.id,
+    mappingStatus: markerMapping.mappingStatus,
+    mappingReason: markerMapping.reason,
+    sourceEditState: markerMapping.sourceEditState,
     previewStatus:
-      mapping.mappingStatus === "unknown"
+      markerMapping.mappingStatus === "unknown"
         ? name
           ? "warning"
           : "unavailable"
         : name
           ? "available"
           : "unavailable",
-    title: mapping.label,
-    ...builderSourceComponentPreview(block, mapping),
+    title: markerMapping.label,
+    ...builderSourceComponentPreview(block, markerMapping),
   };
   const id = sourceComponentMarkerIdForBlock(block);
   return serializeRegistryBlockToMdx("source-component", { id, data });

--- a/templates/content/shared/builder-mdx.ts
+++ b/templates/content/shared/builder-mdx.ts
@@ -8,6 +8,10 @@ import type {
   BuilderTextData,
 } from "./builder-docs-blocks";
 import {
+  builderSourceComponentMappingFor,
+  type BuilderSourceComponentMapping,
+} from "./builder-source-component-registry";
+import {
   parseRegistryBlockData,
   serializeRegistryBlockToMdx,
 } from "./nfm-registry";
@@ -386,6 +390,12 @@ function childBlocks(block: unknown): unknown[] {
   return Array.isArray(block.children) ? block.children : [];
 }
 
+function shouldReadThroughBuilderChildren(componentName: string | null) {
+  return (
+    builderSourceComponentMappingFor(componentName).mappingStatus === "unknown"
+  );
+}
+
 function isReadableUnsupportedBuilderPlaceholder(value: string) {
   const trimmed = value.trim();
   return (
@@ -504,7 +514,7 @@ async function expectedReadableLayoutFingerprint(blocks: unknown[]) {
       continue;
     }
     const children = childBlocks(block);
-    if (children.length && children.some(builderBlockHasReadableOutput)) {
+    if (shouldReadThroughBuilderChildren(name) && children.length) {
       fingerprint.push(...(await expectedReadableLayoutFingerprint(children)));
       continue;
     }
@@ -786,6 +796,7 @@ function pluralize(count: number, singular: string) {
 
 function builderSourceComponentPreview(
   block: unknown,
+  mapping: BuilderSourceComponentMapping,
 ): Pick<
   SourceComponentData,
   "previewKind" | "previewUrl" | "previewItems" | "preview" | "summary"
@@ -883,12 +894,14 @@ function builderSourceComponentPreview(
     };
   }
   const summary = blockSummary(block);
+  const previewStatus =
+    mapping.mappingStatus === "unknown" ? "warning" : "available";
   return {
     previewKind: "component",
     preview: {
-      status: name ? "available" : "unavailable",
+      status: name ? previewStatus : "unavailable",
       kind: "component",
-      label: name ? `Builder ${name}` : "Builder component",
+      label: mapping.label,
       summary,
     },
     summary,
@@ -1075,6 +1088,23 @@ async function builderBlockToMdx(
     });
   }
 
+  const mapping = builderSourceComponentMappingFor(name);
+  if (mapping.mappingStatus === "preserved") {
+    const data: BuilderRawBlockData = {
+      ...raw,
+      summary: blockSummary(block),
+    };
+    if (childBlocks(block).length) {
+      ctx.warnings.push(
+        `${mapping.label} has child blocks that are preserved only in the raw sidecar.`,
+      );
+    }
+    return serializeRegistryBlockToMdx("builder-raw-block", {
+      id,
+      data,
+    });
+  }
+
   const children = childBlocks(block);
   if (children.length) {
     const childBody = await builderBlocksToMdxBody(children, ctx);
@@ -1104,6 +1134,7 @@ async function builderBlockToReadableMdx(
 ) {
   const name = componentName(block);
   const options = componentOptions(block);
+  const mapping = builderSourceComponentMappingFor(name);
 
   if (name === "Text") {
     return htmlToMarkdown(String(options.text ?? "")).trim();
@@ -1140,14 +1171,14 @@ async function builderBlockToReadableMdx(
   }
 
   const children = childBlocks(block);
-  if (children.length) {
+  if (shouldReadThroughBuilderChildren(name) && children.length) {
     const childBody = await builderBlocksToReadableMdxBody(children, ctx);
     if (childBody) return childBody;
   }
 
   if (name) {
     ctx.warnings.push(
-      `${name} is preserved in the Builder raw sidecar and shown as a read-only source component.`,
+      `${mapping.label} is preserved in the Builder raw sidecar and shown as a read-only source component.`,
     );
   }
   const data: SourceComponentData = {
@@ -1156,9 +1187,20 @@ async function builderBlockToReadableMdx(
     rawRef,
     rawHash: stableHash(block),
     sourceLabel: "Builder body",
-    previewStatus: name ? "available" : "unavailable",
-    title: name ? `Builder ${name}` : "Builder component",
-    ...builderSourceComponentPreview(block),
+    mappingId: mapping.id,
+    mappingStatus: mapping.mappingStatus,
+    mappingReason: mapping.reason,
+    sourceEditState: mapping.sourceEditState,
+    previewStatus:
+      mapping.mappingStatus === "unknown"
+        ? name
+          ? "warning"
+          : "unavailable"
+        : name
+          ? "available"
+          : "unavailable",
+    title: mapping.label,
+    ...builderSourceComponentPreview(block, mapping),
   };
   const id = sourceComponentMarkerIdForBlock(block);
   return serializeRegistryBlockToMdx("source-component", { id, data });
@@ -1262,7 +1304,9 @@ function collectReadableEditableSegments(
       }
       continue;
     }
-    collectReadableEditableSegments(childBlocks(block), segments);
+    if (shouldReadThroughBuilderChildren(name)) {
+      collectReadableEditableSegments(childBlocks(block), segments);
+    }
   }
   return segments;
 }
@@ -1289,7 +1333,9 @@ function builderBlockHasReadableOutput(block: unknown): boolean {
     });
   }
   const children = childBlocks(block);
-  return children.length ? children.some(builderBlockHasReadableOutput) : true;
+  return shouldReadThroughBuilderChildren(name) && children.length
+    ? children.some(builderBlockHasReadableOutput)
+    : true;
 }
 
 function countExpectedReadableSourceComponentMarkers(
@@ -1318,7 +1364,11 @@ function countExpectedReadableSourceComponentMarkers(
       continue;
     }
     const children = childBlocks(block);
-    if (children.length && children.some(builderBlockHasReadableOutput)) {
+    if (
+      shouldReadThroughBuilderChildren(name) &&
+      children.length &&
+      children.some(builderBlockHasReadableOutput)
+    ) {
       count += countExpectedReadableSourceComponentMarkers(children);
       continue;
     }

--- a/templates/content/shared/builder-source-component-registry.ts
+++ b/templates/content/shared/builder-source-component-registry.ts
@@ -24,6 +24,15 @@ function normalizeComponentName(value: string | null | undefined) {
     .replace(/[\s:_-]+/g, "");
 }
 
+function componentNameTokens(value: string | null | undefined) {
+  return (value ?? "")
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .split(/[\s:_-]+/g)
+    .filter(Boolean);
+}
+
 export const builderSourceComponentMappings: BuilderSourceComponentMapping[] = [
   {
     id: "builder-text-markdown",
@@ -131,20 +140,9 @@ const mappingsByName = new Map(
   ),
 );
 
-export function builderSourceComponentMappingFor(
+export function unknownBuilderSourceComponentMappingFor(
   componentName: string | null | undefined,
 ): BuilderSourceComponentMapping {
-  const normalized = normalizeComponentName(componentName);
-  const direct = mappingsByName.get(normalized);
-  if (direct) return direct;
-  const tableMapping = mappingsByName.get("materialtable");
-  if (normalized.includes("table") && tableMapping) {
-    return tableMapping;
-  }
-  const referenceMapping = mappingsByName.get("reference");
-  if (normalized.includes("reference") && referenceMapping) {
-    return referenceMapping;
-  }
   return {
     id: componentName
       ? "builder-unknown-preserved"
@@ -158,4 +156,22 @@ export function builderSourceComponentMappingFor(
       ? "No source-component mapper is registered for this Builder component yet, so Content preserves the raw block for review."
       : "Builder returned a block without a component name, so Content preserves the raw block for review.",
   };
+}
+
+export function builderSourceComponentMappingFor(
+  componentName: string | null | undefined,
+): BuilderSourceComponentMapping {
+  const normalized = normalizeComponentName(componentName);
+  const direct = mappingsByName.get(normalized);
+  if (direct) return direct;
+  const tokens = componentNameTokens(componentName);
+  const tableMapping = mappingsByName.get("materialtable");
+  if (tokens.includes("table") && tableMapping) {
+    return tableMapping;
+  }
+  const referenceMapping = mappingsByName.get("reference");
+  if (tokens.includes("reference") && referenceMapping) {
+    return referenceMapping;
+  }
+  return unknownBuilderSourceComponentMappingFor(componentName);
 }

--- a/templates/content/shared/builder-source-component-registry.ts
+++ b/templates/content/shared/builder-source-component-registry.ts
@@ -1,0 +1,161 @@
+import type {
+  SourceComponentEditState,
+  SourceComponentMappingStatus,
+} from "./source-component-block";
+
+export type BuilderSourceComponentReadableMode =
+  | "editable-markdown"
+  | "source-component";
+
+export interface BuilderSourceComponentMapping {
+  id: string;
+  componentNames: string[];
+  readableMode: BuilderSourceComponentReadableMode;
+  mappingStatus: SourceComponentMappingStatus;
+  sourceEditState: SourceComponentEditState;
+  label: string;
+  reason: string;
+}
+
+function normalizeComponentName(value: string | null | undefined) {
+  return (value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s:_-]+/g, "");
+}
+
+export const builderSourceComponentMappings: BuilderSourceComponentMapping[] = [
+  {
+    id: "builder-text-markdown",
+    componentNames: ["Text"],
+    readableMode: "editable-markdown",
+    mappingStatus: "mapped",
+    sourceEditState: "safe-to-edit",
+    label: "Builder Text",
+    reason:
+      "Text maps to editable Markdown while Builder metadata stays in the raw sidecar.",
+  },
+  {
+    id: "builder-code-markdown",
+    componentNames: ["Code Block", "Blog Code Block"],
+    readableMode: "editable-markdown",
+    mappingStatus: "mapped",
+    sourceEditState: "safe-to-edit",
+    label: "Builder Code Block",
+    reason:
+      "Code maps to editable fenced Markdown while Builder metadata stays in the raw sidecar.",
+  },
+  {
+    id: "builder-image-markdown",
+    componentNames: ["Image"],
+    readableMode: "editable-markdown",
+    mappingStatus: "mapped",
+    sourceEditState: "safe-to-edit",
+    label: "Builder Image",
+    reason:
+      "Images map to editable Markdown image syntax while Builder metadata stays in the raw sidecar.",
+  },
+  {
+    id: "builder-tabbed-content-markdown",
+    componentNames: ["Tabbed Content"],
+    readableMode: "editable-markdown",
+    mappingStatus: "mapped",
+    sourceEditState: "safe-to-edit",
+    label: "Builder Tabbed Content",
+    reason:
+      "Tabs map to editable heading-delimited Markdown while tab metadata stays in the raw sidecar.",
+  },
+  {
+    id: "builder-symbol-preserved",
+    componentNames: ["Symbol"],
+    readableMode: "source-component",
+    mappingStatus: "preserved",
+    sourceEditState: "needs-review",
+    label: "Builder Symbol",
+    reason:
+      "Symbols stay linked to their Builder entry and need a dedicated review path before retargeting.",
+  },
+  {
+    id: "builder-table-preserved",
+    componentNames: ["Table", "Material Table"],
+    readableMode: "source-component",
+    mappingStatus: "preserved",
+    sourceEditState: "needs-review",
+    label: "Builder Table",
+    reason:
+      "Builder table-like components preserve their raw source and expose a preview until an editable table mapper is configured.",
+  },
+  {
+    id: "builder-reference-preserved",
+    componentNames: [
+      "Reference",
+      "Reference Block",
+      "Content Reference",
+      "Builder Reference",
+    ],
+    readableMode: "source-component",
+    mappingStatus: "preserved",
+    sourceEditState: "needs-review",
+    label: "Builder Reference",
+    reason:
+      "Reference blocks preserve their provider identity so they can round-trip without detaching the source relation.",
+  },
+  {
+    id: "builder-embed-preserved",
+    componentNames: ["Embed"],
+    readableMode: "source-component",
+    mappingStatus: "preserved",
+    sourceEditState: "needs-review",
+    label: "Builder Embed",
+    reason:
+      "Embeds preserve provider-native configuration and expose a preview instead of editable markup.",
+  },
+  {
+    id: "builder-code-snippets-preserved",
+    componentNames: ["CodeSnippetsV2"],
+    readableMode: "source-component",
+    mappingStatus: "preserved",
+    sourceEditState: "needs-review",
+    label: "Builder CodeSnippetsV2",
+    reason:
+      "CodeSnippetsV2 has structured Builder props and needs a dedicated mapper before safe readable editing.",
+  },
+];
+
+const mappingsByName = new Map(
+  builderSourceComponentMappings.flatMap((mapping) =>
+    mapping.componentNames.map(
+      (componentName) =>
+        [normalizeComponentName(componentName), mapping] as const,
+    ),
+  ),
+);
+
+export function builderSourceComponentMappingFor(
+  componentName: string | null | undefined,
+): BuilderSourceComponentMapping {
+  const normalized = normalizeComponentName(componentName);
+  const direct = mappingsByName.get(normalized);
+  if (direct) return direct;
+  const tableMapping = mappingsByName.get("materialtable");
+  if (normalized.includes("table") && tableMapping) {
+    return tableMapping;
+  }
+  const referenceMapping = mappingsByName.get("reference");
+  if (normalized.includes("reference") && referenceMapping) {
+    return referenceMapping;
+  }
+  return {
+    id: componentName
+      ? "builder-unknown-preserved"
+      : "builder-nameless-preserved",
+    componentNames: componentName ? [componentName] : [],
+    readableMode: "source-component",
+    mappingStatus: "unknown",
+    sourceEditState: "preserved-only",
+    label: componentName ? `Builder ${componentName}` : "Builder component",
+    reason: componentName
+      ? "No source-component mapper is registered for this Builder component yet, so Content preserves the raw block for review."
+      : "Builder returned a block without a component name, so Content preserves the raw block for review.",
+  };
+}

--- a/templates/content/shared/source-component-block.ts
+++ b/templates/content/shared/source-component-block.ts
@@ -5,12 +5,56 @@ import {
 } from "@agent-native/core/blocks/server";
 import { z } from "zod";
 
+export type SourceComponentEditState =
+  | "safe-to-edit"
+  | "needs-review"
+  | "preserved-only";
+
+export type SourceComponentMappingStatus = "mapped" | "preserved" | "unknown";
+
+const sourceComponentMappingStatuses = [
+  "mapped",
+  "preserved",
+  "unknown",
+] as const satisfies readonly SourceComponentMappingStatus[];
+
+const sourceComponentEditStates = [
+  "safe-to-edit",
+  "needs-review",
+  "preserved-only",
+] as const satisfies readonly SourceComponentEditState[];
+
+const sourceComponentPreviewStatuses = [
+  "available",
+  "unavailable",
+  "warning",
+] as const satisfies readonly SourceComponentData["previewStatus"][];
+
+const sourceComponentPreviewKinds = [
+  "summary",
+  "table",
+  "embed",
+  "symbol",
+  "component",
+] as const satisfies readonly SourceComponentData["previewKind"][];
+
+function enumAttr<T extends string>(
+  value: string | undefined,
+  allowed: readonly T[],
+): T | undefined {
+  return allowed.includes(value as T) ? (value as T) : undefined;
+}
+
 export interface SourceComponentData {
   provider: string;
   componentName: string;
   rawRef: string;
   rawHash: string;
   sourceLabel?: string;
+  mappingId?: string;
+  mappingStatus?: SourceComponentMappingStatus;
+  mappingReason?: string;
+  sourceEditState?: SourceComponentEditState;
   previewStatus?: "available" | "unavailable" | "warning";
   previewKind?: "summary" | "table" | "embed" | "symbol" | "component";
   previewUrl?: string;
@@ -78,6 +122,12 @@ export const sourceComponentSchema = z.object({
   rawRef: z.string().trim().min(1),
   rawHash: z.string().trim().min(1),
   sourceLabel: z.string().trim().max(200).optional(),
+  mappingId: z.string().trim().max(120).optional(),
+  mappingStatus: z.enum(["mapped", "preserved", "unknown"]).optional(),
+  mappingReason: z.string().trim().max(1_000).optional(),
+  sourceEditState: z
+    .enum(["safe-to-edit", "needs-review", "preserved-only"])
+    .optional(),
   previewStatus: z.enum(["available", "unavailable", "warning"]).optional(),
   previewKind: z
     .enum(["summary", "table", "embed", "symbol", "component"])
@@ -97,6 +147,10 @@ export const sourceComponentMdx: BlockMdxConfig<SourceComponentData> = {
     rawRef: data.rawRef,
     rawHash: data.rawHash,
     sourceLabel: data.sourceLabel,
+    mappingId: data.mappingId,
+    mappingStatus: data.mappingStatus,
+    mappingReason: data.mappingReason,
+    sourceEditState: data.sourceEditState,
     previewStatus: data.previewStatus,
     previewKind: data.previewKind,
     previewUrl: data.previewUrl,
@@ -111,12 +165,24 @@ export const sourceComponentMdx: BlockMdxConfig<SourceComponentData> = {
     rawRef: attrs.string("rawRef") ?? "",
     rawHash: attrs.string("rawHash") ?? "",
     sourceLabel: attrs.string("sourceLabel"),
-    previewStatus: attrs.string("previewStatus") as
-      | SourceComponentData["previewStatus"]
-      | undefined,
-    previewKind: attrs.string("previewKind") as
-      | SourceComponentData["previewKind"]
-      | undefined,
+    mappingId: attrs.string("mappingId"),
+    mappingStatus: enumAttr(
+      attrs.string("mappingStatus"),
+      sourceComponentMappingStatuses,
+    ),
+    mappingReason: attrs.string("mappingReason"),
+    sourceEditState: enumAttr(
+      attrs.string("sourceEditState"),
+      sourceComponentEditStates,
+    ),
+    previewStatus: enumAttr(
+      attrs.string("previewStatus"),
+      sourceComponentPreviewStatuses,
+    ),
+    previewKind: enumAttr(
+      attrs.string("previewKind"),
+      sourceComponentPreviewKinds,
+    ),
     previewUrl: attrs.string("previewUrl"),
     previewItems: attrs.array<string>("previewItems"),
     preview: attrs.object<SourceComponentPreview>("preview"),


### PR DESCRIPTION
## Summary
- Add a Builder source-component mapping registry for editable Markdown mappings, preserved known source components, and unknown preserved-only blocks.
- Preserve known Builder reference/symbol/table/embed-like blocks as source-aware markers with mapping status and review state metadata.
- Surface source-component review states in the Content editor and document the marker preservation contract for agents.
- Add golden coverage for known mappings, unknown/nameless preservation, reference-block child preservation, legacy marker parsing, and malformed mapping metadata.

## Verification
- `pnpm test shared/builder-mdx.test.ts`
- `pnpm test shared/nfm.registry.spec.ts app/components/editor/registryBlocks.roundtrip.test.ts app/components/editor/registrySlashItems.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`
- `pnpm action process-builder-body-hydration --sourceId source-component-mapping-smoke --limit 1` (expected fake-source failure: source not found; confirms action boundary without Builder writes)

## Claude Code Opus Review
- Initial review log: `templates/content/.task-sweep/logs/claude-opus-review-20260701-144738.log` / output `templates/content/.task-sweep/logs/claude-opus-review-output-20260701-144738.jsonl`
- Final staged-diff review log: `templates/content/.task-sweep/logs/claude-opus-review-20260701-145124.log` / output `templates/content/.task-sweep/logs/claude-opus-review-output-20260701-145124.jsonl`
- Final verdict: no blockers; cleanup nits addressed for non-null registry fallbacks and unused helper removal.

## Notes
- Draft PR only; no ready-for-review, merge, or auto-merge action taken.
- Build/typecheck reported existing `envFile` deprecation warnings; build also reported the existing Tabler large barrel module warning.
