### PR TITLE
fix(desktop-app): sandboxed shell preload crashes on __dirname, so window.electronAPI never loads

### DIFF
--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -1099,6 +1099,11 @@ function createWindow(): BrowserWindow {
       contextIsolation: true,
       webviewTag: true,
       webSecurity: true,
+      // Sandboxed preloads cannot use `__dirname`; hand them the preload dir
+      // so the shell preload can compute the webview preload path.
+      additionalArguments: [
+        `--agent-native-preload-dir=${path.join(__dirname, "../preload")}`,
+      ],
     },
   });
   installSentryWebContentsInstrumentation(win.webContents, {

--- a/packages/desktop-app/src/preload/index.ts
+++ b/packages/desktop-app/src/preload/index.ts
@@ -50,7 +50,21 @@ const CODE_AGENTS_SUBSCRIBE_TRANSCRIPT_CHANNEL =
 const CODE_AGENTS_UNSUBSCRIBE_TRANSCRIPT_CHANNEL =
   "code-agents:unsubscribe-transcript";
 const CODE_AGENTS_TRANSCRIPT_EVENTS_CHANNEL = "code-agents:transcript-events";
-const WEBVIEW_PRELOAD_PATH = `${__dirname.replace(/[/\\]$/, "")}/webview.js`;
+// Sandboxed preloads have no `__dirname` (a ReferenceError at module scope
+// kills the whole preload, so window.electronAPI never appears). Main passes
+// the preload dir via webPreferences.additionalArguments; `process.argv` is
+// available in sandboxed preloads. Fall back to `__dirname` for unsandboxed
+// contexts.
+const PRELOAD_DIR_ARG = "--agent-native-preload-dir=";
+const preloadDirFromArgv = (globalThis.process?.argv ?? [])
+  .find((arg) => arg.startsWith(PRELOAD_DIR_ARG))
+  ?.slice(PRELOAD_DIR_ARG.length);
+const preloadDir =
+  preloadDirFromArgv ??
+  (typeof __dirname !== "undefined" ? __dirname : "");
+const WEBVIEW_PRELOAD_PATH = preloadDir
+  ? `${preloadDir.replace(/[/\\]$/, "")}/webview.js`
+  : "";
 
 type CodeAgentTranscriptSubscriptionBatch = CodeAgentTranscriptResult & {
   subscriptionId?: string;


### PR DESCRIPTION
## Problem

On current `main`, the Desktop shell renderer has **no `window.electronAPI` at all**. The renderer console shows:

```
Unable to load preload script: .../packages/desktop-app/out/preload/index.js
ReferenceError: __dirname is not defined
    at <anonymous>:225:28
    at runPreloadScript (node:electron/js2c/sandbox_bundle:2:144683)
```

The recent self-contained-preload change (inline chunks + `external: ["electron"]`) removed `import path from "node:path"` from `src/preload/index.ts` — correct for sandboxed preloads — but replaced it with:

```ts
const WEBVIEW_PRELOAD_PATH = `${__dirname.replace(/[/\\]$/, "")}/webview.js`;
```

Sandboxed preloads define **neither `node:path` nor `__dirname`** (the shell window doesn't set `sandbox: false`, and Electron ≥20 sandboxes renderers by default). The `ReferenceError` at module scope kills the entire preload before `contextBridge.exposeInMainWorld` runs.

## User-visible symptoms

- Code tab never appears (frame settings unreadable, `showCodeTab` unreachable)
- App Settings: Mode card and Code-tab toggle missing; Software Updates / Remote Control stuck on "Checking…"
- App webviews silently fall back to **production URLs** (renderer takes the `DESKTOP_DEFAULT_APPS` "dev without electron" fallback), ignoring the on-disk dev app-config

## Fix

Main passes the preload directory through `webPreferences.additionalArguments`; the preload reads it from `process.argv`, which **is** available in sandboxed preloads, with a `typeof __dirname` fallback for unsandboxed contexts. `webviewPreloadPath` keeps working for `<webview>` tabs.

Verified on macOS (Electron 41.9.0, dev via `electron-vite dev`): preload loads, `window.electronAPI` exposes all bridges, the Code tab renders and lists existing sessions from the shared run store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)