### PR TITLE
Harden background agent run routing

### DIFF
--- a/.changeset/calm-stale-background-timeout.md
+++ b/.changeset/calm-stale-background-timeout.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep agent-chat workers on the hosted foreground timeout unless they are actually running inside a background function, preventing misrouted workers from being killed as stale runs.

--- a/.changeset/empty-response-token-headroom.md
+++ b/.changeset/empty-response-token-headroom.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Add output-token and reasoning-effort helpers that preserve visible response headroom for reasoning-heavy model calls.
+Fix "The model returned an empty response" on hard/long-context chat turns: interactive chat now resolves max_output_tokens to min(model ceiling, 32K) instead of the flat 4096-8192 per-engine defaults, Anthropic/Gemini numeric thinking budgets are clamped to always leave real output headroom under max_tokens, and the empty-final-response retry now raises the token ceiling and steps reasoning effort down a tier (with the retry budget raised from 1 to 2 attempts) instead of re-issuing the identical doomed request.

--- a/.changeset/empty-response-token-headroom.md
+++ b/.changeset/empty-response-token-headroom.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add output-token and reasoning-effort helpers that preserve visible response headroom for reasoning-heavy model calls.

--- a/.changeset/misrouted-worker-neon-pool.md
+++ b/.changeset/misrouted-worker-neon-pool.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Stop misrouted agent-chat workers from taking the large background Neon connection pool. `isBackgroundFunctionPoolContext()` no longer trusts the dispatch marker (`__AGENT_NATIVE_BACKGROUND_RUNTIME_EXPECTED__`) — a worker dispatched toward a `-background` URL but routed onto the ~60s synchronous function would otherwise open the 8-connection worker pool while running as one of many warm sync-function instances, exhausting the Neon pooled endpoint (connection terminated / statement timeouts / failed heartbeat writes surfacing as stale runs). Only the genuine `-background` runtime marker (set at cold start) unlocks the larger pool now, mirroring the same proof-of-landing tightening applied to the worker soft-timeout.

--- a/packages/core/src/agent/durable-background.spec.ts
+++ b/packages/core/src/agent/durable-background.spec.ts
@@ -57,6 +57,10 @@ beforeEach(() => {
 
 afterEach(() => {
   process.env = saved;
+  Reflect.deleteProperty(
+    globalThis as Record<string, unknown>,
+    "__AGENT_NATIVE_BACKGROUND_RUNTIME__",
+  );
 });
 
 /** Mark the runtime as hosted (Netlify, not local). */
@@ -253,7 +257,7 @@ describe("isInBackgroundFunctionRuntime (real -background function guard)", () =
   });
 });
 
