### PR TITLE
Fix empty responses from non-Anthropic models

### DIFF
--- a/.changeset/strip-propertynames-tool-schema.md
+++ b/.changeset/strip-propertynames-tool-schema.md
@@ -1,0 +1,10 @@
+---
+"@agent-native/core": patch
+---
+
+Fix empty responses from non-Anthropic models (GPT-5.x, Gemini) on the Builder
+gateway. Action tool schemas generated from `z.record(...)` emitted a
+`propertyNames` JSON Schema keyword that OpenAI's function-calling validator
+rejects with `400 invalid_function_parameters`, producing an empty assistant
+turn. Tool schemas now strip `propertyNames` so they stay portable across
+providers (Anthropic already ignored it).

--- a/packages/core/src/action.spec.ts
+++ b/packages/core/src/action.spec.ts
@@ -280,6 +280,18 @@ describe("defineAction schema mode — tool parameter JSON Schema", () => {
     expect("$schema" in (action.tool.parameters as any)).toBe(false);
   });
 
+  it("strips propertyNames (from z.record) so OpenAI/Gemini function schemas are not rejected", () => {
+    const action = defineAction({
+      description: "with a record field",
+      schema: z.object({
+        styleBrief: z.record(z.string(), z.unknown()).optional(),
+      }),
+      run: async () => "ok",
+    });
+    const json = JSON.stringify(action.tool.parameters);
+    expect(json).not.toContain("propertyNames");
+  });
+
   it("stores the original schema on the entry for downstream re-validation", () => {
     const schema = z.object({ x: z.string() });
     const action = defineAction({

--- a/packages/core/src/action.spec.ts
+++ b/packages/core/src/action.spec.ts
@@ -292,6 +292,21 @@ describe("defineAction schema mode — tool parameter JSON Schema", () => {
     expect(json).not.toContain("propertyNames");
   });
 
+  it("preserves a `propertyNames` data key inside a default value while stripping the schema keyword", () => {
+    const action = defineAction({
+      description: "record with a default object",
+      schema: z.object({
+        cfg: z.record(z.string(), z.string()).default({ propertyNames: "x" }),
+      }),
+      run: async () => "ok",
+    });
+    const params = action.tool.parameters as any;
+    // The structural `propertyNames` keyword on the record is stripped…
+    expect("propertyNames" in params.properties.cfg).toBe(false);
+    // …but the identically-named key inside the default *data* survives.
+    expect(params.properties.cfg.default).toEqual({ propertyNames: "x" });
+  });
+
   it("stores the original schema on the entry for downstream re-validation", () => {
     const schema = z.object({ x: z.string() });
     const action = defineAction({

--- a/packages/core/src/action.ts
+++ b/packages/core/src/action.ts
@@ -821,26 +821,75 @@ function wrapRunWithAudit(
 // Schema → JSON Schema conversion
 // ---------------------------------------------------------------------------
 
+// Keywords whose value is a single subschema.
+const SUBSCHEMA_VALUE_KEYS = [
+  "items",
+  "additionalItems",
+  "contains",
+  "additionalProperties",
+  "not",
+  "if",
+  "then",
+  "else",
+] as const;
+// Keywords whose value is an array of subschemas.
+const SUBSCHEMA_ARRAY_KEYS = [
+  "allOf",
+  "anyOf",
+  "oneOf",
+  "prefixItems",
+] as const;
+// Keywords whose value is a map of name → subschema.
+const SUBSCHEMA_MAP_KEYS = [
+  "properties",
+  "patternProperties",
+  "$defs",
+  "definitions",
+  "dependentSchemas",
+] as const;
+
 /**
- * Recursively remove JSON Schema keywords that some providers' function-calling
- * schema validators reject. OpenAI (and Gemini via the Builder gateway) reject
+ * Remove JSON Schema keywords that some providers' function-calling schema
+ * validators reject. OpenAI (and Gemini via the Builder gateway) reject
  * `propertyNames` — which Zod v4 emits for `z.record(z.string(), …)` — with a
  * `400 invalid_function_parameters` error, causing the model turn to produce no
  * content (surfacing as an empty assistant response). Anthropic ignores the
  * keyword, so stripping it is safe across providers and keeps action schemas
  * portable. `propertyNames` only constrained object *keys*; the value/shape of
  * the object is unaffected by its removal.
+ *
+ * Only descends through actual subschema positions (properties, items, union
+ * branches, definitions, etc.) — never through value-bearing keywords like
+ * `default`, `const`, `enum`, or `examples`, whose objects may legitimately
+ * contain a `propertyNames` data key that must be preserved.
  */
 function stripUnsupportedSchemaKeywords<T>(node: T): T {
-  if (Array.isArray(node)) {
-    for (const item of node) stripUnsupportedSchemaKeywords(item);
-    return node;
-  }
-  if (node && typeof node === "object") {
-    const obj = node as Record<string, unknown>;
-    delete obj.propertyNames;
-    for (const value of Object.values(obj)) {
+  if (!node || typeof node !== "object" || Array.isArray(node)) return node;
+  const obj = node as Record<string, unknown>;
+
+  delete obj.propertyNames;
+
+  for (const key of SUBSCHEMA_VALUE_KEYS) {
+    // `items`/`additionalItems` may also be an array of subschemas.
+    const value = obj[key];
+    if (Array.isArray(value)) {
+      for (const sub of value) stripUnsupportedSchemaKeywords(sub);
+    } else {
       stripUnsupportedSchemaKeywords(value);
+    }
+  }
+  for (const key of SUBSCHEMA_ARRAY_KEYS) {
+    const value = obj[key];
+    if (Array.isArray(value)) {
+      for (const sub of value) stripUnsupportedSchemaKeywords(sub);
+    }
+  }
+  for (const key of SUBSCHEMA_MAP_KEYS) {
+    const value = obj[key];
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      for (const sub of Object.values(value)) {
+        stripUnsupportedSchemaKeywords(sub);
+      }
     }
   }
   return node;

--- a/packages/core/src/action.ts
+++ b/packages/core/src/action.ts
@@ -822,6 +822,31 @@ function wrapRunWithAudit(
 // ---------------------------------------------------------------------------
 
 /**
+ * Recursively remove JSON Schema keywords that some providers' function-calling
+ * schema validators reject. OpenAI (and Gemini via the Builder gateway) reject
+ * `propertyNames` — which Zod v4 emits for `z.record(z.string(), …)` — with a
+ * `400 invalid_function_parameters` error, causing the model turn to produce no
+ * content (surfacing as an empty assistant response). Anthropic ignores the
+ * keyword, so stripping it is safe across providers and keeps action schemas
+ * portable. `propertyNames` only constrained object *keys*; the value/shape of
+ * the object is unaffected by its removal.
+ */
+function stripUnsupportedSchemaKeywords<T>(node: T): T {
+  if (Array.isArray(node)) {
+    for (const item of node) stripUnsupportedSchemaKeywords(item);
+    return node;
+  }
+  if (node && typeof node === "object") {
+    const obj = node as Record<string, unknown>;
+    delete obj.propertyNames;
+    for (const value of Object.values(obj)) {
+      stripUnsupportedSchemaKeywords(value);
+    }
+  }
+  return node;
+}
+
+/**
  * Convert a Standard Schema to JSON Schema for the Claude API.
  * Tries vendor-specific toJSONSchema first (Zod v4), then falls back
  * to a basic introspection of the schema shape.
@@ -844,7 +869,7 @@ function schemaToJsonSchema(
       if (result && typeof result === "object") {
         delete result.$schema;
       }
-      return result as ActionTool["parameters"];
+      return stripUnsupportedSchemaKeywords(result) as ActionTool["parameters"];
     } catch {
       // Fall through to manual converter
     }
@@ -852,7 +877,7 @@ function schemaToJsonSchema(
 
   // Fallback: manual conversion from Zod v4 internal defs
   if (s._zod?.def) {
-    return zodDefToJsonSchema(s._zod.def);
+    return stripUnsupportedSchemaKeywords(zodDefToJsonSchema(s._zod.def));
   }
 
   // Last resort: empty object schema


### PR DESCRIPTION
## Problem

Any non-Anthropic model (GPT-5.x, Gemini) returned an empty assistant response ("The model returned an empty response..."). It wasn't a token-budget issue — raising `max_tokens` did nothing.

## Root cause

The gateway 400'd upstream:

```
Invalid schema for function 'create-collection': 'propertyNames' is not permitted.
code: invalid_function_parameters
```

Zod v4 serializes `z.record(z.string(), …)` with a `propertyNames` keyword. Anthropic ignores it; OpenAI and Gemini reject it. So tool-enabled turns failed at the provider, returned no content, and hit the empty-response fallback.

## Fix

Strip `propertyNames` in `schemaToJsonSchema`, the single point where all action tool schemas are generated. Fixes every action using `z.record`
