### PR TITLE
Fix per-calendar color preferences

### DIFF
--- a/templates/calendar/actions/update-calendar-visual-preferences.ts
+++ b/templates/calendar/actions/update-calendar-visual-preferences.ts
@@ -55,9 +55,11 @@ export default defineAction({
     const current = normalizeCalendarViewPreferences(
       (await readAppState(CALENDAR_VIEW_PREFERENCES_KEY)) as any,
     );
+    const hasAccountColorReplacements =
+      args.accountColors && Object.keys(args.accountColors).length > 0;
     const colorMode =
       args.colorMode ??
-      (args.singleColor || args.accountColor || args.accountColors
+      (args.singleColor || args.accountColor || hasAccountColorReplacements
         ? "single"
         : undefined);
     const accountColors = {

--- a/templates/calendar/actions/update-calendar-visual-preferences.ts
+++ b/templates/calendar/actions/update-calendar-visual-preferences.ts
@@ -40,7 +40,7 @@ export default defineAction({
         .record(z.string(), hexColor)
         .optional()
         .describe(
-          "Map of connected Google Calendar account email to hex color",
+          "Replacement map of connected Google Calendar account email to hex color. Pass an empty object to clear account color overrides.",
         ),
       hideWeekends: z
         .boolean()
@@ -61,8 +61,7 @@ export default defineAction({
         ? "single"
         : undefined);
     const accountColors = {
-      ...current.accountColors,
-      ...(args.accountColors ?? {}),
+      ...(args.accountColors ?? current.accountColors),
       ...(args.accountEmail && args.accountColor
         ? { [args.accountEmail]: args.accountColor }
         : {}),

--- a/templates/calendar/actions/update-calendar-visual-preferences.ts
+++ b/templates/calendar/actions/update-calendar-visual-preferences.ts
@@ -14,6 +14,8 @@ const hexColor = z
   .string()
   .regex(/^#[0-9a-fA-F]{6}$/, "Use a 6-digit hex color such as #5B9BD5");
 
+let updateQueue = Promise.resolve();
+
 export default defineAction({
   description:
     "Update the Calendar app's local visual preferences. Use this for UI-only display changes such as color-coding meetings by type or choosing display colors for connected calendars. This does not call Google Calendar and does not use Google Calendar colorId values.",
@@ -52,38 +54,47 @@ export default defineAction({
       path: ["accountColor"],
     }),
   run: async (args) => {
-    const current = normalizeCalendarViewPreferences(
-      (await readAppState(CALENDAR_VIEW_PREFERENCES_KEY)) as any,
-    );
-    const hasAccountColorReplacements =
-      args.accountColors && Object.keys(args.accountColors).length > 0;
-    const colorMode =
-      args.colorMode ??
-      (args.singleColor || args.accountColor || hasAccountColorReplacements
-        ? "single"
-        : undefined);
-    const accountColors = {
-      ...(args.accountColors ?? current.accountColors),
-      ...(args.accountEmail && args.accountColor
-        ? { [args.accountEmail]: args.accountColor }
-        : {}),
-    };
-    const next = normalizeCalendarViewPreferences({
-      ...current,
-      ...args,
-      ...(colorMode ? { colorMode } : {}),
-      accountColors,
-    });
+    const runUpdate = async () => {
+      const current = normalizeCalendarViewPreferences(
+        (await readAppState(CALENDAR_VIEW_PREFERENCES_KEY)) as any,
+      );
+      const hasAccountColorReplacements =
+        args.accountColors && Object.keys(args.accountColors).length > 0;
+      const colorMode =
+        args.colorMode ??
+        (args.singleColor || args.accountColor || hasAccountColorReplacements
+          ? "single"
+          : undefined);
+      const accountColors = {
+        ...(args.accountColors ?? current.accountColors),
+        ...(args.accountEmail && args.accountColor
+          ? { [args.accountEmail]: args.accountColor }
+          : {}),
+      };
+      const next = normalizeCalendarViewPreferences({
+        ...current,
+        ...args,
+        ...(colorMode ? { colorMode } : {}),
+        accountColors,
+      });
 
-    await writeAppState(
-      CALENDAR_VIEW_PREFERENCES_KEY,
-      next as unknown as Record<string, unknown>,
-    );
+      await writeAppState(
+        CALENDAR_VIEW_PREFERENCES_KEY,
+        next as unknown as Record<string, unknown>,
+      );
 
-    return {
-      success: true,
-      preferences: next,
-      note: "Updated local Calendar UI display preferences only; Google Calendar events were not modified.",
+      return {
+        success: true,
+        preferences: next,
+        note: "Updated local Calendar UI display preferences only; Google Calendar events were not modified.",
+      };
     };
+
+    const result = updateQueue.then(runUpdate, runUpdate);
+    updateQueue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
   },
 });

--- a/templates/calendar/actions/update-calendar-visual-preferences.ts
+++ b/templates/calendar/actions/update-calendar-visual-preferences.ts
@@ -16,32 +16,62 @@ const hexColor = z
 
 export default defineAction({
   description:
-    "Update the Calendar app's local visual preferences. Use this for UI-only display changes such as color-coding meetings by type or using one display color. This does not call Google Calendar and does not use Google Calendar colorId values.",
-  schema: z.object({
-    colorMode: z
-      .enum(["multi", "single"])
-      .optional()
-      .describe(
-        "multi colors Google events by local meeting type; single uses one local display color for the user's Google events",
-      ),
-    singleColor: hexColor
-      .optional()
-      .describe("Hex display color to use when colorMode is single"),
-    hideWeekends: z
-      .boolean()
-      .optional()
-      .describe("Whether the calendar UI hides Saturday and Sunday"),
-  }),
+    "Update the Calendar app's local visual preferences. Use this for UI-only display changes such as color-coding meetings by type or choosing display colors for connected calendars. This does not call Google Calendar and does not use Google Calendar colorId values.",
+  schema: z
+    .object({
+      colorMode: z
+        .enum(["multi", "single"])
+        .optional()
+        .describe(
+          "multi colors Google events by local meeting type; single uses connected-calendar display colors for the user's Google events",
+        ),
+      singleColor: hexColor
+        .optional()
+        .describe("Fallback hex display color to use when colorMode is single"),
+      accountEmail: z
+        .string()
+        .email()
+        .optional()
+        .describe("Connected Google Calendar account email to color"),
+      accountColor: hexColor
+        .optional()
+        .describe("Hex display color for the connected accountEmail"),
+      accountColors: z
+        .record(z.string(), hexColor)
+        .optional()
+        .describe(
+          "Map of connected Google Calendar account email to hex color",
+        ),
+      hideWeekends: z
+        .boolean()
+        .optional()
+        .describe("Whether the calendar UI hides Saturday and Sunday"),
+    })
+    .refine((args) => !args.accountEmail === !args.accountColor, {
+      message: "accountEmail and accountColor must be provided together",
+      path: ["accountColor"],
+    }),
   run: async (args) => {
     const current = normalizeCalendarViewPreferences(
       (await readAppState(CALENDAR_VIEW_PREFERENCES_KEY)) as any,
     );
     const colorMode =
-      args.colorMode ?? (args.singleColor ? "single" : undefined);
+      args.colorMode ??
+      (args.singleColor || args.accountColor || args.accountColors
+        ? "single"
+        : undefined);
+    const accountColors = {
+      ...current.accountColors,
+      ...(args.accountColors ?? {}),
+      ...(args.accountEmail && args.accountColor
+        ? { [args.accountEmail]: args.accountColor }
+        : {}),
+    };
     const next = normalizeCalendarViewPreferences({
       ...current,
       ...args,
       ...(colorMode ? { colorMode } : {}),
+      accountColors,
     });
 
     await writeAppState(

--- a/templates/calendar/app/components/layout/Sidebar.tsx
+++ b/templates/calendar/app/components/layout/Sidebar.tsx
@@ -436,6 +436,7 @@ function GoogleAccountsSection({
   const {
     prefs: { accountColors, colorMode, singleColor },
     update: updateViewPreferences,
+    updateAccountColor,
   } = useViewPreferences();
   const [wantAddAccount, setWantAddAccount] = useState(false);
   const addAccountUrl = useGoogleAddAccountUrl(wantAddAccount);
@@ -477,13 +478,7 @@ function GoogleAccountsSection({
   }
 
   function handlePickColor(accountEmail: string, color: string) {
-    updateViewPreferences({
-      colorMode: "single",
-      accountColors: {
-        ...accountColors,
-        [accountEmail]: color,
-      },
-    });
+    updateAccountColor(accountEmail, color);
   }
 
   function handleSetColorMode(mode: CalendarColorMode) {

--- a/templates/calendar/app/components/layout/Sidebar.tsx
+++ b/templates/calendar/app/components/layout/Sidebar.tsx
@@ -434,7 +434,7 @@ function GoogleAccountsSection({
   const t = useT();
   const { toggleHiddenCalendar, isHiddenCalendar } = useCalendarContext();
   const {
-    prefs: { colorMode, singleColor },
+    prefs: { accountColors, colorMode, singleColor },
     update: updateViewPreferences,
   } = useViewPreferences();
   const [wantAddAccount, setWantAddAccount] = useState(false);
@@ -472,8 +472,18 @@ function GoogleAccountsSection({
     setWantAddAccount(true);
   }
 
-  function handlePickColor(color: string) {
-    updateViewPreferences({ colorMode: "single", singleColor: color });
+  function getAccountColor(accountEmail: string) {
+    return accountColors?.[accountEmail] ?? singleColor;
+  }
+
+  function handlePickColor(accountEmail: string, color: string) {
+    updateViewPreferences({
+      colorMode: "single",
+      accountColors: {
+        ...accountColors,
+        [accountEmail]: color,
+      },
+    });
   }
 
   function handleSetColorMode(mode: CalendarColorMode) {
@@ -549,7 +559,7 @@ function GoogleAccountsSection({
                       isHiddenCalendar("accounts", account.email) &&
                         "opacity-40",
                     )}
-                    style={{ backgroundColor: singleColor }}
+                    style={{ backgroundColor: getAccountColor(account.email) }}
                   />
                 )}
               </button>
@@ -579,13 +589,14 @@ function GoogleAccountsSection({
                   <button
                     key={c}
                     type="button"
-                    onClick={() => handlePickColor(c)}
+                    onClick={() => handlePickColor(account.email, c)}
                     className="relative h-5 w-5 rounded-full"
                     style={{ backgroundColor: c }}
                   >
-                    {c === singleColor && colorMode === "single" && (
-                      <IconCheck className="absolute inset-0 m-auto h-3 w-3 text-white drop-shadow" />
-                    )}
+                    {c === getAccountColor(account.email) &&
+                      colorMode === "single" && (
+                        <IconCheck className="absolute inset-0 m-auto h-3 w-3 text-white drop-shadow" />
+                      )}
                   </button>
                 ))}
               </div>

--- a/templates/calendar/app/hooks/use-view-preferences.ts
+++ b/templates/calendar/app/hooks/use-view-preferences.ts
@@ -14,6 +14,14 @@ import {
 
 export type ViewPreferences = CalendarViewPreferences;
 
+const PENDING_ACCOUNT_COLORS_KEY = `${CALENDAR_VIEW_PREFERENCES_KEY}:pending-account-colors`;
+const PENDING_ACCOUNT_COLORS_TTL_MS = 30_000;
+
+interface PendingAccountColors {
+  colors: Record<string, string>;
+  expiresAt: number;
+}
+
 function load(): CalendarViewPreferences {
   try {
     const raw = localStorage.getItem(CALENDAR_VIEW_PREFERENCES_KEY);
@@ -28,6 +36,56 @@ function load(): CalendarViewPreferences {
   } catch {
     return DEFAULT_CALENDAR_VIEW_PREFERENCES;
   }
+}
+
+function loadPendingAccountColors(): Record<string, string> {
+  try {
+    const raw = localStorage.getItem(PENDING_ACCOUNT_COLORS_KEY);
+    if (!raw) return {};
+    const pending = JSON.parse(raw) as PendingAccountColors;
+    if (!pending.expiresAt || pending.expiresAt < Date.now()) {
+      localStorage.removeItem(PENDING_ACCOUNT_COLORS_KEY);
+      return {};
+    }
+    return pending.colors && typeof pending.colors === "object"
+      ? pending.colors
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function savePendingAccountColor(accountEmail: string, accountColor: string) {
+  try {
+    localStorage.setItem(
+      PENDING_ACCOUNT_COLORS_KEY,
+      JSON.stringify({
+        colors: {
+          ...loadPendingAccountColors(),
+          [accountEmail]: accountColor,
+        },
+        expiresAt: Date.now() + PENDING_ACCOUNT_COLORS_TTL_MS,
+      } satisfies PendingAccountColors),
+    );
+  } catch {}
+}
+
+function clearPendingAccountColor(accountEmail: string) {
+  try {
+    const colors = loadPendingAccountColors();
+    delete colors[accountEmail];
+    if (Object.keys(colors).length === 0) {
+      localStorage.removeItem(PENDING_ACCOUNT_COLORS_KEY);
+      return;
+    }
+    localStorage.setItem(
+      PENDING_ACCOUNT_COLORS_KEY,
+      JSON.stringify({
+        colors,
+        expiresAt: Date.now() + PENDING_ACCOUNT_COLORS_TTL_MS,
+      } satisfies PendingAccountColors),
+    );
+  } catch {}
 }
 
 function save(prefs: CalendarViewPreferences) {
@@ -92,13 +150,14 @@ export function useViewPreferences() {
         const remote = await readAppStatePreferences();
         if (!cancelled && remote) {
           setPrefs((current) => {
-            const pendingColors = pendingAccountColors.current;
+            const pendingColors = {
+              ...loadPendingAccountColors(),
+              ...pendingAccountColors.current,
+            };
             const next =
               Object.keys(pendingColors).length > 0
                 ? normalizeCalendarViewPreferences({
                     ...remote,
-                    colorMode: current.colorMode,
-                    singleColor: current.singleColor,
                     accountColors: {
                       ...remote.accountColors,
                       ...pendingColors,
@@ -144,6 +203,7 @@ export function useViewPreferences() {
       const requestId = (accountColorRequestIds.current[accountEmail] ?? 0) + 1;
       accountColorRequestIds.current[accountEmail] = requestId;
       pendingAccountColors.current[accountEmail] = accountColor;
+      savePendingAccountColor(accountEmail, accountColor);
 
       setPrefs((prev) => {
         const next = normalizeCalendarViewPreferences({
@@ -168,6 +228,7 @@ export function useViewPreferences() {
             return;
           }
           delete pendingAccountColors.current[accountEmail];
+          clearPendingAccountColor(accountEmail);
 
           const preferences = (result as { preferences?: unknown }).preferences;
           if (!preferences) return;
@@ -192,6 +253,7 @@ export function useViewPreferences() {
         .catch(() => {
           if (accountColorRequestIds.current[accountEmail] === requestId) {
             delete pendingAccountColors.current[accountEmail];
+            clearPendingAccountColor(accountEmail);
           }
         });
     },

--- a/templates/calendar/app/hooks/use-view-preferences.ts
+++ b/templates/calendar/app/hooks/use-view-preferences.ts
@@ -1,5 +1,5 @@
 import { agentNativePath, callAction } from "@agent-native/core/client";
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 
 import {
   CALENDAR_COLOR_MODE_KEY,
@@ -64,6 +64,7 @@ function writeAppStatePreferences(prefs: CalendarViewPreferences) {
 
 export function useViewPreferences() {
   const [prefs, setPrefs] = useState<ViewPreferences>(load);
+  const accountColorRequestIds = useRef<Record<string, number>>({});
 
   // Sync across components in the same tab via custom event
   useEffect(() => {
@@ -125,6 +126,9 @@ export function useViewPreferences() {
 
   const updateAccountColor = useCallback(
     (accountEmail: string, accountColor: string) => {
+      const requestId = (accountColorRequestIds.current[accountEmail] ?? 0) + 1;
+      accountColorRequestIds.current[accountEmail] = requestId;
+
       setPrefs((prev) => {
         const next = normalizeCalendarViewPreferences({
           ...prev,
@@ -144,10 +148,23 @@ export function useViewPreferences() {
         accountColor,
       })
         .then((result) => {
+          if (accountColorRequestIds.current[accountEmail] !== requestId) {
+            return;
+          }
+
           const preferences = (result as { preferences?: unknown }).preferences;
           if (!preferences) return;
-          const next = normalizeCalendarViewPreferences(preferences);
+          const serverPrefs = normalizeCalendarViewPreferences(preferences);
           setPrefs((current) => {
+            const next = normalizeCalendarViewPreferences({
+              ...serverPrefs,
+              accountColors: {
+                ...serverPrefs.accountColors,
+                ...current.accountColors,
+                [accountEmail]:
+                  serverPrefs.accountColors[accountEmail] ?? accountColor,
+              },
+            });
             if (calendarViewPreferencesEqual(current, next)) return current;
             save(next);
             window.dispatchEvent(

--- a/templates/calendar/app/hooks/use-view-preferences.ts
+++ b/templates/calendar/app/hooks/use-view-preferences.ts
@@ -1,4 +1,4 @@
-import { agentNativePath } from "@agent-native/core/client";
+import { agentNativePath, callAction } from "@agent-native/core/client";
 import { useState, useCallback, useEffect } from "react";
 
 import {
@@ -123,5 +123,43 @@ export function useViewPreferences() {
     });
   }, []);
 
-  return { prefs, update };
+  const updateAccountColor = useCallback(
+    (accountEmail: string, accountColor: string) => {
+      setPrefs((prev) => {
+        const next = normalizeCalendarViewPreferences({
+          ...prev,
+          colorMode: "single",
+          accountColors: {
+            ...prev.accountColors,
+            [accountEmail]: accountColor,
+          },
+        });
+        save(next);
+        window.dispatchEvent(new Event(CALENDAR_VIEW_PREFERENCES_CHANGE_EVENT));
+        return next;
+      });
+
+      callAction("update-calendar-visual-preferences", {
+        accountEmail,
+        accountColor,
+      })
+        .then((result) => {
+          const preferences = (result as { preferences?: unknown }).preferences;
+          if (!preferences) return;
+          const next = normalizeCalendarViewPreferences(preferences);
+          setPrefs((current) => {
+            if (calendarViewPreferencesEqual(current, next)) return current;
+            save(next);
+            window.dispatchEvent(
+              new Event(CALENDAR_VIEW_PREFERENCES_CHANGE_EVENT),
+            );
+            return next;
+          });
+        })
+        .catch(() => {});
+    },
+    [],
+  );
+
+  return { prefs, update, updateAccountColor };
 }

--- a/templates/calendar/app/hooks/use-view-preferences.ts
+++ b/templates/calendar/app/hooks/use-view-preferences.ts
@@ -65,6 +65,7 @@ function writeAppStatePreferences(prefs: CalendarViewPreferences) {
 export function useViewPreferences() {
   const [prefs, setPrefs] = useState<ViewPreferences>(load);
   const accountColorRequestIds = useRef<Record<string, number>>({});
+  const pendingAccountColors = useRef<Record<string, string>>({});
 
   // Sync across components in the same tab via custom event
   useEffect(() => {
@@ -91,12 +92,26 @@ export function useViewPreferences() {
         const remote = await readAppStatePreferences();
         if (!cancelled && remote) {
           setPrefs((current) => {
-            if (calendarViewPreferencesEqual(current, remote)) return current;
-            save(remote);
+            const pendingColors = pendingAccountColors.current;
+            const next =
+              Object.keys(pendingColors).length > 0
+                ? normalizeCalendarViewPreferences({
+                    ...remote,
+                    colorMode: current.colorMode,
+                    singleColor: current.singleColor,
+                    accountColors: {
+                      ...remote.accountColors,
+                      ...pendingColors,
+                    },
+                  })
+                : remote;
+
+            if (calendarViewPreferencesEqual(current, next)) return current;
+            save(next);
             window.dispatchEvent(
               new Event(CALENDAR_VIEW_PREFERENCES_CHANGE_EVENT),
             );
-            return remote;
+            return next;
           });
         }
       } catch {
@@ -128,6 +143,7 @@ export function useViewPreferences() {
     (accountEmail: string, accountColor: string) => {
       const requestId = (accountColorRequestIds.current[accountEmail] ?? 0) + 1;
       accountColorRequestIds.current[accountEmail] = requestId;
+      pendingAccountColors.current[accountEmail] = accountColor;
 
       setPrefs((prev) => {
         const next = normalizeCalendarViewPreferences({
@@ -151,6 +167,7 @@ export function useViewPreferences() {
           if (accountColorRequestIds.current[accountEmail] !== requestId) {
             return;
           }
+          delete pendingAccountColors.current[accountEmail];
 
           const preferences = (result as { preferences?: unknown }).preferences;
           if (!preferences) return;
@@ -173,7 +190,11 @@ export function useViewPreferences() {
             return next;
           });
         })
-        .catch(() => {});
+        .catch(() => {
+          if (accountColorRequestIds.current[accountEmail] === requestId) {
+            delete pendingAccountColors.current[accountEmail];
+          }
+        });
     },
     [],
   );

--- a/templates/calendar/app/hooks/use-view-preferences.ts
+++ b/templates/calendar/app/hooks/use-view-preferences.ts
@@ -81,19 +81,40 @@ function savePendingAccountColor(accountEmail: string, accountColor: string) {
 
 function clearPendingAccountColor(accountEmail: string) {
   try {
-    const colors = loadPendingAccountColors();
+    const pending = loadPendingAccountPreferences();
+    if (!pending) return;
+    const colors = { ...pending.colors };
+    const removedColor = colors[accountEmail];
     delete colors[accountEmail];
     if (Object.keys(colors).length === 0) {
       localStorage.removeItem(PENDING_ACCOUNT_COLORS_KEY);
       return;
     }
-    const colorValues = Object.values(colors);
-    const singleColor = colorValues[colorValues.length - 1];
     localStorage.setItem(
       PENDING_ACCOUNT_COLORS_KEY,
       JSON.stringify({
         colors,
-        ...(singleColor ? { colorMode: "single" as const, singleColor } : {}),
+        ...(pending.singleColor && pending.singleColor !== removedColor
+          ? { colorMode: pending.colorMode, singleColor: pending.singleColor }
+          : {}),
+        expiresAt: Date.now() + PENDING_ACCOUNT_COLORS_TTL_MS,
+      } satisfies PendingAccountColors),
+    );
+  } catch {}
+}
+
+function clearPendingAccountFallback() {
+  try {
+    const pending = loadPendingAccountPreferences();
+    if (!pending) return;
+    if (Object.keys(pending.colors).length === 0) {
+      localStorage.removeItem(PENDING_ACCOUNT_COLORS_KEY);
+      return;
+    }
+    localStorage.setItem(
+      PENDING_ACCOUNT_COLORS_KEY,
+      JSON.stringify({
+        colors: pending.colors,
         expiresAt: Date.now() + PENDING_ACCOUNT_COLORS_TTL_MS,
       } satisfies PendingAccountColors),
     );
@@ -117,19 +138,6 @@ async function readAppStatePreferences(): Promise<CalendarViewPreferences | null
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`${res.status}`);
   return normalizeCalendarViewPreferences(await res.json());
-}
-
-function writeAppStatePreferences(prefs: CalendarViewPreferences) {
-  fetch(
-    agentNativePath(
-      `/_agent-native/application-state/${CALENDAR_VIEW_PREFERENCES_KEY}`,
-    ),
-    {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(prefs),
-    },
-  ).catch(() => {});
 }
 
 export function useViewPreferences() {
@@ -211,13 +219,17 @@ export function useViewPreferences() {
   }, []);
 
   const update = useCallback((patch: Partial<ViewPreferences>) => {
+    if ("colorMode" in patch || "singleColor" in patch) {
+      pendingSingleColor.current = null;
+      clearPendingAccountFallback();
+    }
     setPrefs((prev) => {
       const next = normalizeCalendarViewPreferences({ ...prev, ...patch });
       save(next);
-      writeAppStatePreferences(next);
       window.dispatchEvent(new Event(CALENDAR_VIEW_PREFERENCES_CHANGE_EVENT));
       return next;
     });
+    callAction("update-calendar-visual-preferences", patch).catch(() => {});
   }, []);
 
   const updateAccountColor = useCallback(
@@ -255,7 +267,7 @@ export function useViewPreferences() {
             return;
           }
           delete pendingAccountColors.current[accountEmail];
-          if (Object.keys(pendingAccountColors.current).length === 0) {
+          if (pendingSingleColor.current === accountColor) {
             pendingSingleColor.current = null;
           }
           clearPendingAccountColor(accountEmail);
@@ -267,7 +279,8 @@ export function useViewPreferences() {
             const next = normalizeCalendarViewPreferences({
               ...current,
               colorMode:
-                rollbackPrefs && current.colorMode === rollbackPrefs.colorMode
+                current.colorMode === "single" &&
+                current.singleColor === accountColor
                   ? serverPrefs.colorMode
                   : current.colorMode,
               singleColor:
@@ -293,7 +306,7 @@ export function useViewPreferences() {
         .catch(() => {
           if (accountColorRequestIds.current[accountEmail] === requestId) {
             delete pendingAccountColors.current[accountEmail];
-            if (Object.keys(pendingAccountColors.current).length === 0) {
+            if (pendingSingleColor.current === accountColor) {
               pendingSingleColor.current = null;
             }
             clearPendingAccountColor(accountEmail);

--- a/templates/calendar/app/hooks/use-view-preferences.ts
+++ b/templates/calendar/app/hooks/use-view-preferences.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_CALENDAR_VIEW_PREFERENCES,
   calendarViewPreferencesEqual,
   normalizeCalendarViewPreferences,
+  type CalendarColorMode,
   type CalendarViewPreferences,
 } from "@/lib/calendar-view-preferences";
 
@@ -19,6 +20,8 @@ const PENDING_ACCOUNT_COLORS_TTL_MS = 30_000;
 
 interface PendingAccountColors {
   colors: Record<string, string>;
+  colorMode?: CalendarColorMode;
+  singleColor?: string;
   expiresAt: number;
 }
 
@@ -38,21 +41,25 @@ function load(): CalendarViewPreferences {
   }
 }
 
-function loadPendingAccountColors(): Record<string, string> {
+function loadPendingAccountPreferences(): PendingAccountColors | null {
   try {
     const raw = localStorage.getItem(PENDING_ACCOUNT_COLORS_KEY);
-    if (!raw) return {};
+    if (!raw) return null;
     const pending = JSON.parse(raw) as PendingAccountColors;
     if (!pending.expiresAt || pending.expiresAt < Date.now()) {
       localStorage.removeItem(PENDING_ACCOUNT_COLORS_KEY);
-      return {};
+      return null;
     }
     return pending.colors && typeof pending.colors === "object"
-      ? pending.colors
-      : {};
+      ? pending
+      : null;
   } catch {
-    return {};
+    return null;
   }
+}
+
+function loadPendingAccountColors(): Record<string, string> {
+  return loadPendingAccountPreferences()?.colors ?? {};
 }
 
 function savePendingAccountColor(accountEmail: string, accountColor: string) {
@@ -64,6 +71,8 @@ function savePendingAccountColor(accountEmail: string, accountColor: string) {
           ...loadPendingAccountColors(),
           [accountEmail]: accountColor,
         },
+        colorMode: "single",
+        singleColor: accountColor,
         expiresAt: Date.now() + PENDING_ACCOUNT_COLORS_TTL_MS,
       } satisfies PendingAccountColors),
     );
@@ -78,10 +87,13 @@ function clearPendingAccountColor(accountEmail: string) {
       localStorage.removeItem(PENDING_ACCOUNT_COLORS_KEY);
       return;
     }
+    const colorValues = Object.values(colors);
+    const singleColor = colorValues[colorValues.length - 1];
     localStorage.setItem(
       PENDING_ACCOUNT_COLORS_KEY,
       JSON.stringify({
         colors,
+        ...(singleColor ? { colorMode: "single" as const, singleColor } : {}),
         expiresAt: Date.now() + PENDING_ACCOUNT_COLORS_TTL_MS,
       } satisfies PendingAccountColors),
     );
@@ -124,6 +136,7 @@ export function useViewPreferences() {
   const [prefs, setPrefs] = useState<ViewPreferences>(load);
   const accountColorRequestIds = useRef<Record<string, number>>({});
   const pendingAccountColors = useRef<Record<string, string>>({});
+  const pendingSingleColor = useRef<string | null>(null);
 
   // Sync across components in the same tab via custom event
   useEffect(() => {
@@ -150,14 +163,23 @@ export function useViewPreferences() {
         const remote = await readAppStatePreferences();
         if (!cancelled && remote) {
           setPrefs((current) => {
+            const pendingPreferences = loadPendingAccountPreferences();
             const pendingColors = {
-              ...loadPendingAccountColors(),
+              ...(pendingPreferences?.colors ?? {}),
               ...pendingAccountColors.current,
             };
+            const pendingFallback =
+              pendingSingleColor.current ?? pendingPreferences?.singleColor;
             const next =
-              Object.keys(pendingColors).length > 0
+              Object.keys(pendingColors).length > 0 || pendingFallback
                 ? normalizeCalendarViewPreferences({
                     ...remote,
+                    ...(pendingFallback
+                      ? {
+                          colorMode: "single" as const,
+                          singleColor: pendingFallback,
+                        }
+                      : {}),
                     accountColors: {
                       ...remote.accountColors,
                       ...pendingColors,
@@ -203,12 +225,16 @@ export function useViewPreferences() {
       const requestId = (accountColorRequestIds.current[accountEmail] ?? 0) + 1;
       accountColorRequestIds.current[accountEmail] = requestId;
       pendingAccountColors.current[accountEmail] = accountColor;
+      pendingSingleColor.current = accountColor;
       savePendingAccountColor(accountEmail, accountColor);
+      let rollbackPrefs: CalendarViewPreferences | null = null;
 
       setPrefs((prev) => {
+        rollbackPrefs = prev;
         const next = normalizeCalendarViewPreferences({
           ...prev,
           colorMode: "single",
+          singleColor: accountColor,
           accountColors: {
             ...prev.accountColors,
             [accountEmail]: accountColor,
@@ -222,12 +248,16 @@ export function useViewPreferences() {
       callAction("update-calendar-visual-preferences", {
         accountEmail,
         accountColor,
+        singleColor: accountColor,
       })
         .then((result) => {
           if (accountColorRequestIds.current[accountEmail] !== requestId) {
             return;
           }
           delete pendingAccountColors.current[accountEmail];
+          if (Object.keys(pendingAccountColors.current).length === 0) {
+            pendingSingleColor.current = null;
+          }
           clearPendingAccountColor(accountEmail);
 
           const preferences = (result as { preferences?: unknown }).preferences;
@@ -236,6 +266,16 @@ export function useViewPreferences() {
           setPrefs((current) => {
             const next = normalizeCalendarViewPreferences({
               ...current,
+              colorMode:
+                rollbackPrefs && current.colorMode === rollbackPrefs.colorMode
+                  ? serverPrefs.colorMode
+                  : current.colorMode,
+              singleColor:
+                current.singleColor === accountColor ||
+                (rollbackPrefs &&
+                  current.singleColor === rollbackPrefs.singleColor)
+                  ? (serverPrefs.singleColor ?? accountColor)
+                  : current.singleColor,
               accountColors: {
                 ...current.accountColors,
                 [accountEmail]:
@@ -253,7 +293,42 @@ export function useViewPreferences() {
         .catch(() => {
           if (accountColorRequestIds.current[accountEmail] === requestId) {
             delete pendingAccountColors.current[accountEmail];
+            if (Object.keys(pendingAccountColors.current).length === 0) {
+              pendingSingleColor.current = null;
+            }
             clearPendingAccountColor(accountEmail);
+            setPrefs((current) => {
+              if (!rollbackPrefs) return current;
+              const accountColors = { ...current.accountColors };
+              const previousAccountColor =
+                rollbackPrefs.accountColors[accountEmail];
+              if (current.accountColors[accountEmail] === accountColor) {
+                if (previousAccountColor) {
+                  accountColors[accountEmail] = previousAccountColor;
+                } else {
+                  delete accountColors[accountEmail];
+                }
+              }
+              const next = normalizeCalendarViewPreferences({
+                ...current,
+                colorMode:
+                  current.colorMode === "single" &&
+                  current.singleColor === accountColor
+                    ? rollbackPrefs.colorMode
+                    : current.colorMode,
+                singleColor:
+                  current.singleColor === accountColor
+                    ? rollbackPrefs.singleColor
+                    : current.singleColor,
+                accountColors,
+              });
+              if (calendarViewPreferencesEqual(current, next)) return current;
+              save(next);
+              window.dispatchEvent(
+                new Event(CALENDAR_VIEW_PREFERENCES_CHANGE_EVENT),
+              );
+              return next;
+            });
           }
         });
     },

--- a/templates/calendar/app/hooks/use-view-preferences.ts
+++ b/templates/calendar/app/hooks/use-view-preferences.ts
@@ -9,7 +9,6 @@ import {
   DEFAULT_CALENDAR_VIEW_PREFERENCES,
   calendarViewPreferencesEqual,
   normalizeCalendarViewPreferences,
-  type CalendarColorMode,
   type CalendarViewPreferences,
 } from "@/lib/calendar-view-preferences";
 
@@ -20,8 +19,6 @@ const PENDING_ACCOUNT_COLORS_TTL_MS = 30_000;
 
 interface PendingAccountColors {
   colors: Record<string, string>;
-  colorMode?: CalendarColorMode;
-  singleColor?: string;
   expiresAt: number;
 }
 
@@ -71,8 +68,6 @@ function savePendingAccountColor(accountEmail: string, accountColor: string) {
           ...loadPendingAccountColors(),
           [accountEmail]: accountColor,
         },
-        colorMode: "single",
-        singleColor: accountColor,
         expiresAt: Date.now() + PENDING_ACCOUNT_COLORS_TTL_MS,
       } satisfies PendingAccountColors),
     );
@@ -84,7 +79,6 @@ function clearPendingAccountColor(accountEmail: string) {
     const pending = loadPendingAccountPreferences();
     if (!pending) return;
     const colors = { ...pending.colors };
-    const removedColor = colors[accountEmail];
     delete colors[accountEmail];
     if (Object.keys(colors).length === 0) {
       localStorage.removeItem(PENDING_ACCOUNT_COLORS_KEY);
@@ -94,27 +88,6 @@ function clearPendingAccountColor(accountEmail: string) {
       PENDING_ACCOUNT_COLORS_KEY,
       JSON.stringify({
         colors,
-        ...(pending.singleColor && pending.singleColor !== removedColor
-          ? { colorMode: pending.colorMode, singleColor: pending.singleColor }
-          : {}),
-        expiresAt: Date.now() + PENDING_ACCOUNT_COLORS_TTL_MS,
-      } satisfies PendingAccountColors),
-    );
-  } catch {}
-}
-
-function clearPendingAccountFallback() {
-  try {
-    const pending = loadPendingAccountPreferences();
-    if (!pending) return;
-    if (Object.keys(pending.colors).length === 0) {
-      localStorage.removeItem(PENDING_ACCOUNT_COLORS_KEY);
-      return;
-    }
-    localStorage.setItem(
-      PENDING_ACCOUNT_COLORS_KEY,
-      JSON.stringify({
-        colors: pending.colors,
         expiresAt: Date.now() + PENDING_ACCOUNT_COLORS_TTL_MS,
       } satisfies PendingAccountColors),
     );
@@ -144,7 +117,6 @@ export function useViewPreferences() {
   const [prefs, setPrefs] = useState<ViewPreferences>(load);
   const accountColorRequestIds = useRef<Record<string, number>>({});
   const pendingAccountColors = useRef<Record<string, string>>({});
-  const pendingSingleColor = useRef<string | null>(null);
 
   // Sync across components in the same tab via custom event
   useEffect(() => {
@@ -176,18 +148,10 @@ export function useViewPreferences() {
               ...(pendingPreferences?.colors ?? {}),
               ...pendingAccountColors.current,
             };
-            const pendingFallback =
-              pendingSingleColor.current ?? pendingPreferences?.singleColor;
             const next =
-              Object.keys(pendingColors).length > 0 || pendingFallback
+              Object.keys(pendingColors).length > 0
                 ? normalizeCalendarViewPreferences({
                     ...remote,
-                    ...(pendingFallback
-                      ? {
-                          colorMode: "single" as const,
-                          singleColor: pendingFallback,
-                        }
-                      : {}),
                     accountColors: {
                       ...remote.accountColors,
                       ...pendingColors,
@@ -219,10 +183,6 @@ export function useViewPreferences() {
   }, []);
 
   const update = useCallback((patch: Partial<ViewPreferences>) => {
-    if ("colorMode" in patch || "singleColor" in patch) {
-      pendingSingleColor.current = null;
-      clearPendingAccountFallback();
-    }
     setPrefs((prev) => {
       const next = normalizeCalendarViewPreferences({ ...prev, ...patch });
       save(next);
@@ -237,7 +197,6 @@ export function useViewPreferences() {
       const requestId = (accountColorRequestIds.current[accountEmail] ?? 0) + 1;
       accountColorRequestIds.current[accountEmail] = requestId;
       pendingAccountColors.current[accountEmail] = accountColor;
-      pendingSingleColor.current = accountColor;
       savePendingAccountColor(accountEmail, accountColor);
       let rollbackPrefs: CalendarViewPreferences | null = null;
 
@@ -246,7 +205,6 @@ export function useViewPreferences() {
         const next = normalizeCalendarViewPreferences({
           ...prev,
           colorMode: "single",
-          singleColor: accountColor,
           accountColors: {
             ...prev.accountColors,
             [accountEmail]: accountColor,
@@ -260,16 +218,12 @@ export function useViewPreferences() {
       callAction("update-calendar-visual-preferences", {
         accountEmail,
         accountColor,
-        singleColor: accountColor,
       })
         .then((result) => {
           if (accountColorRequestIds.current[accountEmail] !== requestId) {
             return;
           }
           delete pendingAccountColors.current[accountEmail];
-          if (pendingSingleColor.current === accountColor) {
-            pendingSingleColor.current = null;
-          }
           clearPendingAccountColor(accountEmail);
 
           const preferences = (result as { preferences?: unknown }).preferences;
@@ -278,17 +232,6 @@ export function useViewPreferences() {
           setPrefs((current) => {
             const next = normalizeCalendarViewPreferences({
               ...current,
-              colorMode:
-                current.colorMode === "single" &&
-                current.singleColor === accountColor
-                  ? serverPrefs.colorMode
-                  : current.colorMode,
-              singleColor:
-                current.singleColor === accountColor ||
-                (rollbackPrefs &&
-                  current.singleColor === rollbackPrefs.singleColor)
-                  ? (serverPrefs.singleColor ?? accountColor)
-                  : current.singleColor,
               accountColors: {
                 ...current.accountColors,
                 [accountEmail]:
@@ -306,9 +249,6 @@ export function useViewPreferences() {
         .catch(() => {
           if (accountColorRequestIds.current[accountEmail] === requestId) {
             delete pendingAccountColors.current[accountEmail];
-            if (pendingSingleColor.current === accountColor) {
-              pendingSingleColor.current = null;
-            }
             clearPendingAccountColor(accountEmail);
             setPrefs((current) => {
               if (!rollbackPrefs) return current;
@@ -326,13 +266,9 @@ export function useViewPreferences() {
                 ...current,
                 colorMode:
                   current.colorMode === "single" &&
-                  current.singleColor === accountColor
+                  current.accountColors[accountEmail] === accountColor
                     ? rollbackPrefs.colorMode
                     : current.colorMode,
-                singleColor:
-                  current.singleColor === accountColor
-                    ? rollbackPrefs.singleColor
-                    : current.singleColor,
                 accountColors,
               });
               if (calendarViewPreferencesEqual(current, next)) return current;

--- a/templates/calendar/app/hooks/use-view-preferences.ts
+++ b/templates/calendar/app/hooks/use-view-preferences.ts
@@ -174,9 +174,8 @@ export function useViewPreferences() {
           const serverPrefs = normalizeCalendarViewPreferences(preferences);
           setPrefs((current) => {
             const next = normalizeCalendarViewPreferences({
-              ...serverPrefs,
+              ...current,
               accountColors: {
-                ...serverPrefs.accountColors,
                 ...current.accountColors,
                 [accountEmail]:
                   serverPrefs.accountColors[accountEmail] ?? accountColor,

--- a/templates/calendar/app/lib/calendar-view-preferences.test.ts
+++ b/templates/calendar/app/lib/calendar-view-preferences.test.ts
@@ -32,10 +32,17 @@ describe("calendar view preferences", () => {
         hideWeekends: true,
         colorMode: "rainbow" as any,
         singleColor: "blue",
+        accountColors: {
+          "alice@example.com": "#4ECDC4",
+          "bad@example.com": "green",
+        },
       }),
     ).toEqual({
       ...DEFAULT_CALENDAR_VIEW_PREFERENCES,
       hideWeekends: true,
+      accountColors: {
+        "alice@example.com": "#4ECDC4",
+      },
     });
   });
 
@@ -57,6 +64,30 @@ describe("calendar view preferences", () => {
         preferences,
       ),
     ).toBe("#4ECDC4");
+  });
+
+  it("uses connected account colors independently in single-color mode", () => {
+    const preferences = {
+      hideWeekends: false,
+      colorMode: "single" as const,
+      singleColor: "#CD6B6B",
+      accountColors: {
+        "steve@builder.io": "#4ECDC4",
+        "alice@builder.io": "#B07CC6",
+      },
+    };
+
+    expect(getEventDisplayColor(googleEvent, preferences)).toBe("#4ECDC4");
+    expect(
+      getEventDisplayColor(
+        {
+          ...googleEvent,
+          id: "google-2",
+          accountEmail: "alice@builder.io",
+        },
+        preferences,
+      ),
+    ).toBe("#B07CC6");
   });
 
   it("keeps overlay owner color separate from event color", () => {

--- a/templates/calendar/app/lib/calendar-view-preferences.test.ts
+++ b/templates/calendar/app/lib/calendar-view-preferences.test.ts
@@ -46,7 +46,7 @@ describe("calendar view preferences", () => {
     });
   });
 
-  it("uses the single local display color without changing overlay colors", () => {
+  it("uses the single local display color without changing overlay event colors", () => {
     const preferences = {
       hideWeekends: false,
       colorMode: "single" as const,
@@ -90,13 +90,51 @@ describe("calendar view preferences", () => {
     ).toBe("#B07CC6");
   });
 
-  it("keeps overlay owner color separate from event color", () => {
+  it("uses overlay person colors for their visible event blocks", () => {
     expect(
       getEventDisplayColor({
         ...googleEvent,
         overlayEmail: "teammate@example.com",
         ownerColor: "#4ECDC4",
       }),
-    ).toBe("#5B9BD5");
+    ).toBe("#4ECDC4");
+  });
+
+  it("falls back to the event color for overlay events without a person color", () => {
+    expect(
+      getEventDisplayColor(
+        {
+          ...googleEvent,
+          overlayEmail: "teammate@example.com",
+          color: "#CD6B6B",
+        },
+        {
+          colorMode: "single",
+          singleColor: "#B07CC6",
+          accountColors: {
+            "steve@builder.io": "#4ECDC4",
+          },
+        },
+      ),
+    ).toBe("#CD6B6B");
+  });
+
+  it("keeps overlay person colors independent from connected account colors", () => {
+    expect(
+      getEventDisplayColor(
+        {
+          ...googleEvent,
+          overlayEmail: "teammate@example.com",
+          ownerColor: "#B07CC6",
+        },
+        {
+          colorMode: "single",
+          singleColor: "#CD6B6B",
+          accountColors: {
+            "steve@builder.io": "#4ECDC4",
+          },
+        },
+      ),
+    ).toBe("#B07CC6");
   });
 });

--- a/templates/calendar/app/lib/event-colors.ts
+++ b/templates/calendar/app/lib/event-colors.ts
@@ -22,6 +22,7 @@ export type EventCategory = keyof typeof EVENT_CATEGORY_COLORS;
 export interface CalendarColorPreferences {
   colorMode?: CalendarColorMode;
   singleColor?: string;
+  accountColors?: Record<string, string>;
 }
 
 // ─── Free email providers (skip internal/external when user is on one) ───────
@@ -128,11 +129,16 @@ export function getEventDisplayColor(
 ): string {
   if (
     preferences?.colorMode === "single" &&
-    preferences.singleColor &&
     event.source === "google" &&
     !event.overlayEmail
   ) {
-    return preferences.singleColor;
+    return (
+      (event.accountEmail
+        ? preferences.accountColors?.[event.accountEmail]
+        : undefined) ??
+      preferences.singleColor ??
+      getEventAutoColor(event)
+    );
   }
   return getEventAutoColor(event);
 }

--- a/templates/calendar/app/lib/event-colors.ts
+++ b/templates/calendar/app/lib/event-colors.ts
@@ -127,6 +127,10 @@ export function getEventDisplayColor(
   event: CalendarEvent,
   preferences?: CalendarColorPreferences,
 ): string {
+  if (event.overlayEmail && event.ownerColor) {
+    return event.ownerColor;
+  }
+
   if (
     preferences?.colorMode === "single" &&
     event.source === "google" &&

--- a/templates/calendar/changelog/2026-07-06-connected-calendars-keep-their-own-color-when-you-customize-.md
+++ b/templates/calendar/changelog/2026-07-06-connected-calendars-keep-their-own-color-when-you-customize-.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-06
+---
+
+Connected calendars keep their own color when you customize them.

--- a/templates/calendar/shared/calendar-view-preferences.ts
+++ b/templates/calendar/shared/calendar-view-preferences.ts
@@ -20,12 +20,14 @@ export interface CalendarViewPreferences {
   hideWeekends: boolean;
   colorMode: CalendarColorMode;
   singleColor: string;
+  accountColors: Record<string, string>;
 }
 
 export const DEFAULT_CALENDAR_VIEW_PREFERENCES: CalendarViewPreferences = {
   hideWeekends: false,
   colorMode: "multi",
   singleColor: CALENDAR_COLORS[0],
+  accountColors: {},
 };
 
 export function isValidCalendarColorMode(
@@ -53,6 +55,14 @@ export function normalizeCalendarViewPreferences(
   if (isValidCalendarColor(input.singleColor)) {
     next.singleColor = input.singleColor.trim();
   }
+  if (input.accountColors && typeof input.accountColors === "object") {
+    next.accountColors = Object.fromEntries(
+      Object.entries(input.accountColors).flatMap(([accountEmail, color]) => {
+        if (!accountEmail || !isValidCalendarColor(color)) return [];
+        return [[accountEmail, color.trim()]];
+      }),
+    );
+  }
   return next;
 }
 
@@ -63,6 +73,16 @@ export function calendarViewPreferencesEqual(
   return (
     a.hideWeekends === b.hideWeekends &&
     a.colorMode === b.colorMode &&
-    a.singleColor === b.singleColor
+    a.singleColor === b.singleColor &&
+    recordEqual(a.accountColors, b.accountColors)
   );
+}
+
+function recordEqual(
+  a: Record<string, string>,
+  b: Record<string, string>,
+): boolean {
+  const aEntries = Object.entries(a);
+  if (aEntries.length !== Object.keys(b).length) return false;
+  return aEntries.every(([key, value]) => b[key] === value);
 }


### PR DESCRIPTION
## Summary
- Store connected Google calendar display colors per account instead of sharing one global color across all connected calendars
- Render Google events using the event account email's saved color, with the existing single color as a fallback
- Extend the visual-preferences action and regression coverage for independent account colors
- Add a pending Calendar changelog entry

## Verification
- node_modules/.bin/vitest --run app/lib/calendar-view-preferences.test.ts
- node_modules/.bin/agent-native typecheck (passes; existing React Router Node version warning only)
- Local Claude Code review with claude-fable-5: signed off with no blocking findings
