### PR TITLE
Add client-side file-size check for Clips video uploads

### DIFF
--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -462,6 +462,16 @@ function uploadTooLargeMessage(size: number, detail?: string): string {
   )}) after automatic compression. Trim or export a shorter copy and upload again.`;
 }
 
+/** Pre-upload size rejection for a picked file — no compression has been
+ * attempted yet, so the message must not imply it has. */
+function fileTooLargeMessage(size: number): string {
+  return `This file is too large to upload (${formatMb(
+    size,
+  )}, limit is ${formatMb(
+    MAX_UPLOAD_BYTES,
+  )}). Trim it or export a shorter copy and try again.`;
+}
+
 function isUploadFailureError(error: string): boolean {
   return (
     isUploadSizeError(error) ||
@@ -471,7 +481,7 @@ function isUploadFailureError(error: string): boolean {
 
 function friendlyRecordingErrorMessage(error: string): string {
   if (isUploadSizeError(error)) {
-    return `This video is too large for Clips after automatic compression. Trim or export a shorter copy under ${formatMb(
+    return `This video is too large for Clips. Trim or export a shorter copy under ${formatMb(
       MAX_UPLOAD_BYTES,
     )} and upload again.`;
   }
@@ -1397,6 +1407,22 @@ export default function RecordRoute() {
       if (!mimeType) {
         const message =
           "That file type isn't supported. Try MP4, WebM, or MOV.";
+        if (fileUploadAbortRef.current === abort) {
+          fileUploadAbortRef.current = null;
+        }
+        setError(message);
+        setUiState("error");
+        toast.error(message);
+        return;
+      }
+
+      // Fail fast on oversized files before we probe metadata, attempt
+      // compression, or open the upload session — no point spending time or
+      // chunking bytes for a file the server will reject anyway. Uses the
+      // same MAX_UPLOAD_BYTES ceiling as the (currently compression-gated)
+      // post-compression check below and the server chunk/finalize routes.
+      if (file.size > MAX_UPLOAD_BYTES) {
+        const message = fileTooLargeMessage(file.size);
         if (fileUploadAbortRef.current === abort) {
           fileUploadAbortRef.current = null;
         }


### PR DESCRIPTION
### Summary
Adds an early client-side file-size check to the Clips webapp's "upload existing video" flow, rejecting oversized files immediately instead of after chunking/compression begins.
<img width="1233" height="707" alt="image" src="https://github.com/user-attachments/assets/5789daee-5b30-4777-af0e-4c622053ffd8" />

> for testin purposes I've set the max size to 30 mb

---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/tough-nail-xqcw6nsj"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-tough-nail-xqcw6nsj.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1846`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>tough-nail-xqcw6nsj</branchName>-->