### PR TITLE
Expose data-program read actions over HTTP for extension iframes.

### DIFF
--- a/templates/analytics/actions/get-data-program.ts
+++ b/templates/analytics/actions/get-data-program.ts
@@ -1,0 +1,78 @@
+/**
+ * Analytics HTTP surface for reading a stored data program and its latest run.
+ */
+import { defineAction } from "@agent-native/core";
+import {
+  getDataProgram,
+  getLatestRun,
+  hashDataProgramParams,
+} from "@agent-native/core/data-programs";
+import { getCredentialContext } from "@agent-native/core/server/request-context";
+import { resolveAccess } from "@agent-native/core/sharing";
+import { z } from "zod";
+
+import { ANALYTICS_APP_ID } from "../server/lib/provider-credentials";
+
+export default defineAction({
+  description:
+    "Get one Analytics data program's metadata and last-run summary. Pass includeRows to return cached rows.",
+  schema: z.object({
+    programId: z.string().min(1),
+    includeRows: z.boolean().optional(),
+  }),
+  http: { method: "GET" },
+  readOnly: true,
+  run: async (args) => {
+    const ctx = getCredentialContext();
+    if (!ctx) throw new Error("No authenticated context for get-data-program.");
+
+    const program = await getDataProgram(args.programId, ANALYTICS_APP_ID);
+    if (!program) throw new Error("Data program not found.");
+
+    const access = await resolveAccess("data_program", args.programId, {
+      userEmail: ctx.userEmail,
+      orgId: ctx.orgId ?? undefined,
+    });
+    if (!access) throw new Error("Access denied to this data program.");
+
+    const defaultParams = program.defaultParams
+      ? (JSON.parse(program.defaultParams) as Record<string, unknown>)
+      : {};
+    const hash = hashDataProgramParams(
+      defaultParams,
+      ctx.userEmail,
+      ctx.orgId ?? null,
+    );
+    const lastRun = await getLatestRun(program.id, hash);
+
+    return {
+      id: program.id,
+      name: program.name,
+      title: program.title,
+      description: program.description,
+      code: program.code,
+      paramsSchema: program.paramsSchema
+        ? JSON.parse(program.paramsSchema)
+        : null,
+      defaultParams,
+      refreshMode: program.refreshMode,
+      refreshTtlMs: program.refreshTtlMs,
+      background: program.background,
+      archivedAt: program.archivedAt,
+      columns: program.outputColumns ? JSON.parse(program.outputColumns) : [],
+      lastRun: lastRun
+        ? {
+            status: lastRun.status,
+            rowCount: lastRun.rowCount,
+            truncated: lastRun.truncated,
+            errorCode: lastRun.errorCode,
+            errorMessage: lastRun.errorMessage,
+            finishedAt: lastRun.finishedAt,
+            ...(args.includeRows && lastRun.rowsJson
+              ? { rows: JSON.parse(lastRun.rowsJson) }
+              : {}),
+          }
+        : null,
+    };
+  },
+});

--- a/templates/analytics/actions/list-data-programs.ts
+++ b/templates/analytics/actions/list-data-programs.ts
@@ -1,0 +1,49 @@
+/**
+ * Analytics HTTP surface for listing stored data programs.
+ *
+ * Core registers list-data-programs for the agent tool bag; template apps also
+ * expose it here so extension iframes can call it via
+ * /_agent-native/actions/list-data-programs.
+ */
+import { defineAction } from "@agent-native/core";
+import { listDataPrograms } from "@agent-native/core/data-programs";
+import { getCredentialContext } from "@agent-native/core/server/request-context";
+import { z } from "zod";
+
+import { ANALYTICS_APP_ID } from "../server/lib/provider-credentials";
+
+export default defineAction({
+  description:
+    "List data programs for Analytics, scoped to what the caller can access.",
+  schema: z.object({
+    includeArchived: z.boolean().optional(),
+  }),
+  http: { method: "GET" },
+  readOnly: true,
+  run: async (args) => {
+    const ctx = getCredentialContext();
+    if (!ctx)
+      throw new Error("No authenticated context for list-data-programs.");
+
+    const programs = await listDataPrograms(
+      ANALYTICS_APP_ID,
+      { userEmail: ctx.userEmail, orgId: ctx.orgId ?? undefined },
+      { includeArchived: args.includeArchived },
+    );
+
+    return {
+      programs: programs.map((p) => ({
+        id: p.id,
+        name: p.name,
+        title: p.title,
+        description: p.description,
+        refreshMode: p.refreshMode,
+        refreshTtlMs: p.refreshTtlMs,
+        background: p.background,
+        archivedAt: p.archivedAt,
+        updatedAt: p.updatedAt,
+        columns: p.outputColumns ? JSON.parse(p.outputColumns) : [],
+      })),
+    };
+  },
+});

--- a/templates/analytics/server/db/index.ts
+++ b/templates/analytics/server/db/index.ts
@@ -1,3 +1,4 @@
+import { registerDataProgramsShareable } from "@agent-native/core/data-programs";
 import { createGetDb } from "@agent-native/core/db";
 import { registerShareableResource } from "@agent-native/core/sharing";
 
@@ -11,6 +12,11 @@ import * as schema from "./schema.js";
 
 export const getDb = createGetDb(schema);
 export { schema };
+
+// Core data-program tables live outside analytics/schema.ts; register the
+// sharing type here so get-data-program / resolveAccess work in dev, CLI, and
+// extension iframes (same side-effect pattern as dashboard/analysis below).
+registerDataProgramsShareable();
 
 registerShareableResource({
   type: "dashboard",

--- a/templates/analytics/server/lib/dashboard-panel-query.program.spec.ts
+++ b/templates/analytics/server/lib/dashboard-panel-query.program.spec.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@agent-native/core/data-programs", () => ({
   runDataProgram: mocks.runDataProgram,
+  registerDataProgramsShareable: vi.fn(),
 }));
 
 vi.mock("@agent-native/core/credentials", () => ({


### PR DESCRIPTION
**Summary**

Expose data-program read actions over HTTP for extension iframes. Core registers list-data-programs / get-data-program for the agent, but extensions call appAction() which requires template HTTP routes. Also register data_program shareable in server/db/index.ts for CLI/dev paths that use resolveAccess outside full server boot.

<img width="2874" height="1772" alt="image" src="https://github.com/user-attachments/assets/20691f64-1893-4d8a-a75a-fd0e5fdae3b7" />



**Chnages**

1. templates/analytics/actions/list-data-programs.ts and get-data-program.ts
Thin HTTP wrappers around the same core helpers (listDataPrograms, getDataProgram, resolveAccess, getLatestRun). They exist so extension iframes can call:

GET /_agent-native/actions/list-data-programs
GET /_agent-native/actions/get-data-program?programId=...&includeRows=true
Logic mirrors core’s implementations; the template layer is the HTTP bridge, not new behavior.

2. registerDataProgramsShareable() in templates/analytics/server/db/index.ts
Core already registers this in core-routes-plugin.ts on server boot. I’m also calling it from server/db/index.ts because:

That file is imported by CLI/dev scripts (e.g. fix-risk-meeting-programs.ts) that don’t go through the full Nitro plugin path.
It matches the existing pattern for dashboard / analysis shareables in the same file.
get-data-program calls resolveAccess("data_program", ...) — without the shareable type registered in that import path, we hit Unknown shareable resource type: "data_program".