### PR TITLE
Fix dashboard report capture and Content sidebar scrolling

### DIFF
--- a/templates/analytics/changelog/2026-07-12-daily-dashboard-emails-reliably-include-the-complete-dashboa.md
+++ b/templates/analytics/changelog/2026-07-12-daily-dashboard-emails-reliably-include-the-complete-dashboa.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-12
+---
+
+Daily dashboard emails reliably include the complete dashboard image.

--- a/templates/analytics/server/jobs/dashboard-report.spec.ts
+++ b/templates/analytics/server/jobs/dashboard-report.spec.ts
@@ -57,7 +57,7 @@ describe("dashboard report sweep", () => {
     mocks.sendDashboardReportSubscription.mockReset();
   });
 
-  it("marks a report sent without a screenshot as successful delivery", async () => {
+  it("marks a screenshotless delivery successful while preserving its diagnostic", async () => {
     const sub = subscription();
     mocks.claimDueDashboardReportSubscriptions.mockResolvedValue([sub]);
     mocks.sendDashboardReportSubscription.mockResolvedValue({
@@ -79,6 +79,7 @@ describe("dashboard report sweep", () => {
     expect(mocks.markDashboardReportResult).toHaveBeenCalledWith(
       sub,
       "success",
+      "Dashboard screenshot unavailable: dashboard render timed out",
     );
   });
 

--- a/templates/analytics/server/jobs/dashboard-report.ts
+++ b/templates/analytics/server/jobs/dashboard-report.ts
@@ -56,6 +56,8 @@ export async function runDashboardReportsOnce(): Promise<{
             `[dashboard-report] Subscription ${sub.id} sent without a screenshot:`,
             message,
           );
+          await markDashboardReportResult(sub, "success", message);
+          continue;
         }
         await markDashboardReportResult(sub, "success");
       } catch (err: any) {

--- a/templates/analytics/server/lib/dashboard-report.spec.ts
+++ b/templates/analytics/server/lib/dashboard-report.spec.ts
@@ -173,7 +173,7 @@ describe("dashboard report email", () => {
     expect(emailArgs.text).toContain("reportSettings=1");
   });
 
-  it("fits tall dashboard captures beyond the old viewport cap", async () => {
+  it("captures tall dashboards without expanding the Chromium render surface", async () => {
     const tall = createBrowser({ captureBox: { width: 960, height: 8200 } });
     mocks.launch.mockResolvedValueOnce(tall.browser);
 
@@ -184,13 +184,25 @@ describe("dashboard report email", () => {
       screenshotAttached: true,
       screenshotMode: "full",
     });
-    expect(tall.page.setViewportSize).toHaveBeenCalledWith({
-      width: 1440,
-      height: 8264,
+    expect(tall.page.setViewportSize).not.toHaveBeenCalled();
+    expect(tall.locator.screenshot).toHaveBeenCalledWith({
+      type: "png",
+      animations: "disabled",
     });
-    expect(tall.page.setViewportSize).not.toHaveBeenCalledWith(
-      expect.objectContaining({ height: 7000 }),
-    );
+  });
+
+  it("only expands wide captures while preserving the bounded viewport height", async () => {
+    const wide = createBrowser({ captureBox: { width: 1600, height: 8200 } });
+    mocks.launch.mockResolvedValueOnce(wide.browser);
+
+    await sendDashboardReportSubscription(subscription());
+
+    expect(wide.page.setViewportSize).toHaveBeenCalledOnce();
+    expect(wide.page.setViewportSize).toHaveBeenCalledWith({
+      width: 1664,
+      height: 1800,
+    });
+    expect(wide.locator.screenshot).toHaveBeenCalledOnce();
   });
 
   it("still sends the report email without a screenshot when browser capture fails", async () => {
@@ -212,6 +224,21 @@ describe("dashboard report email", () => {
         html: expect.stringContaining("dashboard image was unavailable"),
         text: expect.stringContaining("Dashboard image unavailable"),
       }),
+    );
+  });
+
+  it("allows enough time for full serverless dashboards to become ready", async () => {
+    vi.stubEnv("NETLIFY", "true");
+    const serverless = createBrowser();
+    mocks.launch.mockResolvedValueOnce(serverless.browser);
+
+    await sendDashboardReportSubscription(subscription());
+
+    expect(serverless.page.setDefaultTimeout).toHaveBeenCalledWith(90_000);
+    expect(serverless.page.waitForFunction).toHaveBeenCalledWith(
+      expect.any(String),
+      undefined,
+      { timeout: 90_000 },
     );
   });
 

--- a/templates/analytics/server/lib/dashboard-report.ts
+++ b/templates/analytics/server/lib/dashboard-report.ts
@@ -42,9 +42,8 @@ const DASHBOARD_REPORT_SCREENSHOT_PARAM = "reportScreenshot";
 const DASHBOARD_REPORT_SETTINGS_PARAM = "reportSettings";
 const DASHBOARD_REPORT_CID = "dashboard-report-snapshot";
 const LOCAL_SCREENSHOT_TIMEOUT_MS = 90_000;
-const SERVERLESS_SCREENSHOT_TIMEOUT_MS = 60_000;
-const SERVERLESS_SECOND_READY_TIMEOUT_MS = 30_000;
-const MAX_SCREENSHOT_VIEWPORT_HEIGHT = 30_000;
+const SERVERLESS_SCREENSHOT_TIMEOUT_MS = 90_000;
+const SERVERLESS_SECOND_READY_TIMEOUT_MS = 45_000;
 const SCREENSHOT_VIEWPORT_PADDING = 64;
 
 type DashboardScreenshotAttempt = {
@@ -328,42 +327,27 @@ async function scrollDashboardForLazyRendering(page: any): Promise<void> {
   })()`);
 }
 
-async function fitViewportToDashboardCapture(
+async function fitViewportWidthToDashboardCapture(
   page: any,
   capture: any,
-  minViewport: { width: number; height: number },
+  viewport: { width: number; height: number },
 ): Promise<void> {
   const box = await capture.boundingBox();
   if (!box) return;
 
-  const size = {
-    width: Math.max(
-      minViewport.width,
-      Math.min(1800, Math.ceil(box.width + SCREENSHOT_VIEWPORT_PADDING)),
-    ),
-    height: Math.max(
-      minViewport.height,
-      Math.min(
-        MAX_SCREENSHOT_VIEWPORT_HEIGHT,
-        Math.ceil(box.height + SCREENSHOT_VIEWPORT_PADDING),
-      ),
-    ),
-  };
-  await page.setViewportSize(size);
-  await page.waitForTimeout(250);
-
-  const resizedBox = await capture.boundingBox();
-  if (!resizedBox) return;
-  const resizedHeight = Math.ceil(
-    resizedBox.height + SCREENSHOT_VIEWPORT_PADDING,
+  const width = Math.max(
+    viewport.width,
+    Math.min(1800, Math.ceil(box.width + SCREENSHOT_VIEWPORT_PADDING)),
   );
-  if (resizedHeight > size.height) {
-    await page.setViewportSize({
-      width: size.width,
-      height: Math.min(MAX_SCREENSHOT_VIEWPORT_HEIGHT, resizedHeight),
-    });
-    await page.waitForTimeout(250);
-  }
+  if (width === viewport.width) return;
+
+  // Keep the render surface bounded. Playwright's locator screenshot captures
+  // the full element beyond the viewport, while growing Chromium to the full
+  // dashboard height can exhaust memory and close the browser on serverless
+  // workers. Width-only fitting preserves the full dashboard without that
+  // oversized render surface.
+  await page.setViewportSize({ width, height: viewport.height });
+  await page.waitForTimeout(250);
 }
 
 async function captureDashboardPng(
@@ -412,7 +396,7 @@ async function captureDashboardPng(
     await scrollDashboardForLazyRendering(page);
     await waitForDashboardReportReady(page, secondReadyTimeoutMs());
 
-    await fitViewportToDashboardCapture(page, capture, attempt.viewport);
+    await fitViewportWidthToDashboardCapture(page, capture, attempt.viewport);
     await capture.scrollIntoViewIfNeeded();
     const image = await capture.screenshot({
       type: "png",

--- a/templates/content/app/components/sidebar/DocumentSidebar.layout.test.ts
+++ b/templates/content/app/components/sidebar/DocumentSidebar.layout.test.ts
@@ -20,17 +20,19 @@ function treeNode(
 }
 
 describe("document sidebar layout", () => {
-  it("keeps deeply nested page rows reachable in the sidebar", () => {
+  it("keeps deeply nested page rows within the sidebar viewport", () => {
     const layout = readSidebarSource("../layout/Layout.tsx");
     const sidebar = readSidebarSource("./DocumentSidebar.tsx");
     const treeItem = readSidebarSource("./DocumentTreeItem.tsx");
-    const scrollArea = readSidebarSource("../ui/scroll-area.tsx");
 
     expect(layout).toContain("const MIN_SIDEBAR_WIDTH = 240");
-    expect(sidebar).toContain('className="min-w-full w-max py-2 pe-2"');
+    expect(sidebar).toContain(
+      "[&_[data-radix-scroll-area-viewport]]:!overflow-x-hidden",
+    );
+    expect(sidebar).toContain('className="w-full min-w-0 py-2 pe-2"');
+    expect(sidebar).not.toContain("w-max");
     expect(treeItem).toContain("const indent = depth * 12 + 12");
     expect(treeItem).toContain("min-w-0");
-    expect(scrollArea).toContain('<ScrollBar orientation="horizontal" />');
   });
 
   it("keeps row actions inside the visible sidebar at narrow widths", () => {

--- a/templates/content/app/components/sidebar/DocumentSidebar.tsx
+++ b/templates/content/app/components/sidebar/DocumentSidebar.tsx
@@ -1188,8 +1188,8 @@ export function DocumentSidebar({
         </div>
       )}
 
-      <ScrollArea className="min-h-0 flex-1">
-        <div className="min-w-full w-max py-2 pe-2">
+      <ScrollArea className="min-h-0 flex-1 [&_[data-radix-scroll-area-viewport]]:!overflow-x-hidden">
+        <div className="w-full min-w-0 py-2 pe-2">
           {/* Search results */}
           {filteredDocuments ? (
             <>

--- a/templates/content/changelog/2026-07-12-the-left-sidebar-stays-fixed-horizontally-while-scrolling-on.md
+++ b/templates/content/changelog/2026-07-12-the-left-sidebar-stays-fixed-horizontally-while-scrolling-on.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-12
+---
+
+The left sidebar stays fixed horizontally while scrolling on desktop and mobile.


### PR DESCRIPTION
## Summary
- keep Analytics dashboard report screenshots on a bounded Chromium viewport while preserving full-element capture
- increase serverless dashboard readiness headroom and retain diagnostics for screenshotless deliveries
- keep the Content document sidebar fixed horizontally while scrolling
- add user-facing changelog entries for both fixes

## Validation
- `corepack pnpm --dir templates/analytics exec vitest --run server/lib/dashboard-report.spec.ts server/jobs/dashboard-report.spec.ts`
- `corepack pnpm --dir templates/analytics typecheck`
- `corepack pnpm --dir templates/content exec vitest --run app/components/sidebar/DocumentSidebar.layout.test.ts`
- `corepack pnpm --dir templates/content run typecheck`
- `git diff --check`

## Build note
- Analytics client/server compilation completed; local Nitro packaging then encountered a pre-existing missing Electron framework trace path (`ReactiveObjC.framework/Versions/A`). GitHub Actions is the clean Linux packaging gate.