### PR TITLE
Keep durable background chat streams attached

### DIFF
--- a/.changeset/durable-background-prep-watchdog.md
+++ b/.changeset/durable-background-prep-watchdog.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep durable background chat runs attached during long action preparation instead of aborting on keepalive-only or zero-byte preparation activity.

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -5106,6 +5106,7 @@ export function createProductionAgentHandler(
           setResponseHeader(event, "Cache-Control", "no-cache");
           setResponseHeader(event, "Connection", "keep-alive");
           setResponseHeader(event, "X-Run-Id", runId);
+          setResponseHeader(event, "X-Dispatch-Mode", "background");
           return stream;
         }
         // A background worker owns this run but we cannot subscribe — surface an
@@ -5912,6 +5913,7 @@ export function createProductionAgentHandler(
     setResponseHeader(event, "Cache-Control", "no-cache");
     setResponseHeader(event, "Connection", "keep-alive");
     setResponseHeader(event, "X-Run-Id", runId);
+    setResponseHeader(event, "X-Dispatch-Mode", "foreground");
 
     return stream;
   });

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -1418,6 +1418,7 @@ export function createAgentChatAdapter(
       const turnId = generateTurnId();
       let runId: string | null = null;
       let lastSeq = -1;
+      let currentRunDispatchMode: string | null = null;
       let currentMessageText = normalizeMentions(
         recoveryMessageText.trim() || userMessageText,
       );
@@ -1579,6 +1580,17 @@ export function createAgentChatAdapter(
         }
       };
 
+      const updateCurrentRunDispatchMode = (value: unknown) => {
+        if (typeof value !== "string") return;
+        const mode = value.trim();
+        if (mode) currentRunDispatchMode = mode;
+      };
+
+      const currentSSEOptions = () => ({
+        durableBackgroundRun:
+          currentRunDispatchMode?.startsWith("background") === true,
+      });
+
       const captureChatClientError = (
         error: unknown,
         phase: string,
@@ -1687,6 +1699,9 @@ export function createAgentChatAdapter(
                 reconnectErrorCaptured = true;
                 break;
               }
+              updateCurrentRunDispatchMode(
+                reconnectRes.headers.get("X-Dispatch-Mode"),
+              );
 
               for await (const result of readSSEStream(
                 reconnectRes.body,
@@ -1698,6 +1713,7 @@ export function createAgentChatAdapter(
                   if (threadId) updateActiveRunSeq(seq);
                 },
                 runId,
+                currentSSEOptions(),
               )) {
                 yield withRequestModeMetadata(result);
               }
@@ -1778,6 +1794,7 @@ export function createAgentChatAdapter(
               }
               const active = await activeRes.json();
               if (active?.active && active.runId) {
+                updateCurrentRunDispatchMode(active.dispatchMode);
                 const activeStatus =
                   typeof active.status === "string" ? active.status : "";
                 const activeTurnId =
@@ -1851,6 +1868,7 @@ export function createAgentChatAdapter(
                   typeof active.dispatchMode === "string"
                     ? active.dispatchMode
                     : "";
+                updateCurrentRunDispatchMode(dispatchMode);
                 if (activeRunId === interruptedRunId) {
                   if (dispatchMode.startsWith("background")) continue;
                   return false;
@@ -2429,6 +2447,7 @@ export function createAgentChatAdapter(
 
             // Track the run ID for reconnection
             runId = res.headers.get("X-Run-Id");
+            updateCurrentRunDispatchMode(res.headers.get("X-Dispatch-Mode"));
             if (runId && !attemptedRunIds.includes(runId)) {
               attemptedRunIds.push(runId);
             }
@@ -2448,6 +2467,7 @@ export function createAgentChatAdapter(
                 }
               },
               runId,
+              currentSSEOptions(),
             )) {
               yield withRequestModeMetadata(result);
             }

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -177,6 +177,56 @@ function preparingActionZeroByteActivityStream(
   });
 }
 
