### PR TITLE
fix(mobile-app): migrate safe area handling to react-native-safe-area…

### DIFF
--- a/packages/mobile-app/app/(tabs)/analytics.tsx
+++ b/packages/mobile-app/app/(tabs)/analytics.tsx
@@ -2,7 +2,6 @@ import { TEMPLATE_APPS } from "@agent-native/shared-app-config";
 import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-
 import AppWebView from "@/components/AppWebView";
 import { getAppUrl } from "@/lib/get-app-url";
 

--- a/packages/mobile-app/app/(tabs)/analytics.tsx
+++ b/packages/mobile-app/app/(tabs)/analytics.tsx
@@ -1,5 +1,7 @@
 import { TEMPLATE_APPS } from "@agent-native/shared-app-config";
-import { SafeAreaView, StyleSheet } from "react-native";
+import { StyleSheet } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
 
 import AppWebView from "@/components/AppWebView";
 import { getAppUrl } from "@/lib/get-app-url";

--- a/packages/mobile-app/app/(tabs)/brain.tsx
+++ b/packages/mobile-app/app/(tabs)/brain.tsx
@@ -2,7 +2,6 @@ import { TEMPLATE_APPS } from "@agent-native/shared-app-config";
 import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-
 import AppWebView from "@/components/AppWebView";
 import { getAppUrl } from "@/lib/get-app-url";
 

--- a/packages/mobile-app/app/(tabs)/brain.tsx
+++ b/packages/mobile-app/app/(tabs)/brain.tsx
@@ -1,5 +1,7 @@
 import { TEMPLATE_APPS } from "@agent-native/shared-app-config";
-import { SafeAreaView, StyleSheet } from "react-native";
+import { StyleSheet } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
 
 import AppWebView from "@/components/AppWebView";
 import { getAppUrl } from "@/lib/get-app-url";

--- a/packages/mobile-app/app/(tabs)/calendar.tsx
+++ b/packages/mobile-app/app/(tabs)/calendar.tsx
@@ -2,7 +2,6 @@ import { TEMPLATE_APPS } from "@agent-native/shared-app-config";
 import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-
 import AppWebView from "@/components/AppWebView";
 import { getAppUrl } from "@/lib/get-app-url";
 

--- a/packages/mobile-app/app/(tabs)/calendar.tsx
+++ b/packages/mobile-app/app/(tabs)/calendar.tsx
@@ -1,5 +1,7 @@
 import { TEMPLATE_APPS } from "@agent-native/shared-app-config";
-import { SafeAreaView, StyleSheet } from "react-native";
+import { StyleSheet } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
 
 import AppWebView from "@/components/AppWebView";
 import { getAppUrl } from "@/lib/get-app-url";

--- a/packages/mobile-app/app/(tabs)/chat.tsx
+++ b/packages/mobile-app/app/(tabs)/chat.tsx
@@ -2,7 +2,6 @@ import { TEMPLATE_APPS } from "@agent-native/shared-app-config";
 import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-
 import AppWebView from "@/components/AppWebView";
 import { getAppUrl } from "@/lib/get-app-url";
 

--- a/packages/mobile-app/app/(tabs)/chat.tsx
+++ b/packages/mobile-app/app/(tabs)/chat.tsx
@@ -1,5 +1,7 @@
 import { TEMPLATE_APPS } from "@agent-native/shared-app-config";
-import { SafeAreaView, StyleSheet } from "react-native";
+import { StyleSheet } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
 
 import AppWebView from "@/components/AppWebView";
 import { getAppUrl } from "@/lib/get-app-url";

--- a/packages/mobile-app/app/(tabs)/clips.tsx
+++ b/packages/mobile-app/app/(tabs)/clips.tsx
@@ -2,7 +2,6 @@ import { TEMPLATE_APPS } from "@agent-native/shared-app-config";
 import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-
 import AppWebView from "@/components/AppWebView";
 import { getAppUrl } from "@/lib/get-app-url";
 

--- a/packages/mobile-app/app/(tabs)/clips.tsx
+++ b/packages/mobile-app/app/(tabs)/clips.tsx
@@ -1,5 +1,7 @@
 import { TEMPLATE_APPS } from "@agent-native/shared-app-config";
-import { SafeAreaView, StyleSheet } from "react-native";
+import { StyleSheet } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
 
 import AppWebView from "@/components/AppWebView";
 import { getAppUrl } from "@/lib/get-app-url";

--- a/packages/mobile-app/app/(tabs)/content.tsx
+++ b/packages/mobile-app/app/(tabs)/content.tsx
@@ -2,7 +2,6 @@ import { TEMPLATE_APPS } from "@agent-native/shared-app-config";
 import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-
 import AppWebView from "@/components/AppWebView";
 import { getAppUrl } from "@/lib/get-app-url";
 

