### PR TITLE
Fix: Microphone not transcribed during meetings

### DIFF
--- a/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
+++ b/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
@@ -377,9 +377,7 @@ export function useMeetingTranscription({
         };
 
         // Resume the engine that initial start settled on (no fallback here —
-        // the engine choice was already made below). Keep voice processing
-        // off: AEC/ducking on the shared mic can make Zoom/Meet callers hear
-        // the local user at a whisper while Clips is transcribed.
+        // the engine choice was already made below).
         const startAudio = async () => {
           await restartTranscriptionEngine(
             session.engine,
@@ -388,7 +386,6 @@ export function useMeetingTranscription({
               label: selectedMicLabel,
             },
             true,
-            false,
           );
         };
 
@@ -559,9 +556,6 @@ export function useMeetingTranscription({
 
         session.engine = await startTranscriptionEngine({
           mic: { deviceId: selectedMicId, label: selectedMicLabel },
-          // Match clip recordings: VoiceProcessingIO AEC/ducking on the shared
-          // mic can tank live meeting volume for remote participants.
-          voiceProcessing: false,
         });
 
         await invoke("silence_detector_start", {


### PR DESCRIPTION
When starting a meeting in the Clips desktop app, the microphone was not being transcribed. The app was starting the audio engine with voice processing disabled, which caused it to receive no audio samples when a meeting app like Zoom or Teams was running at the same time.

Meeting apps use a macOS audio feature called VoiceProcessingIO to access the mic. When Clips disabled voice processing on its own engine, macOS routed all mic audio exclusively through the meeting app's engine, leaving Clips with nothing to transcribe.

The fix re-enables voice processing for meetings. To avoid affecting the call quality for remote participants, audio ducking is already disabled in the underlying Rust code when voice processing is on — so this change does not introduce any side effects on the meeting audio.
