### PR TITLE
Reduce noisy uptime monitor alerts

### DIFF
--- a/.changeset/quiet-notification-emails.md
+++ b/.changeset/quiet-notification-emails.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Notification emails no longer include raw metadata JSON in the message body.

--- a/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
@@ -71,6 +71,12 @@ describe("sync-builder-starter-manifest", () => {
             "utf-8",
           ),
         ).toContain('appId: "builder-agent-native-starter"');
+        expect(fs.existsSync(path.join(snapshot.dir, ".react-router"))).toBe(
+          false,
+        );
+        expect(fs.existsSync(path.join(snapshot.dir, "node_modules"))).toBe(
+          false,
+        );
         expect(files.get("netlify.toml")).toContain('publish = "dist"');
         expect(files.get("netlify.toml")).not.toContain("templates/chat");
         expect(files.get("netlify.toml")).toContain(

--- a/packages/core/src/cli/sync-builder-starter-manifest.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.ts
@@ -25,6 +25,20 @@ export const STARTER_TOOLCHAIN_SYNC_PATHS = [
   "netlify.toml",
 ] as const;
 
+const STANDALONE_SNAPSHOT_EXCLUDED_TOP_LEVEL = new Set([
+  ".deploy-tmp",
+  ".env",
+  ".env.local",
+  ".generated",
+  ".netlify",
+  ".output",
+  ".react-router",
+  "build",
+  "data",
+  "dist",
+  "node_modules",
+]);
+
 export type StarterToolchainSyncPath =
   (typeof STARTER_TOOLCHAIN_SYNC_PATHS)[number];
 
@@ -89,7 +103,11 @@ export function createStandaloneChatSnapshot(
     path.join(os.tmpdir(), "an-builder-starter-sync-"),
   );
 
-  fs.cpSync(chatTemplateDir, tempDir, { recursive: true });
+  fs.cpSync(chatTemplateDir, tempDir, {
+    recursive: true,
+    filter: (source) =>
+      shouldCopyStandaloneSnapshotPath(source, chatTemplateDir),
+  });
   _postProcessStandalone(STARTER_APP_NAME, tempDir, CHAT_TEMPLATE);
 
   const packageJson = JSON.parse(
@@ -110,6 +128,16 @@ export function createStandaloneChatSnapshot(
     pnpmWorkspaceYaml,
     toolchainFiles: collectStarterToolchainFiles(tempDir),
   };
+}
+
+function shouldCopyStandaloneSnapshotPath(
+  source: string,
+  root: string,
+): boolean {
+  const relative = path.relative(root, source);
+  if (!relative) return true;
+  const topLevel = relative.split(path.sep)[0];
+  return !STANDALONE_SNAPSHOT_EXCLUDED_TOP_LEVEL.has(topLevel);
 }
 
 export function generateStandaloneChatManifest(repoRoot?: string): {

--- a/packages/core/src/notifications/channels.spec.ts
+++ b/packages/core/src/notifications/channels.spec.ts
@@ -382,9 +382,13 @@ describe("email notification channel", () => {
       "alice@example.com",
       "ops@example.com",
     ]);
-    expect(sendEmail.mock.calls[0][0].subject).toBe("Custom subject");
-    expect(sendEmail.mock.calls[0][0].text).toContain('"ruleId": "rule_1"');
-    expect(sendEmail.mock.calls[0][0].text).not.toContain("emailRecipients");
+    const sent = sendEmail.mock.calls[0][0];
+    expect(sent.subject).toBe("Custom subject");
+    expect(sent.text).toContain("Error spike");
+    expect(sent.text).toContain("More failures than expected");
+    expect(sent.text).not.toContain('"ruleId": "rule_1"');
+    expect(sent.text).not.toContain("Metadata:");
+    expect(sent.html).not.toContain("<pre>");
   });
 
   it("does nothing when email has no recipients", async () => {

--- a/packages/core/src/notifications/channels.ts
+++ b/packages/core/src/notifications/channels.ts
@@ -189,17 +189,10 @@ function createEmailChannel(): NotificationChannel {
         input.metadata.emailSubject.trim()
           ? input.metadata.emailSubject.trim()
           : `[${input.severity}] ${input.title}`;
-      const metadata = scrubEmailMetadata(input.metadata);
-      const metadataText = metadata
-        ? `\n\nMetadata:\n${JSON.stringify(metadata, null, 2)}`
-        : "";
-      const text = `${input.title}\n\n${input.body ?? ""}${metadataText}`;
+      const text = `${input.title}\n\n${input.body ?? ""}`;
       const html = [
         `<p><strong>${escapeHtml(input.title)}</strong></p>`,
         input.body ? `<p>${escapeHtml(input.body)}</p>` : "",
-        metadata
-          ? `<pre>${escapeHtml(JSON.stringify(metadata, null, 2))}</pre>`
-          : "",
       ].join("");
 
       await Promise.all(
@@ -327,20 +320,6 @@ function commaList(value: string | undefined): string[] {
         .map((item) => item.trim())
         .filter(Boolean)
     : [];
-}
-
-function scrubEmailMetadata(
-  metadata: Record<string, unknown> | undefined,
-): Record<string, unknown> | null {
-  if (!metadata) return null;
-  const entries = Object.entries(metadata).filter(
-    ([key]) =>
-      key !== "emailRecipients" &&
-      key !== "emailSubject" &&
-      key !== "webhookUrl" &&
-      key !== "slackWebhookUrl",
-  );
-  return entries.length ? Object.fromEntries(entries) : null;
 }
 
 function slackText(

--- a/templates/analytics/changelog/2026-07-08-alert-emails-now-show-the-message-without-raw-metadata-json.md
+++ b/templates/analytics/changelog/2026-07-08-alert-emails-now-show-the-message-without-raw-metadata-json.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-08
+---
+
+Alert emails now show the message without raw metadata JSON.

--- a/templates/analytics/changelog/2026-07-08-uptime-checks-no-longer-count-ssrf-setup-time-against-the-re.md
+++ b/templates/analytics/changelog/2026-07-08-uptime-checks-no-longer-count-ssrf-setup-time-against-the-re.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-08
+---
+
+Uptime checks no longer count SSRF setup time against the request timeout, cutting false timeout alerts

--- a/templates/analytics/changelog/2026-07-08-uptime-checks-reuse-one-keep-alive-connection-so-recorded-la.md
+++ b/templates/analytics/changelog/2026-07-08-uptime-checks-reuse-one-keep-alive-connection-so-recorded-la.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-08
+---
+
+Uptime checks reuse one keep-alive connection, so recorded latency reflects the real response time instead of a fresh handshake each probe.

--- a/templates/analytics/changelog/2026-07-08-uptime-monitors-now-confirm-transient-timeout-failures-befor.md
+++ b/templates/analytics/changelog/2026-07-08-uptime-monitors-now-confirm-transient-timeout-failures-befor.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-08
+---
+
+Uptime monitors now confirm transient timeout failures before alerting, reducing noisy false alarms.

--- a/templates/analytics/docs/uptime-monitoring.md
+++ b/templates/analytics/docs/uptime-monitoring.md
@@ -20,7 +20,9 @@ are shareable and the agent can deep-link a monitor.
 Each check runs on the server (`server/lib/uptime-monitors.ts`):
 
 1. Run SSRF setup (dispatcher + DNS private-address check) **outside** the
-   request timeout budget.
+   request timeout budget. The connect-time dispatcher is built once and reused
+   across checks (HTTP keep-alive), so latency reflects the real request round
+   trip instead of a fresh DNS + TCP + TLS handshake on every probe.
 2. Fetch the monitor's `url` with the configured `method`, headers, and body,
    through that SSRF-safe path, with an `AbortController` timeout that covers
    only the HTTP request (headers / redirect chain).

--- a/templates/analytics/docs/uptime-monitoring.md
+++ b/templates/analytics/docs/uptime-monitoring.md
@@ -28,8 +28,8 @@ Each check runs on the server (`server/lib/uptime-monitors.ts`):
    only the HTTP request (headers / redirect chain).
 3. Measure latency from the HTTP response headers. If a body assertion is
    configured, read up to **512 KB** of the response body (skipped for `HEAD`)
-   after clearing the abort timer so a slow body cannot be mislabeled as a
-   request timeout.
+   with a bounded body-read timer after clearing the request abort timer, so a
+   slow body cannot be mislabeled as a request timeout or hang indefinitely.
 4. Evaluate the **status matcher** and every **assertion**.
 5. Classify the result:
    - `up` — status matches and all assertions pass.

--- a/templates/analytics/docs/uptime-monitoring.md
+++ b/templates/analytics/docs/uptime-monitoring.md
@@ -19,12 +19,17 @@ are shareable and the agent can deep-link a monitor.
 
 Each check runs on the server (`server/lib/uptime-monitors.ts`):
 
-1. Fetch the monitor's `url` with the configured `method`, headers, and body,
-   through an SSRF-safe path, with an `AbortController` timeout.
-2. Measure latency and read up to **512 KB** of the response body (skipped for
-   `HEAD`).
-3. Evaluate the **status matcher** and every **assertion**.
-4. Classify the result:
+1. Run SSRF setup (dispatcher + DNS private-address check) **outside** the
+   request timeout budget.
+2. Fetch the monitor's `url` with the configured `method`, headers, and body,
+   through that SSRF-safe path, with an `AbortController` timeout that covers
+   only the HTTP request (headers / redirect chain).
+3. Measure latency from the HTTP response headers. If a body assertion is
+   configured, read up to **512 KB** of the response body (skipped for `HEAD`)
+   after clearing the abort timer so a slow body cannot be mislabeled as a
+   request timeout.
+4. Evaluate the **status matcher** and every **assertion**.
+5. Classify the result:
    - `up` — status matches and all assertions pass.
    - `degraded` — status matches but only a `max_latency_ms` assertion fails
      (the endpoint responded, just too slowly). Alerts at `warning` severity.
@@ -58,14 +63,18 @@ Each check runs on the server (`server/lib/uptime-monitors.ts`):
 
 `evaluateAndNotifyMonitor` manages incidents like the analytics alert engine:
 
-- On a transition **into failure**, it opens a `monitor_incidents` row (one per
-  continuous failure streak) and calls `notifyWithDelivery` with a clear title
-  and body plus safe inbox metadata
+- On a transition **into confirmed failure**, it opens a `monitor_incidents` row
+  (one per continuous failure streak) and calls `notifyWithDelivery` with a
+  clear title and body plus safe inbox metadata
   `{ kind: "uptime_monitor", monitorId, url, statusCode, latencyMs, failedAssertions, emailRecipients }`.
   The `inbox` channel is the in-app bell; `email` uses the monitor's
   `emailRecipients`; `slack` / `webhook` use the monitor's optional
   delivery-only `slackWebhookUrl` / `webhookUrl` (falling back to workspace
   `NOTIFICATIONS_SLACK_WEBHOOK_URL` / `NOTIFICATIONS_WEBHOOK_URL` when unset).
+- Transient no-response failures, such as network errors or timeouts, must fail
+  twice in a row before opening an incident or alerting. Set
+  `UPTIME_MONITOR_TRANSIENT_FAILURE_CONFIRMATION_CHECKS=1` to alert on the first
+  transient failure, or a higher value (max 10) for stricter confirmation.
 - While an incident is open it will not re-alert. After an incident resolves,
   `cooldownMinutes` suppresses a fresh "down" alert for that window to prevent
   flapping.
@@ -101,15 +110,16 @@ incidents, and prunes old check results.
 
 Environment flags (mirrors the analytics alert job):
 
-| flag                                   | effect                                                              |
-| -------------------------------------- | ------------------------------------------------------------------- |
-| `UPTIME_MONITOR_JOBS`                  | `1` enables the in-process cron; `0` disables it.                   |
-| `RUN_BACKGROUND_JOBS`                  | fallback flag when `UPTIME_MONITOR_JOBS` is unset.                  |
-| (production)                           | on by default unless a flag is `0` or a platform scheduler owns it. |
-| `UPTIME_MONITOR_INTERVAL_MS`           | wake interval for the sweep (default 30s, min 10s).                 |
-| `UPTIME_MONITOR_SWEEP_LIMIT`           | max monitors processed per sweep (default 100).                     |
-| `UPTIME_MONITOR_RESULT_RETENTION_DAYS` | how long check results are kept (default 30).                       |
-| `UPTIME_MONITOR_ALLOW_PRIVATE_HOSTS`   | allow probing private/internal hosts.                               |
+| flag                                                   | effect                                                                             |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| `UPTIME_MONITOR_JOBS`                                  | `1` enables the in-process cron; `0` disables it.                                  |
+| `RUN_BACKGROUND_JOBS`                                  | fallback flag when `UPTIME_MONITOR_JOBS` is unset.                                 |
+| (production)                                           | on by default unless a flag is `0` or a platform scheduler owns it.                |
+| `UPTIME_MONITOR_INTERVAL_MS`                           | wake interval for the sweep (default 30s, min 10s).                                |
+| `UPTIME_MONITOR_SWEEP_LIMIT`                           | max monitors processed per sweep (default 100).                                    |
+| `UPTIME_MONITOR_RESULT_RETENTION_DAYS`                 | how long check results are kept (default 30).                                      |
+| `UPTIME_MONITOR_ALLOW_PRIVATE_HOSTS`                   | allow probing private/internal hosts.                                              |
+| `UPTIME_MONITOR_TRANSIENT_FAILURE_CONFIRMATION_CHECKS` | consecutive timeout/network failures required before alerting (default 2, max 10). |
 
 The monitor tables (`monitors`, `monitor_check_results`, `monitor_incidents`)
 are created by the app migration list in `server/plugins/db.ts`, which runs at

--- a/templates/analytics/server/lib/uptime-monitors.spec.ts
+++ b/templates/analytics/server/lib/uptime-monitors.spec.ts
@@ -1,4 +1,21 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const createSsrfSafeDispatcher = vi.fn();
+const isBlockedExtensionUrlWithDns = vi.fn();
+
+vi.mock("@agent-native/core/extensions/url-safety", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@agent-native/core/extensions/url-safety")
+    >();
+  return {
+    ...actual,
+    createSsrfSafeDispatcher: (...args: unknown[]) =>
+      createSsrfSafeDispatcher(...args),
+    isBlockedExtensionUrlWithDns: (...args: unknown[]) =>
+      isBlockedExtensionUrlWithDns(...args),
+  };
+});
 
 import {
   evaluateAssertions,
@@ -7,9 +24,25 @@ import {
   normalizeAssertions,
   normalizeStatusMatcher,
   runMonitorCheck,
+  shouldOpenMonitorIncident,
   type Assertion,
+  type CheckOutcome,
   type StatusMatcher,
 } from "./uptime-monitors";
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  createSsrfSafeDispatcher.mockReset();
+  isBlockedExtensionUrlWithDns.mockReset();
+  createSsrfSafeDispatcher.mockResolvedValue(null);
+  isBlockedExtensionUrlWithDns.mockResolvedValue(false);
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
 
 describe("matchesStatus", () => {
   it("matches by status class", () => {
@@ -286,5 +319,176 @@ describe("runMonitorCheck SSRF guard", () => {
       { allowPrivateHosts: false },
     );
     expect(outcome.status).toBe("error");
+  });
+});
+
+describe("runMonitorCheck response body reads", () => {
+  const base = {
+    url: "https://example.com/health",
+    method: "GET" as const,
+    requestHeaders: {},
+    requestBody: null,
+    timeoutMs: 5000,
+    expectedStatus: { mode: "class", classes: ["2xx"] } as StatusMatcher,
+    assertions: [] as Assertion[],
+    followRedirects: true,
+  };
+
+  it("skips response body reads when no body assertion needs them", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      return {
+        status: 200,
+        headers: new Headers(),
+        body: {
+          getReader() {
+            throw new Error("body should not be read");
+          },
+        },
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const outcome = await runMonitorCheck(base, { allowPrivateHosts: true });
+
+    expect(outcome.status).toBe("up");
+    expect(outcome.ok).toBe(true);
+    expect(outcome.statusCode).toBe(200);
+  });
+
+  it("reads response bodies when body assertions are configured", async () => {
+    const encoder = new TextEncoder();
+    globalThis.fetch = vi.fn(async () => {
+      let done = false;
+      return {
+        status: 200,
+        headers: new Headers(),
+        body: {
+          getReader() {
+            return {
+              async read() {
+                if (done) return { done: true, value: undefined };
+                done = true;
+                return {
+                  done: false,
+                  value: encoder.encode("maintenance"),
+                };
+              },
+              async cancel() {},
+            };
+          },
+        },
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const outcome = await runMonitorCheck(
+      {
+        ...base,
+        assertions: [{ type: "body_contains", value: "ok" }],
+      },
+      { allowPrivateHosts: true },
+    );
+
+    expect(outcome.status).toBe("down");
+    expect(outcome.error).toContain("Body is missing expected text");
+  });
+});
+
+describe("runMonitorCheck timeout budget", () => {
+  // MIN_TIMEOUT_MS is 1000 — keep tests at/above that floor.
+  const base = {
+    url: "https://example.com/health",
+    method: "GET" as const,
+    requestHeaders: {},
+    requestBody: null,
+    timeoutMs: 1000,
+    expectedStatus: { mode: "class", classes: ["2xx"] } as StatusMatcher,
+    assertions: [] as Assertion[],
+    followRedirects: false,
+  };
+
+  it("does not bill SSRF dispatcher/DNS setup against the request timeout", async () => {
+    createSsrfSafeDispatcher.mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 600));
+      return null;
+    });
+    isBlockedExtensionUrlWithDns.mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 600));
+      return false;
+    });
+
+    globalThis.fetch = vi.fn(async () => {
+      return {
+        status: 200,
+        headers: new Headers(),
+        body: null,
+        async text() {
+          return "ok";
+        },
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const outcome = await runMonitorCheck(base, { allowPrivateHosts: false });
+
+    expect(outcome.status).toBe("up");
+    expect(outcome.ok).toBe(true);
+    expect(outcome.statusCode).toBe(200);
+    expect(outcome.error).toBeNull();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("still reports a real fetch timeout after headers never arrive", async () => {
+    globalThis.fetch = vi.fn((_url, init) => {
+      return new Promise((_resolve, reject) => {
+        const signal = (init as RequestInit | undefined)?.signal;
+        if (!signal) return;
+        if (signal.aborted) {
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+          return;
+        }
+        signal.addEventListener("abort", () => {
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    const outcome = await runMonitorCheck(base, { allowPrivateHosts: true });
+
+    expect(outcome.status).toBe("down");
+    expect(outcome.ok).toBe(false);
+    expect(outcome.statusCode).toBeNull();
+    expect(outcome.error).toBe("Timed out after 1000ms");
+    expect(outcome.latencyMs).toBe(1000);
+  });
+});
+
+describe("shouldOpenMonitorIncident", () => {
+  const timeoutOutcome: CheckOutcome = {
+    checkedAt: "2026-07-08T00:00:00.000Z",
+    status: "down",
+    ok: false,
+    statusCode: null,
+    latencyMs: null,
+    error: "Timed out after 10000ms",
+    failedAssertions: ["Timed out after 10000ms"],
+  };
+
+  it("requires confirmation for transient no-response failures", () => {
+    expect(shouldOpenMonitorIncident(timeoutOutcome, 0, 2)).toBe(false);
+    expect(shouldOpenMonitorIncident(timeoutOutcome, 1, 2)).toBe(true);
+  });
+
+  it("opens immediately for HTTP failures that returned a response", () => {
+    expect(
+      shouldOpenMonitorIncident(
+        {
+          ...timeoutOutcome,
+          statusCode: 503,
+          latencyMs: 120,
+          error: "Unexpected status 503",
+          failedAssertions: ["Unexpected status 503"],
+        },
+        0,
+        2,
+      ),
+    ).toBe(true);
   });
 });

--- a/templates/analytics/server/lib/uptime-monitors.spec.ts
+++ b/templates/analytics/server/lib/uptime-monitors.spec.ts
@@ -335,11 +335,13 @@ describe("runMonitorCheck response body reads", () => {
   };
 
   it("skips response body reads when no body assertion needs them", async () => {
+    const cancel = vi.fn(async () => {});
     globalThis.fetch = vi.fn(async () => {
       return {
         status: 200,
         headers: new Headers(),
         body: {
+          cancel,
           getReader() {
             throw new Error("body should not be read");
           },
@@ -352,6 +354,7 @@ describe("runMonitorCheck response body reads", () => {
     expect(outcome.status).toBe("up");
     expect(outcome.ok).toBe(true);
     expect(outcome.statusCode).toBe(200);
+    expect(cancel).toHaveBeenCalledTimes(1);
   });
 
   it("reads response bodies when body assertions are configured", async () => {
@@ -389,6 +392,51 @@ describe("runMonitorCheck response body reads", () => {
 
     expect(outcome.status).toBe("down");
     expect(outcome.error).toContain("Body is missing expected text");
+  });
+
+  it("bounds body assertion reads after headers arrive", async () => {
+    let releaseRead:
+      | ((value: { done: boolean; value?: Uint8Array }) => void)
+      | null = null;
+    const cancel = vi.fn(async () => {
+      releaseRead?.({ done: true });
+    });
+    globalThis.fetch = vi.fn(async () => {
+      return {
+        status: 200,
+        headers: new Headers(),
+        body: {
+          getReader() {
+            return {
+              read() {
+                return new Promise<{ done: boolean; value?: Uint8Array }>(
+                  (resolve) => {
+                    releaseRead = resolve;
+                  },
+                );
+              },
+              cancel,
+            };
+          },
+        },
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const outcome = await runMonitorCheck(
+      {
+        ...base,
+        timeoutMs: 1000,
+        assertions: [{ type: "body_contains", value: "ok" }],
+      },
+      { allowPrivateHosts: true },
+    );
+
+    expect(outcome.status).toBe("down");
+    expect(outcome.statusCode).toBe(200);
+    expect(outcome.error).toContain(
+      "Response body read timed out after 1000ms",
+    );
+    expect(cancel).toHaveBeenCalled();
   });
 });
 

--- a/templates/analytics/server/lib/uptime-monitors.ts
+++ b/templates/analytics/server/lib/uptime-monitors.ts
@@ -763,6 +763,7 @@ async function safeMonitorFetch(
     if (opts.followRedirects && isRedirect) {
       const location = response.headers.get("location");
       if (!location) return response;
+      await cancelResponseBody(response);
       currentUrl = new URL(location, currentUrl).href;
       continue;
     }
@@ -773,17 +774,50 @@ async function safeMonitorFetch(
   );
 }
 
-async function readCappedText(res: Response, cap: number): Promise<string> {
+async function cancelResponseBody(res: Response): Promise<void> {
+  try {
+    await res.body?.cancel();
+  } catch {
+    // Best-effort cleanup only.
+  }
+}
+
+async function readCappedText(
+  res: Response,
+  cap: number,
+  timeoutMs?: number,
+): Promise<{ text: string; timedOut: boolean }> {
+  let timedOut = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
   const body = res.body;
   if (!body) {
     try {
-      const text = await res.text();
-      return text.length > cap ? text.slice(0, cap) : text;
+      const text =
+        timeoutMs && timeoutMs > 0
+          ? await Promise.race([
+              res.text(),
+              new Promise<string>((resolve) => {
+                timer = setTimeout(() => {
+                  timedOut = true;
+                  resolve("");
+                }, timeoutMs);
+              }),
+            ])
+          : await res.text();
+      return { text: text.length > cap ? text.slice(0, cap) : text, timedOut };
     } catch {
-      return "";
+      return { text: "", timedOut };
+    } finally {
+      if (timer) clearTimeout(timer);
     }
   }
   const reader = body.getReader();
+  if (timeoutMs && timeoutMs > 0) {
+    timer = setTimeout(() => {
+      timedOut = true;
+      void reader.cancel().catch(() => {});
+    }, timeoutMs);
+  }
   const chunks: Uint8Array[] = [];
   let total = 0;
   try {
@@ -798,6 +832,7 @@ async function readCappedText(res: Response, cap: number): Promise<string> {
   } catch {
     // Partial body is fine for text assertions.
   } finally {
+    if (timer) clearTimeout(timer);
     try {
       await reader.cancel();
     } catch {
@@ -814,7 +849,10 @@ async function readCappedText(res: Response, cap: number): Promise<string> {
     merged.set(slice, offset);
     offset += slice.length;
   }
-  return new TextDecoder("utf-8", { fatal: false }).decode(merged);
+  return {
+    text: new TextDecoder("utf-8", { fatal: false }).decode(merged),
+    timedOut,
+  };
 }
 
 function headersToObject(headers: Headers): Record<string, string> {
@@ -957,10 +995,21 @@ export async function runMonitorCheck(
     const latencyMs = Date.now() - start;
     const statusCode = response.status;
     const headers = headersToObject(response.headers);
-    const bodyText =
-      method !== "HEAD" && needsResponseBody(assertions)
-        ? await readCappedText(response, MAX_RESPONSE_BODY_BYTES)
-        : "";
+    let bodyText = "";
+    let bodyReadError: string | null = null;
+    if (method !== "HEAD" && needsResponseBody(assertions)) {
+      const body = await readCappedText(
+        response,
+        MAX_RESPONSE_BODY_BYTES,
+        timeoutMs,
+      );
+      bodyText = body.text;
+      if (body.timedOut) {
+        bodyReadError = `Response body read timed out after ${timeoutMs}ms`;
+      }
+    } else {
+      await cancelResponseBody(response);
+    }
 
     const outcome = evaluateCheck({
       statusCode,
@@ -970,17 +1019,19 @@ export async function runMonitorCheck(
       matcher,
       assertions,
     });
+    const failedAssertions = bodyReadError
+      ? [...outcome.failedAssertions, bodyReadError]
+      : outcome.failedAssertions;
+    const status = bodyReadError ? "down" : outcome.status;
 
     return {
       checkedAt,
       statusCode,
       latencyMs,
-      status: outcome.status,
-      ok: outcome.ok,
-      failedAssertions: outcome.failedAssertions,
-      error: outcome.failedAssertions.length
-        ? outcome.failedAssertions.join("; ")
-        : null,
+      status,
+      ok: status === "up" && outcome.ok,
+      failedAssertions,
+      error: failedAssertions.length ? failedAssertions.join("; ") : null,
     };
   } catch (err) {
     const message =

--- a/templates/analytics/server/lib/uptime-monitors.ts
+++ b/templates/analytics/server/lib/uptime-monitors.ts
@@ -34,6 +34,7 @@ import {
   count,
   desc,
   eq,
+  gt,
   gte,
   isNull,
   lte,
@@ -985,7 +986,7 @@ export async function runMonitorCheck(
       maxRedirects: MAX_REDIRECT_HOPS,
       allowPrivateHosts,
       dispatcher,
-      initialDnsChecked: true,
+      initialDnsChecked: Boolean(dispatcher),
     });
 
     // Stop the abort timer as soon as headers arrive so a slow/optional body
@@ -1654,6 +1655,29 @@ async function recentlyResolvedWithinCooldown(
   return now.getTime() - resolved < monitor.cooldownMinutes * 60 * 1000;
 }
 
+async function getFailureStreakStartedAt(
+  monitor: Monitor,
+  ctx: AccessCtx,
+  fallback: string,
+): Promise<string> {
+  const db = getDb() as any;
+  const table = schema.monitorCheckResults;
+  const clauses: any[] = [
+    resultsOwnerWhere(ctx),
+    eq(table.monitorId, monitor.id),
+    eq(table.ok, false),
+  ];
+  if (monitor.lastSuccessAt)
+    clauses.push(gt(table.checkedAt, monitor.lastSuccessAt));
+  const [row] = await db
+    .select({ checkedAt: table.checkedAt })
+    .from(table)
+    .where(and(...clauses))
+    .orderBy(asc(table.checkedAt))
+    .limit(1);
+  return row?.checkedAt ?? fallback;
+}
+
 async function notifyMonitorDown(monitor: Monitor, outcome: CheckOutcome) {
   const host = hostFromUrl(monitor.url);
   const label = outcome.status === "degraded" ? "degraded" : "down";
@@ -1788,8 +1812,8 @@ export async function evaluateAndNotifyMonitor(
     }
     const incidentId = randomUUID();
     const startedAt =
-      nextChecksFailed > 1 && monitor.lastCheckedAt
-        ? monitor.lastCheckedAt
+      nextChecksFailed > 1
+        ? await getFailureStreakStartedAt(monitor, ctx, outcome.checkedAt)
         : outcome.checkedAt;
     await db.insert(schema.monitorIncidents).values({
       id: incidentId,

--- a/templates/analytics/server/lib/uptime-monitors.ts
+++ b/templates/analytics/server/lib/uptime-monitors.ts
@@ -216,6 +216,7 @@ const MIN_INTERVAL_SECONDS = 30;
 const MAX_INTERVAL_SECONDS = 24 * 60 * 60;
 const MIN_TIMEOUT_MS = 1000;
 const MAX_TIMEOUT_MS = 120_000;
+const DEFAULT_TRANSIENT_FAILURE_CONFIRMATION_CHECKS = 2;
 
 const ASSERTION_TYPES: AssertionType[] = [
   "body_contains",
@@ -279,6 +280,14 @@ function monitorLimitPerOwner(): number {
   return Number.isFinite(parsed) && parsed > 0
     ? Math.min(parsed, 1000)
     : DEFAULT_MONITOR_LIMIT_PER_OWNER;
+}
+
+function transientFailureConfirmationChecks(): number {
+  const raw = process.env.UPTIME_MONITOR_TRANSIENT_FAILURE_CONFIRMATION_CHECKS;
+  const parsed = Number.parseInt(raw ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0
+    ? Math.min(parsed, 10)
+    : DEFAULT_TRANSIENT_FAILURE_CONFIRMATION_CHECKS;
 }
 
 export function hostFromUrl(url: string): string {
@@ -675,6 +684,23 @@ export function evaluateCheck(params: EvaluateCheckParams): {
 // SSRF-safe fetch + probe
 // ---------------------------------------------------------------------------
 
+async function prepareMonitorFetch(
+  url: string,
+  opts: { allowPrivateHosts: boolean },
+): Promise<{ dispatcher: unknown | undefined }> {
+  const dispatcher = opts.allowPrivateHosts
+    ? undefined
+    : ((await createSsrfSafeDispatcher()) ?? undefined);
+
+  if (!opts.allowPrivateHosts && (await isBlockedExtensionUrlWithDns(url))) {
+    throw new Error(
+      `SSRF blocked: refusing to fetch private/internal address (${url})`,
+    );
+  }
+
+  return { dispatcher };
+}
+
 async function safeMonitorFetch(
   url: string,
   init: RequestInit,
@@ -682,17 +708,26 @@ async function safeMonitorFetch(
     followRedirects: boolean;
     maxRedirects: number;
     allowPrivateHosts: boolean;
+    /** Prebuilt outside the abort window so SSRF setup is not billed as site latency. */
+    dispatcher?: unknown;
+    /** When true, the caller already DNS-checked `url` before starting the timer. */
+    initialDnsChecked?: boolean;
   },
 ): Promise<Response> {
-  const dispatcher = opts.allowPrivateHosts
-    ? undefined
-    : ((await createSsrfSafeDispatcher()) ?? undefined);
+  const dispatcher =
+    opts.dispatcher !== undefined
+      ? opts.dispatcher
+      : opts.allowPrivateHosts
+        ? undefined
+        : ((await createSsrfSafeDispatcher()) ?? undefined);
 
   let currentUrl = url;
   const maxHops = opts.followRedirects ? opts.maxRedirects : 0;
 
   for (let hop = 0; hop <= maxHops; hop++) {
+    const skipDns = hop === 0 && opts.initialDnsChecked;
     if (
+      !skipDns &&
       !opts.allowPrivateHosts &&
       (await isBlockedExtensionUrlWithDns(currentUrl))
     ) {
@@ -773,10 +808,22 @@ function headersToObject(headers: Headers): Record<string, string> {
   return out;
 }
 
+function needsResponseBody(assertions: Assertion[]): boolean {
+  return assertions.some(
+    (assertion) =>
+      assertion.type === "body_contains" || assertion.type === "body_absent",
+  );
+}
+
 /**
  * Execute one probe for `monitor`. Performs an SSRF-safe fetch with an
  * AbortController timeout, measures latency, caps the response body, and
  * classifies the result. Never throws — failures are captured in the outcome.
+ *
+ * The abort budget covers only the HTTP fetch (headers / redirect chain), not
+ * SSRF dispatcher/DNS setup or optional body reads. Billing setup time against
+ * `timeoutMs` produced false "Timed out after Nms" alerts when the site itself
+ * was fine.
  */
 export async function runMonitorCheck(
   monitor: Pick<
@@ -818,14 +865,50 @@ export async function runMonitorCheck(
     };
   }
 
-  const controller = new AbortController();
   const timeoutMs = clampInt(
     monitor.timeoutMs,
     MIN_TIMEOUT_MS,
     MAX_TIMEOUT_MS,
     DEFAULT_MONITOR_TIMEOUT_MS,
   );
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  let dispatcher: unknown | undefined;
+  try {
+    ({ dispatcher } = await prepareMonitorFetch(monitor.url, {
+      allowPrivateHosts,
+    }));
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : String(err ?? "check failed");
+    const isConfig = message.startsWith("SSRF blocked");
+    const errorText = message.slice(0, 500);
+    const outcome = evaluateCheck({
+      statusCode: null,
+      latencyMs: null,
+      bodyText: "",
+      headers: {},
+      matcher,
+      assertions,
+      fetchError: errorText,
+      errorKind: isConfig ? "config" : "network",
+    });
+    return {
+      checkedAt,
+      statusCode: null,
+      latencyMs: null,
+      status: outcome.status,
+      ok: outcome.ok,
+      failedAssertions: outcome.failedAssertions,
+      error: errorText,
+    };
+  }
+
+  const controller = new AbortController();
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
   const start = Date.now();
 
   try {
@@ -846,15 +929,21 @@ export async function runMonitorCheck(
       followRedirects: monitor.followRedirects,
       maxRedirects: MAX_REDIRECT_HOPS,
       allowPrivateHosts,
+      dispatcher,
+      initialDnsChecked: true,
     });
 
-    const bodyText =
-      method === "HEAD"
-        ? ""
-        : await readCappedText(response, MAX_RESPONSE_BODY_BYTES);
+    // Stop the abort timer as soon as headers arrive so a slow/optional body
+    // read cannot be mislabeled as a request timeout with a null status code.
+    clearTimeout(timer);
+
     const latencyMs = Date.now() - start;
     const statusCode = response.status;
     const headers = headersToObject(response.headers);
+    const bodyText =
+      method !== "HEAD" && needsResponseBody(assertions)
+        ? await readCappedText(response, MAX_RESPONSE_BODY_BYTES)
+        : "";
 
     const outcome = evaluateCheck({
       statusCode,
@@ -877,18 +966,18 @@ export async function runMonitorCheck(
         : null,
     };
   } catch (err) {
-    const isTimeout =
-      (err as { name?: string })?.name === "AbortError" ||
-      controller.signal.aborted;
     const message =
       err instanceof Error ? err.message : String(err ?? "check failed");
     const isConfig = message.startsWith("SSRF blocked");
+    // Only our timer sets `timedOut`. Prefer the real SSRF/config message when
+    // both happened (e.g. abort fired while a redirect DNS check was in flight).
+    const isTimeout = timedOut && !isConfig;
     const errorText = isTimeout
       ? `Timed out after ${timeoutMs}ms`
       : message.slice(0, 500);
     const outcome = evaluateCheck({
       statusCode: null,
-      latencyMs: null,
+      latencyMs: isTimeout ? timeoutMs : null,
       bodyText: "",
       headers: {},
       matcher,
@@ -899,7 +988,7 @@ export async function runMonitorCheck(
     return {
       checkedAt,
       statusCode: null,
-      latencyMs: null,
+      latencyMs: isTimeout ? timeoutMs : null,
       status: outcome.status,
       ok: outcome.ok,
       failedAssertions: outcome.failedAssertions,
@@ -1434,6 +1523,25 @@ function describeCause(outcome: CheckOutcome): string {
   return "Check failed";
 }
 
+function isTransientNoResponseFailure(outcome: CheckOutcome): boolean {
+  return (
+    outcome.status === "down" &&
+    outcome.statusCode == null &&
+    Boolean(outcome.error)
+  );
+}
+
+export function shouldOpenMonitorIncident(
+  outcome: CheckOutcome,
+  priorConsecutiveFailures: number,
+  confirmationChecks = transientFailureConfirmationChecks(),
+): boolean {
+  const needed = isTransientNoResponseFailure(outcome)
+    ? Math.max(1, Math.min(10, Math.floor(confirmationChecks)))
+    : 1;
+  return Math.max(0, Math.floor(priorConsecutiveFailures)) + 1 >= needed;
+}
+
 async function getOpenIncident(
   monitorId: string,
   ctx: AccessCtx,
@@ -1561,8 +1669,8 @@ export interface EvaluateMonitorResult {
 
 /**
  * Open / update / resolve incidents based on the latest outcome and send
- * notifications. On a transition into failure it opens an incident and
- * notifies (respecting an anti-flap cooldown); on recovery it resolves the
+ * notifications. On a transition into confirmed failure it opens an incident
+ * and notifies (respecting an anti-flap cooldown); on recovery it resolves the
  * open incident and sends a recovery notice.
  */
 export async function evaluateAndNotifyMonitor(
@@ -1576,6 +1684,8 @@ export async function evaluateAndNotifyMonitor(
 
   if (!outcome.ok) {
     const cause = describeCause(outcome);
+    const priorConsecutiveFailures = monitor.consecutiveFailures ?? 0;
+    const nextChecksFailed = priorConsecutiveFailures + 1;
     if (open) {
       const nextStatus =
         open.status === "down" ? "down" : (outcome.status as MonitorStatus);
@@ -1589,6 +1699,10 @@ export async function evaluateAndNotifyMonitor(
         })
         .where(eq(schema.monitorIncidents.id, open.id));
       return { status: outcome.status, incidentId: open.id, notified: false };
+    }
+
+    if (!shouldOpenMonitorIncident(outcome, priorConsecutiveFailures)) {
+      return { status: outcome.status, notified: false };
     }
 
     const suppressed = await recentlyResolvedWithinCooldown(monitor, ctx, now);
@@ -1605,17 +1719,21 @@ export async function evaluateAndNotifyMonitor(
       }
     }
     const incidentId = randomUUID();
+    const startedAt =
+      nextChecksFailed > 1 && monitor.lastCheckedAt
+        ? monitor.lastCheckedAt
+        : outcome.checkedAt;
     await db.insert(schema.monitorIncidents).values({
       id: incidentId,
       monitorId: monitor.id,
-      startedAt: outcome.checkedAt,
+      startedAt,
       resolvedAt: null,
       status: outcome.status === "degraded" ? "degraded" : "down",
       severity: monitor.severity,
       cause,
       lastError: outcome.error,
       notificationId: notificationId ?? null,
-      checksFailed: 1,
+      checksFailed: nextChecksFailed,
       createdAt: outcome.checkedAt,
       ownerEmail: monitor.ownerEmail,
       orgId: monitor.orgId,

--- a/templates/analytics/server/lib/uptime-monitors.ts
+++ b/templates/analytics/server/lib/uptime-monitors.ts
@@ -684,13 +684,30 @@ export function evaluateCheck(params: EvaluateCheckParams): {
 // SSRF-safe fetch + probe
 // ---------------------------------------------------------------------------
 
+// A single SSRF-safe dispatcher (undici Agent) is reused across every probe.
+// Building a fresh Agent per check disabled HTTP keep-alive — each check paid a
+// cold DNS + TCP + TLS handshake, inflating the recorded latency well above the
+// site's real response time (and occasionally spiking near the timeout) — and
+// leaked Agents, which are never closed. The connect-time private-IP guard runs
+// on every new socket, so reuse keeps the exact same SSRF protection.
+// `undefined` = not built yet; the resolved value may be `null` on runtimes
+// without undici / node:dns, in which case callers fall back to plain `fetch`.
+let sharedSsrfDispatcherPromise: Promise<unknown | null> | undefined;
+
+function getSharedSsrfDispatcher(): Promise<unknown | null> {
+  if (!sharedSsrfDispatcherPromise) {
+    sharedSsrfDispatcherPromise = createSsrfSafeDispatcher().catch(() => null);
+  }
+  return sharedSsrfDispatcherPromise;
+}
+
 async function prepareMonitorFetch(
   url: string,
   opts: { allowPrivateHosts: boolean },
 ): Promise<{ dispatcher: unknown | undefined }> {
   const dispatcher = opts.allowPrivateHosts
     ? undefined
-    : ((await createSsrfSafeDispatcher()) ?? undefined);
+    : ((await getSharedSsrfDispatcher()) ?? undefined);
 
   if (!opts.allowPrivateHosts && (await isBlockedExtensionUrlWithDns(url))) {
     throw new Error(
@@ -719,7 +736,7 @@ async function safeMonitorFetch(
       ? opts.dispatcher
       : opts.allowPrivateHosts
         ? undefined
-        : ((await createSsrfSafeDispatcher()) ?? undefined);
+        : ((await getSharedSsrfDispatcher()) ?? undefined);
 
   let currentUrl = url;
   const maxHops = opts.followRedirects ? opts.maxRedirects : 0;


### PR DESCRIPTION
## Summary
- Confirm transient no-response uptime failures before opening incidents or alerting.
- Keep SSRF setup and optional body reads outside the monitor request timeout budget.
- Stop including raw metadata JSON in notification email bodies and avoid copying generated template artifacts in starter manifest snapshots.

## Test plan
- pnpm --dir packages/core exec vitest --run src/notifications/channels.spec.ts src/cli/sync-builder-starter-manifest.spec.ts
- pnpm vitest --run server/lib/uptime-monitors.spec.ts (from templates/analytics)
- pnpm run prep


Made with [Cursor](https://cursor.com)