--- a/packages/mobile-app/app/(tabs)/content.tsx
+++ b/packages/mobile-app/app/(tabs)/content.tsx
@@ -1,5 +1,7 @@
 import { TEMPLATE_APPS } from "@agent-native/shared-app-config";
-import { SafeAreaView, StyleSheet } from "react-native";
+import { StyleSheet } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
 
 import AppWebView from "@/components/AppWebView";
 import { getAppUrl } from "@/lib/get-app-url";

--- a/packages/mobile-app/app/(tabs)/design.tsx
+++ b/packages/mobile-app/app/(tabs)/design.tsx
@@ -2,7 +2,6 @@ import { TEMPLATE_APPS } from "@agent-native/shared-app-config";
 import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-
 import AppWebView from "@/components/AppWebView";
 import { getAppUrl } from "@/lib/get-app-url";
 

--- a/packages/mobile-app/app/(tabs)/design.tsx
+++ b/packages/mobile-app/app/(tabs)/design.tsx
@@ -1,5 +1,7 @@
 import { TEMPLATE_APPS } from "@agent-native/shared-app-config";
-import { SafeAreaView, StyleSheet } from "react-native";
+import { StyleSheet } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
 
 import AppWebView from "@/components/AppWebView";
 import { getAppUrl } from "@/lib/get-app-url";

--- a/packages/mobile-app/app/(tabs)/dispatch.tsx
+++ b/packages/mobile-app/app/(tabs)/dispatch.tsx
@@ -2,7 +2,6 @@ import { TEMPLATE_APPS } from "@agent-native/shared-app-config";
 import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-
 import AppWebView from "@/components/AppWebView";
 import { getAppUrl } from "@/lib/get-app-url";
 

--- a/packages/mobile-app/app/(tabs)/dispatch.tsx
+++ b/packages/mobile-app/app/(tabs)/dispatch.tsx
@@ -1,5 +1,7 @@
 import { TEMPLATE_APPS } from "@agent-native/shared-app-config";
-import { SafeAreaView, StyleSheet } from "react-native";
+import { StyleSheet } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
 
 import AppWebView from "@/components/AppWebView";
 import { getAppUrl } from "@/lib/get-app-url";

--- a/packages/mobile-app/app/(tabs)/forms.tsx
+++ b/packages/mobile-app/app/(tabs)/forms.tsx
@@ -2,7 +2,6 @@ import { TEMPLATE_APPS } from "@agent-native/shared-app-config";
 import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-
 import AppWebView from "@/components/AppWebView";
 import { getAppUrl } from "@/lib/get-app-url";
 

--- a/packages/mobile-app/app/(tabs)/forms.tsx
+++ b/packages/mobile-app/app/(tabs)/forms.tsx
@@ -1,5 +1,7 @@
 import { TEMPLATE_APPS } from "@agent-native/shared-app-config";
-import { SafeAreaView, StyleSheet } from "react-native";
+import { StyleSheet } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
 
 import AppWebView from "@/components/AppWebView";
 import { getAppUrl } from "@/lib/get-app-url";

--- a/packages/mobile-app/app/(tabs)/index.tsx
+++ b/packages/mobile-app/app/(tabs)/index.tsx
@@ -2,7 +2,6 @@ import { TEMPLATE_APPS } from "@agent-native/shared-app-config";
 import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-
 import AppWebView from "@/components/AppWebView";
 import { getAppUrl } from "@/lib/get-app-url";
 

--- a/packages/mobile-app/app/(tabs)/index.tsx
+++ b/packages/mobile-app/app/(tabs)/index.tsx
@@ -1,5 +1,7 @@
 import { TEMPLATE_APPS } from "@agent-native/shared-app-config";
-import { SafeAreaView, StyleSheet } from "react-native";
+import { StyleSheet } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
 
 import AppWebView from "@/components/AppWebView";
 import { getAppUrl } from "@/lib/get-app-url";

