### PR TITLE
Stabilize agent chat setup state

### DIFF
--- a/.changeset/stable-chat-setup-state.md
+++ b/.changeset/stable-chat-setup-state.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Make agent chat setup, auth, and title state resilient to transient status checks and hidden context payloads.

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -41,6 +41,20 @@ describe("displayableUserMessageText", () => {
       ),
     ).toBe("");
   });
+
+  it("preserves visible text while stripping hidden context blocks", () => {
+    expect(
+      displayableUserMessageText(
+        "hi\n\n<context>\n## Fusion recap\nHidden selection\n</context>",
+      ),
+    ).toBe("hi");
+  });
+
+  it("strips unfinished context payloads from generated labels", () => {
+    expect(
+      displayableUserMessageText("hi <context> ## Fusion recap hidden payload"),
+    ).toBe("hi");
+  });
 });
 
 describe("latestNonRecoveryUserMessageText", () => {

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -89,6 +89,7 @@ import {
   AssistantMessage,
   SelectionAttachedPill,
   RunningActivityStatus,
+  displayableUserMessageText,
 } from "./chat/message-components.js";
 import {
   repoHasAssistantMessage,
@@ -177,6 +178,8 @@ export {
 } from "./assistant-ui-recovery.js";
 
 export { displayableUserMessageText } from "./chat/message-components.js";
+
+type AuthSessionCheckResult = "available" | "missing" | "unknown";
 
 const useBrowserLayoutEffect =
   typeof window === "undefined" ? useEffect : useLayoutEffect;
@@ -492,13 +495,14 @@ function getMessageText(message: unknown): string {
   const msg = (message as { message?: unknown })?.message ?? message;
   const content = (msg as { content?: unknown })?.content;
   if (Array.isArray(content)) {
-    return content
-      .filter((p: any) => p?.type === "text" && typeof p.text === "string")
-      .map((p: any) => p.text)
-      .join("\n")
-      .trim();
+    return displayableUserMessageText(
+      content
+        .filter((p: any) => p?.type === "text" && typeof p.text === "string")
+        .map((p: any) => p.text)
+        .join("\n"),
+    );
   }
-  return typeof content === "string" ? content.trim() : "";
+  return typeof content === "string" ? displayableUserMessageText(content) : "";
 }
 
 function contentPartFollowKey(part: any): string {
@@ -1263,6 +1267,7 @@ const AssistantChatInner = forwardRef<
   }, [threadRuntime]);
   const agentEngineConfigured = useAgentEngineConfigured(
     providerStatusChecksEnabled,
+    { tabId, threadId },
   );
   const missingApiKey = agentEngineConfigured.missing;
   const isComposerDisabled = missingApiKey || composerDisabled;
@@ -1294,10 +1299,19 @@ const AssistantChatInner = forwardRef<
     setComposerError(LLM_MISSING_CREDENTIALS_MESSAGE);
     setMissingKeyBouncePulse((p) => p + 1);
     if (typeof window !== "undefined") {
-      window.dispatchEvent(new Event("agent-chat:missing-api-key"));
+      window.dispatchEvent(
+        new CustomEvent("agent-chat:missing-api-key", {
+          detail: { tabId, threadId },
+        }),
+      );
     }
     return false;
-  }, [agentEngineConfigured.state, providerStatusChecksEnabled]);
+  }, [
+    agentEngineConfigured.state,
+    providerStatusChecksEnabled,
+    tabId,
+    threadId,
+  ]);
   const [authError, setAuthError] = useState<{
     sessionExpired?: boolean;
   } | null>(null);
@@ -2443,23 +2457,31 @@ const AssistantChatInner = forwardRef<
   }, []);
 
   // Listen for auth error events from the adapter
