### PR TITLE
Retry stale active-run continuations

### DIFF
--- a/.changeset/chat-continuation-conflicts.md
+++ b/.changeset/chat-continuation-conflicts.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Retry internal chat continuations when the server briefly reports the same completed run as active.

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -5126,6 +5126,84 @@ describe("createAgentChatAdapter", () => {
     expect(last.content.at(-1).text).toContain("Working continued");
   });
 
+  it("retries an internal continuation when 409 reports the same completed run", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let chatPostCount = 0;
+    let abortCount = 0;
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/_agent-native/agent-chat" && init?.method === "POST") {
+        chatPostCount += 1;
+        if (chatPostCount === 1) {
+          return sseResponse(
+            [
+              { type: "text", text: "Working" },
+              { type: "auto_continue", reason: "no_progress" },
+            ],
+            "run-first",
+          );
+        }
+        if (chatPostCount === 2) {
+          return jsonResponse({ activeRunId: "run-first" }, 409);
+        }
+        return sseResponse(
+          [{ type: "text", text: " continued" }, { type: "done" }],
+          "run-self-continuation",
+        );
+      }
+      if (url.includes("/runs/run-first/abort")) {
+        abortCount += 1;
+        return jsonResponse({ ok: true });
+      }
+      if (url.includes("/runs/run-first/events")) {
+        return jsonResponse({ error: "should not reconnect stale run" }, 500);
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-same-run-conflict",
+      threadId: "thread-same-run-conflict",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "continue after quiet stream" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(2000);
+    const results = await promise;
+
+    expect(chatPostCount).toBe(3);
+    expect(abortCount).toBe(1);
+    expect(fetchSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("/runs/run-first/events"),
+      expect.any(Object),
+    );
+    const last = results.at(-1) as any;
+    expect(last.content.at(-1).text).toContain("Working continued");
+  });
+
   it("gives up quickly when the model repeats the same narration without finishing", async () => {
     // A degenerate model loop re-streams the same sentence every continuation
     // and never starts or finishes a tool (the create-extension-with-a-huge-

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -2301,11 +2301,18 @@ export function createAgentChatAdapter(
                 // can report a just-finished run as active for up to
                 // RUN_STALE_MS while its terminal status write lands) — adopting
                 // `activeRunId` below would reconnect to that prior run, replay
-                // its final answer, and silently drop this turn. Wait for the
-                // run to clear and retry THIS prompt instead. Only genuine
-                // internal continuations (deliberate resumes of the active run)
-                // fall through to the reconnect path.
-                if (!internalContinuationRequest && activeRunId) {
+                // its final answer, and silently drop this turn. The same race
+                // can happen after an internal auto-continue: if the reported
+                // active run is one this adapter already consumed, reconnecting
+                // to it replays the terminal auto_continue and exits instead of
+                // posting the continuation. Wait for stale/previous active runs
+                // to clear and retry THIS prompt. A genuinely newer background
+                // run still falls through to the reconnect path below.
+                const shouldRetryConflictingActiveRun =
+                  activeRunId !== null &&
+                  (!internalContinuationRequest ||
+                    attemptedRunIds.includes(activeRunId));
+                if (shouldRetryConflictingActiveRun) {
                   queuedConflictRetries += 1;
                   if (queuedConflictRetries <= MAX_QUEUED_CONFLICT_RETRIES) {
                     await delay(500, abortSignal);

--- a/templates/design/changelog/2026-07-03-design-chat-keeps-continuing-after-a-quiet-model-recovery.md
+++ b/templates/design/changelog/2026-07-03-design-chat-keeps-continuing-after-a-quiet-model-recovery.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-03
+---
+
+Design chat now keeps continuing when a quiet model recovery briefly overlaps with the previous run finishing.


### PR DESCRIPTION
## Summary
- retry an internal chat continuation when the server briefly reports a previously-consumed run as active
- keep reconnecting to genuinely newer background continuations, but avoid replaying the stale terminal run and exiting
- add a regression test for the production Design no_progress -> same active run 409 race

## Production evidence
- Design prod at main@70e18ac generated 3 variants successfully
- selecting Dense produced run run-1783042310482-5t5ajg
- backend now emitted auto_continue reason no_progress correctly, but no follow-up run started
- UI stayed on Still working / Thinking because the client raced the active-run slot and did not post the continuation

## Validation
- corepack pnpm --dir packages/core exec vitest run src/client/agent-chat-adapter.spec.ts --maxWorkers=25%
- corepack pnpm --dir packages/core exec vitest run src/agent/production-agent.spec.ts src/agent/run-manager.spec.ts src/client/sse-event-processor.spec.ts src/client/agent-chat-adapter.spec.ts --maxWorkers=25%
- corepack pnpm prep
