### PR TITLE
Surface next required action on agent resume

### DIFF
--- a/.changeset/next-required-action-continuations.md
+++ b/.changeset/next-required-action-continuations.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep explicit `nextRequiredAction` tool-result guidance visible in automatic continuation prompts even when the full tool result is too large to include.

--- a/packages/core/src/agent/run-loop-with-resume.spec.ts
+++ b/packages/core/src/agent/run-loop-with-resume.spec.ts
@@ -817,6 +817,61 @@ describe("runAgentLoopDirectWithSoftTimeout", () => {
     expect(continuationNote).toBeDefined();
   });
 
+  it("keeps completed tool nextRequiredAction guidance visible on resume", async () => {
+    mockGetCurrentTurnEventsForThread.mockResolvedValue([
+      {
+        type: "tool_start",
+        tool: "get-design-snapshot",
+        input: { designId: "design-1", fileId: "file-1" },
+      },
+      {
+        type: "tool_done",
+        tool: "get-design-snapshot",
+        input: { designId: "design-1", fileId: "file-1" },
+        result: JSON.stringify({
+          files: [{ id: "file-1", content: "x".repeat(2000) }],
+          nextRequiredAction:
+            "Call edit-design exactly once with designId design-1 and fileId file-1. Do not call get-design-snapshot again.",
+        }),
+      },
+    ]);
+
+    let attempts = 0;
+    const messages: EngineMessage[] = [
+      { role: "user", content: [{ type: "text", text: "go" }] },
+    ];
+    mockRunAgentLoop.mockImplementation(async () => {
+      attempts++;
+      if (attempts === 1) {
+        throw new EngineError("Builder gateway timed out", {
+          errorCode: "builder_gateway_timeout",
+        });
+      }
+      return {
+        inputTokens: 1,
+        outputTokens: 1,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        model: "test-model",
+      };
+    });
+
+    await runAgentLoopDirectWithSoftTimeout(
+      makeOpts(messages, new AbortController().signal, undefined, "thread-1"),
+      60_000,
+    );
+
+    expect(attempts).toBe(2);
+    const journalNote = messages
+      .map((m) => (m.content[0]?.type === "text" ? m.content[0].text : ""))
+      .find((t) =>
+        t.includes("Tool-call journal from the interrupted attempt"),
+      );
+    expect(journalNote).toContain("Next required action from result");
+    expect(journalNote).toContain("Call edit-design exactly once");
+    expect(journalNote).toContain("Do not call get-design-snapshot again");
+  });
+
   it("does not inject a journal note on resume when the turn had no tool calls", async () => {
     // No tool activity in the ledger → no structured note, so resume behavior is
     // unchanged from before this feature.

--- a/packages/core/src/agent/tool-call-journal.spec.ts
+++ b/packages/core/src/agent/tool-call-journal.spec.ts
@@ -239,6 +239,35 @@ describe("buildResumeJournalNote", () => {
     // Result summary is capped well under the raw length.
     expect(note.length).toBeLessThan(longResult.length);
   });
+
+  it("keeps nextRequiredAction visible when the tool result summary is truncated", () => {
+    const result = JSON.stringify({
+      designId: "design-1",
+      files: [
+        {
+          id: "file-1",
+          content: "x".repeat(2000),
+        },
+      ],
+      nextRequiredAction:
+        "Call edit-design exactly once with designId design-1 and fileId file-1. Do not call get-design-snapshot again.",
+    });
+    const events: AgentChatEvent[] = [
+      start("get-design-snapshot", {
+        designId: "design-1",
+        fileId: "file-1",
+      }),
+      done("get-design-snapshot", result),
+    ];
+
+    const note = buildResumeJournalNote(classifyToolCallJournal(events)) ?? "";
+
+    expect(note).toContain("Next required action from result");
+    expect(note).toContain("Call edit-design exactly once");
+    expect(note).toContain("Do not call get-design-snapshot again");
+    expect(note).toContain("…");
+    expect(note.length).toBeLessThan(result.length);
+  });
 });
 
 describe("findCompletedJournalEntry", () => {

--- a/packages/core/src/agent/tool-call-journal.ts
+++ b/packages/core/src/agent/tool-call-journal.ts
@@ -72,6 +72,9 @@ const INPUT_SIGNATURE_MAX_CHARS = 120;
 /** Max length of a per-tool-call result summary surfaced in the resume note. */
 const RESULT_SUMMARY_MAX_CHARS = 400;
 
+/** Max length of explicit next-step guidance surfaced outside result summaries. */
+const NEXT_REQUIRED_ACTION_MAX_CHARS = 900;
+
 function inputSignature(input: unknown): string {
   if (input == null) return "";
   try {
@@ -279,6 +282,34 @@ function summarizeResult(result: string | undefined): string {
     : oneLine;
 }
 
+function parseResultObject(
+  result: string | undefined,
+): Record<string, unknown> {
+  if (!result) return {};
+  const trimmed = result.trim();
+  if (!trimmed.startsWith("{")) return {};
+  try {
+    const parsed = JSON.parse(trimmed);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function summarizeNextRequiredAction(
+  result: string | undefined,
+): string | null {
+  const action = parseResultObject(result).nextRequiredAction;
+  if (typeof action !== "string") return null;
+  const oneLine = action.replace(/\s+/g, " ").trim();
+  if (!oneLine) return null;
+  return oneLine.length > NEXT_REQUIRED_ACTION_MAX_CHARS
+    ? oneLine.slice(0, NEXT_REQUIRED_ACTION_MAX_CHARS) + "..."
+    : oneLine;
+}
+
 function describeInput(input: unknown): string {
   if (!input) return "";
   const sig = displayInputSignature(input);
@@ -311,9 +342,13 @@ export function buildResumeJournalNote(
       "Already completed (do NOT re-run these — their side effects already happened; reuse the results below):",
     );
     for (const entry of journal.completed) {
+      const nextRequiredAction = summarizeNextRequiredAction(entry.result);
       lines.push(
         `- ${entry.tool}${describeInput(entry.input)} → ${summarizeResult(entry.result)}`,
       );
+      if (nextRequiredAction) {
+        lines.push(`  Next required action from result: ${nextRequiredAction}`);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- keep explicit `nextRequiredAction` fields visible in automatic continuation journal notes even when the full tool result is truncated
- add regression coverage for large Design snapshot results where the follow-up instruction appears after large file content
- add resume-level coverage proving the continuation prompt carries the extracted next action

## Production finding
After #1810 reached production, a fresh Design QA run created three variants successfully and recovered the first stuck follow-up instead of hanging. The remaining loop was snapshot-only continuations: the selected variant run repeatedly completed `get-design-snapshot`, then hit keepalive-only silence and auto-retried without ever calling `edit-design`. The snapshot result already contained `nextRequiredAction: Call edit-design exactly once...`, but the journal summary truncated the large result before that instruction.

## Validation
- `corepack pnpm --filter @agent-native/core exec vitest run src/agent/tool-call-journal.spec.ts src/agent/run-loop-with-resume.spec.ts`
- `corepack pnpm --filter @agent-native/core typecheck`
- `corepack pnpm prep`
