### PR TITLE
Ship notification, Clips, and Design follow-ups

### DIFF
--- a/.agents/plugins/agent-native-design/.codex-plugin/plugin.json
+++ b/.agents/plugins/agent-native-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-native-design",
-  "version": "1.0.0+codex.ec8aaa9c9010",
+  "version": "1.0.0+codex.a8b2ac4c5372",
   "description": "Explore, compare, iterate, and export interactive UI design prototypes from the Design app.",
   "author": { "name": "Agent-Native", "url": "https://agent-native.com" },
   "homepage": "https://design.agent-native.com",

--- a/.agents/plugins/agent-native-design/skills/design-exploration/SKILL.md
+++ b/.agents/plugins/agent-native-design/skills/design-exploration/SKILL.md
@@ -58,14 +58,28 @@ iteration, or a human-in-the-loop choice among design directions.
 
 ## Design Quality Bar
 
+Generic "AI slop" comes from letting one prompt set taste, explore, and emit code
+at once — so the model returns the training-average (Inter, an indigo/violet
+gradient, a centered hero, three rounded cards). The variant flow above exists to
+separate those jobs; use it, and hold this bar:
+
 - Before generating, name the concrete audience, the screen's primary job, and
   the visual thesis. If the brief is vague, make a reasonable choice and state
   it instead of producing a generic dashboard/landing-page default.
-- For existing products, inspect the current screen, design system, tokens,
-  component language, or codebase context before inventing a new direction.
+- Refuse the defaults, and pair every "don't" with a "do" (banning Inter alone
+  just makes you reach for Roboto). Avoid Inter/Roboto/system fonts, the
+  indigo/violet slop palette (`#6366F1`/`#8B5CF6`/`#A855F7`) and purple-on-white
+  gradients, and centered-hero + three-icon-card layouts; instead pick a
+  distinctive font pairing, one non-default palette family with a single decisive
+  accent, and an asymmetric layout with a clear focal point.
 - Make each direction distinct in structure and behavior, not just palette.
   Give every variant one memorable signature choice, then keep the surrounding
-  chrome disciplined.
+  chrome disciplined. Even your creative picks converge (Space Grotesk
+  everywhere) — vary deliberately so two directions never share a fingerprint.
+- For existing products, inspect the current screen, design system, tokens, and
+  component language before inventing a new direction. Treat any drift back to a
+  default as a missing token to pin, and vary layout per screen so on-brand does
+  not become same-in-your-colors.
 - Treat copy, data, and imagery as design material. Use realistic domain
   content and first-party/generated assets when images matter; avoid lorem
   ipsum, vague SaaS filler, and decorative placeholder boxes.

--- a/.agents/skills/frontend-design/SKILL.md
+++ b/.agents/skills/frontend-design/SKILL.md
@@ -53,6 +53,8 @@ Default to Apple/Linear-level restraint: make the primary workflow obvious, then
 - **Visual assets**: Websites, games, and object-focused pages need real or generated media when images help users understand the subject.
 - **Responsive fit**: Text must not overflow buttons, cards, tabs, sidebars, or fixed-format tools. Use stable dimensions for boards, grids, toolbars, and counters.
 
+**Beat convergence, not just defaults.** You sample toward the "on-distribution" center, so naming what to avoid is not enough: every "don't" needs a "do", or you converge on the next safe option (ban Inter and you reach for Roboto; ban purple gradients and you reach for Space Grotesk + a teal accent on every screen). Commit to one named direction, pair any reference with the reason it fits ("Linear: the quiet confidence of its spacing" — a bare "Linear" collapses back to the average), and match implementation effort to the vision: maximalist wants elaborate motion and effects, minimal wants restraint and precise spacing. When building on an existing app, inspect its tokens/type/components first and treat any drift back to a default as a missing token to pin, not something to re-prompt.
+
 ## Agent-Native UI Rules
 
 - Agent-native apps use React, Vite, Tailwind CSS, shadcn/ui, and `@tabler/icons-react`.

--- a/.changeset/fair-alert-delivery.md
+++ b/.changeset/fair-alert-delivery.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Expose notification delivery channel results so callers can distinguish custom-channel delivery from inbox persistence.

--- a/.changeset/green-windows-test.md
+++ b/.changeset/green-windows-test.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Re-enable Claude Sonnet 5 as the visible and default Sonnet model now that the Builder gateway supports it.

--- a/.changeset/sharpen-design-anti-slop-skills.md
+++ b/.changeset/sharpen-design-anti-slop-skills.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Sharpen the exported Design skill's quality bar to defeat "AI slop": frame the variant flow as separating taste/exploration/spec/code, pair every banned default with a concrete alternative, warn about second-order convergence, and add explicit guidance for building on an existing design system or codebase.

--- a/packages/core/src/agent/model-config.ts
+++ b/packages/core/src/agent/model-config.ts
@@ -120,7 +120,7 @@ export function getContextWindowForModel(modelId: string): number {
   return DEFAULT_CONTEXT_WINDOW;
 }
 
-const ENABLE_CLAUDE_SONNET_5 = false;
+const ENABLE_CLAUDE_SONNET_5 = true;
 
 export const CLAUDE_SONNET_MODEL_ID = ENABLE_CLAUDE_SONNET_5
   ? "claude-sonnet-5"

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -363,14 +363,28 @@ iteration, or a human-in-the-loop choice among design directions.
 
 ## Design Quality Bar
 
+Generic "AI slop" comes from letting one prompt set taste, explore, and emit code
+at once — so the model returns the training-average (Inter, an indigo/violet
+gradient, a centered hero, three rounded cards). The variant flow above exists to
+separate those jobs; use it, and hold this bar:
+
 - Before generating, name the concrete audience, the screen's primary job, and
   the visual thesis. If the brief is vague, make a reasonable choice and state
   it instead of producing a generic dashboard/landing-page default.
