### PR TITLE
Fix multi-account event creation and deletion routing

### DIFF
--- a/templates/calendar/.agents/skills/event-management/SKILL.md
+++ b/templates/calendar/.agents/skills/event-management/SKILL.md
@@ -85,7 +85,22 @@ pnpm action create-event \
 ```
 
 Required: `--title`, `--start`, `--end` (all ISO datetime format).
-Optional: `--description`, `--location`, `--attendees`, `--addGoogleMeet`, `--addZoom`, `--sendUpdates`.
+Optional: `--description`, `--location`, `--attendees`, `--addGoogleMeet`, `--addZoom`, `--sendUpdates`, `--accountEmail`.
+
+When multiple Google accounts are connected, choose the destination account's
+primary calendar with `--accountEmail`:
+
+```bash
+pnpm action create-event \
+  --title "Team standup" \
+  --start 2026-04-03T09:00:00 \
+  --end 2026-04-03T09:30:00 \
+  --accountEmail secondary@example.com
+```
+
+Creating without `accountEmail` is only unambiguous when one Google account is
+connected. The action does not support arbitrary non-primary Google calendar
+IDs.
 
 When attendees are invited and no video link/provider is supplied, Calendar
 automatically adds a Google Meet link by default. Pass `--addGoogleMeet=false`
@@ -179,10 +194,12 @@ location, attendees, reminders, attachments, color, and video provider.
 
 ### update-event
 
-Update an existing Google Calendar event. Use the event `id` from `list-events`, `search-events`, or `get-event`. If the event includes `accountEmail`, pass it through so multi-account calendars update the right connected account.
+Update an existing Google Calendar event. Use the event `id` from `list-events`,
+`search-events`, or `get-event`. Always preserve the event's `accountEmail` on
+the update so multi-account calendars use the right connected account.
 
 ```bash
-pnpm action update-event --id google-event-id --title "New title"
+pnpm action update-event --id google-event-id --accountEmail secondary@example.com --title "New title"
 pnpm action update-event --id google-event-id --start 2026-04-03T10:00:00 --end 2026-04-03T10:30:00
 
 # Replace attendee list (Google sends invites to anyone newly added)
@@ -232,10 +249,25 @@ pnpm action update-event \
 
 Delete an event if the user is the organizer, or remove it from their own calendar with `--removeOnly true` when they are not. For recurring events, use `--scope single`, `--scope all`, or `--scope thisAndFollowing`.
 
+Pass the event's `accountEmail` on deletes, including recurring-series choices
+and attendee removals, so the operation uses the account that owns the event.
+
 ```bash
-pnpm action delete-event --id google-event-id --scope single
+pnpm action delete-event --id google-event-id --accountEmail secondary@example.com --scope single
 pnpm action delete-event --id google-event-id --scope thisAndFollowing
 pnpm action delete-event --id google-event-id --removeOnly true
+```
+
+### rsvp-event
+
+Accept, decline, or tentatively accept an invitation with the event's
+`accountEmail`. Preserve it for recurring RSVP scope as well:
+
+```bash
+pnpm action rsvp-event \
+  --id google-event-id \
+  --accountEmail secondary@example.com \
+  --status accepted
 ```
 
 ## Date Patterns

--- a/templates/calendar/AGENTS.md
+++ b/templates/calendar/AGENTS.md
@@ -75,6 +75,10 @@ Detailed event, availability, booking, storage, and UI rules live in
 - `navigate` moves the UI to calendar, event, availability, booking, and settings
   views.
 - Use actions for full event details and availability calculations.
+- Preserve `accountEmail` on every Google event write. When more than one
+  Google account is connected, pass the chosen account to `create-event`, and
+  pass the event's returned `accountEmail` to `update-event`, `delete-event`,
+  and `rsvp-event`. These actions target that account's primary calendar.
 
 ## Skills
 

--- a/templates/calendar/actions/create-event.ts
+++ b/templates/calendar/actions/create-event.ts
@@ -1,10 +1,6 @@
 import { defineAction } from "@agent-native/core";
 import { emit } from "@agent-native/core/event-bus";
