### PR TITLE
fix(plan): allow local recap comments without sign-in

### DIFF
--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -6508,7 +6508,7 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
                   ) : (
                     pendingCommentPin
                   )}
-                  {!session ? (
+                  {!session && !localPlanMode ? (
                     <GuestCommentCta
                       position={inlineCommentPosition}
                       onSignIn={() => {


### PR DESCRIPTION
## Description\nLocal-files recap comments should stay in local mode instead of forcing the sign-in CTA.\n\n## Changes Made\n- Kept the guest comment CTA only for hosted/public recap views\n- Let local recap views open the inline comment composer directly\n\n## Testing\n- Not run; small UI gate change\n\n## Impact\nLocal recap authors can leave comments without being bounced into hosted auth, which avoids the 500 path reported in #1881.\n\nFixes #1881