### PR TITLE
Recover action prep stalls across reconnects

### DIFF
--- a/.changeset/action-prep-reconnect-state.md
+++ b/.changeset/action-prep-reconnect-state.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Carry action-preparation stall detection across reconnect reads for the same run so zero-byte tool input retries cannot keep background chats alive indefinitely.

--- a/packages/core/src/agent/run-store.spec.ts
+++ b/packages/core/src/agent/run-store.spec.ts
@@ -308,8 +308,10 @@ describe("run store", () => {
     );
     expect(repair?.args[0]).toBe("completed");
     expect(repair?.args[1]).toBe(123_456);
-    expect(repair?.args[6]).toBe("done");
-    expect(repair?.args[7]).toBe("run-done-event");
+    expect(repair?.args[2]).toBeNull();
+    expect(repair?.args[3]).toBeNull();
+    expect(repair?.args[4]).toBe("done");
+    expect(repair?.args[5]).toBe("run-done-event");
     expect(
       execCalls.some(
         (call) =>
@@ -384,7 +386,10 @@ describe("run store", () => {
         /SET status = \?/i.test(call.sql),
     );
     expect(repair?.args[0]).toBe("completed");
-    expect(repair?.args[7]).toBe("run-done-event");
+    expect(repair?.args[2]).toBeNull();
+    expect(repair?.args[3]).toBeNull();
+    expect(repair?.args[4]).toBe("done");
+    expect(repair?.args[5]).toBe("run-done-event");
   });
 
   it("reapIfStale honors last_progress_at as liveness so a progressing run is not reaped mid-tool", async () => {

--- a/packages/core/src/agent/run-store.spec.ts
+++ b/packages/core/src/agent/run-store.spec.ts
@@ -21,6 +21,9 @@ let claimStateRows: Array<{
   started_at?: number | null;
   heartbeat_at?: number | null;
 }> = [];
+let runListRows: Array<Record<string, unknown>> = [];
+let refreshedRunListRows: Array<Record<string, unknown>> | null = null;
+let runListSelectCount = 0;
 let runOwnerRows: Array<{ owner_email: string | null }> = [];
 let insertEventBehavior: () => void = () => {};
 
@@ -52,6 +55,20 @@ const mockDb = {
     // getRunStatus: SELECT status FROM agent_runs WHERE id = ?
     if (/SELECT status FROM agent_runs WHERE id/i.test(rawSql)) {
       return { rows: runStatusRows, rowsAffected: 0 };
+    }
+    if (
+      /SELECT id, thread_id, turn_id, status, started_at, heartbeat_at, completed_at, last_progress_at, error_code, abort_reason, dispatch_mode, terminal_reason, diag_stage/i.test(
+        rawSql,
+      ) &&
+      /WHERE thread_id = \?/i.test(rawSql) &&
+      /LIMIT \?/i.test(rawSql)
+    ) {
+      const rows =
+        refreshedRunListRows && runListSelectCount > 0
+          ? refreshedRunListRows
+          : runListRows;
+      runListSelectCount++;
+      return { rows, rowsAffected: 0 };
     }
     // readBackgroundRunClaim: SELECT dispatch_mode, status, diag_stage, started_at, heartbeat_at FROM agent_runs WHERE id = ?
     if (
@@ -102,6 +119,7 @@ const {
   tryClaimRunSlot,
   updateRunStatusIfRunning,
   getRunStatus,
+  listRunsForThread,
   readBackgroundRunClaim,
   getRunOwnerEmail,
   writeLedgerEntry,
@@ -120,6 +138,9 @@ describe("run store", () => {
     claimSlotRows = [];
     runStatusRows = [];
     claimStateRows = [];
+    runListRows = [];
+    refreshedRunListRows = null;
+    runListSelectCount = 0;
     runOwnerRows = [];
     ledgerRows = [];
     insertEventBehavior = () => {};
@@ -315,6 +336,55 @@ describe("run store", () => {
     expect(repair?.sql).toContain("heartbeat_at");
     expect(repair?.args[0]).toBe("completed");
     expect(repair?.args[1]).toBeNull();
+  });
+
+  it("repairs terminal event rows before listing runs for debug surfaces", async () => {
+    runListRows = [
+      {
+        id: "run-done-event",
+        thread_id: "thread-done",
+        turn_id: null,
+        status: "running",
+        started_at: 1000,
+        heartbeat_at: 1500,
+        completed_at: null,
+        last_progress_at: 1500,
+        error_code: null,
+        abort_reason: null,
+        dispatch_mode: "background-processing",
+        terminal_reason: null,
+        diag_stage: null,
+      },
+    ];
+    refreshedRunListRows = [
+      {
+        ...runListRows[0],
+        status: "completed",
+        completed_at: 123_456,
+        terminal_reason: "done",
+      },
+    ];
+    latestEventRows = [
+      {
+        seq: 9,
+        event_at: 123_456,
+        event_data: JSON.stringify({ type: "done" }),
+      },
+    ];
+
+    const runs = await listRunsForThread("thread-done");
+
+    expect(runs[0]?.status).toBe("completed");
+    expect(runs[0]?.completedAt).toBe(123_456);
+    expect(runs[0]?.terminalReason).toBe("done");
+    expect(runListSelectCount).toBe(2);
+    const repair = execCalls.find(
+      (call) =>
+        /UPDATE agent_runs/i.test(call.sql) &&
+        /SET status = \?/i.test(call.sql),
+    );
+    expect(repair?.args[0]).toBe("completed");
+    expect(repair?.args[7]).toBe("run-done-event");
   });
 
   it("reapIfStale honors last_progress_at as liveness so a progressing run is not reaped mid-tool", async () => {

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -763,9 +763,9 @@ export async function reconcileTerminalRunFromEvents(
     sql: `UPDATE agent_runs
           SET status = ?,
               completed_at = COALESCE(completed_at, ?, ${livenessBasisSql()}),
-              error_code = CASE WHEN ? IS NOT NULL THEN ? ELSE error_code END,
-              error_detail = CASE WHEN ? IS NOT NULL THEN ? ELSE error_detail END,
-              terminal_reason = COALESCE(terminal_reason, ?)
+              error_code = ?,
+              error_detail = ?,
+              terminal_reason = ?
           WHERE id = ?
             AND (
               status = 'running'
@@ -775,8 +775,6 @@ export async function reconcileTerminalRunFromEvents(
       status,
       latest.eventAt,
       errorCode,
-      errorCode,
-      errorDetail,
       errorDetail,
       terminalReason,
       runId,

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -1263,14 +1263,15 @@ export async function listRunsForThread(
       status?: string;
       error_code?: string | null;
     };
+    const runId = row.id;
+    if (!runId) continue;
     const canReconcileFromEvents =
-      row.id &&
-      (row.status === "running" ||
-        (row.status === "errored" &&
-          row.error_code === STALE_RUN_ERROR_EVENT.errorCode));
+      row.status === "running" ||
+      (row.status === "errored" &&
+        row.error_code === STALE_RUN_ERROR_EVENT.errorCode);
     if (!canReconcileFromEvents) continue;
     repairedTerminalRow =
-      (await reconcileTerminalRunFromEvents(row.id).catch(() => false)) ||
+      (await reconcileTerminalRunFromEvents(runId).catch(() => false)) ||
       repairedTerminalRow;
   }
   if (repairedTerminalRow) {

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -1248,7 +1248,7 @@ export async function listRunsForThread(
   await ensureRunTables();
   const limit = Math.min(Math.max(options.limit ?? 10, 1), 50);
   const client = getDbExec();
-  const { rows } = await client.execute({
+  let { rows } = await client.execute({
     sql: `SELECT id, thread_id, turn_id, status, started_at, heartbeat_at, completed_at, last_progress_at, error_code, abort_reason, dispatch_mode, terminal_reason, diag_stage
           FROM agent_runs
           WHERE thread_id = ?
@@ -1256,6 +1256,34 @@ export async function listRunsForThread(
           LIMIT ?`,
     args: [threadId, limit],
   });
+  let repairedTerminalRow = false;
+  for (const r of rows) {
+    const row = r as {
+      id?: string;
+      status?: string;
+      error_code?: string | null;
+    };
+    const canReconcileFromEvents =
+      row.id &&
+      (row.status === "running" ||
+        (row.status === "errored" &&
+          row.error_code === STALE_RUN_ERROR_EVENT.errorCode));
+    if (!canReconcileFromEvents) continue;
+    repairedTerminalRow =
+      (await reconcileTerminalRunFromEvents(row.id).catch(() => false)) ||
+      repairedTerminalRow;
+  }
+  if (repairedTerminalRow) {
+    const refreshed = await client.execute({
+      sql: `SELECT id, thread_id, turn_id, status, started_at, heartbeat_at, completed_at, last_progress_at, error_code, abort_reason, dispatch_mode, terminal_reason, diag_stage
+            FROM agent_runs
+            WHERE thread_id = ?
+            ORDER BY started_at DESC
+            LIMIT ?`,
+      args: [threadId, limit],
+    });
+    rows = refreshed.rows;
+  }
   return rows.map((r) => {
     const row = r as {
       id: string;

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -250,6 +250,9 @@ describe("waitForThreadRunToClear", () => {
     );
     expect(helperSource).toContain("if (!sseRes.ok || !sseRes.body)");
     expect(helperSource).toContain("{ preparingActionState }");
+    expect(helperSource).toContain(
+      "reconnectTimedOut && abortCtrl.signal.aborted",
+    );
     expect(helperSource).toContain('activeState !== "inactive"');
     expect(helperSource).toContain("continue;");
   });

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -169,7 +169,7 @@ describe("resolveAssistantChatRunningStatusLabel", () => {
     ).toBe("Preparing generate-design action");
   });
 
-  it("shows replayed recovery as continuing instead of reconnecting", () => {
+  it("shows replayed recovery as still working instead of reconnecting", () => {
     expect(
       resolveAssistantChatRunningStatusLabel({
         runningActivityLabel: null,
@@ -177,7 +177,7 @@ describe("resolveAssistantChatRunningStatusLabel", () => {
         isReconnecting: true,
         hasReconnectContent: true,
       }),
-    ).toBe("Continuing");
+    ).toBe("Still working");
   });
 
   it("keeps bare reconnect recovery as thinking", () => {

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -242,6 +242,7 @@ describe("waitForThreadRunToClear", () => {
       "const preparingActionState: PreparingActionState = {}",
     );
     expect(helperSource).toContain("sameRunStillActive");
+    expect(helperSource).toContain("{ signal: abortCtrl.signal }");
     expect(helperSource).toContain('return "unknown"');
     expect(helperSource).toContain('err.reason === "stream_ended"');
     expect(helperSource).toContain(

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -228,6 +228,24 @@ describe("waitForThreadRunToClear", () => {
     expect(helperSource).not.toContain("20_000");
   });
 
+  it("reattaches to the same active run when a hosted reconnect stream ends", () => {
+    const source = readFileSync("src/client/AssistantChat.tsx", {
+      encoding: "utf8",
+    });
+    const start = source.indexOf("const startReconnectToRun = useCallback");
+    const end = source.indexOf("const reconnectActiveRunForThread");
+    const helperSource = source.slice(start, end);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    expect(helperSource).toContain("sameRunStillActive");
+    expect(helperSource).toContain('err.reason === "stream_ended"');
+    expect(helperSource).toContain(
+      "const reconnectAfterSeq = resolveReconnectAfterSeq(threadId, runId)",
+    );
+    expect(helperSource).toContain("continue;");
+  });
+
   it("shows active tool activity before falling back to calm recovery labels", () => {
     const source = readFileSync("src/client/AssistantChat.tsx", {
       encoding: "utf8",

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -238,11 +238,17 @@ describe("waitForThreadRunToClear", () => {
 
     expect(start).toBeGreaterThan(-1);
     expect(end).toBeGreaterThan(start);
+    expect(helperSource).toContain(
+      "const preparingActionState: PreparingActionState = {}",
+    );
     expect(helperSource).toContain("sameRunStillActive");
+    expect(helperSource).toContain('return "unknown"');
     expect(helperSource).toContain('err.reason === "stream_ended"');
     expect(helperSource).toContain(
       "const reconnectAfterSeq = resolveReconnectAfterSeq(threadId, runId)",
     );
+    expect(helperSource).toContain("{ preparingActionState }");
+    expect(helperSource).toContain('activeState !== "inactive"');
     expect(helperSource).toContain("continue;");
   });
 

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -247,6 +247,7 @@ describe("waitForThreadRunToClear", () => {
     expect(helperSource).toContain(
       "const reconnectAfterSeq = resolveReconnectAfterSeq(threadId, runId)",
     );
+    expect(helperSource).toContain("if (!sseRes.ok || !sseRes.body)");
     expect(helperSource).toContain("{ preparingActionState }");
     expect(helperSource).toContain('activeState !== "inactive"');
     expect(helperSource).toContain("continue;");

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -675,7 +675,7 @@ export function resolveAssistantChatRunningStatusLabel({
 }): string {
   if (runningActivityLabel) return runningActivityLabel;
   if (isAutoResuming) return "Resuming";
-  if (isReconnecting && hasReconnectContent) return "Continuing";
+  if (isReconnecting && hasReconnectContent) return "Still working";
   return "Thinking";
 }
 
@@ -1516,7 +1516,7 @@ const AssistantChatInner = forwardRef<
   const textStreaming = showRunningInUI || externalStreaming;
   // A revealed activity label wins; otherwise keep recovery states calm and
   // product-facing. Reconnect is transport machinery, so normal replay reads as
-  // "Continuing" instead of exposing "Reconnecting" mid-chat.
+  // ongoing work instead of exposing "Reconnecting" mid-chat.
   const runningStatusLabel = resolveAssistantChatRunningStatusLabel({
     runningActivityLabel,
     isAutoResuming,
@@ -1863,6 +1863,23 @@ const AssistantChatInner = forwardRef<
       const streamReconnect = async () => {
         let noProgressDuringReconnect = false;
         let latestContent: ContentPart[] = [];
+        const sameRunStillActive = async (): Promise<boolean> => {
+          try {
+            const res = await fetch(
+              `${apiUrl}/runs/active?threadId=${encodeURIComponent(threadId)}`,
+            );
+            if (!res.ok) return false;
+            const info = (await res.json()) as ActiveRunLookup;
+            return (
+              info.active === true &&
+              String(info.runId ?? "") === runId &&
+              info.status === "running" &&
+              !activeRunLooksStale(info)
+            );
+          } catch {
+            return false;
+          }
+        };
         const threadPollInterval =
           afterSeq > 0
             ? window.setInterval(() => {
@@ -1871,15 +1888,21 @@ const AssistantChatInner = forwardRef<
               }, 2000)
             : undefined;
         try {
-          const sseRes = await fetch(
-            `${apiUrl}/runs/${encodeURIComponent(runId)}/events?after=${afterSeq}`,
-            { signal: abortCtrl.signal },
-          );
-          if (sseRes.ok && sseRes.body) {
-            const content: ContentPart[] = [];
-            latestContent = content;
-            const toolCallCounter = { value: 0 };
+          const content: ContentPart[] = [];
+          latestContent = content;
+          const toolCallCounter = { value: 0 };
 
+          while (
+            reconnectRunIdRef.current === runId &&
+            !abortCtrl.signal.aborted
+          ) {
+            const reconnectAfterSeq = resolveReconnectAfterSeq(threadId, runId);
+            reconnectTailOnlyRef.current = reconnectAfterSeq > 0;
+            const sseRes = await fetch(
+              `${apiUrl}/runs/${encodeURIComponent(runId)}/events?after=${reconnectAfterSeq}`,
+              { signal: abortCtrl.signal },
+            );
+            if (!sseRes.ok || !sseRes.body) break;
             let rafPending = false;
             let latestSnapshot: ContentPart[] = [];
             const scheduleUpdate = (snapshot: ContentPart[]) => {
@@ -1892,19 +1915,38 @@ const AssistantChatInner = forwardRef<
               });
             };
 
-            await readSSEStreamRaw(
-              sseRes.body,
-              content,
-              toolCallCounter,
-              tabId,
-              scheduleUpdate,
-              (seq) => {
-                markReconnectProgress();
-                updateActiveRunSeq(seq);
-              },
-            );
-            if (afterSeq === 0) {
-              setReconnectContent([...content]);
+            try {
+              await readSSEStreamRaw(
+                sseRes.body,
+                content,
+                toolCallCounter,
+                tabId,
+                scheduleUpdate,
+                (seq) => {
+                  markReconnectProgress();
+                  updateActiveRunSeq(seq);
+                },
+              );
+              if (reconnectAfterSeq === 0) {
+                setReconnectContent([...content]);
+              }
+              break;
+            } catch (err) {
+              if (
+                err instanceof AgentAutoContinueSignal &&
+                err.reason === "stream_ended"
+              ) {
+                if (reconnectAfterSeq === 0) {
+                  setReconnectContent([...content]);
+                }
+                if (await sameRunStillActive()) {
+                  await new Promise((resolve) =>
+                    window.setTimeout(resolve, 250),
+                  );
+                  continue;
+                }
+              }
+              throw err;
             }
           }
         } catch (err) {

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1906,7 +1906,14 @@ const AssistantChatInner = forwardRef<
               `${apiUrl}/runs/${encodeURIComponent(runId)}/events?after=${reconnectAfterSeq}`,
               { signal: abortCtrl.signal },
             );
-            if (!sseRes.ok || !sseRes.body) break;
+            if (!sseRes.ok || !sseRes.body) {
+              const activeState = await sameRunStillActive();
+              if (activeState !== "inactive") {
+                await new Promise((resolve) => window.setTimeout(resolve, 250));
+                continue;
+              }
+              break;
+            }
             let rafPending = false;
             let latestSnapshot: ContentPart[] = [];
             const scheduleUpdate = (snapshot: ContentPart[]) => {

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1871,6 +1871,7 @@ const AssistantChatInner = forwardRef<
           try {
             const res = await fetch(
               `${apiUrl}/runs/active?threadId=${encodeURIComponent(threadId)}`,
+              { signal: abortCtrl.signal },
             );
             if (!res.ok) return "unknown";
             const info = (await res.json()) as ActiveRunLookup;

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -153,6 +153,7 @@ import {
 import {
   AgentAutoContinueSignal,
   type ContentPart,
+  type PreparingActionState,
   readSSEStreamRaw,
   settleInterruptedToolCalls,
 } from "./sse-event-processor.js";
@@ -1863,21 +1864,24 @@ const AssistantChatInner = forwardRef<
       const streamReconnect = async () => {
         let noProgressDuringReconnect = false;
         let latestContent: ContentPart[] = [];
-        const sameRunStillActive = async (): Promise<boolean> => {
+        const preparingActionState: PreparingActionState = {};
+        const sameRunStillActive = async (): Promise<
+          "active" | "inactive" | "unknown"
+        > => {
           try {
             const res = await fetch(
               `${apiUrl}/runs/active?threadId=${encodeURIComponent(threadId)}`,
             );
-            if (!res.ok) return false;
+            if (!res.ok) return "unknown";
             const info = (await res.json()) as ActiveRunLookup;
-            return (
-              info.active === true &&
+            return info.active === true &&
               String(info.runId ?? "") === runId &&
               info.status === "running" &&
               !activeRunLooksStale(info)
-            );
+              ? "active"
+              : "inactive";
           } catch {
-            return false;
+            return "unknown";
           }
         };
         const threadPollInterval =
@@ -1926,6 +1930,7 @@ const AssistantChatInner = forwardRef<
                   markReconnectProgress();
                   updateActiveRunSeq(seq);
                 },
+                { preparingActionState },
               );
               if (reconnectAfterSeq === 0) {
                 setReconnectContent([...content]);
@@ -1939,7 +1944,8 @@ const AssistantChatInner = forwardRef<
                 if (reconnectAfterSeq === 0) {
                   setReconnectContent([...content]);
                 }
-                if (await sameRunStillActive()) {
+                const activeState = await sameRunStillActive();
+                if (activeState !== "inactive") {
                   await new Promise((resolve) =>
                     window.setTimeout(resolve, 250),
                   );

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1963,6 +1963,11 @@ const AssistantChatInner = forwardRef<
               throw err;
             }
           }
+          if (reconnectTimedOut && abortCtrl.signal.aborted) {
+            const timeoutError = new Error("Reconnect timed out");
+            timeoutError.name = "AbortError";
+            throw timeoutError;
+          }
         } catch (err) {
           if (
             err instanceof AgentAutoContinueSignal &&

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -20,6 +20,7 @@ import {
   type AgentActivityTrailEntry,
   type AgentAutoContinueErrorInfo,
   type ContentPart,
+  type PreparingActionState,
   readSSEStream,
   settleInterruptedToolCalls,
 } from "./sse-event-processor.js";
@@ -1381,6 +1382,10 @@ export function createAgentChatAdapter(
       let runId: string | null = null;
       let lastSeq = -1;
       const seenRunSeqs = new Map<string, number>();
+      const preparingActionStatesByRun = new Map<
+        string,
+        PreparingActionState
+      >();
       let currentRunDispatchMode: string | null = null;
       let currentMessageText = normalizeMentions(
         recoveryMessageText.trim() || userMessageText,
@@ -1570,9 +1575,23 @@ export function createAgentChatAdapter(
         }
       };
 
+      const preparingActionStateForRun = (
+        id: string | null,
+      ): PreparingActionState | undefined => {
+        if (!id) return undefined;
+        const existing = preparingActionStatesByRun.get(id);
+        if (existing) return existing;
+        const state: PreparingActionState = {};
+        preparingActionStatesByRun.set(id, state);
+        return state;
+      };
+
       const currentSSEOptions = () => ({
         durableBackgroundRun:
           currentRunDispatchMode?.startsWith("background") === true,
+        ...(runId
+          ? { preparingActionState: preparingActionStateForRun(runId) }
+          : {}),
       });
 
       const captureChatClientError = (

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -365,6 +365,57 @@ function parallelSameToolPreparationStream(
   });
 }
 
+function parallelSameToolStalledSiblingStream(
+  tool = "edit-design",
+): ReadableStream<Uint8Array> {
+  const timers: ReturnType<typeof setTimeout>[] = [];
+  let keepalive: ReturnType<typeof setInterval> | undefined;
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(
+        new TextEncoder().encode(
+          `data: ${JSON.stringify({
+            type: "activity",
+            label: `Preparing ${tool} action`,
+            tool,
+            id: "call-a",
+            progressBytes: 0,
+          })}\n\n`,
+        ),
+      );
+      timers.push(
+        setTimeout(() => {
+          controller.enqueue(
+            new TextEncoder().encode(
+              `data: ${JSON.stringify({
+                type: "tool_start",
+                tool,
+                id: "call-b",
+                input: {},
+              })}\n\n`,
+            ),
+          );
+        }, 30_000),
+      );
+      keepalive = setInterval(() => {
+        try {
+          controller.enqueue(
+            new TextEncoder().encode(
+              `data: ${JSON.stringify({ type: "stream_keepalive" })}\n\n`,
+            ),
+          );
+        } catch {
+          // The watchdog may have cancelled the stream first.
+        }
+      }, 10_000);
+    },
+    cancel() {
+      for (const timer of timers) clearTimeout(timer);
+      if (keepalive) clearInterval(keepalive);
+    },
+  });
+}
+
 function noIdPositivePreparationFallbackStream(
   tool = "edit-design",
 ): ReadableStream<Uint8Array> {
@@ -822,6 +873,36 @@ describe("SSE event processor no-progress recovery", () => {
     await vi.advanceTimersByTimeAsync(SSE_NO_PROGRESS_TIMEOUT_MS + 5_000);
 
     await expect(donePromise).resolves.toBeDefined();
+  });
+
+  it("keeps sibling same-tool preparations tracked after an id-specific tool starts", async () => {
+    vi.useFakeTimers();
+
+    const errPromise = (async () => {
+      try {
+        await drain(
+          readSSEStream(
+            parallelSameToolStalledSiblingStream(),
+            [],
+            { value: 0 },
+            undefined,
+            undefined,
+            undefined,
+            { durableBackgroundRun: true },
+          ),
+        );
+      } catch (err) {
+        return err;
+      }
+    })();
+
+    await vi.advanceTimersByTimeAsync(
+      SSE_ACTION_PREPARATION_STALL_TIMEOUT_MS + 1,
+    );
+
+    const err = await errPromise;
+    expect(err).toBeInstanceOf(AgentAutoContinueSignal);
+    expect((err as AgentAutoContinueSignal).reason).toBe("no_progress");
   });
 
   it("keeps no-id positive preparation heartbeats meaningful", async () => {

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -416,6 +416,98 @@ function parallelSameToolStalledSiblingStream(
   });
 }
 
+function clearedOlderSameToolSiblingStream(
+  tool = "edit-design",
+): ReadableStream<Uint8Array> {
+  const timers: ReturnType<typeof setTimeout>[] = [];
+  let keepalive: ReturnType<typeof setInterval> | undefined;
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(
+        new TextEncoder().encode(
+          `data: ${JSON.stringify({
+            type: "activity",
+            label: `Preparing ${tool} action`,
+            tool,
+            id: "call-a",
+            progressBytes: 0,
+          })}\n\n`,
+        ),
+      );
+      timers.push(
+        setTimeout(() => {
+          controller.enqueue(
+            new TextEncoder().encode(
+              `data: ${JSON.stringify({
+                type: "activity",
+                label: `Preparing ${tool} action`,
+                tool,
+                id: "call-b",
+                progressBytes: 0,
+              })}\n\n`,
+            ),
+          );
+          controller.enqueue(
+            new TextEncoder().encode(
+              `data: ${JSON.stringify({
+                type: "tool_start",
+                tool,
+                id: "call-a",
+                input: {},
+              })}\n\n`,
+            ),
+          );
+        }, 60_000),
+      );
+      timers.push(
+        setTimeout(() => {
+          controller.enqueue(
+            new TextEncoder().encode(
+              `data: ${JSON.stringify({
+                type: "tool_start",
+                tool,
+                id: "call-b",
+                input: {},
+              })}\n\n`,
+            ),
+          );
+          controller.enqueue(
+            new TextEncoder().encode(
+              `data: ${JSON.stringify({
+                type: "tool_done",
+                tool,
+                id: "call-b",
+                result: "ok",
+              })}\n\n`,
+            ),
+          );
+          controller.enqueue(
+            new TextEncoder().encode(
+              `data: ${JSON.stringify({ type: "done" })}\n\n`,
+            ),
+          );
+          controller.close();
+        }, SSE_ACTION_PREPARATION_STALL_TIMEOUT_MS + 10_000),
+      );
+      keepalive = setInterval(() => {
+        try {
+          controller.enqueue(
+            new TextEncoder().encode(
+              `data: ${JSON.stringify({ type: "stream_keepalive" })}\n\n`,
+            ),
+          );
+        } catch {
+          // The watchdog may have cancelled the stream first.
+        }
+      }, 10_000);
+    },
+    cancel() {
+      for (const timer of timers) clearTimeout(timer);
+      if (keepalive) clearInterval(keepalive);
+    },
+  });
+}
+
 function noIdPositivePreparationFallbackStream(
   tool = "edit-design",
 ): ReadableStream<Uint8Array> {
@@ -903,6 +995,28 @@ describe("SSE event processor no-progress recovery", () => {
     const err = await errPromise;
     expect(err).toBeInstanceOf(AgentAutoContinueSignal);
     expect((err as AgentAutoContinueSignal).reason).toBe("no_progress");
+  });
+
+  it("recomputes same-tool preparation age after an older sibling clears", async () => {
+    vi.useFakeTimers();
+
+    const donePromise = drain(
+      readSSEStream(
+        clearedOlderSameToolSiblingStream(),
+        [],
+        { value: 0 },
+        undefined,
+        undefined,
+        undefined,
+        { durableBackgroundRun: true },
+      ),
+    );
+
+    await vi.advanceTimersByTimeAsync(
+      SSE_ACTION_PREPARATION_STALL_TIMEOUT_MS + 10_000,
+    );
+
+    await expect(donePromise).resolves.toBeDefined();
   });
 
   it("keeps no-id positive preparation heartbeats meaningful", async () => {

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -685,6 +685,64 @@ describe("SSE event processor no-progress recovery", () => {
     ]);
   });
 
+  it("carries zero-byte preparation stalls across durable reconnect reads", async () => {
+    vi.useFakeTimers();
+
+    const preparingActionState = {};
+    const readPreparationReplay = async (id: string) => {
+      try {
+        await drain(
+          readSSEStream(
+            eventStream([
+              {
+                type: "activity",
+                label: "Preparing edit-design action",
+                tool: "edit-design",
+                id,
+                progressBytes: 0,
+              },
+            ]),
+            [],
+            { value: 0 },
+            undefined,
+            undefined,
+            undefined,
+            { durableBackgroundRun: true, preparingActionState },
+          ),
+        );
+      } catch (err) {
+        return err;
+      }
+      return undefined;
+    };
+
+    const firstErr = await readPreparationReplay("call-a");
+    expect(firstErr).toBeInstanceOf(AgentAutoContinueSignal);
+    expect((firstErr as AgentAutoContinueSignal).reason).toBe("stream_ended");
+
+    await vi.advanceTimersByTimeAsync(
+      Math.floor(SSE_ACTION_PREPARATION_STALL_TIMEOUT_MS / 2),
+    );
+
+    const secondErr = await readPreparationReplay("call-b");
+    expect(secondErr).toBeInstanceOf(AgentAutoContinueSignal);
+    expect((secondErr as AgentAutoContinueSignal).reason).toBe("stream_ended");
+
+    await vi.advanceTimersByTimeAsync(
+      Math.ceil(SSE_ACTION_PREPARATION_STALL_TIMEOUT_MS / 2) + 1,
+    );
+
+    const thirdErr = await readPreparationReplay("call-c");
+    expect(thirdErr).toBeInstanceOf(AgentAutoContinueSignal);
+    expect((thirdErr as AgentAutoContinueSignal).reason).toBe("no_progress");
+    expect((thirdErr as AgentAutoContinueSignal).activityTrail).toEqual([
+      {
+        label: "Preparing edit screen action",
+        tool: "edit-design",
+      },
+    ]);
+  });
+
   it("keeps durable background keepalives attached until a terminal event", async () => {
     vi.useFakeTimers();
 

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -157,6 +157,12 @@ export interface SSEStreamOptions {
    * so one stuck action cannot pin the chat forever.
    */
   durableBackgroundRun?: boolean;
+  /**
+   * Optional caller-owned preparation watchdog state. Passing the same object
+   * across reconnect reads keeps a stuck action preparation from getting a
+   * fresh stall budget every time the browser reattaches to the same run.
+   */
+  preparingActionState?: PreparingActionState;
 }
 
 type ActivityTrailEntry = AgentActivityTrailEntry;
@@ -177,8 +183,9 @@ type PreparingActionEntry = {
   lastProgressAt?: number;
 };
 
-type PreparingActionState = {
+export type PreparingActionState = {
   entries?: Map<string, PreparingActionEntry>;
+  toolEntries?: Map<string, PreparingActionEntry>;
 };
 
 function formatProgressBytes(bytes: number): string {
@@ -320,7 +327,8 @@ function updatePreparingActionState(
   if (ev.type === "activity" && isPreparingActionActivity(ev)) {
     const tool = ev.tool?.trim() || undefined;
     if (!tool) return false;
-    const key = ev.id?.trim() || tool;
+    const id = ev.id?.trim();
+    const key = id || tool;
     const entries = state.entries ?? new Map<string, PreparingActionEntry>();
     state.entries = entries;
     let entry = entries.get(key);
@@ -333,22 +341,35 @@ function updatePreparingActionState(
       };
       entries.set(key, entry);
     }
+    const toolEntries =
+      state.toolEntries ?? new Map<string, PreparingActionEntry>();
+    state.toolEntries = toolEntries;
+    let toolEntry = toolEntries.get(tool);
+    if (!toolEntry) {
+      toolEntry = {
+        tool,
+        startedAt: now,
+        lastProgressAt: undefined,
+        lastProgressBytes: undefined,
+      };
+      toolEntries.set(tool, toolEntry);
+    }
     const progressBytes = activityProgressBytes(ev);
     const previousBytes = entry.lastProgressBytes ?? 0;
+    let madeProgress = false;
     if (progressBytes !== undefined) {
       entry.lastProgressBytes = Math.max(previousBytes, progressBytes);
+      toolEntry.lastProgressBytes = Math.max(
+        toolEntry.lastProgressBytes ?? 0,
+        progressBytes,
+      );
+      madeProgress = id ? progressBytes > previousBytes : progressBytes > 0;
     }
-    if (!ev.id?.trim()) {
-      if (progressBytes !== undefined && progressBytes > 0) {
-        entry.lastProgressAt = now;
-        return true;
-      }
-      return false;
-    }
-    if (progressBytes !== undefined && progressBytes > previousBytes) {
+    if (madeProgress) {
       // A byte increase is proof the model is still streaming this action's
       // argument. Repeated zero-byte prep activity is only a heartbeat.
       entry.lastProgressAt = now;
+      toolEntry.lastProgressAt = now;
       return true;
     }
     return false;
@@ -367,12 +388,14 @@ function updatePreparingActionState(
       const tool = ev.tool?.trim();
       const id = ev.id?.trim();
       for (const [key, entry] of state.entries ?? []) {
-        if ((id && key === id) || (!id && entry.tool === tool)) {
+        if ((id && key === id) || (tool && entry.tool === tool)) {
           state.entries?.delete(key);
         }
       }
+      if (tool) state.toolEntries?.delete(tool);
     } else {
       state.entries?.clear();
+      state.toolEntries?.clear();
     }
   }
   return undefined;
@@ -384,7 +407,10 @@ function hasStalledPreparingAction(state: PreparingActionState, now: number) {
   // streaming for a long time. `lastProgressAt` advances on every delta
   // heartbeat, so an actively-streaming large output keeps resetting this and
   // survives; a genuinely stuck prep (keepalive-only, no deltas) trips it.
-  for (const entry of state.entries?.values() ?? []) {
+  for (const entry of [
+    ...(state.toolEntries?.values() ?? []),
+    ...(state.entries?.values() ?? []),
+  ]) {
     if (
       entry.startedAt !== undefined &&
       now - (entry.lastProgressAt ?? entry.startedAt) >=
@@ -1239,7 +1265,8 @@ export async function* readSSEStream(
   let buf = "";
   let lastMeaningfulEventAt = Date.now();
   const activityTrail: ActivityTrailEntry[] = [];
-  const preparingActionState: PreparingActionState = {};
+  const preparingActionState: PreparingActionState =
+    options?.preparingActionState ?? {};
   const processEventState: ProcessEventState = {
     completedToolsAfterLastAssistantText: new Set(),
   };
@@ -1431,7 +1458,8 @@ export async function readSSEStreamRaw(
   let buf = "";
   let lastMeaningfulEventAt = Date.now();
   const activityTrail: ActivityTrailEntry[] = [];
-  const preparingActionState: PreparingActionState = {};
+  const preparingActionState: PreparingActionState =
+    options?.preparingActionState ?? {};
   const processEventState: ProcessEventState = {
     completedToolsAfterLastAssistantText: new Set(),
   };

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -388,11 +388,18 @@ function updatePreparingActionState(
       const tool = ev.tool?.trim();
       const id = ev.id?.trim();
       for (const [key, entry] of state.entries ?? []) {
-        if ((id && key === id) || (tool && entry.tool === tool)) {
+        if ((id && key === id) || (!id && tool && entry.tool === tool)) {
           state.entries?.delete(key);
         }
       }
-      if (tool) state.toolEntries?.delete(tool);
+      if (
+        tool &&
+        ![...(state.entries?.values() ?? [])].some(
+          (entry) => entry.tool === tool,
+        )
+      ) {
+        state.toolEntries?.delete(tool);
+      }
     } else {
       state.entries?.clear();
       state.toolEntries?.clear();

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -319,6 +319,40 @@ function appendActivityTrail(
   }
 }
 
+function refreshPreparingToolEntry(
+  state: PreparingActionState,
+  tool: string,
+) {
+  const remainingEntries = [...(state.entries?.values() ?? [])].filter(
+    (entry) => entry.tool === tool,
+  );
+  if (remainingEntries.length === 0) {
+    state.toolEntries?.delete(tool);
+    return;
+  }
+  const deadlineBasis = (entry: PreparingActionEntry) =>
+    entry.lastProgressAt ?? entry.startedAt ?? Number.POSITIVE_INFINITY;
+  const oldestEntry = remainingEntries.reduce((oldest, entry) =>
+    deadlineBasis(entry) < deadlineBasis(oldest) ? entry : oldest,
+  );
+  const lastProgressBytes = remainingEntries.reduce<number | undefined>(
+    (max, entry) =>
+      entry.lastProgressBytes === undefined
+        ? max
+        : Math.max(max ?? 0, entry.lastProgressBytes),
+    undefined,
+  );
+  const toolEntries =
+    state.toolEntries ?? new Map<string, PreparingActionEntry>();
+  state.toolEntries = toolEntries;
+  toolEntries.set(tool, {
+    tool,
+    startedAt: oldestEntry.startedAt,
+    lastProgressAt: oldestEntry.lastProgressAt,
+    lastProgressBytes,
+  });
+}
+
 function updatePreparingActionState(
   state: PreparingActionState,
   ev: SSEEvent,
@@ -392,13 +426,8 @@ function updatePreparingActionState(
           state.entries?.delete(key);
         }
       }
-      if (
-        tool &&
-        ![...(state.entries?.values() ?? [])].some(
-          (entry) => entry.tool === tool,
-        )
-      ) {
-        state.toolEntries?.delete(tool);
+      if (tool) {
+        refreshPreparingToolEntry(state, tool);
       }
     } else {
       state.entries?.clear();

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -319,10 +319,7 @@ function appendActivityTrail(
   }
 }
 
-function refreshPreparingToolEntry(
-  state: PreparingActionState,
-  tool: string,
-) {
+function refreshPreparingToolEntry(state: PreparingActionState, tool: string) {
   const remainingEntries = [...(state.entries?.values() ?? [])].filter(
     (entry) => entry.tool === tool,
   );

--- a/templates/analytics/changelog/2026-07-02-agent-chat-can-keep-working-through-longer-data-queries-inst.md
+++ b/templates/analytics/changelog/2026-07-02-agent-chat-can-keep-working-through-longer-data-queries-inst.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-02
+---
+
+Agent chat can keep working through longer data queries instead of stopping mid-action.

--- a/templates/analytics/netlify.toml
+++ b/templates/analytics/netlify.toml
@@ -9,11 +9,14 @@ GA_MEASUREMENT_ID = "G-ESF7FYXGN9"
 NITRO_PRESET = "netlify"
 NPM_CONFIG_PRODUCTION = "false"
 AGENT_PROD_CODE_EXECUTION = "sandboxed"
+AGENT_CHAT_DURABLE_BACKGROUND = "true"
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
 # Hosted agent chat uses a soft timeout before this function timeout so the
 # hidden auto-continuation path can hand off before Netlify kills the function.
 # If AGENT_RUN_SOFT_TIMEOUT_MS is customized, keep it below this timeout.
+# Agent chat runs are dispatched to the emitted Netlify background function;
+# the normal server timeout still protects non-background HTTP handlers.
 [functions."*"]
 timeout = 75
 

--- a/templates/analytics/server/plugins/agent-chat.ts
+++ b/templates/analytics/server/plugins/agent-chat.ts
@@ -28,6 +28,7 @@ import {
 } from "../lib/scoped-settings";
 
 const DATA_DICT_PREFIX = "data-dict-";
+const ANALYTICS_BACKGROUND_RUN_SOFT_TIMEOUT_MS = 13 * 60_000;
 
 const INITIAL_TOOL_NAMES = [
   "view-screen",
@@ -170,6 +171,8 @@ export default createAgentChatPlugin({
   // Operators deploying to trusted internal environments can set
   // AGENT_PROD_CODE_EXECUTION=trusted to also enable bash/read/edit/write.
   codeExecution: { production: "sandboxed" },
+  durableBackgroundRuns: true,
+  runSoftTimeoutMs: ANALYTICS_BACKGROUND_RUN_SOFT_TIMEOUT_MS,
   resolveOrgId: async (event) => {
     const ctx = await getOrgContext(event);
     return ctx.orgId;

--- a/templates/plan/changelog/2026-07-02-agent-chat-can-keep-working-through-longer-visual-plan-updat.md
+++ b/templates/plan/changelog/2026-07-02-agent-chat-can-keep-working-through-longer-visual-plan-updat.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-02
+---
+
+Agent chat can keep working through longer visual plan updates instead of stopping mid-action.

--- a/templates/plan/netlify.toml
+++ b/templates/plan/netlify.toml
@@ -8,8 +8,11 @@ functions = "templates/plan/.netlify/functions-internal"
 GA_MEASUREMENT_ID = "G-ESF7FYXGN9"
 NITRO_PRESET = "netlify"
 NPM_CONFIG_PRODUCTION = "false"
+AGENT_CHAT_DURABLE_BACKGROUND = "true"
 
 # A2A/MCP calls may include plan generation, artifact serialization, and
 # feedback polling. Keep this aligned with other agent-heavy hosted templates.
+# Agent chat runs are dispatched to the emitted Netlify background function;
+# the normal server timeout still protects non-background HTTP handlers.
 [functions."*"]
 timeout = 75

--- a/templates/plan/server/plugins/agent-chat.ts
+++ b/templates/plan/server/plugins/agent-chat.ts
@@ -10,6 +10,8 @@ import actionsRegistry from "../../.generated/actions-registry.js";
 import { PLAN_CONNECTOR_CATALOG } from "../lib/plan-connector-catalog.js";
 import { resolvePlanAnonymousOwner } from "../lib/public-plans.js";
 
+const PLAN_BACKGROUND_RUN_SOFT_TIMEOUT_MS = 13 * 60_000;
+
 // ---------------------------------------------------------------------------
 // Register plan event-bus events
 // ---------------------------------------------------------------------------
@@ -130,6 +132,8 @@ const planAgentChatOptions = {
   resolveOrgId: async (event) => (await getOrgContext(event)).orgId,
   connectorCatalog: PLAN_CONNECTOR_CATALOG,
   disableMcp: true,
+  durableBackgroundRuns: true,
+  runSoftTimeoutMs: PLAN_BACKGROUND_RUN_SOFT_TIMEOUT_MS,
 };
 
 export default createAgentChatPlugin(planAgentChatOptions);


### PR DESCRIPTION
## Summary
- carry action-preparation stall watchdog state across reconnect reads for the same run
- track same-tool zero-byte preparation separately from per-activity ids so fresh ids cannot reset the stall timer forever
- repair run-list debug reads from terminal events and keep reconnect replay labeled as still working

## Validation
- CI=true corepack pnpm --filter @agent-native/core exec vitest --run src/client/sse-event-processor.spec.ts --maxWorkers=25%
- CI=true corepack pnpm --filter @agent-native/core run typecheck
- CI=true corepack pnpm prep

## Notes
This targets the production shape where background runs repeatedly replayed zero-byte `Preparing <tool> action` events with fresh tool ids after stream reconnects, leaving the UI alive but without real tool-input progress.