### PR TITLE
Fix: Clips updates no longer block recording

### DIFF
--- a/templates/clips/changelog/2026-07-07-a-pending-app-update-no-longer-blocks-screen-recording-updat.md
+++ b/templates/clips/changelog/2026-07-07-a-pending-app-update-no-longer-blocks-screen-recording-updat.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-07
+---
+
+A pending app update no longer blocks screen recording — updates now install when you restart, not mid-session

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -57,6 +57,7 @@ import {
   MACOS_CAPTURE_PERMISSION_MESSAGE,
   MACOS_SCREEN_PERMISSION_MESSAGE,
   MACOS_SPEECH_PERMISSION_MESSAGE,
+  MACOS_UPDATE_RESTART_MESSAGE,
 } from "./lib/permissions";
 import { isMacPlatform, isWindowsPlatform } from "./lib/platform";
 import {
@@ -78,6 +79,7 @@ import {
   saveBool,
   saveString,
 } from "./lib/storage";
+import { installAndRestart, isUpdatePendingRestart } from "./lib/updater";
 import { normalizeServerUrl } from "./lib/url";
 import {
   installDesktopVoiceDictation,
@@ -1976,7 +1978,16 @@ export function App() {
       return;
     }
     if (isHardCapturePermissionError(message)) {
-      setRecError(MACOS_CAPTURE_PERMISSION_MESSAGE);
+      // If an update has finished downloading and is waiting to install, the
+      // safe next step is to restart (which applies the update and gives the
+      // process a clean binary + permission state). Prefer that hint over the
+      // "grant permissions" banner, which is misleading when the readiness
+      // checkmarks are already green.
+      setRecError(
+        isUpdatePendingRestart()
+          ? MACOS_UPDATE_RESTART_MESSAGE
+          : MACOS_CAPTURE_PERMISSION_MESSAGE,
+      );
       return;
     }
     if (isStorageSetupFailureMessage(message)) {
@@ -2414,8 +2425,10 @@ export function App() {
             : "Start local recording"}
       </button>
       {recError ? (
-        recError === MACOS_CAPTURE_PERMISSION_MESSAGE ||
-        recError === MACOS_SCREEN_PERMISSION_MESSAGE ? (
+        recError === MACOS_UPDATE_RESTART_MESSAGE ? (
+          <UpdateRestartBanner message={recError} />
+        ) : recError === MACOS_CAPTURE_PERMISSION_MESSAGE ||
+          recError === MACOS_SCREEN_PERMISSION_MESSAGE ? (
           <PermissionRecoveryBanner
             kind="recording"
             message={recError}
@@ -2573,6 +2586,30 @@ function PermissionRecoveryBanner({
         ))}
         <button type="button" className="permission-retry" onClick={onRetry}>
           Try again
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function UpdateRestartBanner({ message }: { message: string }) {
+  return (
+    <div className="error-banner permission-banner">
+      <div className="permission-copy">
+        <div className="permission-title">Restart to finish updating</div>
+        <div>{message}</div>
+      </div>
+      <div className="permission-actions">
+        <button
+          type="button"
+          className="permission-retry"
+          onClick={() => {
+            installAndRestart().catch((err) => {
+              console.error("[clips-updater] relaunch failed:", err);
+            });
+          }}
+        >
+          Restart Clips
         </button>
       </div>
     </div>

--- a/templates/clips/desktop/src/lib/permissions.ts
+++ b/templates/clips/desktop/src/lib/permissions.ts
@@ -8,6 +8,8 @@ export const MACOS_SCREEN_PERMISSION_MESSAGE =
   "Grant Screen Recording permission in macOS Settings, then restart Clips and try again.";
 export const MACOS_SPEECH_PERMISSION_MESSAGE =
   "Grant Speech Recognition and Microphone access, then try again. If you just changed access, restart Clips before retrying.";
+export const MACOS_UPDATE_RESTART_MESSAGE =
+  "An update was downloaded and needs a restart to finish installing. Restart Clips, then record again.";
 
 export function isHardCapturePermissionError(message: string): boolean {
   return /permission denied by system|blocked by system|system settings|screen recording|privacy|sandbox/i.test(

--- a/templates/clips/desktop/src/lib/updater.ts
+++ b/templates/clips/desktop/src/lib/updater.ts
@@ -45,9 +45,15 @@ async function runCheck() {
     const notes = update.body ?? undefined;
     setStatus({ state: "available", version, notes });
 
+    // Download ONLY — do not install here. On macOS `install` swaps the .app
+    // bundle on disk while this process keeps running, which invalidates the
+    // running process's Screen Recording (TCC) grant and breaks capture until
+    // relaunch. We defer the swap to `installAndRestart()` so a downloaded-but-
+    // not-yet-installed update leaves the running app fully functional; the
+    // user records normally until they choose to restart.
     let total = 0;
     let downloaded = 0;
-    await update.downloadAndInstall((event) => {
+    await update.download((event) => {
       if (event.event === "Started") {
         total = event.data.contentLength ?? 0;
         downloaded = 0;
@@ -98,8 +104,25 @@ export function useUpdateStatus(): UpdateStatus {
 }
 
 export async function installAndRestart(): Promise<void> {
-  // downloadAndInstall already applied the bundle; relaunch completes it.
+  // Perform the deferred bundle swap now, then relaunch onto the new binary.
+  // Installing immediately before relaunch keeps the window where the on-disk
+  // bundle no longer matches the running process as short as possible — the
+  // process is torn down by `relaunch()` right after, so capture never runs
+  // against a swapped-out bundle.
+  if (pendingUpdate) {
+    await pendingUpdate.install();
+  }
   await relaunch();
+}
+
+/**
+ * True once an update has been downloaded and is waiting for the user to
+ * restart. The recording flow uses this to explain a post-download capture
+ * failure as "restart to finish updating" instead of a misleading "grant
+ * permissions" message — see `app.tsx` recError routing.
+ */
+export function isUpdatePendingRestart(): boolean {
+  return cachedStatus.state === "downloaded";
 }
 
 /**


### PR DESCRIPTION
When a Clips update downloaded, you couldn't record until you restarted — and the app blamed it on missing macOS permissions that were actually fine.

## The fix

- **Updates wait for you.** A downloaded update sits quietly until you choose to restart. You keep recording as usual until then.
- **Clearer message.** If recording is ever blocked by a waiting update, Clips now says to restart and shows a "Restart Clips" button, instead of the misleading permissions error.