### PR TITLE
Retry provider outage agent runs

### DIFF
--- a/.changeset/provider-outage-resume.md
+++ b/.changeset/provider-outage-resume.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Retry and resume hosted agent runs when upstream model providers report unavailable, overloaded, or service-unavailable outage signals.

--- a/packages/core/docs/content/durable-resume.mdx
+++ b/packages/core/docs/content/durable-resume.mdx
@@ -13,6 +13,8 @@ Hosted agent runs get interrupted: a serverless function hits its hard timeout m
 
 Durable resume closes that gap. On resume, the framework knows which side-effecting tool calls already completed and refuses to re-run them — at two layers.
 
+Provider outage signals are recoverable too: structured `provider_unavailable` / `service_unavailable` errors, overloaded-model messages, and upstream unavailable responses now enter the same retry/resume path instead of ending the run as a terminal failure.
+
 <Diagram id="doc-block-1sldt6j" title="Two layers block duplicate side effects on resume" summary={"The journal reads the durable ledger and classifies prior calls; layer 1 tells the model, layer 2 hard-blocks a re-dispatched write that matches a completed entry."}>
 
 ```html

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -6004,6 +6004,22 @@ describe("isRetryableError", () => {
     );
   });
 
+  it("retries provider-unavailable outage signals", () => {
+    const cases = [
+      new EngineError("provider unavailable", {
+        errorCode: "provider_unavailable",
+      }),
+      new EngineError("service unavailable", {
+        errorCode: "service_unavailable",
+      }),
+      new Error("upstream provider temporarily unavailable"),
+      new Error("model is overloaded, try again later"),
+    ];
+    for (const err of cases) {
+      expect(isRetryableError(err)).toBe(true);
+    }
+  });
+
   it("does NOT retry builder_gateway_timeout", () => {
     const err = new EngineError("timed out", {
       errorCode: "builder_gateway_timeout",

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -1151,6 +1151,63 @@ export function isContextTooLongError(err: unknown): boolean {
   return false;
 }
 
+function isProviderUnavailableOrTransientError({
+  code,
+  text,
+}: {
+  code: string;
+  text: string;
+}): boolean {
+  return (
+    code === "builder_gateway_error" ||
+    code === "builder_gateway_network_error" ||
+    code === "http_429" ||
+    code === "http_500" ||
+    code === "http_502" ||
+    code === "http_503" ||
+    code === "http_504" ||
+    code === "http_529" ||
+    code === "timeout" ||
+    code === "service_unavailable" ||
+    code === "provider_unavailable" ||
+    code === "overloaded" ||
+    // Anthropic
+    text.includes("overloaded") ||
+    text.includes("rate_limit") ||
+    // Bare provider rate-limit messages that carry no structured status,
+    // e.g. the Anthropic/AI-SDK "429 status code (no body)" format.
+    /\b429\b/.test(text) ||
+    text.includes("529") ||
+    // OpenAI phrasing
+    text.includes("rate limit reached") ||
+    // Google / Gemini
+    text.includes("resource_exhausted") ||
+    text.includes("quota exceeded") ||
+    // Generic provider / gateway unavailable phrases
+    text.includes("provider unavailable") ||
+    text.includes("provider is unavailable") ||
+    text.includes("model provider unavailable") ||
+    text.includes("service unavailable") ||
+    text.includes("temporarily unavailable") ||
+    text.includes("upstream unavailable") ||
+    text.includes("upstream provider unavailable") ||
+    text.includes("model is overloaded") ||
+    text.includes("model overloaded") ||
+    // Generic HTTP codes
+    text.includes("502") ||
+    text.includes("503") ||
+    text.includes("504") ||
+    text.includes("gateway error") ||
+    text.includes("socket hang up") ||
+    text.includes("connection reset") ||
+    text.includes("too many requests") ||
+    text.includes("timeout") ||
+    text.includes("gateway timeout") ||
+    text.includes("inactivity timeout") ||
+    text.includes("too much time has passed without sending any data")
+  );
+}
+
 /** @internal exported for unit tests only */
 export function isRetryableError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
@@ -1177,41 +1234,7 @@ export function isRetryableError(err: unknown): boolean {
     if (sc === 429 || sc === 500 || sc === 502 || sc === 503 || sc === 529)
       return true;
   }
-
-  return (
-    code === "builder_gateway_error" ||
-    code === "builder_gateway_network_error" ||
-    code === "http_429" ||
-    code === "http_500" ||
-    code === "http_502" ||
-    code === "http_503" ||
-    code === "http_504" ||
-    code === "timeout" ||
-    // Anthropic
-    msg.includes("overloaded") ||
-    msg.includes("rate_limit") ||
-    // Bare provider rate-limit messages that carry no structured status,
-    // e.g. the Anthropic/AI-SDK "429 status code (no body)" format.
-    /\b429\b/.test(msg) ||
-    msg.includes("529") ||
-    // OpenAI phrasing
-    msg.includes("rate limit reached") ||
-    // Google / Gemini
-    msg.includes("resource_exhausted") ||
-    msg.includes("quota exceeded") ||
-    // Generic HTTP codes
-    msg.includes("502") ||
-    msg.includes("503") ||
-    msg.includes("504") ||
-    msg.includes("gateway error") ||
-    msg.includes("socket hang up") ||
-    msg.includes("connection reset") ||
-    msg.includes("too many requests") ||
-    msg.includes("timeout") ||
-    msg.includes("gateway timeout") ||
-    msg.includes("inactivity timeout") ||
-    msg.includes("too much time has passed without sending any data")
-  );
+  return isProviderUnavailableOrTransientError({ code, text: msg });
 }
 
 // ---------------------------------------------------------------------------
@@ -1867,6 +1890,7 @@ export function isResumableEngineError(err: unknown): boolean {
   }
   const text = errorSearchText(err);
   return (
+    isProviderUnavailableOrTransientError({ code, text }) ||
     text.includes("socket hang up") ||
     text.includes("econnreset") ||
     text.includes("enetreset") ||

--- a/packages/core/src/agent/run-loop-with-resume.spec.ts
+++ b/packages/core/src/agent/run-loop-with-resume.spec.ts
@@ -113,6 +113,22 @@ describe("isResumableEngineError", () => {
     expect(isResumableEngineError(outer)).toBe(true);
   });
 
+  it("recognizes provider-unavailable errors as resumable", () => {
+    const cases = [
+      new EngineError("provider unavailable", {
+        errorCode: "provider_unavailable",
+      }),
+      new EngineError("service unavailable", {
+        errorCode: "service_unavailable",
+      }),
+      new Error("Upstream provider temporarily unavailable"),
+      new Error("The model provider is unavailable right now"),
+    ];
+    for (const err of cases) {
+      expect(isResumableEngineError(err)).toBe(true);
+    }
+  });
+
   it("returns false for terminal user-facing errors", () => {
     expect(
       isResumableEngineError(


### PR DESCRIPTION
## Summary
- Retry provider-unavailable, service-unavailable, overloaded, and upstream unavailable signals inside hosted agent runs.
- Treat the same transient provider outage signals as resumable so durable resume can recover instead of surfacing terminal failures.
- Add a @agent-native/core patch changeset and document the behavior in Durable Resume docs.

Fixes #2024

## Verification
- pnpm --filter @agent-native/core exec vitest --run src/agent/production-agent.spec.ts src/agent/run-loop-with-resume.spec.ts --maxWorkers=25% — 188 passed
- pnpm exec oxfmt --write packages/core/src/agent/production-agent.ts packages/core/src/agent/production-agent.spec.ts packages/core/src/agent/run-loop-with-resume.spec.ts packages/core/docs/content/durable-resume.mdx .changeset/provider-outage-resume.md
- pnpm exec changeset status --verbose
- git diff --check

## Release
- Changeset: .changeset/provider-outage-resume.md
- Package: @agent-native/core patch, expected 0.92.2 through the repo's changesets release workflow
- Docs: packages/core/docs/content/durable-resume.mdx