### PR TITLE
Fix views continue

### DIFF
--- a/templates/analytics/app/i18n-data.ts
+++ b/templates/analytics/app/i18n-data.ts
@@ -668,6 +668,9 @@ const enUS = {
     reportSubscriptionDeleteFailed: "Couldn't delete subscription: {{message}}",
     reportSendFailed: "Couldn't send report: {{message}}",
     never: "Never",
+    savedFiltersTo: 'Saved filters to "{{name}}"',
+    saveCurrentFiltersTo: 'Save current filters to "{{name}}"',
+    viewNameExists: "already saved view name exists",
   },
   analyses: {
     description: "Ad-hoc analyses that can be re-run anytime for fresh results",

--- a/templates/analytics/app/i18n/zh-TW.ts
+++ b/templates/analytics/app/i18n/zh-TW.ts
@@ -903,6 +903,9 @@ const messages = {
     reportSubscriptionDeleteFailed: "無法刪除訂閱：{{message}}",
     reportSendFailed: "無法傳送報告：{{message}}",
     never: "從不",
+    savedFiltersTo: "已將篩選器儲存至「{{name}}」",
+    saveCurrentFiltersTo: "將目前篩選器儲存至「{{name}}」",
+    viewNameExists: "已儲存的檢視名稱已存在",
   },
   analyses: {
     historyTitle: "分析歷史記錄",

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/ViewsMenu.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/ViewsMenu.tsx
@@ -113,10 +113,11 @@ export function ViewsMenu({ dashboardId, canEdit = true }: ViewsMenuProps) {
   const selectedView = useMemo(() => {
     const paramViewId = searchParams.get("view");
     if (paramViewId) {
-      return views.find((x) => x.id === paramViewId) ?? null;
+      const found = views.find((x) => x.id === paramViewId);
+      if (found) return found;
     }
-    return null;
-  }, [searchParams, views]);
+    return views.find((v) => filtersMatch(currentFilters, v.filters)) ?? null;
+  }, [searchParams, views, currentFilters]);
 
   const hasFilterChanges = useMemo(() => {
     if (!selectedView) return false;
@@ -382,7 +383,7 @@ export function ViewsMenu({ dashboardId, canEdit = true }: ViewsMenuProps) {
               value={viewName}
               onChange={(e) => setViewName(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === "Enter") handleSaveView();
+                if (e.key === "Enter") void handleSaveView();
               }}
               autoFocus
             />

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/ViewsMenu.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/ViewsMenu.tsx
@@ -139,7 +139,9 @@ export function ViewsMenu({ dashboardId, canEdit = true }: ViewsMenuProps) {
         name: selectedView.name,
         filters: currentFilters,
       });
-      toast.success(`Saved filters to "${selectedView.name}"`);
+      toast.success(
+        t("sqlDashboard.savedFiltersTo", { name: selectedView.name }),
+      );
     } catch {
       toast.error(t("sqlDashboard.failedToSave"));
     }
@@ -295,12 +297,18 @@ export function ViewsMenu({ dashboardId, canEdit = true }: ViewsMenuProps) {
                                 name: v.name,
                                 filters: currentFilters,
                               });
-                              toast.success(`Saved filters to "${v.name}"`);
+                              toast.success(
+                                t("sqlDashboard.savedFiltersTo", {
+                                  name: v.name,
+                                }),
+                              );
                             } catch {
                               toast.error(t("sqlDashboard.failedToSave"));
                             }
                           }}
-                          title={`Save current filters to "${v.name}"`}
+                          title={t("sqlDashboard.saveCurrentFiltersTo", {
+                            name: v.name,
+                          })}
                         >
                           <IconDeviceFloppy className="h-3.5 w-3.5" />
                         </Button>
@@ -366,7 +374,9 @@ export function ViewsMenu({ dashboardId, canEdit = true }: ViewsMenuProps) {
               </Button>
             </TooltipTrigger>
             <TooltipContent>
-              Save current filters to "{selectedView.name}"
+              {t("sqlDashboard.saveCurrentFiltersTo", {
+                name: selectedView.name,
+              })}
             </TooltipContent>
           </Tooltip>
         )}
