### PR TITLE
Fix parallel preparation progress tracking

### DIFF
--- a/.changeset/parallel-prep-progress-ids.md
+++ b/.changeset/parallel-prep-progress-ids.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Track action-preparation progress by streamed tool-input id so parallel same-name tool calls do not hide real progress.

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -903,11 +903,13 @@ describe("runAgentLoop", () => {
       type: "activity",
       label: "Preparing create-document action",
       tool: "create-document",
+      id: "tool-create",
     });
     expect(events).toContainEqual({
       type: "activity",
       label: "Preparing create-document action",
       tool: "create-document",
+      id: "tool-create",
       progressBytes: 8,
     });
     expect(events).toContainEqual(

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -2795,6 +2795,7 @@ export async function runAgentLoop(opts: {
         let lastToolInputActivityAt = 0;
         const sendToolInputActivity = (
           toolName: string | undefined,
+          toolInputId?: string,
           progressBytes?: number,
           force = false,
         ) => {
@@ -2810,6 +2811,7 @@ export async function runAgentLoop(opts: {
             type: "activity",
             label: toolInputActivityLabel(toolName),
             ...(toolName ? { tool: toolName } : {}),
+            ...(toolInputId ? { id: toolInputId } : {}),
             ...(typeof progressBytes === "number" ? { progressBytes } : {}),
           });
         };
@@ -2848,7 +2850,7 @@ export async function runAgentLoop(opts: {
               toolInputNames.set(key, event.name);
               toolInputBytes.set(key, 0);
             }
-            sendToolInputActivity(event.name, undefined, true);
+            sendToolInputActivity(event.name, key, undefined, true);
           } else if (event.type === "tool-input-delta") {
             const key = event.id ?? event.name;
             const toolName =
@@ -2862,7 +2864,7 @@ export async function runAgentLoop(opts: {
                 new TextEncoder().encode(event.text ?? "").byteLength;
               toolInputBytes.set(key, progressBytes);
             }
-            sendToolInputActivity(toolName, progressBytes);
+            sendToolInputActivity(toolName, key, progressBytes);
           } else if (event.type === "gateway-heartbeat") {
             send({ type: "stream_keepalive" });
           } else if (event.type === "tool-call") {

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -735,12 +735,14 @@ describe("run manager soft timeout", () => {
           type: "activity",
           label: "Preparing edit-design action",
           tool: "edit-design",
+          id: "call-a",
           progressBytes: 0,
         });
         send({
           type: "activity",
           label: "Preparing edit-design action",
           tool: "edit-design",
+          id: "call-a",
           progressBytes: 64,
         });
         vi.setSystemTime(12_000);
@@ -748,6 +750,7 @@ describe("run manager soft timeout", () => {
           type: "activity",
           label: "Preparing edit-design action",
           tool: "edit-design",
+          id: "call-a",
           progressBytes: 64,
         });
         vi.setSystemTime(14_000);
@@ -755,6 +758,7 @@ describe("run manager soft timeout", () => {
           type: "activity",
           label: "Preparing edit-design action",
           tool: "edit-design",
+          id: "call-a",
           progressBytes: 96,
         });
         await new Promise<void>((resolve) => {
@@ -776,6 +780,92 @@ describe("run manager soft timeout", () => {
     );
 
     expect(abortRun("run-streaming-prep-progress")).toBe(true);
+    await vi.waitFor(() => expect(run.status).toBe("aborted"));
+  });
+
+  it("keys durable action-preparation progress by activity id", async () => {
+    vi.setSystemTime(10_000);
+
+    const run = startRun(
+      "run-parallel-prep-progress",
+      "thread-parallel-prep-progress",
+      async (send, signal) => {
+        send({
+          type: "activity",
+          label: "Preparing edit-design action",
+          tool: "edit-design",
+          id: "call-a",
+          progressBytes: 128,
+        });
+        vi.setSystemTime(12_000);
+        send({
+          type: "activity",
+          label: "Preparing edit-design action",
+          tool: "edit-design",
+          id: "call-b",
+          progressBytes: 64,
+        });
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+      },
+      undefined,
+      { softTimeoutMs: 0 },
+    );
+
+    expect(bumpRunProgress).toHaveBeenCalledTimes(2);
+    expect(bumpRunProgress).toHaveBeenNthCalledWith(
+      1,
+      "run-parallel-prep-progress",
+    );
+    expect(bumpRunProgress).toHaveBeenNthCalledWith(
+      2,
+      "run-parallel-prep-progress",
+    );
+
+    expect(abortRun("run-parallel-prep-progress")).toBe(true);
+    await vi.waitFor(() => expect(run.status).toBe("aborted"));
+  });
+
+  it("treats no-id positive preparation bytes as durable progress", async () => {
+    vi.setSystemTime(10_000);
+
+    const run = startRun(
+      "run-no-id-prep-progress",
+      "thread-no-id-prep-progress",
+      async (send, signal) => {
+        send({
+          type: "activity",
+          label: "Preparing edit-design action",
+          tool: "edit-design",
+          progressBytes: 128,
+        });
+        vi.setSystemTime(12_000);
+        send({
+          type: "activity",
+          label: "Preparing edit-design action",
+          tool: "edit-design",
+          progressBytes: 64,
+        });
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+      },
+      undefined,
+      { softTimeoutMs: 0 },
+    );
+
+    expect(bumpRunProgress).toHaveBeenCalledTimes(2);
+    expect(bumpRunProgress).toHaveBeenNthCalledWith(
+      1,
+      "run-no-id-prep-progress",
+    );
+    expect(bumpRunProgress).toHaveBeenNthCalledWith(
+      2,
+      "run-no-id-prep-progress",
+    );
+
+    expect(abortRun("run-no-id-prep-progress")).toBe(true);
     await vi.waitFor(() => expect(run.status).toBe("aborted"));
   });
 

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -441,7 +441,8 @@ export function startRun(
   const shouldBumpProgressForEvent = (event: AgentChatEvent): boolean => {
     if (event.type === "stream_keepalive") return false;
     if (event.type === "activity" && isPreparingActionActivityEvent(event)) {
-      const toolKey = event.tool?.trim() || event.label.trim();
+      const toolKey =
+        event.id?.trim() || event.tool?.trim() || event.label.trim();
       const progressBytes =
         typeof event.progressBytes === "number" &&
         Number.isFinite(event.progressBytes) &&
@@ -449,6 +450,7 @@ export function startRun(
           ? Math.floor(event.progressBytes)
           : undefined;
       if (progressBytes === undefined) return false;
+      if (!event.id?.trim()) return progressBytes > 0;
       const previousBytes = preparingActivityBytes.get(toolKey) ?? 0;
       if (progressBytes <= previousBytes) {
         preparingActivityBytes.set(
@@ -461,8 +463,7 @@ export function startRun(
       return true;
     }
     if (event.type === "tool_start" || event.type === "tool_done") {
-      const tool = event.tool?.trim();
-      if (tool) preparingActivityBytes.delete(tool);
+      preparingActivityBytes.clear();
     }
     if (
       event.type === "clear" ||

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -212,12 +212,19 @@ export type AgentToolInput = Record<string, unknown>;
 export type AgentChatEvent =
   | { type: "text"; text: string }
   | { type: "thinking"; text: string }
-  | { type: "activity"; label: string; tool?: string; progressBytes?: number }
+  | {
+      type: "activity";
+      label: string;
+      tool?: string;
+      id?: string;
+      progressBytes?: number;
+    }
   | { type: "stream_keepalive" }
-  | { type: "tool_start"; tool: string; input: AgentToolInput }
+  | { type: "tool_start"; tool: string; id?: string; input: AgentToolInput }
   | {
       type: "tool_done";
       tool: string;
+      id?: string;
       input?: AgentToolInput;
       result: string;
       isError?: boolean;

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -246,6 +246,122 @@ function preparingActionProgressStream(
   });
 }
 
+function parallelSameToolPreparationStream(
+  tool = "edit-design",
+): ReadableStream<Uint8Array> {
+  const timers: ReturnType<typeof setTimeout>[] = [];
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(
+        new TextEncoder().encode(
+          `data: ${JSON.stringify({
+            type: "activity",
+            label: `Preparing ${tool} action`,
+            tool,
+            id: "call-a",
+            progressBytes: 65_536,
+          })}\n\n`,
+        ),
+      );
+      timers.push(
+        setTimeout(() => {
+          controller.enqueue(
+            new TextEncoder().encode(
+              `data: ${JSON.stringify({
+                type: "activity",
+                label: `Preparing ${tool} action`,
+                tool,
+                id: "call-b",
+                progressBytes: 32_768,
+              })}\n\n`,
+            ),
+          );
+        }, 30_000),
+      );
+      timers.push(
+        setTimeout(() => {
+          controller.enqueue(
+            new TextEncoder().encode(
+              `data: ${JSON.stringify({
+                type: "tool_start",
+                tool,
+                id: "call-b",
+                input: {},
+              })}\n\n`,
+            ),
+          );
+          controller.enqueue(
+            new TextEncoder().encode(
+              `data: ${JSON.stringify({
+                type: "tool_done",
+                tool,
+                id: "call-b",
+                result: "ok",
+              })}\n\n`,
+            ),
+          );
+          controller.enqueue(
+            new TextEncoder().encode(
+              `data: ${JSON.stringify({ type: "done" })}\n\n`,
+            ),
+          );
+          controller.close();
+        }, SSE_NO_PROGRESS_TIMEOUT_MS + 5_000),
+      );
+    },
+    cancel() {
+      for (const timer of timers) clearTimeout(timer);
+    },
+  });
+}
+
+function noIdPositivePreparationFallbackStream(
+  tool = "edit-design",
+): ReadableStream<Uint8Array> {
+  const timers: ReturnType<typeof setTimeout>[] = [];
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(
+        new TextEncoder().encode(
+          `data: ${JSON.stringify({
+            type: "activity",
+            label: `Preparing ${tool} action`,
+            tool,
+            progressBytes: 65_536,
+          })}\n\n`,
+        ),
+      );
+      timers.push(
+        setTimeout(() => {
+          controller.enqueue(
+            new TextEncoder().encode(
+              `data: ${JSON.stringify({
+                type: "activity",
+                label: `Preparing ${tool} action`,
+                tool,
+                progressBytes: 32_768,
+              })}\n\n`,
+            ),
+          );
+        }, 30_000),
+      );
+      timers.push(
+        setTimeout(() => {
+          controller.enqueue(
+            new TextEncoder().encode(
+              `data: ${JSON.stringify({ type: "done" })}\n\n`,
+            ),
+          );
+          controller.close();
+        }, SSE_NO_PROGRESS_TIMEOUT_MS + 5_000),
+      );
+    },
+    cancel() {
+      for (const timer of timers) clearTimeout(timer);
+    },
+  });
+}
+
 function eventStream(events: unknown[]): ReadableStream<Uint8Array> {
   return new ReadableStream<Uint8Array>({
     start(controller) {
@@ -461,6 +577,40 @@ describe("SSE event processor no-progress recovery", () => {
     for (let i = 0; i < 4; i++) {
       await vi.advanceTimersByTimeAsync(30_000);
     }
+
+    await expect(donePromise).resolves.toBeDefined();
+  });
+
+  it("tracks parallel same-tool preparation progress by activity id", async () => {
+    vi.useFakeTimers();
+
+    const donePromise = drain(
+      readSSEStream(
+        parallelSameToolPreparationStream(),
+        [],
+        { value: 0 },
+        undefined,
+      ),
+    );
+
+    await vi.advanceTimersByTimeAsync(SSE_NO_PROGRESS_TIMEOUT_MS + 5_000);
+
+    await expect(donePromise).resolves.toBeDefined();
+  });
+
+  it("keeps no-id positive preparation heartbeats meaningful", async () => {
+    vi.useFakeTimers();
+
+    const donePromise = drain(
+      readSSEStream(
+        noIdPositivePreparationFallbackStream(),
+        [],
+        { value: 0 },
+        undefined,
+      ),
+    );
+
+    await vi.advanceTimersByTimeAsync(SSE_NO_PROGRESS_TIMEOUT_MS + 5_000);
 
     await expect(donePromise).resolves.toBeDefined();
   });

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -150,8 +150,8 @@ export const SSE_ACTION_PREPARATION_STALL_TIMEOUT_MS = 90_000;
 
 type ActivityTrailEntry = AgentActivityTrailEntry;
 
-type PreparingActionState = {
-  tool?: string;
+type PreparingActionEntry = {
+  tool: string;
   startedAt?: number;
   lastProgressBytes?: number;
   /**
@@ -164,6 +164,10 @@ type PreparingActionState = {
    * further deltas) can trip it.
    */
   lastProgressAt?: number;
+};
+
+type PreparingActionState = {
+  entries?: Map<string, PreparingActionEntry>;
 };
 
 function formatProgressBytes(bytes: number): string {
@@ -270,21 +274,35 @@ function updatePreparingActionState(
   if (ev.type === "activity" && isPreparingActionActivity(ev)) {
     const tool = ev.tool?.trim() || undefined;
     if (!tool) return false;
-    if (state.tool !== tool || state.startedAt === undefined) {
-      state.tool = tool;
-      state.startedAt = now;
-      state.lastProgressAt = undefined;
-      state.lastProgressBytes = undefined;
+    const key = ev.id?.trim() || tool;
+    const entries = state.entries ?? new Map<string, PreparingActionEntry>();
+    state.entries = entries;
+    let entry = entries.get(key);
+    if (!entry) {
+      entry = {
+        tool,
+        startedAt: now,
+        lastProgressAt: undefined,
+        lastProgressBytes: undefined,
+      };
+      entries.set(key, entry);
     }
     const progressBytes = activityProgressBytes(ev);
-    const previousBytes = state.lastProgressBytes ?? 0;
+    const previousBytes = entry.lastProgressBytes ?? 0;
     if (progressBytes !== undefined) {
-      state.lastProgressBytes = Math.max(previousBytes, progressBytes);
+      entry.lastProgressBytes = Math.max(previousBytes, progressBytes);
+    }
+    if (!ev.id?.trim()) {
+      if (progressBytes !== undefined && progressBytes > 0) {
+        entry.lastProgressAt = now;
+        return true;
+      }
+      return false;
     }
     if (progressBytes !== undefined && progressBytes > previousBytes) {
       // A byte increase is proof the model is still streaming this action's
       // argument. Repeated zero-byte prep activity is only a heartbeat.
-      state.lastProgressAt = now;
+      entry.lastProgressAt = now;
       return true;
     }
     return false;
@@ -299,10 +317,17 @@ function updatePreparingActionState(
     ev.type === "error" ||
     ev.type === "missing_api_key"
   ) {
-    state.tool = undefined;
-    state.startedAt = undefined;
-    state.lastProgressAt = undefined;
-    state.lastProgressBytes = undefined;
+    if (ev.type === "tool_start" || ev.type === "tool_done") {
+      const tool = ev.tool?.trim();
+      const id = ev.id?.trim();
+      for (const [key, entry] of state.entries ?? []) {
+        if ((id && key === id) || (!id && entry.tool === tool)) {
+          state.entries?.delete(key);
+        }
+      }
+    } else {
+      state.entries?.clear();
+    }
   }
   return undefined;
 }
@@ -313,12 +338,16 @@ function hasStalledPreparingAction(state: PreparingActionState, now: number) {
   // streaming for a long time. `lastProgressAt` advances on every delta
   // heartbeat, so an actively-streaming large output keeps resetting this and
   // survives; a genuinely stuck prep (keepalive-only, no deltas) trips it.
-  return (
-    state.tool !== undefined &&
-    state.startedAt !== undefined &&
-    now - (state.lastProgressAt ?? state.startedAt) >=
-      SSE_ACTION_PREPARATION_STALL_TIMEOUT_MS
-  );
+  for (const entry of state.entries?.values() ?? []) {
+    if (
+      entry.startedAt !== undefined &&
+      now - (entry.lastProgressAt ?? entry.startedAt) >=
+        SSE_ACTION_PREPARATION_STALL_TIMEOUT_MS
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 async function readChunkWithProgressTimeout(


### PR DESCRIPTION
## Summary
- carry streamed tool-input ids on action-preparation activity events
- track client and durable preparation progress by id so parallel same-name calls do not mask real progress
- keep no-id positive progress meaningful for older activity events

## Tests
- corepack pnpm --filter @agent-native/core exec vitest --run src/client/sse-event-processor.spec.ts
- corepack pnpm --filter @agent-native/core exec vitest --run src/agent/run-manager.spec.ts src/agent/production-agent.spec.ts
