### PR TITLE
design: opt + hover to show px distance

### DIFF
--- a/templates/design/.generated/bridge/editor-chrome.generated.ts
+++ b/templates/design/.generated/bridge/editor-chrome.generated.ts
@@ -1204,6 +1204,7 @@ export const editorChromeBridgeScript: string = `"use strict";
     document.body.appendChild(snapGuideH);
     var measurementOverlay = document.createElement("div");
     measurementOverlay.setAttribute("data-agent-native-measurement-overlay", "");
+    measurementOverlay.setAttribute("data-agent-native-edit-overlay", "measurement");
     measurementOverlay.style.cssText = "position:fixed;inset:0;z-index:100001;display:none;pointer-events:none;color:var(--design-editor-measure-color);font:11px/1.2 ui-monospace,SFMono-Regular,Menlo,monospace;";
     document.body.appendChild(measurementOverlay);
     var componentTagOverlay = document.createElement("div");
@@ -2645,6 +2646,9 @@ export const editorChromeBridgeScript: string = `"use strict";
       }
       var selectedRect = a.getBoundingClientRect();
       var hoverRect = b.getBoundingClientRect();
+      if (!measurementOverlay.isConnected) {
+        document.body.appendChild(measurementOverlay);
+      }
       measurementOverlay.innerHTML = "";
       measurementOverlay.style.display = "block";
       if (hoverRect.right <= selectedRect.left) {
@@ -6667,7 +6671,7 @@ export const editorChromeBridgeScript: string = `"use strict";
         } else {
           hideMeasurements();
         }
-        if (hoveredEl !== lastHoverInfoPostedEl) {
+        if (!e.altKey && hoveredEl !== lastHoverInfoPostedEl) {
           lastHoverInfoPostedEl = hoveredEl;
           var info = getLightElementInfo(hoveredEl);
           window.parent.postMessage(
@@ -6721,7 +6725,17 @@ export const editorChromeBridgeScript: string = `"use strict";
     window.addEventListener(
       "keyup",
       function(e) {
-        if (e.key === "Alt") hideMeasurements();
+        if (e.key === "Alt") {
+          hideMeasurements();
+          lastHoverInfoPostedEl = hoveredEl;
+          window.parent.postMessage(
+            {
+              type: "element-hover",
+              payload: hoveredEl ? getLightElementInfo(hoveredEl) : null
+            },
+            "*"
+          );
+        }
       },
       true
     );

--- a/templates/design/.generated/bridge/editor-chrome.generated.ts
+++ b/templates/design/.generated/bridge/editor-chrome.generated.ts
@@ -1204,7 +1204,10 @@ export const editorChromeBridgeScript: string = `"use strict";
     document.body.appendChild(snapGuideH);
     var measurementOverlay = document.createElement("div");
     measurementOverlay.setAttribute("data-agent-native-measurement-overlay", "");
-    measurementOverlay.setAttribute("data-agent-native-edit-overlay", "measurement");
+    measurementOverlay.setAttribute(
+      "data-agent-native-edit-overlay",
+      "measurement"
+    );
     measurementOverlay.style.cssText = "position:fixed;inset:0;z-index:100001;display:none;pointer-events:none;color:var(--design-editor-measure-color);font:11px/1.2 ui-monospace,SFMono-Regular,Menlo,monospace;";
     document.body.appendChild(measurementOverlay);
     var componentTagOverlay = document.createElement("div");

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -4686,17 +4686,29 @@ function SingleScreenCreationOverlay({
         />
       ) : null}
       {previewRect ? (
-        <div
-          data-creation-preview-rect
-          className="pointer-events-none absolute rounded-[2px] border-[1.5px] border-[var(--design-editor-accent-color)] bg-[var(--design-editor-accent-color)]/10"
-          style={{
-            left: previewRect.x,
-            top: previewRect.y,
-            width: Math.max(1, previewRect.width),
-            height: Math.max(1, previewRect.height),
-            borderRadius: tool === "ellipse" ? "9999px" : undefined,
-          }}
-        />
+        <>
+          <div
+            data-creation-preview-rect
+            className="pointer-events-none absolute rounded-[2px] border-[1.5px] border-[var(--design-editor-accent-color)] bg-[var(--design-editor-accent-color)]/10"
+            style={{
+              left: previewRect.x,
+              top: previewRect.y,
+              width: Math.max(1, previewRect.width),
+              height: Math.max(1, previewRect.height),
+              borderRadius: tool === "ellipse" ? "9999px" : undefined,
+            }}
+          />
+          <span
+            data-creation-preview-size
+            className="pointer-events-none absolute z-10 -translate-x-1/2 translate-y-1 rounded bg-[var(--design-editor-accent-color)] px-1.5 py-0.5 text-[10px] font-medium leading-none text-[var(--design-editor-accent-contrast-color)] shadow-sm"
+            style={{
+              left: previewRect.x + previewRect.width / 2,
+              top: previewRect.y + previewRect.height,
+            }}
+          >
+            {Math.round(previewRect.width)} × {Math.round(previewRect.height)}
+          </span>
+        </>
       ) : null}
       {previewLine ? (
         <svg

--- a/templates/design/app/components/design/MultiScreenCanvas.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.tsx
@@ -7741,7 +7741,7 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
           )),
         )}
 
-        {/* Figma-parity alt-hover measurement: red edge-to-edge distance
+        {/* Figma-parity alt-hover measurement: orange edge-to-edge distance
             lines between the current selection and whatever frame/draft is
             under the cursor while Alt is held (pure hover, no drag). */}
         {[altHoverMeasurement?.horizontal, altHoverMeasurement?.vertical]
@@ -7751,7 +7751,7 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
           .map((line) => (
             <span
               key={`alt-hover-${line.orientation}`}
-              className="pointer-events-none absolute z-40 bg-destructive"
+              className="pointer-events-none absolute z-40 bg-[var(--design-editor-measure-color)]"
               style={
                 line.orientation === "vertical"
                   ? {
@@ -7786,7 +7786,7 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
           return (
             <span
               key={`alt-hover-label-${line.orientation}`}
-              className="pointer-events-none absolute z-40 -translate-x-1/2 -translate-y-1/2 rounded bg-destructive px-1 py-0.5 text-[10px] font-medium leading-none text-destructive-foreground shadow-sm"
+              className="pointer-events-none absolute z-40 -translate-x-1/2 -translate-y-1/2 rounded bg-[var(--design-editor-measure-color)] px-1 py-0.5 text-[10px] font-medium leading-none text-white shadow-sm"
               style={{
                 left: pan.x + (SURFACE_PADDING + labelCanvasPoint.x) * scale,
                 top: pan.y + (SURFACE_PADDING + labelCanvasPoint.y) * scale,
@@ -7796,6 +7796,37 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
             </span>
           );
         })}
+
+      {/* Live width × height readout while drawing, pinned below the draft box.
+          Rendered outside the transformed world so it stays a fixed size.
+          Skipped for line/arrow/pen and the pre-drag zero-size state. */}
+      {creationPreview &&
+      creationPreview.tool !== "line" &&
+      creationPreview.tool !== "arrow" &&
+      creationPreview.tool !== "pen" &&
+      creationPreview.geometry.width > 0 &&
+      creationPreview.geometry.height > 0 ? (
+        <span
+          className="pointer-events-none absolute z-40 -translate-x-1/2 translate-y-1 rounded bg-[var(--design-editor-accent-color)] px-1.5 py-0.5 text-[10px] font-medium leading-none text-[var(--design-editor-accent-contrast-color)] shadow-sm"
+          style={{
+            left:
+              pan.x +
+              (SURFACE_PADDING +
+                creationPreview.geometry.x +
+                creationPreview.geometry.width / 2) *
+                scale,
+            top:
+              pan.y +
+              (SURFACE_PADDING +
+                creationPreview.geometry.y +
+                creationPreview.geometry.height) *
+                scale,
+          }}
+        >
+          {Math.round(creationPreview.geometry.width)} ×{" "}
+          {Math.round(creationPreview.geometry.height)}
+        </span>
+      ) : null}
 
       {/* Equal-gap distance labels render outside the pan/scale-transformed
           world container (same reasoning as the marquee/duplicate-preview

--- a/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
+++ b/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
@@ -1700,6 +1700,12 @@ declare var __RUNTIME_LAYER_SNAPSHOT_ENABLED__: boolean;
 
   var measurementOverlay = document.createElement("div");
   measurementOverlay.setAttribute("data-agent-native-measurement-overlay", "");
+  // Tag as an edit overlay so the content-replacement path preserves it (only
+  // [data-agent-native-edit-overlay] nodes survive a body rebuild).
+  measurementOverlay.setAttribute(
+    "data-agent-native-edit-overlay",
+    "measurement",
+  );
   measurementOverlay.style.cssText =
     "position:fixed;inset:0;z-index:100001;display:none;pointer-events:none;color:var(--design-editor-measure-color);font:11px/1.2 ui-monospace,SFMono-Regular,Menlo,monospace;";
   document.body.appendChild(measurementOverlay);
@@ -3941,6 +3947,11 @@ declare var __RUNTIME_LAYER_SNAPSHOT_ENABLED__: boolean;
     }
     var selectedRect = a.getBoundingClientRect();
     var hoverRect = b.getBoundingClientRect();
+    // A content re-render can rebuild document.body and drop this overlay;
+    // re-attach it before drawing so the lines always render.
+    if (!measurementOverlay.isConnected) {
+      document.body.appendChild(measurementOverlay);
+    }
     measurementOverlay.innerHTML = "";
     measurementOverlay.style.display = "block";
 
@@ -9853,7 +9864,11 @@ declare var __RUNTIME_LAYER_SNAPSHOT_ENABLED__: boolean;
       } else {
         hideMeasurements();
       }
-      if (hoveredEl !== lastHoverInfoPostedEl) {
+      // While Alt is held (measurement mode) keep hover local: posting it would
+      // update the host's hoveredSelector, re-run replayIframeEditorState, and
+      // echo selection/hover back every move — a loop that jitters selection
+      // and flickers the measurement lines.
+      if (!e.altKey && hoveredEl !== lastHoverInfoPostedEl) {
         lastHoverInfoPostedEl = hoveredEl;
         var info = getLightElementInfo(hoveredEl);
         (window.parent as Window).postMessage(
@@ -9915,7 +9930,19 @@ declare var __RUNTIME_LAYER_SNAPSHOT_ENABLED__: boolean;
   window.addEventListener(
     "keyup",
     function (e) {
-      if (e.key === "Alt") hideMeasurements();
+      if (e.key === "Alt") {
+        hideMeasurements();
+        // Re-sync the hover suppressed during measurement so the host isn't
+        // left on a stale element until the next pointermove.
+        lastHoverInfoPostedEl = hoveredEl;
+        (window.parent as Window).postMessage(
+          {
+            type: "element-hover",
+            payload: hoveredEl ? getLightElementInfo(hoveredEl) : null,
+          },
+          "*",
+        );
+      }
     },
     true,
   );

--- a/templates/design/app/global.css
+++ b/templates/design/app/global.css
@@ -79,7 +79,7 @@
   );
   --design-editor-accent-strong-color: var(--design-editor-accent-color);
   --design-editor-accent-contrast-color: #ffffff;
-  --design-editor-measure-color: hsl(344 100% 63%);
+  --design-editor-measure-color: hsl(24 95% 53%);
   --design-editor-panel-bg: hsl(var(--background));
   --design-editor-panel-raised-bg: hsl(var(--secondary));
   --design-editor-control-bg: hsl(var(--muted));
@@ -157,7 +157,7 @@
   --design-editor-panel-divider-color: hsl(0 0% 22%);
   --design-editor-accent-strong-color: var(--design-editor-accent-color);
   --design-editor-accent-contrast-color: #ffffff;
-  --design-editor-measure-color: hsl(344 100% 63%);
+  --design-editor-measure-color: hsl(24 95% 53%);
   --design-editor-panel-bg: hsl(0 0% 13%);
   --design-editor-panel-raised-bg: hsl(0 0% 18%);
   --design-editor-control-bg: hsl(0 0% 18%);

--- a/templates/design/changelog/2026-07-10-canvas-size-and-option-hover-measurements.md
+++ b/templates/design/changelog/2026-07-10-canvas-size-and-option-hover-measurements.md
@@ -1,0 +1,6 @@
+---
+type: added
+date: 2026-07-10
+---
+
+The canvas now shows a live size readout while you draw, and holding Option while hovering another element shows the distance between them.


### PR DESCRIPTION
Measurement overlay was being dropped during iframe body rebuilds and host↔iframe hover posts fought each other while Alt was held; tagged the overlay as a persistent edit overlay (with self-heal) and suppressed hover sync during Alt, restoring stable Figma-style distance measurements plus a live draw-size readout.

<img width="266" height="132" alt="image" src="https://github.com/user-attachments/assets/1e33ac08-645b-44b9-b156-a3ba6b2af38d" />
