### PR TITLE
Recover stalled durable action prep

### DIFF
--- a/.changeset/durable-prep-stall-recovery.md
+++ b/.changeset/durable-prep-stall-recovery.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Recover durable background chat runs when action input preparation stops making byte progress, and avoid duplicate tool cards when reconnects replay completed tool events.

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -1417,6 +1417,103 @@ describe("createAgentChatAdapter", () => {
     expect(last.content.at(-1).text).toBe("recovered from active run");
   });
 
+  it("preserves the same-run cursor when active-run recovery follows a failed tail reconnect", async () => {
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let tailReconnects = 0;
+    const eventUrls: string[] = [];
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/_agent-native/agent-chat" && init?.method === "POST") {
+        return sseResponse(
+          [
+            {
+              type: "tool_start",
+              tool: "delete-file",
+              id: "call-1",
+              input: { fileId: "screen-1" },
+              seq: 0,
+            },
+            {
+              type: "tool_done",
+              tool: "delete-file",
+              id: "call-1",
+              result: '{"deleted":true}',
+              seq: 1,
+            },
+          ],
+          "run-existing",
+        );
+      }
+      if (url.includes("/runs/run-existing/events")) {
+        eventUrls.push(url);
+        if (url.includes("after=2")) {
+          tailReconnects += 1;
+          return tailReconnects === 1
+            ? jsonResponse({ error: "temporary failure" }, 503)
+            : sseResponse(
+                [
+                  { type: "text", text: " tail recovered", seq: 2 },
+                  { type: "done", seq: 3 },
+                ],
+                "run-existing",
+              );
+        }
+        return jsonResponse({ error: "replayed from start" }, 500);
+      }
+      if (url.includes("/runs/active")) {
+        return jsonResponse({
+          active: true,
+          runId: "run-existing",
+          threadId: "thread-recover",
+          status: "running",
+          heartbeatAt: Date.now(),
+        });
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-recover-tail",
+      threadId: "thread-recover",
+    });
+
+    const results = await drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "keep going" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    expect(eventUrls).toEqual([
+      "/_agent-native/agent-chat/runs/run-existing/events?after=2",
+      "/_agent-native/agent-chat/runs/run-existing/events?after=2",
+    ]);
+    const last = results.at(-1) as any;
+    const toolCalls = last.content.filter(
+      (part: any) => part.type === "tool-call",
+    );
+    expect(toolCalls).toHaveLength(1);
+    expect(last.content.at(-1).text).toBe(" tail recovered");
+  });
+
   it("retries queued message conflicts instead of binding the old run", async () => {
     vi.useFakeTimers();
     vi.stubGlobal("window", { dispatchEvent: vi.fn() });

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -1380,6 +1380,7 @@ export function createAgentChatAdapter(
       const turnId = generateTurnId();
       let runId: string | null = null;
       let lastSeq = -1;
+      const seenRunSeqs = new Map<string, number>();
       let currentRunDispatchMode: string | null = null;
       let currentMessageText = normalizeMentions(
         recoveryMessageText.trim() || userMessageText,
@@ -1548,6 +1549,27 @@ export function createAgentChatAdapter(
         if (mode) currentRunDispatchMode = mode;
       };
 
+      const rememberRunSeq = (seq: number) => {
+        lastSeq = seq;
+        if (runId) {
+          seenRunSeqs.set(runId, seq);
+        }
+      };
+
+      const reconnectCursorForRun = (
+        nextRunId: string,
+        previousRunId: string | null,
+      ) => {
+        const rememberedSeq = seenRunSeqs.get(nextRunId);
+        if (rememberedSeq !== undefined) {
+          lastSeq = rememberedSeq;
+          return;
+        }
+        if (previousRunId !== nextRunId) {
+          lastSeq = -1;
+        }
+      };
+
       const currentSSEOptions = () => ({
         durableBackgroundRun:
           currentRunDispatchMode?.startsWith("background") === true,
@@ -1671,7 +1693,7 @@ export function createAgentChatAdapter(
                 toolCallCounter,
                 tabId,
                 (seq) => {
-                  lastSeq = seq;
+                  rememberRunSeq(seq);
                   if (threadId) updateActiveRunSeq(seq);
                 },
                 runId,
@@ -1765,12 +1787,13 @@ export function createAgentChatAdapter(
                   return false;
                 }
                 const activeRunId = String(active.runId);
+                const previousRunId = runId;
                 runId = activeRunId;
                 if (!attemptedRunIds.includes(activeRunId)) {
                   attemptedRunIds.push(activeRunId);
                 }
-                lastSeq = -1;
-                setActiveRun({ threadId, runId: activeRunId, lastSeq: -1 });
+                reconnectCursorForRun(activeRunId, previousRunId);
+                setActiveRun({ threadId, runId: activeRunId, lastSeq });
                 const reconnected = yield* reconnectCurrentRun();
                 if (reconnected) return true;
               }
@@ -1844,12 +1867,13 @@ export function createAgentChatAdapter(
                 if (activeStatus !== "running" && activeStatus !== "starting") {
                   return false;
                 }
+                const previousRunId = runId;
                 runId = activeRunId;
                 if (!attemptedRunIds.includes(activeRunId)) {
                   attemptedRunIds.push(activeRunId);
                 }
-                lastSeq = -1;
-                setActiveRun({ threadId, runId: activeRunId, lastSeq: -1 });
+                reconnectCursorForRun(activeRunId, previousRunId);
+                setActiveRun({ threadId, runId: activeRunId, lastSeq });
                 const reconnected = yield* reconnectCurrentRun();
                 if (reconnected) return true;
               } catch (activeErr: unknown) {
@@ -2290,13 +2314,14 @@ export function createAgentChatAdapter(
                 }
                 if (activeRunId) {
                   try {
+                    const previousRunId = runId;
                     runId = activeRunId;
                     if (!attemptedRunIds.includes(runId)) {
                       attemptedRunIds.push(runId);
                     }
-                    lastSeq = -1;
+                    reconnectCursorForRun(activeRunId, previousRunId);
                     if (threadId) {
-                      setActiveRun({ threadId, runId, lastSeq: -1 });
+                      setActiveRun({ threadId, runId, lastSeq });
                     }
                     const reconnected = yield* reconnectCurrentRun();
                     if (reconnected) return;
@@ -2423,7 +2448,7 @@ export function createAgentChatAdapter(
               toolCallCounter,
               tabId,
               (seq) => {
-                lastSeq = seq;
+                rememberRunSeq(seq);
                 if (runId && threadId) {
                   updateActiveRunSeq(seq);
                 }

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -612,26 +612,77 @@ describe("SSE event processor no-progress recovery", () => {
     ]);
   });
 
-  it("keeps a durable background stream alive on zero-byte preparation activity", async () => {
+  it("recovers a durable background stream stuck on zero-byte preparation activity", async () => {
     vi.useFakeTimers();
 
-    const donePromise = drain(
-      readSSEStream(
-        preparingActionZeroByteActivityThenDoneStream(),
-        [],
-        { value: 0 },
-        undefined,
-        undefined,
-        undefined,
-        { durableBackgroundRun: true },
-      ),
-    );
+    const errPromise = (async () => {
+      try {
+        await drain(
+          readSSEStream(
+            preparingActionZeroByteActivityThenDoneStream(),
+            [],
+            { value: 0 },
+            undefined,
+            undefined,
+            undefined,
+            { durableBackgroundRun: true },
+          ),
+        );
+      } catch (err) {
+        return err;
+      }
+    })();
 
     await vi.advanceTimersByTimeAsync(
-      SSE_ACTION_PREPARATION_STALL_TIMEOUT_MS + 30_000,
+      SSE_ACTION_PREPARATION_STALL_TIMEOUT_MS + 1,
     );
 
-    await expect(donePromise).resolves.toBeDefined();
+    const err = await errPromise;
+
+    expect(err).toBeInstanceOf(AgentAutoContinueSignal);
+    expect((err as AgentAutoContinueSignal).reason).toBe("no_progress");
+    expect((err as AgentAutoContinueSignal).activityTrail).toEqual([
+      {
+        label: "Preparing edit screen action",
+        tool: "edit-design",
+      },
+    ]);
+  });
+
+  it("recovers a durable background stream stuck on preparation keepalives", async () => {
+    vi.useFakeTimers();
+
+    const errPromise = (async () => {
+      try {
+        for await (const _ of readSSEStream(
+          preparingActionKeepaliveStream(),
+          [],
+          { value: 0 },
+          undefined,
+          undefined,
+          undefined,
+          { durableBackgroundRun: true },
+        )) {
+          // no-op
+        }
+      } catch (err) {
+        return err;
+      }
+    })();
+
+    await vi.advanceTimersByTimeAsync(
+      SSE_ACTION_PREPARATION_STALL_TIMEOUT_MS + 1,
+    );
+    const err = await errPromise;
+
+    expect(err).toBeInstanceOf(AgentAutoContinueSignal);
+    expect((err as AgentAutoContinueSignal).reason).toBe("no_progress");
+    expect((err as AgentAutoContinueSignal).activityTrail).toEqual([
+      {
+        label: "Preparing edit screen action",
+        tool: "edit-design",
+      },
+    ]);
   });
 
   it("keeps durable background keepalives attached until a terminal event", async () => {
@@ -666,6 +717,28 @@ describe("SSE event processor no-progress recovery", () => {
         [],
         { value: 0 },
         undefined,
+      ),
+    );
+
+    for (let i = 0; i < 4; i++) {
+      await vi.advanceTimersByTimeAsync(30_000);
+    }
+
+    await expect(donePromise).resolves.toBeDefined();
+  });
+
+  it("does not stall a durable background run while large tool input is still streaming progress", async () => {
+    vi.useFakeTimers();
+
+    const donePromise = drain(
+      readSSEStream(
+        preparingActionProgressStream(),
+        [],
+        { value: 0 },
+        undefined,
+        undefined,
+        undefined,
+        { durableBackgroundRun: true },
       ),
     );
 
@@ -1602,6 +1675,58 @@ describe("SSE event processor error classification", () => {
         toolName: "update-dashboard",
         result: '{"saved":true}',
         repeatCount: 2,
+      }),
+    );
+  });
+
+  it("ignores replayed completed tool events with the same server id", async () => {
+    const results = await drain(
+      readSSEStream(
+        eventStream([
+          {
+            type: "tool_start",
+            tool: "delete-file",
+            id: "call-1",
+            input: { fileId: "screen-1" },
+          },
+          {
+            type: "tool_done",
+            tool: "delete-file",
+            id: "call-1",
+            result: '{"deleted":true}',
+          },
+          { type: "text", text: "Continuing with the selected screen." },
+          {
+            type: "tool_start",
+            tool: "delete-file",
+            id: "call-1",
+            input: { fileId: "screen-1" },
+          },
+          {
+            type: "tool_done",
+            tool: "delete-file",
+            id: "call-1",
+            result: '{"deleted":true}',
+          },
+          { type: "done" },
+        ]),
+        [],
+        { value: 0 },
+        "tab-tool-replay",
+      ),
+    );
+
+    const finalContent = results.at(-1)?.content ?? [];
+    const toolCalls = finalContent.filter(
+      (part): part is Extract<ContentPart, { type: "tool-call" }> =>
+        part.type === "tool-call",
+    );
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0]).toEqual(
+      expect.objectContaining({
+        toolCallId: "call-1",
+        toolName: "delete-file",
+        result: '{"deleted":true}',
       }),
     );
   });

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -151,9 +151,10 @@ export const SSE_ACTION_PREPARATION_STALL_TIMEOUT_MS = 90_000;
 export interface SSEStreamOptions {
   /**
    * Durable background runs have their own server-side liveness budget and
-   * heartbeat. While one is active, keepalive-only periods and zero-byte
-   * action-preparation activity should keep the client attached instead of
-   * aborting and starting duplicate continuations.
+   * heartbeat. While one is active, generic keepalive-only periods keep the
+   * client attached. Tool-input preparation is stricter: real byte progress
+   * keeps long payloads alive, but zero-byte/silent preparation still recovers
+   * so one stuck action cannot pin the chat forever.
    */
   durableBackgroundRun?: boolean;
 }
@@ -278,6 +279,24 @@ function findPendingToolCallIndex(
   return -1;
 }
 
+function findCompletedToolCallIndex(
+  content: ContentPart[],
+  toolCallId?: string,
+): number {
+  if (!toolCallId) return -1;
+  for (let i = content.length - 1; i >= 0; i--) {
+    const part = content[i];
+    if (
+      part.type === "tool-call" &&
+      part.toolCallId === toolCallId &&
+      part.result !== undefined
+    ) {
+      return i;
+    }
+  }
+  return -1;
+}
+
 function appendActivityTrail(
   trail: ActivityTrailEntry[],
   next: ActivityTrailEntry,
@@ -359,12 +378,7 @@ function updatePreparingActionState(
   return undefined;
 }
 
-function hasStalledPreparingAction(
-  state: PreparingActionState,
-  now: number,
-  options?: SSEStreamOptions,
-) {
-  if (options?.durableBackgroundRun === true) return false;
+function hasStalledPreparingAction(state: PreparingActionState, now: number) {
   // Fire only when a tool input has gone SILENT — no further streaming deltas
   // for the whole window — never merely because a large input has been
   // streaming for a long time. `lastProgressAt` advances on every delta
@@ -787,6 +801,9 @@ export function processEvent(
   if (ev.type === "tool_start") {
     const args = (ev.input ?? {}) as Record<string, string>;
     const tool = ev.tool ?? "unknown";
+    if (findCompletedToolCallIndex(content, ev.id) >= 0) {
+      return { action: "continue" };
+    }
     if (typeof window !== "undefined") {
       window.dispatchEvent(
         new CustomEvent("agent-native:tool-start", {
@@ -868,6 +885,9 @@ export function processEvent(
     // so a tool_done frame with an undefined tool name still matches its
     // pending tool-call entry instead of leaving it forever unresolved.
     const doneTool = ev.tool ?? "unknown";
+    if (findCompletedToolCallIndex(content, ev.id) >= 0) {
+      return { action: "continue" };
+    }
     if (typeof window !== "undefined") {
       window.dispatchEvent(
         new CustomEvent("agent-native:tool-done", {
@@ -1340,9 +1360,7 @@ export async function* readSSEStream(
         );
 
         if (result) yield withStreamMetadata(result);
-        if (
-          hasStalledPreparingAction(preparingActionState, Date.now(), options)
-        ) {
+        if (hasStalledPreparingAction(preparingActionState, Date.now())) {
           throw new AgentAutoContinueSignal({
             reason: "no_progress",
             activityTrail: [...activityTrail],
@@ -1525,9 +1543,7 @@ export async function readSSEStreamRaw(
               : { reason: "stream_ended", activityTrail: [...activityTrail] },
           );
         }
-        if (
-          hasStalledPreparingAction(preparingActionState, Date.now(), options)
-        ) {
+        if (hasStalledPreparingAction(preparingActionState, Date.now())) {
           onUpdate(contentSnapshot(content));
           throw new AgentAutoContinueSignal({
             reason: "no_progress",


### PR DESCRIPTION
## Summary
- recover durable background chat runs when an action is stuck preparing input without byte progress
- keep genuinely large streamed tool inputs alive while bytes continue advancing
- avoid duplicate tool cards when reconnects replay already-completed server tool events
- preserve same-run reconnect cursors across active-run recovery paths

## Validation
- CI=true corepack pnpm --filter @agent-native/core exec vitest --run src/client/sse-event-processor.spec.ts --maxWorkers=25%
- CI=true corepack pnpm --filter @agent-native/core exec vitest --run src/client/agent-chat-adapter.spec.ts --maxWorkers=25%
- CI=true corepack pnpm --filter @agent-native/core typecheck
- CI=true corepack pnpm prep

## Production evidence
- Production QA run `run-1782996070954-u64q17` still reached `terminal_reason=run_timeout` after zero-byte `Preparing edit-design action` keepalives; this PR makes the connected client recover at the action-prep stall threshold instead of waiting for that long background timeout.