### PR TITLE
Open Clips chapter regeneration in chat

### DIFF
--- a/templates/clips/actions/regenerate-chapters.ts
+++ b/templates/clips/actions/regenerate-chapters.ts
@@ -23,6 +23,12 @@ export default defineAction({
     "Ask the agent to generate chapters for this recording based on its transcript (and the full video when Include full video is enabled). The agent identifies topic transitions and calls set-chapters.",
   schema: z.object({
     recordingId: z.string().describe("Recording ID"),
+    openInChat: z
+      .boolean()
+      .optional()
+      .describe(
+        "When true, focus the queued generation request in the agent chat instead of keeping it hidden.",
+      ),
   }),
   run: async (args) => {
     await assertAccess("recording", args.recordingId, "editor");
@@ -57,6 +63,7 @@ export default defineAction({
       segmentsJson: transcript?.segmentsJson ?? "[]",
       transcriptText: transcript?.fullText ?? "",
       includeFullVideoInAi,
+      openInChat: args.openInChat === true,
       message: withFullVideoAiInstructions(
         baseMessage,
         args.recordingId,

--- a/templates/clips/app/hooks/use-auto-title.test.ts
+++ b/templates/clips/app/hooks/use-auto-title.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { buildAiRequestChatOptions } from "./use-auto-title";
+
+const recording = {
+  id: "rec_123",
+  title: "Demo recording",
+} as any;
+
+describe("buildAiRequestChatOptions", () => {
+  it("keeps queued AI requests hidden by default", () => {
+    const options = buildAiRequestChatOptions(recording, {
+      kind: "regenerate-chapters",
+      recordingId: "rec_123",
+      message: "Generate chapters",
+    });
+
+    expect(options.newTab).toBe(true);
+    expect(options.background).toBe(true);
+    expect(options.openSidebar).toBe(false);
+  });
+
+  it("focuses requests that were explicitly opened from the UI", () => {
+    const options = buildAiRequestChatOptions(recording, {
+      kind: "regenerate-chapters",
+      recordingId: "rec_123",
+      message: "Generate chapters",
+      openInChat: true,
+    });
+
+    expect(options.newTab).toBe(true);
+    expect(options.background).toBe(false);
+    expect(options.openSidebar).toBe(true);
+  });
+});

--- a/templates/clips/app/hooks/use-auto-title.ts
+++ b/templates/clips/app/hooks/use-auto-title.ts
@@ -15,6 +15,7 @@ import {
   agentNativePath,
   callAction,
   sendToAgentChat,
+  type AgentChatMessage,
 } from "@agent-native/core/client";
 import { fullVideoAiModelSelection } from "@shared/clips-ai-prefs";
 import { useEffect, useRef } from "react";
@@ -55,6 +56,7 @@ interface AiRequest {
   thresholdMs?: number;
   message?: string;
   includeFullVideoInAi?: boolean;
+  openInChat?: boolean;
 }
 
 const DISPATCHABLE_REQUESTS = new Set([
@@ -201,25 +203,33 @@ function buildRequestContext(rec: RecordingSummary, request: AiRequest) {
   };
 }
 
-function dispatchAiRequest(rec: RecordingSummary, request: AiRequest) {
+export function buildAiRequestChatOptions(
+  rec: RecordingSummary,
+  request: AiRequest,
+): AgentChatMessage {
   const includeFullVideo = request.includeFullVideoInAi === true;
   const gemini = includeFullVideo ? fullVideoAiModelSelection() : null;
-  sendToAgentChat({
+  const openInChat = request.openInChat === true;
+  return {
     message:
       request.message ??
       `Handle queued ${request.kind} work for recording ${rec.id}.`,
     context: JSON.stringify(buildRequestContext(rec, request)),
     submit: true,
-    openSidebar: false,
+    openSidebar: openInChat ? true : false,
     newTab: true,
-    background: true,
+    background: !openInChat,
     ...(gemini
       ? {
           engine: gemini.engine,
           model: gemini.model,
         }
       : {}),
-  });
+  };
+}
+
+function dispatchAiRequest(rec: RecordingSummary, request: AiRequest) {
+  sendToAgentChat(buildAiRequestChatOptions(rec, request));
 }
 
 function parseJsonArray(raw: string | undefined): unknown[] {

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -1096,6 +1096,7 @@ export default function RecordingPage() {
                   onSelect={() =>
                     regenerateChapters.mutate({
                       recordingId: recording.id,
+                      openInChat: true,
                     } as any)
                   }
                 >

--- a/templates/clips/changelog/2026-07-07-auto-generated-chapter-requests-now-open-the-matching-agent-.md
+++ b/templates/clips/changelog/2026-07-07-auto-generated-chapter-requests-now-open-the-matching-agent-.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-07
+---
+
+Auto-generated chapter requests now open the matching agent chat tab.


### PR DESCRIPTION
## Summary
- Open manual Clips chapter regeneration requests in the matching agent chat tab.
- Keep background queued AI requests hidden by default while adding test coverage for the chat options.
- Add a Clips changelog entry for the user-facing fix.

## Test plan
- pnpm --dir templates/clips exec vitest --run app/hooks/use-auto-title.test.ts --passWithNoTests
- pnpm run prep


Made with [Cursor](https://cursor.com)