### PR TITLE
Publish @agent-native/toolkit as a caret range so apps can dedupe against latest

### DIFF
--- a/.changeset/pin-toolkit-to-core.md
+++ b/.changeset/pin-toolkit-to-core.md
@@ -1,5 +1,6 @@
 ---
 "@agent-native/core": patch
+"@agent-native/scheduling": patch
 ---
 
-Scaffold new apps with `@agent-native/toolkit` pinned to whatever `@agent-native/core@latest` depends on instead of an independent `latest` dist-tag. This prevents pnpm from installing two mismatched toolkit copies side by side (which crashed Vite with `"./collab-ui" is not exported`). The lookup is memoized per scaffold and falls back to `latest` when the registry is unreachable.
+Depend on `@agent-native/toolkit` via `workspace:^` instead of `workspace:*`. Publishing now pins a caret range (e.g. `^0.4.3`) rather than an exact version, so an app that scaffolds `@agent-native/toolkit@latest` separately can dedupe against it through normal semver resolution instead of installing two mismatched toolkit copies side by side (which crashed Vite with `"./collab-ui" is not exported`).

--- a/.changeset/pin-toolkit-to-core.md
+++ b/.changeset/pin-toolkit-to-core.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Scaffold new apps with `@agent-native/toolkit` pinned to whatever `@agent-native/core@latest` depends on instead of an independent `latest` dist-tag. This prevents pnpm from installing two mismatched toolkit copies side by side (which crashed Vite with `"./collab-ui" is not exported`). The lookup is memoized per scaffold and falls back to `latest` when the registry is unreachable.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -235,7 +235,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@agent-native/toolkit": "workspace:*",
+    "@agent-native/toolkit": "workspace:^",
     "@amplitude/analytics-browser": "^2.41.1",
     "@anthropic-ai/sdk": "^0.90.0",
     "@anthropic-ai/tokenizer": "0.0.4",

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "url";
  *   - postinstall scripts missing for required packages
  *   - dist/catalog.json not embedded in the built package
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
 import { addAppToWorkspace, createApp } from "./create.js";
 import {
@@ -31,10 +31,6 @@ import {
   _getCoreDependencyVersion,
   _getDispatchDependencyVersion,
   _getToolkitDependencyVersion,
-  _resolveToolkitVersionFromCore,
-  _normalizeNpmViewVersion,
-  _lookupToolkitVersionFromNpmRegistry,
-  _resetToolkitDependencyVersionCache,
   _getGitHubTemplateRef,
   _getGitHubTemplateRefCandidates,
   _shouldSkipScaffoldEntry,
@@ -873,81 +869,12 @@ describe("template/core version compatibility", () => {
     }
   });
 
-  it("pins the generated toolkit dependency to whatever core@latest requires", () => {
-    // Core hard-pins an exact @agent-native/toolkit internally, so the
-    // scaffold must follow that pin instead of floating on toolkit@latest —
-    // otherwise pnpm cannot dedupe and installs two toolkit copies side by
-    // side (the ./collab-ui crash this fix addresses). With registry access
-    // the resolver returns that exact version; offline it degrades to the
-    // literal "latest" so scaffolding never fails outright.
+  it("pins the generated toolkit dependency to latest by default", () => {
     const previous = process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
     delete process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
-    _resetToolkitDependencyVersionCache();
     try {
-      const resolved = _getToolkitDependencyVersion();
-      expect(
-        resolved === "latest" || /^\d+\.\d+\.\d+(?:[-+].*)?$/.test(resolved),
-      ).toBe(true);
-      // Whatever it resolves to must exactly match the standalone resolver so
-      // every scaffold surface writes an identical spec.
-      expect(resolved).toBe(_resolveToolkitVersionFromCore());
+      expect(_getToolkitDependencyVersion()).toBe("latest");
     } finally {
-      _resetToolkitDependencyVersionCache();
-      if (previous === undefined) {
-        delete process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
-      } else {
-        process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE = previous;
-      }
-    }
-  });
-
-  it("normalizes JSON-quoted npm view output for toolkit pins", () => {
-    expect(_normalizeNpmViewVersion('"0.4.3"\n')).toBe("0.4.3");
-    expect(_normalizeNpmViewVersion("0.4.3\n")).toBe("0.4.3");
-    expect(_normalizeNpmViewVersion("")).toBeNull();
-    expect(_normalizeNpmViewVersion('"latest"')).toBeNull();
-  });
-
-  it("falls back to latest when npm view lookup times out", () => {
-    const execFile = vi.fn(() => {
-      const error = new Error(
-        "spawnSync npm ETIMEDOUT",
-      ) as NodeJS.ErrnoException;
-      error.code = "ETIMEDOUT";
-      throw error;
-    });
-    expect(
-      _resolveToolkitVersionFromCore(
-        execFile as unknown as typeof import("node:child_process").execFileSync,
-      ),
-    ).toBe("latest");
-  });
-
-  it("bounds npm view lookup with a subprocess timeout", () => {
-    const execFile = vi.fn(() => "0.4.3");
-    _lookupToolkitVersionFromNpmRegistry(
-      execFile as unknown as typeof import("node:child_process").execFileSync,
-    );
-    expect(execFile).toHaveBeenCalledWith(
-      "npm",
-      expect.arrayContaining(["--json=false"]),
-      expect.objectContaining({ timeout: 5_000 }),
-    );
-  });
-
-  it("memoizes the toolkit pin so a scaffold resolves it once", () => {
-    // A workspace scaffold rewrites the toolkit dep once per app; the value
-    // must be resolved a single time so every app pins the same version even
-    // if the latest dist-tag moves mid-run.
-    const previous = process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
-    delete process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
-    _resetToolkitDependencyVersionCache();
-    try {
-      const first = _getToolkitDependencyVersion();
-      const second = _getToolkitDependencyVersion();
-      expect(second).toBe(first);
-    } finally {
-      _resetToolkitDependencyVersionCache();
       if (previous === undefined) {
         delete process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
       } else {

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "url";
  *   - postinstall scripts missing for required packages
  *   - dist/catalog.json not embedded in the built package
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 import { addAppToWorkspace, createApp } from "./create.js";
 import {
@@ -32,6 +32,8 @@ import {
   _getDispatchDependencyVersion,
   _getToolkitDependencyVersion,
   _resolveToolkitVersionFromCore,
+  _normalizeNpmViewVersion,
+  _lookupToolkitVersionFromNpmRegistry,
   _resetToolkitDependencyVersionCache,
   _getGitHubTemplateRef,
   _getGitHubTemplateRefCandidates,
@@ -884,7 +886,7 @@ describe("template/core version compatibility", () => {
     try {
       const resolved = _getToolkitDependencyVersion();
       expect(
-        resolved === "latest" || /^\d+\.\d+\.\d+(?:-.+)?$/.test(resolved),
+        resolved === "latest" || /^\d+\.\d+\.\d+(?:[-+].*)?$/.test(resolved),
       ).toBe(true);
       // Whatever it resolves to must exactly match the standalone resolver so
       // every scaffold surface writes an identical spec.
@@ -897,6 +899,40 @@ describe("template/core version compatibility", () => {
         process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE = previous;
       }
     }
+  });
+
+  it("normalizes JSON-quoted npm view output for toolkit pins", () => {
+    expect(_normalizeNpmViewVersion('"0.4.3"\n')).toBe("0.4.3");
+    expect(_normalizeNpmViewVersion("0.4.3\n")).toBe("0.4.3");
+    expect(_normalizeNpmViewVersion("")).toBeNull();
+    expect(_normalizeNpmViewVersion('"latest"')).toBeNull();
+  });
+
+  it("falls back to latest when npm view lookup times out", () => {
+    const execFile = vi.fn(() => {
+      const error = new Error(
+        "spawnSync npm ETIMEDOUT",
+      ) as NodeJS.ErrnoException;
+      error.code = "ETIMEDOUT";
+      throw error;
+    });
+    expect(
+      _resolveToolkitVersionFromCore(
+        execFile as unknown as typeof import("node:child_process").execFileSync,
+      ),
+    ).toBe("latest");
+  });
+
+  it("bounds npm view lookup with a subprocess timeout", () => {
+    const execFile = vi.fn(() => "0.4.3");
+    _lookupToolkitVersionFromNpmRegistry(
+      execFile as unknown as typeof import("node:child_process").execFileSync,
+    );
+    expect(execFile).toHaveBeenCalledWith(
+      "npm",
+      expect.arrayContaining(["--json=false"]),
+      expect.objectContaining({ timeout: 5_000 }),
+    );
   });
 
   it("memoizes the toolkit pin so a scaffold resolves it once", () => {

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -31,6 +31,8 @@ import {
   _getCoreDependencyVersion,
   _getDispatchDependencyVersion,
   _getToolkitDependencyVersion,
+  _resolveToolkitVersionFromCore,
+  _resetToolkitDependencyVersionCache,
   _getGitHubTemplateRef,
   _getGitHubTemplateRefCandidates,
   _shouldSkipScaffoldEntry,
@@ -853,15 +855,63 @@ describe("workspace add-app scaffold", { timeout: 60000 }, () => {
 });
 
 describe("template/core version compatibility", () => {
-  it("uses the npm latest dist-tag for generated projects", () => {
+  it("uses the npm latest dist-tag for the generated core dependency", () => {
     // Pin the default behaviour even when the headless install e2e has set
     // AGENT_NATIVE_CREATE_USE_LOCAL_CORE in the ambient environment.
     const previous = process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
     delete process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
     try {
       expect(_getCoreDependencyVersion()).toBe("latest");
-      expect(_getToolkitDependencyVersion()).toBe("latest");
     } finally {
+      if (previous === undefined) {
+        delete process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
+      } else {
+        process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE = previous;
+      }
+    }
+  });
+
+  it("pins the generated toolkit dependency to whatever core@latest requires", () => {
+    // Core hard-pins an exact @agent-native/toolkit internally, so the
+    // scaffold must follow that pin instead of floating on toolkit@latest —
+    // otherwise pnpm cannot dedupe and installs two toolkit copies side by
+    // side (the ./collab-ui crash this fix addresses). With registry access
+    // the resolver returns that exact version; offline it degrades to the
+    // literal "latest" so scaffolding never fails outright.
+    const previous = process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
+    delete process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
+    _resetToolkitDependencyVersionCache();
+    try {
+      const resolved = _getToolkitDependencyVersion();
+      expect(
+        resolved === "latest" || /^\d+\.\d+\.\d+(?:-.+)?$/.test(resolved),
+      ).toBe(true);
+      // Whatever it resolves to must exactly match the standalone resolver so
+      // every scaffold surface writes an identical spec.
+      expect(resolved).toBe(_resolveToolkitVersionFromCore());
+    } finally {
+      _resetToolkitDependencyVersionCache();
+      if (previous === undefined) {
+        delete process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
+      } else {
+        process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE = previous;
+      }
+    }
+  });
+
+  it("memoizes the toolkit pin so a scaffold resolves it once", () => {
+    // A workspace scaffold rewrites the toolkit dep once per app; the value
+    // must be resolved a single time so every app pins the same version even
+    // if the latest dist-tag moves mid-run.
+    const previous = process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
+    delete process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
+    _resetToolkitDependencyVersionCache();
+    try {
+      const first = _getToolkitDependencyVersion();
+      const second = _getToolkitDependencyVersion();
+      expect(second).toBe(first);
+    } finally {
+      _resetToolkitDependencyVersionCache();
       if (previous === undefined) {
         delete process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
       } else {

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -1336,10 +1336,6 @@ export {
   getCoreDependencyVersion as _getCoreDependencyVersion,
   getDispatchDependencyVersion as _getDispatchDependencyVersion,
   getToolkitDependencyVersion as _getToolkitDependencyVersion,
-  resolveToolkitVersionFromCore as _resolveToolkitVersionFromCore,
-  normalizeNpmViewVersion as _normalizeNpmViewVersion,
-  lookupToolkitVersionFromNpmRegistry as _lookupToolkitVersionFromNpmRegistry,
-  resetToolkitDependencyVersionCache as _resetToolkitDependencyVersionCache,
   getGitHubTemplateRef as _getGitHubTemplateRef,
   getGitHubTemplateRefCandidates as _getGitHubTemplateRefCandidates,
   workspaceAppNameForTemplateSelection as _workspaceAppNameForTemplateSelection,
@@ -1649,106 +1645,13 @@ function getDispatchDependencyVersion(): string {
   return "latest";
 }
 
-// Memoize the registry lookup for the whole scaffold. A single `agent-native
-// create` run rewrites toolkit deps once per app (plus standalone/rewrite
-// paths), so resolving it repeatedly would spawn a synchronous `npm view` per
-// call. Beyond being slow, if the `latest` dist-tag moved mid-scaffold, two
-// apps in the same workspace could pin different toolkit versions — the exact
-// drift this fix exists to prevent. `undefined` means "not resolved yet".
-let cachedToolkitDependencyVersion: string | undefined;
-
-const TOOLKIT_VERSION_LOOKUP_TIMEOUT_MS = 5_000;
-
-// Test-only: clear the memoized value so specs can exercise both the pinned
-// and offline-fallback branches deterministically without process isolation.
-function resetToolkitDependencyVersionCache(): void {
-  cachedToolkitDependencyVersion = undefined;
-}
-
-/** Normalize `npm view` stdout into a package.json-safe version string. */
-function normalizeNpmViewVersion(output: string): string | null {
-  const trimmed = output.trim();
-  if (!trimmed) return null;
-
-  let candidate = trimmed;
-  if (candidate.startsWith('"') && candidate.endsWith('"')) {
-    try {
-      const parsed = JSON.parse(candidate);
-      if (typeof parsed !== "string" || !parsed.trim()) return null;
-      candidate = parsed.trim();
-    } catch {
-      return null;
-    }
-  }
-
-  // Only trust concrete semver-like specs for direct package.json deps.
-  if (/^\d+\.\d+\.\d+(?:[-+].*)?$/.test(candidate)) {
-    return candidate;
-  }
-
-  return null;
-}
-
-function lookupToolkitVersionFromNpmRegistry(
-  execFile: typeof execFileSync = execFileSync,
-): string | null {
-  const pinned = execFile(
-    "npm",
-    [
-      "view",
-      "@agent-native/core@latest",
-      "dependencies.@agent-native/toolkit",
-      "--json=false",
-    ],
-    {
-      encoding: "utf-8",
-      timeout: TOOLKIT_VERSION_LOOKUP_TIMEOUT_MS,
-      env: {
-        ...process.env,
-        // User-level npm config can set json=true, which prints `"0.4.3"` and
-        // breaks package.json if written verbatim (EINVALIDTAGNAME on install).
-        npm_config_json: "false",
-      },
-    },
-  );
-  return normalizeNpmViewVersion(pinned);
-}
-
-function resolveToolkitVersionFromCore(
-  execFile: typeof execFileSync = execFileSync,
-): string {
-  // Core hard-pins an exact @agent-native/toolkit version internally at
-  // publish time (e.g. core@0.91.2 -> toolkit@0.4.3). Because the scaffold
-  // writes `"latest"` for core, resolving toolkit independently via its own
-  // `"latest"` dist-tag lets the two drift out of sync between publishes,
-  // leaving pnpm unable to dedupe and installing two toolkit copies side by
-  // side. Older builds are missing newer subpath exports (e.g. `./collab-ui`),
-  // so whichever copy the bundler picks up first can crash. Pin to whatever
-  // the `latest` core release actually depends on instead so both resolve
-  // from the same core manifest.
-  try {
-    const pinned = lookupToolkitVersionFromNpmRegistry(execFile);
-    if (pinned) return pinned;
-  } catch {
-    // Registry lookup failed (offline, npm outage, subprocess timeout, etc.) —
-    // fall back below. The `try/catch` keeps scaffolding working: worst case
-    // we revert to today's independent `"latest"` behaviour rather than
-    // failing outright.
-  }
-
-  return "latest";
-}
-
 function getToolkitDependencyVersion(): string {
   if (process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE === "1") {
     const localToolkit = findLocalPackage("toolkit");
     if (localToolkit) return pathToFileURL(localToolkit).href;
   }
 
-  if (cachedToolkitDependencyVersion === undefined) {
-    cachedToolkitDependencyVersion = resolveToolkitVersionFromCore();
-  }
-  return cachedToolkitDependencyVersion;
+  return "latest";
 }
 
 function localToolkitOverride(): string | null {

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -1337,6 +1337,8 @@ export {
   getDispatchDependencyVersion as _getDispatchDependencyVersion,
   getToolkitDependencyVersion as _getToolkitDependencyVersion,
   resolveToolkitVersionFromCore as _resolveToolkitVersionFromCore,
+  normalizeNpmViewVersion as _normalizeNpmViewVersion,
+  lookupToolkitVersionFromNpmRegistry as _lookupToolkitVersionFromNpmRegistry,
   resetToolkitDependencyVersionCache as _resetToolkitDependencyVersionCache,
   getGitHubTemplateRef as _getGitHubTemplateRef,
   getGitHubTemplateRefCandidates as _getGitHubTemplateRefCandidates,
@@ -1655,13 +1657,66 @@ function getDispatchDependencyVersion(): string {
 // drift this fix exists to prevent. `undefined` means "not resolved yet".
 let cachedToolkitDependencyVersion: string | undefined;
 
+const TOOLKIT_VERSION_LOOKUP_TIMEOUT_MS = 5_000;
+
 // Test-only: clear the memoized value so specs can exercise both the pinned
 // and offline-fallback branches deterministically without process isolation.
 function resetToolkitDependencyVersionCache(): void {
   cachedToolkitDependencyVersion = undefined;
 }
 
-function resolveToolkitVersionFromCore(): string {
+/** Normalize `npm view` stdout into a package.json-safe version string. */
+function normalizeNpmViewVersion(output: string): string | null {
+  const trimmed = output.trim();
+  if (!trimmed) return null;
+
+  let candidate = trimmed;
+  if (candidate.startsWith('"') && candidate.endsWith('"')) {
+    try {
+      const parsed = JSON.parse(candidate);
+      if (typeof parsed !== "string" || !parsed.trim()) return null;
+      candidate = parsed.trim();
+    } catch {
+      return null;
+    }
+  }
+
+  // Only trust concrete semver-like specs for direct package.json deps.
+  if (/^\d+\.\d+\.\d+(?:[-+].*)?$/.test(candidate)) {
+    return candidate;
+  }
+
+  return null;
+}
+
+function lookupToolkitVersionFromNpmRegistry(
+  execFile: typeof execFileSync = execFileSync,
+): string | null {
+  const pinned = execFile(
+    "npm",
+    [
+      "view",
+      "@agent-native/core@latest",
+      "dependencies.@agent-native/toolkit",
+      "--json=false",
+    ],
+    {
+      encoding: "utf-8",
+      timeout: TOOLKIT_VERSION_LOOKUP_TIMEOUT_MS,
+      env: {
+        ...process.env,
+        // User-level npm config can set json=true, which prints `"0.4.3"` and
+        // breaks package.json if written verbatim (EINVALIDTAGNAME on install).
+        npm_config_json: "false",
+      },
+    },
+  );
+  return normalizeNpmViewVersion(pinned);
+}
+
+function resolveToolkitVersionFromCore(
+  execFile: typeof execFileSync = execFileSync,
+): string {
   // Core hard-pins an exact @agent-native/toolkit version internally at
   // publish time (e.g. core@0.91.2 -> toolkit@0.4.3). Because the scaffold
   // writes `"latest"` for core, resolving toolkit independently via its own
@@ -1672,22 +1727,13 @@ function resolveToolkitVersionFromCore(): string {
   // the `latest` core release actually depends on instead so both resolve
   // from the same core manifest.
   try {
-    const pinned = execFileSync(
-      "npm",
-      [
-        "view",
-        "@agent-native/core@latest",
-        "dependencies.@agent-native/toolkit",
-      ],
-      { encoding: "utf-8" },
-    ).trim();
-    // `npm view` prints an empty string when the field is absent; only trust a
-    // concrete version spec.
+    const pinned = lookupToolkitVersionFromNpmRegistry(execFile);
     if (pinned) return pinned;
   } catch {
-    // Registry lookup failed (offline, npm outage, etc.) — fall back below.
-    // The `try/catch` keeps scaffolding working: worst case we revert to
-    // today's independent `"latest"` behaviour rather than failing outright.
+    // Registry lookup failed (offline, npm outage, subprocess timeout, etc.) —
+    // fall back below. The `try/catch` keeps scaffolding working: worst case
+    // we revert to today's independent `"latest"` behaviour rather than
+    // failing outright.
   }
 
   return "latest";

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -1336,6 +1336,8 @@ export {
   getCoreDependencyVersion as _getCoreDependencyVersion,
   getDispatchDependencyVersion as _getDispatchDependencyVersion,
   getToolkitDependencyVersion as _getToolkitDependencyVersion,
+  resolveToolkitVersionFromCore as _resolveToolkitVersionFromCore,
+  resetToolkitDependencyVersionCache as _resetToolkitDependencyVersionCache,
   getGitHubTemplateRef as _getGitHubTemplateRef,
   getGitHubTemplateRefCandidates as _getGitHubTemplateRefCandidates,
   workspaceAppNameForTemplateSelection as _workspaceAppNameForTemplateSelection,
@@ -1645,13 +1647,62 @@ function getDispatchDependencyVersion(): string {
   return "latest";
 }
 
+// Memoize the registry lookup for the whole scaffold. A single `agent-native
+// create` run rewrites toolkit deps once per app (plus standalone/rewrite
+// paths), so resolving it repeatedly would spawn a synchronous `npm view` per
+// call. Beyond being slow, if the `latest` dist-tag moved mid-scaffold, two
+// apps in the same workspace could pin different toolkit versions — the exact
+// drift this fix exists to prevent. `undefined` means "not resolved yet".
+let cachedToolkitDependencyVersion: string | undefined;
+
+// Test-only: clear the memoized value so specs can exercise both the pinned
+// and offline-fallback branches deterministically without process isolation.
+function resetToolkitDependencyVersionCache(): void {
+  cachedToolkitDependencyVersion = undefined;
+}
+
+function resolveToolkitVersionFromCore(): string {
+  // Core hard-pins an exact @agent-native/toolkit version internally at
+  // publish time (e.g. core@0.91.2 -> toolkit@0.4.3). Because the scaffold
+  // writes `"latest"` for core, resolving toolkit independently via its own
+  // `"latest"` dist-tag lets the two drift out of sync between publishes,
+  // leaving pnpm unable to dedupe and installing two toolkit copies side by
+  // side. Older builds are missing newer subpath exports (e.g. `./collab-ui`),
+  // so whichever copy the bundler picks up first can crash. Pin to whatever
+  // the `latest` core release actually depends on instead so both resolve
+  // from the same core manifest.
+  try {
+    const pinned = execFileSync(
+      "npm",
+      [
+        "view",
+        "@agent-native/core@latest",
+        "dependencies.@agent-native/toolkit",
+      ],
+      { encoding: "utf-8" },
+    ).trim();
+    // `npm view` prints an empty string when the field is absent; only trust a
+    // concrete version spec.
+    if (pinned) return pinned;
+  } catch {
+    // Registry lookup failed (offline, npm outage, etc.) — fall back below.
+    // The `try/catch` keeps scaffolding working: worst case we revert to
+    // today's independent `"latest"` behaviour rather than failing outright.
+  }
+
+  return "latest";
+}
+
 function getToolkitDependencyVersion(): string {
   if (process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE === "1") {
     const localToolkit = findLocalPackage("toolkit");
     if (localToolkit) return pathToFileURL(localToolkit).href;
   }
 
-  return "latest";
+  if (cachedToolkitDependencyVersion === undefined) {
+    cachedToolkitDependencyVersion = resolveToolkitVersionFromCore();
+  }
+  return cachedToolkitDependencyVersion;
 }
 
 function localToolkitOverride(): string | null {

--- a/packages/scheduling/package.json
+++ b/packages/scheduling/package.json
@@ -54,7 +54,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@agent-native/toolkit": "workspace:*",
+    "@agent-native/toolkit": "workspace:^",
     "@date-fns/tz": "^1.2.0",
     "date-fns": "^4.1.0",
     "nanoid": "^5.1.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,7 +153,7 @@ importers:
   packages/core:
     dependencies:
       '@agent-native/toolkit':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../toolkit
       '@ai-sdk/cohere':
         specifier: '>=3'
@@ -1152,7 +1152,7 @@ importers:
   packages/scheduling:
     dependencies:
       '@agent-native/toolkit':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../toolkit
       '@date-fns/tz':
         specifier: ^1.2.0

--- a/scripts/guard-public-packages.ts
+++ b/scripts/guard-public-packages.ts
@@ -124,13 +124,20 @@ function localWorkspaceDependencyFailures(
 ): string[] {
   if (!dependencies) return [];
   return Object.entries(dependencies)
-    .filter(
-      ([dep, version]) =>
-        workspacePackageNames.has(dep) && version !== "workspace:*",
-    )
+    .filter(([dep, version]) => {
+      if (!workspacePackageNames.has(dep)) return false;
+      if (version === "workspace:*") return false;
+      // Published deps may use workspace:^ so pnpm pack rewrites it to a
+      // caret range (e.g. ^0.4.3), letting consumers dedupe against a
+      // compatible version instead of an exact pin.
+      if (version === "workspace:^" && npmPublishAllowlist.has(dep)) {
+        return false;
+      }
+      return true;
+    })
     .map(
       ([dep, version]) =>
-        `${pkgName} ${field}.${dep} must stay workspace:* in source, not ${version}; pnpm pack rewrites it for npm publishing`,
+        `${pkgName} ${field}.${dep} must stay workspace:* (or workspace:^ for published deps) in source, not ${version}; pnpm pack rewrites it for npm publishing`,
     );
 }
 


### PR DESCRIPTION
### **Summary**
Published @agent-native/core hard-pinned an exact @agent-native/toolkit version (workspace:* → 0.4.3), while scaffolded apps and builder-agent-native-starter declare toolkit: "latest" separately. When those resolve to different versions, pnpm installs two toolkit copies side by side. Vite can then pick the older one — missing subpath exports like ./collab-ui — and crash on startup.

This PR fixes the published dependency shape instead of adding scaffold-time registry lookups. @agent-native/core and @agent-native/scheduling now depend on @agent-native/toolkit via workspace:^, which publishes as a caret range (e.g. ^0.4.3). Apps that keep toolkit: "latest" can dedupe through normal semver resolution.

### **Changes**
packages/core/package.json — @agent-native/toolkit: workspace:* → workspace:^
packages/scheduling/package.json — same
scripts/guard-public-packages.ts — allow workspace:^ for publish-allowlisted workspace deps
pnpm-lock.yaml — sync specifiers for frozen-lockfile CI
Why not scaffold-time pinning?
An earlier approach resolved toolkit from npm view @agent-native/core@latest during agent-native create. That was fragile (race with core: "latest", offline fallback to broken behavior, starter sync overwriting pins) and added unnecessary complexity. Fixing what published core declares is simpler and applies to every consumer after the next release.


