### PR TITLE
Enable server-owned agent continuations

### DIFF
--- a/.changeset/byo-provider-429-retry.md
+++ b/.changeset/byo-provider-429-retry.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Classify BYO-provider rate limits (HTTP 429) as retryable. The native Anthropic and AI-SDK engines now forward the provider HTTP status as a structured `http_<status>` errorCode + `statusCode` for every failure (not just 401), so a bare "429 status code (no body)" surfaces as `http_429`. `isRetryableError` also matches `http_429` and bare `429` messages. Previously a directly-connected provider key that Anthropic rate-limited failed hard instead of backing off and retrying like the Builder gateway path does, and rate-limited runs can now auto-continue.

--- a/.changeset/design-connect-registration.md
+++ b/.changeset/design-connect-registration.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix localhost Design bridge self-registration so capability payloads match the Design server action and bridge tokens can be persisted.

--- a/.changeset/server-owned-agent-continuations.md
+++ b/.changeset/server-owned-agent-continuations.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Make hosted foreground agent turns continue from the server by default, so switching tabs or closing the browser no longer leaves long runs dependent on a client-side auto-continue POST.

--- a/packages/core/src/agent/durable-background.spec.ts
+++ b/packages/core/src/agent/durable-background.spec.ts
@@ -160,34 +160,31 @@ describe("isAgentChatDurableBackgroundEnabled (default-off opt-in gate)", () => 
   });
 });
 