+function preparingActionZeroByteActivityThenDoneStream(
+  tool = "edit-design",
+  intervalMs = 30_000,
+  doneAtMs = SSE_ACTION_PREPARATION_STALL_TIMEOUT_MS + 30_000,
+): ReadableStream<Uint8Array> {
+  let interval: ReturnType<typeof setInterval> | undefined;
+  let doneTimer: ReturnType<typeof setTimeout> | undefined;
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      const sendActivity = () => {
+        controller.enqueue(
+          new TextEncoder().encode(
+            `data: ${JSON.stringify({
+              type: "activity",
+              label: `Preparing ${tool} action`,
+              tool,
+              progressBytes: 0,
+            })}\n\n`,
+          ),
+        );
+      };
+      sendActivity();
+      interval = setInterval(() => {
+        try {
+          sendActivity();
+        } catch {
+          // The watchdog may have cancelled the stream first.
+        }
+      }, intervalMs);
+      doneTimer = setTimeout(() => {
+        try {
+          if (interval) clearInterval(interval);
+          controller.enqueue(
+            new TextEncoder().encode(
+              `data: ${JSON.stringify({ type: "done" })}\n\n`,
+            ),
+          );
+          controller.close();
+        } catch {
+          // The watchdog may have cancelled the stream first.
+        }
+      }, doneAtMs);
+    },
+    cancel() {
+      if (interval) clearInterval(interval);
+      if (doneTimer) clearTimeout(doneTimer);
+    },
+  });
+}
+
 function preparingActionProgressStream(
   tool = "edit-design",
   intervalMs = 30_000,
@@ -560,6 +610,51 @@ describe("SSE event processor no-progress recovery", () => {
         tool: "edit-design",
       },
     ]);
