### PR TITLE
Bound stalled action preparation continuations

### DIFF
--- a/.changeset/tall-dancers-checkpoint.md
+++ b/.changeset/tall-dancers-checkpoint.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Checkpoint agent runs that stall while preparing an action input without streaming bytes.

--- a/packages/core/src/agent/action-continuation-guidance.ts
+++ b/packages/core/src/agent/action-continuation-guidance.ts
@@ -1,0 +1,38 @@
+// Concrete "ship a compact first version, then refine incrementally" guidance
+// keyed by the large-payload action the model was cut off while preparing.
+// A run cut off before the tool starts tends to reassemble the same oversized
+// payload on every continuation; pointing the model at the incremental path is
+// what breaks that loop.
+export function incrementalActionGuidance(tool: string): string | undefined {
+  switch (tool) {
+    case "create-extension":
+    case "update-extension":
+      return "create a compact working v1 with `create-extension`, then use focused `update-extension` edits for refinements";
+    case "generate-design":
+    case "update-design":
+      return 'if an existing design file or snapshot is already in history, especially after a Design variant pick, stop retrying `generate-design`: call `get-design-snapshot` for the selected file, then call `edit-design` once on that same `fileId` (`mode: "replace-file"` for a compact full-file replacement, or search/replace for smaller edits). Use `generate-design` only for a brand-new compact first file when no target file exists yet';
+    case "edit-design":
+      return "retry with a smaller `edit-design` payload: prefer a handful of exact search/replace edits against the already-snapshotted file, and avoid `replacementContent` for a huge full-file rewrite. If a selected variant needs expansion, upgrade the highest-value visible sections first, save once, and summarize any remaining refinements";
+    case "present-design-variants":
+      return 'call `present-design-variants` with concise labels, descriptions, accent colors, and feature bullets; omit large `content` HTML when needed so the action can render compact representative screens. After the user picks a direction, delete unchosen screens, snapshot the selected `fileId`, and refine that same file with `edit-design` (`mode: "replace-file"` for placeholder expansion). Do not call `generate-design` after the variant pick';
+    case "create-visual-plan":
+    case "create-ui-plan":
+    case "create-plan-design":
+    case "create-prototype-plan":
+      return "create the plan with its core sections or first screen, then expand it with `update-visual-plan`/`patch-visual-plan-source` follow-up edits";
+    case "update-visual-plan":
+    case "patch-visual-plan-source":
+      return "apply smaller, targeted `patch-visual-plan-source` edits rather than rewriting the whole plan in one call";
+    case "update-dashboard":
+      return "save a small dashboard first, then add panels one at a time with `update-dashboard` incremental `ops` edits instead of authoring the whole config in one call";
+    default:
+      return undefined;
+  }
+}
+
+export function actionPreparationContinuationNote(tool: string): string {
+  const guidance = incrementalActionGuidance(tool);
+  return guidance
+    ? `\n\nThe previous run was cut off while preparing the \`${tool}\` action input before the action could finish. Avoid spending another whole run assembling one large tool payload - ${guidance}.`
+    : `\n\nThe previous run was cut off while preparing the \`${tool}\` action input before the action could finish. Avoid re-assembling one large tool payload: produce a compact first result you can finish in a single run, then refine it with smaller follow-up edits.`;
+}

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -16,6 +16,7 @@ import { EngineError } from "./engine/types.js";
 import {
   AGENT_INTERNAL_CONTINUE_PROMPT,
   appendAgentLoopContinuation,
+  backgroundContinuationReasonForRun,
   buildUserContentWithAttachments,
   claimBackgroundWorkerRunEarly,
   createPlanModeActionRegistry,
@@ -24,6 +25,7 @@ import {
   isRetryableError,
   actionsToEngineTools,
   MAX_BACKGROUND_RUN_CONTINUATIONS,
+  lastUnfinishedPreparingActionToolFromEvents,
   resolveAgentOwnerEmail,
   resolveBackgroundDispatchOutcome,
   resolveSkillReferenceContent,
@@ -4250,6 +4252,68 @@ describe("shouldChainBackgroundContinuation (server-driven background chain)", (
         continuationCount: 3,
       }),
     ).toBe(true);
+  });
+
+  it("preserves the specific continuation reason for recoverable background errors", () => {
+    expect(
+      backgroundContinuationReasonForRun(
+        makeRun([
+          {
+            type: "error",
+            error: "Builder gateway timed out after 45s",
+            errorCode: "builder_gateway_timeout",
+            recoverable: true,
+          },
+        ]),
+      ),
+    ).toBe("gateway_timeout");
+    expect(
+      backgroundContinuationReasonForRun(
+        makeRun([
+          {
+            type: "error",
+            error: "socket hang up",
+            recoverable: true,
+          },
+        ]),
+      ),
+    ).toBe("network_interrupted");
+  });
+
+  it("keeps unfinished action-preparation context through recoverable errors", () => {
+    expect(
+      lastUnfinishedPreparingActionToolFromEvents([
+        {
+          type: "activity",
+          label: "Preparing edit-design action",
+          tool: "edit-design",
+          id: "tool-1",
+          progressBytes: 0,
+        },
+        {
+          type: "error",
+          error: "Builder gateway timed out after 45s",
+          errorCode: "builder_gateway_timeout",
+          recoverable: true,
+        },
+      ]),
+    ).toBe("edit-design");
+    expect(
+      lastUnfinishedPreparingActionToolFromEvents([
+        {
+          type: "activity",
+          label: "Preparing edit-design action",
+          tool: "edit-design",
+          id: "tool-1",
+          progressBytes: 0,
+        },
+        {
+          type: "error",
+          error: "Missing API key",
+          errorCode: "missing_credentials",
+        },
+      ]),
+    ).toBeUndefined();
   });
 
   it("does NOT chain an aborted/user-stopped background run", () => {

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -15,6 +15,7 @@ import type { AgentEngine, EngineEvent } from "./engine/types.js";
 import { EngineError } from "./engine/types.js";
 import {
   AGENT_INTERNAL_CONTINUE_PROMPT,
+  appendAgentLoopContinuation,
   buildUserContentWithAttachments,
   claimBackgroundWorkerRunEarly,
   createPlanModeActionRegistry,
@@ -918,6 +919,136 @@ describe("runAgentLoop", () => {
         tool: "create-document",
       }),
     );
+  });
+
+  it("checkpoints when action input preparation stops streaming bytes", async () => {
+    let now = 1_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        yield {
+          type: "tool-input-start",
+          id: "tool-edit",
+          name: "edit-design",
+        };
+        now += 91_000;
+        yield { type: "gateway-heartbeat" };
+        yield { type: "text-delta", text: "should not continue" };
+      },
+    };
+    const events: AgentChatEvent[] = [];
+
+    try {
+      await runAgentLoop({
+        engine,
+        model: "test-model",
+        systemPrompt: "system",
+        tools: [],
+        messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+        actions: {
+          "edit-design": actionEntry({ readOnly: false }),
+        },
+        send: (event) => events.push(event),
+        signal: new AbortController().signal,
+      });
+    } finally {
+      dateNow.mockRestore();
+    }
+
+    expect(events).toContainEqual({
+      type: "activity",
+      label: "Preparing edit-design action",
+      tool: "edit-design",
+      id: "tool-edit",
+    });
+    expect(events).toContainEqual({ type: "stream_keepalive" });
+    expect(events.at(-1)).toEqual({
+      type: "auto_continue",
+      reason: "no_progress",
+    });
+    expect(events).not.toContainEqual({ type: "done" });
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: "text", text: "should not continue" }),
+    );
+  });
+
+  it("keeps assembling a large action input while bytes keep streaming", async () => {
+    let now = 1_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        yield {
+          type: "tool-input-start",
+          id: "tool-edit",
+          name: "edit-design",
+        };
+        for (let i = 0; i < 4; i++) {
+          now += 60_000;
+          yield {
+            type: "tool-input-delta",
+            id: "tool-edit",
+            text: "x".repeat(1024),
+          };
+        }
+        now += 60_000;
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "text" as const, text: "done" }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    const events: AgentChatEvent[] = [];
+
+    try {
+      await runAgentLoop({
+        engine,
+        model: "test-model",
+        systemPrompt: "system",
+        tools: [],
+        messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+        actions: {},
+        send: (event) => events.push(event),
+        signal: new AbortController().signal,
+      });
+    } finally {
+      dateNow.mockRestore();
+    }
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "activity",
+        tool: "edit-design",
+        progressBytes: 4096,
+      }),
+    );
+    expect(events).not.toContainEqual({
+      type: "auto_continue",
+      reason: "no_progress",
+    });
+    expect(events.at(-1)).toEqual({ type: "done" });
   });
 
   it("serializes tool calls when a turn includes mutating actions", async () => {
@@ -4150,6 +4281,23 @@ describe("shouldChainBackgroundContinuation (server-driven background chain)", (
         continuationCount: MAX_BACKGROUND_RUN_CONTINUATIONS - 1,
       }),
     ).toBe(true);
+  });
+});
+
+describe("appendAgentLoopContinuation", () => {
+  it("includes action-specific guidance for stalled action preparation", () => {
+    const messages: any[] = [];
+
+    appendAgentLoopContinuation(messages, "no_progress", {
+      actionPreparationTool: "edit-design",
+    });
+
+    const text = messages[0].content[0].text;
+    expect(text).toContain(AGENT_INTERNAL_CONTINUE_PROMPT);
+    expect(text).toContain("preparing the `edit-design` action input");
+    expect(text).toContain("smaller `edit-design` payload");
+    expect(text).toContain("exact search/replace edits");
+    expect(text).toContain("avoid `replacementContent`");
   });
 });
 

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -1065,6 +1065,92 @@ describe("runAgentLoop", () => {
     );
   });
 