-describe("background runtime marker fallback", () => {
+describe("background runtime marker diagnostics", () => {
   it("derives marker expectation from the concrete dispatch path", () => {
     expect(
       dispatchPathTargetsNetlifyBackgroundFunction(
@@ -267,17 +271,32 @@ describe("background runtime marker fallback", () => {
     ).toBe(false);
   });
 
-  it("uses the long background timeout when the authenticated dispatch marker proves the Netlify background function URL was targeted", () => {
+  it("does not use the long background timeout from the dispatch marker alone", () => {
     const marker = { backgroundFunctionRuntimeExpected: true };
 
     expect(isInBackgroundFunctionRuntime()).toBe(false);
     expect(backgroundRunMarkerExpectsBackgroundRuntime(marker)).toBe(true);
-    expect(shouldUseBackgroundFunctionTimeoutForWorker(marker)).toBe(true);
+    expect(shouldUseBackgroundFunctionTimeoutForWorker(marker)).toBe(false);
     expect(backgroundRuntimeDiagnosticDetail(marker)).toContain(
       "markerExpected=true",
     );
     expect(backgroundRuntimeDiagnosticDetail(marker)).toContain(
       "runtimeDetected=false",
+    );
+  });
+
+  it("uses the long background timeout when the background function entry marked the runtime", () => {
+    (
+      globalThis as Record<string, unknown>
+    ).__AGENT_NATIVE_BACKGROUND_RUNTIME__ = true;
+
+    expect(isInBackgroundFunctionRuntime()).toBe(true);
+    expect(shouldUseBackgroundFunctionTimeoutForWorker(null)).toBe(true);
+    expect(backgroundRuntimeDiagnosticDetail(null)).toContain(
+      "runtimeDetected=true",
+    );
+    expect(backgroundRuntimeDiagnosticDetail(null)).toContain(
+      "globalMarker=true",
     );
   });
 
@@ -316,8 +335,8 @@ describe("resolveAgentChatProcessRunDispatchPath (default function url on hosted
   it("dispatches to the function's DEFAULT url in deployed Netlify Lambda runtime even when NETLIFY is absent", () => {
     // Production Functions do not always preserve the build-time NETLIFY env
     // flag, but they do expose AWS_LAMBDA_FUNCTION_NAME. The durable dispatcher
-    // must still target the emitted Netlify background function so the marker
-    // unlocks the 15-minute worker budget.
+    // must still target the emitted Netlify background function; the worker
+    // entry's runtime marker unlocks the 15-minute budget after dispatch lands.
     process.env.AWS_LAMBDA_FUNCTION_NAME = "agent-native-design-server";
     expect(resolveAgentChatProcessRunDispatchPath()).toBe(
       AGENT_BACKGROUND_FUNCTION_URL_PATH,

--- a/packages/core/src/agent/durable-background.ts
+++ b/packages/core/src/agent/durable-background.ts
@@ -260,12 +260,12 @@ export function backgroundRunMarkerExpectsBackgroundRuntime(
 }
 
 export function shouldUseBackgroundFunctionTimeoutForWorker(
-  marker: unknown,
+  _marker: unknown,
 ): boolean {
-  return (
-    isInBackgroundFunctionRuntime() ||
-    backgroundRunMarkerExpectsBackgroundRuntime(marker)
-  );
+  // The dispatch marker says which URL the foreground targeted, not where the
+  // request actually landed. Only the worker runtime proof can safely lift the
+  // hosted 40s clamp to the 15-minute background-function budget.
+  return isInBackgroundFunctionRuntime();
 }
 
 export function backgroundRuntimeDiagnosticDetail(marker: unknown): string {

--- a/packages/core/src/agent/engine/ai-sdk-engine.spec.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.spec.ts
@@ -43,6 +43,48 @@ function mockGoogleProvider() {
   return { createGoogleGenerativeAI, provider, googleModel };
 }
 
+function mockAnthropicProvider() {
+  const anthropicModel = { id: "anthropic-model" };
+  const provider = vi.fn().mockReturnValue(anthropicModel);
+  const createAnthropic = vi.fn().mockReturnValue(provider);
+  vi.doMock("@ai-sdk/anthropic", () => ({ createAnthropic }));
+  return { createAnthropic, provider, anthropicModel };
+}
+
+describe("AISDKEngine Anthropic thinking-budget headroom", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it("clamps an explicit large thinking budget so it leaves headroom under maxOutputTokens", async () => {
+    const { streamText } = mockAiSdk();
+    mockAnthropicProvider();
+
+    const { createAISDKEngine } = await import("./ai-sdk-engine.js");
+    const engine = createAISDKEngine("anthropic", { apiKey: "key" });
+
+    await drain(
+      engine.stream({
+        ...BASE_STREAM_OPTIONS,
+        model: "claude-opus-4-8",
+        maxOutputTokens: 32_000,
+        providerOptions: {
+          anthropic: {
+            thinking: { type: "enabled", budgetTokens: 100_000 },
+          },
+        },
+      }),
+    );
+
+    const call = streamText.mock.calls[0][0];
+    const budgetTokens = call.providerOptions.anthropic.thinking
+      .budgetTokens as number;
+    expect(budgetTokens).toBeLessThan(32_000);
+    expect(32_000 - budgetTokens).toBeGreaterThanOrEqual(8000);
+  });
+});
+
 describe("AISDKEngine Google Gemini thinking config", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -61,6 +103,10 @@ describe("AISDKEngine Google Gemini thinking config", () => {
         ...BASE_STREAM_OPTIONS,
         model: "gemini-2.5-flash",
         reasoningEffort: "medium",
+        // Generous maxOutputTokens (matches the interactive chat floor) so
+        // the headroom clamp below is a no-op and the raw effort->budget
+        // mapping is what's under test here.
+        maxOutputTokens: 32_000,
       }),
     );
 
@@ -73,6 +119,31 @@ describe("AISDKEngine Google Gemini thinking config", () => {
         }),
       }),
     );
+  });
+
+  it("clamps Gemini thinkingBudget so it can't consume a small maxOutputTokens entirely", async () => {
+    const { streamText } = mockAiSdk();
+    mockGoogleProvider();
+
+    const { createAISDKEngine } = await import("./ai-sdk-engine.js");
+    const engine = createAISDKEngine("google", { apiKey: "key" });
+
+    await drain(
+      engine.stream({
+        ...BASE_STREAM_OPTIONS,
+        model: "gemini-2.5-flash",
+        reasoningEffort: "medium",
+        // Unclamped, "medium" effort maps to a 4096-token thinkingBudget —
+        // identical to this maxOutputTokens, which would leave zero tokens
+        // for the actual response (the empty-response bug this fixes).
+        maxOutputTokens: 4_096,
+      }),
+    );
+
+    const call = streamText.mock.calls[0][0];
+    const thinkingBudget = call.providerOptions.google.thinkingConfig
+      .thinkingBudget as number;
+    expect(thinkingBudget).toBeLessThan(4_096);
   });
 
   it("uses thinkingLevel for Gemini 3.x models (low effort → 'low')", async () => {

--- a/packages/core/src/agent/engine/ai-sdk-engine.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.ts
@@ -330,11 +330,26 @@ class AISDKEngine implements AgentEngine {
         // Gemini 3.x models reject thinkingBudget — they require thinkingLevel.
         // Gemini 2.5.x models use thinkingBudget (integer token count or -1).
         const isGemini3 = /^gemini-3/.test(opts.model);
+        const thinkingBudget = googleThinkingBudget(reasoningEffort);
         providerOpts.google = {
           ...((providerOpts.google as object) ?? {}),
           thinkingConfig: isGemini3
             ? { thinkingLevel: gemini3ThinkingLevel(reasoningEffort) }
-            : { thinkingBudget: googleThinkingBudget(reasoningEffort) },
+            : {
+                // Unlike Anthropic's adaptive thinking, Gemini 2.5's
+                // thinkingBudget IS a concrete numeric token count, so the
+                // same headroom clamp applies: at "max" effort this maps to
+                // 32000 tokens, which can equal (or exceed) a small
+                // maxOutputTokens cap and leave zero room for the actual
+                // response. Preserve Gemini's -1 "dynamic" sentinel.
+                thinkingBudget:
+                  thinkingBudget > 0
+                    ? clampThinkingBudgetTokens(
+                        thinkingBudget,
+                        resolvedMaxOutputTokens,
+                      )
+                    : thinkingBudget,
+              },
         };
       }
     }

--- a/packages/core/src/agent/engine/ai-sdk-engine.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.ts
@@ -19,7 +19,10 @@ import {
 } from "../../server/credential-provider.js";
 import { normalizeReasoningEffortForModel } from "../../shared/reasoning-effort.js";
 import { AI_SDK_MODEL_CONFIG, type AISDKProvider } from "../model-config.js";
-import { resolveMaxOutputTokensForEngine } from "./output-tokens.js";
+import {
+  clampThinkingBudgetTokens,
+  resolveMaxOutputTokensForEngine,
+} from "./output-tokens.js";
 import {
   engineToolsToAISDK,
   engineMessagesToAISDK,
@@ -262,16 +265,34 @@ class AISDKEngine implements AgentEngine {
       toolResultImages: this.capabilities.vision,
     });
 
+    // Resolved once so both `maxOutputTokens` (below, in the streamText call)
+    // and the thinking-budget headroom clamp agree on the same ceiling.
+    const resolvedMaxOutputTokens = resolveMaxOutputTokensForEngine(
+      this.name,
+      opts.maxOutputTokens,
+      opts.model,
+    );
+
     // Build providerOptions for Anthropic-native features when using Anthropic provider
     const providerOpts: Record<string, unknown> = {};
     if (this.provider === "anthropic" && opts.providerOptions?.anthropic) {
       const anthropicOpts = opts.providerOptions.anthropic;
       if (anthropicOpts.thinking) {
+        // Only the "enabled" config carries a numeric budgetTokens; clamp it
+        // so thinking can't consume the entire maxOutputTokens budget and
+        // leave zero room for the actual response ("adaptive" thinking has
+        // no budgetTokens field at all per @ai-sdk/anthropic's schema).
         providerOpts.anthropic = {
           ...((providerOpts.anthropic as object) ?? {}),
           thinking: {
             type: "enabled",
-            budgetTokens: anthropicOpts.thinking.budgetTokens,
+            budgetTokens:
+              typeof anthropicOpts.thinking.budgetTokens === "number"
+                ? clampThinkingBudgetTokens(
+                    anthropicOpts.thinking.budgetTokens,
+                    resolvedMaxOutputTokens,
+                  )
+                : anthropicOpts.thinking.budgetTokens,
           },
         };
       }
@@ -326,11 +347,7 @@ class AISDKEngine implements AgentEngine {
         system: opts.systemPrompt,
         messages,
         tools: aiSdkTools,
-        maxOutputTokens: resolveMaxOutputTokensForEngine(
-          this.name,
-          opts.maxOutputTokens,
-          opts.model,
-        ),
+        maxOutputTokens: resolvedMaxOutputTokens,
         ...(opts.temperature !== undefined
           ? { temperature: opts.temperature }
           : {}),

--- a/packages/core/src/agent/engine/anthropic-engine.spec.ts
+++ b/packages/core/src/agent/engine/anthropic-engine.spec.ts
@@ -201,6 +201,49 @@ describe("createAnthropicEngine", () => {
     expect(lowParams.max_tokens).toBe(64_000);
   });
 
+  it("clamps an explicit large thinking budget so it leaves headroom under max_tokens", async () => {
+    const requestParams = await captureRequestParams({
+      model: "claude-opus-4-8",
+      systemPrompt: "You are helpful.",
+      messages: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      tools: [],
+      abortSignal: new AbortController().signal,
+      maxOutputTokens: 32_000,
+      providerOptions: {
+        anthropic: {
+          thinking: { type: "enabled", budgetTokens: 100_000 },
+        },
+      },
+    });
+
+    expect(requestParams.max_tokens).toBe(32_000);
+    // Unclamped this would have been 100_000 (> max_tokens, invalid per the
+    // Anthropic API contract). It must stay strictly below max_tokens and
+    // leave at least max(8000, 40% of max_tokens) for the actual response.
+    expect(requestParams.thinking.budget_tokens).toBeLessThan(32_000);
+    expect(
+      requestParams.max_tokens - requestParams.thinking.budget_tokens,
+    ).toBeGreaterThanOrEqual(8000);
+  });
+
+  it("leaves a small, already-safe thinking budget unchanged", async () => {
+    const requestParams = await captureRequestParams({
+      model: "claude-opus-4-8",
+      systemPrompt: "You are helpful.",
+      messages: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      tools: [],
+      abortSignal: new AbortController().signal,
+      maxOutputTokens: 32_000,
+      providerOptions: {
+        anthropic: {
+          thinking: { type: "enabled", budgetTokens: 2_000 },
+        },
+      },
+    });
+
+    expect(requestParams.thinking.budget_tokens).toBe(2_000);
+  });
+
   it("adds no cache_control anywhere when cacheControl is disabled", async () => {
     const requestParams = await captureRequestParams({
       model: "claude-haiku-4-5-20251001",

--- a/packages/core/src/agent/engine/anthropic-engine.ts
+++ b/packages/core/src/agent/engine/anthropic-engine.ts
@@ -19,7 +19,10 @@ import {
   LLM_MISSING_CREDENTIALS_ERROR_CODE,
   LLM_MISSING_CREDENTIALS_MESSAGE,
 } from "./credential-errors.js";
-import { resolveMaxOutputTokensForEngine } from "./output-tokens.js";
+import {
+  clampThinkingBudgetTokens,
+  resolveMaxOutputTokensForEngine,
+} from "./output-tokens.js";
 import {
   engineToolsToAnthropic,
   engineMessagesToAnthropic,
@@ -67,12 +70,31 @@ class AnthropicEngine implements AgentEngine {
     const messages = engineMessagesToAnthropic(opts.messages);
     const anthropicOpts = opts.providerOptions?.anthropic;
 
+    // Resolved once so both max_tokens and the thinking-budget headroom
+    // clamp below agree on the same ceiling.
+    const resolvedMaxOutputTokens = resolveMaxOutputTokensForEngine(
+      this.name,
+      opts.maxOutputTokens,
+      opts.model,
+    );
+
     // Build extra body params for Anthropic-native features
     const extra: Record<string, unknown> = {};
     if (anthropicOpts?.thinking) {
       extra.thinking = {
         type: anthropicOpts.thinking.type,
-        budget_tokens: anthropicOpts.thinking.budgetTokens,
+        // Only the "enabled" config carries a numeric budget_tokens; clamp it
+        // so thinking can't consume the entire max_tokens budget and leave
+        // zero room for the actual response ("adaptive" thinking has no
+        // budget_tokens field at all, so it passes through unclamped).
+        budget_tokens:
+          anthropicOpts.thinking.type === "enabled" &&
+          typeof anthropicOpts.thinking.budgetTokens === "number"
+            ? clampThinkingBudgetTokens(
+                anthropicOpts.thinking.budgetTokens,
+                resolvedMaxOutputTokens,
+              )
+            : anthropicOpts.thinking.budgetTokens,
       };
     }
     if (anthropicOpts?.topK !== undefined) {
@@ -139,11 +161,7 @@ class AnthropicEngine implements AgentEngine {
 
     const requestParams: any = {
       model: opts.model,
-      max_tokens: resolveMaxOutputTokensForEngine(
-        this.name,
-        opts.maxOutputTokens,
-        opts.model,
-      ),
+      max_tokens: resolvedMaxOutputTokens,
       system: systemBlocks,
       tools: cachedTools.length > 0 ? cachedTools : undefined,
       messages: cachedMessages,

--- a/packages/core/src/agent/engine/output-tokens.spec.ts
+++ b/packages/core/src/agent/engine/output-tokens.spec.ts
@@ -148,8 +148,12 @@ describe("agent output-token policy", () => {
         Math.round(0.4 * maxOutputTokens),
       );
 
-      expect(budget).toBeLessThan(maxOutputTokens);
-      expect(maxOutputTokens - budget).toBeGreaterThanOrEqual(requiredHeadroom);
+      expect(budget).toBeDefined();
+      const definedBudget = budget!;
+      expect(definedBudget).toBeLessThan(maxOutputTokens);
+      expect(maxOutputTokens - definedBudget).toBeGreaterThanOrEqual(
+        requiredHeadroom,
+      );
     });
 
     it("passes small requested budgets through unchanged when they already fit", () => {
@@ -160,10 +164,18 @@ describe("agent output-token policy", () => {
       const maxOutputTokens = 64_000;
       const budget = clampThinkingBudgetTokens(500_000, maxOutputTokens);
 
-      expect(budget).toBeGreaterThanOrEqual(
+      expect(budget).toBeDefined();
+      const definedBudget = budget!;
+      expect(definedBudget).toBeGreaterThanOrEqual(
         ANTHROPIC_MIN_THINKING_BUDGET_TOKENS,
       );
-      expect(budget).toBeLessThan(maxOutputTokens);
+      expect(definedBudget).toBeLessThan(maxOutputTokens);
+    });
+
+    it("returns undefined when maxOutputTokens is too small for any valid Anthropic thinking budget", () => {
+      expect(
+        clampThinkingBudgetTokens(10_000, ANTHROPIC_MIN_THINKING_BUDGET_TOKENS),
+      ).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/agent/engine/output-tokens.spec.ts
+++ b/packages/core/src/agent/engine/output-tokens.spec.ts
@@ -1,12 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  ANTHROPIC_MIN_THINKING_BUDGET_TOKENS,
+  clampThinkingBudgetTokens,
   DEFAULT_AI_SDK_MAX_OUTPUT_TOKENS,
   DEFAULT_ANTHROPIC_MAX_OUTPUT_TOKENS,
   DEFAULT_BUILDER_MAX_OUTPUT_TOKENS,
   DEFAULT_OPENROUTER_MAX_OUTPUT_TOKENS,
   defaultMaxOutputTokensForEngine,
+  EMPTY_RESPONSE_RETRY_MAX_OUTPUT_TOKENS_CAP,
+  MAIN_CHAT_MAX_OUTPUT_TOKENS_CAP,
   normalizeMaxOutputTokens,
+  resolveEmptyResponseRetryMaxOutputTokens,
+  resolveMainChatMaxOutputTokens,
   resolveMaxOutputTokensForEngine,
 } from "./output-tokens.js";
 
@@ -90,5 +96,74 @@ describe("agent output-token policy", () => {
     );
     // Without a model the env override is still clamped to 64K.
     expect(defaultMaxOutputTokensForEngine("ai-sdk:openai")).toBe(64_000);
+  });
+
+  describe("interactive chat path max_output_tokens floor", () => {
+    it("resolves to min(modelCeiling, 32K) — far above the flat per-engine defaults", () => {
+      expect(MAIN_CHAT_MAX_OUTPUT_TOKENS_CAP).toBe(32_000);
+      // 128K-ceiling models (Claude flagships, GPT-5.x) still cap at 32K for
+      // the first attempt.
+      expect(resolveMainChatMaxOutputTokens("claude-sonnet-5")).toBe(32_000);
+      expect(resolveMainChatMaxOutputTokens("claude-opus-4-8")).toBe(32_000);
+      expect(resolveMainChatMaxOutputTokens("gpt-5.5")).toBe(32_000);
+      // 64K-ceiling and unknown models stay under their ceiling, but still
+      // land well above the flat per-engine defaults below.
+      expect(resolveMainChatMaxOutputTokens("claude-haiku-4-5")).toBe(32_000);
+      expect(resolveMainChatMaxOutputTokens("some-unknown-model")).toBe(32_000);
+      expect(resolveMainChatMaxOutputTokens(undefined)).toBe(32_000);
+
+      // Never below the flat per-engine defaults this replaces.
+      expect(resolveMainChatMaxOutputTokens(undefined)).toBeGreaterThan(
+        DEFAULT_ANTHROPIC_MAX_OUTPUT_TOKENS,
+      );
+      expect(resolveMainChatMaxOutputTokens(undefined)).toBeGreaterThan(
+        DEFAULT_AI_SDK_MAX_OUTPUT_TOKENS,
+      );
+      expect(resolveMainChatMaxOutputTokens(undefined)).toBeGreaterThan(
+        DEFAULT_BUILDER_MAX_OUTPUT_TOKENS,
+      );
+    });
+
+    it("empty-response retry ceiling (64K) is higher than the first-attempt chat cap", () => {
+      expect(EMPTY_RESPONSE_RETRY_MAX_OUTPUT_TOKENS_CAP).toBe(64_000);
+      expect(resolveEmptyResponseRetryMaxOutputTokens("claude-sonnet-5")).toBe(
+        64_000,
+      );
+      expect(resolveEmptyResponseRetryMaxOutputTokens("claude-haiku-4-5")).toBe(
+        64_000,
+      );
+      expect(resolveEmptyResponseRetryMaxOutputTokens(undefined)).toBe(64_000);
+      expect(
+        resolveEmptyResponseRetryMaxOutputTokens("claude-sonnet-5"),
+      ).toBeGreaterThan(resolveMainChatMaxOutputTokens("claude-sonnet-5"));
+    });
+  });
+
+  describe("clampThinkingBudgetTokens", () => {
+    it("leaves at least max(8000, 40% of maxOutputTokens) of non-thinking headroom", () => {
+      const maxOutputTokens = 32_000;
+      const budget = clampThinkingBudgetTokens(200_000, maxOutputTokens);
+      const requiredHeadroom = Math.max(
+        8000,
+        Math.round(0.4 * maxOutputTokens),
+      );
+
+      expect(budget).toBeLessThan(maxOutputTokens);
+      expect(maxOutputTokens - budget).toBeGreaterThanOrEqual(requiredHeadroom);
+    });
+
+    it("passes small requested budgets through unchanged when they already fit", () => {
+      expect(clampThinkingBudgetTokens(2_000, 32_000)).toBe(2_000);
+    });
+
+    it("never goes below Anthropic's documented minimum and always stays < max_tokens", () => {
+      const maxOutputTokens = 64_000;
+      const budget = clampThinkingBudgetTokens(500_000, maxOutputTokens);
+
+      expect(budget).toBeGreaterThanOrEqual(
+        ANTHROPIC_MIN_THINKING_BUDGET_TOKENS,
+      );
+      expect(budget).toBeLessThan(maxOutputTokens);
+    });
   });
 });

--- a/packages/core/src/agent/engine/output-tokens.ts
+++ b/packages/core/src/agent/engine/output-tokens.ts
@@ -90,16 +90,19 @@ export const ANTHROPIC_MIN_THINKING_BUDGET_TOKENS = 1024;
 export function clampThinkingBudgetTokens(
   requestedBudgetTokens: number,
   maxOutputTokens: number,
-): number {
+): number | undefined {
+  if (maxOutputTokens <= ANTHROPIC_MIN_THINKING_BUDGET_TOKENS) {
+    return undefined;
+  }
   const headroom = Math.max(8000, Math.round(0.4 * maxOutputTokens));
   const budgetCapForHeadroom = Math.max(
     ANTHROPIC_MIN_THINKING_BUDGET_TOKENS,
     maxOutputTokens - headroom,
   );
   // budget_tokens must stay strictly below max_tokens per the API contract.
-  const strictUpperBound = Math.max(1, maxOutputTokens - 1);
+  const strictUpperBound = maxOutputTokens - 1;
   return Math.max(
-    1,
+    ANTHROPIC_MIN_THINKING_BUDGET_TOKENS,
     Math.min(requestedBudgetTokens, budgetCapForHeadroom, strictUpperBound),
   );
 }

--- a/packages/core/src/agent/engine/output-tokens.ts
+++ b/packages/core/src/agent/engine/output-tokens.ts
@@ -13,6 +13,97 @@ export const DEFAULT_AI_SDK_MAX_OUTPUT_TOKENS = 4096;
 export const DEFAULT_ANTHROPIC_MAX_OUTPUT_TOKENS = 8192;
 export const DEFAULT_BUILDER_MAX_OUTPUT_TOKENS = 8192;
 
+// ---------------------------------------------------------------------------
+// Main interactive chat path
+//
+// The per-engine defaults above (4096-8192) exist for internal/eval/
+// observational-memory callers that intentionally want a small explicit cap.
+// The main interactive chat turn (the one the end user is staring at) needs
+// real headroom: on long-context or reasoning-heavy turns, a tiny completion
+// budget means extended thinking alone can consume the entire response,
+// leaving zero tokens for visible text/tool calls ("empty response" bug).
+// These helpers give the chat path a much higher floor while staying at or
+// under each model's documented ceiling — they never lower the ceiling.
+// ---------------------------------------------------------------------------
+
+/** Cap for the first attempt of an interactive chat turn. */
+export const MAIN_CHAT_MAX_OUTPUT_TOKENS_CAP = 32_000;
+/**
+ * Cap used only when retrying a turn that came back with an empty final
+ * response (see production-agent.ts's empty-final-response retry). Higher
+ * than the first-attempt cap so the retry meaningfully raises the ceiling.
+ */
+export const EMPTY_RESPONSE_RETRY_MAX_OUTPUT_TOKENS_CAP = 64_000;
+
+/**
+ * Resolve the max_output_tokens floor for the first attempt of an
+ * interactive chat turn: min(model ceiling, 32K). Always at or above the
+ * flat per-engine defaults above, regardless of whether the model is known.
+ */
+export function resolveMainChatMaxOutputTokens(modelId?: string): number {
+  return Math.min(
+    getMaxOutputTokensForModel(modelId),
+    MAIN_CHAT_MAX_OUTPUT_TOKENS_CAP,
+  );
+}
+
+/**
+ * Resolve the max_output_tokens to use when retrying a turn after an empty
+ * final response: min(model ceiling, 64K).
+ */
+export function resolveEmptyResponseRetryMaxOutputTokens(
+  modelId?: string,
+): number {
+  return Math.min(
+    getMaxOutputTokensForModel(modelId),
+    EMPTY_RESPONSE_RETRY_MAX_OUTPUT_TOKENS_CAP,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Extended-thinking budget headroom
+//
+// Anthropic's `thinking: { type: "enabled", budget_tokens }` config requires
+// budget_tokens >= 1024 and STRICTLY LESS THAN max_tokens (confirmed against
+// the installed @anthropic-ai/sdk@0.90.0 type defs — see ThinkingConfigEnabled
+// in resources/messages/messages.d.ts). budget_tokens counts toward
+// max_tokens, so an unclamped large budget can leave too little (or zero)
+// room for the actual visible completion. This clamp guarantees at least
+// max(8000, 40% of maxOutputTokens) tokens of non-thinking headroom.
+//
+// Note: this only applies to the explicit numeric-budget "enabled" config.
+// Anthropic's `type: "adaptive"` thinking config (used by the
+// reasoningEffort -> output_config.effort mapping in anthropic-engine.ts /
+// ai-sdk-engine.ts) has NO budget_tokens field at all per the SDK types, so
+// there is nothing to clamp there — those callers rely on the raised
+// maxOutputTokens ceiling above instead.
+// ---------------------------------------------------------------------------
+
+/** Anthropic's documented minimum extended-thinking budget. */
+export const ANTHROPIC_MIN_THINKING_BUDGET_TOKENS = 1024;
+
+/**
+ * Clamp a requested Anthropic thinking budget so it leaves guaranteed
+ * headroom under `maxOutputTokens` for non-thinking output, and stays within
+ * the provider's valid range (>= 1024, < maxOutputTokens).
+ */
+export function clampThinkingBudgetTokens(
+  requestedBudgetTokens: number,
+  maxOutputTokens: number,
+): number {
+  const headroom = Math.max(8000, Math.round(0.4 * maxOutputTokens));
+  const budgetCapForHeadroom = Math.max(
+    ANTHROPIC_MIN_THINKING_BUDGET_TOKENS,
+    maxOutputTokens - headroom,
+  );
+  // budget_tokens must stay strictly below max_tokens per the API contract.
+  const strictUpperBound = Math.max(1, maxOutputTokens - 1);
+  return Math.max(
+    1,
+    Math.min(requestedBudgetTokens, budgetCapForHeadroom, strictUpperBound),
+  );
+}
+
 function parsePositiveInteger(value: unknown): number | null {
   if (typeof value === "string" && value.trim() === "") return null;
   const n =

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -11,7 +11,11 @@ import {
   getRequestRunContext,
   runWithRequestContext,
 } from "../server/request-context.js";
-import type { AgentEngine, EngineEvent } from "./engine/types.js";
+import type {
+  AgentEngine,
+  EngineEvent,
+  EngineStreamOptions,
+} from "./engine/types.js";
 import { EngineError } from "./engine/types.js";
 import {
   AGENT_INTERNAL_CONTINUE_PROMPT,
@@ -5056,6 +5060,70 @@ describe("runAgentLoop", () => {
     expect(textEvents).toHaveLength(1);
     expect(textEvents[0].text).toMatch(/empty response/i);
     expect(textEvents[0].text).toMatch(/different model/i);
+  });
+
+  it("adapts each empty-response retry: raises maxOutputTokens and steps reasoning effort down a tier", async () => {
+    const seenOpts: EngineStreamOptions[] = [];
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: true,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: false,
+      },
+      async *stream(opts): AsyncIterable<EngineEvent> {
+        seenOpts.push(opts);
+        yield { type: "thinking-delta", text: "thinking out loud..." };
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "thinking" as const, text: "thinking out loud..." }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "claude-sonnet-5",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {},
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+      maxOutputTokens: 8_000,
+      reasoningEffort: "high",
+    });
+
+    // Initial attempt + 2 retries: EMPTY_FINAL_RESPONSE_RETRY_LIMIT is 2 now
+    // that each retry actually adapts instead of repeating the same request.
+    expect(seenOpts).toHaveLength(3);
+
+    // First attempt uses exactly what the caller asked for.
+    expect(seenOpts[0].maxOutputTokens).toBe(8_000);
+    expect(seenOpts[0].reasoningEffort).toBe("high");
+
+    // First retry: tokens raised well above the first attempt, effort down
+    // one tier (high -> medium).
+    expect(seenOpts[1].maxOutputTokens).toBeGreaterThan(
+      seenOpts[0].maxOutputTokens!,
+    );
+    expect(seenOpts[1].reasoningEffort).toBe("medium");
+
+    // Second retry: effort steps down again (medium -> low); tokens stay at
+    // the raised ceiling rather than climbing indefinitely.
+    expect(seenOpts[2].reasoningEffort).toBe("low");
+    expect(seenOpts[2].maxOutputTokens).toBe(seenOpts[1].maxOutputTokens);
+
+    const textEvents = events.filter((e) => e.type === "text");
+    expect(textEvents).toHaveLength(1);
+    expect(textEvents[0].text).toMatch(/empty response/i);
   });
 
   it("does not surface the empty-response fallback when text was streamed", async () => {

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -2746,8 +2746,8 @@ export async function runAgentLoop(opts: {
   let iterations = 0;
   // Overridden (raised tokens, lowered effort) only after an empty-final-
   // response retry below — kept separate from `opts.maxOutputTokens`/
-  // `opts.reasoningEffort` so the very first attempt is unaffected and later
-  // turns in the same run (if any) revert to the caller's original request.
+  // `opts.reasoningEffort` so the very first attempt is unaffected and fresh
+  // runAgentLoop calls still start from the caller's original request.
   let effectiveMaxOutputTokens = opts.maxOutputTokens;
   let effectiveReasoningEffort = opts.reasoningEffort;
 
@@ -3390,8 +3390,6 @@ export async function runAgentLoop(opts: {
         });
       } else {
         emptyFinalResponseRetries = 0;
-        effectiveMaxOutputTokens = opts.maxOutputTokens;
-        effectiveReasoningEffort = opts.reasoningEffort;
       }
       break;
     }

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -2746,8 +2746,8 @@ export async function runAgentLoop(opts: {
   let iterations = 0;
   // Overridden (raised tokens, lowered effort) only after an empty-final-
   // response retry below — kept separate from `opts.maxOutputTokens`/
-  // `opts.reasoningEffort` so the very first attempt is unaffected and fresh
-  // runAgentLoop calls still start from the caller's original request.
+  // `opts.reasoningEffort` so the very first attempt is unaffected and later
+  // tool-loop turns revert to the caller's original request after a success.
   let effectiveMaxOutputTokens = opts.maxOutputTokens;
   let effectiveReasoningEffort = opts.reasoningEffort;
 
@@ -3390,6 +3390,8 @@ export async function runAgentLoop(opts: {
         });
       } else {
         emptyFinalResponseRetries = 0;
+        effectiveMaxOutputTokens = opts.maxOutputTokens;
+        effectiveReasoningEffort = opts.reasoningEffort;
       }
       break;
     }

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -45,6 +45,7 @@ import { fireInternalDispatch } from "../server/self-dispatch.js";
 import {
   isReasoningEffort,
   normalizeReasoningEffortForModel,
+  stepDownReasoningEffort,
   type ReasoningEffort,
 } from "../shared/reasoning-effort.js";
 import { actionPreparationContinuationNote } from "./action-continuation-guidance.js";
@@ -77,7 +78,11 @@ import {
   normalizeModelForEngine,
   isResolvedEngineUsableForRequest,
 } from "./engine/index.js";
-import { resolveMaxOutputTokensForEngine } from "./engine/output-tokens.js";
+import {
+  resolveEmptyResponseRetryMaxOutputTokens,
+  resolveMainChatMaxOutputTokens,
+  resolveMaxOutputTokensForEngine,
+} from "./engine/output-tokens.js";
 import { PROVIDER_TO_ENV } from "./engine/provider-env-vars.js";
 import {
   backfillEngineMessagesToolResults,
@@ -1015,7 +1020,10 @@ const TOOL_INPUT_ACTIVITY_INTERVAL_MS = 1500;
 const ACTION_PREPARATION_NO_PROGRESS_TIMEOUT_MS = 90_000;
 const ACTION_PREPARATION_ZERO_BYTE_RESTART_LIMIT = 2;
 const MODEL_STREAM_NO_PROGRESS_TIMEOUT_MS = 90_000;
-const EMPTY_FINAL_RESPONSE_RETRY_LIMIT = 1;
+// Raised from 1 -> 2 now that each retry actually adapts (raises the token
+// ceiling and steps reasoning effort down a tier) instead of re-issuing the
+// exact same doomed request twice.
+const EMPTY_FINAL_RESPONSE_RETRY_LIMIT = 2;
 const MAIN_CHAT_INTERNAL_CONTINUATION_LIMIT = 6;
 const RUN_BUDGET_EXHAUSTED_ERROR_CODE = "run_budget_exhausted";
 const RUN_BUDGET_EXHAUSTED_MESSAGE =
@@ -2736,6 +2744,12 @@ export async function runAgentLoop(opts: {
   let finalGuardRetries = 0;
   let emptyFinalResponseRetries = 0;
   let iterations = 0;
+  // Overridden (raised tokens, lowered effort) only after an empty-final-
+  // response retry below — kept separate from `opts.maxOutputTokens`/
+  // `opts.reasoningEffort` so the very first attempt is unaffected and later
+  // turns in the same run (if any) revert to the caller's original request.
+  let effectiveMaxOutputTokens = opts.maxOutputTokens;
+  let effectiveReasoningEffort = opts.reasoningEffort;
 
   // Set when an in-loop processor aborts via `abort()` / throws a `TripWire`.
   // The loop emits the `tripwire` event, surfaces the reason as a final
@@ -2845,10 +2859,10 @@ export async function runAgentLoop(opts: {
           abortSignal: signal,
           maxOutputTokens: resolveMaxOutputTokensForEngine(
             engine.name,
-            opts.maxOutputTokens,
+            effectiveMaxOutputTokens,
             model,
           ),
-          reasoningEffort: opts.reasoningEffort,
+          reasoningEffort: effectiveReasoningEffort,
           providerOptions: opts.providerOptions,
         };
 
@@ -3351,8 +3365,10 @@ export async function runAgentLoop(opts: {
       // text — typically when reasoning consumes the entire output-token
       // budget. Without a final text part the SSE stream still ends with a
       // clean `done`, which renders as a totally empty assistant bubble.
-      // Retry once so a transient reasoning-budget miss can still finish; if
-      // the retry also has no visible content, surface a plain-language error.
+      // Retry so a reasoning-budget miss can still finish; each retry raises
+      // the token ceiling and steps reasoning effort down a tier so it's not
+      // just re-issuing the identical doomed request. If retries also come
+      // back empty, surface a plain-language error.
       const hasEmptyFinalResponse =
         !guardEmittedFallback &&
         collectTextParts(assistantContentForHistory).trim().length === 0 &&
@@ -3360,6 +3376,11 @@ export async function runAgentLoop(opts: {
       if (hasEmptyFinalResponse) {
         if (emptyFinalResponseRetries < EMPTY_FINAL_RESPONSE_RETRY_LIMIT) {
           emptyFinalResponseRetries += 1;
+          effectiveMaxOutputTokens =
+            resolveEmptyResponseRetryMaxOutputTokens(model);
+          effectiveReasoningEffort = stepDownReasoningEffort(
+            effectiveReasoningEffort,
+          );
           appendAgentLoopContinuation(messages, "max_tokens");
           continue;
         }
@@ -3369,6 +3390,8 @@ export async function runAgentLoop(opts: {
         });
       } else {
         emptyFinalResponseRetries = 0;
+        effectiveMaxOutputTokens = opts.maxOutputTokens;
+        effectiveReasoningEffort = opts.reasoningEffort;
       }
       break;
     }
@@ -6795,6 +6818,11 @@ export function createProductionAgentHandler(
           orgId: getRequestOrgId() ?? null,
           attachments: requestAttachments,
           reasoningEffort,
+          // The interactive chat turn needs real completion headroom — the
+          // flat per-engine defaults (4096-8192) exist for internal/eval
+          // callers and are far below what a hard, long-context turn needs
+          // once extended thinking is in play. See output-tokens.ts.
+          maxOutputTokens: resolveMainChatMaxOutputTokens(effectiveModel),
           providerOptions: options.providerOptions,
           executionMode: requestMode,
           maxIterations: loopSettings.maxIterations,

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -180,8 +180,9 @@ export interface AgentChatRequest {
     continuationCount?: number;
     /**
      * True when the dispatcher expects the self-POST to land in a real
-     * Netlify `-background` function (15-min budget) rather than the ~60s
-     * synchronous function. See `shouldUseBackgroundFunctionTimeoutForWorker`.
+     * Netlify `-background` function rather than the ~60s synchronous function.
+     * This is diagnostic only; the 15-minute budget is unlocked by the worker's
+     * actual runtime marker.
      */
     backgroundFunctionRuntimeExpected?: boolean;
     /**

--- a/packages/core/src/db/client.spec.ts
+++ b/packages/core/src/db/client.spec.ts
@@ -98,11 +98,29 @@ describe("db/client dialect detection", () => {
     expect(neonPoolMax()).toBe(2);
   });
 
-  it("uses the background Neon pool when the verified process-run marker expects a background function", async () => {
+  it("keeps the foreground pool when only the dispatch marker (expected, not landed) is set", async () => {
+    // The marker records which URL the foreground TARGETED, not where the
+    // request landed. A misrouted worker on the ~60s sync function must NOT
+    // take the 8-connection background pool (it runs as one of many warm
+    // instances and would exhaust the Neon pooler → connection terminated →
+    // failed heartbeat → stale_run). Only proof-of-landing unlocks the big pool.
     vi.stubEnv("NETLIFY", "true");
     (
       globalThis as Record<string, unknown>
     ).__AGENT_NATIVE_BACKGROUND_RUNTIME_EXPECTED__ = true;
+
+    const { neonPoolMax, isBackgroundFunctionPoolContext } =
+      await import("./client.js");
+
+    expect(isBackgroundFunctionPoolContext()).toBe(false);
+    expect(neonPoolMax()).toBe(2);
+  });
+
+  it("uses the background Neon pool when the -background function marked the runtime at cold start", async () => {
+    vi.stubEnv("NETLIFY", "true");
+    (
+      globalThis as Record<string, unknown>
+    ).__AGENT_NATIVE_BACKGROUND_RUNTIME__ = true;
 
     const { neonPoolMax, isBackgroundFunctionPoolContext } =
       await import("./client.js");

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -856,15 +856,18 @@ export function isBackgroundFunctionPoolContext(): boolean {
   ) {
     return true;
   }
-  // Set by the HMAC-authenticated agent-chat `_process-run` route before it
-  // re-enters the normal chat handler. This mirrors the marker-only runtime
-  // proof used by durable-background.ts without importing agent code into db/.
-  if (
-    (globalThis as Record<string, unknown>)
-      .__AGENT_NATIVE_BACKGROUND_RUNTIME_EXPECTED__ === true
-  ) {
-    return true;
-  }
+  // NOTE: we deliberately do NOT trust `__AGENT_NATIVE_BACKGROUND_RUNTIME_EXPECTED__`
+  // here. That flag is set from the dispatch MARKER (which URL the foreground
+  // targeted), not from proof the request actually LANDED on a background
+  // function. A worker dispatched toward `-background` but routed onto the ~60s
+  // synchronous function would otherwise take the 8-connection background pool
+  // while running as one of MANY warm sync-function instances — multiplying
+  // Neon connections and exhausting the pooled endpoint ("connection
+  // terminated" / statement timeouts / failed heartbeat writes → stale runs).
+  // The genuine `-background` function sets `__AGENT_NATIVE_BACKGROUND_RUNTIME__`
+  // as its first cold-start statement, so a real background worker still gets
+  // the larger pool via the check above. Mirrors the same proof-of-landing
+  // tightening applied to `shouldUseBackgroundFunctionTimeoutForWorker`.
   const lambdaName = process.env.AWS_LAMBDA_FUNCTION_NAME;
   if (
     typeof lambdaName === "string" &&

--- a/packages/core/src/shared/reasoning-effort.spec.ts
+++ b/packages/core/src/shared/reasoning-effort.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   getReasoningEffortOptionsForModel,
   normalizeReasoningEffortForModel,
+  stepDownReasoningEffort,
 } from "./reasoning-effort.js";
 
 describe("supportsClaudeXHigh (via getReasoningEffortOptionsForModel)", () => {
@@ -73,5 +74,25 @@ describe("normalizeReasoningEffortForModel", () => {
     expect(
       normalizeReasoningEffortForModel("llama-3.3-70b-versatile", "high"),
     ).toBeUndefined();
+  });
+});
+
+describe("stepDownReasoningEffort", () => {
+  it("steps down one tier at a time through the standard ladder", () => {
+    expect(stepDownReasoningEffort("max")).toBe("xhigh");
+    expect(stepDownReasoningEffort("xhigh")).toBe("high");
+    expect(stepDownReasoningEffort("high")).toBe("medium");
+    expect(stepDownReasoningEffort("medium")).toBe("low");
+    expect(stepDownReasoningEffort("low")).toBe("minimal");
+  });
+
+  it("leaves minimal, none, and auto unchanged (nothing lower to step to)", () => {
+    expect(stepDownReasoningEffort("minimal")).toBe("minimal");
+    expect(stepDownReasoningEffort("none")).toBe("none");
+    expect(stepDownReasoningEffort("auto")).toBe("auto");
+  });
+
+  it("passes through undefined unchanged", () => {
+    expect(stepDownReasoningEffort(undefined)).toBeUndefined();
   });
 });

--- a/packages/core/src/shared/reasoning-effort.ts
+++ b/packages/core/src/shared/reasoning-effort.ts
@@ -98,6 +98,29 @@ export function reasoningEffortLabel(effort: ReasoningEffort | undefined) {
   return REASONING_EFFORT_LABELS[effort ?? "auto"];
 }
 
+/**
+ * One tier down from each effort, stopping at "minimal" — "none"/"auto"
+ * (not really "tiers") and "minimal" itself are left unchanged. Used by the
+ * empty-final-response retry so a retried turn asks for meaningfully less
+ * reasoning instead of repeating the exact request that came back empty.
+ */
+const REASONING_EFFORT_STEP_DOWN: Partial<
+  Record<ReasoningEffort, ReasoningEffort>
+> = {
+  max: "xhigh",
+  xhigh: "high",
+  high: "medium",
+  medium: "low",
+  low: "minimal",
+};
+
+export function stepDownReasoningEffort(
+  effort: ReasoningEffort | undefined,
+): ReasoningEffort | undefined {
+  if (!effort) return effort;
+  return REASONING_EFFORT_STEP_DOWN[effort] ?? effort;
+}
+
 function isGPTReasoningModel(model: string) {
   return /^gpt-5/.test(model) || /^o\d/.test(model);
 }

--- a/templates/clips/app/routes/download.tsx
+++ b/templates/clips/app/routes/download.tsx
@@ -4,7 +4,6 @@ import {
   IconBrandApple,
   IconBrandWindows,
   IconExternalLink,
-  IconPlayerRecord,
 } from "@tabler/icons-react";
 import { useEffect, useState } from "react";
 
@@ -201,9 +200,18 @@ export default function DownloadPage() {
             href={appPath("/")}
             className="flex items-center gap-2 font-semibold"
           >
-            <span className="grid h-7 w-7 place-items-center rounded-md bg-primary text-primary-foreground">
-              <IconPlayerRecord className="h-4 w-4" />
-            </span>
+            <img
+              src={appPath("/agent-native-icon-light.svg")}
+              alt=""
+              aria-hidden="true"
+              className="block h-4 w-auto shrink-0 dark:hidden"
+            />
+            <img
+              src={appPath("/agent-native-icon-dark.svg")}
+              alt=""
+              aria-hidden="true"
+              className="hidden h-4 w-auto shrink-0 dark:block"
+            />
             <span>Clips</span>
           </a>
           <a

--- a/templates/clips/changelog/2026-07-07-the-clips-desktop-download-page-now-uses-the-agent-native-ap.md
+++ b/templates/clips/changelog/2026-07-07-the-clips-desktop-download-page-now-uses-the-agent-native-ap.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-07
+---
+
+The Clips Desktop download page now uses the Agent Native app icon in its header.


### PR DESCRIPTION
## Summary
- Require actual background-function runtime proof before agent-chat workers use the long timeout or larger Neon pool.
- Keep dispatch markers as diagnostics only so misrouted workers stay within foreground-safe limits and avoid stale-run heartbeat failures.
- Include the Clips download page header icon polish and changelog already present on the branch.

## Test plan
- pnpm run prep
- pnpm --filter @agent-native/core exec vitest --run src/agent/durable-background.spec.ts
- pnpm --filter @agent-native/core typecheck

Made with [Cursor](https://cursor.com)