### PR TITLE
Keep prepared tool calls under prep watchdog

### DIFF
--- a/.changeset/prepared-tool-calls-still-stall.md
+++ b/.changeset/prepared-tool-calls-still-stall.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep action preparation stall detection active after prepared tool-call snapshots until the tool actually starts.

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -1050,6 +1050,88 @@ describe("runAgentLoop", () => {
     );
   });
 
+  it("keeps tracking stalled action input after a prepared tool-call snapshot", async () => {
+    let now = 1_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        yield {
+          type: "tool-input-start",
+          id: "tool-edit",
+          name: "edit-design",
+        };
+        now += 1_600;
+        yield {
+          type: "tool-input-delta",
+          id: "tool-edit",
+          text: '{"designId":"design-1"',
+        };
+        yield {
+          type: "assistant-content",
+          parts: [
+            {
+              type: "tool-call",
+              id: "tool-edit",
+              name: "edit-design",
+              input: { designId: "design-1" },
+            },
+          ],
+        };
+        now += 91_000;
+        yield { type: "gateway-heartbeat" };
+        yield { type: "text-delta", text: "should not continue" };
+      },
+    };
+    const events: AgentChatEvent[] = [];
+
+    try {
+      await runAgentLoop({
+        engine,
+        model: "test-model",
+        systemPrompt: "system",
+        tools: [],
+        messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+        actions: {
+          "edit-design": actionEntry({ readOnly: false }),
+        },
+        send: (event) => events.push(event),
+        signal: new AbortController().signal,
+      });
+    } finally {
+      dateNow.mockRestore();
+    }
+
+    expect(events).toContainEqual({
+      type: "activity",
+      label: "Preparing edit-design action",
+      tool: "edit-design",
+      id: "tool-edit",
+      progressBytes: 22,
+    });
+    expect(events.at(-1)).toEqual({
+      type: "auto_continue",
+      reason: "no_progress",
+    });
+    expect(events).not.toContainEqual({ type: "stream_keepalive" });
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: "text", text: "should not continue" }),
+    );
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: "tool_start" }),
+    );
+  });
+
   it("checkpoints a stalled action input before accepting a delayed progress event", async () => {
     let now = 1_000_000;
     const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -2854,22 +2854,6 @@ export async function runAgentLoop(opts: {
             ...(typeof progressBytes === "number" ? { progressBytes } : {}),
           });
         };
-        const resetActiveToolInput = (
-          toolName: string | undefined,
-          toolInputId?: string,
-        ) => {
-          if (toolInputId) {
-            activeToolInputs.delete(toolInputId);
-            return;
-          }
-          if (toolName) {
-            for (const [id, active] of activeToolInputs) {
-              if (active.toolName === toolName) {
-                activeToolInputs.delete(id);
-              }
-            }
-          }
-        };
         const hasActionPreparationStalled = () => {
           if (activeToolInputs.size === 0) return false;
           const now = Date.now();
@@ -2930,10 +2914,6 @@ export async function runAgentLoop(opts: {
               ACTION_PREPARATION_NO_PROGRESS_TIMEOUT_MS
           );
         };
-        const clearActiveToolInputs = () => {
-          activeToolInputs.clear();
-        };
-
         for await (const event of eventStream) {
           if (hasActionPreparationStalled()) {
             send({
@@ -3006,24 +2986,13 @@ export async function runAgentLoop(opts: {
             send({ type: "stream_keepalive" });
           } else if (event.type === "tool-call") {
             // The authoritative tool-call blocks arrive in assistant-content.
-            resetActiveToolInput(event.name, event.id);
-            resetZeroByteToolInputRestart(event.name);
           } else if (event.type === "tool-call-error") {
-            resetActiveToolInput(event.name, event.id);
-            resetZeroByteToolInputRestart(event.name);
             toolCallErrors.set(event.id, {
               name: event.name,
               input: event.input,
               error: event.error,
             });
           } else if (event.type === "assistant-content") {
-            const contentHasPreparedToolCall = event.parts.some(
-              (part) => part.type === "tool-call",
-            );
-            if (contentHasPreparedToolCall) {
-              clearActiveToolInputs();
-              resetZeroByteToolInputRestart();
-            }
             assistantContent = event.parts;
           } else if (event.type === "usage") {
             usage.inputTokens += event.inputTokens;


### PR DESCRIPTION
## Summary
- keep active action-preparation stall tracking through `tool-call` and assistant-content tool-call snapshots
- only let actual stream/tool execution move past the preparation watchdog
- add regression coverage for partial `edit-design` argument streaming followed by a prepared tool-call snapshot and keepalives

## Production evidence
After #1806 reached Design prod, live design `b1TprmLoAwAF-AW5lcISJ` still got stuck on `run-1782979893835-t720ne`: `edit-design` emitted 82 bytes, then repeated prepared `edit-design` snapshots/keepalives without `tool_start` or auto-continue. The premature reset on prepared tool-call snapshots was clearing the server guard before actual tool execution.

## Validation
- corepack pnpm --filter @agent-native/core exec vitest run src/agent/production-agent.spec.ts --testNamePattern "action input|zero-byte|large action input|assistant snapshots|prepared tool-call snapshot"
- corepack pnpm --filter @agent-native/core exec vitest run src/agent/production-agent.spec.ts src/agent/run-loop-with-resume.spec.ts src/client/sse-event-processor.spec.ts src/client/agent-chat-adapter.spec.ts
- corepack pnpm --filter @agent-native/core typecheck
- corepack pnpm prep