### PR TITLE
Fix Clips mobile playback readiness

### DIFF
--- a/templates/clips/app/components/player/video-player.test.tsx
+++ b/templates/clips/app/components/player/video-player.test.tsx
@@ -131,6 +131,26 @@ describe("VideoPlayer playback", () => {
     expect(onPause).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps the center play control actionable before media readiness events fire", () => {
+    const video = getVideo();
+    const centerPlay = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="videoPlayer.playClip"]',
+    );
+
+    // Mobile Safari can remain at HAVE_NOTHING until playback is initiated,
+    // so loadeddata/canplay may not arrive before the user needs this control.
+    expect(video.readyState).toBe(0);
+    expect(container.textContent).not.toContain("Preparing clip");
+    expect(centerPlay).not.toBeNull();
+
+    act(() => {
+      centerPlay?.click();
+    });
+
+    expect(video.paused).toBe(false);
+    expect(onPlay).toHaveBeenCalledTimes(1);
+  });
+
   it("suppresses the synthetic click that follows a touch tap instead of double-toggling playback", () => {
     const surface = getPlayerSurface();
     const video = getVideo();

--- a/templates/clips/app/components/player/video-player.tsx
+++ b/templates/clips/app/components/player/video-player.tsx
@@ -1083,13 +1083,17 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
     const fullscreenMenuContainer = isFullscreen ? containerRef.current : null;
 
     const showThroughoutCta = cta && cta.placement === "throughout";
+    // Mobile Safari may defer loadeddata/canplay until playback starts. Keep
+    // the paused state actionable even when those readiness events have not
+    // fired yet; once the user asks to play, the pending/buffering states give
+    // them accurate loading feedback.
     const centerOverlayMode =
       activeVideoSrc &&
       !isLoomEmbed &&
       !unsupportedFormat &&
       !showEndCta &&
       (!isPlaying || isPlayPending || isBuffering)
-        ? isPreparing || isPlayPending || isBuffering || !canPlay
+        ? isPlayPending || isBuffering
           ? "loading"
           : "ready"
         : null;

--- a/templates/clips/changelog/2026-07-11-clips-no-longer-stay-stuck-on-preparing-clip-when-they-are-r.md
+++ b/templates/clips/changelog/2026-07-11-clips-no-longer-stay-stuck-on-preparing-clip-when-they-are-r.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-11
+---
+
+Clips no longer stay stuck on Preparing clip when they are ready to play on mobile.


### PR DESCRIPTION
## Summary
- keep the center play control actionable before mobile Safari emits media readiness events
- show loading only after a playback attempt or while actively buffering
- add regression coverage for the pre-readiness mobile state
- record the user-visible fix in the Clips changelog

## Validation
- `corepack pnpm --filter clips exec vitest --run app/components/player/video-player.test.tsx --config vitest.config.ts`
- `corepack pnpm --filter clips typecheck`
- `git diff --check`