### PR TITLE
Keep assistant snapshots from clearing tool prep stalls

### DIFF
--- a/.changeset/assistant-snapshots-arent-progress.md
+++ b/.changeset/assistant-snapshots-arent-progress.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep action preparation stall detection active across assistant text snapshots so hosted runs recover from zero-byte tool prep.

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -985,7 +985,7 @@ describe("runAgentLoop", () => {
     );
   });
 
-  it("keeps tracking a stalled action input across empty assistant snapshots", async () => {
+  it("keeps tracking a stalled action input across assistant snapshots", async () => {
     let now = 1_000_000;
     const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
     const engine: AgentEngine = {
@@ -1008,7 +1008,7 @@ describe("runAgentLoop", () => {
         };
         yield {
           type: "assistant-content",
-          parts: [],
+          parts: [{ type: "text", text: "previous assistant text snapshot" }],
         };
         now += 91_000;
         yield { type: "gateway-heartbeat" };

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -3020,13 +3020,7 @@ export async function runAgentLoop(opts: {
             const contentHasPreparedToolCall = event.parts.some(
               (part) => part.type === "tool-call",
             );
-            const contentHasAssistantText = event.parts.some(
-              (part) =>
-                part.type === "text" &&
-                typeof part.text === "string" &&
-                part.text.length > 0,
-            );
-            if (contentHasPreparedToolCall || contentHasAssistantText) {
+            if (contentHasPreparedToolCall) {
               clearActiveToolInputs();
               resetZeroByteToolInputRestart();
             }


### PR DESCRIPTION
## Summary
- keep action-preparation stall tracking active across assistant-content text snapshots
- only clear pending tool-input stall state when the assistant snapshot contains a prepared tool call
- extend the production-agent regression test to cover non-empty assistant text snapshots during zero-byte tool prep

## Why
Production Design runs can emit assistant-content text snapshots while still stuck preparing a zero-byte edit-design input. Treating that snapshot as progress cleared the server-side stall watchdog, so the background run stayed alive without recovering.

## Validation
- corepack pnpm --filter @agent-native/core exec vitest run src/agent/production-agent.spec.ts --testNamePattern "action input|zero-byte|large action input|assistant snapshots"
- corepack pnpm --filter @agent-native/core exec vitest run src/agent/production-agent.spec.ts src/agent/run-loop-with-resume.spec.ts src/client/sse-event-processor.spec.ts src/client/agent-chat-adapter.spec.ts
- corepack pnpm --filter @agent-native/core typecheck
- corepack pnpm prep