### PR TITLE
fix: live-edit 401s

### DIFF
--- a/.agents/plugins/agent-native-design/.codex-plugin/plugin.json
+++ b/.agents/plugins/agent-native-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-native-design",
-  "version": "1.0.0+codex.a8b2ac4c5372",
+  "version": "1.0.0+codex.e5519282396d",
   "description": "Explore, compare, iterate, and export interactive UI design prototypes from the Design app.",
   "author": { "name": "Agent-Native", "url": "https://agent-native.com" },
   "homepage": "https://design.agent-native.com",

--- a/.agents/plugins/agent-native-design/skills/visual-edit/SKILL.md
+++ b/.agents/plugins/agent-native-design/skills/visual-edit/SKILL.md
@@ -63,11 +63,11 @@ iframe-backed screens on the infinite canvas.
 The live-edit bridge is unlocked by a shared secret (the "bridge token") that
 must match on two sides: the local bridge process, and the user's connection row
 in Design (which the browser reads to authorize `/live-edit-bridge`,
-`/read-file`, `/write-file`). Get them to match by letting the **authenticated**
-`open-visual-edit` action mint the token, then starting the bridge with it. This
-is the only ordering that works for the remote-MCP flow — the bridge can't push
-its own token to the server without a CLI auth token, so the server mints
-instead and the bridge adopts.
+`/read-file`, `/write-file`). Get them to match by letting the
+**authenticated** `open-visual-edit` action mint the token, then starting the
+bridge with it. This is the only ordering that works for the remote-MCP flow —
+the bridge cannot push its own token to the server without a CLI auth token, so
+the server mints instead and the bridge adopts.
 
 From the target app repo, make sure its dev server is running, then:
 
@@ -81,20 +81,18 @@ This prints the manifest (routes + capabilities). Parse it to build
 `routeManifest` for the next step. (Skip this if the user already gave explicit
 paths/URLs to place.)
 
-**2. Call `open-visual-edit`** (see Action Flow below) with NO `bridgeToken`. The
-server mints one, stores it on the user's connection row, copies it into the
+**2. Call `open-visual-edit`** (see Action Flow below) with NO `bridgeToken`.
+The server mints one, stores it on the user's connection row, copies it into the
 placed screens' metadata, and returns it to you as `bridgeToken`. Capture it.
 
-**3. Start the persistent bridge adopting that token:**
+**3. Start the persistent bridge adopting that token** (single line; prefer the
+env var so the secret does not appear in `ps`):
 
 ```bash
-AGENT_NATIVE_BRIDGE_TOKEN="<bridgeToken from step 2>" \
-  npx @agent-native/core@latest design connect \
-  --url http://localhost:5173 --root . --daemon
+AGENT_NATIVE_BRIDGE_TOKEN="<bridgeToken from step 2>" npx @agent-native/core@latest design connect --url http://localhost:5173 --root . --daemon
 ```
 
-(Equivalently, pass `--bridge-token <token>`. Prefer the env var so the secret
-does not appear in `ps`.) This starts a detached bridge on
+(Equivalently, pass `--bridge-token <token>`.) This starts a detached bridge on
 `http://127.0.0.1:7331`, adopts the server-minted token — so bridge and row
 agree and live-edit authorizes with no self-registration — and stays alive after
 the command exits.
@@ -105,9 +103,9 @@ For a manual health/manifest check on the running bridge:
 curl http://127.0.0.1:7331/manifest.json
 ```
 
-Only use `--json` for the step-1 route probe. Never use `--json`, `--once`, or
-`--dry-run` for the durable step-3 bridge: they print the manifest and exit, so
-Design falls back to a non-editable live iframe.
+Only use `--json` for the step-1 route probe. Never use `--json`, `--once`,
+or `--dry-run` for the durable step-3 bridge: they print the manifest and exit,
+so Design falls back to a non-editable live iframe.
 
 ## Action Flow
 
@@ -120,8 +118,8 @@ a tokenized URL that may be shadowed by an existing session.
 
 Call it BEFORE starting the durable bridge (step 3 above): it does not contact
 the bridge, so the bridge need not be running yet, and you need its returned
-`bridgeToken` to start the bridge with a matching secret. Omit `bridgeToken` on
-the call so the server mints one.
+`bridgeToken` to start the bridge with a matching secret. Omit `bridgeToken`
+on the call so the server mints one.
 
 ```bash
 pnpm action open-visual-edit '{
@@ -135,10 +133,11 @@ pnpm action open-visual-edit '{
 ```
 
 The action returns `designId`, `connectionId`, `bridgeToken`, `screens`,
-`urlPath`, and `openUrl`. Keep `designId`/`connectionId` in the chat context for
-follow-ups, and pass `bridgeToken` to `design connect` (step 3) to start the
-bridge. On follow-up calls reusing an existing `connectionId`, the same token is
-returned (it is minted once and reused), so the running bridge stays valid.
+`urlPath`, and `openUrl`. Keep `designId`/`connectionId` in the chat context
+for follow-ups, and pass `bridgeToken` to `design connect` (step 3) to start
+the bridge. On follow-up calls reusing an existing `connectionId`, the same
+token is returned (it is minted once and reused), so the running bridge stays
+valid.
 
 For a numbered flow the user describes in chat, keep the labels and order:
 

--- a/.agents/plugins/agent-native-design/skills/visual-edit/SKILL.md
+++ b/.agents/plugins/agent-native-design/skills/visual-edit/SKILL.md
@@ -60,34 +60,68 @@ iframe-backed screens on the infinite canvas.
 
 ## Required Local Bridge
 
-From the target app repo, make sure its dev server is running, then run:
+The live-edit bridge is unlocked by a shared secret (the "bridge token") that
+must match on two sides: the local bridge process, and the user's connection row
+in Design (which the browser reads to authorize `/live-edit-bridge`,
+`/read-file`, `/write-file`). Get them to match by letting the **authenticated**
+`open-visual-edit` action mint the token, then starting the bridge with it. This
+is the only ordering that works for the remote-MCP flow — the bridge can't push
+its own token to the server without a CLI auth token, so the server mints
+instead and the bridge adopts.
+
+From the target app repo, make sure its dev server is running, then:
+
+**1. Discover routes without starting a durable bridge** (one-shot, exits):
 
 ```bash
