### PR TITLE
Fix slides persistence test selection

### DIFF
--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -498,9 +498,15 @@ describe("DeckContext deck creation persistence", () => {
       "<div>Generated</div>",
     );
 
-    const patchCall = fetchMock.mock.calls.find(([url]) =>
-      String(url).includes("/_agent-native/actions/patch-deck"),
-    );
+    const patchCall = fetchMock.mock.calls.find(([url, init]) => {
+      if (!String(url).includes("/_agent-native/actions/patch-deck")) {
+        return false;
+      }
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        deckId?: string;
+      };
+      return body.deckId === deckId;
+    });
     expect(patchCall).toBeTruthy();
     expect(JSON.parse(String(patchCall?.[1]?.body))).toMatchObject({
       deckId,


### PR DESCRIPTION
## Summary
- make the slides persistence regression test select the patch request for the deck it created
- prevents full-suite timing from matching unrelated debounced deck saves

## Verification
- corepack pnpm --filter slides exec vitest run app/context/DeckContext.persistence.test.ts --maxWorkers=25%