### PR TITLE
Recover zero-byte tool input stalls

### DIFF
--- a/.changeset/zero-byte-tool-delta-stalls.md
+++ b/.changeset/zero-byte-tool-delta-stalls.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Recover stalled action preparation when a provider emits a zero-byte tool input delta without a start event.

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -1050,6 +1050,73 @@ describe("runAgentLoop", () => {
     );
   });
 
+  it("tracks a zero-byte action input delta without a start event", async () => {
+    let now = 1_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        yield { type: "gateway-heartbeat" };
+        now += 10_000;
+        yield {
+          type: "tool-input-delta",
+          id: "tool-edit",
+          name: "edit-design",
+          text: "",
+        };
+        now += 91_000;
+        yield { type: "gateway-heartbeat" };
+        yield { type: "text-delta", text: "should not continue" };
+      },
+    };
+    const events: AgentChatEvent[] = [];
+
+    try {
+      await runAgentLoop({
+        engine,
+        model: "test-model",
+        systemPrompt: "system",
+        tools: [],
+        messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+        actions: {
+          "edit-design": actionEntry({ readOnly: false }),
+        },
+        send: (event) => events.push(event),
+        signal: new AbortController().signal,
+      });
+    } finally {
+      dateNow.mockRestore();
+    }
+
+    expect(events).toContainEqual({
+      type: "activity",
+      label: "Preparing edit-design action",
+      tool: "edit-design",
+      id: "tool-edit",
+      progressBytes: 0,
+    });
+    expect(events.at(-1)).toEqual({
+      type: "auto_continue",
+      reason: "no_progress",
+    });
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: "text", text: "should not continue" }),
+    );
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: "tool_start" }),
+    );
+  });
+
   it("keeps tracking stalled action input after a prepared tool-call snapshot", async () => {
     let now = 1_000_000;
     const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -2971,14 +2971,19 @@ export async function runAgentLoop(opts: {
               (event.id ? toolInputNames.get(event.id) : undefined);
             let progressBytes: number | undefined;
             if (key) {
-              const previous = toolInputBytes.get(key) ?? 0;
+              const hadByteRecord = toolInputBytes.has(key);
+              const previous = hadByteRecord
+                ? (toolInputBytes.get(key) ?? 0)
+                : 0;
               progressBytes =
                 previous +
                 new TextEncoder().encode(event.text ?? "").byteLength;
               toolInputBytes.set(key, progressBytes);
-              if (progressBytes > previous) {
+              if (!hadByteRecord || progressBytes > previous) {
                 trackActiveToolInput(key, toolName, progressBytes);
-                resetZeroByteToolInputRestart(toolName);
+                if (progressBytes > 0) {
+                  resetZeroByteToolInputRestart(toolName);
+                }
               }
             }
             sendToolInputActivity(toolName, key, progressBytes);


### PR DESCRIPTION
## Summary
- Treat a first zero-byte `tool-input-delta` as active action preparation even when the provider omits `tool-input-start`.
- Keep the no-progress watchdog armed for that zero-byte preparation so keepalive-only streams auto-continue instead of hanging.
- Add a regression test matching the production event shape seen in Design: heartbeat, zero-byte `edit-design` delta, then only keepalives.

## Production evidence
The fresh Design prod QA run `run-1782981510491-mldv7t` emitted `Preparing edit-design action` with `progressBytes: 0` and then only `stream_keepalive` events for more than 90 seconds. The UI now warned visibly, but the server had not tracked that zero-byte delta as active preparation, so no server auto-continue fired.

## Validation
- `corepack pnpm --filter @agent-native/core exec vitest run src/agent/production-agent.spec.ts --testNamePattern "zero-byte action input delta|stalled action input|prepared tool-call snapshot|checkpoints a stalled action input"`
- `corepack pnpm --filter @agent-native/core exec vitest run src/agent/production-agent.spec.ts src/agent/run-loop-with-resume.spec.ts src/client/sse-event-processor.spec.ts src/client/agent-chat-adapter.spec.ts`
- `corepack pnpm --filter @agent-native/core typecheck`
- `corepack pnpm prep`