@@ -389,7 +399,7 @@ export function ViewsMenu({ dashboardId, canEdit = true }: ViewsMenuProps) {
             />
             {slugExists && (
               <p className="mt-2 text-xs text-amber-600 dark:text-amber-400 font-medium">
-                already saved view name exists
+                {t("sqlDashboard.viewNameExists")}
               </p>
             )}
             {Object.keys(currentFilters).length === 0 && (

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/ViewsMenu.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/ViewsMenu.tsx
@@ -113,11 +113,10 @@ export function ViewsMenu({ dashboardId, canEdit = true }: ViewsMenuProps) {
   const selectedView = useMemo(() => {
     const paramViewId = searchParams.get("view");
     if (paramViewId) {
-      const found = views.find((x) => x.id === paramViewId);
-      if (found) return found;
+      return views.find((x) => x.id === paramViewId) ?? null;
     }
-    return views.find((v) => filtersMatch(currentFilters, v.filters)) ?? null;
-  }, [searchParams, views, currentFilters]);
+    return null;
+  }, [searchParams, views]);
 
   const hasFilterChanges = useMemo(() => {
     if (!selectedView) return false;

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/ViewsMenu.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/ViewsMenu.tsx
@@ -125,8 +125,22 @@ export function ViewsMenu({ dashboardId, canEdit = true }: ViewsMenuProps) {
   }, [selectedView, currentFilters]);
 
   const slugExists = useMemo(() => {
-    const slug = slugify(viewName.trim());
-    return views.some((v) => v.id === slug);
+    const name = viewName.trim().toLowerCase();
+    if (!name) return false;
+
+    const baseSlug = viewName
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "")
+      .slice(0, 60);
+
+    return views.some((v) => {
+      const existingName = v.name.trim().toLowerCase();
+      if (existingName === name) return true;
+      if (baseSlug && v.id === baseSlug) return true;
+      return false;
+    });
   }, [viewName, views]);
 
   const handleUpdateActiveView = async (e: React.MouseEvent) => {

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/ViewsMenu.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/ViewsMenu.tsx
@@ -1,12 +1,16 @@
+import { cn } from "@/lib/utils";
 import { useT } from "@agent-native/core/client";
 import {
+  IconCheck,
   IconChevronDown,
   IconDeviceFloppy,
-  IconTrash,
   IconLayoutGrid,
+  IconPlus,
+  IconTrash,
 } from "@tabler/icons-react";
 import { useMemo, useState } from "react";
 import { useSearchParams } from "react-router";
+import { toast } from "sonner";
 
 import { ResourceLoadError } from "@/components/ResourceLoadError";
 import {
@@ -32,8 +36,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
+  DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import {
@@ -107,15 +110,40 @@ export function ViewsMenu({ dashboardId, canEdit = true }: ViewsMenuProps) {
     [searchParams],
   );
 
-  const activeView = useMemo(() => {
+
+  const selectedView = useMemo(() => {
     const paramViewId = searchParams.get("view");
     if (paramViewId) {
-      const v = views.find((x) => x.id === paramViewId);
-      if (v && filtersMatch(currentFilters, v.filters)) return v;
+      return views.find((x) => x.id === paramViewId) ?? null;
     }
-    // Fall back to any view whose filter set matches exactly.
-    return views.find((v) => filtersMatch(currentFilters, v.filters)) ?? null;
-  }, [searchParams, views, currentFilters]);
+    return null;
+  }, [searchParams, views]);
+
+  const hasFilterChanges = useMemo(() => {
+    if (!selectedView) return false;
+    return !filtersMatch(currentFilters, selectedView.filters);
+  }, [selectedView, currentFilters]);
+
+  const slugExists = useMemo(() => {
+    const slug = slugify(viewName.trim());
+    return views.some((v) => v.id === slug);
+  }, [viewName, views]);
+
+  const handleUpdateActiveView = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!selectedView) return;
+    try {
+      await saveView({
+        id: selectedView.id,
+        name: selectedView.name,
+        filters: currentFilters,
+      });
+      toast.success(`Saved filters to "${selectedView.name}"`);
+    } catch {
+      toast.error("Failed to save changes");
+    }
+  };
 
   const applyView = (view: DashboardView) => {
     setSearchParams((prev) => {
@@ -137,7 +165,7 @@ export function ViewsMenu({ dashboardId, canEdit = true }: ViewsMenuProps) {
 
   const handleSaveView = async () => {
     const name = viewName.trim();
-    if (!name || savingView) return;
+    if (!name || savingView || slugExists) return;
     setSavingView(true);
     try {
       await saveView({
@@ -154,95 +182,177 @@ export function ViewsMenu({ dashboardId, canEdit = true }: ViewsMenuProps) {
 
   const handleDeleteView = async () => {
     if (!deleteTarget) return;
-    await deleteView(deleteTarget.id);
+    const viewId = deleteTarget.id;
+    await deleteView(viewId);
+    if (searchParams.get("view") === viewId || views.length <= 1) {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete("view");
+        return next;
+      }, { replace: true });
+    }
     setDeleteTarget(null);
   };
 
-  const triggerLabel = activeView ? activeView.name : t("sqlDashboard.views");
+  const triggerLabel = selectedView ? selectedView.name : t("sqlDashboard.views");
 
   return (
     <>
-      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="sm" className="h-8 text-xs gap-1.5">
-                <IconLayoutGrid className="h-3.5 w-3.5" />
-                <span className="max-w-[160px] truncate">{triggerLabel}</span>
-                <IconChevronDown className="h-3 w-3 opacity-60" />
-              </Button>
-            </DropdownMenuTrigger>
-          </TooltipTrigger>
-          <TooltipContent>{t("sqlDashboard.savedViews")}</TooltipContent>
-        </Tooltip>
-        <DropdownMenuContent align="start" className="w-60">
-          <DropdownMenuLabel className="text-xs text-muted-foreground">
-            {t("sqlDashboard.savedViews")}
-          </DropdownMenuLabel>
-          {error ? (
-            <ResourceLoadError
-              inline
-              message={t("commandPalette.loadFailed")}
-              retryLabel={t("sidebar.retry")}
-              onRetry={() => void refetch()}
-            />
-          ) : views.length === 0 ? (
-            <div className="px-2 py-2 text-xs text-muted-foreground">
-              {t("sqlDashboard.noSavedViews")}
-            </div>
-          ) : (
-            views.map((v) => (
-              <DropdownMenuItem
-                key={v.id}
-                className="group flex items-center justify-between gap-2"
-                onSelect={(e) => {
+      <div className="flex items-center gap-1.5">
+        <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="sm" className="h-8 text-xs gap-1.5">
+                  <IconLayoutGrid className="h-3.5 w-3.5" />
+                  <span className="max-w-[160px] truncate">{triggerLabel}</span>
+                  <IconChevronDown className="h-3 w-3 opacity-60" />
+                </Button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent>{t("sqlDashboard.savedViews")}</TooltipContent>
+          </Tooltip>
+          <DropdownMenuContent align="start" className="w-60">
+            <DropdownMenuLabel className="flex items-center justify-between text-xs text-muted-foreground font-semibold">
+              <span>{t("sqlDashboard.savedViews")}</span>
+              {canEdit && (
+                <button
+                  type="button"
+                  className="h-5 w-5 flex items-center justify-center text-muted-foreground hover:text-foreground rounded hover:bg-muted"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setMenuOpen(false);
+                    setViewName("");
+                    setSaveDialogOpen(true);
+                  }}
+                  title="Save as new view"
+                >
+                  <IconPlus className="h-3.5 w-3.5" />
+                </button>
+              )}
+            </DropdownMenuLabel>
+            {error ? (
+              <ResourceLoadError
+                inline
+                message={t("commandPalette.loadFailed")}
+                retryLabel={t("sidebar.retry")}
+                onRetry={() => void refetch()}
+              />
+            ) : views.length === 0 ? (
+              <div className="px-2 py-2 text-xs text-muted-foreground">
+                {t("sqlDashboard.noSavedViews")}
+              </div>
+            ) : (
+              views.map((v) => (
+                <DropdownMenuItem
+                  key={v.id}
+                  className={cn(
+                    "group flex items-center justify-between gap-2",
+                    selectedView?.id === v.id && "bg-muted font-medium",
+                  )}
+                  onSelect={(e) => {
+                    e.preventDefault();
+                    applyView(v);
+                  }}
+                >
+                  <div className="flex items-center gap-2 min-w-0 flex-1">
+                    {selectedView?.id === v.id && (
+                      <IconCheck className="h-3.5 w-3.5 shrink-0" />
+                    )}
+                    <span className="truncate">{v.name}</span>
+                  </div>
+                  {canEdit ? (
+                    <div className="flex items-center gap-1 shrink-0">
+                      {v.id === selectedView?.id && hasFilterChanges && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-5 w-5 text-muted-foreground hover:text-foreground"
+                          onClick={async (e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            try {
+                              await saveView({
+                                id: v.id,
+                                name: v.name,
+                                filters: currentFilters,
+                              });
+                              toast.success(`Saved filters to "${v.name}"`);
+                            } catch {
+                              toast.error("Failed to save changes");
+                            }
+                          }}
+                          title={`Save current filters to "${v.name}"`}
+                        >
+                          <IconDeviceFloppy className="h-3.5 w-3.5" />
+                        </Button>
+                      )}
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-5 w-5 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-foreground"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              setDeleteTarget(v);
+                              setMenuOpen(false);
+                            }}
+                          >
+                            <IconTrash className="h-3 w-3" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {t("sqlDashboard.deleteView", { name: v.name })}
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  ) : null}
+                </DropdownMenuItem>
+              ))
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {canEdit && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-muted-foreground hover:text-foreground shrink-0 border border-input bg-background hover:bg-accent"
+                onClick={(e) => {
                   e.preventDefault();
-                  applyView(v);
-                }}
-              >
-                <span className="truncate flex-1">{v.name}</span>
-                {canEdit ? (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-5 w-5 shrink-0 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-foreground"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          e.stopPropagation();
-                          setDeleteTarget(v);
-                          setMenuOpen(false);
-                        }}
-                      >
-                        <IconTrash className="h-3 w-3" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      {t("sqlDashboard.deleteView", { name: v.name })}
-                    </TooltipContent>
-                  </Tooltip>
-                ) : null}
-              </DropdownMenuItem>
-            ))
-          )}
-          {canEdit ? (
-            <>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                onSelect={(e) => {
-                  e.preventDefault();
-                  setMenuOpen(false);
+                  setViewName("");
                   setSaveDialogOpen(true);
                 }}
               >
-                <IconDeviceFloppy className="h-4 w-4 mr-2" />
-                {t("sqlDashboard.saveCurrentView")}
-              </DropdownMenuItem>
-            </>
-          ) : null}
-        </DropdownMenuContent>
-      </DropdownMenu>
+                <IconPlus className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Save as new view</TooltipContent>
+          </Tooltip>
+        )}
+
+        {canEdit && selectedView && hasFilterChanges && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-muted-foreground hover:text-foreground shrink-0 border border-input bg-background hover:bg-accent"
+                onClick={handleUpdateActiveView}
+              >
+                <IconDeviceFloppy className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              Save current filters to "{selectedView.name}"
+            </TooltipContent>
+          </Tooltip>
+        )}
+      </div>
 
       <Dialog open={canEdit && saveDialogOpen} onOpenChange={setSaveDialogOpen}>
         <DialogContent className="sm:max-w-[400px]">
@@ -259,6 +369,11 @@ export function ViewsMenu({ dashboardId, canEdit = true }: ViewsMenuProps) {
               }}
               autoFocus
             />
+            {slugExists && (
+              <p className="mt-2 text-xs text-amber-600 dark:text-amber-400 font-medium">
+                already saved view name exists
+              </p>
+            )}
             {Object.keys(currentFilters).length === 0 && (
               <p className="mt-2 text-xs text-muted-foreground">
                 {t("sqlDashboard.noActiveFilters")}
@@ -277,7 +392,7 @@ export function ViewsMenu({ dashboardId, canEdit = true }: ViewsMenuProps) {
             <Button
               size="sm"
               onClick={handleSaveView}
-              disabled={!viewName.trim() || savingView}
+              disabled={!viewName.trim() || savingView || slugExists}
             >
               {savingView ? t("sqlDashboard.saving") : t("sqlDashboard.save")}
             </Button>

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/ViewsMenu.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/ViewsMenu.tsx
@@ -1,4 +1,3 @@
-import { cn } from "@/lib/utils";
 import { useT } from "@agent-native/core/client";
 import {
   IconCheck,
@@ -36,7 +35,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
-  DropdownMenuTrigger
+  DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import {
@@ -48,6 +47,7 @@ import {
   useDashboardViews,
   type DashboardView,
 } from "@/hooks/use-dashboard-views";
+import { cn } from "@/lib/utils";
 
 import { FILTER_PARAM_PREFIX } from "./DashboardFilterBar";
 
@@ -110,7 +110,6 @@ export function ViewsMenu({ dashboardId, canEdit = true }: ViewsMenuProps) {
     [searchParams],
   );
 
-
   const selectedView = useMemo(() => {
     const paramViewId = searchParams.get("view");
     if (paramViewId) {
@@ -141,7 +140,7 @@ export function ViewsMenu({ dashboardId, canEdit = true }: ViewsMenuProps) {
       });
       toast.success(`Saved filters to "${selectedView.name}"`);
     } catch {
-      toast.error("Failed to save changes");
+      toast.error(t("sqlDashboard.failedToSave"));
     }
   };
 
@@ -168,11 +167,20 @@ export function ViewsMenu({ dashboardId, canEdit = true }: ViewsMenuProps) {
     if (!name || savingView || slugExists) return;
     setSavingView(true);
     try {
+      const newId = slugify(name);
       await saveView({
-        id: slugify(name),
+        id: newId,
         name,
         filters: currentFilters,
       });
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.set("view", newId);
+          return next;
+        },
+        { replace: true },
+      );
       setViewName("");
       setSaveDialogOpen(false);
     } finally {
@@ -185,16 +193,21 @@ export function ViewsMenu({ dashboardId, canEdit = true }: ViewsMenuProps) {
     const viewId = deleteTarget.id;
     await deleteView(viewId);
     if (searchParams.get("view") === viewId || views.length <= 1) {
-      setSearchParams((prev) => {
-        const next = new URLSearchParams(prev);
-        next.delete("view");
-        return next;
-      }, { replace: true });
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.delete("view");
+          return next;
+        },
+        { replace: true },
+      );
     }
     setDeleteTarget(null);
   };
 
-  const triggerLabel = selectedView ? selectedView.name : t("sqlDashboard.views");
+  const triggerLabel = selectedView
+    ? selectedView.name
+    : t("sqlDashboard.views");
 
   return (
     <>
@@ -203,7 +216,11 @@ export function ViewsMenu({ dashboardId, canEdit = true }: ViewsMenuProps) {
           <Tooltip>
             <TooltipTrigger asChild>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="sm" className="h-8 text-xs gap-1.5">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 text-xs gap-1.5"
+                >
                   <IconLayoutGrid className="h-3.5 w-3.5" />
                   <span className="max-w-[160px] truncate">{triggerLabel}</span>
                   <IconChevronDown className="h-3 w-3 opacity-60" />
@@ -225,7 +242,7 @@ export function ViewsMenu({ dashboardId, canEdit = true }: ViewsMenuProps) {
                     setViewName("");
                     setSaveDialogOpen(true);
                   }}
-                  title="Save as new view"
+                  title={t("sqlDashboard.saveAsView")}
                 >
                   <IconPlus className="h-3.5 w-3.5" />
                 </button>
@@ -279,7 +296,7 @@ export function ViewsMenu({ dashboardId, canEdit = true }: ViewsMenuProps) {
                               });
                               toast.success(`Saved filters to "${v.name}"`);
                             } catch {
-                              toast.error("Failed to save changes");
+                              toast.error(t("sqlDashboard.failedToSave"));
                             }
                           }}
                           title={`Save current filters to "${v.name}"`}
@@ -331,7 +348,7 @@ export function ViewsMenu({ dashboardId, canEdit = true }: ViewsMenuProps) {
                 <IconPlus className="h-4 w-4" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Save as new view</TooltipContent>
+            <TooltipContent>{t("sqlDashboard.saveAsView")}</TooltipContent>
           </Tooltip>
         )}
 

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -692,7 +692,7 @@ export default function SqlDashboardPage() {
   } = useUserPref<{ filters: Record<string, string> }>(filterPrefKey);
 
   // Dashboard views
-  const { saveView } = useDashboardViews(dashboardId ?? undefined);
+  const { views = [], saveView } = useDashboardViews(dashboardId ?? undefined);
 
   // Track whether we've applied saved filters on initial load
   const appliedSaved = useRef(false);
@@ -824,6 +824,69 @@ export default function SqlDashboardPage() {
     searchParams,
     setSearchParams,
   ]);
+
+  // Apply view filters when view ID is in the URL on load
+  const appliedViewRef = useRef<{ dashboardId: string; viewId: string } | null>(
+    null,
+  );
+  useEffect(() => {
+    if (!dashboardId || !loaded || !dashboard || !views?.length) return;
+
+    const viewId = searchParams.get("view");
+    if (!viewId) {
+      appliedViewRef.current = null;
+      return;
+    }
+
+    // Only apply the view's filters once when the viewId (or dashboardId) is first seen
+    if (
+      appliedViewRef.current?.dashboardId === dashboardId &&
+      appliedViewRef.current?.viewId === viewId
+    ) {
+      return;
+    }
+
+    const matchedView = views.find((v) => v.id === viewId);
+    if (!matchedView) return;
+
+    appliedViewRef.current = { dashboardId, viewId };
+
+    // Compare current URL filters with matchedView.filters
+    const currentFilters: Record<string, string> = {};
+    searchParams.forEach((value, key) => {
+      if (key.startsWith(FILTER_PARAM_PREFIX)) {
+        currentFilters[key] = value;
+      }
+    });
+
+    const isMatch =
+      Object.keys(matchedView.filters).every(
+        (k) => currentFilters[k] === matchedView.filters[k],
+      ) &&
+      Object.keys(currentFilters).every(
+        (k) => currentFilters[k] === matchedView.filters[k],
+      );
+
+    if (!isMatch) {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          // Strip existing filters
+          const toDelete: string[] = [];
+          next.forEach((_, k) => {
+            if (k.startsWith(FILTER_PARAM_PREFIX)) toDelete.push(k);
+          });
+          toDelete.forEach((k) => next.delete(k));
+          // Apply view filters
+          for (const [key, value] of Object.entries(matchedView.filters)) {
+            if (value) next.set(key, value);
+          }
+          return next;
+        },
+        { replace: true },
+      );
+    }
+  }, [dashboardId, loaded, dashboard, views, searchParams, setSearchParams]);
 
   // Auto-save filter state when URL params change (debounced)
   const saveTimer = useRef<ReturnType<typeof setTimeout>>(undefined);

--- a/templates/analytics/changelog/2026-07-12-fix-500-error-when-saving-new-dashboard-views-and-improve-vi.md
+++ b/templates/analytics/changelog/2026-07-12-fix-500-error-when-saving-new-dashboard-views-and-improve-vi.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-12
+---
+
+Fix 500 error when saving new dashboard views and improve views management dropdown with inline actions

--- a/templates/analytics/server/lib/dashboards-store.ts
+++ b/templates/analytics/server/lib/dashboards-store.ts
@@ -1847,7 +1847,17 @@ export async function saveDashboardView(
   });
   const db = getDb() as any;
   const id = view.id ?? nanoidFallback();
