### PR TITLE
Add read-only banner for viewers in design editor

### DIFF
--- a/templates/design/app/components/design/ReadOnlyDesignBanner.tsx
+++ b/templates/design/app/components/design/ReadOnlyDesignBanner.tsx
@@ -9,7 +9,7 @@ import { IconInfoCircle } from "@tabler/icons-react";
 export function ReadOnlyDesignBanner() {
   return (
     <div className="pointer-events-none absolute inset-x-0 bottom-0 z-30 flex items-center justify-center px-3 pb-2">
-      <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1.5 text-xs text-blue-600 shadow-sm backdrop-blur-sm dark:text-blue-400">
+      <div className="flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1.5 text-xs text-blue-600 shadow-sm backdrop-blur-sm dark:text-blue-400">
         <IconInfoCircle className="size-3.5 shrink-0" />
         <span className="truncate">
           {

--- a/templates/design/app/components/design/ReadOnlyDesignBanner.tsx
+++ b/templates/design/app/components/design/ReadOnlyDesignBanner.tsx
@@ -1,0 +1,22 @@
+import { IconLock } from "@tabler/icons-react";
+
+/**
+ * Slim, non-blocking banner shown above the canvas when the current user only
+ * has viewer access to the design (Figma-style "you can't edit this" notice).
+ * Purely informational — editing affordances are already disabled elsewhere
+ * via `canEditDesign`; this just tells the viewer why.
+ */
+export function ReadOnlyDesignBanner() {
+  return (
+    <div className="pointer-events-none absolute inset-x-0 top-0 z-30 flex items-center justify-center px-3 pt-2">
+      <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-border/60 bg-background/95 px-3 py-1.5 text-xs text-muted-foreground shadow-sm backdrop-blur-sm">
+        <IconLock className="size-3.5 shrink-0" />
+        <span className="truncate">
+          {
+            "You don't have access to edit this design" /* i18n-ignore Figma-style read-only notice */
+          }
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/templates/design/app/components/design/ReadOnlyDesignBanner.tsx
+++ b/templates/design/app/components/design/ReadOnlyDesignBanner.tsx
@@ -1,16 +1,16 @@
-import { IconLock } from "@tabler/icons-react";
+import { IconInfoCircle } from "@tabler/icons-react";
 
 /**
- * Slim, non-blocking banner shown above the canvas when the current user only
+ * Slim, non-blocking banner shown below the canvas when the current user only
  * has viewer access to the design (Figma-style "you can't edit this" notice).
  * Purely informational — editing affordances are already disabled elsewhere
  * via `canEditDesign`; this just tells the viewer why.
  */
 export function ReadOnlyDesignBanner() {
   return (
-    <div className="pointer-events-none absolute inset-x-0 top-0 z-30 flex items-center justify-center px-3 pt-2">
-      <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-border/60 bg-background/95 px-3 py-1.5 text-xs text-muted-foreground shadow-sm backdrop-blur-sm">
-        <IconLock className="size-3.5 shrink-0" />
+    <div className="pointer-events-none absolute inset-x-0 bottom-0 z-30 flex items-center justify-center px-3 pb-2">
+      <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1.5 text-xs text-blue-600 shadow-sm backdrop-blur-sm dark:text-blue-400">
+        <IconInfoCircle className="size-3.5 shrink-0" />
         <span className="truncate">
           {
             "You don't have access to edit this design" /* i18n-ignore Figma-style read-only notice */

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -246,6 +246,7 @@ import {
   type StyleChangeMeta,
 } from "@/components/design/EditPanel";
 import { FusionAppBanner } from "@/components/design/FusionAppBanner";
+import { ReadOnlyDesignBanner } from "@/components/design/ReadOnlyDesignBanner";
 import type { ExportSettingsValue } from "@/components/design/inspector";
 import { InspectorAiActions } from "@/components/design/inspector/InspectorAiActions";
 import {
@@ -22024,6 +22025,10 @@ ${serializedHtml}
                       }}
                     />
                   )}
+                  {/* Figma-style notice for viewers who can't edit this
+                      design. Only shown once accessRole has actually
+                      resolved to "viewer" to avoid flashing during load. */}
+                  {designAccessRole === "viewer" && <ReadOnlyDesignBanner />}
                   {/* Full-app building status/controls. Renders only for
                       designs backed by a fusion app (see readFusionApp) and
                       only while the flag is on — the fusion actions the

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -246,7 +246,6 @@ import {
   type StyleChangeMeta,
 } from "@/components/design/EditPanel";
 import { FusionAppBanner } from "@/components/design/FusionAppBanner";
-import { ReadOnlyDesignBanner } from "@/components/design/ReadOnlyDesignBanner";
 import type { ExportSettingsValue } from "@/components/design/inspector";
 import { InspectorAiActions } from "@/components/design/inspector/InspectorAiActions";
 import {
@@ -276,6 +275,7 @@ import {
   type VectorEditOverlayState,
 } from "@/components/design/MultiScreenCanvas";
 import { QuestionFlow } from "@/components/design/QuestionFlow";
+import { ReadOnlyDesignBanner } from "@/components/design/ReadOnlyDesignBanner";
 import type { ReviewPanelProps } from "@/components/design/ReviewPanel";
 import { TokensPanel } from "@/components/design/TokensPanel";
 import type {


### PR DESCRIPTION
### Summary
Adds a Figma-style informational banner shown at the bottom of the design canvas when a user only has viewer access, letting them know they can't edit the design.

### Problem
Users with viewer-only access to a design had no explicit indication of why editing was disabled, which could be confusing since editing affordances are silently disabled elsewhere.

### Solution
Introduced a new `ReadOnlyDesignBanner` component that renders a non-blocking, informational banner at the bottom of the canvas, and wired it into `DesignEditor` to display only once the user's access role has resolved to `"viewer"`.

<img width="1029" height="740" alt="image" src="https://github.com/user-attachments/assets/bb49d467-a538-4808-8c30-2acae7d9b523" />


### Key Changes
- Added `ReadOnlyDesignBanner.tsx` — a slim, pointer-events-safe banner with an info icon and blue-toned styling, positioned at the bottom of the canvas.
- Updated `DesignEditor.tsx` to import and conditionally render `ReadOnlyDesignBanner` when `designAccessRole === "viewer"`, avoiding a flash during initial load by waiting for the role to resolve.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/inferno-highway-snl6nsu0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-inferno-highway-snl6nsu0.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1907`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>inferno-highway-snl6nsu0</branchName>-->