-npx @agent-native/core@latest design connect --url http://localhost:5173 --root . --daemon
+npx @agent-native/core@latest design connect --url http://localhost:5173 --root . --json
 ```
 
-Use the app's real port. The command starts a detached local bridge on
-`http://127.0.0.1:7331` by default, waits for `/health`, prints the
-manifest JSON, and keeps the bridge alive after the agent command exits.
+This prints the manifest (routes + capabilities). Parse it to build
+`routeManifest` for the next step. (Skip this if the user already gave explicit
+paths/URLs to place.)
 
-For a manual health/manifest check:
+**2. Call `open-visual-edit`** (see Action Flow below) with NO `bridgeToken`. The
+server mints one, stores it on the user's connection row, copies it into the
+placed screens' metadata, and returns it to you as `bridgeToken`. Capture it.
+
+**3. Start the persistent bridge adopting that token:**
+
+```bash
+AGENT_NATIVE_BRIDGE_TOKEN="<bridgeToken from step 2>" \
+  npx @agent-native/core@latest design connect \
+  --url http://localhost:5173 --root . --daemon
+```
+
+(Equivalently, pass `--bridge-token <token>`. Prefer the env var so the secret
+does not appear in `ps`.) This starts a detached bridge on
+`http://127.0.0.1:7331`, adopts the server-minted token — so bridge and row
+agree and live-edit authorizes with no self-registration — and stays alive after
+the command exits.
+
+For a manual health/manifest check on the running bridge:
 
 ```bash
 curl http://127.0.0.1:7331/manifest.json
 ```
 
-Do not use `--json` for an editable session. `--json`, `--once`, and
-`--dry-run` print the manifest and exit, so Design will fall back to a
-non-editable live iframe as soon as it tries to refresh the snapshot.
+Only use `--json` for the step-1 route probe. Never use `--json`, `--once`, or
+`--dry-run` for the durable step-3 bridge: they print the manifest and exit, so
+Design falls back to a non-editable live iframe.
 
 ## Action Flow
 
 Prefer the single authenticated `open-visual-edit` action. It registers or
-refreshes the localhost bridge, creates or reuses a Design project, places
-URL-backed screens, stores the active visual-edit context, and navigates to
-overview mode in one call. This avoids creating a private design under a
-synthetic CLI user and then handing the browser a tokenized URL that may be
-shadowed by an existing session.
+refreshes the localhost bridge connection, mints and stores the bridge token,
+creates or reuses a Design project, places URL-backed screens, stores the active
+visual-edit context, and navigates to overview mode in one call. This avoids
+creating a private design under a synthetic CLI user and then handing the browser
+a tokenized URL that may be shadowed by an existing session.
+
+Call it BEFORE starting the durable bridge (step 3 above): it does not contact
+the bridge, so the bridge need not be running yet, and you need its returned
+`bridgeToken` to start the bridge with a matching secret. Omit `bridgeToken` on
+the call so the server mints one.
 
 ```bash
 pnpm action open-visual-edit '{
@@ -100,8 +134,11 @@ pnpm action open-visual-edit '{
 }'
 ```
 
-The action returns `designId`, `connectionId`, `screens`, `urlPath`, and
-`openUrl`. Keep those IDs in the chat context for follow-ups.
+The action returns `designId`, `connectionId`, `bridgeToken`, `screens`,
+`urlPath`, and `openUrl`. Keep `designId`/`connectionId` in the chat context for
+follow-ups, and pass `bridgeToken` to `design connect` (step 3) to start the
+bridge. On follow-up calls reusing an existing `connectionId`, the same token is
+returned (it is minted once and reused), so the running bridge stays valid.
 
 For a numbered flow the user describes in chat, keep the labels and order:
 

--- a/.changeset/visual-edit-bridge-token.md
+++ b/.changeset/visual-edit-bridge-token.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix `/visual-edit` live-edit 401s. The design server now mints the bridge token in `connect-localhost` and returns it from `open-visual-edit`, and `design connect` adopts it via a new `--bridge-token` flag (or `AGENT_NATIVE_BRIDGE_TOKEN`) instead of minting its own. The local bridge and the user's connection row now share the secret without the CLI needing its own auth to self-register — which was impossible under OAuth-based MCP and was the root cause of the 401s. The `visual-edit` skill is updated to call `open-visual-edit` first and start the bridge with the returned token.

--- a/packages/core/src/cli/design-connect.ts
+++ b/packages/core/src/cli/design-connect.ts
@@ -60,6 +60,10 @@ export interface DesignConnectArgs {
    *  are present) the CLI POSTs to `/_agent-native/actions/connect-localhost`
    *  with the real bridge token so the server can store it for grant minting. */
   appUrl?: string;
+  /** Server-minted bridge token to adopt instead of minting one, so the bridge
+   *  matches the token already stored on the user's connection row (no
+   *  self-registration). Also read from AGENT_NATIVE_BRIDGE_TOKEN. */
+  bridgeToken?: string;
   json: boolean;
   once: boolean;
   dryRun: boolean;