--- a/packages/mobile-app/app/(tabs)/sessions.tsx
+++ b/packages/mobile-app/app/(tabs)/sessions.tsx
@@ -6,7 +6,6 @@ import {
   KeyboardAvoidingView,
   Platform,
   RefreshControl,
-  SafeAreaView,
   ScrollView,
   StyleSheet,
   Text,
@@ -14,6 +13,7 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 import {
   appendRemoteFollowUp,
@@ -21,10 +21,10 @@ import {
   createRemoteRun,
   decidePendingCommand,
   getPendingCommand,
-  getRemoteRunDetail,
   getRemoteRelayBaseUrl,
-  isRemoteRunActive,
+  getRemoteRunDetail,
   isRemoteAuthError,
+  isRemoteRunActive,
   listPairedHosts,
   listRemoteRuns,
   readRemoteTranscript,

--- a/packages/mobile-app/app/(tabs)/slides.tsx
+++ b/packages/mobile-app/app/(tabs)/slides.tsx
@@ -2,7 +2,6 @@ import { TEMPLATE_APPS } from "@agent-native/shared-app-config";
 import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-
 import AppWebView from "@/components/AppWebView";
 import { getAppUrl } from "@/lib/get-app-url";
 

--- a/packages/mobile-app/app/(tabs)/slides.tsx
+++ b/packages/mobile-app/app/(tabs)/slides.tsx
@@ -1,5 +1,7 @@
 import { TEMPLATE_APPS } from "@agent-native/shared-app-config";
-import { SafeAreaView, StyleSheet } from "react-native";
+import { StyleSheet } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
 
 import AppWebView from "@/components/AppWebView";
 import { getAppUrl } from "@/lib/get-app-url";

--- a/packages/mobile-app/app/_layout.tsx
+++ b/packages/mobile-app/app/_layout.tsx
@@ -27,4 +27,3 @@ export default function RootLayout() {
     </SafeAreaProvider>
   );
 }
-

--- a/packages/mobile-app/app/_layout.tsx
+++ b/packages/mobile-app/app/_layout.tsx
@@ -1,9 +1,10 @@
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
+import { SafeAreaProvider } from "react-native-safe-area-context";
 
 export default function RootLayout() {
   return (
-    <>
+    <SafeAreaProvider>
       <StatusBar style="light" />
       <Stack
         screenOptions={{
@@ -23,6 +24,7 @@ export default function RootLayout() {
         />
         <Stack.Screen name="oauth-complete" options={{ headerShown: false }} />
       </Stack>
-    </>
+    </SafeAreaProvider>
   );
 }
+

--- a/packages/mobile-app/components/AppForm.tsx
+++ b/packages/mobile-app/components/AppForm.tsx
@@ -3,15 +3,16 @@ import { generateAppId } from "@agent-native/shared-app-config";
 import { Feather } from "@expo/vector-icons";
 import { useState } from "react";
 import {
-  View,
+  Alert,
+  Modal,
+  ScrollView,
+  StyleSheet,
   Text,
   TextInput,
   TouchableOpacity,
-  ScrollView,
-  StyleSheet,
-  Alert,
-  Modal,
+  View,
 } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 const ICON_PRESETS: { name: string; icon: keyof typeof Feather.glyphMap }[] = [
   { name: "Globe", icon: "globe" },
@@ -88,8 +89,13 @@ export default function AppForm({
       visible={visible}
       animationType="slide"
       presentationStyle="pageSheet"
+      statusBarTranslucent={true}
+      navigationBarTranslucent={true}
+      onRequestClose={()=>{
+        onClose()
+      }}
     >
-      <View style={styles.container}>
+      <SafeAreaView style={styles.container}>
         <View style={styles.header}>
           <TouchableOpacity onPress={onClose}>
             <Text style={styles.cancelText}>Cancel</Text>
@@ -149,7 +155,7 @@ export default function AppForm({
 
           <View style={{ height: 40 }} />
         </ScrollView>
-      </View>
+      </SafeAreaView>
     </Modal>
   );
 }

--- a/packages/mobile-app/components/AppForm.tsx
+++ b/packages/mobile-app/components/AppForm.tsx
@@ -91,8 +91,8 @@ export default function AppForm({
       presentationStyle="pageSheet"
       statusBarTranslucent={true}
       navigationBarTranslucent={true}
-      onRequestClose={()=>{
-        onClose()
+      onRequestClose={() => {
+        onClose();
       }}
     >
       <SafeAreaView style={styles.container}>


### PR DESCRIPTION
## Safe Area & Modal Improvements

### Root Configuration

* Wrapped the root stack with `SafeAreaProvider` in `app/_layout.tsx` to provide safe area context across the application.

### Tab Screens

* Migrated all 11 tab screens (Calendar, Content, Clips, Chat, etc.) to use `SafeAreaView` from `react-native-safe-area-context` so content correctly respects device notches, status bars, and other safe area insets.

### App Forms

* Wrapped the custom add/edit app form modal in `SafeAreaView` within `components/AppForm.tsx`.
* Enabled `statusBarTranslucent={true}` so the modal can render beneath the Android status bar.
* Enabled `navigationBarTranslucent={true}` so the modal extends beneath the Android navigation bar (requires `statusBarTranslucent` to be enabled).
* Added `onRequestClose={() => onClose()}` to support Android hardware back button behavior while the modal is open, ensuring the modal closes correctly.

## Before
<img width="1080" height="893" alt="1" src="https://github.com/user-attachments/assets/40123c42-6c6a-4ca0-a1a0-f650a3703770" />
<img width="1080" height="903" alt="2" src="https://github.com/user-attachments/assets/4b99648c-6cb6-4b58-b769-b29b126060bc" />

## After
<img width="1080" height="1261" alt="4" src="https://github.com/user-attachments/assets/fd250a9d-93c3-41d3-9002-84798bfad2cf" />
<img width="1080" height="1261" alt="4" src="https://github.com/user-attachments/assets/285db0e4-726c-493c-acd8-f549ad97149e" />

