### PR TITLE
Clear stale Design selection off editor routes

### DIFF
--- a/templates/design/app/hooks/use-navigation-state.effect.test.tsx
+++ b/templates/design/app/hooks/use-navigation-state.effect.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const coreClientMocks = vi.hoisted(() => ({
+  getBrowserTabId: vi.fn(() => "tab-123"),
+  setClientAppState: vi.fn(() => Promise.resolve(null)),
+  useAgentRouteState: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/client", () => coreClientMocks);
+
+import { useNavigationState } from "./use-navigation-state";
+
+function Probe({ enabled = true }: { enabled?: boolean }) {
+  useNavigationState(enabled);
+  return null;
+}
+
+async function renderProbe(pathname: string, enabled = true) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={[pathname]}>
+        <Probe enabled={enabled} />
+      </MemoryRouter>,
+    );
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  root.unmount();
+  container.remove();
+}
+
+describe("useNavigationState selection cleanup", () => {
+  beforeEach(() => {
+    coreClientMocks.getBrowserTabId.mockReturnValue("tab-123");
+    coreClientMocks.setClientAppState.mockClear();
+    coreClientMocks.useAgentRouteState.mockClear();
+  });
+
+  it("clears stale editor selection outside design editor routes", async () => {
+    await renderProbe("/");
+
+    expect(coreClientMocks.setClientAppState.mock.calls).toEqual([
+      ["design-selection:tab-123", null],
+      ["design-selection", null],
+    ]);
+  });
+
+  it("keeps editor selection while the design editor route is active", async () => {
+    await renderProbe("/design/design-123");
+
+    expect(coreClientMocks.setClientAppState).not.toHaveBeenCalled();
+  });
+
+  it("does not clear selection while route sync is disabled", async () => {
+    await renderProbe("/", false);
+
+    expect(coreClientMocks.setClientAppState).not.toHaveBeenCalled();
+  });
+});

--- a/templates/design/app/hooks/use-navigation-state.test.ts
+++ b/templates/design/app/hooks/use-navigation-state.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   designEditorCommandKeysForTab,
+  designSelectionStateKeysForTab,
   editorCommandFromNavigate,
   editorPathFromCommand,
 } from "./use-navigation-state";
@@ -109,5 +110,13 @@ describe("design navigation state", () => {
       "design-editor-command:tab-123",
     ]);
     expect(designEditorCommandKeysForTab()).toEqual(["design-editor-command"]);
+  });
+
+  it("clears design selection for both the active browser tab and global fallback", () => {
+    expect(designSelectionStateKeysForTab("tab-123")).toEqual([
+      "design-selection:tab-123",
+      "design-selection",
+    ]);
+    expect(designSelectionStateKeysForTab()).toEqual(["design-selection"]);
   });
 });

--- a/templates/design/app/hooks/use-navigation-state.ts
+++ b/templates/design/app/hooks/use-navigation-state.ts
@@ -3,7 +3,8 @@ import {
   getBrowserTabId,
   setClientAppState,
 } from "@agent-native/core/client";
-import { useParams } from "react-router";
+import { useEffect } from "react";
+import { useLocation, useParams } from "react-router";
 
 export interface NavigationState {
   view: string;
@@ -84,6 +85,14 @@ export function designEditorCommandKey(browserTabId?: string): string {
 
 export function designEditorCommandKeysForTab(browserTabId?: string): string[] {
   return [designEditorCommandKey(browserTabId)];
+}
+
+export function designSelectionStateKeysForTab(
+  browserTabId?: string,
+): string[] {
+  return browserTabId
+    ? [`design-selection:${browserTabId}`, "design-selection"]
+    : ["design-selection"];
 }
 
 function normalizeEditorView(
@@ -191,7 +200,16 @@ export function editorCommandFromNavigate(
 
 export function useNavigationState(enabled = true) {
   const params = useParams();
+  const location = useLocation();
   const browserTabId = getBrowserTabId();
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (location.pathname.startsWith("/design/")) return;
+    for (const key of designSelectionStateKeysForTab(browserTabId)) {
+      setClientAppState(key, null).catch(() => {});
+    }
+  }, [browserTabId, enabled, location.pathname]);
 
   useAgentRouteState<NavigationState>({
     browserTabId,

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -264,6 +264,7 @@ import { useAgentGenerating } from "@/hooks/use-agent-generating";
 import { useDesignSystems } from "@/hooks/use-design-systems";
 import {
   designEditorCommandKey,
+  designSelectionStateKeysForTab,
   type DesignEditorCommand,
 } from "@/hooks/use-navigation-state";
 import { useQuestionFlow } from "@/hooks/use-question-flow";
@@ -297,10 +298,7 @@ const TAB_ID = generateTabId();
 // overwrite this tab's selection context. The global key is mirrored as a
 // fallback for CLI/external agents that do not send a browser tab id.
 function designSelectionStateKeys(): string[] {
-  const tabId = getBrowserTabId();
-  return tabId
-    ? [`design-selection:${tabId}`, "design-selection"]
-    : ["design-selection"];
+  return designSelectionStateKeysForTab(getBrowserTabId());
 }
 // Stable symbol used as the Yjs transaction origin for all local user edits.
 // The UndoManager tracks only this origin so remote peers' and the agent's

--- a/templates/design/changelog/2026-07-02-design-chat-now-starts-new-requests-from-the-design-list-wit.md
+++ b/templates/design/changelog/2026-07-02-design-chat-now-starts-new-requests-from-the-design-list-wit.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-02
+---
+
+Design chat now starts new requests from the design list without carrying over a previously selected screen.

--- a/templates/design/server/plugins/agent-chat.ts
+++ b/templates/design/server/plugins/agent-chat.ts
@@ -47,6 +47,8 @@ export default createAgentChatPlugin({
   resolveOrgId: async (event) => (await getOrgContext(event)).orgId,
   systemPrompt: `You are an AI prototyping assistant. You create and edit designs, files, design systems, variants, exports, sharing, and connected repository context through actions and shared application state.
 
+When the user asks for a new design and the current navigation view is list, settings, design-systems, or otherwise has no designId, create a new design first. Do not reuse, delete screens from, or edit a previous design unless the user explicitly names that design or the current navigation state is an editor/present view with that designId.
+
 When the user asks you to refine an existing design, call view-screen if the open design is unclear, then read the live current file with get-design-snapshot before editing. For small localized changes, call edit-design with exact search/replace edits. For broad copy-only changes such as translating all visible text, call edit-design in replace-file mode with the complete updated file content from the snapshot so the HTML structure, scripts, styles, and tweaks are preserved without dozens of fragile search blocks. Do not claim the design is updated until the mutating action succeeds.
 
 When the user picks one direction from a set of presented variants, delete each unchosen variant screen at most once, then call get-design-snapshot exactly once for the kept screen's fileId and call edit-design on that same fileId. Use edit-design replace-file when expanding the placeholder into the full chosen direction. Do not call generate-design after a variant pick unless the user explicitly asks to create a separate new screen.


### PR DESCRIPTION
## Summary
- Clear tab-scoped and global Design selection app state whenever the user leaves the Design editor route.
- Reuse the same selection-state key helper in the editor and route sync code.
- Harden the Design agent prompt so new requests from the design list create a new design instead of mutating a previous one.
- Add a pending Design changelog entry.

## Validation
- corepack pnpm prep
- corepack pnpm --filter design exec vitest run app/hooks/use-navigation-state.test.ts actions/view-screen.test.ts --maxWorkers=25%
- corepack pnpm --filter design typecheck