### PR TITLE
Keep chat recovery inside active worker

### DIFF
--- a/.changeset/chat-main-loop-internal-recovery.md
+++ b/.changeset/chat-main-loop-internal-recovery.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep hosted chat runs inside the active worker when a progress-aware action-preparation checkpoint asks to continue, instead of depending on the browser to start the recovery turn.

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -30,6 +30,7 @@ import {
   resolveBackgroundDispatchOutcome,
   resolveSkillReferenceContent,
   runAgentLoop,
+  runAgentLoopWithMainChatInternalContinuations,
   shouldChainBackgroundContinuation,
   shouldGuardRepeatedSourceSweep,
   structuredHistoryToEngineMessages,
@@ -999,6 +1000,90 @@ describe("runAgentLoop", () => {
     });
     expect(events).not.toContainEqual({ type: "stream_keepalive" });
     expect(events).not.toContainEqual({ type: "done" });
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: "text", text: "should not continue" }),
+    );
+  });
+
+  it("continues main chat internally after a no-progress action preparation checkpoint", async () => {
+    let now = 1_000_000;
+    let attempts = 0;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        attempts++;
+        if (attempts === 1) {
+          yield {
+            type: "tool-input-start",
+            id: "tool-edit",
+            name: "edit-design",
+          };
+          now += 91_000;
+          yield { type: "gateway-heartbeat" };
+          yield { type: "text-delta", text: "should not continue" };
+          return;
+        }
+        yield { type: "text-delta", text: "continued" };
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "text" as const, text: "continued" }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    const events: AgentChatEvent[] = [];
+    const messages = [
+      {
+        role: "user" as const,
+        content: [{ type: "text" as const, text: "go" }],
+      },
+    ];
+
+    try {
+      await runAgentLoopWithMainChatInternalContinuations({
+        engine,
+        model: "test-model",
+        systemPrompt: "system",
+        tools: [],
+        messages,
+        actions: {
+          "edit-design": actionEntry({ readOnly: false }),
+        },
+        send: (event) => events.push(event),
+        signal: new AbortController().signal,
+      });
+    } finally {
+      dateNow.mockRestore();
+    }
+
+    expect(attempts).toBe(2);
+    const continuationText = messages
+      .map((message) =>
+        message.content[0]?.type === "text" ? message.content[0].text : "",
+      )
+      .find((text) => text.includes(AGENT_INTERNAL_CONTINUE_PROMPT));
+    expect(continuationText).toContain(AGENT_INTERNAL_CONTINUE_PROMPT);
+    expect(continuationText).toContain(
+      "preparing the `edit-design` action input",
+    );
+    expect(events).toContainEqual({ type: "clear" });
+    expect(events).toContainEqual({ type: "text", text: "continued" });
+    expect(events).toContainEqual({ type: "done" });
+    expect(events).not.toContainEqual({
+      type: "auto_continue",
+      reason: "no_progress",
+    });
     expect(events).not.toContainEqual(
       expect.objectContaining({ type: "text", text: "should not continue" }),
     );

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -971,6 +971,12 @@ const TOOL_INPUT_ACTIVITY_INTERVAL_MS = 1500;
 const ACTION_PREPARATION_NO_PROGRESS_TIMEOUT_MS = 90_000;
 const ACTION_PREPARATION_ZERO_BYTE_RESTART_LIMIT = 2;
 const MODEL_STREAM_NO_PROGRESS_TIMEOUT_MS = 90_000;
+const MAIN_CHAT_INTERNAL_CONTINUATION_LIMIT = 6;
+const RUN_BUDGET_EXHAUSTED_ERROR_CODE = "run_budget_exhausted";
+const RUN_BUDGET_EXHAUSTED_MESSAGE =
+  "I ran out of time before finishing this step. " +
+  "I stopped rather than keep retrying silently. " +
+  "Check any completed tool cards above before retrying, ideally as one smaller follow-up.";
 const MAX_TEXT_ATTACHMENT_CHARS = 60_000;
 const MAX_SELECTION_CONTEXT_CHARS = 8_000;
 const MAX_RESOURCE_INVENTORY_ITEMS = 40;
@@ -2978,7 +2984,7 @@ export async function runAgentLoop(opts: {
             };
           }
           return (
-            zeroByteToolInputRestart.count >
+            zeroByteToolInputRestart.count >=
               ACTION_PREPARATION_ZERO_BYTE_RESTART_LIMIT &&
             now - zeroByteToolInputRestart.firstStartedAt >=
               ACTION_PREPARATION_NO_PROGRESS_TIMEOUT_MS
@@ -4430,6 +4436,82 @@ export function backgroundContinuationReasonForRun(
   return "run_timeout";
 }
 
+export async function runAgentLoopWithMainChatInternalContinuations(
+  opts: Parameters<typeof runAgentLoop>[0],
+): Promise<Awaited<ReturnType<typeof runAgentLoop>>> {
+  const usage: Awaited<ReturnType<typeof runAgentLoop>> = {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    model: opts.model,
+  };
+  const addUsage = (next: Awaited<ReturnType<typeof runAgentLoop>>) => {
+    usage.inputTokens += next.inputTokens;
+    usage.outputTokens += next.outputTokens;
+    usage.cacheReadTokens += next.cacheReadTokens;
+    usage.cacheWriteTokens += next.cacheWriteTokens;
+    usage.model = next.model;
+  };
+
+  const localTurnEvents: AgentChatEvent[] = [];
+  let lastAttemptWasUnfinishedContinuation = false;
+  for (
+    let attempt = 0;
+    !opts.signal.aborted && attempt < MAIN_CHAT_INTERNAL_CONTINUATION_LIMIT;
+    attempt++
+  ) {
+    lastAttemptWasUnfinishedContinuation = false;
+    let continuationReason: AgentLoopContinuationReason | undefined;
+    const attemptStartIndex = localTurnEvents.length;
+    const send = (event: AgentChatEvent) => {
+      localTurnEvents.push(event);
+      if (
+        event.type === "auto_continue" &&
+        isAgentLoopContinuationReason(event.reason)
+      ) {
+        continuationReason = event.reason;
+        return;
+      }
+      opts.send(event);
+    };
+
+    const nextUsage = await runAgentLoop({ ...opts, send });
+    addUsage(nextUsage);
+
+    if (!continuationReason || opts.signal.aborted) {
+      return usage;
+    }
+
+    lastAttemptWasUnfinishedContinuation = true;
+    const attemptEvents = localTurnEvents.slice(attemptStartIndex);
+    const completedSideEffect = attemptEvents.some(
+      (event) =>
+        event.type === "tool_done" &&
+        event.completedSideEffect === true &&
+        event.isError !== true,
+    );
+    if (!completedSideEffect) {
+      opts.send({ type: "clear" });
+    }
+    const actionPreparationTool =
+      lastUnfinishedPreparingActionToolFromEvents(localTurnEvents);
+    appendAgentLoopContinuation(opts.messages, continuationReason, {
+      ...(actionPreparationTool ? { actionPreparationTool } : {}),
+    });
+  }
+
+  if (!opts.signal.aborted && lastAttemptWasUnfinishedContinuation) {
+    opts.send({
+      type: "error",
+      error: RUN_BUDGET_EXHAUSTED_MESSAGE,
+      errorCode: RUN_BUDGET_EXHAUSTED_ERROR_CODE,
+      recoverable: true,
+    });
+  }
+  return usage;
+}
+
 function endsAtContinuationBoundary(run: ActiveRun): boolean {
   return (
     endsAtInternalContinuationBoundary(run) ||
@@ -5770,6 +5852,11 @@ export function createProductionAgentHandler(
                     continuationDispatchPath,
                   );
                 try {
+                  await recordRunDiagnostic(
+                    run.runId,
+                    RUN_DIAG_STAGE.workerSetupStep,
+                    `chain_dispatch_start nextRunId=${nextRunId} reason=${continuationReason} path=${continuationDispatchPath}`,
+                  ).catch(() => {});
                   await fireInternalDispatch({
                     event,
                     // Continuation chunks use the same path resolution as the
@@ -5795,11 +5882,28 @@ export function createProductionAgentHandler(
                           continuationExpectsNetlifyBackgroundFunction,
                       },
                     },
+                    settleMs: continuationExpectsNetlifyBackgroundFunction
+                      ? BACKGROUND_CLAIM_GRACE_MS
+                      : undefined,
                   });
+                  await recordRunDiagnostic(
+                    run.runId,
+                    RUN_DIAG_STAGE.workerSetupStep,
+                    `chain_dispatch_sent nextRunId=${nextRunId} reason=${continuationReason}`,
+                  ).catch(() => {});
                 } catch (chainErr) {
                   // Chain dispatch failed — fail loud so the held row goes
                   // terminal instead of spinning. The reaper would also catch
                   // it, but this is immediate and truthful.
+                  await recordRunDiagnostic(
+                    run.runId,
+                    RUN_DIAG_STAGE.workerThrew,
+                    `chain_dispatch_failed nextRunId=${nextRunId} ${
+                      chainErr instanceof Error
+                        ? chainErr.message
+                        : String(chainErr)
+                    }`,
+                  ).catch(() => {});
                   console.error(
                     "[agent-chat] background continuation dispatch failed:",
                     chainErr instanceof Error ? chainErr.message : chainErr,
@@ -6242,7 +6346,7 @@ export function createProductionAgentHandler(
           if (obsConfig.enabled) {
             instrumented = true;
             loopUsage = await instrumentAgentLoop({
-              runAgentLoop,
+              runAgentLoop: runAgentLoopWithMainChatInternalContinuations,
               loopOpts: agentLoopOpts,
               runId,
               threadId: threadId ?? null,
@@ -6272,7 +6376,8 @@ export function createProductionAgentHandler(
           if (instrumented) throw err;
         }
         if (!instrumented) {
-          loopUsage = await runAgentLoop(agentLoopOpts);
+          loopUsage =
+            await runAgentLoopWithMainChatInternalContinuations(agentLoopOpts);
         }
 
         // Record token usage for cost monitoring so the Usage panel in

--- a/templates/design/changelog/2026-07-03-design-chat-recovers-stuck-screen-edits-inside-the-worker.md
+++ b/templates/design/changelog/2026-07-03-design-chat-recovers-stuck-screen-edits-inside-the-worker.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+---
+
+Design chat now keeps selected-variant screen edits moving when a large edit stalls during preparation, instead of leaving the chat waiting for a browser-side recovery.


### PR DESCRIPTION
## Summary
- keep main chat runs inside the active worker when a progress-aware action-preparation checkpoint asks to continue
- make zero-byte same-tool preparation restarts hit the configured limit inclusively
- give background continuation dispatches a longer Netlify background-function acknowledgement window and record chain-dispatch diagnostics

## Validation
- corepack pnpm --filter @agent-native/core exec vitest run src/agent/production-agent.spec.ts --maxWorkers=25%
- corepack pnpm --filter @agent-native/core exec vitest run src/agent/production-agent.spec.ts src/client/agent-chat-adapter.spec.ts src/client/sse-event-processor.spec.ts src/agent/run-manager.spec.ts src/agent/run-loop-with-resume.spec.ts --maxWorkers=25%
- corepack pnpm prep

## Production target
This targets the Design selected-variant follow-up where the background worker emitted terminal no_progress but no continuation run appeared, leaving the browser thinking indefinitely.