### PR TITLE
Soften Design code sidebar tabs

### DIFF
--- a/templates/design/app/components/design/code-workbench/SideBar.tsx
+++ b/templates/design/app/components/design/code-workbench/SideBar.tsx
@@ -80,15 +80,12 @@ export function SideBar({
                     "relative flex size-8 cursor-pointer items-center justify-center rounded-[5px] text-[var(--workbench-muted-fg)] outline-none transition-colors",
                     "hover:bg-[var(--workbench-hover-bg)] hover:text-[var(--workbench-fg)] focus-visible:ring-1 focus-visible:ring-[var(--workbench-accent)]",
                     active &&
-                      "bg-[var(--workbench-list-active-bg,var(--workbench-active-bg))] text-[var(--workbench-accent)]",
+                      "bg-[var(--workbench-list-active-bg,var(--workbench-active-bg))] text-[var(--workbench-fg)]",
                   )}
                   onClick={() => {
                     if (!active) api.setSideView(item.view);
                   }}
                 >
-                  {active ? (
-                    <span className="absolute inset-x-1 bottom-0 h-[2px] rounded-full bg-[var(--workbench-accent)]" />
-                  ) : null}
                   <Icon className="size-[18px]" />
                 </button>
               </TooltipTrigger>

--- a/templates/design/changelog/2026-07-05-code-sidebar-tabs-now-use-a-quieter-active-highlight-that-ma.md
+++ b/templates/design/changelog/2026-07-05-code-sidebar-tabs-now-use-a-quieter-active-highlight-that-ma.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-05
+---
+
+Code sidebar tabs now use a quieter active highlight that matches the editor chrome.


### PR DESCRIPTION
## Summary
- remove the blue active underline from Design code sidebar view tabs
- use the neutral active background with foreground-colored active icons
- add a pending Design changelog entry

## Validation
- corepack pnpm --filter design typecheck
- corepack pnpm --filter design exec playwright screenshot --timeout=60000 --wait-for-selector='[data-testid="design-code-workbench"]' 'http://localhost:9303/design/uDDzi-1g27c4eUQRZKCNZ?panel=code' /tmp/design-code-tab.png