### PR TITLE
Recover silent action preparation stalls

### DIFF
--- a/.changeset/chatty-action-prep-recovery.md
+++ b/.changeset/chatty-action-prep-recovery.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Recover action preparation stalls even when the model stream goes silent before sending any tool input bytes.

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -1004,6 +1004,70 @@ describe("runAgentLoop", () => {
     );
   });
 
+  it("checkpoints when zero-byte action input preparation goes silent", async () => {
+    vi.useFakeTimers({ now: 1_000_000 });
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        yield {
+          type: "tool-input-delta",
+          id: "tool-edit",
+          name: "edit-design",
+          text: "",
+        };
+        await new Promise(() => {});
+      },
+    };
+    const events: AgentChatEvent[] = [];
+
+    try {
+      const run = runAgentLoop({
+        engine,
+        model: "test-model",
+        systemPrompt: "system",
+        tools: [],
+        messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+        actions: {
+          "edit-design": actionEntry({ readOnly: false }),
+        },
+        send: (event) => events.push(event),
+        signal: new AbortController().signal,
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(events).toContainEqual({
+        type: "activity",
+        label: "Preparing edit-design action",
+        tool: "edit-design",
+        id: "tool-edit",
+        progressBytes: 0,
+      });
+
+      await vi.advanceTimersByTimeAsync(90_000);
+      await run;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(events.at(-1)).toEqual({
+      type: "auto_continue",
+      reason: "no_progress",
+    });
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: "tool_start" }),
+    );
+  });
+
   it("keeps tracking a stalled action input across assistant snapshots", async () => {
     let now = 1_000_000;
     const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -1068,6 +1068,131 @@ describe("runAgentLoop", () => {
     );
   });
 
+  it("clears the action-preparation timeout when the stream rejects", async () => {
+    vi.useFakeTimers({ now: 1_000_000 });
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        yield {
+          type: "tool-input-start",
+          id: "tool-edit",
+          name: "edit-design",
+        };
+        throw new Error("fatal stream exploded");
+      },
+    };
+    const events: AgentChatEvent[] = [];
+
+    try {
+      await expect(
+        runAgentLoop({
+          engine,
+          model: "test-model",
+          systemPrompt: "system",
+          tools: [],
+          messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+          actions: {
+            "edit-design": actionEntry({ readOnly: false }),
+          },
+          send: (event) => events.push(event),
+          signal: new AbortController().signal,
+        }),
+      ).rejects.toThrow("fatal stream exploded");
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(events).toContainEqual({
+      type: "activity",
+      label: "Preparing edit-design action",
+      tool: "edit-design",
+      id: "tool-edit",
+    });
+  });
+
+  it("closes the event stream after an action-preparation stall", async () => {
+    let now = 1_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const returnSpy = vi.fn(async () => ({ done: true, value: undefined }));
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      stream(): AsyncIterable<EngineEvent> {
+        let step = 0;
+        return {
+          [Symbol.asyncIterator]() {
+            return {
+              async next() {
+                if (step === 0) {
+                  step += 1;
+                  return {
+                    done: false,
+                    value: {
+                      type: "tool-input-start",
+                      id: "tool-edit",
+                      name: "edit-design",
+                    },
+                  };
+                }
+                now += 91_000;
+                return {
+                  done: false,
+                  value: { type: "gateway-heartbeat" },
+                };
+              },
+              return: returnSpy,
+            };
+          },
+        };
+      },
+    };
+    const events: AgentChatEvent[] = [];
+
+    try {
+      await runAgentLoop({
+        engine,
+        model: "test-model",
+        systemPrompt: "system",
+        tools: [],
+        messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+        actions: {
+          "edit-design": actionEntry({ readOnly: false }),
+        },
+        send: (event) => events.push(event),
+        signal: new AbortController().signal,
+      });
+    } finally {
+      dateNow.mockRestore();
+    }
+
+    expect(returnSpy).toHaveBeenCalledTimes(1);
+    expect(events.at(-1)).toEqual({
+      type: "auto_continue",
+      reason: "no_progress",
+    });
+    expect(events).not.toContainEqual({ type: "stream_keepalive" });
+  });
+
   it("keeps tracking a stalled action input across assistant snapshots", async () => {
     let now = 1_000_000;
     const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
@@ -1748,6 +1873,82 @@ describe("runAgentLoop", () => {
         id: "search-replacement",
         progressBytes: 43,
       }),
+    );
+    expect(events).not.toContainEqual({
+      type: "auto_continue",
+      reason: "no_progress",
+    });
+    expect(events.at(-1)).toEqual({ type: "done" });
+  });
+
+  it("keeps a different tool streaming after an abandoned zero-byte tool", async () => {
+    let now = 1_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        yield {
+          type: "tool-input-delta",
+          id: "edit-abandoned",
+          name: "edit-design",
+          text: "",
+        };
+        now += 89_000;
+        yield {
+          type: "tool-input-delta",
+          id: "generate-replacement",
+          name: "generate-design",
+          text: '{"prompt":"fresh generated screen',
+        };
+        now += 2_000;
+        yield { type: "text-delta", text: "still preparing" };
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "text" as const, text: "done" }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    const events: AgentChatEvent[] = [];
+
+    try {
+      await runAgentLoop({
+        engine,
+        model: "test-model",
+        systemPrompt: "system",
+        tools: [],
+        messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+        actions: {
+          "edit-design": actionEntry({ readOnly: false }),
+          "generate-design": actionEntry({ readOnly: false }),
+        },
+        send: (event) => events.push(event),
+        signal: new AbortController().signal,
+      });
+    } finally {
+      dateNow.mockRestore();
+    }
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "activity",
+        tool: "generate-design",
+        id: "generate-replacement",
+        progressBytes: 33,
+      }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: "text", text: "still preparing" }),
     );
     expect(events).not.toContainEqual({
       type: "auto_continue",

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -2883,6 +2883,25 @@ export async function runAgentLoop(opts: {
           });
           endedForActionPreparationNoProgress = true;
         };
+        let eventIteratorReturnRequested = false;
+        const requestEventIteratorReturn = (
+          iterator: AsyncIterator<EngineEvent>,
+          awaitReturn: boolean,
+        ) => {
+          if (eventIteratorReturnRequested) return;
+          eventIteratorReturnRequested = true;
+          let returnPromise:
+            | ReturnType<NonNullable<typeof iterator.return>>
+            | undefined;
+          try {
+            returnPromise = iterator.return?.();
+          } catch {
+            return;
+          }
+          if (!returnPromise) return;
+          if (awaitReturn) return returnPromise.catch(() => undefined);
+          void returnPromise.catch(() => undefined);
+        };
         const nextEngineEventWithActionPreparationTimeout = async (
           iterator: AsyncIterator<EngineEvent>,
         ): Promise<IteratorResult<EngineEvent>> => {
@@ -2891,7 +2910,7 @@ export async function runAgentLoop(opts: {
           const timeoutMs = Math.max(0, deadlineAt - Date.now());
           if (timeoutMs <= 0) {
             checkpointActionPreparationNoProgress();
-            void iterator.return?.().catch(() => undefined);
+            requestEventIteratorReturn(iterator, false);
             return { done: true, value: undefined };
           }
           let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -2900,14 +2919,17 @@ export async function runAgentLoop(opts: {
           const timeout = new Promise<"timeout">((resolve) => {
             timeoutId = setTimeout(() => resolve("timeout"), timeoutMs);
           });
-          const result = await Promise.race([next, timeout]);
-          if (timeoutId) clearTimeout(timeoutId);
-          if (result === "timeout") {
-            checkpointActionPreparationNoProgress();
-            void iterator.return?.().catch(() => undefined);
-            return { done: true, value: undefined };
+          try {
+            const result = await Promise.race([next, timeout]);
+            if (result === "timeout") {
+              checkpointActionPreparationNoProgress();
+              requestEventIteratorReturn(iterator, false);
+              return { done: true, value: undefined };
+            }
+            return result;
+          } finally {
+            if (timeoutId) clearTimeout(timeoutId);
           }
-          return result;
         };
         const trackActiveToolInput = (
           key: string,
@@ -2956,127 +2978,138 @@ export async function runAgentLoop(opts: {
           );
         };
         const eventIterator = eventStream[Symbol.asyncIterator]();
-        while (true) {
-          const nextEvent =
-            await nextEngineEventWithActionPreparationTimeout(eventIterator);
-          if (nextEvent.done) break;
-          const event = nextEvent.value;
-          if (hasActionPreparationStalled()) {
-            checkpointActionPreparationNoProgress();
-            void eventIterator.return?.().catch(() => undefined);
-            break;
-          }
-          // In-loop processor seam (stream hook). Each chunk is offered to every
-          // processor's `processOutputStream` before the loop handles it. A
-          // processor `abort()` throws a TripWire; catch it locally so it is not
-          // mistaken for a retryable engine error, then break out cleanly.
-          if (processorChain) {
-            try {
-              await processorChain.runStream(event);
-            } catch (err) {
-              if (err instanceof TripWire) {
-                emitTripwire(err);
+        let eventIteratorDone = false;
+        try {
+          while (true) {
+            const nextEvent =
+              await nextEngineEventWithActionPreparationTimeout(eventIterator);
+            if (nextEvent.done) {
+              eventIteratorDone = true;
+              break;
+            }
+            const event = nextEvent.value;
+            if (hasActionPreparationStalled()) {
+              checkpointActionPreparationNoProgress();
+              break;
+            }
+            // In-loop processor seam (stream hook). Each chunk is offered to every
+            // processor's `processOutputStream` before the loop handles it. A
+            // processor `abort()` throws a TripWire; catch it locally so it is not
+            // mistaken for a retryable engine error, then break out cleanly.
+            if (processorChain) {
+              try {
+                await processorChain.runStream(event);
+              } catch (err) {
+                if (err instanceof TripWire) {
+                  emitTripwire(err);
+                  break;
+                }
+                throw err;
+              }
+            }
+            if (event.type === "text-delta") {
+              resetZeroByteToolInputRestart();
+              streamedAssistantText += event.text;
+              send({ type: "text", text: event.text });
+            } else if (event.type === "thinking-delta") {
+              thinkingBuffer += event.text;
+              // Forward thinking deltas as a distinct event type so the UI
+              // can render a collapsible "Thinking…" cell while the model
+              // reasons, then collapse it when content arrives.
+              send({ type: "thinking", text: event.text });
+            } else if (event.type === "tool-input-start") {
+              const key = event.id ?? event.name;
+              if (key && event.name) {
+                toolInputNames.set(key, event.name);
+                toolInputBytes.set(key, 0);
+                trackActiveToolInput(key, event.name, 0);
+              }
+              sendToolInputActivity(event.name, key, undefined, true);
+              if (noteZeroByteToolInputStart(event.name)) {
+                send({
+                  type: "auto_continue",
+                  reason: "no_progress",
+                });
+                endedForActionPreparationNoProgress = true;
                 break;
               }
-              throw err;
-            }
-          }
-          if (event.type === "text-delta") {
-            resetZeroByteToolInputRestart();
-            streamedAssistantText += event.text;
-            send({ type: "text", text: event.text });
-          } else if (event.type === "thinking-delta") {
-            thinkingBuffer += event.text;
-            // Forward thinking deltas as a distinct event type so the UI
-            // can render a collapsible "Thinking…" cell while the model
-            // reasons, then collapse it when content arrives.
-            send({ type: "thinking", text: event.text });
-          } else if (event.type === "tool-input-start") {
-            const key = event.id ?? event.name;
-            if (key && event.name) {
-              toolInputNames.set(key, event.name);
-              toolInputBytes.set(key, 0);
-              trackActiveToolInput(key, event.name, 0);
-            }
-            sendToolInputActivity(event.name, key, undefined, true);
-            if (noteZeroByteToolInputStart(event.name)) {
-              send({
-                type: "auto_continue",
-                reason: "no_progress",
-              });
-              endedForActionPreparationNoProgress = true;
-              break;
-            }
-          } else if (event.type === "tool-input-delta") {
-            const key = event.id ?? event.name;
-            const toolName =
-              event.name ??
-              (event.id ? toolInputNames.get(event.id) : undefined);
-            let progressBytes: number | undefined;
-            let startedZeroByteInput = false;
-            if (key) {
-              const hadByteRecord = toolInputBytes.has(key);
-              const previous = hadByteRecord
-                ? (toolInputBytes.get(key) ?? 0)
-                : 0;
-              progressBytes =
-                previous +
-                new TextEncoder().encode(event.text ?? "").byteLength;
-              toolInputBytes.set(key, progressBytes);
-              if (!hadByteRecord || progressBytes > previous) {
-                trackActiveToolInput(key, toolName, progressBytes);
-                if (progressBytes > 0) {
-                  resetZeroByteToolInputRestart(toolName);
-                } else if (!hadByteRecord) {
-                  startedZeroByteInput = true;
+            } else if (event.type === "tool-input-delta") {
+              const key = event.id ?? event.name;
+              const toolName =
+                event.name ??
+                (event.id ? toolInputNames.get(event.id) : undefined);
+              let progressBytes: number | undefined;
+              let startedZeroByteInput = false;
+              if (key) {
+                const hadByteRecord = toolInputBytes.has(key);
+                const previous = hadByteRecord
+                  ? (toolInputBytes.get(key) ?? 0)
+                  : 0;
+                progressBytes =
+                  previous +
+                  new TextEncoder().encode(event.text ?? "").byteLength;
+                toolInputBytes.set(key, progressBytes);
+                if (!hadByteRecord || progressBytes > previous) {
+                  trackActiveToolInput(key, toolName, progressBytes);
+                  if (progressBytes > 0) {
+                    resetZeroByteToolInputRestart();
+                  } else if (!hadByteRecord) {
+                    startedZeroByteInput = true;
+                  }
                 }
               }
-            }
-            sendToolInputActivity(toolName, key, progressBytes);
-            if (
-              startedZeroByteInput &&
-              toolName &&
-              noteZeroByteToolInputStart(toolName)
-            ) {
-              send({
-                type: "auto_continue",
-                reason: "no_progress",
+              sendToolInputActivity(toolName, key, progressBytes);
+              if (
+                startedZeroByteInput &&
+                toolName &&
+                noteZeroByteToolInputStart(toolName)
+              ) {
+                send({
+                  type: "auto_continue",
+                  reason: "no_progress",
+                });
+                endedForActionPreparationNoProgress = true;
+                break;
+              }
+            } else if (event.type === "gateway-heartbeat") {
+              send({ type: "stream_keepalive" });
+            } else if (event.type === "tool-call") {
+              // The authoritative tool-call blocks arrive in assistant-content.
+            } else if (event.type === "tool-call-error") {
+              toolCallErrors.set(event.id, {
+                name: event.name,
+                input: event.input,
+                error: event.error,
               });
-              endedForActionPreparationNoProgress = true;
+            } else if (event.type === "assistant-content") {
+              assistantContent = event.parts;
+            } else if (event.type === "usage") {
+              usage.inputTokens += event.inputTokens;
+              usage.outputTokens += event.outputTokens;
+              usage.cacheReadTokens += event.cacheReadTokens ?? 0;
+              usage.cacheWriteTokens += event.cacheWriteTokens ?? 0;
+            } else if (event.type === "stop") {
+              terminalStopReason = event.reason;
+              if (event.reason === "error") {
+                throw new EngineError(event.error ?? "Engine stream error", {
+                  errorCode: event.errorCode,
+                  upgradeUrl: event.upgradeUrl,
+                  statusCode: event.statusCode,
+                  providerRetryable: event.providerRetryable,
+                });
+              }
+            }
+            if (hasActionPreparationStalled()) {
+              checkpointActionPreparationNoProgress();
               break;
             }
-          } else if (event.type === "gateway-heartbeat") {
-            send({ type: "stream_keepalive" });
-          } else if (event.type === "tool-call") {
-            // The authoritative tool-call blocks arrive in assistant-content.
-          } else if (event.type === "tool-call-error") {
-            toolCallErrors.set(event.id, {
-              name: event.name,
-              input: event.input,
-              error: event.error,
-            });
-          } else if (event.type === "assistant-content") {
-            assistantContent = event.parts;
-          } else if (event.type === "usage") {
-            usage.inputTokens += event.inputTokens;
-            usage.outputTokens += event.outputTokens;
-            usage.cacheReadTokens += event.cacheReadTokens ?? 0;
-            usage.cacheWriteTokens += event.cacheWriteTokens ?? 0;
-          } else if (event.type === "stop") {
-            terminalStopReason = event.reason;
-            if (event.reason === "error") {
-              throw new EngineError(event.error ?? "Engine stream error", {
-                errorCode: event.errorCode,
-                upgradeUrl: event.upgradeUrl,
-                statusCode: event.statusCode,
-                providerRetryable: event.providerRetryable,
-              });
-            }
           }
-          if (hasActionPreparationStalled()) {
-            checkpointActionPreparationNoProgress();
-            void eventIterator.return?.().catch(() => undefined);
-            break;
+        } finally {
+          if (!eventIteratorDone) {
+            await requestEventIteratorReturn(
+              eventIterator,
+              !eventIteratorReturnRequested,
+            );
           }
         }
 

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -2837,9 +2837,15 @@ export async function runAgentLoop(opts: {
             ...(typeof progressBytes === "number" ? { progressBytes } : {}),
           });
         };
-        const hasActionPreparationStalled = () => {
-          if (activeToolInputs.size === 0) return false;
-          const now = Date.now();
+        const actionPreparationDeadlineAt = () => {
+          let deadlineAt = Number.POSITIVE_INFINITY;
+          if (zeroByteToolInputRestart) {
+            deadlineAt = Math.min(
+              deadlineAt,
+              zeroByteToolInputRestart.firstStartedAt +
+                ACTION_PREPARATION_NO_PROGRESS_TIMEOUT_MS,
+            );
+          }
           let earliestStartedAt = Number.POSITIVE_INFINITY;
           let latestPositiveProgressAt = 0;
           for (const active of activeToolInputs.values()) {
@@ -2857,8 +2863,51 @@ export async function runAgentLoop(opts: {
             latestPositiveProgressAt > 0
               ? latestPositiveProgressAt
               : earliestStartedAt;
-          if (!Number.isFinite(progressAt)) return false;
-          return now - progressAt >= ACTION_PREPARATION_NO_PROGRESS_TIMEOUT_MS;
+          if (Number.isFinite(progressAt)) {
+            deadlineAt = Math.min(
+              deadlineAt,
+              progressAt + ACTION_PREPARATION_NO_PROGRESS_TIMEOUT_MS,
+            );
+          }
+          return Number.isFinite(deadlineAt) ? deadlineAt : undefined;
+        };
+        const hasActionPreparationStalled = () => {
+          const deadlineAt = actionPreparationDeadlineAt();
+          return deadlineAt !== undefined && Date.now() >= deadlineAt;
+        };
+        const checkpointActionPreparationNoProgress = () => {
+          if (endedForActionPreparationNoProgress) return;
+          send({
+            type: "auto_continue",
+            reason: "no_progress",
+          });
+          endedForActionPreparationNoProgress = true;
+        };
+        const nextEngineEventWithActionPreparationTimeout = async (
+          iterator: AsyncIterator<EngineEvent>,
+        ): Promise<IteratorResult<EngineEvent>> => {
+          const deadlineAt = actionPreparationDeadlineAt();
+          if (deadlineAt === undefined) return iterator.next();
+          const timeoutMs = Math.max(0, deadlineAt - Date.now());
+          if (timeoutMs <= 0) {
+            checkpointActionPreparationNoProgress();
+            void iterator.return?.().catch(() => undefined);
+            return { done: true, value: undefined };
+          }
+          let timeoutId: ReturnType<typeof setTimeout> | undefined;
+          const next = iterator.next();
+          void next.catch(() => undefined);
+          const timeout = new Promise<"timeout">((resolve) => {
+            timeoutId = setTimeout(() => resolve("timeout"), timeoutMs);
+          });
+          const result = await Promise.race([next, timeout]);
+          if (timeoutId) clearTimeout(timeoutId);
+          if (result === "timeout") {
+            checkpointActionPreparationNoProgress();
+            void iterator.return?.().catch(() => undefined);
+            return { done: true, value: undefined };
+          }
+          return result;
         };
         const trackActiveToolInput = (
           key: string,
@@ -2906,13 +2955,15 @@ export async function runAgentLoop(opts: {
               ACTION_PREPARATION_NO_PROGRESS_TIMEOUT_MS
           );
         };
-        for await (const event of eventStream) {
+        const eventIterator = eventStream[Symbol.asyncIterator]();
+        while (true) {
+          const nextEvent =
+            await nextEngineEventWithActionPreparationTimeout(eventIterator);
+          if (nextEvent.done) break;
+          const event = nextEvent.value;
           if (hasActionPreparationStalled()) {
-            send({
-              type: "auto_continue",
-              reason: "no_progress",
-            });
-            endedForActionPreparationNoProgress = true;
+            checkpointActionPreparationNoProgress();
+            void eventIterator.return?.().catch(() => undefined);
             break;
           }
           // In-loop processor seam (stream hook). Each chunk is offered to every
@@ -3023,11 +3074,8 @@ export async function runAgentLoop(opts: {
             }
           }
           if (hasActionPreparationStalled()) {
-            send({
-              type: "auto_continue",
-              reason: "no_progress",
-            });
-            endedForActionPreparationNoProgress = true;
+            checkpointActionPreparationNoProgress();
+            void eventIterator.return?.().catch(() => undefined);
             break;
           }
         }

--- a/templates/design/changelog/2026-07-02-design-now-recovers-cleanly-when-an-edit-screen-action-stall.md
+++ b/templates/design/changelog/2026-07-02-design-now-recovers-cleanly-when-an-edit-screen-action-stall.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-02
+---
+
+Design now recovers cleanly when an edit screen action stalls before streaming any content.


### PR DESCRIPTION
## Summary
- recover action preparation when the model stream goes silent before sending any tool-input bytes
- keep large streaming action inputs supported by using byte-progress deadlines, while zero-byte/silent prep now auto-continues cleanly
- add a Design changelog entry for the stalled edit-screen recovery

## Production evidence
- Design prod run `run-1783037258981-sueck1` stayed `background-processing` with heartbeats moving, but `last_progress_at` stale after `get-design-snapshot`
- its events showed `remove screen`, `get screen snapshot`, then repeated `Preparing edit-design action` with `progressBytes: 0` and only keepalives
- this PR adds a regression for that zero-byte/silent stream shape and makes the action-prep timeout independent of another provider event arriving

## Validation
- `corepack pnpm --dir packages/core exec vitest run src/agent/production-agent.spec.ts src/agent/run-manager.spec.ts src/client/sse-event-processor.spec.ts --maxWorkers=25%`
- `git diff --check`
- `corepack pnpm prep`
