### PR TITLE
Fix serverless Yjs runtime packaging

### DIFF
--- a/.changeset/bundle-yjs-in-serverless-functions.md
+++ b/.changeset/bundle-yjs-in-serverless-functions.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Prevent Netlify, Vercel, and AWS Lambda deployments from failing SSR requests when collaboration runtime chunks import Yjs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,6 +446,16 @@ jobs:
         # SQLite setup cannot call process.exit during this import-only probe.
         run: NETLIFY=true timeout 120 node scripts/ssr-boot-smoke.mjs plan clips
 
+      # Exercise the two other Node serverless presets as well. These import
+      # their generated handlers, so an unresolved bare runtime dependency
+      # fails before a deployment can be published.
+      - name: Build and import Plan SSR handlers (Vercel and AWS Lambda)
+        run: |
+          NITRO_PRESET=vercel pnpm --filter plan build
+          VERCEL=true timeout 120 node scripts/ssr-boot-smoke.mjs --preset vercel plan
+          NITRO_PRESET=aws-lambda pnpm --filter plan build
+          AWS_LAMBDA_FUNCTION_NAME=ssr-smoke timeout 120 node scripts/ssr-boot-smoke.mjs --preset aws-lambda plan
+
   guards:
     name: Security guards
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,17 +433,16 @@ jobs:
           pnpm --filter @agent-native/toolkit build
           pnpm --filter @agent-native/core build
 
-      # The `plan` template exercises the Excalidraw/Mermaid diagram blocks, so
-      # its server bundle is the canonical reproducer for browser-only libs
-      # leaking into SSR. The fix lives in @agent-native/core, so one template
-      # guards the whole fleet.
-      - name: Build plan template (netlify preset)
-        run: NITRO_PRESET=netlify pnpm --filter plan build
+      # Plan covers diagram-heavy SSR and Clips covers public-share SSR. Build
+      # both real Netlify function artifacts so a core runtime dependency cannot
+      # be missing from either deployment's server bundle.
+      - name: Build Plan and Clips templates (netlify preset)
+        run: NITRO_PRESET=netlify pnpm --filter plan --filter clips build
 
       - name: Import SSR handler — must not crash at cold-start
         # External timeout is a backstop against a pathological synchronous hang;
         # the script itself races module eval against a 30s window and force-exits.
-        run: timeout 120 node scripts/ssr-boot-smoke.mjs plan
+        run: timeout 120 node scripts/ssr-boot-smoke.mjs plan clips
 
   guards:
     name: Security guards

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,7 +442,9 @@ jobs:
       - name: Import SSR handler — must not crash at cold-start
         # External timeout is a backstop against a pathological synchronous hang;
         # the script itself races module eval against a 30s window and force-exits.
