### PR TITLE
Fix Content database permanent delete timeout

### DIFF
--- a/templates/content/actions/delete-document.test.ts
+++ b/templates/content/actions/delete-document.test.ts
@@ -1,15 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("./_database-utils.js", () => ({
-  deleteDatabaseDataForDocument: vi.fn().mockResolvedValue(undefined),
-}));
-
 vi.mock("drizzle-orm", async (importOriginal) => {
   const actual = await importOriginal<typeof import("drizzle-orm")>();
   return {
     ...actual,
     and: (...conds: unknown[]) => ({ __and: conds }),
     eq: (col: unknown, value: unknown) => ({ __eq: [col, value] }),
+    inArray: (col: unknown, values: unknown[]) => ({
+      __inArray: [col, values],
+    }),
   };
 });
 
@@ -21,6 +20,50 @@ const { schema } = vi.hoisted(() => ({
       id: "documents.id",
       parentId: "documents.parentId",
       ownerEmail: "documents.ownerEmail",
+    },
+    contentDatabases: {
+      id: "contentDatabases.id",
+      documentId: "contentDatabases.documentId",
+    },
+    contentDatabaseItems: {
+      databaseId: "contentDatabaseItems.databaseId",
+      documentId: "contentDatabaseItems.documentId",
+    },
+    documentPropertyDefinitions: {
+      id: "documentPropertyDefinitions.id",
+      databaseId: "documentPropertyDefinitions.databaseId",
+    },
+    contentDatabaseSources: {
+      id: "contentDatabaseSources.id",
+      databaseId: "contentDatabaseSources.databaseId",
+    },
+    contentDatabaseBodyHydrationQueue: {
+      sourceId: "contentDatabaseBodyHydrationQueue.sourceId",
+      documentId: "contentDatabaseBodyHydrationQueue.documentId",
+    },
+    contentDatabaseSourceExecutions: {
+      sourceId: "contentDatabaseSourceExecutions.sourceId",
+    },
+    contentDatabaseSourceChangeReviews: {
+      sourceId: "contentDatabaseSourceChangeReviews.sourceId",
+    },
+    contentDatabaseSourceChangeSets: {
+      sourceId: "contentDatabaseSourceChangeSets.sourceId",
+    },
+    contentDatabaseSourceRows: {
+      sourceId: "contentDatabaseSourceRows.sourceId",
+    },
+    contentDatabaseSourceFields: {
+      sourceId: "contentDatabaseSourceFields.sourceId",
+    },
+    documentPropertyValues: {
+      propertyId: "documentPropertyValues.propertyId",
+      documentId: "documentPropertyValues.documentId",
+      ownerEmail: "documentPropertyValues.ownerEmail",
+    },
+    documentBlockFieldContents: {
+      propertyId: "documentBlockFieldContents.propertyId",
+      documentId: "documentBlockFieldContents.documentId",
     },
     documentSyncLinks: {
       documentId: "documentSyncLinks.documentId",
@@ -61,6 +104,11 @@ function matches(row: Record<string, unknown>, cond: any): boolean {
     const [col, value] = cond.__eq;
     const key = String(col).split(".").pop() as string;
     return row[key] === value;
+  }
+  if (cond.__inArray) {
+    const [col, values] = cond.__inArray;
+    const key = String(col).split(".").pop() as string;
+    return values.includes(row[key]);
   }
   return true;
 }
@@ -104,7 +152,7 @@ describe("deleteDocumentRecursive", () => {
     expect(commentDeletes).toHaveLength(1);
     expect(commentDeletes[0].cond).toEqual({
       __and: [
-        { __eq: [schema.documentComments.documentId, "doc-1"] },
+        { __inArray: [schema.documentComments.documentId, ["doc-1"]] },
         { __eq: [schema.documentComments.ownerEmail, "owner-a@example.com"] },
       ],
     });
@@ -125,9 +173,39 @@ describe("deleteDocumentRecursive", () => {
     expect(deleted.sort()).toEqual(["child-1", "child-2", "doc-1"].sort());
     const commentDeleteDocIds = deleteCalls
       .filter((c) => c.table === "documentComments")
-      .map((c: any) => c.cond.__and[0].__eq[1]);
+      .flatMap((c: any) => c.cond.__and[0].__inArray[1]);
     expect(commentDeleteDocIds.sort()).toEqual(
       ["child-1", "child-2", "doc-1"].sort(),
     );
+  });
+
+  it("includes database item pages in one recursive delete pass", async () => {
+    selectRows.contentDatabases = [
+      { id: "database-1", documentId: "database-doc" },
+    ];
+    selectRows.contentDatabaseItems = [
+      { databaseId: "database-1", documentId: "row-doc-1" },
+      { databaseId: "database-1", documentId: "row-doc-2" },
+    ];
+
+    const deleted = await deleteDocumentRecursive(
+      db,
+      "database-doc",
+      "owner-a@example.com",
+    );
+
+    expect(deleted.sort()).toEqual(
+      ["database-doc", "row-doc-1", "row-doc-2"].sort(),
+    );
+
+    const membershipDeletes = deleteCalls.filter(
+      (c) =>
+        c.table === "contentDatabaseItems" &&
+        c.cond.__inArray?.[0] === schema.contentDatabaseItems.databaseId,
+    );
+    expect(membershipDeletes).toHaveLength(1);
+    expect(membershipDeletes[0].cond).toEqual({
+      __inArray: [schema.contentDatabaseItems.databaseId, ["database-1"]],
+    });
   });
 });

--- a/templates/content/actions/delete-document.test.ts
+++ b/templates/content/actions/delete-document.test.ts
@@ -24,10 +24,12 @@ const { schema } = vi.hoisted(() => ({
     contentDatabases: {
       id: "contentDatabases.id",
       documentId: "contentDatabases.documentId",
+      ownerEmail: "contentDatabases.ownerEmail",
     },
     contentDatabaseItems: {
       databaseId: "contentDatabaseItems.databaseId",
       documentId: "contentDatabaseItems.documentId",
+      ownerEmail: "contentDatabaseItems.ownerEmail",
     },
     documentPropertyDefinitions: {
       id: "documentPropertyDefinitions.id",
@@ -181,11 +183,27 @@ describe("deleteDocumentRecursive", () => {
 
   it("includes database item pages in one recursive delete pass", async () => {
     selectRows.contentDatabases = [
-      { id: "database-1", documentId: "database-doc" },
+      {
+        id: "database-1",
+        documentId: "database-doc",
+        ownerEmail: "owner-a@example.com",
+      },
     ];
     selectRows.contentDatabaseItems = [
-      { databaseId: "database-1", documentId: "row-doc-1" },
-      { databaseId: "database-1", documentId: "row-doc-2" },
+      {
+        databaseId: "database-1",
+        documentId: "row-doc-1",
+        ownerEmail: "owner-a@example.com",
+      },
+      {
+        databaseId: "database-1",
+        documentId: "row-doc-2",
+        ownerEmail: "owner-a@example.com",
+      },
+    ];
+    selectRows.documents = [
+      { id: "row-doc-1", ownerEmail: "owner-a@example.com" },
+      { id: "row-doc-2", ownerEmail: "owner-a@example.com" },
     ];
 
     const deleted = await deleteDocumentRecursive(
@@ -207,5 +225,61 @@ describe("deleteDocumentRecursive", () => {
     expect(membershipDeletes[0].cond).toEqual({
       __inArray: [schema.contentDatabaseItems.databaseId, ["database-1"]],
     });
+  });
+
+  it("does not collect foreign-owned database item documents", async () => {
+    selectRows.contentDatabases = [
+      {
+        id: "database-1",
+        documentId: "database-doc",
+        ownerEmail: "owner-a@example.com",
+      },
+    ];
+    selectRows.contentDatabaseItems = [
+      {
+        databaseId: "database-1",
+        documentId: "row-doc-1",
+        ownerEmail: "owner-a@example.com",
+      },
+      {
+        databaseId: "database-1",
+        documentId: "foreign-row-doc",
+        ownerEmail: "owner-b@example.com",
+      },
+      {
+        databaseId: "database-1",
+        documentId: "mismatched-row-doc",
+        ownerEmail: "owner-a@example.com",
+      },
+    ];
+    selectRows.documents = [
+      { id: "row-doc-1", ownerEmail: "owner-a@example.com" },
+      { id: "foreign-row-doc", ownerEmail: "owner-b@example.com" },
+      { id: "mismatched-row-doc", ownerEmail: "owner-b@example.com" },
+    ];
+
+    const deleted = await deleteDocumentRecursive(
+      db,
+      "database-doc",
+      "owner-a@example.com",
+    );
+
+    expect(deleted.sort()).toEqual(["database-doc", "row-doc-1"].sort());
+  });
+
+  it("chunks the final documents delete", async () => {
+    selectRows.documents = Array.from({ length: 95 }, (_, index) => ({
+      id: `child-${index}`,
+      parentId: "doc-1",
+      ownerEmail: "owner-a@example.com",
+    }));
+
+    await deleteDocumentRecursive(db, "doc-1", "owner-a@example.com");
+
+    const documentDeletes = deleteCalls.filter((c) => c.table === "documents");
+    expect(documentDeletes).toHaveLength(2);
+    expect(
+      documentDeletes.map((c: any) => c.cond.__and[0].__inArray[1].length),
+    ).toEqual([90, 6]);
   });
 });

--- a/templates/content/actions/delete-document.ts
+++ b/templates/content/actions/delete-document.ts
@@ -1,78 +1,325 @@
 import { defineAction } from "@agent-native/core";
 import { writeAppState } from "@agent-native/core/application-state";
 import { assertAccess } from "@agent-native/core/sharing";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
-import { deleteDatabaseDataForDocument } from "./_database-utils.js";
 import {
   deleteLocalFileDocument,
   isLocalDocumentId,
   isContentLocalFileMode,
 } from "./_local-file-documents.js";
 
+function chunks<T>(items: T[], size = 500): T[][] {
+  const out: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    out.push(items.slice(index, index + size));
+  }
+  return out;
+}
+
+async function selectDocumentChildren(
+  db: ReturnType<typeof getDb>,
+  parentIds: string[],
+  ownerEmail: string,
+) {
+  const rows: Array<{ id: string }> = [];
+  for (const batch of chunks(parentIds)) {
+    rows.push(
+      ...(await db
+        .select({ id: schema.documents.id })
+        .from(schema.documents)
+        .where(
+          and(
+            inArray(schema.documents.parentId, batch),
+            eq(schema.documents.ownerEmail, ownerEmail),
+          ),
+        )),
+    );
+  }
+  return rows;
+}
+
+async function selectOwnedDatabaseIds(
+  db: ReturnType<typeof getDb>,
+  documentIds: string[],
+) {
+  const rows: Array<{ id: string }> = [];
+  for (const batch of chunks(documentIds)) {
+    rows.push(
+      ...(await db
+        .select({ id: schema.contentDatabases.id })
+        .from(schema.contentDatabases)
+        .where(inArray(schema.contentDatabases.documentId, batch))),
+    );
+  }
+  return rows;
+}
+
+async function selectDatabaseItemDocuments(
+  db: ReturnType<typeof getDb>,
+  databaseIds: string[],
+) {
+  const rows: Array<{ documentId: string }> = [];
+  for (const batch of chunks(databaseIds)) {
+    rows.push(
+      ...(await db
+        .select({ documentId: schema.contentDatabaseItems.documentId })
+        .from(schema.contentDatabaseItems)
+        .where(inArray(schema.contentDatabaseItems.databaseId, batch))),
+    );
+  }
+  return rows;
+}
+
+async function collectDocumentSubtreeForDelete(
+  db: ReturnType<typeof getDb>,
+  rootId: string,
+  ownerEmail: string,
+) {
+  const documentIds = new Set([rootId]);
+  const ownedDatabaseIds = new Set<string>();
+  let frontier = [rootId];
+
+  while (frontier.length > 0) {
+    const next = new Set<string>();
+
+    for (const child of await selectDocumentChildren(
+      db,
+      frontier,
+      ownerEmail,
+    )) {
+      if (!documentIds.has(child.id)) {
+        documentIds.add(child.id);
+        next.add(child.id);
+      }
+    }
+
+    const ownedDatabases = await selectOwnedDatabaseIds(db, frontier);
+    const newDatabaseIds = ownedDatabases
+      .map((database) => database.id)
+      .filter((databaseId) => {
+        if (ownedDatabaseIds.has(databaseId)) return false;
+        ownedDatabaseIds.add(databaseId);
+        return true;
+      });
+
+    if (newDatabaseIds.length > 0) {
+      const itemDocuments = await selectDatabaseItemDocuments(
+        db,
+        newDatabaseIds,
+      );
+      for (const item of itemDocuments) {
+        if (!documentIds.has(item.documentId)) {
+          documentIds.add(item.documentId);
+          next.add(item.documentId);
+        }
+      }
+    }
+
+    frontier = [...next];
+  }
+
+  return {
+    documentIds: [...documentIds],
+    ownedDatabaseIds: [...ownedDatabaseIds],
+  };
+}
+
+async function deleteWhereIn<T>(
+  items: T[],
+  run: (batch: T[]) => Promise<unknown>,
+) {
+  for (const batch of chunks(items)) {
+    if (batch.length > 0) await run(batch);
+  }
+}
+
 export async function deleteDocumentRecursive(
   db: ReturnType<typeof getDb>,
   id: string,
   ownerEmail: string,
 ): Promise<string[]> {
-  const children = await db
-    .select({ id: schema.documents.id })
-    .from(schema.documents)
+  const { documentIds, ownedDatabaseIds } =
+    await collectDocumentSubtreeForDelete(db, id, ownerEmail);
+
+  const propertyDefinitionIds: string[] = [];
+  await deleteWhereIn(ownedDatabaseIds, async (databaseIdBatch) => {
+    propertyDefinitionIds.push(
+      ...(
+        await db
+          .select({ id: schema.documentPropertyDefinitions.id })
+          .from(schema.documentPropertyDefinitions)
+          .where(
+            inArray(
+              schema.documentPropertyDefinitions.databaseId,
+              databaseIdBatch,
+            ),
+          )
+      ).map((definition) => definition.id),
+    );
+  });
+
+  const sourceIds: string[] = [];
+  await deleteWhereIn(ownedDatabaseIds, async (databaseIdBatch) => {
+    sourceIds.push(
+      ...(
+        await db
+          .select({ id: schema.contentDatabaseSources.id })
+          .from(schema.contentDatabaseSources)
+          .where(
+            inArray(schema.contentDatabaseSources.databaseId, databaseIdBatch),
+          )
+      ).map((source) => source.id),
+    );
+  });
+
+  // Delete database membership/schema, sync links, versions, shares, then documents.
+  await deleteWhereIn(sourceIds, async (sourceIdBatch) => {
+    await db
+      .delete(schema.contentDatabaseBodyHydrationQueue)
+      .where(
+        inArray(
+          schema.contentDatabaseBodyHydrationQueue.sourceId,
+          sourceIdBatch,
+        ),
+      );
+    await db
+      .delete(schema.contentDatabaseSourceExecutions)
+      .where(
+        inArray(schema.contentDatabaseSourceExecutions.sourceId, sourceIdBatch),
+      );
+    await db
+      .delete(schema.contentDatabaseSourceChangeReviews)
+      .where(
+        inArray(
+          schema.contentDatabaseSourceChangeReviews.sourceId,
+          sourceIdBatch,
+        ),
+      );
+    await db
+      .delete(schema.contentDatabaseSourceChangeSets)
+      .where(
+        inArray(schema.contentDatabaseSourceChangeSets.sourceId, sourceIdBatch),
+      );
+    await db
+      .delete(schema.contentDatabaseSourceRows)
+      .where(inArray(schema.contentDatabaseSourceRows.sourceId, sourceIdBatch));
+    await db
+      .delete(schema.contentDatabaseSourceFields)
+      .where(
+        inArray(schema.contentDatabaseSourceFields.sourceId, sourceIdBatch),
+      );
+  });
+
+  await deleteWhereIn(propertyDefinitionIds, async (propertyIdBatch) => {
+    await db
+      .delete(schema.documentPropertyValues)
+      .where(
+        inArray(schema.documentPropertyValues.propertyId, propertyIdBatch),
+      );
+    await db
+      .delete(schema.documentBlockFieldContents)
+      .where(
+        inArray(schema.documentBlockFieldContents.propertyId, propertyIdBatch),
+      );
+  });
+
+  await deleteWhereIn(documentIds, async (documentIdBatch) => {
+    await db
+      .delete(schema.contentDatabaseBodyHydrationQueue)
+      .where(
+        inArray(
+          schema.contentDatabaseBodyHydrationQueue.documentId,
+          documentIdBatch,
+        ),
+      );
+    await db
+      .delete(schema.documentPropertyValues)
+      .where(
+        and(
+          inArray(schema.documentPropertyValues.documentId, documentIdBatch),
+          eq(schema.documentPropertyValues.ownerEmail, ownerEmail),
+        ),
+      );
+    await db
+      .delete(schema.documentBlockFieldContents)
+      .where(
+        inArray(schema.documentBlockFieldContents.documentId, documentIdBatch),
+      );
+    await db
+      .delete(schema.contentDatabaseItems)
+      .where(inArray(schema.contentDatabaseItems.documentId, documentIdBatch));
+  });
+
+  await deleteWhereIn(ownedDatabaseIds, async (databaseIdBatch) => {
+    await db
+      .delete(schema.contentDatabaseItems)
+      .where(inArray(schema.contentDatabaseItems.databaseId, databaseIdBatch));
+    await db
+      .delete(schema.contentDatabaseSources)
+      .where(
+        inArray(schema.contentDatabaseSources.databaseId, databaseIdBatch),
+      );
+    await db
+      .delete(schema.documentPropertyDefinitions)
+      .where(
+        inArray(schema.documentPropertyDefinitions.databaseId, databaseIdBatch),
+      );
+    await db
+      .delete(schema.contentDatabases)
+      .where(inArray(schema.contentDatabases.id, databaseIdBatch));
+  });
+
+  await deleteWhereIn(documentIds, async (documentIdBatch) => {
+    await db
+      .delete(schema.documentSyncLinks)
+      .where(
+        and(
+          inArray(schema.documentSyncLinks.documentId, documentIdBatch),
+          eq(schema.documentSyncLinks.ownerEmail, ownerEmail),
+        ),
+      );
+    await db
+      .delete(schema.documentVersions)
+      .where(
+        and(
+          inArray(schema.documentVersions.documentId, documentIdBatch),
+          eq(schema.documentVersions.ownerEmail, ownerEmail),
+        ),
+      );
+    await db
+      .delete(schema.builderDocSidecars)
+      .where(
+        and(
+          inArray(schema.builderDocSidecars.documentId, documentIdBatch),
+          eq(schema.builderDocSidecars.ownerEmail, ownerEmail),
+        ),
+      );
+    await db
+      .delete(schema.documentComments)
+      .where(
+        and(
+          inArray(schema.documentComments.documentId, documentIdBatch),
+          eq(schema.documentComments.ownerEmail, ownerEmail),
+        ),
+      );
+    await db
+      .delete(schema.documentShares)
+      .where(inArray(schema.documentShares.resourceId, documentIdBatch));
+  });
+
+  await db
+    .delete(schema.documents)
     .where(
       and(
-        eq(schema.documents.parentId, id),
+        inArray(schema.documents.id, documentIds),
         eq(schema.documents.ownerEmail, ownerEmail),
       ),
     );
 
-  const deleted: string[] = [];
-  for (const child of children) {
-    deleted.push(...(await deleteDocumentRecursive(db, child.id, ownerEmail)));
-  }
-
-  // Delete database membership/schema, sync links, versions, shares, then document.
-  await deleteDatabaseDataForDocument(id, ownerEmail, db);
-  await db
-    .delete(schema.documentSyncLinks)
-    .where(
-      and(
-        eq(schema.documentSyncLinks.documentId, id),
-        eq(schema.documentSyncLinks.ownerEmail, ownerEmail),
-      ),
-    );
-  await db
-    .delete(schema.documentVersions)
-    .where(
-      and(
-        eq(schema.documentVersions.documentId, id),
-        eq(schema.documentVersions.ownerEmail, ownerEmail),
-      ),
-    );
-  await db
-    .delete(schema.builderDocSidecars)
-    .where(
-      and(
-        eq(schema.builderDocSidecars.documentId, id),
-        eq(schema.builderDocSidecars.ownerEmail, ownerEmail),
-      ),
-    );
-  await db
-    .delete(schema.documentComments)
-    .where(
-      and(
-        eq(schema.documentComments.documentId, id),
-        eq(schema.documentComments.ownerEmail, ownerEmail),
-      ),
-    );
-  await db
-    .delete(schema.documentShares)
-    .where(eq(schema.documentShares.resourceId, id));
-  await db.delete(schema.documents).where(eq(schema.documents.id, id));
-  deleted.push(id);
-
-  return deleted;
+  return documentIds;
 }
 
 export default defineAction({

--- a/templates/content/actions/delete-document.ts
+++ b/templates/content/actions/delete-document.ts
@@ -11,7 +11,9 @@ import {
   isContentLocalFileMode,
 } from "./_local-file-documents.js";
 
-function chunks<T>(items: T[], size = 500): T[][] {
+const DELETE_BATCH_SIZE = 90;
+
+function chunks<T>(items: T[], size = DELETE_BATCH_SIZE): T[][] {
   const out: T[][] = [];
   for (let index = 0; index < items.length; index += size) {
     out.push(items.slice(index, index + size));
@@ -44,6 +46,7 @@ async function selectDocumentChildren(
 async function selectOwnedDatabaseIds(
   db: ReturnType<typeof getDb>,
   documentIds: string[],
+  ownerEmail: string,
 ) {
   const rows: Array<{ id: string }> = [];
   for (const batch of chunks(documentIds)) {
@@ -51,7 +54,12 @@ async function selectOwnedDatabaseIds(
       ...(await db
         .select({ id: schema.contentDatabases.id })
         .from(schema.contentDatabases)
-        .where(inArray(schema.contentDatabases.documentId, batch))),
+        .where(
+          and(
+            inArray(schema.contentDatabases.documentId, batch),
+            eq(schema.contentDatabases.ownerEmail, ownerEmail),
+          ),
+        )),
     );
   }
   return rows;
@@ -60,6 +68,7 @@ async function selectOwnedDatabaseIds(
 async function selectDatabaseItemDocuments(
   db: ReturnType<typeof getDb>,
   databaseIds: string[],
+  ownerEmail: string,
 ) {
   const rows: Array<{ documentId: string }> = [];
   for (const batch of chunks(databaseIds)) {
@@ -67,10 +76,32 @@ async function selectDatabaseItemDocuments(
       ...(await db
         .select({ documentId: schema.contentDatabaseItems.documentId })
         .from(schema.contentDatabaseItems)
-        .where(inArray(schema.contentDatabaseItems.databaseId, batch))),
+        .where(
+          and(
+            inArray(schema.contentDatabaseItems.databaseId, batch),
+            eq(schema.contentDatabaseItems.ownerEmail, ownerEmail),
+          ),
+        )),
     );
   }
-  return rows;
+  if (rows.length === 0) return rows;
+
+  const ownedRows: Array<{ id: string }> = [];
+  for (const batch of chunks(rows.map((row) => row.documentId))) {
+    ownedRows.push(
+      ...(await db
+        .select({ id: schema.documents.id })
+        .from(schema.documents)
+        .where(
+          and(
+            inArray(schema.documents.id, batch),
+            eq(schema.documents.ownerEmail, ownerEmail),
+          ),
+        )),
+    );
+  }
+
+  return ownedRows.map((row) => ({ documentId: row.id }));
 }
 
 async function collectDocumentSubtreeForDelete(
@@ -96,7 +127,11 @@ async function collectDocumentSubtreeForDelete(
       }
     }
 
-    const ownedDatabases = await selectOwnedDatabaseIds(db, frontier);
+    const ownedDatabases = await selectOwnedDatabaseIds(
+      db,
+      frontier,
+      ownerEmail,
+    );
     const newDatabaseIds = ownedDatabases
       .map((database) => database.id)
       .filter((databaseId) => {
@@ -109,6 +144,7 @@ async function collectDocumentSubtreeForDelete(
       const itemDocuments = await selectDatabaseItemDocuments(
         db,
         newDatabaseIds,
+        ownerEmail,
       );
       for (const item of itemDocuments) {
         if (!documentIds.has(item.documentId)) {
@@ -310,14 +346,16 @@ export async function deleteDocumentRecursive(
       .where(inArray(schema.documentShares.resourceId, documentIdBatch));
   });
 
-  await db
-    .delete(schema.documents)
-    .where(
-      and(
-        inArray(schema.documents.id, documentIds),
-        eq(schema.documents.ownerEmail, ownerEmail),
-      ),
-    );
+  await deleteWhereIn(documentIds, async (documentIdBatch) => {
+    await db
+      .delete(schema.documents)
+      .where(
+        and(
+          inArray(schema.documents.id, documentIdBatch),
+          eq(schema.documents.ownerEmail, ownerEmail),
+        ),
+      );
+  });
 
   return documentIds;
 }

--- a/templates/content/changelog/2026-07-07-permanently-deleting-trashed-databases-now-finishes-reliably.md
+++ b/templates/content/changelog/2026-07-07-permanently-deleting-trashed-databases-now-finishes-reliably.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-07
+---
+
+Permanently deleting trashed databases now finishes reliably instead of timing out.


### PR DESCRIPTION
## Summary
- batch Content permanent delete cleanup for document subtrees and database item pages
- preserve owner scoping while deleting related comments, versions, shares, database rows, sources, and property data
- add regression coverage for database item pages in recursive deletes

## Verification
- ./node_modules/.bin/oxfmt --write actions/delete-document.ts actions/delete-document.test.ts
- /opt/homebrew/bin/pnpm --filter content exec vitest --run actions/delete-document.test.ts actions/content-database-lifecycle.db.test.ts --config vitest.config.ts
- /opt/homebrew/bin/pnpm --filter content typecheck

## Manual note
The captured production clip showed `delete-document` returning an HTML Inactivity Timeout after permanently deleting a trashed database. This change reduces that path from row-by-row recursive cleanup to chunked set-based cleanup so large database pages can finish within the hosted action window.