### PR TITLE
Fix tail reconnect materialization guard

### DIFF
--- a/.changeset/chat-reconnect-tail-followup.md
+++ b/.changeset/chat-reconnect-tail-followup.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Keep tail-resume reconnect content display-only and polish Design screen tool labels.
+Keep tail-resume reconnect content display-only, recover zero-byte action-prep stalls, and polish Design screen tool labels.

--- a/.changeset/chat-reconnect-tail-followup.md
+++ b/.changeset/chat-reconnect-tail-followup.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep tail-resume reconnect content display-only and polish Design screen tool labels.

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -2843,22 +2843,24 @@ export async function runAgentLoop(opts: {
             // reasons, then collapse it when content arrives.
             send({ type: "thinking", text: event.text });
           } else if (event.type === "tool-input-start") {
-            if (event.id && event.name) {
-              toolInputNames.set(event.id, event.name);
-              toolInputBytes.set(event.id, 0);
+            const key = event.id ?? event.name;
+            if (key && event.name) {
+              toolInputNames.set(key, event.name);
+              toolInputBytes.set(key, 0);
             }
             sendToolInputActivity(event.name, undefined, true);
           } else if (event.type === "tool-input-delta") {
+            const key = event.id ?? event.name;
             const toolName =
               event.name ??
               (event.id ? toolInputNames.get(event.id) : undefined);
             let progressBytes: number | undefined;
-            if (event.id) {
-              const previous = toolInputBytes.get(event.id) ?? 0;
+            if (key) {
+              const previous = toolInputBytes.get(key) ?? 0;
               progressBytes =
                 previous +
                 new TextEncoder().encode(event.text ?? "").byteLength;
-              toolInputBytes.set(event.id, progressBytes);
+              toolInputBytes.set(key, progressBytes);
             }
             sendToolInputActivity(toolName, progressBytes);
           } else if (event.type === "gateway-heartbeat") {

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -24,6 +24,7 @@ vi.mock("./run-store.js", () => ({
   bumpRunProgress: vi.fn(() => Promise.resolve()),
   reapIfStale: vi.fn(() => Promise.resolve(null)),
   reapUnclaimedBackgroundRun: vi.fn(() => Promise.resolve(false)),
+  reconcileTerminalRunFromEvents: vi.fn(() => Promise.resolve(false)),
   ensureTerminalRunEvent: vi.fn(() => Promise.resolve()),
   setRunError: vi.fn(() => Promise.resolve()),
   setRunTerminalReason: vi.fn(() => Promise.resolve()),
@@ -74,6 +75,7 @@ import {
   setRunTerminalReason,
   reapIfStale,
   reapUnclaimedBackgroundRun,
+  reconcileTerminalRunFromEvents,
 } from "./run-store.js";
 
 const originalTimeoutEnv = process.env.AGENT_RUN_SOFT_TIMEOUT_MS;
@@ -158,6 +160,8 @@ describe("run manager soft timeout", () => {
     vi.mocked(reapUnclaimedBackgroundRun).mockResolvedValue(false);
     vi.mocked(reapIfStale).mockReset();
     vi.mocked(reapIfStale).mockResolvedValue(null as any);
+    vi.mocked(reconcileTerminalRunFromEvents).mockReset();
+    vi.mocked(reconcileTerminalRunFromEvents).mockResolvedValue(false);
   });
 
   afterEach(() => {
@@ -808,6 +812,34 @@ describe("run manager soft timeout", () => {
         "run-insert-race",
         "completed",
       ),
+    );
+  });
+
+  it("reconciles from the terminal event when the final status write misses", async () => {
+    vi.mocked(updateRunStatusIfRunning).mockRejectedValueOnce(
+      new Error("transient status write failure"),
+    );
+    vi.mocked(reconcileTerminalRunFromEvents).mockResolvedValueOnce(true);
+
+    const run = startRun(
+      "run-terminal-reconcile-fallback",
+      "thread-terminal-reconcile-fallback",
+      async (send) => {
+        send({ type: "text", text: "fast answer" });
+      },
+      undefined,
+      { softTimeoutMs: 0 },
+    );
+
+    await vi.waitFor(() => expect(run.status).toBe("completed"));
+    await vi.waitFor(() =>
+      expect(updateRunStatusIfRunning).toHaveBeenCalledWith(
+        "run-terminal-reconcile-fallback",
+        "completed",
+      ),
+    );
+    expect(reconcileTerminalRunFromEvents).toHaveBeenCalledWith(
+      "run-terminal-reconcile-fallback",
     );
   });
 

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -69,6 +69,7 @@ import {
   updateRunStatusIfRunning,
   ensureTerminalRunEvent,
   cleanupOldRuns,
+  bumpRunProgress,
   setRunError,
   setRunTerminalReason,
   reapIfStale,
@@ -150,6 +151,7 @@ describe("run manager soft timeout", () => {
     vi.mocked(updateRunStatusIfRunning).mockReset();
     vi.mocked(updateRunStatusIfRunning).mockResolvedValue(true);
     vi.mocked(cleanupOldRuns).mockClear();
+    vi.mocked(bumpRunProgress).mockClear();
     vi.mocked(setRunError).mockClear();
     vi.mocked(setRunTerminalReason).mockClear();
     vi.mocked(reapUnclaimedBackgroundRun).mockReset();
@@ -683,6 +685,94 @@ describe("run manager soft timeout", () => {
 
     expect(abortReason).toBe("no_progress");
     expect(run.abortReason).toBe("no_progress");
+  });
+
+  it("does not bump durable progress for keepalives or zero-byte action preparation", async () => {
+    vi.setSystemTime(10_000);
+
+    const run = startRun(
+      "run-empty-prep-progress",
+      "thread-empty-prep-progress",
+      async (send, signal) => {
+        send({ type: "stream_keepalive" });
+        send({
+          type: "activity",
+          label: "Preparing edit-design action",
+          tool: "edit-design",
+        });
+        send({
+          type: "activity",
+          label: "Preparing edit-design action",
+          tool: "edit-design",
+          progressBytes: 0,
+        });
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+      },
+      undefined,
+      { softTimeoutMs: 0 },
+    );
+
+    expect(bumpRunProgress).not.toHaveBeenCalled();
+
+    expect(abortRun("run-empty-prep-progress")).toBe(true);
+    await vi.waitFor(() => expect(run.status).toBe("aborted"));
+  });
+
+  it("bumps durable progress only when action-preparation bytes increase", async () => {
+    vi.setSystemTime(10_000);
+
+    const run = startRun(
+      "run-streaming-prep-progress",
+      "thread-streaming-prep-progress",
+      async (send, signal) => {
+        send({
+          type: "activity",
+          label: "Preparing edit-design action",
+          tool: "edit-design",
+          progressBytes: 0,
+        });
+        send({
+          type: "activity",
+          label: "Preparing edit-design action",
+          tool: "edit-design",
+          progressBytes: 64,
+        });
+        vi.setSystemTime(12_000);
+        send({
+          type: "activity",
+          label: "Preparing edit-design action",
+          tool: "edit-design",
+          progressBytes: 64,
+        });
+        vi.setSystemTime(14_000);
+        send({
+          type: "activity",
+          label: "Preparing edit-design action",
+          tool: "edit-design",
+          progressBytes: 96,
+        });
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+      },
+      undefined,
+      { softTimeoutMs: 0 },
+    );
+
+    expect(bumpRunProgress).toHaveBeenCalledTimes(2);
+    expect(bumpRunProgress).toHaveBeenNthCalledWith(
+      1,
+      "run-streaming-prep-progress",
+    );
+    expect(bumpRunProgress).toHaveBeenNthCalledWith(
+      2,
+      "run-streaming-prep-progress",
+    );
+
+    expect(abortRun("run-streaming-prep-progress")).toBe(true);
+    await vi.waitFor(() => expect(run.status).toBe("aborted"));
   });
 
   it("waits for the SQL run row insert before writing terminal status", async () => {

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -16,6 +16,7 @@ import {
   bumpRunProgress,
   reapIfStale,
   reapUnclaimedBackgroundRun,
+  reconcileTerminalRunFromEvents,
   ensureTerminalRunEvent,
   setRunError,
   setRunTerminalReason,
@@ -779,12 +780,16 @@ export function startRun(
       try {
         await insertRunPromise;
         if (!terminalPersistenceError) {
-          const statusUpdated = await updateRunStatusIfRunning(
-            runId,
-            finalStatus,
-          );
+          let statusUpdated = false;
+          try {
+            statusUpdated = await updateRunStatusIfRunning(runId, finalStatus);
+          } catch {
+            statusUpdated = false;
+          }
           if (statusUpdated) {
             await setRunTerminalReason(runId, terminalReason);
+          } else {
+            await reconcileTerminalRunFromEvents(runId).catch(() => false);
           }
         }
       } catch {

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -125,6 +125,12 @@ export const TERMINAL_RUN_RECONNECT_WINDOW_MS = 10 * 60 * 1000;
 
 const PROVIDER_RATE_LIMITED_ERROR_CODE = "provider_rate_limited";
 
+function isPreparingActionActivityEvent(event: AgentChatEvent): boolean {
+  if (event.type !== "activity") return false;
+  const label = event.label.trim().toLowerCase();
+  return label.startsWith("preparing ") && label.includes(" action");
+}
+
 function getRunErrorMessage(err: unknown): string {
   if (
     typeof err === "object" &&
@@ -423,12 +429,48 @@ export function startRun(
   // chunk. The stuck-detector threshold is on the order of tens of seconds,
   // so 1s resolution is plenty.
   let lastProgressBumpAt = 0;
+  const preparingActivityBytes = new Map<string, number>();
   let eventPersistenceErrorCaptured = false;
   const bumpProgressIfDue = () => {
     const now = Date.now();
     if (now - lastProgressBumpAt < 1000) return;
     lastProgressBumpAt = now;
     bumpRunProgress(runId).catch(() => {});
+  };
+  const shouldBumpProgressForEvent = (event: AgentChatEvent): boolean => {
+    if (event.type === "stream_keepalive") return false;
+    if (event.type === "activity" && isPreparingActionActivityEvent(event)) {
+      const toolKey = event.tool?.trim() || event.label.trim();
+      const progressBytes =
+        typeof event.progressBytes === "number" &&
+        Number.isFinite(event.progressBytes) &&
+        event.progressBytes >= 0
+          ? Math.floor(event.progressBytes)
+          : undefined;
+      if (progressBytes === undefined) return false;
+      const previousBytes = preparingActivityBytes.get(toolKey) ?? 0;
+      if (progressBytes <= previousBytes) {
+        preparingActivityBytes.set(
+          toolKey,
+          Math.max(previousBytes, progressBytes),
+        );
+        return false;
+      }
+      preparingActivityBytes.set(toolKey, progressBytes);
+      return true;
+    }
+    if (event.type === "tool_start" || event.type === "tool_done") {
+      const tool = event.tool?.trim();
+      if (tool) preparingActivityBytes.delete(tool);
+    }
+    if (
+      event.type === "clear" ||
+      event.type === "done" ||
+      event.type === "error"
+    ) {
+      preparingActivityBytes.clear();
+    }
+    return true;
   };
 
   // Periodic SQL abort check interval (for cross-isolate abort on Workers).
@@ -539,8 +581,12 @@ export function startRun(
     // Bump the durable progress timestamp. Distinct from the heartbeat:
     // heartbeat = "process is up", progress = "real work is happening." The
     // gap between them is what the client-side stuck-detector reads to tell
-    // a hung run from a healthy one.
-    bumpProgressIfDue();
+    // a hung run from a healthy one. Keepalive and zero-byte action prep are
+    // liveness only; streamed input bytes, text, and tool lifecycle events are
+    // real progress.
+    if (shouldBumpProgressForEvent(runEvent.event)) {
+      bumpProgressIfDue();
+    }
 
     // Persist event to SQL. Events are chained through persistenceChain so
     // inserts commit in seq order — an out-of-order commit would advance the

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -282,6 +282,23 @@ describe("waitForThreadRunToClear", () => {
     expect(renderSource).toContain("reconnectContent.length === 0");
     expect(renderSource).not.toContain("reconnectAfterSeq");
   });
+
+  it("keeps tail-resume reconnect content display-only on normal completion", () => {
+    const source = readFileSync("src/client/AssistantChat.tsx", {
+      encoding: "utf8",
+    });
+    const start = source.indexOf("setReconnectFrozen(afterSeq === 0)");
+    const end = source.indexOf("const reconnectActiveRunForThread");
+    const completionSource = source.slice(start, end);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    expect(completionSource).toContain("setReconnectFrozen(afterSeq === 0)");
+    expect(completionSource).toContain("if (afterSeq > 0)");
+    expect(completionSource).toContain("setReconnectContent([])");
+    expect(completionSource).toContain("setReconnectFrozen(false)");
+    expect(completionSource).not.toContain("setReconnectFrozen(true)");
+  });
 });
 
 describe("reconnectProgressTimedOut", () => {

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -290,14 +290,30 @@ describe("waitForThreadRunToClear", () => {
     const start = source.indexOf("setReconnectFrozen(afterSeq === 0)");
     const end = source.indexOf("const reconnectActiveRunForThread");
     const completionSource = source.slice(start, end);
+    const materializeStart = source.indexOf(
+      "const materializeFrozenReconnectContent = useCallback",
+    );
+    const materializeEnd = source.indexOf(
+      "// Abort the active server run",
+      materializeStart,
+    );
+    const materializeSource = source.slice(materializeStart, materializeEnd);
 
     expect(start).toBeGreaterThan(-1);
     expect(end).toBeGreaterThan(start);
+    expect(materializeStart).toBeGreaterThan(-1);
+    expect(materializeEnd).toBeGreaterThan(materializeStart);
+    expect(source).toContain(
+      "reconnectCanMaterializeRef.current = afterSeq === 0",
+    );
     expect(completionSource).toContain("setReconnectFrozen(afterSeq === 0)");
     expect(completionSource).toContain("if (afterSeq > 0)");
     expect(completionSource).toContain("setReconnectContent([])");
     expect(completionSource).toContain("setReconnectFrozen(false)");
     expect(completionSource).not.toContain("setReconnectFrozen(true)");
+    expect(materializeSource).toContain("!reconnectCanMaterializeRef.current");
+    expect(materializeSource).toContain("setReconnectContent([])");
+    expect(materializeSource).toContain("return;");
   });
 });
 

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -310,10 +310,69 @@ describe("waitForThreadRunToClear", () => {
     expect(completionSource).toContain("if (afterSeq > 0)");
     expect(completionSource).toContain("setReconnectContent([])");
     expect(completionSource).toContain("setReconnectFrozen(false)");
+    expect(completionSource).toContain(
+      "if (loaded || afterSeq > 0 || latestContent.length === 0)",
+    );
+    expect(completionSource).toContain(
+      "afterSeq > 0 || repoHasAssistantMessage(repo)",
+    );
     expect(completionSource).not.toContain("setReconnectFrozen(true)");
     expect(materializeSource).toContain("!reconnectCanMaterializeRef.current");
     expect(materializeSource).toContain("setReconnectContent([])");
     expect(materializeSource).toContain("return;");
+  });
+
+  it("keeps stopped fresh reconnect content materializable", () => {
+    const source = readFileSync("src/client/AssistantChat.tsx", {
+      encoding: "utf8",
+    });
+    const stopStart = source.indexOf("const stopActiveRun = useCallback");
+    const stopEnd = source.indexOf(
+      "// Keep the ref current so addToQueue can call it",
+      stopStart,
+    );
+    const stopSource = source.slice(stopStart, stopEnd);
+    const freezeStart = stopSource.indexOf("if (shouldFreezeReconnectContent)");
+    const elseStart = stopSource.indexOf("} else {", freezeStart);
+    const freezeBranch = stopSource.slice(freezeStart, elseStart);
+
+    expect(stopStart).toBeGreaterThan(-1);
+    expect(stopEnd).toBeGreaterThan(stopStart);
+    expect(stopSource).toContain(
+      "reconnectCanMaterializeRef.current && reconnectContent.length > 0",
+    );
+    expect(freezeStart).toBeGreaterThan(-1);
+    expect(elseStart).toBeGreaterThan(freezeStart);
+    expect(freezeBranch).toContain("setReconnectFrozen(true)");
+    expect(freezeBranch).not.toContain(
+      "reconnectCanMaterializeRef.current = false",
+    );
+  });
+
+  it("keeps no-progress fresh reconnect content materializable", () => {
+    const source = readFileSync("src/client/AssistantChat.tsx", {
+      encoding: "utf8",
+    });
+    const start = source.indexOf(
+      "if (noProgressDuringReconnect && reconnectRunIdRef.current === runId)",
+    );
+    const end = source.indexOf("setReconnectFrozen(afterSeq === 0)", start);
+    const noProgressSource = source.slice(start, end);
+    const tailStart = noProgressSource.indexOf("if (afterSeq > 0)");
+    const freshStart = noProgressSource.indexOf("} else {", tailStart);
+    const freshEnd = noProgressSource.indexOf("setRunErrorInfo", freshStart);
+    const freshBranch = noProgressSource.slice(freshStart, freshEnd);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    expect(tailStart).toBeGreaterThan(-1);
+    expect(freshStart).toBeGreaterThan(tailStart);
+    expect(freshBranch).toContain(
+      "reconnectCanMaterializeRef.current = latestContent.length > 0",
+    );
+    expect(noProgressSource).toContain(
+      "if (afterSeq > 0) {\n            reconnectCanMaterializeRef.current = false;\n          }",
+    );
   });
 });
 

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1964,7 +1964,7 @@ const AssistantChatInner = forwardRef<
           return;
         }
 
-        setReconnectFrozen(true);
+        setReconnectFrozen(afterSeq === 0);
         let loaded = false;
         for (let attempt = 0; attempt < 10; attempt++) {
           await new Promise((r) => setTimeout(r, 500));
@@ -1979,6 +1979,10 @@ const AssistantChatInner = forwardRef<
         }
 
         if (reconnectRunIdRef.current === runId) {
+          if (afterSeq > 0) {
+            setReconnectContent([]);
+            setReconnectFrozen(false);
+          }
           clearActiveRunIfMatches(threadId, runId);
           reconnectAbortRef.current = null;
           setIsReconnecting(false);
@@ -1991,6 +1995,10 @@ const AssistantChatInner = forwardRef<
         }
         if (!loaded) {
           await refreshThreadFromServer();
+          if (afterSeq > 0) {
+            setReconnectContent([]);
+            setReconnectFrozen(false);
+          }
         }
       };
 

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1456,6 +1456,7 @@ const AssistantChatInner = forwardRef<
   // When stop is clicked during reconnect, keep content visible (don't wipe it)
   const [reconnectFrozen, setReconnectFrozen] = useState(false);
   const reconnectRunIdRef = useRef<string | null>(null);
+  const reconnectCanMaterializeRef = useRef(false);
   const reconnectAbortRef = useRef<AbortController | null>(null);
   // Nuclear stop: user clicked stop. Clears the stop button/indicator AND
   // lets new submissions go through immediately — prevents the "stuck
@@ -1774,6 +1775,7 @@ const AssistantChatInner = forwardRef<
 
       reconnectRunIdRef.current = runId;
       const afterSeq = resolveReconnectAfterSeq(threadId, runId);
+      reconnectCanMaterializeRef.current = afterSeq === 0;
       const storedActivityTool = getActiveRunActivityTool(threadId, runId);
       setRunningActivityTool(storedActivityTool);
       setActiveRun({
@@ -1956,6 +1958,7 @@ const AssistantChatInner = forwardRef<
           reconnectAbortRef.current = null;
           setIsReconnecting(false);
           reconnectRunIdRef.current = null;
+          reconnectCanMaterializeRef.current = false;
           window.dispatchEvent(
             new CustomEvent("agentNative.chatRunning", {
               detail: { isRunning: false, tabId: tabId || threadId },
@@ -1987,6 +1990,7 @@ const AssistantChatInner = forwardRef<
           reconnectAbortRef.current = null;
           setIsReconnecting(false);
           reconnectRunIdRef.current = null;
+          reconnectCanMaterializeRef.current = false;
           window.dispatchEvent(
             new CustomEvent("agentNative.chatRunning", {
               detail: { isRunning: false, tabId: tabId || threadId },
@@ -2712,6 +2716,11 @@ const AssistantChatInner = forwardRef<
 
   const materializeFrozenReconnectContent = useCallback(() => {
     if (!reconnectFrozen || reconnectContent.length === 0) return;
+    if (!reconnectCanMaterializeRef.current) {
+      setReconnectFrozen(false);
+      setReconnectContent([]);
+      return;
+    }
     try {
       const frozenContent = cloneContentParts(reconnectContent);
       settleInterruptedToolCalls(frozenContent);
@@ -2800,7 +2809,13 @@ const AssistantChatInner = forwardRef<
       reconnectAbortRef.current = null;
       reconnectRunIdRef.current = null;
       setIsReconnecting(false);
-      setReconnectFrozen(reconnectContent.length > 0);
+      if (reconnectCanMaterializeRef.current) {
+        setReconnectFrozen(reconnectContent.length > 0);
+      } else {
+        setReconnectFrozen(false);
+        setReconnectContent([]);
+      }
+      reconnectCanMaterializeRef.current = false;
     }
     threadRuntime.cancelRun();
     if (typeof window !== "undefined") {

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1945,6 +1945,7 @@ const AssistantChatInner = forwardRef<
             settleInterruptedToolCalls(latestContent);
             setReconnectContent([...latestContent]);
             setReconnectFrozen(latestContent.length > 0);
+            reconnectCanMaterializeRef.current = latestContent.length > 0;
           }
           setRunErrorInfo({
             message:
@@ -1958,7 +1959,9 @@ const AssistantChatInner = forwardRef<
           reconnectAbortRef.current = null;
           setIsReconnecting(false);
           reconnectRunIdRef.current = null;
-          reconnectCanMaterializeRef.current = false;
+          if (afterSeq > 0) {
+            reconnectCanMaterializeRef.current = false;
+          }
           window.dispatchEvent(
             new CustomEvent("agentNative.chatRunning", {
               detail: { isRunning: false, tabId: tabId || threadId },
@@ -1976,6 +1979,7 @@ const AssistantChatInner = forwardRef<
           if (repoHasAssistantMessage(repo)) {
             setReconnectContent([]);
             setReconnectFrozen(false);
+            reconnectCanMaterializeRef.current = false;
             loaded = true;
             break;
           }
@@ -1990,7 +1994,9 @@ const AssistantChatInner = forwardRef<
           reconnectAbortRef.current = null;
           setIsReconnecting(false);
           reconnectRunIdRef.current = null;
-          reconnectCanMaterializeRef.current = false;
+          if (loaded || afterSeq > 0 || latestContent.length === 0) {
+            reconnectCanMaterializeRef.current = false;
+          }
           window.dispatchEvent(
             new CustomEvent("agentNative.chatRunning", {
               detail: { isRunning: false, tabId: tabId || threadId },
@@ -1998,10 +2004,11 @@ const AssistantChatInner = forwardRef<
           );
         }
         if (!loaded) {
-          await refreshThreadFromServer();
-          if (afterSeq > 0) {
+          const repo = await refreshThreadFromServer();
+          if (afterSeq > 0 || repoHasAssistantMessage(repo)) {
             setReconnectContent([]);
             setReconnectFrozen(false);
+            reconnectCanMaterializeRef.current = false;
           }
         }
       };
@@ -2696,6 +2703,7 @@ const AssistantChatInner = forwardRef<
       if (reconnectFrozen) {
         setReconnectFrozen(false);
         setReconnectContent([]);
+        reconnectCanMaterializeRef.current = false;
       }
       if (forceStopped) {
         setForceStopped(false);
@@ -2761,6 +2769,7 @@ const AssistantChatInner = forwardRef<
       threadRuntime.import(ensureMessageMetadata(repo));
       setReconnectFrozen(false);
       setReconnectContent([]);
+      reconnectCanMaterializeRef.current = false;
     } catch (err) {
       captureError(err, {
         tags: {
@@ -2809,13 +2818,15 @@ const AssistantChatInner = forwardRef<
       reconnectAbortRef.current = null;
       reconnectRunIdRef.current = null;
       setIsReconnecting(false);
-      if (reconnectCanMaterializeRef.current) {
-        setReconnectFrozen(reconnectContent.length > 0);
+      const shouldFreezeReconnectContent =
+        reconnectCanMaterializeRef.current && reconnectContent.length > 0;
+      if (shouldFreezeReconnectContent) {
+        setReconnectFrozen(true);
       } else {
         setReconnectFrozen(false);
         setReconnectContent([]);
+        reconnectCanMaterializeRef.current = false;
       }
-      reconnectCanMaterializeRef.current = false;
     }
     threadRuntime.cancelRun();
     if (typeof window !== "undefined") {

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -143,6 +143,40 @@ function preparingActionKeepaliveStream(
   });
 }
 
+function preparingActionZeroByteActivityStream(
+  tool = "edit-design",
+  intervalMs = 30_000,
+): ReadableStream<Uint8Array> {
+  let timer: ReturnType<typeof setInterval> | undefined;
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      const sendActivity = () => {
+        controller.enqueue(
+          new TextEncoder().encode(
+            `data: ${JSON.stringify({
+              type: "activity",
+              label: `Preparing ${tool} action`,
+              tool,
+              progressBytes: 0,
+            })}\n\n`,
+          ),
+        );
+      };
+      sendActivity();
+      timer = setInterval(() => {
+        try {
+          sendActivity();
+        } catch {
+          // The watchdog may have cancelled the stream first.
+        }
+      }, intervalMs);
+    },
+    cancel() {
+      if (timer) clearInterval(timer);
+    },
+  });
+}
+
 function preparingActionProgressStream(
   tool = "edit-design",
   intervalMs = 30_000,
@@ -369,6 +403,37 @@ describe("SSE event processor no-progress recovery", () => {
     await vi.advanceTimersByTimeAsync(
       SSE_ACTION_PREPARATION_STALL_TIMEOUT_MS + 1,
     );
+    const err = await errPromise;
+
+    expect(err).toBeInstanceOf(AgentAutoContinueSignal);
+    expect((err as AgentAutoContinueSignal).reason).toBe("no_progress");
+    expect((err as AgentAutoContinueSignal).activityTrail).toEqual([
+      {
+        label: "Preparing edit screen action",
+        tool: "edit-design",
+      },
+    ]);
+  });
+
+  it("does not let repeated zero-byte preparation activity hide a stalled action", async () => {
+    vi.useFakeTimers();
+
+    const errPromise = (async () => {
+      try {
+        for await (const _ of readSSEStream(
+          preparingActionZeroByteActivityStream(),
+          [],
+          { value: 0 },
+          undefined,
+        )) {
+          // no-op
+        }
+      } catch (err) {
+        return err;
+      }
+    })();
+
+    await vi.advanceTimersByTimeAsync(SSE_NO_PROGRESS_TIMEOUT_MS + 1);
     const err = await errPromise;
 
     expect(err).toBeInstanceOf(AgentAutoContinueSignal);

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -186,10 +186,6 @@ function isPreparingActionActivity(ev: SSEEvent): boolean {
   return label.startsWith("preparing ") && label.includes(" action");
 }
 
-function isProgressEvent(ev: SSEEvent): boolean {
-  return ev.type !== "stream_keepalive";
-}
-
 function isMeaningfulProgressEvent(
   ev: SSEEvent,
   actionPreparationProgress?: boolean,

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -153,6 +153,7 @@ type ActivityTrailEntry = AgentActivityTrailEntry;
 type PreparingActionState = {
   tool?: string;
   startedAt?: number;
+  lastProgressBytes?: number;
   /**
    * Timestamp of the last real streaming progress for the in-preparation tool
    * input. The server emits a throttled `activity` heartbeat per
@@ -187,6 +188,17 @@ function isPreparingActionActivity(ev: SSEEvent): boolean {
 
 function isProgressEvent(ev: SSEEvent): boolean {
   return ev.type !== "stream_keepalive";
+}
+
+function isMeaningfulProgressEvent(
+  ev: SSEEvent,
+  actionPreparationProgress?: boolean,
+): boolean {
+  if (ev.type === "stream_keepalive") return false;
+  if (ev.type === "activity" && isPreparingActionActivity(ev)) {
+    return actionPreparationProgress === true;
+  }
+  return true;
 }
 
 function baseActivityLabel(ev: SSEEvent, tool?: string): string {
@@ -258,19 +270,28 @@ function updatePreparingActionState(
   state: PreparingActionState,
   ev: SSEEvent,
   now: number,
-) {
+): boolean | undefined {
   if (ev.type === "activity" && isPreparingActionActivity(ev)) {
     const tool = ev.tool?.trim() || undefined;
-    if (!tool) return;
+    if (!tool) return false;
     if (state.tool !== tool || state.startedAt === undefined) {
       state.tool = tool;
       state.startedAt = now;
+      state.lastProgressAt = undefined;
+      state.lastProgressBytes = undefined;
     }
-    // Every tool-input activity is a throttled proof the model is still
-    // streaming this action's argument. Treat it as progress so large inputs
-    // that take many seconds/minutes to stream are NOT flagged as stalled.
-    state.lastProgressAt = now;
-    return;
+    const progressBytes = activityProgressBytes(ev);
+    const previousBytes = state.lastProgressBytes ?? 0;
+    if (progressBytes !== undefined) {
+      state.lastProgressBytes = Math.max(previousBytes, progressBytes);
+    }
+    if (progressBytes !== undefined && progressBytes > previousBytes) {
+      // A byte increase is proof the model is still streaming this action's
+      // argument. Repeated zero-byte prep activity is only a heartbeat.
+      state.lastProgressAt = now;
+      return true;
+    }
+    return false;
   }
 
   if (
@@ -285,7 +306,9 @@ function updatePreparingActionState(
     state.tool = undefined;
     state.startedAt = undefined;
     state.lastProgressAt = undefined;
+    state.lastProgressBytes = undefined;
   }
+  return undefined;
 }
 
 function hasStalledPreparingAction(state: PreparingActionState, now: number) {
@@ -296,8 +319,9 @@ function hasStalledPreparingAction(state: PreparingActionState, now: number) {
   // survives; a genuinely stuck prep (keepalive-only, no deltas) trips it.
   return (
     state.tool !== undefined &&
-    state.lastProgressAt !== undefined &&
-    now - state.lastProgressAt >= SSE_ACTION_PREPARATION_STALL_TIMEOUT_MS
+    state.startedAt !== undefined &&
+    now - (state.lastProgressAt ?? state.startedAt) >=
+      SSE_ACTION_PREPARATION_STALL_TIMEOUT_MS
   );
 }
 
@@ -1193,11 +1217,15 @@ export async function* readSSEStream(
           continue;
         }
         const now = Date.now();
-        if (isProgressEvent(ev)) {
+        const actionPreparationProgress = updatePreparingActionState(
+          preparingActionState,
+          ev,
+          now,
+        );
+        if (isMeaningfulProgressEvent(ev, actionPreparationProgress)) {
           sawProgressEvent = true;
           lastMeaningfulEventAt = now;
         }
-        updatePreparingActionState(preparingActionState, ev, now);
 
         // Track sequence number for reconnection
         if (ev.seq !== undefined && onSeq) {
@@ -1355,11 +1383,15 @@ export async function readSSEStreamRaw(
           continue;
         }
         const now = Date.now();
-        if (isProgressEvent(ev)) {
+        const actionPreparationProgress = updatePreparingActionState(
+          preparingActionState,
+          ev,
+          now,
+        );
+        if (isMeaningfulProgressEvent(ev, actionPreparationProgress)) {
           sawProgressEvent = true;
           lastMeaningfulEventAt = now;
         }
-        updatePreparingActionState(preparingActionState, ev, now);
 
         if (ev.seq !== undefined && onSeq) {
           onSeq(ev.seq);

--- a/packages/core/src/client/tool-display.spec.ts
+++ b/packages/core/src/client/tool-display.spec.ts
@@ -16,7 +16,7 @@ describe("tool display labels", () => {
   });
 
   it("uses user-facing labels for Design screen tools", () => {
-    expect(humanizeToolName("delete-file")).toBe("delete screen");
+    expect(humanizeToolName("delete-file")).toBe("remove screen");
     expect(humanizeToolName("get-design-snapshot")).toBe("get screen snapshot");
     expect(humanizeToolName("edit-design")).toBe("edit screen");
   });

--- a/packages/core/src/client/tool-display.ts
+++ b/packages/core/src/client/tool-display.ts
@@ -1,5 +1,5 @@
 const TOOL_DISPLAY_NAMES: Record<string, string> = {
-  "delete-file": "delete screen",
+  "delete-file": "remove screen",
   "get-design-snapshot": "get screen snapshot",
   "edit-design": "edit screen",
 };

--- a/packages/desktop-app/electron.vite.config.ts
+++ b/packages/desktop-app/electron.vite.config.ts
@@ -3,6 +3,8 @@ import { resolve } from "path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react-swc";
 import { defineConfig, externalizeDepsPlugin } from "electron-vite";
+import type { OutputBundle, OutputChunk } from "rollup";
+import type { Plugin } from "vite";
 
 const workspaceRendererPackages = [
   "@agent-native/code-agents-ui",
@@ -12,6 +14,82 @@ const workspaceRendererPackages = [
   "@agent-native/core/client",
   "@agent-native/shared-app-config",
 ];
+
+const PRELOAD_CHUNK_REQUIRE_RE =
+  /const\s+([A-Za-z_$][\w$]*)\s*=\s*require\(["']\.\/chunks\/([^"']+)["']\);?\n?/g;
+
+function asOutputChunk(
+  bundle: OutputBundle,
+  fileName: string,
+): OutputChunk | null {
+  const output = bundle[fileName];
+  return output?.type === "chunk" ? output : null;
+}
+
+function indentInlineModule(code: string): string {
+  return code
+    .split("\n")
+    .map((line) => (line ? `  ${line}` : ""))
+    .join("\n");
+}
+
+function inlineChunkRequires(
+  code: string,
+  bundle: OutputBundle,
+  stack: string[] = [],
+): string {
+  return code.replace(
+    PRELOAD_CHUNK_REQUIRE_RE,
+    (match, variableName: string, chunkName: string) => {
+      const fileName = `chunks/${chunkName}`;
+      const chunk = asOutputChunk(bundle, fileName);
+      if (!chunk) return match;
+      if (stack.includes(fileName)) {
+        throw new Error(`Circular preload chunk dependency: ${fileName}`);
+      }
+
+      const inlinedCode = inlineChunkRequires(chunk.code, bundle, [
+        ...stack,
+        fileName,
+      ]);
+      return `const ${variableName} = (() => {
+  const exports = {};
+  const module = { exports };
+${indentInlineModule(inlinedCode)}
+  return module.exports;
+})();
+`;
+    },
+  );
+}
+
+function inlinePreloadChunksPlugin(): Plugin {
+  return {
+    name: "agent-native:inline-preload-chunks",
+    generateBundle(_options, bundle) {
+      const sharedChunks = Object.entries(bundle).flatMap(
+        ([fileName, output]) =>
+          output.type === "chunk" && !output.isEntry ? [fileName] : [],
+      );
+      if (sharedChunks.length === 0) return;
+
+      for (const output of Object.values(bundle)) {
+        if (output.type !== "chunk" || !output.isEntry) continue;
+        output.code = inlineChunkRequires(output.code, bundle);
+        if (PRELOAD_CHUNK_REQUIRE_RE.test(output.code)) {
+          throw new Error(
+            `Preload entry ${output.fileName} still requires a generated chunk`,
+          );
+        }
+        PRELOAD_CHUNK_REQUIRE_RE.lastIndex = 0;
+      }
+
+      for (const fileName of sharedChunks) {
+        delete bundle[fileName];
+      }
+    },
+  };
+}
 
 function firstNonEmpty(...values: Array<string | undefined>): string {
   for (const value of values) {
@@ -95,6 +173,7 @@ export default defineConfig({
           "electron-updater",
         ],
       }),
+      inlinePreloadChunksPlugin(),
     ],
     resolve: {
       alias: {
@@ -120,6 +199,7 @@ export default defineConfig({
     },
     build: {
       rollupOptions: {
+        external: ["electron"],
         input: {
           index: resolve("src/preload/index.ts"),
           webview: resolve("src/preload/webview.ts"),
@@ -127,7 +207,6 @@ export default defineConfig({
         output: {
           format: "cjs",
           entryFileNames: "[name].js",
-          chunkFileNames: "chunks/[name]-[hash].js",
         },
       },
     },

--- a/packages/desktop-app/electron.vite.config.ts
+++ b/packages/desktop-app/electron.vite.config.ts
@@ -82,6 +82,7 @@ function inlinePreloadChunksPlugin(): Plugin {
   return {
     name: "agent-native:inline-preload-chunks",
     generateBundle(_options, bundle) {
+      // Sandboxed Electron preloads need to be self-contained inside app.asar.
       const preloadBundle = bundle as PreloadOutputBundle;
       const sharedChunks = Object.entries(preloadBundle).flatMap(
         ([fileName, output]) =>

--- a/packages/desktop-app/electron.vite.config.ts
+++ b/packages/desktop-app/electron.vite.config.ts
@@ -3,7 +3,6 @@ import { resolve } from "path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react-swc";
 import { defineConfig, externalizeDepsPlugin } from "electron-vite";
-import type { OutputBundle, OutputChunk } from "rollup";
 import type { Plugin } from "vite";
 
 const workspaceRendererPackages = [
@@ -18,10 +17,26 @@ const workspaceRendererPackages = [
 const PRELOAD_CHUNK_REQUIRE_RE =
   /const\s+([A-Za-z_$][\w$]*)\s*=\s*require\(["']\.\/chunks\/([^"']+)["']\);?\n?/g;
 
+type PreloadOutputChunk = {
+  type: "chunk";
+  fileName: string;
+  code: string;
+  isEntry: boolean;
+};
+
+type PreloadOutputAsset = {
+  type: "asset";
+};
+
+type PreloadOutputBundle = Record<
+  string,
+  PreloadOutputAsset | PreloadOutputChunk
+>;
+
 function asOutputChunk(
-  bundle: OutputBundle,
+  bundle: PreloadOutputBundle,
   fileName: string,
-): OutputChunk | null {
+): PreloadOutputChunk | null {
   const output = bundle[fileName];
   return output?.type === "chunk" ? output : null;
 }
@@ -35,7 +50,7 @@ function indentInlineModule(code: string): string {
 
 function inlineChunkRequires(
   code: string,
-  bundle: OutputBundle,
+  bundle: PreloadOutputBundle,
   stack: string[] = [],
 ): string {
   return code.replace(
@@ -67,15 +82,16 @@ function inlinePreloadChunksPlugin(): Plugin {
   return {
     name: "agent-native:inline-preload-chunks",
     generateBundle(_options, bundle) {
-      const sharedChunks = Object.entries(bundle).flatMap(
+      const preloadBundle = bundle as PreloadOutputBundle;
+      const sharedChunks = Object.entries(preloadBundle).flatMap(
         ([fileName, output]) =>
           output.type === "chunk" && !output.isEntry ? [fileName] : [],
       );
       if (sharedChunks.length === 0) return;
 
-      for (const output of Object.values(bundle)) {
+      for (const output of Object.values(preloadBundle)) {
         if (output.type !== "chunk" || !output.isEntry) continue;
-        output.code = inlineChunkRequires(output.code, bundle);
+        output.code = inlineChunkRequires(output.code, preloadBundle);
         if (PRELOAD_CHUNK_REQUIRE_RE.test(output.code)) {
           throw new Error(
             `Preload entry ${output.fileName} still requires a generated chunk`,
@@ -173,7 +189,6 @@ export default defineConfig({
           "electron-updater",
         ],
       }),
-      inlinePreloadChunksPlugin(),
     ],
     resolve: {
       alias: {
@@ -191,6 +206,7 @@ export default defineConfig({
           "@agent-native/shared-app-config",
         ],
       }),
+      inlinePreloadChunksPlugin(),
     ],
     resolve: {
       alias: {

--- a/packages/desktop-app/src/preload/index.ts
+++ b/packages/desktop-app/src/preload/index.ts
@@ -1,5 +1,3 @@
-import path from "node:path";
-
 import type { AppConfig, FrameSettings } from "@shared/app-registry";
 import type { CodeAgentPermissionMode } from "@shared/code-agents";
 import {
@@ -52,6 +50,7 @@ const CODE_AGENTS_SUBSCRIBE_TRANSCRIPT_CHANNEL =
 const CODE_AGENTS_UNSUBSCRIBE_TRANSCRIPT_CHANNEL =
   "code-agents:unsubscribe-transcript";
 const CODE_AGENTS_TRANSCRIPT_EVENTS_CHANNEL = "code-agents:transcript-events";
+const WEBVIEW_PRELOAD_PATH = `${__dirname.replace(/[/\\]$/, "")}/webview.js`;
 
 type CodeAgentTranscriptSubscriptionBatch = CodeAgentTranscriptResult & {
   subscriptionId?: string;
@@ -69,7 +68,7 @@ const electronAPI = {
   },
 
   /** Dedicated preload for hosted app webviews. Exposes only app-safe bridges. */
-  webviewPreloadPath: path.join(__dirname, "webview.js"),
+  webviewPreloadPath: WEBVIEW_PRELOAD_PATH,
 
   /** Window chrome controls */
   windowControls: {

--- a/templates/clips/.agents/skills/video-sharing/SKILL.md
+++ b/templates/clips/.agents/skills/video-sharing/SKILL.md
@@ -184,8 +184,10 @@ These endpoints follow the same access model as `/api/public-recording`:
   raw provider URLs.
 
 The share popover's "Share with agents" field should copy the agent context URL,
-not raw transcript text. The context response points agents at the transcript and
-frame APIs so they can fetch only the visual context they need.
+not raw transcript text. Its "Copy agent prompt" field may wrap that URL with
+instructions to fetch transcripts, frames, and browser diagnostics, but it should
+still point agents at the context response so they can fetch only the visual
+context they need.
 
 ## View counting
 

--- a/templates/clips/app/components/player/share-dialog.tsx
+++ b/templates/clips/app/components/player/share-dialog.tsx
@@ -324,6 +324,9 @@ function LinkTab({
     ? tokenizedAgentContextUrl
     : publicAgentContextUrl;
   const agentShareDisabled = isPending || !isPublic || !agentContextUrl;
+  const agentPrompt = agentContextUrl
+    ? t("shareDialog.agentPrompt", { agentContextUrl })
+    : "";
 
   return (
     <div className="space-y-4">
@@ -348,6 +351,12 @@ function LinkTab({
       <CopyField
         label={t("shareDialog.shareWithAgents")}
         value={agentContextUrl}
+        disabled={agentShareDisabled}
+      />
+
+      <CopyField
+        label={t("shareDialog.copyAgentPrompt")}
+        value={agentPrompt}
         disabled={agentShareDisabled}
       />
 

--- a/templates/clips/app/i18n/ar-SA.ts
+++ b/templates/clips/app/i18n/ar-SA.ts
@@ -415,6 +415,9 @@ const messages = {
     embed: "تضمين",
     shareLink: "رابط المشاركة",
     shareWithAgents: "شارك مع الوكلاء",
+    copyAgentPrompt: "نسخ مطالبة الوكيل",
+    agentPrompt:
+      "اجلب عنوان URL لسياق وكيل Clips هذا: {{agentContextUrl}}. استخدم transcript.segments للسياق المنطوق، واجلب recommendedFrames أو عناوين URL الخاصة بواجهة API للإطارات لرؤية الشاشة، وتحقق من browserDiagnostics إن وجدت لسجلات وحدة التحكم المنقحة وبيانات طلبات fetch/XHR الوصفية.",
     agentTokenDescription:
       "يستخدم هذا الوكيل URL رمزًا مميزًا قصير العمر، بحيث يمكن للعملاء قراءة المقطع دون الكشف عن كلمة المرور.",
     gifPreview: "معاينة GIF",

--- a/templates/clips/app/i18n/de-DE.ts
+++ b/templates/clips/app/i18n/de-DE.ts
@@ -432,6 +432,9 @@ const messages = {
     embed: "Einbetten",
     shareLink: "Teillink",
     shareWithAgents: "Mit Agenten teilen",
+    copyAgentPrompt: "Agent-Prompt kopieren",
+    agentPrompt:
+      "Rufe diese Clips-Agent-Kontext-URL ab: {{agentContextUrl}}. Verwende transcript.segments fuer den gesprochenen Kontext, rufe recommendedFrames oder die Frame-API-URLs ab, um den Bildschirm zu sehen, und pruefe browserDiagnostics, falls vorhanden, fuer redigierte Konsolenprotokolle und fetch/XHR-Anfragemetadaten.",
     agentTokenDescription:
       "Dieser Agent URL verwendet ein kurzlebiges Token, sodass Agenten den Clip lesen können, ohne das Passwort preiszugeben.",
     gifPreview: "GIF-Vorschau",

--- a/templates/clips/app/i18n/en-US.ts
+++ b/templates/clips/app/i18n/en-US.ts
@@ -415,6 +415,9 @@ const messages = {
     embed: "Embed",
     shareLink: "Share link",
     shareWithAgents: "Share with agents",
+    copyAgentPrompt: "Copy agent prompt",
+    agentPrompt:
+      "Fetch this Clips agent context URL: {{agentContextUrl}}. Use transcript.segments for spoken context, fetch recommendedFrames or the frame API URLs to see the screen, and check browserDiagnostics if present for redacted console logs and fetch/XHR request metadata.",
     agentTokenDescription:
       "This agent URL uses a short-lived token, so agents can read the clip without exposing the password.",
     gifPreview: "GIF preview",

--- a/templates/clips/app/i18n/es-ES.ts
+++ b/templates/clips/app/i18n/es-ES.ts
@@ -427,6 +427,9 @@ const messages = {
     embed: "Insertar",
     shareLink: "Enlace para compartir",
     shareWithAgents: "Compartir con agentes",
+    copyAgentPrompt: "Copiar indicación para agente",
+    agentPrompt:
+      "Obtén esta URL de contexto para agentes de Clips: {{agentContextUrl}}. Usa transcript.segments para el contexto hablado, obtén recommendedFrames o las URLs de la API de fotogramas para ver la pantalla y revisa browserDiagnostics si está presente para ver registros de consola redactados y metadatos de solicitudes fetch/XHR.",
     agentTokenDescription:
       "Este agente URL utiliza un token de corta duración, por lo que los agentes pueden leer el clip sin exponer la contraseña.",
     gifPreview: "vista previa de GIF",

--- a/templates/clips/app/i18n/fr-FR.ts
+++ b/templates/clips/app/i18n/fr-FR.ts
@@ -427,6 +427,9 @@ const messages = {
     embed: "Intégrer",
     shareLink: "Lien de partage",
     shareWithAgents: "Partager avec les agents",
+    copyAgentPrompt: "Copier le prompt pour agent",
+    agentPrompt:
+      "Récupère cette URL de contexte Clips pour agent : {{agentContextUrl}}. Utilise transcript.segments pour le contexte parlé, récupère recommendedFrames ou les URLs de l'API d'images pour voir l'écran, et consulte browserDiagnostics s'il est présent pour les journaux de console expurgés et les métadonnées de requêtes fetch/XHR.",
     agentTokenDescription:
       "Cet agent URL utilise un jeton de courte durée, afin que les agents puissent lire le clip sans exposer le mot de passe.",
     gifPreview: "aperçu de GIF",

--- a/templates/clips/app/i18n/hi-IN.ts
+++ b/templates/clips/app/i18n/hi-IN.ts
@@ -412,6 +412,9 @@ const messages = {
     embed: "एम्बेड",
     shareLink: "शेयर लिंक",
     shareWithAgents: "एजेंटों के साथ साझा करें",
+    copyAgentPrompt: "एजेंट प्रॉम्प्ट कॉपी करें",
+    agentPrompt:
+      "यह Clips एजेंट संदर्भ URL प्राप्त करें: {{agentContextUrl}}। बोले गए संदर्भ के लिए transcript.segments का उपयोग करें, स्क्रीन देखने के लिए recommendedFrames या फ्रेम API URL प्राप्त करें, और यदि browserDiagnostics मौजूद हो तो संशोधित कंसोल लॉग और fetch/XHR अनुरोध मेटाडेटा जांचें।",
     agentTokenDescription:
       "यह एजेंट URL एक अल्पकालिक टोकन का उपयोग करता है, ताकि एजेंट पासवर्ड उजागर किए बिना क्लिप पढ़ सकें।",
     gifPreview: "GIF पूर्वावलोकन",

--- a/templates/clips/app/i18n/ja-JP.ts
+++ b/templates/clips/app/i18n/ja-JP.ts
@@ -424,6 +424,9 @@ const messages = {
     embed: "埋め込み",
     shareLink: "共有リンク",
     shareWithAgents: "エージェントと共有する",
+    copyAgentPrompt: "エージェント用プロンプトをコピー",
+    agentPrompt:
+      "この Clips エージェントコンテキスト URL を取得してください: {{agentContextUrl}}。音声の文脈には transcript.segments を使い、画面を見るために recommendedFrames またはフレーム API URL を取得し、browserDiagnostics がある場合は、編集済みのコンソールログと fetch/XHR リクエストのメタデータを確認してください。",
     agentTokenDescription:
       "このエージェント URL は有効期間の短いトークンを使用するため、エージェントはパスワードを公開せずにクリップを読み取ることができます。",
     gifPreview: "GIF プレビュー",

--- a/templates/clips/app/i18n/ko-KR.ts
+++ b/templates/clips/app/i18n/ko-KR.ts
@@ -417,6 +417,9 @@ const messages = {
     embed: "임베드",
     shareLink: "공유 링크",
     shareWithAgents: "상담원과 공유",
+    copyAgentPrompt: "에이전트 프롬프트 복사",
+    agentPrompt:
+      "이 Clips 에이전트 컨텍스트 URL을 가져오세요: {{agentContextUrl}}. 말한 내용의 맥락은 transcript.segments를 사용하고, 화면을 보기 위해 recommendedFrames 또는 프레임 API URL을 가져오며, browserDiagnostics가 있으면 수정된 콘솔 로그와 fetch/XHR 요청 메타데이터를 확인하세요.",
     agentTokenDescription:
       "이 에이전트 URL는 수명이 짧은 토큰을 사용하므로 에이전트는 비밀번호를 노출하지 않고도 클립을 읽을 수 있습니다.",
     gifPreview: "GIF 미리보기",

--- a/templates/clips/app/i18n/pt-BR.ts
+++ b/templates/clips/app/i18n/pt-BR.ts
@@ -425,6 +425,9 @@ const messages = {
     embed: "Incorporar",
     shareLink: "Link de compartilhamento",
     shareWithAgents: "Compartilhe com agentes",
+    copyAgentPrompt: "Copiar prompt para agente",
+    agentPrompt:
+      "Busque esta URL de contexto para agentes do Clips: {{agentContextUrl}}. Use transcript.segments para o contexto falado, busque recommendedFrames ou as URLs da API de quadros para ver a tela e confira browserDiagnostics, se presente, para logs de console redigidos e metadados de solicitações fetch/XHR.",
     agentTokenDescription:
       "Este agente URL usa um token de curta duração, para que os agentes possam ler o clipe sem expor a senha.",
     gifPreview: "visualização de GIF",

--- a/templates/clips/app/i18n/zh-CN.ts
+++ b/templates/clips/app/i18n/zh-CN.ts
@@ -399,6 +399,9 @@ const messages = {
     embed: "嵌入",
     shareLink: "分享链接",
     shareWithAgents: "与代理商分享",
+    copyAgentPrompt: "复制代理提示",
+    agentPrompt:
+      "获取这个 Clips 代理上下文 URL：{{agentContextUrl}}。使用 transcript.segments 读取语音上下文，获取 recommendedFrames 或帧 API URL 来查看屏幕，并在 browserDiagnostics 存在时检查经过脱敏的控制台日志和 fetch/XHR 请求元数据。",
     agentTokenDescription:
       "该代理 URL 使用短期令牌，因此代理可以在不暴露密码的情况下读取剪辑。",
     gifPreview: "GIF 预览",

--- a/templates/clips/app/i18n/zh-TW.ts
+++ b/templates/clips/app/i18n/zh-TW.ts
@@ -399,6 +399,9 @@ const messages = {
     embed: "嵌入",
     shareLink: "分享連結",
     shareWithAgents: "與 Agent 分享",
+    copyAgentPrompt: "複製 Agent 提示",
+    agentPrompt:
+      "取得這個 Clips Agent 脈絡 URL：{{agentContextUrl}}。使用 transcript.segments 讀取語音脈絡，取得 recommendedFrames 或影格 API URL 來查看螢幕，並在 browserDiagnostics 存在時檢查已遮蔽的主控台記錄和 fetch/XHR 請求中繼資料。",
     agentTokenDescription:
       "此 Agent URL 使用短期權杖，因此 Agent 可以在不暴露密碼的情況下讀取剪輯。",
     gifPreview: "GIF 預覽",

--- a/templates/clips/changelog/2026-07-01-shared-clips-can-now-copy-a-ready-to-send-prompt-that-tells-.md
+++ b/templates/clips/changelog/2026-07-01-shared-clips-can-now-copy-a-ready-to-send-prompt-that-tells-.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-01
+---
+
+Shared clips can now copy a ready-to-send prompt that tells agents how to read transcripts, frames, and diagnostics.


### PR DESCRIPTION
## Summary
- prevent tail-resume reconnect replay content from being materialized as a duplicate assistant message
- add regression coverage for the reconnect materialization guard
- rename the Design delete-file tool display label to “remove screen” for less alarming screen cleanup cards
- include the Clips share-prompt follow-up changes already present on this branch

## Validation
- corepack pnpm --filter @agent-native/core exec vitest --run src/client/AssistantChat.display.spec.ts src/client/tool-display.spec.ts

Follow-up for BuilderIO/agent-native#1765 review comment: https://github.com/BuilderIO/agent-native/pull/1765#discussion_r3509001554