### PR TITLE
Improve Clips playback and Plan comments

### DIFF
--- a/templates/clips/app/components/library/library-grid.tsx
+++ b/templates/clips/app/components/library/library-grid.tsx
@@ -1,30 +1,18 @@
 import {
   getBrowserTabId,
   setClientAppState,
-  useSession,
   useT,
 } from "@agent-native/core/client";
-import { Button } from "@agent-native/toolkit/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from "@agent-native/toolkit/ui/dialog";
-import { Input } from "@agent-native/toolkit/ui/input";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import { ShareRecordingDialog } from "@/components/player/share-dialog";
-import { isDefaultTitle } from "@/hooks/use-auto-title";
 import {
   useFolders,
   useRecordings,
   useTrashRecording,
   useArchiveRecording,
   useRestoreRecording,
-  useRenameRecording,
   useMoveRecording,
   type ListRecordingsArgs,
   type RecordingSummary,
@@ -109,10 +97,7 @@ export function LibraryGrid({
   const [sort, setSort] = useState<SortKey>("recent");
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const selectionMode = selected.size > 0;
-  const [renamingRec, setRenamingRec] = useState<RecordingSummary | null>(null);
-  const [renameValue, setRenameValue] = useState("");
   const [sharingRec, setSharingRec] = useState<RecordingSummary | null>(null);
-  const renameInputRef = useRef<HTMLInputElement>(null);
   const [isBulkPending, setIsBulkPending] = useState(false);
   const selectionStateKey = useMemo(() => `selection:${getBrowserTabId()}`, []);
 
@@ -129,13 +114,10 @@ export function LibraryGrid({
 
   const { data, isLoading } = useRecordings(args);
   const recordings = data?.recordings ?? [];
-  const { session } = useSession();
-  const currentUserEmail = session?.email?.toLowerCase();
 
   const trashRecording = useTrashRecording();
   const archiveRecording = useArchiveRecording();
   const restoreRecording = useRestoreRecording();
-  const renameRecording = useRenameRecording();
   const moveRecording = useMoveRecording();
   const canMoveSelection = view === "library" || view === "space";
   const { data: scopedFolders } = useFolders(
@@ -239,32 +221,6 @@ export function LibraryGrid({
     }
   };
 
-  const openRenameDialog = (rec: RecordingSummary) => {
-    setRenamingRec(rec);
-    setRenameValue(isDefaultTitle(rec.title) ? "" : (rec.title ?? ""));
-    // Focus the input after dialog opens
-    setTimeout(() => renameInputRef.current?.select(), 50);
-  };
-
-  const submitRename = () => {
-    if (!renamingRec) return;
-    const trimmed = renameValue.trim();
-    if (!trimmed) {
-      toast.error(t("libraryGrid.titleRequired"));
-      return;
-    }
-    renameRecording.mutate(
-      { id: renamingRec.id, title: trimmed },
-      {
-        onSuccess: () => {
-          toast.success(t("libraryGrid.clipRenamed"));
-          setRenamingRec(null);
-        },
-        onError: () => toast.error(t("libraryGrid.renameFailed")),
-      },
-    );
-  };
-
   const chips: FilterChip[] = [];
   if (tagFilter) {
     chips.push({
@@ -300,48 +256,6 @@ export function LibraryGrid({
           }}
         />
       )}
-
-      {/* Rename dialog */}
-      <Dialog
-        open={!!renamingRec}
-        onOpenChange={(open) => {
-          if (!open) setRenamingRec(null);
-        }}
-      >
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{t("libraryGrid.renameClip")}</DialogTitle>
-          </DialogHeader>
-          <Input
-            ref={renameInputRef}
-            value={renameValue}
-            onChange={(e) => setRenameValue(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") submitRename();
-            }}
-            placeholder={t("libraryGrid.clipTitle")}
-            className="mt-1"
-            autoFocus
-          />
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setRenamingRec(null)}
-              disabled={renameRecording.isPending}
-            >
-              {t("common.cancel")}
-            </Button>
-            <Button
-              onClick={submitRename}
-              disabled={renameRecording.isPending || !renameValue.trim()}
-            >
-              {renameRecording.isPending
-                ? t("common.saving")
-                : t("common.save")}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
 
       {/* Page header — rendered into the top app bar */}
       <PageHeader>
@@ -389,16 +303,6 @@ export function LibraryGrid({
                   selectionMode={selectionMode}
                   onToggleSelect={toggleSelect}
                   onShare={(rec) => setSharingRec(rec)}
-                  canRenameTitle={
-                    !!currentUserEmail &&
-                    r.ownerEmail.toLowerCase() === currentUserEmail
-                  }
-                  onRename={
-                    currentUserEmail &&
-                    r.ownerEmail.toLowerCase() === currentUserEmail
-                      ? openRenameDialog
-                      : undefined
-                  }
                   moveTargets={moveTargets}
                   onMove={canMoveSelection ? moveSingle : undefined}
                   isMovePending={moveRecording.isPending}

--- a/templates/clips/app/components/library/recording-card.test.ts
+++ b/templates/clips/app/components/library/recording-card.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+function readSource(name: string): string {
+  return readFileSync(new URL(name, import.meta.url), "utf8");
+}
+
+describe("library recording cards", () => {
+  it("do not render inline title editing in the grid card", () => {
+    const source = readSource("./recording-card.tsx");
+
+    expect(source).not.toContain("EditableRecordingTitle");
+    expect(source).not.toContain("canRenameTitle");
+    expect(source).not.toContain("onRename");
+    expect(source).not.toContain("IconEdit");
+    expect(source).toContain("navigate(recordingPath)");
+    expect(source).toContain("select-none text-sm font-medium");
+  });
+
+  it("does not pass rename/edit title wiring from the library grid", () => {
+    const source = readSource("./library-grid.tsx");
+
+    expect(source).not.toContain("useRenameRecording");
+    expect(source).not.toContain("useSession");
+    expect(source).not.toContain("openRenameDialog");
+    expect(source).not.toContain("renameInputRef");
+    expect(source).not.toContain("canRenameTitle");
+    expect(source).not.toContain("onRename");
+  });
+});

--- a/templates/clips/app/components/library/recording-card.tsx
+++ b/templates/clips/app/components/library/recording-card.tsx
@@ -15,6 +15,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@agent-native/toolkit/ui/dropdown-menu";
+import { Skeleton } from "@agent-native/toolkit/ui/skeleton";
 import {
   IconDots,
   IconLock,
@@ -25,14 +26,12 @@ import {
   IconFolder,
   IconArchive,
   IconTrash,
-  IconEdit,
   IconCheck,
   IconAlertTriangle,
 } from "@tabler/icons-react";
 import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 
-import { EditableRecordingTitle } from "@/components/editable-recording-title";
 import { isDefaultTitle } from "@/hooks/use-auto-title";
 import type { RecordingSummary } from "@/hooks/use-library";
 import { isStaleRecordingUpload } from "@/lib/recording-status";
@@ -71,10 +70,8 @@ interface RecordingCardProps {
   onMove?: (rec: RecordingSummary, folderId: string | null) => void;
   moveTargets?: BulkMoveTarget[];
   isMovePending?: boolean;
-  onRename?: (rec: RecordingSummary) => void;
   onArchive?: (rec: RecordingSummary) => void;
   onTrash?: (rec: RecordingSummary) => void;
-  canRenameTitle?: boolean;
 }
 
 export function RecordingCard({
@@ -86,10 +83,8 @@ export function RecordingCard({
   onMove,
   moveTargets = [],
   isMovePending = false,
-  onRename,
   onArchive,
   onTrash,
-  canRenameTitle = false,
 }: RecordingCardProps) {
   const navigate = useNavigate();
   const t = useT();
@@ -126,6 +121,10 @@ export function RecordingCard({
       recording.failureReason ?? "",
     );
   const canMove = Boolean(onMove && moveTargets.length > 0);
+  const hasDefaultTitle = isDefaultTitle(recording.title);
+  const displayTitle = hasDefaultTitle
+    ? t("editableTitle.untitled")
+    : recording.title;
 
   const displayThumbnail = useMemo(() => {
     if (hovered && recording.animatedThumbnailUrl)
@@ -298,20 +297,16 @@ export function RecordingCard({
       <div className="flex-1 p-3 space-y-2">
         <div className="flex items-start gap-2">
           <div className="min-w-0 flex-1">
-            <EditableRecordingTitle
-              recordingId={recording.id}
-              title={recording.title}
-              canEdit={canRenameTitle}
-              displayTitle={
-                isDefaultTitle(recording.title)
-                  ? t("editableTitle.untitled")
-                  : recording.title
-              }
-              showPendingSkeleton={isDefaultTitle(recording.title)}
-              className="text-sm font-medium text-foreground"
-              inputClassName="h-7 text-sm font-medium"
-              skeletonClassName="h-3.5 w-3/4"
-            />
+            {hasDefaultTitle ? (
+              <Skeleton
+                aria-label={t("editableTitle.generatingTitle")}
+                className="h-3.5 w-3/4"
+              />
+            ) : (
+              <div className="min-w-0 truncate select-none text-sm font-medium text-foreground">
+                {displayTitle}
+              </div>
+            )}
             <div className="mt-0.5 flex items-center gap-1.5 text-[11px] text-muted-foreground">
               <PrivacyIcon
                 visibility={recording.visibility}
@@ -376,15 +371,6 @@ export function RecordingCard({
                     ))}
                   </DropdownMenuSubContent>
                 </DropdownMenuSub>
-              ) : null}
-              {onRename ? (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem onSelect={() => onRename(recording)}>
-                    <IconEdit className="h-4 w-4 me-2" />{" "}
-                    {t("folderTree.rename")}
-                  </DropdownMenuItem>
-                </>
               ) : null}
               <DropdownMenuSeparator />
               {recording.archivedAt ? (

--- a/templates/clips/app/components/player/player-controls.tsx
+++ b/templates/clips/app/components/player/player-controls.tsx
@@ -115,7 +115,7 @@ export function PlayerControls(props: PlayerControlsProps) {
         excludedRanges={excludedRanges}
       />
 
-      <div className="flex items-center gap-1.5 text-white">
+      <div className="flex min-w-0 items-center gap-1.5 text-white">
         <IconBtn
           onClick={onPlayPause}
           tooltip={isPlaying ? "Pause (K)" : "Play (K)"}
@@ -128,7 +128,7 @@ export function PlayerControls(props: PlayerControlsProps) {
         </IconBtn>
 
         <div
-          className="relative flex shrink-0 items-center"
+          className="relative hidden shrink-0 items-center sm:flex"
           onMouseEnter={() => setVolumePopoverOpen(true)}
           onMouseLeave={() => setVolumePopoverOpen(false)}
           onFocus={() => setVolumePopoverOpen(true)}
@@ -183,13 +183,15 @@ export function PlayerControls(props: PlayerControlsProps) {
         <div className="flex-1" />
 
         {hasCaptions ? (
-          <IconBtn
-            onClick={onToggleCaptions}
-            active={captionsOn}
-            tooltip="Captions (C)"
-          >
-            <IconSubtitles className="h-5 w-5" />
-          </IconBtn>
+          <div className="hidden sm:block">
+            <IconBtn
+              onClick={onToggleCaptions}
+              active={captionsOn}
+              tooltip="Captions (C)"
+            >
+              <IconSubtitles className="h-5 w-5" />
+            </IconBtn>
+          </div>
         ) : null}
 
         <DropdownMenu>
@@ -226,22 +228,26 @@ export function PlayerControls(props: PlayerControlsProps) {
           </DropdownMenuContent>
         </DropdownMenu>
 
-        <IconBtn
-          onClick={onTogglePip}
-          active={isPip}
-          tooltip="Picture in picture"
-        >
-          <IconPictureInPicture className="h-5 w-5" />
-        </IconBtn>
+        <div className="hidden sm:block">
+          <IconBtn
+            onClick={onTogglePip}
+            active={isPip}
+            tooltip="Picture in picture"
+          >
+            <IconPictureInPicture className="h-5 w-5" />
+          </IconBtn>
+        </div>
 
         {onToggleTheater ? (
-          <IconBtn
-            onClick={onToggleTheater}
-            active={theaterMode}
-            tooltip="Theater mode (T)"
-          >
-            <IconRectangle className="h-5 w-5" />
-          </IconBtn>
+          <div className="hidden sm:block">
+            <IconBtn
+              onClick={onToggleTheater}
+              active={theaterMode}
+              tooltip="Theater mode (T)"
+            >
+              <IconRectangle className="h-5 w-5" />
+            </IconBtn>
+          </div>
         ) : null}
 
         <IconBtn onClick={onToggleFullscreen} tooltip="Fullscreen (F)">

--- a/templates/clips/app/components/player/reactions-tray.tsx
+++ b/templates/clips/app/components/player/reactions-tray.tsx
@@ -45,7 +45,7 @@ export function ReactionsTray({ onReact, disabled }: ReactionsTrayProps) {
               onClick={() => fire(emoji)}
               disabled={disabled}
               className={cn(
-                "flex h-8 w-8 items-center justify-center rounded-full text-lg sm:h-9 sm:w-9 sm:text-xl",
+                "flex h-7 w-7 items-center justify-center rounded-full text-base sm:h-9 sm:w-9 sm:text-xl",
                 disabled && "opacity-50 cursor-not-allowed",
               )}
             >

--- a/templates/clips/app/components/player/video-player.tsx
+++ b/templates/clips/app/components/player/video-player.tsx
@@ -359,6 +359,12 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
     const resolvePlayAttempt = useCallback((attemptId: number) => {
       if (attemptId !== playAttemptIdRef.current) return;
       playAttemptPendingRef.current = false;
+      const v = videoRef.current;
+      if (v && !v.paused && !v.ended) {
+        setIsPlaying(true);
+        setHasPlaybackStarted(true);
+      }
+      setCanPlay(true);
       setIsPlayPending(false);
       setIsBuffering(false);
       setIsPreparing(false);
@@ -410,6 +416,10 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
 
       bumpControls();
       setPlayError(null);
+      if (v.readyState >= 2 || v.currentTime > 0) {
+        setCanPlay(true);
+        setIsPreparing(false);
+      }
       setIsBuffering(v.readyState < 3);
       setIsPlayPending(true);
 
@@ -810,7 +820,10 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
         return;
       }
       setIsPreparing(true);
-      const t = setTimeout(() => setIsPreparing(false), 10000);
+      const t = setTimeout(() => {
+        setIsPreparing(false);
+        setCanPlay(true);
+      }, 10000);
       return () => clearTimeout(t);
     }, [activeVideoSrc]);
 
@@ -958,6 +971,9 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
             onPlay={() => {
               setIsPlaying(true);
               setHasPlaybackStarted(true);
+              setCanPlay(true);
+              setIsPreparing(false);
+              setIsBuffering(false);
               onPlay?.();
             }}
             onPlaying={() => {
@@ -996,6 +1012,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
             }}
             onCanPlayThrough={(e) => {
               setCanPlay(true);
+              setIsPreparing(false);
               setIsBuffering(false);
               retryPendingPlay(e.currentTarget);
             }}
@@ -1010,7 +1027,9 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
               }
             }}
             onSeeked={() => {
+              setCanPlay(true);
               setIsPreparing(false);
+              setIsBuffering(false);
               captureThumbnail();
             }}
             onTimeUpdate={(e) => {
@@ -1030,20 +1049,29 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
               if (visibleMs !== ms) {
                 v.currentTime = visibleMs / 1000;
                 setCurrentMs(visibleMs);
-                if (visibleMs > 0) setHasPlaybackStarted(true);
-                if (visibleMs > 0) setIsPreparing(false);
+                if (visibleMs > 0) {
+                  setCanPlay(true);
+                  setHasPlaybackStarted(true);
+                  setIsPreparing(false);
+                  setIsBuffering(false);
+                }
                 onTimeUpdate?.(visibleMs, resolvedDurationMs);
                 return;
               }
               setCurrentMs(ms);
-              if (ms > 0) setHasPlaybackStarted(true);
-              if (ms > 0) setIsPreparing(false);
+              if (ms > 0) {
+                setCanPlay(true);
+                setHasPlaybackStarted(true);
+                setIsPreparing(false);
+                setIsBuffering(false);
+              }
               onTimeUpdate?.(ms, resolvedDurationMs);
             }}
             onEnded={() => {
               setIsPlaying(false);
               setIsPlayPending(false);
               setIsBuffering(false);
+              setIsPreparing(false);
               onEnded?.();
             }}
             onError={(e) => {

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -20,12 +20,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@agent-native/toolkit/ui/dropdown-menu";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetTitle,
-} from "@agent-native/toolkit/ui/sheet";
 import { Spinner } from "@agent-native/toolkit/ui/spinner";
 import {
   Tabs,
@@ -58,7 +52,6 @@ import {
   IconFileText,
   IconSparkles,
   IconExternalLink,
-  IconMessageDots,
 } from "@tabler/icons-react";
 import { useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -219,7 +212,6 @@ export default function RecordingPage() {
   const playerRef = useRef<VideoPlayerHandle | null>(null);
 
   const [panel, setPanel] = useState<SidePanel>("agent");
-  const [sidePanelOpen, setSidePanelOpen] = useState(false);
   const [theaterMode, setTheaterMode] = useState(false);
   const [editing, setEditing] = useState(false);
   const [currentMs, setCurrentMs] = useState(0);
@@ -266,8 +258,11 @@ export default function RecordingPage() {
       panelParam === "settings"
     ) {
       setPanel(panelParam);
-      if (isCompactLayout) setSidePanelOpen(true);
     }
+  }, [panelParam]);
+
+  useEffect(() => {
+    if (!panelParam && isCompactLayout) setPanel("comments");
   }, [isCompactLayout, panelParam]);
 
   const playerDataQ = useActionQuery<any>(
@@ -539,10 +534,6 @@ export default function RecordingPage() {
   }, [canUseNativeEditor, editing]);
 
   useEffect(() => {
-    if (editing || !isCompactLayout) setSidePanelOpen(false);
-  }, [editing, isCompactLayout]);
-
-  useEffect(() => {
     if (!recording) return;
     document.title = isDefaultTitle(recording.title)
       ? t("recordingPage.pageTitle")
@@ -778,167 +769,178 @@ export default function RecordingPage() {
     );
   }
 
-  const renderSidePanel = (compact = false) => (
-    <Tabs
-      value={panel}
-      onValueChange={(v) => setPanel(v as SidePanel)}
-      className={cn("flex h-full flex-col", compact && "pt-8")}
-    >
-      <TabsList
-        className={cn(
-          "mx-3 mt-3 grid w-auto",
-          canEdit ? "grid-cols-5" : "grid-cols-4",
-        )}
-      >
-        <TabsTrigger value="agent" className="min-w-0 px-2 text-xs">
-          {t("recordingPage.agent")}
-        </TabsTrigger>
-        <TabsTrigger value="comments" className="min-w-0 px-2 text-xs">
-          {t("recordingPage.activity")}
-        </TabsTrigger>
-        <TabsTrigger value="transcript" className="min-w-0 px-2 text-xs">
-          {t("recordingPage.transcript")}
-        </TabsTrigger>
-        <TabsTrigger value="insights" className="min-w-0 px-2 text-xs">
-          {t("recordingPage.insights")}
-        </TabsTrigger>
-        {canEdit ? (
-          <TabsTrigger value="settings" className="min-w-0 px-2 text-xs">
-            {t("recordingPage.settings")}
-          </TabsTrigger>
-        ) : null}
-      </TabsList>
+  const renderSidePanel = (variant: "desktop" | "inline" = "desktop") => {
+    const compact = variant === "inline";
+    const tabTriggerClass = "min-w-0 px-2 text-xs";
+    const trigger = (value: SidePanel, label: string) => (
+      <TabsTrigger key={value} value={value} className={tabTriggerClass}>
+        {label}
+      </TabsTrigger>
+    );
+    const triggers = compact
+      ? [
+          trigger("comments", t("recordingPage.activity")),
+          trigger("transcript", t("recordingPage.transcript")),
+          trigger("agent", t("recordingPage.agent")),
+          trigger("insights", t("recordingPage.insights")),
+          canEdit ? trigger("settings", t("recordingPage.settings")) : null,
+        ]
+      : [
+          trigger("agent", t("recordingPage.agent")),
+          trigger("comments", t("recordingPage.activity")),
+          trigger("transcript", t("recordingPage.transcript")),
+          trigger("insights", t("recordingPage.insights")),
+          canEdit ? trigger("settings", t("recordingPage.settings")) : null,
+        ];
 
-      <TabsContent
-        value="agent"
-        className="mt-0 flex flex-1 min-h-0 flex-col data-[state=inactive]:hidden"
+    return (
+      <Tabs
+        value={panel}
+        onValueChange={(v) => setPanel(v as SidePanel)}
+        className="flex h-full flex-col"
       >
-        <AgentPanel
-          browserTabId={browserTabId}
-          scope={recordingScope}
-          emptyStateText={t("recordingPage.askAboutClip")}
-          dynamicSuggestions={false}
-          chatNotice={
-            generatedWorkflow ? (
-              <GeneratedWorkflowNotice workflow={generatedWorkflow} />
-            ) : null
-          }
-          suggestions={
-            canEdit
-              ? [
-                  t("recordingPage.summarizeClip"),
-                  t("recordingPage.generateChapters"),
-                  t("recordingPage.findActionItems"),
-                  t("recordingPage.draftRecap"),
-                ]
-              : [
-                  t("recordingPage.summarizeClip"),
-                  t("recordingPage.findKeyMoments"),
-                  t("recordingPage.listFollowUpActions"),
-                  t("recordingPage.draftQuestions"),
-                ]
-          }
-        />
-      </TabsContent>
-      <TabsContent
-        value="transcript"
-        className="flex-1 min-h-0 mt-3 data-[state=inactive]:hidden"
-      >
-        <TranscriptPanel
-          segments={transcriptSegments}
-          fullText={transcriptFullText}
-          durationMs={recording.durationMs}
-          currentMs={currentMs}
-          onSeek={(ms) => playerRef.current?.seek(ms)}
-          status={transcriptStatus}
-          failureReason={transcriptFailureReason}
-          cleanup={transcriptCleanup}
-          recordingTitle={recording.title}
-          onRetry={() => {
-            // Force a fresh transcript job, then let polling swap the panel
-            // back to the pending state while it runs.
-            fetch(
-              agentNativePath("/_agent-native/actions/request-transcript"),
-              {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                  recordingId: recording.id,
-                  force: true,
-                }),
-              },
-            )
-              .then((res) => {
-                if (!res.ok) throw new Error(`HTTP ${res.status}`);
-              })
-              .catch((err) =>
-                toast.error(
-                  t("recordingPage.retryFailed", {
-                    message: err?.message ?? t("recordingPage.networkError"),
-                  }),
-                ),
-              )
-              .finally(() => playerDataQ.refetch());
-          }}
-        />
-      </TabsContent>
-      <TabsContent
-        value="comments"
-        className="flex-1 min-h-0 mt-3 data-[state=inactive]:hidden"
-      >
-        <CommentsPanel
-          recordingId={recording.id}
-          comments={comments}
-          currentMs={currentMs}
-          currentUserEmail={session?.email}
-          enableComments={recording.enableComments}
-          onSeek={(ms) => playerRef.current?.seek(ms)}
-          queryKey={[
-            "action",
-            "get-recording-player-data",
-            { recordingId: recordingId ?? "" },
-          ]}
-        />
-      </TabsContent>
-      <TabsContent
-        value="insights"
-        className="flex-1 min-h-0 mt-3 overflow-y-auto data-[state=inactive]:hidden"
-      >
-        {canEdit ? (
-          <InsightsPanel
-            recordingId={recording.id}
-            durationMs={recording.durationMs}
-          />
-        ) : (
-          <InsightsUnavailableState />
-        )}
-      </TabsContent>
-      {canEdit ? (
-        <TabsContent
-          value="settings"
-          className="mt-3 flex flex-1 min-h-0 flex-col data-[state=inactive]:hidden"
+        <TabsList
+          className={cn(
+            "mx-3 mt-3 grid w-auto",
+            canEdit ? "grid-cols-5" : "grid-cols-4",
+          )}
         >
-          <SettingsPanel
-            recording={recording}
-            visibility={recording.visibility}
-            ctas={ctas}
-            onClose={() => setPanel("agent")}
-            onRefetch={() => playerDataQ.refetch()}
-            showHeader={false}
+          {triggers}
+        </TabsList>
+
+        <TabsContent
+          value="agent"
+          className="mt-0 flex flex-1 min-h-0 flex-col data-[state=inactive]:hidden"
+        >
+          <AgentPanel
+            browserTabId={browserTabId}
+            scope={recordingScope}
+            emptyStateText={t("recordingPage.askAboutClip")}
+            dynamicSuggestions={false}
+            chatNotice={
+              generatedWorkflow ? (
+                <GeneratedWorkflowNotice workflow={generatedWorkflow} />
+              ) : null
+            }
+            suggestions={
+              canEdit
+                ? [
+                    t("recordingPage.summarizeClip"),
+                    t("recordingPage.generateChapters"),
+                    t("recordingPage.findActionItems"),
+                    t("recordingPage.draftRecap"),
+                  ]
+                : [
+                    t("recordingPage.summarizeClip"),
+                    t("recordingPage.findKeyMoments"),
+                    t("recordingPage.listFollowUpActions"),
+                    t("recordingPage.draftQuestions"),
+                  ]
+            }
           />
         </TabsContent>
-      ) : null}
-    </Tabs>
-  );
+        <TabsContent
+          value="transcript"
+          className="flex-1 min-h-0 mt-3 data-[state=inactive]:hidden"
+        >
+          <TranscriptPanel
+            segments={transcriptSegments}
+            fullText={transcriptFullText}
+            durationMs={recording.durationMs}
+            currentMs={currentMs}
+            onSeek={(ms) => playerRef.current?.seek(ms)}
+            status={transcriptStatus}
+            failureReason={transcriptFailureReason}
+            cleanup={transcriptCleanup}
+            recordingTitle={recording.title}
+            onRetry={() => {
+              // Force a fresh transcript job, then let polling swap the panel
+              // back to the pending state while it runs.
+              fetch(
+                agentNativePath("/_agent-native/actions/request-transcript"),
+                {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({
+                    recordingId: recording.id,
+                    force: true,
+                  }),
+                },
+              )
+                .then((res) => {
+                  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                })
+                .catch((err) =>
+                  toast.error(
+                    t("recordingPage.retryFailed", {
+                      message: err?.message ?? t("recordingPage.networkError"),
+                    }),
+                  ),
+                )
+                .finally(() => playerDataQ.refetch());
+            }}
+          />
+        </TabsContent>
+        <TabsContent
+          value="comments"
+          className="flex-1 min-h-0 mt-3 data-[state=inactive]:hidden"
+        >
+          <CommentsPanel
+            recordingId={recording.id}
+            comments={comments}
+            currentMs={currentMs}
+            currentUserEmail={session?.email}
+            enableComments={recording.enableComments}
+            onSeek={(ms) => playerRef.current?.seek(ms)}
+            queryKey={[
+              "action",
+              "get-recording-player-data",
+              { recordingId: recordingId ?? "" },
+            ]}
+            presentation={compact ? "share" : "default"}
+          />
+        </TabsContent>
+        <TabsContent
+          value="insights"
+          className="flex-1 min-h-0 mt-3 overflow-y-auto data-[state=inactive]:hidden"
+        >
+          {canEdit ? (
+            <InsightsPanel
+              recordingId={recording.id}
+              durationMs={recording.durationMs}
+            />
+          ) : (
+            <InsightsUnavailableState />
+          )}
+        </TabsContent>
+        {canEdit ? (
+          <TabsContent
+            value="settings"
+            className="mt-3 flex flex-1 min-h-0 flex-col data-[state=inactive]:hidden"
+          >
+            <SettingsPanel
+              recording={recording}
+              visibility={recording.visibility}
+              ctas={ctas}
+              onClose={() => setPanel("agent")}
+              onRefetch={() => playerDataQ.refetch()}
+              showHeader={false}
+            />
+          </TabsContent>
+        ) : null}
+      </Tabs>
+    );
+  };
 
   return (
-    <div className="flex min-h-screen w-full bg-background xl:h-screen xl:overflow-hidden">
+    <div className="flex min-h-screen w-full max-w-full flex-col overflow-x-hidden bg-background xl:h-screen xl:flex-row xl:overflow-hidden">
       {/* Main video column */}
       <div className="flex w-full min-w-0 flex-col xl:flex-1">
-        <header className="flex items-center gap-3 px-4 py-3 border-b border-border shrink-0">
+        <header className="flex min-w-0 shrink-0 items-center gap-2 border-b border-border px-3 py-2 sm:gap-3 sm:px-4 sm:py-3">
           <Button
             variant="ghost"
             size="icon"
+            className="shrink-0"
             onClick={() => navigate("/")}
             aria-label={t("recordingPage.back")}
           >
@@ -970,7 +972,7 @@ export default function RecordingPage() {
             <Button
               variant={editing ? "secondary" : "outline"}
               size="sm"
-              className="gap-1.5"
+              className={cn("gap-1.5", !editing && "hidden sm:inline-flex")}
               onClick={() => setEditing((v) => !v)}
             >
               <IconScissors className="h-4 w-4" />
@@ -981,7 +983,11 @@ export default function RecordingPage() {
           {canEdit ? (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="outline" size="sm" className="gap-1.5">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="hidden gap-1.5 sm:inline-flex"
+                >
                   {t("recordingPage.aiTools")}
                   <IconChevronDown className="h-4 w-4" />
                 </Button>
@@ -1084,22 +1090,6 @@ export default function RecordingPage() {
             </DropdownMenu>
           ) : null}
 
-          {!editing ? (
-            <Button
-              variant="outline"
-              size="sm"
-              className="gap-1.5 xl:hidden"
-              onClick={() => {
-                setPanel("agent");
-                setSidePanelOpen(true);
-              }}
-              aria-label={t("recordingPage.askAboutClip")}
-            >
-              <IconMessageDots className="h-4 w-4" />
-              <span>{t("recordingPage.agent")}</span>
-            </Button>
-          ) : null}
-
           <ShareRecordingPopover
             recordingId={recording.id}
             recordingTitle={recording.title}
@@ -1109,7 +1099,7 @@ export default function RecordingPage() {
             hasPassword={Boolean(recording.hasPassword)}
           >
             <Button
-              className="bg-primary hover:bg-primary/90 text-primary-foreground gap-1.5"
+              className="shrink-0 gap-1.5 bg-primary text-primary-foreground hover:bg-primary/90"
               size="sm"
             >
               <IconShare3 className="h-4 w-4" />
@@ -1136,7 +1126,7 @@ export default function RecordingPage() {
             "flex flex-col",
             editing && canUseNativeEditor
               ? "min-h-0 flex-1 overflow-hidden"
-              : "gap-4 p-4 xl:min-h-0 xl:flex-1 xl:overflow-hidden",
+              : "gap-0 sm:gap-4 sm:p-4 xl:min-h-0 xl:flex-1 xl:overflow-hidden",
           )}
         >
           {editing && canUseNativeEditor ? (
@@ -1166,7 +1156,7 @@ export default function RecordingPage() {
                   cta={firstCta}
                   onCtaClick={() => tracking.reportCtaClick()}
                   onTimeUpdate={(ms) => setCurrentMs(ms)}
-                  className="h-full w-full"
+                  className="h-full w-full rounded-none sm:rounded-xl"
                 />
                 {commentOpen ? (
                   <TimestampedCommentBar
@@ -1175,7 +1165,6 @@ export default function RecordingPage() {
                     onClose={() => setCommentOpen(false)}
                     onAdded={() => {
                       setPanel("comments");
-                      if (isCompactLayout) setSidePanelOpen(true);
                       void playerDataQ.refetch();
                     }}
                   />
@@ -1183,8 +1172,26 @@ export default function RecordingPage() {
               </div>
 
               {/* Title + reactions row */}
-              <div className="flex items-start gap-3 shrink-0">
-                <div className="flex-1 min-w-0">
+              <div className="flex shrink-0 flex-col gap-3 px-4 py-4 sm:flex-row sm:items-start sm:px-0 sm:py-0">
+                <div className="min-w-0 flex-1">
+                  <div className="mb-3 sm:hidden">
+                    <EditableRecordingTitle
+                      recordingId={recording.id}
+                      title={recording.title}
+                      canEdit={canEdit}
+                      displayTitle={visibleTitle}
+                      showPendingSkeleton={showTitleSkeleton}
+                      className="text-2xl font-semibold leading-tight"
+                      inputClassName="h-9 text-2xl font-semibold"
+                      skeletonClassName="h-7 w-72 max-w-full"
+                    />
+                    <p className="mt-1 truncate text-sm text-muted-foreground">
+                      {recording.ownerEmail}
+                      {recording.visibility !== "private" ? (
+                        <> · {capitalize(recording.visibility)}</>
+                      ) : null}
+                    </p>
+                  </div>
                   {/* G9 — "From meeting" badge surfaced when this recording is
                       attached to a meeting (server fix 6 attaches `meeting`). */}
                   {playerDataQ.data?.meeting ? (
@@ -1202,44 +1209,56 @@ export default function RecordingPage() {
                       </span>
                     </NavLink>
                   ) : null}
-                  <TimestampedCommentButton
-                    enableComments={recording.enableComments}
-                    onOpen={() => {
-                      setCommentAtMs(resolvePlaybackMs());
-                      setCommentOpen(true);
-                    }}
-                  />
+                  <div className="flex flex-wrap items-center gap-2">
+                    <TimestampedCommentButton
+                      enableComments={recording.enableComments}
+                      className="shrink-0"
+                      onOpen={() => {
+                        if (isCompactLayout) {
+                          setPanel("comments");
+                          requestAnimationFrame(() => {
+                            document
+                              .getElementById("clip-activity-panel")
+                              ?.scrollIntoView({ block: "start" });
+                          });
+                          return;
+                        }
+                        setCommentAtMs(resolvePlaybackMs());
+                        setCommentOpen(true);
+                      }}
+                    />
+                    {recording.enableReactions ? (
+                      <ReactionsTray
+                        disabled={!recording.enableReactions}
+                        onReact={(emoji) => {
+                          tracking.reportReaction(emoji);
+                          const liveMs = resolvePlaybackMs();
+                          fetch(
+                            agentNativePath(
+                              "/_agent-native/actions/react-to-recording",
+                            ),
+                            {
+                              method: "POST",
+                              headers: { "Content-Type": "application/json" },
+                              body: JSON.stringify({
+                                recordingId: recording.id,
+                                emoji,
+                                videoTimestampMs: liveMs,
+                              }),
+                            },
+                          )
+                            .then(() => playerDataQ.refetch())
+                            .catch(() => {});
+                        }}
+                      />
+                    ) : null}
+                  </div>
                   {recording.description ? (
-                    <p className="text-sm text-muted-foreground line-clamp-2">
+                    <p className="mt-3 line-clamp-2 text-sm text-muted-foreground">
                       {recording.description}
                     </p>
                   ) : null}
                 </div>
-                {recording.enableReactions ? (
-                  <ReactionsTray
-                    disabled={!recording.enableReactions}
-                    onReact={(emoji) => {
-                      tracking.reportReaction(emoji);
-                      const liveMs = resolvePlaybackMs();
-                      fetch(
-                        agentNativePath(
-                          "/_agent-native/actions/react-to-recording",
-                        ),
-                        {
-                          method: "POST",
-                          headers: { "Content-Type": "application/json" },
-                          body: JSON.stringify({
-                            recordingId: recording.id,
-                            emoji,
-                            videoTimestampMs: liveMs,
-                          }),
-                        },
-                      )
-                        .then(() => playerDataQ.refetch())
-                        .catch(() => {});
-                    }}
-                  />
-                ) : null}
               </div>
             </>
           )}
@@ -1250,20 +1269,12 @@ export default function RecordingPage() {
       {!editing ? (
         <>
           {isCompactLayout ? (
-            <Sheet open={sidePanelOpen} onOpenChange={setSidePanelOpen}>
-              <SheetContent
-                side="right"
-                className="flex h-full w-[calc(100vw-24px)] max-w-[420px] flex-col gap-0 p-0 sm:max-w-[420px]"
-              >
-                <SheetTitle className="sr-only">
-                  {t("recordingPage.details")}
-                </SheetTitle>
-                <SheetDescription className="sr-only">
-                  {t("recordingPage.askAboutClip")}
-                </SheetDescription>
-                {renderSidePanel(true)}
-              </SheetContent>
-            </Sheet>
+            <aside
+              id="clip-activity-panel"
+              className="flex min-h-[420px] w-full min-w-0 flex-col border-t border-border bg-background xl:hidden"
+            >
+              {renderSidePanel("inline")}
+            </aside>
           ) : null}
           {!isCompactLayout ? (
             <aside className="hidden w-[380px] shrink-0 flex-col border-s border-border bg-background xl:flex">

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -792,10 +792,10 @@ export default function ShareRoute() {
   );
 
   return (
-    <div className="flex min-h-screen flex-col bg-background text-foreground lg:h-screen lg:flex-row lg:overflow-hidden">
+    <div className="flex min-h-screen max-w-full flex-col overflow-x-hidden bg-background text-foreground lg:h-screen lg:flex-row lg:overflow-hidden">
       {agentDiscovery}
       <div className="flex w-full min-w-0 flex-col lg:flex-1">
-        <header className="flex shrink-0 flex-wrap items-center gap-3 border-b border-border px-4 py-3 lg:flex-nowrap">
+        <header className="flex min-w-0 shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 sm:gap-3 sm:px-4 sm:py-3 lg:flex-nowrap">
           {session ? (
             <Button
               variant="ghost"
@@ -817,7 +817,7 @@ export default function ShareRoute() {
             )}
           </div>
 
-          <div className="flex w-full min-w-0 items-center justify-between gap-2 sm:w-auto sm:justify-end">
+          <div className="flex w-full min-w-0 flex-wrap items-center justify-between gap-2 sm:w-auto sm:justify-end">
             {viewerCanEdit ? (
               <Button variant="outline" size="sm" asChild>
                 <a
@@ -901,7 +901,7 @@ export default function ShareRoute() {
           </div>
         </header>
 
-        <div className="flex flex-col gap-4 overflow-visible p-4 lg:min-h-0 lg:flex-1 lg:overflow-hidden">
+        <div className="flex flex-col gap-4 overflow-hidden p-0 sm:p-4 lg:min-h-0 lg:flex-1">
           <div className="aspect-video w-full lg:min-h-0 lg:flex-1 lg:aspect-auto">
             <VideoPlayer
               ref={playerRef}
@@ -920,11 +920,11 @@ export default function ShareRoute() {
               cta={firstCta}
               onCtaClick={() => tracking.reportCtaClick()}
               onTimeUpdate={(ms) => setCurrentMs(ms)}
-              className="h-full w-full"
+              className="h-full w-full rounded-none sm:rounded-xl"
             />
           </div>
 
-          <div className="flex shrink-0 flex-col gap-3 sm:flex-row sm:items-start">
+          <div className="flex shrink-0 flex-col gap-3 px-4 pb-4 sm:flex-row sm:items-start sm:px-0 sm:pb-0">
             <div className="min-w-0 flex-1">
               {showTitleSkeleton ? (
                 <Skeleton
@@ -999,14 +999,11 @@ export default function ShareRoute() {
         </div>
       </div>
 
-      <aside className="flex min-h-[420px] w-full shrink-0 flex-col border-t border-border bg-background lg:min-h-0 lg:w-[380px] lg:border-s lg:border-t-0">
-        <Tabs defaultValue="agent" className="flex h-full flex-col">
+      <aside className="flex min-h-[420px] w-full min-w-0 shrink-0 flex-col border-t border-border bg-background lg:min-h-0 lg:w-[380px] lg:border-s lg:border-t-0">
+        <Tabs defaultValue="comments" className="flex h-full flex-col">
           <TabsList className="mx-3 mt-3 grid w-auto grid-cols-4">
-            <TabsTrigger value="agent" className="text-xs">
-              {t("sharePage.agent")}
-            </TabsTrigger>
             <TabsTrigger value="comments" className="text-xs gap-1">
-              {t("sharePage.comments")}
+              {t("recordingPage.activity")}
               {comments.length > 0 ? (
                 <span className="ms-0.5 rounded-full bg-accent px-1.5 text-[10px] tabular-nums">
                   {comments.length}
@@ -1015,6 +1012,9 @@ export default function ShareRoute() {
             </TabsTrigger>
             <TabsTrigger value="transcript" className="text-xs">
               {t("sharePage.transcript")}
+            </TabsTrigger>
+            <TabsTrigger value="agent" className="text-xs">
+              {t("sharePage.agent")}
             </TabsTrigger>
             <TabsTrigger value="insights" className="text-xs">
               {t("sharePage.insights")}
@@ -1070,7 +1070,12 @@ export default function ShareRoute() {
               enableComments={recording.enableComments}
               onSeek={(ms) => playerRef.current?.seek(ms)}
               onUnauthenticated={requireSignIn}
-              queryKey={["public-recording", shareId, password]}
+              queryKey={[
+                "public-recording",
+                shareId,
+                password,
+                agentAccessToken,
+              ]}
               selectComments={(d: any) => d?.data?.comments}
               applyComments={(d: any, next) =>
                 d ? { ...d, data: { ...(d.data ?? {}), comments: next } } : d

--- a/templates/clips/changelog/2026-07-05-mobile-clip-pages-use-a-tighter-viewer-layout-with-inline-ac.md
+++ b/templates/clips/changelog/2026-07-05-mobile-clip-pages-use-a-tighter-viewer-layout-with-inline-ac.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-05
+---
+
+Mobile clip pages use a tighter viewer layout with inline activity and a reliable preparing overlay.

--- a/templates/clips/changelog/2026-07-06-clip-titles-in-the-library-grid-now-open-the-clip-instead-of.md
+++ b/templates/clips/changelog/2026-07-06-clip-titles-in-the-library-grid-now-open-the-clip-instead-of.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-06
+---
+
+Clip titles in the library grid now open the clip instead of entering rename mode.

--- a/templates/plan/app/global.css
+++ b/templates/plan/app/global.css
@@ -110,10 +110,22 @@
 }
 
 @layer base {
+  html:not([data-embed="1"]),
+  html:not([data-embed="1"]) body {
+    height: 100%;
+    overflow: hidden;
+  }
+
   body {
     @apply bg-background text-foreground;
     font-family: "Inter Variable", "Inter", sans-serif;
     font-feature-settings: "cv02", "cv03", "cv04", "cv11";
+  }
+}
+
+@supports (height: 100dvh) {
+  html:not([data-embed="1"]) .agent-layout-shell {
+    height: 100dvh;
   }
 }
 

--- a/templates/plan/app/pages/PlansPage.comments.test.ts
+++ b/templates/plan/app/pages/PlansPage.comments.test.ts
@@ -2,7 +2,7 @@
 
 import { SOURCE_AUTHOR_COMMENT_MENTION_EMAIL } from "@shared/comment-context";
 import type { PlanBundle } from "@shared/types";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { planBundleQueryKey } from "@/hooks/use-plans";
 
@@ -31,6 +31,7 @@ import {
   shouldKeepCommentPopoverOpenForTarget,
   shouldHandlePlanCommentShortcut,
   resolvePlanOrgAccessPrompt,
+  resetPlanReaderScrollPosition,
 } from "./PlansPage";
 
 type PlanComment = PlanBundle["comments"][number];
@@ -105,6 +106,52 @@ function rect(left: number, top: number, width: number, height: number) {
 }
 
 describe("plan comment thread UI model", () => {
+  it("resets the plan reader and window scroll to the top", () => {
+    const windowScrollTo = vi.fn();
+    const originalWindowScrollTo = window.scrollTo;
+    Object.defineProperty(window, "scrollTo", {
+      value: windowScrollTo,
+      configurable: true,
+    });
+
+    const reader = document.createElement("div");
+    const readerScrollTo = vi.fn(
+      (options?: ScrollToOptions | number, y?: number) => {
+        if (typeof options === "number") {
+          reader.scrollLeft = options;
+          reader.scrollTop = y ?? 0;
+          return;
+        }
+        reader.scrollLeft = options?.left ?? reader.scrollLeft;
+        reader.scrollTop = options?.top ?? reader.scrollTop;
+      },
+    );
+    Object.defineProperty(reader, "scrollTo", {
+      value: readerScrollTo,
+      configurable: true,
+    });
+    reader.scrollLeft = 40;
+    reader.scrollTop = 320;
+
+    try {
+      resetPlanReaderScrollPosition(reader);
+    } finally {
+      Object.defineProperty(window, "scrollTo", {
+        value: originalWindowScrollTo,
+        configurable: true,
+      });
+    }
+
+    expect(readerScrollTo).toHaveBeenCalledWith({
+      left: 0,
+      top: 0,
+      behavior: "auto",
+    });
+    expect(reader.scrollLeft).toBe(0);
+    expect(reader.scrollTop).toBe(0);
+    expect(windowScrollTo).toHaveBeenCalledWith(0, 0);
+  });
+
   it("uses the exact get-visual-plan query key for optimistic bundle updates", () => {
     expect(planBundleQueryKey("plan_1")).toEqual([
       "action",

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -196,6 +196,7 @@ import { useTheme } from "next-themes";
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -261,6 +262,9 @@ import { planDocumentTitle } from "@/lib/plan-document-title";
 import { cn } from "@/lib/utils";
 
 import { parsePlanMdxFolder } from "../../server/plan-mdx";
+
+const useBrowserLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 function GoogleLogoIcon({ className }: { className?: string }) {
   return (
@@ -462,6 +466,17 @@ type PlanDocumentState = {
   clientWidth: number;
   clientHeight: number;
 };
+
+export function resetPlanReaderScrollPosition(reader: HTMLElement | null) {
+  if (reader) {
+    reader.scrollTo({ left: 0, top: 0, behavior: "auto" });
+    reader.scrollLeft = 0;
+    reader.scrollTop = 0;
+  }
+  if (typeof window !== "undefined") {
+    window.scrollTo(0, 0);
+  }
+}
 
 function shortDate(value: string) {
   return new Intl.DateTimeFormat(undefined, {
@@ -3067,6 +3082,7 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
   const pendingDocumentRestoreRef = useRef<PlanDocumentState | null>(null);
   const pendingDocumentRestoreTimerRef = useRef<number | null>(null);
   const nativeScrollFrameRef = useRef<number | null>(null);
+  const initialReaderScrollResetKeyRef = useRef<string | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [annotationsOpen, setAnnotationsOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
@@ -4241,6 +4257,47 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
   }, [clearPendingDocumentRestore, postRuntimeState]);
 
   useEffect(() => clearPendingDocumentRestore, [clearPendingDocumentRestore]);
+
+  useBrowserLayoutEffect(() => {
+    if (!selectedId || !bundle?.plan.content || location.hash) return;
+    const resetKey = `${bundle.plan.kind}:${selectedId}`;
+    if (initialReaderScrollResetKeyRef.current === resetKey) return;
+    initialReaderScrollResetKeyRef.current = resetKey;
+    clearPendingDocumentRestore();
+    documentStateRef.current = null;
+
+    const reset = () => resetPlanReaderScrollPosition(nativeReaderRef.current);
+    const frameIds: number[] = [];
+    const timeoutIds: number[] = [];
+    const scheduleFrame = () => {
+      frameIds.push(window.requestAnimationFrame(reset));
+    };
+    const scheduleTimeout = (delay: number) => {
+      timeoutIds.push(
+        window.setTimeout(() => {
+          reset();
+          scheduleFrame();
+        }, delay),
+      );
+    };
+
+    reset();
+    scheduleFrame();
+    scheduleTimeout(0);
+    scheduleTimeout(120);
+    scheduleTimeout(500);
+
+    return () => {
+      frameIds.forEach((id) => window.cancelAnimationFrame(id));
+      timeoutIds.forEach((id) => window.clearTimeout(id));
+    };
+  }, [
+    bundle?.plan.content,
+    bundle?.plan.kind,
+    clearPendingDocumentRestore,
+    location.hash,
+    selectedId,
+  ]);
 
   useEffect(() => {
     const frame = requestAnimationFrame(() => postRuntimeState());

--- a/templates/plan/changelog/2026-07-05-plan-pages-open-at-the-top-unless-a-shared-link-targets-a-sp.md
+++ b/templates/plan/changelog/2026-07-05-plan-pages-open-at-the-top-unless-a-shared-link-targets-a-sp.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-05
+---
+
+Plan pages open at the top unless a shared link targets a specific section.


### PR DESCRIPTION
## Summary
- Tighten Clips mobile clip viewing with a cleaner compact header, flush video, inline Activity/comment composer, and overflow-safe player/reaction controls.
- Make the video "Preparing clip" overlay clear from real playback readiness and the safety timeout instead of sticking behind stale `canPlay` state.
- Include the branch's Clips library-card title behavior and Plan comments/scroll reset UI updates, with pending changelog entries for Clips and Plan.

## Validation
- `templates/clips/node_modules/.bin/oxfmt --write templates/clips/app/routes/r.$recordingId.tsx templates/clips/app/routes/share.$shareId.tsx templates/clips/app/components/player/video-player.tsx templates/clips/app/components/player/reactions-tray.tsx templates/clips/app/components/player/player-controls.tsx`
- `corepack pnpm --filter clips typecheck`
- `corepack pnpm --filter clips test`
- `corepack pnpm --filter plan typecheck`
- `corepack pnpm --filter plan exec vitest run app/pages/PlansPage.comments.test.ts`
- `corepack pnpm --filter clips exec vitest run app/components/library/recording-card.test.ts app/components/player/scrubber-position.test.ts`
- Local browser check on SQLite sample `/share/GvDutFLAec98` at 390px: no horizontal overflow, Activity selected, comment composer present, and "Preparing clip" not visible after load.
