### PR TITLE
Chain tool-only background continuations

### DIFF
--- a/.changeset/quiet-rivers-continue.md
+++ b/.changeset/quiet-rivers-continue.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Continue durable background runs when a chunk completes tool calls without final assistant text.

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -4400,6 +4400,55 @@ describe("shouldChainBackgroundContinuation (server-driven background chain)", (
     ).toBe(false);
   });
 
+  it("CHAINS a background run that completed tools but stopped before final text", () => {
+    const run = makeRun([
+      { type: "text", text: "I will update it now." },
+      {
+        type: "tool_start",
+        tool: "edit-design",
+        id: "tool-1",
+        input: { fileId: "f1" },
+      },
+      {
+        type: "tool_done",
+        tool: "edit-design",
+        id: "tool-1",
+        input: { fileId: "f1" },
+        result: '{"ok":true}',
+        completedSideEffect: true,
+      },
+      { type: "done" },
+    ]);
+
+    expect(
+      shouldChainBackgroundContinuation({
+        isBackgroundWorker: true,
+        run,
+        continuationCount: 0,
+      }),
+    ).toBe(true);
+    expect(backgroundContinuationReasonForRun(run)).toBe("stream_ended");
+  });
+
+  it("does NOT chain a background run that sent final text after completed tools", () => {
+    expect(
+      shouldChainBackgroundContinuation({
+        isBackgroundWorker: true,
+        run: makeRun([
+          {
+            type: "tool_done",
+            tool: "edit-design",
+            result: '{"ok":true}',
+            completedSideEffect: true,
+          },
+          { type: "text", text: "Done." },
+          { type: "done" },
+        ]),
+        continuationCount: 0,
+      }),
+    ).toBe(false);
+  });
+
   it("CHAINS a background run that ended at an auto_continue boundary", () => {
     expect(
       shouldChainBackgroundContinuation({
@@ -4480,6 +4529,46 @@ describe("shouldChainBackgroundContinuation (server-driven background chain)", (
         },
       ]),
     ).toBeUndefined();
+  });
+
+  it("keeps earlier unfinished action-preparation context when a later parallel input starts and finishes", () => {
+    expect(
+      lastUnfinishedPreparingActionToolFromEvents([
+        {
+          type: "activity",
+          label: "Preparing edit-design action",
+          tool: "edit-design",
+          id: "edit-1",
+          progressBytes: 1024,
+        },
+        {
+          type: "activity",
+          label: "Preparing generate-design action",
+          tool: "generate-design",
+          id: "generate-1",
+          progressBytes: 512,
+        },
+        {
+          type: "tool_start",
+          tool: "generate-design",
+          id: "generate-1",
+          input: { designId: "d1" },
+        },
+        {
+          type: "tool_done",
+          tool: "generate-design",
+          id: "generate-1",
+          input: { designId: "d1" },
+          result: '{"ok":true}',
+        },
+        {
+          type: "error",
+          error: "Builder gateway timed out after 45s",
+          errorCode: "builder_gateway_timeout",
+          recoverable: true,
+        },
+      ]),
+    ).toBe("edit-design");
   });
 
   it("does NOT chain an aborted/user-stopped background run", () => {

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -4571,6 +4571,44 @@ describe("shouldChainBackgroundContinuation (server-driven background chain)", (
     ).toBe("edit-design");
   });
 
+  it("keeps same-tool action-preparation context when id-less tool events finish one parallel input", () => {
+    expect(
+      lastUnfinishedPreparingActionToolFromEvents([
+        {
+          type: "activity",
+          label: "Preparing edit-design action",
+          tool: "edit-design",
+          id: "edit-1",
+          progressBytes: 1024,
+        },
+        {
+          type: "activity",
+          label: "Preparing edit-design action",
+          tool: "edit-design",
+          id: "edit-2",
+          progressBytes: 2048,
+        },
+        {
+          type: "tool_start",
+          tool: "edit-design",
+          input: { fileId: "file-1" },
+        },
+        {
+          type: "tool_done",
+          tool: "edit-design",
+          input: { fileId: "file-1" },
+          result: '{"ok":true}',
+        },
+        {
+          type: "error",
+          error: "Builder gateway timed out after 45s",
+          errorCode: "builder_gateway_timeout",
+          recoverable: true,
+        },
+      ]),
+    ).toBe("edit-design");
+  });
+
   it("does NOT chain an aborted/user-stopped background run", () => {
     expect(
       shouldChainBackgroundContinuation({

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -4145,25 +4145,72 @@ export function lastUnfinishedPreparingActionToolFromEvents(
       tool: string;
     }
   >();
+  const idlessToolStarts = new Map<string, number>();
+  const removeOldestMatchingActivePreparation = (
+    tool: string,
+    shouldRemove: (value: {
+      id?: string;
+      order: number;
+      tool: string;
+    }) => boolean = () => true,
+  ) => {
+    let oldest:
+      | {
+          key: string;
+          order: number;
+        }
+      | undefined;
+    for (const [key, value] of active) {
+      if (value.tool !== tool || !shouldRemove(value)) continue;
+      if (!oldest || value.order < oldest.order) {
+        oldest = {
+          key,
+          order: value.order,
+        };
+      }
+    }
+    if (oldest) active.delete(oldest.key);
+    return Boolean(oldest);
+  };
   const removeMatchingActivePreparation = (event: {
     id?: string;
     tool?: string;
+    type: "tool_done" | "tool_start";
   }) => {
     const id = event.id?.trim();
     const tool = event.tool?.trim();
-    if (id) active.delete(`id:${id}`);
     if (!tool) return;
-    for (const [key, value] of active) {
-      if (value.tool !== tool) continue;
-      if (!id || !value.id) active.delete(key);
+    if (id) {
+      if (!active.delete(`id:${id}`)) {
+        removeOldestMatchingActivePreparation(tool, (value) => !value.id);
+      }
+      return;
     }
+
+    if (event.type === "tool_start") {
+      if (removeOldestMatchingActivePreparation(tool)) {
+        idlessToolStarts.set(tool, (idlessToolStarts.get(tool) ?? 0) + 1);
+      }
+      return;
+    }
+
+    const startedCount = idlessToolStarts.get(tool) ?? 0;
+    if (startedCount > 0) {
+      if (startedCount === 1) {
+        idlessToolStarts.delete(tool);
+      } else {
+        idlessToolStarts.set(tool, startedCount - 1);
+      }
+      return;
+    }
+    removeOldestMatchingActivePreparation(tool);
   };
   events.forEach((event, order) => {
     if (isPreparingActionActivityEvent(event)) {
       const tool = event.tool?.trim();
       if (tool) {
         const id = event.id?.trim();
-        const key = id ? `id:${id}` : `tool:${tool}`;
+        const key = id ? `id:${id}` : `tool:${tool}:${order}`;
         active.set(key, {
           tool,
           order,
@@ -4186,6 +4233,7 @@ export function lastUnfinishedPreparingActionToolFromEvents(
       event.type === "missing_api_key"
     ) {
       active.clear();
+      idlessToolStarts.clear();
     }
   });
   let latest:
@@ -5433,7 +5481,7 @@ export function createProductionAgentHandler(
       completionError?: unknown,
     ) => {
       if (!trackedProgressRunId || !trackedProgressOwner) return;
-      if (!completionError && endsAtInternalContinuationBoundary(run)) {
+      if (!completionError && endsAtContinuationBoundary(run)) {
         return;
       }
       const terminalStatus =
@@ -5529,7 +5577,7 @@ export function createProductionAgentHandler(
               if (
                 isBackgroundWorker &&
                 run.status === "errored" &&
-                !endsAtInternalContinuationBoundary(run)
+                !endsAtContinuationBoundary(run)
               ) {
                 const errEvent = [...run.events]
                   .reverse()

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -5475,13 +5475,19 @@ export function createProductionAgentHandler(
           turnId: effectiveTurnId,
         }
       : null;
+    const willChainBackgroundContinuation = (run: ActiveRun) =>
+      shouldChainBackgroundContinuation({
+        isBackgroundWorker,
+        run,
+        continuationCount: backgroundContinuationCount,
+      });
 
     const completeTrackedProgressRun = async (
       run: ActiveRun,
       completionError?: unknown,
     ) => {
       if (!trackedProgressRunId || !trackedProgressOwner) return;
-      if (!completionError && endsAtContinuationBoundary(run)) {
+      if (!completionError && willChainBackgroundContinuation(run)) {
         return;
       }
       const terminalStatus =
@@ -5577,7 +5583,7 @@ export function createProductionAgentHandler(
               if (
                 isBackgroundWorker &&
                 run.status === "errored" &&
-                !endsAtContinuationBoundary(run)
+                !willChainBackgroundContinuation(run)
               ) {
                 const errEvent = [...run.events]
                   .reverse()
@@ -5606,30 +5612,24 @@ export function createProductionAgentHandler(
               // agent-teams `fireInternalDispatch({ body: { mode: "continue" }})`
               // chain. Bounded by MAX_BACKGROUND_RUN_CONTINUATIONS. Aborted /
               // user-stopped runs do NOT chain.
-              if (
-                shouldChainBackgroundContinuation({
-                  // Self-chain server-side for EVERY durable worker, not only the
-                  // ones inside a `-background` function. Server-driven
-                  // continuation is the whole point of durable background: the run
-                  // must survive the client disconnecting (closed tab), so it
-                  // cannot depend on the browser re-POSTing `auto_continue`. A
-                  // worker on the regular ~60s function — a Netlify routing miss,
-                  // or a non-Netlify host (Vercel/Cloudflare/Render/Fly) that
-                  // never emits a `-background` function — checkpoints at the 40s
-                  // soft-timeout and self-dispatches the next 40s chunk; a worker
-                  // in a real `-background` function chains ~13-min chunks. Only
-                  // the per-chunk BUDGET differs by function type (gated by
-                  // `runsInBackgroundFunction` at the startRun call below); the
-                  // continuation itself must stay server-driven on both. (The
-                  // self-chain is only reachable when the initial dispatch already
-                  // succeeded — a dispatch fast-fail degrades to the inline
-                  // foreground fallback, which is not a worker and rides the
-                  // connected client's auto_continue instead.)
-                  isBackgroundWorker,
-                  run,
-                  continuationCount: backgroundContinuationCount,
-                })
-              ) {
+              // Self-chain server-side for EVERY durable worker, not only the
+              // ones inside a `-background` function. Server-driven
+              // continuation is the whole point of durable background: the run
+              // must survive the client disconnecting (closed tab), so it
+              // cannot depend on the browser re-POSTing `auto_continue`. A
+              // worker on the regular ~60s function — a Netlify routing miss,
+              // or a non-Netlify host (Vercel/Cloudflare/Render/Fly) that
+              // never emits a `-background` function — checkpoints at the 40s
+              // soft-timeout and self-dispatches the next 40s chunk; a worker
+              // in a real `-background` function chains ~13-min chunks. Only
+              // the per-chunk BUDGET differs by function type (gated by
+              // `runsInBackgroundFunction` at the startRun call below); the
+              // continuation itself must stay server-driven on both. (The
+              // self-chain is only reachable when the initial dispatch already
+              // succeeded — a dispatch fast-fail degrades to the inline
+              // foreground fallback, which is not a worker and rides the
+              // connected client's auto_continue instead.)
+              if (willChainBackgroundContinuation(run)) {
                 // Mint the next chunk's runId here and sign the dispatch token
                 // over it, so the `_process-run` route's HMAC check and the
                 // worker's run identity agree. Fresh runId (not this chunk's) so

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -4137,34 +4137,47 @@ function isPreparingActionActivityEvent(
 export function lastUnfinishedPreparingActionToolFromEvents(
   events: readonly AgentChatEvent[],
 ): string | undefined {
-  let active: {
+  const active = new Map<
+    string,
+    {
+      id?: string;
+      order: number;
+      tool: string;
+    }
+  >();
+  const removeMatchingActivePreparation = (event: {
     id?: string;
-    tool: string;
-  } | null = null;
-  for (const event of events) {
+    tool?: string;
+  }) => {
+    const id = event.id?.trim();
+    const tool = event.tool?.trim();
+    if (id) active.delete(`id:${id}`);
+    if (!tool) return;
+    for (const [key, value] of active) {
+      if (value.tool !== tool) continue;
+      if (!id || !value.id) active.delete(key);
+    }
+  };
+  events.forEach((event, order) => {
     if (isPreparingActionActivityEvent(event)) {
       const tool = event.tool?.trim();
       if (tool) {
-        active = {
+        const id = event.id?.trim();
+        const key = id ? `id:${id}` : `tool:${tool}`;
+        active.set(key, {
           tool,
-          ...(event.id?.trim() ? { id: event.id.trim() } : {}),
-        };
+          order,
+          ...(id ? { id } : {}),
+        });
       }
-      continue;
+      return;
     }
     if (event.type === "tool_start" || event.type === "tool_done") {
-      const tool = event.tool?.trim();
-      const id = event.id?.trim();
-      if (
-        active &&
-        ((id && active.id === id) || (!id && tool && active.tool === tool))
-      ) {
-        active = null;
-      }
-      continue;
+      removeMatchingActivePreparation(event);
+      return;
     }
     if (event.type === "error" && isRecoverableContinuationError(event)) {
-      continue;
+      return;
     }
     if (
       event.type === "clear" ||
@@ -4172,10 +4185,45 @@ export function lastUnfinishedPreparingActionToolFromEvents(
       event.type === "error" ||
       event.type === "missing_api_key"
     ) {
-      active = null;
+      active.clear();
+    }
+  });
+  let latest:
+    | {
+        order: number;
+        tool: string;
+      }
+    | undefined;
+  for (const value of active.values()) {
+    if (!latest || value.order > latest.order) {
+      latest = value;
     }
   }
-  return active?.tool;
+  return latest?.tool;
+}
+
+function endsAfterCompletedToolWithoutAssistantFinal(run: ActiveRun): boolean {
+  let completedToolAfterLastAssistantText = false;
+  for (const { event } of run.events) {
+    if (event.type === "text" && event.text.trim().length > 0) {
+      completedToolAfterLastAssistantText = false;
+      continue;
+    }
+    if (event.type === "tool_done" && event.isError !== true) {
+      completedToolAfterLastAssistantText = true;
+      continue;
+    }
+    if (
+      event.type === "clear" ||
+      event.type === "error" ||
+      event.type === "missing_api_key" ||
+      event.type === "auto_continue" ||
+      event.type === "loop_limit"
+    ) {
+      completedToolAfterLastAssistantText = false;
+    }
+  }
+  return completedToolAfterLastAssistantText;
 }
 
 function lastUnfinishedPreparingActionTool(run: ActiveRun): string | undefined {
@@ -4200,7 +4248,17 @@ export function backgroundContinuationReasonForRun(
       new EngineError(last.error, { errorCode: last.errorCode }),
     );
   }
+  if (endsAfterCompletedToolWithoutAssistantFinal(run)) {
+    return "stream_ended";
+  }
   return "run_timeout";
+}
+
+function endsAtContinuationBoundary(run: ActiveRun): boolean {
+  return (
+    endsAtInternalContinuationBoundary(run) ||
+    endsAfterCompletedToolWithoutAssistantFinal(run)
+  );
 }
 
 /**
@@ -4215,9 +4273,8 @@ export const MAX_BACKGROUND_RUN_CONTINUATIONS = 20;
 /**
  * Whether the background worker should self-fire the next server-driven
  * continuation chunk. True only when this is a background worker run that ended
- * at a recoverable soft-timeout boundary (not aborted/stopped) and the chain is
- * still under its budget. Extracted so the decision is unit testable without
- * booting the whole handler.
+ * at a recoverable unfinished boundary (not aborted/stopped) and the chain is
+ * still under its budget. Aborted / user-stopped runs do NOT chain.
  */
 export function shouldChainBackgroundContinuation(opts: {
   isBackgroundWorker: boolean;
@@ -4227,7 +4284,7 @@ export function shouldChainBackgroundContinuation(opts: {
   return (
     opts.isBackgroundWorker &&
     opts.run.status !== "aborted" &&
-    endsAtInternalContinuationBoundary(opts.run) &&
+    endsAtContinuationBoundary(opts.run) &&
     opts.continuationCount < MAX_BACKGROUND_RUN_CONTINUATIONS
   );
 }


### PR DESCRIPTION
## Summary
- continue durable background runs when a chunk completes tool calls but ends before final assistant text
- keep unfinished action-preparation context across parallel tool inputs so continuation guidance names the real stuck tool
- add regression tests for tool-only chunks, final-text chunks, and parallel preparation tracking

## Testing
- corepack pnpm --filter @agent-native/core exec vitest run src/agent/production-agent.spec.ts src/agent/run-loop-with-resume.spec.ts
- corepack pnpm --filter @agent-native/core typecheck
- corepack pnpm prep
- corepack pnpm guards

## Production QA context
- Fresh Design production test no longer hit a connection_error, but variant selection stopped after remove screen/get screen snapshot with no final assistant message. This PR makes that completed-tool/no-final-text boundary self-continue in the background.