### PR TITLE
Recover quiet model stream stalls

### DIFF
--- a/.changeset/quiet-model-stream-recovery.md
+++ b/.changeset/quiet-model-stream-recovery.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Recover agent runs when a model stream stays open with keepalives but stops producing text, tool input, or tool calls.

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -1193,6 +1193,133 @@ describe("runAgentLoop", () => {
     expect(events).not.toContainEqual({ type: "stream_keepalive" });
   });
 
+  it("checkpoints when the model stream goes keepalive-only after a tool result", async () => {
+    let now = 1_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
+    let streamCount = 0;
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        streamCount += 1;
+        if (streamCount === 1) {
+          yield {
+            type: "assistant-content",
+            parts: [
+              {
+                type: "tool-call" as const,
+                id: "tool-snapshot",
+                name: "get-design-snapshot",
+                input: { designId: "design-1", fileId: "file-1" },
+              },
+            ],
+          };
+          yield { type: "stop", reason: "tool_use" };
+          return;
+        }
+        now += 91_000;
+        yield { type: "gateway-heartbeat" };
+        yield { type: "text-delta", text: "should not continue" };
+      },
+    };
+    const events: AgentChatEvent[] = [];
+
+    try {
+      await runAgentLoop({
+        engine,
+        model: "test-model",
+        systemPrompt: "system",
+        tools: [],
+        messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+        actions: {
+          "get-design-snapshot": actionEntry({ readOnly: true }),
+        },
+        send: (event) => events.push(event),
+        signal: new AbortController().signal,
+      });
+    } finally {
+      dateNow.mockRestore();
+    }
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_done",
+        tool: "get-design-snapshot",
+      }),
+    );
+    expect(events.at(-1)).toEqual({
+      type: "auto_continue",
+      reason: "no_progress",
+    });
+    expect(events).not.toContainEqual({ type: "stream_keepalive" });
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: "text", text: "should not continue" }),
+    );
+  });
+
+  it("keeps a model stream alive when non-heartbeat events continue", async () => {
+    let now = 1_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        now += 45_000;
+        yield { type: "gateway-heartbeat" };
+        now += 44_000;
+        yield { type: "text-delta", text: "still alive" };
+        now += 89_000;
+        yield { type: "gateway-heartbeat" };
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "text" as const, text: "still alive" }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    const events: AgentChatEvent[] = [];
+
+    try {
+      await runAgentLoop({
+        engine,
+        model: "test-model",
+        systemPrompt: "system",
+        tools: [],
+        messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+        actions: {},
+        send: (event) => events.push(event),
+        signal: new AbortController().signal,
+      });
+    } finally {
+      dateNow.mockRestore();
+    }
+
+    expect(events).toContainEqual({ type: "text", text: "still alive" });
+    expect(events).toContainEqual({ type: "done" });
+    expect(events).not.toContainEqual({
+      type: "auto_continue",
+      reason: "no_progress",
+    });
+  });
+
   it("keeps tracking a stalled action input across assistant snapshots", async () => {
     let now = 1_000_000;
     const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -970,6 +970,7 @@ function maxRetriesForError(err: unknown): number {
 const TOOL_INPUT_ACTIVITY_INTERVAL_MS = 1500;
 const ACTION_PREPARATION_NO_PROGRESS_TIMEOUT_MS = 90_000;
 const ACTION_PREPARATION_ZERO_BYTE_RESTART_LIMIT = 2;
+const MODEL_STREAM_NO_PROGRESS_TIMEOUT_MS = 90_000;
 const MAX_TEXT_ATTACHMENT_CHARS = 60_000;
 const MAX_SELECTION_CONTEXT_CHARS = 8_000;
 const MAX_RESOURCE_INVENTORY_ITEMS = 40;
@@ -2814,7 +2815,8 @@ export async function runAgentLoop(opts: {
         };
         const activeToolInputs = new Map<string, ActiveToolInputPreparation>();
         let zeroByteToolInputRestart: ZeroByteToolInputRestart | undefined;
-        let endedForActionPreparationNoProgress = false;
+        let endedForNoProgress = false;
+        let lastModelStreamProgressAt = Date.now();
         const sendToolInputActivity = (
           toolName: string | undefined,
           toolInputId?: string,
@@ -2871,17 +2873,23 @@ export async function runAgentLoop(opts: {
           }
           return Number.isFinite(deadlineAt) ? deadlineAt : undefined;
         };
-        const hasActionPreparationStalled = () => {
-          const deadlineAt = actionPreparationDeadlineAt();
-          return deadlineAt !== undefined && Date.now() >= deadlineAt;
+        const modelStreamNoProgressDeadlineAt = () =>
+          lastModelStreamProgressAt + MODEL_STREAM_NO_PROGRESS_TIMEOUT_MS;
+        const noProgressDeadlineAt = () => {
+          const actionDeadlineAt = actionPreparationDeadlineAt();
+          const modelDeadlineAt = modelStreamNoProgressDeadlineAt();
+          return actionDeadlineAt === undefined
+            ? modelDeadlineAt
+            : Math.min(actionDeadlineAt, modelDeadlineAt);
         };
-        const checkpointActionPreparationNoProgress = () => {
-          if (endedForActionPreparationNoProgress) return;
+        const hasNoProgressStalled = () => Date.now() >= noProgressDeadlineAt();
+        const checkpointNoProgress = () => {
+          if (endedForNoProgress) return;
           send({
             type: "auto_continue",
             reason: "no_progress",
           });
-          endedForActionPreparationNoProgress = true;
+          endedForNoProgress = true;
         };
         let eventIteratorReturnRequested = false;
         const requestEventIteratorReturn = (
@@ -2902,14 +2910,13 @@ export async function runAgentLoop(opts: {
           if (awaitReturn) return returnPromise.catch(() => undefined);
           void returnPromise.catch(() => undefined);
         };
-        const nextEngineEventWithActionPreparationTimeout = async (
+        const nextEngineEventWithNoProgressTimeout = async (
           iterator: AsyncIterator<EngineEvent>,
         ): Promise<IteratorResult<EngineEvent>> => {
-          const deadlineAt = actionPreparationDeadlineAt();
-          if (deadlineAt === undefined) return iterator.next();
+          const deadlineAt = noProgressDeadlineAt();
           const timeoutMs = Math.max(0, deadlineAt - Date.now());
           if (timeoutMs <= 0) {
-            checkpointActionPreparationNoProgress();
+            checkpointNoProgress();
             requestEventIteratorReturn(iterator, false);
             return { done: true, value: undefined };
           }
@@ -2922,7 +2929,7 @@ export async function runAgentLoop(opts: {
           try {
             const result = await Promise.race([next, timeout]);
             if (result === "timeout") {
-              checkpointActionPreparationNoProgress();
+              checkpointNoProgress();
               requestEventIteratorReturn(iterator, false);
               return { done: true, value: undefined };
             }
@@ -2982,15 +2989,18 @@ export async function runAgentLoop(opts: {
         try {
           while (true) {
             const nextEvent =
-              await nextEngineEventWithActionPreparationTimeout(eventIterator);
+              await nextEngineEventWithNoProgressTimeout(eventIterator);
             if (nextEvent.done) {
               eventIteratorDone = true;
               break;
             }
             const event = nextEvent.value;
-            if (hasActionPreparationStalled()) {
-              checkpointActionPreparationNoProgress();
+            if (hasNoProgressStalled()) {
+              checkpointNoProgress();
               break;
+            }
+            if (event.type !== "gateway-heartbeat") {
+              lastModelStreamProgressAt = Date.now();
             }
             // In-loop processor seam (stream hook). Each chunk is offered to every
             // processor's `processOutputStream` before the loop handles it. A
@@ -3030,7 +3040,7 @@ export async function runAgentLoop(opts: {
                   type: "auto_continue",
                   reason: "no_progress",
                 });
-                endedForActionPreparationNoProgress = true;
+                endedForNoProgress = true;
                 break;
               }
             } else if (event.type === "tool-input-delta") {
@@ -3068,7 +3078,7 @@ export async function runAgentLoop(opts: {
                   type: "auto_continue",
                   reason: "no_progress",
                 });
-                endedForActionPreparationNoProgress = true;
+                endedForNoProgress = true;
                 break;
               }
             } else if (event.type === "gateway-heartbeat") {
@@ -3099,8 +3109,8 @@ export async function runAgentLoop(opts: {
                 });
               }
             }
-            if (hasActionPreparationStalled()) {
-              checkpointActionPreparationNoProgress();
+            if (hasNoProgressStalled()) {
+              checkpointNoProgress();
               break;
             }
           }
@@ -3113,7 +3123,7 @@ export async function runAgentLoop(opts: {
           }
         }
 
-        if (endedForActionPreparationNoProgress) {
+        if (endedForNoProgress) {
           return usage;
         }
 

--- a/templates/design/changelog/2026-07-02-design-chat-now-recovers-when-the-model-connection-goes-quie.md
+++ b/templates/design/changelog/2026-07-02-design-chat-now-recovers-when-the-model-connection-goes-quie.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-02
+---
+
+Design chat now recovers when the model connection goes quiet after reading a screen.


### PR DESCRIPTION
## Summary
- add a model-stream no-progress watchdog so keepalive-only provider streams checkpoint `no_progress` instead of burning the full background run budget
- keep large output support intact by still resetting on real text/thinking/tool-input/tool-call events
- add regression coverage for the prod shape: tool completes, then the next model stream only emits keepalives
- add a Design changelog entry for the visible chat recovery improvement

## Production evidence
- Fresh Design prod QA on `main@231460f` created `/design/fyqhZ0lRY0r23yXDWKxau` and generated 3 variants successfully.
- After choosing Dense Productivity Dashboard, run `run-1783040203768-hre2vn` completed delete/snapshot tool calls, then emitted only `stream_keepalive` events while heartbeat stayed fresh.
- Current deployed code therefore stays visibly “Still working” but never progresses until the long background timeout; this patch checkpoints `no_progress` after 90s of keepalive-only model silence.

## Validation
- `corepack pnpm --dir packages/core exec vitest run src/agent/production-agent.spec.ts src/agent/run-manager.spec.ts src/client/sse-event-processor.spec.ts src/client/agent-chat-adapter.spec.ts --maxWorkers=25%`
- `corepack pnpm prep`
