### PR TITLE
Fix wrong duration for paused fullscreen recordings

### DIFF
--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -1538,6 +1538,13 @@ fn take_and_finalize_active_session(
             session.lost_segment_duration.as_secs()
         );
     }
+
+    if let Some(paused_at) = session.paused_at.take() {
+        session.paused_total = session
+            .paused_total
+            .checked_add(paused_at.elapsed())
+            .unwrap_or(session.paused_total);
+    }
     let duration_ms = session
         .started_at
         .elapsed()


### PR DESCRIPTION

Fixes a bug where a fullscreen recording could report a much longer duration than the video actually contained.

If you paused a recording and then stopped it without resuming, the time spent paused was still counted as part of the recording. For example, a 2-minute clip that was paused for 18 minutes before stopping showed a duration of 20 minutes, even though the video was only 2 minutes long.

After this change, the reported duration matches the real length of the recorded content.

## Impact

- Only affects the desktop fullscreen recorder.
- No changes to the recording files themselves, only to the duration that gets reported and saved.