+  });
+
+  it("keeps a durable background stream alive on zero-byte preparation activity", async () => {
+    vi.useFakeTimers();
+
+    const donePromise = drain(
+      readSSEStream(
+        preparingActionZeroByteActivityThenDoneStream(),
+        [],
+        { value: 0 },
+        undefined,
+        undefined,
+        undefined,
+        { durableBackgroundRun: true },
+      ),
+    );
+
+    await vi.advanceTimersByTimeAsync(
+      SSE_ACTION_PREPARATION_STALL_TIMEOUT_MS + 30_000,
+    );
+
+    await expect(donePromise).resolves.toBeDefined();
+  });
+
+  it("keeps durable background keepalives attached until a terminal event", async () => {
+    vi.useFakeTimers();
+
+    const donePromise = drain(
+      readSSEStream(
+        keepaliveThenDelayedDoneStream(
+          30_000,
+          SSE_NO_PROGRESS_TIMEOUT_MS + 5_000,
+        ),
+        [],
+        { value: 0 },
+        undefined,
+        undefined,
+        undefined,
+        { durableBackgroundRun: true },
+      ),
+    );
+
+    await vi.advanceTimersByTimeAsync(SSE_NO_PROGRESS_TIMEOUT_MS + 5_000);
+
+    await expect(donePromise).resolves.toBeDefined();
   });
 
   it("does not stall while a large tool input is still streaming progress", async () => {

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -148,6 +148,16 @@ export class AgentAutoContinueSignal extends Error {
 export const SSE_NO_PROGRESS_TIMEOUT_MS = 75_000;
 export const SSE_ACTION_PREPARATION_STALL_TIMEOUT_MS = 90_000;
 
+export interface SSEStreamOptions {
+  /**
+   * Durable background runs have their own server-side liveness budget and
+   * heartbeat. While one is active, keepalive-only periods and zero-byte
+   * action-preparation activity should keep the client attached instead of
+   * aborting and starting duplicate continuations.
+   */
+  durableBackgroundRun?: boolean;
+}
+
 type ActivityTrailEntry = AgentActivityTrailEntry;
 
 type PreparingActionEntry = {
@@ -193,9 +203,13 @@ function isPreparingActionActivity(ev: SSEEvent): boolean {
 function isMeaningfulProgressEvent(
   ev: SSEEvent,
   actionPreparationProgress?: boolean,
+  options?: SSEStreamOptions,
 ): boolean {
-  if (ev.type === "stream_keepalive") return false;
+  if (ev.type === "stream_keepalive") {
+    return options?.durableBackgroundRun === true;
+  }
   if (ev.type === "activity" && isPreparingActionActivity(ev)) {
+    if (options?.durableBackgroundRun === true) return true;
     return actionPreparationProgress === true;
   }
   return true;
@@ -345,7 +359,12 @@ function updatePreparingActionState(
   return undefined;
 }
 
-function hasStalledPreparingAction(state: PreparingActionState, now: number) {
+function hasStalledPreparingAction(
+  state: PreparingActionState,
+  now: number,
+  options?: SSEStreamOptions,
+) {
+  if (options?.durableBackgroundRun === true) return false;
   // Fire only when a tool input has gone SILENT — no further streaming deltas
   // for the whole window — never merely because a large input has been
   // streaming for a long time. `lastProgressAt` advances on every delta
@@ -1193,6 +1212,7 @@ export async function* readSSEStream(
   tabId: string | undefined,
   onSeq?: (seq: number) => void,
   runId?: string | null,
+  options?: SSEStreamOptions,
 ): AsyncGenerator<ChatModelRunResult> {
   const reader = body.getReader();
   const decoder = new TextDecoder();
@@ -1278,7 +1298,7 @@ export async function* readSSEStream(
           ev,
           now,
         );
-        if (isMeaningfulProgressEvent(ev, actionPreparationProgress)) {
+        if (isMeaningfulProgressEvent(ev, actionPreparationProgress, options)) {
           sawProgressEvent = true;
           lastMeaningfulEventAt = now;
         }
@@ -1320,7 +1340,9 @@ export async function* readSSEStream(
         );
 
         if (result) yield withStreamMetadata(result);
-        if (hasStalledPreparingAction(preparingActionState, Date.now())) {
+        if (
+          hasStalledPreparingAction(preparingActionState, Date.now(), options)
+        ) {
           throw new AgentAutoContinueSignal({
             reason: "no_progress",
             activityTrail: [...activityTrail],
@@ -1384,6 +1406,7 @@ export async function readSSEStreamRaw(
   tabId: string | undefined,
   onUpdate: (content: ContentPart[]) => void,
   onSeq?: (seq: number) => void,
+  options?: SSEStreamOptions,
 ): Promise<void> {
   const reader = body.getReader();
   const decoder = new TextDecoder();
@@ -1444,7 +1467,7 @@ export async function readSSEStreamRaw(
           ev,
           now,
         );
-        if (isMeaningfulProgressEvent(ev, actionPreparationProgress)) {
+        if (isMeaningfulProgressEvent(ev, actionPreparationProgress, options)) {
           sawProgressEvent = true;
           lastMeaningfulEventAt = now;
         }
@@ -1502,7 +1525,9 @@ export async function readSSEStreamRaw(
               : { reason: "stream_ended", activityTrail: [...activityTrail] },
           );
         }
-        if (hasStalledPreparingAction(preparingActionState, Date.now())) {
+        if (
+          hasStalledPreparingAction(preparingActionState, Date.now(), options)
+        ) {
           onUpdate(contentSnapshot(content));
           throw new AgentAutoContinueSignal({
             reason: "no_progress",

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -7346,6 +7346,9 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
               setResponseStatus(event, 404);
               return { error: "Run not found" };
             }
+            const runClaim = await readBackgroundRunClaim(runId).catch(
+              () => null,
+            );
             const query = getQuery(event);
             const after = parseInt(String(query.after ?? "0"), 10) || 0;
 
@@ -7358,6 +7361,11 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
             setResponseHeader(event, "Content-Type", "text/event-stream");
             setResponseHeader(event, "Cache-Control", "no-cache");
             setResponseHeader(event, "Connection", "keep-alive");
+            setResponseHeader(
+              event,
+              "X-Dispatch-Mode",
+              runClaim?.dispatchMode ?? "foreground",
+            );
             return stream;
           }
 


### PR DESCRIPTION
## Summary
- add dispatch-mode headers to chat event streams so the client knows when a run is durable/background
- keep SSE streams attached for durable background runs during keepalive-only or zero-byte action preparation activity
- cover the foreground stall behavior and durable-background wait behavior with SSE processor tests

## Validation
- corepack pnpm --filter @agent-native/core exec vitest run src/client/sse-event-processor.spec.ts src/client/agent-chat-adapter.spec.ts
- corepack pnpm prep