@@ -174,6 +178,11 @@ export function parseDesignConnectArgs(argv: string[]): DesignConnectArgs {
       index += 1;
     } else if (arg.startsWith("--app-url=")) {
       parsed.appUrl = arg.slice("--app-url=".length);
+    } else if (arg === "--bridge-token") {
+      parsed.bridgeToken = stringFlagValue(args, index, arg);
+      index += 1;
+    } else if (arg.startsWith("--bridge-token=")) {
+      parsed.bridgeToken = arg.slice("--bridge-token=".length);
     } else if (arg === "--json") {
       parsed.json = true;
       parsed.once = true;
@@ -1215,12 +1224,16 @@ async function walkBridgeFiles(rootPath: string): Promise<ListFilesResult> {
 
 export async function startDesignConnectBridge(
   manifest: DesignConnectManifest,
+  seedToken?: string,
 ): Promise<DesignConnectBridge> {
-  // Mint a cryptographically random per-rootPath bridge token.  This token is
-  // kept in-process only and is never emitted via the public GET routes so that
-  // an unauthenticated caller cannot read it.  The server-side grant action
-  // obtains it out-of-band (via the exported bridge reference).
-  const bridgeToken = crypto.randomBytes(32).toString("hex");
+  // Shared secret the browser sends (x-bridge-token) to unlock live-edit/read/
+  // write. Bridge and the user's connection row must agree on it. Adopt a
+  // server-minted seed when given (MCP flow); otherwise mint one and rely on
+  // --app-url self-registration to push it up. Kept in-process, never served.
+  const bridgeToken =
+    seedToken ||
+    process.env["AGENT_NATIVE_BRIDGE_TOKEN"] ||
+    crypto.randomBytes(32).toString("hex");
   let liveEditBridgeScript = "";
 
   const server = http.createServer(
@@ -1795,6 +1808,12 @@ Options:
   --route-manifest <path> Non-destructive route manifest output path
   --app-url <url>         Deployed design app URL for self-registration
                           (also reads AGENT_NATIVE_URL / DESIGN_APP_URL env)
+  --bridge-token <token>  Adopt a bridge token minted server-side by the
+                          authenticated connect-localhost / open-visual-edit
+                          action instead of minting one. Used by the remote-MCP
+                          /visual-edit flow so the bridge and the user's stored
+                          connection token match with no self-registration.
+                          (also reads AGENT_NATIVE_BRIDGE_TOKEN env)
   --daemon                Start the bridge detached, wait for /health, then exit
   --json                  Print the manifest JSON and exit
   --once                  Prepare/scaffold the manifest and exit
@@ -1931,25 +1950,33 @@ export async function runDesign(argv: string[]) {
     return 0;
   }
 
-  const bridge = await startDesignConnectBridge(manifest);
+  const seedToken =
+    parsed.bridgeToken || process.env["AGENT_NATIVE_BRIDGE_TOKEN"] || undefined;
+  const bridge = await startDesignConnectBridge(manifest, seedToken);
   console.error("Design localhost bridge running");
   console.error(`Bridge:   ${manifest.bridgeUrl}`);
   console.error(`Manifest: ${manifest.bridgeUrl}/manifest.json`);
   console.error(`Routes:   ${manifest.routeCount}`);
   console.error(`Dev URL:  ${manifest.devServerUrl}`);
 
-  // Self-register with the design app server (best-effort): POST the bridge
-  // token to connect-localhost so the server row stores the real token. Without
-  // it, the bridge and server tokens diverge and every write returns 401.
-  const appUrl = resolveAppUrl(parsed.appUrl);
-  if (appUrl) {
-    void registerConnectionWithServer(appUrl, bridge, resolveAuthToken());
-  } else {
-    // No app URL means the token never reaches the DB — surface it instead of
-    // silently skipping, since live-edit will then 401.
+  if (seedToken) {
+    // Server already stored this token on the row; bridge matches it, so no
+    // self-registration needed. Zero-config path for the remote-MCP flow.
     console.error(
-      "[design connect] No app URL resolved (pass --app-url or set AGENT_NATIVE_URL); skipping self-registration — live-edit will fail to authorize.",
+      "[design connect] Using server-provided bridge token; skipping self-registration.",
     );
+  } else {
+    // No seed: fall back to self-registration — POST the minted token to
+    // connect-localhost. Needs an auth token in env or it 401s (the old gap).
+    const appUrl = resolveAppUrl(parsed.appUrl);
+    if (appUrl) {
+      void registerConnectionWithServer(appUrl, bridge, resolveAuthToken());
+    } else {
+      // No token source at all — warn rather than 401 silently at edit time.
+      console.error(
+        "[design connect] No bridge token or app URL resolved (pass --bridge-token, or --app-url / AGENT_NATIVE_URL); skipping self-registration — live-edit will fail to authorize.",
+      );
+    }
   }
 
   return await new Promise<number>((resolve) => {

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -486,34 +486,66 @@ iframe-backed screens on the infinite canvas.
 
 ## Required Local Bridge
 
-From the target app repo, make sure its dev server is running, then run:
+The live-edit bridge is unlocked by a shared secret (the "bridge token") that
+must match on two sides: the local bridge process, and the user's connection row
+in Design (which the browser reads to authorize \`/live-edit-bridge\`,
+\`/read-file\`, \`/write-file\`). Get them to match by letting the
+**authenticated** \`open-visual-edit\` action mint the token, then starting the
+bridge with it. This is the only ordering that works for the remote-MCP flow —
+the bridge cannot push its own token to the server without a CLI auth token, so
+the server mints instead and the bridge adopts.
+
+From the target app repo, make sure its dev server is running, then:
+
+**1. Discover routes without starting a durable bridge** (one-shot, exits):
 
 \`\`\`bash
-npx @agent-native/core@latest design connect --url http://localhost:5173 --root . --daemon
+npx @agent-native/core@latest design connect --url http://localhost:5173 --root . --json
 \`\`\`
 
-Use the app's real port. The command starts a detached local bridge on
-\`http://127.0.0.1:7331\` by default, waits for \`/health\`, prints the
-manifest JSON, and keeps the bridge alive after the agent command exits.
+This prints the manifest (routes + capabilities). Parse it to build
+\`routeManifest\` for the next step. (Skip this if the user already gave explicit
+paths/URLs to place.)
 
-For a manual health/manifest check:
+**2. Call \`open-visual-edit\`** (see Action Flow below) with NO \`bridgeToken\`.
+The server mints one, stores it on the user's connection row, copies it into the
+placed screens' metadata, and returns it to you as \`bridgeToken\`. Capture it.
+
+**3. Start the persistent bridge adopting that token** (single line; prefer the
+env var so the secret does not appear in \`ps\`):
+
+\`\`\`bash
+AGENT_NATIVE_BRIDGE_TOKEN="<bridgeToken from step 2>" npx @agent-native/core@latest design connect --url http://localhost:5173 --root . --daemon
+\`\`\`
+
+(Equivalently, pass \`--bridge-token <token>\`.) This starts a detached bridge on
+\`http://127.0.0.1:7331\`, adopts the server-minted token — so bridge and row
+agree and live-edit authorizes with no self-registration — and stays alive after
+the command exits.
+
+For a manual health/manifest check on the running bridge:
 
 \`\`\`bash
 curl http://127.0.0.1:7331/manifest.json
 \`\`\`
 
-Do not use \`--json\` for an editable session. \`--json\`, \`--once\`, and
-\`--dry-run\` print the manifest and exit, so Design will fall back to a
-non-editable live iframe as soon as it tries to refresh the snapshot.
+Only use \`--json\` for the step-1 route probe. Never use \`--json\`, \`--once\`,
+or \`--dry-run\` for the durable step-3 bridge: they print the manifest and exit,
+so Design falls back to a non-editable live iframe.
 
 ## Action Flow
 
 Prefer the single authenticated \`open-visual-edit\` action. It registers or
-refreshes the localhost bridge, creates or reuses a Design project, places
-URL-backed screens, stores the active visual-edit context, and navigates to
-overview mode in one call. This avoids creating a private design under a
-synthetic CLI user and then handing the browser a tokenized URL that may be
-shadowed by an existing session.
+refreshes the localhost bridge connection, mints and stores the bridge token,
+creates or reuses a Design project, places URL-backed screens, stores the active
+visual-edit context, and navigates to overview mode in one call. This avoids
+creating a private design under a synthetic CLI user and then handing the browser
+a tokenized URL that may be shadowed by an existing session.
+
+Call it BEFORE starting the durable bridge (step 3 above): it does not contact
+the bridge, so the bridge need not be running yet, and you need its returned
+\`bridgeToken\` to start the bridge with a matching secret. Omit \`bridgeToken\`
+on the call so the server mints one.
 
 \`\`\`bash
 pnpm action open-visual-edit '{
@@ -526,8 +558,12 @@ pnpm action open-visual-edit '{
 }'
 \`\`\`
 
-The action returns \`designId\`, \`connectionId\`, \`screens\`, \`urlPath\`, and
-\`openUrl\`. Keep those IDs in the chat context for follow-ups.
+The action returns \`designId\`, \`connectionId\`, \`bridgeToken\`, \`screens\`,
+\`urlPath\`, and \`openUrl\`. Keep \`designId\`/\`connectionId\` in the chat context
+for follow-ups, and pass \`bridgeToken\` to \`design connect\` (step 3) to start
+the bridge. On follow-up calls reusing an existing \`connectionId\`, the same
+token is returned (it is minted once and reused), so the running bridge stays
+valid.
 
 For a numbered flow the user describes in chat, keep the labels and order:
 

--- a/skills/visual-edit/SKILL.md
+++ b/skills/visual-edit/SKILL.md
@@ -63,11 +63,11 @@ iframe-backed screens on the infinite canvas.
 The live-edit bridge is unlocked by a shared secret (the "bridge token") that
 must match on two sides: the local bridge process, and the user's connection row
 in Design (which the browser reads to authorize `/live-edit-bridge`,
-`/read-file`, `/write-file`). Get them to match by letting the **authenticated**
-`open-visual-edit` action mint the token, then starting the bridge with it. This
-is the only ordering that works for the remote-MCP flow — the bridge can't push
-its own token to the server without a CLI auth token, so the server mints
-instead and the bridge adopts.
+`/read-file`, `/write-file`). Get them to match by letting the
+**authenticated** `open-visual-edit` action mint the token, then starting the
+bridge with it. This is the only ordering that works for the remote-MCP flow —
+the bridge cannot push its own token to the server without a CLI auth token, so
+the server mints instead and the bridge adopts.
 
 From the target app repo, make sure its dev server is running, then:
 
@@ -81,20 +81,18 @@ This prints the manifest (routes + capabilities). Parse it to build
 `routeManifest` for the next step. (Skip this if the user already gave explicit
 paths/URLs to place.)
 
-**2. Call `open-visual-edit`** (see Action Flow below) with NO `bridgeToken`. The
-server mints one, stores it on the user's connection row, copies it into the
+**2. Call `open-visual-edit`** (see Action Flow below) with NO `bridgeToken`.
+The server mints one, stores it on the user's connection row, copies it into the
 placed screens' metadata, and returns it to you as `bridgeToken`. Capture it.
 
-**3. Start the persistent bridge adopting that token:**
+**3. Start the persistent bridge adopting that token** (single line; prefer the
+env var so the secret does not appear in `ps`):
 
 ```bash
-AGENT_NATIVE_BRIDGE_TOKEN="<bridgeToken from step 2>" \
-  npx @agent-native/core@latest design connect \
-  --url http://localhost:5173 --root . --daemon
+AGENT_NATIVE_BRIDGE_TOKEN="<bridgeToken from step 2>" npx @agent-native/core@latest design connect --url http://localhost:5173 --root . --daemon
 ```
 
-(Equivalently, pass `--bridge-token <token>`. Prefer the env var so the secret
-does not appear in `ps`.) This starts a detached bridge on
+(Equivalently, pass `--bridge-token <token>`.) This starts a detached bridge on
 `http://127.0.0.1:7331`, adopts the server-minted token — so bridge and row
 agree and live-edit authorizes with no self-registration — and stays alive after
 the command exits.
@@ -105,9 +103,9 @@ For a manual health/manifest check on the running bridge:
 curl http://127.0.0.1:7331/manifest.json
 ```
 
-Only use `--json` for the step-1 route probe. Never use `--json`, `--once`, or
-`--dry-run` for the durable step-3 bridge: they print the manifest and exit, so
-Design falls back to a non-editable live iframe.
+Only use `--json` for the step-1 route probe. Never use `--json`, `--once`,
+or `--dry-run` for the durable step-3 bridge: they print the manifest and exit,
+so Design falls back to a non-editable live iframe.
 
 ## Action Flow
 
@@ -120,8 +118,8 @@ a tokenized URL that may be shadowed by an existing session.
 
 Call it BEFORE starting the durable bridge (step 3 above): it does not contact
 the bridge, so the bridge need not be running yet, and you need its returned
-`bridgeToken` to start the bridge with a matching secret. Omit `bridgeToken` on
-the call so the server mints one.
+`bridgeToken` to start the bridge with a matching secret. Omit `bridgeToken`
+on the call so the server mints one.
 
 ```bash
 pnpm action open-visual-edit '{
@@ -135,10 +133,11 @@ pnpm action open-visual-edit '{
 ```
 
 The action returns `designId`, `connectionId`, `bridgeToken`, `screens`,
-`urlPath`, and `openUrl`. Keep `designId`/`connectionId` in the chat context for
-follow-ups, and pass `bridgeToken` to `design connect` (step 3) to start the
-bridge. On follow-up calls reusing an existing `connectionId`, the same token is
-returned (it is minted once and reused), so the running bridge stays valid.
+`urlPath`, and `openUrl`. Keep `designId`/`connectionId` in the chat context
+for follow-ups, and pass `bridgeToken` to `design connect` (step 3) to start
+the bridge. On follow-up calls reusing an existing `connectionId`, the same
+token is returned (it is minted once and reused), so the running bridge stays
+valid.
 
 For a numbered flow the user describes in chat, keep the labels and order:
 

--- a/skills/visual-edit/SKILL.md
+++ b/skills/visual-edit/SKILL.md
@@ -60,34 +60,68 @@ iframe-backed screens on the infinite canvas.
 
 ## Required Local Bridge
 
-From the target app repo, make sure its dev server is running, then run:
+The live-edit bridge is unlocked by a shared secret (the "bridge token") that
+must match on two sides: the local bridge process, and the user's connection row
+in Design (which the browser reads to authorize `/live-edit-bridge`,
+`/read-file`, `/write-file`). Get them to match by letting the **authenticated**
+`open-visual-edit` action mint the token, then starting the bridge with it. This
+is the only ordering that works for the remote-MCP flow — the bridge can't push
+its own token to the server without a CLI auth token, so the server mints
+instead and the bridge adopts.
+
+From the target app repo, make sure its dev server is running, then:
+
+**1. Discover routes without starting a durable bridge** (one-shot, exits):
 
 ```bash
-npx @agent-native/core@latest design connect --url http://localhost:5173 --root . --daemon
+npx @agent-native/core@latest design connect --url http://localhost:5173 --root . --json
 ```
 
-Use the app's real port. The command starts a detached local bridge on
-`http://127.0.0.1:7331` by default, waits for `/health`, prints the
-manifest JSON, and keeps the bridge alive after the agent command exits.
+This prints the manifest (routes + capabilities). Parse it to build
+`routeManifest` for the next step. (Skip this if the user already gave explicit
+paths/URLs to place.)
 
-For a manual health/manifest check:
+**2. Call `open-visual-edit`** (see Action Flow below) with NO `bridgeToken`. The
+server mints one, stores it on the user's connection row, copies it into the
+placed screens' metadata, and returns it to you as `bridgeToken`. Capture it.
+
+**3. Start the persistent bridge adopting that token:**
+
+```bash
+AGENT_NATIVE_BRIDGE_TOKEN="<bridgeToken from step 2>" \
+  npx @agent-native/core@latest design connect \
+  --url http://localhost:5173 --root . --daemon
+```
+
+(Equivalently, pass `--bridge-token <token>`. Prefer the env var so the secret
+does not appear in `ps`.) This starts a detached bridge on
+`http://127.0.0.1:7331`, adopts the server-minted token — so bridge and row
+agree and live-edit authorizes with no self-registration — and stays alive after
+the command exits.
+
+For a manual health/manifest check on the running bridge:
 
 ```bash
 curl http://127.0.0.1:7331/manifest.json
 ```
 
-Do not use `--json` for an editable session. `--json`, `--once`, and
-`--dry-run` print the manifest and exit, so Design will fall back to a
-non-editable live iframe as soon as it tries to refresh the snapshot.
+Only use `--json` for the step-1 route probe. Never use `--json`, `--once`, or
+`--dry-run` for the durable step-3 bridge: they print the manifest and exit, so
+Design falls back to a non-editable live iframe.
 
 ## Action Flow
 
 Prefer the single authenticated `open-visual-edit` action. It registers or
-refreshes the localhost bridge, creates or reuses a Design project, places
-URL-backed screens, stores the active visual-edit context, and navigates to
-overview mode in one call. This avoids creating a private design under a
-synthetic CLI user and then handing the browser a tokenized URL that may be
-shadowed by an existing session.
+refreshes the localhost bridge connection, mints and stores the bridge token,
+creates or reuses a Design project, places URL-backed screens, stores the active
+visual-edit context, and navigates to overview mode in one call. This avoids
+creating a private design under a synthetic CLI user and then handing the browser
+a tokenized URL that may be shadowed by an existing session.
+
+Call it BEFORE starting the durable bridge (step 3 above): it does not contact
+the bridge, so the bridge need not be running yet, and you need its returned
+`bridgeToken` to start the bridge with a matching secret. Omit `bridgeToken` on
+the call so the server mints one.
 
 ```bash
 pnpm action open-visual-edit '{
@@ -100,8 +134,11 @@ pnpm action open-visual-edit '{
 }'
 ```
 
-The action returns `designId`, `connectionId`, `screens`, `urlPath`, and
-`openUrl`. Keep those IDs in the chat context for follow-ups.
+The action returns `designId`, `connectionId`, `bridgeToken`, `screens`,
+`urlPath`, and `openUrl`. Keep `designId`/`connectionId` in the chat context for
+follow-ups, and pass `bridgeToken` to `design connect` (step 3) to start the
+bridge. On follow-up calls reusing an existing `connectionId`, the same token is
+returned (it is minted once and reused), so the running bridge stays valid.
 
 For a numbered flow the user describes in chat, keep the labels and order:
 

--- a/templates/design/.agents/skills/visual-edit/SKILL.md
+++ b/templates/design/.agents/skills/visual-edit/SKILL.md
@@ -60,31 +60,43 @@ iframe-backed screens on the infinite canvas.
 
 ## Required Local Bridge
 
-From the target app repo, make sure its dev server is running, then run the
-Design bridge with `npx`:
+The live-edit bridge is unlocked by a shared secret (the "bridge token") that
+must match on two sides: the local bridge process and the user's connection row
+(which the browser reads to authorize `/live-edit-bridge`, `/read-file`,
+`/write-file`). Let the authenticated `connect-localhost` / `open-visual-edit`
+action mint the token, then start the bridge adopting it — the bridge cannot
+push its own token to the server without a CLI auth token, so the server mints.
+
+From the target app repo, make sure its dev server is running, then:
+
+**1. Discover routes without a durable bridge** (one-shot, exits):
 
 ```bash
-npx @agent-native/core@latest design connect --url http://localhost:5173 --root .
+npx @agent-native/core@latest design connect --url http://localhost:5173 --root . --json
 ```
 
-Use the app's real port. The command starts a local bridge on
-`http://127.0.0.1:7331` by default and exposes:
+Prints the manifest (routes + capabilities). Use it to build `routeManifest` for
+the action call. Skip if the user already gave explicit paths/URLs.
 
-- `GET /manifest.json` — dev server URL, bridge URL, discovered routes, root.
-- `GET /routes.json` — route manifest only.
-- `GET /health` — bridge liveness.
+**2. Register the connection** via `connect-localhost` / `open-visual-edit`
+(Action Flow below) with NO `bridgeToken`. The server mints one, stores it on the
+connection row, and returns it as `bridgeToken`. Capture it.
 
-For one-shot agent setup, ask for JSON and keep the long-running bridge open in
-a second terminal if the user needs live updates:
+**3. Start the persistent bridge adopting that token:**
 
 ```bash
-npx @agent-native/core@latest design connect --url http://localhost:5173 --root .
-curl http://127.0.0.1:7331/manifest.json
+AGENT_NATIVE_BRIDGE_TOKEN="<bridgeToken from step 2>" \
+  npx @agent-native/core@latest design connect \
+  --url http://localhost:5173 --root . --daemon
 ```
 
-Do not use `--json` for an editable session. `--json`, `--once`, and
-`--dry-run` print the manifest and exit, so Design will fall back to a
-non-editable live iframe as soon as it tries to refresh the snapshot.
+(Or pass `--bridge-token <token>`; prefer the env var to keep the secret out of
+`ps`.) The bridge exposes `GET /manifest.json`, `GET /routes.json`,
+`GET /health`, and now authorizes live-edit because its token matches the row.
+
+Only use `--json` for the step-1 route probe. Never use `--json`, `--once`, or
+`--dry-run` for the durable step-3 bridge: they print the manifest and exit, so
+Design falls back to a non-editable live iframe.
 
 ## Action Flow
 

--- a/templates/design/actions/connect-localhost.spec.ts
+++ b/templates/design/actions/connect-localhost.spec.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 
+import { SQL } from "drizzle-orm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const requestContextMock = vi.hoisted(() => ({
@@ -17,6 +18,11 @@ type ExistingConnection = {
 };
 
 let existingConnection: ExistingConnection | null = null;
+// Row the post-upsert reread sees (the value actually persisted). `undefined`
+// mirrors `existingConnection`; set it explicitly to model a race winner or a
+// cross-user no-op where the owner-scoped reread finds nothing.
+let rereadRow: { bridgeToken: string | null } | null | undefined = undefined;
+let selectCallCount = 0;
 let insertedValues: Record<string, unknown> | null = null;
 let upsertConfig: {
   target: unknown;
@@ -36,8 +42,14 @@ function makeSelectChain(rows: unknown[]) {
 
 vi.mock("../server/db/index.js", () => ({
   getDb: () => ({
-    select: () =>
-      makeSelectChain(existingConnection ? [existingConnection] : []),
+    select: () => {
+      // 1st select = ownership pre-check; 2nd = post-upsert reread.
+      selectCallCount += 1;
+      if (selectCallCount >= 2 && rereadRow !== undefined) {
+        return makeSelectChain(rereadRow ? [rereadRow] : []);
+      }
+      return makeSelectChain(existingConnection ? [existingConnection] : []);
+    },
     insert: () => ({
       values: (vals: Record<string, unknown>) => {
         insertedValues = vals;
@@ -68,6 +80,8 @@ import action from "./connect-localhost.js";
 beforeEach(() => {
   requestContextMock.orgId = "org_1";
   existingConnection = null;
+  rereadRow = undefined;
+  selectCallCount = 0;
   insertedValues = null;
   upsertConfig = null;
 });
@@ -118,15 +132,19 @@ describe("connect-localhost", () => {
       bridgeToken: "existing_bridge_token",
     };
 
-    await action.run({
+    const result = await action.run({
       id: "conn_1",
       devServerUrl: "http://localhost:5173",
       bridgeUrl: "http://127.0.0.1:7666",
       rootPath: "/tmp/app",
     });
 
+    // Insert reuses the existing token; the conflict set uses a coalesce()
+    // expression that fills a null token but never clobbers an existing one.
     expect(insertedValues?.bridgeToken).toBe("existing_bridge_token");
-    expect(upsertConfig?.set.bridgeToken).toBe("existing_bridge_token");
+    expect(upsertConfig?.set.bridgeToken).toBeInstanceOf(SQL);
+    // The action returns the token the row actually holds (read back).
+    expect(result.bridgeToken).toBe("existing_bridge_token");
   });
 
   it("stores a new bridge token when the bridge provides one", async () => {
@@ -134,8 +152,9 @@ describe("connect-localhost", () => {
       ownerEmail: "user@example.com",
       bridgeToken: "old_bridge_token",
     };
+    rereadRow = { bridgeToken: "new_bridge_token" }; // DB state after overwrite
 
-    await action.run({
+    const result = await action.run({
       id: "conn_1",
       devServerUrl: "http://localhost:5173",
       bridgeUrl: "http://127.0.0.1:7666",
@@ -143,8 +162,61 @@ describe("connect-localhost", () => {
       bridgeToken: " new_bridge_token ",
     });
 
+    // An explicit token overwrites unconditionally (literal, not coalesce).
     expect(insertedValues?.bridgeToken).toBe("new_bridge_token");
     expect(upsertConfig?.set.bridgeToken).toBe("new_bridge_token");
+    expect(result.bridgeToken).toBe("new_bridge_token");
+  });
+
+  it("mints and persists a token when the existing row has none (legacy null)", async () => {
+    existingConnection = { ownerEmail: "user@example.com", bridgeToken: null };
+
+    const result = await action.run({
+      id: "conn_1",
+      devServerUrl: "http://localhost:5173",
+      rootPath: "/tmp/app",
+    });
+
+    // A fresh 64-hex token is minted and carried on the insert, and the conflict
+    // set coalesces so a null legacy row gets filled instead of staying tokenless.
+    expect(insertedValues?.bridgeToken).toMatch(/^[0-9a-f]{64}$/);
+    expect(upsertConfig?.set.bridgeToken).toBeInstanceOf(SQL);
+    // The caller always receives a usable token (never null/undefined).
+    expect(result.bridgeToken).toBe(insertedValues?.bridgeToken);
+  });
+
+  it("returns the token the row actually holds, not the one this call minted", async () => {
+    // Two concurrent first-time callers each mint; by read-back time another
+    // call's token is what persisted. We must return the persisted winner.
+    existingConnection = null;
+    rereadRow = { bridgeToken: "winner_token" };
+
+    const result = await action.run({
+      id: "conn_race",
+      devServerUrl: "http://localhost:5173",
+      rootPath: "/tmp/app",
+    });
+
+    expect(insertedValues?.bridgeToken).toMatch(/^[0-9a-f]{64}$/);
+    expect(selectCallCount).toBe(2); // pre-check + post-upsert reread
+    expect(result.bridgeToken).toBe("winner_token");
+  });
+
+  it("never returns another user's token when the guarded upsert is a no-op", async () => {
+    // Pre-check passes (no row yet), but the owner-scoped reread finds nothing —
+    // a concurrent insert by another user made our upsert a no-op.
+    existingConnection = null;
+    rereadRow = null;
+
+    const result = await action.run({
+      id: "conn_1",
+      devServerUrl: "http://localhost:5173",
+      rootPath: "/tmp/app",
+      bridgeToken: "our_token",
+    });
+
+    // Fall back to our own token — never a foreign one from the colliding row.
+    expect(result.bridgeToken).toBe("our_token");
   });
 
   it("writes through a single upsert guarded by ownerEmail (no check-then-insert race)", async () => {

--- a/templates/design/actions/connect-localhost.ts
+++ b/templates/design/actions/connect-localhost.ts
@@ -5,7 +5,7 @@ import {
   getRequestOrgId,
   getRequestUserEmail,
 } from "@agent-native/core/server/request-context";
-import { eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
@@ -225,27 +225,37 @@ export default defineAction({
       updatedAt: now,
     };
 
-    // Write-once token: on conflict only overwrite it for an explicit token;
-    // a server-minted one leaves any existing token alone, so concurrent
-    // first-time callers cannot clobber each other (read->mint->write isn't
-    // atomic). setWhere keeps a cross-user conflict a no-op.
+    // On conflict, an explicit token overwrites; a server-minted one uses
+    // coalesce(existing, minted) evaluated at write time — it fills a null token
+    // but never clobbers one, so concurrent first-time callers converge on the
+    // first writer (read->mint->write isn't atomic). setWhere keeps a cross-user
+    // conflict a no-op.
     await db
       .insert(schema.designLocalhostConnections)
       .values({ ...baseValues, bridgeToken: nextBridgeToken, createdAt: now })
       .onConflictDoUpdate({
         target: schema.designLocalhostConnections.id,
-        set: explicitToken
-          ? { ...baseValues, bridgeToken: nextBridgeToken }
-          : baseValues,
+        set: {
+          ...baseValues,
+          bridgeToken: explicitToken
+            ? nextBridgeToken
+            : sql`coalesce(${schema.designLocalhostConnections.bridgeToken}, excluded.bridge_token)`,
+        },
         setWhere: eq(schema.designLocalhostConnections.ownerEmail, ownerEmail),
       });
 
-    // Return the token the row actually holds, not the one we minted, so
+    // Return the token the row actually holds (owner-scoped, so a cross-user
+    // no-op never leaks another user's token), not the one we minted — so
     // concurrent callers converge on the winner (no 401 on a lost race).
     const [stored] = await db
       .select({ bridgeToken: schema.designLocalhostConnections.bridgeToken })
       .from(schema.designLocalhostConnections)
-      .where(eq(schema.designLocalhostConnections.id, id))
+      .where(
+        and(
+          eq(schema.designLocalhostConnections.id, id),
+          eq(schema.designLocalhostConnections.ownerEmail, ownerEmail),
+        ),
+      )
       .limit(1);
     const effectiveBridgeToken = stored?.bridgeToken ?? nextBridgeToken;
 

--- a/templates/design/actions/connect-localhost.ts
+++ b/templates/design/actions/connect-localhost.ts
@@ -202,15 +202,14 @@ export default defineAction({
       );
     }
 
-    // Bridge token: caller-provided, else existing (idempotent refresh), else
-    // mint. Minting here — the authenticated action — lets the server own the
-    // secret and return it (below), so the CLI no longer needs its own auth to
-    // self-register the token. That auth gap was the root cause of live-edit 401s.
+    // Token for a new row: explicit, else existing, else mint. The authenticated
+    // action owning the mint is what lets the CLI skip its own auth (the 401 gap).
+    const explicitToken = args.bridgeToken?.trim() || undefined;
     const nextBridgeToken =
-      args.bridgeToken?.trim() ||
+      explicitToken ||
       existing[0]?.bridgeToken ||
       crypto.randomBytes(32).toString("hex");
-    const values = {
+    const baseValues = {
       id,
       name: args.name ?? new URL(devServerUrl).host,
       sourceType: "localhost" as const,
@@ -219,7 +218,6 @@ export default defineAction({
       rootPath: routeManifest.rootPath ?? null,
       routeManifest: JSON.stringify(routeManifest),
       capabilities: JSON.stringify(capabilities),
-      bridgeToken: nextBridgeToken,
       status: args.status,
       lastSeenAt: now,
       ownerEmail,
@@ -227,23 +225,34 @@ export default defineAction({
       updatedAt: now,
     };
 
-    // Atomic upsert keyed on the id primary key — no check-then-insert race.
-    // setWhere keeps a concurrent insert by another user (TOCTOU on the
-    // ownership check above) from being overwritten: on a cross-user conflict
-    // the update filters to a no-op instead of hijacking the other row.
+    // Write-once token: on conflict only overwrite it for an explicit token;
+    // a server-minted one leaves any existing token alone, so concurrent
+    // first-time callers cannot clobber each other (read->mint->write isn't
+    // atomic). setWhere keeps a cross-user conflict a no-op.
     await db
       .insert(schema.designLocalhostConnections)
-      .values({ ...values, createdAt: now })
+      .values({ ...baseValues, bridgeToken: nextBridgeToken, createdAt: now })
       .onConflictDoUpdate({
         target: schema.designLocalhostConnections.id,
-        set: values,
+        set: explicitToken
+          ? { ...baseValues, bridgeToken: nextBridgeToken }
+          : baseValues,
         setWhere: eq(schema.designLocalhostConnections.ownerEmail, ownerEmail),
       });
+
+    // Return the token the row actually holds, not the one we minted, so
+    // concurrent callers converge on the winner (no 401 on a lost race).
+    const [stored] = await db
+      .select({ bridgeToken: schema.designLocalhostConnections.bridgeToken })
+      .from(schema.designLocalhostConnections)
+      .where(eq(schema.designLocalhostConnections.id, id))
+      .limit(1);
+    const effectiveBridgeToken = stored?.bridgeToken ?? nextBridgeToken;
 
     return {
       id,
       sourceType: "localhost",
-      name: values.name,
+      name: baseValues.name,
       devServerUrl,
       bridgeUrl: bridgeUrl ?? null,
       rootPath: routeManifest.rootPath ?? null,
@@ -254,7 +263,7 @@ export default defineAction({
       lastSeenAt: now,
       // Returned so the caller can start the bridge with
       // `design connect --bridge-token <this>`, matching this row.
-      bridgeToken: nextBridgeToken,
+      bridgeToken: effectiveBridgeToken,
     };
   },
 });

--- a/templates/design/actions/connect-localhost.ts
+++ b/templates/design/actions/connect-localhost.ts
@@ -202,7 +202,14 @@ export default defineAction({
       );
     }
 
-    const nextBridgeToken = args.bridgeToken?.trim() || undefined;
+    // Bridge token: caller-provided, else existing (idempotent refresh), else
+    // mint. Minting here — the authenticated action — lets the server own the
+    // secret and return it (below), so the CLI no longer needs its own auth to
+    // self-register the token. That auth gap was the root cause of live-edit 401s.
+    const nextBridgeToken =
+      args.bridgeToken?.trim() ||
+      existing[0]?.bridgeToken ||
+      crypto.randomBytes(32).toString("hex");
     const values = {
       id,
       name: args.name ?? new URL(devServerUrl).host,
@@ -212,7 +219,7 @@ export default defineAction({
       rootPath: routeManifest.rootPath ?? null,
       routeManifest: JSON.stringify(routeManifest),
       capabilities: JSON.stringify(capabilities),
-      bridgeToken: nextBridgeToken ?? existing[0]?.bridgeToken ?? null,
+      bridgeToken: nextBridgeToken,
       status: args.status,
       lastSeenAt: now,
       ownerEmail,
@@ -245,6 +252,9 @@ export default defineAction({
       capabilities,
       status: args.status,
       lastSeenAt: now,
+      // Returned so the caller can start the bridge with
+      // `design connect --bridge-token <this>`, matching this row.
+      bridgeToken: nextBridgeToken,
     };
   },
 });

--- a/templates/design/actions/open-visual-edit.ts
+++ b/templates/design/actions/open-visual-edit.ts
@@ -162,7 +162,10 @@ export default defineAction({
       .string()
       .optional()
       .describe(
-        "Real bridge token from the running bridge. Stored server-side only; never returned.",
+        "Optional bridge token to store on the connection (e.g. one a CLI " +
+          "self-registered). Omit it and the server mints one, stores it, and " +
+          "returns it as `bridgeToken` so the caller can start the local bridge " +
+          "with `design connect --bridge-token <token>`.",
       ),
     routes: jsonArray(z.array(screenRouteSchema))
       .optional()
@@ -315,6 +318,9 @@ export default defineAction({
       overview: true,
       urlPath,
       openUrl: designOverviewDeepLink(designId),
+      // Minted/stored by connect-localhost; the skill starts the bridge with
+      // `design connect --bridge-token <this>` so bridge and row agree.
+      bridgeToken: connection.bridgeToken,
     };
   },
   link: ({ result }) => {


### PR DESCRIPTION
still 401s in the edit page, turns out it needs a AGENT_NATIVE_TOKEN to be passed to the CLI so that agent can auto authenticate which doesnt happen automatically, this removes that hassle by using a bridge token on connect (random) and we pass that into design connect to be used as a shared secret

recap: https://plan.agent-native.com/plans/recap-ffe8ca26b2f44b36