-- For existing products, inspect the current screen, design system, tokens,
-  component language, or codebase context before inventing a new direction.
+- Refuse the defaults, and pair every "don't" with a "do" (banning Inter alone
+  just makes you reach for Roboto). Avoid Inter/Roboto/system fonts, the
+  indigo/violet slop palette (\`#6366F1\`/\`#8B5CF6\`/\`#A855F7\`) and purple-on-white
+  gradients, and centered-hero + three-icon-card layouts; instead pick a
+  distinctive font pairing, one non-default palette family with a single decisive
+  accent, and an asymmetric layout with a clear focal point.
 - Make each direction distinct in structure and behavior, not just palette.
   Give every variant one memorable signature choice, then keep the surrounding
-  chrome disciplined.
+  chrome disciplined. Even your creative picks converge (Space Grotesk
+  everywhere) — vary deliberately so two directions never share a fingerprint.
+- For existing products, inspect the current screen, design system, tokens, and
+  component language before inventing a new direction. Treat any drift back to a
+  default as a missing token to pin, and vary layout per screen so on-brand does
+  not become same-in-your-colors.
 - Treat copy, data, and imagery as design material. Use realistic domain
   content and first-party/generated assets when images matter; avoid lorem
   ipsum, vague SaaS filler, and decorative placeholder boxes.

--- a/packages/core/src/notifications/index.ts
+++ b/packages/core/src/notifications/index.ts
@@ -8,6 +8,7 @@ export type {
 
 export {
   notify,
+  notifyWithDelivery,
   registerNotificationChannel,
   unregisterNotificationChannel,
   listNotificationChannels,

--- a/packages/core/src/notifications/notifications.spec.ts
+++ b/packages/core/src/notifications/notifications.spec.ts
@@ -54,6 +54,7 @@ vi.mock("../server/auth.js", () => ({
 import { createNotificationToolEntries } from "./actions.js";
 import {
   notify,
+  notifyWithDelivery,
   registerNotificationChannel,
   unregisterNotificationChannel,
   listNotificationChannels,
@@ -218,6 +219,28 @@ describe("notifications registry", () => {
       expect(deliverSlack).toHaveBeenCalled();
       expect(deliverPager).not.toHaveBeenCalled();
       expect(mockInsertNotification).not.toHaveBeenCalled();
+    });
+
+    it("exposes custom-channel delivery even when there is no inbox row", async () => {
+      const deliverSlack = vi.fn();
+      registerNotificationChannel({ name: "slack", deliver: deliverSlack });
+
+      const delivery = await notifyWithDelivery(
+        { severity: "critical", title: "Test", channels: ["slack"] },
+        { owner: "boni@local" },
+      );
+
+      expect(delivery.notification).toBeUndefined();
+      expect(delivery.deliveredChannels).toEqual(["slack"]);
+      expect(mockInsertNotification).not.toHaveBeenCalled();
+      expect(mockEmit).toHaveBeenCalledWith(
+        "notification.sent",
+        expect.objectContaining({
+          notificationId: undefined,
+          deliveredChannels: ["slack"],
+        }),
+        { owner: "boni@local" },
+      );
     });
 
     it("channels=['inbox'] persists but skips custom channels", async () => {

--- a/packages/core/src/notifications/registry.ts
+++ b/packages/core/src/notifications/registry.ts
@@ -13,6 +13,11 @@ import {
   type Notification,
 } from "./types.js";
 
+export interface NotificationDeliveryResult {
+  notification?: Notification;
+  deliveredChannels: string[];
+}
+
 registerEvent({
   name: "notification.sent",
   description:
@@ -84,6 +89,13 @@ export async function notify(
   input: NotificationInput,
   meta: NotificationMeta,
 ): Promise<Notification | undefined> {
+  return (await notifyWithDelivery(input, meta)).notification;
+}
+
+export async function notifyWithDelivery(
+  input: NotificationInput,
+  meta: NotificationMeta,
+): Promise<NotificationDeliveryResult> {
   if (!meta?.owner) {
     throw new Error("notify: meta.owner is required");
   }
@@ -166,7 +178,7 @@ export async function notify(
     }
   }
 
-  return stored;
+  return { notification: stored, deliveredChannels: delivered };
 }
 
 function selectChannels(allowlist?: string[]): NotificationChannel[] {

--- a/packages/core/src/templates/default/.agents/skills/frontend-design/SKILL.md
+++ b/packages/core/src/templates/default/.agents/skills/frontend-design/SKILL.md
@@ -53,6 +53,8 @@ Default to Apple/Linear-level restraint: make the primary workflow obvious, then
 - **Visual assets**: Websites, games, and object-focused pages need real or generated media when images help users understand the subject.
 - **Responsive fit**: Text must not overflow buttons, cards, tabs, sidebars, or fixed-format tools. Use stable dimensions for boards, grids, toolbars, and counters.
 
+**Beat convergence, not just defaults.** You sample toward the "on-distribution" center, so naming what to avoid is not enough: every "don't" needs a "do", or you converge on the next safe option (ban Inter and you reach for Roboto; ban purple gradients and you reach for Space Grotesk + a teal accent on every screen). Commit to one named direction, pair any reference with the reason it fits ("Linear: the quiet confidence of its spacing" — a bare "Linear" collapses back to the average), and match implementation effort to the vision: maximalist wants elaborate motion and effects, minimal wants restraint and precise spacing. When building on an existing app, inspect its tokens/type/components first and treat any drift back to a default as a missing token to pin, not something to re-prompt.
+
 ## Agent-Native UI Rules
 
 - Agent-native apps use React, Vite, Tailwind CSS, shadcn/ui, and `@tabler/icons-react`.

--- a/packages/core/src/templates/workspace-core/.agents/skills/frontend-design/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/frontend-design/SKILL.md
@@ -53,6 +53,8 @@ Default to Apple/Linear-level restraint: make the primary workflow obvious, then
 - **Visual assets**: Websites, games, and object-focused pages need real or generated media when images help users understand the subject.
 - **Responsive fit**: Text must not overflow buttons, cards, tabs, sidebars, or fixed-format tools. Use stable dimensions for boards, grids, toolbars, and counters.
 
+**Beat convergence, not just defaults.** You sample toward the "on-distribution" center, so naming what to avoid is not enough: every "don't" needs a "do", or you converge on the next safe option (ban Inter and you reach for Roboto; ban purple gradients and you reach for Space Grotesk + a teal accent on every screen). Commit to one named direction, pair any reference with the reason it fits ("Linear: the quiet confidence of its spacing" — a bare "Linear" collapses back to the average), and match implementation effort to the vision: maximalist wants elaborate motion and effects, minimal wants restraint and precise spacing. When building on an existing app, inspect its tokens/type/components first and treat any drift back to a default as a missing token to pin, not something to re-prompt.
+
 ## Agent-Native UI Rules
 
 - Agent-native apps use React, Vite, Tailwind CSS, shadcn/ui, and `@tabler/icons-react`.

--- a/skills/design-exploration/SKILL.md
+++ b/skills/design-exploration/SKILL.md
@@ -58,14 +58,28 @@ iteration, or a human-in-the-loop choice among design directions.
 
 ## Design Quality Bar
 
+Generic "AI slop" comes from letting one prompt set taste, explore, and emit code
+at once — so the model returns the training-average (Inter, an indigo/violet
+gradient, a centered hero, three rounded cards). The variant flow above exists to
+separate those jobs; use it, and hold this bar:
+
 - Before generating, name the concrete audience, the screen's primary job, and
   the visual thesis. If the brief is vague, make a reasonable choice and state
   it instead of producing a generic dashboard/landing-page default.
-- For existing products, inspect the current screen, design system, tokens,
-  component language, or codebase context before inventing a new direction.
+- Refuse the defaults, and pair every "don't" with a "do" (banning Inter alone
+  just makes you reach for Roboto). Avoid Inter/Roboto/system fonts, the
+  indigo/violet slop palette (`#6366F1`/`#8B5CF6`/`#A855F7`) and purple-on-white
+  gradients, and centered-hero + three-icon-card layouts; instead pick a
+  distinctive font pairing, one non-default palette family with a single decisive
+  accent, and an asymmetric layout with a clear focal point.
 - Make each direction distinct in structure and behavior, not just palette.
   Give every variant one memorable signature choice, then keep the surrounding
-  chrome disciplined.
+  chrome disciplined. Even your creative picks converge (Space Grotesk
+  everywhere) — vary deliberately so two directions never share a fingerprint.
+- For existing products, inspect the current screen, design system, tokens, and
+  component language before inventing a new direction. Treat any drift back to a
+  default as a missing token to pin, and vary layout per screen so on-brand does
+  not become same-in-your-colors.
 - Treat copy, data, and imagery as design material. Use realistic domain
   content and first-party/generated assets when images matter; avoid lorem
   ipsum, vague SaaS filler, and decorative placeholder boxes.

--- a/templates/analytics/.agents/skills/frontend-design/SKILL.md
+++ b/templates/analytics/.agents/skills/frontend-design/SKILL.md
@@ -53,6 +53,8 @@ Default to Apple/Linear-level restraint: make the primary workflow obvious, then
 - **Visual assets**: Websites, games, and object-focused pages need real or generated media when images help users understand the subject.
 - **Responsive fit**: Text must not overflow buttons, cards, tabs, sidebars, or fixed-format tools. Use stable dimensions for boards, grids, toolbars, and counters.
 
+**Beat convergence, not just defaults.** You sample toward the "on-distribution" center, so naming what to avoid is not enough: every "don't" needs a "do", or you converge on the next safe option (ban Inter and you reach for Roboto; ban purple gradients and you reach for Space Grotesk + a teal accent on every screen). Commit to one named direction, pair any reference with the reason it fits ("Linear: the quiet confidence of its spacing" — a bare "Linear" collapses back to the average), and match implementation effort to the vision: maximalist wants elaborate motion and effects, minimal wants restraint and precise spacing. When building on an existing app, inspect its tokens/type/components first and treat any drift back to a default as a missing token to pin, not something to re-prompt.
+
 ## Agent-Native UI Rules
 
 - Agent-native apps use React, Vite, Tailwind CSS, shadcn/ui, and `@tabler/icons-react`.

--- a/templates/analytics/server/lib/analytics-alerts.spec.ts
+++ b/templates/analytics/server/lib/analytics-alerts.spec.ts
@@ -136,24 +136,25 @@ describe("analytics alert evaluation", () => {
     );
   });
 
