### PR TITLE
Assets: Add URL import action for Assets reference images

### DIFF
--- a/.changeset/https-only-ssrf-safe-fetch.md
+++ b/.changeset/https-only-ssrf-safe-fetch.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add an `httpsOnly` option to `ssrfSafeFetch` that validates the URL scheme on the initial request and on every redirect hop, so HTTPS-only callers cannot be downgraded to plain HTTP by a redirect from the untrusted origin.

--- a/.changeset/https-only-ssrf-safe-fetch.md
+++ b/.changeset/https-only-ssrf-safe-fetch.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Add an `httpsOnly` option to `ssrfSafeFetch` that validates the URL scheme on the initial request and on every redirect hop, so HTTPS-only callers cannot be downgraded to plain HTTP by a redirect from the untrusted origin.
+`ssrfSafeFetch` hardening: a new `httpsOnly` option validates the URL scheme on the initial request and on every redirect hop, so HTTPS-only callers cannot be downgraded to plain HTTP by a redirect from the untrusted origin. Followed redirect responses now also have their bodies cancelled so each hop's connection is released immediately instead of being held until GC.

--- a/packages/core/src/extensions/url-safety.spec.ts
+++ b/packages/core/src/extensions/url-safety.spec.ts
@@ -113,14 +113,20 @@ describe("ssrfSafeFetch httpsOnly", () => {
   });
 
   it("still follows HTTP redirects when httpsOnly is not set", async () => {
+    const redirectResponse = new Response("moved", {
+      status: 302,
+      headers: { location: httpOrigin },
+    });
     const fetchMock = vi.fn(async (url: string) =>
       url === httpsOrigin
-        ? new Response(null, { status: 302, headers: { location: httpOrigin } })
+        ? redirectResponse
         : new Response("ok", { status: 200 }),
     );
     vi.stubGlobal("fetch", fetchMock);
     const response = await ssrfSafeFetch(httpsOrigin);
     expect(response.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    // The followed hop's body must be drained so its connection is released.
+    expect(redirectResponse.bodyUsed).toBe(true);
   });
 });

--- a/packages/core/src/extensions/url-safety.spec.ts
+++ b/packages/core/src/extensions/url-safety.spec.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   isBlockedExtensionUrl,
   isBlockedExtensionUrlWithDns,
