### PR TITLE
Fix chat keepalive recovery and embed polish

### DIFF
--- a/.changeset/full-width-tool-call-rows.md
+++ b/.changeset/full-width-tool-call-rows.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix chat tool-call rows shrinking, keep running chats visibly thinking, stream reconnect content incrementally, and collapse exact repeated tool rows.

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -240,6 +240,48 @@ describe("waitForThreadRunToClear", () => {
     );
     expect(helperSource).toContain("activityTool: storedActivityTool");
   });
+
+  it("clears stored active-run state when reconnect or stop unwinds the run", () => {
+    const source = readFileSync("src/client/AssistantChat.tsx", {
+      encoding: "utf8",
+    });
+    const reconnectStart = source.indexOf(
+      "const startReconnectToRun = useCallback",
+    );
+    const reconnectEnd = source.indexOf("const reconnectActiveRunForThread");
+    const reconnectSource = source.slice(reconnectStart, reconnectEnd);
+    const stopStart = source.indexOf("const stopActiveRun = useCallback");
+    const stopEnd = source.indexOf(
+      "// Keep the ref current so addToQueue can call it",
+    );
+    const stopSource = source.slice(stopStart, stopEnd);
+
+    expect(reconnectStart).toBeGreaterThan(-1);
+    expect(reconnectEnd).toBeGreaterThan(reconnectStart);
+    expect(stopStart).toBeGreaterThan(-1);
+    expect(stopEnd).toBeGreaterThan(stopStart);
+    expect(reconnectSource).toContain(
+      "clearActiveRunIfMatches(threadId, runId)",
+    );
+    expect(stopSource).toContain(
+      "clearActiveRunIfMatches(threadId, runIdToAbort)",
+    );
+  });
+
+  it("renders tail-resume reconnect content instead of hiding it behind the fallback", () => {
+    const source = readFileSync("src/client/AssistantChat.tsx", {
+      encoding: "utf8",
+    });
+    const start = source.indexOf("{(isReconnecting || reconnectFrozen) &&");
+    const end = source.indexOf("{showRunningInUI &&", start);
+    const renderSource = source.slice(start, end);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    expect(renderSource).toContain("reconnectContent.length > 0");
+    expect(renderSource).toContain("reconnectContent.length === 0");
+    expect(renderSource).not.toContain("reconnectAfterSeq");
+  });
 });
 
 describe("reconnectProgressTimedOut", () => {

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -117,6 +117,19 @@ describe("resolveAssistantChatRunningState", () => {
     ).toEqual({ isRunning: false, showRunningInUI: true });
   });
 
+  it("keeps the chat visibly running while the server still has an active run", () => {
+    expect(
+      resolveAssistantChatRunningState({
+        forceStopped: false,
+        isRuntimeRunning: false,
+        isReconnecting: false,
+        optimisticRunning: false,
+        isAutoResuming: false,
+        hasActiveServerRun: true,
+      }),
+    ).toEqual({ isRunning: true, showRunningInUI: true });
+  });
+
   it("keeps auto-resume visible through the between-chunk idle gap", () => {
     const source = readFileSync("src/client/AssistantChat.tsx", {
       encoding: "utf8",

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -38,6 +38,7 @@ import { LLM_MISSING_CREDENTIALS_MESSAGE } from "../agent/engine/credential-erro
 import type { ReasoningEffort } from "../shared/reasoning-effort.js";
 import {
   ACTIVE_RUN_STATE_EVENT,
+  clearActiveRunIfMatches,
   getActiveRunActivityTool,
   getActiveRun,
   resolveReconnectAfterSeq,
@@ -1455,7 +1456,6 @@ const AssistantChatInner = forwardRef<
   // When stop is clicked during reconnect, keep content visible (don't wipe it)
   const [reconnectFrozen, setReconnectFrozen] = useState(false);
   const reconnectRunIdRef = useRef<string | null>(null);
-  const [reconnectAfterSeq, setReconnectAfterSeq] = useState(0);
   const reconnectAbortRef = useRef<AbortController | null>(null);
   // Nuclear stop: user clicked stop. Clears the stop button/indicator AND
   // lets new submissions go through immediately — prevents the "stuck
@@ -1776,7 +1776,6 @@ const AssistantChatInner = forwardRef<
       const afterSeq = resolveReconnectAfterSeq(threadId, runId);
       const storedActivityTool = getActiveRunActivityTool(threadId, runId);
       setRunningActivityTool(storedActivityTool);
-      setReconnectAfterSeq(afterSeq);
       setActiveRun({
         threadId,
         runId,
@@ -1953,10 +1952,10 @@ const AssistantChatInner = forwardRef<
             runId,
           });
           setDismissedRunErrorKey(null);
+          clearActiveRunIfMatches(threadId, runId);
           reconnectAbortRef.current = null;
           setIsReconnecting(false);
           reconnectRunIdRef.current = null;
-          setReconnectAfterSeq(0);
           window.dispatchEvent(
             new CustomEvent("agentNative.chatRunning", {
               detail: { isRunning: false, tabId: tabId || threadId },
@@ -1980,10 +1979,10 @@ const AssistantChatInner = forwardRef<
         }
 
         if (reconnectRunIdRef.current === runId) {
+          clearActiveRunIfMatches(threadId, runId);
           reconnectAbortRef.current = null;
           setIsReconnecting(false);
           reconnectRunIdRef.current = null;
-          setReconnectAfterSeq(0);
           window.dispatchEvent(
             new CustomEvent("agentNative.chatRunning", {
               detail: { isRunning: false, tabId: tabId || threadId },
@@ -2783,6 +2782,7 @@ const AssistantChatInner = forwardRef<
     setRunErrorInfo(null);
     setDismissedRunErrorKey(null);
     if (runIdToAbort) {
+      if (threadId) clearActiveRunIfMatches(threadId, runIdToAbort);
       fetch(`${apiUrl}/runs/${encodeURIComponent(runIdToAbort)}/abort`, {
         method: "POST",
       }).catch(() => {});
@@ -2791,7 +2791,6 @@ const AssistantChatInner = forwardRef<
       reconnectAbortRef.current?.abort();
       reconnectAbortRef.current = null;
       reconnectRunIdRef.current = null;
-      setReconnectAfterSeq(0);
       setIsReconnecting(false);
       setReconnectFrozen(reconnectContent.length > 0);
     }
@@ -3645,12 +3644,11 @@ const AssistantChatInner = forwardRef<
                         />
                       )}
                       {(isReconnecting || reconnectFrozen) &&
-                        reconnectAfterSeq === 0 &&
                         reconnectContent.length > 0 && (
                           <ReconnectStreamMessage content={reconnectContent} />
                         )}
                       {(isReconnecting || reconnectFrozen) &&
-                        reconnectAfterSeq > 0 &&
+                        reconnectContent.length === 0 &&
                         reconnectActivityContent.length > 0 && (
                           <ReconnectStreamMessage
                             content={reconnectActivityContent}

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -37,10 +37,12 @@ import React, {
 import { LLM_MISSING_CREDENTIALS_MESSAGE } from "../agent/engine/credential-errors.js";
 import type { ReasoningEffort } from "../shared/reasoning-effort.js";
 import {
+  ACTIVE_RUN_STATE_EVENT,
   getActiveRunActivityTool,
   getActiveRun,
   resolveReconnectAfterSeq,
   setActiveRun,
+  type ActiveRunState,
   updateActiveRunActivity,
   updateActiveRunSeq,
 } from "./active-run-state.js";
@@ -280,6 +282,13 @@ export function reconnectProgressTimedOut(args: {
 }): boolean {
   const threshold = args.thresholdMs ?? ACTIVE_RUN_STUCK_THRESHOLD_MS;
   return args.now - args.lastProgressAt >= threshold;
+}
+
+function activeRunMatchesThread(
+  state: ActiveRunState | null,
+  threadId: string | undefined,
+): boolean {
+  return Boolean(threadId && state?.threadId === threadId && state.runId);
 }
 
 function isAssistantUiDuplicateMessageIdError(error: unknown): boolean {
@@ -627,15 +636,21 @@ export function resolveAssistantChatRunningState({
   isReconnecting,
   optimisticRunning,
   isAutoResuming,
+  hasActiveServerRun,
 }: {
   forceStopped: boolean;
   isRuntimeRunning: boolean;
   isReconnecting: boolean;
   optimisticRunning: boolean;
   isAutoResuming: boolean;
+  hasActiveServerRun?: boolean;
 }): { isRunning: boolean; showRunningInUI: boolean } {
   const isRunning =
-    !forceStopped && (isRuntimeRunning || isReconnecting || optimisticRunning);
+    !forceStopped &&
+    (isRuntimeRunning ||
+      isReconnecting ||
+      optimisticRunning ||
+      Boolean(hasActiveServerRun));
   return {
     isRunning,
     // During auto-continuation, assistant-ui can briefly mark the message done
@@ -1447,6 +1462,27 @@ const AssistantChatInner = forwardRef<
   // queueing forever" state where isReconnecting or isRuntimeRunning gets
   // wedged (e.g. after a tab refresh + stop during reconnect).
   const [forceStopped, setForceStopped] = useState(false);
+  const [hasActiveServerRun, setHasActiveServerRun] = useState(() =>
+    activeRunMatchesThread(getActiveRun(), threadId),
+  );
+  useEffect(() => {
+    const syncActiveRun = (state = getActiveRun()) => {
+      setHasActiveServerRun(activeRunMatchesThread(state, threadId));
+    };
+    syncActiveRun();
+    const handler = (event: Event) => {
+      const state = (event as CustomEvent<{ state?: ActiveRunState | null }>)
+        .detail?.state;
+      syncActiveRun(state ?? null);
+    };
+    const storageHandler = () => syncActiveRun();
+    window.addEventListener(ACTIVE_RUN_STATE_EVENT, handler);
+    window.addEventListener("storage", storageHandler);
+    return () => {
+      window.removeEventListener(ACTIVE_RUN_STATE_EVENT, handler);
+      window.removeEventListener("storage", storageHandler);
+    };
+  }, [threadId]);
   // Real running state drives submission/queue gating; UI running also covers
   // short auto-continuation gaps so the latest assistant message does not flash
   // into a done state while the agent is still working.
@@ -1456,14 +1492,14 @@ const AssistantChatInner = forwardRef<
     isReconnecting,
     optimisticRunning,
     isAutoResuming,
+    hasActiveServerRun,
   });
   const textStreaming = showRunningInUI || externalStreaming;
   // A revealed activity label wins; otherwise stay a steady "Thinking" by
   // default. We only surface "Reconnecting" while we are actively replaying
   // recovered content (reconnectContent populated). A bare reconnect with no
-  // replayed content — e.g. a tail-resume after the serverless wall, where
-  // `scheduleUpdate` intentionally leaves reconnectContent empty — is normal
-  // ongoing work, so it must read as "Thinking", never a perpetual "Working".
+  // replayed content is normal ongoing work, so it must read as "Thinking",
+  // never a perpetual "Working".
   const runningStatusLabel = runningActivityLabel
     ? runningActivityLabel
     : isAutoResuming
@@ -1830,7 +1866,6 @@ const AssistantChatInner = forwardRef<
             let rafPending = false;
             let latestSnapshot: ContentPart[] = [];
             const scheduleUpdate = (snapshot: ContentPart[]) => {
-              if (afterSeq > 0) return;
               latestSnapshot = snapshot;
               if (rafPending) return;
               rafPending = true;

--- a/packages/core/src/client/active-run-state.spec.ts
+++ b/packages/core/src/client/active-run-state.spec.ts
@@ -8,6 +8,7 @@ import {
   getActiveRun,
   getActiveRunActivityTool,
   resolveReconnectAfterSeq,
+  clearActiveRunIfMatches,
   setActiveRun,
   updateActiveRunActivity,
   updateActiveRunSeq,
@@ -102,5 +103,19 @@ describe("resolveReconnectAfterSeq", () => {
       { threadId: "thread-1", runId: "run-1", lastSeq: 1 },
       null,
     ]);
+  });
+
+  it("only clears active run state when the thread and run match", () => {
+    setActiveRun({ threadId: "thread-1", runId: "run-1", lastSeq: 7 });
+
+    clearActiveRunIfMatches("thread-1", "run-2");
+    expect(getActiveRun()).toMatchObject({
+      threadId: "thread-1",
+      runId: "run-1",
+      lastSeq: 7,
+    });
+
+    clearActiveRunIfMatches("thread-1", "run-1");
+    expect(getActiveRun()).toBeNull();
   });
 });

--- a/packages/core/src/client/active-run-state.spec.ts
+++ b/packages/core/src/client/active-run-state.spec.ts
@@ -1,6 +1,9 @@
+// @vitest-environment happy-dom
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  ACTIVE_RUN_STATE_EVENT,
   clearActiveRun,
   getActiveRun,
   getActiveRunActivityTool,
@@ -81,5 +84,23 @@ describe("resolveReconnectAfterSeq", () => {
       lastSeq: 12,
     });
     expect(getActiveRun()?.activityTool).toBeUndefined();
+  });
+
+  it("notifies listeners when the active run changes", () => {
+    const events: Array<unknown> = [];
+    const listener = (event: Event) => {
+      events.push((event as CustomEvent).detail?.state ?? null);
+    };
+    window.addEventListener(ACTIVE_RUN_STATE_EVENT, listener);
+
+    setActiveRun({ threadId: "thread-1", runId: "run-1", lastSeq: 1 });
+    clearActiveRun();
+
+    window.removeEventListener(ACTIVE_RUN_STATE_EVENT, listener);
+
+    expect(events).toEqual([
+      { threadId: "thread-1", runId: "run-1", lastSeq: 1 },
+      null,
+    ]);
   });
 });

--- a/packages/core/src/client/active-run-state.ts
+++ b/packages/core/src/client/active-run-state.ts
@@ -82,6 +82,12 @@ export function clearActiveRun(): void {
   notifyActiveRunStateChanged(null);
 }
 
+export function clearActiveRunIfMatches(threadId: string, runId: string): void {
+  const state = getActiveRun();
+  if (state?.threadId !== threadId || state.runId !== runId) return;
+  clearActiveRun();
+}
+
 /** Resume reconnect SSE after the last seen event (0 = replay from the start). */
 export function resolveReconnectAfterSeq(
   threadId: string,

--- a/packages/core/src/client/active-run-state.ts
+++ b/packages/core/src/client/active-run-state.ts
@@ -1,10 +1,24 @@
 const STORAGE_KEY = "agent-chat-active-run";
+export const ACTIVE_RUN_STATE_EVENT = "agent-chat:active-run-state-change";
 
 export interface ActiveRunState {
   threadId: string;
   runId: string;
   lastSeq: number;
   activityTool?: string | null;
+}
+
+function notifyActiveRunStateChanged(state: ActiveRunState | null): void {
+  if (
+    typeof window === "undefined" ||
+    typeof window.dispatchEvent !== "function" ||
+    typeof CustomEvent === "undefined"
+  ) {
+    return;
+  }
+  window.dispatchEvent(
+    new CustomEvent(ACTIVE_RUN_STATE_EVENT, { detail: { state } }),
+  );
 }
 
 function normalizeActivityTool(toolName: unknown): string | null {
@@ -17,6 +31,7 @@ export function setActiveRun(state: ActiveRunState): void {
   try {
     sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state));
   } catch {}
+  notifyActiveRunStateChanged(state);
 }
 
 export function getActiveRun(): ActiveRunState | null {
@@ -64,6 +79,7 @@ export function clearActiveRun(): void {
   try {
     sessionStorage.removeItem(STORAGE_KEY);
   } catch {}
+  notifyActiveRunStateChanged(null);
 }
 
 /** Resume reconnect SSE after the last seen event (0 = replay from the start). */

--- a/packages/core/src/client/chat/message-components.spec.tsx
+++ b/packages/core/src/client/chat/message-components.spec.tsx
@@ -91,7 +91,7 @@ describe("shouldShowAssistantMessageFooter", () => {
     ).toBe(false);
   });
 
-  it("keeps completed historical assistant messages actionable", () => {
+  it("hides completed historical assistant controls while any chat work is running", () => {
     expect(
       shouldShowAssistantMessageFooter({
         isLast: false,
@@ -99,7 +99,7 @@ describe("shouldShowAssistantMessageFooter", () => {
         hasRenderableContent: true,
         statusIsTerminal: true,
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 });
 

--- a/packages/core/src/client/chat/message-components.tsx
+++ b/packages/core/src/client/chat/message-components.tsx
@@ -807,6 +807,7 @@ export function shouldShowAssistantMessageFooter({
   hasUnresolvedTool?: boolean;
 }): boolean {
   if (!hasRenderableContent) return false;
+  if (chatRunning) return false;
   if (!isLast) return true;
   if (hasUnresolvedTool) return false;
   return !chatRunning && statusIsTerminal;
@@ -909,7 +910,7 @@ export function AssistantMessage() {
       className="group relative"
       style={{ contentVisibility: isComplete ? "auto" : "visible" }}
     >
-      <div className="max-w-[95%] text-sm leading-relaxed text-foreground">
+      <div className="w-full max-w-[95%] text-sm leading-relaxed text-foreground">
         <MessagePrimitive.Parts
           components={{
             Text: MarkdownText,

--- a/packages/core/src/client/chat/tool-call-display.spec.tsx
+++ b/packages/core/src/client/chat/tool-call-display.spec.tsx
@@ -164,6 +164,39 @@ describe("ToolCallDisplay native renderers", () => {
     expect(container.querySelector(".animate-spin")).not.toBeNull();
   });
 
+  it("lets generic tool rows fill the assistant message column", () => {
+    act(() => {
+      root.render(
+        <ToolCallDisplay
+          toolName="hubspot-deals"
+          args={{ query: "recent deals" }}
+          isRunning={true}
+        />,
+      );
+    });
+
+    const row = container.querySelector("button")?.parentElement;
+    expect(row?.className).toContain("w-full");
+    expect(container.querySelector("button")?.className).toContain("w-full");
+  });
+
+  it("shows a compact repeat count for coalesced tool rows", () => {
+    act(() => {
+      root.render(
+        <ToolCallDisplay
+          toolName="update-dashboard"
+          args={{ dashboardId: "dash-1" }}
+          result="saved"
+          isRunning={false}
+          repeatCount={3}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("update dashboard");
+    expect(container.textContent).toContain("3x");
+  });
+
   it("shows reconnect activity cards as running without global chat state", () => {
     const content: ContentPart[] = [
       {

--- a/packages/core/src/client/chat/tool-call-display.tsx
+++ b/packages/core/src/client/chat/tool-call-display.tsx
@@ -418,6 +418,7 @@ export function ToolCallDisplay({
   isRunning,
   structuredMeta,
   approval,
+  repeatCount,
 }: {
   toolName: string;
   argsText?: string;
@@ -428,6 +429,7 @@ export function ToolCallDisplay({
   isRunning: boolean;
   structuredMeta?: Record<string, unknown>;
   approval?: { approvalKey: string; dismissed?: boolean };
+  repeatCount?: number;
 }) {
   // Delegate to bespoke cells when structured metadata is present.
   // These must be separate components so hook order in ToolCallDisplayGeneric
@@ -474,6 +476,7 @@ export function ToolCallDisplay({
       chatUI={chatUI}
       isRunning={isRunning}
       approval={approval}
+      repeatCount={repeatCount}
     />
   );
 }
@@ -487,6 +490,7 @@ function ToolCallDisplayGeneric({
   chatUI,
   isRunning,
   approval,
+  repeatCount,
 }: {
   toolName: string;
   argsText?: string;
@@ -496,6 +500,7 @@ function ToolCallDisplayGeneric({
   chatUI?: ActionChatUIConfig;
   isRunning: boolean;
   approval?: { approvalKey: string; dismissed?: boolean };
+  repeatCount?: number;
 }) {
   const streamRef = useRef<HTMLDivElement>(null);
 
@@ -614,7 +619,7 @@ function ToolCallDisplayGeneric({
   const isExpanded = isAgentCall ? hasStreamText && expanded : expanded;
 
   return (
-    <div className="my-1 overflow-hidden">
+    <div className="my-1 w-full overflow-hidden">
       {mcpApp && <McpAppRenderer app={mcpApp} className="mb-1.5" />}
       <button
         onClick={() => canExpand && setExpanded(!isExpanded)}
@@ -640,6 +645,14 @@ function ToolCallDisplayGeneric({
         <span className="truncate min-w-0">
           <span className="font-medium">{displayName}</span>
         </span>
+        {repeatCount && repeatCount > 1 && (
+          <span
+            className="shrink-0 rounded border border-border/60 px-1.5 py-0.5 text-[10px] leading-none text-muted-foreground"
+            title={`Repeated ${repeatCount} times`}
+          >
+            {repeatCount}x
+          </span>
+        )}
         {canExpand && (
           <IconChevronDown
             className={cn(
@@ -694,6 +707,7 @@ export function ToolCallFallback({
   structuredMeta?: Record<string, unknown>;
   activity?: boolean;
   approval?: { approvalKey: string; dismissed?: boolean };
+  repeatCount?: number;
 }) {
   const chatRunning = React.useContext(ChatRunningContext);
   const isRunning =
@@ -715,6 +729,7 @@ export function ToolCallFallback({
       structuredMeta={rest.structuredMeta}
       isRunning={isRunning}
       approval={rest.approval}
+      repeatCount={rest.repeatCount}
     />
   );
 }
@@ -734,7 +749,7 @@ export function ReconnectStreamMessage({
 
   return (
     <div className="flex justify-start">
-      <div className="max-w-[95%] text-sm leading-relaxed text-foreground space-y-1">
+      <div className="w-full max-w-[95%] text-sm leading-relaxed text-foreground space-y-1">
         {content.map((part, i) => {
           if (part.type === "text") {
             const partStreaming = chatRunning && i === streamingTextPartIndex;
@@ -764,6 +779,7 @@ export function ReconnectStreamMessage({
                   (chatRunning || part.activity === true)
                 }
                 approval={part.approval}
+                repeatCount={part.repeatCount}
               />
             );
           }

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -77,6 +77,39 @@ function keepaliveThenDelayedDoneStream(
   });
 }
 
+function activityThenKeepaliveStream(
+  keepaliveAtMs: number,
+): ReadableStream<Uint8Array> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(
+        new TextEncoder().encode(
+          `data: ${JSON.stringify({
+            type: "activity",
+            label: "Still generating image",
+            tool: "generate-image",
+          })}\n\n`,
+        ),
+      );
+      timer = setTimeout(() => {
+        try {
+          controller.enqueue(
+            new TextEncoder().encode(
+              `data: ${JSON.stringify({ type: "stream_keepalive" })}\n\n`,
+            ),
+          );
+        } catch {
+          // The watchdog may have cancelled the stream first.
+        }
+      }, keepaliveAtMs);
+    },
+    cancel() {
+      if (timer) clearTimeout(timer);
+    },
+  });
+}
+
 function preparingActionKeepaliveStream(
   tool = "edit-design",
 ): ReadableStream<Uint8Array> {
@@ -284,6 +317,37 @@ describe("SSE event processor no-progress recovery", () => {
     expect((err as AgentAutoContinueSignal).reason).toBe("no_progress");
   });
 
+  it("preserves activity trail when keepalive-only streams hit no-progress recovery", async () => {
+    vi.useFakeTimers();
+
+    const errPromise = (async () => {
+      try {
+        for await (const _ of readSSEStream(
+          activityThenKeepaliveStream(SSE_NO_PROGRESS_TIMEOUT_MS),
+          [],
+          { value: 0 },
+          undefined,
+        )) {
+          // no-op
+        }
+      } catch (err) {
+        return err;
+      }
+    })();
+
+    await vi.advanceTimersByTimeAsync(SSE_NO_PROGRESS_TIMEOUT_MS);
+    const err = await errPromise;
+
+    expect(err).toBeInstanceOf(AgentAutoContinueSignal);
+    expect((err as AgentAutoContinueSignal).reason).toBe("no_progress");
+    expect((err as AgentAutoContinueSignal).activityTrail).toEqual([
+      {
+        label: "Still generating image",
+        tool: "generate-image",
+      },
+    ]);
+  });
+
   it("does not let keepalives hide a stalled action preparation", async () => {
     vi.useFakeTimers();
 
@@ -380,6 +444,34 @@ describe("SSE event processor no-progress recovery", () => {
     expect(err).toBeInstanceOf(AgentAutoContinueSignal);
     expect((err as AgentAutoContinueSignal).reason).toBe("no_progress");
     expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it("preserves raw activity trail when keepalive-only streams hit no-progress recovery", async () => {
+    vi.useFakeTimers();
+    const onUpdate = vi.fn();
+
+    const errPromise = readSSEStreamRaw(
+      activityThenKeepaliveStream(SSE_NO_PROGRESS_TIMEOUT_MS),
+      [],
+      { value: 0 },
+      undefined,
+      onUpdate,
+    ).then(
+      () => undefined,
+      (err) => err,
+    );
+
+    await vi.advanceTimersByTimeAsync(SSE_NO_PROGRESS_TIMEOUT_MS);
+    const err = await errPromise;
+
+    expect(err).toBeInstanceOf(AgentAutoContinueSignal);
+    expect((err as AgentAutoContinueSignal).reason).toBe("no_progress");
+    expect((err as AgentAutoContinueSignal).activityTrail).toEqual([
+      {
+        label: "Still generating image",
+        tool: "generate-image",
+      },
+    ]);
   });
 
   it("turns raw streams that close without a terminal event into a recovery signal", async () => {

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -36,32 +36,43 @@ function silentStream(): ReadableStream<Uint8Array> {
   });
 }
 
-function keepaliveThenDoneStream(
+function keepaliveThenDelayedDoneStream(
   keepaliveAtMs: number,
+  doneAtMs: number,
 ): ReadableStream<Uint8Array> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timers: ReturnType<typeof setTimeout>[] = [];
   return new ReadableStream<Uint8Array>({
     start(controller) {
-      timer = setTimeout(() => {
-        try {
-          controller.enqueue(
-            new TextEncoder().encode(
-              `data: ${JSON.stringify({ type: "stream_keepalive" })}\n\n`,
-            ),
-          );
-          controller.enqueue(
-            new TextEncoder().encode(
-              `data: ${JSON.stringify({ type: "done" })}\n\n`,
-            ),
-          );
-          controller.close();
-        } catch {
-          // The watchdog may have cancelled the stream first.
-        }
-      }, keepaliveAtMs);
+      timers.push(
+        setTimeout(() => {
+          try {
+            controller.enqueue(
+              new TextEncoder().encode(
+                `data: ${JSON.stringify({ type: "stream_keepalive" })}\n\n`,
+              ),
+            );
+          } catch {
+            // The watchdog may have cancelled the stream first.
+          }
+        }, keepaliveAtMs),
+      );
+      timers.push(
+        setTimeout(() => {
+          try {
+            controller.enqueue(
+              new TextEncoder().encode(
+                `data: ${JSON.stringify({ type: "done" })}\n\n`,
+              ),
+            );
+            controller.close();
+          } catch {
+            // The watchdog may have cancelled the stream first.
+          }
+        }, doneAtMs),
+      );
     },
     cancel() {
-      if (timer) clearTimeout(timer);
+      for (const timer of timers) clearTimeout(timer);
     },
   });
 }
@@ -244,22 +255,33 @@ describe("SSE event processor no-progress recovery", () => {
     expect((err as AgentAutoContinueSignal).reason).toBe("no_progress");
   });
 
-  it("stream_keepalive events reset the no-progress watchdog", async () => {
+  it("stream_keepalive events do not reset the no-progress watchdog", async () => {
     vi.useFakeTimers();
 
-    const donePromise = drain(
-      readSSEStream(
-        keepaliveThenDoneStream(SSE_NO_PROGRESS_TIMEOUT_MS - 5_000),
-        [],
-        { value: 0 },
-        undefined,
-      ),
-    );
+    const errPromise = (async () => {
+      try {
+        for await (const _ of readSSEStream(
+          keepaliveThenDelayedDoneStream(
+            SSE_NO_PROGRESS_TIMEOUT_MS - 5_000,
+            SSE_NO_PROGRESS_TIMEOUT_MS + 5_000,
+          ),
+          [],
+          { value: 0 },
+          undefined,
+        )) {
+          // no-op
+        }
+      } catch (err) {
+        return err;
+      }
+    })();
 
     await vi.advanceTimersByTimeAsync(SSE_NO_PROGRESS_TIMEOUT_MS - 5_000);
     await vi.advanceTimersByTimeAsync(10_000);
+    const err = await errPromise;
 
-    await expect(donePromise).resolves.toBeDefined();
+    expect(err).toBeInstanceOf(AgentAutoContinueSignal);
+    expect((err as AgentAutoContinueSignal).reason).toBe("no_progress");
   });
 
   it("does not let keepalives hide a stalled action preparation", async () => {
@@ -378,6 +400,48 @@ describe("SSE event processor no-progress recovery", () => {
     expect(err).toBeInstanceOf(AgentAutoContinueSignal);
     expect((err as AgentAutoContinueSignal).reason).toBe("stream_ended");
     expect(onUpdate).toHaveBeenCalledWith([{ type: "text", text: "partial" }]);
+  });
+
+  it("updates raw stream consumers after each meaningful event in the same chunk", async () => {
+    const onUpdate = vi.fn();
+
+    await readSSEStreamRaw(
+      eventStream([
+        { type: "tool_start", id: "call-1", tool: "hubspot-deals", input: {} },
+        {
+          type: "tool_done",
+          id: "call-1",
+          tool: "hubspot-deals",
+          result: "ok",
+        },
+        { type: "text", text: "Done." },
+        { type: "done" },
+      ]),
+      [],
+      { value: 0 },
+      undefined,
+      onUpdate,
+    );
+
+    expect(onUpdate).toHaveBeenCalledTimes(4);
+    expect(onUpdate.mock.calls[0][0]).toEqual([
+      expect.objectContaining({
+        type: "tool-call",
+        toolName: "hubspot-deals",
+      }),
+    ]);
+    expect(onUpdate.mock.calls[0][0][0].result).toBeUndefined();
+    expect(onUpdate.mock.calls[1][0]).toEqual([
+      expect.objectContaining({
+        type: "tool-call",
+        toolName: "hubspot-deals",
+        result: "ok",
+      }),
+    ]);
+    expect(onUpdate.mock.calls[2][0]).toEqual([
+      expect.objectContaining({ type: "tool-call" }),
+      { type: "text", text: "Done." },
+    ]);
   });
 
   it("turns raw keepalive-only action preparation into a recovery signal", async () => {
@@ -1034,6 +1098,57 @@ describe("SSE event processor error classification", () => {
         result: '{"saved":true}',
       }),
     ]);
+  });
+
+  it("coalesces adjacent duplicate completed tool calls", async () => {
+    const results = await drain(
+      readSSEStream(
+        eventStream([
+          {
+            type: "tool_start",
+            tool: "update-dashboard",
+            id: "call-1",
+            input: { dashboardId: "dash-1" },
+          },
+          {
+            type: "tool_done",
+            tool: "update-dashboard",
+            id: "call-1",
+            result: '{"saved":true}',
+          },
+          {
+            type: "tool_start",
+            tool: "update-dashboard",
+            id: "call-2",
+            input: { dashboardId: "dash-1" },
+          },
+          {
+            type: "tool_done",
+            tool: "update-dashboard",
+            id: "call-2",
+            result: '{"saved":true}',
+          },
+          { type: "done" },
+        ]),
+        [],
+        { value: 0 },
+        "tab-tool-repeat",
+      ),
+    );
+
+    const finalContent = results.at(-1)?.content ?? [];
+    const toolCalls = finalContent.filter(
+      (part): part is Extract<ContentPart, { type: "tool-call" }> =>
+        part.type === "tool-call",
+    );
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0]).toEqual(
+      expect.objectContaining({
+        toolName: "update-dashboard",
+        result: '{"saved":true}',
+        repeatCount: 2,
+      }),
+    );
   });
 
   it("adds a visible warning when a run completes after tools but sends no final text", async () => {

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -1262,7 +1262,10 @@ export async function* readSSEStream(
         !sawProgressEvent &&
         Date.now() - lastMeaningfulEventAt >= SSE_NO_PROGRESS_TIMEOUT_MS
       ) {
-        throw new AgentAutoContinueSignal({ reason: "no_progress" });
+        throw new AgentAutoContinueSignal({
+          reason: "no_progress",
+          activityTrail: [...activityTrail],
+        });
       }
     }
   } finally {
@@ -1431,7 +1434,10 @@ export async function readSSEStreamRaw(
         !sawProgressEvent &&
         Date.now() - lastMeaningfulEventAt >= SSE_NO_PROGRESS_TIMEOUT_MS
       ) {
-        throw new AgentAutoContinueSignal({ reason: "no_progress" });
+        throw new AgentAutoContinueSignal({
+          reason: "no_progress",
+          activityTrail: [...activityTrail],
+        });
       }
     }
   } finally {

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -27,6 +27,7 @@ export type ContentPart =
       mcpApp?: AgentMcpAppPayload;
       chatUI?: ActionChatUIConfig;
       activity?: boolean;
+      repeatCount?: number;
       /**
        * Set when the server emitted an `approval_required` event for this tool
        * call (opt-in `needsApproval` actions). The action did NOT run; the UI
@@ -182,6 +183,10 @@ function isPreparingActionActivity(ev: SSEEvent): boolean {
   if (ev.type !== "activity") return false;
   const label = (ev.label ?? "").trim().toLowerCase();
   return label.startsWith("preparing ") && label.includes(" action");
+}
+
+function isProgressEvent(ev: SSEEvent): boolean {
+  return ev.type !== "stream_keepalive";
 }
 
 function baseActivityLabel(ev: SSEEvent, tool?: string): string {
@@ -460,6 +465,81 @@ function pendingToolNames(content: ContentPart[]): {
   return { activity: [...activity], running: [...running] };
 }
 
+function contentSnapshot(content: ContentPart[]): ContentPart[] {
+  return content.map((part) => {
+    if (part.type === "text") return { ...part };
+    return {
+      ...part,
+      args: { ...part.args },
+      ...(part.mcpApp ? { mcpApp: { ...part.mcpApp } } : {}),
+      ...(part.chatUI ? { chatUI: { ...part.chatUI } } : {}),
+      ...(part.approval ? { approval: { ...part.approval } } : {}),
+      ...(part.structuredMeta
+        ? { structuredMeta: { ...part.structuredMeta } }
+        : {}),
+    };
+  });
+}
+
+function repeatSignatureValue(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value ?? "");
+  }
+}
+
+function completedToolRepeatSignature(
+  part: Extract<ContentPart, { type: "tool-call" }>,
+): string | null {
+  if (
+    part.result === undefined ||
+    part.activity === true ||
+    part.approval ||
+    part.mcpApp ||
+    part.chatUI ||
+    part.structuredMeta
+  ) {
+    return null;
+  }
+  return [
+    part.toolName,
+    part.argsText,
+    repeatSignatureValue(part.args),
+    part.result,
+    part.isError === true ? "error" : "",
+    part.completedSideEffect === true ? "side-effect" : "",
+  ].join("\u0000");
+}
+
+function coalesceCompletedToolRepeat(
+  content: ContentPart[],
+  completedIndex: number,
+): void {
+  const current = content[completedIndex];
+  const previous = content[completedIndex - 1];
+  if (
+    !current ||
+    !previous ||
+    current.type !== "tool-call" ||
+    previous.type !== "tool-call"
+  ) {
+    return;
+  }
+
+  const currentSignature = completedToolRepeatSignature(current);
+  if (
+    !currentSignature ||
+    currentSignature !== completedToolRepeatSignature(previous)
+  ) {
+    return;
+  }
+
+  previous.repeatCount =
+    (previous.repeatCount ?? 1) + (current.repeatCount ?? 1);
+  content.splice(completedIndex, 1);
+}
+
 function formatToolNames(tools: string[]): string {
   const names = tools.map(humanizeToolName);
   if (names.length === 0) return "the promised action";
@@ -578,7 +658,7 @@ export function processEvent(
     }
     return {
       action: "yield",
-      result: { content: [...content] } as ChatModelRunResult,
+      result: { content: contentSnapshot(content) } as ChatModelRunResult,
     };
   }
 
@@ -615,7 +695,7 @@ export function processEvent(
     }
     return {
       action: "yield",
-      result: { content: [...content] } as ChatModelRunResult,
+      result: { content: contentSnapshot(content) } as ChatModelRunResult,
     };
   }
 
@@ -672,7 +752,7 @@ export function processEvent(
     }
     return {
       action: "yield",
-      result: { content: [...content] } as ChatModelRunResult,
+      result: { content: contentSnapshot(content) } as ChatModelRunResult,
     };
   }
 
@@ -694,7 +774,7 @@ export function processEvent(
     }
     return {
       action: "yield",
-      result: { content: [...content] } as ChatModelRunResult,
+      result: { content: contentSnapshot(content) } as ChatModelRunResult,
     };
   }
 
@@ -730,11 +810,12 @@ export function processEvent(
         if (part.activity !== true && part.isError !== true) {
           markCompletedToolAfterAssistantText(state, part.toolName);
         }
+        coalesceCompletedToolRepeat(content, doneIdx);
       }
     }
     return {
       action: "yield",
-      result: { content: [...content] } as ChatModelRunResult,
+      result: { content: contentSnapshot(content) } as ChatModelRunResult,
     };
   }
 
@@ -764,7 +845,7 @@ export function processEvent(
     }
     return {
       action: "yield",
-      result: { content: [...content] } as ChatModelRunResult,
+      result: { content: contentSnapshot(content) } as ChatModelRunResult,
     };
   }
 
@@ -784,7 +865,7 @@ export function processEvent(
     }
     return {
       action: "yield",
-      result: { content: [...content] } as ChatModelRunResult,
+      result: { content: contentSnapshot(content) } as ChatModelRunResult,
     };
   }
 
@@ -826,7 +907,7 @@ export function processEvent(
     return {
       action: "missing_api_key",
       result: {
-        content: [...content],
+        content: contentSnapshot(content),
         status: { type: "incomplete" as const, reason: "error" as const },
         metadata: { custom: { runError } },
       } as ChatModelRunResult,
@@ -938,7 +1019,7 @@ export function processEvent(
     return {
       action: "error",
       result: {
-        content: [...content],
+        content: contentSnapshot(content),
         status: { type: "incomplete" as const, reason: "error" as const },
         metadata: { custom: { runError } },
       } as ChatModelRunResult,
@@ -974,7 +1055,7 @@ export function processEvent(
       return {
         action: "error",
         result: {
-          content: [...content],
+          content: contentSnapshot(content),
           status: { type: "incomplete" as const, reason: "error" as const },
           metadata: { custom: { runError } },
         } as ChatModelRunResult,
@@ -993,7 +1074,7 @@ export function processEvent(
       return {
         action: "done",
         result: {
-          content: [...content],
+          content: contentSnapshot(content),
           status: { type: "complete" as const, reason: "stop" as const },
           metadata: {
             custom: {
@@ -1009,7 +1090,7 @@ export function processEvent(
     }
     return {
       action: "done",
-      result: { content: [...content] } as ChatModelRunResult,
+      result: { content: contentSnapshot(content) } as ChatModelRunResult,
     };
   }
 
@@ -1075,16 +1156,30 @@ export async function* readSSEStream(
 
   try {
     while (true) {
-      const { done, value } = await readChunkWithProgressTimeout(
-        reader,
-        lastMeaningfulEventAt,
-      );
+      let readResult: ReadableStreamReadResult<Uint8Array>;
+      try {
+        readResult = await readChunkWithProgressTimeout(
+          reader,
+          lastMeaningfulEventAt,
+        );
+      } catch (err) {
+        if (err instanceof AgentAutoContinueSignal) {
+          throw new AgentAutoContinueSignal({
+            reason: err.reason,
+            maxIterations: err.maxIterations,
+            activityTrail: [...activityTrail],
+            errorInfo: err.errorInfo,
+          });
+        }
+        throw err;
+      }
+      const { done, value } = readResult;
       if (done) break;
 
       buf += decoder.decode(value, { stream: true });
       const lines = buf.split("\n");
       buf = lines.pop() ?? "";
-      let sawDataEvent = false;
+      let sawProgressEvent = false;
 
       for (const line of lines) {
         if (!line.startsWith("data: ")) continue;
@@ -1097,9 +1192,11 @@ export async function* readSSEStream(
         } catch {
           continue;
         }
-        sawDataEvent = true;
         const now = Date.now();
-        lastMeaningfulEventAt = now;
+        if (isProgressEvent(ev)) {
+          sawProgressEvent = true;
+          lastMeaningfulEventAt = now;
+        }
         updatePreparingActionState(preparingActionState, ev, now);
 
         // Track sequence number for reconnection
@@ -1162,7 +1259,7 @@ export async function* readSSEStream(
       }
 
       if (
-        !sawDataEvent &&
+        !sawProgressEvent &&
         Date.now() - lastMeaningfulEventAt >= SSE_NO_PROGRESS_TIMEOUT_MS
       ) {
         throw new AgentAutoContinueSignal({ reason: "no_progress" });
@@ -1218,18 +1315,31 @@ export async function readSSEStreamRaw(
 
   try {
     while (true) {
-      const { done, value } = await readChunkWithProgressTimeout(
-        reader,
-        lastMeaningfulEventAt,
-      );
+      let readResult: ReadableStreamReadResult<Uint8Array>;
+      try {
+        readResult = await readChunkWithProgressTimeout(
+          reader,
+          lastMeaningfulEventAt,
+        );
+      } catch (err) {
+        if (err instanceof AgentAutoContinueSignal) {
+          throw new AgentAutoContinueSignal({
+            reason: err.reason,
+            maxIterations: err.maxIterations,
+            activityTrail: [...activityTrail],
+            errorInfo: err.errorInfo,
+          });
+        }
+        throw err;
+      }
+      const { done, value } = readResult;
       if (done) break;
 
       buf += decoder.decode(value, { stream: true });
       const lines = buf.split("\n");
       buf = lines.pop() ?? "";
 
-      let updated = false;
-      let sawDataEvent = false;
+      let sawProgressEvent = false;
       for (const line of lines) {
         if (!line.startsWith("data: ")) continue;
         const raw = line.slice(6).trim();
@@ -1241,9 +1351,11 @@ export async function readSSEStreamRaw(
         } catch {
           continue;
         }
-        sawDataEvent = true;
         const now = Date.now();
-        lastMeaningfulEventAt = now;
+        if (isProgressEvent(ev)) {
+          sawProgressEvent = true;
+          lastMeaningfulEventAt = now;
+        }
         updatePreparingActionState(preparingActionState, ev, now);
 
         if (ev.seq !== undefined && onSeq) {
@@ -1287,10 +1399,12 @@ export async function readSSEStreamRaw(
           action === "error" ||
           action === "missing_api_key"
         ) {
-          updated = true;
+          onUpdate(contentSnapshot(content));
+          emittedLatestContent = true;
         }
         if (action === "auto_continue") {
-          onUpdate([...content]);
+          onUpdate(contentSnapshot(content));
+          emittedLatestContent = true;
           throw new AgentAutoContinueSignal(
             autoContinue
               ? { ...autoContinue, activityTrail: [...activityTrail] }
@@ -1298,7 +1412,7 @@ export async function readSSEStreamRaw(
           );
         }
         if (hasStalledPreparingAction(preparingActionState, Date.now())) {
-          onUpdate([...content]);
+          onUpdate(contentSnapshot(content));
           throw new AgentAutoContinueSignal({
             reason: "no_progress",
             activityTrail: [...activityTrail],
@@ -1309,17 +1423,12 @@ export async function readSSEStreamRaw(
           action === "error" ||
           action === "missing_api_key"
         ) {
-          onUpdate([...content]);
           return;
         }
       }
 
-      if (updated) {
-        onUpdate([...content]);
-        emittedLatestContent = true;
-      }
       if (
-        !sawDataEvent &&
+        !sawProgressEvent &&
         Date.now() - lastMeaningfulEventAt >= SSE_NO_PROGRESS_TIMEOUT_MS
       ) {
         throw new AgentAutoContinueSignal({ reason: "no_progress" });
@@ -1332,6 +1441,8 @@ export async function readSSEStreamRaw(
       // See readSSEStream: cancellation may race lock release in browsers.
     }
   }
-  if (content.length > 0 && !emittedLatestContent) onUpdate([...content]);
+  if (content.length > 0 && !emittedLatestContent) {
+    onUpdate(contentSnapshot(content));
+  }
   throw new AgentAutoContinueSignal({ reason: "stream_ended" });
 }

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/SqlChartCard.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/SqlChartCard.tsx
@@ -466,6 +466,21 @@ export function SqlChartCard({
                 <TooltipContent>{t("sqlDashboard.refreshing")}</TooltipContent>
               </Tooltip>
             ) : null}
+            {editable && onSaveSql ? (
+              <ViewSqlPopover
+                panel={panel}
+                resolvedSql={resolvedSql}
+                onSaveSql={onSaveSql}
+              >
+                <button
+                  className="p-1 rounded text-muted-foreground hover:text-foreground"
+                  aria-label={t("sqlDashboard.viewSql")}
+                  title={t("sqlDashboard.viewSql")}
+                >
+                  <IconCode className="h-3.5 w-3.5" />
+                </button>
+              </ViewSqlPopover>
+            ) : null}
             {showPanelMenu ? (
               <DropdownMenu>
                 <Tooltip>
@@ -503,19 +518,6 @@ export function SqlChartCard({
                   {editable && panel.chartType === "table" ? (
                     <DropdownMenuSeparator />
                   ) : null}
-                  {editable && onSaveSql ? (
-                    <ViewSqlPopover
-                      panel={panel}
-                      resolvedSql={resolvedSql}
-                      onSaveSql={onSaveSql}
-                    >
-                      <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
-                        <IconCode className="h-4 w-4 mr-2" />
-                        {t("sqlDashboard.viewSql")}
-                      </DropdownMenuItem>
-                    </ViewSqlPopover>
-                  ) : null}
-                  {editable ? <DropdownMenuSeparator /> : null}
                   {editable && onEdit && (
                     <DropdownMenuItem onSelect={() => onEdit()}>
                       <IconPencil className="h-4 w-4 mr-2" />

--- a/templates/clips/app/components/player/share-dialog.tsx
+++ b/templates/clips/app/components/player/share-dialog.tsx
@@ -452,8 +452,8 @@ function ClipsEmbedConfigurator({
 
   const code =
     mode === "responsive"
-      ? `<div style="position:relative;padding-bottom:56.25%;height:0"><iframe src="${src}" frameborder="0" allowfullscreen allow="autoplay; picture-in-picture" style="position:absolute;inset:0;width:100%;height:100%"></iframe></div>`
-      : `<iframe src="${src}" width="${width}" height="${height}" frameborder="0" allowfullscreen allow="autoplay; picture-in-picture"></iframe>`;
+      ? `<div style="position:relative;padding-bottom:56.25%;height:0;background:#000;overflow:hidden"><iframe src="${src}" title="${t("shareDialog.embedIframeTitle")}" frameborder="0" scrolling="no" allowfullscreen allow="autoplay; fullscreen; picture-in-picture" style="position:absolute;inset:0;width:100%;height:100%;border:0;background:#000;overflow:hidden"></iframe></div>`
+      : `<iframe src="${src}" title="${t("shareDialog.embedIframeTitle")}" width="${width}" height="${height}" frameborder="0" scrolling="no" allowfullscreen allow="autoplay; fullscreen; picture-in-picture" style="display:block;max-width:100%;border:0;background:#000;overflow:hidden"></iframe>`;
 
   return (
     <div className="space-y-3">

--- a/templates/clips/app/i18n/ar-SA.ts
+++ b/templates/clips/app/i18n/ar-SA.ts
@@ -428,6 +428,7 @@ const messages = {
     askOwnerPublic: "اطلب من المالك نشره.",
     responsive: "مستجيب (16:9)",
     fixedSize: "حجم ثابت",
+    embedIframeTitle: "فيديو Clips",
     width: "عرض",
     height: "ارتفاع",
     autoplay: "التشغيل التلقائي",

--- a/templates/clips/app/i18n/de-DE.ts
+++ b/templates/clips/app/i18n/de-DE.ts
@@ -445,6 +445,7 @@ const messages = {
     askOwnerPublic: "Bitten Sie den Eigentümer, es öffentlich zu machen.",
     responsive: "Responsiv (16:9)",
     fixedSize: "Feste Größe",
+    embedIframeTitle: "Clips-Video",
     width: "Breite",
     height: "Höhe",
     autoplay: "Übersetzt: Autoplay",

--- a/templates/clips/app/i18n/en-US.ts
+++ b/templates/clips/app/i18n/en-US.ts
@@ -428,6 +428,7 @@ const messages = {
     askOwnerPublic: "Ask the owner to make it public.",
     responsive: "Responsive (16:9)",
     fixedSize: "Fixed size",
+    embedIframeTitle: "Clips video",
     width: "Width",
     height: "Height",
     autoplay: "Autoplay",

--- a/templates/clips/app/i18n/es-ES.ts
+++ b/templates/clips/app/i18n/es-ES.ts
@@ -440,6 +440,7 @@ const messages = {
     askOwnerPublic: "Pídele al propietario que lo haga público.",
     responsive: "Responsivo (16:9)",
     fixedSize: "Tamaño fijo",
+    embedIframeTitle: "Video de Clips",
     width: "Ancho",
     height: "Altura",
     autoplay: "Reproducción automática",

--- a/templates/clips/app/i18n/fr-FR.ts
+++ b/templates/clips/app/i18n/fr-FR.ts
@@ -440,6 +440,7 @@ const messages = {
     askOwnerPublic: "Demandez au propriétaire de le rendre public.",
     responsive: "Réactif (16:9)",
     fixedSize: "Taille fixe",
+    embedIframeTitle: "Video Clips",
     width: "Largeur",
     height: "Hauteur",
     autoplay: "Lecture automatique",

--- a/templates/clips/app/i18n/hi-IN.ts
+++ b/templates/clips/app/i18n/hi-IN.ts
@@ -425,6 +425,7 @@ const messages = {
     askOwnerPublic: "मालिक से इसे सार्वजनिक करने के लिए कहें.",
     responsive: "प्रतिक्रियाशील (16:9)",
     fixedSize: "निश्चित आकार",
+    embedIframeTitle: "Clips वीडियो",
     width: "चौड़ाई",
     height: "ऊंचाई",
     autoplay: "स्वत: प्ले",

--- a/templates/clips/app/i18n/ja-JP.ts
+++ b/templates/clips/app/i18n/ja-JP.ts
@@ -437,6 +437,7 @@ const messages = {
     askOwnerPublic: "所有者に公開するよう依頼してください。",
     responsive: "レスポンシブ (16:9)",
     fixedSize: "固定サイズ",
+    embedIframeTitle: "Clips動画",
     width: "幅",
     height: "身長",
     autoplay: "自動再生",

--- a/templates/clips/app/i18n/ko-KR.ts
+++ b/templates/clips/app/i18n/ko-KR.ts
@@ -430,6 +430,7 @@ const messages = {
     askOwnerPublic: "소유자에게 공개하도록 요청하세요.",
     responsive: "반응형(16:9)",
     fixedSize: "고정 크기",
+    embedIframeTitle: "Clips 동영상",
     width: "너비",
     height: "키",
     autoplay: "자동재생",

--- a/templates/clips/app/i18n/pt-BR.ts
+++ b/templates/clips/app/i18n/pt-BR.ts
@@ -438,6 +438,7 @@ const messages = {
     askOwnerPublic: "Peça ao proprietário para torná-lo público.",
     responsive: "Responsivo (16:9)",
     fixedSize: "Tamanho fixo",
+    embedIframeTitle: "Video do Clips",
     width: "Largura",
     height: "Altura",
     autoplay: "Reprodução automática",

--- a/templates/clips/app/i18n/zh-CN.ts
+++ b/templates/clips/app/i18n/zh-CN.ts
@@ -412,6 +412,7 @@ const messages = {
     askOwnerPublic: "请楼主公开一下。",
     responsive: "反应灵敏 (16:9)",
     fixedSize: "固定尺寸",
+    embedIframeTitle: "Clips 视频",
     width: "宽度",
     height: "高度",
     autoplay: "自动播放",

--- a/templates/clips/app/i18n/zh-TW.ts
+++ b/templates/clips/app/i18n/zh-TW.ts
@@ -412,6 +412,7 @@ const messages = {
     askOwnerPublic: "請樓主公開一下。",
     responsive: "反應靈敏 (16:9)",
     fixedSize: "固定尺寸",
+    embedIframeTitle: "Clips 影片",
     width: "寬度",
     height: "高度",
     autoplay: "自動播放",

--- a/templates/clips/app/routes/embed.$shareId.tsx
+++ b/templates/clips/app/routes/embed.$shareId.tsx
@@ -78,6 +78,34 @@ export default function EmbedRoute() {
   });
   const [pwError, setPwError] = useState<string | null>(null);
 
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+
+    const html = document.documentElement;
+    const body = document.body;
+    const previous = {
+      htmlOverflow: html.style.overflow,
+      htmlHeight: html.style.height,
+      bodyOverflow: body.style.overflow,
+      bodyHeight: body.style.height,
+      bodyBackground: body.style.background,
+    };
+
+    html.style.overflow = "hidden";
+    html.style.height = "100%";
+    body.style.overflow = "hidden";
+    body.style.height = "100%";
+    body.style.background = "#000";
+
+    return () => {
+      html.style.overflow = previous.htmlOverflow;
+      html.style.height = previous.htmlHeight;
+      body.style.overflow = previous.bodyOverflow;
+      body.style.height = previous.bodyHeight;
+      body.style.background = previous.bodyBackground;
+    };
+  }, []);
+
   const dataQ = useQuery({
     queryKey: ["public-recording", shareId, password],
     queryFn: async () => {
@@ -135,7 +163,7 @@ export default function EmbedRoute() {
 
   if (dataQ.isLoading) {
     return (
-      <div className="flex items-center justify-center h-screen w-full bg-black">
+      <div className="fixed inset-0 flex h-dvh w-dvw items-center justify-center overflow-hidden bg-black">
         <Spinner className="h-8 w-8 text-white/70" />
       </div>
     );
@@ -153,14 +181,14 @@ export default function EmbedRoute() {
 
   if (!recording) {
     return (
-      <div className="flex items-center justify-center h-screen w-full bg-black text-white">
+      <div className="fixed inset-0 flex h-dvh w-dvw items-center justify-center overflow-hidden bg-black text-white">
         <p className="text-sm">{t("embedRoute.unavailable")}</p>
       </div>
     );
   }
 
   return (
-    <div className="h-screen w-screen bg-black overflow-hidden">
+    <div className="fixed inset-0 h-dvh w-dvw overflow-hidden bg-black">
       <VideoPlayer
         ref={playerRef}
         recordingId={recording.id}

--- a/templates/clips/changelog/2026-07-01-clip-embeds-now-render-as-a-clean-video-only-player-without-.md
+++ b/templates/clips/changelog/2026-07-01-clip-embeds-now-render-as-a-clean-video-only-player-without-.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-01
+---
+
+Clip embeds now render as a clean video-only player without extra page chrome or scrollbars.

--- a/templates/clips/chrome-extension/public/manifest.json
+++ b/templates/clips/chrome-extension/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Agent-Native Clips",
   "short_name": "Clips",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Start Clips recordings from Chrome, capture optional diagnostics, and preview Clips links on GitHub.",
   "minimum_chrome_version": "116",
   "action": {

--- a/templates/clips/chrome-extension/src/github-preview-content.ts
+++ b/templates/clips/chrome-extension/src/github-preview-content.ts
@@ -168,10 +168,10 @@
     Object.assign(frame.style, {
       display: "block",
       width: "100%",
-      height: "430px",
+      height: "405px",
       border: "0",
       borderRadius: "8px",
-      background: "transparent",
+      background: "#000",
       overflow: "hidden",
     });
 

--- a/templates/clips/chrome-extension/src/github-preview.ts
+++ b/templates/clips/chrome-extension/src/github-preview.ts
@@ -121,36 +121,39 @@ function renderPreview(
   root.textContent = "";
 
   const card = document.createElement("section");
-  card.className = "clips-preview-card";
+  card.className =
+    state.kind === "playable"
+      ? "clips-preview-card clips-preview-card--player"
+      : "clips-preview-card";
 
-  const header = document.createElement("header");
-  header.className = "clips-preview-header";
+  if (state.kind !== "playable") {
+    const header = document.createElement("header");
+    header.className = "clips-preview-header";
 
-  const titleWrap = document.createElement("div");
-  titleWrap.className = "clips-preview-title-wrap";
+    const titleWrap = document.createElement("div");
+    titleWrap.className = "clips-preview-title-wrap";
 
-  const title = document.createElement("div");
-  title.className = "clips-preview-title";
-  title.textContent =
-    state.kind === "playable" || state.kind === "unavailable"
-      ? state.title
-      : "Clips preview";
+    const title = document.createElement("div");
+    title.className = "clips-preview-title";
+    title.textContent =
+      state.kind === "unavailable" ? state.title : "Clips preview";
 
-  const subtitle = document.createElement("div");
-  subtitle.className = "clips-preview-subtitle";
-  subtitle.textContent = preview.host;
+    const subtitle = document.createElement("div");
+    subtitle.className = "clips-preview-subtitle";
+    subtitle.textContent = preview.host;
 
-  titleWrap.append(title, subtitle);
+    titleWrap.append(title, subtitle);
 
-  const open = document.createElement("a");
-  open.className = "clips-preview-open";
-  open.href = preview.sourceUrl.toString();
-  open.target = "_blank";
-  open.rel = "noreferrer noopener";
-  open.textContent = "Open clip";
+    const open = document.createElement("a");
+    open.className = "clips-preview-open";
+    open.href = preview.sourceUrl.toString();
+    open.target = "_blank";
+    open.rel = "noreferrer noopener";
+    open.textContent = "Open clip";
 
-  header.append(titleWrap, open);
-  card.append(header);
+    header.append(titleWrap, open);
+    card.append(header);
+  }
 
   if (state.kind === "playable") {
     const player = document.createElement("div");
@@ -161,6 +164,7 @@ function renderPreview(
     frame.src = preview.embedUrl.toString();
     frame.allow = "autoplay; fullscreen; picture-in-picture";
     frame.allowFullscreen = true;
+    frame.scrolling = "no";
     frame.referrerPolicy = "no-referrer";
 
     player.append(frame);
@@ -273,6 +277,7 @@ function installStyles(): void {
     body {
       margin: 0;
       min-width: 0;
+      width: 100%;
       background: transparent;
     }
 
@@ -290,6 +295,12 @@ function installStyles(): void {
       border-radius: 8px;
       background: var(--clips-bg);
       box-shadow: var(--clips-shadow);
+    }
+
+    .clips-preview-card--player {
+      border: 0;
+      background: #000000;
+      box-shadow: none;
     }
 
     .clips-preview-header {
@@ -348,7 +359,6 @@ function installStyles(): void {
       position: relative;
       width: 100%;
       aspect-ratio: 16 / 9;
-      min-height: 240px;
       background: #000000;
     }
 


### PR DESCRIPTION
## Summary
- keep chat/tool-call UI visibly running for active server runs, including reconnect recovery and full-width tool rows
- treat SSE keepalives as non-progress so keepalive-only streams cannot leave the browser stuck in Thinking after the backend is done/stalled
- preserve activity trail when no-progress auto-continue fires, and coalesce exact repeated completed tool rows
- polish Analytics SQL-card access plus Clips embed/player/Chrome preview behavior; bump Clips Chrome manifest to 0.1.12

## Verification
- `corepack pnpm prep`
- `corepack pnpm --filter @agent-native/core exec vitest --run src/client/sse-event-processor.spec.ts src/client/chat/tool-call-display.spec.tsx src/client/chat/message-components.spec.tsx src/client/AssistantChat.display.spec.ts src/client/active-run-state.spec.ts`
- `corepack pnpm --dir templates/clips/chrome-extension package`
- Production Design pre-ship browser smoke: small edits completed in ~15-20s with no new delete-screen churn; selected-variant build used 2 delete-screen calls for unchosen variants, 1 snapshot, 1 edit-screen, and no generate-design loop
- Production Design pre-ship repro of remaining issue: backend run completed in DB while the browser stayed in Thinking until reload, matching the keepalive-only client recovery fix in this PR

## Notes
- The Chrome extension zip was generated locally at `templates/clips/chrome-extension/releases/clips-chrome-extension-0.1.12.zip` for store upload.