-  const checkAuthSession = useCallback(async () => {
-    try {
-      const res = await fetch(agentNativePath("/_agent-native/auth/session"), {
-        cache: "no-store",
-      });
-      if (!res.ok) return false;
-      const data = await res.json().catch(() => null);
-      const hasSession = !!data && !data.error;
-      setAuthSessionAvailable(hasSession);
-      if (hasSession) {
-        setAuthError(null);
+  const checkAuthSession =
+    useCallback(async (): Promise<AuthSessionCheckResult> => {
+      try {
+        const res = await fetch(
+          agentNativePath("/_agent-native/auth/session"),
+          {
+            cache: "no-store",
+          },
+        );
+        if (!res.ok) {
+          return res.status === 401 || res.status === 403
+            ? "missing"
+            : "unknown";
+        }
+        const data = await res.json().catch(() => null);
+        const hasSession = !!data && !data.error;
+        setAuthSessionAvailable(hasSession);
+        if (hasSession) {
+          setAuthError(null);
+        }
+        return hasSession ? "available" : "missing";
+      } catch {
+        return "unknown";
       }
-      return hasSession;
-    } catch {
-      return false;
-    }
-  }, []);
+    }, []);
 
   useEffect(() => {
     const handler = (e: Event) => {
@@ -2481,9 +2503,12 @@ const AssistantChatInner = forwardRef<
       ) {
         return;
       }
-      setAuthSessionAvailable(false);
-      setAuthError({ sessionExpired: detail?.reason === "session-expired" });
-      void checkAuthSession();
+      void (async () => {
+        const sessionState = await checkAuthSession();
+        if (sessionState !== "missing") return;
+        setAuthSessionAvailable(false);
+        setAuthError({ sessionExpired: detail?.reason === "session-expired" });
+      })();
     };
     window.addEventListener("agent-chat:auth-error", handler);
     return () => window.removeEventListener("agent-chat:auth-error", handler);
@@ -2499,8 +2524,9 @@ const AssistantChatInner = forwardRef<
     // symptom we want signal on.
     const stuckCapture = window.setTimeout(() => {
       void (async () => {
-        const hasSession = await checkAuthSession();
-        if (hasSession) return;
+        const sessionState = await checkAuthSession();
+        if (sessionState === "available") return;
+        if (sessionState !== "missing") return;
         if (!shouldCaptureStuckAuthCard) return;
         captureError(new Error("agent-chat:auth_error_card_stuck"), {
           tags: {
@@ -3781,9 +3807,9 @@ const AssistantChatInner = forwardRef<
                         <RunningActivityStatus label={runningStatusLabel} />
                       )}
                       {queuedMessages.map((msg) => {
-                        const displayText = msg.text
-                          .replace(/<context>[\s\S]*?<\/context>\n?/g, "")
-                          .trim();
+                        const displayText = displayableUserMessageText(
+                          msg.text,
+                        );
                         return (
                           <div
                             key={msg.id}

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -751,7 +751,10 @@ describe("createAgentChatAdapter", () => {
     );
 
     expect(dispatchEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "agent-chat:missing-api-key" }),
+      expect.objectContaining({
+        type: "agent-chat:missing-api-key",
+        detail: { tabId: "chat-missing-credentials" },
+      }),
     );
     expect(dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({ type: "agent-chat:run-error" }),

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -1526,6 +1526,18 @@ export function createAgentChatAdapter(
         );
       };
 
+      const dispatchMissingApiKey = () => {
+        if (typeof window === "undefined") return;
+        window.dispatchEvent(
+          new CustomEvent("agent-chat:missing-api-key", {
+            detail: {
+              ...(tabId ? { tabId } : {}),
+              ...(threadId ? { threadId } : {}),
+            },
+          }),
+        );
+      };
+
       const tryRecoverAuthOnce = async (): Promise<boolean> => {
         if (authRecoveryAttempted || abortSignal.aborted) return false;
         authRecoveryAttempted = true;
@@ -2418,9 +2430,7 @@ export function createAgentChatAdapter(
                 if (isMissingCredentialMessage(body)) {
                   const failure = missingCredentialFailure(body);
                   if (typeof window !== "undefined") {
-                    window.dispatchEvent(
-                      new Event("agent-chat:missing-api-key"),
-                    );
+                    dispatchMissingApiKey();
                     window.dispatchEvent(
                       new CustomEvent("agent-chat:run-error", {
                         detail: { ...failure.runError, tabId },
@@ -2633,7 +2643,7 @@ export function createAgentChatAdapter(
             if (isMissingCredentialMessage(errMsg)) {
               const failure = missingCredentialFailure(errMsg);
               if (typeof window !== "undefined") {
-                window.dispatchEvent(new Event("agent-chat:missing-api-key"));
+                dispatchMissingApiKey();
                 window.dispatchEvent(
                   new CustomEvent("agent-chat:run-error", {
                     detail: { ...failure.runError, tabId },

--- a/packages/core/src/client/chat/message-components.tsx
+++ b/packages/core/src/client/chat/message-components.tsx
@@ -75,7 +75,11 @@ const PENDING_SELECTION_KEY = "pending-selection-context";
 // ─── displayableUserMessageText ───────────────────────────────────────────────
 
 export function displayableUserMessageText(text: string): string {
-  return text.replace(/<context>[\s\S]*?<\/context>\n?/g, "").trim();
+  return text
+    .replace(/<context\b[^>]*>[\s\S]*?<\/context>\n?/gi, "")
+    .replace(/<context\b[^>]*>[\s\S]*$/gi, "")
+    .replace(/<\/context>/gi, "")
+    .trim();
 }
 
 // ─── Message timestamp helpers ────────────────────────────────────────────────

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -1465,7 +1465,10 @@ describe("SSE event processor error classification", () => {
     );
 
     expect(dispatchEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "agent-chat:missing-api-key" }),
+      expect.objectContaining({
+        type: "agent-chat:missing-api-key",
+        detail: { tabId: "tab-missing" },
+      }),
     );
     expect(dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({ type: "agent-chat:run-error" }),
@@ -1551,7 +1554,10 @@ describe("SSE event processor error classification", () => {
     );
 
     expect(dispatchEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "agent-chat:missing-api-key" }),
+      expect.objectContaining({
+        type: "agent-chat:missing-api-key",
+        detail: { tabId: "tab-missing-legacy" },
+      }),
     );
     expect(dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({ type: "agent-chat:run-error" }),

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -601,6 +601,15 @@ function dispatchActivityClear(tabId: string | undefined) {
   );
 }
 
+function dispatchMissingApiKey(tabId: string | undefined) {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent("agent-chat:missing-api-key", {
+      detail: { tabId },
+    }),
+  );
+}
+
 function pendingToolNames(content: ContentPart[]): {
   activity: string[];
   running: string[];
@@ -1056,7 +1065,7 @@ export function processEvent(
       errorCode,
     };
     if (typeof window !== "undefined") {
-      window.dispatchEvent(new Event("agent-chat:missing-api-key"));
+      dispatchMissingApiKey(tabId);
       window.dispatchEvent(
         new CustomEvent("agent-chat:run-error", {
           detail: { ...runError, tabId },
@@ -1156,9 +1165,7 @@ export function processEvent(
     }
     const normalized = normalizeChatError(errMsg, ev.errorCode);
     if (isMissingCredentialText(errMsg, ev.errorCode)) {
-      if (typeof window !== "undefined") {
-        window.dispatchEvent(new Event("agent-chat:missing-api-key"));
-      }
+      dispatchMissingApiKey(tabId);
     }
     const runError = {
       message: normalized.message,

--- a/packages/core/src/client/use-agent-engine-configured.spec.tsx
+++ b/packages/core/src/client/use-agent-engine-configured.spec.tsx
@@ -19,6 +19,17 @@ function Probe({ enabled = true }: { enabled?: boolean }) {
   return <output>{status.state}</output>;
 }
 
+function ScopedProbe({
+  tabId,
+  threadId,
+}: {
+  tabId?: string;
+  threadId?: string;
+}) {
+  const status = useAgentEngineConfigured(true, { tabId, threadId });
+  return <output>{status.state}</output>;
+}
+
 describe("useAgentEngineConfigured", () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -139,6 +150,26 @@ describe("useAgentEngineConfigured", () => {
     await expect(fetchAgentEngineConfiguredState()).resolves.toBe("missing");
   });
 
+  it("keeps setup state unknown when provider status checks are partial", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL | Request) => {
+        const href = String(url);
+        if (href.includes("/_agent-native/env-status")) {
+          return jsonResponse([]);
+        }
+        if (href.includes("/_agent-native/agent-engine/status")) {
+          return jsonResponse({ configured: false });
+        }
+        return new Promise<Response>(() => {});
+      }),
+    );
+
+    await expect(
+      fetchAgentEngineConfiguredState(true, { timeoutMs: 25 }),
+    ).resolves.toBe("unknown");
+  });
+
   it("returns unknown when every status check times out", async () => {
     vi.useFakeTimers();
     vi.stubGlobal(
@@ -152,7 +183,7 @@ describe("useAgentEngineConfigured", () => {
     await expect(status).resolves.toBe("unknown");
   });
 
-  it("honors missing fallback when timed-out status checks follow a missing-key event", async () => {
+  it("does not use missing fallback after timed-out status checks", async () => {
     vi.useFakeTimers();
     vi.stubGlobal(
       "fetch",
@@ -165,6 +196,50 @@ describe("useAgentEngineConfigured", () => {
     });
 
     await vi.advanceTimersByTimeAsync(25);
-    await expect(status).resolves.toBe("missing");
+    await expect(status).resolves.toBe("unknown");
+  });
+
+  it("ignores scoped missing-key events for other tabs", async () => {
+    let initialCheck = true;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL | Request) => {
+        const href = String(url);
+        if (initialCheck) {
+          if (href.includes("/_agent-native/builder/status")) {
+            return jsonResponse({ configured: true });
+          }
+          if (href.includes("/_agent-native/agent-engine/status")) {
+            return jsonResponse({ configured: true });
+          }
+          return jsonResponse([]);
+        }
+        if (href.includes("/_agent-native/env-status")) {
+          return jsonResponse([]);
+        }
+        return jsonResponse({ configured: false });
+      }),
+    );
+
+    await act(async () => {
+      root.render(<ScopedProbe tabId="active-tab" threadId="thread-a" />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toBe("configured");
+    initialCheck = false;
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent("agent-chat:missing-api-key", {
+          detail: { tabId: "other-tab", threadId: "thread-b" },
+        }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toBe("configured");
   });
 });

--- a/packages/core/src/client/use-agent-engine-configured.ts
+++ b/packages/core/src/client/use-agent-engine-configured.ts
@@ -15,8 +15,18 @@ export interface UseAgentEngineConfiguredResult {
 }
 
 export interface FetchAgentEngineConfiguredStateOptions {
+  /**
+   * Legacy hint from explicit missing-key stream events. Kept for API
+   * compatibility, but missing state still requires authoritative status
+   * responses so transient endpoint failures do not clobber connected state.
+   */
   missingFallback?: boolean;
   timeoutMs?: number;
+}
+
+export interface UseAgentEngineConfiguredOptions {
+  tabId?: string | null;
+  threadId?: string | null;
 }
 
 const DEFAULT_STATUS_CHECK_TIMEOUT_MS = 2500;
@@ -60,6 +70,27 @@ function hasConfiguredFlag(value: unknown): value is { configured: boolean } {
   );
 }
 
+function missingKeyEventMatchesScope(
+  event: Event,
+  options: UseAgentEngineConfiguredOptions | undefined,
+): boolean {
+  const detail = (event as CustomEvent).detail as
+    | { tabId?: unknown; threadId?: unknown }
+    | undefined;
+  const eventTabId = typeof detail?.tabId === "string" ? detail.tabId : null;
+  const eventThreadId =
+    typeof detail?.threadId === "string" ? detail.threadId : null;
+  if (!eventTabId && !eventThreadId) return true;
+
+  const tabId = options?.tabId ?? null;
+  const threadId = options?.threadId ?? null;
+  if (!tabId && !threadId) return true;
+  return (
+    (eventTabId != null && eventTabId === tabId) ||
+    (eventThreadId != null && eventThreadId === threadId)
+  );
+}
+
 export async function fetchAgentEngineConfiguredState(
   enabled = true,
   options?: FetchAgentEngineConfiguredStateOptions,
@@ -76,22 +107,31 @@ export async function fetchAgentEngineConfiguredState(
     fetchStatusJson("/_agent-native/agent-engine/status", timeoutMs),
   ]);
 
-  // All three failed — likely a flaky network; keep the caller in unknown
-  // unless this check is reacting to an explicit missing-key stream event.
+  // All three failed — likely a flaky network; keep the caller in unknown.
+  // Even an explicit missing-key stream event should not pin the composer into
+  // setup without a fresh authoritative status response.
   if (envKeys == null && builderStatus == null && engineStatus == null) {
-    return options?.missingFallback ? "missing" : "unknown";
+    return "unknown";
   }
 
-  const keys = (envKeys ?? []) as Array<{
-    key: string;
-    configured: boolean;
-  }>;
+  const envKeysKnown = Array.isArray(envKeys);
+  const builderStatusKnown = hasConfiguredFlag(builderStatus);
+  const engineStatusKnown = hasConfiguredFlag(engineStatus);
+  const keys = envKeysKnown
+    ? (envKeys as Array<{
+        key: string;
+        configured: boolean;
+      }>)
+    : [];
   const llmKeys = keys.filter((k) => PROVIDER_ENV_VAR_SET.has(k.key));
   const anyConfigured =
     llmKeys.some((k) => k.configured) ||
-    (hasConfiguredFlag(builderStatus) && builderStatus.configured) ||
-    (hasConfiguredFlag(engineStatus) && engineStatus.configured);
-  return anyConfigured ? "configured" : "missing";
+    (builderStatusKnown && builderStatus.configured) ||
+    (engineStatusKnown && engineStatus.configured);
+  if (anyConfigured) return "configured";
+  return envKeysKnown && builderStatusKnown && engineStatusKnown
+    ? "missing"
+    : "unknown";
 }
 
 /**
@@ -103,6 +143,7 @@ export async function fetchAgentEngineConfiguredState(
  */
 export function useAgentEngineConfigured(
   enabled = true,
+  options?: UseAgentEngineConfiguredOptions,
 ): UseAgentEngineConfiguredResult {
   const [state, setState] = useState<AgentEngineConfiguredState>("unknown");
 
@@ -119,7 +160,8 @@ export function useAgentEngineConfigured(
     const onConfiguredChanged = () => {
       void check();
     };
-    const onMissing = () => {
+    const onMissing = (event: Event) => {
+      if (!missingKeyEventMatchesScope(event, options)) return;
       if (!enabled) {
         setState("configured");
         return;
@@ -143,7 +185,7 @@ export function useAgentEngineConfigured(
       );
       window.removeEventListener("agent-chat:missing-api-key", onMissing);
     };
-  }, [enabled]);
+  }, [enabled, options?.tabId, options?.threadId]);
 
   return { missing: state === "missing", state };
 }

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -7124,11 +7124,15 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
             setResponseStatus(event, 400);
             return { error: "message is required" };
           }
-          // Strip mention markup: @[Name|type] → @Name
-          const cleanMessage = message.replace(
-            /@\[([^\]|]+)\|[^\]]*\]/g,
-            "@$1",
-          );
+          // Strip hidden context and mention markup before title generation.
+          // Fallback titles are often direct truncations, so never let injected
+          // prompt context become a visible tab label.
+          const cleanMessage = message
+            .replace(/<context\b[^>]*>[\s\S]*?<\/context>\n?/gi, "")
+            .replace(/<context\b[^>]*>[\s\S]*$/gi, "")
+            .replace(/<\/context>/gi, "")
+            .replace(/@\[([^\]|]+)\|[^\]]*\]/g, "@$1")
+            .trim();
           // Mirror the chat-run resolution so BYO-key users have title
           // generation billed to their own key instead of the platform key.
           const { getOwnerActiveApiKey } =


### PR DESCRIPTION
## Summary
- Prevent transient provider/setup status failures from flipping chat into a false missing-LLM state.
- Scope missing-key events to the originating chat tab and verify auth state before showing signed-out recovery UI.
- Strip hidden `<context>` payloads from visible user text and generated chat titles.

## Test plan
- `pnpm --dir "packages/core" exec vitest --run src/client/use-agent-engine-configured.spec.tsx src/client/AssistantChat.display.spec.ts src/client/sse-event-processor.spec.ts src/client/agent-chat-adapter.spec.ts --maxWorkers=25%`
- `pnpm --dir "packages/core" typecheck`

Made with [Cursor](https://cursor.com)