### PR TITLE
Fix Content database property interactions

### DIFF
--- a/.changeset/quiet-property-dialogs.md
+++ b/.changeset/quiet-property-dialogs.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/toolkit": patch
+---
+
+Keep alert dialogs centered above full-app overlays.

--- a/packages/toolkit/src/ui/alert-dialog.tsx
+++ b/packages/toolkit/src/ui/alert-dialog.tsx
@@ -13,12 +13,13 @@ const AlertDialogPortal = AlertDialogPrimitive.Portal;
 const AlertDialogOverlay = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
+>(({ className, style, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-[250] bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[340] bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
+    style={{ zIndex: 340, ...style }}
     {...props}
     ref={ref}
   />
@@ -28,15 +29,16 @@ AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
 const AlertDialogContent = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
->(({ className, ...props }, ref) => (
+>(({ className, style, ...props }, ref) => (
   <AlertDialogPortal>
     <AlertDialogOverlay />
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-[250] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
+        "fixed left-1/2 top-1/2 z-[350] grid w-11/12 max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
         className,
       )}
+      style={{ zIndex: 350, ...style }}
       {...props}
     />
   </AlertDialogPortal>

--- a/templates/content/app/components/editor/DocumentProperties.tsx
+++ b/templates/content/app/components/editor/DocumentProperties.tsx
@@ -69,6 +69,8 @@ import {
   useMemo,
   useRef,
   useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
 } from "react";
@@ -1110,7 +1112,11 @@ export function PropertyManagementPopover({
             {triggerTrailing}
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-72">
+        <DropdownMenuContent
+          align="start"
+          collisionPadding={12}
+          className="relative z-[300] w-72"
+        >
           <div
             className="flex items-center gap-2 p-1"
             onKeyDown={(event) => event.stopPropagation()}
@@ -1379,15 +1385,17 @@ export function PropertyManagementPopover({
       </DropdownMenu>
 
       <AlertDialog open={confirmDeleteOpen} onOpenChange={setConfirmDeleteOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
+        <AlertDialogContent className="max-w-sm gap-0 rounded-lg p-5">
+          <AlertDialogHeader className="space-y-0 gap-1.5 text-start">
+            <AlertDialogTitle className="text-base leading-tight tracking-tight">
               {t("editor.properties.deletePropertyQuestion")}
             </AlertDialogTitle>
-            <AlertDialogDescription>
-              {t("editor.properties.deletePropertyDescription", {
-                name: property.definition.name,
-              })}
+            <AlertDialogDescription className="leading-normal [text-wrap:pretty]">
+              {t("editor.properties.deletePropertyDescriptionPrefix")}
+              <span className="font-medium text-foreground">
+                {property.definition.name}
+              </span>
+              {t("editor.properties.deletePropertyDescriptionSuffix")}
             </AlertDialogDescription>
           </AlertDialogHeader>
           {isOnlyBlocksField ? (
@@ -1395,12 +1403,12 @@ export function PropertyManagementPopover({
               {t("editor.properties.onlyBlocksPropertyWarning")}
             </div>
           ) : null}
-          <AlertDialogFooter>
-            <AlertDialogCancel>
+          <AlertDialogFooter className="mt-4 flex-row items-center justify-end gap-2 sm:space-x-0">
+            <AlertDialogCancel className="mt-0 h-8 px-3 focus-visible:ring-1 focus-visible:ring-muted-foreground/40 focus-visible:ring-offset-1">
               {t("editor.properties.cancel")}
             </AlertDialogCancel>
             <AlertDialogAction
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              className="h-8 bg-destructive px-3 text-destructive-foreground hover:bg-destructive/90 focus-visible:ring-1 focus-visible:ring-muted-foreground/40 focus-visible:ring-offset-1"
               onClick={() => void deleteProperty()}
             >
               {t("editor.properties.deleteProperty")}
@@ -2651,6 +2659,7 @@ export function AddProperty({
     }))
     .filter((group) => group.fields.length > 0);
   const addPropertySearchInputRef = useRef<HTMLInputElement>(null);
+  const addActivationRef = useRef<{ key: string; at: number } | null>(null);
   const [pendingPropertyType, setPendingPropertyType] =
     useState<DocumentPropertyType | null>(null);
   const [pendingSourceFieldId, setPendingSourceFieldId] = useState<
@@ -2718,6 +2727,38 @@ export function AddProperty({
     }
   }
 
+  function runAddPropertyActivation(key: string, action: () => void) {
+    const now = Date.now();
+    const previous = addActivationRef.current;
+    if (previous?.key === key && now - previous.at < 750) return;
+    addActivationRef.current = { key, at: now };
+    action();
+  }
+
+  function activateAddPropertyItem(
+    event:
+      | ReactPointerEvent<HTMLButtonElement>
+      | ReactMouseEvent<HTMLButtonElement>,
+    key: string,
+    action: () => void,
+  ) {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    runAddPropertyActivation(key, action);
+  }
+
+  function activateAddPropertyItemFromKeyboard(
+    event: ReactKeyboardEvent<HTMLButtonElement>,
+    key: string,
+    action: () => void,
+  ) {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    event.stopPropagation();
+    runAddPropertyActivation(key, action);
+  }
+
   return (
     <Popover
       open={open}
@@ -2747,9 +2788,10 @@ export function AddProperty({
         </button>
       </PopoverTrigger>
       <PopoverContent
-        align="start"
+        align={variant === "default" ? "start" : "end"}
+        collisionPadding={12}
         portalled={popoversPortalled}
-        className="w-80 p-2"
+        className="relative z-[300] w-80 p-2"
       >
         <div className="grid gap-2">
           <div className="flex h-8 items-center gap-1 rounded border border-border bg-background px-2">
@@ -2800,7 +2842,33 @@ export function AddProperty({
                       disabled={isAddingProperty}
                       aria-busy={pendingSourceFieldId === field.id}
                       className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-accent disabled:opacity-50"
-                      onClick={() => void addFromSourceField(field.id)}
+                      onPointerDownCapture={(event) =>
+                        activateAddPropertyItem(
+                          event,
+                          `source:${field.id}`,
+                          () => {
+                            void addFromSourceField(field.id);
+                          },
+                        )
+                      }
+                      onClick={(event) =>
+                        activateAddPropertyItem(
+                          event,
+                          `source:${field.id}`,
+                          () => {
+                            void addFromSourceField(field.id);
+                          },
+                        )
+                      }
+                      onKeyDown={(event) =>
+                        activateAddPropertyItemFromKeyboard(
+                          event,
+                          `source:${field.id}`,
+                          () => {
+                            void addFromSourceField(field.id);
+                          },
+                        )
+                      }
                     >
                       {pendingSourceFieldId === field.id ? (
                         <Spinner className="size-4 shrink-0 text-muted-foreground" />
@@ -2837,7 +2905,25 @@ export function AddProperty({
                   className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-accent"
                   disabled={isAddingProperty}
                   aria-busy={pendingPropertyType === type}
-                  onClick={() => void add(type)}
+                  onPointerDownCapture={(event) =>
+                    activateAddPropertyItem(event, `type:${type}`, () => {
+                      void add(type);
+                    })
+                  }
+                  onClick={(event) =>
+                    activateAddPropertyItem(event, `type:${type}`, () => {
+                      void add(type);
+                    })
+                  }
+                  onKeyDown={(event) =>
+                    activateAddPropertyItemFromKeyboard(
+                      event,
+                      `type:${type}`,
+                      () => {
+                        void add(type);
+                      },
+                    )
+                  }
                 >
                   {pendingPropertyType === type ? (
                     <Spinner className="size-4 text-muted-foreground" />

--- a/templates/content/app/components/editor/DocumentProperties.tsx
+++ b/templates/content/app/components/editor/DocumentProperties.tsx
@@ -2736,9 +2736,10 @@ export function AddProperty({
   }
 
   function activateAddPropertyItem(
-    event:
-      | ReactPointerEvent<HTMLButtonElement>
-      | ReactMouseEvent<HTMLButtonElement>,
+    event: Pick<
+      ReactMouseEvent<HTMLButtonElement>,
+      "button" | "preventDefault" | "stopPropagation"
+    >,
     key: string,
     action: () => void,
   ) {

--- a/templates/content/app/hooks/use-content-database.test.ts
+++ b/templates/content/app/hooks/use-content-database.test.ts
@@ -6,6 +6,7 @@ import { QueryClient } from "@tanstack/react-query";
 import { describe, expect, it } from "vitest";
 
 import {
+  applyDocumentPropertiesToDatabaseResponse,
   applyDocumentPropertyValueToDatabaseResponse,
   applyOptimisticSourceFieldPropertyToDatabaseResponse,
   applySourceFieldPropertyToDatabaseResponse,
@@ -14,6 +15,7 @@ import {
   invalidateBuilderBodyHydrationQueries,
   invalidateContentDatabaseSourceRefreshQueries,
   readCachedContentDatabaseResponse,
+  removeDocumentPropertyFromDatabaseResponse,
   writeContentDatabaseResponseToCache,
 } from "./use-content-database";
 
@@ -310,6 +312,61 @@ describe("applyDocumentPropertyValueToDatabaseResponse", () => {
       value: "Agent Native",
       editable: true,
     });
+  });
+});
+
+describe("applyDocumentPropertiesToDatabaseResponse", () => {
+  it("updates definitions while preserving each row's stored value", () => {
+    const current = databaseResponse();
+    current.items[0]!.properties = [
+      { ...current.properties[0]!, value: "Draft" },
+    ];
+    const renamed = {
+      ...current.properties[0]!,
+      definition: {
+        ...current.properties[0]!.definition,
+        name: "Workflow",
+      },
+    };
+
+    const updated = applyDocumentPropertiesToDatabaseResponse(current, {
+      databaseId: "database",
+      properties: [renamed],
+    });
+
+    expect(updated?.properties[0]?.definition.name).toBe("Workflow");
+    expect(updated?.items[0]?.properties[0]).toMatchObject({
+      definition: { id: "status", name: "Workflow" },
+      value: "Draft",
+    });
+  });
+
+  it("does not patch a cache entry for another database", () => {
+    const current = databaseResponse();
+
+    expect(
+      applyDocumentPropertiesToDatabaseResponse(current, {
+        databaseId: "other-database",
+        properties: [],
+      }),
+    ).toBe(current);
+  });
+});
+
+describe("removeDocumentPropertyFromDatabaseResponse", () => {
+  it("removes a property from the schema and every cached row", () => {
+    const current = databaseResponse();
+    current.items[0]!.properties = [
+      { ...current.properties[0]!, value: "Draft" },
+    ];
+
+    const updated = removeDocumentPropertyFromDatabaseResponse(
+      current,
+      "status",
+    );
+
+    expect(updated?.properties).toEqual([]);
+    expect(updated?.items[0]?.properties).toEqual([]);
   });
 });
 

--- a/templates/content/app/hooks/use-content-database.ts
+++ b/templates/content/app/hooks/use-content-database.ts
@@ -18,6 +18,7 @@ import type {
   CreateDatabaseRequest,
   DatabaseItemsBatchRequest,
   DisconnectContentDatabaseSourceRequest,
+  DocumentPropertiesResponse,
   ExecuteBuilderSourceBatchRequest,
   ExecuteBuilderSourceBatchResponse,
   DuplicateDatabaseItemRequest,
@@ -129,6 +130,57 @@ export function applyDocumentPropertyValueToDatabaseResponse(
   });
 
   return changed ? { ...current, items } : current;
+}
+
+export function applyDocumentPropertiesToDatabaseResponse(
+  current: ContentDatabaseResponse | undefined,
+  response: Pick<DocumentPropertiesResponse, "databaseId" | "properties">,
+): ContentDatabaseResponse | undefined {
+  if (!current) return current;
+  if (response.databaseId && current.database.id !== response.databaseId) {
+    return current;
+  }
+
+  const sortedProperties = [...response.properties].sort(
+    (a, b) => a.definition.position - b.definition.position,
+  );
+  const propertyById = new Map(
+    sortedProperties.map((property) => [property.definition.id, property]),
+  );
+
+  return {
+    ...current,
+    properties: sortedProperties,
+    items: current.items.map((item) => ({
+      ...item,
+      properties: item.properties
+        .filter((property) => propertyById.has(property.definition.id))
+        .map((property) => ({
+          ...propertyById.get(property.definition.id)!,
+          value: property.value,
+        })),
+    })),
+  };
+}
+
+export function removeDocumentPropertyFromDatabaseResponse(
+  current: ContentDatabaseResponse | undefined,
+  propertyId: string,
+): ContentDatabaseResponse | undefined {
+  if (!current) return current;
+
+  return {
+    ...current,
+    properties: current.properties.filter(
+      (property) => property.definition.id !== propertyId,
+    ),
+    items: current.items.map((item) => ({
+      ...item,
+      properties: item.properties.filter(
+        (property) => property.definition.id !== propertyId,
+      ),
+    })),
+  };
 }
 
 // `get-content-database` returns a union at runtime: the full response, or an

--- a/templates/content/app/hooks/use-document-properties.ts
+++ b/templates/content/app/hooks/use-document-properties.ts
@@ -12,9 +12,11 @@ import type {
 import { useQueryClient } from "@tanstack/react-query";
 
 import {
+  applyDocumentPropertiesToDatabaseResponse,
   applyDocumentPropertyValueToDatabaseResponse,
   contentDatabaseQueryFilter,
   contentDatabaseQueryKey,
+  removeDocumentPropertyFromDatabaseResponse,
 } from "./use-content-database";
 
 export function useDocumentProperties(documentId: string | null) {
@@ -37,7 +39,12 @@ export function useConfigureDocumentProperty(
     DocumentPropertiesResponse,
     ConfigureDocumentPropertyRequest
   >("configure-document-property", {
-    onSuccess: () => {
+    skipActionQueryInvalidation: true,
+    onSuccess: (data) => {
+      queryClient.setQueriesData<ContentDatabaseResponse>(
+        contentDatabaseQueryFilter(databaseDocumentId),
+        (current) => applyDocumentPropertiesToDatabaseResponse(current, data),
+      );
       queryClient.invalidateQueries({
         queryKey: ["action", "list-document-properties", { documentId }],
       });
@@ -45,7 +52,7 @@ export function useConfigureDocumentProperty(
         queryKey: ["action", "get-document", { id: documentId }],
       });
       queryClient.invalidateQueries({
-        queryKey: contentDatabaseQueryKey(databaseDocumentId),
+        ...contentDatabaseQueryFilter(databaseDocumentId),
       });
     },
   });
@@ -135,7 +142,12 @@ export function useDuplicateDocumentProperty(
     DocumentPropertiesResponse,
     DuplicateDocumentPropertyRequest
   >("duplicate-document-property", {
-    onSuccess: () => {
+    skipActionQueryInvalidation: true,
+    onSuccess: (data) => {
+      queryClient.setQueriesData<ContentDatabaseResponse>(
+        contentDatabaseQueryFilter(databaseDocumentId),
+        (current) => applyDocumentPropertiesToDatabaseResponse(current, data),
+      );
       queryClient.invalidateQueries({
         queryKey: ["action", "list-document-properties", { documentId }],
       });
@@ -143,7 +155,7 @@ export function useDuplicateDocumentProperty(
         queryKey: ["action", "get-document", { id: documentId }],
       });
       queryClient.invalidateQueries({
-        queryKey: contentDatabaseQueryKey(databaseDocumentId),
+        ...contentDatabaseQueryFilter(databaseDocumentId),
       });
     },
   });
@@ -181,7 +193,39 @@ export function useDeleteDocumentProperty(
     DocumentPropertiesResponse,
     DeleteDocumentPropertyRequest
   >("delete-document-property", {
-    onSuccess: () => {
+    skipActionQueryInvalidation: true,
+    onMutate: async (variables) => {
+      await queryClient.cancelQueries(
+        contentDatabaseQueryFilter(databaseDocumentId),
+      );
+      const previous = queryClient.getQueriesData<ContentDatabaseResponse>(
+        contentDatabaseQueryFilter(databaseDocumentId),
+      );
+      queryClient.setQueriesData<ContentDatabaseResponse>(
+        contentDatabaseQueryFilter(databaseDocumentId),
+        (current) =>
+          removeDocumentPropertyFromDatabaseResponse(
+            current,
+            variables.propertyId,
+          ),
+      );
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      const rollback = context as
+        | {
+            previous?: Array<[readonly unknown[], unknown]>;
+          }
+        | undefined;
+      for (const [queryKey, data] of rollback?.previous ?? []) {
+        queryClient.setQueryData(queryKey, data);
+      }
+    },
+    onSuccess: (data) => {
+      queryClient.setQueriesData<ContentDatabaseResponse>(
+        contentDatabaseQueryFilter(databaseDocumentId),
+        (current) => applyDocumentPropertiesToDatabaseResponse(current, data),
+      );
       queryClient.invalidateQueries({
         queryKey: ["action", "list-document-properties", { documentId }],
       });
@@ -189,7 +233,7 @@ export function useDeleteDocumentProperty(
         queryKey: ["action", "get-document", { id: documentId }],
       });
       queryClient.invalidateQueries({
-        queryKey: contentDatabaseQueryKey(databaseDocumentId),
+        ...contentDatabaseQueryFilter(databaseDocumentId),
       });
     },
   });

--- a/templates/content/app/i18n-data.ts
+++ b/templates/content/app/i18n-data.ts
@@ -1958,6 +1958,9 @@ const editorPropertiesMessages = {
   deleteProperty: "Delete property",
   deletePropertyDescription:
     'This removes "{{name}}" and its values from every document in this workspace.',
+  deletePropertyDescriptionPrefix: 'This removes "',
+  deletePropertyDescriptionSuffix:
+    '" and its values from every document in this workspace.',
   deletePropertyQuestion: "Delete property?",
   duplicateProperty: "Duplicate property",
   editEndDate: "Edit {{name}} end date",
@@ -4978,6 +4981,8 @@ const editorMessagesByLocale = {
       deleteProperty: "删除属性",
       deletePropertyDescription:
         '这将从该工作区中的每个文档中删除"{{name}}"及其值。',
+      deletePropertyDescriptionPrefix: '这将从该工作区中的每个文档中删除"',
+      deletePropertyDescriptionSuffix: '"及其值。',
       deletePropertyQuestion: "删除属性？",
       duplicateProperty: "重复的属性",
       editEndDate: "编辑 {{name}} 结束日期",
@@ -5304,6 +5309,9 @@ const editorMessagesByLocale = {
       deleteProperty: "Eliminar propiedad",
       deletePropertyDescription:
         'Esto elimina "{{name}}" y sus valores de todos los documentos de este espacio de trabajo.',
+      deletePropertyDescriptionPrefix: 'Esto elimina "',
+      deletePropertyDescriptionSuffix:
+        '" y sus valores de todos los documentos de este espacio de trabajo.',
       deletePropertyQuestion: "¿Eliminar propiedad?",
       duplicateProperty: "Propiedad duplicada",
       editEndDate: "Editar fecha de finalización de {{name}}",
@@ -5641,6 +5649,9 @@ const editorMessagesByLocale = {
       deleteProperty: "Supprimer la propriété",
       deletePropertyDescription:
         "Cela supprime « {{name}} » et ses valeurs de chaque document de cet espace de travail.",
+      deletePropertyDescriptionPrefix: "Cela supprime « ",
+      deletePropertyDescriptionSuffix:
+        " » et ses valeurs de chaque document de cet espace de travail.",
       deletePropertyQuestion: "Supprimer la propriété ?",
       duplicateProperty: "Propriété en double",
       editEndDate: "Modifier la date de fin de {{name}}",
@@ -5978,6 +5989,9 @@ const editorMessagesByLocale = {
       deleteProperty: "Eigenschaft löschen",
       deletePropertyDescription:
         'Dadurch werden „{{name}}" und seine Werte aus jedem Dokument in diesem Arbeitsbereich entfernt.',
+      deletePropertyDescriptionPrefix: "Dadurch werden „",
+      deletePropertyDescriptionSuffix:
+        '" und seine Werte aus jedem Dokument in diesem Arbeitsbereich entfernt.',
       deletePropertyQuestion: "Eigenschaft löschen?",
       duplicateProperty: "Doppelte Eigenschaft",
       editEndDate: "{{name}}-Enddatum bearbeiten",
@@ -6315,6 +6329,9 @@ const editorMessagesByLocale = {
       deleteProperty: "プロパティの削除",
       deletePropertyDescription:
         "これにより、このワークスペース内のすべてのドキュメントから「{{name}}」とその値が削除されます。",
+      deletePropertyDescriptionPrefix:
+        "これにより、このワークスペース内のすべてのドキュメントから「",
+      deletePropertyDescriptionSuffix: "」とその値が削除されます。",
       deletePropertyQuestion: "プロパティを削除しますか?",
       duplicateProperty: "重複したプロパティ",
       editEndDate: "{{name}} の終了日を編集",
@@ -6645,6 +6662,9 @@ const editorMessagesByLocale = {
       deleteProperty: "속성 삭제",
       deletePropertyDescription:
         '이렇게 하면 이 작업공간의 모든 문서에서 "{{name}}"와 해당 값이 제거됩니다.',
+      deletePropertyDescriptionPrefix:
+        '이렇게 하면 이 작업공간의 모든 문서에서 "',
+      deletePropertyDescriptionSuffix: '"와 해당 값이 제거됩니다.',
       deletePropertyQuestion: "속성을 삭제하시겠습니까?",
       duplicateProperty: "중복된 속성",
       editEndDate: "{{name}} 종료일 수정",
@@ -6978,6 +6998,9 @@ const editorMessagesByLocale = {
       deleteProperty: "Excluir propriedade",
       deletePropertyDescription:
         'Isso remove "{{name}}" e seus valores de todos os documentos nesta área de trabalho.',
+      deletePropertyDescriptionPrefix: 'Isso remove "',
+      deletePropertyDescriptionSuffix:
+        '" e seus valores de todos os documentos nesta área de trabalho.',
       deletePropertyQuestion: "Excluir propriedade?",
       duplicateProperty: "Propriedade duplicada",
       editEndDate: "Editar data de término do {{name}}",
@@ -7311,6 +7334,8 @@ const editorMessagesByLocale = {
       deleteProperty: "संपत्ति हटाएं",
       deletePropertyDescription:
         'यह इस कार्यक्षेत्र के प्रत्येक दस्तावेज़ से "{{name}}" और उसके मानों को हटा देता है।',
+      deletePropertyDescriptionPrefix: 'यह इस कार्यक्षेत्र के प्रत्येक दस्तावेज़ से "',
+      deletePropertyDescriptionSuffix: '" और उसके मानों को हटा देता है।',
       deletePropertyQuestion: "संपत्ति हटाएं?",
       duplicateProperty: "डुप्लिकेट संपत्ति",
       editEndDate: "{{name}} समाप्ति तिथि संपादित करें",
@@ -7638,6 +7663,9 @@ const editorMessagesByLocale = {
       deleteProperty: "حذف الممتلكات",
       deletePropertyDescription:
         'يؤدي هذا إلى إزالة "{{name}}" وقيمه من كل مستند في مساحة العمل هذه.',
+      deletePropertyDescriptionPrefix: 'يؤدي هذا إلى إزالة "',
+      deletePropertyDescriptionSuffix:
+        '" وقيمه من كل مستند في مساحة العمل هذه.',
       deletePropertyQuestion: "هل تريد حذف الخاصية؟",
       duplicateProperty: "خاصية مكررة",
       editEndDate: "تحرير تاريخ انتهاء {{name}}",

--- a/templates/content/app/i18n/zh-TW.ts
+++ b/templates/content/app/i18n/zh-TW.ts
@@ -307,6 +307,8 @@ const messages = {
       deleteProperty: "刪除屬性",
       deletePropertyDescription:
         '這將從該工作區中的每個檔案中刪除"{{name}}"及其值。',
+      deletePropertyDescriptionPrefix: '這將從該工作區中的每個檔案中刪除"',
+      deletePropertyDescriptionSuffix: '"及其值。',
       deletePropertyQuestion: "刪除屬性？",
       duplicateProperty: "重複的屬性",
       editEndDate: "編輯 {{name}} 結束日期",

--- a/templates/content/changelog/2026-07-09-property-menus-and-delete-confirmations-now-open-visibly-and.md
+++ b/templates/content/changelog/2026-07-09-property-menus-and-delete-confirmations-now-open-visibly-and.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-09
+---
+
+Property menus and delete confirmations now open visibly and respond reliably in database tables.


### PR DESCRIPTION
## Summary
- keep add-property and column-property menus visible and reliably actionable above large database tables
- update Content database caches narrowly after property mutations, including optimistic delete rollback
- center the destructive confirmation over a full-app scrim with compact, localized copy

## Verification
- `./node_modules/.bin/vitest --run app/components/editor/DocumentProperties.test.ts app/components/editor/DocumentProperties.layout.test.ts app/hooks/use-content-database.test.ts app/components/editor/DocumentDatabase.test.ts --config vitest.config.ts`
- `/opt/homebrew/bin/pnpm typecheck`
- `/opt/homebrew/bin/pnpm --filter @agent-native/toolkit build`
- Chrome QA against the real 597-row Blog database: add menu, Read Time column menu, delete dialog, full-app overlay hit testing, keyboard focus, and non-destructive cancel