### PR TITLE
Preserve starter-pinned toolkit during manifest sync.

### DIFF
--- a/.changeset/preserve-starter-toolkit-pin.md
+++ b/.changeset/preserve-starter-toolkit-pin.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Preserve starter-pinned `@agent-native/toolkit` versions during builder-agent-native-starter manifest sync so template sync does not reset the update bot's exact toolkit pin back to `"latest"`.

--- a/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
@@ -137,6 +137,39 @@ describe("sync-builder-starter-manifest", () => {
   );
 
   it(
+    "preserves starter-pinned toolkit instead of canonical latest",
+    () => {
+      const { packageJson: canonical } =
+        generateStandaloneChatManifest(repoRoot);
+      expect(
+        (canonical.dependencies as Record<string, string>)[
+          "@agent-native/toolkit"
+        ],
+      ).toBe("latest");
+
+      const merged = mergeStarterManifest(
+        {
+          dependencies: {
+            "@agent-native/core": "0.92.5",
+            "@agent-native/toolkit": "0.4.4",
+          },
+        },
+        canonical,
+      );
+
+      expect(
+        (merged.dependencies as Record<string, string>)["@agent-native/core"],
+      ).toBe("0.92.5");
+      expect(
+        (merged.dependencies as Record<string, string>)[
+          "@agent-native/toolkit"
+        ],
+      ).toBe("0.4.4");
+    },
+    STARTER_MANIFEST_TIMEOUT_MS,
+  );
+
+  it(
     "preserves starter-only manifest fields not present in templates/chat",
     () => {
       const { packageJson: canonical } =

--- a/packages/core/src/cli/sync-builder-starter-manifest.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.ts
@@ -198,7 +198,7 @@ export function mergeStarterManifest(
   merged.dependencies = mergePackageJsonRecords(
     canonicalPackageJson.dependencies as Record<string, string> | undefined,
     starterPackageJson.dependencies as Record<string, string> | undefined,
-    ["@agent-native/core"],
+    ["@agent-native/core", "@agent-native/toolkit"],
   );
   merged.devDependencies = mergePackageJsonRecords(
     canonicalPackageJson.devDependencies as Record<string, string> | undefined,


### PR DESCRIPTION
<h2 class="ui-markdown__heading ui-13ebx5f ui-x6cpbe ui-14l7nz5 ui-zboxd6 ui-zqzdrm ui-1x419k1 ui-1qaq26d" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; font-size: 1.428em; font-weight: 590; line-height: 1.42; margin-bottom: 4px; margin-top: 0px; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><p class="ui-markdown__paragraph ui-1mdx765 ui-uu7i3w ui-8kmwxx ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 6px; margin-top: 6px; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Preserve the starter’s pinned<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">@agent-native/toolkit</code><span> </span>version during<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">builder-agent-native-starter</code><span> </span>manifest sync by adding it to<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk md-inline-variable-like" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">starterPinnedKeys</code><span> </span>in<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">mergeStarterManifest()</code>.</p><p class="ui-markdown__paragraph ui-1mdx765 ui-uu7i3w ui-8kmwxx ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 6px; margin-top: 6px; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Template sync already preserves<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">@agent-native/core</code><span> </span>this way. Toolkit was missing, so every sync from<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk md-inline-path-filename-like" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;"><span class="ui-markdown__inline-path-prefix ui-1heor9g md-inline-path-prefix" style="color: inherit;">templates/</span><span class="ui-markdown__inline-path-filename ui-1heor9g md-inline-path-filename" style="color: inherit;">chat</span></code><span> </span>reset<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">toolkit</code><span> </span>back to<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">"latest"</code><span> </span>and undid the update bot’s exact pin.</p><h2 class="ui-markdown__heading ui-13ebx5f ui-x6cpbe ui-14l7nz5 ui-zboxd6 ui-zqzdrm ui-1x419k1 ui-1qaq26d" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; font-size: 1.428em; font-weight: 590; line-height: 1.42; margin-bottom: 4px; margin-top: 16px; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Problem</h2><p class="ui-markdown__paragraph ui-1mdx765 ui-uu7i3w ui-8kmwxx ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 6px; margin-top: 6px; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Starter sync builds a canonical manifest from<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk md-inline-path-filename-like" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;"><span class="ui-markdown__inline-path-prefix ui-1heor9g md-inline-path-prefix" style="color: inherit;">templates/</span><span class="ui-markdown__inline-path-filename ui-1heor9g md-inline-path-filename" style="color: inherit;">chat</span></code><span> </span>via<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">postProcessStandalone()</code>, which rewrites:</p><div class="composer-message-codeblock" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 8px; margin-top: 8px; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-code-block ui-1n2onr6 ui-1om1abp ui-14l7nz5 ui-1yf7rl7 ui-1qaq26d ui-zboxd6 ui-j3b58b ui-1vb4fzf ui-14gibnr ui-10a2chs ui-1u51yxl ui-178xt8z ui-13fuv20 ui-1aeic0j ui-s1s249 ui-32b0ac ui-141kqco ui-so031l ui-1q0q8m5 ui-17fyfba ui-e0pwq ui-19ypqd9 ui-1arpupx ui-6ikm8r ui-10wlt62 ui-1ua6jya ui-1k89b3v ui-8nuxf3 ui-w0qwo3 ui-y3gzh4 ui-1gpzi3k" style="--ui-code-block-copy-overlay-display: none; background-color: rgb(245, 245, 245); position: relative; border-color: color(srgb 0.2 0.2 0.2 / 0.08); border-radius: 8px; border-style: solid; border-width: 1px; margin: 0px; overflow: hidden; min-height: 26px;"><div class="ui-code-block-content ui-1n2onr6" style="position: relative; min-height: 26px;"><div class="ui-scroll-area ui-1ekbvf6 ui-1logqu4 ui-1fx8caa ui-8ddqcf ui-1n2onr6 ui-6ikm8r ui-10wlt62 ui-rvj5dj ui-ypqxfk" data-scroll-padding="4" data-visibility="hover" data-direction="horizontal" style="--scroll-area-scroll-padding: 4px; --scrollbar-inset: 1px; --scrollbar-size: 6px; --scrollbar-thumb-top-offset: 6px; grid-template: 1fr / 1fr; display: grid; position: relative; overflow: hidden;"><div class="ui-scroll-area__viewport ui-175mniq ui-2lwn1j ui-mz0i5r ui-1pjcqnp ui-1rohswg ui-6ehuon ui-fk6m8 ui-w2csxc ui-10wlt62 ui-k8sdt9 ui-1duton ui-101ixbw ui-exgr1p ui-7p5m3t ui-y5w88m" style="grid-area: 1 / 1; border-radius: inherit; scrollbar-width: none; max-height: 100%; min-height: 0px; overflow: auto hidden; overscroll-behavior: contain auto; scroll-padding: 0px 4px;"><div class="ui-scroll-area__content ui-9f619 ui-gqtt45 ui-193iq5w ui-1us19tq ui-78zum5 ui-14atkfc ui-g7h5cd ui-1q0g3np" style="box-sizing: border-box; display: flex; flex-direction: row; height: fit-content; max-width: none; min-height: 100%; min-width: 100%; width: max-content;"><div class="ui-default-code ui-1wm8ruf ui-1lfj9qp ui-1yxxptd ui-1ua6jya ui-1m21r4p ui-cj37ws ui-13r5tfd ui-uve7l6 ui-1xpa7k ui-1rgtt3y ui-1uhho1l ui-o9w7m5 ui-17ewauw ui-1vakzcb ui-105xmc4 ui-1nsav61 ui-1jxofbz ui-947h55 ui-ta7kcf ui-1iagb1a ui-ez8t0j ui-i2wo5x ui-1iq2d2k ui-1qoclnz ui-k609h7 ui-1rqnq8e ui-19gwdp1 ui-1yfyyyg ui-1apie5d ui-dcvkk1 ui-code-block-default-code" style="--shiki-background: transparent; --shiki-foreground: #333333; --shiki-token-attribute: #7A3E9D; --shiki-token-class: #7A3E9D; --shiki-token-comment: #AAAAAA; --shiki-token-constant-variable: #7A3E9D; --shiki-token-constant: #9C5D27; --shiki-token-function: #AA3731; --shiki-token-keyword: #4B69C6; --shiki-token-language-variable: #9C5D27; --shiki-token-link: #87c3ff; --shiki-token-parameter: #7A3E9D; --shiki-token-property: #7A3E9D; --shiki-token-punctuation: #777777; --shiki-token-string-expression: #448C27; --shiki-token-string: #448C27; --shiki-token-tag: #4B69C6; --shiki-token-type: #7A3E9D; --shiki-token-variable: #7A3E9D; background-color: transparent; contain: layout style paint; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 12px; font-weight: 400; line-height: 20px; tab-size: 4; padding: 6px 0px; --ui-default-code-tab-size: 4; min-height: 0px; width: max-content; min-width: 100%;"><div class="ui-1pshirs ui-awy1a7" style="contain: layout style; min-width: fit-content;"><div class="ui-78zum5 ui-1f4zecs" style="display: flex; min-height: 20px;"><div class="ui-default-code__line-content ui-98rzlu ui-1sdyfia ui-b3r6kr ui-lyipyv ui-1lfpczk ui-lgbajd ui-1yxiud8 ui-1n2onr6" style="flex: 1 1 0%; overflow: hidden; color: rgb(51, 51, 51); position: relative; text-overflow: ellipsis; white-space: pre; padding-left: 6px; padding-right: 8px;"><span style="color: rgb(119, 119, 119);">"</span><span style="color: rgb(68, 140, 39);">@agent-native/toolkit</span><span style="color: rgb(119, 119, 119);">"</span><span style="color: rgb(51, 51, 51);">: </span><span style="color: rgb(119, 119, 119);">"</span><span style="color: rgb(68, 140, 39);">workspace:*</span><span style="color: rgb(119, 119, 119);">"</span></div></div></div></div></div></div></div></div></div></div><p class="ui-markdown__paragraph ui-1mdx765 ui-uu7i3w ui-8kmwxx ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 6px; margin-top: 6px; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">into:</p><div class="composer-message-codeblock" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 8px; margin-top: 8px; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-code-block ui-1n2onr6 ui-1om1abp ui-14l7nz5 ui-1yf7rl7 ui-1qaq26d ui-zboxd6 ui-j3b58b ui-1vb4fzf ui-14gibnr ui-10a2chs ui-1u51yxl ui-178xt8z ui-13fuv20 ui-1aeic0j ui-s1s249 ui-32b0ac ui-141kqco ui-so031l ui-1q0q8m5 ui-17fyfba ui-e0pwq ui-19ypqd9 ui-1arpupx ui-6ikm8r ui-10wlt62 ui-1ua6jya ui-1k89b3v ui-8nuxf3 ui-w0qwo3 ui-y3gzh4 ui-1gpzi3k" style="--ui-code-block-copy-overlay-display: none; background-color: rgb(245, 245, 245); position: relative; border-color: color(srgb 0.2 0.2 0.2 / 0.08); border-radius: 8px; border-style: solid; border-width: 1px; margin: 0px; overflow: hidden; min-height: 26px;"><div class="ui-code-block-content ui-1n2onr6" style="position: relative; min-height: 26px;"><div class="ui-scroll-area ui-1ekbvf6 ui-1logqu4 ui-1fx8caa ui-8ddqcf ui-1n2onr6 ui-6ikm8r ui-10wlt62 ui-rvj5dj ui-ypqxfk" data-scroll-padding="4" data-visibility="hover" data-direction="horizontal" style="--scroll-area-scroll-padding: 4px; --scrollbar-inset: 1px; --scrollbar-size: 6px; --scrollbar-thumb-top-offset: 6px; grid-template: 1fr / 1fr; display: grid; position: relative; overflow: hidden;"><div class="ui-scroll-area__viewport ui-175mniq ui-2lwn1j ui-mz0i5r ui-1pjcqnp ui-1rohswg ui-6ehuon ui-fk6m8 ui-w2csxc ui-10wlt62 ui-k8sdt9 ui-1duton ui-101ixbw ui-exgr1p ui-7p5m3t ui-y5w88m" style="grid-area: 1 / 1; border-radius: inherit; scrollbar-width: none; max-height: 100%; min-height: 0px; overflow: auto hidden; overscroll-behavior: contain auto; scroll-padding: 0px 4px;"><div class="ui-scroll-area__content ui-9f619 ui-gqtt45 ui-193iq5w ui-1us19tq ui-78zum5 ui-14atkfc ui-g7h5cd ui-1q0g3np" style="box-sizing: border-box; display: flex; flex-direction: row; height: fit-content; max-width: none; min-height: 100%; min-width: 100%; width: max-content;"><div class="ui-default-code ui-1wm8ruf ui-1lfj9qp ui-1yxxptd ui-1ua6jya ui-1m21r4p ui-cj37ws ui-13r5tfd ui-uve7l6 ui-1xpa7k ui-1rgtt3y ui-1uhho1l ui-o9w7m5 ui-17ewauw ui-1vakzcb ui-105xmc4 ui-1nsav61 ui-1jxofbz ui-947h55 ui-ta7kcf ui-1iagb1a ui-ez8t0j ui-i2wo5x ui-1iq2d2k ui-1qoclnz ui-k609h7 ui-1rqnq8e ui-19gwdp1 ui-1yfyyyg ui-1apie5d ui-dcvkk1 ui-code-block-default-code" style="--shiki-background: transparent; --shiki-foreground: #333333; --shiki-token-attribute: #7A3E9D; --shiki-token-class: #7A3E9D; --shiki-token-comment: #AAAAAA; --shiki-token-constant-variable: #7A3E9D; --shiki-token-constant: #9C5D27; --shiki-token-function: #AA3731; --shiki-token-keyword: #4B69C6; --shiki-token-language-variable: #9C5D27; --shiki-token-link: #87c3ff; --shiki-token-parameter: #7A3E9D; --shiki-token-property: #7A3E9D; --shiki-token-punctuation: #777777; --shiki-token-string-expression: #448C27; --shiki-token-string: #448C27; --shiki-token-tag: #4B69C6; --shiki-token-type: #7A3E9D; --shiki-token-variable: #7A3E9D; background-color: transparent; contain: layout style paint; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 12px; font-weight: 400; line-height: 20px; tab-size: 4; padding: 6px 0px; --ui-default-code-tab-size: 4; min-height: 0px; width: max-content; min-width: 100%;"><div class="ui-1pshirs ui-awy1a7" style="contain: layout style; min-width: fit-content;"><div class="ui-78zum5 ui-1f4zecs" style="display: flex; min-height: 20px;"><div class="ui-default-code__line-content ui-98rzlu ui-1sdyfia ui-b3r6kr ui-lyipyv ui-1lfpczk ui-lgbajd ui-1yxiud8 ui-1n2onr6" style="flex: 1 1 0%; overflow: hidden; color: rgb(51, 51, 51); position: relative; text-overflow: ellipsis; white-space: pre; padding-left: 6px; padding-right: 8px;"><span style="color: rgb(119, 119, 119);">"</span><span style="color: rgb(68, 140, 39);">@agent-native/toolkit</span><span style="color: rgb(119, 119, 119);">"</span><span style="color: rgb(51, 51, 51);">: </span><span style="color: rgb(119, 119, 119);">"</span><span style="color: rgb(68, 140, 39);">latest</span><span style="color: rgb(119, 119, 119);">"</span></div></div></div></div></div></div></div></div></div></div><p class="ui-markdown__paragraph ui-1mdx765 ui-uu7i3w ui-8kmwxx ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 6px; margin-top: 6px; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">mergeStarterManifest()</code><span> </span>then merges that canonical manifest into the starter’s<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk ui-s2xxs2 ui-7pq1vu ui-6tor67 ui-1ypdohk ui-l1v4ol ui-1sur9pj md-clickable-code md-inline-path-filename-like" role="button" tabindex="0" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(4, 81, 165); cursor: pointer; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; transition-duration: 0.1s; transition-property: background-color, color; transition-timing-function: ease-out; word-break: normal; padding: 1.5px 2px;"><span class="ui-markdown__inline-path-filename ui-1heor9g md-inline-path-filename" style="color: inherit;">package.json</span></code>. Core is protected via<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">starterPinnedKeys: ["@agent-native/core"]</code>, but toolkit is not.</p><p class="ui-markdown__paragraph ui-1mdx765 ui-uu7i3w ui-8kmwxx ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 6px; margin-top: 6px; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">That means:</p><ol class="ui-markdown__list ui-78zum5 ui-dt5ytf ui-pkkfsy ui-1mdx765 ui-8kmwxx ui-j7cesy ui-1bae07f" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; gap: 6px; display: flex; flex-direction: column; margin-bottom: 6px; margin-top: 6px; padding-left: 2em; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;">The update bot pins<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">@agent-native/toolkit</code><span> </span>to an exact version (e.g.<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">0.4.4</code>)</li><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;">A later template sync runs (chat changes,<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk ui-s2xxs2 ui-7pq1vu ui-6tor67 ui-1ypdohk ui-l1v4ol ui-1sur9pj md-clickable-code md-inline-path-filename-like" role="button" tabindex="0" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(4, 81, 165); cursor: pointer; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; transition-duration: 0.1s; transition-property: background-color, color; transition-timing-function: ease-out; word-break: normal; padding: 1.5px 2px;"><span class="ui-markdown__inline-path-filename ui-1heor9g md-inline-path-filename" style="color: inherit;">create.ts</span></code><span> </span>changes, cron, etc.)</li><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;">Sync overwrites<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">toolkit: "0.4.4"</code><span> </span>→<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">toolkit: "latest"</code></li><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;">Stale or drifting lockfiles can resolve<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">"latest"</code><span> </span>to ancient toolkit copies (e.g.<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">0.2.0</code>)</li><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;">Vite hoists the wrong copy →<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk md-inline-path-filename-like" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;"><span class="ui-markdown__inline-path-prefix ui-1heor9g md-inline-path-prefix" style="color: inherit;">./</span><span class="ui-markdown__inline-path-filename ui-1heor9g md-inline-path-filename" style="color: inherit;">collab-ui</span></code><span> </span>export crash</li></ol><p class="ui-markdown__paragraph ui-1mdx765 ui-uu7i3w ui-8kmwxx ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 6px; margin-top: 6px; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">This is the sync half of the starter/toolkit mismatch bug. The update bot fix alone is not enough if template sync keeps resetting toolkit to<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">"latest"</code>.</p><h2 class="ui-markdown__heading ui-13ebx5f ui-x6cpbe ui-14l7nz5 ui-zboxd6 ui-zqzdrm ui-1x419k1 ui-1qaq26d" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; font-size: 1.428em; font-weight: 590; line-height: 1.42; margin-bottom: 4px; margin-top: 16px; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Solution</h2><p class="ui-markdown__paragraph ui-1mdx765 ui-uu7i3w ui-8kmwxx ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 6px; margin-top: 6px; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Add<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">@agent-native/toolkit</code><span> </span>to<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk md-inline-variable-like" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">starterPinnedKeys</code><span> </span>alongside<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">@agent-native/core</code>:</p><div class="composer-message-codeblock" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 8px; margin-top: 8px; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-code-block ui-1n2onr6 ui-1om1abp ui-14l7nz5 ui-1yf7rl7 ui-1qaq26d ui-zboxd6 ui-j3b58b ui-1vb4fzf ui-14gibnr ui-10a2chs ui-1u51yxl ui-178xt8z ui-13fuv20 ui-1aeic0j ui-s1s249 ui-32b0ac ui-141kqco ui-so031l ui-1q0q8m5 ui-17fyfba ui-e0pwq ui-19ypqd9 ui-1arpupx ui-6ikm8r ui-10wlt62 ui-1ua6jya ui-1k89b3v ui-8nuxf3 ui-w0qwo3 ui-y3gzh4 ui-1gpzi3k" style="--ui-code-block-copy-overlay-display: none; background-color: rgb(245, 245, 245); position: relative; border-color: color(srgb 0.2 0.2 0.2 / 0.08); border-radius: 8px; border-style: solid; border-width: 1px; margin: 0px; overflow: hidden; min-height: 26px;"><div class="ui-code-block-content ui-1n2onr6" style="position: relative; min-height: 26px;"><div class="ui-scroll-area ui-1ekbvf6 ui-1logqu4 ui-1fx8caa ui-8ddqcf ui-1n2onr6 ui-6ikm8r ui-10wlt62 ui-rvj5dj ui-ypqxfk" data-scroll-padding="4" data-visibility="hover" data-direction="horizontal" style="--scroll-area-scroll-padding: 4px; --scrollbar-inset: 1px; --scrollbar-size: 6px; --scrollbar-thumb-top-offset: 6px; grid-template: 1fr / 1fr; display: grid; position: relative; overflow: hidden;"><div class="ui-scroll-area__viewport ui-175mniq ui-2lwn1j ui-mz0i5r ui-1pjcqnp ui-1rohswg ui-6ehuon ui-fk6m8 ui-w2csxc ui-10wlt62 ui-k8sdt9 ui-1duton ui-101ixbw ui-exgr1p ui-7p5m3t ui-y5w88m" style="grid-area: 1 / 1; border-radius: inherit; scrollbar-width: none; max-height: 100%; min-height: 0px; overflow: auto hidden; overscroll-behavior: contain auto; scroll-padding: 0px 4px;"><div class="ui-scroll-area__content ui-9f619 ui-gqtt45 ui-193iq5w ui-1us19tq ui-78zum5 ui-14atkfc ui-g7h5cd ui-1q0g3np" style="box-sizing: border-box; display: flex; flex-direction: row; height: fit-content; max-width: none; min-height: 100%; min-width: 100%; width: max-content;"><div class="ui-default-code ui-1wm8ruf ui-1lfj9qp ui-1yxxptd ui-1ua6jya ui-1m21r4p ui-cj37ws ui-13r5tfd ui-uve7l6 ui-1xpa7k ui-1rgtt3y ui-1uhho1l ui-o9w7m5 ui-17ewauw ui-1vakzcb ui-105xmc4 ui-1nsav61 ui-1jxofbz ui-947h55 ui-ta7kcf ui-1iagb1a ui-ez8t0j ui-i2wo5x ui-1iq2d2k ui-1qoclnz ui-k609h7 ui-1rqnq8e ui-19gwdp1 ui-1yfyyyg ui-1apie5d ui-dcvkk1 ui-code-block-default-code" style="--shiki-background: transparent; --shiki-foreground: #333333; --shiki-token-attribute: #7A3E9D; --shiki-token-class: #7A3E9D; --shiki-token-comment: #AAAAAA; --shiki-token-constant-variable: #7A3E9D; --shiki-token-constant: #9C5D27; --shiki-token-function: #AA3731; --shiki-token-keyword: #4B69C6; --shiki-token-language-variable: #9C5D27; --shiki-token-link: #87c3ff; --shiki-token-parameter: #7A3E9D; --shiki-token-property: #7A3E9D; --shiki-token-punctuation: #777777; --shiki-token-string-expression: #448C27; --shiki-token-string: #448C27; --shiki-token-tag: #4B69C6; --shiki-token-type: #7A3E9D; --shiki-token-variable: #7A3E9D; background-color: transparent; contain: layout style paint; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 12px; font-weight: 400; line-height: 20px; tab-size: 4; padding: 6px 0px; --ui-default-code-tab-size: 4; min-height: 0px; width: max-content; min-width: 100%;"><div class="ui-1pshirs ui-awy1a7" style="contain: layout style; min-width: fit-content;"><div class="ui-78zum5 ui-1f4zecs" style="display: flex; min-height: 20px;"><div class="ui-default-code__line-content ui-98rzlu ui-1sdyfia ui-b3r6kr ui-lyipyv ui-1lfpczk ui-lgbajd ui-1yxiud8 ui-1n2onr6" style="flex: 1 1 0%; overflow: hidden; color: rgb(51, 51, 51); position: relative; text-overflow: ellipsis; white-space: pre; padding-left: 6px; padding-right: 8px;"><span style="color: rgb(119, 119, 119);">[</span><span style="color: rgb(119, 119, 119);">"</span><span style="color: rgb(68, 140, 39);">@agent-native/core</span><span style="color: rgb(119, 119, 119);">"</span><span style="color: rgb(119, 119, 119);">,</span><span style="color: rgb(51, 51, 51);"> </span><span style="color: rgb(119, 119, 119);">"</span><span style="color: rgb(68, 140, 39);">@agent-native/toolkit</span><span style="color: rgb(119, 119, 119);">"</span><span style="color: rgb(119, 119, 119);">]</span></div></div></div></div></div></div></div></div></div></div><p class="ui-markdown__paragraph ui-1mdx765 ui-uu7i3w ui-8kmwxx ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 6px; margin-top: 6px; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Template sync now preserves the starter’s pinned toolkit version the same way it preserves pinned core.</p><div class="ui-scroll-area ui-1ekbvf6 ui-1logqu4 ui-1fx8caa ui-8ddqcf ui-1n2onr6 ui-6ikm8r ui-10wlt62 ui-rvj5dj ui-ypqxfk ui-tr57km ui-14beivq ui-13xjzxd ui-178xt8z ui-13fuv20 ui-1aeic0j ui-s1s249 ui-32b0ac ui-141kqco ui-so031l ui-1q0q8m5 ui-17fyfba ui-e0pwq ui-19ypqd9 ui-1arpupx ui-1043rbw ui-14l7nz5 ui-zboxd6" data-scroll-padding="4" data-visibility="hover" data-direction="horizontal" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; --scroll-area-scroll-padding: 4px; --scrollbar-inset: 1px; --scrollbar-size: 6px; --scrollbar-thumb-top-offset: 6px; grid-template: 1fr / 1fr; border-radius: 6px; display: grid; position: relative; border-color: color(srgb 0.2 0.2 0.2 / 0.08); border-style: solid; border-width: 1px; margin-bottom: 1em; margin-top: 1em; overflow: hidden; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-scroll-area__viewport ui-175mniq ui-2lwn1j ui-mz0i5r ui-1pjcqnp ui-1rohswg ui-6ehuon ui-fk6m8 ui-w2csxc ui-10wlt62 ui-k8sdt9 ui-1duton ui-101ixbw ui-exgr1p ui-7p5m3t ui-y5w88m" style="grid-area: 1 / 1; border-radius: inherit; scrollbar-width: none; max-height: 100%; min-height: 0px; overflow: auto hidden; overscroll-behavior: contain auto; scroll-padding: 0px 4px;"><div class="ui-scroll-area__content ui-9f619 ui-gqtt45 ui-193iq5w ui-1us19tq ui-78zum5 ui-14atkfc ui-g7h5cd ui-1q0g3np" style="box-sizing: border-box; display: flex; flex-direction: row; height: fit-content; max-width: 100%; min-height: 100%; min-width: 100%; width: auto;">
Step | Before this PR | After this PR
-- | -- | --
Update bot pins toolkit | 0.4.4 | 0.4.4
Template sync runs | resets to "latest" | keeps 0.4.4

</div></div></div><h2 class="ui-markdown__heading ui-13ebx5f ui-x6cpbe ui-14l7nz5 ui-zboxd6 ui-zqzdrm ui-1x419k1 ui-1qaq26d" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; font-size: 1.428em; font-weight: 590; line-height: 1.42; margin-bottom: 4px; margin-top: 16px; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">How this fits the full fix</h2><p class="ui-markdown__paragraph ui-1mdx765 ui-uu7i3w ui-8kmwxx ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 6px; margin-top: 6px; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">This PR is one layer in a three-part fix:</p><ol class="ui-markdown__list ui-78zum5 ui-dt5ytf ui-pkkfsy ui-1mdx765 ui-8kmwxx ui-j7cesy ui-1bae07f" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; gap: 6px; display: flex; flex-direction: column; margin-bottom: 6px; margin-top: 6px; padding-left: 2em; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;"><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">workspace:^</code><span> </span>in published core/scheduling</span><span> </span>— published core declares<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">toolkit: "^0.4.x"</code><span> </span>so compatible versions dedupe at install time</li><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Starter update bot pins toolkit</span><span> </span>— writes exact version into<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk ui-s2xxs2 ui-7pq1vu ui-6tor67 ui-1ypdohk ui-l1v4ol ui-1sur9pj md-clickable-code md-inline-path-filename-like" role="button" tabindex="0" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(4, 81, 165); cursor: pointer; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; transition-duration: 0.1s; transition-property: background-color, color; transition-timing-function: ease-out; word-break: normal; padding: 1.5px 2px;"><span class="ui-markdown__inline-path-filename ui-1heor9g md-inline-path-filename" style="color: inherit;">package.json</span></code><span> </span>(<code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">builder-agent-native-starter</code><span> </span>PR)</li><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">This PR (<code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk md-inline-variable-like" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">starterPinnedKeys</code>)</span><span> </span>— prevents template sync from clobbering that pin back to<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">"latest"</code></li></ol><p class="ui-markdown__paragraph ui-1mdx765 ui-uu7i3w ui-8kmwxx ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 6px; margin-top: 6px; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Without (2), there is nothing to preserve.<br>Without (3), (2) gets overwritten on the next template sync.</p><h2 class="ui-markdown__heading ui-13ebx5f ui-x6cpbe ui-14l7nz5 ui-zboxd6 ui-zqzdrm ui-1x419k1 ui-1qaq26d" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; font-size: 1.428em; font-weight: 590; line-height: 1.42; margin-bottom: 4px; margin-top: 16px; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Changes</h2><ul class="ui-markdown__list ui-78zum5 ui-dt5ytf ui-pkkfsy ui-1mdx765 ui-8kmwxx ui-j7cesy ui-1bae07f" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; gap: 6px; display: flex; flex-direction: column; margin-bottom: 6px; margin-top: 6px; padding-left: 2em; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;"><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk ui-s2xxs2 ui-7pq1vu ui-6tor67 ui-1ypdohk ui-l1v4ol ui-1sur9pj md-clickable-code md-inline-path-filename-like" role="button" tabindex="0" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(4, 81, 165); cursor: pointer; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; transition-duration: 0.1s; transition-property: background-color, color; transition-timing-function: ease-out; word-break: normal; padding: 1.5px 2px;"><span class="ui-markdown__inline-path-prefix ui-1heor9g md-inline-path-prefix" style="color: inherit;">packages/core/src/cli/</span><span class="ui-markdown__inline-path-filename ui-1heor9g md-inline-path-filename" style="color: inherit;">sync-builder-starter-manifest.ts</span></code><span> </span>— add<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">@agent-native/toolkit</code><span> </span>to<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk md-inline-variable-like" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">starterPinnedKeys</code></li><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;"><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk ui-s2xxs2 ui-7pq1vu ui-6tor67 ui-1ypdohk ui-l1v4ol ui-1sur9pj md-clickable-code md-inline-path-filename-like" role="button" tabindex="0" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(4, 81, 165); cursor: pointer; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; transition-duration: 0.1s; transition-property: background-color, color; transition-timing-function: ease-out; word-break: normal; padding: 1.5px 2px;"><span class="ui-markdown__inline-path-prefix ui-1heor9g md-inline-path-prefix" style="color: inherit;">packages/core/src/cli/</span><span class="ui-markdown__inline-path-filename ui-1heor9g md-inline-path-filename" style="color: inherit;">sync-builder-starter-manifest.spec.ts</span></code><span> </span>— test that a pinned toolkit survives merge against canonical<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">"latest"</code></li></ul><h2 class="ui-markdown__heading ui-13ebx5f ui-x6cpbe ui-14l7nz5 ui-zboxd6 ui-zqzdrm ui-1x419k1 ui-1qaq26d" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; font-size: 1.428em; font-weight: 590; line-height: 1.42; margin-bottom: 4px; margin-top: 16px; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Test plan</h2><ul class="ui-markdown__list ui-78zum5 ui-dt5ytf ui-pkkfsy ui-1mdx765 ui-8kmwxx ui-j7cesy ui-3ct3a4 ui-1uhho1l ui-em2tdd contains-task-list" style="gap: 6px; display: flex; flex-direction: column; list-style-type: none; margin-bottom: 6px; margin-top: 6px; padding-left: 0px; color: rgb(51, 51, 51); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(245, 245, 245); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb task-list-item" data-md-list-item="" style="word-break: break-word; padding: 0px;"><span class="ui-checkbox ui-3nfvp2 ui-6s0dn4 ui-l56j7k ui-1n2onr6 ui-1ypdohk ui-markdown__task-checkbox ui-8zvuic ui-xymvpz ui-47corl" data-size="sm" data-variant="neutral" style="align-items: center; cursor: pointer; display: inline-flex; justify-content: center; pointer-events: none; position: relative; vertical-align: middle; margin-right: 0.4em;"><input class="ui-checkbox__input ui-10l6tqk ui-13vifvy ui-3m8u43 ui-1ey2m1c ui-u96u03 ui-1vjfegm ui-jyslct ui-g01cxk ui-dj266r ui-1yf7rl7 ui-at24cr ui-j3b58b ui-mper1u ui-1k57tk5 ui-1t137rt ui-1wfwxd8 ui-1uczgqu ui-1cpjm7i ui-1hmns74 ui-y5mcqj ui-6udnff ui-1hlfbpq ui-1hjx8jx ui-mlpkb0 ui--default-marker" data-checkbox-input="" tabindex="-1" aria-disabled="true" aria-label="Completed task" type="checkbox" checked="" style="padding: 0px; margin: 0px; appearance: none; cursor: inherit; opacity: 0; outline: transparent none 0px; outline-offset: 0px; position: absolute; z-index: 1; inset: 0px; color: inherit; font-family: inherit; font-size: 13px;"><span class="ui-checkbox__box ui-3nfvp2 ui-6s0dn4 ui-l56j7k ui-9f619 ui-1k57tk5 ui-1hpasb9 ui-1t137rt ui-1ka25eh ui-1uczgqu ui-14kghwa ui-1wfwxd8 ui-164o0fh ui-flwf2 ui-g3p6pi ui-sagj69 ui-6ekqhr ui-178xt8z ui-13fuv20 ui-s1s249 ui-32b0ac ui-so031l ui-1q0q8m5 ui-e0pwq ui-19ypqd9 ui-1e1y6u3 ui-ek66a6 ui-1q5geii ui-19aaqeu ui-i07v4r ui-ccbpao ui-oex33d ui-1ih835e ui-1rzsz3d ui-1gnnqk1" data-checked="true" aria-hidden="true" style="border-radius: 4px; align-items: center; background-color: color(srgb 0.2 0.2 0.2 / 0.08); box-shadow: none; box-sizing: border-box; color: color(srgb 0.2 0.2 0.2 / 0.74); display: inline-flex; justify-content: center; outline: transparent none 0px; outline-offset: 0px; transition-duration: 0.15s; transition-property: color, background-color, border-color, opacity, transform; transition-timing-function: ease; border-color: color(srgb 0.2 0.2 0.2 / 0.2); border-style: solid; border-width: 1px; height: 14px; width: 14px;"></span></span><span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">pnpm --filter @agent-native/core exec vitest --run src/cli/sync-builder-starter-manifest.spec.ts</code></li><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb task-list-item" data-md-list-item="" style="word-break: break-word; padding: 0px;"><span class="ui-checkbox ui-3nfvp2 ui-6s0dn4 ui-l56j7k ui-1n2onr6 ui-1ypdohk ui-markdown__task-checkbox ui-8zvuic ui-xymvpz ui-47corl" data-size="sm" data-variant="neutral" style="align-items: center; cursor: pointer; display: inline-flex; justify-content: center; pointer-events: none; position: relative; vertical-align: middle; margin-right: 0.4em;"><input class="ui-checkbox__input ui-10l6tqk ui-13vifvy ui-3m8u43 ui-1ey2m1c ui-u96u03 ui-1vjfegm ui-jyslct ui-g01cxk ui-dj266r ui-1yf7rl7 ui-at24cr ui-j3b58b ui-mper1u ui-1k57tk5 ui-1t137rt ui-1wfwxd8 ui-1uczgqu ui-1cpjm7i ui-1hmns74 ui-y5mcqj ui-6udnff ui-1hlfbpq ui-1hjx8jx ui-mlpkb0 ui--default-marker" data-checkbox-input="" tabindex="-1" aria-disabled="true" aria-label="Incomplete task" type="checkbox" style="padding: 0px; margin: 0px; appearance: none; cursor: inherit; opacity: 0; outline: transparent none 0px; outline-offset: 0px; position: absolute; z-index: 1; inset: 0px; color: inherit; font-family: inherit; font-size: 13px;"><span class="ui-checkbox__box ui-3nfvp2 ui-6s0dn4 ui-l56j7k ui-9f619 ui-1ypigh8 ui-1k57tk5 ui-1hpasb9 ui-1t137rt ui-1ka25eh ui-1uczgqu ui-14kghwa ui-1wfwxd8 ui-164o0fh ui-flwf2 ui-g3p6pi ui-sagj69 ui-6ekqhr ui-178xt8z ui-13fuv20 ui-ccbpao ui-s1s249 ui-32b0ac ui-oex33d ui-so031l ui-1q0q8m5 ui-1ih835e ui-e0pwq ui-19ypqd9 ui-1rzsz3d ui-1e1y6u3 ui-i07v4r ui-ek66a6 ui-1q5geii" aria-hidden="true" style="border-radius: 4px; align-items: center; background-color: color(srgb 0.2 0.2 0.2 / 0.08); box-sizing: border-box; color: rgb(25, 28, 34); display: inline-flex; justify-content: center; outline: transparent none 0px; outline-offset: 0px; transition-duration: 0.15s; transition-property: color, background-color, border-color, opacity, transform; transition-timing-function: ease; border-color: color(srgb 0.2 0.2 0.2 / 0.2); border-style: solid; border-width: 1px; height: 14px; width: 14px;"></span></span><span> </span>After merge, run starter template sync and confirm pinned<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">@agent-native/toolkit</code><span> </span>is not reset to<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.2 0.2 0.2 / 0.08); color: rgb(51, 51, 51); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">"latest"</code></li><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb task-list-item" data-md-list-item="" style="word-break: break-word; padding: 0px;"><span class="ui-checkbox ui-3nfvp2 ui-6s0dn4 ui-l56j7k ui-1n2onr6 ui-1ypdohk ui-markdown__task-checkbox ui-8zvuic ui-xymvpz ui-47corl" data-size="sm" data-variant="neutral" style="align-items: center; cursor: pointer; display: inline-flex; justify-content: center; pointer-events: none; position: relative; vertical-align: middle; margin-right: 0.4em;"><input class="ui-checkbox__input ui-10l6tqk ui-13vifvy ui-3m8u43 ui-1ey2m1c ui-u96u03 ui-1vjfegm ui-jyslct ui-g01cxk ui-dj266r ui-1yf7rl7 ui-at24cr ui-j3b58b ui-mper1u ui-1k57tk5 ui-1t137rt ui-1wfwxd8 ui-1uczgqu ui-1cpjm7i ui-1hmns74 ui-y5mcqj ui-6udnff ui-1hlfbpq ui-1hjx8jx ui-mlpkb0 ui--default-marker" data-checkbox-input="" tabindex="-1" aria-disabled="true" aria-label="Incomplete task" type="checkbox" style="padding: 0px; margin: 0px; appearance: none; cursor: inherit; opacity: 0; outline: transparent none 0px; outline-offset: 0px; position: absolute; z-index: 1; inset: 0px; color: inherit; font-family: inherit; font-size: 13px;"><span class="ui-checkbox__box ui-3nfvp2 ui-6s0dn4 ui-l56j7k ui-9f619 ui-1ypigh8 ui-1k57tk5 ui-1hpasb9 ui-1t137rt ui-1ka25eh ui-1uczgqu ui-14kghwa ui-1wfwxd8 ui-164o0fh ui-flwf2 ui-g3p6pi ui-sagj69 ui-6ekqhr ui-178xt8z ui-13fuv20 ui-ccbpao ui-s1s249 ui-32b0ac ui-oex33d ui-so031l ui-1q0q8m5 ui-1ih835e ui-e0pwq ui-19ypqd9 ui-1rzsz3d ui-1e1y6u3 ui-i07v4r ui-ek66a6 ui-1q5geii" aria-hidden="true" style="border-radius: 4px; align-items: center; background-color: color(srgb 0.2 0.2 0.2 / 0.08); box-sizing: border-box; color: rgb(25, 28, 34); display: inline-flex; justify-content: center; outline: transparent none 0px; outline-offset: 0px; transition-duration: 0.15s; transition-property: color, background-color, border-color, opacity, transform; transition-timing-function: ease; border-color: color(srgb 0.2 0.2 0.2 / 0.2); border-style: solid; border-width: 1px; height: 14px; width: 14px;"></span></span><span> </span>After starter update bot PR merges, confirm bot PR updates both core and toolkit, and lockfile contains a single toolkit version</li></ul>
