### PR TITLE
Fix SSR error visibility and recap screenshots

### DIFF
--- a/.changeset/guard-recap-ssr-failures.md
+++ b/.changeset/guard-recap-ssr-failures.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Prevent PR recap workflows from publishing screenshots of failed recap pages, and report SSR render failures through configured error monitoring.

--- a/packages/core/src/cli/recap.io.spec.ts
+++ b/packages/core/src/cli/recap.io.spec.ts
@@ -543,6 +543,12 @@ describe("runShot — playwright not available", () => {
     const fakePage = {
       goto: vi.fn(async (nextUrl: string) => {
         gotoUrls.push(nextUrl);
+        return {
+          ok: () => true,
+          status: () => 200,
+          url: () => nextUrl,
+          headers: () => ({ "content-type": "text/html; charset=utf-8" }),
+        };
       }),
       waitForLoadState: vi.fn(async () => {}),
       waitForSelector: vi.fn(async () => {}),

--- a/packages/core/src/cli/recap.spec.ts
+++ b/packages/core/src/cli/recap.spec.ts
@@ -1277,7 +1277,12 @@ describe("recap screenshot browser launch", () => {
 describe("recap screenshot capture", () => {
   function createShotPlaywright(screenshotBytes: Buffer[]) {
     const page = {
-      goto: vi.fn(async () => undefined),
+      goto: vi.fn(async () => ({
+        ok: () => true,
+        status: () => 200,
+        url: () => "https://plan.agent-native.com/recaps/plan-abc123",
+        headers: () => ({ "content-type": "text/html; charset=utf-8" }),
+      })),
       waitForLoadState: vi.fn(async () => undefined),
       waitForSelector: vi.fn(async () => undefined),
       waitForTimeout: vi.fn(async () => undefined),
@@ -1379,6 +1384,47 @@ describe("recap screenshot capture", () => {
       );
       expect(page.waitForLoadState).toHaveBeenCalledWith("load", {
         timeout: 15_000,
+      });
+    } finally {
+      stdout.mockRestore();
+      fs.rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  it("does not upload a screenshot when the recap page returns an HTTP error", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "an-recap-shot-"));
+    const out = path.join(dir, "recap.png");
+    const { page, importPlaywright } = createShotPlaywright([
+      Buffer.from("png"),
+    ]);
+    page.goto.mockResolvedValueOnce({
+      ok: () => false,
+      status: () => 500,
+      url: () => "https://plan.agent-native.com/recaps/recap-broken",
+      headers: () => ({ "content-type": "text/plain" }),
+    });
+    const writes: string[] = [];
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk: string | Uint8Array) => {
+        writes.push(String(chunk));
+        return true;
+      });
+
+    try {
+      await runShot(
+        {
+          url: "https://plan.agent-native.com/recaps/recap-broken",
+          out,
+        },
+        importPlaywright,
+      );
+
+      expect(page.screenshot).not.toHaveBeenCalled();
+      expect(JSON.parse(writes.join("").trim())).toMatchObject({
+        ok: false,
+        reason:
+          "recap page returned HTTP 500 while loading https://plan.agent-native.com/recaps/recap-broken",
       });
     } finally {
       stdout.mockRestore();

--- a/packages/core/src/cli/recap.ts
+++ b/packages/core/src/cli/recap.ts
@@ -2987,10 +2987,24 @@ export async function runShot(
       });
     }
     const page = await context.newPage();
-    await page.goto(captureUrl, {
+    const navigationResponse = await page.goto(captureUrl, {
       waitUntil: "domcontentloaded",
       timeout: 45_000,
     });
+    if (!navigationResponse) {
+      throw new Error("recap page did not return an HTTP response");
+    }
+    if (!navigationResponse.ok()) {
+      throw new Error(
+        `recap page returned HTTP ${navigationResponse.status()} while loading ${navigationResponse.url()}`,
+      );
+    }
+    const contentType = navigationResponse.headers()["content-type"] ?? "";
+    if (contentType && !/\btext\/html\b/i.test(contentType)) {
+      throw new Error(
+        `recap page returned unexpected content type ${contentType} while loading ${navigationResponse.url()}`,
+      );
+    }
     await page.waitForLoadState("load", { timeout: 15_000 }).catch(() => {
       // The selectors below are the real readiness signal for screenshots.
       // Some recap pages keep long-lived/background requests open.

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -9,6 +9,7 @@ import {
   AGENT_NATIVE_SOCIAL_IMAGE_CACHE_BUSTER,
   AGENT_NATIVE_SOCIAL_IMAGE_PATH,
 } from "../shared/social-meta.js";
+import { registerErrorCaptureProvider } from "./capture-error.js";
 import { getRequestUserEmail } from "./request-context.js";
 import {
   createH3SSRHandler,
@@ -98,6 +99,37 @@ describe("createH3SSRHandler", () => {
 
     await expect(response.text()).resolves.toBe("GET /inbox?view=unread");
     expect(mocks.requestHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("captures SSR exceptions with request context before returning a safe 500", async () => {
+    const error = new Error("render failed");
+    const provider = vi.fn();
+    const unregister = registerErrorCaptureProvider(
+      "ssr-handler-test",
+      provider,
+    );
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mocks.requestHandler.mockImplementationOnce(async () => {
+      throw error;
+    });
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    try {
+      const response = await handler(createEvent("/recaps/recap_test"));
+
+      expect(response.status).toBe(500);
+      expect(provider).toHaveBeenCalledWith(error, {
+        route: "/recaps/recap_test",
+        method: "GET",
+        userAgent: undefined,
+        tags: { renderMode: "anonymous-public", surface: "ssr" },
+      });
+    } finally {
+      consoleError.mockRestore();
+      unregister();
+    }
   });
 
   it("strips APP_BASE_PATH from React Router lazy route manifest paths", async () => {

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -34,6 +34,7 @@ import {
   getAppBasePathFromViteEnv,
   stripAppBasePath as canonicalStripAppBasePath,
 } from "./app-base-path.js";
+import { captureError } from "./capture-error.js";
 import { runWithRequestContext } from "./request-context.js";
 import { getSentryClientConfigScript } from "./sentry-config.js";
 
@@ -391,6 +392,12 @@ export function createH3SSRHandler(getBuild: () => Promise<unknown> | unknown) {
       // that aid reconnaissance attacks. In dev we surface the message text
       // so devtools shows something useful; in prod we return a bare 500.
       console.error("[ssr-handler] SSR error:", err);
+      captureError(err, {
+        route: p,
+        method: event.req.method,
+        userAgent: event.req.headers.get("user-agent") ?? undefined,
+        tags: { renderMode: "anonymous-public", surface: "ssr" },
+      });
       const isProd = process.env.NODE_ENV === "production";
       const body = isProd
         ? "Internal Server Error"


### PR DESCRIPTION
## Summary

- Fail recap screenshots when the navigation response is missing, non-2xx, or non-HTML.
- Report caught SSR rendering exceptions with route and request-method context.
- Cover both failure paths and include a core patch changeset.

## Why

Generic production SSR errors could be captured as recap images and did not reach configured error monitoring with enough request context to investigate quickly.

## Validation

- `corepack pnpm --filter @agent-native/core exec vitest run src/cli/recap.spec.ts src/server/ssr-handler.spec.ts`
- `NITRO_PRESET=netlify corepack pnpm --filter plan build`
- `corepack pnpm --filter @agent-native/core build`