+  it("tracks action-preparation stalls for multiple in-flight tool inputs", async () => {
+    let now = 1_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        yield {
+          type: "tool-input-start",
+          id: "tool-a",
+          name: "edit-design",
+        };
+        now += 30_000;
+        yield {
+          type: "tool-input-start",
+          id: "tool-b",
+          name: "generate-design",
+        };
+        now += 30_000;
+        yield {
+          type: "tool-input-delta",
+          id: "tool-b",
+          text: "healthy",
+        };
+        now += 31_000;
+        yield {
+          type: "tool-input-delta",
+          id: "tool-b",
+          text: "still healthy",
+        };
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "text" as const, text: "should not finish" }],
+        };
+      },
+    };
+    const events: AgentChatEvent[] = [];
+
+    try {
+      await runAgentLoop({
+        engine,
+        model: "test-model",
+        systemPrompt: "system",
+        tools: [],
+        messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+        actions: {
+          "edit-design": actionEntry({ readOnly: false }),
+          "generate-design": actionEntry({ readOnly: false }),
+        },
+        send: (event) => events.push(event),
+        signal: new AbortController().signal,
+      });
+    } finally {
+      dateNow.mockRestore();
+    }
+
+    expect(events).toContainEqual({
+      type: "activity",
+      label: "Preparing edit-design action",
+      tool: "edit-design",
+      id: "tool-a",
+    });
+    expect(events).toContainEqual({
+      type: "activity",
+      label: "Preparing generate-design action",
+      tool: "generate-design",
+      id: "tool-b",
+    });
+    expect(events.at(-1)).toEqual({
+      type: "auto_continue",
+      reason: "no_progress",
+    });
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: "text", text: "should not finish" }),
+    );
+  });
+
   it("keeps assembling a large action input while bytes keep streaming", async () => {
     let now = 1_000_000;
     const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -974,14 +974,94 @@ describe("runAgentLoop", () => {
       tool: "edit-design",
       id: "tool-edit",
     });
-    expect(events).toContainEqual({ type: "stream_keepalive" });
     expect(events.at(-1)).toEqual({
       type: "auto_continue",
       reason: "no_progress",
     });
+    expect(events).not.toContainEqual({ type: "stream_keepalive" });
     expect(events).not.toContainEqual({ type: "done" });
     expect(events).not.toContainEqual(
       expect.objectContaining({ type: "text", text: "should not continue" }),
+    );
+  });
+
+  it("checkpoints a stalled action input before accepting a delayed progress event", async () => {
+    let now = 1_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        yield {
+          type: "tool-input-start",
+          id: "tool-edit",
+          name: "edit-design",
+        };
+        now += 91_000;
+        yield {
+          type: "tool-input-delta",
+          id: "tool-edit",
+          text: "delayed bytes",
+        };
+        yield {
+          type: "assistant-content",
+          parts: [
+            {
+              type: "tool-call" as const,
+              id: "tool-edit",
+              name: "edit-design",
+              input: { replacementContent: "late" },
+            },
+          ],
+        };
+      },
+    };
+    const events: AgentChatEvent[] = [];
+
+    try {
+      await runAgentLoop({
+        engine,
+        model: "test-model",
+        systemPrompt: "system",
+        tools: [],
+        messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+        actions: {
+          "edit-design": actionEntry({ readOnly: false }),
+        },
+        send: (event) => events.push(event),
+        signal: new AbortController().signal,
+      });
+    } finally {
+      dateNow.mockRestore();
+    }
+
+    expect(events).toContainEqual({
+      type: "activity",
+      label: "Preparing edit-design action",
+      tool: "edit-design",
+      id: "tool-edit",
+    });
+    expect(events.at(-1)).toEqual({
+      type: "auto_continue",
+      reason: "no_progress",
+    });
+    expect(events).not.toContainEqual(
+      expect.objectContaining({
+        type: "activity",
+        progressBytes: expect.any(Number),
+      }),
+    );
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: "tool_start" }),
     );
   });
 

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -2867,6 +2867,14 @@ export async function runAgentLoop(opts: {
         };
 
         for await (const event of eventStream) {
+          if (hasActionPreparationStalled()) {
+            send({
+              type: "auto_continue",
+              reason: "no_progress",
+            });
+            endedForActionPreparationNoProgress = true;
+            break;
+          }
           // In-loop processor seam (stream hook). Each chunk is offered to every
           // processor's `processOutputStream` before the loop handles it. A
           // processor `abort()` throws a TripWire; catch it locally so it is not

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -44,6 +44,7 @@ import {
   normalizeReasoningEffortForModel,
   type ReasoningEffort,
 } from "../shared/reasoning-effort.js";
+import { actionPreparationContinuationNote } from "./action-continuation-guidance.js";
 import { applyContextDirectives } from "./context-xray/apply-directives.js";
 import { loadContextDirectives } from "./context-xray/directives-store.js";
 import {
@@ -984,6 +985,7 @@ function maxRetriesForError(err: unknown): number {
   return MAX_RETRIES;
 }
 const TOOL_INPUT_ACTIVITY_INTERVAL_MS = 1500;
+const ACTION_PREPARATION_NO_PROGRESS_TIMEOUT_MS = 90_000;
 const MAX_TEXT_ATTACHMENT_CHARS = 60_000;
 const MAX_SELECTION_CONTEXT_CHARS = 8_000;
 const MAX_RESOURCE_INVENTORY_ITEMS = 40;
@@ -1693,11 +1695,13 @@ export type AgentLoopContinuationReason =
   | "max_tokens"
   | "stream_ended"
   | "gateway_timeout"
-  | "network_interrupted";
+  | "network_interrupted"
+  | "no_progress";
 
 export function appendAgentLoopContinuation(
   messages: EngineMessage[],
   reason: AgentLoopContinuationReason,
+  options: { actionPreparationTool?: string } = {},
 ) {
   const note =
     reason === "loop_limit"
@@ -1710,16 +1714,35 @@ export function appendAgentLoopContinuation(
             ? "The previous LLM call hit an upstream gateway timeout before the response finished streaming."
             : reason === "network_interrupted"
               ? "The previous LLM call was cut off by a transport-level interruption (socket dropped, connection reset, or stream closed unexpectedly)."
-              : "The previous run reached an internal execution budget.";
+              : reason === "no_progress"
+                ? "The previous run stopped producing progress events while the connection stayed open."
+                : "The previous run reached an internal execution budget.";
+  const actionInputNote = options.actionPreparationTool
+    ? actionPreparationContinuationNote(options.actionPreparationTool)
+    : "";
   messages.push({
     role: "user",
     content: [
       {
         type: "text",
-        text: `${AGENT_INTERNAL_CONTINUE_PROMPT}\n\nInternal note: ${note}`,
+        text: `${AGENT_INTERNAL_CONTINUE_PROMPT}\n\nInternal note: ${note}${actionInputNote}`,
       },
     ],
   });
+}
+
+function isAgentLoopContinuationReason(
+  reason: unknown,
+): reason is AgentLoopContinuationReason {
+  return (
+    reason === "run_timeout" ||
+    reason === "loop_limit" ||
+    reason === "max_tokens" ||
+    reason === "stream_ended" ||
+    reason === "gateway_timeout" ||
+    reason === "network_interrupted" ||
+    reason === "no_progress"
+  );
 }
 
 /**
@@ -2792,6 +2815,15 @@ export async function runAgentLoop(opts: {
         const toolInputNames = new Map<string, string>();
         const toolInputBytes = new Map<string, number>();
         let lastToolInputActivityAt = 0;
+        type ActiveToolInputPreparation = {
+          id: string;
+          toolName?: string;
+          startedAt: number;
+          lastProgressAt: number;
+          bytes: number;
+        };
+        let activeToolInput: ActiveToolInputPreparation | null = null;
+        let endedForActionPreparationNoProgress = false;
         const sendToolInputActivity = (
           toolName: string | undefined,
           toolInputId?: string,
@@ -2813,6 +2845,25 @@ export async function runAgentLoop(opts: {
             ...(toolInputId ? { id: toolInputId } : {}),
             ...(typeof progressBytes === "number" ? { progressBytes } : {}),
           });
+        };
+        const resetActiveToolInput = (
+          toolName: string | undefined,
+          toolInputId?: string,
+        ) => {
+          if (!activeToolInput) return;
+          if (
+            (toolInputId && activeToolInput.id === toolInputId) ||
+            (!toolInputId && toolName && activeToolInput.toolName === toolName)
+          ) {
+            activeToolInput = null;
+          }
+        };
+        const hasActionPreparationStalled = () => {
+          if (!activeToolInput) return false;
+          return (
+            Date.now() - activeToolInput.lastProgressAt >=
+            ACTION_PREPARATION_NO_PROGRESS_TIMEOUT_MS
+          );
         };
 
         for await (const event of eventStream) {
@@ -2845,6 +2896,14 @@ export async function runAgentLoop(opts: {
             if (key && event.name) {
               toolInputNames.set(key, event.name);
               toolInputBytes.set(key, 0);
+              const now = Date.now();
+              activeToolInput = {
+                id: key,
+                toolName: event.name,
+                startedAt: now,
+                lastProgressAt: now,
+                bytes: 0,
+              };
             }
             sendToolInputActivity(event.name, key, undefined, true);
           } else if (event.type === "tool-input-delta") {
@@ -2859,19 +2918,32 @@ export async function runAgentLoop(opts: {
                 previous +
                 new TextEncoder().encode(event.text ?? "").byteLength;
               toolInputBytes.set(key, progressBytes);
+              if (progressBytes > previous) {
+                const now = Date.now();
+                activeToolInput = {
+                  id: key,
+                  ...(toolName ? { toolName } : {}),
+                  startedAt: now,
+                  lastProgressAt: now,
+                  bytes: progressBytes,
+                };
+              }
             }
             sendToolInputActivity(toolName, key, progressBytes);
           } else if (event.type === "gateway-heartbeat") {
             send({ type: "stream_keepalive" });
           } else if (event.type === "tool-call") {
             // The authoritative tool-call blocks arrive in assistant-content.
+            resetActiveToolInput(event.name, event.id);
           } else if (event.type === "tool-call-error") {
+            resetActiveToolInput(event.name, event.id);
             toolCallErrors.set(event.id, {
               name: event.name,
               input: event.input,
               error: event.error,
             });
           } else if (event.type === "assistant-content") {
+            activeToolInput = null;
             assistantContent = event.parts;
           } else if (event.type === "usage") {
             usage.inputTokens += event.inputTokens;
@@ -2889,6 +2961,18 @@ export async function runAgentLoop(opts: {
               });
             }
           }
+          if (hasActionPreparationStalled()) {
+            send({
+              type: "auto_continue",
+              reason: "no_progress",
+            });
+            endedForActionPreparationNoProgress = true;
+            break;
+          }
+        }
+
+        if (endedForActionPreparationNoProgress) {
+          return usage;
         }
 
         break;
@@ -4018,6 +4102,67 @@ function endsAtInternalContinuationBoundary(run: ActiveRun): boolean {
   return last.type === "error" && isRecoverableContinuationError(last);
 }
 
+function isPreparingActionActivityEvent(
+  event: AgentChatEvent,
+): event is Extract<AgentChatEvent, { type: "activity" }> {
+  if (event.type !== "activity") return false;
+  const label = event.label.trim().toLowerCase();
+  return label.startsWith("preparing ") && label.includes(" action");
+}
+
+function lastUnfinishedPreparingActionTool(run: ActiveRun): string | undefined {
+  let active: {
+    id?: string;
+    tool: string;
+  } | null = null;
+  for (const { event } of run.events) {
+    if (isPreparingActionActivityEvent(event)) {
+      const tool = event.tool?.trim();
+      if (tool) {
+        active = {
+          tool,
+          ...(event.id?.trim() ? { id: event.id.trim() } : {}),
+        };
+      }
+      continue;
+    }
+    if (event.type === "tool_start" || event.type === "tool_done") {
+      const tool = event.tool?.trim();
+      const id = event.id?.trim();
+      if (
+        active &&
+        ((id && active.id === id) || (!id && tool && active.tool === tool))
+      ) {
+        active = null;
+      }
+      continue;
+    }
+    if (
+      event.type === "clear" ||
+      event.type === "done" ||
+      event.type === "error" ||
+      event.type === "missing_api_key"
+    ) {
+      active = null;
+    }
+  }
+  return active?.tool;
+}
+
+function backgroundContinuationReasonForRun(
+  run: ActiveRun,
+): AgentLoopContinuationReason {
+  const last = run.events.at(-1)?.event;
+  if (last?.type === "loop_limit") return "loop_limit";
+  if (
+    last?.type === "auto_continue" &&
+    isAgentLoopContinuationReason(last.reason)
+  ) {
+    return last.reason;
+  }
+  return "run_timeout";
+}
+
 /**
  * Hard cap on server-driven background→background continuation chunks for a
  * single logical turn. A `backgroundFunction` run gets a ~13-min soft timeout,
@@ -4981,7 +5126,19 @@ export function createProductionAgentHandler(
           ?.threadData;
         const resumed = threadDataToEngineMessages(priorThreadData);
         if (resumed.length > 0) {
-          appendAgentLoopContinuation(resumed, "run_timeout");
+          const actionPreparationTool =
+            typeof backgroundRunMarker?.actionPreparationTool === "string" &&
+            backgroundRunMarker.actionPreparationTool.trim()
+              ? backgroundRunMarker.actionPreparationTool.trim()
+              : undefined;
+          const continuationReason = isAgentLoopContinuationReason(
+            backgroundRunMarker?.continuationReason,
+          )
+            ? backgroundRunMarker.continuationReason
+            : "run_timeout";
+          appendAgentLoopContinuation(resumed, continuationReason, {
+            ...(actionPreparationTool ? { actionPreparationTool } : {}),
+          });
           messages.length = 0;
           messages.push(...resumed);
         }
@@ -5334,6 +5491,10 @@ export function createProductionAgentHandler(
                 // its seq log starts clean; same turnId folds the assistant
                 // message across chunks.
                 const nextRunId = generateRunId();
+                const actionPreparationTool =
+                  lastUnfinishedPreparingActionTool(run);
+                const continuationReason =
+                  backgroundContinuationReasonForRun(run);
                 const continuationDispatchPath =
                   resolveAgentChatProcessRunDispatchPath();
                 const continuationExpectsNetlifyBackgroundFunction =
@@ -5358,6 +5519,10 @@ export function createProductionAgentHandler(
                         runId: nextRunId,
                         turnId: effectiveTurnId,
                         continuationCount: backgroundContinuationCount + 1,
+                        continuationReason,
+                        ...(actionPreparationTool
+                          ? { actionPreparationTool }
+                          : {}),
                         backgroundFunctionRuntimeExpected:
                           continuationExpectsNetlifyBackgroundFunction,
                       },

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -2822,7 +2822,7 @@ export async function runAgentLoop(opts: {
           lastProgressAt: number;
           bytes: number;
         };
-        let activeToolInput: ActiveToolInputPreparation | null = null;
+        const activeToolInputs = new Map<string, ActiveToolInputPreparation>();
         let endedForActionPreparationNoProgress = false;
         const sendToolInputActivity = (
           toolName: string | undefined,
@@ -2850,20 +2850,50 @@ export async function runAgentLoop(opts: {
           toolName: string | undefined,
           toolInputId?: string,
         ) => {
-          if (!activeToolInput) return;
-          if (
-            (toolInputId && activeToolInput.id === toolInputId) ||
-            (!toolInputId && toolName && activeToolInput.toolName === toolName)
-          ) {
-            activeToolInput = null;
+          if (toolInputId) {
+            activeToolInputs.delete(toolInputId);
+            return;
+          }
+          if (toolName) {
+            for (const [id, active] of activeToolInputs) {
+              if (active.toolName === toolName) {
+                activeToolInputs.delete(id);
+              }
+            }
           }
         };
         const hasActionPreparationStalled = () => {
-          if (!activeToolInput) return false;
-          return (
-            Date.now() - activeToolInput.lastProgressAt >=
-            ACTION_PREPARATION_NO_PROGRESS_TIMEOUT_MS
-          );
+          if (activeToolInputs.size === 0) return false;
+          const now = Date.now();
+          for (const active of activeToolInputs.values()) {
+            if (
+              now - active.lastProgressAt >=
+              ACTION_PREPARATION_NO_PROGRESS_TIMEOUT_MS
+            ) {
+              return true;
+            }
+          }
+          return false;
+        };
+        const trackActiveToolInput = (
+          key: string,
+          toolName: string | undefined,
+          bytes: number,
+        ) => {
+          const now = Date.now();
+          const previous = activeToolInputs.get(key);
+          activeToolInputs.set(key, {
+            id: key,
+            ...((toolName ?? previous?.toolName)
+              ? { toolName: toolName ?? previous?.toolName }
+              : {}),
+            startedAt: previous?.startedAt ?? now,
+            lastProgressAt: now,
+            bytes,
+          });
+        };
+        const clearActiveToolInputs = () => {
+          activeToolInputs.clear();
         };
 
         for await (const event of eventStream) {
@@ -2904,14 +2934,7 @@ export async function runAgentLoop(opts: {
             if (key && event.name) {
               toolInputNames.set(key, event.name);
               toolInputBytes.set(key, 0);
-              const now = Date.now();
-              activeToolInput = {
-                id: key,
-                toolName: event.name,
-                startedAt: now,
-                lastProgressAt: now,
-                bytes: 0,
-              };
+              trackActiveToolInput(key, event.name, 0);
             }
             sendToolInputActivity(event.name, key, undefined, true);
           } else if (event.type === "tool-input-delta") {
@@ -2927,14 +2950,7 @@ export async function runAgentLoop(opts: {
                 new TextEncoder().encode(event.text ?? "").byteLength;
               toolInputBytes.set(key, progressBytes);
               if (progressBytes > previous) {
-                const now = Date.now();
-                activeToolInput = {
-                  id: key,
-                  ...(toolName ? { toolName } : {}),
-                  startedAt: now,
-                  lastProgressAt: now,
-                  bytes: progressBytes,
-                };
+                trackActiveToolInput(key, toolName, progressBytes);
               }
             }
             sendToolInputActivity(toolName, key, progressBytes);
@@ -2951,7 +2967,7 @@ export async function runAgentLoop(opts: {
               error: event.error,
             });
           } else if (event.type === "assistant-content") {
-            activeToolInput = null;
+            clearActiveToolInputs();
             assistantContent = event.parts;
           } else if (event.type === "usage") {
             usage.inputTokens += event.inputTokens;

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -4110,12 +4110,14 @@ function isPreparingActionActivityEvent(
   return label.startsWith("preparing ") && label.includes(" action");
 }
 
-function lastUnfinishedPreparingActionTool(run: ActiveRun): string | undefined {
+export function lastUnfinishedPreparingActionToolFromEvents(
+  events: readonly AgentChatEvent[],
+): string | undefined {
   let active: {
     id?: string;
     tool: string;
   } | null = null;
-  for (const { event } of run.events) {
+  for (const event of events) {
     if (isPreparingActionActivityEvent(event)) {
       const tool = event.tool?.trim();
       if (tool) {
@@ -4137,6 +4139,9 @@ function lastUnfinishedPreparingActionTool(run: ActiveRun): string | undefined {
       }
       continue;
     }
+    if (event.type === "error" && isRecoverableContinuationError(event)) {
+      continue;
+    }
     if (
       event.type === "clear" ||
       event.type === "done" ||
@@ -4149,7 +4154,13 @@ function lastUnfinishedPreparingActionTool(run: ActiveRun): string | undefined {
   return active?.tool;
 }
 
-function backgroundContinuationReasonForRun(
+function lastUnfinishedPreparingActionTool(run: ActiveRun): string | undefined {
+  return lastUnfinishedPreparingActionToolFromEvents(
+    run.events.map(({ event }) => event),
+  );
+}
+
+export function backgroundContinuationReasonForRun(
   run: ActiveRun,
 ): AgentLoopContinuationReason {
   const last = run.events.at(-1)?.event;
@@ -4159,6 +4170,11 @@ function backgroundContinuationReasonForRun(
     isAgentLoopContinuationReason(last.reason)
   ) {
     return last.reason;
+  }
+  if (last?.type === "error" && isRecoverableContinuationError(last)) {
+    return continuationReasonForResumableError(
+      new EngineError(last.error, { errorCode: last.errorCode }),
+    );
   }
   return "run_timeout";
 }

--- a/packages/core/src/agent/run-loop-with-resume.spec.ts
+++ b/packages/core/src/agent/run-loop-with-resume.spec.ts
@@ -244,6 +244,53 @@ describe("runAgentLoopDirectWithSoftTimeout", () => {
     expect(continuationMessages).toHaveLength(1);
   });
 
+  it("includes unfinished action-preparation guidance on foreground resume", async () => {
+    let attempts = 0;
+    const messages: EngineMessage[] = [
+      { role: "user", content: [{ type: "text", text: "go" }] },
+    ];
+    mockGetCurrentTurnEventsForThread.mockResolvedValue([
+      {
+        type: "activity",
+        label: "Preparing edit-design action",
+        tool: "edit-design",
+        id: "tool-1",
+        progressBytes: 0,
+      },
+    ]);
+
+    mockRunAgentLoop.mockImplementation(async () => {
+      attempts++;
+      if (attempts === 1) {
+        throw new EngineError("Builder gateway timed out after 45s", {
+          errorCode: "builder_gateway_timeout",
+        });
+      }
+      return {
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadTokens: 80,
+        cacheWriteTokens: 0,
+        model: "test-model",
+      };
+    });
+
+    await runAgentLoopDirectWithSoftTimeout(
+      makeOpts(messages, new AbortController().signal, undefined, "thread-1"),
+      60_000,
+    );
+
+    expect(attempts).toBe(2);
+    const continuationText = messages
+      .map((m) => (m.content[0]?.type === "text" ? m.content[0].text : ""))
+      .find((t) => t.startsWith(AGENT_INTERNAL_CONTINUE_PROMPT));
+    expect(continuationText).toContain("upstream gateway timeout");
+    expect(continuationText).toContain(
+      "preparing the `edit-design` action input",
+    );
+    expect(continuationText).toContain("smaller `edit-design` payload");
+  });
+
   it("allows direct callers to use the background-function timeout regime", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/core/src/agent/run-loop-with-resume.spec.ts
+++ b/packages/core/src/agent/run-loop-with-resume.spec.ts
@@ -292,6 +292,7 @@ describe("runAgentLoopDirectWithSoftTimeout", () => {
 
   it("continues internally when runAgentLoop checkpoints for no-progress action preparation", async () => {
     let attempts = 0;
+    const sentEvents: AgentChatEvent[] = [];
     const messages: EngineMessage[] = [
       { role: "user", content: [{ type: "text", text: "go" }] },
     ];
@@ -300,6 +301,10 @@ describe("runAgentLoopDirectWithSoftTimeout", () => {
     mockRunAgentLoop.mockImplementation(async (opts) => {
       attempts++;
       if (attempts === 1) {
+        opts.send({
+          type: "text",
+          text: "partial lead-in",
+        });
         opts.send({
           type: "activity",
           label: "Preparing edit-design action",
@@ -329,12 +334,23 @@ describe("runAgentLoopDirectWithSoftTimeout", () => {
     });
 
     const usage = await runAgentLoopDirectWithSoftTimeout(
-      makeOpts(messages, new AbortController().signal, undefined, "thread-1"),
+      makeOpts(
+        messages,
+        new AbortController().signal,
+        (event) => sentEvents.push(event),
+        "thread-1",
+      ),
       60_000,
     );
 
     expect(attempts).toBe(2);
     expect(usage.inputTokens).toBe(107);
+    const autoContinueIndex = sentEvents.findIndex(
+      (event) => event.type === "auto_continue",
+    );
+    const clearIndex = sentEvents.findIndex((event) => event.type === "clear");
+    expect(autoContinueIndex).toBeGreaterThanOrEqual(0);
+    expect(clearIndex).toBeGreaterThan(autoContinueIndex);
     const continuationText = messages
       .map((m) => (m.content[0]?.type === "text" ? m.content[0].text : ""))
       .find((t) => t.startsWith(AGENT_INTERNAL_CONTINUE_PROMPT));

--- a/packages/core/src/agent/run-loop-with-resume.spec.ts
+++ b/packages/core/src/agent/run-loop-with-resume.spec.ts
@@ -249,19 +249,18 @@ describe("runAgentLoopDirectWithSoftTimeout", () => {
     const messages: EngineMessage[] = [
       { role: "user", content: [{ type: "text", text: "go" }] },
     ];
-    mockGetCurrentTurnEventsForThread.mockResolvedValue([
-      {
-        type: "activity",
-        label: "Preparing edit-design action",
-        tool: "edit-design",
-        id: "tool-1",
-        progressBytes: 0,
-      },
-    ]);
+    mockGetCurrentTurnEventsForThread.mockResolvedValue([]);
 
-    mockRunAgentLoop.mockImplementation(async () => {
+    mockRunAgentLoop.mockImplementation(async (opts) => {
       attempts++;
       if (attempts === 1) {
+        opts.send({
+          type: "activity",
+          label: "Preparing edit-design action",
+          tool: "edit-design",
+          id: "tool-1",
+          progressBytes: 0,
+        });
         throw new EngineError("Builder gateway timed out after 45s", {
           errorCode: "builder_gateway_timeout",
         });
@@ -285,6 +284,63 @@ describe("runAgentLoopDirectWithSoftTimeout", () => {
       .map((m) => (m.content[0]?.type === "text" ? m.content[0].text : ""))
       .find((t) => t.startsWith(AGENT_INTERNAL_CONTINUE_PROMPT));
     expect(continuationText).toContain("upstream gateway timeout");
+    expect(continuationText).toContain(
+      "preparing the `edit-design` action input",
+    );
+    expect(continuationText).toContain("smaller `edit-design` payload");
+  });
+
+  it("continues internally when runAgentLoop checkpoints for no-progress action preparation", async () => {
+    let attempts = 0;
+    const messages: EngineMessage[] = [
+      { role: "user", content: [{ type: "text", text: "go" }] },
+    ];
+    mockGetCurrentTurnEventsForThread.mockResolvedValue([]);
+
+    mockRunAgentLoop.mockImplementation(async (opts) => {
+      attempts++;
+      if (attempts === 1) {
+        opts.send({
+          type: "activity",
+          label: "Preparing edit-design action",
+          tool: "edit-design",
+          id: "tool-1",
+          progressBytes: 0,
+        });
+        opts.send({
+          type: "auto_continue",
+          reason: "no_progress",
+        });
+        return {
+          inputTokens: 7,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          model: "test-model",
+        };
+      }
+      return {
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadTokens: 80,
+        cacheWriteTokens: 0,
+        model: "test-model",
+      };
+    });
+
+    const usage = await runAgentLoopDirectWithSoftTimeout(
+      makeOpts(messages, new AbortController().signal, undefined, "thread-1"),
+      60_000,
+    );
+
+    expect(attempts).toBe(2);
+    expect(usage.inputTokens).toBe(107);
+    const continuationText = messages
+      .map((m) => (m.content[0]?.type === "text" ? m.content[0].text : ""))
+      .find((t) => t.startsWith(AGENT_INTERNAL_CONTINUE_PROMPT));
+    expect(continuationText).toContain(
+      "stopped producing progress events while the connection stayed open",
+    );
     expect(continuationText).toContain(
       "preparing the `edit-design` action input",
     );

--- a/packages/core/src/agent/run-loop-with-resume.ts
+++ b/packages/core/src/agent/run-loop-with-resume.ts
@@ -27,6 +27,8 @@ import {
   appendAgentLoopContinuation,
   isResumableEngineError,
   continuationReasonForResumableError,
+  lastUnfinishedPreparingActionToolFromEvents,
+  type AgentLoopContinuationReason,
 } from "./production-agent.js";
 import { resolveRunSoftTimeoutMs } from "./run-manager.js";
 import type { ResolveRunSoftTimeoutOptions } from "./run-manager.js";
@@ -35,6 +37,26 @@ import {
   classifyToolCallJournal,
   buildResumeJournalNote,
 } from "./tool-call-journal.js";
+import type { AgentChatEvent } from "./types.js";
+
+async function readCurrentTurnEventsForResume(
+  threadId: string | undefined,
+): Promise<AgentChatEvent[]> {
+  if (!threadId) return [];
+  try {
+    return await getCurrentTurnEventsForThread(threadId);
+  } catch {
+    return [];
+  }
+}
+
+function actionPreparationContinuationOptions(
+  events: readonly AgentChatEvent[],
+): { actionPreparationTool?: string } {
+  const actionPreparationTool =
+    lastUnfinishedPreparingActionToolFromEvents(events);
+  return actionPreparationTool ? { actionPreparationTool } : {};
+}
 
 /**
  * Derive the per-turn tool-call journal from the durable run-event ledger and,
@@ -57,13 +79,11 @@ import {
  * complete write tool (returning the journaled result instead). See
  * `tool-call-journal.ts` (`findCompletedJournalEntry`) for the keying used.
  */
-async function appendToolCallJournalNote(
+function appendToolCallJournalNote(
   messages: EngineMessage[],
-  threadId: string | undefined,
-): Promise<void> {
-  if (!threadId) return;
+  events: readonly AgentChatEvent[],
+): void {
   try {
-    const events = await getCurrentTurnEventsForThread(threadId);
     if (events.length === 0) return;
     const journal = classifyToolCallJournal(events);
     const note = buildResumeJournalNote(journal);
@@ -77,6 +97,20 @@ async function appendToolCallJournalNote(
     // parse must not break the resume that the continuation nudge already set
     // up — the model still continues, just without the structured journal.
   }
+}
+
+async function appendContinuationAndJournal(
+  messages: EngineMessage[],
+  reason: AgentLoopContinuationReason,
+  threadId: string | undefined,
+): Promise<void> {
+  const events = await readCurrentTurnEventsForResume(threadId);
+  appendAgentLoopContinuation(
+    messages,
+    reason,
+    actionPreparationContinuationOptions(events),
+  );
+  appendToolCallJournalNote(messages, events);
 }
 
 async function hasCompletedSideEffectToolCallInCurrentTurn(
@@ -197,8 +231,11 @@ export async function runAgentLoopDirectWithSoftTimeout(
       addUsage(nextUsage);
       if (softTimedOut && !upstreamSignal.aborted) {
         lastAttemptWasUnfinishedContinuation = true;
-        appendAgentLoopContinuation(opts.messages, "run_timeout");
-        await appendToolCallJournalNote(opts.messages, opts.threadId);
+        await appendContinuationAndJournal(
+          opts.messages,
+          "run_timeout",
+          opts.threadId,
+        );
         continue;
       }
       return usage;
@@ -212,8 +249,11 @@ export async function runAgentLoopDirectWithSoftTimeout(
         ) {
           opts.send({ type: "clear" });
         }
-        appendAgentLoopContinuation(opts.messages, "run_timeout");
-        await appendToolCallJournalNote(opts.messages, opts.threadId);
+        await appendContinuationAndJournal(
+          opts.messages,
+          "run_timeout",
+          opts.threadId,
+        );
         continue;
       }
       // Resumable transport / gateway interruptions: the LLM call was cut off
@@ -236,11 +276,11 @@ export async function runAgentLoopDirectWithSoftTimeout(
         ) {
           opts.send({ type: "clear" });
         }
-        appendAgentLoopContinuation(
+        await appendContinuationAndJournal(
           opts.messages,
           continuationReasonForResumableError(err),
+          opts.threadId,
         );
-        await appendToolCallJournalNote(opts.messages, opts.threadId);
         continue;
       }
       throw err;

--- a/packages/core/src/agent/run-loop-with-resume.ts
+++ b/packages/core/src/agent/run-loop-with-resume.ts
@@ -270,11 +270,20 @@ export async function runAgentLoopDirectWithSoftTimeout(
         internalContinuationReasonForAttempt(attemptEvents);
       if (internalContinuationReason && !upstreamSignal.aborted) {
         lastAttemptWasUnfinishedContinuation = true;
+        const continuationEvents = [...localTurnEvents];
+        if (
+          !(await hasCompletedSideEffectToolCallInCurrentTurn(
+            opts.threadId,
+            continuationEvents,
+          ))
+        ) {
+          opts.send({ type: "clear" });
+        }
         await appendContinuationAndJournal(
           opts.messages,
           internalContinuationReason,
           opts.threadId,
-          localTurnEvents,
+          continuationEvents,
         );
         continue;
       }

--- a/packages/core/src/agent/run-loop-with-resume.ts
+++ b/packages/core/src/agent/run-loop-with-resume.ts
@@ -41,13 +41,22 @@ import type { AgentChatEvent } from "./types.js";
 
 async function readCurrentTurnEventsForResume(
   threadId: string | undefined,
+  localEvents: readonly AgentChatEvent[] = [],
 ): Promise<AgentChatEvent[]> {
-  if (!threadId) return [];
+  let persistedEvents: AgentChatEvent[] = [];
   try {
-    return await getCurrentTurnEventsForThread(threadId);
+    persistedEvents = threadId
+      ? await getCurrentTurnEventsForThread(threadId)
+      : [];
   } catch {
-    return [];
+    persistedEvents = [];
   }
+  if (localEvents.length === 0) return persistedEvents;
+  const seen = new Set(persistedEvents.map((event) => JSON.stringify(event)));
+  return [
+    ...persistedEvents,
+    ...localEvents.filter((event) => !seen.has(JSON.stringify(event))),
+  ];
 }
 
 function actionPreparationContinuationOptions(
@@ -103,8 +112,9 @@ async function appendContinuationAndJournal(
   messages: EngineMessage[],
   reason: AgentLoopContinuationReason,
   threadId: string | undefined,
+  localEvents: readonly AgentChatEvent[] = [],
 ): Promise<void> {
-  const events = await readCurrentTurnEventsForResume(threadId);
+  const events = await readCurrentTurnEventsForResume(threadId, localEvents);
   appendAgentLoopContinuation(
     messages,
     reason,
@@ -115,10 +125,10 @@ async function appendContinuationAndJournal(
 
 async function hasCompletedSideEffectToolCallInCurrentTurn(
   threadId: string | undefined,
+  localEvents: readonly AgentChatEvent[] = [],
 ): Promise<boolean> {
-  if (!threadId) return false;
   try {
-    const events = await getCurrentTurnEventsForThread(threadId);
+    const events = await readCurrentTurnEventsForResume(threadId, localEvents);
     if (events.length === 0) return false;
     return events.some(
       (event) =>
@@ -129,6 +139,24 @@ async function hasCompletedSideEffectToolCallInCurrentTurn(
   } catch {
     return false;
   }
+}
+
+function internalContinuationReasonForAttempt(
+  events: readonly AgentChatEvent[],
+): AgentLoopContinuationReason | undefined {
+  const last = events.at(-1);
+  if (last?.type !== "auto_continue") return undefined;
+  if (
+    last.reason === "run_timeout" ||
+    last.reason === "loop_limit" ||
+    last.reason === "no_progress" ||
+    last.reason === "stream_ended" ||
+    last.reason === "gateway_timeout" ||
+    last.reason === "network_interrupted"
+  ) {
+    return last.reason;
+  }
+  return undefined;
 }
 
 /**
@@ -195,6 +223,7 @@ export async function runAgentLoopDirectWithSoftTimeout(
     usage.model = next.model;
   };
 
+  const localTurnEvents: AgentChatEvent[] = [];
   let attempts = 0;
   // Tracks whether the most recent attempt ended by scheduling another
   // continuation (soft-timeout or resumable error → `continue`) rather than
@@ -223,18 +252,39 @@ export async function runAgentLoopDirectWithSoftTimeout(
       controller.abort();
     }, timeoutMs);
 
+    const attemptStartIndex = localTurnEvents.length;
+    const send = (event: AgentChatEvent) => {
+      localTurnEvents.push(event);
+      opts.send(event);
+    };
+
     try {
       const nextUsage = await runAgentLoop({
         ...opts,
+        send,
         signal: controller.signal,
       });
       addUsage(nextUsage);
+      const attemptEvents = localTurnEvents.slice(attemptStartIndex);
+      const internalContinuationReason =
+        internalContinuationReasonForAttempt(attemptEvents);
+      if (internalContinuationReason && !upstreamSignal.aborted) {
+        lastAttemptWasUnfinishedContinuation = true;
+        await appendContinuationAndJournal(
+          opts.messages,
+          internalContinuationReason,
+          opts.threadId,
+          localTurnEvents,
+        );
+        continue;
+      }
       if (softTimedOut && !upstreamSignal.aborted) {
         lastAttemptWasUnfinishedContinuation = true;
         await appendContinuationAndJournal(
           opts.messages,
           "run_timeout",
           opts.threadId,
+          localTurnEvents,
         );
         continue;
       }
@@ -245,7 +295,10 @@ export async function runAgentLoopDirectWithSoftTimeout(
         // resumed model doesn't re-emit it and produce duplicated output.
         lastAttemptWasUnfinishedContinuation = true;
         if (
-          !(await hasCompletedSideEffectToolCallInCurrentTurn(opts.threadId))
+          !(await hasCompletedSideEffectToolCallInCurrentTurn(
+            opts.threadId,
+            localTurnEvents,
+          ))
         ) {
           opts.send({ type: "clear" });
         }
@@ -253,6 +306,7 @@ export async function runAgentLoopDirectWithSoftTimeout(
           opts.messages,
           "run_timeout",
           opts.threadId,
+          localTurnEvents,
         );
         continue;
       }
@@ -272,7 +326,10 @@ export async function runAgentLoopDirectWithSoftTimeout(
       if (!upstreamSignal.aborted && isResumableEngineError(err)) {
         lastAttemptWasUnfinishedContinuation = true;
         if (
-          !(await hasCompletedSideEffectToolCallInCurrentTurn(opts.threadId))
+          !(await hasCompletedSideEffectToolCallInCurrentTurn(
+            opts.threadId,
+            localTurnEvents,
+          ))
         ) {
           opts.send({ type: "clear" });
         }
@@ -280,6 +337,7 @@ export async function runAgentLoopDirectWithSoftTimeout(
           opts.messages,
           continuationReasonForResumableError(err),
           opts.threadId,
+          localTurnEvents,
         );
         continue;
       }
@@ -302,7 +360,12 @@ export async function runAgentLoopDirectWithSoftTimeout(
     // the terminal message stands alone instead of trailing a half sentence.
     // Preserve completed tool cards: they are the user's only durable proof
     // that a side effect landed before the final assistant note timed out.
-    if (!(await hasCompletedSideEffectToolCallInCurrentTurn(opts.threadId))) {
+    if (
+      !(await hasCompletedSideEffectToolCallInCurrentTurn(
+        opts.threadId,
+        localTurnEvents,
+      ))
+    ) {
       opts.send({ type: "clear" });
     }
     opts.send({

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -163,6 +163,14 @@ export interface AgentChatRequest {
   __backgroundRun?: {
     runId: string;
     turnId?: string;
+    continuationReason?:
+      | "run_timeout"
+      | "loop_limit"
+      | "no_progress"
+      | "stream_ended"
+      | "gateway_timeout"
+      | "network_interrupted";
+    actionPreparationTool?: string;
     /**
      * Number of server-driven background→background continuations already
      * chained into this logical turn (0 on the first chunk). The worker

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -1,5 +1,6 @@
 import type { ChatModelAdapter, ChatModelRunResult } from "@assistant-ui/react";
 
+import { actionPreparationContinuationNote } from "../agent/action-continuation-guidance.js";
 import type {
   AgentChatStructuredContentPart,
   AgentChatStructuredMessage,
@@ -927,42 +928,6 @@ function contentAfterContinuationPrefix(
   return [...delta, ...content.slice(contentIndex)];
 }
 
-// Concrete "ship a compact first version, then refine incrementally" guidance
-// keyed by the large-payload action the model was cut off while preparing. A run
-// cut off mid-stream while streaming one big tool input (extension HTML, a full
-// design file set, an entire dashboard config) re-streams the SAME oversized
-// payload on every continuation and never finishes inside the soft-timeout
-// window — the classic thrash loop. Pointing the resumed model at the
-// incremental-edit path for that specific action is what breaks the loop.
-// Returns undefined for tools with no known incremental counterpart so the
-// caller falls back to generic compact-first advice.
-function incrementalActionGuidance(tool: string): string | undefined {
-  switch (tool) {
-    case "create-extension":
-    case "update-extension":
-      return "create a compact working v1 with `create-extension`, then use focused `update-extension` edits for refinements";
-    case "generate-design":
-    case "update-design":
-      return 'if an existing design file or snapshot is already in history, especially after a Design variant pick, stop retrying `generate-design`: call `get-design-snapshot` for the selected file, then call `edit-design` once on that same `fileId` (`mode: "replace-file"` for a compact full-file replacement, or search/replace for smaller edits). Use `generate-design` only for a brand-new compact first file when no target file exists yet';
-    case "edit-design":
-      return "retry with a smaller `edit-design` payload: prefer a handful of exact search/replace edits against the already-snapshotted file, and avoid `replacementContent` for a huge full-file rewrite. If a selected variant needs expansion, upgrade the highest-value visible sections first, save once, and summarize any remaining refinements";
-    case "present-design-variants":
-      return 'call `present-design-variants` with concise labels, descriptions, accent colors, and feature bullets; omit large `content` HTML when needed so the action can render compact representative screens. After the user picks a direction, delete unchosen screens, snapshot the selected `fileId`, and refine that same file with `edit-design` (`mode: "replace-file"` for placeholder expansion). Do not call `generate-design` after the variant pick';
-    case "create-visual-plan":
-    case "create-ui-plan":
-    case "create-plan-design":
-    case "create-prototype-plan":
-      return "create the plan with its core sections or first screen, then expand it with `update-visual-plan`/`patch-visual-plan-source` follow-up edits";
-    case "update-visual-plan":
-    case "patch-visual-plan-source":
-      return "apply smaller, targeted `patch-visual-plan-source` edits rather than rewriting the whole plan in one call";
-    case "update-dashboard":
-      return "save a small dashboard first, then add panels one at a time with `update-dashboard` incremental `ops` edits instead of authoring the whole config in one call";
-    default:
-      return undefined;
-  }
-}
-
 function autoContinueMessage(signal: AgentAutoContinueSignal): string {
   const tool = lastActivityTool(signal.activityTrail);
   const reason =
@@ -987,10 +952,7 @@ function autoContinueMessage(signal: AgentAutoContinueSignal): string {
     signal.reason === "no_progress";
   let actionInputNote = "";
   if (cutoffPreparingAction && tool) {
-    const guidance = incrementalActionGuidance(tool);
-    actionInputNote = guidance
-      ? `\n\nThe previous run was cut off while preparing the \`${tool}\` action input before the action could finish. Avoid spending another whole run assembling one large tool payload — ${guidance}.`
-      : `\n\nThe previous run was cut off while preparing the \`${tool}\` action input before the action could finish. Avoid re-assembling one large tool payload: produce a compact first result you can finish in a single run, then refine it with smaller follow-up edits.`;
+    actionInputNote = actionPreparationContinuationNote(tool);
   }
   return `${AUTO_CONTINUE_PROMPT}\n\n${AUTO_CONTINUE_COMPLETION_GUARD}\n\nInternal note: ${reason}${actionInputNote}`;
 }


### PR DESCRIPTION
## Summary
- checkpoint agent runs when action input preparation stays at zero streamed bytes instead of burning the full background budget
- carry stalled action/reason through durable background continuation markers so the next worker gets compact/incremental guidance
- share the action-specific continuation guidance between client and server paths

## Validation
- corepack pnpm --filter @agent-native/core exec vitest run src/agent/production-agent.spec.ts
- corepack pnpm --filter @agent-native/core exec vitest run src/client/agent-chat-adapter.spec.ts --testNamePattern "preparing|edit-design|large action|action preparation"
- corepack pnpm --filter @agent-native/core exec vitest run src/client/sse-event-processor.spec.ts --testNamePattern "preparation|large tool input|zero-byte"
- corepack pnpm --filter @agent-native/core typecheck
- corepack pnpm prep

## Production observation
The latest production QA chain stayed attached, but repeatedly entered zero-byte `Preparing edit-design action` runs and chained at the 13-minute budget. This change checkpoints that true no-progress state after the stall window while preserving large inputs that are actively streaming bytes.