-describe("isAgentChatForegroundSelfChainEnabled (default-off opt-in gate)", () => {
+describe("isAgentChatForegroundSelfChainEnabled (default-on opt-out gate)", () => {
   it("is OFF with nothing configured", () => {
     expect(isAgentChatForegroundSelfChainEnabled()).toBe(false);
   });
 
-  it("is OFF BY DEFAULT (flag unset) even when hosted + secret are present", () => {
-    // GUARDRAIL: default-off is deliberate — durable/server-driven chat run
-    // paths were default-on twice in June 2026 and broke real users twice.
-    // The default must never flip without an explicit product decision.
+  it("is ON BY DEFAULT when hosted + secret are present", () => {
     makeHosted();
     process.env.A2A_SECRET = "shhh";
     delete process.env.AGENT_CHAT_FOREGROUND_SELF_CHAIN;
-    expect(isAgentChatForegroundSelfChainEnabled()).toBe(false);
+    expect(isAgentChatForegroundSelfChainEnabled()).toBe(true);
   });
 
-  it("is ON only when explicitly opted in via a truthy flag (hosted + secret)", () => {
+  it("stays ON for truthy, empty, or unrecognized flag values (hosted + secret)", () => {
     makeHosted();
     process.env.A2A_SECRET = "shhh";
-    for (const val of ["1", "true", "yes", "on", " TRUE "]) {
+    for (const val of ["1", "true", "yes", "on", " TRUE ", "", "maybe"]) {
       process.env.AGENT_CHAT_FOREGROUND_SELF_CHAIN = val;
       expect(isAgentChatForegroundSelfChainEnabled()).toBe(true);
     }
   });
 
-  it("is OFF for falsy, unrecognized, or empty flag values (default-off)", () => {
+  it("is OFF for explicit falsy flag values", () => {
     makeHosted();
     process.env.A2A_SECRET = "shhh";
-    for (const val of ["0", "false", "no", "off", "FALSE", "", "maybe"]) {
+    for (const val of ["0", "false", "no", "off", "FALSE", " Off "]) {
       process.env.AGENT_CHAT_FOREGROUND_SELF_CHAIN = val;
       expect(isAgentChatForegroundSelfChainEnabled()).toBe(false);
     }
@@ -205,15 +202,14 @@ describe("isAgentChatForegroundSelfChainEnabled (default-off opt-in gate)", () =
     expect(isAgentChatForegroundSelfChainEnabled()).toBe(false);
   });
 
-  it("is independent of AGENT_CHAT_DURABLE_BACKGROUND (neither implies the other)", () => {
+  it("can be explicitly disabled independently of AGENT_CHAT_DURABLE_BACKGROUND", () => {
     makeHosted();
     process.env.A2A_SECRET = "shhh";
-    process.env.AGENT_CHAT_FOREGROUND_SELF_CHAIN = "true";
     expect(isAgentChatForegroundSelfChainEnabled()).toBe(true);
     expect(isAgentChatDurableBackgroundEnabled()).toBe(false);
 
-    Reflect.deleteProperty(process.env, "AGENT_CHAT_FOREGROUND_SELF_CHAIN");
     process.env.AGENT_CHAT_DURABLE_BACKGROUND = "true";
+    process.env.AGENT_CHAT_FOREGROUND_SELF_CHAIN = "false";
     expect(isAgentChatForegroundSelfChainEnabled()).toBe(false);
     expect(isAgentChatDurableBackgroundEnabled()).toBe(true);
   });

--- a/packages/core/src/agent/durable-background.ts
+++ b/packages/core/src/agent/durable-background.ts
@@ -340,17 +340,17 @@ export function isAgentChatDurableBackgroundEnabled(options?: {
 }
 
 /**
- * Env flag for the FOREGROUND server-driven self-chain. DEFAULT-OFF (opt-in):
- * unset means disabled; an app opts IN with an explicit truthy value
- * (`true`/`1`/`yes`/`on`) — same parsing convention as
- * `AGENT_CHAT_DURABLE_BACKGROUND`, deliberately kept as a separate flag so
- * this narrower capability can be enabled/disabled independently of the full
- * durable-background worker path.
+ * Env flag for the FOREGROUND server-driven self-chain. DEFAULT-ON for hosted
+ * deployments with `A2A_SECRET`: unset/empty/unknown means enabled, and an app
+ * opts OUT with an explicit falsy value (`false`/`0`/`no`/`off`). Deliberately
+ * kept separate from `AGENT_CHAT_DURABLE_BACKGROUND` so this narrower
+ * capability can be disabled independently of the full durable-background
+ * worker path.
  */
 export const AGENT_CHAT_FOREGROUND_SELF_CHAIN_ENV =
   "AGENT_CHAT_FOREGROUND_SELF_CHAIN";
 
-function isForegroundSelfChainFlagEnabled(): boolean {
+function isForegroundSelfChainExplicitlyDisabled(): boolean {
   // Read the literal key (not `process.env[CONST]`) so guard:no-env-credentials
   // can statically verify it against the allowlisted `AGENT_*` prefix. Keep this
   // in sync with AGENT_CHAT_FOREGROUND_SELF_CHAIN_ENV.
@@ -358,26 +358,26 @@ function isForegroundSelfChainFlagEnabled(): boolean {
   if (raw == null) return false;
   const normalized = raw.trim().toLowerCase();
   return (
-    normalized === "1" ||
-    normalized === "true" ||
-    normalized === "yes" ||
-    normalized === "on"
+    normalized === "0" ||
+    normalized === "false" ||
+    normalized === "no" ||
+    normalized === "off"
   );
 }
 
 /**
- * Gate for the OPT-IN foreground self-chain: a normal (non-durable-background)
+ * Gate for the foreground self-chain: a normal (non-durable-background)
  * agent-chat turn that hits its soft-timeout chunk boundary continues via a
  * server-side self-dispatch on the REGULAR function (not a Netlify
  * `-background` function) instead of depending on the client to re-POST
  * `auto_continue`. Composes exactly like `isAgentChatDurableBackgroundEnabled`:
- * true only when the env flag is explicitly truthy AND the runtime is hosted
- * AND `A2A_SECRET` is configured (the HMAC handoff authenticates the
- * self-dispatch). False otherwise — and false means the existing
- * client-driven `auto_continue` re-POST path is used unchanged, byte-for-byte.
+ * true when the runtime is hosted AND `A2A_SECRET` is configured (the HMAC
+ * handoff authenticates the self-dispatch), unless the env flag is explicitly
+ * falsy. False otherwise — and false means the existing client-driven
+ * `auto_continue` re-POST path is used unchanged, byte-for-byte.
  *
  * Deliberately independent of `isAgentChatDurableBackgroundEnabled`: an app can
- * enable this narrower capability without opting into the full 15-min
+ * use this narrower capability without opting into the full 15-min
  * background-function worker path, and the two gates never need to agree.
  * When BOTH would be true for a given run, the durable-background dispatch
  * decision in `production-agent.ts` is evaluated first and takes precedence —
@@ -386,7 +386,7 @@ function isForegroundSelfChainFlagEnabled(): boolean {
  */
 export function isAgentChatForegroundSelfChainEnabled(): boolean {
   return (
-    isForegroundSelfChainFlagEnabled() &&
+    !isForegroundSelfChainExplicitlyDisabled() &&
     isHostedRuntimeForDurableBackground() &&
     hasConfiguredA2ASecret()
   );

--- a/packages/core/src/agent/engine/ai-sdk-engine.spec.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.spec.ts
@@ -147,6 +147,44 @@ describe("AISDKEngine Google Gemini thinking config", () => {
   });
 });
 
+describe("AISDKEngine error tagging", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it("tags a 429 APICallError with http_429 + statusCode + providerRetryable", async () => {
+    class MockApiCallError extends Error {
+      statusCode = 429;
+      isRetryable = true;
+      constructor() {
+        super("Too Many Requests");
+      }
+    }
+    const streamText = vi.fn().mockReturnValue({
+      fullStream: (async function* () {
+        throw new MockApiCallError();
+      })(),
+    });
+    vi.doMock("ai", () => ({ streamText, jsonSchema: (s: unknown) => s }));
+    mockOpenAIProvider();
+
+    const { createAISDKEngine } = await import("./ai-sdk-engine.js");
+    const engine = createAISDKEngine("openai", { apiKey: "sk-test" });
+
+    const events: any[] = [];
+    await expect(async () => {
+      for await (const e of engine.stream(BASE_STREAM_OPTIONS)) events.push(e);
+    }).rejects.toThrow();
+
+    const stopEvent = events.find((e) => e.type === "stop");
+    expect(stopEvent?.reason).toBe("error");
+    expect(stopEvent?.errorCode).toBe("http_429");
+    expect(stopEvent?.statusCode).toBe(429);
+    expect(stopEvent?.providerRetryable).toBe(true);
+  });
+});
+
 describe("AISDKEngine OpenAI model selection", () => {
   beforeEach(() => {
     vi.resetModules();

--- a/packages/core/src/agent/engine/ai-sdk-engine.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.ts
@@ -384,8 +384,14 @@ class AISDKEngine implements AgentEngine {
         type: "stop",
         reason: "error",
         error: err?.message ?? String(err),
-        ...(statusCode === 401 ? { errorCode: "http_401" } : {}),
-        ...(statusCode !== undefined ? { statusCode } : {}),
+        // Tag every known status with `http_<status>` (not just 401) so a
+        // rate limit surfaces as `http_429`. The structured statusCode
+        // already drives turn-level retries, but the run-level continuation
+        // logic keys off the errorCode, so this lets a rate-limited turn
+        // auto-resume too — matching the Builder gateway path.
+        ...(statusCode !== undefined
+          ? { errorCode: `http_${statusCode}`, statusCode }
+          : {}),
         ...(providerRetryable !== undefined ? { providerRetryable } : {}),
       };
       throw err;

--- a/packages/core/src/agent/engine/anthropic-engine.spec.ts
+++ b/packages/core/src/agent/engine/anthropic-engine.spec.ts
@@ -215,6 +215,56 @@ describe("createAnthropicEngine", () => {
     expect(requestParams.messages[0].content[0].cache_control).toBeUndefined();
   });
 
+  it("tags upstream 429 rate limits with http_429 + statusCode so retries kick in", async () => {
+    // The Anthropic SDK reports an empty-body rate limit as a bare
+    // "429 status code (no body)" message. Without forwarding the structured
+    // status, isRetryableError couldn't classify it and the run failed hard.
+    class MockRateLimitError extends Error {
+      status = 429;
+      constructor() {
+        super("429 status code (no body)");
+      }
+    }
+    const mockStream = {
+      [Symbol.asyncIterator]: async function* () {
+        throw new MockRateLimitError();
+      },
+      finalMessage: vi.fn(),
+    };
+    vi.doMock("@anthropic-ai/sdk", () => ({
+      default: class MockAnthropic {
+        messages = { stream: vi.fn().mockReturnValue(mockStream) };
+      },
+    }));
+
+    vi.resetModules();
+    const { createAnthropicEngine: freshCreate } =
+      await import("./anthropic-engine.js");
+    const engine = freshCreate({ apiKey: "test" });
+    const opts: EngineStreamOptions = {
+      model: "claude-haiku-4-5-20251001",
+      systemPrompt: "Test",
+      messages: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      tools: [],
+      abortSignal: new AbortController().signal,
+    };
+
+    // The engine yields the terminal stop event and then rethrows the raw SDK
+    // error, so collect events defensively.
+    const events: any[] = [];
+    await expect(async () => {
+      for await (const e of engine.stream(opts)) events.push(e);
+    }).rejects.toThrow();
+
+    const stopEvent = events.find((e) => e.type === "stop");
+    expect(stopEvent?.reason).toBe("error");
+    expect(stopEvent?.error).toBe("429 status code (no body)");
+    expect(stopEvent?.errorCode).toBe("http_429");
+    expect(stopEvent?.statusCode).toBe(429);
+
+    vi.doUnmock("@anthropic-ai/sdk");
+  });
+
   it("stream emits stop with error when API key is missing", async () => {
     const engine = createAnthropicEngine({});
     const opts: EngineStreamOptions = {

--- a/packages/core/src/agent/engine/anthropic-engine.ts
+++ b/packages/core/src/agent/engine/anthropic-engine.ts
@@ -227,7 +227,17 @@ class AnthropicEngine implements AgentEngine {
         type: "stop",
         reason: "error",
         error: err?.message ?? String(err),
-        ...(statusCode === 401 ? { errorCode: "http_401", statusCode } : {}),
+        // Forward the provider HTTP status for EVERY known status, not just
+        // 401. The Anthropic SDK reports empty-body failures as a bare
+        // "429 status code (no body)" message, so without a structured
+        // statusCode/errorCode `isRetryableError` couldn't classify a rate
+        // limit (it matches "529"/"502" substrings but not "429") and the
+        // run failed hard instead of backing off + retrying like the Builder
+        // gateway path does. `http_429`/`http_529` also let the run-level
+        // continuation logic auto-resume a rate-limited turn.
+        ...(statusCode !== undefined
+          ? { errorCode: `http_${statusCode}`, statusCode }
+          : {}),
       };
       throw err;
     }

--- a/packages/core/src/agent/production-agent.chain-continuation.spec.ts
+++ b/packages/core/src/agent/production-agent.chain-continuation.spec.ts
@@ -15,7 +15,7 @@ import type { AgentChatEvent } from "./types.js";
 
 /**
  * Unit tests for the server-driven continuation handoff shared by the
- * durable-background worker chain and the OPT-IN foreground self-chain
+ * durable-background worker chain and the foreground self-chain
  * (`AGENT_CHAT_FOREGROUND_SELF_CHAIN`). Every dependency is injected, so
  * each Phase-0 discipline is pinned in isolation:
  *   - the successor run row is PRE-INSERTED before the dispatch fires,

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -5442,6 +5442,19 @@ describe("isRetryableError", () => {
     expect(isRetryableError(err)).toBe(true);
   });
 
+  it("retries on the http_429 errorCode", () => {
+    const err = new EngineError("429 status code (no body)", {
+      errorCode: "http_429",
+    });
+    expect(isRetryableError(err)).toBe(true);
+  });
+
+  it("retries on a bare '429 status code (no body)' message with no structured status", () => {
+    // The Anthropic/AI-SDK empty-body rate-limit format historically slipped
+    // past retries because the keyword list matched "529"/"502" but not 429.
+    expect(isRetryableError(new Error("429 status code (no body)"))).toBe(true);
+  });
+
   it("retries on HTTP 529 (Anthropic overloaded) from statusCode field", () => {
     const err = new EngineError("overloaded", { statusCode: 529 });
     expect(isRetryableError(err)).toBe(true);
@@ -5754,13 +5767,11 @@ describe("shouldChainBackgroundContinuation (server-driven background chain)", (
     ).toBe(true);
   });
 
-  // ── Opt-in foreground self-chain (AGENT_CHAT_FOREGROUND_SELF_CHAIN) ──────
-  // Default-OFF: with the eligibility flag omitted/false, a foreground run
-  // must behave exactly as before (never chains; the client's auto_continue
-  // re-POST is the only continuation path). The first test in this describe
-  // ("does NOT chain a foreground run") pins the omitted-flag default.
+  // ── Foreground self-chain (AGENT_CHAT_FOREGROUND_SELF_CHAIN) ─────────────
+  // The boolean passed to shouldChainBackgroundContinuation is the already
+  // resolved gate (hosted + A2A_SECRET + not explicitly opted out).
 
-  it("does NOT chain a foreground run when the self-chain flag is explicitly false (default)", () => {
+  it("does NOT chain a foreground run when the resolved self-chain gate is false", () => {
     expect(
       shouldChainBackgroundContinuation({
         isBackgroundWorker: false,

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -1132,6 +1132,7 @@ export function isRetryableError(err: unknown): boolean {
   return (
     code === "builder_gateway_error" ||
     code === "builder_gateway_network_error" ||
+    code === "http_429" ||
     code === "http_500" ||
     code === "http_502" ||
     code === "http_503" ||
@@ -1140,6 +1141,9 @@ export function isRetryableError(err: unknown): boolean {
     // Anthropic
     msg.includes("overloaded") ||
     msg.includes("rate_limit") ||
+    // Bare provider rate-limit messages that carry no structured status,
+    // e.g. the Anthropic/AI-SDK "429 status code (no body)" format.
+    /\b429\b/.test(msg) ||
     msg.includes("529") ||
     // OpenAI phrasing
     msg.includes("rate limit reached") ||
@@ -4620,8 +4624,8 @@ export const MAX_BACKGROUND_RUN_CONTINUATIONS = 20;
  * budget:
  *   - a durable-background WORKER run (`isBackgroundWorker`) — unconditional,
  *     unchanged from before; or
- *   - a FOREGROUND run when the opt-in `foregroundSelfChainEligible` flag is
- *     set (see `isAgentChatForegroundSelfChainEnabled` in
+ *   - a FOREGROUND run when the resolved `foregroundSelfChainEligible` gate is
+ *     true (see `isAgentChatForegroundSelfChainEnabled` in
  *     `durable-background.ts`) AND this specific run was never dispatched to
  *     the durable background worker (`dispatchedToBackground` false) — a run
  *     already headed to the durable background path chains via the
@@ -6189,12 +6193,12 @@ export function createProductionAgentHandler(
           turnId: effectiveTurnId,
         }
       : null;
-    // Opt-in (default-OFF) foreground self-chain: gated on the env flag AND
-    // this specific run never having been routed to the durable background
-    // worker. A run that WAS dispatched to background (`dispatchToBackground`)
-    // already has its recovery owned by the background circuit-breaker /
-    // `isBackgroundWorker` chain above — this flag must never double up with
-    // that path, only stand in for it on plain foreground turns. A persistent
+    // Foreground self-chain: gated on hosted runtime + A2A_SECRET, with an
+    // explicit env opt-out, AND this specific run never having been routed to
+    // the durable background worker. A run that WAS dispatched to background
+    // (`dispatchToBackground`) already has its recovery owned by the background
+    // circuit-breaker / `isBackgroundWorker` chain above — this flag must never
+    // double up with that path, only stand in for it on plain foreground turns. A persistent
     // threadId is required: the client discovers the pre-inserted successor
     // via `/runs/active?threadId` and the successor chunk resumes from the
     // thread's persisted thread_data — without a thread there is neither a
@@ -6302,8 +6306,8 @@ export function createProductionAgentHandler(
 
     // Wrap so the background worker is unblocked even when there is no app
     // onRunComplete / tracked-progress callback configured. Also installed for
-    // a foreground run eligible for the opt-in self-chain — that path needs
-    // this same wrapper to fire the continuation dispatch below.
+    // a foreground run eligible for self-chain — that path needs this same
+    // wrapper to fire the continuation dispatch below.
     const handleRunComplete =
       isBackgroundWorker || foregroundSelfChainEligible || baseHandleRunComplete
         ? async (run: ActiveRun) => {
@@ -6897,6 +6901,9 @@ export function createProductionAgentHandler(
         // assistant message. Falls back to the runId (turn == run) when the
         // client doesn't supply a turnId.
         turnId: effectiveTurnId,
+        dispatchMode: foregroundSelfChainEligible
+          ? "foreground-self-chain"
+          : "foreground",
       },
     );
 
@@ -6920,7 +6927,11 @@ export function createProductionAgentHandler(
     setResponseHeader(event, "Cache-Control", "no-cache");
     setResponseHeader(event, "Connection", "keep-alive");
     setResponseHeader(event, "X-Run-Id", runId);
-    setResponseHeader(event, "X-Dispatch-Mode", "foreground");
+    setResponseHeader(
+      event,
+      "X-Dispatch-Mode",
+      foregroundSelfChainEligible ? "foreground-self-chain" : "foreground",
+    );
 
     return stream;
   });

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -264,6 +264,12 @@ export interface StartRunOptions {
    * and to disabled otherwise (local dev stays unbounded).
    */
   noProgressTimeoutMs?: number;
+  /**
+   * Lifecycle metadata persisted to `agent_runs.dispatch_mode` and surfaced to
+   * clients through `/runs/active`. This does not change run-manager behavior;
+   * callers use it to describe who owns continuation at hosted chunk boundaries.
+   */
+  dispatchMode?: "foreground" | "foreground-self-chain";
 }
 
 export interface ResolveRunSoftTimeoutOptions {
@@ -480,11 +486,16 @@ export function startRun(
   // Persist run to SQL without blocking the response. Keep the promise so
   // final status cannot race ahead of a slow initial INSERT and then get
   // overwritten by a late row stuck at status='running'.
-  const insertRunPromise = insertRun(runId, threadId, options?.turnId).catch(
-    (error) => {
-      captureRunPersistenceError(error, "insert-run");
-    },
-  );
+  const insertOptions = options?.dispatchMode
+    ? { dispatchMode: options.dispatchMode }
+    : undefined;
+  const insertRunPromise = (
+    insertOptions
+      ? insertRun(runId, threadId, options?.turnId, insertOptions)
+      : insertRun(runId, threadId, options?.turnId)
+  ).catch((error) => {
+    captureRunPersistenceError(error, "insert-run");
+  });
 
   // Per-run event persistence chain: events are chained so SQL inserts commit
   // in seq order. Without this, a fast seq=5 commit before a slow seq=4 means
@@ -1356,7 +1367,7 @@ export async function getActiveRunForThreadAsync(threadId: string): Promise<{
   status: string;
   heartbeatAt: number;
   lastProgressAt: number | null;
-  /** How the run was dispatched (NULL/foreground, background, background-processing). */
+  /** How the run was dispatched/continued (foreground, foreground-self-chain, background...). */
   dispatchMode?: string | null;
   /** Compact terminal classification, e.g. done, run_timeout, stale_run. */
   terminalReason?: string | null;

--- a/packages/core/src/agent/run-store.foreground-self-chain.spec.ts
+++ b/packages/core/src/agent/run-store.foreground-self-chain.spec.ts
@@ -2,7 +2,7 @@ import Database from "better-sqlite3";
 import { describe, expect, it, vi } from "vitest";
 
 /**
- * SQL invariants behind the OPT-IN foreground self-chain
+ * SQL invariants behind the foreground self-chain
  * (`AGENT_CHAT_FOREGROUND_SELF_CHAIN`) — the "no double-run when the client
  * also continues" proof, exercised against a real SQLite engine (so the
  * conditional UPDATE / rowsAffected semantics are real, not mocked).

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -183,9 +183,11 @@ async function ensureRunTables(): Promise<void> {
           //                at completion so errored/cut-off runs are queryable for
           //                pattern analysis (see listErroredRuns).
           // dispatch_mode marks how a run was started: NULL/"foreground" for the
-          // normal synchronous path, "background" for a run dispatched into a
-          // Netlify background function. The reaper/claim widen the stale window
-          // for background rows so a slow cold-start isn't falsely reaped.
+          // normal client-continued synchronous path, "foreground-self-chain" for
+          // a foreground run whose continuation boundary is server-driven, and
+          // "background" for a run dispatched into a Netlify background function.
+          // The reaper/claim widen the stale window for background rows so a slow
+          // cold-start isn't falsely reaped.
           // diag_stage records the last reached pipeline stage (+ any error) for a
           // background-dispatched run so a silent worker death is DIAGNOSABLE from
           // the client (/runs/active surfaces it) without reading the unreadable
@@ -273,9 +275,11 @@ async function ensureRunTables(): Promise<void> {
       //                at completion so errored/cut-off runs are queryable for
       //                pattern analysis (see listErroredRuns).
       // dispatch_mode marks how a run was started: NULL/"foreground" for the
-      // normal synchronous path, "background" for a run dispatched into a
-      // Netlify background function. The reaper/claim widen the stale window
-      // for background rows so a slow cold-start isn't falsely reaped.
+      // normal client-continued synchronous path, "foreground-self-chain" for
+      // a foreground run whose continuation boundary is server-driven, and
+      // "background" for a run dispatched into a Netlify background function.
+      // The reaper/claim widen the stale window for background rows so a slow
+      // cold-start isn't falsely reaped.
       // diag_stage records the last reached pipeline stage (+ any error) for a
       // background-dispatched run so a silent worker death is DIAGNOSABLE from
       // the client (/runs/active surfaces it) without reading the unreadable
@@ -420,7 +424,7 @@ export async function insertRun(
   threadId: string,
   turnId?: string,
   options?: {
-    dispatchMode?: "foreground" | "background";
+    dispatchMode?: "foreground" | "foreground-self-chain" | "background";
     /**
      * JSON-serialized request body for a background dispatch. Persisted on the
      * run row so the self-POST to the background function carries only the
@@ -456,10 +460,11 @@ export async function insertRun(
  * subtracted by the resolved window so the comparison is
  * `COALESCE(heartbeat_at, started_at) < (now - window)`.
  *
- * `dispatch_mode` is one of NULL/"foreground" (normal sync path), "background"
- * (foreground inserted the row for a background dispatch), or
- * "background-processing" (the background worker claimed it). Both background
- * states get the wider window via a LIKE-prefix match.
+ * `dispatch_mode` is one of NULL/"foreground" (normal client-continued sync
+ * path), "foreground-self-chain" (server-driven continuation at the foreground
+ * chunk boundary), "background" (foreground inserted the row for a background
+ * dispatch), or "background-processing" (the background worker claimed it). Both
+ * background states get the wider window via a LIKE-prefix match.
  */
 function backgroundAwareStaleCutoffSql(): string {
   // `CAST(? AS BIGINT)` is required: without it Postgres infers the param as

--- a/packages/core/src/cli/design-connect.spec.ts
+++ b/packages/core/src/cli/design-connect.spec.ts
@@ -468,6 +468,16 @@ describe("design connect bridge endpoints", () => {
       expect(html.body).toContain('src="/src/main.ts"');
       expect(html.body).toContain("agent-native:editor-chrome-ready");
 
+      const interactHtml = await getText(
+        `${base}/live-edit?path=/dashboard&bridge=0`,
+      );
+      expect(interactHtml.status).toBe(200);
+      expect(interactHtml.body).toContain(`<base href="${base}/">`);
+      expect(interactHtml.body).toContain('src="/src/main.ts"');
+      expect(interactHtml.body).not.toContain(
+        "agent-native:editor-chrome-ready",
+      );
+
       const module = await getText(`${base}/src/main.ts`);
       expect(module.status).toBe(200);
       expect(module.headers["content-type"]).toContain(

--- a/packages/core/src/cli/design-connect.spec.ts
+++ b/packages/core/src/cli/design-connect.spec.ts
@@ -921,6 +921,14 @@ describe("design connect bridge endpoints", () => {
         expect(captured?.["bridgeToken"]).toBe(bridge.bridgeToken);
         expect(captured?.["devServerUrl"]).toBe(manifest.devServerUrl);
         expect(captured?.["bridgeUrl"]).toBe(manifest.bridgeUrl);
+        const registeredOperations = (
+          captured?.["capabilities"] as Array<{ operation?: string }>
+        ).map((capability) => capability.operation);
+        expect(
+          manifest.capabilities.map((capability) => capability.operation),
+        ).toContain("listFiles");
+        expect(registeredOperations).not.toContain("listFiles");
+        expect(registeredOperations).toContain("readFile");
       } finally {
         await new Promise<void>((resolve) =>
           captureServer.close(() => resolve()),

--- a/packages/core/src/cli/design-connect.ts
+++ b/packages/core/src/cli/design-connect.ts
@@ -1286,10 +1286,12 @@ export async function startDesignConnectBridge(
               manifest.devServerUrl,
               targetUrl,
             );
+            const includeEditorBridge =
+              requestUrl.searchParams.get("bridge") !== "0";
             const html = injectLiveEditBridge(
               snapshot.html,
               new URL("/", manifest.bridgeUrl).toString(),
-              liveEditBridgeScript,
+              includeEditorBridge ? liveEditBridgeScript : "",
             );
             sendText(
               res,

--- a/packages/core/src/cli/design-connect.ts
+++ b/packages/core/src/cli/design-connect.ts
@@ -33,6 +33,16 @@ const BRIDGE_OPERATIONS = [
 
 type BridgeOperation = (typeof BRIDGE_OPERATIONS)[number];
 
+const SERVER_REGISTRATION_BRIDGE_OPERATIONS = new Set<BridgeOperation>([
+  "select",
+  "resolveNodeToFile",
+  "readFile",
+  "applyEdit",
+  "writeFile",
+  "captureSnapshot",
+  "captureState",
+]);
+
 /** Additive manifest capability flags advertised alongside the operation list. */
 const MANIFEST_CAPABILITIES = {
   listFiles: true,
@@ -1680,7 +1690,9 @@ export async function registerConnectionWithServer(
     devServerUrl: manifest.devServerUrl,
     bridgeUrl: manifest.bridgeUrl,
     rootPath: manifest.rootPath,
-    capabilities: manifest.capabilities,
+    capabilities: manifest.capabilities.filter((capability) =>
+      SERVER_REGISTRATION_BRIDGE_OPERATIONS.has(capability.operation),
+    ),
     routeManifest: {
       version: 1 as const,
       sourceType: "localhost" as const,

--- a/packages/core/src/client/KeepTabOpenNotice.spec.tsx
+++ b/packages/core/src/client/KeepTabOpenNotice.spec.tsx
@@ -91,7 +91,24 @@ describe("KeepTabOpenNotice", () => {
     expect(container.textContent ?? "").toBe("");
   });
 
-  it("hides immediately when the run transitions to a server-owned background dispatch", async () => {
+  it("never shows for a foreground self-chained run (server owns continuation)", async () => {
+    const fetchSpy = vi.fn(async () =>
+      jsonResponse(activeRun({ dispatchMode: "foreground-self-chain" })),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await act(async () => {
+      root.render(
+        <KeepTabOpenNotice threadId="thread-1" hosted showAfterMs={5_000} />,
+      );
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(40_000);
+    });
+    expect(container.textContent ?? "").toBe("");
+  });
+
+  it("hides immediately when the run transitions to server-owned continuation", async () => {
     let dispatchMode: string | null = null;
     const fetchSpy = vi.fn(async () =>
       jsonResponse(activeRun({ dispatchMode })),
@@ -113,10 +130,9 @@ describe("KeepTabOpenNotice", () => {
     });
     expect(container.textContent).toContain("Keep this tab open");
 
-    // The foreground self-chain handed the turn to a server-side successor
-    // (or the client adopted a durable worker): the tab is no longer
+    // The foreground run became self-chainable: the tab is no longer
     // load-bearing — no linger, hide on the next poll.
-    dispatchMode = "background-processing";
+    dispatchMode = "foreground-self-chain";
     await act(async () => {
       await vi.advanceTimersByTimeAsync(10_000);
     });

--- a/packages/core/src/client/KeepTabOpenNotice.tsx
+++ b/packages/core/src/client/KeepTabOpenNotice.tsx
@@ -9,23 +9,22 @@ import { cn } from "./utils.js";
 export const DEFAULT_KEEP_TAB_OPEN_AFTER_MS = 30_000;
 
 /**
- * Subtle, non-blocking notice that a long-running FOREGROUND agent turn
- * depends on this tab staying open.
+ * Subtle, non-blocking notice that a long-running client-continued foreground
+ * agent turn depends on this tab staying open.
  *
  * On hosted deployments a foreground turn runs in ~40s chunks and the CLIENT
- * re-POSTs `auto_continue` to start each next chunk — close the tab
- * mid-turn and the work silently stops at the next chunk boundary. Only
- * server-driven runs (`dispatchMode` starting with "background": the durable
- * background worker, or a server self-chained continuation) survive a closed
- * tab, and for those this notice never shows.
+ * may need to re-POST `auto_continue` to start each next chunk. Server-owned
+ * runs (`dispatchMode` starting with "background" or equal to
+ * "foreground-self-chain") survive a closed tab, and for those this notice
+ * never shows.
  *
  * Visibility rules (show only while the condition is true — no new
  * always-visible chrome):
- *   - a foreground-dispatched run for this thread has been continuously
+ *   - a client-continued foreground run for this thread has been continuously
  *     running for `showAfterMs` (default 30s — approaching the hosted ~40s
  *     chunk boundary where the client-driven continuation starts), and
- *   - the run is NOT background-dispatched (hidden immediately when the
- *     server owns recovery), and
+ *   - the run is not server-continued (hidden immediately when the server owns
+ *     recovery), and
  *   - this is a production client bundle (`hosted` auto-detect): local dev
  *     runs a turn unbounded in a single chunk that survives a closed tab,
  *     so the notice would be wrong there.
@@ -78,6 +77,13 @@ function isDevClientBundle(): boolean {
   }
 }
 
+function isServerContinuedDispatch(dispatchMode: string | null): boolean {
+  return (
+    dispatchMode === "foreground-self-chain" ||
+    dispatchMode?.startsWith("background") === true
+  );
+}
+
 export function KeepTabOpenNotice({
   threadId,
   enabled = true,
@@ -93,10 +99,9 @@ export function KeepTabOpenNotice({
     apiUrl,
     pollIntervalMs: NOTICE_POLL_INTERVAL_MS,
   });
-  const isBackgroundDispatch =
-    state.dispatchMode?.startsWith("background") === true;
+  const isServerContinued = isServerContinuedDispatch(state.dispatchMode);
   const foregroundRunning =
-    state.status === "running" && Boolean(state.runId) && !isBackgroundDispatch;
+    state.status === "running" && Boolean(state.runId) && !isServerContinued;
 
   const [visible, setVisible] = useState(false);
   const runningSinceRef = useRef<number | null>(null);
@@ -109,7 +114,7 @@ export function KeepTabOpenNotice({
   }, [threadId]);
 
   useEffect(() => {
-    if (!effectiveHosted || isBackgroundDispatch) {
+    if (!effectiveHosted || isServerContinued) {
       // Server-owned turn (or non-hosted client): the tab is not load-bearing.
       // Hide immediately and reset — no linger.
       runningSinceRef.current = null;
@@ -143,7 +148,7 @@ export function KeepTabOpenNotice({
   }, [
     effectiveHosted,
     foregroundRunning,
-    isBackgroundDispatch,
+    isServerContinued,
     showAfterMs,
     visible,
   ]);

--- a/packages/core/src/client/RunStuckBanner.spec.tsx
+++ b/packages/core/src/client/RunStuckBanner.spec.tsx
@@ -103,10 +103,10 @@ describe("RunStuckBanner", () => {
     ).toHaveLength(1);
   });
 
-  // UPDATED: background-dispatched runs now use the wider 180s stuck
-  // threshold (the server's 150s no-progress backstop and chained
-  // continuations own recovery), so the fixture's elapsed time was raised
-  // past 180s for the banner to render at all. Auto-retry stays off.
+  // UPDATED: server-continued runs now use the wider 180s stuck threshold (the
+  // server's 150s no-progress backstop and chained continuations own recovery),
+  // so the fixture's elapsed time was raised past 180s for the banner to render
+  // at all. Auto-retry stays off.
   it("does not automatically abort a stuck but heartbeating background worker", async () => {
     const onRetry = vi.fn();
     const fetchSpy = vi.fn(async (url: string) => {
@@ -193,17 +193,55 @@ describe("RunStuckBanner", () => {
     ).toBe(false);
   });
 
-  it("uses the wider 180s stuck threshold for background-dispatched runs", async () => {
-    // 120s without progress marks a FOREGROUND run stuck (90s threshold) but
-    // must not mark a background run stuck — the server's recovery machinery
-    // is still within its own windows.
+  it("never auto-retries a foreground self-chained run", async () => {
+    const onRetry = vi.fn();
+    const fetchSpy = vi.fn(async (url: string) => {
+      if (url.includes("/runs/active")) {
+        return jsonResponse({
+          active: true,
+          runId: "run-foreground-self-chain",
+          status: "running",
+          dispatchMode: "foreground-self-chain",
+          heartbeatAt: 100_000,
+          lastProgressAt: 10_000,
+          serverNow: 300_000,
+        });
+      }
+      return jsonResponse({ error: "unexpected" }, false);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await act(async () => {
+      root.render(
+        <RunStuckBanner threadId="thread-1" autoRetry onRetry={onRetry} />,
+      );
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+
+    expect(container.textContent).toContain("This chat looks stuck.");
+    expect(container.textContent).not.toContain("Retrying automatically now.");
+    expect(onRetry).not.toHaveBeenCalled();
+    expect(
+      fetchSpy.mock.calls.some(
+        ([url, init]) =>
+          String(url).includes("/abort") && init?.method === "POST",
+      ),
+    ).toBe(false);
+  });
+
+  it("uses the wider 180s stuck threshold for server-continued runs", async () => {
+    // 120s without progress marks a client-continued foreground run stuck (90s
+    // threshold) but must not mark a server-continued run stuck — the server's
+    // recovery machinery is still within its own windows.
     const fetchSpy = vi.fn(async (url: string) => {
       if (url.includes("/runs/active")) {
         return jsonResponse({
           active: true,
           runId: "run-background-quiet",
           status: "running",
-          dispatchMode: "background-processing",
+          dispatchMode: "foreground-self-chain",
           heartbeatAt: 129_000,
           lastProgressAt: 10_000,
           serverNow: 130_000,

--- a/packages/core/src/client/RunStuckBanner.tsx
+++ b/packages/core/src/client/RunStuckBanner.tsx
@@ -175,15 +175,16 @@ export function RunStuckBanner({
   }
   const ownerId = autoRetryOwnerId ?? generatedOwnerIdRef.current;
   const backgroundWorkerStillAlive = isFreshBackgroundWorker(state);
-  // Background-dispatched runs are recovered by the SERVER (chained
-  // continuation chunks + lost-handoff sweep); an automatic client abort
-  // would kill a live server-chained run. Auto-retry is therefore disabled
-  // unconditionally for ANY background dispatch mode — not just a
-  // fresh-heartbeat worker — and the localStorage/Web-Locks auto-retry claim
-  // below is never taken for these runs (the adapter's follow loop is
-  // read-only, so multiple tabs need no retry dedup). Only the manual banner
-  // remains, on the wider background threshold from useRunStuckDetection.
-  const isBackgroundDispatch =
+  // Server-continued runs are recovered by the SERVER (chained continuation
+  // chunks + lost-handoff sweep); an automatic client abort would kill a live
+  // server-chained run. Auto-retry is therefore disabled unconditionally for
+  // these modes — not just a fresh-heartbeat worker — and the
+  // localStorage/Web-Locks auto-retry claim below is never taken for them (the
+  // adapter's follow loop is read-only, so multiple tabs need no retry dedup).
+  // Only the manual banner remains, on the wider server-owned threshold from
+  // useRunStuckDetection.
+  const isServerContinuedDispatch =
+    state.dispatchMode === "foreground-self-chain" ||
     state.dispatchMode?.startsWith("background") === true;
 
   const lastReportedRef = useRef<{
@@ -224,9 +225,9 @@ export function RunStuckBanner({
   useEffect(() => {
     if (
       !autoRetry ||
-      // Server owns recovery for background dispatch modes — never auto-abort
-      // (see comment on isBackgroundDispatch above).
-      isBackgroundDispatch ||
+      // Server owns recovery for these dispatch modes — never auto-abort (see
+      // comment on isServerContinuedDispatch above).
+      isServerContinuedDispatch ||
       backgroundWorkerStillAlive ||
       !state.isStuck ||
       !state.runId ||
@@ -263,7 +264,7 @@ export function RunStuckBanner({
     autoRetry,
     backgroundWorkerStillAlive,
     busy,
-    isBackgroundDispatch,
+    isServerContinuedDispatch,
     onRetry,
     ownerId,
     state.isStuck,

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -50,6 +50,29 @@ function backgroundSseResponse(events: unknown[], runId: string): Response {
   );
 }
 
+function foregroundSelfChainSseResponse(
+  events: unknown[],
+  runId: string,
+): Response {
+  const body = events.map((event) => `data: ${JSON.stringify(event)}\n\n`);
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(body.join("")));
+        controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "X-Run-Id": runId,
+        "X-Dispatch-Mode": "foreground-self-chain",
+      },
+    },
+  );
+}
+
 function emptySseResponse(runId = "run-empty"): Response {
   return new Response(
     new ReadableStream<Uint8Array>({
@@ -5382,6 +5405,79 @@ describe("createAgentChatAdapter", () => {
     const results = await promise;
 
     expect(postCount).toBe(2);
+    const last = results.at(-1) as any;
+    expect(last.content.at(-1).text).toContain("Working continued");
+  });
+
+  it("follows server state instead of self-posting when foreground self-chain is enabled", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let postCount = 0;
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/_agent-native/agent-chat" && init?.method === "POST") {
+        postCount += 1;
+        return foregroundSelfChainSseResponse(
+          [
+            { type: "text", text: "Working" },
+            { type: "auto_continue", reason: "run_timeout" },
+          ],
+          "run-fg-self-1",
+        );
+      }
+      if (url.includes("/runs/active")) {
+        return jsonResponse({
+          active: true,
+          runId: "run-fg-self-2",
+          threadId: "thread-fg-self",
+          status: "running",
+          dispatchMode: "background-processing",
+          heartbeatAt: Date.now(),
+          lastProgressAt: Date.now(),
+        });
+      }
+      if (url.includes("/runs/run-fg-self-2/events")) {
+        return backgroundSseResponse(
+          [{ type: "text", text: " continued" }, { type: "done" }],
+          "run-fg-self-2",
+        );
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-fg-self",
+      threadId: "thread-fg-self",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "do a self-chained task" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    const results = await promise;
+
+    expect(postCount).toBe(1);
     const last = results.at(-1) as any;
     expect(last.content.at(-1).text).toContain("Working continued");
   });

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -5482,6 +5482,85 @@ describe("createAgentChatAdapter", () => {
     expect(last.content.at(-1).text).toContain("Working continued");
   });
 
+  it("falls back to a client continuation when foreground self-chain dispatch fails", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let postCount = 0;
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/_agent-native/agent-chat" && init?.method === "POST") {
+        postCount += 1;
+        return postCount === 1
+          ? foregroundSelfChainSseResponse(
+              [
+                { type: "text", text: "Working" },
+                {
+                  type: "error",
+                  error:
+                    "The agent's foreground continuation could not hand off.",
+                  errorCode: "background_continuation_dispatch_failed",
+                  recoverable: true,
+                },
+              ],
+              "run-fg-self-failed-1",
+            )
+          : sseResponse(
+              [{ type: "text", text: " fallback continued" }, { type: "done" }],
+              "run-client-fallback",
+            );
+      }
+      if (url.includes("/runs/active")) {
+        return jsonResponse({
+          active: false,
+          threadId: "thread-fg-self-failed",
+          status: "idle",
+          heartbeatAt: null,
+          lastProgressAt: null,
+        });
+      }
+      if (url.includes("/runs/run-fg-self-failed-1/events")) {
+        return jsonResponse({ error: "Run not found" }, 404);
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-fg-self-failed",
+      threadId: "thread-fg-self-failed",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "do a self-chained task" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    const results = await promise;
+
+    expect(postCount).toBe(2);
+    const last = results.at(-1) as any;
+    expect(last.content.at(-1).text).toContain("Working fallback continued");
+  });
+
   it("retries an internal continuation when 409 reports the same completed run", async () => {
     vi.useFakeTimers();
     vi.stubGlobal("window", { dispatchEvent: vi.fn() });

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -133,16 +133,17 @@ const MAX_HISTORY_LARGE_TOOL_ARGS_CHARS = 200_000;
 const STARTUP_RESPONSE_TIMEOUT_MS = 45_000;
 
 // ── Background follow mode ──────────────────────────────────────────────────
-// For background-dispatched runs (dispatchMode starts with "background") the
-// SERVER is the sole recovery brain: it chains continuation chunks itself
-// (fresh runId, same turnId), pre-inserts the successor run row BEFORE the old
-// chunk completes (so /runs/active shows an active run continuously across
-// chunk boundaries), and a server sweep reaps lost handoffs into loud terminal
-// errors. The client therefore never POSTs synthetic continuations for these
-// runs — it demotes itself to a READER of server state: poll /runs/active,
-// (re)attach to whichever run of this turn is live, and fold its events into
-// the same assistant message. Read-only, so multiple tabs following the same
-// run are safe (no localStorage/Web-Locks claim needed).
+// For server-continued runs (dispatchMode starts with "background" or equals
+// "foreground-self-chain") the SERVER is the sole recovery brain: it chains
+// continuation chunks itself (fresh runId, same turnId), pre-inserts the
+// successor run row BEFORE the old chunk completes (so /runs/active shows an
+// active run continuously across chunk boundaries), and a server sweep reaps
+// lost handoffs into loud terminal errors. The client therefore never POSTs
+// synthetic continuations for these runs — it demotes itself to a READER of
+// server state: poll /runs/active, (re)attach to whichever run of this turn is
+// live, and fold its events into the same assistant message. Read-only, so
+// multiple tabs following the same run are safe (no localStorage/Web-Locks
+// claim needed).
 const BACKGROUND_FOLLOW_POLL_INTERVAL_MS = 1_000;
 // How long the follow loop tolerates seeing NO active run for this turn before
 // treating the turn as ended. The server pre-inserts the successor row before
@@ -1687,11 +1688,13 @@ export function createAgentChatAdapter(
         if (mode) currentRunDispatchMode = mode;
       };
 
-      // Mode switch for recovery ownership: background-dispatched runs are
-      // recovered by the SERVER (chained continuations, sweeps); the client
-      // only follows. Foreground (null/"foreground"/unknown) keeps the full
-      // client-side continuation machinery unchanged.
+      // Mode switch for recovery ownership: background-dispatched runs and
+      // foreground-self-chain runs are recovered by the SERVER (chained
+      // continuations, sweeps); the client only follows. Plain foreground
+      // (null/"foreground"/unknown) keeps the full client-side continuation
+      // machinery unchanged.
       const isBackgroundDispatch = () =>
+        currentRunDispatchMode === "foreground-self-chain" ||
         currentRunDispatchMode?.startsWith("background") === true;
 
       const rememberRunSeq = (seq: number) => {

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -134,16 +134,14 @@ const STARTUP_RESPONSE_TIMEOUT_MS = 45_000;
 
 // ── Background follow mode ──────────────────────────────────────────────────
 // For server-continued runs (dispatchMode starts with "background" or equals
-// "foreground-self-chain") the SERVER is the sole recovery brain: it chains
-// continuation chunks itself (fresh runId, same turnId), pre-inserts the
-// successor run row BEFORE the old chunk completes (so /runs/active shows an
-// active run continuously across chunk boundaries), and a server sweep reaps
-// lost handoffs into loud terminal errors. The client therefore never POSTs
-// synthetic continuations for these runs — it demotes itself to a READER of
-// server state: poll /runs/active, (re)attach to whichever run of this turn is
-// live, and fold its events into the same assistant message. Read-only, so
-// multiple tabs following the same run are safe (no localStorage/Web-Locks
-// claim needed).
+// "foreground-self-chain") the SERVER normally chains continuation chunks
+// itself (fresh runId, same turnId), pre-inserts the successor run row BEFORE
+// the old chunk completes (so /runs/active shows an active run continuously
+// across chunk boundaries), and a server sweep reaps lost handoffs into loud
+// terminal errors. The client demotes itself to a READER of server state for
+// healthy handoffs. Foreground self-chain keeps one escape hatch: if the server
+// reports that the self-dispatch itself failed before a successor claimed the
+// run, the existing client auto-continue POST remains the fallback.
 const BACKGROUND_FOLLOW_POLL_INTERVAL_MS = 1_000;
 // How long the follow loop tolerates seeing NO active run for this turn before
 // treating the turn as ended. The server pre-inserts the successor row before
@@ -1688,14 +1686,24 @@ export function createAgentChatAdapter(
         if (mode) currentRunDispatchMode = mode;
       };
 
-      // Mode switch for recovery ownership: background-dispatched runs and
-      // foreground-self-chain runs are recovered by the SERVER (chained
-      // continuations, sweeps); the client only follows. Plain foreground
-      // (null/"foreground"/unknown) keeps the full client-side continuation
-      // machinery unchanged.
-      const isBackgroundDispatch = () =>
-        currentRunDispatchMode === "foreground-self-chain" ||
+      // Mode switch for recovery ownership: durable/background-dispatched runs
+      // are always recovered by the server. Foreground self-chain follows the
+      // server on healthy handoffs, but a loud self-dispatch failure falls back
+      // to the client POST path because no successor run owns recovery yet.
+      const isDurableBackgroundDispatch = () =>
         currentRunDispatchMode?.startsWith("background") === true;
+      const isForegroundSelfChainDispatch = () =>
+        currentRunDispatchMode === "foreground-self-chain";
+      const shouldFollowServerContinuation = (
+        signal?: AgentAutoContinueSignal,
+      ) => {
+        if (isDurableBackgroundDispatch()) return true;
+        if (!isForegroundSelfChainDispatch()) return false;
+        return (
+          signal?.errorInfo?.errorCode !==
+          "background_continuation_dispatch_failed"
+        );
+      };
 
       const rememberRunSeq = (seq: number) => {
         lastSeq = seq;
@@ -2969,7 +2977,7 @@ export function createAgentChatAdapter(
               // following of server state instead. This is the fix for the
               // client/server recovery race: client watchdog signals here are
               // just "reattach", not "recover".
-              if (isBackgroundDispatch() && threadId) {
+              if (shouldFollowServerContinuation(err) && threadId) {
                 yield* followBackgroundTurn(err);
                 return;
               }
@@ -3148,7 +3156,7 @@ export function createAgentChatAdapter(
             // synthetic-continuation POST below. (An initial POST that failed
             // before any response headers arrived has no dispatch mode yet
             // and keeps the foreground startup-retry path.)
-            if (isBackgroundDispatch() && threadId) {
+            if (shouldFollowServerContinuation() && threadId) {
               yield* followBackgroundTurn(
                 new AgentAutoContinueSignal({ reason: "stream_ended" }),
               );

--- a/packages/core/src/client/use-run-stuck-detection.ts
+++ b/packages/core/src/client/use-run-stuck-detection.ts
@@ -26,7 +26,7 @@ export interface RunStuckState {
   heartbeatAt: number | null;
   /** Milliseconds since `heartbeatAt`, computed against the server clock. */
   heartbeatSinceMs: number | null;
-  /** How the run was dispatched, e.g. foreground or background-processing. */
+  /** How the run was dispatched/continued, e.g. foreground-self-chain or background-processing. */
   dispatchMode: string | null;
 }
 
@@ -133,10 +133,13 @@ export function useRunStuckDetection({
             heartbeatAt != null ? nowMs - heartbeatAt : null;
           const dispatchMode =
             typeof data.dispatchMode === "string" ? data.dispatchMode : null;
-          // Background-dispatched runs get the wider threshold: the server's
-          // own recovery (150s no-progress backstop + chained continuations)
-          // must get its chance before the user sees a "stuck" affordance.
-          const effectiveThresholdMs = dispatchMode?.startsWith("background")
+          // Server-continued runs get the wider threshold: the server's own
+          // recovery (150s no-progress backstop + chained continuations) must
+          // get its chance before the user sees a "stuck" affordance.
+          const serverContinued =
+            dispatchMode === "foreground-self-chain" ||
+            dispatchMode?.startsWith("background") === true;
+          const effectiveThresholdMs = serverContinued
             ? backgroundStuckThresholdMs
             : stuckThresholdMs;
           const isStuck = Boolean(

--- a/templates/design/actions/connect-localhost.spec.ts
+++ b/templates/design/actions/connect-localhost.spec.ts
@@ -1,11 +1,11 @@
+import crypto from "node:crypto";
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@agent-native/core/server/request-context", () => ({
   getRequestUserEmail: () => "user@example.com",
   getRequestOrgId: () => "org_1",
 }));
-
-vi.mock("nanoid", () => ({ nanoid: () => "fixed_connection_id" }));
 
 type ExistingConnection = {
   ownerEmail: string;
@@ -68,6 +68,24 @@ beforeEach(() => {
 });
 
 describe("connect-localhost", () => {
+  it("derives the stable per-user connection id when id is omitted", async () => {
+    await action.run({
+      devServerUrl: "http://localhost:5173/",
+      bridgeUrl: "http://127.0.0.1:7666",
+      rootPath: "/tmp/app",
+      bridgeToken: "bridge_token",
+    });
+
+    const hash = crypto
+      .createHash("sha256")
+      .update("user@example.com\nhttp://localhost:5173\n/tmp/app")
+      .digest("base64url")
+      .slice(0, 16);
+    const expectedId = `localhost_${hash}`;
+    expect(insertedValues?.id).toBe(expectedId);
+    expect(upsertConfig?.set.id).toBe(expectedId);
+  });
+
   it("preserves an existing bridge token when a refresh omits bridgeToken", async () => {
     existingConnection = {
       ownerEmail: "user@example.com",

--- a/templates/design/actions/connect-localhost.spec.ts
+++ b/templates/design/actions/connect-localhost.spec.ts
@@ -2,9 +2,13 @@ import crypto from "node:crypto";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const requestContextMock = vi.hoisted(() => ({
+  orgId: "org_1" as string | null,
+}));
+
 vi.mock("@agent-native/core/server/request-context", () => ({
   getRequestUserEmail: () => "user@example.com",
-  getRequestOrgId: () => "org_1",
+  getRequestOrgId: () => requestContextMock.orgId,
 }));
 
 type ExistingConnection = {
@@ -62,6 +66,7 @@ vi.mock("../server/db/index.js", () => ({
 import action from "./connect-localhost.js";
 
 beforeEach(() => {
+  requestContextMock.orgId = "org_1";
   existingConnection = null;
   insertedValues = null;
   upsertConfig = null;
@@ -78,12 +83,33 @@ describe("connect-localhost", () => {
 
     const hash = crypto
       .createHash("sha256")
-      .update("user@example.com\nhttp://localhost:5173\n/tmp/app")
+      .update("user@example.com\norg_1\nhttp://localhost:5173\n/tmp/app")
       .digest("base64url")
       .slice(0, 16);
     const expectedId = `localhost_${hash}`;
     expect(insertedValues?.id).toBe(expectedId);
     expect(upsertConfig?.set.id).toBe(expectedId);
+  });
+
+  it("scopes derived connection ids by org", async () => {
+    await action.run({
+      devServerUrl: "http://localhost:5173/",
+      bridgeUrl: "http://127.0.0.1:7666",
+      rootPath: "/tmp/app",
+    });
+    const firstOrgId = insertedValues?.id;
+
+    requestContextMock.orgId = "org_2";
+    insertedValues = null;
+    upsertConfig = null;
+
+    await action.run({
+      devServerUrl: "http://localhost:5173/",
+      bridgeUrl: "http://127.0.0.1:7666",
+      rootPath: "/tmp/app",
+    });
+
+    expect(insertedValues?.id).not.toBe(firstOrgId);
   });
 
   it("preserves an existing bridge token when a refresh omits bridgeToken", async () => {

--- a/templates/design/actions/connect-localhost.ts
+++ b/templates/design/actions/connect-localhost.ts
@@ -1,10 +1,11 @@
+import crypto from "node:crypto";
+
 import { defineAction } from "@agent-native/core";
 import {
   getRequestOrgId,
   getRequestUserEmail,
 } from "@agent-native/core/server/request-context";
 import { eq } from "drizzle-orm";
-import { nanoid } from "nanoid";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
@@ -76,6 +77,19 @@ function normalizeBridgeUrl(value: string): string {
   return parsed.toString().replace(/\/$/, "");
 }
 
+function stableConnectionId(
+  devServerUrl: string,
+  rootPath: string | undefined,
+  ownerEmail: string,
+) {
+  const hash = crypto
+    .createHash("sha256")
+    .update(`${ownerEmail}\n${devServerUrl}\n${rootPath ?? ""}`)
+    .digest("base64url")
+    .slice(0, 16);
+  return `localhost_${hash}`;
+}
+
 export default defineAction({
   description:
     "Register or refresh a localhost Design source connection produced by `agent-native design connect`. Stores the dev server URL, bridge URL, route manifest, and operation capabilities so the UI can later list local-code artboards.",
@@ -128,7 +142,6 @@ export default defineAction({
     if (!ownerEmail) throw new Error("no authenticated user");
 
     const now = new Date().toISOString();
-    const id = args.id ?? nanoid();
     const db = getDb();
     const devServerUrl = normalizeUrl(args.devServerUrl, "devServerUrl");
     const bridgeUrl = args.bridgeUrl
@@ -152,6 +165,9 @@ export default defineAction({
       routes,
       generatedAt: args.routeManifest?.generatedAt ?? now,
     };
+    const id =
+      args.id ??
+      stableConnectionId(devServerUrl, routeManifest.rootPath, ownerEmail);
     const capabilities =
       args.capabilities ??
       DESIGN_BRIDGE_OPERATIONS.map((operation) => ({

--- a/templates/design/actions/connect-localhost.ts
+++ b/templates/design/actions/connect-localhost.ts
@@ -81,10 +81,11 @@ function stableConnectionId(
   devServerUrl: string,
   rootPath: string | undefined,
   ownerEmail: string,
+  orgId: string | null,
 ) {
   const hash = crypto
     .createHash("sha256")
-    .update(`${ownerEmail}\n${devServerUrl}\n${rootPath ?? ""}`)
+    .update(`${ownerEmail}\n${orgId ?? ""}\n${devServerUrl}\n${rootPath ?? ""}`)
     .digest("base64url")
     .slice(0, 16);
   return `localhost_${hash}`;
@@ -140,6 +141,7 @@ export default defineAction({
   run: async (args) => {
     const ownerEmail = getRequestUserEmail();
     if (!ownerEmail) throw new Error("no authenticated user");
+    const orgId = getRequestOrgId() ?? null;
 
     const now = new Date().toISOString();
     const db = getDb();
@@ -167,7 +169,12 @@ export default defineAction({
     };
     const id =
       args.id ??
-      stableConnectionId(devServerUrl, routeManifest.rootPath, ownerEmail);
+      stableConnectionId(
+        devServerUrl,
+        routeManifest.rootPath,
+        ownerEmail,
+        orgId,
+      );
     const capabilities =
       args.capabilities ??
       DESIGN_BRIDGE_OPERATIONS.map((operation) => ({
@@ -209,7 +216,7 @@ export default defineAction({
       status: args.status,
       lastSeenAt: now,
       ownerEmail,
-      orgId: getRequestOrgId() ?? null,
+      orgId,
       updatedAt: now,
     };
 

--- a/templates/design/actions/open-visual-edit.spec.ts
+++ b/templates/design/actions/open-visual-edit.spec.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  addLocalhostScreensRun: vi.fn(),
+  connectLocalhostRun: vi.fn(),
+  createDesignRun: vi.fn(),
+  navigateRun: vi.fn(),
+  writeAppState: vi.fn(),
+}));
+
+vi.mock("@agent-native/core", () => ({
+  defineAction: (config: unknown) => config,
+  embedApp: (config: unknown) => config,
+}));
+
+vi.mock("@agent-native/core/application-state", () => ({
+  writeAppState: mocks.writeAppState,
+}));
+
+vi.mock("@agent-native/core/server", () => ({
+  buildDeepLink: ({
+    to,
+  }: {
+    app: string;
+    view: string;
+    params: Record<string, unknown>;
+    to: string;
+  }) => `agent-native://open${to}`,
+}));
+
+vi.mock("./connect-localhost.js", () => ({
+  default: {
+    run: mocks.connectLocalhostRun,
+  },
+}));
+
+vi.mock("./add-localhost-screens.js", () => ({
+  default: {
+    run: mocks.addLocalhostScreensRun,
+  },
+  pathFromUrl: (_baseUrl: string, _url: string, fallback?: string) =>
+    fallback ?? "/",
+  routeUrl: (baseUrl: string, route: { path?: string; url?: string }) =>
+    new URL(route.url ?? route.path ?? "/", `${baseUrl}/`).toString(),
+}));
+
+vi.mock("./create-design.js", () => ({
+  default: {
+    run: mocks.createDesignRun,
+  },
+}));
+
+vi.mock("./navigate.js", () => ({
+  default: {
+    run: mocks.navigateRun,
+  },
+}));
+
+import action from "./open-visual-edit.js";
+
+describe("open-visual-edit", () => {
+  beforeEach(() => {
+    mocks.addLocalhostScreensRun.mockReset();
+    mocks.connectLocalhostRun.mockReset();
+    mocks.createDesignRun.mockReset();
+    mocks.navigateRun.mockReset();
+    mocks.writeAppState.mockReset();
+
+    mocks.connectLocalhostRun.mockResolvedValue({
+      id: "localhost_canonical",
+      bridgeUrl: "http://127.0.0.1:7331",
+      rootPath: "/tmp/app",
+    });
+    mocks.addLocalhostScreensRun.mockResolvedValue({
+      screenCount: 1,
+      screens: [{ id: "screen_1", bridgeToken: "stored_bridge_token" }],
+      placedFrames: [{ fileId: "screen_1" }],
+    });
+  });
+
+  it("uses the connection id returned by connect-localhost when no id is supplied", async () => {
+    const result = await action.run({
+      designId: "design_1",
+      devServerUrl: "http://localhost:5173/",
+      bridgeUrl: "http://127.0.0.1:7331",
+      rootPath: "/tmp/app",
+      routeManifest: {
+        version: 1,
+        sourceType: "localhost",
+        devServerUrl: "http://localhost:5173",
+        rootPath: "/tmp/app",
+        routes: [{ path: "/", title: "Home" }],
+      },
+      navigate: false,
+    });
+
+    expect(mocks.connectLocalhostRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: undefined,
+        bridgeToken: undefined,
+        devServerUrl: "http://localhost:5173",
+        rootPath: "/tmp/app",
+      }),
+    );
+    expect(mocks.addLocalhostScreensRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        designId: "design_1",
+        connectionId: "localhost_canonical",
+      }),
+    );
+    expect(mocks.writeAppState).toHaveBeenCalledWith(
+      "visual-edit",
+      expect.objectContaining({
+        designId: "design_1",
+        connectionId: "localhost_canonical",
+        bridgeUrl: "http://127.0.0.1:7331",
+      }),
+    );
+    expect(result.connectionId).toBe("localhost_canonical");
+  });
+
+  it("passes an explicit connection id through for follow-up visual-edit calls", async () => {
+    await action.run({
+      designId: "design_1",
+      connectionId: "localhost_existing",
+      devServerUrl: "http://localhost:5173",
+      bridgeUrl: "http://127.0.0.1:7331",
+      rootPath: "/tmp/app",
+      paths: ["/settings"],
+      navigate: false,
+    });
+
+    expect(mocks.connectLocalhostRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "localhost_existing",
+      }),
+    );
+  });
+});

--- a/templates/design/actions/open-visual-edit.ts
+++ b/templates/design/actions/open-visual-edit.ts
@@ -1,9 +1,6 @@
-import crypto from "node:crypto";
-
 import { defineAction, embedApp } from "@agent-native/core";
 import { writeAppState } from "@agent-native/core/application-state";
 import { buildDeepLink } from "@agent-native/core/server";
-import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -87,28 +84,6 @@ function isLoopbackUrl(value: string): boolean {
     parts[0] === "127" &&
     parts.every((part) => /^\d+$/.test(part) && Number(part) <= 255)
   );
-}
-
-/**
- * Derive a stable per-user connection id for a devServerUrl + rootPath pair.
- *
- * The owner email is embedded in the hash so two users with an identical
- * devServerUrl + rootPath (common with devcontainers/codespaces images) derive
- * DIFFERENT ids and never collide on the shared primary key. Connections
- * created before user scoping keep their old ids; those users simply
- * reconnect fresh under the new per-user id.
- */
-function stableConnectionId(
-  devServerUrl: string,
-  rootPath: string | undefined,
-  ownerEmail: string,
-) {
-  const hash = crypto
-    .createHash("sha256")
-    .update(`${ownerEmail}\n${devServerUrl}\n${rootPath ?? ""}`)
-    .digest("base64url")
-    .slice(0, 16);
-  return `localhost_${hash}`;
 }
 
 function designOverviewDeepLink(designId: string): string {
@@ -254,19 +229,11 @@ export default defineAction({
             }) ?? [],
           generatedAt: new Date().toISOString(),
         };
-    let connectionId = args.connectionId;
-    if (!connectionId) {
-      const ownerEmail = getRequestUserEmail();
-      if (!ownerEmail) throw new Error("no authenticated user");
-      connectionId = stableConnectionId(
-        devServerUrl,
-        args.rootPath,
-        ownerEmail,
-      );
-    }
-
     const connection = await connectLocalhostAction.run({
-      id: connectionId,
+      // Let connect-localhost be the single source of truth for stable
+      // per-user/per-org id derivation. Duplicating it here can create a second
+      // tokenless row after the CLI self-registers the bridge token.
+      id: args.connectionId,
       name: args.name,
       devServerUrl,
       bridgeUrl: args.bridgeUrl,

--- a/templates/design/app/components/design/DesignCanvas.embedded-frame.test.ts
+++ b/templates/design/app/components/design/DesignCanvas.embedded-frame.test.ts
@@ -5,6 +5,7 @@ import {
   getEmbeddedFrameBackgroundStyle,
   getEmbeddedIframeBackgroundColor,
   isElementInfoPayload,
+  liveEditEndpointUrl,
 } from "./DesignCanvas";
 
 describe("DesignCanvas embedded frame backgrounds", () => {
@@ -82,5 +83,19 @@ describe("DesignCanvas bridge payload validation", () => {
         isFlexContainer: true,
       }),
     ).toBe(false);
+  });
+});
+
+describe("DesignCanvas live-edit URLs", () => {
+  it("can request the bridge proxy without editor chrome for Interact mode", () => {
+    const url = liveEditEndpointUrl(
+      "http://127.0.0.1:7331",
+      "http://localhost:5173/forms",
+      { includeEditorBridge: false },
+    );
+
+    expect(url).toBe(
+      "http://127.0.0.1:7331/live-edit?url=http%3A%2F%2Flocalhost%3A5173%2Fforms&bridge=0",
+    );
   });
 });

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -865,9 +865,16 @@ function snapshotEndpointUrl(bridgeUrl: string, previewUrl: string): string {
   return endpoint.toString();
 }
 
-function liveEditEndpointUrl(bridgeUrl: string, previewUrl: string): string {
+export function liveEditEndpointUrl(
+  bridgeUrl: string,
+  previewUrl: string,
+  options?: { includeEditorBridge?: boolean },
+): string {
   const endpoint = new URL("/live-edit", bridgeUrl);
   endpoint.searchParams.set("url", previewUrl);
+  if (options?.includeEditorBridge === false) {
+    endpoint.searchParams.set("bridge", "0");
+  }
   return endpoint.toString();
 }
 
@@ -1268,19 +1275,28 @@ export function DesignCanvas({
     () => contentHash(liveEditBridgeScript),
     [liveEditBridgeScript],
   );
-  const usesLiveEditExternalFrame =
+  const hasLiveEditExternalFrame =
+    sourceType === "localhost" && Boolean(bridgeUrl && rawExternalPreviewUrl);
+  const usesLiveEditEditorBridge =
     sourceType === "localhost" &&
     Boolean(bridgeUrl && rawExternalPreviewUrl) &&
     !interactMode &&
     !readOnly;
   const liveEditBridgeRegistered =
-    usesLiveEditExternalFrame &&
+    usesLiveEditEditorBridge &&
     registeredLiveEditBridgeKey === liveEditBridgeKey;
   const requiresEditableExternalSnapshot = false;
   const liveEditExternalPreviewUrl =
-    liveEditBridgeRegistered && bridgeUrl && rawExternalPreviewUrl
-      ? liveEditEndpointUrl(bridgeUrl, rawExternalPreviewUrl)
-      : null;
+    hasLiveEditExternalFrame &&
+    bridgeUrl &&
+    rawExternalPreviewUrl &&
+    interactMode
+      ? liveEditEndpointUrl(bridgeUrl, rawExternalPreviewUrl, {
+          includeEditorBridge: false,
+        })
+      : liveEditBridgeRegistered && bridgeUrl && rawExternalPreviewUrl
+        ? liveEditEndpointUrl(bridgeUrl, rawExternalPreviewUrl)
+        : null;
   const iframeRenderContent =
     activeExternalSnapshotHtml ??
     (requiresEditableExternalSnapshot ? "" : renderedContent);
@@ -1292,7 +1308,7 @@ export function DesignCanvas({
   const waitingForEditableExternalSnapshot =
     requiresEditableExternalSnapshot && !activeExternalSnapshotHtml;
   const waitingForLiveEditBridge =
-    usesLiveEditExternalFrame && !liveEditBridgeRegistered;
+    usesLiveEditEditorBridge && !liveEditBridgeRegistered;
   zoomRef.current = zoom;
   runtimeReplacementContentRef.current = runtimeReplacementContent;
   runtimeReplacementKeyRef.current = runtimeReplacementKey;
@@ -1302,7 +1318,7 @@ export function DesignCanvas({
   }, [onExternalContentSnapshot]);
 
   useEffect(() => {
-    if (!usesLiveEditExternalFrame || !bridgeUrl) {
+    if (!usesLiveEditEditorBridge || !bridgeUrl) {
       setRegisteredLiveEditBridgeKey(null);
       return;
     }
@@ -1345,7 +1361,7 @@ export function DesignCanvas({
     bridgeToken,
     liveEditBridgeKey,
     liveEditBridgeScript,
-    usesLiveEditExternalFrame,
+    usesLiveEditEditorBridge,
   ]);
 
   useEffect(() => {

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -3020,7 +3020,7 @@ export function DesignCanvas({
         </div>
       ) : null}
       {waitingForEditableExternalSnapshot || waitingForLiveEditBridge ? (
-        <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-background/85 px-4 text-center text-sm text-muted-foreground">
+        <div className="pointer-events-auto absolute inset-0 z-10 flex items-center justify-center bg-background/85 px-4 text-center text-sm text-muted-foreground">
           {waitingForLiveEditBridge ? (
             <div className="max-w-[28rem] rounded-md border bg-card px-4 py-3 shadow-sm">
               {

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -22109,6 +22109,14 @@ export default function DesignEditor() {
     ) {
       return;
     }
+    const preservePreviewPatches = pendingVisualStyleEdits
+      .map((edit) => ({
+        screenId: edit.screenId,
+        selector: edit.selector,
+        sourceId: edit.sourceId,
+        styles: edit.styles,
+      }))
+      .filter((patch) => Object.keys(patch.styles).length > 0);
     sendToDesignAgentChat({
       message: t("designEditor.pendingVisualStyles.agentMessage"),
       context: pendingVisualStylePrompt,
@@ -22132,13 +22140,22 @@ export default function DesignEditor() {
       });
     }
     clearPendingLiveEditState();
-    setPendingVisualStyleBaselineResetRequest(Date.now() + Math.random());
+    const previewRequestId = Date.now() + Math.random();
+    window.setTimeout(() => {
+      if (preservePreviewPatches.length > 0) {
+        setPendingVisualStyleRevertRequest({
+          requestId: previewRequestId,
+          patches: preservePreviewPatches,
+        });
+      }
+      setPendingVisualStyleBaselineResetRequest(previewRequestId);
+    }, 50);
     setActiveLeftPanel("agent");
     toast.success(t("designEditor.pendingVisualStyles.sentToast"));
   }, [
     clearPendingLiveEditState,
     pendingLiveNonStyleEdits,
-    pendingVisualStyleEdits.length,
+    pendingVisualStyleEdits,
     pendingVisualStylePrompt,
     t,
   ]);

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -21167,7 +21167,13 @@ export default function DesignEditor() {
   }, [activeFile, enterOverviewFromZoom, mode, viewMode, zoom]);
 
   const handleModeChange = useCallback(
-    (next: EditorMode, options?: { discardPendingLiveEdits?: boolean }) => {
+    (
+      next: EditorMode,
+      options?: {
+        discardPendingLiveEdits?: boolean;
+        pendingLiveEditsAlreadyHandled?: boolean;
+      },
+    ) => {
       if (!canEditDesign && next === "annotate") return;
       if ((next === "annotate" || next === "interact") && !activeFile) {
         return;
@@ -21176,7 +21182,8 @@ export default function DesignEditor() {
         next === "interact" &&
         (pendingVisualStyleEdits.length > 0 ||
           pendingLiveNonStyleEdits.length > 0) &&
-        !options?.discardPendingLiveEdits
+        !options?.discardPendingLiveEdits &&
+        !options?.pendingLiveEditsAlreadyHandled
       ) {
         toast.error(t("designEditor.pendingVisualStyles.interactBlocked"));
         return;
@@ -22142,12 +22149,20 @@ export default function DesignEditor() {
     ) {
       return;
     }
-    handleModeChange("interact", { discardPendingLiveEdits: true });
+    requestPendingVisualStyleRevert(pendingVisualStyleEdits);
+    requestPendingLiveNonStyleRevert(pendingLiveNonStyleEdits);
+    clearPendingLiveEditState();
+    window.setTimeout(() => {
+      handleModeChange("interact", { pendingLiveEditsAlreadyHandled: true });
+    }, 50);
     toast.success(t("designEditor.pendingVisualStyles.abortedToast"));
   }, [
+    clearPendingLiveEditState,
     handleModeChange,
-    pendingLiveNonStyleEdits.length,
-    pendingVisualStyleEdits.length,
+    pendingLiveNonStyleEdits,
+    pendingVisualStyleEdits,
+    requestPendingLiveNonStyleRevert,
+    requestPendingVisualStyleRevert,
     t,
   ]);
   const handleCopyPendingVisualStylePrompt = useCallback(async () => {

--- a/templates/design/changelog/2026-07-07-local-visual-edit-keeps-bridge-access-when-opening-previousl.md
+++ b/templates/design/changelog/2026-07-07-local-visual-edit-keeps-bridge-access-when-opening-previousl.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-07
+---
+
+Local visual edit keeps bridge access when opening previously connected localhost apps

--- a/templates/design/changelog/2026-07-07-local-visual-edit-now-keeps-the-live-app-connection-authenti.md
+++ b/templates/design/changelog/2026-07-07-local-visual-edit-now-keeps-the-live-app-connection-authenti.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-07
+---
+
+Local visual edit now keeps the live app connection authenticated when applying or discarding style previews.


### PR DESCRIPTION
## Summary
- Default hosted foreground agent turns with `A2A_SECRET` to server-owned self-chain continuation, with an explicit env opt-out.
- Forward provider HTTP status metadata from Anthropic/AI-SDK engines and treat `http_429`/bare 429 errors as retryable.
- Keep server-continued runs in client follow mode and tighten localhost Design bridge registration/id stability.

## Test plan
- `pnpm run prep`


Made with [Cursor](https://cursor.com)