### PR TITLE
Hide redundant diff show-all footer

### DIFF
--- a/.changeset/gentle-diff-footer.md
+++ b/.changeset/gentle-diff-footer.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Hide the diff "Show all lines" footer when annotation anchoring already renders every line.

--- a/packages/core/src/client/blocks/library/DiffBlock.spec.tsx
+++ b/packages/core/src/client/blocks/library/DiffBlock.spec.tsx
@@ -85,6 +85,7 @@ describe("DiffBlock", () => {
     filename = "src/example.ts",
     language,
     mode,
+    annotations,
   }: {
     before?: string;
     after: string;
@@ -92,6 +93,12 @@ describe("DiffBlock", () => {
     filename?: string;
     language?: string;
     mode?: "unified" | "split";
+    annotations?: Array<{
+      side?: "before" | "after";
+      lines: string;
+      label?: string;
+      note: string;
+    }>;
   }) {
     act(() => {
       root.render(
@@ -99,7 +106,7 @@ describe("DiffBlock", () => {
           key={blockId}
           blockId={blockId}
           ctx={{}}
-          data={{ before, after, filename, language, mode }}
+          data={{ before, after, filename, language, mode, annotations }}
         />,
       );
     });
@@ -143,6 +150,24 @@ describe("DiffBlock", () => {
     expect(container.textContent).toContain("split-15");
     expect(container.textContent).not.toContain("split-16");
     expect(container.textContent).toContain("Show all 18 lines");
+  });
+
+  it("hides the show-all footer when annotations already reveal every split row", () => {
+    const addedLines = Array.from(
+      { length: 23 },
+      (_, index) => `annotated-${String(index + 1).padStart(2, "0")}`,
+    ).join("\n");
+
+    renderDiff({
+      after: addedLines,
+      mode: "split",
+      annotations: [
+        { lines: "23", label: "Tail", note: "Keep the tail visible." },
+      ],
+    });
+
+    expect(container.textContent).toContain("annotated-23");
+    expect(container.textContent).not.toContain("Show all 23 lines");
   });
 
   it("defaults to split (two columns) when no mode is authored", () => {

--- a/packages/core/src/client/blocks/library/DiffBlock.tsx
+++ b/packages/core/src/client/blocks/library/DiffBlock.tsx
@@ -838,8 +838,8 @@ function DiffRead({
     effectiveMode === "split" ? splitLineCount : rows.length;
   const shouldLimitRows = totalVisibleLineCount > DEFAULT_VISIBLE_DIFF_LINES;
   // Never truncate away an annotated row: extend the window past the last one.
-  const effectiveRowLimit = useMemo(() => {
-    if (showAllRows || !shouldLimitRows) return undefined;
+  const collapsedRowLimit = useMemo(() => {
+    if (!shouldLimitRows) return undefined;
     let limit = DEFAULT_VISIBLE_DIFF_LINES;
     if (hasAnnotations) {
       for (let idx = rows.length - 1; idx >= limit; idx -= 1) {
@@ -850,8 +850,10 @@ function DiffRead({
       }
     }
     return limit;
-  }, [showAllRows, shouldLimitRows, hasAnnotations, rows, markersForRow]);
-  const rowLimit = effectiveRowLimit;
+  }, [shouldLimitRows, hasAnnotations, rows, markersForRow]);
+  const hasHiddenRows =
+    collapsedRowLimit != null && collapsedRowLimit < totalVisibleLineCount;
+  const rowLimit = showAllRows ? undefined : collapsedRowLimit;
   const displayedRows =
     effectiveMode === "unified" && rowLimit ? rows.slice(0, rowLimit) : rows;
 
@@ -965,7 +967,7 @@ function DiffRead({
           ctx={ctx}
         />
       )}
-      {!unchanged && shouldLimitRows && (
+      {!unchanged && hasHiddenRows && (
         <button
           type="button"
           data-plan-interactive


### PR DESCRIPTION
## Summary
- hide the diff footer when the collapsed preview already renders every row
- add a regression test for annotated split diffs that reveal line 23 up front
- add a patch changeset for @agent-native/core

## Validation
- corepack pnpm --filter @agent-native/core exec vitest --run src/client/blocks/library/DiffBlock.spec.tsx
- corepack pnpm --filter @agent-native/core typecheck