### PR TITLE
Extend durable background no-progress window

### DIFF
--- a/.changeset/wide-background-no-progress.md
+++ b/.changeset/wide-background-no-progress.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow durable background agent runs to wait longer between real progress events before checkpointing, so large hosted tool generations can use the background-function budget instead of retrying every few minutes.

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -879,6 +879,8 @@ export interface ProductionAgentOptions {
    *  timeout. When reached, the client receives an internal auto-continuation
    *  signal instead of a user-facing warning. */
   runSoftTimeoutMs?: number;
+  /** Optional no-progress watchdog override for this app's runs. */
+  runNoProgressTimeoutMs?: number;
   /**
    * Opt this app into durable Netlify background-function agent-chat runs. This
    * is a runtime opt-in layered on top of the hosted-runtime + A2A_SECRET gates;
@@ -6608,6 +6610,7 @@ export function createProductionAgentHandler(
         // worker." Foreground runs never set this, so their 40s clamp is
         // unchanged.
         backgroundFunction: runsInBackgroundFunction,
+        noProgressTimeoutMs: options.runNoProgressTimeoutMs,
         // Fold continuation runs of one logical turn onto a single durable
         // assistant message. Falls back to the runId (turn == run) when the
         // client doesn't supply a turnId.

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -44,6 +44,7 @@ import { isInBackgroundFunctionRuntime } from "./durable-background.js";
 import {
   abortRun,
   BACKGROUND_SOFT_TIMEOUT_CEILING_MS,
+  DEFAULT_BACKGROUND_NO_PROGRESS_TIMEOUT_MS,
   DEFAULT_BACKGROUND_RUN_SOFT_TIMEOUT_MS,
   DEFAULT_COMPLETED_RUN_RETENTION_MS,
   DEFAULT_ERRORED_RUN_RETENTION_MS,
@@ -1906,8 +1907,12 @@ describe("run manager soft timeout", () => {
   // segment that never emits a real-progress event (only keepalives), while
   // leaving a run with a tool genuinely in flight alone.
   describe("no-progress backstop", () => {
-    it("exports the 150s backstop constant", () => {
+    it("exports foreground and background backstop constants", () => {
       expect(RUN_NO_PROGRESS_HARD_TIMEOUT_MS).toBe(150_000);
+      expect(DEFAULT_BACKGROUND_NO_PROGRESS_TIMEOUT_MS).toBe(12 * 60_000);
+      expect(DEFAULT_BACKGROUND_NO_PROGRESS_TIMEOUT_MS).toBeLessThan(
+        BACKGROUND_SOFT_TIMEOUT_CEILING_MS,
+      );
     });
 
     it("checkpoints via auto_continue(no_progress) and aborts when only keepalives stream past the window", async () => {
@@ -2138,7 +2143,7 @@ describe("run manager soft timeout", () => {
       await vi.waitFor(() => expect(aborted).toBe(true));
     });
 
-    it("is armed with the default 150s window when a soft-timeout regime is active (hosted) and no override is given", async () => {
+    it("is armed with the default 150s window when a foreground soft-timeout regime is active and no override is given", async () => {
       let aborted = false;
       let abortReason: unknown;
 
@@ -2159,14 +2164,56 @@ describe("run manager soft timeout", () => {
           });
         },
         undefined,
-        // A soft timeout far beyond the no-progress window is active (hosted
-        // background regime), so the no-progress backstop should still arm at
-        // its default 150s and fire well before the soft timeout would.
+        // A soft timeout far beyond the no-progress window is active, but this
+        // is still foreground mode (no backgroundFunction flag), so the 150s
+        // hosted backstop remains the default.
         { softTimeoutMs: BACKGROUND_SOFT_TIMEOUT_CEILING_MS },
       );
       run.subscribers.add(() => {});
 
       await vi.advanceTimersByTimeAsync(RUN_NO_PROGRESS_HARD_TIMEOUT_MS + 1);
+
+      expect(aborted).toBe(true);
+      expect(abortReason).toBe("no_progress");
+      expect(run.status).toBe("completed");
+    });
+
+    it("uses the wider durable-background no-progress window by default", async () => {
+      let aborted = false;
+      let abortReason: unknown;
+
+      const run = startRun(
+        "run-no-progress-background-default-armed",
+        "thread-no-progress-background-default-armed",
+        async (send, signal) => {
+          const keepaliveTimer = setInterval(() => {
+            send({ type: "stream_keepalive" });
+          }, 1500);
+          await new Promise<void>((resolve) => {
+            signal.addEventListener("abort", () => {
+              clearInterval(keepaliveTimer);
+              aborted = true;
+              abortReason = signal.reason;
+              resolve();
+            });
+          });
+        },
+        undefined,
+        {
+          softTimeoutMs: BACKGROUND_SOFT_TIMEOUT_CEILING_MS,
+          backgroundFunction: true,
+        },
+      );
+      run.subscribers.add(() => {});
+
+      await vi.advanceTimersByTimeAsync(RUN_NO_PROGRESS_HARD_TIMEOUT_MS + 1);
+      expect(aborted).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(
+        DEFAULT_BACKGROUND_NO_PROGRESS_TIMEOUT_MS -
+          RUN_NO_PROGRESS_HARD_TIMEOUT_MS +
+          1_500,
+      );
 
       expect(aborted).toBe(true);
       expect(abortReason).toBe("no_progress");

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -106,6 +106,17 @@ export const DEFAULT_BACKGROUND_RUN_SOFT_TIMEOUT_MS =
   BACKGROUND_SOFT_TIMEOUT_CEILING_MS;
 
 /**
+ * Default no-progress window for a run executing inside a proven durable
+ * background function. Keep this below the 13-minute soft timeout so a truly
+ * wedged background turn can still checkpoint, persist, and continue before
+ * the function budget expires, but far above the foreground 150s window so
+ * large Design/Plan/Assets generations are not chopped up while the model is
+ * legitimately planning a big tool payload.
+ */
+export const DEFAULT_BACKGROUND_NO_PROGRESS_TIMEOUT_MS =
+  BACKGROUND_SOFT_TIMEOUT_CEILING_MS - 60_000;
+
+/**
  * AUTHORITATIVE no-progress backstop for a run, enforced by the run manager
  * itself (timer-driven, independent of any layer below).
  *
@@ -123,8 +134,11 @@ export const DEFAULT_BACKGROUND_RUN_SOFT_TIMEOUT_MS =
  * like the soft timeout, so the normal continuation machinery recovers it.
  *
  * Sits above the 90s in-loop watchdogs (they get first chance to recover with
- * better context) and far below the 13-min background budget. Only armed when
- * a soft-timeout regime is active (hosted runs); local dev stays unbounded.
+ * better context). Foreground hosted chunks keep this short so the user sees
+ * recovery promptly; proven durable-background chunks use
+ * `DEFAULT_BACKGROUND_NO_PROGRESS_TIMEOUT_MS` so large outputs can use the
+ * background budget. Only armed when a soft-timeout regime is active (hosted
+ * runs); local dev stays unbounded.
  */
 export const RUN_NO_PROGRESS_HARD_TIMEOUT_MS = 150_000;
 
@@ -659,7 +673,11 @@ export function startRun(
   // first, so in practice this guards the long background chunks.
   const noProgressTimeoutMs =
     options?.noProgressTimeoutMs ??
-    (softTimeoutMs > 0 ? RUN_NO_PROGRESS_HARD_TIMEOUT_MS : 0);
+    (softTimeoutMs > 0
+      ? options?.backgroundFunction === true
+        ? DEFAULT_BACKGROUND_NO_PROGRESS_TIMEOUT_MS
+        : RUN_NO_PROGRESS_HARD_TIMEOUT_MS
+      : 0);
   const softTimeoutTimer =
     softTimeoutMs > 0
       ? setTimeout(() => {

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -957,9 +957,12 @@ describe("SSE event processor no-progress recovery", () => {
       }
     })();
 
+    expect(SSE_DURABLE_NO_PROGRESS_TIMEOUT_MS).toBe(13 * 60_000);
+
     // The foreground 75s no-progress window must NOT fire for a durable
-    // background read — the server's 150s backstop owns stall recovery and
-    // its auto_continue event normally arrives over this same stream first.
+    // background read — the server-side background backstop owns stall
+    // recovery and its auto_continue event normally arrives over this same
+    // stream first.
     await vi.advanceTimersByTimeAsync(SSE_NO_PROGRESS_TIMEOUT_MS + 1_000);
     expect(await Promise.race([errPromise, Promise.resolve("pending")])).toBe(
       "pending",

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -151,19 +151,19 @@ export const SSE_ACTION_PREPARATION_STALL_TIMEOUT_MS = 90_000;
 /**
  * Widened client watchdog windows for durable background runs. The SERVER is
  * the recovery brain for these runs: its run-manager no-progress backstop
- * (150s, `RUN_NO_PROGRESS_HARD_TIMEOUT_MS`) emits `auto_continue` over the
- * same stream the client is already reading, and its unclaimed-run sweep reaps
- * dead workers into loud terminal errors. The client watchdogs therefore sit
- * ABOVE the server's 150s backstop so a healthy background run never trips
- * them — the server's own recovery event arrives first over the wire. When one
- * does fire, the thrown signal only means "reattach the read" (the adapter's
- * background follow loop re-polls /runs/active); it never escalates to a
- * client-declared error or a synthetic continuation POST. Progress ACCOUNTING
- * (what counts as a meaningful event) is unchanged — only the client-initiated
- * recovery timing is relaxed.
+ * emits `auto_continue` over the same stream the client is already reading,
+ * and its unclaimed-run sweep reaps dead workers into loud terminal errors.
+ * The client watchdogs therefore sit ABOVE the server's durable-background
+ * backstop so a healthy background run never trips them — the server's own
+ * recovery event arrives first over the wire. When one does fire, the thrown
+ * signal only means "reattach the read" (the adapter's background follow loop
+ * re-polls /runs/active); it never escalates to a client-declared error or a
+ * synthetic continuation POST. Progress ACCOUNTING (what counts as a
+ * meaningful event) is unchanged — only the client-initiated recovery timing
+ * is relaxed.
  */
-export const SSE_DURABLE_NO_PROGRESS_TIMEOUT_MS = 180_000;
-export const SSE_DURABLE_ACTION_PREPARATION_STALL_TIMEOUT_MS = 180_000;
+export const SSE_DURABLE_NO_PROGRESS_TIMEOUT_MS = 13 * 60_000;
+export const SSE_DURABLE_ACTION_PREPARATION_STALL_TIMEOUT_MS = 13 * 60_000;
 
 export function sseNoProgressTimeoutMs(options?: SSEStreamOptions): number {
   return options?.durableBackgroundRun === true

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -2581,6 +2581,8 @@ export interface AgentChatPluginOptions {
    * timeout. When reached, long runs continue through the hidden continuation
    * path instead of surfacing a timeout warning. */
   runSoftTimeoutMs?: number;
+  /** Optional per-app run-manager no-progress watchdog in milliseconds. */
+  runNoProgressTimeoutMs?: number;
   /**
    * Opt this app into Netlify durable background-function agent-chat runs. This
    * gives hosted agent turns the 15-minute async-function budget when the app's
@@ -5872,6 +5874,7 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
         appId: options?.appId,
         apiKey: options?.apiKey,
         runSoftTimeoutMs: options?.runSoftTimeoutMs,
+        runNoProgressTimeoutMs: options?.runNoProgressTimeoutMs,
         durableBackgroundRuns: options?.durableBackgroundRuns,
         finalResponseGuard: options?.finalResponseGuard,
         prepareRequest: async (details) => {
@@ -5963,6 +5966,7 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
               appId: options?.appId,
               apiKey: options?.apiKey,
               runSoftTimeoutMs: options?.runSoftTimeoutMs,
+              runNoProgressTimeoutMs: options?.runNoProgressTimeoutMs,
               durableBackgroundRuns: options?.durableBackgroundRuns,
               finalResponseGuard: options?.finalResponseGuard,
               prepareRequest: options?.prepareRequest,
@@ -6094,6 +6098,7 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
           appId: options?.appId,
           apiKey: options?.apiKey,
           runSoftTimeoutMs: options?.runSoftTimeoutMs,
+          runNoProgressTimeoutMs: options?.runNoProgressTimeoutMs,
           durableBackgroundRuns: options?.durableBackgroundRuns,
           finalResponseGuard: options?.finalResponseGuard,
           prepareRequest: options?.prepareRequest,

--- a/templates/design/changelog/2026-07-03-design-chat-can-now-wait-longer-for-large-background-scr.md
+++ b/templates/design/changelog/2026-07-03-design-chat-can-now-wait-longer-for-large-background-scr.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+---
+
+Design chat can now wait longer for large background screen updates instead of retrying the same step too early.

--- a/templates/design/server/plugins/agent-chat.ts
+++ b/templates/design/server/plugins/agent-chat.ts
@@ -8,6 +8,7 @@ import actionsRegistry from "../../.generated/actions-registry.js";
 import "../register-secrets.js";
 
 const DESIGN_BACKGROUND_RUN_SOFT_TIMEOUT_MS = 13 * 60_000;
+const DESIGN_BACKGROUND_RUN_NO_PROGRESS_TIMEOUT_MS = 12 * 60_000;
 
 const INITIAL_TOOL_NAMES = [
   "view-screen",
@@ -44,6 +45,7 @@ export default createAgentChatPlugin({
   codeExecution: { production: "sandboxed" },
   durableBackgroundRuns: true,
   runSoftTimeoutMs: DESIGN_BACKGROUND_RUN_SOFT_TIMEOUT_MS,
+  runNoProgressTimeoutMs: DESIGN_BACKGROUND_RUN_NO_PROGRESS_TIMEOUT_MS,
   resolveOrgId: async (event) => (await getOrgContext(event)).orgId,
   systemPrompt: `You are an AI prototyping assistant. You create and edit designs, files, design systems, variants, exports, sharing, and connected repository context through actions and shared application state.
 


### PR DESCRIPTION
## Summary
- use a 12-minute no-progress backstop for proven durable background agent runs while keeping foreground hosted runs at 150s
- expose a per-app no-progress watchdog override through the agent chat plugin and configure Design explicitly
- keep durable client read/preparation watchdogs above the server background backstop so streamed large tool payloads can continue

## Validation
- corepack pnpm oxfmt --write packages/core/src/agent/production-agent.ts packages/core/src/agent/run-manager.ts packages/core/src/agent/run-manager.spec.ts packages/core/src/client/sse-event-processor.ts packages/core/src/client/sse-event-processor.spec.ts packages/core/src/server/agent-chat-plugin.ts templates/design/server/plugins/agent-chat.ts
- corepack pnpm --filter @agent-native/core build
- corepack pnpm --filter @agent-native/core typecheck
- corepack pnpm --filter design typecheck
- corepack pnpm --filter @agent-native/core exec vitest run src/agent/run-manager.spec.ts src/client/sse-event-processor.spec.ts --maxWorkers=25%
- corepack pnpm prep

## Production test target
- Re-test Design after the Netlify production deploy for this merge is live; the previous prod blocker was a keepalive-only post-variant followup getting auto-continued at about 150s before edit-design input began.