### PR TITLE
Recover repeated zero-byte tool input restarts

### DIFF
--- a/.changeset/fair-mirrors-decide.md
+++ b/.changeset/fair-mirrors-decide.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Recover long-running agent turns that repeatedly prepare zero-byte tool inputs.

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -1516,6 +1516,83 @@ describe("runAgentLoop", () => {
     expect(events.at(-1)).toEqual({ type: "done" });
   });
 
+  it("retires an abandoned zero-byte read-only input after a fresh id streams bytes", async () => {
+    let now = 1_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        yield {
+          type: "tool-input-delta",
+          id: "search-abandoned",
+          name: "search",
+          text: "",
+        };
+        now += 45_000;
+        yield {
+          type: "tool-input-delta",
+          id: "search-replacement",
+          name: "search",
+          text: '{"query":"first bytes',
+        };
+        now += 46_000;
+        yield {
+          type: "tool-input-delta",
+          id: "search-replacement",
+          name: "search",
+          text: ' and still streaming"}',
+        };
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "text" as const, text: "done" }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    const events: AgentChatEvent[] = [];
+
+    try {
+      await runAgentLoop({
+        engine,
+        model: "test-model",
+        systemPrompt: "system",
+        tools: [],
+        messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+        actions: {
+          search: actionEntry({ readOnly: true }),
+        },
+        send: (event) => events.push(event),
+        signal: new AbortController().signal,
+      });
+    } finally {
+      dateNow.mockRestore();
+    }
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "activity",
+        tool: "search",
+        id: "search-replacement",
+        progressBytes: 43,
+      }),
+    );
+    expect(events).not.toContainEqual({
+      type: "auto_continue",
+      reason: "no_progress",
+    });
+    expect(events.at(-1)).toEqual({ type: "done" });
+  });
+
   it("keeps parallel-safe same-action input stalls tracked while a sibling streams", async () => {
     let now = 1_000_000;
     const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -1359,6 +1359,86 @@ describe("runAgentLoop", () => {
     );
   });
 
+  it("checkpoints repeated zero-byte action input deltas with fresh ids", async () => {
+    let now = 1_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        yield {
+          type: "tool-input-delta",
+          id: "tool-edit-a",
+          name: "edit-design",
+          text: "",
+        };
+        yield { type: "gateway-heartbeat" };
+        now += 45_000;
+        yield {
+          type: "tool-input-delta",
+          id: "tool-edit-b",
+          name: "edit-design",
+          text: "",
+        };
+        yield { type: "gateway-heartbeat" };
+        now += 46_000;
+        yield {
+          type: "tool-input-delta",
+          id: "tool-edit-c",
+          name: "edit-design",
+          text: "",
+        };
+        yield { type: "text-delta", text: "should not continue" };
+      },
+    };
+    const events: AgentChatEvent[] = [];
+
+    try {
+      await runAgentLoop({
+        engine,
+        model: "test-model",
+        systemPrompt: "system",
+        tools: [],
+        messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+        actions: {
+          "edit-design": actionEntry({ readOnly: false }),
+        },
+        send: (event) => events.push(event),
+        signal: new AbortController().signal,
+      });
+    } finally {
+      dateNow.mockRestore();
+    }
+
+    expect(
+      events.filter(
+        (event) =>
+          event.type === "activity" &&
+          event.tool === "edit-design" &&
+          event.progressBytes === 0,
+      ).length,
+    ).toBeGreaterThanOrEqual(2);
+    expect(events.at(-1)).toEqual({
+      type: "auto_continue",
+      reason: "no_progress",
+    });
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: "text", text: "should not continue" }),
+    );
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: "tool_start" }),
+    );
+  });
+
   it("tracks action-preparation stalls for multiple in-flight tool inputs", async () => {
     let now = 1_000_000;
     const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -1439,6 +1439,81 @@ describe("runAgentLoop", () => {
     );
   });
 
+  it("retires an abandoned zero-byte action input after a fresh id streams bytes", async () => {
+    let now = 1_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        yield {
+          type: "tool-input-delta",
+          id: "tool-edit-abandoned",
+          name: "edit-design",
+          text: "",
+        };
+        now += 45_000;
+        yield {
+          type: "tool-input-delta",
+          id: "tool-edit-replacement",
+          name: "edit-design",
+          text: '{"replacementContent":"first bytes',
+        };
+        now += 46_000;
+        yield {
+          type: "tool-input-delta",
+          id: "tool-edit-replacement",
+          name: "edit-design",
+          text: ' and still streaming"}',
+        };
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "text" as const, text: "done" }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    const events: AgentChatEvent[] = [];
+
+    try {
+      await runAgentLoop({
+        engine,
+        model: "test-model",
+        systemPrompt: "system",
+        tools: [],
+        messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+        actions: {},
+        send: (event) => events.push(event),
+        signal: new AbortController().signal,
+      });
+    } finally {
+      dateNow.mockRestore();
+    }
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "activity",
+        tool: "edit-design",
+        id: "tool-edit-replacement",
+        progressBytes: 56,
+      }),
+    );
+    expect(events).not.toContainEqual({
+      type: "auto_continue",
+      reason: "no_progress",
+    });
+    expect(events.at(-1)).toEqual({ type: "done" });
+  });
+
   it("tracks action-preparation stalls for multiple in-flight tool inputs", async () => {
     let now = 1_000_000;
     const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -1439,7 +1439,7 @@ describe("runAgentLoop", () => {
     );
   });
 
-  it("retires an abandoned zero-byte action input after a fresh id streams bytes", async () => {
+  it("keeps a fresh action-input id streaming after an abandoned zero-byte id", async () => {
     let now = 1_000_000;
     const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
     const engine: AgentEngine = {
@@ -1516,7 +1516,7 @@ describe("runAgentLoop", () => {
     expect(events.at(-1)).toEqual({ type: "done" });
   });
 
-  it("retires an abandoned zero-byte read-only input after a fresh id streams bytes", async () => {
+  it("keeps a fresh read-only input id streaming after an abandoned zero-byte id", async () => {
     let now = 1_000_000;
     const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
     const engine: AgentEngine = {
@@ -1634,6 +1634,9 @@ describe("runAgentLoop", () => {
           name: "search",
           text: ' still streaming"}',
         };
+        yield { type: "text-delta", text: "still preparing" };
+        now += 91_000;
+        yield { type: "gateway-heartbeat" };
         yield { type: "text-delta", text: "should not continue" };
       },
     };
@@ -1663,6 +1666,97 @@ describe("runAgentLoop", () => {
         id: "parallel-search-b",
         progressBytes: 25,
       }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: "text", text: "still preparing" }),
+    );
+    expect(events.at(-1)).toEqual({
+      type: "auto_continue",
+      reason: "no_progress",
+    });
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: "text", text: "should not continue" }),
+    );
+  });
+
+  it("keeps delta-only same-action input progress alive while a sibling is silent", async () => {
+    let now = 1_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        yield {
+          type: "tool-input-delta",
+          id: "delta-search-a",
+          name: "search",
+          text: "",
+        };
+        now += 45_000;
+        yield {
+          type: "tool-input-delta",
+          id: "delta-search-b",
+          name: "search",
+          text: "",
+        };
+        now += 2_000;
+        yield {
+          type: "tool-input-delta",
+          id: "delta-search-c",
+          name: "search",
+          text: '{"query":"healthy sibling',
+        };
+        now += 44_000;
+        yield {
+          type: "tool-input-delta",
+          id: "delta-search-c",
+          name: "search",
+          text: ' still streaming"}',
+        };
+        yield { type: "text-delta", text: "still preparing" };
+        now += 91_000;
+        yield { type: "gateway-heartbeat" };
+        yield { type: "text-delta", text: "should not continue" };
+      },
+    };
+    const events: AgentChatEvent[] = [];
+
+    try {
+      await runAgentLoop({
+        engine,
+        model: "test-model",
+        systemPrompt: "system",
+        tools: [],
+        messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+        actions: {
+          search: actionEntry({ readOnly: true }),
+        },
+        send: (event) => events.push(event),
+        signal: new AbortController().signal,
+      });
+    } finally {
+      dateNow.mockRestore();
+    }
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "activity",
+        tool: "search",
+        id: "delta-search-c",
+        progressBytes: 25,
+      }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: "text", text: "still preparing" }),
     );
     expect(events.at(-1)).toEqual({
       type: "auto_continue",
@@ -1712,9 +1806,12 @@ describe("runAgentLoop", () => {
           id: "tool-b",
           text: "still healthy",
         };
+        yield { type: "text-delta", text: "still preparing" };
+        now += 91_000;
+        yield { type: "gateway-heartbeat" };
         yield {
-          type: "assistant-content",
-          parts: [{ type: "text" as const, text: "should not finish" }],
+          type: "text-delta",
+          text: "should not continue",
         };
       },
     };
@@ -1750,12 +1847,15 @@ describe("runAgentLoop", () => {
       tool: "generate-design",
       id: "tool-b",
     });
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: "text", text: "still preparing" }),
+    );
     expect(events.at(-1)).toEqual({
       type: "auto_continue",
       reason: "no_progress",
     });
     expect(events).not.toContainEqual(
-      expect.objectContaining({ type: "text", text: "should not finish" }),
+      expect.objectContaining({ type: "text", text: "should not continue" }),
     );
   });
 

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -1491,7 +1491,9 @@ describe("runAgentLoop", () => {
         systemPrompt: "system",
         tools: [],
         messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
-        actions: {},
+        actions: {
+          "edit-design": actionEntry({ readOnly: false }),
+        },
         send: (event) => events.push(event),
         signal: new AbortController().signal,
       });