-import {
-  buildDeepLink,
-  getRequestOrgId,
-  getRequestUserEmail,
-} from "@agent-native/core/server";
+import { buildDeepLink, getRequestUserEmail } from "@agent-native/core/server";
 import { z } from "zod";
 
 import {
@@ -24,6 +20,7 @@ import {
   googleColorIdInput,
   ensureOrganizerInAttendees,
   normalizeAttendees,
+  resolveOwnedAccountEmail,
   reminderMethodInput,
   reminderMinutesInput,
   remindersInput,
@@ -108,7 +105,9 @@ export default defineAction({
     accountEmail: z
       .string()
       .optional()
-      .describe("Account email to create the event on"),
+      .describe(
+        "Connected Google account email whose primary calendar receives the event. Required when multiple accounts are connected.",
+      ),
   }),
   run: async (args) => {
     const email = getRequestUserEmail();
@@ -130,19 +129,7 @@ export default defineAction({
       );
     }
 
-    // Resolve account email
-    let acctEmail = email;
-    if (args.accountEmail && args.accountEmail !== email) {
-      const status = await googleCalendar.getAuthStatus(
-        email,
-        getRequestOrgId(),
-      );
-      const isOwned = status.accounts.some(
-        (a) => a.email === args.accountEmail,
-      );
-      if (!isOwned) throw new Error("Account not owned by current user");
-      acctEmail = args.accountEmail;
-    }
+    const acctEmail = await resolveOwnedAccountEmail(args.accountEmail, email);
 
     const attendees = ensureOrganizerInAttendees(
       normalizeAttendees(args.attendees),
@@ -194,6 +181,7 @@ export default defineAction({
     }
 
     const result = await googleCalendar.createEvent(calEvent, {
+      account: { ownerEmail: email, accountEmail: acctEmail },
       addGoogleMeet: shouldAutoAddGoogleMeet(calEvent, {
         addGoogleMeet: args.addGoogleMeet,
         addZoom: args.addZoom,

--- a/templates/calendar/actions/delete-event.ts
+++ b/templates/calendar/actions/delete-event.ts
@@ -72,17 +72,24 @@ export default defineAction({
         : (args.sendUpdates ?? (shouldNotifyGuests ? "all" : "none")),
     };
     const eventForNotification = shouldNotifyGuests
-      ? await googleCalendar.getEvent(googleEventId, accountEmail)
+      ? await googleCalendar.getEvent(googleEventId, {
+          ownerEmail,
+          accountEmail,
+        })
       : undefined;
 
     if (args.removeOnly) {
       await googleCalendar.removeEventFromCalendar(
         googleEventId,
-        accountEmail,
+        { ownerEmail, accountEmail },
         options,
       );
     } else {
-      await googleCalendar.deleteEvent(googleEventId, accountEmail, options);
+      await googleCalendar.deleteEvent(
+        googleEventId,
+        { ownerEmail, accountEmail },
+        options,
+      );
     }
 
     const guestNotification =

--- a/templates/calendar/actions/event-action-helpers.test.ts
+++ b/templates/calendar/actions/event-action-helpers.test.ts
@@ -1,15 +1,52 @@
 import { describe, expect, it, vi } from "vitest";
 
+const getAuthStatusMock = vi.hoisted(() => vi.fn());
+
 vi.mock("@agent-native/core/server", () => ({
+  getRequestOrgId: () => undefined,
   getRequestUserEmail: () => "test@example.com",
 }));
 
-vi.mock("../server/lib/google-calendar.js", () => ({}));
+vi.mock("../server/lib/google-calendar.js", () => ({
+  getAuthStatus: getAuthStatusMock,
+}));
 
 import {
   buildStatusEventFields,
   ensureOrganizerInAttendees,
+  resolveOwnedAccountEmail,
 } from "./event-action-helpers";
+
+describe("resolveOwnedAccountEmail", () => {
+  it("accepts a connected secondary account beneath the signed-in owner", async () => {
+    getAuthStatusMock.mockResolvedValue({
+      accounts: [
+        { email: "owner@example.com" },
+        { email: "secondary@example.com" },
+      ],
+    });
+
+    await expect(
+      resolveOwnedAccountEmail("secondary@example.com", "owner@example.com"),
+    ).resolves.toBe("secondary@example.com");
+  });
+
+  it("rejects missing or ambiguous account choices", async () => {
+    getAuthStatusMock.mockResolvedValue({
+      accounts: [
+        { email: "owner@example.com" },
+        { email: "secondary@example.com" },
+      ],
+    });
+
+    await expect(
+      resolveOwnedAccountEmail(undefined, "owner@example.com"),
+    ).rejects.toThrow("Multiple Google Calendar accounts are connected");
+    await expect(
+      resolveOwnedAccountEmail("missing@example.com", "owner@example.com"),
+    ).rejects.toThrow("Account not owned by current user");
+  });
+});
 
 describe("ensureOrganizerInAttendees", () => {
   it("leaves empty or solo events unchanged", () => {

--- a/templates/calendar/actions/rsvp-event.ts
+++ b/templates/calendar/actions/rsvp-event.ts
@@ -58,7 +58,7 @@ export default defineAction({
     await googleCalendar.rsvpEvent(
       googleEventId,
       args.status,
-      accountEmail,
+      { ownerEmail, accountEmail },
       args.scope,
       args.note?.trim() ?? args.note,
       args.sendUpdates,

--- a/templates/calendar/actions/update-event.ts
+++ b/templates/calendar/actions/update-event.ts
@@ -246,10 +246,10 @@ export default defineAction({
 
     let existingEvent: CalendarEvent | undefined;
     const loadExistingEvent = async () => {
-      existingEvent ??= await googleCalendar.getEvent(
-        googleEventId,
+      existingEvent ??= await googleCalendar.getEvent(googleEventId, {
+        ownerEmail,
         accountEmail,
-      );
+      });
       return existingEvent;
     };
 
@@ -297,6 +297,7 @@ export default defineAction({
     }
 
     const result = await googleCalendar.updateEvent(googleEventId, updates, {
+      account: { ownerEmail, accountEmail },
       sendUpdates:
         args.sendUpdates ??
         (guestNotificationMessage || (attendeesToAdd?.length ?? 0) > 0

--- a/templates/calendar/app/components/calendar/CreateEventDialog.tsx
+++ b/templates/calendar/app/components/calendar/CreateEventDialog.tsx
@@ -66,10 +66,11 @@ import { useViewPreferences } from "@/hooks/use-view-preferences";
 import { useConnectZoom, useZoomStatus } from "@/hooks/use-zoom-auth";
 import { defaultColorForAccount } from "@/lib/calendar-view-preferences";
 import {
-  resolveEventAccountEmail,
+  reconcileEventAccountEmail,
   shouldShowEventAccountSelector,
 } from "@/lib/event-account-selection";
 import { getGoogleEventColorHex } from "@/lib/event-colors";
+import { buildEventFormInitializationKey } from "@/lib/event-form-initialization";
 import {
   attachmentsToDrafts,
   buildReminderPayload,
@@ -91,6 +92,8 @@ type EventType = "default" | "outOfOffice" | "focusTime" | "workingLocation";
 type Availability = "opaque" | "transparent";
 type Visibility = "default" | "public" | "private" | "confidential";
 type WorkingLocationType = "homeOffice" | "officeLocation" | "customLocation";
+
+const EMPTY_CONNECTED_ACCOUNTS: Array<{ email: string }> = [];
 
 function addDaysToDateString(date: string, days: number) {
   const next = new Date(`${date}T00:00:00`);
@@ -269,12 +272,12 @@ export function CreateEventPopover({
   const createEvent = useCreateEvent();
   const delEvent = useDeleteEvent();
   const googleStatus = useGoogleAuthStatus();
-  const connectedAccounts = googleStatus.data?.accounts ?? [];
+  const connectedAccounts =
+    googleStatus.data?.accounts ?? EMPTY_CONNECTED_ACCOUNTS;
   const connectedAccountEmails = useMemo(
     () => connectedAccounts.map((account) => account.email),
     [connectedAccounts],
   );
-  const defaultAccountEmail = connectedAccountEmails[0];
   const { prefs: viewPrefs } = useViewPreferences();
   const zoomStatus = useZoomStatus();
   const connectZoom = useConnectZoom();
@@ -291,13 +294,14 @@ export function CreateEventPopover({
     const nextDate = format(defaultDate || new Date(), "yyyy-MM-dd");
     const draftTimezone =
       draft?.startTimeZone || draft?.endTimeZone || defaultTimezone;
-    const selectedDraftAccount = resolveEventAccountEmail(
-      connectedAccounts,
-      draft?.accountEmail,
-    );
-    const initKey = draft?.id
-      ? `draft:${draft.id}:${draftTimezone}:${selectedDraftAccount ?? ""}`
-      : `new:${nextDate}:${defaultStart || fallbackStart}:${defaultEnd || fallbackEnd}:${defaultTimezone}:${defaultAccountEmail ?? ""}`;
+    const initKey = buildEventFormInitializationKey({
+      draftId: draft?.id,
+      draftTimezone,
+      date: nextDate,
+      startTime: defaultStart || fallbackStart,
+      endTime: defaultEnd || fallbackEnd,
+      defaultTimezone,
+    });
     if (initializedKeyRef.current === initKey) return;
     initializedKeyRef.current = initKey;
 
@@ -350,7 +354,6 @@ export function CreateEventPopover({
           })),
         ),
       );
-      setAccountEmail(selectedDraftAccount);
       return;
     }
 
@@ -374,7 +377,6 @@ export function CreateEventPopover({
     setVideoProvider("none");
     setVideoProviderTouched(false);
     setAttendees([]);
-    setAccountEmail(defaultAccountEmail);
   }, [
     open,
     draft,
@@ -384,9 +386,22 @@ export function CreateEventPopover({
     fallbackStart,
     fallbackEnd,
     defaultTimezone,
-    connectedAccountEmails,
-    defaultAccountEmail,
   ]);
+
+  useEffect(() => {
+    if (!open) {
+      setAccountEmail(undefined);
+      return;
+    }
+
+    setAccountEmail((currentAccountEmail) =>
+      reconcileEventAccountEmail(
+        connectedAccounts,
+        currentAccountEmail,
+        draft?.accountEmail,
+      ),
+    );
+  }, [open, connectedAccounts, draft?.accountEmail]);
 
   useEffect(() => {
     if (!open) setFindTimeOpen(false);

--- a/templates/calendar/app/components/calendar/CreateEventDialog.tsx
+++ b/templates/calendar/app/components/calendar/CreateEventDialog.tsx
@@ -15,7 +15,7 @@ import {
   IconUsers,
 } from "@tabler/icons-react";
 import { differenceInMinutes, format } from "date-fns";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { toast } from "sonner";
 
 import {
@@ -46,6 +46,7 @@ import {
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
   SelectTrigger,
   SelectValue,
@@ -58,9 +59,16 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useCreateEvent, useDeleteEvent } from "@/hooks/use-events";
+import { useGoogleAuthStatus } from "@/hooks/use-google-auth";
 import { useSettings } from "@/hooks/use-settings";
 import { setUndoAction } from "@/hooks/use-undo";
+import { useViewPreferences } from "@/hooks/use-view-preferences";
 import { useConnectZoom, useZoomStatus } from "@/hooks/use-zoom-auth";
+import { defaultColorForAccount } from "@/lib/calendar-view-preferences";
+import {
+  resolveEventAccountEmail,
+  shouldShowEventAccountSelector,
+} from "@/lib/event-account-selection";
 import { getGoogleEventColorHex } from "@/lib/event-colors";
 import {
   attachmentsToDrafts,
@@ -76,6 +84,7 @@ import {
   type ReminderMode,
   validateAttachmentDrafts,
 } from "@/lib/event-form-utils";
+import { buildDeleteEventMutationInput } from "@/lib/event-mutation-inputs";
 
 type VideoProvider = "none" | "google_meet" | "zoom";
 type EventType = "default" | "outOfOffice" | "focusTime" | "workingLocation";
@@ -252,12 +261,21 @@ export function CreateEventPopover({
   const [videoProvider, setVideoProvider] = useState<VideoProvider>("none");
   const [videoProviderTouched, setVideoProviderTouched] = useState(false);
   const [attendees, setAttendees] = useState<AttendeeRecipient[]>([]);
+  const [accountEmail, setAccountEmail] = useState<string>();
   const [findTimeOpen, setFindTimeOpen] = useState(false);
   const timedOnlyStatus =
     eventType === "outOfOffice" || eventType === "focusTime";
 
   const createEvent = useCreateEvent();
   const delEvent = useDeleteEvent();
+  const googleStatus = useGoogleAuthStatus();
+  const connectedAccounts = googleStatus.data?.accounts ?? [];
+  const connectedAccountEmails = useMemo(
+    () => connectedAccounts.map((account) => account.email),
+    [connectedAccounts],
+  );
+  const defaultAccountEmail = connectedAccountEmails[0];
+  const { prefs: viewPrefs } = useViewPreferences();
   const zoomStatus = useZoomStatus();
   const connectZoom = useConnectZoom();
   const formRef = useRef<HTMLFormElement>(null);
@@ -273,9 +291,13 @@ export function CreateEventPopover({
     const nextDate = format(defaultDate || new Date(), "yyyy-MM-dd");
     const draftTimezone =
       draft?.startTimeZone || draft?.endTimeZone || defaultTimezone;
+    const selectedDraftAccount = resolveEventAccountEmail(
+      connectedAccounts,
+      draft?.accountEmail,
+    );
     const initKey = draft?.id
-      ? `draft:${draft.id}:${draftTimezone}`
-      : `new:${nextDate}:${defaultStart || fallbackStart}:${defaultEnd || fallbackEnd}:${defaultTimezone}`;
+      ? `draft:${draft.id}:${draftTimezone}:${selectedDraftAccount ?? ""}`
+      : `new:${nextDate}:${defaultStart || fallbackStart}:${defaultEnd || fallbackEnd}:${defaultTimezone}:${defaultAccountEmail ?? ""}`;
     if (initializedKeyRef.current === initKey) return;
     initializedKeyRef.current = initKey;
 
@@ -328,6 +350,7 @@ export function CreateEventPopover({
           })),
         ),
       );
+      setAccountEmail(selectedDraftAccount);
       return;
     }
 
@@ -351,6 +374,7 @@ export function CreateEventPopover({
     setVideoProvider("none");
     setVideoProviderTouched(false);
     setAttendees([]);
+    setAccountEmail(defaultAccountEmail);
   }, [
     open,
     draft,
@@ -360,6 +384,8 @@ export function CreateEventPopover({
     fallbackStart,
     fallbackEnd,
     defaultTimezone,
+    connectedAccountEmails,
+    defaultAccountEmail,
   ]);
 
   useEffect(() => {
@@ -419,7 +445,7 @@ export function CreateEventPopover({
             }))
           : undefined,
       ...buildVideoProviderPatch(videoProvider, videoProviderTouched),
-      accountEmail: draft?.accountEmail,
+      accountEmail,
       workingLocationType,
       workingLocationLabel:
         workingLocationType === "customLocation" ? location : undefined,
@@ -444,7 +470,7 @@ export function CreateEventPopover({
     open,
     draft?.id,
     draft?.createdAt,
-    draft?.accountEmail,
+    accountEmail,
     title,
     description,
     date,
@@ -651,7 +677,7 @@ export function CreateEventPopover({
       startTimeZone: effectiveAllDay ? undefined : timezone,
       endTimeZone: effectiveAllDay ? undefined : timezone,
       location,
-      accountEmail: draft?.accountEmail,
+      accountEmail,
       allDay: effectiveAllDay,
       transparency:
         eventType === "workingLocation"
@@ -689,11 +715,15 @@ export function CreateEventPopover({
         const eventId = result?.id;
         const undo = eventId
           ? () => {
-              delEvent.mutate({
-                id: eventId,
-                scope: "single",
-                sendUpdates: "none",
-              });
+              delEvent.mutate(
+                buildDeleteEventMutationInput(
+                  {
+                    id: eventId,
+                    accountEmail: result.accountEmail ?? accountEmail,
+                  },
+                  { scope: "single", sendUpdates: "none" },
+                ),
+              );
             }
           : undefined;
         if (undo) setUndoAction(undo);
@@ -752,6 +782,47 @@ export function CreateEventPopover({
                 className="h-8 text-sm"
               />
             </div>
+
+            {shouldShowEventAccountSelector(connectedAccounts) &&
+              accountEmail && (
+                <div className="space-y-1.5">
+                  <Label htmlFor="event-calendar" className="text-xs">
+                    {t("navigation.calendar")}
+                  </Label>
+                  <Select value={accountEmail} onValueChange={setAccountEmail}>
+                    <SelectTrigger
+                      id="event-calendar"
+                      aria-label={t("navigation.calendar")}
+                      className="h-8 text-sm"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectGroup>
+                        {connectedAccounts.map((account) => (
+                          <SelectItem key={account.email} value={account.email}>
+                            <span className="flex min-w-0 items-center gap-2">
+                              <span
+                                className="size-2.5 shrink-0 rounded-full"
+                                style={{
+                                  backgroundColor:
+                                    viewPrefs.accountColors[account.email] ??
+                                    viewPrefs.singleColor ??
+                                    defaultColorForAccount(
+                                      account.email,
+                                      connectedAccountEmails,
+                                    ),
+                                }}
+                              />
+                              <span className="truncate">{account.email}</span>
+                            </span>
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
 
             <div className="space-y-1.5">
               <Label htmlFor="event-type" className="text-xs">
@@ -1201,7 +1272,7 @@ export function CreateEventPopover({
             timezone={timezone}
             durationMinutes={findTimeDurationMinutes}
             attendees={attendees}
-            accountEmail={draft?.accountEmail}
+            accountEmail={accountEmail}
             selectedStart={currentStartISO}
             selectedEnd={currentEndISO}
             onSelectSlot={handleSelectFindTimeSlot}
@@ -1232,6 +1303,7 @@ export function CreateEventPopover({
                 className="h-7 text-xs"
                 disabled={
                   createEvent.isPending ||
+                  !accountEmail ||
                   (videoProvider === "zoom" && !zoomStatus.data?.connected)
                 }
               >

--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -55,7 +55,7 @@ interface DayViewProps {
     title: string,
     accountEmail?: string,
   ) => void;
-  onQuickEditCancel?: (eventId: string) => void;
+  onQuickEditCancel?: (eventId: string, accountEmail?: string) => void;
   draftEventIds?: string[];
   onDraftUpdate?: (
     eventId: string,
@@ -219,7 +219,7 @@ interface DayEventCardProps {
     title: string,
     accountEmail?: string,
   ) => void;
-  onQuickEditCancel?: (eventId: string) => void;
+  onQuickEditCancel?: (eventId: string, accountEmail?: string) => void;
   onDraftUpdate?: DayViewProps["onDraftUpdate"];
   onDraftCreate?: DayViewProps["onDraftCreate"];
   onDraftDiscard?: DayViewProps["onDraftDiscard"];

--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -50,7 +50,11 @@ interface DayViewProps {
     options?: { explicitDuration?: boolean },
   ) => void;
   quickEditEventId?: string | null;
-  onQuickEditSave?: (eventId: string, title: string) => void;
+  onQuickEditSave?: (
+    eventId: string,
+    title: string,
+    accountEmail?: string,
+  ) => void;
   onQuickEditCancel?: (eventId: string) => void;
   draftEventIds?: string[];
   onDraftUpdate?: (
@@ -210,7 +214,11 @@ interface DayEventCardProps {
   onDeleteEvent: (eventId: string) => void;
   isDraft: boolean;
   defaultOpen: boolean;
-  onQuickEditSave?: (eventId: string, title: string) => void;
+  onQuickEditSave?: (
+    eventId: string,
+    title: string,
+    accountEmail?: string,
+  ) => void;
   onQuickEditCancel?: (eventId: string) => void;
   onDraftUpdate?: DayViewProps["onDraftUpdate"];
   onDraftCreate?: DayViewProps["onDraftCreate"];

--- a/templates/calendar/app/components/calendar/EventDetailPanel.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPanel.tsx
@@ -61,7 +61,7 @@ interface EventDetailPanelProps {
   event: CalendarEvent | null;
   onClose: () => void;
   onDelete: (eventId: string) => void;
-  onTitleSave?: (eventId: string, title: string) => void;
+  onTitleSave?: (eventId: string, title: string, accountEmail?: string) => void;
 }
 
 function formatDuration(start: string, end: string): string {
@@ -310,7 +310,7 @@ export function EventDetailPanel({
                         e.preventDefault();
                         const trimmed = editingTitle.trim();
                         if (trimmed && trimmed !== event.title) {
-                          onTitleSave?.(event.id, trimmed);
+                          onTitleSave?.(event.id, trimmed, event.accountEmail);
                         }
                         setIsEditingTitle(false);
                       } else if (e.key === "Escape") {
@@ -322,7 +322,7 @@ export function EventDetailPanel({
                     onBlur={() => {
                       const trimmed = editingTitle.trim();
                       if (trimmed && trimmed !== event.title) {
-                        onTitleSave?.(event.id, trimmed);
+                        onTitleSave?.(event.id, trimmed, event.accountEmail);
                       }
                       setIsEditingTitle(false);
                     }}

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -460,7 +460,7 @@ interface EventDetailPopoverProps {
   /** When true, the popover opens immediately and title is focused for editing */
   defaultOpen?: boolean;
   /** Called when the title is changed and should be persisted */
-  onTitleSave?: (eventId: string, title: string) => void;
+  onTitleSave?: (eventId: string, title: string, accountEmail?: string) => void;
   /** Called when the popover is dismissed for a new event (to clean up if no title was set) */
   onDismissNew?: (eventId: string) => void;
   onDraftUpdate?: (
@@ -1190,12 +1190,12 @@ export function EventDetailPopover({
         ? { title: editingTitle.trim() }
         : undefined;
     if (updates) {
-      onTitleSave?.(event.id, updates.title);
+      onTitleSave?.(event.id, updates.title, event.accountEmail);
       setIsEditingTitle(false);
       isNewEventRef.current = false;
     }
     onDraftCreate(event.id, updates);
-  }, [editingTitle, event.id, isEditingTitle, onDraftCreate, onTitleSave]);
+  }, [editingTitle, event, isEditingTitle, onDraftCreate, onTitleSave]);
 
   // Keyboard shortcut: Cmd+J to join meeting when popover is open
   const handleKeyDown = useCallback(
@@ -1242,7 +1242,7 @@ export function EventDetailPopover({
         // Popover is closing — handle saves
         if (isEditingTitle) {
           if (trimmedTitle && trimmedTitle !== "(No title)") {
-            onTitleSave?.(event.id, trimmedTitle);
+            onTitleSave?.(event.id, trimmedTitle, event.accountEmail);
             isNewEventRef.current = false;
             savedPendingChange = true;
           }
@@ -1282,6 +1282,7 @@ export function EventDetailPopover({
       isEditingTitle,
       editingTitle,
       event.id,
+      event.accountEmail,
       onTitleSave,
       onDismissNew,
       editingField,
@@ -1391,7 +1392,7 @@ export function EventDetailPopover({
                       e.preventDefault();
                       const trimmed = editingTitle.trim();
                       if (trimmed && trimmed !== "(No title)") {
-                        onTitleSave?.(event.id, trimmed);
+                        onTitleSave?.(event.id, trimmed, event.accountEmail);
                         isNewEventRef.current = false;
                       }
                       setIsEditingTitle(false);
@@ -1421,7 +1422,7 @@ export function EventDetailPopover({
                       trimmed !== "(No title)" &&
                       trimmed !== event.title
                     ) {
-                      onTitleSave?.(event.id, trimmed);
+                      onTitleSave?.(event.id, trimmed, event.accountEmail);
                       isNewEventRef.current = false;
                     }
                     setIsEditingTitle(false);

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -462,7 +462,7 @@ interface EventDetailPopoverProps {
   /** Called when the title is changed and should be persisted */
   onTitleSave?: (eventId: string, title: string, accountEmail?: string) => void;
   /** Called when the popover is dismissed for a new event (to clean up if no title was set) */
-  onDismissNew?: (eventId: string) => void;
+  onDismissNew?: (eventId: string, accountEmail?: string) => void;
   onDraftUpdate?: (
     eventId: string,
     updates: Partial<CalendarEvent> & {
@@ -1269,7 +1269,7 @@ export function EventDetailPopover({
           (!trimmedTitle || trimmedTitle === "(No title)") &&
           onDismissNew
         ) {
-          onDismissNew(event.id);
+          onDismissNew(event.id, event.accountEmail);
         }
 
         setEditingField(null);

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -58,6 +58,7 @@ import {
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
   SelectTrigger,
   SelectValue,
@@ -70,8 +71,12 @@ import {
   TooltipProvider,
 } from "@/components/ui/tooltip";
 import { useEvent, useUpdateEvent } from "@/hooks/use-events";
+import { useGoogleAuthStatus } from "@/hooks/use-google-auth";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useViewPreferences } from "@/hooks/use-view-preferences";
 import { useConnectZoom, useZoomStatus } from "@/hooks/use-zoom-auth";
+import { defaultColorForAccount } from "@/lib/calendar-view-preferences";
+import { shouldShowEventAccountSelector } from "@/lib/event-account-selection";
 import { getGoogleEventColorHex } from "@/lib/event-colors";
 import {
   attachmentsToDrafts,
@@ -100,6 +105,7 @@ import { shortcutModifierLabel } from "@/lib/utils";
 
 const ZOOM_AFTER_CONNECT_EVENT_ID_KEY = "calendar.zoomAfterConnectEventId";
 const ZOOM_AFTER_CONNECT_MAX_AGE_MS = 10 * 60 * 1000;
+const EMPTY_CONNECTED_ACCOUNTS: Array<{ email: string }> = [];
 
 function buildEventDetailSlotContext(event: CalendarEvent) {
   return {
@@ -382,6 +388,68 @@ function formatEventDateRange(start: string, end: string, allDay?: boolean) {
   const startLabel = format(startDate, "EEE MMM d");
   const endLabel = format(displayEndDate, "EEE MMM d");
   return startLabel === endLabel ? startLabel : `${startLabel} - ${endLabel}`;
+}
+
+function DraftEventAccountSelect({
+  event,
+  onAccountChange,
+}: {
+  event: CalendarEvent;
+  onAccountChange: (accountEmail: string) => void;
+}) {
+  const t = useT();
+  const googleStatus = useGoogleAuthStatus();
+  const connectedAccounts =
+    googleStatus.data?.accounts ?? EMPTY_CONNECTED_ACCOUNTS;
+  const connectedAccountEmails = useMemo(
+    () => connectedAccounts.map((account) => account.email),
+    [connectedAccounts],
+  );
+  const { prefs: viewPrefs } = useViewPreferences();
+
+  if (
+    !shouldShowEventAccountSelector(connectedAccounts) ||
+    !event.accountEmail
+  ) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center gap-3 py-1.5">
+      <IconCalendarTime className="h-4 w-4 shrink-0 text-muted-foreground" />
+      <Select value={event.accountEmail} onValueChange={onAccountChange}>
+        <SelectTrigger
+          aria-label={t("navigation.calendar")}
+          className="h-8 flex-1 text-sm"
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            {connectedAccounts.map((account) => (
+              <SelectItem key={account.email} value={account.email}>
+                <span className="flex min-w-0 items-center gap-2">
+                  <span
+                    className="size-2.5 shrink-0 rounded-full"
+                    style={{
+                      backgroundColor:
+                        viewPrefs.accountColors[account.email] ??
+                        viewPrefs.singleColor ??
+                        defaultColorForAccount(
+                          account.email,
+                          connectedAccountEmails,
+                        ),
+                    }}
+                  />
+                  <span className="truncate">{account.email}</span>
+                </span>
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+    </div>
+  );
 }
 
 interface EventDetailPopoverProps {
@@ -1376,6 +1444,15 @@ export function EventDetailPopover({
             </div>
 
             <div className="px-4 space-y-1">
+              {isDraft && (
+                <DraftEventAccountSelect
+                  event={event}
+                  onAccountChange={(accountEmail) =>
+                    onDraftUpdate?.(event.id, { accountEmail })
+                  }
+                />
+              )}
+
               {/* Time — editable */}
               {editingField === "time" ? (
                 <div className="flex items-start gap-3 py-1.5">

--- a/templates/calendar/app/components/calendar/EventDialog.tsx
+++ b/templates/calendar/app/components/calendar/EventDialog.tsx
@@ -26,6 +26,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { useUpdateEvent, useDeleteEvent } from "@/hooks/use-events";
 import { useViewPreferences } from "@/hooks/use-view-preferences";
 import { getEventDisplayColor } from "@/lib/event-colors";
+import { buildDeleteEventMutationInput } from "@/lib/event-mutation-inputs";
 import {
   sanitizeHtml,
   stripGcalInviteHtml,
@@ -136,6 +137,7 @@ export function EventDialog({
     updateEvent.mutate(
       {
         id: event.id,
+        accountEmail: event.accountEmail,
         ...updates,
         ...guestNotification,
       },
@@ -162,7 +164,7 @@ export function EventDialog({
       });
       if (!guestNotification) return;
       deleteEvent.mutate(
-        { id: event.id, ...guestNotification },
+        buildDeleteEventMutationInput(event, guestNotification),
         {
           onSuccess: () => {
             toast.success(t("eventDialog.eventDeleted"));

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -60,7 +60,7 @@ interface WeekViewProps {
     title: string,
     accountEmail?: string,
   ) => void;
-  onQuickEditCancel?: (eventId: string) => void;
+  onQuickEditCancel?: (eventId: string, accountEmail?: string) => void;
   draftEventIds?: string[];
   onDraftUpdate?: (
     eventId: string,
@@ -290,7 +290,7 @@ interface WeekEventCardProps {
     title: string,
     accountEmail?: string,
   ) => void;
-  onQuickEditCancel?: (eventId: string) => void;
+  onQuickEditCancel?: (eventId: string, accountEmail?: string) => void;
   onDraftUpdate?: WeekViewProps["onDraftUpdate"];
   onDraftCreate?: WeekViewProps["onDraftCreate"];
   onDraftDiscard?: WeekViewProps["onDraftDiscard"];

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -55,7 +55,11 @@ interface WeekViewProps {
     options?: { explicitDuration?: boolean },
   ) => void;
   quickEditEventId?: string | null;
-  onQuickEditSave?: (eventId: string, title: string) => void;
+  onQuickEditSave?: (
+    eventId: string,
+    title: string,
+    accountEmail?: string,
+  ) => void;
   onQuickEditCancel?: (eventId: string) => void;
   draftEventIds?: string[];
   onDraftUpdate?: (
@@ -281,7 +285,11 @@ interface WeekEventCardProps {
   onDeleteEvent: (eventId: string) => void;
   isDraft: boolean;
   defaultOpen: boolean;
-  onQuickEditSave?: (eventId: string, title: string) => void;
+  onQuickEditSave?: (
+    eventId: string,
+    title: string,
+    accountEmail?: string,
+  ) => void;
   onQuickEditCancel?: (eventId: string) => void;
   onDraftUpdate?: WeekViewProps["onDraftUpdate"];
   onDraftCreate?: WeekViewProps["onDraftCreate"];

--- a/templates/calendar/app/hooks/use-events.ts
+++ b/templates/calendar/app/hooks/use-events.ts
@@ -389,6 +389,7 @@ export function useDeleteEvent() {
     },
     {
       id: string;
+      accountEmail?: string;
       scope?: "single" | "all" | "thisAndFollowing";
       sendUpdates?: "all" | "none";
       removeOnly?: boolean;

--- a/templates/calendar/app/lib/event-account-selection.test.ts
+++ b/templates/calendar/app/lib/event-account-selection.test.ts
@@ -48,17 +48,27 @@ describe("event account selection", () => {
     );
   });
 
-  it("keeps a valid draft or user-selected account as accounts change", () => {
+  it("keeps a valid user selection as accounts refetch", () => {
     expect(
       reconcileEventAccountEmail(
         accounts,
         "primary@example.com",
         "secondary@example.com",
       ),
-    ).toBe("secondary@example.com");
+    ).toBe("primary@example.com");
     expect(reconcileEventAccountEmail(accounts, "secondary@example.com")).toBe(
       "secondary@example.com",
     );
+  });
+
+  it("falls back to a valid draft account when the current selection disconnects", () => {
+    expect(
+      reconcileEventAccountEmail(
+        accounts,
+        "missing@example.com",
+        "secondary@example.com",
+      ),
+    ).toBe("secondary@example.com");
     expect(
       reconcileEventAccountEmail(
         accounts,

--- a/templates/calendar/app/lib/event-account-selection.test.ts
+++ b/templates/calendar/app/lib/event-account-selection.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  reconcileEventAccountEmail,
   resolveEventAccountEmail,
   shouldShowEventAccountSelector,
 } from "./event-account-selection";
+import { buildEventFormInitializationKey } from "./event-form-initialization";
 
 const accounts = [
   { email: "primary@example.com" },
@@ -25,6 +27,45 @@ describe("event account selection", () => {
     expect(resolveEventAccountEmail(accounts, "missing@example.com")).toBe(
       "primary@example.com",
     );
+  });
+
+  it("updates only the account when connected accounts resolve after form initialization", () => {
+    const initialization = {
+      draftTimezone: "America/Indiana/Indianapolis",
+      date: "2026-07-10",
+      startTime: "09:00",
+      endTime: "09:30",
+      defaultTimezone: "America/Indiana/Indianapolis",
+    };
+    const initializationKey = buildEventFormInitializationKey(initialization);
+
+    expect(reconcileEventAccountEmail([], undefined)).toBeUndefined();
+    expect(reconcileEventAccountEmail(accounts, undefined)).toBe(
+      "primary@example.com",
+    );
+    expect(buildEventFormInitializationKey(initialization)).toBe(
+      initializationKey,
+    );
+  });
+
+  it("keeps a valid draft or user-selected account as accounts change", () => {
+    expect(
+      reconcileEventAccountEmail(
+        accounts,
+        "primary@example.com",
+        "secondary@example.com",
+      ),
+    ).toBe("secondary@example.com");
+    expect(reconcileEventAccountEmail(accounts, "secondary@example.com")).toBe(
+      "secondary@example.com",
+    );
+    expect(
+      reconcileEventAccountEmail(
+        accounts,
+        "missing@example.com",
+        "also-missing@example.com",
+      ),
+    ).toBe("primary@example.com");
   });
 
   it("only adds selector chrome for multiple connected accounts", () => {

--- a/templates/calendar/app/lib/event-account-selection.test.ts
+++ b/templates/calendar/app/lib/event-account-selection.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveEventAccountEmail,
+  shouldShowEventAccountSelector,
+} from "./event-account-selection";
+
+const accounts = [
+  { email: "primary@example.com" },
+  { email: "secondary@example.com" },
+];
+
+describe("event account selection", () => {
+  it("defaults new events to the first connected account", () => {
+    expect(resolveEventAccountEmail(accounts)).toBe("primary@example.com");
+  });
+
+  it("preserves a connected account from a persisted or agent draft", () => {
+    expect(resolveEventAccountEmail(accounts, "secondary@example.com")).toBe(
+      "secondary@example.com",
+    );
+  });
+
+  it("falls back when a draft account has since disconnected", () => {
+    expect(resolveEventAccountEmail(accounts, "missing@example.com")).toBe(
+      "primary@example.com",
+    );
+  });
+
+  it("only adds selector chrome for multiple connected accounts", () => {
+    expect(shouldShowEventAccountSelector(accounts)).toBe(true);
+    expect(shouldShowEventAccountSelector(accounts.slice(0, 1))).toBe(false);
+  });
+});

--- a/templates/calendar/app/lib/event-account-selection.ts
+++ b/templates/calendar/app/lib/event-account-selection.ts
@@ -20,10 +20,13 @@ export function reconcileEventAccountEmail(
   currentAccountEmail?: string,
   draftAccountEmail?: string,
 ): string | undefined {
-  return resolveEventAccountEmail(
-    accounts,
-    draftAccountEmail ?? currentAccountEmail,
-  );
+  if (
+    currentAccountEmail &&
+    accounts.some((account) => account.email === currentAccountEmail)
+  ) {
+    return currentAccountEmail;
+  }
+  return resolveEventAccountEmail(accounts, draftAccountEmail);
 }
 
 export function shouldShowEventAccountSelector(

--- a/templates/calendar/app/lib/event-account-selection.ts
+++ b/templates/calendar/app/lib/event-account-selection.ts
@@ -15,6 +15,17 @@ export function resolveEventAccountEmail(
   return accounts[0]?.email;
 }
 
+export function reconcileEventAccountEmail(
+  accounts: ConnectedCalendarAccount[],
+  currentAccountEmail?: string,
+  draftAccountEmail?: string,
+): string | undefined {
+  return resolveEventAccountEmail(
+    accounts,
+    draftAccountEmail ?? currentAccountEmail,
+  );
+}
+
 export function shouldShowEventAccountSelector(
   accounts: ConnectedCalendarAccount[],
 ): boolean {

--- a/templates/calendar/app/lib/event-account-selection.ts
+++ b/templates/calendar/app/lib/event-account-selection.ts
@@ -1,0 +1,22 @@
+export interface ConnectedCalendarAccount {
+  email: string;
+}
+
+export function resolveEventAccountEmail(
+  accounts: ConnectedCalendarAccount[],
+  requestedAccountEmail?: string,
+): string | undefined {
+  if (
+    requestedAccountEmail &&
+    accounts.some((account) => account.email === requestedAccountEmail)
+  ) {
+    return requestedAccountEmail;
+  }
+  return accounts[0]?.email;
+}
+
+export function shouldShowEventAccountSelector(
+  accounts: ConnectedCalendarAccount[],
+): boolean {
+  return accounts.length > 1;
+}

--- a/templates/calendar/app/lib/event-form-initialization.ts
+++ b/templates/calendar/app/lib/event-form-initialization.ts
@@ -1,0 +1,21 @@
+interface EventFormInitializationInput {
+  draftId?: string;
+  draftTimezone: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  defaultTimezone: string;
+}
+
+export function buildEventFormInitializationKey({
+  draftId,
+  draftTimezone,
+  date,
+  startTime,
+  endTime,
+  defaultTimezone,
+}: EventFormInitializationInput): string {
+  return draftId
+    ? `draft:${draftId}:${draftTimezone}`
+    : `new:${date}:${startTime}:${endTime}:${defaultTimezone}`;
+}

--- a/templates/calendar/app/lib/event-mutation-inputs.test.ts
+++ b/templates/calendar/app/lib/event-mutation-inputs.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { buildDeleteEventMutationInput } from "./event-mutation-inputs";
+
+describe("buildDeleteEventMutationInput", () => {
+  it("preserves the connected account through recurring and guest options", () => {
+    expect(
+      buildDeleteEventMutationInput(
+        { id: "google-event-1", accountEmail: "secondary@example.com" },
+        {
+          scope: "thisAndFollowing",
+          sendUpdates: "all",
+          notificationMessage: "The meeting is cancelled.",
+          removeOnly: false,
+        },
+      ),
+    ).toEqual({
+      id: "google-event-1",
+      accountEmail: "secondary@example.com",
+      scope: "thisAndFollowing",
+      sendUpdates: "all",
+      notificationMessage: "The meeting is cancelled.",
+      removeOnly: false,
+    });
+  });
+
+  it("keeps the account on quiet cleanup and undo deletes", () => {
+    expect(
+      buildDeleteEventMutationInput(
+        { id: "google-event-2", accountEmail: "secondary@example.com" },
+        { scope: "single", sendUpdates: "none" },
+      ),
+    ).toMatchObject({
+      id: "google-event-2",
+      accountEmail: "secondary@example.com",
+      scope: "single",
+      sendUpdates: "none",
+    });
+  });
+});

--- a/templates/calendar/app/lib/event-mutation-inputs.ts
+++ b/templates/calendar/app/lib/event-mutation-inputs.ts
@@ -1,0 +1,18 @@
+import type { CalendarEvent, DeleteEventOptions } from "@shared/api";
+
+export type DeleteEventMutationInput = DeleteEventOptions & {
+  id: string;
+  accountEmail?: string;
+};
+
+/** Keep the event's connected account attached to every delete variant. */
+export function buildDeleteEventMutationInput(
+  event: Pick<CalendarEvent, "id" | "accountEmail">,
+  options: DeleteEventOptions = {},
+): DeleteEventMutationInput {
+  return {
+    id: event.id,
+    accountEmail: event.accountEmail,
+    ...options,
+  };
+}

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -1283,7 +1283,7 @@ export default function CalendarView() {
   );
 
   const handleQuickEditSave = useCallback(
-    async (eventId: string, title: string) => {
+    async (eventId: string, title: string, accountEmail?: string) => {
       setQuickEditEventId(null);
       if (calendarDraftIdFromEventId(eventId)) {
         updateDraftEvent(eventId, { title: title.trim() });
@@ -1307,7 +1307,7 @@ export default function CalendarView() {
         if (!guestNotification) return;
         updateEvent.mutate({
           id: eventId,
-          accountEmail: event?.accountEmail,
+          accountEmail: event?.accountEmail ?? accountEmail,
           ...updates,
           ...guestNotification,
         });
@@ -1317,7 +1317,7 @@ export default function CalendarView() {
   );
 
   const handleTitleSave = useCallback(
-    async (eventId: string, title: string) => {
+    async (eventId: string, title: string, accountEmail?: string) => {
       if (calendarDraftIdFromEventId(eventId)) {
         updateDraftEvent(eventId, { title });
         return;
@@ -1334,7 +1334,7 @@ export default function CalendarView() {
       if (!guestNotification) return;
       updateEvent.mutate({
         id: eventId,
-        accountEmail: event?.accountEmail,
+        accountEmail: event?.accountEmail ?? accountEmail,
         ...updates,
         ...guestNotification,
       });

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -1343,7 +1343,7 @@ export default function CalendarView() {
   );
 
   const handleQuickEditCancel = useCallback(
-    (eventId: string) => {
+    (eventId: string, accountEmail?: string) => {
       setQuickEditEventId(null);
       if (calendarDraftIdFromEventId(eventId)) {
         discardDraftEvent(eventId);
@@ -1361,7 +1361,8 @@ export default function CalendarView() {
           buildDeleteEventMutationInput(
             {
               id: eventId,
-              accountEmail: ev?.accountEmail ?? defaultAccountEmail,
+              accountEmail:
+                ev?.accountEmail ?? accountEmail ?? defaultAccountEmail,
             },
             {
               scope: "single",

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -84,11 +84,13 @@ import { useOverlayPeople } from "@/hooks/use-overlay-people";
 import { useSettings } from "@/hooks/use-settings";
 import { setUndoAction, runUndo } from "@/hooks/use-undo";
 import { useViewPreferences } from "@/hooks/use-view-preferences";
+import { resolveEventAccountEmail } from "@/lib/event-account-selection";
 import { getGoogleEventColorHex } from "@/lib/event-colors";
 import {
   dateTimeInTimezoneToIso,
   getLocalTimezone,
 } from "@/lib/event-form-utils";
+import { buildDeleteEventMutationInput } from "@/lib/event-mutation-inputs";
 import { isMcpEmbedSurface } from "@/lib/mcp-embed";
 import { cn } from "@/lib/utils";
 
@@ -330,6 +332,7 @@ export default function CalendarView() {
 
   const queryClient = useQueryClient();
   const googleStatus = useGoogleAuthStatus();
+  const defaultAccountEmail = googleStatus.data?.accounts?.[0]?.email;
   const settingsQuery = useSettings();
   const { data: settings } = settingsQuery;
   const { data: rawOverlayPeople } = useOverlayPeople();
@@ -393,6 +396,28 @@ export default function CalendarView() {
     () => (draftEvent ? [draftEvent.id] : []),
     [draftEvent],
   );
+
+  useEffect(() => {
+    if (!eventDraft || !defaultAccountEmail) return;
+    const resolvedAccountEmail = resolveEventAccountEmail(
+      googleStatus.data?.accounts ?? [],
+      eventDraft.accountEmail,
+    );
+    if (
+      !resolvedAccountEmail ||
+      eventDraft.accountEmail === resolvedAccountEmail
+    ) {
+      return;
+    }
+    const nextDraft = { ...eventDraft, accountEmail: resolvedAccountEmail };
+    setEventDraft(nextDraft);
+    persistCalendarDraft(nextDraft);
+  }, [
+    defaultAccountEmail,
+    eventDraft,
+    googleStatus.data?.accounts,
+    setEventDraft,
+  ]);
 
   // Warm the adjacent ranges so j/k (and the chevron buttons) feel instant.
   // Borrowed from the mail template's background-warm pattern — fire-and-forget
@@ -621,7 +646,7 @@ export default function CalendarView() {
           ? undefined
           : (draft.endTimeZone ?? draft.startTimeZone ?? timezone),
         location,
-        accountEmail: draft.accountEmail,
+        accountEmail: draft.accountEmail ?? defaultAccountEmail,
         allDay: draft.allDay ?? false,
         transparency:
           eventType === "workingLocation"
@@ -653,11 +678,18 @@ export default function CalendarView() {
           const createdEventId = result?.id;
           if (createdEventId) {
             const undo = () => {
-              deleteEvent.mutate({
-                id: createdEventId,
-                scope: "single",
-                sendUpdates: "none",
-              });
+              deleteEvent.mutate(
+                buildDeleteEventMutationInput(
+                  {
+                    id: createdEventId,
+                    accountEmail:
+                      result.accountEmail ??
+                      draft.accountEmail ??
+                      defaultAccountEmail,
+                  },
+                  { scope: "single", sendUpdates: "none" },
+                ),
+              );
             };
             setUndoAction(undo);
           }
@@ -682,7 +714,15 @@ export default function CalendarView() {
         },
       });
     },
-    [createEvent, deleteEvent, eventDraft, selectedDate, setEventDraft, t],
+    [
+      createEvent,
+      defaultAccountEmail,
+      deleteEvent,
+      eventDraft,
+      selectedDate,
+      setEventDraft,
+      t,
+    ],
   );
 
   const updateDraftEvent = useCallback(
@@ -841,12 +881,11 @@ export default function CalendarView() {
           };
 
       deleteEvent.mutate(
-        {
-          id: ev.id,
+        buildDeleteEventMutationInput(ev, {
           scope: "single",
           ...guestNotification,
           removeOnly,
-        },
+        }),
         {
           onSuccess: () => {
             if (sidebarEvent?.id === ev.id) setSidebarEvent(null);
@@ -966,6 +1005,7 @@ export default function CalendarView() {
     const undo = () => {
       updateEvent.mutate({
         id: eventId,
+        accountEmail: event.accountEmail,
         start: oldStartISO,
         end: oldEndISO,
         sendUpdates: "none",
@@ -981,6 +1021,7 @@ export default function CalendarView() {
     updateEvent.mutate(
       {
         id: eventId,
+        accountEmail: event.accountEmail,
         ...updates,
         ...guestNotification,
       },
@@ -1046,6 +1087,7 @@ export default function CalendarView() {
       const undo = () => {
         updateEvent.mutate({
           id: eventId,
+          accountEmail: event.accountEmail,
           start: oldStartISO,
           end: oldEndISO,
           sendUpdates: "none",
@@ -1061,6 +1103,7 @@ export default function CalendarView() {
       updateEvent.mutate(
         {
           id: eventId,
+          accountEmail: event.accountEmail,
           ...updates,
           ...guestNotification,
         },
@@ -1135,6 +1178,7 @@ export default function CalendarView() {
         endTimeZone: timezone,
         allDay: false,
         eventType: "default",
+        accountEmail: defaultAccountEmail,
         createdAt: now,
         updatedAt: now,
       };
@@ -1143,7 +1187,14 @@ export default function CalendarView() {
       setEventDraft(draft);
       setQuickEditEventId(calendarDraftEventId(draftId));
     },
-    [settings, settingsQuery, t, setSelectedDate, setEventDraft],
+    [
+      defaultAccountEmail,
+      settings,
+      settingsQuery,
+      t,
+      setSelectedDate,
+      setEventDraft,
+    ],
   );
 
   // Command palette natural-language quick create (e.g. "lunch with Sam
@@ -1197,6 +1248,7 @@ export default function CalendarView() {
         endTimeZone: timezone,
         allDay: false,
         eventType: "default",
+        accountEmail: defaultAccountEmail,
         createdAt: now,
         updatedAt: now,
       };
@@ -1205,7 +1257,15 @@ export default function CalendarView() {
       setEventDraft(draft);
       setQuickEditEventId(calendarDraftEventId(draftId));
     },
-    [settings, settingsQuery, t, setSelectedDate, setViewMode, setEventDraft],
+    [
+      defaultAccountEmail,
+      settings,
+      settingsQuery,
+      t,
+      setSelectedDate,
+      setViewMode,
+      setEventDraft,
+    ],
   );
 
   const handleQuickEditSave = useCallback(
@@ -1231,7 +1291,12 @@ export default function CalendarView() {
             })
           : { sendUpdates: "none" as const };
         if (!guestNotification) return;
-        updateEvent.mutate({ id: eventId, ...updates, ...guestNotification });
+        updateEvent.mutate({
+          id: eventId,
+          accountEmail: event?.accountEmail,
+          ...updates,
+          ...guestNotification,
+        });
       }
     },
     [events, updateDraftEvent, promptGuestNotification, updateEvent],
@@ -1253,7 +1318,12 @@ export default function CalendarView() {
           })
         : { sendUpdates: "none" as const };
       if (!guestNotification) return;
-      updateEvent.mutate({ id: eventId, ...updates, ...guestNotification });
+      updateEvent.mutate({
+        id: eventId,
+        accountEmail: event?.accountEmail,
+        ...updates,
+        ...guestNotification,
+      });
     },
     [events, updateDraftEvent, promptGuestNotification, updateEvent],
   );
@@ -1272,12 +1342,13 @@ export default function CalendarView() {
       });
       // Delete the event if title was never set
       const ev = events.find((e) => e.id === eventId);
-      if (!ev || ev.title === "(No title)") {
-        deleteEvent.mutate({
-          id: eventId,
-          scope: "single",
-          sendUpdates: "none",
-        });
+      if (ev?.title === "(No title)") {
+        deleteEvent.mutate(
+          buildDeleteEventMutationInput(ev, {
+            scope: "single",
+            sendUpdates: "none",
+          }),
+        );
       }
     },
     [discardDraftEvent, events, deleteEvent],
@@ -1743,6 +1814,7 @@ export default function CalendarView() {
                 visibility: snapshot.visibility,
                 reminders: snapshot.reminders,
                 remindersUseDefault: snapshot.remindersUseDefault,
+                accountEmail: snapshot.accountEmail,
                 outOfOfficeProperties: snapshot.outOfOfficeProperties,
                 focusTimeProperties: snapshot.focusTimeProperties,
                 workingLocationProperties: snapshot.workingLocationProperties,
@@ -1754,7 +1826,7 @@ export default function CalendarView() {
               setSidebarEvent(null);
             }
             deleteEvent.mutate(
-              { id: eventId, ...options },
+              buildDeleteEventMutationInput(snapshot, options),
               {
                 onSuccess: () => {
                   setUndoAction(undo);

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -594,11 +594,24 @@ export default function CalendarView() {
       if (!draftId || !eventDraft || eventDraft.id !== draftId) return;
       if (committingDraftIdsRef.current.has(draftId)) return;
       committingDraftIdsRef.current.add(draftId);
-      const draft = pendingPatch
+      const pendingDraft = pendingPatch
         ? applyDraftPatch(eventDraft, pendingPatch)
         : eventDraft;
+      const accountEmail = resolveEventAccountEmail(
+        googleStatus.data?.accounts ?? [],
+        pendingDraft.accountEmail,
+      );
+      if (!accountEmail) {
+        committingDraftIdsRef.current.delete(draftId);
+        toast.error(t("calendarView.calendarSettingsLoading"));
+        return;
+      }
+      const draft =
+        pendingDraft.accountEmail === accountEmail
+          ? pendingDraft
+          : { ...pendingDraft, accountEmail };
       discardedCommittingDraftsRef.current.delete(draftId);
-      if (pendingPatch) {
+      if (pendingPatch || draft !== pendingDraft) {
         setEventDraft(draft);
         persistCalendarDraft(draft);
       }
@@ -646,7 +659,7 @@ export default function CalendarView() {
           ? undefined
           : (draft.endTimeZone ?? draft.startTimeZone ?? timezone),
         location,
-        accountEmail: draft.accountEmail ?? defaultAccountEmail,
+        accountEmail,
         allDay: draft.allDay ?? false,
         transparency:
           eventType === "workingLocation"
@@ -719,6 +732,7 @@ export default function CalendarView() {
       defaultAccountEmail,
       deleteEvent,
       eventDraft,
+      googleStatus.data?.accounts,
       selectedDate,
       setEventDraft,
       t,
@@ -1342,16 +1356,22 @@ export default function CalendarView() {
       });
       // Delete the event if title was never set
       const ev = events.find((e) => e.id === eventId);
-      if (ev?.title === "(No title)") {
+      if (!ev || ev.title === "(No title)") {
         deleteEvent.mutate(
-          buildDeleteEventMutationInput(ev, {
-            scope: "single",
-            sendUpdates: "none",
-          }),
+          buildDeleteEventMutationInput(
+            {
+              id: eventId,
+              accountEmail: ev?.accountEmail ?? defaultAccountEmail,
+            },
+            {
+              scope: "single",
+              sendUpdates: "none",
+            },
+          ),
         );
       }
     },
-    [discardDraftEvent, events, deleteEvent],
+    [defaultAccountEmail, discardDraftEvent, events, deleteEvent],
   );
 
   // IconKeyboard shortcuts — don't fire when user is typing in an input

--- a/templates/calendar/changelog/2026-07-10-choose-which-connected-google-account-receives-a-new-event-w.md
+++ b/templates/calendar/changelog/2026-07-10-choose-which-connected-google-account-receives-a-new-event-w.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-10
+---
+
+Choose which connected Google account receives a new event, with updates and deletions staying on that calendar.

--- a/templates/calendar/server/db/schema.ts
+++ b/templates/calendar/server/db/schema.ts
@@ -21,6 +21,8 @@ export const bookings = table("bookings", {
   meetingLink: text("meeting_link"),
   /** Google Calendar event created for this booking, if any */
   googleEventId: text("google_event_id"),
+  /** Connected calendar account that owns the provider event, if any */
+  calendarAccountId: text("calendar_account_id"),
   /** Token for public cancel/reschedule link */
   cancelToken: text("cancel_token"),
   status: text("status", { enum: ["confirmed", "cancelled"] })

--- a/templates/calendar/server/handlers/bookings.spec.ts
+++ b/templates/calendar/server/handlers/bookings.spec.ts
@@ -238,4 +238,24 @@ describe("booking calendar account provenance", () => {
       "alice@example.com",
     );
   });
+
+  it("prefers a resolved booking-link host over a legacy owner placeholder", async () => {
+    vi.mocked(googleCalendar.getDefaultAccountSelection).mockResolvedValue({
+      ownerEmail: "alice@example.com",
+      accountEmail: "primary@example.com",
+    });
+
+    await resolveBookingCalendarAccount({
+      booking: {
+        slug: "alice-meeting",
+        ownerEmail: "local@localhost",
+        calendarAccountId: null,
+      },
+      hostEmail: "alice@example.com",
+    });
+
+    expect(googleCalendar.getDefaultAccountSelection).toHaveBeenCalledWith(
+      "alice@example.com",
+    );
+  });
 });

--- a/templates/calendar/server/handlers/bookings.spec.ts
+++ b/templates/calendar/server/handlers/bookings.spec.ts
@@ -2,10 +2,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AvailabilityConfig } from "../../shared/api";
 import * as googleCalendar from "../lib/google-calendar.js";
-import { generateAvailableSlotsForDate, getConflictItems } from "./bookings";
+import {
+  generateAvailableSlotsForDate,
+  getConflictItems,
+  resolveBookingCalendarAccount,
+} from "./bookings";
 
 vi.mock("../lib/google-calendar.js", () => ({
   getFreeBusy: vi.fn(),
+  getDefaultAccountSelection: vi.fn(),
   isConnected: vi.fn(),
   listEvents: vi.fn(),
 }));
@@ -187,5 +192,50 @@ describe("booking availability", () => {
       unavailableReason:
         "Calendar availability unavailable for host@example.com",
     });
+  });
+});
+
+describe("booking calendar account provenance", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the account stored with the booking event", async () => {
+    const account = await resolveBookingCalendarAccount({
+      booking: {
+        slug: "alice-meeting",
+        ownerEmail: "alice@example.com",
+        calendarAccountId: "secondary@example.com",
+      },
+    });
+
+    expect(account).toEqual({
+      ownerEmail: "alice@example.com",
+      accountEmail: "secondary@example.com",
+    });
+    expect(googleCalendar.getDefaultAccountSelection).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the current default for legacy booking rows", async () => {
+    vi.mocked(googleCalendar.getDefaultAccountSelection).mockResolvedValue({
+      ownerEmail: "alice@example.com",
+      accountEmail: "primary@example.com",
+    });
+
+    const account = await resolveBookingCalendarAccount({
+      booking: {
+        slug: "alice-meeting",
+        ownerEmail: "alice@example.com",
+        calendarAccountId: null,
+      },
+    });
+
+    expect(account).toEqual({
+      ownerEmail: "alice@example.com",
+      accountEmail: "primary@example.com",
+    });
+    expect(googleCalendar.getDefaultAccountSelection).toHaveBeenCalledWith(
+      "alice@example.com",
+    );
   });
 });

--- a/templates/calendar/server/handlers/bookings.ts
+++ b/templates/calendar/server/handlers/bookings.ts
@@ -98,23 +98,50 @@ function isValidEmail(value: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
 }
 
+export async function resolveBookingCalendarAccount({
+  booking,
+  hostEmail,
+}: {
+  booking: Pick<
+    typeof schema.bookings.$inferSelect,
+    "slug" | "ownerEmail" | "calendarAccountId"
+  >;
+  hostEmail?: string;
+}) {
+  const ownerEmail =
+    booking.ownerEmail ||
+    hostEmail ||
+    (await getBookingLinkOwnerEmail(booking.slug));
+  if (!ownerEmail) return;
+
+  if (booking.calendarAccountId) {
+    return {
+      ownerEmail,
+      accountEmail: booking.calendarAccountId,
+    };
+  }
+
+  return googleCalendar.getDefaultAccountSelection(ownerEmail);
+}
+
 async function deleteGoogleEventForBooking({
   booking,
   hostEmail,
 }: {
   booking: Pick<
     typeof schema.bookings.$inferSelect,
-    "id" | "slug" | "googleEventId"
+    "id" | "slug" | "googleEventId" | "ownerEmail" | "calendarAccountId"
   >;
   hostEmail?: string;
 }) {
   if (!booking.googleEventId) return;
-  const ownerEmail =
-    hostEmail ?? (await getBookingLinkOwnerEmail(booking.slug));
-  if (!ownerEmail) return;
 
   try {
-    const account = await googleCalendar.getDefaultAccountSelection(ownerEmail);
+    const account = await resolveBookingCalendarAccount({
+      booking,
+      hostEmail,
+    });
+    if (!account) return;
     await googleCalendar.deleteEvent(booking.googleEventId, account, {
       sendUpdates: "none",
     });
@@ -974,6 +1001,7 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
     }
     let meetingLink: string | undefined;
     let googleEventId: string | undefined;
+    let calendarAccountId: string | undefined;
 
     // For custom-URL conferencing, use the static URL — only http(s).
     if (conferencing?.type === "custom" && conferencing.url) {
@@ -1069,6 +1097,7 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
         });
         // Google Meet link is returned by the API when created
         googleEventId = result.id;
+        calendarAccountId = account.accountEmail;
         if (result.meetLink) {
           meetingLink = result.meetLink;
         }
@@ -1086,9 +1115,13 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
       const providerUpdates: {
         meetingLink?: string;
         googleEventId?: string;
+        calendarAccountId?: string;
       } = {};
       if (meetingLink) providerUpdates.meetingLink = meetingLink;
       if (googleEventId) providerUpdates.googleEventId = googleEventId;
+      if (googleEventId && calendarAccountId) {
+        providerUpdates.calendarAccountId = calendarAccountId;
+      }
       await getDb()
         .update(schema.bookings)
         .set(providerUpdates)

--- a/templates/calendar/server/handlers/bookings.ts
+++ b/templates/calendar/server/handlers/bookings.ts
@@ -109,8 +109,8 @@ export async function resolveBookingCalendarAccount({
   hostEmail?: string;
 }) {
   const ownerEmail =
-    booking.ownerEmail ||
     hostEmail ||
+    booking.ownerEmail ||
     (await getBookingLinkOwnerEmail(booking.slug));
   if (!ownerEmail) return;
 

--- a/templates/calendar/server/handlers/bookings.ts
+++ b/templates/calendar/server/handlers/bookings.ts
@@ -114,7 +114,8 @@ async function deleteGoogleEventForBooking({
   if (!ownerEmail) return;
 
   try {
-    await googleCalendar.deleteEvent(booking.googleEventId, ownerEmail, {
+    const account = await googleCalendar.getDefaultAccountSelection(ownerEmail);
+    await googleCalendar.deleteEvent(booking.googleEventId, account, {
       sendUpdates: "none",
     });
   } catch (error) {
@@ -1016,6 +1017,8 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
     // host rather than relying on ambient user state.
     if (await googleCalendar.isConnected(hostEmail)) {
       try {
+        const account =
+          await googleCalendar.getDefaultAccountSelection(hostEmail);
         const descParts: string[] = [
           `Booking by ${attendeeName} (${attendeeEmail})`,
         ];
@@ -1050,7 +1053,7 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
           location: meetingLink || "",
           allDay: false,
           source: "google",
-          accountEmail: hostEmail,
+          accountEmail: account.accountEmail,
           attendees: buildBookingEventAttendees({
             attendeeEmail,
             attendeeName,
@@ -1060,6 +1063,7 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
           updatedAt: now,
         };
         const result = await googleCalendar.createEvent(calEvent, {
+          account,
           addGoogleMeet: conferencing?.type === "google_meet",
           sendUpdates: "all",
         });

--- a/templates/calendar/server/handlers/events.ts
+++ b/templates/calendar/server/handlers/events.ts
@@ -43,10 +43,17 @@ async function resolveAccountEmail(
   requestAccountEmail: string | undefined,
   ownerEmail: string,
 ): Promise<string> {
-  if (!requestAccountEmail || requestAccountEmail === ownerEmail) {
+  if (requestAccountEmail === ownerEmail) {
     return ownerEmail;
   }
   const status = await googleCalendar.getAuthStatus(ownerEmail);
+  if (!requestAccountEmail) {
+    return (
+      status.accounts.find((account) => account.email === ownerEmail)?.email ??
+      status.accounts[0]?.email ??
+      ownerEmail
+    );
+  }
   const isOwned = status.accounts.some((a) => a.email === requestAccountEmail);
   if (!isOwned) {
     throw new ForbiddenError("Account not owned by current user");
@@ -290,6 +297,7 @@ export const createEvent = defineEventHandler(async (event: H3Event) => {
     }
 
     const result = await googleCalendar.createEvent(calEvent, {
+      account: { ownerEmail: email, accountEmail: acctEmail },
       addGoogleMeet: shouldAutoAddGoogleMeet(calEvent, {
         addGoogleMeet:
           typeof addGoogleMeet === "boolean" ? addGoogleMeet : undefined,
@@ -372,7 +380,10 @@ export const updateEvent = defineEventHandler(async (event: H3Event) => {
 
     let existingEvent: CalendarEvent | undefined;
     const loadExistingEvent = async () => {
-      existingEvent ??= await googleCalendar.getEvent(googleEventId, acctEmail);
+      existingEvent ??= await googleCalendar.getEvent(googleEventId, {
+        ownerEmail: email,
+        accountEmail: acctEmail,
+      });
       return existingEvent;
     };
 
@@ -415,6 +426,7 @@ export const updateEvent = defineEventHandler(async (event: H3Event) => {
 
     try {
       const result = await googleCalendar.updateEvent(googleEventId, updates, {
+        account: { ownerEmail: email, accountEmail: acctEmail },
         sendUpdates:
           sendUpdates ?? (guestNotificationMessage ? "all" : undefined),
         addGoogleMeet: addGoogleMeet === true,
@@ -521,7 +533,10 @@ export const deleteEvent = defineEventHandler(async (event: H3Event) => {
     const shouldNotifyGuests = !!guestNotificationMessage && !removeOnly;
     const effectiveSendUpdates = removeOnly ? "none" : sendUpdates;
     const eventForNotification = shouldNotifyGuests
-      ? await googleCalendar.getEvent(googleEventId, accountEmail)
+      ? await googleCalendar.getEvent(googleEventId, {
+          ownerEmail: email,
+          accountEmail,
+        })
       : undefined;
 
     try {
@@ -529,15 +544,19 @@ export const deleteEvent = defineEventHandler(async (event: H3Event) => {
         // Non-organizer: decline the event to remove from calendar
         await googleCalendar.removeEventFromCalendar(
           googleEventId,
-          accountEmail,
+          { ownerEmail: email, accountEmail },
           { scope, sendUpdates: effectiveSendUpdates },
         );
       } else {
         // Organizer: actually delete the event
-        await googleCalendar.deleteEvent(googleEventId, accountEmail, {
-          scope,
-          sendUpdates: effectiveSendUpdates,
-        });
+        await googleCalendar.deleteEvent(
+          googleEventId,
+          { ownerEmail: email, accountEmail },
+          {
+            scope,
+            sendUpdates: effectiveSendUpdates,
+          },
+        );
       }
     } catch (error: any) {
       setResponseStatus(event, 500);
@@ -614,7 +633,7 @@ export const rsvpEvent = defineEventHandler(async (event: H3Event) => {
       await googleCalendar.rsvpEvent(
         googleEventId,
         status,
-        acctEmail,
+        { ownerEmail: email, accountEmail: acctEmail },
         scope,
         note,
         sendUpdates,

--- a/templates/calendar/server/lib/google-calendar.spec.ts
+++ b/templates/calendar/server/lib/google-calendar.spec.ts
@@ -11,6 +11,7 @@ const calendarGetEventMock = vi.hoisted(() => vi.fn());
 const calendarListEventsMock = vi.hoisted(() => vi.fn());
 const calendarFreeBusyMock = vi.hoisted(() => vi.fn());
 const calendarInsertEventMock = vi.hoisted(() => vi.fn());
+const calendarDeleteEventMock = vi.hoisted(() => vi.fn());
 const calendarPatchEventMock = vi.hoisted(() => vi.fn());
 const dbExecuteMock = vi.hoisted(() => vi.fn());
 const resolveSecretMock = vi.hoisted(() => vi.fn());
@@ -49,7 +50,7 @@ vi.mock("./google-api.js", () => ({
   calendarListEvents: calendarListEventsMock,
   calendarGetEvent: calendarGetEventMock,
   calendarInsertEvent: calendarInsertEventMock,
-  calendarDeleteEvent: vi.fn(),
+  calendarDeleteEvent: calendarDeleteEventMock,
   calendarPatchEvent: calendarPatchEventMock,
   calendarFreeBusy: calendarFreeBusyMock,
 }));
@@ -62,6 +63,9 @@ import {
   getFreeBusy,
   getPrimaryAccountPhotoUrl,
   createEvent,
+  deleteEvent,
+  getClientForAccount,
+  getDefaultAccountSelection,
   listEvents,
   listOverlayEvents,
   rsvpEvent,
@@ -486,31 +490,39 @@ describe("calendar event creation", () => {
   });
 
   it("sends attendee RSVP statuses when creating an event", async () => {
-    await createEvent({
-      id: "",
-      title: "Planning",
-      description: "",
-      location: "",
-      start: "2026-07-09T16:00:00.000Z",
-      end: "2026-07-09T16:30:00.000Z",
-      allDay: false,
-      source: "google",
-      accountEmail: "steve@example.com",
-      attendees: [
-        {
-          email: "steve@example.com",
-          organizer: true,
-          self: true,
-          responseStatus: "accepted",
+    await createEvent(
+      {
+        id: "",
+        title: "Planning",
+        description: "",
+        location: "",
+        start: "2026-07-09T16:00:00.000Z",
+        end: "2026-07-09T16:30:00.000Z",
+        allDay: false,
+        source: "google",
+        accountEmail: "steve@example.com",
+        attendees: [
+          {
+            email: "steve@example.com",
+            organizer: true,
+            self: true,
+            responseStatus: "accepted",
+          },
+          {
+            email: "guest@example.com",
+            responseStatus: "needsAction",
+          },
+        ],
+        createdAt: "2026-07-09T15:00:00.000Z",
+        updatedAt: "2026-07-09T15:00:00.000Z",
+      },
+      {
+        account: {
+          ownerEmail: "steve@example.com",
+          accountEmail: "steve@example.com",
         },
-        {
-          email: "guest@example.com",
-          responseStatus: "needsAction",
-        },
-      ],
-      createdAt: "2026-07-09T15:00:00.000Z",
-      updatedAt: "2026-07-09T15:00:00.000Z",
-    });
+      },
+    );
 
     expect(calendarInsertEventMock).toHaveBeenCalledWith(
       "access-token",
@@ -571,7 +583,13 @@ describe("calendar recurring event updates", () => {
         start: "2026-05-20T16:00:00Z",
         end: "2026-05-20T17:00:00Z",
       },
-      { scope: "all" },
+      {
+        account: {
+          ownerEmail: "steve@example.com",
+          accountEmail: "steve@example.com",
+        },
+        scope: "all",
+      },
     );
 
     expect(calendarPatchEventMock).toHaveBeenCalledWith(
@@ -605,7 +623,10 @@ describe("calendar RSVP updates", () => {
     await rsvpEvent(
       "event-1",
       "declined",
-      "steve@example.com",
+      {
+        ownerEmail: "steve@example.com",
+        accountEmail: "steve@example.com",
+      },
       "single",
       "I have a conflict",
     );
@@ -629,7 +650,16 @@ describe("calendar RSVP updates", () => {
   });
 
   it("sends an empty comment so an RSVP note can be cleared", async () => {
-    await rsvpEvent("event-1", "accepted", "steve@example.com", "single", "");
+    await rsvpEvent(
+      "event-1",
+      "accepted",
+      {
+        ownerEmail: "steve@example.com",
+        accountEmail: "steve@example.com",
+      },
+      "single",
+      "",
+    );
 
     expect(calendarPatchEventMock).toHaveBeenCalledWith(
       "access-token",
@@ -646,6 +676,108 @@ describe("calendar RSVP updates", () => {
         attendeesOmitted: true,
       },
       { sendUpdates: "none" },
+    );
+  });
+});
+
+describe("owner-aware Google Calendar writes", () => {
+  const ownerEmail = "owner@example.com";
+  const secondaryEmail = "secondary@example.com";
+  const account = { ownerEmail, accountEmail: secondaryEmail };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listOAuthAccountsByOwnerMock.mockResolvedValue([
+      {
+        accountId: ownerEmail,
+        tokens: {
+          access_token: "owner-access-token",
+          expiry_date: Date.now() + 10 * 60_000,
+        },
+      },
+      {
+        accountId: secondaryEmail,
+        tokens: {
+          access_token: "secondary-access-token",
+          expiry_date: Date.now() + 10 * 60_000,
+        },
+      },
+    ]);
+    calendarInsertEventMock.mockResolvedValue({ id: "event-secondary" });
+    calendarPatchEventMock.mockResolvedValue({ id: "event-secondary" });
+    calendarDeleteEventMock.mockResolvedValue(undefined);
+  });
+
+  it("resolves a secondary account beneath the signed-in owner", async () => {
+    await expect(getClientForAccount(account)).resolves.toEqual({
+      accessToken: "secondary-access-token",
+    });
+    expect(listOAuthAccountsByOwnerMock).toHaveBeenCalledWith(
+      "google",
+      ownerEmail,
+    );
+  });
+
+  it("keeps legacy owner-scoped callers on the owner's default account", async () => {
+    await expect(getDefaultAccountSelection(ownerEmail)).resolves.toEqual({
+      ownerEmail,
+      accountEmail: ownerEmail,
+    });
+  });
+
+  it("fails loudly when the selected account is not connected for the owner", async () => {
+    await expect(
+      getClientForAccount({
+        ownerEmail,
+        accountEmail: "missing@example.com",
+      }),
+    ).rejects.toThrow(
+      "Google Calendar account not connected for this user: missing@example.com",
+    );
+  });
+
+  it("routes create, update, delete, and RSVP through the secondary account", async () => {
+    const event = {
+      id: "",
+      title: "Secondary planning",
+      description: "",
+      location: "",
+      start: "2026-07-09T16:00:00.000Z",
+      end: "2026-07-09T16:30:00.000Z",
+      allDay: false,
+      source: "google" as const,
+      accountEmail: secondaryEmail,
+      createdAt: "2026-07-09T15:00:00.000Z",
+      updatedAt: "2026-07-09T15:00:00.000Z",
+    };
+
+    await createEvent(event, { account });
+    await updateEvent(
+      "event-secondary",
+      { accountEmail: secondaryEmail, title: "Updated" },
+      { account },
+    );
+    await deleteEvent("event-secondary", account);
+    await rsvpEvent("event-secondary", "accepted", account);
+
+    expect(calendarInsertEventMock).toHaveBeenCalledWith(
+      "secondary-access-token",
+      "primary",
+      expect.any(Object),
+      undefined,
+    );
+    expect(calendarPatchEventMock).toHaveBeenCalledWith(
+      "secondary-access-token",
+      "primary",
+      "event-secondary",
+      expect.any(Object),
+      expect.any(Object),
+    );
+    expect(calendarDeleteEventMock).toHaveBeenCalledWith(
+      "secondary-access-token",
+      "primary",
+      "event-secondary",
+      undefined,
     );
   });
 });

--- a/templates/calendar/server/lib/google-calendar.ts
+++ b/templates/calendar/server/lib/google-calendar.ts
@@ -574,6 +574,54 @@ export async function getClient(
   return { accessToken };
 }
 
+export interface GoogleAccountSelection {
+  ownerEmail: string;
+  accountEmail: string;
+}
+
+export async function getDefaultAccountSelection(
+  ownerEmail: string,
+): Promise<GoogleAccountSelection> {
+  const accounts = await listOAuthAccountsByOwner("google", ownerEmail);
+  const account =
+    accounts.find(
+      (candidate) =>
+        candidate.accountId.trim().toLowerCase() ===
+        ownerEmail.trim().toLowerCase(),
+    ) ?? accounts[0];
+  if (!account) {
+    throw new Error(
+      "Google Calendar not connected. Connect via Settings first.",
+    );
+  }
+  return { ownerEmail, accountEmail: account.accountId };
+}
+
+/** Resolve one connected Google account beneath its signed-in owner. */
+export async function getClientForAccount({
+  ownerEmail,
+  accountEmail,
+}: GoogleAccountSelection): Promise<{ accessToken: string }> {
+  const normalizedAccountEmail = accountEmail.trim().toLowerCase();
+  const accounts = await listOAuthAccountsByOwner("google", ownerEmail);
+  const account = accounts.find(
+    (candidate) =>
+      candidate.accountId.trim().toLowerCase() === normalizedAccountEmail,
+  );
+  if (!account) {
+    throw new Error(
+      `Google Calendar account not connected for this user: ${accountEmail}`,
+    );
+  }
+
+  const accessToken = await getValidAccessToken(
+    account.accountId,
+    account.tokens as unknown as GoogleTokens,
+    ownerEmail,
+  );
+  return { accessToken };
+}
+
 /**
  * Get OAuth credentials. When `forEmail` is provided, returns only that
  * user's credentials (multi-user mode). Otherwise returns an empty array.
@@ -1006,14 +1054,9 @@ export async function listOverlayEvents(
 
 export async function getEvent(
   googleEventId: string,
-  accountEmail: string,
+  account: GoogleAccountSelection,
 ): Promise<CalendarEvent> {
-  const client = await getClient(accountEmail);
-  if (!client) {
-    throw new Error(
-      `Google Calendar account not connected: ${accountEmail || "selected account"}`,
-    );
-  }
+  const client = await getClientForAccount(account);
 
   const event = await calendarGetEvent(
     client.accessToken,
@@ -1035,7 +1078,7 @@ export async function getEvent(
     source: "google",
     googleEventId: event.id || undefined,
     htmlLink: event.htmlLink || undefined,
-    accountEmail,
+    accountEmail: account.accountEmail,
     responseStatus: selfAttendee?.responseStatus || undefined,
     transparency: event.transparency || undefined,
     ...mapColor(event),
@@ -1060,7 +1103,8 @@ export async function getEvent(
 
 export async function createEvent(
   event: CalendarEvent,
-  opts?: {
+  opts: {
+    account: GoogleAccountSelection;
     addGoogleMeet?: boolean;
     sendUpdates?: "all" | "externalOnly" | "none";
   },
@@ -1070,8 +1114,7 @@ export async function createEvent(
   meetLink?: string;
   conferenceData?: CalendarEvent["conferenceData"];
 }> {
-  const client = await getClient(event.accountEmail);
-  if (!client) return {};
+  const client = await getClientForAccount(opts.account);
   if (
     (event.eventType === "outOfOffice" || event.eventType === "focusTime") &&
     event.allDay
@@ -1131,7 +1174,8 @@ export async function createEvent(
 export async function updateEvent(
   googleEventId: string,
   event: Partial<CalendarEvent>,
-  options?: {
+  options: {
+    account: GoogleAccountSelection;
     sendUpdates?: "all" | "none";
     addGoogleMeet?: boolean;
     scope?: UpdateEventScope;
@@ -1142,12 +1186,7 @@ export async function updateEvent(
   conferenceData?: CalendarEvent["conferenceData"];
   attendees?: CalendarEvent["attendees"];
 }> {
-  const client = await getClient(event.accountEmail);
-  if (!client) {
-    throw new Error(
-      `Google Calendar account not connected: ${event.accountEmail ?? "selected account"}`,
-    );
-  }
+  const client = await getClientForAccount(options.account);
 
   let targetEventId = googleEventId;
   let eventPatch = event;
@@ -1252,18 +1291,13 @@ export async function updateEvent(
 
 export async function deleteEvent(
   googleEventId: string,
-  accountEmail?: string,
+  account: GoogleAccountSelection,
   options?: {
     scope?: "single" | "all" | "thisAndFollowing";
     sendUpdates?: "all" | "none";
   },
 ): Promise<void> {
-  const client = await getClient(accountEmail);
-  if (!client) {
-    throw new Error(
-      `Google Calendar account not connected: ${accountEmail ?? "selected account"}`,
-    );
-  }
+  const client = await getClientForAccount(account);
 
   const scope = options?.scope || "single";
   const sendUpdates = options?.sendUpdates;
@@ -1358,16 +1392,13 @@ export async function deleteEvent(
  */
 export async function removeEventFromCalendar(
   googleEventId: string,
-  accountEmail: string,
+  account: GoogleAccountSelection,
   options?: {
     scope?: "single" | "all" | "thisAndFollowing";
     sendUpdates?: "all" | "none";
   },
 ): Promise<void> {
-  const client = await getClient(accountEmail);
-  if (!client) {
-    throw new Error(`Google Calendar account not connected: ${accountEmail}`);
-  }
+  const client = await getClientForAccount(account);
 
   const scope = options?.scope || "single";
   const sendUpdates = options?.sendUpdates;
@@ -1444,22 +1475,19 @@ async function rsvpSingleEvent(
 export async function rsvpEvent(
   googleEventId: string,
   responseStatus: "accepted" | "declined" | "tentative",
-  accountEmail: string,
+  account: GoogleAccountSelection,
   scope: "single" | "all" | "thisAndFollowing" = "single",
   comment?: string,
   sendUpdates?: string,
 ): Promise<void> {
-  const client = await getClient(accountEmail);
-  if (!client) {
-    throw new Error(`Google Calendar account not connected: ${accountEmail}`);
-  }
+  const client = await getClientForAccount(account);
 
   if (scope === "single") {
     await rsvpSingleEvent(
       client.accessToken,
       googleEventId,
       responseStatus,
-      accountEmail,
+      account.accountEmail,
       comment,
       sendUpdates,
     );
@@ -1481,7 +1509,7 @@ export async function rsvpEvent(
       client.accessToken,
       recurringEventId,
       responseStatus,
-      accountEmail,
+      account.accountEmail,
       comment,
       sendUpdates,
     );
@@ -1516,7 +1544,7 @@ export async function rsvpEvent(
         client.accessToken,
         e.id,
         responseStatus,
-        accountEmail,
+        account.accountEmail,
         comment,
         sendUpdates,
       ),

--- a/templates/calendar/server/plugins/db.ts
+++ b/templates/calendar/server/plugins/db.ts
@@ -206,6 +206,11 @@ CREATE INDEX IF NOT EXISTS idx_bookings_slug_start ON bookings (slug, "start");`
       version: 20,
       sql: `ALTER TABLE booking_links ADD COLUMN IF NOT EXISTS hosts TEXT`,
     },
+    {
+      version: 21,
+      name: "bookings-calendar-account-id",
+      sql: `ALTER TABLE bookings ADD COLUMN IF NOT EXISTS calendar_account_id TEXT`,
+    },
   ],
   { table: "calendar_migrations" },
 );


### PR DESCRIPTION
## Summary

- add a compact Calendar selector beneath the event title when multiple Google accounts are connected, defaulting new, slot-click, quick-create, and persisted drafts to the first connected account
- resolve OAuth credentials with an explicit signed-in owner plus selected Google account so create, update, delete, and RSVP writes reach the intended account primary calendar and missing credentials fail loudly
- preserve `accountEmail` through every frontend delete path, including recurring/guest confirmation, create undo, untitled cleanup, CreateEventDialog, EventDialog, and CalendarView; update paths now preserve it too
- document the multi-account write contract and add a Calendar changelog entry

## Scope

This intentionally selects between connected Google account primary calendars only. Arbitrary non-primary Google `calendarId` selection and moving an existing event between accounts remain out of scope.

## Verification

- `pnpm --filter calendar test` (37 files, 216 tests)
- `pnpm --filter calendar typecheck`
- `pnpm guard:i18n-catalogs` (16 catalog directories)
- `pnpm --filter calendar build`
- `git diff --check`

No real user calendars were mutated during implementation.

## Manual verification story

As a user with two disposable/mock connected Google accounts, open New Event and confirm a compact Calendar selector appears directly below Title with both account emails and their existing colors. Select the second account and create an event; verify the action payload and returned event preserve the second `accountEmail` and target `calendarId: primary`. Repeat from a clicked time slot, natural-language quick create, and a persisted/agent draft. Then update, RSVP, delete, undo-create, cancel an untitled quick event, and delete recurring single/all/this-and-following variants; each request should preserve that same account. With one connected account, confirm the selector is hidden and creation still defaults correctly. With a disconnected/missing selected account, confirm the write fails visibly instead of reporting success.