+  ssrfSafeFetch,
 } from "./url-safety.js";
 
 describe("isBlockedExtensionUrl", () => {
@@ -76,5 +77,50 @@ describe("isBlockedExtensionUrlWithDns (DNS rebinding guard)", () => {
     );
     vi.doUnmock("node:dns/promises");
     vi.resetModules();
+  });
+});
+
+describe("ssrfSafeFetch httpsOnly", () => {
+  // Public IP literals skip the DNS lookup, so these tests stay offline.
+  const httpsOrigin = "https://93.184.216.34/image.png";
+  const httpOrigin = "http://93.184.216.34/image.png";
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects a non-HTTPS initial URL before any request is sent", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(
+      ssrfSafeFetch(httpOrigin, {}, { httpsOnly: true }),
+    ).rejects.toThrow(/SSRF blocked: refusing to fetch non-HTTPS/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an HTTPS→HTTP redirect downgrade before following it", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(null, { status: 302, headers: { location: httpOrigin } }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(
+      ssrfSafeFetch(httpsOrigin, {}, { httpsOnly: true }),
+    ).rejects.toThrow(/SSRF blocked: refusing to fetch non-HTTPS/);
+    // Only the initial HTTPS request went out; the HTTP hop was never fetched.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(httpsOrigin);
+  });
+
+  it("still follows HTTP redirects when httpsOnly is not set", async () => {
+    const fetchMock = vi.fn(async (url: string) =>
+      url === httpsOrigin
+        ? new Response(null, { status: 302, headers: { location: httpOrigin } })
+        : new Response("ok", { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const response = await ssrfSafeFetch(httpsOrigin);
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/core/src/extensions/url-safety.ts
+++ b/packages/core/src/extensions/url-safety.ts
@@ -282,6 +282,9 @@ export async function ssrfSafeFetch(
     if (response.status >= 300 && response.status < 400) {
       const location = response.headers.get("location");
       if (!location) return response;
+      // Drain the redirect body so the hop's connection is released instead
+      // of being held until GC.
+      await response.body?.cancel().catch(() => {});
       currentUrl = new URL(location, currentUrl).href;
       continue;
     }

--- a/packages/core/src/extensions/url-safety.ts
+++ b/packages/core/src/extensions/url-safety.ts
@@ -247,17 +247,26 @@ export async function createSsrfSafeDispatcher(): Promise<unknown | null> {
  * Throws an Error whose message starts with "SSRF blocked:" when a target
  * (initial or via redirect) resolves to a private/internal address, or when the
  * redirect limit is exceeded. Otherwise returns the final Response.
+ *
+ * `httpsOnly` extends the per-hop validation to the URL scheme: redirects are
+ * followed only to `https:` targets, so an HTTPS-only caller cannot be
+ * downgraded to plain HTTP by a 30x from the (untrusted) origin.
  */
 export async function ssrfSafeFetch(
   url: string,
   init: RequestInit = {},
-  options: { maxRedirects?: number } = {},
+  options: { maxRedirects?: number; httpsOnly?: boolean } = {},
 ): Promise<Response> {
   const maxRedirects = options.maxRedirects ?? 3;
   const dispatcher = (await createSsrfSafeDispatcher()) ?? undefined;
 
   let currentUrl = url;
   for (let hop = 0; hop <= maxRedirects; hop++) {
+    if (options.httpsOnly && new URL(currentUrl).protocol !== "https:") {
+      throw new Error(
+        `SSRF blocked: refusing to fetch non-HTTPS address (${currentUrl})`,
+      );
+    }
     if (await isBlockedExtensionUrlWithDns(currentUrl)) {
       throw new Error(
         `SSRF blocked: refusing to fetch private/internal address (${currentUrl})`,

--- a/templates/assets/.agents/skills/image-generation/SKILL.md
+++ b/templates/assets/.agents/skills/image-generation/SKILL.md
@@ -27,6 +27,9 @@ Use this skill before calling `generate-image`, `generate-image-batch`, or
 - Use category-tagged references. Blog heroes should prefer `hero`; diagrams
   should prefer `diagram`; product imagery should include `product` and `logo`
   references.
+- Imported external images with `status: "reference"` are valid generation
+  inputs. Use their returned asset IDs in preset reference fills or reference
+  boards the same way you would use uploaded reference assets.
 - Keep reference sets small and deterministic. Prefer anchors listed in
   `assetLibraries.settings.canonicalStyleAssetIds` and assets marked
   `assets.metadata.isStyleAnchor` before sampling other relevant references.

--- a/templates/assets/.agents/skills/library-management/SKILL.md
+++ b/templates/assets/.agents/skills/library-management/SKILL.md
@@ -90,6 +90,22 @@ Reference images and generated images live in the **same** `image_assets` table,
 
 The unified table simplifies access control (one `library_id`, one access check) and makes "use a saved generation as a reference for a future generation" a first-class operation — just bump its `role` to `prior-candidate` (planned for v2; v1 just selects from any non-archived asset).
 
+## Importing external references
+
+Use `import-asset-from-url` when the agent has found a public HTTPS image that
+belongs in a brand kit, such as a blog hero, product shot, logo, campaign image,
+or diagram. Choose the narrowest reference `role` (`style_reference`,
+`subject_reference`, `product_reference`, `background_reference`,
+`logo_reference`, or `diagram_reference`) and preserve a useful title or
+description when known.
+
+For a blog-to-brand-kit workflow: inspect the page, pick the strongest image
+URLs, import each URL into the target `libraryId`, then wire the returned
+`assetId`s into generation preset reference fills or call `set-canonical-logo`
+for the exact logo. Imported assets are stored as `status: "reference"` with
+`sourceUrl` provenance, so downstream generation, preset boards, and logo
+compositing can use them like uploaded reference assets.
+
 ## When to add a collection
 
 Collections are optional. Most users won't create them. Use them when:

--- a/templates/assets/.agents/skills/library-management/SKILL.md
+++ b/templates/assets/.agents/skills/library-management/SKILL.md
@@ -97,7 +97,10 @@ belongs in a brand kit, such as a blog hero, product shot, logo, campaign image,
 or diagram. Choose the narrowest reference `role` (`style_reference`,
 `subject_reference`, `product_reference`, `background_reference`,
 `logo_reference`, or `diagram_reference`) and preserve a useful title or
-description when known.
+description when known. The deliverable `category` defaults to match the role
+(logo → `logo`, product → `product`, diagram → `diagram`); pass an explicit
+`category` such as `hero` or `campaign` when the image belongs in one of those
+filtered views.
 
 For a blog-to-brand-kit workflow: inspect the page, pick the strongest image
 URLs, import each URL into the target `libraryId`, then wire the returned

--- a/templates/assets/AGENTS.md
+++ b/templates/assets/AGENTS.md
@@ -24,6 +24,8 @@ Detailed library, generation, image, embed, and engine rules live in
 - Use the configured generation/engine path for image and asset work. Do not add
   ad hoc provider calls when the app has an action/engine abstraction.
 - Preserve provenance and metadata for generated or imported assets.
+- Ingest external brand or blog imagery with `import-asset-from-url`, then pin
+  the returned asset to preset reference boards or set it as the canonical logo.
 - Use `view-screen` when the active library, selected asset, picker, generation,
   or embed target is unclear. The human Library surface is `/library` for
   cross-kit browsing and `/library/:libraryId` for a single brand kit; embedded

--- a/templates/assets/actions/import-asset-from-url.spec.ts
+++ b/templates/assets/actions/import-asset-from-url.spec.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const assertAccessMock = vi.hoisted(() => vi.fn());
+const createAssetFromBufferMock = vi.hoisted(() => vi.fn());
+const getDbMock = vi.hoisted(() => vi.fn());
+const serializeAssetMock = vi.hoisted(() => vi.fn((row: unknown) => row));
+const ssrfSafeFetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@agent-native/core", () => ({
+  defineAction: (entry: unknown) => entry,
+}));
+
+vi.mock("@agent-native/core/extensions/url-safety", () => ({
+  ssrfSafeFetch: ssrfSafeFetchMock,
+}));
+
+vi.mock("@agent-native/core/sharing", () => ({
+  assertAccess: assertAccessMock,
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((column, value) => ({ op: "eq", column, value })),
+}));
+
+vi.mock("../server/db/index.js", () => ({
+  getDb: getDbMock,
+  schema: {
+    assetCollections: {
+      id: "asset_collections.id",
+      libraryId: "asset_collections.library_id",
+    },
+    assetFolders: {
+      id: "asset_folders.id",
+      libraryId: "asset_folders.library_id",
+    },
+  },
+}));
+
+vi.mock("../server/lib/assets.js", () => ({
+  createAssetFromBuffer: createAssetFromBufferMock,
+}));
+
+vi.mock("./_helpers.js", () => ({
+  serializeAsset: serializeAssetMock,
+}));
+
+import action from "./import-asset-from-url.js";
+
+const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+function response(
+  body: BodyInit | null,
+  headers: Record<string, string>,
+  status = 200,
+) {
+  return new Response(body, { status, headers });
+}
+
+function createDb(rows: unknown[][]) {
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => rows.shift() ?? []),
+        })),
+      })),
+    })),
+  };
+}
+
+describe("import-asset-from-url", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    assertAccessMock.mockResolvedValue(undefined);
+    ssrfSafeFetchMock.mockResolvedValue(
+      response(pngBytes, {
+        "content-type": "image/png; charset=utf-8",
+        "content-length": String(pngBytes.byteLength),
+      }),
+    );
+    createAssetFromBufferMock.mockImplementation(async (input) => ({
+      id: "asset-1",
+      objectKey: "local:original.png",
+      thumbnailObjectKey: "local:thumb.webp",
+      createdAt: "2026-07-09T00:00:00.000Z",
+      updatedAt: "2026-07-09T00:00:00.000Z",
+      width: 1,
+      height: 1,
+      sizeBytes: input.buffer.byteLength,
+      ...input,
+      metadata: JSON.stringify(input.metadata ?? {}),
+    }));
+    getDbMock.mockReturnValue(createDb([]));
+  });
+
+  it("imports a remote PNG as a reference asset", async () => {
+    const result = await action.run({
+      libraryId: "lib-1",
+      url: "https://cdn.example.test/blog-hero.png",
+      role: "style_reference",
+      title: "Blog hero",
+      description: "Imported from the launch post.",
+    });
+
+    expect(assertAccessMock).toHaveBeenCalledWith(
+      "asset-library",
+      "lib-1",
+      "editor",
+    );
+    expect(ssrfSafeFetchMock).toHaveBeenCalledWith(
+      "https://cdn.example.test/blog-hero.png",
+      { signal: expect.any(AbortSignal) },
+      { maxRedirects: 3 },
+    );
+    expect(createAssetFromBufferMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        libraryId: "lib-1",
+        collectionId: null,
+        folderId: null,
+        mimeType: "image/png",
+        mediaType: "image",
+        role: "style_reference",
+        status: "reference",
+        title: "Blog hero",
+        description: "Imported from the launch post.",
+        sourceUrl: "https://cdn.example.test/blog-hero.png",
+        metadata: {
+          importedFrom: "https://cdn.example.test/blog-hero.png",
+        },
+      }),
+    );
+    expect(createAssetFromBufferMock.mock.calls[0][0].buffer).toEqual(pngBytes);
+    expect(result).toMatchObject({
+      id: "asset-1",
+      role: "style_reference",
+      status: "reference",
+      sourceUrl: "https://cdn.example.test/blog-hero.png",
+      thumbnailObjectKey: "local:thumb.webp",
+    });
+  });
+
+  it("rejects non-image content types", async () => {
+    ssrfSafeFetchMock.mockResolvedValue(
+      response("hello", { "content-type": "text/html" }),
+    );
+
+    await expect(
+      action.run({
+        libraryId: "lib-1",
+        url: "https://example.test/page",
+      }),
+    ).rejects.toThrow("Only PNG, JPEG, WebP, and AVIF images are supported.");
+    expect(createAssetFromBufferMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects content-type and magic-byte mismatches", async () => {
+    ssrfSafeFetchMock.mockResolvedValue(
+      response("not a png", { "content-type": "image/png" }),
+    );
+
+    await expect(
+      action.run({
+        libraryId: "lib-1",
+        url: "https://example.test/fake.png",
+      }),
+    ).rejects.toThrow("fetched bytes do not match");
+    expect(createAssetFromBufferMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects private or redirected targets through the SSRF-safe fetch guard", async () => {
+    ssrfSafeFetchMock.mockRejectedValue(new Error("SSRF blocked: private"));
+
+    await expect(
+      action.run({
+        libraryId: "lib-1",
+        url: "https://169.254.169.254/latest/meta-data",
+      }),
+    ).rejects.toThrow("Could not fetch that URL.");
+    await expect(
+      action.run({
+        libraryId: "lib-1",
+        url: "https://public.example.test/redirects-to-private",
+      }),
+    ).rejects.toThrow("Could not fetch that URL.");
+    expect(createAssetFromBufferMock).not.toHaveBeenCalled();
+  });
+
+  it("requires https URLs before fetching", async () => {
+    await expect(
+      action.run({
+        libraryId: "lib-1",
+        url: "http://example.test/logo.png",
+      }),
+    ).rejects.toThrow("Only HTTPS image URLs can be imported.");
+    expect(ssrfSafeFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("enforces the upload size cap before buffering the body", async () => {
+    ssrfSafeFetchMock.mockResolvedValue(
+      response(pngBytes, {
+        "content-type": "image/png",
+        "content-length": String(25 * 1024 * 1024 + 1),
+      }),
+    );
+
+    await expect(
+      action.run({
+        libraryId: "lib-1",
+        url: "https://example.test/large.png",
+      }),
+    ).rejects.toThrow("Image too large");
+    expect(createAssetFromBufferMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects callers without editor access", async () => {
+    assertAccessMock.mockRejectedValue(new Error("No access"));
+
+    await expect(
+      action.run({
+        libraryId: "lib-1",
+        url: "https://example.test/image.png",
+      }),
+    ).rejects.toThrow("No access");
+    expect(ssrfSafeFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("validates collection and folder membership when provided", async () => {
+    getDbMock.mockReturnValue(
+      createDb([
+        [{ id: "collection-1", libraryId: "lib-1" }],
+        [{ id: "folder-1", libraryId: "lib-1" }],
+      ]),
+    );
+
+    await action.run({
+      libraryId: "lib-1",
+      url: "https://example.test/image.png",
+      collectionId: "collection-1",
+      folderId: "folder-1",
+      role: "logo_reference",
+    });
+
+    expect(createAssetFromBufferMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collectionId: "collection-1",
+        folderId: "folder-1",
+        role: "logo_reference",
+      }),
+    );
+  });
+});

--- a/templates/assets/actions/import-asset-from-url.spec.ts
+++ b/templates/assets/actions/import-asset-from-url.spec.ts
@@ -72,7 +72,8 @@ describe("import-asset-from-url", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     assertAccessMock.mockResolvedValue(undefined);
-    ssrfSafeFetchMock.mockResolvedValue(
+    // Fresh Response per call — a Response body stream can only be read once.
+    ssrfSafeFetchMock.mockImplementation(async () =>
       response(pngBytes, {
         "content-type": "image/png; charset=utf-8",
         "content-length": String(pngBytes.byteLength),
@@ -110,7 +111,7 @@ describe("import-asset-from-url", () => {
     expect(ssrfSafeFetchMock).toHaveBeenCalledWith(
       "https://cdn.example.test/blog-hero.png",
       { signal: expect.any(AbortSignal) },
-      { maxRedirects: 3 },
+      { maxRedirects: 3, httpsOnly: true },
     );
     expect(createAssetFromBufferMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -120,6 +121,7 @@ describe("import-asset-from-url", () => {
         mimeType: "image/png",
         mediaType: "image",
         role: "style_reference",
+        category: "style-only",
         status: "reference",
         title: "Blog hero",
         description: "Imported from the launch post.",
@@ -245,7 +247,29 @@ describe("import-asset-from-url", () => {
         collectionId: "collection-1",
         folderId: "folder-1",
         role: "logo_reference",
+        category: "logo",
       }),
+    );
+  });
+
+  it("defaults the category from the role and honors explicit overrides", async () => {
+    await action.run({
+      libraryId: "lib-1",
+      url: "https://example.test/diagram.png",
+      role: "diagram_reference",
+    });
+    expect(createAssetFromBufferMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ category: "diagram" }),
+    );
+
+    await action.run({
+      libraryId: "lib-1",
+      url: "https://example.test/hero.png",
+      role: "style_reference",
+      category: "hero",
+    });
+    expect(createAssetFromBufferMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ role: "style_reference", category: "hero" }),
     );
   });
 });

--- a/templates/assets/actions/import-asset-from-url.spec.ts
+++ b/templates/assets/actions/import-asset-from-url.spec.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const assertAccessMock = vi.hoisted(() => vi.fn());
@@ -19,6 +21,7 @@ vi.mock("@agent-native/core/sharing", () => ({
 }));
 
 vi.mock("drizzle-orm", () => ({
+  and: vi.fn((...conditions) => ({ op: "and", conditions })),
   eq: vi.fn((column, value) => ({ op: "eq", column, value })),
 }));
 
@@ -33,11 +36,40 @@ vi.mock("../server/db/index.js", () => ({
       id: "asset_folders.id",
       libraryId: "asset_folders.library_id",
     },
+    assets: {
+      id: "assets.id",
+      title: "assets.title",
+      mediaType: "assets.media_type",
+      mimeType: "assets.mime_type",
+      sizeBytes: "assets.size_bytes",
+      metadata: "assets.metadata",
+      objectKey: "assets.object_key",
+      libraryId: "assets.library_id",
+      status: "assets.status",
+      role: "assets.role",
+    },
   },
 }));
 
 vi.mock("../server/lib/assets.js", () => ({
   createAssetFromBuffer: createAssetFromBufferMock,
+}));
+
+vi.mock("../server/lib/storage.js", () => ({
+  getObject: vi.fn(),
+}));
+
+// json.js pulls in @agent-native/core/server; upload-dedupe (kept real) only
+// needs parseJson from it.
+vi.mock("../server/lib/json.js", () => ({
+  parseJson: (value: string | null | undefined, fallback: unknown) => {
+    if (!value) return fallback;
+    try {
+      return JSON.parse(value);
+    } catch {
+      return fallback;
+    }
+  },
 }));
 
 vi.mock("./_helpers.js", () => ({
@@ -56,17 +88,27 @@ function response(
   return new Response(body, { status, headers });
 }
 
+// Each select() consumes the next row set, whether the query ends at
+// `.where(...)` (awaited directly) or chains `.limit(n)`.
 function createDb(rows: unknown[][]) {
   return {
     select: vi.fn(() => ({
       from: vi.fn(() => ({
-        where: vi.fn(() => ({
-          limit: vi.fn(async () => rows.shift() ?? []),
-        })),
+        where: vi.fn(() => {
+          const result = rows.shift() ?? [];
+          const query = Promise.resolve(result) as Promise<unknown[]> & {
+            limit: (n: number) => Promise<unknown[]>;
+          };
+          query.limit = vi.fn(async () => result);
+          return query;
+        }),
       })),
     })),
   };
 }
+
+const pngContentHash = () =>
+  createHash("sha256").update(pngBytes).digest("hex");
 
 describe("import-asset-from-url", () => {
   beforeEach(() => {
@@ -127,6 +169,7 @@ describe("import-asset-from-url", () => {
         description: "Imported from the launch post.",
         sourceUrl: "https://cdn.example.test/blog-hero.png",
         metadata: {
+          contentHash: pngContentHash(),
           importedFrom: "https://cdn.example.test/blog-hero.png",
         },
       }),
@@ -271,5 +314,125 @@ describe("import-asset-from-url", () => {
     expect(createAssetFromBufferMock).toHaveBeenLastCalledWith(
       expect.objectContaining({ role: "style_reference", category: "hero" }),
     );
+  });
+
+  it("returns the existing asset instead of duplicating a re-imported image", async () => {
+    const existingForDedupe = {
+      id: "asset-existing",
+      title: "Blog hero",
+      mediaType: "image",
+      mimeType: "image/png",
+      sizeBytes: pngBytes.byteLength,
+      metadata: JSON.stringify({ contentHash: pngContentHash() }),
+      objectKey: "local:original.png",
+    };
+    const existingFullRow = {
+      ...existingForDedupe,
+      role: "style_reference",
+      status: "reference",
+    };
+    getDbMock.mockReturnValue(
+      createDb([[existingForDedupe], [existingFullRow]]),
+    );
+
+    const result = await action.run({
+      libraryId: "lib-1",
+      url: "https://cdn.example.test/blog-hero.png",
+      role: "style_reference",
+    });
+
+    expect(createAssetFromBufferMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      id: "asset-existing",
+      deduplicated: true,
+    });
+  });
+
+  it("treats empty-string collection and folder ids as unassigned", async () => {
+    const db = createDb([]);
+    getDbMock.mockReturnValue(db);
+
+    await action.run({
+      libraryId: "lib-1",
+      url: "https://example.test/image.png",
+      collectionId: "",
+      folderId: "",
+    });
+
+    // Only the dedupe lookup ran — no membership validation for "" ids.
+    expect(db.select).toHaveBeenCalledTimes(1);
+    expect(createAssetFromBufferMock).toHaveBeenCalledWith(
+      expect.objectContaining({ collectionId: null, folderId: null }),
+    );
+  });
+
+  it("rejects URLs with embedded credentials before fetching", async () => {
+    await expect(
+      action.run({
+        libraryId: "lib-1",
+        url: "https://user:secret@example.test/image.png",
+      }),
+    ).rejects.toThrow("URLs with embedded credentials cannot be imported.");
+    expect(ssrfSafeFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("strips credential-bearing query strings from persisted provenance", async () => {
+    const signedUrl =
+      "https://bucket.example.test/hero.png?X-Amz-Signature=abc123&X-Amz-Expires=300";
+
+    await action.run({ libraryId: "lib-1", url: signedUrl });
+
+    // The fetch uses the full signed URL; the stored provenance does not.
+    expect(ssrfSafeFetchMock).toHaveBeenCalledWith(
+      signedUrl,
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(createAssetFromBufferMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceUrl: "https://bucket.example.test/hero.png",
+        metadata: expect.objectContaining({
+          importedFrom: "https://bucket.example.test/hero.png",
+        }),
+      }),
+    );
+  });
+
+  it("keeps innocuous query strings in provenance", async () => {
+    await action.run({
+      libraryId: "lib-1",
+      url: "https://cms.example.test/media?id=42",
+    });
+    expect(createAssetFromBufferMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceUrl: "https://cms.example.test/media?id=42",
+      }),
+    );
+  });
+
+  it("releases the response body when rejecting bad responses", async () => {
+    const badStatus = response("nope", { "content-type": "image/png" }, 404);
+    ssrfSafeFetchMock.mockResolvedValueOnce(badStatus);
+    await expect(
+      action.run({ libraryId: "lib-1", url: "https://example.test/a.png" }),
+    ).rejects.toThrow("(404)");
+    expect(badStatus.bodyUsed).toBe(true);
+
+    const badMime = response("<html>", { "content-type": "text/html" });
+    ssrfSafeFetchMock.mockResolvedValueOnce(badMime);
+    await expect(
+      action.run({ libraryId: "lib-1", url: "https://example.test/b.png" }),
+    ).rejects.toThrow("Only PNG");
+    expect(badMime.bodyUsed).toBe(true);
+
+    const oversized = response(pngBytes, {
+      "content-type": "image/png",
+      "content-length": String(25 * 1024 * 1024 + 1),
+    });
+    ssrfSafeFetchMock.mockResolvedValueOnce(oversized);
+    await expect(
+      action.run({ libraryId: "lib-1", url: "https://example.test/c.png" }),
+    ).rejects.toThrow("Image too large");
+    expect(oversized.bodyUsed).toBe(true);
   });
 });

--- a/templates/assets/actions/import-asset-from-url.ts
+++ b/templates/assets/actions/import-asset-from-url.ts
@@ -5,6 +5,8 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import { IMAGE_CATEGORIES } from "../shared/api.js";
+import type { ImageCategory } from "../shared/api.js";
 import { createAssetFromBuffer } from "../server/lib/assets.js";
 import {
   hasAllowedSignature,
@@ -24,6 +26,20 @@ const IMPORTABLE_REFERENCE_ROLES = [
 
 const FETCH_TIMEOUT_MS = 15_000;
 const MAX_REDIRECTS = 3;
+
+// Mirrors the upload route's category↔role mapping so imported references
+// appear in the same category-filtered views as uploaded equivalents.
+const DEFAULT_CATEGORY_BY_ROLE: Record<
+  (typeof IMPORTABLE_REFERENCE_ROLES)[number],
+  ImageCategory
+> = {
+  style_reference: "style-only",
+  subject_reference: "other",
+  product_reference: "product",
+  background_reference: "other",
+  logo_reference: "logo",
+  diagram_reference: "diagram",
+};
 
 function normalizedImageMimeType(contentType: string | null): string {
   return contentType?.split(";")[0]?.trim().toLowerCase() ?? "";
@@ -114,7 +130,7 @@ async function fetchImageBytes(url: string): Promise<{
     response = await ssrfSafeFetch(
       url,
       { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
-      { maxRedirects: MAX_REDIRECTS },
+      { maxRedirects: MAX_REDIRECTS, httpsOnly: true },
     );
   } catch {
     throw new Error("Could not fetch that URL.");
@@ -148,6 +164,12 @@ export default defineAction({
     libraryId: z.string(),
     url: z.string().url(),
     role: z.enum(IMPORTABLE_REFERENCE_ROLES).default("style_reference"),
+    category: z
+      .enum(IMAGE_CATEGORIES)
+      .optional()
+      .describe(
+        "Deliverable category for filtered views (e.g. hero, campaign). Defaults to the category matching the chosen role.",
+      ),
     collectionId: z.string().nullable().optional(),
     folderId: z.string().nullable().optional(),
     title: z.string().max(200).optional(),
@@ -157,6 +179,7 @@ export default defineAction({
     libraryId,
     url,
     role,
+    category,
     collectionId,
     folderId,
     title,
@@ -180,6 +203,7 @@ export default defineAction({
       mimeType,
       mediaType: "image",
       role,
+      category: category ?? DEFAULT_CATEGORY_BY_ROLE[role],
       status: "reference",
       title: title ?? null,
       description: description ?? null,

--- a/templates/assets/actions/import-asset-from-url.ts
+++ b/templates/assets/actions/import-asset-from-url.ts
@@ -1,11 +1,16 @@
 import { defineAction } from "@agent-native/core";
 import { ssrfSafeFetch } from "@agent-native/core/extensions/url-safety";
 import { assertAccess } from "@agent-native/core/sharing";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { createAssetFromBuffer } from "../server/lib/assets.js";
+import { getObject } from "../server/lib/storage.js";
+import {
+  filterDuplicateAssetUploads,
+  hashAssetBuffer,
+} from "../server/lib/upload-dedupe.js";
 import {
   hasAllowedSignature,
   IMAGE_MIME_TYPES,
@@ -84,11 +89,40 @@ function validateHttpsUrl(url: string) {
   if (parsed.protocol !== "https:") {
     throw new Error("Only HTTPS image URLs can be imported.");
   }
+  if (parsed.username || parsed.password) {
+    throw new Error("URLs with embedded credentials cannot be imported.");
+  }
+}
+
+// Query params that carry bearer credentials (S3/GCS presigning, Azure SAS,
+// generic tokens). Provenance drops the query when one is present so signed
+// URLs do not become durable asset metadata; the fetch still uses the full URL.
+const CREDENTIAL_QUERY_PARAM_RE =
+  /^(x-amz-|x-goog-)|^(sig|signature|token|access[-_]?token|auth|authorization|expires|policy|credential|apikey|api[-_]?key|key|secret|session|sv|se|sp|st|spr|sr|skoid)$/i;
+
+function sanitizeProvenanceUrl(url: string): string {
+  const parsed = new URL(url);
+  parsed.username = "";
+  parsed.password = "";
+  parsed.hash = "";
+  for (const param of parsed.searchParams.keys()) {
+    if (CREDENTIAL_QUERY_PARAM_RE.test(param)) {
+      parsed.search = "";
+      break;
+    }
+  }
+  return parsed.toString();
+}
+
+/** Release an unread response body so its connection is not held until GC. */
+async function discardResponseBody(response: Response) {
+  await response.body?.cancel().catch(() => {});
 }
 
 async function readResponseBytes(response: Response): Promise<Buffer> {
   const contentLength = response.headers.get("content-length");
   if (contentLength && Number(contentLength) > MAX_IMAGE_UPLOAD_BYTES) {
+    await discardResponseBody(response);
     throw new Error("Image too large (max 25 MB).");
   }
 
@@ -137,6 +171,7 @@ async function fetchImageBytes(url: string): Promise<{
   }
 
   if (!response.ok) {
+    await discardResponseBody(response);
     throw new Error(`Could not fetch that URL (${response.status}).`);
   }
 
@@ -144,6 +179,7 @@ async function fetchImageBytes(url: string): Promise<{
     response.headers.get("content-type"),
   );
   if (!IMAGE_MIME_TYPES.has(mimeType)) {
+    await discardResponseBody(response);
     throw new Error("Only PNG, JPEG, WebP, and AVIF images are supported.");
   }
 
@@ -155,6 +191,67 @@ async function fetchImageBytes(url: string): Promise<{
   }
 
   return { buffer, mimeType };
+}
+
+/**
+ * Same dedupe scope as the upload route: reference assets in this library
+ * with the same role. Returns the existing asset when the fetched bytes are
+ * already stored, so repeat imports are idempotent instead of duplicating
+ * the asset row and blob.
+ */
+async function findDuplicateReferenceAsset(input: {
+  libraryId: string;
+  role: (typeof IMPORTABLE_REFERENCE_ROLES)[number];
+  buffer: Buffer;
+  mimeType: string;
+  contentHash: string;
+  filename: string | null;
+}): Promise<typeof schema.assets.$inferSelect | null> {
+  const db = getDb();
+  const existingReferenceAssets = await db
+    .select({
+      id: schema.assets.id,
+      title: schema.assets.title,
+      mediaType: schema.assets.mediaType,
+      mimeType: schema.assets.mimeType,
+      sizeBytes: schema.assets.sizeBytes,
+      metadata: schema.assets.metadata,
+      objectKey: schema.assets.objectKey,
+    })
+    .from(schema.assets)
+    .where(
+      and(
+        eq(schema.assets.libraryId, input.libraryId),
+        eq(schema.assets.status, "reference"),
+        eq(schema.assets.role, input.role),
+      ),
+    );
+  const { skippedDuplicates } = await filterDuplicateAssetUploads({
+    files: [
+      {
+        altText: null,
+        buffer: input.buffer,
+        contentHash: input.contentHash,
+        filename: input.filename,
+        mediaType: "image",
+        metadata: {},
+        mimeType: input.mimeType,
+        title: "",
+      },
+    ],
+    existingAssets: existingReferenceAssets,
+    readExistingAssetBuffer: (asset) => getObject(asset.objectKey),
+  });
+  const duplicate = skippedDuplicates.find(
+    (skip) => skip.reason === "existing-asset" && skip.assetId,
+  );
+  if (!duplicate?.assetId) return null;
+  const [asset] = await db
+    .select()
+    .from(schema.assets)
+    .where(eq(schema.assets.id, duplicate.assetId))
+    .limit(1);
+  return asset ?? null;
 }
 
 export default defineAction({
@@ -175,16 +272,12 @@ export default defineAction({
     title: z.string().max(200).optional(),
     description: z.string().max(1000).optional(),
   }),
-  run: async ({
-    libraryId,
-    url,
-    role,
-    category,
-    collectionId,
-    folderId,
-    title,
-    description,
-  }) => {
+  run: async (args) => {
+    const { libraryId, url, role, category, title, description } = args;
+    // An empty-string id means "unassigned", never a real row — normalize to
+    // null so it can't skip membership validation yet still land in the row.
+    const collectionId = args.collectionId || null;
+    const folderId = args.folderId || null;
     await assertAccess("asset-library", libraryId, "editor");
     validateHttpsUrl(url);
     if (collectionId) {
@@ -195,10 +288,24 @@ export default defineAction({
     }
 
     const { buffer, mimeType } = await fetchImageBytes(url);
+    const contentHash = hashAssetBuffer(buffer);
+    const duplicate = await findDuplicateReferenceAsset({
+      libraryId,
+      role,
+      buffer,
+      mimeType,
+      contentHash,
+      filename: new URL(url).pathname.split("/").pop() || null,
+    });
+    if (duplicate) {
+      return { ...serializeAsset(duplicate), deduplicated: true };
+    }
+
+    const provenanceUrl = sanitizeProvenanceUrl(url);
     const asset = await createAssetFromBuffer({
       libraryId,
-      collectionId: collectionId ?? null,
-      folderId: folderId ?? null,
+      collectionId,
+      folderId,
       buffer,
       mimeType,
       mediaType: "image",
@@ -207,8 +314,8 @@ export default defineAction({
       status: "reference",
       title: title ?? null,
       description: description ?? null,
-      sourceUrl: url,
-      metadata: { importedFrom: url },
+      sourceUrl: provenanceUrl,
+      metadata: { contentHash, importedFrom: provenanceUrl },
     });
 
     return serializeAsset(asset);

--- a/templates/assets/actions/import-asset-from-url.ts
+++ b/templates/assets/actions/import-asset-from-url.ts
@@ -5,14 +5,14 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
-import { IMAGE_CATEGORIES } from "../shared/api.js";
-import type { ImageCategory } from "../shared/api.js";
 import { createAssetFromBuffer } from "../server/lib/assets.js";
 import {
   hasAllowedSignature,
   IMAGE_MIME_TYPES,
   MAX_IMAGE_UPLOAD_BYTES,
 } from "../server/lib/upload-validation.js";
+import { IMAGE_CATEGORIES } from "../shared/api.js";
+import type { ImageCategory } from "../shared/api.js";
 import { serializeAsset } from "./_helpers.js";
 
 const IMPORTABLE_REFERENCE_ROLES = [

--- a/templates/assets/actions/import-asset-from-url.ts
+++ b/templates/assets/actions/import-asset-from-url.ts
@@ -1,0 +1,192 @@
+import { defineAction } from "@agent-native/core";
+import { ssrfSafeFetch } from "@agent-native/core/extensions/url-safety";
+import { assertAccess } from "@agent-native/core/sharing";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { getDb, schema } from "../server/db/index.js";
+import { createAssetFromBuffer } from "../server/lib/assets.js";
+import {
+  hasAllowedSignature,
+  IMAGE_MIME_TYPES,
+  MAX_IMAGE_UPLOAD_BYTES,
+} from "../server/lib/upload-validation.js";
+import { serializeAsset } from "./_helpers.js";
+
+const IMPORTABLE_REFERENCE_ROLES = [
+  "style_reference",
+  "subject_reference",
+  "product_reference",
+  "background_reference",
+  "logo_reference",
+  "diagram_reference",
+] as const;
+
+const FETCH_TIMEOUT_MS = 15_000;
+const MAX_REDIRECTS = 3;
+
+function normalizedImageMimeType(contentType: string | null): string {
+  return contentType?.split(";")[0]?.trim().toLowerCase() ?? "";
+}
+
+async function assertCollectionBelongsToLibrary(
+  collectionId: string,
+  libraryId: string,
+) {
+  const [collection] = await getDb()
+    .select({
+      id: schema.assetCollections.id,
+      libraryId: schema.assetCollections.libraryId,
+    })
+    .from(schema.assetCollections)
+    .where(eq(schema.assetCollections.id, collectionId))
+    .limit(1);
+  if (!collection || collection.libraryId !== libraryId) {
+    throw new Error("collectionId does not belong to this library.");
+  }
+}
+
+async function assertFolderBelongsToLibrary(
+  folderId: string,
+  libraryId: string,
+) {
+  const [folder] = await getDb()
+    .select({
+      id: schema.assetFolders.id,
+      libraryId: schema.assetFolders.libraryId,
+    })
+    .from(schema.assetFolders)
+    .where(eq(schema.assetFolders.id, folderId))
+    .limit(1);
+  if (!folder || folder.libraryId !== libraryId) {
+    throw new Error("folderId does not belong to this library.");
+  }
+}
+
+function validateHttpsUrl(url: string) {
+  const parsed = new URL(url);
+  if (parsed.protocol !== "https:") {
+    throw new Error("Only HTTPS image URLs can be imported.");
+  }
+}
+
+async function readResponseBytes(response: Response): Promise<Buffer> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength && Number(contentLength) > MAX_IMAGE_UPLOAD_BYTES) {
+    throw new Error("Image too large (max 25 MB).");
+  }
+
+  const reader = response.body?.getReader?.();
+  if (!reader) {
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.byteLength > MAX_IMAGE_UPLOAD_BYTES) {
+      throw new Error("Image too large (max 25 MB).");
+    }
+    return buffer;
+  }
+
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > MAX_IMAGE_UPLOAD_BYTES) {
+      await reader.cancel().catch(() => {});
+      throw new Error("Image too large (max 25 MB).");
+    }
+    chunks.push(value);
+  }
+
+  return Buffer.concat(
+    chunks.map((chunk) => Buffer.from(chunk)),
+    total,
+  );
+}
+
+async function fetchImageBytes(url: string): Promise<{
+  buffer: Buffer;
+  mimeType: string;
+}> {
+  let response: Response;
+  try {
+    response = await ssrfSafeFetch(
+      url,
+      { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
+      { maxRedirects: MAX_REDIRECTS },
+    );
+  } catch {
+    throw new Error("Could not fetch that URL.");
+  }
+
+  if (!response.ok) {
+    throw new Error(`Could not fetch that URL (${response.status}).`);
+  }
+
+  const mimeType = normalizedImageMimeType(
+    response.headers.get("content-type"),
+  );
+  if (!IMAGE_MIME_TYPES.has(mimeType)) {
+    throw new Error("Only PNG, JPEG, WebP, and AVIF images are supported.");
+  }
+
+  const buffer = await readResponseBytes(response);
+  if (!hasAllowedSignature(mimeType, buffer)) {
+    throw new Error(
+      "The fetched bytes do not match the advertised image type.",
+    );
+  }
+
+  return { buffer, mimeType };
+}
+
+export default defineAction({
+  description:
+    "Import an external image URL into a library as a reference asset (style, subject, product, background, logo, or diagram reference). Use for ingesting brand imagery found on the web — e.g. a blog hero or logo — so it can be pinned to preset reference boards or set as the canonical logo.",
+  schema: z.object({
+    libraryId: z.string(),
+    url: z.string().url(),
+    role: z.enum(IMPORTABLE_REFERENCE_ROLES).default("style_reference"),
+    collectionId: z.string().nullable().optional(),
+    folderId: z.string().nullable().optional(),
+    title: z.string().max(200).optional(),
+    description: z.string().max(1000).optional(),
+  }),
+  run: async ({
+    libraryId,
+    url,
+    role,
+    collectionId,
+    folderId,
+    title,
+    description,
+  }) => {
+    await assertAccess("asset-library", libraryId, "editor");
+    validateHttpsUrl(url);
+    if (collectionId) {
+      await assertCollectionBelongsToLibrary(collectionId, libraryId);
+    }
+    if (folderId) {
+      await assertFolderBelongsToLibrary(folderId, libraryId);
+    }
+
+    const { buffer, mimeType } = await fetchImageBytes(url);
+    const asset = await createAssetFromBuffer({
+      libraryId,
+      collectionId: collectionId ?? null,
+      folderId: folderId ?? null,
+      buffer,
+      mimeType,
+      mediaType: "image",
+      role,
+      status: "reference",
+      title: title ?? null,
+      description: description ?? null,
+      sourceUrl: url,
+      metadata: { importedFrom: url },
+    });
+
+    return serializeAsset(asset);
+  },
+});

--- a/templates/assets/changelog/2026-07-09-import-reference-images-from-url.md
+++ b/templates/assets/changelog/2026-07-09-import-reference-images-from-url.md
@@ -1,0 +1,5 @@
+---
+type: added
+date: 2026-07-09
+---
+Import reference images into a brand kit directly from a URL - the agent can now ingest blog or web imagery as style, logo, or subject references.

--- a/templates/assets/changelog/2026-07-09-import-reference-images-from-url.md
+++ b/templates/assets/changelog/2026-07-09-import-reference-images-from-url.md
@@ -2,4 +2,5 @@
 type: added
 date: 2026-07-09
 ---
+
 Import reference images into a brand kit directly from a URL - the agent can now ingest blog or web imagery as style, logo, or subject references.

--- a/templates/assets/server/handlers/assets.ts
+++ b/templates/assets/server/handlers/assets.ts
@@ -18,16 +18,18 @@ import { IMAGE_CATEGORIES, MAX_ASSET_UPLOAD_FILES } from "../../shared/api.js";
 import type { ImageCategory, ImageRole } from "../../shared/api.js";
 import { getDb, schema } from "../db/index.js";
 import { createAssetFromBuffer, mediaTypeFromMime } from "../lib/assets.js";
-import {
-  hasRasterImageSignature,
-  hasVideoSignature,
-} from "../lib/image-processing.js";
 import { nowIso, parseJson, stringifyJson } from "../lib/json.js";
 import { getObject } from "../lib/storage.js";
 import {
   filterDuplicateAssetUploads,
   hashAssetBuffer,
 } from "../lib/upload-dedupe.js";
+import {
+  hasAllowedSignature,
+  IMAGE_MIME_TYPES,
+  maxUploadBytesForMediaType,
+  VIDEO_MIME_TYPES,
+} from "../lib/upload-validation.js";
 
 const MIME_BY_EXT: Record<string, string> = {
   png: "image/png",
@@ -40,20 +42,6 @@ const MIME_BY_EXT: Record<string, string> = {
   mov: "video/quicktime",
   webm: "video/webm",
 };
-
-const IMAGE_MIME_TYPES = new Set([
-  "image/png",
-  "image/jpeg",
-  "image/webp",
-  "image/avif",
-]);
-
-const VIDEO_MIME_TYPES = new Set([
-  "video/mp4",
-  "video/x-m4v",
-  "video/quicktime",
-  "video/webm",
-]);
 
 const UPLOAD_CONCURRENCY = 3;
 
@@ -115,13 +103,6 @@ function defaultUploadTitle(
     return mediaType === "video" ? "Content video" : "Content image";
   }
   return mediaType === "video" ? "Reference video" : "Reference image";
-}
-
-function hasAllowedSignature(mimeType: string, data: Uint8Array): boolean {
-  if (IMAGE_MIME_TYPES.has(mimeType))
-    return hasRasterImageSignature(mimeType, data);
-  if (VIDEO_MIME_TYPES.has(mimeType)) return hasVideoSignature(mimeType, data);
-  return false;
 }
 
 async function assertCollectionBelongsToLibrary(
@@ -213,8 +194,7 @@ export const uploadAssets = defineEventHandler(async (event) =>
     for (const part of files) {
       const mimeType = cleanMime(part.type, part.filename);
       const mediaType = mediaTypeFromMime(mimeType);
-      const maxBytes =
-        mediaType === "video" ? 250 * 1024 * 1024 : 25 * 1024 * 1024;
+      const maxBytes = maxUploadBytesForMediaType(mediaType);
       if (part.data.byteLength > maxBytes) {
         setResponseStatus(event, 413);
         return {

--- a/templates/assets/server/lib/upload-validation.ts
+++ b/templates/assets/server/lib/upload-validation.ts
@@ -1,0 +1,38 @@
+import type { AssetMediaType } from "../../shared/api.js";
+import {
+  hasRasterImageSignature,
+  hasVideoSignature,
+} from "./image-processing.js";
+
+export const IMAGE_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/avif",
+]);
+
+export const VIDEO_MIME_TYPES = new Set([
+  "video/mp4",
+  "video/x-m4v",
+  "video/quicktime",
+  "video/webm",
+]);
+
+export const MAX_IMAGE_UPLOAD_BYTES = 25 * 1024 * 1024;
+export const MAX_VIDEO_UPLOAD_BYTES = 250 * 1024 * 1024;
+
+export function maxUploadBytesForMediaType(mediaType: AssetMediaType): number {
+  return mediaType === "video"
+    ? MAX_VIDEO_UPLOAD_BYTES
+    : MAX_IMAGE_UPLOAD_BYTES;
+}
+
+export function hasAllowedSignature(
+  mimeType: string,
+  data: Uint8Array,
+): boolean {
+  if (IMAGE_MIME_TYPES.has(mimeType))
+    return hasRasterImageSignature(mimeType, data);
+  if (VIDEO_MIME_TYPES.has(mimeType)) return hasVideoSignature(mimeType, data);
+  return false;
+}


### PR DESCRIPTION
Adds an import-asset-from-url action to the Assets template so agents can ingest public HTTPS image URLs into a brand kit as reference assets.
Changes include:
Adds SSRF-safe URL fetching with timeout, redirect cap, HTTPS-only validation, MIME checks, magic-byte validation, and streaming size enforcement.
Reuses shared upload validation helpers between multipart uploads and URL imports.
Stores imported images through createAssetFromBuffer with status: "reference", role, sourceUrl, and provenance metadata.
Documents the blog/web-image-to-brand-kit workflow in Assets agent instructions and skills.
Adds focused tests for happy path, access checks, non-image responses, MIME/signature mismatch, private/redirect-blocked URLs, HTTPS-only enforcement, and size caps.
Adds a pending Assets changelog entry.