### PR TITLE
Improve Slack agent reliability and Analytics execution

### DIFF
--- a/.changeset/bright-streams-listen.md
+++ b/.changeset/bright-streams-listen.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Improve Slack agent progress and diagnostics, and continue long-running delegated tasks reliably.

--- a/packages/core/src/a2a/client.spec.ts
+++ b/packages/core/src/a2a/client.spec.ts
@@ -176,6 +176,43 @@ describe("A2AClient", () => {
     await assertion;
   });
 
+  it("preserves the timeout task when recoverable artifacts are disabled", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        if (init?.method !== "POST")
+          return new Response("not found", { status: 404 });
+        const body = JSON.parse(String(init.body));
+        if (body.method === "message/send") {
+          return workingResponse(body, "task-deck-continuation");
+        }
+        return workingResponse(body, "task-deck-continuation", {
+          message: {
+            role: "agent",
+            metadata: { agentNativeRecoverableArtifacts: true },
+            parts: [
+              {
+                type: "text",
+                text: "Artifacts:\n- Deck: https://slides.agent.test/deck/deck-real (ID: deck-real)",
+              },
+            ],
+          },
+        });
+      }),
+    );
+
+    await expect(
+      callAgent("https://slides.agent.test", "make a deck", {
+        timeoutMs: 3,
+        pollIntervalMs: 1,
+        returnRecoverableArtifactsOnTimeout: false,
+      }),
+    ).rejects.toMatchObject({
+      name: "A2ATaskTimeoutError",
+      taskId: "task-deck-continuation",
+    });
+  });
+
   it("does not treat unmarked timeout text as a recoverable artifact", async () => {
     vi.stubGlobal(
       "fetch",

--- a/packages/core/src/a2a/client.ts
+++ b/packages/core/src/a2a/client.ts
@@ -551,6 +551,13 @@ export async function callAgent(
     /** Poll interval for async calls. Primarily useful for tests/retries. */
     pollIntervalMs?: number;
     /**
+     * Return receiver-verified artifact text from the last polled task when
+     * the call times out. Defaults to true for backwards compatibility.
+     * Callers that can continue polling the remote task separately should set
+     * this to false so the A2ATaskTimeoutError (and its taskId) is preserved.
+     */
+    returnRecoverableArtifactsOnTimeout?: boolean;
+    /**
      * Called with each successfully polled task while an async call is still
      * in flight (see `A2AClient.sendAndWait`). Fires once per real poll
      * round-trip that returns a task — including the terminal poll — so
@@ -614,7 +621,10 @@ export async function callAgent(
 
       return "";
     } catch (err) {
-      if (err instanceof A2ATaskTimeoutError) {
+      if (
+        opts?.returnRecoverableArtifactsOnTimeout !== false &&
+        err instanceof A2ATaskTimeoutError
+      ) {
         const recoverableText = extractRecoverableArtifactText(err.lastTask);
         if (recoverableText) return recoverableText;
       }

--- a/packages/core/src/integrations/a2a-continuation-processor.spec.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.spec.ts
@@ -734,6 +734,82 @@ describe("A2A continuation processor", () => {
     expect(completeA2AContinuationMock).not.toHaveBeenCalled();
   });
 
+  it("includes a safe downstream error code and request ID in failure replies", async () => {
+    const sendResponse = vi.fn(async () => undefined);
+    claimA2AContinuationMock.mockResolvedValueOnce(
+      continuation({
+        id: "cont-slack-lookup-456",
+        integrationTaskId: "task-slack-lookup-123",
+        a2aTaskId: "a2a-slack-lookup-789",
+      }),
+    );
+    claimA2AContinuationDeliveryMock.mockResolvedValueOnce(
+      continuation({
+        id: "cont-slack-lookup-456",
+        integrationTaskId: "task-slack-lookup-123",
+        a2aTaskId: "a2a-slack-lookup-789",
+      }),
+    );
+    getTaskMock.mockResolvedValueOnce({
+      id: "a2a-task-1",
+      status: {
+        state: "failed",
+        message: {
+          role: "agent",
+          parts: [
+            {
+              type: "text",
+              text: "I ran out of time before finishing this step. code: run_budget_exhausted",
+            },
+          ],
+        },
+        timestamp: new Date().toISOString(),
+      },
+    });
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    await processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+
+    const sentText = vi.mocked(sendResponse).mock.calls[0]?.[0].text ?? "";
+    expect(sentText).toContain("Error code: `run_budget_exhausted`");
+    expect(sentText).toContain("Request ID: `task-slack-lookup-123`");
+    expect(sentText).toContain("Continuation ID: `cont-slack-lookup-456`");
+    expect(sentText).toContain("Downstream task ID: `a2a-slack-lookup-789`");
+  });
+
+  it("normalizes explicit code= markers before including them in failure replies", async () => {
+    const sendResponse = vi.fn(async () => undefined);
+    claimA2AContinuationMock.mockResolvedValueOnce(continuation());
+    getTaskMock.mockResolvedValueOnce({
+      id: "a2a-task-1",
+      status: {
+        state: "failed",
+        message: {
+          role: "agent",
+          parts: [
+            {
+              type: "text",
+              text: "Analysis failed. code=UPSTREAM_UNAVAILABLE",
+            },
+          ],
+        },
+        timestamp: new Date().toISOString(),
+      },
+    });
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    await processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+
+    const sentText = vi.mocked(sendResponse).mock.calls[0]?.[0].text ?? "";
+    expect(sentText).toContain("Error code: `upstream_unavailable`");
+  });
+
   it("describes downstream LLM credential failures without naming a raw env var", async () => {
     const sendResponse = vi.fn(async () => undefined);
     claimA2AContinuationMock.mockResolvedValueOnce(continuation());
@@ -759,6 +835,8 @@ describe("A2A continuation processor", () => {
     expect(sentText).toContain("needs an LLM connection");
     expect(sentText).toContain("Agent settings > LLM");
     expect(sentText).not.toContain("ANTHROPIC_API_KEY");
+    expect(sentText).toContain("Error code: `missing_credentials`");
+    expect(sentText).toContain("Request ID: `task-1`");
     expect(failA2AContinuationMock).toHaveBeenCalledWith(
       "cont-1",
       "ANTHROPIC_API_KEY is not set",

--- a/packages/core/src/integrations/a2a-continuation-processor.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.ts
@@ -4,6 +4,7 @@ import type { Task } from "../a2a/types.js";
 import {
   formatLlmCredentialErrorMessage,
   isLlmCredentialError,
+  LLM_MISSING_CREDENTIALS_ERROR_CODE,
 } from "../agent/engine/credential-errors.js";
 import { withConfiguredAppBasePath } from "../server/app-base-path.js";
 import { FRAMEWORK_ROUTE_PREFIX } from "../server/core-routes-plugin.js";
@@ -457,15 +458,44 @@ function formatContinuationFailureMessage(
   continuation: A2AContinuation,
   reason: string,
 ): string {
-  if (isLlmCredentialError(reason)) {
-    return formatLlmCredentialErrorMessage({
-      agentName: continuation.agentName,
-    });
+  const explicitCode = extractFailureCode(reason);
+  const diagnostics = formatContinuationFailureDiagnostics(
+    continuation,
+    reason,
+  );
+  if (isLlmCredentialError(reason, explicitCode)) {
+    return (
+      formatLlmCredentialErrorMessage({
+        agentName: continuation.agentName,
+      }) + diagnostics
+    );
   }
 
   return `The ${continuation.agentName} agent could not finish this request: ${sanitizeFailureReason(
     reason,
-  )}`;
+  )}${diagnostics}`;
+}
+
+function formatContinuationFailureDiagnostics(
+  continuation: A2AContinuation,
+  reason: string,
+): string {
+  return `\n\nError code: \`${continuationFailureCode(reason)}\`\nRequest ID: \`${continuation.integrationTaskId}\`\nContinuation ID: \`${continuation.id}\`\nDownstream task ID: \`${continuation.a2aTaskId}\``;
+}
+
+function continuationFailureCode(reason: string): string {
+  const explicitCode = extractFailureCode(reason);
+  if (explicitCode) return explicitCode;
+  if (isLlmCredentialError(reason, explicitCode)) {
+    return LLM_MISSING_CREDENTIALS_ERROR_CODE;
+  }
+  if (/\btimed out polling\b/i.test(reason)) return "a2a_remote_timeout";
+  return "a2a_downstream_error";
+}
+
+function extractFailureCode(reason: string): string | null {
+  const match = /\bcode\s*[:=]\s*[`"']?([a-z][a-z0-9_]{0,79})\b/i.exec(reason);
+  return match?.[1]?.toLowerCase() ?? null;
 }
 
 function isRemoteWorkExpired(continuation: A2AContinuation): boolean {

--- a/packages/core/src/integrations/adapters/slack.spec.ts
+++ b/packages/core/src/integrations/adapters/slack.spec.ts
@@ -606,6 +606,20 @@ describe("slackAdapter", () => {
         channel: "C123",
         thread_ts: "111.222",
         task_display_mode: "plan",
+        markdown_text: "I’m looking into this for you.",
+        chunks: [
+          {
+            type: "plan_update",
+            title: "I’m looking into this for you",
+          },
+          {
+            type: "task_update",
+            id: "agent-native:context",
+            title: "Review the request",
+            status: "in_progress",
+            details: "Finding the information needed for an answer",
+          },
+        ],
       },
     });
     expect(
@@ -707,7 +721,7 @@ describe("slackAdapter", () => {
             chunks: [
               expect.objectContaining({
                 type: "task_update",
-                title: "Ask Design",
+                title: "Contact Design",
                 status: "in_progress",
               }),
             ],
@@ -878,7 +892,7 @@ describe("slackAdapter", () => {
       .flatMap((request) => request.body.chunks ?? [])
       .filter(
         (chunk) =>
-          chunk.type === "task_update" && chunk.title === "Ask Analytics",
+          chunk.type === "task_update" && chunk.title === "Contact Analytics",
       );
 
     expect(agentUpdates).toHaveLength(3);
@@ -890,8 +904,12 @@ describe("slackAdapter", () => {
       "in_progress",
       "complete",
     ]);
+    expect(agentUpdates[0]).toMatchObject({
+      details: "I’m contacting Analytics for an answer.",
+    });
     expect(agentUpdates[1]).toMatchObject({
-      details: "Joining HubSpot and BigQuery data",
+      details:
+        "Working · 30s — Joining HubSpot and BigQuery data. This is taking longer than usual, but Analytics is still working. I’ll post the result here.",
     });
   });
 

--- a/packages/core/src/integrations/adapters/slack.ts
+++ b/packages/core/src/integrations/adapters/slack.ts
@@ -37,6 +37,7 @@ const SLACK_API_TIMEOUT_MS = 10_000;
 const SLACK_PERMALINK_TIMEOUT_MS = 1_000;
 const SLACK_CONTEXT_MESSAGE_LIMIT = 15;
 const SLACK_CONTEXT_TEXT_LIMIT = 2_000;
+const SLACK_CALM_PROGRESS_THRESHOLD_SECONDS = 30;
 
 export interface SlackAdapterOptions {
   /** Resolve the bot token for the exact Slack installation. */
@@ -323,12 +324,10 @@ export function slackAdapter(
     async postProcessingPlaceholder(
       incoming: IncomingMessage,
     ): Promise<{ placeholderRef: string } | null> {
-      // No placeholder reply in the thread — Slack's native assistant
-      // status bar ("agent-native is thinking…", below the composer) is the
-      // loading affordance. A second visible "Working on it…" reply was
-      // redundant and added an extra chunk that we then had to overwrite.
-      // We just set the native status and return null so sendResponse posts
-      // the final reply as a fresh message.
+      // No placeholder reply in the thread — Slack's native assistant status
+      // bar and the task stream are the loading affordance. Keep the status
+      // specific about intent instead of presenting the generic thinking
+      // state while the native plan is opening.
       const token = await resolveBotToken(incoming);
       if (!token) return null;
 
@@ -336,11 +335,16 @@ export function slackAdapter(
       const threadTs = incoming.platformContext.threadTs as string;
       if (!channelId || !threadTs) return null;
 
-      // Best-effort: flip the native Agent "is thinking…" status bar in the
+      // Best-effort: flip the native Agent status bar in the
       // channel input area. Slack accepts chat:write for this method. The
       // canonical manifest separately requests assistant:write for Agent View
       // and app_context_changed events.
-      setSlackAssistantStatus(token, channelId, threadTs, "is thinking…");
+      setSlackAssistantStatus(
+        token,
+        channelId,
+        threadTs,
+        "I’m looking into this now…",
+      );
       return null;
     },
 
@@ -1266,6 +1270,42 @@ function shortTaskTitle(value: unknown): string {
   return text.replace(/[-_]/g, " ").slice(0, 200);
 }
 
+function delegatedTaskTitle(agent: unknown): string {
+  return `Contact ${shortTaskTitle(agent)}`;
+}
+
+function formatElapsedSeconds(elapsedSeconds: number): string {
+  const totalSeconds = Math.max(0, Math.round(elapsedSeconds));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
+}
+
+function formatProgressState(state: string): string {
+  if (state === "submitted") return "Queued";
+  if (state === "working") return "Working";
+  return shortTaskTitle(state);
+}
+
+function delegatedProgressDetails(
+  agent: unknown,
+  state: string,
+  elapsedSeconds: number,
+  detail?: string,
+): string {
+  const elapsed = formatElapsedSeconds(elapsedSeconds);
+  const progress = `${formatProgressState(state)} · ${elapsed}`;
+  const update = detail ? shortTaskTitle(detail) : "";
+
+  if (elapsedSeconds >= SLACK_CALM_PROGRESS_THRESHOLD_SECONDS) {
+    const agentName = shortTaskTitle(agent);
+    const context = update ? ` — ${update}.` : ".";
+    return `${progress}${context} This is taking longer than usual, but ${agentName} is still working. I’ll post the result here.`;
+  }
+
+  return update ? `${progress} — ${update}` : progress;
+}
+
 async function postSlackJson(
   token: string,
   method: string,
@@ -1315,18 +1355,18 @@ async function startSlackRunProgress(
       ...(incoming.tenantId ? { recipient_team_id: incoming.tenantId } : {}),
       ...(incoming.senderId ? { recipient_user_id: incoming.senderId } : {}),
       task_display_mode: "plan",
-      markdown_text: "Working on your request…",
+      markdown_text: "I’m looking into this for you.",
       chunks: [
         {
           type: "plan_update",
-          title: "Working on your request",
+          title: "I’m looking into this for you",
         },
         {
           type: "task_update",
           id: "agent-native:context",
-          title: "Understand the request",
+          title: "Review the request",
           status: "in_progress",
-          details: "Loading relevant context",
+          details: "Finding the information needed for an answer",
         },
       ],
     });
@@ -1373,7 +1413,7 @@ function createSlackRunProgress(
   const toolTaskIds = new Map<string, string>();
   const agentTaskIds = new Map<string, string>();
   tasks.set("agent-native:context", {
-    title: "Understand the request",
+    title: "Review the request",
     status: "in_progress",
   });
   let sequence = 0;
@@ -1540,9 +1580,19 @@ function createSlackRunProgress(
             : event.status === "done"
               ? "complete"
               : "error";
-        const title = `Ask ${shortTaskTitle(event.agent)}`;
+        const title = delegatedTaskTitle(event.agent);
         tasks.set(id, { title, status });
-        await append({ type: "task_update", id, title, status });
+        await append({
+          type: "task_update",
+          id,
+          title,
+          status,
+          ...(event.status === "start"
+            ? {
+                details: `I’m contacting ${shortTaskTitle(event.agent)} for an answer.`,
+              }
+            : {}),
+        });
       } else if (event.type === "agent_call_progress") {
         // A2A calls can stay healthy for minutes. Keep the same native Slack
         // task card alive with each real downstream poll rather than creating
@@ -1550,10 +1600,13 @@ function createSlackRunProgress(
         const id =
           agentTaskIds.get(event.agent) ?? taskId("agent", event.agent);
         agentTaskIds.set(event.agent, id);
-        const title = `Ask ${shortTaskTitle(event.agent)}`;
-        const details = event.detail
-          ? shortTaskTitle(event.detail)
-          : `Still ${event.state} after ${event.elapsedSeconds}s`;
+        const title = delegatedTaskTitle(event.agent);
+        const details = delegatedProgressDetails(
+          event.agent,
+          event.state,
+          event.elapsedSeconds,
+          event.detail,
+        );
         tasks.set(id, { title, status: "in_progress" });
         await append({
           type: "task_update",
@@ -1566,9 +1619,9 @@ function createSlackRunProgress(
         await append({
           type: "task_update",
           id: "agent-native:context",
-          title: "Understand the request",
+          title: "Review the request",
           status: "in_progress",
-          details: shortTaskTitle(event.label),
+          details: `Working · ${shortTaskTitle(event.label)}`,
         });
       }
     },

--- a/packages/core/src/scripts/call-agent.spec.ts
+++ b/packages/core/src/scripts/call-agent.spec.ts
@@ -401,6 +401,7 @@ describe("call-agent action", () => {
         expect.objectContaining({
           timeoutMs: 2_000,
           onUpdate: expect.any(Function),
+          returnRecoverableArtifactsOnTimeout: false,
         }),
       );
     });

--- a/packages/core/src/scripts/call-agent.spec.ts
+++ b/packages/core/src/scripts/call-agent.spec.ts
@@ -170,6 +170,52 @@ describe("call-agent action", () => {
     );
   });
 
+  it("returns receiver-verified artifacts when continuation enqueue fails", async () => {
+    process.env.NETLIFY = "true";
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    insertA2AContinuationMock.mockRejectedValueOnce(
+      new Error("database temporarily unavailable"),
+    );
+    const timeout = Object.assign(
+      new Error("A2A task remote-task-artifact did not complete within 2000ms"),
+      {
+        name: "A2ATaskTimeoutError",
+        taskId: "remote-task-artifact",
+        lastTask: {
+          id: "remote-task-artifact",
+          status: {
+            state: "working",
+            timestamp: "",
+            message: {
+              role: "agent",
+              metadata: { agentNativeRecoverableArtifacts: true },
+              parts: [
+                {
+                  type: "text",
+                  text: "Artifacts:\n- Deck: /deck/deck-real (ID: deck-real)",
+                },
+              ],
+            },
+          },
+        },
+      },
+    );
+    callAgentMock.mockRejectedValueOnce(timeout);
+    const { run } = await import("./call-agent.js");
+
+    const result = await run(
+      { agent: "slides", message: "create the QA deck" },
+      { send: vi.fn() } as any,
+    );
+
+    expect(result).toContain("https://slides.agent-native.test/deck/deck-real");
+    expect(result).not.toContain("[agent-native:a2a-continuation-queued]");
+    expect(dispatchA2AContinuationMock).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
   describe("poll-driven progress", () => {
     // Minimal A2A Task shaped like what callAgent()'s poll passes to onUpdate.
     const makeTask = (state: string, detailText?: string): any => ({

--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -321,7 +321,14 @@ export async function run(
           orgDomain: callerOrgDomain,
           orgSecret: callerOrgSecret,
           onUpdate: onRemotePollUpdate,
-          ...(callTimeoutMs ? { timeoutMs: callTimeoutMs } : {}),
+          ...(callTimeoutMs
+            ? {
+                timeoutMs: callTimeoutMs,
+                // Integration callers must keep the timeout task id so the
+                // catch below can enqueue durable continuation polling.
+                returnRecoverableArtifactsOnTimeout: false,
+              }
+            : {}),
         });
         responseText =
           formatDownstreamLlmCredentialFailure(agent.name, responseText) ??

--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -355,8 +355,23 @@ export async function run(
               `The ${agent.name} agent accepted this delegated subtask and will post its own final result to the originating integration thread automatically. ` +
               `Do not call ${agent.name} again for this same subtask. Continue any other requested work, then answer with the completed results you have; if needed, mention that ${agent.name} is posting its result separately.`;
           } else {
-            const reason = pollErr?.message ?? "unknown error";
-            responseText = `The ${agent.name} agent is taking longer than expected and didn't reply in time. (${reason})`;
+            // The normal integration path must preserve the timeout task id so
+            // it can enqueue a durable continuation. If that enqueue fails,
+            // do not hide receiver-verified artifacts that were already
+            // returned with the last poll; this mirrors callAgent's default
+            // timeout behavior without treating arbitrary remote status text
+            // as a completed response.
+            const recoverableArtifactText =
+              extractRecoverableTimeoutArtifactText(pollErr);
+            if (recoverableArtifactText) {
+              responseText = expandRelativeUrls(
+                recoverableArtifactText,
+                agent.url,
+              );
+            } else {
+              const reason = pollErr?.message ?? "unknown error";
+              responseText = `The ${agent.name} agent is taking longer than expected and didn't reply in time. (${reason})`;
+            }
           }
         } else {
           const reason = pollErr?.message ?? "unknown error";
@@ -495,6 +510,34 @@ function getA2ATaskTimeoutTaskId(err: unknown): string | null {
 
   const match = message.match(/^A2A task ([^\s]+) did not complete\b/);
   return match?.[1] ?? null;
+}
+
+/**
+ * Mirrors the A2A client's default timeout recovery for the exceptional case
+ * where an integration cannot enqueue a durable continuation. Only an
+ * explicitly receiver-marked task message is safe to surface as a completed
+ * partial result; ordinary working-state text remains a timeout failure.
+ */
+function extractRecoverableTimeoutArtifactText(err: unknown): string {
+  const candidate = err as
+    | { lastTask?: Task | unknown; name?: unknown }
+    | null
+    | undefined;
+  const lastTask =
+    err instanceof A2ATaskTimeoutError
+      ? err.lastTask
+      : candidate?.name === "A2ATaskTimeoutError"
+        ? (candidate.lastTask as Task | undefined)
+        : undefined;
+  const message = lastTask?.status?.message;
+  if (!message?.metadata?.agentNativeRecoverableArtifacts) return "";
+
+  return message.parts
+    .filter(
+      (part): part is { type: "text"; text: string } => part.type === "text",
+    )
+    .map((part) => part.text)
+    .join("\n");
 }
 
 async function formatExistingIntegrationContinuationIfRetry(

--- a/packages/core/src/server/agent-chat-plugin.a2a.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin.a2a.spec.ts
@@ -4,6 +4,7 @@ import { loadActionsFromStaticRegistry } from "./action-discovery.js";
 import {
   assembleA2AFinalResponse,
   buildPublicAgentA2ASkills,
+  createA2AEngineToolSurface,
   runA2AAgentLoop,
 } from "./agent-chat-plugin.js";
 
@@ -71,6 +72,46 @@ describe("delegated A2A final response guards", () => {
       12_345,
       { backgroundFunction: true },
     );
+  });
+});
+
+describe("delegated A2A tool surface", () => {
+  const tool = (name: string) => ({
+    name,
+    description: `${name} description`,
+    inputSchema: { type: "object" as const },
+  });
+
+  it("starts with configured tools plus tool-search and retains the full registry for discovery", () => {
+    const availableTools = [
+      tool("starter"),
+      tool("tool-search"),
+      tool("rare-analytics-action"),
+    ];
+
+    const surface = createA2AEngineToolSurface(availableTools, ["starter"]);
+
+    expect(surface.tools.map((entry) => entry.name)).toEqual([
+      "starter",
+      "tool-search",
+    ]);
+    // `runAgentLoop` uses this full list to load a matched schema after the
+    // initial `tool-search` call, rather than forcing the whole registry into
+    // the first model request.
+    expect(surface.availableTools.map((entry) => entry.name)).toEqual([
+      "starter",
+      "tool-search",
+      "rare-analytics-action",
+    ]);
+  });
+
+  it("keeps the existing full A2A tool surface without an initial allow-list", () => {
+    const availableTools = [tool("starter"), tool("tool-search"), tool("rare")];
+
+    const surface = createA2AEngineToolSurface(availableTools);
+
+    expect(surface.tools).toBe(availableTools);
+    expect(surface.availableTools).toBe(availableTools);
   });
 });
 

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -54,11 +54,16 @@ import {
   listAgentEngines,
   registerBuiltinEngines,
 } from "../agent/engine/index.js";
-import type { AgentEngine, EngineMessage } from "../agent/engine/types.js";
+import type {
+  AgentEngine,
+  EngineMessage,
+  EngineTool,
+} from "../agent/engine/types.js";
 import {
   createProductionAgentHandler,
   actionsToEngineTools,
   executeAgentToolCall,
+  filterInitialEngineTools,
   getActiveRunForThreadAsync,
   abortRunDurably,
   subscribeToRun,
@@ -2941,6 +2946,22 @@ export function runA2AAgentLoop(
 }
 
 /**
+ * Keep delegated A2A turns on the same compact initial tool surface as
+ * interactive chat. `tool-search` remains in the initial set, while the
+ * complete registry is supplied separately so the run loop can load a matched
+ * schema after a tool-search result.
+ */
+export function createA2AEngineToolSurface(
+  availableTools: EngineTool[],
+  initialToolNames?: string[],
+): { tools: EngineTool[]; availableTools: EngineTool[] } {
+  return {
+    tools: filterInitialEngineTools(availableTools, initialToolNames),
+    availableTools,
+  };
+}
+
+/**
  * Verbose framework sections returned by the `get-framework-context` tool.
  * Keyed by topic so the agent can request specific sections.
  * Not template-specific — lives outside buildFrameworkPrompts().
@@ -5077,7 +5098,10 @@ export function createAgentChatPlugin(
                 },
           );
 
-          const a2aTools = actionsToEngineTools(a2aActions);
+          const a2aToolSurface = createA2AEngineToolSurface(
+            actionsToEngineTools(a2aActions),
+            options?.initialToolNames,
+          );
 
           // Precise current time rides the user message (not the cached
           // system-prompt prefix) — same pattern as the interactive handler.
@@ -5098,7 +5122,7 @@ export function createAgentChatPlugin(
           const controller = new AbortController();
 
           console.log(
-            `[A2A] Starting agent loop: ${a2aTools.length} tools, prompt ${systemPrompt.length} chars`,
+            `[A2A] Starting agent loop: ${a2aToolSurface.tools.length}/${a2aToolSurface.availableTools.length} initial tools, prompt ${systemPrompt.length} chars`,
           );
 
           await runA2AAgentLoop(
@@ -5106,7 +5130,8 @@ export function createAgentChatPlugin(
               engine: a2aEngine,
               model,
               systemPrompt,
-              tools: a2aTools,
+              tools: a2aToolSurface.tools,
+              availableTools: a2aToolSurface.availableTools,
               messages: a2aMessages,
               actions: a2aActions,
               send: (event) => {

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -20,6 +20,13 @@ details live in `.agents/skills/`.
   status) and the injected `<data-dictionary>` to learn what exists and which
   table/columns/join paths to use. Don't fan out blind queries when the catalog
   already answers where a fact lives.
+- Simple time-bounded metric fast path: when the data dictionary or a known
+  canonical source already identifies the metric, run one bounded aggregate.
+  Once that query returns a valid result, answer immediately with the source,
+  time window, row count, and only necessary caveats. Do not schema-discover,
+  retry, enrich, or add breakdowns unless the query fails or its result
+  conflicts with the known metric definition. This never waives the real-data
+  requirement: do not answer from a guess, stale value, or unverified result.
 - Clarify-first for ambiguous ad-hoc work: when the metric definition, date
   range, or grain is ambiguous and a wrong guess would change the numbers, use
   the `ask-question` clarifying tool (multiple-choice) before computing. Ask at

--- a/templates/analytics/actions/bigquery.spec.ts
+++ b/templates/analytics/actions/bigquery.spec.ts
@@ -69,7 +69,7 @@ describe("bigquery action error handling", () => {
     expect(result).toEqual([{ week: "2026-05-11", signups: 42 }]);
   });
 
-  it("forwards the agent run signal and preserves cancellation", async () => {
+  it("forwards the agent run signal and stops cleanly when the run is cancelled", async () => {
     const controller = new AbortController();
     const aborted = new DOMException("BigQuery query aborted", "AbortError");
     controller.abort();
@@ -80,7 +80,15 @@ describe("bigquery action error handling", () => {
         { sql: "SELECT 1" },
         { caller: "tool", signal: controller.signal },
       ),
-    ).rejects.toBe(aborted);
+    ).rejects.toSatisfy((err: unknown) => {
+      if (!isAgentActionStopError(err)) return false;
+      expect(err.errorCode).toBe("run_cancelled");
+      expect(err.message).toBe(
+        "The BigQuery query was cancelled because the agent run ended before it could finish.",
+      );
+      expect(err.toolResult).toContain('"recoverable": false');
+      return true;
+    });
 
     expect(runQuery).toHaveBeenCalledWith("SELECT 1", {
       signal: controller.signal,

--- a/templates/analytics/actions/bigquery.spec.ts
+++ b/templates/analytics/actions/bigquery.spec.ts
@@ -4,7 +4,8 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 const runQuery = vi.fn();
 
 vi.mock("../server/lib/bigquery", () => ({
-  runQuery: (sql: string) => runQuery(sql),
+  runQuery: (sql: string, options?: { signal?: AbortSignal }) =>
+    runQuery(sql, options),
 }));
 
 // Imported after the mock is registered so the action picks up the stub.
@@ -66,5 +67,23 @@ describe("bigquery action error handling", () => {
     const result = await bigquery.run({ sql: "SELECT 1" });
 
     expect(result).toEqual([{ week: "2026-05-11", signups: 42 }]);
+  });
+
+  it("forwards the agent run signal and preserves cancellation", async () => {
+    const controller = new AbortController();
+    const aborted = new DOMException("BigQuery query aborted", "AbortError");
+    controller.abort();
+    runQuery.mockRejectedValue(aborted);
+
+    await expect(
+      bigquery.run(
+        { sql: "SELECT 1" },
+        { caller: "tool", signal: controller.signal },
+      ),
+    ).rejects.toBe(aborted);
+
+    expect(runQuery).toHaveBeenCalledWith("SELECT 1", {
+      signal: controller.signal,
+    });
   });
 });

--- a/templates/analytics/actions/bigquery.ts
+++ b/templates/analytics/actions/bigquery.ts
@@ -1,4 +1,5 @@
 import { AgentActionStopError, defineAction } from "@agent-native/core";
+import type { ActionRunContext } from "@agent-native/core/action";
 import { z } from "zod";
 
 import { runQuery } from "../server/lib/bigquery";
@@ -57,10 +58,15 @@ export default defineAction({
   }),
   readOnly: true,
   toolCallable: true,
-  run: async (args) => {
+  run: async (args, context?: ActionRunContext) => {
     try {
-      return await runQuery(args.sql);
+      return await runQuery(args.sql, { signal: context?.signal });
     } catch (err) {
+      // A run cancellation is terminal for this invocation. Returning it as a
+      // recoverable SQL error would invite the agent to retry work after the
+      // parent run has already ended.
+      if (context?.signal?.aborted) throw err;
+
       const msg = err instanceof Error ? err.message : String(err);
       if (
         /GOOGLE_APPLICATION_CREDENTIALS_JSON not configured/i.test(msg) ||

--- a/templates/analytics/actions/bigquery.ts
+++ b/templates/analytics/actions/bigquery.ts
@@ -50,6 +50,23 @@ function stopForBigQueryNotConfigured(message: string): never {
   });
 }
 
+function stopForBigQueryCancellation(): never {
+  const message =
+    "The BigQuery query was cancelled because the agent run ended before it could finish.";
+  throw new AgentActionStopError(message, {
+    errorCode: "run_cancelled",
+    toolResult: JSON.stringify(
+      {
+        error: "run_cancelled",
+        message,
+        recoverable: false,
+      },
+      null,
+      2,
+    ),
+  });
+}
+
 export default defineAction({
   description:
     "Query the user-configured BigQuery data warehouse. Use this when the user asks for warehouse SQL, BigQuery, or a data-dictionary metric/table that lives in BigQuery. If the user names a provider action such as Jira or Pylon, use that provider action first and do not use BigQuery unless the user explicitly asks for a warehouse copy. Pass standard SQL via the `sql` arg. Do NOT use `db-query` for warehouse data (it only reaches the app's own SQL database). If a query fails with a schema or SQL error (unknown dataset/table/column, syntax), treat it as a normal debugging signal: inspect the real schema with `search-bigquery-schema` (or query INFORMATION_SCHEMA), correct the query based on the error, and run it again — a few corrective attempts are expected. Surface the error to the user only if it still fails after a few attempts or is non-recoverable (missing credentials, permission, quota). Never rerun identical failing SQL, and never substitute made-up numbers for data you could not query.",
@@ -64,8 +81,9 @@ export default defineAction({
     } catch (err) {
       // A run cancellation is terminal for this invocation. Returning it as a
       // recoverable SQL error would invite the agent to retry work after the
-      // parent run has already ended.
-      if (context?.signal?.aborted) throw err;
+      // parent run has already ended. Normalize the provider's AbortError so
+      // the generic tool-error path cannot record it as a warehouse failure.
+      if (context?.signal?.aborted) stopForBigQueryCancellation();
 
       const msg = err instanceof Error ? err.message : String(err);
       if (

--- a/templates/analytics/changelog/2026-07-10-analytics-answers-simple-time-bounded-metrics-without-unnece.md
+++ b/templates/analytics/changelog/2026-07-10-analytics-answers-simple-time-bounded-metrics-without-unnece.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-10
+---
+
+Analytics answers simple time-bounded metrics without unnecessary follow-up queries.

--- a/templates/analytics/server/lib/bigquery.spec.ts
+++ b/templates/analytics/server/lib/bigquery.spec.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const execute = vi.fn();
+const resolveCredential = vi.fn();
+const getAccessToken = vi.fn();
+
+vi.mock("@agent-native/core/db", () => ({
+  getDbExec: () => ({ execute }),
+}));
+
+vi.mock("./credentials", () => ({ resolveCredential }));
+
+vi.mock("./credentials-context", () => ({
+  requireRequestCredentialContext: () => ({
+    userEmail: "test@example.com",
+    orgId: null,
+  }),
+}));
+
+vi.mock("./gcloud", () => ({ getAccessToken }));
+
+const { runQuery } = await import("./bigquery");
+
+function jsonResponse(data: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => data,
+    text: async () => JSON.stringify(data),
+  } as Response;
+}
+
+describe("runQuery cancellation", () => {
+  beforeEach(() => {
+    execute.mockReset();
+    execute.mockResolvedValue({ rows: [] });
+    resolveCredential.mockReset();
+    resolveCredential.mockImplementation(async (key: string) =>
+      key === "BIGQUERY_PROJECT_ID" ? "test-project" : null,
+    );
+    getAccessToken.mockReset();
+    getAccessToken.mockResolvedValue("test-access-token");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("stops an incomplete job's poll wait immediately when the agent run aborts", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const fetchMock = vi.fn<typeof globalThis.fetch>().mockResolvedValue(
+      jsonResponse({
+        jobComplete: false,
+        jobReference: { jobId: "job-1" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = runQuery("SELECT 1", { signal: controller.signal });
+
+    // Advance only pending microtasks: the query request has completed and
+    // BigQuery polling is now waiting for its first one-second interval.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/projects/test-project/queries"),
+      expect.objectContaining({ signal: controller.signal }),
+    );
+
+    controller.abort();
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // Cancellation clears the pending interval, so no getQueryResults poll is
+    // issued after the agent run has ended.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards the signal to completed-job polling requests", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const fetchMock = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          jobComplete: false,
+          jobReference: { jobId: "job-1" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          jobComplete: true,
+          schema: { fields: [{ name: "signups", type: "INT64" }] },
+          rows: [{ f: [{ v: "42" }] }],
+          totalBytesProcessed: "12",
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = runQuery("SELECT 1", { signal: controller.signal });
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(result).resolves.toMatchObject({
+      rows: [{ signups: 42 }],
+      bytesProcessed: 12,
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      expect.stringContaining("/projects/test-project/queries/job-1"),
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+});

--- a/templates/analytics/server/lib/bigquery.ts
+++ b/templates/analytics/server/lib/bigquery.ts
@@ -241,6 +241,15 @@ export interface QueryResult {
   cached?: boolean;
 }
 
+export interface RunQueryOptions {
+  /**
+   * The current agent run's abort signal. This cancels in-flight BigQuery
+   * requests and, importantly, stops the one-second job polling wait without
+   * starting another request after the parent run has ended.
+   */
+  signal?: AbortSignal;
+}
+
 interface BigQueryField {
   name: string;
   type: string;
@@ -263,6 +272,35 @@ interface BigQueryGetQueryResultsResponse {
   totalRows?: string;
   jobComplete?: boolean;
   totalBytesProcessed?: string;
+}
+
+function createAbortError(): Error {
+  if (typeof DOMException !== "undefined") {
+    return new DOMException("BigQuery query aborted", "AbortError");
+  }
+  const error = new Error("BigQuery query aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw createAbortError();
+}
+
+function waitForPollInterval(signal?: AbortSignal): Promise<void> {
+  throwIfAborted(signal);
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, 1000);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", onAbort);
+      reject(createAbortError());
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 /**
@@ -361,7 +399,12 @@ export async function dryRunQuery(sql: string): Promise<string | null> {
   return `BigQuery validation failed (${res.status})`;
 }
 
-export async function runQuery(sql: string): Promise<QueryResult> {
+export async function runQuery(
+  sql: string,
+  options: RunQueryOptions = {},
+): Promise<QueryResult> {
+  const { signal } = options;
+  throwIfAborted(signal);
   const { projectId, cacheScope, appEventsTable } = await getProjectInfo();
   const resolvedSql = await resolveTablePlaceholder(
     sql,
@@ -383,8 +426,10 @@ export async function runQuery(sql: string): Promise<QueryResult> {
   const token = await getAccessToken();
   const url = `https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/queries`;
 
+  throwIfAborted(signal);
   const res = await fetch(url, {
     method: "POST",
+    ...(signal ? { signal } : {}),
     headers: {
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
@@ -410,8 +455,10 @@ export async function runQuery(sql: string): Promise<QueryResult> {
 
     let attempts = 0;
     while (!data.jobComplete && attempts < 60) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await waitForPollInterval(signal);
+      throwIfAborted(signal);
       const pollRes = await fetch(resultsUrl, {
+        ...(signal ? { signal } : {}),
         headers: {
           Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",

--- a/templates/analytics/server/plugins/agent-chat.spec.ts
+++ b/templates/analytics/server/plugins/agent-chat.spec.ts
@@ -1,11 +1,17 @@
 import type { ActionEntry } from "@agent-native/core/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../.generated/actions-registry.js", () => ({ default: {} }));
 
 import {
   applyAnalyticsPlanModePolicy,
   PLAN_MODE_ACT_ONLY_TOOLS,
   INITIAL_TOOL_NAMES,
 } from "../lib/agent-chat-plan-mode";
+import {
+  analyticsSourceGuidanceOpening,
+  SIMPLE_TIME_BOUNDED_METRIC_FAST_PATH_GUIDANCE,
+} from "./agent-chat";
 
 type PlanModePolicyEntry = ActionEntry & { allowInPlanMode?: boolean };
 
@@ -21,6 +27,16 @@ function action(readOnly = true): ActionEntry {
 }
 
 describe("Analytics agent Plan mode policy", () => {
+  it("injects the simple, time-bounded metric fast path into source guidance", () => {
+    const guidance = analyticsSourceGuidanceOpening();
+
+    expect(guidance).toContain("<data-source-guidance>");
+    expect(guidance).toContain(SIMPLE_TIME_BOUNDED_METRIC_FAST_PATH_GUIDANCE);
+    expect(guidance).toContain("run one bounded aggregate");
+    expect(guidance).toContain("Once it returns a valid result");
+    expect(guidance).toContain("does not waive the real-data requirement");
+  });
+
   it("marks substantive data-analysis tools as Act-only without changing lightweight planning tools", () => {
     const actions = applyAnalyticsPlanModePolicy({
       "data-source-status": action(),

--- a/templates/analytics/server/plugins/agent-chat.ts
+++ b/templates/analytics/server/plugins/agent-chat.ts
@@ -34,6 +34,18 @@ import {
 const DATA_DICT_PREFIX = "data-dict-";
 const ANALYTICS_BACKGROUND_RUN_SOFT_TIMEOUT_MS = 13 * 60_000;
 
+export const SIMPLE_TIME_BOUNDED_METRIC_FAST_PATH_GUIDANCE =
+  "SIMPLE TIME-BOUNDED METRIC FAST PATH — When the data dictionary or a known canonical source identifies the metric, run one bounded aggregate. Once it returns a valid result, answer the explicit question immediately with the source, time window, row count, and only necessary caveats. Do not schema-discover, retry, enrich, cross-check, or add breakdowns after that successful result unless the query failed or the result conflicts with the known metric definition. This does not waive the real-data requirement: never answer from a guess, stale value, or unverified result. ";
+
+export function analyticsSourceGuidanceOpening(): string {
+  return (
+    "<data-source-guidance>\n" +
+    "Apply real-data requirements only when presenting analytics results, source records, or derived metrics. Do not call data-source tools for workflow migration, recurring-job setup, UI/code fixes, settings help, conceptual planning, or other non-data tasks unless the user explicitly asks for data. " +
+    SIMPLE_TIME_BOUNDED_METRIC_FAST_PATH_GUIDANCE +
+    "SURFACE DIFFERENTIATION — You are the analytics assistant for definitions, deep-dive analysis, and action. For questions about what a metric, model, or table means, use the Data Dictionary and configured schema tools first. For trends, comparisons, anomalies, current data, or anything that requires querying live data, answer directly in chat with the relevant provider query, dashboard analysis, and inline charts when useful. "
+  );
+}
+
 export {
   applyAnalyticsPlanModePolicy,
   INITIAL_TOOL_NAMES,
@@ -159,9 +171,7 @@ export default createAgentChatPlugin({
     // The generic template can ship provider actions without every deployment
     // having credentials or workspace-specific schemas configured.
     const sourceGuidance =
-      "<data-source-guidance>\n" +
-      "Apply real-data requirements only when presenting analytics results, source records, or derived metrics. Do not call data-source tools for workflow migration, recurring-job setup, UI/code fixes, settings help, conceptual planning, or other non-data tasks unless the user explicitly asks for data. " +
-      "SURFACE DIFFERENTIATION — You are the analytics assistant for definitions, deep-dive analysis, and action. For questions about what a metric, model, or table means, use the Data Dictionary and configured schema tools first. For trends, comparisons, anomalies, current data, or anything that requires querying live data, answer directly in chat with the relevant provider query, dashboard analysis, and inline charts when useful. " +
+      analyticsSourceGuidanceOpening() +
       "DASHBOARD CREATION RULE — You may create dashboards, analyses, SQL panels, or other resources only when the user explicitly asks you to (e.g. 'build me a dashboard for...', 'create a new analysis', 'add a chart for...'). Never create any resource proactively during research, trend analysis, or answering questions. If you think a dashboard would be useful, suggest it and wait for explicit confirmation before creating anything. Never add new items to the sidebar or modify existing dashboards without an explicit user directive. " +
       "DASHBOARD MUTATION RULE — For dashboard edits, default to `mutate-dashboard` with the typed `dashboard.*` script API so the main payload is a string and avoids native-array serialization traps. It can move panels by id, edit titles/SQL/config, insert, duplicate, remove, and patch dashboard fields in one atomic save. The script API is constrained: no variables/imports/loops/functions, only JSON-compatible arguments on documented dashboard methods. Do not count shifting `/panels/<index>` positions for ordinary dashboard edits unless the user specifically asks for low-level JSON-pointer operations. " +
       "DASHBOARD READ RULE — `get-sql-dashboard` is compact by default: use its `panels` summaries plus `layout.panelOrder`, `layout.firstPanelIds`, and `layout.groups[].rows[].rowNumber/panelIds` for orientation and verification. Pass `includeConfig: true` only when you truly need full panel SQL/config. " +


### PR DESCRIPTION
## Summary
- preserve A2A timeout task IDs so Slack continues durable downstream work instead of replying with an interim artifact
- add Slack-native intent, delegation, live elapsed progress, and safe error diagnostics with lookup IDs
- reduce Analytics A2A to its focused initial tools, finish simple bounded metrics after a valid aggregate, and cancel BigQuery polling when the run stops

## Root cause
A production Slack request at 2026-07-10 19:02 PDT reached Analytics, completed two valid one-row signup aggregates, then continued with additional BigQuery work. A 60-second polling loop ignored the agent abort signal and the remote run exhausted six continuation attempts.

## Validation
- Core: 114 focused tests
- Analytics: 11 focused tests
- Core and Analytics typechecks
- oxfmt and git diff checks
- changeset validation