+  let exists = false;
   if (view.id) {
+    const [existingRow] = await db
+      .select({ id: schema.dashboardViews.id })
+      .from(schema.dashboardViews)
+      .where(eq(schema.dashboardViews.id, view.id))
+      .limit(1);
+    exists = !!existingRow;
+  }
+
+  if (exists) {
     await db
       .update(schema.dashboardViews)
       .set({ name: view.name, filters: JSON.stringify(view.filters) })

--- a/templates/analytics/server/lib/dashboards-store.ts
+++ b/templates/analytics/server/lib/dashboards-store.ts
@@ -1852,7 +1852,12 @@ export async function saveDashboardView(
     const [existingRow] = await db
       .select({ id: schema.dashboardViews.id })
       .from(schema.dashboardViews)
-      .where(eq(schema.dashboardViews.id, view.id))
+      .where(
+        and(
+          eq(schema.dashboardViews.id, view.id),
+          eq(schema.dashboardViews.dashboardId, dashboardId),
+        ),
+      )
       .limit(1);
     exists = !!existingRow;
   }
@@ -1861,7 +1866,12 @@ export async function saveDashboardView(
     await db
       .update(schema.dashboardViews)
       .set({ name: view.name, filters: JSON.stringify(view.filters) })
-      .where(eq(schema.dashboardViews.id, id));
+      .where(
+        and(
+          eq(schema.dashboardViews.id, id),
+          eq(schema.dashboardViews.dashboardId, dashboardId),
+        ),
+      );
   } else {
     await db.insert(schema.dashboardViews).values({
       id,


### PR DESCRIPTION
# Description
This PR resolves database persistence issues when saving dashboard views and completely refactors the Views Management UI/UX for a streamlined, responsive workflow.

## Summary of Changes

### 1. Database & Persistence Fixes
- **Resolved 500 Server Error:** Fixed `saveDashboardView` in [dashboards-store.ts](file:///home/phenom/Projects/agent-native/templates/analytics/server/lib/dashboards-store.ts) to explicitly query the DB and verify if a view exists before deciding whether to perform an `insert` or an `update`, avoiding ID collision issues.

### 2. UI/UX Improvements in `ViewsMenu`
- **Header Action Buttons:**
  - Added a `+` button in the main header for quick "Save as new view" creation.
  - Added a `💾` floppy save button side-by-side with the views trigger that appears only when the selected view has unsaved filter modifications.
- **Dropdown List Refinement:**
  - Added a matching checkmark and highlighted background based on `selectedView` (linked directly to the URL `?view=` query parameter), ensuring the active view remains checked even when filters are actively changed.
  - Rendered a quick-save disk icon directly inside the list item row for the active view, positioned immediately before the delete button, visible only when modifications exist.
  - Removed standard Radix Tooltip wrappers from list items to resolve rendering/overlapping issues in dropdown containers, substituting with standard browser `title` attributes.
  - Cleaned up duplicate/redundant full-width buttons from the bottom of the dropdown list.
  - Added a mini `+` save-new button inside the dropdown's `"Saved views"` label top-right.

### 3. Safety & Cleanup Gates
- **Duplicate View Checking:** Prevented view names from colliding by gating `handleSaveView` from running if the slug exists (`slugExists`). Additionally, disabled the dialog's save button and display a warnings warning ("already saved view name exists").
- **Delete Parameter Cleanup:** Updated `handleDeleteView` to clear the `view` parameter from the URL parameters if the deleted view was either the active view or the last view remaining.

### Before
<img width="464" height="182" alt="2" src="https://github.com/user-attachments/assets/7dce3207-11e6-4aff-8168-5f288f5c3098" />

### After
<img width="459" height="191" alt="1" src="https://github.com/user-attachments/assets/113dfb57-3d45-4ba1-b3d0-db22c93cccfd" />