@@ -1512,6 +1514,86 @@ describe("runAgentLoop", () => {
       reason: "no_progress",
     });
     expect(events.at(-1)).toEqual({ type: "done" });
+  });
+
+  it("keeps parallel-safe same-action input stalls tracked while a sibling streams", async () => {
+    let now = 1_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        yield {
+          type: "tool-input-start",
+          id: "parallel-search-a",
+          name: "search",
+        };
+        now += 45_000;
+        yield {
+          type: "tool-input-start",
+          id: "parallel-search-b",
+          name: "search",
+        };
+        now += 2_000;
+        yield {
+          type: "tool-input-delta",
+          id: "parallel-search-b",
+          name: "search",
+          text: '{"query":"healthy sibling',
+        };
+        now += 44_000;
+        yield {
+          type: "tool-input-delta",
+          id: "parallel-search-b",
+          name: "search",
+          text: ' still streaming"}',
+        };
+        yield { type: "text-delta", text: "should not continue" };
+      },
+    };
+    const events: AgentChatEvent[] = [];
+
+    try {
+      await runAgentLoop({
+        engine,
+        model: "test-model",
+        systemPrompt: "system",
+        tools: [],
+        messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+        actions: {
+          search: actionEntry({ readOnly: false, parallelSafe: true }),
+        },
+        send: (event) => events.push(event),
+        signal: new AbortController().signal,
+      });
+    } finally {
+      dateNow.mockRestore();
+    }
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "activity",
+        tool: "search",
+        id: "parallel-search-b",
+        progressBytes: 25,
+      }),
+    );
+    expect(events.at(-1)).toEqual({
+      type: "auto_continue",
+      reason: "no_progress",
+    });
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: "text", text: "should not continue" }),
+    );
   });
 
   it("tracks action-preparation stalls for multiple in-flight tool inputs", async () => {

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -2970,6 +2970,7 @@ export async function runAgentLoop(opts: {
               event.name ??
               (event.id ? toolInputNames.get(event.id) : undefined);
             let progressBytes: number | undefined;
+            let startedZeroByteInput = false;
             if (key) {
               const hadByteRecord = toolInputBytes.has(key);
               const previous = hadByteRecord
@@ -2983,10 +2984,24 @@ export async function runAgentLoop(opts: {
                 trackActiveToolInput(key, toolName, progressBytes);
                 if (progressBytes > 0) {
                   resetZeroByteToolInputRestart(toolName);
+                } else if (!hadByteRecord) {
+                  startedZeroByteInput = true;
                 }
               }
             }
             sendToolInputActivity(toolName, key, progressBytes);
+            if (
+              startedZeroByteInput &&
+              toolName &&
+              noteZeroByteToolInputStart(toolName)
+            ) {
+              send({
+                type: "auto_continue",
+                reason: "no_progress",
+              });
+              endedForActionPreparationNoProgress = true;
+              break;
+            }
           } else if (event.type === "gateway-heartbeat") {
             send({ type: "stream_keepalive" });
           } else if (event.type === "tool-call") {

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -2822,7 +2822,6 @@ export async function runAgentLoop(opts: {
           startedAt: number;
           lastProgressAt: number;
           bytes: number;
-          startedFromDelta: boolean;
         };
         type ZeroByteToolInputRestart = {
           toolName: string;
@@ -2858,44 +2857,30 @@ export async function runAgentLoop(opts: {
         const hasActionPreparationStalled = () => {
           if (activeToolInputs.size === 0) return false;
           const now = Date.now();
+          let latestProgressAt = 0;
           for (const active of activeToolInputs.values()) {
-            if (
-              now - active.lastProgressAt >=
-              ACTION_PREPARATION_NO_PROGRESS_TIMEOUT_MS
-            ) {
-              return true;
+            if (active.lastProgressAt > latestProgressAt) {
+              latestProgressAt = active.lastProgressAt;
             }
           }
-          return false;
+          return (
+            now - latestProgressAt >= ACTION_PREPARATION_NO_PROGRESS_TIMEOUT_MS
+          );
         };
         const trackActiveToolInput = (
           key: string,
           toolName: string | undefined,
           bytes: number,
-          source?: "start" | "delta",
         ) => {
           const now = Date.now();
           const previous = activeToolInputs.get(key);
           const resolvedToolName = toolName ?? previous?.toolName;
-          if (bytes > 0 && resolvedToolName) {
-            for (const [activeKey, active] of activeToolInputs) {
-              if (
-                activeKey !== key &&
-                active.toolName === resolvedToolName &&
-                active.bytes === 0 &&
-                active.startedFromDelta
-              ) {
-                activeToolInputs.delete(activeKey);
-              }
-            }
-          }
           activeToolInputs.set(key, {
             id: key,
             ...(resolvedToolName ? { toolName: resolvedToolName } : {}),
             startedAt: previous?.startedAt ?? now,
             lastProgressAt: now,
             bytes,
-            startedFromDelta: previous?.startedFromDelta ?? source === "delta",
           });
         };
         const resetZeroByteToolInputRestart = (toolName?: string) => {
@@ -2967,7 +2952,7 @@ export async function runAgentLoop(opts: {
             if (key && event.name) {
               toolInputNames.set(key, event.name);
               toolInputBytes.set(key, 0);
-              trackActiveToolInput(key, event.name, 0, "start");
+              trackActiveToolInput(key, event.name, 0);
             }
             sendToolInputActivity(event.name, key, undefined, true);
             if (noteZeroByteToolInputStart(event.name)) {
@@ -2995,12 +2980,7 @@ export async function runAgentLoop(opts: {
                 new TextEncoder().encode(event.text ?? "").byteLength;
               toolInputBytes.set(key, progressBytes);
               if (!hadByteRecord || progressBytes > previous) {
-                trackActiveToolInput(
-                  key,
-                  toolName,
-                  progressBytes,
-                  hadByteRecord ? undefined : "delta",
-                );
+                trackActiveToolInput(key, toolName, progressBytes);
                 if (progressBytes > 0) {
                   resetZeroByteToolInputRestart(toolName);
                 } else if (!hadByteRecord) {

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -2867,6 +2867,13 @@ export async function runAgentLoop(opts: {
           }
           return false;
         };
+        const allowsParallelInputPreparation = (toolName?: string) => {
+          if (!toolName) return true;
+          const entry = actions[toolName];
+          return (
+            !entry || entry.readOnly === true || entry.parallelSafe === true
+          );
+        };
         const trackActiveToolInput = (
           key: string,
           toolName: string | undefined,
@@ -2875,7 +2882,11 @@ export async function runAgentLoop(opts: {
           const now = Date.now();
           const previous = activeToolInputs.get(key);
           const resolvedToolName = toolName ?? previous?.toolName;
-          if (bytes > 0 && resolvedToolName) {
+          if (
+            bytes > 0 &&
+            resolvedToolName &&
+            !allowsParallelInputPreparation(resolvedToolName)
+          ) {
             for (const [activeKey, active] of activeToolInputs) {
               if (
                 activeKey !== key &&

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -2822,6 +2822,7 @@ export async function runAgentLoop(opts: {
           startedAt: number;
           lastProgressAt: number;
           bytes: number;
+          startedFromDelta: boolean;
         };
         type ZeroByteToolInputRestart = {
           toolName: string;
@@ -2867,31 +2868,22 @@ export async function runAgentLoop(opts: {
           }
           return false;
         };
-        const allowsParallelInputPreparation = (toolName?: string) => {
-          if (!toolName) return true;
-          const entry = actions[toolName];
-          return (
-            !entry || entry.readOnly === true || entry.parallelSafe === true
-          );
-        };
         const trackActiveToolInput = (
           key: string,
           toolName: string | undefined,
           bytes: number,
+          source?: "start" | "delta",
         ) => {
           const now = Date.now();
           const previous = activeToolInputs.get(key);
           const resolvedToolName = toolName ?? previous?.toolName;
-          if (
-            bytes > 0 &&
-            resolvedToolName &&
-            !allowsParallelInputPreparation(resolvedToolName)
-          ) {
+          if (bytes > 0 && resolvedToolName) {
             for (const [activeKey, active] of activeToolInputs) {
               if (
                 activeKey !== key &&
                 active.toolName === resolvedToolName &&
-                active.bytes === 0
+                active.bytes === 0 &&
+                active.startedFromDelta
               ) {
                 activeToolInputs.delete(activeKey);
               }
@@ -2903,6 +2895,7 @@ export async function runAgentLoop(opts: {
             startedAt: previous?.startedAt ?? now,
             lastProgressAt: now,
             bytes,
+            startedFromDelta: previous?.startedFromDelta ?? source === "delta",
           });
         };
         const resetZeroByteToolInputRestart = (toolName?: string) => {
@@ -2974,7 +2967,7 @@ export async function runAgentLoop(opts: {
             if (key && event.name) {
               toolInputNames.set(key, event.name);
               toolInputBytes.set(key, 0);
-              trackActiveToolInput(key, event.name, 0);
+              trackActiveToolInput(key, event.name, 0, "start");
             }
             sendToolInputActivity(event.name, key, undefined, true);
             if (noteZeroByteToolInputStart(event.name)) {
@@ -3002,7 +2995,12 @@ export async function runAgentLoop(opts: {
                 new TextEncoder().encode(event.text ?? "").byteLength;
               toolInputBytes.set(key, progressBytes);
               if (!hadByteRecord || progressBytes > previous) {
-                trackActiveToolInput(key, toolName, progressBytes);
+                trackActiveToolInput(
+                  key,
+                  toolName,
+                  progressBytes,
+                  hadByteRecord ? undefined : "delta",
+                );
                 if (progressBytes > 0) {
                   resetZeroByteToolInputRestart(toolName);
                 } else if (!hadByteRecord) {

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -2874,11 +2874,21 @@ export async function runAgentLoop(opts: {
         ) => {
           const now = Date.now();
           const previous = activeToolInputs.get(key);
+          const resolvedToolName = toolName ?? previous?.toolName;
+          if (bytes > 0 && resolvedToolName) {
+            for (const [activeKey, active] of activeToolInputs) {
+              if (
+                activeKey !== key &&
+                active.toolName === resolvedToolName &&
+                active.bytes === 0
+              ) {
+                activeToolInputs.delete(activeKey);
+              }
+            }
+          }
           activeToolInputs.set(key, {
             id: key,
-            ...((toolName ?? previous?.toolName)
-              ? { toolName: toolName ?? previous?.toolName }
-              : {}),
+            ...(resolvedToolName ? { toolName: resolvedToolName } : {}),
             startedAt: previous?.startedAt ?? now,
             lastProgressAt: now,
             bytes,


### PR DESCRIPTION
## Summary
- recover no-progress agent turns when the model repeatedly emits fresh zero-byte tool-input deltas for the same action
- preserve support for genuinely large outputs by resetting the restart state when positive tool-input bytes stream
- add a regression test for repeated zero-byte edit-design deltas with fresh IDs

## Validation
- corepack pnpm --filter @agent-native/core exec vitest run src/agent/production-agent.spec.ts src/agent/run-loop-with-resume.spec.ts src/agent/tool-call-journal.spec.ts
- corepack pnpm --filter @agent-native/core typecheck
- corepack pnpm prep

## Production Evidence
- Fresh production Design QA run MVv1ghNInAn_VxRBq2sMN created three variants successfully on main@a234670.
- Selected-variant build then stalled on repeated zero-byte edit-design prep events with fresh IDs and no tool_start/tool_done, matching the fixed path here.
