### PR TITLE
Keep background chat reconnects alive

### DIFF
--- a/.changeset/background-reconnects-stay-alive.md
+++ b/.changeset/background-reconnects-stay-alive.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep chat restore and active-run polling on the durable background timeout budget so healthy long-running background turns do not look stale to the browser.

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -1680,6 +1680,75 @@ describe("run manager soft timeout", () => {
     });
   });
 
+  it("enriches in-memory active runs with SQL dispatch metadata", async () => {
+    const run = startRun(
+      "run-mem-background",
+      "thread-mem-background",
+      async (_send, signal) => {
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+      },
+    );
+    vi.mocked(getRunByThread).mockResolvedValueOnce({
+      id: "run-mem-background",
+      threadId: "thread-mem-background",
+      status: "running",
+      startedAt: Date.now() - 5_000,
+      heartbeatAt: Date.now() - 1_000,
+      completedAt: null,
+      lastProgressAt: Date.now() - 1_000,
+      dispatchMode: "background-processing",
+      terminalReason: null,
+      diagStage: '{"stage":"worker_started","at":1}',
+    });
+
+    const result = await getActiveRunForThreadAsync("thread-mem-background");
+
+    expect(result).toMatchObject({
+      runId: "run-mem-background",
+      status: "running",
+      dispatchMode: "background-processing",
+      terminalReason: null,
+      diagStage: '{"stage":"worker_started","at":1}',
+    });
+    abortRun(run.runId, "test");
+  });
+
+  it("prefers terminal SQL truth over a stale in-memory running buffer", async () => {
+    const run = startRun(
+      "run-mem-terminal",
+      "thread-mem-terminal",
+      async (_send, signal) => {
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+      },
+    );
+    vi.mocked(getRunByThread).mockResolvedValueOnce({
+      id: "run-mem-terminal",
+      threadId: "thread-mem-terminal",
+      status: "completed",
+      startedAt: Date.now() - 120_000,
+      heartbeatAt: Date.now() - 5_000,
+      completedAt: Date.now() - 2_000,
+      lastProgressAt: Date.now() - 3_000,
+      dispatchMode: "background-processing",
+      terminalReason: "done",
+      diagStage: '{"stage":"completed","at":1}',
+    });
+
+    const result = await getActiveRunForThreadAsync("thread-mem-terminal");
+
+    expect(result).toMatchObject({
+      runId: "run-mem-terminal",
+      status: "completed",
+      dispatchMode: "background-processing",
+      terminalReason: "done",
+    });
+    abortRun(run.runId, "test");
+  });
+
   // ─── FALLBACK HARDENING: unclaimed background run recovery ──────────────────
   it("recovers an unclaimed-stale background run (202 acked, worker never started)", async () => {
     // dispatch_mode still 'background' (never flipped to 'background-processing')

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -1362,20 +1362,32 @@ export async function getActiveRunForThreadAsync(threadId: string): Promise<{
   // the full conversation from completed runs via SSE.
   const memRun = getActiveRunForThread(threadId);
   if (memRun && (memRun.status === "running" || memRun.events.length > 0)) {
+    const sqlSnapshot = await fetchRunThreadSnapshot(memRun.runId, threadId);
+    const status = sqlSnapshot?.status ?? memRun.status;
+    const heartbeatAt =
+      status === "running"
+        ? Date.now()
+        : (sqlSnapshot?.heartbeatAt ?? memRun.startedAt);
     return {
       runId: memRun.runId,
       threadId: memRun.threadId,
       turnId: memRun.turnId,
-      status: memRun.status,
+      status,
       // In-memory means this isolate is the producer. By definition, the
-      // heartbeat is fresh as of "now" — the client can trust this.
-      heartbeatAt: Date.now(),
+      // heartbeat is fresh as of "now" while the run is still running. Once
+      // SQL has terminal truth, prefer that timestamp so a stale in-memory
+      // buffer cannot keep the browser believing a finished background run is
+      // still alive.
+      heartbeatAt,
       // For an in-memory run we don't have a separate "last event emit"
       // timestamp tracked in JS — the SQL bump is throttled per-second.
       // Read it back from SQL on demand. For the common case the SQL row
       // is well under 1s old; if it isn't, the stuck-detector will pick
       // it up on the next poll cycle.
-      lastProgressAt: await fetchLastProgressAt(memRun.runId),
+      lastProgressAt: sqlSnapshot?.lastProgressAt ?? null,
+      dispatchMode: sqlSnapshot?.dispatchMode ?? null,
+      terminalReason: sqlSnapshot?.terminalReason ?? null,
+      diagStage: sqlSnapshot?.diagStage ?? null,
     };
   }
   // Fall back to SQL — also surface recently terminated runs so the client
@@ -1454,16 +1466,14 @@ export async function getActiveRunForThreadAsync(threadId: string): Promise<{
   return null;
 }
 
-async function fetchLastProgressAt(runId: string): Promise<number | null> {
+async function fetchRunThreadSnapshot(runId: string, threadId: string) {
   try {
-    const run = await getRunById(runId);
-    if (!run) return null;
     // `getRunById` returns a narrow projection today; ask for the row via
-    // the thread lookup which carries last_progress_at.
-    const byThread = await getRunByThread(run.threadId, {
+    // the thread lookup which carries dispatch/terminal/progress fields.
+    const byThread = await getRunByThread(threadId, {
       includeTerminal: true,
     });
-    if (byThread && byThread.id === runId) return byThread.lastProgressAt;
+    if (byThread && byThread.id === runId) return byThread;
     return null;
   } catch {
     return null;

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -365,6 +365,21 @@ describe("waitForThreadRunToClear", () => {
     expect(helperSource).not.toContain("heartbeatAt");
   });
 
+  it("uses the background run budget when deciding whether an active run is stale", () => {
+    const source = readFileSync("src/client/AssistantChat.tsx", {
+      encoding: "utf8",
+    });
+    const start = source.indexOf("function activeRunStuckThresholdMs");
+    const end = source.indexOf("function activeRunLooksStale");
+    const helperSource = source.slice(start, end);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    expect(helperSource).toContain('dispatchMode.startsWith("background")');
+    expect(helperSource).toContain("BACKGROUND_ACTIVE_RUN_STUCK_THRESHOLD_MS");
+    expect(helperSource).toContain("ACTIVE_RUN_STUCK_THRESHOLD_MS");
+  });
+
   it("aborts the reconnect on an idle gap, not a fixed total duration", () => {
     const source = readFileSync("src/client/AssistantChat.tsx", {
       encoding: "utf8",
@@ -380,6 +395,7 @@ describe("waitForThreadRunToClear", () => {
     // total reconnect duration and falsely fails a healthy long run.
     expect(helperSource).toContain("markReconnectProgress");
     expect(helperSource).toContain("reconnectProgressTimedOut");
+    expect(helperSource).toContain("thresholdMs: reconnectStuckThresholdMs");
     expect(helperSource).not.toContain(
       "setTimeout(() => {\n        reconnectTimedOut = true;",
     );

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -239,6 +239,7 @@ function createUserMessageRunConfig(
 const PENDING_SELECTION_KEY = "pending-selection-context";
 const ACTIVE_RUN_CLEAR_TIMEOUT_MS = 5_000;
 const ACTIVE_RUN_STUCK_THRESHOLD_MS = 90_000;
+const BACKGROUND_ACTIVE_RUN_STUCK_THRESHOLD_MS = 13 * 60_000;
 const ACTIVE_RUN_POLL_INTERVAL_MS = 150;
 const AUTO_RESUME_STATUS_TIMEOUT_MS = 30_000;
 // How long a single activity (model call, tool prep, long tool) must stay
@@ -271,15 +272,24 @@ function isReplayableTerminalRun(runInfo: ActiveRunLookup): boolean {
   );
 }
 
+function activeRunStuckThresholdMs(runInfo: ActiveRunLookup): number {
+  const dispatchMode =
+    typeof runInfo.dispatchMode === "string" ? runInfo.dispatchMode : "";
+  return dispatchMode.startsWith("background")
+    ? BACKGROUND_ACTIVE_RUN_STUCK_THRESHOLD_MS
+    : ACTIVE_RUN_STUCK_THRESHOLD_MS;
+}
+
 function activeRunLooksStale(runInfo: ActiveRunLookup): boolean {
   const lastProgressAt =
     typeof runInfo.lastProgressAt === "number" ? runInfo.lastProgressAt : null;
   const nowMs =
     typeof runInfo.serverNow === "number" ? runInfo.serverNow : Date.now();
+  const thresholdMs = activeRunStuckThresholdMs(runInfo);
   return (
     runInfo.status === "running" &&
     lastProgressAt != null &&
-    nowMs - lastProgressAt > ACTIVE_RUN_STUCK_THRESHOLD_MS
+    nowMs - lastProgressAt > thresholdMs
   );
 }
 
@@ -1894,6 +1904,7 @@ const AssistantChatInner = forwardRef<
       reconnectAbortRef.current = abortCtrl;
       let reconnectTerminalReason: AgentAutoContinueSignal["reason"] | null =
         null;
+      const reconnectStuckThresholdMs = activeRunStuckThresholdMs(runInfo);
 
       const watchdog = setInterval(async () => {
         try {
@@ -1937,6 +1948,7 @@ const AssistantChatInner = forwardRef<
           !reconnectProgressTimedOut({
             lastProgressAt: lastReconnectProgressAt,
             now: Date.now(),
+            thresholdMs: reconnectStuckThresholdMs,
           })
         ) {
           return;

--- a/templates/design/AGENTS.md
+++ b/templates/design/AGENTS.md
@@ -243,10 +243,12 @@ patterns live in `.agents/skills/`.
   wait for the user to pick one in chat, delete each other generated variant
   screen with `delete-file` at most once, call `get-design-snapshot` exactly
   once with the selected screen's `fileId`, then call `edit-design` exactly once
-  on that same `fileId` for follow-up refinement. Use `mode: "replace-file"`
-  when expanding the representative placeholder into the full chosen direction.
-  Do not repeat delete/snapshot cycles, and do not call `generate-design` after
-  a variant pick.
+  on that same `fileId` for follow-up refinement. The kept variant screen is a
+  representative direction, not the final deliverable: use `mode:
+"replace-file"` to replace it with the actual requested app/product UI in the
+  chosen visual style. Do not leave a direction board, variant brief, summary
+  card, or prose description as the final screen. Do not repeat delete/snapshot
+  cycles, and do not call `generate-design` after a variant pick.
 - If inline chat choice buttons are unavailable, the user can tell you the
   preferred screen name. Do not show a separate variant picker or ask them to
   paste a copyable handoff summary.

--- a/templates/design/actions/present-design-variants.spec.ts
+++ b/templates/design/actions/present-design-variants.spec.ts
@@ -234,6 +234,12 @@ describe("present-design-variants", () => {
       "exact file ids and tool instructions in the selected answer",
     );
     expect(guidedQuestions.submitMessage).toContain(
+      "full requested app/product UI",
+    );
+    expect(guidedQuestions.submitMessage).toContain(
+      "must not be a direction board",
+    );
+    expect(guidedQuestions.submitMessage).toContain(
       "Do not repeat cleanup/read cycles",
     );
     expect(guidedQuestions.submitMessage).not.toContain("delete-file");
@@ -249,6 +255,11 @@ describe("present-design-variants", () => {
     expect(firstOption?.value).toContain("fileId file-a");
     expect(firstOption?.value).toContain("edit-design with fileId file-a");
     expect(firstOption?.value).toContain('mode "replace-file"');
+    expect(firstOption?.value).toContain(
+      "replace the representative direction screen",
+    );
+    expect(firstOption?.value).toContain("actual usable UI requested");
+    expect(firstOption?.value).toContain("not a direction board");
     expect(firstOption?.value).toContain("bounded single-file pass");
     expect(firstOption?.value).toContain(
       "do not repeat delete/snapshot cycles",
@@ -302,6 +313,12 @@ describe("present-design-variants", () => {
     expect(result.nextRequiredAction).toContain("fileId");
     expect(result.nextRequiredAction).toContain("edit-design");
     expect(result.nextRequiredAction).toContain('mode "replace-file"');
+    expect(result.nextRequiredAction).toContain(
+      "full requested app/product UI",
+    );
+    expect(result.nextRequiredAction).toContain(
+      "Do not leave a direction board",
+    );
     expect(result.nextRequiredAction).toContain(
       "Do not repeat delete/snapshot cycles",
     );

--- a/templates/design/actions/present-design-variants.ts
+++ b/templates/design/actions/present-design-variants.ts
@@ -42,13 +42,18 @@ const FALLBACK_INSTRUCTIONS =
   "a screen by name if the inline buttons are not available; after they pick, " +
   "delete each other variant screen at most once, call get-design-snapshot with fileId for " +
   "the kept screen once, then call edit-design on that same fileId in a bounded pass. " +
-  'Use mode "replace-file" when expanding the representative placeholder. ' +
+  'Use mode "replace-file" to replace the representative direction screen with ' +
+  "the actual requested product UI; do not leave a direction board, summary card, " +
+  "or variant brief as the final result. " +
   "Do not call generate-design after a variant pick.";
 
 const VARIANT_PICK_SUBMIT_MESSAGE =
   "Use this design direction. Keep the selected screen, clean up each other " +
   "variant screen at most once, read only the kept screen, then update that " +
-  "same screen in one bounded pass. If a cleanup action reports a screen was " +
+  "same screen in one bounded pass into the full requested app/product UI. " +
+  "The selected screen is only a representative direction; the final saved " +
+  "screen must not be a direction board, variant brief, or summary card. " +
+  "If a cleanup action reports a screen was " +
   "already missing, continue. Use the exact file ids and tool instructions in " +
   "the selected answer below. Do not repeat cleanup/read cycles, do not create " +
   "a new index.html, and stop after the first successful screen update.";
@@ -580,7 +585,7 @@ export default defineAction({
     await writeAppStateForCurrentTab("guided-questions", {
       title: prompt ?? "Pick a direction",
       description:
-        "All options are on the board. Choose one to keep; I will delete the others, read only the kept screen, and edit that same file in a bounded pass.",
+        "All options are on the board. Choose one to keep; I will delete the others, read only the kept screen, and turn that direction into the final requested screen.",
       submitLabel: "Use selected direction",
       submitMessage: VARIANT_PICK_SUBMIT_MESSAGE,
       skipLabel: "Show another set",
@@ -608,7 +613,7 @@ export default defineAction({
               value:
                 `Keep "${screen.label}" (${screen.filename}, file id ${screen.id}) ` +
                 `from variant set ${variantSetId}. Delete each other variant screen at most once: ${otherScreens}. If delete-file says a screen is already missing, continue. ` +
-                `Then call get-design-snapshot exactly once with designId ${designId} and fileId ${screen.id} (filename ${screen.filename}), then call edit-design with fileId ${screen.id} on that same kept file in a bounded single-file pass. Use mode "replace-file" when replacing the representative placeholder with the full chosen direction, or search/replace for smaller refinements. Do not call generate-design after this variant pick, do not repeat delete/snapshot cycles, do not create index.html, and do not resend a huge payload. Stop after the first successful edit-design save.`,
+                `Then call get-design-snapshot exactly once with designId ${designId} and fileId ${screen.id} (filename ${screen.filename}), then call edit-design with fileId ${screen.id} on that same kept file in a bounded single-file pass. Use mode "replace-file" to replace the representative direction screen with the full requested app/product UI in the chosen visual style. The final saved screen must be the actual usable UI requested by the user, not a direction board, variant brief, summary card, or description of the direction. Do not call generate-design after this variant pick, do not repeat delete/snapshot cycles, do not create index.html, and do not resend a huge payload. Stop after the first successful edit-design save.`,
             };
           }),
         },
@@ -626,7 +631,7 @@ export default defineAction({
       embed: true,
       fallbackInstructions: FALLBACK_INSTRUCTIONS,
       nextRequiredAction:
-        'Wait for the user to pick a screen in chat. Then delete each unchosen variant screen with delete-file at most once, call get-design-snapshot exactly once with fileId for the chosen screen, and call edit-design with that same fileId in a bounded pass. Use mode "replace-file" when expanding the placeholder into the full chosen direction. Do not repeat delete/snapshot cycles. Do not call generate-design after a variant pick. Stop after the first successful edit-design save.',
+        'Wait for the user to pick a screen in chat. Then delete each unchosen variant screen with delete-file at most once, call get-design-snapshot exactly once with fileId for the chosen screen, and call edit-design with that same fileId in a bounded pass. Use mode "replace-file" to replace the representative direction screen with the full requested app/product UI in the chosen visual style. Do not leave a direction board, variant brief, or summary card as the final result. Do not repeat delete/snapshot cycles. Do not call generate-design after a variant pick. Stop after the first successful edit-design save.',
     };
   },
   link: ({ result }) => {

--- a/templates/design/changelog/2026-07-03-variant-picks-build-the-selected-app.md
+++ b/templates/design/changelog/2026-07-03-variant-picks-build-the-selected-app.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+---
+
+Variant picks now more reliably expand the selected direction into the full requested screen instead of leaving a direction summary behind.


### PR DESCRIPTION
## Summary
- keep active-run restore/reconnect stale detection on the durable background timeout budget for background-dispatched runs
- enrich in-memory active-run responses with SQL dispatch and terminal metadata so stale buffers do not hide completed background runs
- harden Design variant-pick instructions so selected directions are replaced with the full requested screen, not a direction board

## Verification
- corepack pnpm --filter @agent-native/core exec vitest run src/agent/run-manager.spec.ts src/client/AssistantChat.display.spec.ts --maxWorkers=25%
- corepack pnpm --filter design exec vitest run actions/present-design-variants.spec.ts --maxWorkers=25%
- corepack pnpm --filter @agent-native/core typecheck
- corepack pnpm --filter design typecheck
- corepack pnpm --filter @agent-native/core build
- corepack pnpm prep (before syncing origin/main)
- corepack pnpm prep (after syncing origin/main)