-  it("keeps triggered rules retryable when no notification was delivered", () => {
+  it("keeps triggered rules retryable only when no notification channel delivered", () => {
     const source = readFileSync(
       new URL("./analytics-alerts.ts", import.meta.url),
       "utf8",
     );
-    const noDeliveryIndex = source.indexOf("if (!stored?.id)");
+    const noDeliveryIndex = source.indexOf(
+      "if (delivery.deliveredChannels.length === 0)",
+    );
     const incidentIndex = source.indexOf("recordIncident(rule");
 
+    expect(source).toContain("notifyWithDelivery");
     expect(source).toContain("ensureInboxNotificationChannel(rule.channels)");
-    expect(source).toContain("if (!stored?.id)");
-    expect(source).toContain(
-      "Analytics alert notification was not delivered; no inbox notification was stored.",
-    );
+    expect(source).toContain("delivery.deliveredChannels.length === 0");
+    expect(source).toContain("Analytics alert notification was not delivered.");
     expect(source).toContain('lastStatus: "error"');
     expect(noDeliveryIndex).toBeGreaterThan(-1);
     expect(noDeliveryIndex).toBeLessThan(incidentIndex);
-    expect(source).toContain("notificationId: stored.id");
-    expect(source).not.toContain("notificationId: stored?.id");
+    expect(source).toContain("notificationId: delivery.notification?.id");
+    expect(source).not.toContain("if (!stored?.id)");
   });
 
   it("requires Netlify scheduled invocation payload before forwarding alert cron token", () => {

--- a/templates/analytics/server/lib/analytics-alerts.ts
+++ b/templates/analytics/server/lib/analytics-alerts.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import { notify } from "@agent-native/core/notifications";
+import { notifyWithDelivery } from "@agent-native/core/notifications";
 import { recordChange } from "@agent-native/core/server";
 import { and, asc, desc, eq, gte, isNull, lte, or, sql } from "drizzle-orm";
 
@@ -471,7 +471,7 @@ export async function evaluateAndNotifyAnalyticsAlertRule(
 
   const body = alertBody(rule, evaluation);
   const channels = ensureInboxNotificationChannel(rule.channels);
-  const stored = await notify(
+  const delivery = await notifyWithDelivery(
     {
       severity: rule.severity,
       title: `Analytics alert: ${rule.name}`,
@@ -498,18 +498,17 @@ export async function evaluateAndNotifyAnalyticsAlertRule(
     },
     { owner: rule.ownerEmail },
   );
-  if (!stored?.id) {
+  if (delivery.deliveredChannels.length === 0) {
     await markRuleStatus(rule.id, {
       lastEvaluatedAt: evaluatedAt,
       lastStatus: "error",
-      lastError:
-        "Analytics alert notification was not delivered; no inbox notification was stored.",
+      lastError: "Analytics alert notification was not delivered.",
     });
     return { ruleId: rule.id, status: "error", ...evaluation };
   }
 
   await recordIncident(rule, {
-    notificationId: stored.id,
+    notificationId: delivery.notification?.id,
     triggeredAt: evaluatedAt,
     windowStart,
     windowEnd,
@@ -524,7 +523,7 @@ export async function evaluateAndNotifyAnalyticsAlertRule(
   return {
     ruleId: rule.id,
     status: "triggered",
-    notificationId: stored.id,
+    notificationId: delivery.notification?.id,
     ...evaluation,
   };
 }

--- a/templates/assets/.agents/skills/frontend-design/SKILL.md
+++ b/templates/assets/.agents/skills/frontend-design/SKILL.md
@@ -53,6 +53,8 @@ Default to Apple/Linear-level restraint: make the primary workflow obvious, then
 - **Visual assets**: Websites, games, and object-focused pages need real or generated media when images help users understand the subject.
 - **Responsive fit**: Text must not overflow buttons, cards, tabs, sidebars, or fixed-format tools. Use stable dimensions for boards, grids, toolbars, and counters.
 
+**Beat convergence, not just defaults.** You sample toward the "on-distribution" center, so naming what to avoid is not enough: every "don't" needs a "do", or you converge on the next safe option (ban Inter and you reach for Roboto; ban purple gradients and you reach for Space Grotesk + a teal accent on every screen). Commit to one named direction, pair any reference with the reason it fits ("Linear: the quiet confidence of its spacing" — a bare "Linear" collapses back to the average), and match implementation effort to the vision: maximalist wants elaborate motion and effects, minimal wants restraint and precise spacing. When building on an existing app, inspect its tokens/type/components first and treat any drift back to a default as a missing token to pin, not something to re-prompt.
+
 ## Agent-Native UI Rules
 
 - Agent-native apps use React, Vite, Tailwind CSS, shadcn/ui, and `@tabler/icons-react`.

--- a/templates/brain/.agents/skills/frontend-design/SKILL.md
+++ b/templates/brain/.agents/skills/frontend-design/SKILL.md
@@ -53,6 +53,8 @@ Default to Apple/Linear-level restraint: make the primary workflow obvious, then
 - **Visual assets**: Websites, games, and object-focused pages need real or generated media when images help users understand the subject.
 - **Responsive fit**: Text must not overflow buttons, cards, tabs, sidebars, or fixed-format tools. Use stable dimensions for boards, grids, toolbars, and counters.
 
+**Beat convergence, not just defaults.** You sample toward the "on-distribution" center, so naming what to avoid is not enough: every "don't" needs a "do", or you converge on the next safe option (ban Inter and you reach for Roboto; ban purple gradients and you reach for Space Grotesk + a teal accent on every screen). Commit to one named direction, pair any reference with the reason it fits ("Linear: the quiet confidence of its spacing" — a bare "Linear" collapses back to the average), and match implementation effort to the vision: maximalist wants elaborate motion and effects, minimal wants restraint and precise spacing. When building on an existing app, inspect its tokens/type/components first and treat any drift back to a default as a missing token to pin, not something to re-prompt.
+
 ## Agent-Native UI Rules
 
 - Agent-native apps use React, Vite, Tailwind CSS, shadcn/ui, and `@tabler/icons-react`.

--- a/templates/calendar/.agents/skills/frontend-design/SKILL.md
+++ b/templates/calendar/.agents/skills/frontend-design/SKILL.md
@@ -53,6 +53,8 @@ Default to Apple/Linear-level restraint: make the primary workflow obvious, then
 - **Visual assets**: Websites, games, and object-focused pages need real or generated media when images help users understand the subject.
 - **Responsive fit**: Text must not overflow buttons, cards, tabs, sidebars, or fixed-format tools. Use stable dimensions for boards, grids, toolbars, and counters.
 
+**Beat convergence, not just defaults.** You sample toward the "on-distribution" center, so naming what to avoid is not enough: every "don't" needs a "do", or you converge on the next safe option (ban Inter and you reach for Roboto; ban purple gradients and you reach for Space Grotesk + a teal accent on every screen). Commit to one named direction, pair any reference with the reason it fits ("Linear: the quiet confidence of its spacing" — a bare "Linear" collapses back to the average), and match implementation effort to the vision: maximalist wants elaborate motion and effects, minimal wants restraint and precise spacing. When building on an existing app, inspect its tokens/type/components first and treat any drift back to a default as a missing token to pin, not something to re-prompt.
+
 ## Agent-Native UI Rules
 
 - Agent-native apps use React, Vite, Tailwind CSS, shadcn/ui, and `@tabler/icons-react`.

--- a/templates/chat/.agents/skills/frontend-design/SKILL.md
+++ b/templates/chat/.agents/skills/frontend-design/SKILL.md
@@ -53,6 +53,8 @@ Default to Apple/Linear-level restraint: make the primary workflow obvious, then
 - **Visual assets**: Websites, games, and object-focused pages need real or generated media when images help users understand the subject.
 - **Responsive fit**: Text must not overflow buttons, cards, tabs, sidebars, or fixed-format tools. Use stable dimensions for boards, grids, toolbars, and counters.
 
+**Beat convergence, not just defaults.** You sample toward the "on-distribution" center, so naming what to avoid is not enough: every "don't" needs a "do", or you converge on the next safe option (ban Inter and you reach for Roboto; ban purple gradients and you reach for Space Grotesk + a teal accent on every screen). Commit to one named direction, pair any reference with the reason it fits ("Linear: the quiet confidence of its spacing" — a bare "Linear" collapses back to the average), and match implementation effort to the vision: maximalist wants elaborate motion and effects, minimal wants restraint and precise spacing. When building on an existing app, inspect its tokens/type/components first and treat any drift back to a default as a missing token to pin, not something to re-prompt.
+
 ## Agent-Native UI Rules
 
 - Agent-native apps use React, Vite, Tailwind CSS, shadcn/ui, and `@tabler/icons-react`.

--- a/templates/clips/.agents/skills/frontend-design/SKILL.md
+++ b/templates/clips/.agents/skills/frontend-design/SKILL.md
@@ -53,6 +53,8 @@ Default to Apple/Linear-level restraint: make the primary workflow obvious, then
 - **Visual assets**: Websites, games, and object-focused pages need real or generated media when images help users understand the subject.
 - **Responsive fit**: Text must not overflow buttons, cards, tabs, sidebars, or fixed-format tools. Use stable dimensions for boards, grids, toolbars, and counters.
 
+**Beat convergence, not just defaults.** You sample toward the "on-distribution" center, so naming what to avoid is not enough: every "don't" needs a "do", or you converge on the next safe option (ban Inter and you reach for Roboto; ban purple gradients and you reach for Space Grotesk + a teal accent on every screen). Commit to one named direction, pair any reference with the reason it fits ("Linear: the quiet confidence of its spacing" — a bare "Linear" collapses back to the average), and match implementation effort to the vision: maximalist wants elaborate motion and effects, minimal wants restraint and precise spacing. When building on an existing app, inspect its tokens/type/components first and treat any drift back to a default as a missing token to pin, not something to re-prompt.
+
 ## Agent-Native UI Rules
 
 - Agent-native apps use React, Vite, Tailwind CSS, shadcn/ui, and `@tabler/icons-react`.

--- a/templates/clips/.agents/skills/recording/SKILL.md
+++ b/templates/clips/.agents/skills/recording/SKILL.md
@@ -31,8 +31,37 @@ Some recordings are linked to a meeting — when `meeting_id` is non-null on the
 4. **Record.** Start a `MediaRecorder` with `mimeType: "video/webm;codecs=vp9,opus"` (fallback to vp8, then browser default). Use `timeslice: 2000` so chunks arrive every 2s.
 5. **Upload each chunk.** `ondataavailable` POSTs the chunk bytes to `/api/uploads/chunk` with headers `X-Recording-Id` and `X-Chunk-Index`. Don't retry inline — buffer failed chunks in `IndexedDB` and let a background worker re-send.
 6. **Live transcription.** Alongside the MediaRecorder, `useLiveTranscription` runs the Web Speech API to accumulate transcript text in real time. On stop, the client calls `save-browser-transcript` to persist the result immediately — no API key needed. Desktop recordings use local Whisper/macOS speech first when available, and fall back to Web Speech in the webview on non-mac before relying on upload transcription.
-7. **Finalize.** On stop, send the final chunk to `/api/uploads/:id/chunk?isFinal=1`. The route calls `finalize-recording`, which stitches chunks, uploads the finished media when storage is configured, transitions `status` to `ready`, then kicks off `request-transcript` for higher-quality output (see `ai-video-tools`).
+7. **Finalize.** On stop, send the final chunk to `/api/uploads/:id/chunk?isFinal=1`. The route calls `finalize-recording`, which stitches chunks, makes the media seekable (see below), uploads the finished media when storage is configured, transitions `status` to `ready`, then kicks off `request-transcript` for higher-quality output (see `ai-video-tools`).
 8. **Navigate.** Once the row is `ready` the UI navigates to `/r/:id`.
+
+## Seekable playback (don't ship raw MediaRecorder output)
+
+Raw `MediaRecorder` files are not friendly to progressive HTTP playback, which
+shows up as "clip takes minutes to load" and "re-buffers every time I seek"
+even though the file downloads fine:
+
+- **MP4** is written with the `moov` metadata atom *after* `mdat`, so a player
+  must fetch the whole file before it can start or seek.
+- **WebM** is a live stream with no Cues (seek index) and an unknown Segment
+  duration, so Chrome won't honor `currentTime = X` and has to scan/download.
+
+`finalize-recording` fixes this before upload: MP4 gets pure-TS faststart
+(`server/lib/faststart.ts`), WebM gets a lossless `ffmpeg -c copy` remux that
+writes a SeekHead + Cues + real duration (`server/lib/video-remux.ts`). Both are
+best-effort — on failure we upload the original, never block finalize. Recordings
+above `CLIPS_INLINE_REMUX_MAX_BYTES` (default 200 MB) skip the inline pass and
+are repaired in the background.
+
+The **streaming/resumable** upload path forwards raw bytes straight to the
+provider and cannot rewrite them inline, so `finalize-recording` schedules a
+background `ensureRecordingSeekable` pass for those.
+
+To repair clips uploaded before this existed (or via streaming), call the
+`reprocess-recording` action: `--id`, `--ids='[...]'`, or `--all --limit=N`. It
+re-fetches provider media, rewrites it, re-uploads, and repoints the row. It's
+idempotent (already-seekable clips are skipped unless `--force`) and only touches
+provider-hosted clips owned by the caller. This is the right tool when a user
+reports a specific slow/buffering clip.
 
 ## Loom import
 

--- a/templates/clips/actions/finalize-recording.ts
+++ b/templates/clips/actions/finalize-recording.ts
@@ -40,11 +40,26 @@ import {
   getResumableSession,
 } from "../server/lib/resumable-session.js";
 import { isStreamingUploadDisabled } from "../server/lib/streaming-upload-mode.js";
+import { remuxWebmToSeekable } from "../server/lib/video-remux.js";
 import {
   requiresConfiguredVideoStorage,
   STORAGE_SETUP_REQUIRED_REASON,
 } from "../server/lib/video-storage.js";
+import {
+  ensureRecordingSeekable,
+  markRecordingSeekable,
+} from "./lib/ensure-seekable-video.js";
 import requestTranscript from "./request-transcript.js";
+
+// Recordings up to this size get their seekable rewrite applied inline during
+// finalize (we already hold the assembled bytes). Larger recordings are handed
+// off to the background/reprocess path so we don't stretch the finalize
+// request or exhaust serverless /tmp. Override with CLIPS_INLINE_REMUX_MAX_BYTES.
+function inlineRemuxMaxBytes(): number {
+  const raw = Number(process.env.CLIPS_INLINE_REMUX_MAX_BYTES ?? "");
+  if (Number.isFinite(raw) && raw > 0) return Math.floor(raw);
+  return 200 * 1024 * 1024;
+}
 
 /**
  * Decode a base64 string back into a Uint8Array.
@@ -118,6 +133,10 @@ async function markRecordingReady(params: {
   finalHasAudio: boolean;
   finalHasCamera: boolean;
   existingTitle: string;
+  // Whether a seekable rewrite (MP4 faststart / WebM Cues remux) was already
+  // applied to the uploaded bytes. When false, a best-effort background repair
+  // is triggered so streamed/raw uploads still become seekable.
+  seekableApplied: boolean;
 }) {
   const {
     id,
@@ -131,6 +150,7 @@ async function markRecordingReady(params: {
     finalHasAudio,
     finalHasCamera,
     existingTitle,
+    seekableApplied,
   } = params;
   const db = getDb();
   const now = new Date().toISOString();
@@ -180,6 +200,30 @@ async function markRecordingReady(params: {
     finishedAt: now,
   });
   await writeAppState("refresh-signal", { ts: Date.now() });
+
+  if (seekableApplied) {
+    // Uploaded bytes are already start-playable and seekable — remember it so
+    // later reprocess sweeps skip this clip.
+    await markRecordingSeekable(id, videoUrl).catch((err) => {
+      console.warn("[finalize] failed to write seekable marker", {
+        id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  } else {
+    // Streaming/resumable (or oversized) uploads shipped raw MediaRecorder
+    // bytes with no seekable rewrite: an MP4 with a trailing moov or a WebM
+    // without a Cues index buffers on load and re-buffers on every seek. Fix
+    // it in the background so playback is smooth without blocking finalize.
+    void Promise.resolve(
+      ensureRecordingSeekable({ recordingId: id, ownerEmail }),
+    ).catch((err: unknown) => {
+      console.warn("[finalize] background seekable remux failed", {
+        id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }
 
   // Kick off transcription in the background — fire-and-forget so the chunk
   // endpoint gets a quick response. The request context (user email via
@@ -375,6 +419,10 @@ export default defineAction({
             ...readyParams,
             videoUrl,
             videoSizeBytes: resumableSession.bytesUploaded,
+            // Streaming path forwards raw MediaRecorder bytes straight to the
+            // provider — no faststart/Cues rewrite happened. Repair in the
+            // background.
+            seekableApplied: false,
           });
           // Delete only after durable state is written — so a retry before
           // this point can still find the session and re-enter this path.
@@ -521,9 +569,14 @@ export default defineAction({
       // recordings.
       parts.length = 0;
 
-      // Apply faststart to MP4 files — moves the moov atom before mdat so
-      // browsers can begin playback immediately via HTTP range requests.
+      // Make the assembled recording seekable before upload — we already hold
+      // the full bytes, so a viewer never has to wait through a non-seekable
+      // first play. MP4: relocate moov ahead of mdat (pure TS). WebM: remux to
+      // add a Cues index + real duration (ffmpeg -c copy). When neither runs
+      // (unknown format, oversized, or ffmpeg unavailable) `seekableApplied`
+      // stays false and markRecordingReady schedules a background repair.
       let uploadData = assembled;
+      let seekableApplied = false;
       if (videoFormat === "mp4") {
         try {
           uploadData = applyFaststart(assembled);
@@ -560,6 +613,32 @@ export default defineAction({
             // Sentry must never mask the real validation error.
           }
           throw err;
+        }
+        // moov is present and validated — the MP4 is start-playable/seekable.
+        seekableApplied = true;
+      } else if (videoFormat === "webm") {
+        // MediaRecorder WebM has no Cues index and an unknown duration, so
+        // Chrome buffers on load and re-buffers on every seek. A lossless
+        // `ffmpeg -c copy` remux rewrites it with a SeekHead + Cues + real
+        // duration. Bounded by size so finalize stays fast; larger clips get a
+        // background pass. Best-effort: on any failure we upload the original.
+        if (assembled.byteLength <= inlineRemuxMaxBytes()) {
+          try {
+            const seekable = await remuxWebmToSeekable(uploadData);
+            if (seekable.changed) {
+              uploadData = seekable.bytes;
+              seekableApplied = true;
+              debugLog("[finalize] webm remux applied", {
+                id,
+                bytes: uploadData.byteLength,
+              });
+            }
+          } catch (err) {
+            console.warn("[finalize] webm remux failed, uploading as-is", {
+              id,
+              err: err instanceof Error ? err.message : String(err),
+            });
+          }
         }
       }
 
@@ -721,12 +800,13 @@ export default defineAction({
       debugLog("[finalize] done", {
         id,
         videoUrl: upload.url,
-        bytes: assembled.byteLength,
+        bytes: uploadData.byteLength,
       });
       return markRecordingReady({
         ...readyParams,
         videoUrl: upload.url,
-        videoSizeBytes: assembled.byteLength,
+        videoSizeBytes: uploadData.byteLength,
+        seekableApplied,
       });
     } finally {
       // Unconditional chunk scratch-space cleanup. Runs on success AND on

--- a/templates/clips/actions/lib/ensure-seekable-video.ts
+++ b/templates/clips/actions/lib/ensure-seekable-video.ts
@@ -1,0 +1,256 @@
+/**
+ * Repair an already-stored recording so it plays back and seeks instantly.
+ *
+ * This is the fetch-based counterpart to the inline seekable pass in
+ * `finalize-recording`. It re-fetches a recording's stored provider media,
+ * runs the format-appropriate seekable rewrite (MP4 faststart / WebM Cues
+ * remux), and, when that changed the bytes, re-uploads the fixed file and
+ * repoints the recording at it.
+ *
+ * Used by:
+ *   - `reprocess-recording` — owner/agent triggered backfill of clips that were
+ *     uploaded before the seekable pass existed (or via the streaming path,
+ *     which never applied it).
+ *   - `finalize-recording` — a best-effort background pass for the resumable
+ *     streaming path, whose bytes live at the provider and were never buffered
+ *     server-side for an inline rewrite.
+ *
+ * Everything is best-effort and non-destructive: if we can't fetch, can't
+ * improve, or can't re-upload, the existing recording is left exactly as-is.
+ */
+
+import {
+  readAppState,
+  writeAppState,
+} from "@agent-native/core/application-state";
+import { uploadFile } from "@agent-native/core/file-upload";
+import { MAX_UPLOAD_BYTES } from "@shared/upload-limits.js";
+import { and, eq } from "drizzle-orm";
+
+import { getDb, schema } from "../../server/db/index.js";
+import { ownerEmailMatches } from "../../server/lib/recordings.js";
+import {
+  makeSeekable,
+  type VideoFormat,
+} from "../../server/lib/video-remux.js";
+import { isLoomRecordingSource } from "../../shared/loom.js";
+
+const PROVIDER_FETCH_TIMEOUT_MS = 60_000;
+
+export type EnsureSeekableStatus =
+  | "optimized"
+  | "already-optimized"
+  | "skipped-not-ready"
+  | "skipped-no-media"
+  | "skipped-local-media"
+  | "skipped-too-large"
+  | "skipped-fetch-failed"
+  | "skipped-upload-failed"
+  | "not-found";
+
+export interface EnsureSeekableResult {
+  recordingId: string;
+  status: EnsureSeekableStatus;
+  changed: boolean;
+  videoUrl?: string | null;
+  detail?: string;
+}
+
+/** application_state key marking a recording's media as already made seekable. */
+export function seekableMarkerKey(recordingId: string): string {
+  return `recording-seekable-${recordingId}`;
+}
+
+/**
+ * Record that `videoUrl` for `recordingId` has been made seekable, so later
+ * sweeps skip it. Scoped by URL so a re-upload that changes the URL is not
+ * mistaken for already-processed.
+ */
+export async function markRecordingSeekable(
+  recordingId: string,
+  videoUrl: string | null | undefined,
+): Promise<void> {
+  await writeAppState(seekableMarkerKey(recordingId), {
+    recordingId,
+    videoUrl: videoUrl ?? null,
+    at: new Date().toISOString(),
+  });
+}
+
+async function isAlreadyMarked(
+  recordingId: string,
+  videoUrl: string | null,
+): Promise<boolean> {
+  const marker = await readAppState(seekableMarkerKey(recordingId)).catch(
+    () => null,
+  );
+  return Boolean(
+    marker &&
+    typeof marker === "object" &&
+    (marker as { videoUrl?: unknown }).videoUrl === videoUrl,
+  );
+}
+
+function isRemoteProviderUrl(videoUrl: string | null | undefined): boolean {
+  return typeof videoUrl === "string" && /^https:\/\//i.test(videoUrl.trim());
+}
+
+async function fetchProviderBytes(
+  videoUrl: string,
+): Promise<
+  { ok: true; bytes: Uint8Array } | { ok: false; reason: EnsureSeekableStatus }
+> {
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    PROVIDER_FETCH_TIMEOUT_MS,
+  );
+  try {
+    const res = await fetch(videoUrl, { signal: controller.signal });
+    if (!res.ok) return { ok: false, reason: "skipped-fetch-failed" };
+
+    const declaredLength = Number(res.headers.get("content-length") ?? "0");
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_UPLOAD_BYTES) {
+      return { ok: false, reason: "skipped-too-large" };
+    }
+
+    const buf = new Uint8Array(await res.arrayBuffer());
+    if (buf.byteLength === 0)
+      return { ok: false, reason: "skipped-fetch-failed" };
+    if (buf.byteLength > MAX_UPLOAD_BYTES) {
+      return { ok: false, reason: "skipped-too-large" };
+    }
+    return { ok: true, bytes: buf };
+  } catch {
+    return { ok: false, reason: "skipped-fetch-failed" };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Ensure a single recording's stored media is seekable. Owner-scoped: pass the
+ * resolved owner email so the DB lookup can only touch that owner's rows.
+ */
+export async function ensureRecordingSeekable(params: {
+  recordingId: string;
+  ownerEmail: string;
+  force?: boolean;
+}): Promise<EnsureSeekableResult> {
+  const { recordingId, ownerEmail, force = false } = params;
+  const db = getDb();
+
+  const [rec] = await db
+    .select({
+      id: schema.recordings.id,
+      status: schema.recordings.status,
+      videoUrl: schema.recordings.videoUrl,
+      videoFormat: schema.recordings.videoFormat,
+      sourceAppName: schema.recordings.sourceAppName,
+    })
+    .from(schema.recordings)
+    .where(
+      and(
+        eq(schema.recordings.id, recordingId),
+        ownerEmailMatches(schema.recordings.ownerEmail, ownerEmail),
+      ),
+    );
+
+  if (!rec) {
+    return { recordingId, status: "not-found", changed: false };
+  }
+  if (rec.status !== "ready") {
+    return { recordingId, status: "skipped-not-ready", changed: false };
+  }
+  if (isLoomRecordingSource(rec)) {
+    return { recordingId, status: "skipped-local-media", changed: false };
+  }
+  if (!rec.videoUrl) {
+    return { recordingId, status: "skipped-no-media", changed: false };
+  }
+  // Only provider-hosted media can be re-fetched and re-uploaded. Local/dev
+  // blobs (served from application_state via /api/video) and other relative
+  // URLs are left untouched.
+  if (!isRemoteProviderUrl(rec.videoUrl)) {
+    return {
+      recordingId,
+      status: "skipped-local-media",
+      changed: false,
+      videoUrl: rec.videoUrl,
+    };
+  }
+
+  if (!force && (await isAlreadyMarked(recordingId, rec.videoUrl))) {
+    return {
+      recordingId,
+      status: "already-optimized",
+      changed: false,
+      videoUrl: rec.videoUrl,
+    };
+  }
+
+  const fetched = await fetchProviderBytes(rec.videoUrl);
+  if (!fetched.ok) {
+    return { recordingId, status: fetched.reason, changed: false };
+  }
+
+  const videoFormat: VideoFormat = rec.videoFormat === "mp4" ? "mp4" : "webm";
+  const seekable = await makeSeekable({
+    mediaBytes: fetched.bytes,
+    videoFormat,
+  });
+
+  if (!seekable.changed) {
+    // Already seekable (or unimprovable) — remember so we don't refetch it.
+    await markRecordingSeekable(recordingId, rec.videoUrl);
+    return {
+      recordingId,
+      status: "already-optimized",
+      changed: false,
+      videoUrl: rec.videoUrl,
+    };
+  }
+
+  const mimeType = videoFormat === "mp4" ? "video/mp4" : "video/webm";
+  const upload = await uploadFile({
+    data: seekable.bytes,
+    filename: `${recordingId}.${videoFormat}`,
+    mimeType,
+    ownerEmail,
+    skipCompressionWait: true,
+  });
+
+  if (!upload?.url) {
+    // Could not re-upload — do NOT touch the row; the original still plays.
+    return {
+      recordingId,
+      status: "skipped-upload-failed",
+      changed: false,
+      videoUrl: rec.videoUrl,
+    };
+  }
+
+  await db
+    .update(schema.recordings)
+    .set({
+      videoUrl: upload.url,
+      videoSizeBytes: seekable.bytes.byteLength,
+      updatedAt: new Date().toISOString(),
+    })
+    .where(
+      and(
+        eq(schema.recordings.id, recordingId),
+        ownerEmailMatches(schema.recordings.ownerEmail, ownerEmail),
+      ),
+    );
+
+  await markRecordingSeekable(recordingId, upload.url);
+  await writeAppState("refresh-signal", { ts: Date.now() });
+
+  return {
+    recordingId,
+    status: "optimized",
+    changed: true,
+    videoUrl: upload.url,
+  };
+}

--- a/templates/clips/actions/reprocess-recording.ts
+++ b/templates/clips/actions/reprocess-recording.ts
@@ -1,0 +1,160 @@
+/**
+ * Repair the playback of already-stored recordings.
+ *
+ * Clips uploaded via the streaming path (or before the seekable rewrite
+ * existed) can ship raw MediaRecorder output: an MP4 with a trailing `moov`
+ * atom or a WebM with no Cues index. Those load slowly and re-buffer on every
+ * seek even though the file downloads fine. This action re-fetches the stored
+ * media, rewrites it to be start-playable and seekable (MP4 faststart / WebM
+ * Cues remux), re-uploads the fixed file, and repoints the recording at it.
+ *
+ * It's idempotent and non-destructive: clips that are already seekable are
+ * skipped, and any clip we can't improve or re-upload is left untouched.
+ *
+ * Usage:
+ *   pnpm action reprocess-recording --id=<recordingId>
+ *   pnpm action reprocess-recording --ids='["id1","id2"]'
+ *   pnpm action reprocess-recording --all --limit=20
+ *   pnpm action reprocess-recording --id=<recordingId> --force
+ */
+
+import { defineAction } from "@agent-native/core";
+import { and, desc, eq, isNotNull } from "drizzle-orm";
+import { z } from "zod";
+
+import { getDb, schema } from "../server/db/index.js";
+import {
+  getCurrentOwnerEmail,
+  ownerEmailMatches,
+} from "../server/lib/recordings.js";
+import {
+  ensureRecordingSeekable,
+  type EnsureSeekableResult,
+} from "./lib/ensure-seekable-video.js";
+
+const MAX_TARGETS_PER_CALL = 100;
+const DEFAULT_ALL_LIMIT = 20;
+
+function parseIds(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((v): v is string => typeof v === "string" && !!v);
+  }
+  if (typeof value === "string" && value.trim()) {
+    try {
+      const parsed = JSON.parse(value);
+      if (Array.isArray(parsed)) {
+        return parsed.filter((v): v is string => typeof v === "string" && !!v);
+      }
+    } catch {
+      // Fall back to a single comma-separated / plain id string.
+      return value
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+    }
+  }
+  return [];
+}
+
+export default defineAction({
+  description:
+    "Repair slow-loading or buffering recordings by rewriting their stored video to be start-playable and seekable (MP4 faststart / WebM Cues remux) and re-uploading it. Use for clips that take a long time to load or re-buffer when scrubbing. Pass `id` for one clip, `ids` for several, or `all: true` to sweep the caller's ready clips (bounded by `limit`). Already-seekable clips are skipped unless `force` is true.",
+  schema: z.object({
+    id: z.string().optional().describe("A single recording id to repair."),
+    ids: z
+      .union([z.array(z.string()), z.string()])
+      .optional()
+      .describe(
+        "Multiple recording ids (array, or JSON/comma string for CLI).",
+      ),
+    all: z.coerce
+      .boolean()
+      .optional()
+      .describe(
+        "Repair the caller's own ready clips, most recent first, up to `limit`.",
+      ),
+    limit: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(MAX_TARGETS_PER_CALL)
+      .optional()
+      .describe(
+        `Max clips to process when using \`all\` (default ${DEFAULT_ALL_LIMIT}).`,
+      ),
+    force: z.coerce
+      .boolean()
+      .optional()
+      .describe("Re-run even on clips already marked seekable."),
+  }),
+  run: async (args) => {
+    const db = getDb();
+    const ownerEmail = getCurrentOwnerEmail();
+    const force = Boolean(args.force);
+
+    let targetIds: string[] = [];
+    if (args.id) targetIds.push(args.id);
+    targetIds.push(...parseIds(args.ids));
+
+    if (args.all) {
+      const limit = args.limit ?? DEFAULT_ALL_LIMIT;
+      const rows = await db
+        .select({ id: schema.recordings.id })
+        .from(schema.recordings)
+        .where(
+          and(
+            ownerEmailMatches(schema.recordings.ownerEmail, ownerEmail),
+            eq(schema.recordings.status, "ready"),
+            isNotNull(schema.recordings.videoUrl),
+          ),
+        )
+        .orderBy(desc(schema.recordings.createdAt))
+        .limit(limit);
+      targetIds.push(...rows.map((r) => r.id));
+    }
+
+    // De-dupe while preserving order, and bound the batch so a single call
+    // can't run unboundedly under the hosted foreground budget.
+    targetIds = Array.from(new Set(targetIds)).slice(0, MAX_TARGETS_PER_CALL);
+
+    if (targetIds.length === 0) {
+      return {
+        ok: true,
+        processed: 0,
+        changed: 0,
+        results: [] as EnsureSeekableResult[],
+        message:
+          "No recordings to reprocess. Pass id / ids, or all: true to sweep your clips.",
+      };
+    }
+
+    const results: EnsureSeekableResult[] = [];
+    for (const recordingId of targetIds) {
+      try {
+        results.push(
+          await ensureRecordingSeekable({ recordingId, ownerEmail, force }),
+        );
+      } catch (err) {
+        console.warn("[reprocess-recording] failed for", recordingId, err);
+        results.push({
+          recordingId,
+          status: "skipped-fetch-failed",
+          changed: false,
+          detail: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    const changed = results.filter((r) => r.changed).length;
+    console.log(
+      `Reprocessed ${results.length} recording(s); ${changed} rewritten for smoother playback.`,
+    );
+
+    return {
+      ok: true,
+      processed: results.length,
+      changed,
+      results,
+    };
+  },
+});

--- a/templates/clips/changelog/2026-07-01-shared-clips-now-start-playing-and-scrub-instantly-instead-o.md
+++ b/templates/clips/changelog/2026-07-01-shared-clips-now-start-playing-and-scrub-instantly-instead-o.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-01
+---
+
+Shared clips now start playing and scrub instantly instead of buffering — recordings are made seekable on upload, and you can repair older clips

--- a/templates/clips/server/lib/video-remux.test.ts
+++ b/templates/clips/server/lib/video-remux.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  faststartMp4,
+  isFfmpegAvailable,
+  makeSeekable,
+  remuxWebmToSeekable,
+} from "./video-remux";
+
+function atom(type: string, payload: Uint8Array = new Uint8Array()) {
+  const bytes = new Uint8Array(8 + payload.byteLength);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(0, bytes.byteLength);
+  for (let i = 0; i < 4; i++) bytes[4 + i] = type.charCodeAt(i);
+  bytes.set(payload, 8);
+  return bytes;
+}
+
+function concat(...chunks: Uint8Array[]) {
+  const total = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+function firstTopLevelType(data: Uint8Array): string {
+  return String.fromCharCode(data[4], data[5], data[6], data[7]);
+}
+
+function typeOffset(data: Uint8Array, type: string): number {
+  const needle = new TextEncoder().encode(type);
+  for (let i = 4; i <= data.byteLength - needle.byteLength; i++) {
+    if (needle.every((byte, n) => data[i + n] === byte)) return i;
+  }
+  return -1;
+}
+
+describe("faststartMp4", () => {
+  it("relocates a trailing moov ahead of mdat", () => {
+    const input = concat(
+      atom("ftyp", new TextEncoder().encode("isommp42")),
+      atom("mdat", new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])),
+      atom("moov", new Uint8Array([0, 0, 0, 0])),
+    );
+
+    const result = faststartMp4(input);
+
+    expect(result.changed).toBe(true);
+    // ftyp still first, then moov must precede mdat now.
+    expect(firstTopLevelType(result.bytes)).toBe("ftyp");
+    const moovIdx = typeOffset(result.bytes, "moov");
+    const mdatIdx = typeOffset(result.bytes, "mdat");
+    expect(moovIdx).toBeGreaterThan(0);
+    expect(moovIdx).toBeLessThan(mdatIdx);
+  });
+
+  it("leaves an already-faststarted mp4 unchanged", () => {
+    const input = concat(
+      atom("ftyp", new TextEncoder().encode("isommp42")),
+      atom("moov", new Uint8Array([0, 0, 0, 0])),
+      atom("mdat", new Uint8Array([1, 2, 3, 4])),
+    );
+
+    const result = faststartMp4(input);
+
+    expect(result.changed).toBe(false);
+    expect(result.bytes).toBe(input);
+  });
+
+  it("returns non-mp4 and empty input unchanged", () => {
+    const empty = faststartMp4(new Uint8Array());
+    expect(empty.changed).toBe(false);
+
+    const notMp4 = new Uint8Array([0x1a, 0x45, 0xdf, 0xa3, 1, 2, 3, 4]);
+    const result = faststartMp4(notMp4);
+    expect(result.changed).toBe(false);
+    expect(result.bytes).toBe(notMp4);
+  });
+});
+
+describe("remuxWebmToSeekable", () => {
+  it("returns empty input unchanged without invoking ffmpeg", async () => {
+    const result = await remuxWebmToSeekable(new Uint8Array());
+    expect(result.changed).toBe(false);
+    expect(result.bytes.byteLength).toBe(0);
+  });
+
+  it("returns non-webm input unchanged (wrong magic bytes)", async () => {
+    // MP4-looking bytes: no EBML magic, so we never touch ffmpeg.
+    const notWebm = concat(atom("ftyp", new TextEncoder().encode("isommp42")));
+    const result = await remuxWebmToSeekable(notWebm);
+    expect(result.changed).toBe(false);
+    expect(result.bytes).toBe(notWebm);
+  });
+
+  it("keeps the original bytes when the input cannot be remuxed", async () => {
+    // Valid EBML magic but garbage body: whether ffmpeg is present (it fails)
+    // or absent (guarded out), the fallback must preserve the input.
+    const garbageEbml = new Uint8Array([
+      0x1a, 0x45, 0xdf, 0xa3, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44,
+    ]);
+    const result = await remuxWebmToSeekable(garbageEbml);
+    expect(result.changed).toBe(false);
+    expect(result.bytes).toBe(garbageEbml);
+  });
+});
+
+describe("makeSeekable dispatch", () => {
+  it("faststarts mp4 input", async () => {
+    const input = concat(
+      atom("ftyp", new TextEncoder().encode("isommp42")),
+      atom("mdat", new Uint8Array([1, 2, 3, 4])),
+      atom("moov", new Uint8Array([0, 0, 0, 0])),
+    );
+    const result = await makeSeekable({
+      mediaBytes: input,
+      videoFormat: "mp4",
+    });
+    expect(result.changed).toBe(true);
+  });
+
+  it("reports ffmpeg availability as a boolean", () => {
+    expect(typeof isFfmpegAvailable()).toBe("boolean");
+  });
+});

--- a/templates/clips/server/lib/video-remux.ts
+++ b/templates/clips/server/lib/video-remux.ts
@@ -1,0 +1,222 @@
+/**
+ * Make recorded video seekable so browsers can start playback immediately and
+ * scrub without re-buffering the whole file.
+ *
+ * Two problems this fixes, both produced by `MediaRecorder` output:
+ *   - MP4: the `moov` metadata atom is written AFTER `mdat`, so a player must
+ *     download the entire file before it can start / seek. We relocate it with
+ *     the pure-TypeScript {@link applyFaststart} (no ffmpeg needed).
+ *   - WebM: MediaRecorder emits a "live" stream with no Cues (seek index) and an
+ *     unknown Segment duration, so Chrome refuses to honor `currentTime = X`
+ *     seeks and has to scan/download to move around. A cheap `ffmpeg -c copy`
+ *     remux rewrites the container with a SeekHead + Cues index and a real
+ *     duration — no re-encode, so it's fast and lossless.
+ *
+ * Everything here is best-effort: on any failure (ffmpeg missing, bad input,
+ * timeout) we return the ORIGINAL bytes with `changed: false`, so callers never
+ * regress relative to uploading the raw recording.
+ */
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { applyFaststart, hasPlayableMp4Metadata } from "./faststart.js";
+
+const REMUX_TIMEOUT_MS = 120_000;
+const STDERR_LIMIT = 16 * 1024;
+const MAX_CONCURRENT_REMUXES = 2;
+// EBML magic that every valid Matroska/WebM file starts with.
+const EBML_MAGIC = [0x1a, 0x45, 0xdf, 0xa3];
+
+const requireFromThisFile = createRequire(import.meta.url);
+let cachedFfmpegStaticPath: string | null | undefined;
+let activeRemuxes = 0;
+const remuxWaiters: Array<() => void> = [];
+
+export type VideoFormat = "webm" | "mp4";
+
+export interface SeekableResult {
+  /** The seekable bytes, or the original bytes when nothing changed. */
+  bytes: Uint8Array;
+  /** True when the returned bytes differ from the input. */
+  changed: boolean;
+}
+
+function ffmpegCommand(): string {
+  if (process.env.FFMPEG_PATH) return process.env.FFMPEG_PATH;
+  return resolveFfmpegStaticPath() ?? "ffmpeg";
+}
+
+function resolveFfmpegStaticPath(): string | null {
+  if (cachedFfmpegStaticPath !== undefined) return cachedFfmpegStaticPath;
+  try {
+    const resolved = requireFromThisFile("ffmpeg-static");
+    cachedFfmpegStaticPath =
+      typeof resolved === "string" && resolved && existsSync(resolved)
+        ? resolved
+        : null;
+  } catch {
+    cachedFfmpegStaticPath = null;
+  }
+  return cachedFfmpegStaticPath;
+}
+
+/** Whether a server-side ffmpeg binary is resolvable. */
+export function isFfmpegAvailable(): boolean {
+  return Boolean(process.env.FFMPEG_PATH) || resolveFfmpegStaticPath() !== null;
+}
+
+function startsWithMagic(bytes: Uint8Array, magic: number[]): boolean {
+  if (bytes.byteLength < magic.length) return false;
+  for (let i = 0; i < magic.length; i++) {
+    if (bytes[i] !== magic[i]) return false;
+  }
+  return true;
+}
+
+async function runFfmpeg(args: string[]): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(ffmpegCommand(), args, {
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let stderr = "";
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`ffmpeg remux timed out\n${stderr}`));
+    }, REMUX_TIMEOUT_MS);
+
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr = (stderr + chunk.toString("utf8")).slice(-STDERR_LIMIT);
+    });
+    child.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(new Error(`${err.message}\n${stderr}`));
+    });
+    child.on("close", (code) => {
+      clearTimeout(timeout);
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`ffmpeg exited with code ${code}\n${stderr}`));
+    });
+  });
+}
+
+async function withRemuxSlot<T>(fn: () => Promise<T>): Promise<T> {
+  if (activeRemuxes >= MAX_CONCURRENT_REMUXES) {
+    await new Promise<void>((resolve) => remuxWaiters.push(resolve));
+  }
+  activeRemuxes += 1;
+  try {
+    return await fn();
+  } finally {
+    activeRemuxes = Math.max(0, activeRemuxes - 1);
+    remuxWaiters.shift()?.();
+  }
+}
+
+/**
+ * Rewrite a WebM/Matroska file with a SeekHead + Cues index and a real
+ * duration via a lossless `ffmpeg -c copy` remux. Returns the original bytes
+ * unchanged when ffmpeg is unavailable, the input isn't WebM, or anything
+ * goes wrong.
+ */
+export async function remuxWebmToSeekable(
+  mediaBytes: Uint8Array,
+): Promise<SeekableResult> {
+  const unchanged: SeekableResult = { bytes: mediaBytes, changed: false };
+
+  if (mediaBytes.byteLength === 0) return unchanged;
+  if (!startsWithMagic(mediaBytes, EBML_MAGIC)) return unchanged;
+  if (!isFfmpegAvailable()) return unchanged;
+
+  const dir = await mkdtemp(join(tmpdir(), "clips-remux-"));
+  const inputPath = join(dir, "input.webm");
+  const outputPath = join(dir, "output.webm");
+
+  try {
+    await writeFile(inputPath, mediaBytes);
+    await withRemuxSlot(() =>
+      runFfmpeg([
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-nostdin",
+        "-y",
+        // Regenerate presentation timestamps so a live MediaRecorder stream
+        // gets a coherent, seekable timeline in the remuxed output.
+        "-fflags",
+        "+genpts",
+        "-i",
+        inputPath,
+        // Stream-copy every track: no re-encode, so this stays fast + lossless.
+        "-map",
+        "0",
+        "-c",
+        "copy",
+        "-f",
+        "webm",
+        outputPath,
+      ]),
+    );
+
+    const info = await stat(outputPath).catch(() => null);
+    if (!info || info.size === 0) return unchanged;
+
+    const out = new Uint8Array(await readFile(outputPath));
+    // Validate the muxer actually produced a WebM before trusting it.
+    if (!startsWithMagic(out, EBML_MAGIC)) return unchanged;
+
+    return { bytes: out, changed: true };
+  } catch (err) {
+    console.warn("[video-remux] webm remux failed, keeping original", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return unchanged;
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+/**
+ * Make an MP4 start-playable by moving its `moov` atom ahead of `mdat`. Pure
+ * TypeScript — no ffmpeg. Returns the original bytes when already faststarted
+ * or when the result would fail metadata validation.
+ */
+export function faststartMp4(mediaBytes: Uint8Array): SeekableResult {
+  if (mediaBytes.byteLength === 0) return { bytes: mediaBytes, changed: false };
+  try {
+    const out = applyFaststart(mediaBytes);
+    if (out === mediaBytes) return { bytes: mediaBytes, changed: false };
+    if (!hasPlayableMp4Metadata(out)) {
+      return { bytes: mediaBytes, changed: false };
+    }
+    return { bytes: out, changed: true };
+  } catch (err) {
+    console.warn("[video-remux] mp4 faststart failed, keeping original", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return { bytes: mediaBytes, changed: false };
+  }
+}
+
+/**
+ * Make recorded media seekable based on its container format. Dispatches to
+ * {@link faststartMp4} for MP4 and {@link remuxWebmToSeekable} for WebM.
+ * Always resolves; unknown formats and failures return the input unchanged.
+ */
+export async function makeSeekable(input: {
+  mediaBytes: Uint8Array;
+  videoFormat: VideoFormat;
+}): Promise<SeekableResult> {
+  if (input.videoFormat === "mp4") return faststartMp4(input.mediaBytes);
+  if (input.videoFormat === "webm") {
+    return remuxWebmToSeekable(input.mediaBytes);
+  }
+  return { bytes: input.mediaBytes, changed: false };
+}

--- a/templates/content/.agents/skills/frontend-design/SKILL.md
+++ b/templates/content/.agents/skills/frontend-design/SKILL.md
@@ -53,6 +53,8 @@ Default to Apple/Linear-level restraint: make the primary workflow obvious, then
 - **Visual assets**: Websites, games, and object-focused pages need real or generated media when images help users understand the subject.
 - **Responsive fit**: Text must not overflow buttons, cards, tabs, sidebars, or fixed-format tools. Use stable dimensions for boards, grids, toolbars, and counters.
 
+**Beat convergence, not just defaults.** You sample toward the "on-distribution" center, so naming what to avoid is not enough: every "don't" needs a "do", or you converge on the next safe option (ban Inter and you reach for Roboto; ban purple gradients and you reach for Space Grotesk + a teal accent on every screen). Commit to one named direction, pair any reference with the reason it fits ("Linear: the quiet confidence of its spacing" — a bare "Linear" collapses back to the average), and match implementation effort to the vision: maximalist wants elaborate motion and effects, minimal wants restraint and precise spacing. When building on an existing app, inspect its tokens/type/components first and treat any drift back to a default as a missing token to pin, not something to re-prompt.
+
 ## Agent-Native UI Rules
 
 - Agent-native apps use React, Vite, Tailwind CSS, shadcn/ui, and `@tabler/icons-react`.

--- a/templates/design/.agents/skills/design-generation/SKILL.md
+++ b/templates/design/.agents/skills/design-generation/SKILL.md
@@ -18,22 +18,62 @@ Every generated design uses:
 - **Google Fonts** — for distinctive typography (never Inter/Roboto/Arial)
 - **CSS Custom Properties** — for theming and tweaks panel integration
 
-## Aesthetic Quality Bar — avoid generic "AI slop"
+## Why the workflow exists — it is the anti-slop engine
 
-The single biggest lever on quality is refusing the defaults the model reaches
-for. Before generating, commit to a specific, opinionated direction. Banned by
-default (use only if the user explicitly asks):
+Generic output ("AI slop") is a *workflow* failure, not a lack of talent. When one
+prompt has to set the taste, explore the options, and emit final code all at once,
+the safest answer is the statistical average of the training data: Inter, an
+indigo→violet gradient, a centered hero, three rounded icon cards. Design beats
+this by splitting those jobs across the tools — use them in order, don't collapse
+them:
 
-- **Fonts:** Inter, Roboto, Arial, system-ui, or other safe defaults. Always
-  pick a distinctive Google Font pairing (see the table below).
-- **The purple/indigo gradient on white** and other one-click hero clichés.
-- **Default shadcn/Tailwind grays** as the whole palette; flat indigo/blue
-  accents; the recurring "fingerprint" combo (teal accent + blinking status dot
-  + left accent bars + three-column hero).
-- **Predictable, evenly-weighted layouts** with no focal point.
+1. **Direction** — `show-design-questions` (or a stated thesis) sets taste on purpose.
+2. **Exploration** — `present-design-variants` compares genuinely different directions
+   before committing to one. **This step kills sameness; never skip it for open-ended work.**
+3. **Spec** — a linked design system and the `:root` token block capture the chosen look as reusable rules.
+4. **Code** — `generate-design` / `edit-design` execute a decision already made instead of guessing.
 
-Do not converge even within your own "creative" picks — vary deliberately across
-generations so two designs never share the same fingerprint.
+Jumping straight to code is how you get slop. Let the phases (below) do the work.
+
+## Aesthetic quality bar — beat distributional convergence
+
+You sample toward the "on-distribution" center by default; refuse it. **Every
+"don't" here carries a "do"** — a banned default plus where to go instead —
+because banning Inter alone just makes you reach for Roboto next. Use a banned
+item only if the user explicitly asks.
+
+- **Fonts.** Don't: Inter, Roboto, Arial, Open Sans, system-ui. Do: a distinctive
+  Google Font pairing matched to the chosen aesthetic (see the table) — editorial
+  serif, grotesk display + mono, or one variable font pushed across weight extremes.
+- **Color.** Don't: the indigo/violet slop palette (`#6366F1`, `#8B5CF6`,
+  `#A855F7`), a purple gradient on white, or everything in default grays. Do:
+  anchor on one non-default family — clay/ochre/terracotta, ink/bone/mustard,
+  charcoal/lime, oxblood/cream, navy/copper, warm paper (`#FBF7F0`) over pure
+  white — with one decisive accent used sparingly for hierarchy, not decoration.
+- **Layout.** Don't: centered hero + one CTA + a row of three icon cards,
+  rounded-everything, `0.1`-opacity drop shadows, blanket glassmorphism, or the
+  badge-above-headline cliché. Do: asymmetric 60/40 or 70/30 splits, uneven
+  visual weight, one clear focal point, and flat confident surfaces.
+- **Background.** Don't: a single flat fill. Do: layered gradients, a geometric
+  pattern, grain, or a contextual texture that matches the theme.
+- **Copy & voice.** Don't: lorem ipsum or buzzword filler ("empower", "seamless",
+  "leverage", "revolutionize", "in today's fast-paced world"). Do: realistic
+  domain content in a specific voice — copy is design material.
+
+**Second-order convergence is real.** Even your "creative" picks converge (Space
+Grotesk everywhere; teal accent + blinking dot + left accent bars). Vary
+deliberately across generations so two designs never share a fingerprint.
+
+**Principles to quote back while building:** color creates hierarchy, not
+decoration · density over decoration · earn every animation · commit to one point
+of view. **Match code to the vision** — maximalist themes want elaborate motion
+and effects; minimal themes want restraint and precise spacing. Elegance is
+executing one vision fully.
+
+**References beat adjectives, but only with a reason.** "Linear: the quiet
+confidence of its spacing" or "Stripe: dense but never crowded" points somewhere
+specific; "Linear" alone collapses back to the average, and replying to your own
+output with "make it cleaner / more premium" means you're negotiating with vibes.
 
 ## Prompt the design in four layers
 
@@ -69,6 +109,23 @@ Pick a preset by `projectType`:
 - **Token grounding is non-negotiable:** every color/font/radius references a
   `:root` CSS variable. Never hardcode `text-white` / `bg-black` / hex literals
   in the markup — that's what keeps brand + multi-screen consistency automatic.
+
+## Building on existing code, screens, or a design system
+
+When a design system, tokens, current screens, or a connected codebase already
+exist, the slop risk flips: the failure is ignoring the brand and reverting to
+defaults. The banned-defaults list above still applies, plus:
+
+- **Inspect before inventing.** Read the linked design system, the current
+  `:root` tokens, and existing screens (or the connected localhost/repo) first.
+  Derive the type scale, palette, radius, density, and component language from
+  what is actually there — don't restate a generic direction.
+- **Treat every reversion as a missing spec entry.** If output drifts to a
+  default (Inter, pill buttons, a stock radius) despite the brand, don't just
+  re-prompt — pin the explicit value into `:root` so it can't drift again.
+- **Consistency is not sameness.** Tokens alone make every screen "the same in
+  your colors". Keep structure and layout genuinely varied per screen while the
+  palette, type, and components stay on-brand.
 
 ## Generation Workflow — the canonical 4-phase flow
 
@@ -502,9 +559,8 @@ regeneration is slow, expensive, and regresses unrelated parts.
 
 ## What NOT to Do
 
-- Never use safe/generic fonts (Inter, Roboto, Arial, system-ui) or the
-  purple-on-white gradient, default shadcn grays, or the teal-accent +
-  blinking-dot + three-column-hero cliché — see the Aesthetic Quality Bar.
+- For aesthetics (fonts, palette, layout, backgrounds, copy), see the Aesthetic
+  quality bar above — every banned default there is out unless the user asks.
 - Never link prototype screens with real/relative URLs — use Alpine state,
   `data-screen`, or `#` anchors (see Multi-screen prototypes & navigation).
 - Never hardcode colors — always reference CSS custom properties (no raw

--- a/templates/design/.agents/skills/frontend-design/SKILL.md
+++ b/templates/design/.agents/skills/frontend-design/SKILL.md
@@ -53,6 +53,8 @@ Default to Apple/Linear-level restraint: make the primary workflow obvious, then
 - **Visual assets**: Websites, games, and object-focused pages need real or generated media when images help users understand the subject.
 - **Responsive fit**: Text must not overflow buttons, cards, tabs, sidebars, or fixed-format tools. Use stable dimensions for boards, grids, toolbars, and counters.
 
+**Beat convergence, not just defaults.** You sample toward the "on-distribution" center, so naming what to avoid is not enough: every "don't" needs a "do", or you converge on the next safe option (ban Inter and you reach for Roboto; ban purple gradients and you reach for Space Grotesk + a teal accent on every screen). Commit to one named direction, pair any reference with the reason it fits ("Linear: the quiet confidence of its spacing" — a bare "Linear" collapses back to the average), and match implementation effort to the vision: maximalist wants elaborate motion and effects, minimal wants restraint and precise spacing. When building on an existing app, inspect its tokens/type/components first and treat any drift back to a default as a missing token to pin, not something to re-prompt.
+
 ## Agent-Native UI Rules
 
 - Agent-native apps use React, Vite, Tailwind CSS, shadcn/ui, and `@tabler/icons-react`.

--- a/templates/design/app/pages/DesignEditor.selection.test.ts
+++ b/templates/design/app/pages/DesignEditor.selection.test.ts
@@ -37,6 +37,7 @@ import {
   shouldIgnoreOverviewLayerCreationEcho,
   shouldBlockPendingVisualStyleNavigation,
   shouldShowPendingVisualStyleApply,
+  shouldMirrorSelectedElementToAgentChat,
   sortCodeLayerIdsByTreeOrder,
   formatPendingVisualStylePrompt,
   mergePendingVisualStyleEdit,
@@ -62,6 +63,36 @@ describe("DesignEditor overview selection state", () => {
         viewMode: "single",
       }),
     ).toEqual(["screen-active"]);
+  });
+});
+
+describe("DesignEditor agent chat selection context", () => {
+  it("skips empty-state selections", () => {
+    expect(
+      shouldMirrorSelectedElementToAgentChat({
+        tagName: "div",
+        classes: [],
+        computedStyles: {},
+        boundingRect: { x: 0, y: 0, width: 320, height: 180 },
+        textContent: "* Nothing here yet Add your first screen",
+        isFlexChild: false,
+        isFlexContainer: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps regular selected element context", () => {
+    expect(
+      shouldMirrorSelectedElementToAgentChat({
+        tagName: "button",
+        classes: ["primary"],
+        computedStyles: {},
+        boundingRect: { x: 0, y: 0, width: 120, height: 36 },
+        textContent: "Start trial",
+        isFlexChild: false,
+        isFlexContainer: false,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -360,6 +360,16 @@ export function isScreenRootElementInfo(info: ElementInfo | null | undefined) {
   return tagName === "BODY" || tagName === "HTML";
 }
 
+export function shouldMirrorSelectedElementToAgentChat(
+  info: ElementInfo | null | undefined,
+): info is ElementInfo {
+  if (!info || isScreenRootElementInfo(info)) return false;
+  const text = info.textContent?.replace(/\s+/g, " ").trim();
+  if (!text) return true;
+  const labelText = text.replace(/^[^A-Za-z0-9]+/, "").toLowerCase();
+  return !labelText.startsWith("nothing here yet");
+}
+
 export function shouldIgnoreOverviewLayerCreationEcho(args: {
   pendingLayerId: string | null | undefined;
   pendingScreenId: string | null | undefined;
@@ -9162,7 +9172,7 @@ export default function DesignEditor() {
 
   useEffect(() => {
     const key = "design:selected-element";
-    if (!id || !selectedElement) {
+    if (!id || !shouldMirrorSelectedElementToAgentChat(selectedElement)) {
       removeAgentChatContextItem(key);
       return;
     }

--- a/templates/design/changelog/2026-07-01-design-chat-no-longer-shows-an-empty-state-selection-chip-in-the-composer.md
+++ b/templates/design/changelog/2026-07-01-design-chat-no-longer-shows-an-empty-state-selection-chip-in-the-composer.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-01
+---
+
+Design chat no longer shows an empty-state selection chip in the composer.

--- a/templates/dispatch/.agents/skills/frontend-design/SKILL.md
+++ b/templates/dispatch/.agents/skills/frontend-design/SKILL.md
@@ -53,6 +53,8 @@ Default to Apple/Linear-level restraint: make the primary workflow obvious, then
 - **Visual assets**: Websites, games, and object-focused pages need real or generated media when images help users understand the subject.
 - **Responsive fit**: Text must not overflow buttons, cards, tabs, sidebars, or fixed-format tools. Use stable dimensions for boards, grids, toolbars, and counters.
 
+**Beat convergence, not just defaults.** You sample toward the "on-distribution" center, so naming what to avoid is not enough: every "don't" needs a "do", or you converge on the next safe option (ban Inter and you reach for Roboto; ban purple gradients and you reach for Space Grotesk + a teal accent on every screen). Commit to one named direction, pair any reference with the reason it fits ("Linear: the quiet confidence of its spacing" — a bare "Linear" collapses back to the average), and match implementation effort to the vision: maximalist wants elaborate motion and effects, minimal wants restraint and precise spacing. When building on an existing app, inspect its tokens/type/components first and treat any drift back to a default as a missing token to pin, not something to re-prompt.
+
 ## Agent-Native UI Rules
 
 - Agent-native apps use React, Vite, Tailwind CSS, shadcn/ui, and `@tabler/icons-react`.

--- a/templates/forms/.agents/skills/frontend-design/SKILL.md
+++ b/templates/forms/.agents/skills/frontend-design/SKILL.md
@@ -53,6 +53,8 @@ Default to Apple/Linear-level restraint: make the primary workflow obvious, then
 - **Visual assets**: Websites, games, and object-focused pages need real or generated media when images help users understand the subject.
 - **Responsive fit**: Text must not overflow buttons, cards, tabs, sidebars, or fixed-format tools. Use stable dimensions for boards, grids, toolbars, and counters.
 
+**Beat convergence, not just defaults.** You sample toward the "on-distribution" center, so naming what to avoid is not enough: every "don't" needs a "do", or you converge on the next safe option (ban Inter and you reach for Roboto; ban purple gradients and you reach for Space Grotesk + a teal accent on every screen). Commit to one named direction, pair any reference with the reason it fits ("Linear: the quiet confidence of its spacing" — a bare "Linear" collapses back to the average), and match implementation effort to the vision: maximalist wants elaborate motion and effects, minimal wants restraint and precise spacing. When building on an existing app, inspect its tokens/type/components first and treat any drift back to a default as a missing token to pin, not something to re-prompt.
+
 ## Agent-Native UI Rules
 
 - Agent-native apps use React, Vite, Tailwind CSS, shadcn/ui, and `@tabler/icons-react`.

--- a/templates/macros/.agents/skills/frontend-design/SKILL.md
+++ b/templates/macros/.agents/skills/frontend-design/SKILL.md
@@ -53,6 +53,8 @@ Default to Apple/Linear-level restraint: make the primary workflow obvious, then
 - **Visual assets**: Websites, games, and object-focused pages need real or generated media when images help users understand the subject.
 - **Responsive fit**: Text must not overflow buttons, cards, tabs, sidebars, or fixed-format tools. Use stable dimensions for boards, grids, toolbars, and counters.
 
+**Beat convergence, not just defaults.** You sample toward the "on-distribution" center, so naming what to avoid is not enough: every "don't" needs a "do", or you converge on the next safe option (ban Inter and you reach for Roboto; ban purple gradients and you reach for Space Grotesk + a teal accent on every screen). Commit to one named direction, pair any reference with the reason it fits ("Linear: the quiet confidence of its spacing" — a bare "Linear" collapses back to the average), and match implementation effort to the vision: maximalist wants elaborate motion and effects, minimal wants restraint and precise spacing. When building on an existing app, inspect its tokens/type/components first and treat any drift back to a default as a missing token to pin, not something to re-prompt.
+
 ## Agent-Native UI Rules
 
 - Agent-native apps use React, Vite, Tailwind CSS, shadcn/ui, and `@tabler/icons-react`.

--- a/templates/mail/.agents/skills/frontend-design/SKILL.md
+++ b/templates/mail/.agents/skills/frontend-design/SKILL.md
@@ -53,6 +53,8 @@ Default to Apple/Linear-level restraint: make the primary workflow obvious, then
 - **Visual assets**: Websites, games, and object-focused pages need real or generated media when images help users understand the subject.
 - **Responsive fit**: Text must not overflow buttons, cards, tabs, sidebars, or fixed-format tools. Use stable dimensions for boards, grids, toolbars, and counters.
 
+**Beat convergence, not just defaults.** You sample toward the "on-distribution" center, so naming what to avoid is not enough: every "don't" needs a "do", or you converge on the next safe option (ban Inter and you reach for Roboto; ban purple gradients and you reach for Space Grotesk + a teal accent on every screen). Commit to one named direction, pair any reference with the reason it fits ("Linear: the quiet confidence of its spacing" — a bare "Linear" collapses back to the average), and match implementation effort to the vision: maximalist wants elaborate motion and effects, minimal wants restraint and precise spacing. When building on an existing app, inspect its tokens/type/components first and treat any drift back to a default as a missing token to pin, not something to re-prompt.
+
 ## Agent-Native UI Rules
 
 - Agent-native apps use React, Vite, Tailwind CSS, shadcn/ui, and `@tabler/icons-react`.

--- a/templates/plan/.agents/skills/frontend-design/SKILL.md
+++ b/templates/plan/.agents/skills/frontend-design/SKILL.md
@@ -53,6 +53,8 @@ Default to Apple/Linear-level restraint: make the primary workflow obvious, then
 - **Visual assets**: Websites, games, and object-focused pages need real or generated media when images help users understand the subject.
 - **Responsive fit**: Text must not overflow buttons, cards, tabs, sidebars, or fixed-format tools. Use stable dimensions for boards, grids, toolbars, and counters.
 
+**Beat convergence, not just defaults.** You sample toward the "on-distribution" center, so naming what to avoid is not enough: every "don't" needs a "do", or you converge on the next safe option (ban Inter and you reach for Roboto; ban purple gradients and you reach for Space Grotesk + a teal accent on every screen). Commit to one named direction, pair any reference with the reason it fits ("Linear: the quiet confidence of its spacing" — a bare "Linear" collapses back to the average), and match implementation effort to the vision: maximalist wants elaborate motion and effects, minimal wants restraint and precise spacing. When building on an existing app, inspect its tokens/type/components first and treat any drift back to a default as a missing token to pin, not something to re-prompt.
+
 ## Agent-Native UI Rules
 
 - Agent-native apps use React, Vite, Tailwind CSS, shadcn/ui, and `@tabler/icons-react`.

--- a/templates/slides/.agents/skills/frontend-design/SKILL.md
+++ b/templates/slides/.agents/skills/frontend-design/SKILL.md
@@ -53,6 +53,8 @@ Default to Apple/Linear-level restraint: make the primary workflow obvious, then
 - **Visual assets**: Websites, games, and object-focused pages need real or generated media when images help users understand the subject.
 - **Responsive fit**: Text must not overflow buttons, cards, tabs, sidebars, or fixed-format tools. Use stable dimensions for boards, grids, toolbars, and counters.
 
+**Beat convergence, not just defaults.** You sample toward the "on-distribution" center, so naming what to avoid is not enough: every "don't" needs a "do", or you converge on the next safe option (ban Inter and you reach for Roboto; ban purple gradients and you reach for Space Grotesk + a teal accent on every screen). Commit to one named direction, pair any reference with the reason it fits ("Linear: the quiet confidence of its spacing" — a bare "Linear" collapses back to the average), and match implementation effort to the vision: maximalist wants elaborate motion and effects, minimal wants restraint and precise spacing. When building on an existing app, inspect its tokens/type/components first and treat any drift back to a default as a missing token to pin, not something to re-prompt.
+
 ## Agent-Native UI Rules
 
 - Agent-native apps use React, Vite, Tailwind CSS, shadcn/ui, and `@tabler/icons-react`.

--- a/templates/videos/.agents/skills/frontend-design/SKILL.md
+++ b/templates/videos/.agents/skills/frontend-design/SKILL.md
@@ -53,6 +53,8 @@ Default to Apple/Linear-level restraint: make the primary workflow obvious, then
 - **Visual assets**: Websites, games, and object-focused pages need real or generated media when images help users understand the subject.
 - **Responsive fit**: Text must not overflow buttons, cards, tabs, sidebars, or fixed-format tools. Use stable dimensions for boards, grids, toolbars, and counters.
 
+**Beat convergence, not just defaults.** You sample toward the "on-distribution" center, so naming what to avoid is not enough: every "don't" needs a "do", or you converge on the next safe option (ban Inter and you reach for Roboto; ban purple gradients and you reach for Space Grotesk + a teal accent on every screen). Commit to one named direction, pair any reference with the reason it fits ("Linear: the quiet confidence of its spacing" — a bare "Linear" collapses back to the average), and match implementation effort to the vision: maximalist wants elaborate motion and effects, minimal wants restraint and precise spacing. When building on an existing app, inspect its tokens/type/components first and treat any drift back to a default as a missing token to pin, not something to re-prompt.
+
 ## Agent-Native UI Rules
 
 - Agent-native apps use React, Vite, Tailwind CSS, shadcn/ui, and `@tabler/icons-react`.


### PR DESCRIPTION
## Summary
- expose notification delivery results for custom channels and Analytics alert retry behavior
- restore Claude Sonnet 5 as the visible/default Sonnet model
- make Clips uploads seekable, add remux/reprocess support, and update recording guidance
- polish Design skill guidance and avoid mirroring empty-state selections into chat context

## Validation
- corepack pnpm prep