### PR TITLE
Fix Clips agent share link loading

### DIFF
--- a/templates/clips/app/components/player/share-dialog.tsx
+++ b/templates/clips/app/components/player/share-dialog.tsx
@@ -31,7 +31,14 @@ import {
   IconLink,
   IconMail,
 } from "@tabler/icons-react";
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
 import {
   CopyField,
@@ -291,25 +298,55 @@ function LinkTab({
   const visibility: Visibility =
     (data?.visibility as Visibility | null) ?? "private";
   const isPublic = visibility === "public";
+  const sharesLoaded = data !== undefined;
   const isLoomRecording = isLoomRecordingProp || isLoomEmbedUrl(videoUrl);
   const createAgentLink = useActionMutation(
     "create-recording-agent-link" as any,
   );
+  const createAgentLinkAsyncRef = useRef(createAgentLink.mutateAsync);
+  const agentLinkRequestIdRef = useRef(0);
   const [agentContextUrl, setAgentContextUrl] = useState("");
+  const [agentLinkError, setAgentLinkError] = useState(false);
+
+  useEffect(() => {
+    createAgentLinkAsyncRef.current = createAgentLink.mutateAsync;
+  });
+
+  const loadAgentContextUrl = useCallback(async () => {
+    const requestId = agentLinkRequestIdRef.current + 1;
+    agentLinkRequestIdRef.current = requestId;
+
+    setAgentContextUrl("");
+    setAgentLinkError(false);
+
+    try {
+      const result = (await createAgentLinkAsyncRef.current({
+        recordingId,
+      })) as { url?: string };
+      if (agentLinkRequestIdRef.current !== requestId) return;
+      if (result?.url) {
+        setAgentContextUrl(result.url);
+      } else {
+        setAgentLinkError(true);
+      }
+    } catch {
+      if (agentLinkRequestIdRef.current === requestId) {
+        setAgentLinkError(true);
+      }
+    }
+  }, [recordingId]);
 
   useEffect(() => {
     setAgentContextUrl("");
-  }, [recordingId, visibility]);
+    setAgentLinkError(false);
+    if (!sharesLoaded) return;
 
-  async function handleCreateAgentLink() {
-    if (createAgentLink.isPending) return;
-    const result = (await createAgentLink.mutateAsync({
-      recordingId,
-    })) as { url?: string };
-    if (!result?.url) return;
-    setAgentContextUrl(result.url);
-    copyToClipboard(result.url);
-  }
+    void loadAgentContextUrl();
+
+    return () => {
+      agentLinkRequestIdRef.current += 1;
+    };
+  }, [recordingId, visibility, sharesLoaded, loadAgentContextUrl]);
 
   const agentShareDisabled =
     isPending || createAgentLink.isPending || !agentContextUrl;
@@ -338,26 +375,28 @@ function LinkTab({
       {isPublic ? <SlackShareHint canManage={canManage} /> : null}
 
       <div className="space-y-2">
-        <div className="flex items-end justify-between gap-2">
-          <div className="text-xs font-medium text-muted-foreground">
-            {t("shareDialog.shareWithAgents")}
-          </div>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="h-7"
-            onClick={() => void handleCreateAgentLink()}
-            disabled={isPending || createAgentLink.isPending}
-          >
-            {t("shareUi.copy")}
-          </Button>
-        </div>
         <CopyField
-          label=""
+          label={t("shareDialog.shareWithAgents")}
           value={agentContextUrl}
           disabled={agentShareDisabled}
         />
+        {agentLinkError ? (
+          <div className="flex items-center justify-between gap-2 rounded-md border border-border bg-muted/40 px-3 py-2">
+            <p className="text-xs text-muted-foreground">
+              {t("shareDialog.agentLinkUnavailable")}
+            </p>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7"
+              onClick={() => void loadAgentContextUrl()}
+              disabled={createAgentLink.isPending}
+            >
+              {t("shareDialog.retryAgentLink")}
+            </Button>
+          </div>
+        ) : null}
       </div>
 
       <CopyField

--- a/templates/clips/app/i18n/ar-SA.ts
+++ b/templates/clips/app/i18n/ar-SA.ts
@@ -424,6 +424,8 @@ const messages = {
       "اجلب عنوان URL لسياق وكيل Clips هذا: {{agentContextUrl}}. استخدم transcript.segments للسياق المنطوق، واجلب recommendedFrames أو عناوين URL الخاصة بواجهة API للإطارات لرؤية الشاشة، وتحقق من browserDiagnostics إن وجدت لسجلات وحدة التحكم المنقحة وبيانات طلبات fetch/XHR الوصفية.",
     agentTokenDescription:
       "يسمح URL المؤقت هذا للوكلاء بقراءة المقطع دون جعله عاما. تنتهي صلاحيته بعد ساعتين.",
+    agentLinkUnavailable: "تعذر إنشاء رابط الوكيل.",
+    retryAgentLink: "إعادة المحاولة",
     gifPreview: "معاينة GIF",
     openPlayer: "مشغل مفتوح",
     downloadMp4: "تحميل MP4",

--- a/templates/clips/app/i18n/de-DE.ts
+++ b/templates/clips/app/i18n/de-DE.ts
@@ -442,6 +442,8 @@ const messages = {
       "Rufe diese Clips-Agent-Kontext-URL ab: {{agentContextUrl}}. Verwende transcript.segments fuer den gesprochenen Kontext, rufe recommendedFrames oder die Frame-API-URLs ab, um den Bildschirm zu sehen, und pruefe browserDiagnostics, falls vorhanden, fuer redigierte Konsolenprotokolle und fetch/XHR-Anfragemetadaten.",
     agentTokenDescription:
       "Diese temporare Agent-URL lasst Agenten den Clip lesen, ohne ihn offentlich zu machen. Sie lauft nach zwei Stunden ab.",
+    agentLinkUnavailable: "Agent-Link konnte nicht erstellt werden.",
+    retryAgentLink: "Erneut versuchen",
     gifPreview: "GIF-Vorschau",
     openPlayer: "Spieler öffnen",
     downloadMp4: "Laden Sie MP4 herunter",

--- a/templates/clips/app/i18n/en-US.ts
+++ b/templates/clips/app/i18n/en-US.ts
@@ -424,6 +424,8 @@ const messages = {
       "Fetch this Clips agent context URL: {{agentContextUrl}}. Use transcript.segments for spoken context, fetch recommendedFrames or the frame API URLs to see the screen, and check browserDiagnostics if present for redacted console logs and fetch/XHR request metadata.",
     agentTokenDescription:
       "This temporary agent URL lets agents read the clip without making it public. It expires after two hours.",
+    agentLinkUnavailable: "Couldn't create the agent link.",
+    retryAgentLink: "Retry",
     gifPreview: "GIF preview",
     openPlayer: "Open player",
     downloadMp4: "Download MP4",

--- a/templates/clips/app/i18n/es-ES.ts
+++ b/templates/clips/app/i18n/es-ES.ts
@@ -436,6 +436,8 @@ const messages = {
       "Obtén esta URL de contexto para agentes de Clips: {{agentContextUrl}}. Usa transcript.segments para el contexto hablado, obtén recommendedFrames o las URLs de la API de fotogramas para ver la pantalla y revisa browserDiagnostics si está presente para ver registros de consola redactados y metadatos de solicitudes fetch/XHR.",
     agentTokenDescription:
       "Esta URL temporal para agentes permite leer el clip sin hacerlo publico. Caduca en dos horas.",
+    agentLinkUnavailable: "No se pudo crear el enlace para agentes.",
+    retryAgentLink: "Reintentar",
     gifPreview: "vista previa de GIF",
     openPlayer: "jugador abierto",
     downloadMp4: "Descargar MP4",

--- a/templates/clips/app/i18n/fr-FR.ts
+++ b/templates/clips/app/i18n/fr-FR.ts
@@ -436,6 +436,8 @@ const messages = {
       "Récupère cette URL de contexte Clips pour agent : {{agentContextUrl}}. Utilise transcript.segments pour le contexte parlé, récupère recommendedFrames ou les URLs de l'API d'images pour voir l'écran, et consulte browserDiagnostics s'il est présent pour les journaux de console expurgés et les métadonnées de requêtes fetch/XHR.",
     agentTokenDescription:
       "Cette URL temporaire pour agents permet de lire le clip sans le rendre public. Elle expire dans deux heures.",
+    agentLinkUnavailable: "Impossible de créer le lien pour agents.",
+    retryAgentLink: "Réessayer",
     gifPreview: "aperçu de GIF",
     openPlayer: "Joueur ouvert",
     downloadMp4: "Télécharger MP4",

--- a/templates/clips/app/i18n/hi-IN.ts
+++ b/templates/clips/app/i18n/hi-IN.ts
@@ -421,6 +421,8 @@ const messages = {
       "यह Clips एजेंट संदर्भ URL प्राप्त करें: {{agentContextUrl}}। बोले गए संदर्भ के लिए transcript.segments का उपयोग करें, स्क्रीन देखने के लिए recommendedFrames या फ्रेम API URL प्राप्त करें, और यदि browserDiagnostics मौजूद हो तो संशोधित कंसोल लॉग और fetch/XHR अनुरोध मेटाडेटा जांचें।",
     agentTokenDescription:
       "यह अस्थायी एजेंट URL क्लिप को सार्वजनिक किए बिना एजेंटों को इसे पढ़ने देता है। यह दो घंटे बाद समाप्त हो जाता है।",
+    agentLinkUnavailable: "एजेंट लिंक नहीं बन सका।",
+    retryAgentLink: "फिर से प्रयास करें",
     gifPreview: "GIF पूर्वावलोकन",
     openPlayer: "खुला खिलाड़ी",
     downloadMp4: "MP4 डाउनलोड करें",

--- a/templates/clips/app/i18n/ja-JP.ts
+++ b/templates/clips/app/i18n/ja-JP.ts
@@ -433,6 +433,8 @@ const messages = {
       "この Clips エージェントコンテキスト URL を取得してください: {{agentContextUrl}}。音声の文脈には transcript.segments を使い、画面を見るために recommendedFrames またはフレーム API URL を取得し、browserDiagnostics がある場合は、編集済みのコンソールログと fetch/XHR リクエストのメタデータを確認してください。",
     agentTokenDescription:
       "この一時的なエージェント URL により、クリップを公開せずにエージェントが読み取れます。2 時間後に期限切れになります。",
+    agentLinkUnavailable: "エージェント用リンクを作成できませんでした。",
+    retryAgentLink: "再試行",
     gifPreview: "GIF プレビュー",
     openPlayer: "プレーヤーを開く",
     downloadMp4: "ダウンロード",

--- a/templates/clips/app/i18n/ko-KR.ts
+++ b/templates/clips/app/i18n/ko-KR.ts
@@ -426,6 +426,8 @@ const messages = {
       "이 Clips 에이전트 컨텍스트 URL을 가져오세요: {{agentContextUrl}}. 말한 내용의 맥락은 transcript.segments를 사용하고, 화면을 보기 위해 recommendedFrames 또는 프레임 API URL을 가져오며, browserDiagnostics가 있으면 수정된 콘솔 로그와 fetch/XHR 요청 메타데이터를 확인하세요.",
     agentTokenDescription:
       "이 임시 에이전트 URL을 사용하면 클립을 공개하지 않고도 에이전트가 읽을 수 있습니다. 2시간 후 만료됩니다.",
+    agentLinkUnavailable: "에이전트 링크를 만들 수 없습니다.",
+    retryAgentLink: "다시 시도",
     gifPreview: "GIF 미리보기",
     openPlayer: "플레이어 열기",
     downloadMp4: "MP4 다운로드",

--- a/templates/clips/app/i18n/pt-BR.ts
+++ b/templates/clips/app/i18n/pt-BR.ts
@@ -434,6 +434,8 @@ const messages = {
       "Busque esta URL de contexto para agentes do Clips: {{agentContextUrl}}. Use transcript.segments para o contexto falado, busque recommendedFrames ou as URLs da API de quadros para ver a tela e confira browserDiagnostics, se presente, para logs de console redigidos e metadados de solicitações fetch/XHR.",
     agentTokenDescription:
       "Esta URL temporaria para agentes permite ler o clipe sem torna-lo publico. Ela expira em duas horas.",
+    agentLinkUnavailable: "Não foi possível criar o link para agentes.",
+    retryAgentLink: "Tentar novamente",
     gifPreview: "visualização de GIF",
     openPlayer: "Jogador aberto",
     downloadMp4: "Baixar MP4",

--- a/templates/clips/app/i18n/zh-CN.ts
+++ b/templates/clips/app/i18n/zh-CN.ts
@@ -408,6 +408,8 @@ const messages = {
       "获取这个 Clips 代理上下文 URL：{{agentContextUrl}}。使用 transcript.segments 读取语音上下文，获取 recommendedFrames 或帧 API URL 来查看屏幕，并在 browserDiagnostics 存在时检查经过脱敏的控制台日志和 fetch/XHR 请求元数据。",
     agentTokenDescription:
       "这个临时代理 URL 可让代理读取剪辑，而无需将其设为公开。它会在两小时后过期。",
+    agentLinkUnavailable: "无法创建代理链接。",
+    retryAgentLink: "重试",
     gifPreview: "GIF 预览",
     openPlayer: "开放玩家",
     downloadMp4: "下载MP4",

--- a/templates/clips/app/i18n/zh-TW.ts
+++ b/templates/clips/app/i18n/zh-TW.ts
@@ -408,6 +408,8 @@ const messages = {
       "取得這個 Clips Agent 脈絡 URL：{{agentContextUrl}}。使用 transcript.segments 讀取語音脈絡，取得 recommendedFrames 或影格 API URL 來查看螢幕，並在 browserDiagnostics 存在時檢查已遮蔽的主控台記錄和 fetch/XHR 請求中繼資料。",
     agentTokenDescription:
       "這個臨時 Agent URL 可讓 Agent 讀取剪輯，而不必將其設為公開。它會在兩小時後過期。",
+    agentLinkUnavailable: "無法建立 Agent 連結。",
+    retryAgentLink: "重試",
     gifPreview: "GIF 預覽",
     openPlayer: "開啟播放器",
     downloadMp4: "下載 MP4",

--- a/templates/clips/changelog/2026-07-06-share-links-for-agents-now-appear-as-soon-as-the-share-menu-.md
+++ b/templates/clips/changelog/2026-07-06-share-links-for-agents-now-appear-as-soon-as-the-share-menu-.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-06
+---
+
+Share links for agents now appear as soon as the share menu opens.


### PR DESCRIPTION
## Summary
- auto-mint Clips agent share links when the share menu opens after share/access data loads
- remove the extra row-level Copy button so the existing field copy controls are used
- add a scoped retry/error state and localized share-dialog copy

## Review
- claude-fable-5 in local Claude Code reviewed the diff and signed off after the request-id race handling and hook identity caveat were fixed

## Verification
- `node_modules/.bin/oxfmt app/components/player/share-dialog.tsx app/i18n/*.ts`
- `PATH=/Users/alicemoore/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node_modules/.bin/agent-native typecheck`