### PR TITLE
Fix: Clips Chrome extension recordings survive a tab refresh

### DIFF
--- a/templates/clips/changelog/2026-07-07-chrome-extension-recordings-keep-audio-after-refreshing-tab.md
+++ b/templates/clips/changelog/2026-07-07-chrome-extension-recordings-keep-audio-after-refreshing-tab.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-07
+---
+
+Chrome extension recordings now survive refreshing the tab being recorded: the camera bubble and recording toolbar reappear, and tab audio and microphone sound keep recording.

--- a/templates/clips/chrome-extension/src/background.ts
+++ b/templates/clips/chrome-extension/src/background.ts
@@ -2332,6 +2332,7 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
     if (tabId !== overlayTabId) return;
     await mountOverlayOnTab(tabId);
     broadcastOverlayState();
+    if (overlayPhase === "countdown") await handleOverlaySkip();
   })();
 });
 

--- a/templates/clips/chrome-extension/src/background.ts
+++ b/templates/clips/chrome-extension/src/background.ts
@@ -2318,6 +2318,23 @@ chrome.tabs.onActivated.addListener((info) => {
   })();
 });
 
+// The overlay content script is injected on demand (activeTab), so reloading the
+// launch tab wipes it — the camera bubble and toolbar would vanish for the rest
+// of the recording even though capture keeps running in the offscreen document.
+// Re-inject and re-mount once the launch tab finishes reloading while a recording
+// is active. Scoped to the launch tab (the only tab activeTab lets us touch); a
+// same-URL reload keeps that grant.
+chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+  if (changeInfo.status !== "complete") return;
+  void (async () => {
+    await ensureRestored();
+    if (overlayPhase === "idle" || !activeNativeRecording) return;
+    if (tabId !== overlayTabId) return;
+    await mountOverlayOnTab(tabId);
+    broadcastOverlayState();
+  })();
+});
+
 // While recording, the popup is disabled (setActionPopup("")), so clicking the
 // extension icon lands here: stop & save immediately (or discard if we're still
 // in the pre-roll countdown). When idle, the popup opens and this never fires.

--- a/templates/clips/chrome-extension/src/offscreen.ts
+++ b/templates/clips/chrome-extension/src/offscreen.ts
@@ -733,19 +733,34 @@ async function buildCompositor(
 async function createMixedAudio(
   streams: MediaStream[],
 ): Promise<{ audioContext: AudioContext | null; tracks: MediaStreamTrack[] }> {
-  const streamsWithAudio = streams.filter(
-    (stream) => stream.getAudioTracks().length,
-  );
-  if (!streamsWithAudio.length) return { audioContext: null, tracks: [] };
-  if (streamsWithAudio.length === 1) {
-    return { audioContext: null, tracks: streamsWithAudio[0].getAudioTracks() };
+  const audioTracks = streams.flatMap((stream) => stream.getAudioTracks());
+  if (!audioTracks.length) return { audioContext: null, tracks: [] };
+  if (audioTracks.length === 1) {
+    return { audioContext: null, tracks: audioTracks };
   }
 
   const audioContext = new AudioContext();
   await audioContext.resume().catch(() => undefined);
   const destination = audioContext.createMediaStreamDestination();
-  for (const stream of streamsWithAudio) {
-    audioContext.createMediaStreamSource(stream).connect(destination);
+  for (const track of audioTracks) {
+    // One source per track (not per stream) so each input is isolated in the
+    // mix graph and can be detached independently.
+    const source = audioContext.createMediaStreamSource(
+      new MediaStream([track]),
+    );
+    source.connect(destination);
+    // A mixed input track can end mid-recording — most commonly the shared
+    // tab's audio track when the user refreshes the captured tab. Disconnect
+    // just that dead source so the mixed output keeps carrying the surviving
+    // inputs (the microphone). Without this the whole mixed destination can go
+    // silent, dropping both the tab audio and the mic for the rest of the clip.
+    track.addEventListener("ended", () => {
+      try {
+        source.disconnect();
+      } catch {
+        /* already disconnected */
+      }
+    });
   }
   return { audioContext, tracks: destination.stream.getAudioTracks() };
 }


### PR DESCRIPTION
Refreshing the tab you are recording used to break the recording. This fixes it.

Before, if you refreshed the tab mid-recording:

- The camera bubble and the recording toolbar disappeared for the rest of the recording.
- The tab sound and the microphone sound went silent for the rest of the recording.

After this change, refreshing the tab keeps everything working. The camera bubble and toolbar come back, and both the tab audio and the microphone keep recording.
