### PR TITLE
Keep Slack progress through A2A continuations

### DIFF
--- a/.changeset/durable-slack-a2a-progress.md
+++ b/.changeset/durable-slack-a2a-progress.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep Slack agent task cards active through deferred cross-agent work, show durable progress, and deliver the true final result instead of treating interim artifacts as complete.

--- a/packages/core/src/integrations/a2a-continuation-processor.spec.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.spec.ts
@@ -57,6 +57,7 @@ function continuation(
       platformContext: { channelId: "C123", threadTs: "123.456" },
     },
     placeholderRef: null,
+    progressRef: null,
     ownerEmail: "alice+qa@agent-native.test",
     orgId: null,
     agentName: "Slides",
@@ -220,6 +221,48 @@ describe("A2A continuation processor", () => {
     );
     expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
     expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("finishes the resumed native progress stream when the remote task completes", async () => {
+    const sendResponse = vi.fn(async () => undefined);
+    const onEvent = vi.fn(async () => undefined);
+    const complete = vi.fn(async () => undefined);
+    const resumeRunProgress = vi.fn(async () => ({
+      ref: { kind: "slack-stream", streamTs: "1719000000.000001" },
+      onEvent,
+      complete,
+    }));
+    const resumedAdapter = adapter(sendResponse);
+    resumedAdapter.resumeRunProgress = resumeRunProgress;
+    claimA2AContinuationMock.mockResolvedValueOnce(
+      continuation({
+        progressRef: {
+          kind: "slack-stream",
+          streamTs: "1719000000.000001",
+        },
+      }),
+    );
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    await processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", resumedAdapter]]),
+    });
+
+    expect(resumeRunProgress).toHaveBeenCalledWith(
+      expect.objectContaining({ platform: "slack" }),
+      { kind: "slack-stream", streamTs: "1719000000.000001" },
+    );
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "agent_call", status: "done" }),
+    );
+    expect(complete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "https://slides.agent-native.test/deck/deck-qa",
+      }),
+    );
+    expect(sendResponse).not.toHaveBeenCalled();
+    expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
   });
 
   it("expands relative URLs against the agent public base, not the A2A endpoint", async () => {
@@ -662,10 +705,24 @@ describe("A2A continuation processor", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("delivers a verified recoverable artifact from a still-working remote task", async () => {
+  it("keeps polling when a still-working remote task reports recoverable artifacts", async () => {
     vi.useFakeTimers();
     const sendResponse = vi.fn(async () => undefined);
-    claimA2AContinuationMock.mockResolvedValueOnce(continuation());
+    const onEvent = vi.fn(async () => undefined);
+    const resumedAdapter = adapter(sendResponse);
+    resumedAdapter.resumeRunProgress = vi.fn(async () => ({
+      ref: { kind: "slack-stream", streamTs: "1719000000.000001" },
+      onEvent,
+      complete: vi.fn(async () => undefined),
+    }));
+    claimA2AContinuationMock.mockResolvedValueOnce(
+      continuation({
+        progressRef: {
+          kind: "slack-stream",
+          streamTs: "1719000000.000001",
+        },
+      }),
+    );
     getTaskMock.mockResolvedValue({
       id: "a2a-task-1",
       status: {
@@ -687,22 +744,23 @@ describe("A2A continuation processor", () => {
       await import("./a2a-continuation-processor.js");
 
     const processing = processA2AContinuationById("cont-1", {
-      adapters: new Map([["slack", adapter(sendResponse)]]),
+      adapters: new Map([["slack", resumedAdapter]]),
     });
     await vi.advanceTimersByTimeAsync(20_000);
     await processing;
 
-    expect(sendResponse).toHaveBeenCalledWith(
-      expect.objectContaining({
-        text: expect.stringContaining(
-          "https://slides.agent-native.test/deck/deck-qa",
-        ),
-      }),
-      expect.any(Object),
-      { placeholderRef: undefined },
+    expect(sendResponse).not.toHaveBeenCalled();
+    expect(completeA2AContinuationMock).not.toHaveBeenCalled();
+    expect(rescheduleA2AContinuationMock).toHaveBeenCalledWith(
+      "cont-1",
+      20_000,
     );
-    expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
-    expect(rescheduleA2AContinuationMock).not.toHaveBeenCalled();
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "agent_call_progress",
+        agent: "Slides",
+      }),
+    );
     expect(failA2AContinuationMock).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/integrations/a2a-continuation-processor.spec.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.spec.ts
@@ -265,6 +265,51 @@ describe("A2A continuation processor", () => {
     expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
   });
 
+  it("falls back to a normal reply when completing resumed native progress fails", async () => {
+    const sendResponse = vi.fn(async () => undefined);
+    const onEvent = vi.fn(async () => undefined);
+    const complete = vi.fn(async () => {
+      throw new Error("Slack stream is no longer active");
+    });
+    const resumedAdapter = adapter(sendResponse);
+    resumedAdapter.resumeRunProgress = vi.fn(async () => ({
+      ref: { kind: "slack-stream", streamTs: "1719000000.000001" },
+      onEvent,
+      complete,
+    }));
+    claimA2AContinuationMock.mockResolvedValueOnce(
+      continuation({
+        progressRef: {
+          kind: "slack-stream",
+          streamTs: "1719000000.000001",
+        },
+      }),
+    );
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    await processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", resumedAdapter]]),
+    });
+
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "agent_call", status: "done" }),
+    );
+    expect(complete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "https://slides.agent-native.test/deck/deck-qa",
+      }),
+    );
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "https://slides.agent-native.test/deck/deck-qa",
+      }),
+      expect.any(Object),
+      { placeholderRef: undefined },
+    );
+    expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
+  });
+
   it("expands relative URLs against the agent public base, not the A2A endpoint", async () => {
     const sendResponse = vi.fn(async () => undefined);
     claimA2AContinuationMock.mockResolvedValueOnce(

--- a/packages/core/src/integrations/a2a-continuation-processor.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.ts
@@ -393,13 +393,18 @@ async function deliverA2AContinuationResponse(
   status: "done" | "error",
 ): Promise<void> {
   if (progress) {
-    await progress.onEvent({
-      type: "agent_call",
-      agent: continuation.agentName,
-      status,
-    });
-    await progress.complete(message);
-    return;
+    try {
+      await progress.onEvent({
+        type: "agent_call",
+        agent: continuation.agentName,
+        status,
+      });
+      await progress.complete(message);
+      return;
+    } catch {
+      // A stale or failed native stream must not prevent the continuation's
+      // terminal message from reaching the requester through the normal reply.
+    }
   }
   await adapter.sendResponse(message, continuation.incoming, {
     placeholderRef: continuation.placeholderRef ?? undefined,

--- a/packages/core/src/integrations/a2a-continuation-processor.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.ts
@@ -18,7 +18,11 @@ import {
   type A2AContinuation,
 } from "./a2a-continuations-store.js";
 import { signInternalToken } from "./internal-token.js";
-import type { PlatformAdapter } from "./types.js";
+import type {
+  OutgoingMessage,
+  PlatformAdapter,
+  PlatformRunProgress,
+} from "./types.js";
 
 const PROCESSOR_PATH = `${FRAMEWORK_ROUTE_PREFIX}/integrations/process-a2a-continuation`;
 const TERMINAL_STATES = new Set(["completed", "failed", "canceled"]);
@@ -150,6 +154,8 @@ async function processClaimedContinuation(
     return;
   }
 
+  const progress = await resumeA2AContinuationProgress(continuation, adapter);
+
   const auth = await signContinuationToken(continuation);
   const client = new A2AClient(continuation.agentUrl, auth.apiKey, {
     requestTimeoutMs: POLL_REQUEST_TIMEOUT_MS,
@@ -162,6 +168,7 @@ async function processClaimedContinuation(
     while (Date.now() < deadline) {
       task = await client.getTask(continuation.a2aTaskId);
       if (TERMINAL_STATES.has(task.status.state)) break;
+      await reportA2AContinuationProgress(continuation, progress, task);
       await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
     }
   } catch (err) {
@@ -171,6 +178,7 @@ async function processClaimedContinuation(
           continuation,
           adapter,
           remotePollFailureReason(continuation),
+          progress,
         );
         return;
       }
@@ -182,6 +190,7 @@ async function processClaimedContinuation(
         continuation,
         adapter,
         err instanceof Error ? err.message : String(err),
+        progress,
       );
       return;
     }
@@ -190,24 +199,12 @@ async function processClaimedContinuation(
   }
 
   if (!task || !TERMINAL_STATES.has(task.status.state)) {
-    const recoverableArtifactText = extractRecoverableArtifactText(task);
-    if (recoverableArtifactText) {
-      await deliverAndCompleteA2AContinuation(
-        continuation,
-        adapter,
-        formatContinuationArtifactText(
-          recoverableArtifactText,
-          continuation.agentUrl,
-        ),
-      );
-      return;
-    }
-
     if (shouldStopPollingRemoteTask(continuation)) {
       await notifyAndFailA2AContinuation(
         continuation,
         adapter,
         remotePollFailureReason(continuation),
+        progress,
       );
       return;
     }
@@ -219,7 +216,7 @@ async function processClaimedContinuation(
     const reason =
       extractTaskText(task) ||
       `Remote A2A task ${continuation.a2aTaskId} ended with state ${task.status.state}`;
-    await notifyAndFailA2AContinuation(continuation, adapter, reason);
+    await notifyAndFailA2AContinuation(continuation, adapter, reason, progress);
     return;
   }
 
@@ -232,11 +229,64 @@ async function processClaimedContinuation(
       continuation,
       adapter,
       `Remote A2A task ${continuation.a2aTaskId} completed without text`,
+      progress,
     );
     return;
   }
 
-  await deliverAndCompleteA2AContinuation(continuation, adapter, text);
+  await deliverAndCompleteA2AContinuation(
+    continuation,
+    adapter,
+    text,
+    progress,
+  );
+}
+
+async function resumeA2AContinuationProgress(
+  continuation: A2AContinuation,
+  adapter: PlatformAdapter,
+): Promise<PlatformRunProgress | null> {
+  if (!continuation.progressRef || !adapter.resumeRunProgress) return null;
+  try {
+    const progress = await adapter.resumeRunProgress(
+      continuation.incoming,
+      continuation.progressRef,
+    );
+    if (!progress) return null;
+    await progress.onEvent({
+      type: "agent_call_progress",
+      agent: continuation.agentName,
+      state: "working",
+      elapsedSeconds: Math.max(
+        0,
+        Math.round((Date.now() - continuation.createdAt) / 1_000),
+      ),
+      detail: "Continuing in the background",
+    });
+    return progress;
+  } catch {
+    // A continuation still has a normal reply fallback. Do not log the
+    // opaque provider reference or the inbound message payload.
+    return null;
+  }
+}
+
+async function reportA2AContinuationProgress(
+  continuation: A2AContinuation,
+  progress: PlatformRunProgress | null,
+  task: Task,
+): Promise<void> {
+  if (!progress) return;
+  await progress.onEvent({
+    type: "agent_call_progress",
+    agent: continuation.agentName,
+    state: task.status.state,
+    elapsedSeconds: Math.max(
+      0,
+      Math.round((Date.now() - continuation.createdAt) / 1_000),
+    ),
+    detail: "Still working on the delegated request",
+  });
 }
 
 async function waitForContinuationDue(
@@ -262,6 +312,7 @@ async function notifyAndFailA2AContinuation(
   continuation: A2AContinuation,
   adapter: PlatformAdapter,
   reason: string,
+  progress: PlatformRunProgress | null = null,
 ): Promise<void> {
   const deliveryContinuation = await claimA2AContinuationDelivery(
     continuation.id,
@@ -273,11 +324,14 @@ async function notifyAndFailA2AContinuation(
     reason,
   );
   try {
+    const outgoing = adapter.formatAgentResponse(message);
     await withTimeout(
-      adapter.sendResponse(
-        adapter.formatAgentResponse(message),
-        deliveryContinuation.incoming,
-        { placeholderRef: deliveryContinuation.placeholderRef ?? undefined },
+      deliverA2AContinuationResponse(
+        adapter,
+        deliveryContinuation,
+        outgoing,
+        progress,
+        "error",
       ),
       PLATFORM_SEND_TIMEOUT_MS,
       `${deliveryContinuation.platform} failure notification timed out`,
@@ -296,6 +350,7 @@ async function deliverAndCompleteA2AContinuation(
   continuation: A2AContinuation,
   adapter: PlatformAdapter,
   text: string,
+  progress: PlatformRunProgress | null = null,
 ): Promise<void> {
   const deliveryContinuation = await claimA2AContinuationDelivery(
     continuation.id,
@@ -303,11 +358,14 @@ async function deliverAndCompleteA2AContinuation(
   if (!deliveryContinuation) return;
 
   try {
+    const outgoing = adapter.formatAgentResponse(text);
     await withTimeout(
-      adapter.sendResponse(
-        adapter.formatAgentResponse(text),
-        deliveryContinuation.incoming,
-        { placeholderRef: deliveryContinuation.placeholderRef ?? undefined },
+      deliverA2AContinuationResponse(
+        adapter,
+        deliveryContinuation,
+        outgoing,
+        progress,
+        "done",
       ),
       PLATFORM_SEND_TIMEOUT_MS,
       `${deliveryContinuation.platform} response delivery timed out`,
@@ -325,6 +383,27 @@ async function deliverAndCompleteA2AContinuation(
   }
 
   await completeAfterSuccessfulDelivery(deliveryContinuation);
+}
+
+async function deliverA2AContinuationResponse(
+  adapter: PlatformAdapter,
+  continuation: A2AContinuation,
+  message: OutgoingMessage,
+  progress: PlatformRunProgress | null,
+  status: "done" | "error",
+): Promise<void> {
+  if (progress) {
+    await progress.onEvent({
+      type: "agent_call",
+      agent: continuation.agentName,
+      status,
+    });
+    await progress.complete(message);
+    return;
+  }
+  await adapter.sendResponse(message, continuation.incoming, {
+    placeholderRef: continuation.placeholderRef ?? undefined,
+  });
 }
 
 async function rescheduleAndRedispatchA2AContinuation(
@@ -522,13 +601,6 @@ function extractTaskText(task: Task): string {
     })
     .map((part) => part.text)
     .join("\n");
-}
-
-function extractRecoverableArtifactText(task: Task | null): string {
-  if (!task?.status.message?.metadata?.agentNativeRecoverableArtifacts) {
-    return "";
-  }
-  return extractTaskText(task);
 }
 
 function formatContinuationArtifactText(

--- a/packages/core/src/integrations/a2a-continuations-store.spec.ts
+++ b/packages/core/src/integrations/a2a-continuations-store.spec.ts
@@ -44,6 +44,7 @@ function continuationRow(overrides: Record<string, unknown> = {}) {
     }),
     placeholder_ref: null,
     progress_ref: null,
+    progress_ref_claimed: 0,
     owner_email: "alice+qa@agent-native.test",
     org_id: null,
     agent_name: "Slides",
@@ -87,6 +88,15 @@ describe("A2A continuations store", () => {
     expect(calls).toContainEqual(
       expect.stringContaining("ADD COLUMN progress_ref"),
     );
+    const progressOwnerAlterIndex = calls.findIndex((sql) =>
+      sql.includes("ADD COLUMN progress_ref_claimed"),
+    );
+    const progressOwnerIndexIndex = calls.findIndex((sql) =>
+      sql.includes("idx_a2a_continuations_one_progress_owner"),
+    );
+    expect(progressOwnerAlterIndex).toBeGreaterThan(-1);
+    expect(progressOwnerIndexIndex).toBeGreaterThan(-1);
+    expect(progressOwnerAlterIndex).toBeLessThan(progressOwnerIndexIndex);
   });
 
   it("does not swallow non-duplicate column migration errors", async () => {
@@ -204,8 +214,10 @@ describe("A2A continuations store", () => {
     ]);
   });
 
-  it("allows multiple downstream continuations for one integration task", async () => {
+  it("assigns a native progress stream to only one continuation per integration task", async () => {
     const { insertA2AContinuation } = await loadStore();
+    const progressRefs = new Map<string, string | null>();
+    let progressOwnerClaimed = false;
     executeMock.mockImplementation(
       async (query: string | { sql: string; args?: unknown[] }) => {
         const sql = querySql(query);
@@ -213,6 +225,17 @@ describe("A2A continuations store", () => {
         if (
           sql.trim().startsWith("INSERT INTO integration_a2a_continuations")
         ) {
+          progressRefs.set(args[0] as string, null);
+          return { rows: [], rowsAffected: 1 };
+        }
+        if (sql.includes("SET progress_ref = ?, progress_ref_claimed = 1")) {
+          if (progressOwnerClaimed) {
+            throw new Error(
+              "UNIQUE constraint failed: integration_a2a_continuations.integration_task_id",
+            );
+          }
+          progressOwnerClaimed = true;
+          progressRefs.set(args[1] as string, args[0] as string);
           return { rows: [], rowsAffected: 1 };
         }
         if (
@@ -228,10 +251,7 @@ describe("A2A continuations store", () => {
                 agent_name: "Analytics",
                 agent_url: "https://analytics.agent-native.test",
                 a2a_task_id: "a2a-task-new",
-                progress_ref: JSON.stringify({
-                  kind: "slack-stream",
-                  streamTs: "1719000000.000001",
-                }),
+                progress_ref: progressRefs.get(args[0] as string),
               }),
             ],
             rowsAffected: 0,
@@ -241,7 +261,7 @@ describe("A2A continuations store", () => {
       },
     );
 
-    const continuation = await insertA2AContinuation({
+    const first = await insertA2AContinuation({
       integrationTaskId: "task-existing",
       platform: "slack",
       externalThreadId: "C123:123.456",
@@ -260,25 +280,54 @@ describe("A2A continuations store", () => {
       a2aTaskId: "a2a-task-new",
     });
 
-    expect(continuation.integrationTaskId).toBe("task-existing");
-    expect(continuation.agentName).toBe("Analytics");
-    expect(continuation.a2aTaskId).toBe("a2a-task-new");
-    expect(continuation.progressRef).toEqual({
+    const second = await insertA2AContinuation({
+      integrationTaskId: "task-existing",
+      platform: "slack",
+      externalThreadId: "C123:123.456",
+      incoming: {
+        platform: "slack",
+        externalThreadId: "C123:123.456",
+        text: "make a report",
+        platformContext: {},
+        responseContext: { interactionToken: "active-token-example" },
+        timestamp: 1,
+      },
+      progressRef: { kind: "slack-stream", streamTs: "1719000000.000001" },
+      ownerEmail: "alice+qa@agent-native.test",
+      agentName: "Research",
+      agentUrl: "https://research.agent-native.test",
+      a2aTaskId: "a2a-task-second",
+    });
+
+    expect(first.integrationTaskId).toBe("task-existing");
+    expect(first.agentName).toBe("Analytics");
+    expect(first.a2aTaskId).toBe("a2a-task-new");
+    expect(first.progressRef).toEqual({
       kind: "slack-stream",
       streamTs: "1719000000.000001",
     });
-    const insertCall = executeMock.mock.calls.find(([query]) =>
+    expect(second.progressRef).toBeNull();
+    const insertCalls = executeMock.mock.calls.filter(([query]) =>
       querySql(query)
         .trim()
         .startsWith("INSERT INTO integration_a2a_continuations"),
     );
-    expect(insertCall).toBeDefined();
-    expect(JSON.parse(String(queryArgs(insertCall![0])[4]))).toMatchObject({
+    expect(insertCalls).toHaveLength(2);
+    expect(JSON.parse(String(queryArgs(insertCalls[0]![0])[4]))).toMatchObject({
       responseContext: { interactionToken: "active-token-example" },
     });
-    expect(queryArgs(insertCall![0])[6]).toBe(
-      JSON.stringify({ kind: "slack-stream", streamTs: "1719000000.000001" }),
+    expect(queryArgs(insertCalls[0]![0])[6]).toBeNull();
+    expect(queryArgs(insertCalls[0]![0])[7]).toBe(0);
+    const progressClaimCalls = executeMock.mock.calls.filter(([query]) =>
+      querySql(query).includes(
+        "SET progress_ref = ?, progress_ref_claimed = 1",
+      ),
     );
+    expect(progressClaimCalls).toHaveLength(2);
+    expect(queryArgs(progressClaimCalls[0]![0])).toEqual([
+      JSON.stringify({ kind: "slack-stream", streamTs: "1719000000.000001" }),
+      expect.any(String),
+    ]);
   });
 
   it("treats invalid stored progress references as unavailable", async () => {
@@ -325,6 +374,7 @@ describe("A2A continuations store", () => {
       expect(update.sql).toContain("incoming_payload = ?");
       expect(update.sql).toContain("a2a_auth_token = NULL");
       expect(update.sql).toContain("progress_ref = NULL");
+      expect(update.sql).not.toContain("progress_ref_claimed =");
     }
     expect(terminalUpdates[0].args).toEqual([
       "completed",

--- a/packages/core/src/integrations/a2a-continuations-store.spec.ts
+++ b/packages/core/src/integrations/a2a-continuations-store.spec.ts
@@ -43,6 +43,7 @@ function continuationRow(overrides: Record<string, unknown> = {}) {
       timestamp: 1,
     }),
     placeholder_ref: null,
+    progress_ref: null,
     owner_email: "alice+qa@agent-native.test",
     org_id: null,
     agent_name: "Slides",
@@ -83,6 +84,9 @@ describe("A2A continuations store", () => {
     expect(dedupeAlterIndex).toBeGreaterThan(-1);
     expect(dedupeIndexIndex).toBeGreaterThan(-1);
     expect(dedupeAlterIndex).toBeLessThan(dedupeIndexIndex);
+    expect(calls).toContainEqual(
+      expect.stringContaining("ADD COLUMN progress_ref"),
+    );
   });
 
   it("does not swallow non-duplicate column migration errors", async () => {
@@ -224,6 +228,10 @@ describe("A2A continuations store", () => {
                 agent_name: "Analytics",
                 agent_url: "https://analytics.agent-native.test",
                 a2a_task_id: "a2a-task-new",
+                progress_ref: JSON.stringify({
+                  kind: "slack-stream",
+                  streamTs: "1719000000.000001",
+                }),
               }),
             ],
             rowsAffected: 0,
@@ -245,6 +253,7 @@ describe("A2A continuations store", () => {
         responseContext: { interactionToken: "active-token-example" },
         timestamp: 1,
       },
+      progressRef: { kind: "slack-stream", streamTs: "1719000000.000001" },
       ownerEmail: "alice+qa@agent-native.test",
       agentName: "Analytics",
       agentUrl: "https://analytics.agent-native.test",
@@ -254,6 +263,10 @@ describe("A2A continuations store", () => {
     expect(continuation.integrationTaskId).toBe("task-existing");
     expect(continuation.agentName).toBe("Analytics");
     expect(continuation.a2aTaskId).toBe("a2a-task-new");
+    expect(continuation.progressRef).toEqual({
+      kind: "slack-stream",
+      streamTs: "1719000000.000001",
+    });
     const insertCall = executeMock.mock.calls.find(([query]) =>
       querySql(query)
         .trim()
@@ -263,6 +276,34 @@ describe("A2A continuations store", () => {
     expect(JSON.parse(String(queryArgs(insertCall![0])[4]))).toMatchObject({
       responseContext: { interactionToken: "active-token-example" },
     });
+    expect(queryArgs(insertCall![0])[6]).toBe(
+      JSON.stringify({ kind: "slack-stream", streamTs: "1719000000.000001" }),
+    );
+  });
+
+  it("treats invalid stored progress references as unavailable", async () => {
+    const { getA2AContinuation } = await loadStore();
+    executeMock.mockImplementation(
+      async (query: string | { sql: string; args?: unknown[] }) => {
+        const sql = querySql(query);
+        const args = queryArgs(query);
+        if (
+          sql.includes(
+            "SELECT * FROM integration_a2a_continuations WHERE id = ?",
+          )
+        ) {
+          return {
+            rows: [continuationRow({ id: args[0], progress_ref: "not-json" })],
+            rowsAffected: 0,
+          };
+        }
+        return { rows: [], rowsAffected: 0 };
+      },
+    );
+
+    const continuation = await getA2AContinuation("cont-invalid-progress");
+
+    expect(continuation?.progressRef).toBeNull();
   });
 
   it("scrubs short-lived delivery context from terminal continuation rows", async () => {
@@ -283,6 +324,7 @@ describe("A2A continuations store", () => {
     for (const update of terminalUpdates) {
       expect(update.sql).toContain("incoming_payload = ?");
       expect(update.sql).toContain("a2a_auth_token = NULL");
+      expect(update.sql).toContain("progress_ref = NULL");
     }
     expect(terminalUpdates[0].args).toEqual([
       "completed",

--- a/packages/core/src/integrations/a2a-continuations-store.ts
+++ b/packages/core/src/integrations/a2a-continuations-store.ts
@@ -10,7 +10,7 @@ import {
   ensureIndexExists,
 } from "../db/ddl-guard.js";
 import { isDuplicateColumnError } from "../db/migrations.js";
-import type { IncomingMessage } from "./types.js";
+import type { IncomingMessage, PlatformRunProgressRef } from "./types.js";
 
 let _initPromise: Promise<void> | undefined;
 const PROCESSING_STUCK_AFTER_MS = 5 * 60 * 1000;
@@ -28,6 +28,7 @@ function buildCreateSql(): string {
     external_thread_id TEXT NOT NULL,
     incoming_payload TEXT NOT NULL,
     placeholder_ref TEXT,
+    progress_ref TEXT,
     owner_email TEXT NOT NULL,
     org_id TEXT,
     agent_name TEXT NOT NULL,
@@ -76,6 +77,11 @@ async function ensureTable(): Promise<void> {
           "dedupe_key",
           `ALTER TABLE integration_a2a_continuations ADD COLUMN IF NOT EXISTS dedupe_key TEXT`,
         );
+        await ensureColumnExists(
+          "integration_a2a_continuations",
+          "progress_ref",
+          `ALTER TABLE integration_a2a_continuations ADD COLUMN IF NOT EXISTS progress_ref TEXT`,
+        );
         await ensureIndexExists(
           "idx_a2a_continuations_dedupe_key",
           `CREATE INDEX IF NOT EXISTS idx_a2a_continuations_dedupe_key ON integration_a2a_continuations(integration_task_id, agent_url, dedupe_key)`,
@@ -101,6 +107,7 @@ async function ensureTable(): Promise<void> {
       );
       await addColumnIfMissing("a2a_auth_token", "TEXT");
       await addColumnIfMissing("dedupe_key", "TEXT");
+      await addColumnIfMissing("progress_ref", "TEXT");
       await retryOnDdlRace(() =>
         client.execute(
           `CREATE INDEX IF NOT EXISTS idx_a2a_continuations_dedupe_key ON integration_a2a_continuations(integration_task_id, agent_url, dedupe_key)`,
@@ -142,6 +149,7 @@ export interface A2AContinuation {
   externalThreadId: string;
   incoming: IncomingMessage;
   placeholderRef: string | null;
+  progressRef: PlatformRunProgressRef | null;
   ownerEmail: string;
   orgId: string | null;
   agentName: string;
@@ -158,6 +166,44 @@ export interface A2AContinuation {
   completedAt: number | null;
 }
 
+const MAX_PROGRESS_REF_KIND_CHARS = 128;
+const MAX_PROGRESS_REF_STREAM_TS_CHARS = 256;
+
+/**
+ * Keep only the tiny, adapter-owned continuation reference. Invalid rows are
+ * treated as unavailable rather than throwing during a retry sweep.
+ */
+function parseProgressRef(value: unknown): PlatformRunProgressRef | null {
+  if (typeof value !== "string" || value.length === 0) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    const { kind, streamTs } = parsed as Record<string, unknown>;
+    if (
+      typeof kind !== "string" ||
+      typeof streamTs !== "string" ||
+      kind.length === 0 ||
+      streamTs.length === 0 ||
+      kind.length > MAX_PROGRESS_REF_KIND_CHARS ||
+      streamTs.length > MAX_PROGRESS_REF_STREAM_TS_CHARS
+    ) {
+      return null;
+    }
+    return { kind, streamTs };
+  } catch {
+    return null;
+  }
+}
+
+function serializeProgressRef(value: unknown): string | null {
+  const parsed = parseProgressRef(
+    typeof value === "string" ? value : JSON.stringify(value),
+  );
+  return parsed ? JSON.stringify(parsed) : null;
+}
+
 function rowToContinuation(row: Record<string, unknown>): A2AContinuation {
   return {
     id: row.id as string,
@@ -166,6 +212,7 @@ function rowToContinuation(row: Record<string, unknown>): A2AContinuation {
     externalThreadId: row.external_thread_id as string,
     incoming: JSON.parse(row.incoming_payload as string) as IncomingMessage,
     placeholderRef: (row.placeholder_ref as string | null) ?? null,
+    progressRef: parseProgressRef(row.progress_ref),
     ownerEmail: row.owner_email as string,
     orgId: (row.org_id as string | null) ?? null,
     agentName: row.agent_name as string,
@@ -190,6 +237,7 @@ export async function insertA2AContinuation(input: {
   externalThreadId: string;
   incoming: IncomingMessage;
   placeholderRef?: string | null;
+  progressRef?: PlatformRunProgressRef | null;
   ownerEmail: string;
   orgId?: string | null;
   agentName: string;
@@ -203,14 +251,15 @@ export async function insertA2AContinuation(input: {
   const now = Date.now();
   const id = `a2a-cont-${now}-${Math.random().toString(36).slice(2, 8)}`;
   const payload = JSON.stringify(input.incoming);
+  const progressRef = serializeProgressRef(input.progressRef);
 
   try {
     await client.execute({
       sql: `INSERT INTO integration_a2a_continuations
         (id, integration_task_id, platform, external_thread_id, incoming_payload,
-         placeholder_ref, owner_email, org_id, agent_name, agent_url, dedupe_key, a2a_task_id, a2a_auth_token,
+         placeholder_ref, progress_ref, owner_email, org_id, agent_name, agent_url, dedupe_key, a2a_task_id, a2a_auth_token,
          status, attempts, next_check_at, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       args: [
         id,
         input.integrationTaskId,
@@ -218,6 +267,7 @@ export async function insertA2AContinuation(input: {
         input.externalThreadId,
         payload,
         input.placeholderRef ?? null,
+        progressRef,
         input.ownerEmail,
         input.orgId ?? null,
         input.agentName,
@@ -462,7 +512,7 @@ export async function completeA2AContinuation(id: string): Promise<void> {
   await client.execute({
     sql: `UPDATE integration_a2a_continuations
           SET status = ?, updated_at = ?, completed_at = ?,
-              incoming_payload = ?, a2a_auth_token = NULL
+              incoming_payload = ?, a2a_auth_token = NULL, progress_ref = NULL
           WHERE id = ? AND status IN ('processing', 'delivering', 'completed')`,
     args: ["completed", now, now, "{}", id],
   });
@@ -478,7 +528,7 @@ export async function failA2AContinuation(
   await client.execute({
     sql: `UPDATE integration_a2a_continuations
           SET status = ?, updated_at = ?, error_message = ?,
-              incoming_payload = ?, a2a_auth_token = NULL
+              incoming_payload = ?, a2a_auth_token = NULL, progress_ref = NULL
           WHERE id = ? AND status <> 'completed'`,
     args: ["failed", now, errorMessage.slice(0, 2000), "{}", id],
   });

--- a/packages/core/src/integrations/a2a-continuations-store.ts
+++ b/packages/core/src/integrations/a2a-continuations-store.ts
@@ -29,6 +29,7 @@ function buildCreateSql(): string {
     incoming_payload TEXT NOT NULL,
     placeholder_ref TEXT,
     progress_ref TEXT,
+    progress_ref_claimed ${intType()} NOT NULL DEFAULT 0,
     owner_email TEXT NOT NULL,
     org_id TEXT,
     agent_name TEXT NOT NULL,
@@ -82,9 +83,18 @@ async function ensureTable(): Promise<void> {
           "progress_ref",
           `ALTER TABLE integration_a2a_continuations ADD COLUMN IF NOT EXISTS progress_ref TEXT`,
         );
+        await ensureColumnExists(
+          "integration_a2a_continuations",
+          "progress_ref_claimed",
+          `ALTER TABLE integration_a2a_continuations ADD COLUMN IF NOT EXISTS progress_ref_claimed ${intType()} NOT NULL DEFAULT 0`,
+        );
         await ensureIndexExists(
           "idx_a2a_continuations_dedupe_key",
           `CREATE INDEX IF NOT EXISTS idx_a2a_continuations_dedupe_key ON integration_a2a_continuations(integration_task_id, agent_url, dedupe_key)`,
+        );
+        await ensureIndexExists(
+          "idx_a2a_continuations_one_progress_owner",
+          `CREATE UNIQUE INDEX IF NOT EXISTS idx_a2a_continuations_one_progress_owner ON integration_a2a_continuations(integration_task_id) WHERE progress_ref_claimed = 1`,
         );
         return;
       }
@@ -108,9 +118,18 @@ async function ensureTable(): Promise<void> {
       await addColumnIfMissing("a2a_auth_token", "TEXT");
       await addColumnIfMissing("dedupe_key", "TEXT");
       await addColumnIfMissing("progress_ref", "TEXT");
+      await addColumnIfMissing(
+        "progress_ref_claimed",
+        `${intType()} NOT NULL DEFAULT 0`,
+      );
       await retryOnDdlRace(() =>
         client.execute(
           `CREATE INDEX IF NOT EXISTS idx_a2a_continuations_dedupe_key ON integration_a2a_continuations(integration_task_id, agent_url, dedupe_key)`,
+        ),
+      );
+      await retryOnDdlRace(() =>
+        client.execute(
+          `CREATE UNIQUE INDEX IF NOT EXISTS idx_a2a_continuations_one_progress_owner ON integration_a2a_continuations(integration_task_id) WHERE progress_ref_claimed = 1`,
         ),
       );
     })().catch((err) => {
@@ -257,9 +276,9 @@ export async function insertA2AContinuation(input: {
     await client.execute({
       sql: `INSERT INTO integration_a2a_continuations
         (id, integration_task_id, platform, external_thread_id, incoming_payload,
-         placeholder_ref, progress_ref, owner_email, org_id, agent_name, agent_url, dedupe_key, a2a_task_id, a2a_auth_token,
+         placeholder_ref, progress_ref, progress_ref_claimed, owner_email, org_id, agent_name, agent_url, dedupe_key, a2a_task_id, a2a_auth_token,
          status, attempts, next_check_at, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       args: [
         id,
         input.integrationTaskId,
@@ -267,7 +286,8 @@ export async function insertA2AContinuation(input: {
         input.externalThreadId,
         payload,
         input.placeholderRef ?? null,
-        progressRef,
+        null,
+        0,
         input.ownerEmail,
         input.orgId ?? null,
         input.agentName,
@@ -282,7 +302,6 @@ export async function insertA2AContinuation(input: {
         now,
       ],
     });
-    return (await getA2AContinuation(id))!;
   } catch (err: any) {
     if (!isDuplicateContinuationError(err)) throw err;
     const existing = await findA2AContinuation(
@@ -291,6 +310,36 @@ export async function insertA2AContinuation(input: {
       input.a2aTaskId,
     );
     if (existing) return existing;
+    throw err;
+  }
+
+  if (progressRef) {
+    await claimA2AContinuationProgressRef(id, progressRef);
+  }
+  return (await getA2AContinuation(id))!;
+}
+
+/**
+ * A native platform stream can only have one terminal completion. Claim it for
+ * one downstream continuation, then retain the non-sensitive ownership marker
+ * after terminal cleanup scrubs the short-lived stream reference. The partial
+ * unique index makes the claim safe when multiple A2A calls enqueue in parallel.
+ */
+async function claimA2AContinuationProgressRef(
+  id: string,
+  progressRef: string,
+): Promise<void> {
+  try {
+    await getDbExec().execute({
+      sql: `UPDATE integration_a2a_continuations
+            SET progress_ref = ?, progress_ref_claimed = 1
+            WHERE id = ? AND progress_ref_claimed = 0`,
+      args: [progressRef, id],
+    });
+  } catch (err) {
+    // A sibling continuation already owns the stream. It still completes via
+    // the adapter's normal response path, without attempting to resume it.
+    if (isDuplicateContinuationError(err)) return;
     throw err;
   }
 }

--- a/packages/core/src/integrations/adapters/slack.spec.ts
+++ b/packages/core/src/integrations/adapters/slack.spec.ts
@@ -577,6 +577,10 @@ describe("slackAdapter", () => {
     });
 
     expect(progress).not.toBeNull();
+    expect(progress?.ref).toEqual({
+      kind: "slack-stream",
+      streamTs: "999.000",
+    });
     await progress?.onEvent({
       type: "tool_start",
       tool: "create-report",
@@ -640,6 +644,179 @@ describe("slackAdapter", () => {
         markdown_text: "Report complete.",
       },
     });
+  });
+
+  it("resumes a Slack stream without starting a second task card", async () => {
+    const requests: Array<{ method: string; body: Record<string, any> }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        requests.push({
+          method: new URL(url).pathname.split("/").at(-1)!,
+          body: init?.body ? JSON.parse(String(init.body)) : {},
+        });
+        return new Response(JSON.stringify({ ok: true }));
+      }),
+    );
+    const progress = await slackAdapter({
+      resolveBotToken: async () => "managed-token",
+    }).resumeRunProgress?.(
+      {
+        platform: "slack",
+        externalThreadId: "A123:T123:C123:111.222",
+        text: "build it",
+        senderId: "U123",
+        tenantId: "T123",
+        timestamp: 1,
+        platformContext: { channelId: "C123", threadTs: "111.222" },
+      },
+      { kind: "slack-stream", streamTs: "999.003" },
+    );
+
+    await progress?.onEvent({
+      type: "agent_call_progress",
+      agent: "Design",
+      state: "working",
+      elapsedSeconds: 20,
+      detail: "Continuing in the background",
+    });
+    await progress?.onEvent({
+      type: "agent_call",
+      agent: "Design",
+      status: "done",
+    });
+    await progress?.complete({
+      text: "Created the Design Ask.",
+      platformContext: {},
+    });
+
+    expect(progress?.ref).toEqual({
+      kind: "slack-stream",
+      streamTs: "999.003",
+    });
+    expect(
+      requests.find((request) => request.method === "chat.startStream"),
+    ).toBeUndefined();
+    expect(
+      requests.filter((request) => request.method === "chat.appendStream"),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          body: expect.objectContaining({
+            ts: "999.003",
+            chunks: [
+              expect.objectContaining({
+                type: "task_update",
+                title: "Ask Design",
+                status: "in_progress",
+              }),
+            ],
+          }),
+        }),
+      ]),
+    );
+    expect(
+      requests.find((request) => request.method === "chat.stopStream"),
+    ).toMatchObject({
+      body: expect.objectContaining({ ts: "999.003" }),
+    });
+  });
+
+  it("does not resume an invalid Slack progress reference", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const progress = await slackAdapter({
+      resolveBotToken: async () => "managed-token",
+    }).resumeRunProgress?.(
+      {
+        platform: "slack",
+        externalThreadId: "A123:T123:C123:111.222",
+        timestamp: 1,
+        platformContext: { channelId: "C123", threadTs: "111.222" },
+      },
+      { kind: "not-slack", streamTs: "999.003" },
+    );
+
+    expect(progress).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("records a safe diagnostic when Slack rejects starting a native stream", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ ok: false, error: "missing_scope" })),
+      ),
+    );
+
+    const progress = await slackAdapter({
+      resolveBotToken: async () => "managed-token",
+    }).startRunProgress?.({
+      platform: "slack",
+      externalThreadId: "A123:T123:C123:111.222",
+      text: "build it",
+      senderId: "U123",
+      tenantId: "T123",
+      timestamp: 1,
+      platformContext: { channelId: "C123", threadTs: "111.222" },
+    });
+
+    expect(progress).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      "[slack] chat.startStream failed; using standard reply",
+      {
+        errorCode: "missing_scope",
+        hasRecipientTeam: true,
+        hasRecipientUser: true,
+        isDirectMessage: false,
+      },
+    );
+  });
+
+  it("records a safe diagnostic when a native stream progress append fails", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        const method = new URL(url).pathname.split("/").at(-1)!;
+        if (method === "chat.startStream") {
+          return new Response(JSON.stringify({ ok: true, ts: "999.002" }));
+        }
+        if (method === "chat.appendStream") {
+          return new Response(
+            JSON.stringify({ ok: false, error: "invalid_arguments" }),
+          );
+        }
+        return new Response(JSON.stringify({ ok: true }));
+      }),
+    );
+    const progress = await slackAdapter({
+      resolveBotToken: async () => "managed-token",
+    }).startRunProgress?.({
+      platform: "slack",
+      externalThreadId: "A123:T123:C123:111.222",
+      text: "build it",
+      senderId: "U123",
+      tenantId: "T123",
+      timestamp: 1,
+      platformContext: { channelId: "C123", threadTs: "111.222" },
+    });
+
+    await progress?.onEvent({
+      type: "tool_start",
+      tool: "create-report",
+      id: "call-1",
+      input: {},
+    } as any);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(warn).toHaveBeenCalledWith(
+      "[slack] chat.appendStream failed; progress may be stale",
+      { chunkType: "task_update", errorCode: "invalid_arguments" },
+    );
   });
 
   it("keeps one Slack task card updated with downstream A2A progress", async () => {

--- a/packages/core/src/integrations/adapters/slack.ts
+++ b/packages/core/src/integrations/adapters/slack.ts
@@ -22,6 +22,7 @@ import type {
   IntegrationStatus,
   OutboundTarget,
   PlatformRunProgress,
+  PlatformRunProgressRef,
   IntegrationContextMessage,
   IntegrationFileReference,
 } from "../types.js";
@@ -357,6 +358,16 @@ export function slackAdapter(
       const token = await resolveBotToken(incoming);
       if (!token) return null;
       return startSlackRunProgress(token, incoming);
+    },
+
+    async resumeRunProgress(
+      incoming: IncomingMessage,
+      ref: PlatformRunProgressRef,
+    ): Promise<PlatformRunProgress | null> {
+      if (!isSlackStreamProgressRef(ref)) return null;
+      const token = await resolveBotToken(incoming);
+      if (!token) return null;
+      return resumeSlackRunProgress(token, incoming, ref.streamTs);
     },
 
     async sendResponse(
@@ -1273,6 +1284,21 @@ async function postSlackJson(
   return data;
 }
 
+function streamFailureCode(error: unknown): string {
+  const message = error instanceof Error ? error.message.trim() : "";
+  return /^[a-z0-9_:-]{1,80}$/i.test(message) ? message : "unknown";
+}
+
+function streamChunkType(chunk: Record<string, unknown>): string {
+  const type = chunk.type;
+  return type === "task_update" ||
+    type === "plan_update" ||
+    type === "markdown_text" ||
+    type === "blocks"
+    ? type
+    : "unknown";
+}
+
 async function startSlackRunProgress(
   token: string,
   incoming: IncomingMessage,
@@ -1304,12 +1330,45 @@ async function startSlackRunProgress(
         },
       ],
     });
-  } catch {
+  } catch (error) {
+    console.warn("[slack] chat.startStream failed; using standard reply", {
+      errorCode: streamFailureCode(error),
+      isDirectMessage: incoming.conversationType === "dm",
+      hasRecipientTeam: Boolean(incoming.tenantId),
+      hasRecipientUser: Boolean(incoming.senderId),
+    });
     return null;
   }
 
   const streamTs = started.ts;
   if (typeof streamTs !== "string") return null;
+  return createSlackRunProgress(token, incoming, channel, threadTs, streamTs);
+}
+
+function isSlackStreamProgressRef(ref: PlatformRunProgressRef): boolean {
+  return (
+    ref.kind === "slack-stream" && /^\d{1,20}\.\d{1,9}$/.test(ref.streamTs)
+  );
+}
+
+async function resumeSlackRunProgress(
+  token: string,
+  incoming: IncomingMessage,
+  streamTs: string,
+): Promise<PlatformRunProgress | null> {
+  const channel = incoming.platformContext.channelId;
+  const threadTs = incoming.platformContext.threadTs;
+  if (typeof channel !== "string" || typeof threadTs !== "string") return null;
+  return createSlackRunProgress(token, incoming, channel, threadTs, streamTs);
+}
+
+function createSlackRunProgress(
+  token: string,
+  incoming: IncomingMessage,
+  channel: string,
+  threadTs: string,
+  streamTs: string,
+): PlatformRunProgress {
   const tasks = new Map<string, { title: string; status: string }>();
   const toolTaskIds = new Map<string, string>();
   const agentTaskIds = new Map<string, string>();
@@ -1328,12 +1387,22 @@ async function startSlackRunProgress(
     const now = Date.now();
     const write = async (value: Record<string, unknown>) => {
       lastWriteAt = Date.now();
-      await postSlackJson(token, "chat.appendStream", {
-        channel,
-        ts: streamTs,
-        markdown_text: "Progress updated.",
-        chunks: [value],
-      }).catch(() => {});
+      try {
+        await postSlackJson(token, "chat.appendStream", {
+          channel,
+          ts: streamTs,
+          markdown_text: "Progress updated.",
+          chunks: [value],
+        });
+      } catch (error) {
+        console.warn(
+          "[slack] chat.appendStream failed; progress may be stale",
+          {
+            chunkType: streamChunkType(value),
+            errorCode: streamFailureCode(error),
+          },
+        );
+      }
     };
     if (now - lastWriteAt >= 900) {
       await write(chunk);
@@ -1357,6 +1426,7 @@ async function startSlackRunProgress(
     `${prefix}:${explicit || ++sequence}`.slice(0, 240);
 
   return {
+    ref: { kind: "slack-stream", streamTs },
     async onEvent(event) {
       if (!cancelControl) {
         const context = getIntegrationRequestContext();

--- a/packages/core/src/integrations/types.ts
+++ b/packages/core/src/integrations/types.ts
@@ -181,12 +181,31 @@ export interface PlatformAdapterCapabilities {
 }
 
 export interface PlatformRunProgress {
+  /**
+   * Opaque, provider-owned reference for resuming this progress surface from a
+   * durable continuation. It deliberately contains no user content,
+   * credentials, or provider payload.
+   */
+  ref?: PlatformRunProgressRef;
   /** Receive normalized agent events. Implementations should throttle writes. */
   onEvent(event: AgentChatEvent): Promise<void> | void;
   /** Finalize the provider-native progress surface with the answer. */
   complete(message: OutgoingMessage): Promise<void>;
   /** Mark the provider-native surface failed and leave a retryable explanation. */
   fail?(message: string): Promise<void>;
+}
+
+/**
+ * Safe, minimal reference to a provider-native run-progress surface.
+ *
+ * The field values are opaque to the framework. Adapters may use `kind` to
+ * distinguish their own resume strategy and `streamTs` to identify the
+ * provider-side stream. No incoming message text, platform payload, or
+ * credential belongs here.
+ */
+export interface PlatformRunProgressRef {
+  kind: string;
+  streamTs: string;
 }
 
 export interface ImmediateWebhookResponse {
@@ -302,6 +321,17 @@ export interface PlatformAdapter {
   /** Start a provider-native progress/streaming surface for an agent run. */
   startRunProgress?(
     incoming: IncomingMessage,
+  ): Promise<PlatformRunProgress | null>;
+
+  /**
+   * Reattach a durable continuation to a provider-native progress surface
+   * previously started by this adapter. Adapters that cannot resume a native
+   * surface should omit this and the continuation will use its normal reply
+   * path instead.
+   */
+  resumeRunProgress?(
+    incoming: IncomingMessage,
+    ref: PlatformRunProgressRef,
   ): Promise<PlatformRunProgress | null>;
 
   /**

--- a/packages/core/src/integrations/webhook-handler-engine.spec.ts
+++ b/packages/core/src/integrations/webhook-handler-engine.spec.ts
@@ -923,6 +923,53 @@ describe("integration webhook handler engine resolution", () => {
     expect(updateThreadDataMock).toHaveBeenCalled();
   });
 
+  it("keeps a resumable native progress stream open for a queued A2A continuation", async () => {
+    const { processIntegrationTask } = await import("./webhook-handler.js");
+    const { A2A_CONTINUATION_QUEUED_MARKER } =
+      await import("./a2a-continuation-marker.js");
+    const sendResponse = vi.fn();
+    const onEvent = vi.fn(async () => undefined);
+    const complete = vi.fn(async () => undefined);
+    const adapter = {
+      ...createAdapter(sendResponse),
+      startRunProgress: async () => ({
+        ref: { kind: "slack-stream", streamTs: "1719000000.000001" },
+        onEvent,
+        complete,
+      }),
+    };
+    runAgentLoopMock.mockImplementationOnce(async ({ send }) => {
+      send({ type: "agent_call", agent: "Design", status: "start" });
+      send({
+        type: "tool_done",
+        tool: "call-agent",
+        result: `${A2A_CONTINUATION_QUEUED_MARKER}\nThe Design agent is still working.`,
+      });
+    });
+
+    await processIntegrationTask(
+      pendingTask({ id: "task-stream-continuation" }),
+      {
+        adapter,
+        systemPrompt: "system",
+        actions: {},
+        model: "claude-sonnet-4-6",
+        apiKey: "",
+        ownerEmail: "dispatch+qa@integration.local",
+      },
+    );
+
+    expect(complete).not.toHaveBeenCalled();
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "agent_call_progress",
+        agent: "Design",
+        state: "working",
+      }),
+    );
+    expect(sendResponse).not.toHaveBeenCalled();
+  });
+
   it("projects a successful Slack ask-question call into a reply window", async () => {
     const { processIntegrationTask } = await import("./webhook-handler.js");
     const sendResponse = vi.fn();

--- a/packages/core/src/integrations/webhook-handler-engine.spec.ts
+++ b/packages/core/src/integrations/webhook-handler-engine.spec.ts
@@ -1137,11 +1137,21 @@ describe("integration webhook handler engine resolution", () => {
     expect(sendResponse).not.toHaveBeenCalled();
   });
 
-  it("still sends real final text after an A2A continuation marker", async () => {
+  it("sends real parent text without closing a queued continuation's native progress stream", async () => {
     const { processIntegrationTask } = await import("./webhook-handler.js");
     const { A2A_CONTINUATION_QUEUED_MARKER } =
       await import("./a2a-continuation-marker.js");
     const sendResponse = vi.fn();
+    const onEvent = vi.fn(async () => undefined);
+    const complete = vi.fn(async () => undefined);
+    const adapter = {
+      ...createAdapter(sendResponse),
+      startRunProgress: async () => ({
+        ref: { kind: "slack-stream", streamTs: "1719000000.000002" },
+        onEvent,
+        complete,
+      }),
+    };
     runAgentLoopMock.mockImplementationOnce(async ({ send }) => {
       send({
         type: "tool_start",
@@ -1160,7 +1170,7 @@ describe("integration webhook handler engine resolution", () => {
     });
 
     await processIntegrationTask(pendingTask({ id: "task-final" }), {
-      adapter: createAdapter(sendResponse),
+      adapter,
       systemPrompt: "system",
       actions: {},
       model: "claude-sonnet-4-6",
@@ -1168,6 +1178,7 @@ describe("integration webhook handler engine resolution", () => {
       ownerEmail: "dispatch+qa@integration.local",
     });
 
+    expect(complete).not.toHaveBeenCalled();
     expect(sendResponse).toHaveBeenCalledWith(
       expect.objectContaining({
         text: "371 pageview events were recorded in the requested window.",
@@ -1175,9 +1186,14 @@ describe("integration webhook handler engine resolution", () => {
       expect.any(Object),
       expect.objectContaining({ placeholderRef: undefined }),
     );
+    expect(
+      onEvent.mock.calls.some(
+        ([event]) => event.type === "agent_call_progress",
+      ),
+    ).toBe(false);
   });
 
-  it("sends substantive partial answers even when one A2A continuation will post separately", async () => {
+  it("sends substantive partial answers without closing a queued continuation stream", async () => {
     const { processIntegrationTask } = await import("./webhook-handler.js");
     const { A2A_CONTINUATION_QUEUED_MARKER } =
       await import("./a2a-continuation-marker.js");

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -796,6 +796,7 @@ async function processIncomingMessage(
                   attempts: opts.attempts,
                   incoming,
                   placeholderRef: opts.placeholderRef,
+                  progressRef: progress?.ref,
                   scopeId: incoming.integrationScopeId,
                   principalType: opts.principalType ?? "user",
                   lineage: {
@@ -988,24 +989,35 @@ async function processIncomingMessage(
               keepSlackInputWindow = true;
             }
           } else if (progress) {
-            // The downstream agent owns the eventual reply, but this parent
-            // integration run owns the native progress stream it opened. End
-            // that stream now so Slack does not leave an eternal task card;
-            // the continuation processor will post the final result into the
-            // same thread when the downstream task completes.
-            const deferred = adapter.formatAgentResponse(
-              "The delegated agent is still working. I’ll post its final result in this thread automatically.",
-            );
-            try {
-              await progress.complete(deferred);
-            } catch {
-              // A failed complete must still terminate a provider-native
-              // stream when the adapter offers a failure lifecycle. Do not
-              // duplicate the deferred text as a regular reply: a later
-              // continuation delivery is authoritative.
-              await progress.fail?.(
+            // A continuation owns the eventual final response. If the adapter
+            // supplied a durable progress reference, leave the same native
+            // stream open for the continuation processor to update and close;
+            // ending it here discards the plan/task UI before the delegated
+            // work has actually finished.
+            if (progress.ref) {
+              await progress.onEvent({
+                type: "agent_call_progress",
+                agent:
+                  getQueuedA2AContinuationAgent(completedRun) ??
+                  "delegated agent",
+                state: "working",
+                elapsedSeconds: 0,
+                detail: "Continuing in the background",
+              });
+            } else {
+              // Older adapters have no resumable native surface. Close their
+              // stream cleanly; the continuation will deliver one standard
+              // final reply when the downstream task is terminal.
+              const deferred = adapter.formatAgentResponse(
                 "The delegated agent is still working. I’ll post its final result in this thread automatically.",
               );
+              try {
+                await progress.complete(deferred);
+              } catch {
+                await progress.fail?.(
+                  "The delegated agent is still working. I’ll post its final result in this thread automatically.",
+                );
+              }
             }
           }
 
@@ -1320,6 +1332,17 @@ function hasQueuedA2AContinuation(completedRun: ActiveRun): boolean {
       String(event.result ?? "").includes(A2A_CONTINUATION_QUEUED_MARKER)
     );
   });
+}
+
+function getQueuedA2AContinuationAgent(completedRun: ActiveRun): string | null {
+  for (let i = completedRun.events.length - 1; i >= 0; i--) {
+    const event = completedRun.events[i]!.event;
+    if (event.type !== "agent_call") continue;
+    if (typeof event.agent === "string" && event.agent.trim()) {
+      return event.agent;
+    }
+  }
+  return null;
 }
 
 function extractSlackInputRequest(

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -774,6 +774,7 @@ async function processIncomingMessage(
   const progress = await adapter.startRunProgress?.(incoming).catch(() => null);
   let usage: Awaited<ReturnType<typeof runAgentLoop>> | null = null;
   let budgetsSettled = false;
+  let continuationOwnsProgress = false;
 
   // Wait for the run to complete inside this fresh function execution.
   // We use a Promise so the processor endpoint can await the full lifecycle.
@@ -875,6 +876,8 @@ async function processIncomingMessage(
         let keepSlackInputWindow = false;
         try {
           const queuedA2AContinuation = hasQueuedA2AContinuation(completedRun);
+          continuationOwnsProgress =
+            queuedA2AContinuation && Boolean(progress?.ref);
           const slackInputRequest =
             incoming.platform === "slack"
               ? extractSlackInputRequest(completedRun)
@@ -964,7 +967,16 @@ async function processIncomingMessage(
               threadDeepLinkUrl,
             });
             let delivered = false;
-            if (progress) {
+            // A queued continuation keeps the native stream open. Deliver a
+            // substantive parent partial as a normal thread reply instead of
+            // completing that stream, which the continuation needs for its
+            // eventual task/plan result.
+            if (queuedA2AContinuation && progress?.ref) {
+              await adapter.sendResponse(outgoing, incoming, {
+                placeholderRef: opts.placeholderRef,
+              });
+              delivered = true;
+            } else if (progress) {
               try {
                 await progress.complete(outgoing);
                 delivered = true;
@@ -1049,15 +1061,18 @@ async function processIncomingMessage(
             err,
           );
           // Last-ditch: try to post a brief apology so the thread isn't silent.
-          try {
-            await progress?.fail?.(
-              "Something went wrong on my end while replying. Please try again.",
-            );
-            const fallback = adapter.formatAgentResponse(
-              "Something went wrong on my end while replying. Please try again.",
-            );
-            if (!progress?.fail) await adapter.sendResponse(fallback, incoming);
-          } catch {}
+          if (!continuationOwnsProgress) {
+            try {
+              await progress?.fail?.(
+                "Something went wrong on my end while replying. Please try again.",
+              );
+              const fallback = adapter.formatAgentResponse(
+                "Something went wrong on my end while replying. Please try again.",
+              );
+              if (!progress?.fail)
+                await adapter.sendResponse(fallback, incoming);
+            } catch {}
+          }
         } finally {
           // Any terminal path (including a failed run or an unrelated new
           // mention) invalidates an older clarification window. The only

--- a/packages/core/src/scripts/call-agent.spec.ts
+++ b/packages/core/src/scripts/call-agent.spec.ts
@@ -50,6 +50,7 @@ vi.mock("../server/request-context.js", () => ({
       timestamp: 123,
     },
     placeholderRef: "placeholder-1",
+    progressRef: { kind: "slack-stream", streamTs: "1719000000.000001" },
   }),
 }));
 
@@ -153,6 +154,10 @@ describe("call-agent action", () => {
         agentUrl: "https://slides.agent-native.test",
         a2aTaskId: "remote-task-1",
         dedupeKey: expect.any(String),
+        progressRef: {
+          kind: "slack-stream",
+          streamTs: "1719000000.000001",
+        },
       }),
     );
     expect(dispatchA2AContinuationMock).toHaveBeenCalledWith("cont-1");

--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -427,6 +427,7 @@ async function enqueueIntegrationContinuationIfPossible(
       externalThreadId: integration.incoming.externalThreadId,
       incoming: integration.incoming,
       placeholderRef: integration.placeholderRef,
+      progressRef: integration.progressRef,
       ownerEmail,
       orgId: getRequestOrgId() ?? null,
       agentName: agent.name,

--- a/packages/core/src/server/request-context.ts
+++ b/packages/core/src/server/request-context.ts
@@ -164,6 +164,8 @@ export interface RequestContext {
     attempts?: number;
     incoming: import("../integrations/types.js").IncomingMessage;
     placeholderRef?: string;
+    /** Opaque provider-native progress surface for a durable continuation. */
+    progressRef?: import("../integrations/types.js").PlatformRunProgressRef;
     installationId?: string;
     scopeId?: string;
     principalType?: "user" | "service";


### PR DESCRIPTION
## Summary
- keep Slack task cards alive while a queued A2A continuation runs
- resume the same native Slack stream for each continuation poll and final delivery
- avoid treating interim recoverable artifacts as terminal replies; log safe stream-fallback diagnostics

## Validation
- `corepack pnpm --filter @agent-native/core exec vitest run src/integrations/webhook-handler-engine.spec.ts src/integrations/a2a-continuation-processor.spec.ts src/integrations/a2a-continuations-store.spec.ts src/integrations/adapters/slack.spec.ts src/scripts/call-agent.spec.ts`
- `corepack pnpm --filter @agent-native/core typecheck`
- `node scripts/check-changeset.mjs`
- `corepack pnpm exec oxfmt --check …`