-        run: timeout 120 node scripts/ssr-boot-smoke.mjs plan clips
+        # Match the deployed Netlify environment so failed best-effort local
+        # SQLite setup cannot call process.exit during this import-only probe.
+        run: NETLIFY=true timeout 120 node scripts/ssr-boot-smoke.mjs plan clips
 
   guards:
     name: Security guards

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -25,6 +25,8 @@ import {
   getNodeBuiltinNames,
   isDurableBackgroundDeployEnabled,
   NITRO_RUNTIME_IGNORE_PATTERNS,
+  nitroNoExternalsForPreset,
+  rewriteBareYjsImportsForServerlessOutput,
   runNitroBuildPipeline,
   sanitizeServerlessFunctionPackageManifest,
   shouldBundleFfmpegStaticForServerless,
@@ -38,6 +40,19 @@ const DEFAULT_SSR_CDN_CACHE_CONTROL = DEFAULT_SSR_CACHE_CONTROL;
 const DEFAULT_SSR_NETLIFY_CDN_CACHE_CONTROL =
   "public, durable, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
 const tempDirs: string[] = [];
+
+describe("nitroNoExternalsForPreset", () => {
+  it("bundles Yjs in Node/serverless output", () => {
+    expect(nitroNoExternalsForPreset("netlify")).toEqual(["yjs"]);
+    expect(nitroNoExternalsForPreset("vercel")).toEqual(["yjs"]);
+    expect(nitroNoExternalsForPreset("node-server")).toEqual(["yjs"]);
+  });
+
+  it("bundles every dependency for edge output", () => {
+    expect(nitroNoExternalsForPreset("cloudflare-pages")).toBe(true);
+    expect(nitroNoExternalsForPreset("deno-deploy")).toBe(true);
+  });
+});
 
 function expectDefaultWorkerSsrCacheHeaders(response: Response) {
   expect(response.headers.get("cache-control")).toBe(DEFAULT_SSR_CACHE_CONTROL);
@@ -1343,6 +1358,8 @@ describe("durable-background Netlify function emit (single-template, flag-gated)
     fs.mkdirSync(serverDir, { recursive: true });
     fs.writeFileSync(path.join(serverDir, "main.mjs"), "export default {};\n");
     fs.writeFileSync(path.join(serverDir, "server.mjs"), SERVER_ENTRY);
+    fs.mkdirSync(path.join(serverDir, "_libs"), { recursive: true });
+    fs.writeFileSync(path.join(serverDir, "_libs", "yjs.mjs"), "export {};\n");
     return cwd;
   }
 
@@ -1562,6 +1579,50 @@ describe("durable-background Netlify function emit (single-template, flag-gated)
     expect(() => assertSingleTemplateNetlifyBuildOutput(cwd)).toThrow(
       /preferStatic: true/,
     );
+  });
+
+  it("fails deploy output with a bare Yjs runtime import", () => {
+    const cwd = setupNetlifyOutput();
+    prepareSingleTemplateNetlifyOutput(cwd);
+    const collabChunk = path.join(
+      cwd,
+      ".netlify",
+      "functions-internal",
+      "server",
+      "_chunks",
+      "collab.mjs",
+    );
+    fs.mkdirSync(path.dirname(collabChunk), { recursive: true });
+    fs.writeFileSync(collabChunk, 'import * as Y from "yjs";\nexport { Y };\n');
+
+    expect(() => assertSingleTemplateNetlifyBuildOutput(cwd)).toThrow(
+      /leaves yjs as a runtime import/,
+    );
+  });
+
+  it("rewrites bare Yjs imports to the bundled server copy", () => {
+    const cwd = setupNetlifyOutput();
+    const serverDir = path.join(
+      cwd,
+      ".netlify",
+      "functions-internal",
+      "server",
+    );
+    const collabChunk = path.join(serverDir, "_chunks", "collab.mjs");
+    fs.mkdirSync(path.dirname(collabChunk), { recursive: true });
+    fs.writeFileSync(
+      collabChunk,
+      'import * as Y from "yjs";\nconst dynamic = import("yjs");\nexport { Y, dynamic };\n',
+    );
+
+    expect(rewriteBareYjsImportsForServerlessOutput(serverDir)).toEqual([
+      collabChunk,
+    ]);
+    const rewritten = fs.readFileSync(collabChunk, "utf-8");
+    expect(rewritten).toContain('from "../_libs/yjs.mjs"');
+    expect(rewritten).toContain('import("../_libs/yjs.mjs")');
+    prepareSingleTemplateNetlifyOutput(cwd);
+    expect(() => assertSingleTemplateNetlifyBuildOutput(cwd)).not.toThrow();
   });
 
   it("fails deploy output that would publish without client assets in dist", () => {

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -45,6 +45,7 @@ describe("nitroNoExternalsForPreset", () => {
   it("bundles Yjs in Node/serverless output", () => {
     expect(nitroNoExternalsForPreset("netlify")).toEqual(["yjs"]);
     expect(nitroNoExternalsForPreset("vercel")).toEqual(["yjs"]);
+    expect(nitroNoExternalsForPreset("aws-lambda")).toEqual(["yjs"]);
     expect(nitroNoExternalsForPreset("node-server")).toEqual(["yjs"]);
   });
 
@@ -1623,6 +1624,26 @@ describe("durable-background Netlify function emit (single-template, flag-gated)
     expect(rewritten).toContain('import("../_libs/yjs.mjs")');
     prepareSingleTemplateNetlifyOutput(cwd);
     expect(() => assertSingleTemplateNetlifyBuildOutput(cwd)).not.toThrow();
+  });
+
+  it("rejects unsupported Yjs subpath imports instead of rewriting their semantics", () => {
+    const cwd = setupNetlifyOutput();
+    const serverDir = path.join(
+      cwd,
+      ".netlify",
+      "functions-internal",
+      "server",
+    );
+    const collabChunk = path.join(serverDir, "_chunks", "collab.mjs");
+    fs.mkdirSync(path.dirname(collabChunk), { recursive: true });
+    fs.writeFileSync(
+      collabChunk,
+      'import * as Y from "yjs/src/index.js";\nexport { Y };\n',
+    );
+
+    expect(() => rewriteBareYjsImportsForServerlessOutput(serverDir)).toThrow(
+      /unsupported yjs subpath imports/,
+    );
   });
 
   it("fails deploy output that would publish without client assets in dist", () => {

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -2437,6 +2437,73 @@ export const config = {
 const NETLIFY_DEFAULT_FUNCTION_URL_REDIRECT =
   "/* /.netlify/functions/server 200";
 
+function hasBareYjsRuntimeImport(source: string): boolean {
+  return /\b(?:from\s*|import\s*\(\s*|import\s*)["']yjs(?:\/[^"']*)?["']/.test(
+    source,
+  );
+}
+
+function walkServerJavaScriptFiles(
+  dir: string,
+  onFile: (filePath: string) => void,
+): void {
+  if (!fs.existsSync(dir)) return;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkServerJavaScriptFiles(entryPath, onFile);
+      continue;
+    }
+    if (/\.(?:[cm]?js)$/.test(entry.name)) onFile(entryPath);
+  }
+}
+
+/**
+ * Nitro can preserve Vite's `yjs` external in a split server chunk even when
+ * its own server build has emitted `_libs/yjs.mjs`. Netlify does not install
+ * that bare package at runtime, so make every emitted server chunk use the
+ * bundled copy before its function is packaged.
+ */
+export function rewriteBareYjsImportsForServerlessOutput(
+  serverDir: string,
+): string[] {
+  const bareImports: string[] = [];
+  const bundledYjsPath = path.join(serverDir, "_libs", "yjs.mjs");
+
+  walkServerJavaScriptFiles(serverDir, (filePath) => {
+    const source = fs.readFileSync(filePath, "utf-8");
+    if (hasBareYjsRuntimeImport(source)) bareImports.push(filePath);
+  });
+
+  if (bareImports.length === 0) return [];
+  if (!fs.existsSync(bundledYjsPath)) {
+    throw new Error(
+      `[deploy] Serverless output left yjs as a runtime import but did not emit ${bundledYjsPath}`,
+    );
+  }
+
+  for (const filePath of bareImports) {
+    const bundledImport = path
+      .relative(path.dirname(filePath), bundledYjsPath)
+      .split(path.sep)
+      .join("/");
+    const relativeBundledImport = bundledImport.startsWith(".")
+      ? bundledImport
+      : `./${bundledImport}`;
+    const source = fs.readFileSync(filePath, "utf-8");
+    fs.writeFileSync(
+      filePath,
+      source.replace(
+        /(\b(?:from\s*|import\s*\(\s*|import\s*))(["'])yjs\2/g,
+        (_match, importPrefix: string, quote: string) =>
+          `${importPrefix}${quote}${relativeBundledImport}${quote}`,
+      ),
+    );
+  }
+
+  return bareImports;
+}
+
 export function assertSingleTemplateNetlifyBuildOutput(
   projectCwd: string,
 ): void {
@@ -2517,6 +2584,23 @@ export function assertSingleTemplateNetlifyBuildOutput(
         "Netlify server entry must keep preferStatic: true so /assets/* is served from dist before the SSR catch-all",
       );
     }
+  }
+
+  // Netlify's function packager does not install arbitrary runtime package
+  // imports left in Nitro chunks. A bare Yjs import here would deploy
+  // successfully but fail on the first SSR request with ERR_MODULE_NOT_FOUND.
+  // Keep this check adjacent to the output guard so both local builds and CI
+  // reject that artifact before it reaches Netlify.
+  const bareYjsImports: string[] = [];
+  walkServerJavaScriptFiles(serverDir, (filePath) => {
+    if (hasBareYjsRuntimeImport(fs.readFileSync(filePath, "utf-8"))) {
+      bareYjsImports.push(path.relative(projectCwd, filePath));
+    }
+  });
+  if (bareYjsImports.length > 0) {
+    failures.push(
+      `Netlify server bundle leaves yjs as a runtime import: ${bareYjsImports.join(", ")}`,
+    );
   }
 
   if (isDurableBackgroundDeployEnabled()) {
@@ -2970,6 +3054,32 @@ const BROWSER_ONLY_SERVER_LIBS = [
 ];
 
 /**
+ * Dependencies that must be bundled into every Nitro server output instead of
+ * being left as runtime package imports.
+ *
+ * `yjs` is a direct core dependency, but it is deliberately externalized from
+ * the intermediate Vite SSR graph so that Vite and Nitro do not create two
+ * incompatible Yjs constructors. On file-traced serverless presets, leaving it
+ * external at Nitro's final build can emit `import "yjs"` into a function
+ * chunk without placing the package in that function's `node_modules`. Bundle
+ * it in Nitro's final output so every template receives the one portable copy.
+ */
+export const NITRO_SERVER_RUNTIME_BUNDLED_DEPS = ["yjs"] as const;
+
+/**
+ * Edge runtimes have no node_modules, while Node/serverless outputs only need
+ * the small set above bundled to keep their package manifests traceable.
+ */
+export function nitroNoExternalsForPreset(
+  targetPreset: string,
+): true | readonly string[] {
+  return targetPreset.startsWith("cloudflare") ||
+    targetPreset.startsWith("deno")
+    ? true
+    : NITRO_SERVER_RUNTIME_BUNDLED_DEPS;
+}
+
+/**
  * Rolldown plugin for the Nitro server bundle that replaces the browser-only
  * renderers above with an inert proxy module.
  *
@@ -3124,11 +3234,11 @@ export default bundle;
       ? { plugins: [providedPluginsNitroPlugin] }
       : {}),
     routeRules: mcpEmbedStaticAssetRouteRules(appBasePath),
-    // For edge presets (cloudflare, deno), bundle all deps — node_modules
-    // aren't available at runtime. Netlify/Vercel/Node have node_modules.
-    ...(preset.startsWith("cloudflare") || preset.startsWith("deno")
-      ? { noExternals: true }
-      : {}),
+    // Edge presets (cloudflare, deno) bundle all deps because node_modules are
+    // unavailable at runtime. Node/serverless presets also bundle Yjs: Nitro's
+    // file tracer otherwise leaves a bare import that Netlify function bundles
+    // cannot resolve under pnpm.
+    noExternals: nitroNoExternalsForPreset(preset),
   } as any);
 
   await runNitroBuildPipeline({
@@ -3145,6 +3255,7 @@ export default bundle;
     copyInstalledResvgPackages(nitro.options.output.serverDir);
     copyInstalledFfmpegStaticPackage(nitro.options.output.serverDir);
     sanitizeServerlessFunctionPackageManifest(nitro.options.output.serverDir);
+    rewriteBareYjsImportsForServerlessOutput(nitro.options.output.serverDir);
   }
 
   // Durable background agent runs (default-OFF / opt-in; enable with a truthy

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -2443,6 +2443,12 @@ function hasBareYjsRuntimeImport(source: string): boolean {
   );
 }
 
+function hasUnsupportedYjsSubpathImport(source: string): boolean {
+  return /\b(?:from\s*|import\s*\(\s*|import\s*)["']yjs\/[^"']*["']/.test(
+    source,
+  );
+}
+
 function walkServerJavaScriptFiles(
   dir: string,
   onFile: (filePath: string) => void,
@@ -2468,13 +2474,24 @@ export function rewriteBareYjsImportsForServerlessOutput(
   serverDir: string,
 ): string[] {
   const bareImports: string[] = [];
+  const unsupportedSubpathImports: string[] = [];
   const bundledYjsPath = path.join(serverDir, "_libs", "yjs.mjs");
 
   walkServerJavaScriptFiles(serverDir, (filePath) => {
     const source = fs.readFileSync(filePath, "utf-8");
-    if (hasBareYjsRuntimeImport(source)) bareImports.push(filePath);
+    if (!hasBareYjsRuntimeImport(source)) return;
+    if (hasUnsupportedYjsSubpathImport(source)) {
+      unsupportedSubpathImports.push(filePath);
+      return;
+    }
+    bareImports.push(filePath);
   });
 
+  if (unsupportedSubpathImports.length > 0) {
+    throw new Error(
+      `[deploy] Serverless output left unsupported yjs subpath imports in ${unsupportedSubpathImports.join(", ")}`,
+    );
+  }
   if (bareImports.length === 0) return [];
   if (!fs.existsSync(bundledYjsPath)) {
     throw new Error(

--- a/scripts/ssr-boot-smoke.mjs
+++ b/scripts/ssr-boot-smoke.mjs
@@ -2,7 +2,7 @@
 /**
  * SSR cold-start smoke test.
  *
- * Imports a template's built Netlify SSR handler (`main.mjs`) and asserts the
+ * Imports a template's built serverless SSR handler and asserts the
  * server module graph evaluates without throwing. This reproduces the serverless
  * cold-start: the runtime imports the handler at first invocation, and any code
  * that runs browser-only / SSR-incompatible logic at module scope throws here
@@ -25,12 +25,13 @@
  * lingering runtime init. The CI step also wraps this in an external `timeout`
  * as a backstop against a pathological synchronous hang during evaluation.
  *
- * `main.mjs` is the pure function handler (it does NOT call `.listen()`), so
+ * Each configured entry is the pure function handler (it does NOT call
+ * `.listen()`), so
  * importing it evaluates the full server module graph without starting a server,
  * and needs no DATABASE_URL/env — the crash happens before any request.
  *
- * Usage (after `NITRO_PRESET=netlify pnpm --filter <template> build`):
- *   node scripts/ssr-boot-smoke.mjs <template> [<template> ...]
+ * Usage (after `NITRO_PRESET=<preset> pnpm --filter <template> build`):
+ *   node scripts/ssr-boot-smoke.mjs [--preset <netlify|vercel|aws-lambda>] <template> [<template> ...]
  */
 import { existsSync } from "node:fs";
 import path from "node:path";
@@ -40,25 +41,38 @@ import { pathToFileURL } from "node:url";
 // thus any `window is not defined`-style throw) happens almost immediately; if
 // we get this far without a rejection, the dangerous code did not run.
 const EVAL_WINDOW_MS = 30_000;
-const HANDLER_REL = ".netlify/functions-internal/server/main.mjs";
+const HANDLER_REL_BY_PRESET = {
+  netlify: ".netlify/functions-internal/server/main.mjs",
+  vercel: ".vercel/output/functions/__server.func/index.mjs",
+  "aws-lambda": ".output/server/index.mjs",
+};
 
-const templates = process.argv.slice(2);
-if (templates.length === 0) {
+let args = process.argv.slice(2);
+let preset = "netlify";
+if (args[0] === "--preset") {
+  preset = args[1] ?? "";
+  args = args.slice(2);
+}
+const handlerRel = HANDLER_REL_BY_PRESET[preset];
+
+if (!handlerRel || args.length === 0) {
   console.error(
-    "[ssr-smoke] Usage: node scripts/ssr-boot-smoke.mjs <template> [<template> ...]",
+    "[ssr-smoke] Usage: node scripts/ssr-boot-smoke.mjs [--preset <netlify|vercel|aws-lambda>] <template> [<template> ...]",
   );
   process.exit(2);
 }
 
+const templates = args;
+
 let failed = false;
 
 for (const template of templates) {
-  const entry = path.resolve("templates", template, HANDLER_REL);
+  const entry = path.resolve("templates", template, handlerRel);
 
   if (!existsSync(entry)) {
     console.error(
       `[ssr-smoke] ${template}: MISSING built handler at ${entry}\n` +
-        `            Run \`NITRO_PRESET=netlify pnpm --filter ${template} build\` first.`,
+        `            Run \`NITRO_PRESET=${preset} pnpm --filter ${template} build\` first.`,
     );
     failed = true;
     continue;

--- a/scripts/ssr-boot-smoke.mjs
+++ b/scripts/ssr-boot-smoke.mjs
@@ -52,6 +52,20 @@ if (templates.length === 0) {
 
 let failed = false;
 
+// A handler can start best-effort background setup after its module graph has
+// evaluated (for example, local SQLite migrations). CI deliberately installs
+// without native build scripts, so those background promises may reject even
+// though the serverless handler imported successfully. The smoke test's
+// contract is module-load safety; direct import failures are handled below,
+// while these late rejections must not turn a passing cold-start into a false
+// negative before we force-exit.
+process.on("unhandledRejection", (error) => {
+  const message = String(error?.message ?? error).split("\n")[0];
+  console.warn(
+    `[ssr-smoke] Ignoring post-import background rejection: ${message}`,
+  );
+});
+
 for (const template of templates) {
   const entry = path.resolve("templates", template, HANDLER_REL);
 

--- a/scripts/ssr-boot-smoke.mjs
+++ b/scripts/ssr-boot-smoke.mjs
@@ -52,20 +52,6 @@ if (templates.length === 0) {
 
 let failed = false;
 
-// A handler can start best-effort background setup after its module graph has
-// evaluated (for example, local SQLite migrations). CI deliberately installs
-// without native build scripts, so those background promises may reject even
-// though the serverless handler imported successfully. The smoke test's
-// contract is module-load safety; direct import failures are handled below,
-// while these late rejections must not turn a passing cold-start into a false
-// negative before we force-exit.
-process.on("unhandledRejection", (error) => {
-  const message = String(error?.message ?? error).split("\n")[0];
-  console.warn(
-    `[ssr-smoke] Ignoring post-import background rejection: ${message}`,
-  );
-});
-
 for (const template of templates) {
   const entry = path.resolve("templates", template, HANDLER_REL);
 


### PR DESCRIPTION
## Summary
- bundle and rewrite Yjs imports in Netlify, Vercel, and AWS Lambda output
- abort serverless builds if a bare Yjs runtime import remains
- cold-start both Plan and Clips Netlify artifacts in CI

## Validation
- `pnpm --filter @agent-native/core exec vitest run src/deploy/build.spec.ts`
- `NITRO_PRESET=netlify pnpm --filter clips build`
- `NITRO_PRESET=netlify pnpm --filter plan build`
- `node scripts/ssr-boot-smoke.mjs plan clips`