### PR TITLE
Harden analytics alert sweeps

### DIFF
--- a/templates/analytics/scripts/emit-netlify-dashboard-report-cron.ts
+++ b/templates/analytics/scripts/emit-netlify-dashboard-report-cron.ts
@@ -135,7 +135,24 @@ function siteOrigin(request) {
   return url.origin;
 }
 
+async function readScheduledInvocation(request) {
+  if (request.method !== "POST") return null;
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return null;
+  }
+  const nextRun = typeof body?.next_run === "string" ? body.next_run : "";
+  return nextRun && Number.isFinite(Date.parse(nextRun))
+    ? { nextRun }
+    : null;
+}
+
 export default async function handler(request) {
+  const scheduled = await readScheduledInvocation(request);
+  if (!scheduled) return new Response("Not Found", { status: 404 });
+
   const url = new URL(WORKER_PATH, siteOrigin(request));
   const response = await fetch(url.toString(), {
     method: "POST",
@@ -143,7 +160,7 @@ export default async function handler(request) {
       "content-type": "application/json",
       "x-agent-native-analytics-alert-cron": CRON_TOKEN,
     },
-    body: JSON.stringify({ scheduled: true }),
+    body: JSON.stringify({ scheduled: true, next_run: scheduled.nextRun }),
   });
 
   if (!response.ok && response.status !== 202) {

--- a/templates/analytics/server/db/schema.ts
+++ b/templates/analytics/server/db/schema.ts
@@ -207,7 +207,7 @@ export const analyticsAlertRules = table("analytics_alert_rules", {
   lastEvaluatedAt: text("last_evaluated_at"),
   lastTriggeredAt: text("last_triggered_at"),
   lastStatus: text("last_status", {
-    enum: ["ok", "triggered", "cooldown", "error"],
+    enum: ["ok", "triggered", "cooldown", "error", "running"],
   }),
   lastError: text("last_error"),
   createdAt: text("created_at").notNull().default(now()),

--- a/templates/analytics/server/jobs/analytics-alerts.ts
+++ b/templates/analytics/server/jobs/analytics-alerts.ts
@@ -1,4 +1,5 @@
 import {
+  claimAnalyticsAlertRuleEvaluation,
   evaluateAndNotifyAnalyticsAlertRule,
   listEnabledAnalyticsAlertRules,
   markAnalyticsAlertRuleError,
@@ -50,8 +51,10 @@ export async function runAnalyticsAlertsOnce(
     remaining = rules.length >= sweepLimit ? 1 : 0;
 
     for (const rule of rules) {
-      processed++;
       try {
+        const claimed = await claimAnalyticsAlertRuleEvaluation(rule);
+        if (!claimed) continue;
+        processed++;
         const result = await evaluateAndNotifyAnalyticsAlertRule(rule);
         if (result.status === "triggered") triggered++;
       } catch (err) {

--- a/templates/analytics/server/lib/analytics-alerts.spec.ts
+++ b/templates/analytics/server/lib/analytics-alerts.spec.ts
@@ -110,4 +110,75 @@ describe("analytics alert evaluation", () => {
     expect(source).not.toContain(".limit(maxCandidateEventsPerRule())");
     expect(source).not.toContain("function maxCandidateEventsPerRule");
   });
+
+  it("claims alert rules before evaluating so parallel sweeps cannot double-send", () => {
+    const source = readFileSync(
+      new URL("./analytics-alerts.ts", import.meta.url),
+      "utf8",
+    );
+    const jobSource = readFileSync(
+      new URL("../jobs/analytics-alerts.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).toContain(
+      "export async function claimAnalyticsAlertRuleEvaluation",
+    );
+    expect(source).toContain('lastStatus: "running"');
+    expect(source).toContain("alertRuleNotRunningWhere(now)");
+    expect(source).toContain("alertRulePreviousEvaluationWhere(rule)");
+    expect(source).toContain(".returning({ id: table.id })");
+    expect(jobSource).toContain("claimAnalyticsAlertRuleEvaluation(rule)");
+    expect(
+      jobSource.indexOf("claimAnalyticsAlertRuleEvaluation(rule)"),
+    ).toBeLessThan(
+      jobSource.indexOf("evaluateAndNotifyAnalyticsAlertRule(rule)"),
+    );
+  });
+
+  it("keeps triggered rules retryable when no notification was delivered", () => {
+    const source = readFileSync(
+      new URL("./analytics-alerts.ts", import.meta.url),
+      "utf8",
+    );
+    const noDeliveryIndex = source.indexOf("if (!stored?.id)");
+    const incidentIndex = source.indexOf("recordIncident(rule");
+
+    expect(source).toContain("ensureInboxNotificationChannel(rule.channels)");
+    expect(source).toContain("if (!stored?.id)");
+    expect(source).toContain(
+      "Analytics alert notification was not delivered; no inbox notification was stored.",
+    );
+    expect(source).toContain('lastStatus: "error"');
+    expect(noDeliveryIndex).toBeGreaterThan(-1);
+    expect(noDeliveryIndex).toBeLessThan(incidentIndex);
+    expect(source).toContain("notificationId: stored.id");
+    expect(source).not.toContain("notificationId: stored?.id");
+  });
+
+  it("requires Netlify scheduled invocation payload before forwarding alert cron token", () => {
+    const source = readFileSync(
+      new URL(
+        "../../scripts/emit-netlify-dashboard-report-cron.ts",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    const alertTriggerIndex = source.indexOf(
+      "function emitAlertScheduledTrigger",
+    );
+    const alertSource = source.slice(alertTriggerIndex);
+
+    expect(alertSource).toContain("async function readScheduledInvocation");
+    expect(alertSource).toContain('request.method !== "POST"');
+    expect(alertSource).toContain("body?.next_run");
+    expect(alertSource).toContain(
+      'if (!scheduled) return new Response("Not Found", { status: 404 });',
+    );
+    expect(
+      alertSource.indexOf("readScheduledInvocation(request)"),
+    ).toBeLessThan(
+      alertSource.indexOf('"x-agent-native-analytics-alert-cron": CRON_TOKEN'),
+    );
+  });
 });

--- a/templates/analytics/server/lib/analytics-alerts.ts
+++ b/templates/analytics/server/lib/analytics-alerts.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import { notify } from "@agent-native/core/notifications";
 import { recordChange } from "@agent-native/core/server";
-import { and, asc, desc, eq, gte, isNull, lte, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gte, isNull, lte, or, sql } from "drizzle-orm";
 
 import { getDb, schema } from "../db/index.js";
 
@@ -21,7 +21,12 @@ export interface AnalyticsAlertFilter {
 
 export type AnalyticsAlertThresholdMode = "event_count" | "distinct_count";
 export type AnalyticsAlertSeverity = "warning" | "critical";
-export type AnalyticsAlertStatus = "ok" | "triggered" | "cooldown" | "error";
+export type AnalyticsAlertStatus =
+  | "ok"
+  | "triggered"
+  | "cooldown"
+  | "error"
+  | "running";
 
 export interface AnalyticsAlertRuleInput {
   id?: string;
@@ -107,6 +112,8 @@ export interface RunRuleResult extends AnalyticsAlertEvaluation {
 function nowIso(): string {
   return new Date().toISOString();
 }
+
+const ALERT_RULE_RUNNING_STALE_MS = 15 * 60 * 1000;
 
 function safeJsonParse<T>(raw: unknown, fallback: T): T {
   if (typeof raw !== "string" || !raw.trim()) return fallback;
@@ -372,6 +379,7 @@ export async function listEnabledAnalyticsAlertRules(options: {
       options.orgId ? eq(table.orgId, options.orgId) : isNull(table.orgId),
     );
   }
+  clauses.push(alertRuleNotRunningWhere(new Date()));
   const rows = await db
     .select()
     .from(table)
@@ -383,6 +391,52 @@ export async function listEnabledAnalyticsAlertRules(options: {
     )
     .limit(clampInt(options.limit, 1, 500));
   return rows.map(rowToRule);
+}
+
+function alertRuleNotRunningWhere(now: Date) {
+  const table = schema.analyticsAlertRules;
+  const staleRunningBefore = new Date(
+    now.getTime() - ALERT_RULE_RUNNING_STALE_MS,
+  ).toISOString();
+  return or(
+    isNull(table.lastStatus),
+    sql`${table.lastStatus} <> 'running'`,
+    isNull(table.lastEvaluatedAt),
+    lte(table.lastEvaluatedAt, staleRunningBefore),
+  );
+}
+
+function alertRulePreviousEvaluationWhere(rule: AnalyticsAlertRule) {
+  const table = schema.analyticsAlertRules;
+  return rule.lastEvaluatedAt
+    ? eq(table.lastEvaluatedAt, rule.lastEvaluatedAt)
+    : isNull(table.lastEvaluatedAt);
+}
+
+export async function claimAnalyticsAlertRuleEvaluation(
+  rule: AnalyticsAlertRule,
+  now: Date = new Date(),
+): Promise<boolean> {
+  const db = getDb() as any;
+  const table = schema.analyticsAlertRules;
+  const claimedAt = now.toISOString();
+  const rows = await db
+    .update(table)
+    .set({
+      lastEvaluatedAt: claimedAt,
+      lastStatus: "running",
+      lastError: null,
+    })
+    .where(
+      and(
+        eq(table.id, rule.id),
+        eq(table.enabled, true),
+        alertRuleNotRunningWhere(now),
+        alertRulePreviousEvaluationWhere(rule),
+      ),
+    )
+    .returning({ id: table.id });
+  return rows.length > 0;
 }
 
 export async function evaluateAndNotifyAnalyticsAlertRule(
@@ -416,12 +470,13 @@ export async function evaluateAndNotifyAnalyticsAlertRule(
   }
 
   const body = alertBody(rule, evaluation);
+  const channels = ensureInboxNotificationChannel(rule.channels);
   const stored = await notify(
     {
       severity: rule.severity,
       title: `Analytics alert: ${rule.name}`,
       body,
-      channels: rule.channels,
+      channels,
       metadata: {
         kind: "analytics_alert",
         ruleId: rule.id,
@@ -438,13 +493,23 @@ export async function evaluateAndNotifyAnalyticsAlertRule(
         filters: rule.filters,
         sampleEvents: evaluation.sampleEvents,
         emailRecipients: rule.emailRecipients,
+        requestedChannels: rule.channels,
       },
     },
     { owner: rule.ownerEmail },
   );
+  if (!stored?.id) {
+    await markRuleStatus(rule.id, {
+      lastEvaluatedAt: evaluatedAt,
+      lastStatus: "error",
+      lastError:
+        "Analytics alert notification was not delivered; no inbox notification was stored.",
+    });
+    return { ruleId: rule.id, status: "error", ...evaluation };
+  }
 
   await recordIncident(rule, {
-    notificationId: stored?.id,
+    notificationId: stored.id,
     triggeredAt: evaluatedAt,
     windowStart,
     windowEnd,
@@ -459,9 +524,14 @@ export async function evaluateAndNotifyAnalyticsAlertRule(
   return {
     ruleId: rule.id,
     status: "triggered",
-    notificationId: stored?.id,
+    notificationId: stored.id,
     ...evaluation,
   };
+}
+
+function ensureInboxNotificationChannel(channels: string[]): string[] {
+  const normalized = channels.map((channel) => channel.trim()).filter(Boolean);
+  return normalized.includes("inbox") ? normalized : ["inbox", ...normalized];
 }
 
 export async function markAnalyticsAlertRuleError(


### PR DESCRIPTION
## Summary
- require Netlify scheduled invocation payload before the analytics alert cron trigger forwards its internal token
- claim analytics alert rules in the database before evaluating them so parallel sweeps do not double-send
- keep triggered rules retryable when no inbox notification was stored, instead of recording an incident/cooldown

## Validation
- corepack pnpm --dir templates/analytics test -- server/lib/analytics-alerts.spec.ts
- corepack pnpm --dir templates/analytics typecheck
- corepack pnpm prep