### PR TITLE
Fix replay fidelity and tab-isolated recordings

### DIFF
--- a/.changeset/clean-replay-tab-identities.md
+++ b/.changeset/clean-replay-tab-identities.md
@@ -1,5 +1,6 @@
 ---
 "@agent-native/core": patch
+"@agent-native/dispatch": patch
 ---
 
 Keep session replay identities isolated per browser tab so recordings from
@@ -8,3 +9,4 @@ signed DOM stylesheet, font, image, and other load-bearing resource URLs while
 continuing to redact navigation and diagnostic URL secrets. Recover long-lived
 tabs from replay upload identity conflicts by restarting once with a fresh
 snapshot, and report the content-free recovery outcome to Analytics.
+Stabilize Dispatch's deferred-navigation behavior under test-runner load.

--- a/.changeset/clean-replay-tab-identities.md
+++ b/.changeset/clean-replay-tab-identities.md
@@ -1,0 +1,10 @@
+---
+"@agent-native/core": patch
+---
+
+Keep session replay identities isolated per browser tab so recordings from
+concurrent or duplicated tabs cannot be merged into a corrupt replay. Preserve
+signed DOM stylesheet, font, image, and other load-bearing resource URLs while
+continuing to redact navigation and diagnostic URL secrets. Recover long-lived
+tabs from replay upload identity conflicts by restarting once with a fresh
+snapshot, and report the content-free recovery outcome to Analytics.

--- a/.changeset/fast-demo-replay-redaction.md
+++ b/.changeset/fast-demo-replay-redaction.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep demo-mode session replay playback fast by bypassing raw event payload redaction while still anonymizing email-backed frontend identities.

--- a/packages/core/src/client/analytics.ts
+++ b/packages/core/src/client/analytics.ts
@@ -1227,6 +1227,18 @@ function configuredSessionReplayOptions(
       ...(publicKey && !options.publicKey ? { publicKey } : {}),
       ...(endpoint && !options.endpoint ? { endpoint } : {}),
       ...options,
+      onUploadRejected:
+        options.onUploadRejected ??
+        ((details) => {
+          trackEvent("session replay upload rejected", {
+            status: details.status,
+            restart_attempted: details.restartAttempted,
+            restart_succeeded: details.restartSucceeded,
+            ...(details.restartReason
+              ? { restart_reason: details.restartReason }
+              : {}),
+          });
+        }),
       requireSignedInUser:
         options.requireSignedInUser ??
         sessionReplayRequiresSignedInUserFromEnv() ??

--- a/packages/core/src/client/session-replay.spec.ts
+++ b/packages/core/src/client/session-replay.spec.ts
@@ -83,6 +83,45 @@ async function parseReplayUpload(init: RequestInit): Promise<any> {
   return JSON.parse(bytes.toString("utf8"));
 }
 
+// The channel name the duplicated-tab claim guard uses internally
+// (SESSION_REPLAY_BROADCAST_CHANNEL_NAME in session-replay.ts). Not
+// exported -- kept in sync here rather than widening the module's public
+// surface just for a test.
+const REPLAY_BROADCAST_CHANNEL_NAME = "agent-native-session-replay";
+
+/**
+ * A minimal same-process BroadcastChannel stand-in: instances constructed
+ * with the same name and returned by the same factory call can message each
+ * other (never themselves), same as the real API. Each test gets its own
+ * isolated "network" by calling the factory fresh.
+ */
+function createFakeBroadcastChannelClass() {
+  const registry = new Map<string, Set<InstanceType<typeof FakeChannel>>>();
+  class FakeChannel {
+    name: string;
+    onmessage: ((event: { data: unknown }) => void) | null = null;
+    closed = false;
+    constructor(name: string) {
+      this.name = name;
+      const peers = registry.get(name) ?? new Set();
+      peers.add(this);
+      registry.set(name, peers);
+    }
+    postMessage(data: unknown) {
+      if (this.closed) return;
+      for (const peer of registry.get(this.name) ?? []) {
+        if (peer === this || peer.closed) continue;
+        queueMicrotask(() => peer.onmessage?.({ data }));
+      }
+    }
+    close() {
+      this.closed = true;
+      registry.get(this.name)?.delete(this);
+    }
+  }
+  return FakeChannel;
+}
+
 function setLocation(
   location: {
     href: string;
@@ -108,7 +147,8 @@ function installBrowser(
   session: Record<string, unknown> = { error: "not authenticated" },
 ) {
   const parsed = new URL(url);
-  const storage = new Map<string, string>();
+  const localStorageMap = new Map<string, string>();
+  const sessionStorageMap = new Map<string, string>();
   const location = {
     href: parsed.href,
     origin: parsed.origin,
@@ -146,18 +186,28 @@ function installBrowser(
     ),
   };
   const localStorage = {
-    getItem: vi.fn((key: string) => storage.get(key) ?? null),
+    getItem: vi.fn((key: string) => localStorageMap.get(key) ?? null),
     setItem: vi.fn((key: string, value: string) => {
-      storage.set(key, value);
+      localStorageMap.set(key, value);
     }),
     removeItem: vi.fn((key: string) => {
-      storage.delete(key);
+      localStorageMap.delete(key);
+    }),
+  };
+  const sessionStorage = {
+    getItem: vi.fn((key: string) => sessionStorageMap.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      sessionStorageMap.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      sessionStorageMap.delete(key);
     }),
   };
   vi.stubGlobal("window", {
     location,
     history,
     localStorage,
+    sessionStorage,
     gtag: vi.fn(),
     addEventListener: vi.fn(addWindowListener),
     removeEventListener: vi.fn(removeWindowListener),
@@ -179,6 +229,11 @@ function installBrowser(
   vi.stubGlobal("crypto", {
     randomUUID: vi.fn(() => `00000000-0000-4000-8000-${++idCounter}`),
   });
+  // Node exposes a real global BroadcastChannel, which would otherwise make
+  // every resumed-session start wait out the duplicated-tab claim timeout
+  // for no reason in tests that don't care about it. Tests exercising that
+  // guard stub their own BroadcastChannel back in.
+  vi.stubGlobal("BroadcastChannel", undefined);
   const fetchMock = vi.fn(async (input: unknown) => {
     if (String(input).includes("/_agent-native/auth/session")) {
       return new Response(JSON.stringify(session), {
@@ -188,7 +243,16 @@ function installBrowser(
     return new Response("{}");
   });
   vi.stubGlobal("fetch", fetchMock);
-  return { fetchMock, history, location, storage };
+  // `storage` is the sessionStorage-backed map -- the replay session record
+  // (replayId + sequence) is per-tab and lives there. `localStorage` is
+  // exposed separately for tests asserting the legacy key gets cleared.
+  return {
+    fetchMock,
+    history,
+    location,
+    storage: sessionStorageMap,
+    localStorage: localStorageMap,
+  };
 }
 
 async function freshSessionReplay() {
@@ -530,6 +594,114 @@ describe("session replay", () => {
 
     stopSessionReplay();
     expect(stop).toHaveBeenCalled();
+  });
+
+  it("preserves signed DOM resources without leaking navigation secrets", async () => {
+    const { fetchMock } = installBrowser();
+    let recordOptions: any;
+    recordMock.mockImplementation((options) => {
+      recordOptions = options;
+      return vi.fn();
+    });
+    const { flushSessionReplay, startSessionReplay } =
+      await freshSessionReplay();
+    await startSessionReplay({
+      publicKey: "anpk_test",
+      endpoint: "https://analytics.example.test/session-replay",
+      maxEventsPerBatch: 1,
+      flushIntervalMs: 100_000,
+    });
+
+    recordOptions.emit({
+      type: 2,
+      timestamp: Date.now(),
+      data: {
+        node: {
+          type: 0,
+          childNodes: [
+            {
+              type: 2,
+              id: 12,
+              tagName: "link",
+              attributes: {
+                rel: "stylesheet",
+                href: "https://cdn.example.test/app.css?token=signed-style",
+                _cssText:
+                  '@import "https://fonts.example.test/css?family=Inter&token=signed-font";',
+              },
+            },
+            {
+              type: 2,
+              tagName: "img",
+              attributes: {
+                src: "https://cdn.example.test/hero.png?token=signed-image",
+                srcset:
+                  "https://cdn.example.test/hero-2x.png?token=signed-image-2x 2x",
+              },
+            },
+            {
+              type: 2,
+              id: 13,
+              tagName: "a",
+              attributes: {
+                href: "/oauth/callback?p=private&token=secret&keep=1",
+              },
+            },
+          ],
+        },
+      },
+    });
+    await waitForAssertion(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [stylesheet, image, anchor] = (await parseReplayUpload(init))
+      .events[0].data.node.childNodes;
+    expect(stylesheet.attributes).toEqual({
+      rel: "stylesheet",
+      href: "https://cdn.example.test/app.css?token=signed-style",
+      _cssText:
+        '@import "https://fonts.example.test/css?family=Inter&token=signed-font";',
+    });
+    expect(image.attributes).toEqual({
+      src: "https://cdn.example.test/hero.png?token=signed-image",
+      srcset: "https://cdn.example.test/hero-2x.png?token=signed-image-2x 2x",
+    });
+    expect(anchor.attributes.href).toBe(
+      "/oauth/callback?p=%3Credacted%3E&token=%3Credacted%3E&keep=1",
+    );
+
+    recordOptions.emit({
+      type: 3,
+      timestamp: Date.now() + 1,
+      data: {
+        source: 0,
+        attributes: [
+          {
+            id: 12,
+            attributes: {
+              href: "https://cdn.example.test/app.css?token=rotated-signature",
+            },
+          },
+          {
+            id: 13,
+            attributes: { href: "/next?p=private&token=secret" },
+          },
+        ],
+      },
+    });
+    await flushSessionReplay("test");
+    await waitForAssertion(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    const [, mutationInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    const [stylesheetMutation, anchorMutation] = (
+      await parseReplayUpload(mutationInit)
+    ).events[0].data.attributes;
+    expect(stylesheetMutation.attributes.href).toBe(
+      "https://cdn.example.test/app.css?token=rotated-signature",
+    );
+    expect(anchorMutation.attributes.href).toBe(
+      "/next?p=%3Credacted%3E&token=%3Credacted%3E",
+    );
   });
 
   it("does not force keepalive for oversized cross-origin replay batches", async () => {
@@ -1104,6 +1276,107 @@ describe("session replay", () => {
     expect(new Set(bodies.map((body) => body.replayId)).size).toBe(1);
   });
 
+  it("keeps replay identity per tab and clears the legacy shared record", async () => {
+    const { localStorage, storage } = installBrowser();
+    localStorage.set(
+      "agent-native.session_replay_id",
+      JSON.stringify({
+        sessionId: "legacy-session",
+        replayId: "legacy-shared-replay",
+        startedAtMs: 1,
+        sequence: 12,
+      }),
+    );
+    recordMock.mockReturnValue(vi.fn());
+    const { startSessionReplay } = await freshSessionReplay();
+
+    const result = await startSessionReplay({ publicKey: "anpk_test" });
+
+    expect(result.replayId).not.toBe("legacy-shared-replay");
+    expect(localStorage.has("agent-native.session_replay_id")).toBe(false);
+    expect(
+      JSON.parse(storage.get("agent-native.session_replay_id") ?? "{}")
+        .replayId,
+    ).toBe(result.replayId);
+  });
+
+  it("restarts once with a fresh replay identity after a definitive 409 conflict", async () => {
+    const { fetchMock, storage } = installBrowser();
+    vi.stubGlobal("CompressionStream", undefined);
+    fetchMock
+      .mockResolvedValueOnce(new Response("conflict", { status: 409 }))
+      .mockResolvedValue(new Response("{}"));
+    const stops: Array<ReturnType<typeof vi.fn>> = [];
+    const recordOptions: any[] = [];
+    recordMock.mockImplementation((options) => {
+      recordOptions.push(options);
+      const stop = vi.fn();
+      stops.push(stop);
+      return stop;
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const onUploadRejected = vi.fn();
+    const replay = await freshSessionReplay();
+    const first = await replay.startSessionReplay({
+      publicKey: "anpk_test",
+      maxEventsPerBatch: 1,
+      flushIntervalMs: 100_000,
+      onUploadRejected,
+    });
+
+    recordOptions[0].emit({ type: 3, data: { href: "/conflicting" } });
+    await waitForAssertion(() => expect(recordOptions).toHaveLength(2));
+    await waitForAssertion(() => expect(onUploadRejected).toHaveBeenCalled());
+
+    expect(replay.isSessionReplayActive()).toBe(true);
+    expect(stops[0]).toHaveBeenCalledTimes(1);
+    const restarted = JSON.parse(
+      storage.get("agent-native.session_replay_id") ?? "{}",
+    );
+    expect(restarted.replayId).not.toBe(first.replayId);
+    expect(onUploadRejected).toHaveBeenCalledWith({
+      status: 409,
+      restartAttempted: true,
+      restartSucceeded: true,
+    });
+
+    recordOptions[1].emit({ type: 3, data: { href: "/recovered" } });
+    await waitForAssertion(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("does not loop automatic restarts when every fresh identity receives 409", async () => {
+    const { fetchMock, storage } = installBrowser();
+    vi.stubGlobal("CompressionStream", undefined);
+    fetchMock.mockResolvedValue(new Response("conflict", { status: 409 }));
+    const stops: Array<ReturnType<typeof vi.fn>> = [];
+    const recordOptions: any[] = [];
+    recordMock.mockImplementation((options) => {
+      recordOptions.push(options);
+      const stop = vi.fn();
+      stops.push(stop);
+      return stop;
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const replay = await freshSessionReplay();
+    await replay.startSessionReplay({
+      publicKey: "anpk_test",
+      maxEventsPerBatch: 1,
+      flushIntervalMs: 100_000,
+    });
+
+    recordOptions[0].emit({ type: 3, data: { href: "/first-conflict" } });
+    await waitForAssertion(() => expect(recordOptions).toHaveLength(2));
+    recordOptions[1].emit({ type: 3, data: { href: "/second-conflict" } });
+    await waitForAssertion(() =>
+      expect(replay.isSessionReplayActive()).toBe(false),
+    );
+
+    expect(recordOptions).toHaveLength(2);
+    expect(stops).toHaveLength(2);
+    expect(stops.every((stop) => stop.mock.calls.length === 1)).toBe(true);
+    expect(storage.has("agent-native.session_replay_id")).toBe(false);
+  });
+
   it("retries failed replay uploads without advancing the sequence", async () => {
     const { fetchMock, storage } = installBrowser(
       "https://app.agent-native.com/inbox",
@@ -1151,6 +1424,249 @@ describe("session replay", () => {
       "[session-replay] upload failed",
       expect.any(Error),
     );
+  });
+
+  it("gives two tabs on the same analytics session different replayIds", async () => {
+    const tab1 = installBrowser("https://app.agent-native.com/inbox");
+    recordMock.mockImplementation(() => vi.fn());
+    const first = await freshSessionReplay();
+    const firstResult = await first.startSessionReplay({
+      publicKey: "anpk_test",
+      endpoint: "https://analytics.example.test/session-replay",
+      flushIntervalMs: 100_000,
+    });
+    expect(firstResult.started).toBe(true);
+    await first.stopSessionReplay();
+
+    // Simulate a second tab of the same browser session: same origin, same
+    // localStorage-backed analytics sessionId (localStorage is shared by
+    // every tab), but its own empty sessionStorage (never shared across
+    // tabs) -- so it must mint its own replayId rather than resume tab1's.
+    const sharedSessionId = tab1.localStorage.get("agent-native.session_id");
+    const sharedLastActivity = tab1.localStorage.get(
+      "agent-native.session_last_activity",
+    );
+    expect(sharedSessionId).toBeTruthy();
+
+    delete (globalThis as any)[replayStateKey];
+    const tab2 = installBrowser("https://app.agent-native.com/inbox");
+    tab2.localStorage.set("agent-native.session_id", sharedSessionId!);
+    tab2.localStorage.set(
+      "agent-native.session_last_activity",
+      sharedLastActivity!,
+    );
+    recordMock.mockImplementation(() => vi.fn());
+    const second = await freshSessionReplay();
+    const secondResult = await second.startSessionReplay({
+      publicKey: "anpk_test",
+      endpoint: "https://analytics.example.test/session-replay",
+      flushIntervalMs: 100_000,
+    });
+
+    expect(secondResult.started).toBe(true);
+    expect(secondResult.sessionId).toBe(firstResult.sessionId);
+    expect(secondResult.replayId).toBeTruthy();
+    expect(secondResult.replayId).not.toBe(firstResult.replayId);
+    await second.stopSessionReplay();
+  });
+
+  it("resumes the same replayId from sessionStorage after a simulated reload in the same tab", async () => {
+    const { storage } = installBrowser("https://app.agent-native.com/inbox");
+    recordMock.mockImplementation(() => vi.fn());
+    const first = await freshSessionReplay();
+    const firstResult = await first.startSessionReplay({
+      publicKey: "anpk_test",
+      endpoint: "https://analytics.example.test/session-replay",
+      flushIntervalMs: 100_000,
+    });
+    expect(firstResult.started).toBe(true);
+    await first.stopSessionReplay();
+
+    expect(
+      JSON.parse(storage.get("agent-native.session_replay_id") ?? "{}")
+        .replayId,
+    ).toBe(firstResult.replayId);
+
+    // Simulate a reload within the same tab: the module's in-memory state
+    // resets, but window.sessionStorage (this test's installBrowser() mock,
+    // never reset mid-test) persists exactly like a real tab's
+    // sessionStorage does across a reload/navigation.
+    delete (globalThis as any)[replayStateKey];
+    const second = await freshSessionReplay();
+    const secondResult = await second.startSessionReplay({
+      publicKey: "anpk_test",
+      endpoint: "https://analytics.example.test/session-replay",
+      flushIntervalMs: 100_000,
+    });
+
+    expect(secondResult.started).toBe(true);
+    expect(secondResult.replayId).toBe(firstResult.replayId);
+    await second.stopSessionReplay();
+  });
+
+  it("retries a transient 503 response", async () => {
+    const { fetchMock } = installBrowser("https://app.agent-native.com/inbox");
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response("service unavailable", { status: 503 }),
+      )
+      .mockResolvedValue(new Response("{}"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let recordOptions: any;
+    recordMock.mockImplementation((options) => {
+      recordOptions = options;
+      return vi.fn();
+    });
+    const { startSessionReplay, flushSessionReplay } =
+      await freshSessionReplay();
+
+    await startSessionReplay({
+      publicKey: "anpk_test",
+      endpoint: "https://analytics.example.test/session-replay",
+      maxEventsPerBatch: 1,
+      flushIntervalMs: 100_000,
+    });
+    recordOptions.emit({ type: 3, data: { href: "/transient" } });
+    await waitForAssertion(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    await tick();
+
+    expect(warn).toHaveBeenCalledWith(
+      "[session-replay] upload failed",
+      expect.any(Error),
+    );
+    await flushSessionReplay("retry");
+    await waitForAssertion(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const [, lastInit] = fetchMock.mock.calls[
+      fetchMock.mock.calls.length - 1
+    ] as [string, RequestInit];
+    const lastBody = await parseReplayUpload(lastInit);
+    expect(lastBody.events[0].data.href).toBe("/transient");
+  });
+
+  it("mints a fresh replayId when a peer tab claims the resumed id over BroadcastChannel", async () => {
+    const FakeBroadcastChannel = createFakeBroadcastChannelClass();
+    const { storage } = installBrowser("https://app.agent-native.com/inbox");
+    vi.stubGlobal("BroadcastChannel", FakeBroadcastChannel as any);
+    recordMock.mockImplementation(() => vi.fn());
+
+    const first = await freshSessionReplay();
+    const firstResult = await first.startSessionReplay({
+      publicKey: "anpk_test",
+      endpoint: "https://analytics.example.test/session-replay",
+      flushIntervalMs: 100_000,
+    });
+    expect(firstResult.started).toBe(true);
+    await first.stopSessionReplay();
+    const resumedReplayId = firstResult.replayId!;
+
+    // A peer that still owns (and replies "taken" for) the resumed id --
+    // e.g. the browser duplicated this tab, so both copies briefly share the
+    // exact same sessionStorage snapshot and would otherwise both try to
+    // resume the same replayId.
+    const peer = new FakeBroadcastChannel(REPLAY_BROADCAST_CHANNEL_NAME);
+    peer.onmessage = (event: { data: any }) => {
+      if (
+        event.data?.type === "an-replay-claim" &&
+        event.data.replayId === resumedReplayId
+      ) {
+        peer.postMessage({
+          type: "an-replay-claim-taken",
+          replayId: event.data.replayId,
+        });
+      }
+    };
+
+    delete (globalThis as any)[replayStateKey];
+    const second = await freshSessionReplay();
+    const secondResult = await second.startSessionReplay({
+      publicKey: "anpk_test",
+      endpoint: "https://analytics.example.test/session-replay",
+      flushIntervalMs: 100_000,
+    });
+
+    expect(secondResult.started).toBe(true);
+    expect(secondResult.replayId).toBeTruthy();
+    expect(secondResult.replayId).not.toBe(resumedReplayId);
+    expect(
+      JSON.parse(storage.get("agent-native.session_replay_id") ?? "{}")
+        .replayId,
+    ).toBe(secondResult.replayId);
+    await second.stopSessionReplay();
+    peer.close();
+  });
+
+  it("arbitrates simultaneous duplicated-tab claims instead of letting both resume", async () => {
+    const FakeBroadcastChannel = createFakeBroadcastChannelClass();
+    installBrowser("https://app.agent-native.com/inbox");
+    vi.stubGlobal("BroadcastChannel", FakeBroadcastChannel as any);
+    recordMock.mockImplementation(() => vi.fn());
+
+    const first = await freshSessionReplay();
+    const firstResult = await first.startSessionReplay({
+      publicKey: "anpk_test",
+      flushIntervalMs: 100_000,
+    });
+    await first.stopSessionReplay();
+
+    const peer = new FakeBroadcastChannel(REPLAY_BROADCAST_CHANNEL_NAME);
+    peer.onmessage = (event: { data: any }) => {
+      if (event.data?.type !== "an-replay-claim") return;
+      // Simulate another copied tab probing at the same time. Its lower nonce
+      // wins deterministically, so this tab must abandon the shared id.
+      peer.postMessage({
+        type: "an-replay-claim",
+        replayId: event.data.replayId,
+        instanceNonce: "00000000-0000-4000-8000-0",
+      });
+    };
+
+    delete (globalThis as any)[replayStateKey];
+    const duplicate = await freshSessionReplay();
+    const result = await duplicate.startSessionReplay({
+      publicKey: "anpk_test",
+      flushIntervalMs: 100_000,
+    });
+
+    expect(result.replayId).not.toBe(firstResult.replayId);
+    await duplicate.stopSessionReplay();
+    peer.close();
+  });
+
+  it("keeps the resumed replayId when no peer claims it within the claim timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const FakeBroadcastChannel = createFakeBroadcastChannelClass();
+      installBrowser("https://app.agent-native.com/inbox");
+      vi.stubGlobal("BroadcastChannel", FakeBroadcastChannel as any);
+      recordMock.mockImplementation(() => vi.fn());
+
+      const first = await freshSessionReplay();
+      const firstResult = await first.startSessionReplay({
+        publicKey: "anpk_test",
+        endpoint: "https://analytics.example.test/session-replay",
+        flushIntervalMs: 100_000,
+      });
+      expect(firstResult.started).toBe(true);
+      await first.stopSessionReplay();
+
+      // No peer is registered on the channel this time, so the claim goes
+      // unanswered -- advance fake time past the ~150ms claim timeout.
+      delete (globalThis as any)[replayStateKey];
+      const second = await freshSessionReplay();
+      const startPromise = second.startSessionReplay({
+        publicKey: "anpk_test",
+        endpoint: "https://analytics.example.test/session-replay",
+        flushIntervalMs: 100_000,
+      });
+      await vi.advanceTimersByTimeAsync(500);
+      const secondResult = await startPromise;
+
+      expect(secondResult.started).toBe(true);
+      expect(secondResult.replayId).toBe(firstResult.replayId);
+      await second.stopSessionReplay();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("blocks disallowed URLs before importing the recorder", async () => {

--- a/packages/core/src/client/session-replay.spec.ts
+++ b/packages/core/src/client/session-replay.spec.ts
@@ -632,6 +632,7 @@ describe("session replay", () => {
             },
             {
               type: 2,
+              id: 14,
               tagName: "img",
               attributes: {
                 src: "https://cdn.example.test/hero.png?token=signed-image",
@@ -647,6 +648,59 @@ describe("session replay", () => {
                 href: "/oauth/callback?p=private&token=secret&keep=1",
               },
             },
+            {
+              type: 2,
+              id: 15,
+              tagName: "script",
+              attributes: {
+                src: "https://app.example.test/runtime.js?token=script-secret",
+              },
+            },
+            {
+              type: 2,
+              id: 16,
+              tagName: "iframe",
+              attributes: {
+                src: "https://app.example.test/embed?token=frame-secret",
+              },
+            },
+            {
+              type: 2,
+              id: 17,
+              tagName: "object",
+              attributes: {
+                data: "https://app.example.test/file?token=object-secret",
+              },
+            },
+            {
+              type: 2,
+              id: 18,
+              tagName: "video",
+              attributes: {
+                src: "https://cdn.example.test/demo.mp4?token=signed-video",
+                poster:
+                  "https://cdn.example.test/poster.png?token=signed-poster",
+              },
+            },
+            {
+              type: 2,
+              id: 19,
+              tagName: "link",
+              attributes: {
+                rel: "preload",
+                as: "font",
+                href: "https://cdn.example.test/inter.woff2?token=signed-font",
+              },
+            },
+            {
+              type: 2,
+              id: 20,
+              tagName: "link",
+              attributes: {
+                rel: "modulepreload",
+                href: "https://app.example.test/chunk.js?token=module-secret",
+              },
+            },
           ],
         },
       },
@@ -654,8 +708,17 @@ describe("session replay", () => {
     await waitForAssertion(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    const [stylesheet, image, anchor] = (await parseReplayUpload(init))
-      .events[0].data.node.childNodes;
+    const [
+      stylesheet,
+      image,
+      anchor,
+      script,
+      iframe,
+      object,
+      video,
+      fontPreload,
+      modulePreload,
+    ] = (await parseReplayUpload(init)).events[0].data.node.childNodes;
     expect(stylesheet.attributes).toEqual({
       rel: "stylesheet",
       href: "https://cdn.example.test/app.css?token=signed-style",
@@ -668,6 +731,25 @@ describe("session replay", () => {
     });
     expect(anchor.attributes.href).toBe(
       "/oauth/callback?p=%3Credacted%3E&token=%3Credacted%3E&keep=1",
+    );
+    expect(script.attributes.src).toBe(
+      "https://app.example.test/runtime.js?token=%3Credacted%3E",
+    );
+    expect(iframe.attributes.src).toBe(
+      "https://app.example.test/embed?token=%3Credacted%3E",
+    );
+    expect(object.attributes.data).toBe(
+      "https://app.example.test/file?token=%3Credacted%3E",
+    );
+    expect(video.attributes).toMatchObject({
+      src: "https://cdn.example.test/demo.mp4?token=signed-video",
+      poster: "https://cdn.example.test/poster.png?token=signed-poster",
+    });
+    expect(fontPreload.attributes.href).toBe(
+      "https://cdn.example.test/inter.woff2?token=signed-font",
+    );
+    expect(modulePreload.attributes.href).toBe(
+      "https://app.example.test/chunk.js?token=%3Credacted%3E",
     );
 
     recordOptions.emit({
@@ -686,6 +768,50 @@ describe("session replay", () => {
             id: 13,
             attributes: { href: "/next?p=private&token=secret" },
           },
+          {
+            id: 14,
+            attributes: {
+              src: "https://cdn.example.test/next.png?token=rotated-image",
+            },
+          },
+          {
+            id: 15,
+            attributes: {
+              src: "https://app.example.test/next.js?token=rotated-script",
+            },
+          },
+          {
+            id: 16,
+            attributes: {
+              src: "https://app.example.test/next?token=rotated-frame",
+            },
+          },
+          {
+            id: 17,
+            attributes: {
+              data: "https://app.example.test/next-file?token=rotated-object",
+            },
+          },
+          {
+            id: 18,
+            attributes: {
+              poster:
+                "https://cdn.example.test/next-poster.png?token=rotated-poster",
+            },
+          },
+          {
+            id: 19,
+            attributes: {
+              href: "https://cdn.example.test/inter.woff2?token=rotated-font",
+            },
+          },
+          {
+            id: 12,
+            attributes: {
+              rel: "modulepreload",
+              href: "https://app.example.test/next.js?token=changed-to-script",
+            },
+          },
         ],
       },
     });
@@ -693,14 +819,43 @@ describe("session replay", () => {
     await waitForAssertion(() => expect(fetchMock).toHaveBeenCalledTimes(2));
 
     const [, mutationInit] = fetchMock.mock.calls[1] as [string, RequestInit];
-    const [stylesheetMutation, anchorMutation] = (
-      await parseReplayUpload(mutationInit)
-    ).events[0].data.attributes;
+    const [
+      stylesheetMutation,
+      anchorMutation,
+      imageMutation,
+      scriptMutation,
+      iframeMutation,
+      objectMutation,
+      videoMutation,
+      fontMutation,
+      changedLinkMutation,
+    ] = (await parseReplayUpload(mutationInit)).events[0].data.attributes;
     expect(stylesheetMutation.attributes.href).toBe(
       "https://cdn.example.test/app.css?token=rotated-signature",
     );
     expect(anchorMutation.attributes.href).toBe(
       "/next?p=%3Credacted%3E&token=%3Credacted%3E",
+    );
+    expect(imageMutation.attributes.src).toBe(
+      "https://cdn.example.test/next.png?token=rotated-image",
+    );
+    expect(scriptMutation.attributes.src).toBe(
+      "https://app.example.test/next.js?token=%3Credacted%3E",
+    );
+    expect(iframeMutation.attributes.src).toBe(
+      "https://app.example.test/next?token=%3Credacted%3E",
+    );
+    expect(objectMutation.attributes.data).toBe(
+      "https://app.example.test/next-file?token=%3Credacted%3E",
+    );
+    expect(videoMutation.attributes.poster).toBe(
+      "https://cdn.example.test/next-poster.png?token=rotated-poster",
+    );
+    expect(fontMutation.attributes.href).toBe(
+      "https://cdn.example.test/inter.woff2?token=rotated-font",
+    );
+    expect(changedLinkMutation.attributes.href).toBe(
+      "https://app.example.test/next.js?token=%3Credacted%3E",
     );
   });
 
@@ -1301,10 +1456,13 @@ describe("session replay", () => {
   });
 
   it("restarts once with a fresh replay identity after a definitive 409 conflict", async () => {
-    const { fetchMock, storage } = installBrowser();
+    const { fetchMock, storage, localStorage } = installBrowser();
+    localStorage.set("agent-native.session_id", "sample-in");
+    localStorage.set("agent-native.session_last_activity", String(Date.now()));
     vi.stubGlobal("CompressionStream", undefined);
+    const conflictResponse = deferred<Response>();
     fetchMock
-      .mockResolvedValueOnce(new Response("conflict", { status: 409 }))
+      .mockImplementationOnce(() => conflictResponse.promise)
       .mockResolvedValue(new Response("{}"));
     const stops: Array<ReturnType<typeof vi.fn>> = [];
     const recordOptions: any[] = [];
@@ -1319,17 +1477,47 @@ describe("session replay", () => {
     const replay = await freshSessionReplay();
     const first = await replay.startSessionReplay({
       publicKey: "anpk_test",
+      sampleRate: 0.5,
       maxEventsPerBatch: 1,
       flushIntervalMs: 100_000,
+      console: { maxEvents: 7 },
+      network: {
+        maxEvents: 9,
+        captureErrorBodies: false,
+        maxErrorBodyLength: 123,
+      },
       onUploadRejected,
     });
+    const initialNormalizedOptions = (globalThis as any)[replayStateKey]
+      .options;
 
     recordOptions[0].emit({ type: 3, data: { href: "/conflicting" } });
+    await waitForAssertion(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const rejectedUpload = await parseReplayUpload(
+      fetchMock.mock.calls[0][1] as RequestInit,
+    );
+    expect(rejectedUpload.sessionId).toBe("sample-in");
+
+    // Simulate the analytics session rotating while the rejected upload is in
+    // flight. This id scores above 0.5, but conflict recovery must preserve the
+    // original recording's accepted sampling decision and session id.
+    localStorage.set("agent-native.session_id", "a");
+    localStorage.set("agent-native.session_last_activity", String(Date.now()));
+    conflictResponse.resolve(new Response("conflict", { status: 409 }));
+
     await waitForAssertion(() => expect(recordOptions).toHaveLength(2));
     await waitForAssertion(() => expect(onUploadRejected).toHaveBeenCalled());
 
     expect(replay.isSessionReplayActive()).toBe(true);
     expect(stops[0]).toHaveBeenCalledTimes(1);
+    const recoveredState = (globalThis as any)[replayStateKey];
+    expect(recoveredState.options).toBe(initialNormalizedOptions);
+    expect(recoveredState.options.console).toMatchObject({ maxEvents: 7 });
+    expect(recoveredState.options.network).toMatchObject({
+      maxEvents: 9,
+      captureErrorBodies: false,
+      maxErrorBodyLength: 123,
+    });
     const restarted = JSON.parse(
       storage.get("agent-native.session_replay_id") ?? "{}",
     );
@@ -1342,6 +1530,10 @@ describe("session replay", () => {
 
     recordOptions[1].emit({ type: 3, data: { href: "/recovered" } });
     await waitForAssertion(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const recoveredUpload = await parseReplayUpload(
+      fetchMock.mock.calls[1][1] as RequestInit,
+    );
+    expect(recoveredUpload.sessionId).toBe("a");
   });
 
   it("does not loop automatic restarts when every fresh identity receives 409", async () => {
@@ -1375,6 +1567,49 @@ describe("session replay", () => {
     expect(stops).toHaveLength(2);
     expect(stops.every((stop) => stop.mock.calls.length === 1)).toBe(true);
     expect(storage.has("agent-native.session_replay_id")).toBe(false);
+  });
+
+  it.each([
+    { label: "an explicit stop", action: "stop" as const },
+    { label: "a pagehide final flush", action: "pagehide" as const },
+  ])("does not restart after a 409 during $label", async ({ action }) => {
+    const { fetchMock, storage } = installBrowser();
+    vi.stubGlobal("CompressionStream", undefined);
+    fetchMock.mockResolvedValue(new Response("conflict", { status: 409 }));
+    const stops: Array<ReturnType<typeof vi.fn>> = [];
+    const recordOptions: any[] = [];
+    recordMock.mockImplementation((options) => {
+      recordOptions.push(options);
+      const stop = vi.fn();
+      stops.push(stop);
+      return stop;
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const onUploadRejected = vi.fn();
+    const replay = await freshSessionReplay();
+    await replay.startSessionReplay({
+      publicKey: "anpk_test",
+      flushIntervalMs: 100_000,
+      onUploadRejected,
+    });
+
+    recordOptions[0].emit({ type: 3, data: { href: "/final" } });
+    if (action === "stop") {
+      await replay.stopSessionReplay();
+    } else {
+      await replay.flushSessionReplay("pagehide");
+    }
+
+    expect(recordOptions).toHaveLength(1);
+    expect(stops).toHaveLength(1);
+    expect(stops[0]).toHaveBeenCalledTimes(1);
+    expect(replay.isSessionReplayActive()).toBe(false);
+    expect(storage.has("agent-native.session_replay_id")).toBe(false);
+    expect(onUploadRejected).toHaveBeenCalledWith({
+      status: 409,
+      restartAttempted: false,
+      restartSucceeded: false,
+    });
   });
 
   it("retries failed replay uploads without advancing the sequence", async () => {

--- a/packages/core/src/client/session-replay.ts
+++ b/packages/core/src/client/session-replay.ts
@@ -11,6 +11,12 @@ type QueuedReplayEvent = {
   type: number | null;
 };
 type ReplayStopFn = () => void;
+type ReplayResourceNode = {
+  tagName: string;
+  rel: string;
+  as: string;
+  type: string;
+};
 export type SessionReplayUrlMatcher =
   | string
   | RegExp
@@ -68,8 +74,8 @@ interface SessionReplayState {
   restoreCaptures: (() => void) | null;
   options: NormalizedSessionReplayOptions | null;
   lastAuthenticatedProperties: Record<string, unknown> | null;
-  /** rrweb node ids for resource-bearing `<link>` elements in this checkout. */
-  resourceLinkNodeIds: Set<number>;
+  /** Resource tag metadata used to classify later rrweb attribute mutations. */
+  resourceNodes: Map<number, ReplayResourceNode>;
   /**
    * Prevents a permanently misconfigured endpoint from causing an automatic
    * 409 -> restart -> 409 loop. A successful upload resets the allowance, so
@@ -404,12 +410,15 @@ function getState(): SessionReplayState {
       restoreCaptures: null,
       options: null,
       lastAuthenticatedProperties: null,
-      resourceLinkNodeIds: new Set(),
+      resourceNodes: new Map(),
       automaticConflictRestartAttempted: false,
       broadcastChannel: null,
     };
   }
-  return g[SESSION_REPLAY_STATE_KEY]!;
+  const state = g[SESSION_REPLAY_STATE_KEY]!;
+  // Keep Vite HMR safe when an older recorder state survives a module reload.
+  state.resourceNodes ??= new Map();
+  return state;
 }
 
 // The replay session record (replayId + sequence counter) lives in
@@ -965,36 +974,107 @@ function scrubReplayValue(
  * the scrub into the single serialization pass avoids a separate deep-clone of
  * every emitted event (FullSnapshots are large DOM trees) on the hot path.
  */
-const REPLAY_RESOURCE_URL_ATTRIBUTES = new Set([
-  "src",
-  "srcset",
-  "poster",
-  "data",
-]);
-
 const REPLAY_RESOURCE_LINK_RELS = new Set([
   "stylesheet",
-  "preload",
-  "modulepreload",
   "icon",
   "apple-touch-icon",
   "mask-icon",
 ]);
+const REPLAY_RESOURCE_PRELOAD_TYPES = new Set([
+  "style",
+  "font",
+  "image",
+  "audio",
+  "video",
+  "track",
+]);
+const REPLAY_RESOURCE_TAGS = new Set([
+  "img",
+  "source",
+  "video",
+  "audio",
+  "track",
+  "input",
+  "link",
+]);
+const NO_REPLAY_RESOURCE_ATTRIBUTES = new Set<string>();
+const REPLAY_SRC_ATTRIBUTES = new Set(["src"]);
+const REPLAY_SRCSET_ATTRIBUTES = new Set(["src", "srcset"]);
+const REPLAY_VIDEO_ATTRIBUTES = new Set(["src", "poster"]);
+const REPLAY_HREF_ATTRIBUTES = new Set(["href"]);
+
+function replayAttributeString(
+  attributes: Record<string, unknown>,
+  key: string,
+): string {
+  return typeof attributes[key] === "string"
+    ? attributes[key].toLowerCase()
+    : "";
+}
+
+function updateReplayResourceNode(
+  current: ReplayResourceNode,
+  attributes: Record<string, unknown>,
+): ReplayResourceNode {
+  return {
+    tagName: current.tagName,
+    rel: Object.hasOwn(attributes, "rel")
+      ? replayAttributeString(attributes, "rel")
+      : current.rel,
+    as: Object.hasOwn(attributes, "as")
+      ? replayAttributeString(attributes, "as")
+      : current.as,
+    type: Object.hasOwn(attributes, "type")
+      ? replayAttributeString(attributes, "type")
+      : current.type,
+  };
+}
+
+function replayPreservedResourceAttributes(
+  node: ReplayResourceNode,
+): ReadonlySet<string> {
+  switch (node.tagName) {
+    case "img":
+    case "source":
+      return REPLAY_SRCSET_ATTRIBUTES;
+    case "video":
+      return REPLAY_VIDEO_ATTRIBUTES;
+    case "audio":
+    case "track":
+      return REPLAY_SRC_ATTRIBUTES;
+    case "input":
+      return node.type === "image"
+        ? REPLAY_SRC_ATTRIBUTES
+        : NO_REPLAY_RESOURCE_ATTRIBUTES;
+    case "link": {
+      const rels = node.rel.split(/\s+/);
+      const isLoadBearingResource =
+        rels.some((rel) => REPLAY_RESOURCE_LINK_RELS.has(rel)) ||
+        (rels.includes("preload") &&
+          REPLAY_RESOURCE_PRELOAD_TYPES.has(node.as));
+      return isLoadBearingResource
+        ? REPLAY_HREF_ATTRIBUTES
+        : NO_REPLAY_RESOURCE_ATTRIBUTES;
+    }
+    default:
+      return NO_REPLAY_RESOURCE_ATTRIBUTES;
+  }
+}
 
 /**
  * Build a path-aware replay serializer without cloning the rrweb event.
  *
- * Privacy still wins for Meta/navigation URLs, anchor hrefs, and custom
- * console/network diagnostics. The narrow exception is captured DOM resource
- * attributes: changing a signed stylesheet/image/font URL makes rrweb rebuild
- * a page that never existed and commonly produces missing CSS or giant fallback
- * icons. JSON.stringify calls a replacer for an `attributes` object before its
- * children, so the WeakMap lets the child callback recognize only that bag.
+ * Privacy still wins for Meta/navigation URLs, executable/embed URLs, anchor
+ * hrefs, and custom console/network diagnostics. The narrow exception is
+ * load-bearing stylesheet, font, image, and media attributes: changing those
+ * signed URLs makes rrweb rebuild a page that never existed. JSON.stringify
+ * calls a replacer for an `attributes` object before its children, so the
+ * WeakMap lets the child callback recognize only that bag.
  */
 function createReplayScrubReplacer(
-  resourceLinkNodeIds: Set<number>,
+  resourceNodes: Map<number, ReplayResourceNode>,
 ): (this: unknown, key: string, value: unknown) => unknown {
-  const preservedAttributes = new WeakMap<object, Set<string>>();
+  const preservedAttributes = new WeakMap<object, ReadonlySet<string>>();
 
   return function replayScrubReplacer(
     this: unknown,
@@ -1003,13 +1083,6 @@ function createReplayScrubReplacer(
   ): unknown {
     if (key === "attributes" && value && typeof value === "object") {
       const attributes = value as Record<string, unknown>;
-      const resourceKeys = new Set<string>();
-      for (const attribute of REPLAY_RESOURCE_URL_ATTRIBUTES) {
-        if (typeof attributes[attribute] === "string") {
-          resourceKeys.add(attribute);
-        }
-      }
-
       const holder =
         this && typeof this === "object"
           ? (this as Record<string, unknown>)
@@ -1020,29 +1093,25 @@ function createReplayScrubReplacer(
         typeof holder?.id === "number" && Number.isFinite(holder.id)
           ? holder.id
           : undefined;
-      const rel = String(attributes.rel ?? "")
-        .toLowerCase()
-        .split(/\s+/);
-      const hasResourceRel = rel.some((token) =>
-        REPLAY_RESOURCE_LINK_RELS.has(token),
-      );
-      if (nodeId !== undefined && tagName === "link" && hasResourceRel) {
-        resourceLinkNodeIds.add(nodeId);
-      } else if (
-        nodeId !== undefined &&
-        tagName === "" &&
-        Object.hasOwn(attributes, "rel")
-      ) {
-        if (hasResourceRel) resourceLinkNodeIds.add(nodeId);
-        else resourceLinkNodeIds.delete(nodeId);
+      let resourceNode: ReplayResourceNode | undefined;
+      if (tagName && REPLAY_RESOURCE_TAGS.has(tagName)) {
+        resourceNode = updateReplayResourceNode(
+          { tagName, rel: "", as: "", type: "" },
+          attributes,
+        );
+      } else if (nodeId !== undefined && !tagName) {
+        const current = resourceNodes.get(nodeId);
+        if (current) {
+          resourceNode = updateReplayResourceNode(current, attributes);
+        }
       }
-      if (
-        typeof attributes.href === "string" &&
-        ((tagName === "link" && hasResourceRel) ||
-          (nodeId !== undefined && resourceLinkNodeIds.has(nodeId)))
-      ) {
-        resourceKeys.add("href");
+      if (nodeId !== undefined && resourceNode) {
+        resourceNodes.set(nodeId, resourceNode);
       }
+
+      const resourceKeys = resourceNode
+        ? replayPreservedResourceAttributes(resourceNode)
+        : NO_REPLAY_RESOURCE_ATTRIBUTES;
 
       if (resourceKeys.size > 0) preservedAttributes.set(value, resourceKeys);
       return value;
@@ -1067,13 +1136,11 @@ function createReplayScrubReplacer(
  */
 function serializeReplayEvent(
   event: ReplayEvent,
-  resourceLinkNodeIds: Set<number>,
+  resourceNodes: Map<number, ReplayResourceNode>,
 ): string {
   try {
-    return JSON.stringify(
-      event,
-      createReplayScrubReplacer(resourceLinkNodeIds),
-    );
+    if (event.type === 2) resourceNodes.clear();
+    return JSON.stringify(event, createReplayScrubReplacer(resourceNodes));
   } catch {
     return "";
   }
@@ -1096,7 +1163,7 @@ function enqueueReplayEvent(
   event: ReplayEvent,
 ): void {
   if (!state.options) return;
-  const serialized = serializeReplayEvent(event, state.resourceLinkNodeIds);
+  const serialized = serializeReplayEvent(event, state.resourceNodes);
   if (!serialized) return;
   const estimatedBytes = serialized.length;
   if (
@@ -1532,6 +1599,8 @@ export async function flushSessionReplay(reason = "manual"): Promise<void> {
     const rejectedOptions = state.options;
     const shouldRestartAfterConflict =
       definitiveClientErrorStatus === 409 &&
+      state.active &&
+      !isFinalFlushReason(reason) &&
       !state.automaticConflictRestartAttempted;
     if (shouldRestartAfterConflict) {
       state.automaticConflictRestartAttempted = true;
@@ -1548,11 +1617,11 @@ export async function flushSessionReplay(reason = "manual"): Promise<void> {
     // configuration/input errors and must not create a restart loop.
     let restartResult: SessionReplayStartResult | null = null;
     if (shouldRestartAfterConflict && rejectedOptions) {
-      restartResult = await startSessionReplay({
-        ...rejectedOptions,
-        console: rejectedOptions.console ?? false,
-        network: rejectedOptions.network ?? false,
-      });
+      restartResult = await restartSessionReplayAfterConflict(
+        state,
+        rejectedOptions,
+        payload.sessionId,
+      );
     }
 
     // Rare recovery-path telemetry lets Analytics owners quantify conflicts
@@ -1570,6 +1639,54 @@ export async function flushSessionReplay(reason = "manual"): Promise<void> {
       // best-effort telemetry must never interfere with recording recovery
     }
   }
+}
+
+/**
+ * Restart a recorder whose replay identity was rejected without routing the
+ * already-normalized options back through the public start API.
+ *
+ * The original recording already passed whole-session sampling. Re-entering
+ * `startSessionReplay` here would ask `getOrCreateAnalyticsSessionId` again;
+ * if the analytics session rotated while the upload was in flight, recovery
+ * could be sampled out and leave a long-lived SPA tab silently unrecorded.
+ * Keeping the original session id and accepted sampling decision also lets us
+ * reuse the exact normalized console/network capture caps instead of relying
+ * on internal option shapes continuing to round-trip through the public API.
+ */
+async function restartSessionReplayAfterConflict(
+  state: SessionReplayState,
+  options: NormalizedSessionReplayOptions,
+  sessionId: string,
+): Promise<SessionReplayStartResult> {
+  if (options.shouldStart && !options.shouldStart()) {
+    return { started: false, reason: "disabled", sessionId, sampled: true };
+  }
+
+  const initialProperties = replayExtraProperties(options);
+  if (options.requireSignedInUser && !replayUserEmail(initialProperties)) {
+    return {
+      started: false,
+      reason: "missing-user-id",
+      sessionId,
+      sampled: true,
+    };
+  }
+  if (!isUrlRecordable(window.location.href, options)) {
+    return {
+      started: false,
+      reason: "url-blocked",
+      sessionId,
+      sampled: true,
+    };
+  }
+
+  return startSessionReplayRecorder(
+    state,
+    options,
+    sessionId,
+    true,
+    initialProperties,
+  );
 }
 
 function installUrlMonitor(state: SessionReplayState): void {
@@ -2499,7 +2616,7 @@ async function startSessionReplayRecorder(
   state.queue = [];
   state.queuedBytes = 0;
   state.retryBatches = [];
-  state.resourceLinkNodeIds.clear();
+  state.resourceNodes.clear();
   state.stopRecorder = null;
   state.broadcastChannel = replayChannel;
   state.lastAuthenticatedProperties = replayUserEmail(initialProperties)

--- a/packages/core/src/client/session-replay.ts
+++ b/packages/core/src/client/session-replay.ts
@@ -68,6 +68,20 @@ interface SessionReplayState {
   restoreCaptures: (() => void) | null;
   options: NormalizedSessionReplayOptions | null;
   lastAuthenticatedProperties: Record<string, unknown> | null;
+  /** rrweb node ids for resource-bearing `<link>` elements in this checkout. */
+  resourceLinkNodeIds: Set<number>;
+  /**
+   * Prevents a permanently misconfigured endpoint from causing an automatic
+   * 409 -> restart -> 409 loop. A successful upload resets the allowance, so
+   * a later, independent sequence conflict can still recover in-place.
+   */
+  automaticConflictRestartAttempted: boolean;
+  /**
+   * Cross-tab "who is recording this replayId" channel, open for the
+   * lifetime of an active recording. See `getOrCreateReplaySession` for why
+   * this exists (duplicated-tab guard against a shared `replayId`).
+   */
+  broadcastChannel: BroadcastChannel | null;
 }
 
 interface StoredReplaySession {
@@ -76,6 +90,27 @@ interface StoredReplaySession {
   startedAtMs?: number;
   sequence?: number;
 }
+
+/** Broadcast on `SESSION_REPLAY_BROADCAST_CHANNEL_NAME` by a tab resuming a
+ * stored replay session, to check whether another tab is already recording
+ * that same `replayId` (see the duplicated-tab guard in
+ * `getOrCreateReplaySession`'s doc comment). */
+interface ReplayClaimMessage {
+  type: "an-replay-claim";
+  replayId: string;
+  instanceNonce: string;
+}
+
+/** Reply from a tab that is actively recording the claimed `replayId`. */
+interface ReplayClaimTakenMessage {
+  type: "an-replay-claim-taken";
+  replayId: string;
+  /** Only the claimant with this nonce should yield the stored replay id.
+   * Optional while older recorder bundles can still be open during rollout. */
+  claimantNonce?: string;
+}
+
+type ReplayBroadcastMessage = ReplayClaimMessage | ReplayClaimTakenMessage;
 
 /** rrweb `sampling` shape (mousemove/scroll/media throttles, input strategy). */
 export type ReplayEventSampling = Record<string, unknown>;
@@ -105,6 +140,13 @@ export interface SessionReplayNetworkOptions {
   maxEvents?: number;
   captureErrorBodies?: boolean;
   maxErrorBodyLength?: number;
+}
+
+export interface SessionReplayUploadRejectedDetails {
+  status: number;
+  restartAttempted: boolean;
+  restartSucceeded: boolean;
+  restartReason?: SessionReplayStartResult["reason"];
 }
 
 export interface SessionReplayOptions {
@@ -157,6 +199,8 @@ export interface SessionReplayOptions {
    * disable, or an options object to override caps.
    */
   network?: boolean | SessionReplayNetworkOptions;
+  /** Rare recorder lifecycle signal; never includes replay content or URLs. */
+  onUploadRejected?: (details: SessionReplayUploadRejectedDetails) => void;
   extraProperties?:
     | Record<string, unknown>
     | (() => Record<string, unknown> | undefined);
@@ -209,6 +253,7 @@ interface NormalizedSessionReplayOptions {
   console: NormalizedCaptureOptions | null;
   /** Null disables network capture entirely. */
   network: NormalizedCaptureOptions | null;
+  onUploadRejected?: SessionReplayOptions["onUploadRejected"];
   extraProperties?: SessionReplayOptions["extraProperties"];
   shouldStart?: SessionReplayOptions["shouldStart"];
 }
@@ -266,6 +311,11 @@ const DEFAULT_MAX_EVENTS_PER_BATCH = 50;
 const DEFAULT_MAX_BATCH_BYTES = 256 * 1024;
 const MAX_KEEPALIVE_REPLAY_UPLOAD_BYTES = 60 * 1024;
 const RRWEB_FULL_SNAPSHOT_EVENT_TYPE = 2;
+/** Cross-tab channel name used by the duplicated-tab claim guard. */
+const SESSION_REPLAY_BROADCAST_CHANNEL_NAME = "agent-native-session-replay";
+/** How long a resuming tab waits for a "someone else already owns this
+ * replayId" reply before proceeding to record with the resumed id. */
+const SESSION_REPLAY_CLAIM_TIMEOUT_MS = 150;
 
 /** rrweb custom-event tag for captured console/window-error entries. */
 export const SESSION_REPLAY_CONSOLE_EVENT_TAG = "agent-native.console";
@@ -354,24 +404,58 @@ function getState(): SessionReplayState {
       restoreCaptures: null,
       options: null,
       lastAuthenticatedProperties: null,
+      resourceLinkNodeIds: new Set(),
+      automaticConflictRestartAttempted: false,
+      broadcastChannel: null,
     };
   }
   return g[SESSION_REPLAY_STATE_KEY]!;
 }
 
-function safeStorageGet(key: string): string | null {
+// The replay session record (replayId + sequence counter) lives in
+// `sessionStorage`, not `localStorage`: `localStorage` is shared by every
+// open tab of the origin, which would hand every tab the same `replayId` and
+// the same sequence counter. See the guard comment above
+// `getOrCreateReplaySession` for the corruption that causes.
+function safeSessionStorageGet(key: string): string | null {
   try {
-    return window.localStorage.getItem(key);
+    return window.sessionStorage.getItem(key);
   } catch {
     return null;
   }
 }
 
-function safeStorageSet(key: string, value: string): void {
+function safeSessionStorageSet(key: string, value: string): void {
   try {
-    window.localStorage.setItem(key, value);
+    window.sessionStorage.setItem(key, value);
   } catch {
     // private browsing / storage disabled -- replay still works for this page
+  }
+}
+
+function safeSessionStorageRemove(key: string): void {
+  try {
+    window.sessionStorage.removeItem(key);
+  } catch {
+    // private browsing / storage disabled -- replay still works for this page
+  }
+}
+
+let legacyLocalStorageReplaySessionCleared = false;
+
+/**
+ * Best-effort, one-time removal of the pre-fix replay session record that
+ * used to live in `localStorage`. Never read from it -- adopting its
+ * `replayId` would recreate the exact shared-identity bug this file now
+ * avoids by using `sessionStorage` instead.
+ */
+function clearLegacyLocalStorageReplaySession(): void {
+  if (legacyLocalStorageReplaySessionCleared) return;
+  legacyLocalStorageReplaySessionCleared = true;
+  try {
+    window.localStorage.removeItem(SESSION_REPLAY_ID_STORAGE_KEY);
+  } catch {
+    // best-effort only -- a stray legacy record is harmless once ignored
   }
 }
 
@@ -390,7 +474,7 @@ function generateReplayId(): string {
 }
 
 function readStoredReplaySession(): StoredReplaySession | null {
-  const raw = safeStorageGet(SESSION_REPLAY_ID_STORAGE_KEY);
+  const raw = safeSessionStorageGet(SESSION_REPLAY_ID_STORAGE_KEY);
   if (!raw) return null;
   try {
     const parsed = JSON.parse(raw) as StoredReplaySession;
@@ -402,14 +486,47 @@ function readStoredReplaySession(): StoredReplaySession | null {
 }
 
 function writeStoredReplaySession(value: StoredReplaySession): void {
-  safeStorageSet(SESSION_REPLAY_ID_STORAGE_KEY, JSON.stringify(value));
+  safeSessionStorageSet(SESSION_REPLAY_ID_STORAGE_KEY, JSON.stringify(value));
 }
 
+function removeStoredReplaySession(replayId: string): void {
+  if (readStoredReplaySession()?.replayId !== replayId) return;
+  safeSessionStorageRemove(SESSION_REPLAY_ID_STORAGE_KEY);
+}
+
+/**
+ * Per-tab replay identity is deliberate -- do not "fix" this by reading or
+ * writing the session record through `localStorage` again.
+ *
+ * `sessionStorage` is scoped to a single tab (and survives reloads/
+ * navigations within that tab, which is exactly the lifetime a recording
+ * needs). `localStorage` is shared by every open tab of the origin. If this
+ * record lived there, two tabs open to the same app would read/write the
+ * *same* `replayId` and the *same* sequence counter, so rrweb in each tab
+ * would record independently but upload chunks under one shared identity.
+ * The two interleaved DOM mutation streams get merged into a single
+ * recording server-side: mutations reference the other tab's node ids
+ * (broken CSS), the viewport/meta events reflect whichever tab resized last
+ * (wrong or ultra-wide viewport), and lost mousemove batches from the
+ * "other" tab's chunks read as a frozen cursor or a fake inactivity gap. A
+ * chunk-sequence collision with a different checksum gets rejected
+ * server-side (409) rather than merged, so one tab's batches are silently
+ * dropped -- there is no way to reconstruct or repair this at playback time.
+ * Keep this per-tab. A tab *duplicated* mid-session still shares a
+ * `sessionStorage` snapshot, which is what the `BroadcastChannel` claim
+ * check in `startSessionReplayRecorder` guards against.
+ */
 function getOrCreateReplaySession(sessionId: string): {
   replayId: string;
   startedAtMs: number;
   sequence: number;
+  /** True when resuming a session found in this tab's `sessionStorage`
+   * (e.g. a reload), as opposed to minting a brand-new id. Only the resumed
+   * case needs the duplicated-tab claim check -- a fresh id can never
+   * collide with anything already recording. */
+  resumed: boolean;
 } {
+  clearLegacyLocalStorageReplaySession();
   const parsed = readStoredReplaySession();
   if (parsed?.sessionId === sessionId && parsed.replayId) {
     const startedAtMs =
@@ -424,12 +541,127 @@ function getOrCreateReplaySession(sessionId: string): {
       parsed.sequence >= 0
         ? Math.floor(parsed.sequence)
         : 0;
-    return { replayId: parsed.replayId, startedAtMs, sequence };
+    return { replayId: parsed.replayId, startedAtMs, sequence, resumed: true };
   }
   const replayId = generateReplayId();
   const startedAtMs = Date.now();
   writeStoredReplaySession({ sessionId, replayId, startedAtMs, sequence: 0 });
-  return { replayId, startedAtMs, sequence: 0 };
+  return { replayId, startedAtMs, sequence: 0, resumed: false };
+}
+
+/**
+ * Open the cross-tab claim channel used to detect a *duplicated* tab (a
+ * browser "duplicate tab" or same-origin `window.open` copies
+ * `sessionStorage`, so two tabs can legitimately start with the same
+ * resumed `replayId`). Returns `null` when `BroadcastChannel` is
+ * unavailable -- callers must treat that as "skip the guard", never as an
+ * error.
+ */
+function openReplayBroadcastChannel(): BroadcastChannel | null {
+  if (typeof BroadcastChannel === "undefined") return null;
+  try {
+    return new BroadcastChannel(SESSION_REPLAY_BROADCAST_CHANNEL_NAME);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Wires up the duplicated-tab claim channel for one recorder lifetime.
+ * `respond` keeps listening for the whole life of the channel (any tab may
+ * later claim the `replayId` this tab is actively recording); `probeClaim`
+ * is used once, only when resuming a stored session, to ask "is anyone else
+ * already recording this id?" and wait up to
+ * `SESSION_REPLAY_CLAIM_TIMEOUT_MS` for a reply.
+ */
+function createReplayClaimChannel(
+  state: SessionReplayState,
+  instanceNonce: string,
+): {
+  channel: BroadcastChannel | null;
+  probeClaim: (replayId: string) => Promise<boolean>;
+} {
+  const channel = openReplayBroadcastChannel();
+  if (!channel) {
+    return { channel: null, probeClaim: async () => false };
+  }
+  let pending: {
+    replayId: string;
+    resolve: (taken: boolean) => void;
+    timer: number;
+  } | null = null;
+  channel.onmessage = (event: MessageEvent) => {
+    const data = event?.data as ReplayBroadcastMessage | undefined | null;
+    if (!data || typeof data !== "object") return;
+    if (data.type === "an-replay-claim") {
+      if (data.instanceNonce === instanceNonce) return;
+      const ownsReplayId = state.active && state.replayId === data.replayId;
+      const winsSimultaneousClaim =
+        pending?.replayId === data.replayId &&
+        instanceNonce.localeCompare(data.instanceNonce) < 0;
+      if (!ownsReplayId && !winsSimultaneousClaim) {
+        // If both duplicated tabs start simultaneously, deterministically
+        // yield to the lower nonce rather than letting both probes time out
+        // and record under the copied replay id.
+        if (
+          pending?.replayId === data.replayId &&
+          data.instanceNonce.localeCompare(instanceNonce) < 0
+        ) {
+          window.clearTimeout(pending.timer);
+          const resolve = pending.resolve;
+          pending = null;
+          resolve(true);
+        }
+        return;
+      }
+      try {
+        const reply: ReplayClaimTakenMessage = {
+          type: "an-replay-claim-taken",
+          replayId: data.replayId,
+          claimantNonce: data.instanceNonce,
+        };
+        channel.postMessage(reply);
+      } catch {
+        // best-effort -- a lost reply just means the duplicate tab resumes
+        // recording under the shared id; later 409s still protect the
+        // stream from getting corrupted merges.
+      }
+      return;
+    }
+    if (data.type === "an-replay-claim-taken") {
+      if (
+        pending &&
+        data.replayId === pending.replayId &&
+        (!data.claimantNonce || data.claimantNonce === instanceNonce)
+      ) {
+        window.clearTimeout(pending.timer);
+        const resolve = pending.resolve;
+        pending = null;
+        resolve(true);
+      }
+    }
+  };
+  const probeClaim = (replayId: string): Promise<boolean> =>
+    new Promise((resolve) => {
+      const timer = window.setTimeout(() => {
+        pending = null;
+        resolve(false);
+      }, SESSION_REPLAY_CLAIM_TIMEOUT_MS);
+      pending = { replayId, resolve, timer };
+      try {
+        const claim: ReplayClaimMessage = {
+          type: "an-replay-claim",
+          replayId,
+          instanceNonce,
+        };
+        channel.postMessage(claim);
+      } catch {
+        window.clearTimeout(timer);
+        pending = null;
+        resolve(false);
+      }
+    });
+  return { channel, probeClaim };
 }
 
 function persistReplaySequence(
@@ -658,6 +890,7 @@ function normalizeOptions(
       options.network,
       DEFAULT_MAX_NETWORK_EVENTS,
     ),
+    onUploadRejected: options.onUploadRejected,
     extraProperties: options.extraProperties,
     shouldStart: options.shouldStart,
   };
@@ -732,8 +965,99 @@ function scrubReplayValue(
  * the scrub into the single serialization pass avoids a separate deep-clone of
  * every emitted event (FullSnapshots are large DOM trees) on the hot path.
  */
-function scrubReplayReplacer(key: string, value: unknown): unknown {
-  return typeof value === "string" ? scrubStringValue(key, value) : value;
+const REPLAY_RESOURCE_URL_ATTRIBUTES = new Set([
+  "src",
+  "srcset",
+  "poster",
+  "data",
+]);
+
+const REPLAY_RESOURCE_LINK_RELS = new Set([
+  "stylesheet",
+  "preload",
+  "modulepreload",
+  "icon",
+  "apple-touch-icon",
+  "mask-icon",
+]);
+
+/**
+ * Build a path-aware replay serializer without cloning the rrweb event.
+ *
+ * Privacy still wins for Meta/navigation URLs, anchor hrefs, and custom
+ * console/network diagnostics. The narrow exception is captured DOM resource
+ * attributes: changing a signed stylesheet/image/font URL makes rrweb rebuild
+ * a page that never existed and commonly produces missing CSS or giant fallback
+ * icons. JSON.stringify calls a replacer for an `attributes` object before its
+ * children, so the WeakMap lets the child callback recognize only that bag.
+ */
+function createReplayScrubReplacer(
+  resourceLinkNodeIds: Set<number>,
+): (this: unknown, key: string, value: unknown) => unknown {
+  const preservedAttributes = new WeakMap<object, Set<string>>();
+
+  return function replayScrubReplacer(
+    this: unknown,
+    key: string,
+    value: unknown,
+  ): unknown {
+    if (key === "attributes" && value && typeof value === "object") {
+      const attributes = value as Record<string, unknown>;
+      const resourceKeys = new Set<string>();
+      for (const attribute of REPLAY_RESOURCE_URL_ATTRIBUTES) {
+        if (typeof attributes[attribute] === "string") {
+          resourceKeys.add(attribute);
+        }
+      }
+
+      const holder =
+        this && typeof this === "object"
+          ? (this as Record<string, unknown>)
+          : undefined;
+      const tagName =
+        typeof holder?.tagName === "string" ? holder.tagName.toLowerCase() : "";
+      const nodeId =
+        typeof holder?.id === "number" && Number.isFinite(holder.id)
+          ? holder.id
+          : undefined;
+      const rel = String(attributes.rel ?? "")
+        .toLowerCase()
+        .split(/\s+/);
+      const hasResourceRel = rel.some((token) =>
+        REPLAY_RESOURCE_LINK_RELS.has(token),
+      );
+      if (nodeId !== undefined && tagName === "link" && hasResourceRel) {
+        resourceLinkNodeIds.add(nodeId);
+      } else if (
+        nodeId !== undefined &&
+        tagName === "" &&
+        Object.hasOwn(attributes, "rel")
+      ) {
+        if (hasResourceRel) resourceLinkNodeIds.add(nodeId);
+        else resourceLinkNodeIds.delete(nodeId);
+      }
+      if (
+        typeof attributes.href === "string" &&
+        ((tagName === "link" && hasResourceRel) ||
+          (nodeId !== undefined && resourceLinkNodeIds.has(nodeId)))
+      ) {
+        resourceKeys.add("href");
+      }
+
+      if (resourceKeys.size > 0) preservedAttributes.set(value, resourceKeys);
+      return value;
+    }
+
+    if (
+      typeof value === "string" &&
+      this &&
+      typeof this === "object" &&
+      preservedAttributes.get(this)?.has(key.toLowerCase())
+    ) {
+      return value;
+    }
+    return typeof value === "string" ? scrubStringValue(key, value) : value;
+  };
 }
 
 /**
@@ -741,9 +1065,15 @@ function scrubReplayReplacer(key: string, value: unknown): unknown {
  * directly on the queue and reused verbatim at flush, so each event is
  * stringified exactly once (was: deep-clone + size-stringify + flush-stringify).
  */
-function serializeReplayEvent(event: ReplayEvent): string {
+function serializeReplayEvent(
+  event: ReplayEvent,
+  resourceLinkNodeIds: Set<number>,
+): string {
   try {
-    return JSON.stringify(event, scrubReplayReplacer);
+    return JSON.stringify(
+      event,
+      createReplayScrubReplacer(resourceLinkNodeIds),
+    );
   } catch {
     return "";
   }
@@ -766,7 +1096,7 @@ function enqueueReplayEvent(
   event: ReplayEvent,
 ): void {
   if (!state.options) return;
-  const serialized = serializeReplayEvent(event);
+  const serialized = serializeReplayEvent(event, state.resourceLinkNodeIds);
   if (!serialized) return;
   const estimatedBytes = serialized.length;
   if (
@@ -977,6 +1307,27 @@ function canUseReplayKeepalive(body: BodyInit): boolean {
   return replayUploadBodyBytes(body) <= MAX_KEEPALIVE_REPLAY_UPLOAD_BYTES;
 }
 
+/** Thrown by `sendReplayUpload` on a non-ok HTTP response, carrying the
+ * status so `flushSessionReplay` can tell a permanent client rejection
+ * (e.g. a 409 checksum conflict, which can never succeed on retry) apart
+ * from a transient failure worth retrying. */
+class ReplayUploadHttpError extends Error {
+  readonly status: number;
+  constructor(status: number) {
+    super(`Session replay upload failed with HTTP ${status}`);
+    this.name = "ReplayUploadHttpError";
+    this.status = status;
+  }
+}
+
+/** 4xx statuses where retrying the exact same batch can never succeed --
+ * e.g. a 409 chunk-sequence/checksum conflict, or a 400 the server will
+ * reject again. 408 (timeout) and 429 (rate limit) are excluded because a
+ * later retry can plausibly succeed. */
+function isDefinitiveReplayUploadClientError(status: number): boolean {
+  return status >= 400 && status < 500 && status !== 408 && status !== 429;
+}
+
 async function sendReplayUpload(
   options: NormalizedSessionReplayOptions,
   body: string,
@@ -992,9 +1343,7 @@ async function sendReplayUpload(
       headers: { "Content-Type": "text/plain;charset=UTF-8" },
     });
     if (!response.ok) {
-      throw new Error(
-        `Session replay upload failed with HTTP ${response.status}`,
-      );
+      throw new ReplayUploadHttpError(response.status);
     }
     return;
   }
@@ -1012,9 +1361,7 @@ async function sendReplayUpload(
     },
   });
   if (!response.ok) {
-    throw new Error(
-      `Session replay upload failed with HTTP ${response.status}`,
-    );
+    throw new ReplayUploadHttpError(response.status);
   }
 }
 
@@ -1120,6 +1467,7 @@ export async function flushSessionReplay(reason = "manual"): Promise<void> {
   state.flushing = true;
   let uploaded = false;
   let reservedSequence = false;
+  let definitiveClientErrorStatus: number | null = null;
   try {
     await sendReplayUpload(state.options, payload.body, {
       beforeKeepaliveUpload: shouldReserveSequenceBeforeKeepalive(reason)
@@ -1130,16 +1478,44 @@ export async function flushSessionReplay(reason = "manual"): Promise<void> {
         : undefined,
     });
     if (!reservedSequence) advanceReplaySequence(state, payload);
+    state.automaticConflictRestartAttempted = false;
     uploaded = true;
   } catch (error) {
     if (reservedSequence) rollbackReplaySequenceReservation(state, payload);
-    restoreReplayEvents(state, events);
+    // A definitive 4xx (e.g. a 409 chunk-sequence/checksum conflict) can
+    // never succeed by retrying the exact same batch -- requeuing it would
+    // just spin forever, blocking every later batch behind it (flushes are
+    // FIFO via `retryBatches`). Drop it and move on instead.
+    const isDefinitiveClientError =
+      error instanceof ReplayUploadHttpError &&
+      isDefinitiveReplayUploadClientError(error.status);
+    if (isDefinitiveClientError) {
+      // Continuing after a checksum/sequence conflict would reuse the same
+      // rejected sequence forever. More importantly, advancing past it would
+      // append mutations to a replay whose DOM stream may belong to another
+      // tab. End this recorder and clear its persisted identity so the next
+      // start creates a clean replay instead of producing corrupt playback.
+      state.queue = [];
+      state.queuedBytes = 0;
+      state.retryBatches = [];
+      removeStoredReplaySession(payload.replayId);
+      definitiveClientErrorStatus = error.status;
+    } else {
+      restoreReplayEvents(state, events);
+    }
     // Guard the recorder's own warning so console capture never records it
     // (a captured warning would enqueue an event and retrigger a flush).
     const previousInternal = replayCaptureInternal;
     replayCaptureInternal = true;
     try {
-      console.warn("[session-replay] upload failed", error);
+      if (isDefinitiveClientError) {
+        console.warn(
+          `[session-replay] dropping upload (HTTP ${(error as ReplayUploadHttpError).status})`,
+          error,
+        );
+      } else {
+        console.warn("[session-replay] upload failed", error);
+      }
     } finally {
       replayCaptureInternal = previousInternal;
     }
@@ -1148,6 +1524,51 @@ export async function flushSessionReplay(reason = "manual"): Promise<void> {
   }
   if (uploaded && hasPendingReplayBatch(state)) {
     flushQueuedReplayIfNeeded(state);
+  }
+  if (
+    definitiveClientErrorStatus !== null &&
+    state.replayId === payload.replayId
+  ) {
+    const rejectedOptions = state.options;
+    const shouldRestartAfterConflict =
+      definitiveClientErrorStatus === 409 &&
+      !state.automaticConflictRestartAttempted;
+    if (shouldRestartAfterConflict) {
+      state.automaticConflictRestartAttempted = true;
+    }
+
+    await stopSessionReplay("upload-rejected");
+
+    // A 409 means this replay identity can no longer append safely (usually a
+    // duplicated tab that inherited sessionStorage, or an old shared identity
+    // still open during rollout). Do not leave a long-lived SPA tab silently
+    // unrecorded until its next page load: restart rrweb under a fresh per-tab
+    // id so it emits a new Meta + FullSnapshot stream. Limit this to one retry
+    // until an upload succeeds; other definitive 4xx responses usually reflect
+    // configuration/input errors and must not create a restart loop.
+    let restartResult: SessionReplayStartResult | null = null;
+    if (shouldRestartAfterConflict && rejectedOptions) {
+      restartResult = await startSessionReplay({
+        ...rejectedOptions,
+        console: rejectedOptions.console ?? false,
+        network: rejectedOptions.network ?? false,
+      });
+    }
+
+    // Rare recovery-path telemetry lets Analytics owners quantify conflicts
+    // without recording the rejected replay id, URL, or any captured content.
+    try {
+      rejectedOptions?.onUploadRejected?.({
+        status: definitiveClientErrorStatus,
+        restartAttempted: shouldRestartAfterConflict,
+        restartSucceeded: restartResult?.started === true,
+        ...(restartResult?.reason
+          ? { restartReason: restartResult.reason }
+          : {}),
+      });
+    } catch {
+      // best-effort telemetry must never interfere with recording recovery
+    }
   }
 }
 
@@ -2043,7 +2464,34 @@ async function startSessionReplayRecorder(
     return { started: false, reason: "disabled", sessionId, sampled };
   }
 
-  const replaySession = getOrCreateReplaySession(sessionId);
+  let replaySession = getOrCreateReplaySession(sessionId);
+  const instanceNonce = generateReplayId();
+  const { channel: replayChannel, probeClaim } = createReplayClaimChannel(
+    state,
+    instanceNonce,
+  );
+  // Only a *resumed* id needs the duplicated-tab check -- a freshly minted
+  // id can never collide with a recorder that's already running, so this
+  // never adds startup latency for the common "new tab" case.
+  if (replaySession.resumed && replayChannel) {
+    const taken = await probeClaim(replaySession.replayId);
+    if (taken) {
+      const freshReplayId = generateReplayId();
+      const freshStartedAtMs = Date.now();
+      writeStoredReplaySession({
+        sessionId,
+        replayId: freshReplayId,
+        startedAtMs: freshStartedAtMs,
+        sequence: 0,
+      });
+      replaySession = {
+        replayId: freshReplayId,
+        startedAtMs: freshStartedAtMs,
+        sequence: 0,
+        resumed: false,
+      };
+    }
+  }
   state.options = normalized;
   state.replayId = replaySession.replayId;
   state.startedAtMs = replaySession.startedAtMs;
@@ -2051,7 +2499,9 @@ async function startSessionReplayRecorder(
   state.queue = [];
   state.queuedBytes = 0;
   state.retryBatches = [];
+  state.resourceLinkNodeIds.clear();
   state.stopRecorder = null;
+  state.broadcastChannel = replayChannel;
   state.lastAuthenticatedProperties = replayUserEmail(initialProperties)
     ? { ...initialProperties }
     : null;
@@ -2096,6 +2546,12 @@ async function startSessionReplayRecorder(
       state.replayId = null;
       state.startedAtMs = null;
       state.lastAuthenticatedProperties = null;
+      try {
+        state.broadcastChannel?.close();
+      } catch {
+        // best-effort cleanup
+      }
+      state.broadcastChannel = null;
       return { started: false, reason: "record-failed", sessionId, sampled };
     }
     state.stopRecorder = stopRecorder;
@@ -2133,6 +2589,12 @@ async function startSessionReplayRecorder(
     state.replayId = null;
     state.startedAtMs = null;
     state.lastAuthenticatedProperties = null;
+    try {
+      state.broadcastChannel?.close();
+    } catch {
+      // best-effort cleanup
+    }
+    state.broadcastChannel = null;
     return { started: false, reason: "record-failed", sessionId, sampled };
   }
 }
@@ -2167,6 +2629,12 @@ export async function stopSessionReplay(reason = "manual"): Promise<void> {
   }
   state.restoreUrlMonitor?.();
   state.removeLifecycleListeners?.();
+  try {
+    state.broadcastChannel?.close();
+  } catch {
+    // best-effort cleanup
+  }
+  state.broadcastChannel = null;
   await flushSessionReplay(reason);
 }
 
@@ -2182,9 +2650,10 @@ export function isSessionReplayActive(): boolean {
 
 /**
  * The active session replay id when a recording is running, or the last one
- * persisted for this analytics session in `localStorage`. First-party error
- * capture uses this to tie each captured exception to the replay it happened
- * in, so triage can jump straight to `/sessions/<recordingId>`.
+ * persisted for this analytics session in this tab's `sessionStorage`.
+ * First-party error capture uses this to tie each captured exception to the
+ * replay it happened in, so triage can jump straight to
+ * `/sessions/<recordingId>`.
  */
 export function getSessionReplayId(): string | null {
   const state = getState();

--- a/packages/core/src/client/settings/DemoModeSection.tsx
+++ b/packages/core/src/client/settings/DemoModeSection.tsx
@@ -64,9 +64,9 @@ export function DemoModeSection() {
           Enable demo mode
         </div>
         <p className="text-[10px] text-muted-foreground mt-0.5">
-          Replace emails and numbers with realistic fake data everywhere — in
-          the UI and what the agent sees. Names, free text, labels, IDs, and
-          structure are preserved so the app keeps working.
+          Anonymize emails in the UI and reshape supported dashboard charts for
+          presentations. Agent-visible emails and numbers are also anonymized.
+          Names, labels, IDs, and structure stay intact.
         </p>
         {forced && (
           <p className="text-[10px] text-muted-foreground mt-0.5">

--- a/packages/core/src/demo/actions/toggle-demo-mode.ts
+++ b/packages/core/src/demo/actions/toggle-demo-mode.ts
@@ -5,7 +5,7 @@ import { writeAppState } from "../../application-state/script-helpers.js";
 
 export default defineAction({
   description:
-    "Turn demo mode on or off. When demo mode is on, the app replaces email addresses and numbers with realistic fake data everywhere — in the UI and in what you (the agent) see — while keeping names, free text, labels, IDs, dates, and structure intact so everything still works. Use when the user asks to 'hide my data', 'turn on demo mode', 'anonymize this for a screen share / recording', or similar. This is the same toggle as the Demo mode switch in settings.",
+    "Turn demo mode on or off. When demo mode is on, the UI replaces email addresses with realistic fake data and supported dashboards reshape chart values for presentations. Agent-visible results replace emails and numbers while keeping names, free text, labels, IDs, dates, and structure intact. Use when the user asks to 'hide my data', 'turn on demo mode', 'anonymize this for a screen share / recording', or similar. This is the same toggle as the Demo mode switch in settings.",
   schema: z.object({
     enabled: z
       .boolean()
@@ -16,7 +16,7 @@ export default defineAction({
     return {
       enabled,
       message: enabled
-        ? "Demo mode is ON — emails and numbers are now replaced with deterministic fake data everywhere (UI and agent). Names, free text, labels, IDs, and structure are preserved so everything keeps working."
+        ? "Demo mode is ON — UI emails are anonymized and supported dashboard charts are reshaped for presentation. Agent-visible emails and numbers are also anonymized. Names, free text, labels, IDs, and structure are preserved."
         : "Demo mode is OFF — real data is shown again.",
     };
   },

--- a/packages/core/src/demo/fetch-interceptor.spec.ts
+++ b/packages/core/src/demo/fetch-interceptor.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldSkipDemoResponseRedaction } from "./fetch-interceptor.js";
+
+describe("shouldSkipDemoResponseRedaction", () => {
+  it.each([
+    "/api/session-replay/recordings/sr_1/chunks?seqs=0,1",
+    "/api/session-replay/recordings/sr_1/chunks/0",
+    "/api/session-replay/recordings/sr_1/events?limit=1000",
+    "/api/session-replay/agent-events.json?id=sr_1",
+  ])("bypasses raw replay payload %s", (url) => {
+    expect(shouldSkipDemoResponseRedaction(url)).toBe(true);
+  });
+
+  it.each([
+    "/api/session-replay/recordings",
+    "/api/session-replay/recordings/sr_1",
+    "/api/session-replay/recordings/sr_1/manifest",
+    "/api/emails",
+  ])("keeps rendered record response %s eligible", (url) => {
+    expect(shouldSkipDemoResponseRedaction(url)).toBe(false);
+  });
+});

--- a/packages/core/src/demo/fetch-interceptor.ts
+++ b/packages/core/src/demo/fetch-interceptor.ts
@@ -46,6 +46,23 @@ const SKIP_SUBSTRINGS = [
   "/_agent-native/runs",
 ];
 
+// Raw rrweb payloads are playback data, not ordinary app UI records. Walking
+// and cloning their huge DOM/event trees on the main thread stalls playback
+// and can corrupt replay fidelity. Small list/summary/manifest responses stay
+// eligible so rendered visitor identities are still anonymized.
+const RAW_REPLAY_PAYLOAD_RE =
+  /\/api\/session-replay\/recordings\/[^/?#]+\/(?:chunks(?:\/[^/?#]+)?|events)(?:[/?#]|$)/;
+const RAW_AGENT_REPLAY_EVENTS_RE =
+  /\/api\/session-replay\/agent-events\.json(?:[?#]|$)/;
+
+export function shouldSkipDemoResponseRedaction(url: string): boolean {
+  return (
+    SKIP_SUBSTRINGS.some((substring) => url.includes(substring)) ||
+    RAW_REPLAY_PAYLOAD_RE.test(url) ||
+    RAW_AGENT_REPLAY_EVENTS_RE.test(url)
+  );
+}
+
 let installed = false;
 let demoEnabled = false;
 let originalFetch: typeof fetch | null = null;
@@ -148,7 +165,7 @@ export function ensureDemoModeFetchInterceptor(): void {
 
     try {
       const url = urlOf(input);
-      if (SKIP_SUBSTRINGS.some((s) => url.includes(s))) return res;
+      if (shouldSkipDemoResponseRedaction(url)) return res;
 
       // Only buffered, finite JSON. SSE / streaming / chunked-forever bodies
       // never reach `redactDemoData`: streaming content-types are excluded,
@@ -167,7 +184,13 @@ export function ensureDemoModeFetchInterceptor(): void {
       if (res.bodyUsed) return res;
 
       const data = await withTimeout(res.clone().json(), 3_000);
-      const redacted = redactDemoData(data);
+      // Frontend reads only need identity privacy. Dashboard charts apply
+      // their purpose-built demo trend transform at render time, so mutating
+      // every numeric field in every JSON response is unnecessary work.
+      const redacted = redactDemoData(data, {
+        redactNumbers: false,
+        redactProtectedEmails: true,
+      });
 
       const headers = new Headers(res.headers);
       // Body is re-serialized — these would be wrong now.

--- a/packages/core/src/demo/redact.spec.ts
+++ b/packages/core/src/demo/redact.spec.ts
@@ -80,6 +80,49 @@ describe("emails", () => {
     expect(emails[0]).toBe(emails[1]);
     expect(emails[0]).not.toContain("example.com");
   });
+
+  it("can redact email-backed identities while preserving other IDs", () => {
+    const out = redactDemoData(
+      {
+        userId: "jane.doe@acme.com",
+        user_key: "jane.doe@acme.com",
+        sessionId: "session-1234",
+      },
+      {
+        salt: "s",
+        redactNumbers: false,
+        redactProtectedEmails: true,
+      },
+    ) as {
+      userId: string;
+      user_key: string;
+      sessionId: string;
+    };
+
+    expect(out.userId).not.toBe("jane.doe@acme.com");
+    expect(out.user_key).toBe(out.userId);
+    expect(out.sessionId).toBe("session-1234");
+  });
+
+  it("supports email-only frontend redaction without changing numbers", () => {
+    const out = redactDemoData(
+      {
+        email: "jane.doe@acme.com",
+        count: 4200,
+        summary: "4200 visits by jane.doe@acme.com",
+      },
+      { salt: "s", redactNumbers: false },
+    ) as {
+      email: string;
+      count: number;
+      summary: string;
+    };
+
+    expect(out.email).not.toBe("jane.doe@acme.com");
+    expect(out.count).toBe(4200);
+    expect(out.summary).toContain("4200 visits");
+    expect(out.summary).not.toContain("jane.doe@acme.com");
+  });
 });
 
 describe("names and free text", () => {

--- a/packages/core/src/demo/redact.ts
+++ b/packages/core/src/demo/redact.ts
@@ -14,6 +14,13 @@
 
 export interface RedactOptions {
   salt?: string;
+  /** Redact numeric values. Defaults to true for backward compatibility. */
+  redactNumbers?: boolean;
+  /**
+   * Redact emails stored in otherwise protected structural fields such as
+   * `userId` and `userKey`. Intended for display-only frontend responses.
+   */
+  redactProtectedEmails?: boolean;
 }
 
 /* ------------------------------------------------------------------ *
@@ -532,18 +539,29 @@ function transformNumbers(text: string, salt: string): string {
  * Public: string redactor
  * ------------------------------------------------------------------ */
 
-function redactDemoStringInternal(text: string, salt: string): string {
+function redactDemoStringInternal(
+  text: string,
+  salt: string,
+  redactNumbers: boolean,
+): string {
   if (typeof text !== "string" || text.length === 0) return text;
+  if (!text.includes("@") && (!redactNumbers || !/[\d$€£¥]/.test(text))) {
+    return text;
+  }
 
   const { text: masked, restore } = protect(text);
   let out = masked;
   out = transformEmails(out, salt);
-  out = transformNumbers(out, salt);
+  if (redactNumbers) out = transformNumbers(out, salt);
   return unprotect(out, restore);
 }
 
 export function redactDemoString(text: string, opts?: RedactOptions): string {
-  return redactDemoStringInternal(text, opts?.salt ?? "");
+  return redactDemoStringInternal(
+    text,
+    opts?.salt ?? "",
+    opts?.redactNumbers !== false,
+  );
 }
 
 /* ------------------------------------------------------------------ *
@@ -586,6 +604,8 @@ function walk(
   salt: string,
   depth: number,
   seen: WeakSet<object>,
+  redactNumbers: boolean,
+  redactProtectedEmails: boolean,
 ): unknown {
   if (depth > MAX_DEPTH) return value;
 
@@ -594,11 +614,11 @@ function walk(
   const t = typeof value;
 
   if (t === "string") {
-    return redactDemoStringInternal(value as string, salt);
+    return redactDemoStringInternal(value as string, salt, redactNumbers);
   }
 
   if (t === "number") {
-    return redactNumberLeaf(value as number, salt);
+    return redactNumbers ? redactNumberLeaf(value as number, salt) : value;
   }
 
   if (t === "boolean" || t === "bigint" || t === "function" || t === "symbol") {
@@ -610,7 +630,9 @@ function walk(
   if (Array.isArray(value)) {
     if (seen.has(value)) return value;
     seen.add(value);
-    const out = value.map((item) => walk(item, salt, depth + 1, seen));
+    const out = value.map((item) =>
+      walk(item, salt, depth + 1, seen, redactNumbers, redactProtectedEmails),
+    );
     seen.delete(value);
     return out;
   }
@@ -629,14 +651,34 @@ function walk(
         ) {
           // Still recurse into nested structures, but the protected key does
           // not transform its own leaf value.
-          out[key] = walk(entry, salt, depth + 1, seen);
+          out[key] = walk(
+            entry,
+            salt,
+            depth + 1,
+            seen,
+            redactNumbers,
+            redactProtectedEmails,
+          );
+        } else if (
+          redactProtectedEmails &&
+          typeof entry === "string" &&
+          entry.includes("@")
+        ) {
+          out[key] = redactDemoStringInternal(entry, salt, false);
         } else {
           // Leaf under a protected key: pass through completely untouched.
           out[key] = entry;
         }
         continue;
       }
-      out[key] = walk(entry, salt, depth + 1, seen);
+      out[key] = walk(
+        entry,
+        salt,
+        depth + 1,
+        seen,
+        redactNumbers,
+        redactProtectedEmails,
+      );
     }
     seen.delete(value);
     return out;
@@ -648,7 +690,14 @@ function walk(
 
 export function redactDemoData<T>(value: T, opts?: RedactOptions): T {
   const salt = opts?.salt ?? "";
-  return walk(value, salt, 0, new WeakSet<object>()) as T;
+  return walk(
+    value,
+    salt,
+    0,
+    new WeakSet<object>(),
+    opts?.redactNumbers !== false,
+    opts?.redactProtectedEmails === true,
+  ) as T;
 }
 
 /**

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -140,7 +140,12 @@ export function createRequestHandler() {
     .default;
 }
 
-describe("generateWorkerEntry", () => {
+// These tests dynamically import generated workers. Under the full workspace
+// prep run, module startup shares CPU with many package suites and can exceed
+// Vitest's generic 5s default even though the worker responds correctly. Keep
+// a bounded suite-local allowance so local prep tests behavior, not scheduler
+// contention; focused runs normally complete well below this limit.
+describe("generateWorkerEntry", { timeout: 15_000 }, () => {
   afterEach(() => {
     for (const dir of tempDirs.splice(0)) {
       fs.rmSync(dir, { recursive: true, force: true });

--- a/packages/dispatch/src/routes/pages/chat.spec.tsx
+++ b/packages/dispatch/src/routes/pages/chat.spec.tsx
@@ -29,6 +29,11 @@ describe("Dispatch ChatRoute", () => {
   let root: Root;
 
   beforeEach(() => {
+    // ChatRoute intentionally clears navigation handoff state on a zero-delay
+    // timer. Keep that timer deterministic so a busy workspace test run cannot
+    // advance to the post-handoff hero render before this spec inspects the
+    // transition frame.
+    vi.useFakeTimers();
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
     clientState.surfaceProps = null;
     container = document.createElement("div");
@@ -39,6 +44,7 @@ describe("Dispatch ChatRoute", () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 

--- a/templates/analytics/.agents/skills/session-replay/SKILL.md
+++ b/templates/analytics/.agents/skills/session-replay/SKILL.md
@@ -102,9 +102,9 @@ agent answers about browser recordings in the Analytics template.
 - Wait for all replay chunks (`isComplete`) before constructing the rrweb
   `Replayer`. Progressive chunk publishes should only update the loading bar;
   rebuilding the player mid-load desyncs the scrubber and playhead.
-- Pass events to `Replayer` untouched. rrweb rebuilds them in a sandboxed iframe;
-  pre-processing DOM, stylesheet, resource, or mutation payloads makes playback
-  diverge from the captured page. In particular, never rewrite `href`, `src`,
+- Pass normal events to `Replayer` untouched. rrweb rebuilds them in a sandboxed
+  iframe; pre-processing DOM, stylesheet, resource, or mutation payloads makes
+  playback diverge from the captured page. In particular, never rewrite `href`, `src`,
   `_cssText`, CSS `url()`, or Meta URLs to `about:blank`; that exact remediation
   broke historical replay CSS in PR #2040. Handle request privacy at capture or
   the sandbox boundary instead of mutating stored rrweb events. Historical
@@ -112,15 +112,46 @@ agent answers about browser recordings in the Analytics template.
   requests for accurate rendering; the viewer accepts that fidelity tradeoff,
   uses rrweb's script-disabled sandbox plus `referrerpolicy="no-referrer"`, and
   must never add credentials or proxy those URLs through a privileged server.
+- Capture-time URL scrubbing must preserve load-bearing DOM resource attributes:
+  `src`, `srcset`, `poster`, `data`, and `href` only on resource links such as
+  stylesheets, preloads, and icons. Signed CDN query parameters are part of the
+  resource identity; redacting them produces missing CSS, fonts, images, and
+  oversized fallback icons. Keep scrubbing Meta/navigation URLs, anchor hrefs,
+  and console/network diagnostics. Captured `_cssText` and CSS `@import`/`url()`
+  values must remain byte-identical.
+- rrweb rebuilds into an `about:srcdoc` iframe, which inherits the Analytics
+  document's CSP. Analytics currently sends no CSP header; if a future change
+  adds restrictive `style-src`, `font-src`, or `img-src` directives, verify
+  historical replays and resolve external imports/fonts at capture before
+  blocking the recorded resource origins. Do not diagnose current font loss as
+  CSP without checking the deployed response headers first.
 - Let rrweb own normal iframe sizing via Meta / ViewportResize, and keep the
   outer wrapper in that same coordinate system for fit-to-stage scaling. Some
   legacy recordings contain demonstrably corrupt 4,000–7,500px-wide viewport
   values from ordinary desktop sessions. Only widths of at least 4,000px with
   aspect ratios above 4:1 are recovered to a 16:10 viewport; real 32:9 and
   mobile portrait captures remain untouched. The resize handler applies the
-  recovery to **both** rrweb's iframe and the outer stage.
+  recovery to **both** rrweb's iframe and the outer stage. This includes the
+  historical 3,000–3,999px-wide, sub-1,000px-high malformed shape; do not
+  narrow the guard back to only 4,000px+ recordings.
   Never remove this recovery, clamp only one layer, or broadly rewrite event
   geometry: those changes repeatedly recreated the ribbon/clipping regression.
+- The malformed-viewport recovery's sole event-data exception is pointer
+  geometry: project MouseMove, TouchMove, Drag, and MouseInteraction x/y into
+  the corrected camera and clamp impossible coordinates. Correcting the iframe
+  without its paired pointer projection makes rrweb cast valid target ids
+  thousands of pixels off-stage. Normal-viewport pointer events must retain
+  their original object references and exact coordinates.
+- Keep rrweb's stock cursor stylesheet and its hotspot transform. During
+  playback, hide the viewer's native pointer over Analytics' transparent
+  click-to-pause overlay so it cannot masquerade as a frozen recorded cursor.
+- Keep rrweb's recorded focus handling enabled. Focus and focus-visible state
+  affect menus, forms, and keyboard UX; disabling `triggerFocus` makes a valid
+  snapshot diverge from the source page.
+- `insertStyleRules` may suppress known toast/snackbar containers only. Never
+  hide generic framework primitives such as
+  `[data-radix-popper-content-wrapper]`: Radix dropdowns, selects, tooltips,
+  and other real recorded product UI all share that wrapper.
 - Keep the realistic fidelity and malformed-viewport tests in
   `SessionDetailPage.spec.ts`. Do not change their expectations merely to bless
   a new sanitizer or raw ultra-wide sizing; validate the affected replay in a
@@ -161,3 +192,14 @@ agent answers about browser recordings in the Analytics template.
   `.an-mask` or `data-an-mask`.
 - Use `.an-block`, `.an-ignore`, `data-an-block`, or `data-an-ignore` for
   sensitive zones that should not be captured.
+- A definitive upload `409` abandons only the conflicted replay identity and
+  immediately starts rrweb again under a fresh per-tab id, producing a new
+  Meta + FullSnapshot for long-lived SPA tabs. Recovery is limited to one
+  restart until an upload succeeds so a misconfigured endpoint cannot loop;
+  Analytics tracks the content-free `session replay upload rejected` lifecycle
+  event so conflicts and recovery success are measurable.
+- Do not label an old recording "corrupt" from pointer coordinates, unknown
+  mutation node ids, or changing Meta geometry alone. Those shapes can be
+  legitimate with scrolling, iframes/shadow DOM, navigation, and resize. A
+  historical-artifact notice needs a durable capture/ingest marker or another
+  low-false-positive invariant; do not guess from playback heuristics.

--- a/templates/analytics/app/global.css
+++ b/templates/analytics/app/global.css
@@ -245,9 +245,13 @@
   transform-origin: top left;
 }
 
-/* IMPORTANT: Keep rrweb's cursor styles stock. Its bundled stylesheet owns
-   the pointer plus click/touch states. App-specific cursor CSS previously made
-   Analytics disagree with rrweb and the builder-internal reference player. */
+/* IMPORTANT: Keep rrweb's stock SVG arrow. Only suppress its permanently
+   visible purple ::after disc, which can otherwise read as the cursor itself
+   when the arrow is small. The stock .active animation still supplies the
+   brief click halo. Do not replace the arrow with an app-colored dot. */
+.an-replay-stage-root .replayer-mouse::after {
+  opacity: 0;
+}
 
 .analytics-session-snippet .plan-code-surface {
   border: 0;

--- a/templates/analytics/app/global.css
+++ b/templates/analytics/app/global.css
@@ -245,71 +245,9 @@
   transform-origin: top left;
 }
 
-/* First-party visitor-cursor styles for rrweb playback. These are bundled
-   statically so the cursor stays visible even if the lazily imported
-   `@rrweb/replay/dist/style.css` sheet fails to load, and they replace the
-   default black arrow sprite with an app-styled indicator. The cursor lives
-   inside `.replayer-wrapper`, so it scales with the fit-to-stage transform. */
-.an-replay-stage-root .replayer-mouse {
-  position: absolute;
-  z-index: 2;
-  width: 1.125rem;
-  height: 1.5rem;
-  border-radius: 0;
-  background: transparent;
-  background-image: none;
-  box-shadow: none;
-  transform: none;
-  transition:
-    left 80ms linear,
-    top 80ms linear;
-  pointer-events: none;
-}
-
-.an-replay-stage-root .replayer-mouse::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: hsl(0 0% 100%);
-  clip-path: polygon(0 0, 0 77%, 30% 57%, 48% 100%, 68% 92%, 50% 51%, 92% 51%);
-  filter: drop-shadow(0 0 1px hsl(0 0% 0% / 0.95))
-    drop-shadow(0 1px 3px hsl(0 0% 0% / 0.35));
-}
-
-.an-replay-stage-root .replayer-mouse::after {
-  content: "";
-  position: absolute;
-  left: -0.5rem;
-  top: -0.5rem;
-  width: 1rem;
-  height: 1rem;
-  border-radius: 9999px;
-  border: 2px solid hsl(217 91% 60%);
-  background: transparent;
-  opacity: 0;
-}
-
-/* rrweb toggles `.active` on mouse interactions; pulse a click ripple. */
-.an-replay-stage-root .replayer-mouse.active::after {
-  animation: an-replay-mouse-click 0.4s ease-out 1;
-}
-
-@keyframes an-replay-mouse-click {
-  0% {
-    opacity: 0.5;
-    transform: scale(1);
-  }
-  100% {
-    opacity: 0;
-    transform: scale(3.5);
-  }
-}
-
-.an-replay-stage-root .replayer-mouse-tail {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-}
+/* IMPORTANT: Keep rrweb's cursor styles stock. Its bundled stylesheet owns
+   the pointer plus click/touch states. App-specific cursor CSS previously made
+   Analytics disagree with rrweb and the builder-internal reference player. */
 
 .analytics-session-snippet .plan-code-surface {
   border: 0;

--- a/templates/analytics/app/pages/sessions/SessionDetailPage.spec.ts
+++ b/templates/analytics/app/pages/sessions/SessionDetailPage.spec.ts
@@ -9,6 +9,8 @@ import {
   filterReplayMarkers,
   normalizeReplayEvents,
   partitionReplayChunkBatches,
+  projectReplayPointerCoordinates,
+  REPLAY_OVERLAY_STYLE_RULES,
   replayDevToolsIssueCount,
   replayInitialDisplayDimensions,
   replayInitialViewportDimensions,
@@ -26,6 +28,14 @@ afterEach(() => {
 });
 
 describe("session replay event normalization", () => {
+  it("suppresses only toast notifications, not recorded Radix product UI", () => {
+    const rules = REPLAY_OVERLAY_STYLE_RULES.join("\n");
+
+    expect(rules).toContain("Toastify");
+    expect(rules).toContain("Snackbar");
+    expect(rules).not.toContain("data-radix-popper-content-wrapper");
+  });
+
   it("passes captured rrweb URL and CSS payloads through untouched", () => {
     const events = [
       {
@@ -88,8 +98,13 @@ describe("session replay event normalization", () => {
       },
     ];
 
+    const serializedBeforeNormalization = JSON.stringify(events);
     const normalized = normalizeReplayEvents(events);
     expect(normalized).toEqual(events);
+    // Structural tripwire: playback normalization may filter and stable-sort,
+    // but it must never rewrite a byte of valid rrweb event data.
+    expect(JSON.stringify(normalized)).toBe(serializedBeforeNormalization);
+    expect(JSON.stringify(events)).toBe(serializedBeforeNormalization);
     expect(normalized[0]).toBe(events[0]);
     expect(normalized[1]).toBe(events[1]);
     expect(normalized[2]).toBe(events[2]);
@@ -109,6 +124,70 @@ describe("session replay event normalization", () => {
     expect(normalized).toEqual([earlier, later]);
     expect(normalized[0]).toBe(earlier);
     expect(normalized[1]).toBe(later);
+  });
+
+  it("projects pointer coordinates with malformed viewport recovery", () => {
+    const meta = {
+      type: 4,
+      timestamp: 1_000,
+      data: { width: 4_491, height: 941 },
+    };
+    const snapshot = {
+      type: 2,
+      timestamp: 1_010,
+      data: { node: { type: 0 } },
+    };
+    const move = {
+      type: 3,
+      timestamp: 2_000,
+      data: {
+        source: 1,
+        positions: [
+          { id: 417, x: 4_462, y: 125, timeOffset: 0 },
+          { id: 417, x: 8_114, y: 125, timeOffset: 40 },
+        ],
+      },
+    };
+    const click = {
+      type: 3,
+      timestamp: 2_050,
+      data: { source: 2, type: 2, id: 417, x: 4_462, y: 125 },
+    };
+
+    const projected = projectReplayPointerCoordinates([
+      meta,
+      snapshot,
+      move,
+      click,
+    ]);
+
+    expect(projected[0]).toBe(meta);
+    expect(projected[1]).toBe(snapshot);
+    expect(projected[2]).not.toBe(move);
+    expect(projected[2]?.data.positions[0].x).toBeCloseTo(1_496.28, 2);
+    expect(projected[2]?.data.positions[0].y).toBe(125);
+    expect(projected[2]?.data.positions[1].x).toBe(1_505);
+    expect(projected[3]).not.toBe(click);
+    expect(projected[3]?.data.x).toBeCloseTo(1_496.28, 2);
+    expect(projected[3]?.data.y).toBe(125);
+  });
+
+  it("preserves normal-viewport pointer references and coordinates", () => {
+    const meta = {
+      type: 4,
+      timestamp: 1_000,
+      data: { width: 1_440, height: 900 },
+    };
+    const click = {
+      type: 3,
+      timestamp: 2_000,
+      data: { source: 2, type: 2, id: 7, x: 900, y: 450 },
+    };
+
+    const projected = projectReplayPointerCoordinates([meta, click]);
+
+    expect(projected[0]).toBe(meta);
+    expect(projected[1]).toBe(click);
   });
 
   it("starts the display camera at the first recorded viewport", () => {
@@ -170,6 +249,16 @@ describe("session replay event normalization", () => {
       width: 300,
       height: 1200,
     });
+    expect(clampReplayDisplayDimensions({ width: 3189, height: 885 })).toEqual({
+      width: 1416,
+      height: 885,
+    });
+    expect(clampReplayDisplayDimensions({ width: 3440, height: 1440 })).toEqual(
+      {
+        width: 3440,
+        height: 1440,
+      },
+    );
     expect(clampReplayDisplayDimensions({ width: 5120, height: 1440 })).toEqual(
       {
         width: 5120,
@@ -430,7 +519,7 @@ describe("session replay timeline markers", () => {
 });
 
 describe("session replay inactivity ranges", () => {
-  it("ignores mutation, mouse-move, and custom diagnostic noise", () => {
+  it("ignores mutation, empty mouse-move, and custom diagnostic noise", () => {
     const ranges = buildIdleSkipRanges([
       { type: 4, timestamp: 1_000, data: {} },
       { type: 3, timestamp: 5_000, data: { source: 0 } },
@@ -459,6 +548,38 @@ describe("session replay inactivity ranges", () => {
     expect(ranges).toEqual([
       { startMs: 1_200, endMs: 18_800 },
       { startMs: 25_200, endMs: 47_800 },
+    ]);
+  });
+
+  it("keeps captured pointer movement out of inactivity skip ranges", () => {
+    const ranges = buildIdleSkipRanges([
+      { type: 4, timestamp: 1_000, data: {} },
+      {
+        type: 3,
+        timestamp: 10_000,
+        data: {
+          source: 1,
+          positions: [
+            { id: 1, x: 10, y: 20, timeOffset: -400 },
+            { id: 1, x: 30, y: 40, timeOffset: 0 },
+          ],
+        },
+      },
+      {
+        type: 3,
+        timestamp: 20_000,
+        data: {
+          source: 12,
+          positions: [{ id: 1, x: 50, y: 60, timeOffset: 100 }],
+        },
+      },
+      { type: 3, timestamp: 30_000, data: { source: 0 } },
+    ]);
+
+    expect(ranges).toEqual([
+      { startMs: 1_200, endMs: 7_400 },
+      { startMs: 10_200, endMs: 17_900 },
+      { startMs: 20_300, endMs: 27_800 },
     ]);
   });
 

--- a/templates/analytics/app/pages/sessions/SessionDetailPage.spec.ts
+++ b/templates/analytics/app/pages/sessions/SessionDetailPage.spec.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -17,6 +19,7 @@ import {
   replayPayloadEvents,
   replayViewportDimensions,
   replayViewportDimensionsAtTime,
+  shouldPublishReplayClockUpdate,
 } from "./SessionDetailPage";
 
 const originalFetch = globalThis.fetch;
@@ -28,12 +31,39 @@ afterEach(() => {
 });
 
 describe("session replay event normalization", () => {
-  it("suppresses only toast notifications, not recorded Radix product UI", () => {
-    const rules = REPLAY_OVERLAY_STYLE_RULES.join("\n");
+  it("coalesces animation-frame clock updates before publishing React state", () => {
+    expect(shouldPublishReplayClockUpdate(null, 1_000, 0, 10)).toBe(true);
+    expect(shouldPublishReplayClockUpdate(1_000, 1_016, 10, 26)).toBe(false);
+    expect(shouldPublishReplayClockUpdate(1_000, 1_100, 10, 110)).toBe(true);
+    expect(shouldPublishReplayClockUpdate(1_000, 1_100, 110, 110)).toBe(false);
+    expect(shouldPublishReplayClockUpdate(1_000, 1_100, 110, NaN)).toBe(false);
+  });
 
-    expect(rules).toContain("Toastify");
-    expect(rules).toContain("Snackbar");
-    expect(rules).not.toContain("data-radix-popper-content-wrapper");
+  it("keeps both the viewer pointer and rrweb's arrow cursor visible", () => {
+    const pageSource = readFileSync(
+      new URL("./SessionDetailPage.tsx", import.meta.url),
+      "utf8",
+    );
+    const globalStyles = readFileSync(
+      new URL("../../global.css", import.meta.url),
+      "utf8",
+    );
+
+    expect(pageSource).not.toContain('playing ? "cursor-none"');
+    expect(pageSource).toContain("z-20 cursor-pointer");
+    expect(globalStyles).toContain(
+      ".an-replay-stage-root .replayer-mouse::after",
+    );
+    expect(globalStyles).toMatch(
+      /\.an-replay-stage-root \.replayer-mouse::after\s*\{[^}]*opacity:\s*0;/,
+    );
+    expect(globalStyles).not.toContain(
+      ".an-replay-stage-root .replayer-mouse {",
+    );
+  });
+
+  it("preserves captured product overlays, including Sonner toasts", () => {
+    expect(REPLAY_OVERLAY_STYLE_RULES).toEqual([]);
   });
 
   it("passes captured rrweb URL and CSS payloads through untouched", () => {
@@ -252,6 +282,26 @@ describe("session replay event normalization", () => {
     expect(clampReplayDisplayDimensions({ width: 3189, height: 885 })).toEqual({
       width: 1416,
       height: 885,
+    });
+    expect(clampReplayDisplayDimensions({ width: 3188, height: 885 })).toEqual({
+      width: 3188,
+      height: 885,
+    });
+    expect(clampReplayDisplayDimensions({ width: 3190, height: 885 })).toEqual({
+      width: 3190,
+      height: 885,
+    });
+    expect(clampReplayDisplayDimensions({ width: 3189, height: 884 })).toEqual({
+      width: 3189,
+      height: 884,
+    });
+    expect(clampReplayDisplayDimensions({ width: 3189, height: 886 })).toEqual({
+      width: 3189,
+      height: 886,
+    });
+    expect(clampReplayDisplayDimensions({ width: 3440, height: 900 })).toEqual({
+      width: 3440,
+      height: 900,
     });
     expect(clampReplayDisplayDimensions({ width: 3440, height: 1440 })).toEqual(
       {

--- a/templates/analytics/app/pages/sessions/SessionDetailPage.tsx
+++ b/templates/analytics/app/pages/sessions/SessionDetailPage.tsx
@@ -168,10 +168,11 @@ const DEFAULT_PLAYER_WIDTH = 1024;
 const DEFAULT_PLAYER_HEIGHT = 640;
 const MALFORMED_REPLAY_MIN_WIDTH = 4000;
 const MALFORMED_REPLAY_MIN_ASPECT_RATIO = 4;
-const LEGACY_MALFORMED_REPLAY_MIN_WIDTH = 3000;
-const LEGACY_MALFORMED_REPLAY_MAX_WIDTH = 4000;
-const LEGACY_MALFORMED_REPLAY_MAX_HEIGHT = 1000;
-const LEGACY_MALFORMED_REPLAY_MIN_ASPECT_RATIO = 3.5;
+// Evidence-backed exception for the one pre-fix viewport shape observed in a
+// stored recording. Do not broaden this to an aspect-ratio range: valid
+// 3440x900 ultrawide browser viewports occupy the same range.
+const LEGACY_MALFORMED_REPLAY_WIDTH = 3189;
+const LEGACY_MALFORMED_REPLAY_HEIGHT = 885;
 const MIN_REPLAY_DISPLAY_DIMENSION = 240;
 const RECOVERED_REPLAY_DISPLAY_ASPECT_RATIO =
   DEFAULT_PLAYER_WIDTH / DEFAULT_PLAYER_HEIGHT;
@@ -190,24 +191,14 @@ const MIN_STAGE_HEIGHT_PX = 240;
 const SCRUBBER_MARKER_LIMIT = 500;
 const TIMELINE_MARKER_LIMIT = 300;
 const TIMELINE_FOLLOW_PAUSE_MS = 4000;
+const REPLAY_CLOCK_UPDATE_INTERVAL_MS = 100;
 /**
- * Toast/snackbar noise only — keep this aligned with builder-internal.
- *
- * IMPORTANT: never hide Radix's generic popper wrapper here. Dropdowns,
- * selects, tooltips, and other recorded product UI all share that wrapper;
- * suppressing it makes a structurally correct rrweb snapshot look broken.
+ * Keep captured overlays intact. Toasts and snackbars are product feedback,
+ * not recorder chrome, and can be essential to understanding the session.
+ * The recorder does not inject notification UI into the recorded document, so
+ * blanket selectors (including Sonner's data attributes) are not justified.
  */
-export const REPLAY_OVERLAY_STYLE_RULES = [
-  `.MuiSnackbar-root,
-  [class*="Snackbar-root"],
-  [class*="toast-container"],
-  [class*="Toast-container"],
-  [class*="Toastify"],
-  [class*="notistack-SnackbarContainer"],
-  [class*="notification-container"],
-  [class*="NotificationContainer"]
-  { display: none !important; }`,
-];
+export const REPLAY_OVERLAY_STYLE_RULES: string[] = [];
 type ReplayConsoleDiagnostics = ReturnType<
   typeof extractReplayDiagnostics
 >["console"];
@@ -500,6 +491,7 @@ function ReplayPlayer({
   const stageRootRef = useRef<HTMLDivElement>(null);
   const replayerRef = useRef<any>(null);
   const rafRef = useRef<number | null>(null);
+  const lastClockUpdateAtRef = useRef<number | null>(null);
   const [status, setStatus] = useState<ReplayPlayerStatus>("idle");
   const [error, setError] = useState<string | null>(null);
   const [playing, setPlaying] = useState(false);
@@ -544,9 +536,9 @@ function ReplayPlayer({
   // values even though the browser was a normal desktop viewport. Rendering
   // those raw values collapses the replay into a tiny horizontal ribbon. Keep
   // normal recordings exact—including 32:9 and mobile portrait. Recover only
-  // widths >=4,000px with aspect >4:1, plus the known 3,000–3,999px / short-
-  // height legacy shape, to the standard 16:10 viewport. The same dimensions
-  // are applied to rrweb's iframe so CSS breakpoints/camera agree.
+  // widths >=4,000px with aspect >4:1, plus the exact known 3,189x885 legacy
+  // shape, to the standard 16:10 viewport. The same dimensions are applied to
+  // rrweb's iframe so CSS breakpoints/camera agree.
   const displayDims = clampReplayDisplayDimensions(streamedDims ?? initialDims);
   const playerWidth = displayDims?.width ?? DEFAULT_PLAYER_WIDTH;
   const playerHeight = displayDims?.height ?? DEFAULT_PLAYER_HEIGHT;
@@ -645,10 +637,16 @@ function ReplayPlayer({
 
   const updateTime = useCallback(
     (next: number) => {
+      if (!Number.isFinite(next) || next === currentTimeRef.current) return;
+      // Keep the live value in sync before React commits. The animation clock
+      // can run again while React is still processing the previous render;
+      // relying on useLiveRef's effect here republishes the same value and can
+      // create a nested update loop in development.
+      currentTimeRef.current = next;
       setCurrentTime(next);
       onTimeUpdate(next);
     },
-    [onTimeUpdate],
+    [currentTimeRef, onTimeUpdate],
   );
 
   const seek = useCallback(
@@ -901,10 +899,11 @@ function ReplayPlayer({
     if (!playing || status !== "ready") {
       if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
       rafRef.current = null;
+      lastClockUpdateAtRef.current = null;
       return;
     }
 
-    const tick = () => {
+    const tick = (frameTime: number) => {
       const replayer = replayerRef.current;
       if (replayer && !scrubbingRef.current) {
         let nextTime = Number(
@@ -927,7 +926,17 @@ function ReplayPlayer({
             }
           }
         }
-        if (Number.isFinite(nextTime)) updateTime(nextTime);
+        if (
+          shouldPublishReplayClockUpdate(
+            lastClockUpdateAtRef.current,
+            frameTime,
+            currentTimeRef.current,
+            nextTime,
+          )
+        ) {
+          lastClockUpdateAtRef.current = frameTime;
+          updateTime(nextTime);
+        }
       }
       rafRef.current = requestAnimationFrame(tick);
     };
@@ -936,6 +945,7 @@ function ReplayPlayer({
     return () => {
       if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
       rafRef.current = null;
+      lastClockUpdateAtRef.current = null;
     };
   }, [
     currentTimeRef,
@@ -1021,14 +1031,11 @@ function ReplayPlayer({
                 />
                 <button
                   type="button"
-                  className={cn(
-                    "absolute inset-0 z-20 rounded-[inherit] border-0 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-default",
-                    // The full-stage click target is an Analytics convenience,
-                    // not part of stock rrweb. Hide the viewer's stationary
-                    // native pointer during playback so it cannot cover or be
-                    // mistaken for rrweb's recorded moving cursor underneath.
-                    playing ? "cursor-none" : "cursor-pointer",
-                  )}
+                  // IMPORTANT: Keep the viewer's real OS pointer visible while
+                  // the synthetic rrweb pointer replays underneath it. Hiding
+                  // this during playback makes the page feel broken whenever
+                  // the viewer moves their mouse over the full-stage control.
+                  className="absolute inset-0 z-20 cursor-pointer rounded-[inherit] border-0 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-default"
                   disabled={disabled}
                   aria-label={
                     playing ? t("sessions.pause") : t("sessions.play")
@@ -2548,10 +2555,8 @@ export function clampReplayDisplayDimensions(
     dims.width >= MALFORMED_REPLAY_MIN_WIDTH &&
     aspect > MALFORMED_REPLAY_MIN_ASPECT_RATIO;
   const hasLegacyMalformedWideGeometry =
-    dims.width >= LEGACY_MALFORMED_REPLAY_MIN_WIDTH &&
-    dims.width < LEGACY_MALFORMED_REPLAY_MAX_WIDTH &&
-    dims.height < LEGACY_MALFORMED_REPLAY_MAX_HEIGHT &&
-    aspect > LEGACY_MALFORMED_REPLAY_MIN_ASPECT_RATIO;
+    dims.width === LEGACY_MALFORMED_REPLAY_WIDTH &&
+    dims.height === LEGACY_MALFORMED_REPLAY_HEIGHT;
   if (hasMalformedWideGeometry || hasLegacyMalformedWideGeometry) {
     return {
       width: Math.round(dims.height * RECOVERED_REPLAY_DISPLAY_ASPECT_RATIO),
@@ -2715,6 +2720,20 @@ function formatNumber(value: number): string {
 function clamp(value: number, min: number, max: number): number {
   if (!Number.isFinite(value)) return min;
   return Math.min(max, Math.max(min, value));
+}
+
+export function shouldPublishReplayClockUpdate(
+  lastUpdateAt: number | null,
+  frameTime: number,
+  currentTime: number,
+  nextTime: number,
+): boolean {
+  if (!Number.isFinite(frameTime) || !Number.isFinite(nextTime)) return false;
+  if (nextTime === currentTime) return false;
+  return (
+    lastUpdateAt == null ||
+    frameTime - lastUpdateAt >= REPLAY_CLOCK_UPDATE_INTERVAL_MS
+  );
 }
 
 function isRecord(value: unknown): value is AnyRecord {

--- a/templates/analytics/app/pages/sessions/SessionDetailPage.tsx
+++ b/templates/analytics/app/pages/sessions/SessionDetailPage.tsx
@@ -168,6 +168,10 @@ const DEFAULT_PLAYER_WIDTH = 1024;
 const DEFAULT_PLAYER_HEIGHT = 640;
 const MALFORMED_REPLAY_MIN_WIDTH = 4000;
 const MALFORMED_REPLAY_MIN_ASPECT_RATIO = 4;
+const LEGACY_MALFORMED_REPLAY_MIN_WIDTH = 3000;
+const LEGACY_MALFORMED_REPLAY_MAX_WIDTH = 4000;
+const LEGACY_MALFORMED_REPLAY_MAX_HEIGHT = 1000;
+const LEGACY_MALFORMED_REPLAY_MIN_ASPECT_RATIO = 3.5;
 const MIN_REPLAY_DISPLAY_DIMENSION = 240;
 const RECOVERED_REPLAY_DISPLAY_ASPECT_RATIO =
   DEFAULT_PLAYER_WIDTH / DEFAULT_PLAYER_HEIGHT;
@@ -186,9 +190,23 @@ const MIN_STAGE_HEIGHT_PX = 240;
 const SCRUBBER_MARKER_LIMIT = 500;
 const TIMELINE_MARKER_LIMIT = 300;
 const TIMELINE_FOLLOW_PAUSE_MS = 4000;
-/** Toast/snackbar noise only — keep insertStyleRules minimal like builder-internal. */
-const SUPPRESS_OVERLAYS_CSS = [
-  "[data-radix-popper-content-wrapper], .Toastify, [class*='toast'], [class*='Toast'], [class*='Snackbar'] { display: none !important; }",
+/**
+ * Toast/snackbar noise only — keep this aligned with builder-internal.
+ *
+ * IMPORTANT: never hide Radix's generic popper wrapper here. Dropdowns,
+ * selects, tooltips, and other recorded product UI all share that wrapper;
+ * suppressing it makes a structurally correct rrweb snapshot look broken.
+ */
+export const REPLAY_OVERLAY_STYLE_RULES = [
+  `.MuiSnackbar-root,
+  [class*="Snackbar-root"],
+  [class*="toast-container"],
+  [class*="Toast-container"],
+  [class*="Toastify"],
+  [class*="notistack-SnackbarContainer"],
+  [class*="notification-container"],
+  [class*="NotificationContainer"]
+  { display: none !important; }`,
 ];
 type ReplayConsoleDiagnostics = ReturnType<
   typeof extractReplayDiagnostics
@@ -235,11 +253,13 @@ const RRWEB_EVENT_TYPE = {
 
 const INCREMENTAL_SOURCE = {
   Mutation: 0,
+  MouseMove: 1,
   MouseInteraction: 2,
   Scroll: 3,
   ViewportResize: 4,
   Input: 5,
   TouchMove: 6,
+  Drag: 12,
 } as const;
 
 const MOUSE_INTERACTION = {
@@ -520,12 +540,13 @@ function ReplayPlayer({
   const scrubResumePlayingRef = useRef(false);
 
   // IMPORTANT — DO NOT REMOVE THIS LEGACY VIEWPORT CORRECTION.
-  // Some stored sessions contain impossible 4,000–7,500px-wide Meta/resize
+  // Some stored sessions contain impossible 3,000–7,500px-wide Meta/resize
   // values even though the browser was a normal desktop viewport. Rendering
   // those raw values collapses the replay into a tiny horizontal ribbon. Keep
   // normal recordings exact—including 32:9 and mobile portrait. Recover only
-  // widths >=4,000px with aspect >4:1 to the standard 16:10 viewport. The same
-  // dimensions are applied to rrweb's iframe so CSS breakpoints/camera agree.
+  // widths >=4,000px with aspect >4:1, plus the known 3,000–3,999px / short-
+  // height legacy shape, to the standard 16:10 viewport. The same dimensions
+  // are applied to rrweb's iframe so CSS breakpoints/camera agree.
   const displayDims = clampReplayDisplayDimensions(streamedDims ?? initialDims);
   const playerWidth = displayDims?.width ?? DEFAULT_PLAYER_WIDTH;
   const playerHeight = displayDims?.height ?? DEFAULT_PLAYER_HEIGHT;
@@ -709,27 +730,17 @@ function ReplayPlayer({
     let localReplayer: any = null;
 
     async function loadReplay() {
-      // Wait for the full recording before creating the Replayer. Progressive
-      // chunk publishes used to rebuild the player on every append, which
-      // reset the clock, disabled the scrubber, and desynced the playhead.
       const replayEvents = eventsRef.current;
+      // Replayer construction remains all-or-nothing. Progressive response
+      // publishes update loading progress only; rebuilding during download
+      // rewinds the player and can desync the scrubber/playhead.
       if (!response.isComplete) {
         setStatus("loading");
         setError(null);
         setPlaying(false);
         return;
       }
-      if (replayEvents.length < 2) {
-        throw new Error(t("sessions.noReplayEvents"));
-      }
-      if (
-        !replayEvents.some(
-          (event) => event.type === RRWEB_EVENT_TYPE.FullSnapshot,
-        )
-      ) {
-        throw new Error(t("sessions.noReplayEvents"));
-      }
-      if (!hasPlayableReplayEvents(replayEvents)) {
+      if (replayEvents.length < 2 || !hasPlayableReplayEvents(replayEvents)) {
         throw new Error(t("sessions.noReplayEvents"));
       }
       setStatus("loading");
@@ -747,15 +758,27 @@ function ReplayPlayer({
       const rawInitialDims = replayInitialViewportDimensions(replayEvents);
       const correctedInitialDims = replayInitialDisplayDimensions(replayEvents);
       setStreamedDims(correctedInitialDims);
-      localReplayer = new Replayer(replayEvents as any[], {
+      // The legacy malformed-width recordings need one paired exception to
+      // raw-event pass-through: pointer coordinates were captured in the same
+      // impossible viewport coordinate space. Correcting only the iframe makes
+      // rrweb cast clicks thousands of pixels off-stage. Project pointer data
+      // with each malformed Meta/resize while retaining every other raw field.
+      const playerEvents = projectReplayPointerCoordinates(replayEvents);
+      // Keep this loosely typed because the legacy viewport recovery below
+      // intentionally calls rrweb's runtime handleResize hook, which its
+      // TypeScript declaration marks private.
+      localReplayer = new Replayer(playerEvents as any[], {
         root: stageRootRef.current,
         speed: speedRef.current,
         skipInactive: false,
         showWarning: false,
         showDebug: false,
-        triggerFocus: false,
         mouseTail: false,
-        insertStyleRules: SUPPRESS_OVERLAYS_CSS,
+        // Match stock rrweb/builder-internal focus replay. Disabling focus
+        // drops recorded focus-visible state and can leave menus/forms looking
+        // unlike the source page even when the snapshot CSS is correct.
+        triggerFocus: true,
+        insertStyleRules: REPLAY_OVERLAY_STYLE_RULES,
       });
       // IMPORTANT: rrweb constructs its iframe from the raw initial Meta event.
       // When that legacy Meta width is malformed, correcting only streamedDims
@@ -766,7 +789,7 @@ function ReplayPlayer({
         (rawInitialDims?.width !== correctedInitialDims.width ||
           rawInitialDims?.height !== correctedInitialDims.height)
       ) {
-        localReplayer.handleResize?.(correctedInitialDims);
+        (localReplayer as any).handleResize?.(correctedInitialDims);
       }
       // rrweb already sandboxes the replay document without script execution.
       // Do not mutate recorded URLs/CSS; suppress viewer-page referrer leakage
@@ -805,18 +828,23 @@ function ReplayPlayer({
           // rrweb handles the raw resize before notifying us. Override only
           // impossible legacy geometry so its iframe and our stage stay equal.
           // DO NOT clamp just one layer; that breaks responsive CSS and clicks.
+          if (
+            correctedDims.width !== rawDims.width ||
+            correctedDims.height !== rawDims.height
+          ) {
+            // rrweb applies the raw Meta/ViewportResize to its iframe before
+            // emitting this callback. Re-apply the correction every time the
+            // raw event is malformed, even when React already stores the same
+            // corrected dimensions. Returning early here recreates the exact
+            // bug where the outer stage is normal but the iframe is ultra-wide.
+            (localReplayer as any).handleResize?.(correctedDims);
+          }
           const currentDims = streamedDimsRef.current;
           if (
             currentDims?.width === correctedDims.width &&
             currentDims?.height === correctedDims.height
           ) {
             return;
-          }
-          if (
-            correctedDims.width !== rawDims.width ||
-            correctedDims.height !== rawDims.height
-          ) {
-            localReplayer.handleResize?.(correctedDims);
           }
           setStreamedDims(correctedDims);
         }
@@ -851,6 +879,7 @@ function ReplayPlayer({
       try {
         localReplayer?.pause?.();
         localReplayer?.destroy?.();
+        replayerRef.current?.pause?.();
         replayerRef.current?.destroy?.();
       } catch {
         // rrweb cleanup is best-effort across versions.
@@ -858,9 +887,6 @@ function ReplayPlayer({
       replayerRef.current = null;
       if (stageRootRef.current) stageRootRef.current.innerHTML = "";
     };
-    // Key only on isComplete + a stable events identity. Including the events
-    // array reference would rebuild the Replayer when the final publish()
-    // replaces the chunks object even though the event set is unchanged.
   }, [
     currentTimeRef,
     eventsIdentity,
@@ -995,7 +1021,14 @@ function ReplayPlayer({
                 />
                 <button
                   type="button"
-                  className="absolute inset-0 z-20 cursor-pointer rounded-[inherit] border-0 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-default"
+                  className={cn(
+                    "absolute inset-0 z-20 rounded-[inherit] border-0 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-default",
+                    // The full-stage click target is an Analytics convenience,
+                    // not part of stock rrweb. Hide the viewer's stationary
+                    // native pointer during playback so it cannot cover or be
+                    // mistaken for rrweb's recorded moving cursor underneath.
+                    playing ? "cursor-none" : "cursor-pointer",
+                  )}
                   disabled={disabled}
                   aria-label={
                     playing ? t("sessions.pause") : t("sessions.play")
@@ -1954,6 +1987,102 @@ export function normalizeReplayEvents(events: unknown[]): AnyReplayEvent[] {
     .sort((a, b) => Number(a.timestamp ?? 0) - Number(b.timestamp ?? 0));
 }
 
+/**
+ * Pair pointer coordinates with the narrowly gated legacy viewport recovery.
+ *
+ * IMPORTANT: do not apply this to normal recordings and do not rewrite the
+ * Meta/resize events themselves. rrweb must still rebuild the captured DOM
+ * from raw events; only pointer coordinates need projection into the corrected
+ * iframe camera. Returning original references for untouched events keeps this
+ * compatible with stock rrweb and avoids cloning large snapshots.
+ */
+export function projectReplayPointerCoordinates(
+  events: AnyReplayEvent[],
+): AnyReplayEvent[] {
+  let rawDims: ReplayViewportDimensions | null = null;
+  let displayDims: ReplayViewportDimensions | null = null;
+
+  return events.map((event) => {
+    const nextDims = dimensionsFromReplayEvent(event);
+    if (nextDims) {
+      rawDims = nextDims;
+      displayDims = clampReplayDisplayDimensions(nextDims);
+      return event;
+    }
+    if (
+      !rawDims ||
+      !displayDims ||
+      (rawDims.width === displayDims.width &&
+        rawDims.height === displayDims.height) ||
+      event.type !== RRWEB_EVENT_TYPE.IncrementalSnapshot
+    ) {
+      return event;
+    }
+
+    const source = event.data?.source;
+    if (source === INCREMENTAL_SOURCE.MouseInteraction) {
+      const data = projectReplayPointerData(event.data, rawDims, displayDims);
+      return data === event.data ? event : { ...event, data };
+    }
+    if (
+      source !== INCREMENTAL_SOURCE.MouseMove &&
+      source !== INCREMENTAL_SOURCE.TouchMove &&
+      source !== INCREMENTAL_SOURCE.Drag
+    ) {
+      return event;
+    }
+    const positions = Array.isArray(event.data?.positions)
+      ? event.data.positions
+      : [];
+    let changed = false;
+    const projectedPositions = positions.map((position: unknown) => {
+      if (!isRecord(position)) return position;
+      const projected = projectReplayPointerData(
+        position,
+        rawDims!,
+        displayDims!,
+      );
+      if (projected !== position) changed = true;
+      return projected;
+    });
+    return changed
+      ? { ...event, data: { ...event.data, positions: projectedPositions } }
+      : event;
+  });
+}
+
+function projectReplayPointerData(
+  data: AnyReplayEvent,
+  rawDims: ReplayViewportDimensions,
+  displayDims: ReplayViewportDimensions,
+): AnyReplayEvent {
+  const projectedX = projectReplayCoordinate(
+    data.x,
+    displayDims.width / rawDims.width,
+    displayDims.width,
+  );
+  const projectedY = projectReplayCoordinate(
+    data.y,
+    displayDims.height / rawDims.height,
+    displayDims.height,
+  );
+  if (projectedX === data.x && projectedY === data.y) return data;
+  return {
+    ...data,
+    ...(projectedX !== undefined ? { x: projectedX } : {}),
+    ...(projectedY !== undefined ? { y: projectedY } : {}),
+  };
+}
+
+function projectReplayCoordinate(
+  value: unknown,
+  scale: number,
+  maximum: number,
+): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return clamp(value * scale, 0, Math.max(0, maximum - 1));
+}
+
 export function buildReplayMarkers(events: AnyReplayEvent[]): ReplayMarker[] {
   const startedAt = replayStartedAt(events);
   const markers: ReplayMarker[] = [];
@@ -2169,9 +2298,7 @@ export function buildIdleSkipRanges(events: AnyReplayEvent[]): SkipRange[] {
     const timestamp = Number(event.timestamp ?? 0);
     if (!Number.isFinite(timestamp) || timestamp <= 0) continue;
     lastTimestamp = Math.max(lastTimestamp, timestamp);
-    if (isReplayActivityEvent(event)) {
-      interactions.push(timestamp);
-    }
+    interactions.push(...replayActivityTimestamps(event, timestamp));
   }
   interactions.sort((a, b) => a - b);
   const ranges: SkipRange[] = [];
@@ -2194,22 +2321,42 @@ export function buildIdleSkipRanges(events: AnyReplayEvent[]): SkipRange[] {
   return ranges;
 }
 
-function isReplayActivityEvent(event: AnyReplayEvent): boolean {
-  if (event.type === RRWEB_EVENT_TYPE.Meta) return true;
-  if (event.type !== RRWEB_EVENT_TYPE.IncrementalSnapshot) return false;
+function replayActivityTimestamps(
+  event: AnyReplayEvent,
+  timestamp: number,
+): number[] {
+  if (event.type === RRWEB_EVENT_TYPE.Meta) return [timestamp];
+  if (event.type !== RRWEB_EVENT_TYPE.IncrementalSnapshot) return [];
 
   const source = event.data?.source;
   if (
-    source === INCREMENTAL_SOURCE.Input ||
-    source === INCREMENTAL_SOURCE.Scroll ||
-    source === INCREMENTAL_SOURCE.TouchMove
+    source === INCREMENTAL_SOURCE.MouseMove ||
+    source === INCREMENTAL_SOURCE.TouchMove ||
+    source === INCREMENTAL_SOURCE.Drag
   ) {
-    return true;
+    const positions = Array.isArray(event.data?.positions)
+      ? event.data.positions
+      : [];
+    // IMPORTANT: rrweb batches pointer positions and schedules each one at
+    // event.timestamp + timeOffset. Treat those exact moments as activity.
+    // Ignoring the batch made Skip inactivity jump across visible movement,
+    // which looked like a frozen cursor even though the recording was intact.
+    return positions.flatMap((position: unknown) => {
+      if (!isRecord(position)) return [];
+      const timeOffset = Number(position.timeOffset ?? 0);
+      return [timestamp + (Number.isFinite(timeOffset) ? timeOffset : 0)];
+    });
   }
-  if (source !== INCREMENTAL_SOURCE.MouseInteraction) return false;
+  if (
+    source === INCREMENTAL_SOURCE.Input ||
+    source === INCREMENTAL_SOURCE.Scroll
+  ) {
+    return [timestamp];
+  }
+  if (source !== INCREMENTAL_SOURCE.MouseInteraction) return [];
 
   const interactionType = event.data?.type;
-  return (
+  return [
     interactionType === MOUSE_INTERACTION.MouseUp ||
     interactionType === MOUSE_INTERACTION.MouseDown ||
     interactionType === MOUSE_INTERACTION.Click ||
@@ -2218,7 +2365,9 @@ function isReplayActivityEvent(event: AnyReplayEvent): boolean {
     interactionType === MOUSE_INTERACTION.Focus ||
     interactionType === MOUSE_INTERACTION.TouchStart ||
     interactionType === MOUSE_INTERACTION.TouchEnd
-  );
+      ? timestamp
+      : null,
+  ].filter((value): value is number => value !== null);
 }
 
 function pushIdleRange(
@@ -2395,10 +2544,15 @@ export function clampReplayDisplayDimensions(
     return { width: DEFAULT_PLAYER_WIDTH, height: DEFAULT_PLAYER_HEIGHT };
   }
   const aspect = dims.width / dims.height;
-  if (
+  const hasMalformedWideGeometry =
     dims.width >= MALFORMED_REPLAY_MIN_WIDTH &&
-    aspect > MALFORMED_REPLAY_MIN_ASPECT_RATIO
-  ) {
+    aspect > MALFORMED_REPLAY_MIN_ASPECT_RATIO;
+  const hasLegacyMalformedWideGeometry =
+    dims.width >= LEGACY_MALFORMED_REPLAY_MIN_WIDTH &&
+    dims.width < LEGACY_MALFORMED_REPLAY_MAX_WIDTH &&
+    dims.height < LEGACY_MALFORMED_REPLAY_MAX_HEIGHT &&
+    aspect > LEGACY_MALFORMED_REPLAY_MIN_ASPECT_RATIO;
+  if (hasMalformedWideGeometry || hasLegacyMalformedWideGeometry) {
     return {
       width: Math.round(dims.height * RECOVERED_REPLAY_DISPLAY_ASPECT_RATIO),
       height: dims.height,

--- a/templates/analytics/changelog/2026-07-12-fixed-session-replays-that-appeared-ultra-wide-hid-recorded-.md
+++ b/templates/analytics/changelog/2026-07-12-fixed-session-replays-that-appeared-ultra-wide-hid-recorded-.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-12
+---
+
+Fixed session replays that appeared ultra-wide, hid recorded menus, or skipped captured cursor movement.

--- a/templates/analytics/changelog/2026-07-12-session-replays-load-faster-in-demo-mode-while-visitor-email.md
+++ b/templates/analytics/changelog/2026-07-12-session-replays-load-faster-in-demo-mode-while-visitor-email.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-12
+---
+
+Session replays load faster in demo mode while visitor emails stay anonymized.

--- a/templates/calendar/app/components/calendar/DeleteEventDialog.test.tsx
+++ b/templates/calendar/app/components/calendar/DeleteEventDialog.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment happy-dom
+
+import type { CalendarEvent } from "@shared/api";
+import {
+  act,
+  type KeyboardEventHandler,
+  type ReactNode,
+  useEffect,
+} from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DeleteEventDialog } from "./DeleteEventDialog";
+
+vi.mock("@agent-native/core/client", () => ({
+  useT:
+    () =>
+    (key: string): string =>
+      key,
+}));
+
+vi.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({ children }: { children: ReactNode }) => <>{children}</>,
+  AlertDialogContent: ({
+    children,
+    onKeyDown,
+    onOpenAutoFocus,
+  }: {
+    children: ReactNode;
+    onKeyDown?: KeyboardEventHandler<HTMLDivElement>;
+    onOpenAutoFocus?: (event: { preventDefault: () => void }) => void;
+  }) => {
+    useEffect(() => {
+      onOpenAutoFocus?.({ preventDefault: vi.fn() });
+    }, [onOpenAutoFocus]);
+    return <div onKeyDown={onKeyDown}>{children}</div>;
+  },
+  AlertDialogHeader: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogTitle: ({ children }: { children: ReactNode }) => (
+    <h2>{children}</h2>
+  ),
+  AlertDialogDescription: ({ children }: { children: ReactNode }) => (
+    <p>{children}</p>
+  ),
+  AlertDialogFooter: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogCancel: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/radio-group", () => ({
+  RadioGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  RadioGroupItem: ({ value }: { value: string }) => (
+    <input type="radio" value={value} />
+  ),
+}));
+
+describe("DeleteEventDialog", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("focuses the delete action so Enter can confirm the default scope", () => {
+    const onConfirm = vi.fn();
+    const event: CalendarEvent = {
+      id: "event-1",
+      title: "Recurring sync",
+      description: "",
+      location: "",
+      start: "2026-07-12T16:00:00.000Z",
+      end: "2026-07-12T16:30:00.000Z",
+      allDay: false,
+      source: "google",
+      recurringEventId: "series-1",
+      createdAt: "2026-07-12T15:00:00.000Z",
+      updatedAt: "2026-07-12T15:00:00.000Z",
+    };
+
+    act(() => {
+      root.render(
+        <DeleteEventDialog
+          event={event}
+          open
+          onClose={() => undefined}
+          onConfirm={onConfirm}
+        />,
+      );
+    });
+
+    const deleteButton = Array.from(document.querySelectorAll("button")).find(
+      (button) => button.textContent === "deleteEvent.deleteEvent",
+    );
+    expect(deleteButton).toBeTruthy();
+    expect(document.activeElement).toBe(deleteButton);
+
+    act(() => deleteButton!.click());
+
+    expect(onConfirm).toHaveBeenCalledWith({
+      scope: "single",
+      sendUpdates: "none",
+      notificationMessage: undefined,
+      removeOnly: false,
+    });
+  });
+});

--- a/templates/calendar/app/components/calendar/DeleteEventDialog.tsx
+++ b/templates/calendar/app/components/calendar/DeleteEventDialog.tsx
@@ -1,6 +1,6 @@
 import { useT } from "@agent-native/core/client";
 import type { CalendarEvent, DeleteEventScope } from "@shared/api";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { getGuestAttendeeCount } from "@/components/calendar/GuestNotificationDialog";
 import {
@@ -36,6 +36,7 @@ export function DeleteEventDialog({
   onConfirm,
 }: DeleteEventDialogProps) {
   const t = useT();
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
   const [scope, setScope] = useState<DeleteEventScope>("single");
   const [message, setMessage] = useState("");
 
@@ -108,7 +109,14 @@ export function DeleteEventDialog({
 
   return (
     <AlertDialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <AlertDialogContent className="max-w-[420px]" onKeyDown={handleKeyDown}>
+      <AlertDialogContent
+        className="max-w-[420px]"
+        onKeyDown={handleKeyDown}
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          confirmButtonRef.current?.focus();
+        }}
+      >
         <AlertDialogHeader>
           <AlertDialogTitle className="text-sm">{copy.title}</AlertDialogTitle>
           <AlertDialogDescription>{copy.description}</AlertDialogDescription>
@@ -174,6 +182,7 @@ export function DeleteEventDialog({
             </Button>
           )}
           <Button
+            ref={confirmButtonRef}
             variant="destructive"
             onClick={() => handleConfirm(canNotifyGuests ? "all" : "none")}
           >

--- a/templates/calendar/app/components/calendar/EventAttendeesSection.test.tsx
+++ b/templates/calendar/app/components/calendar/EventAttendeesSection.test.tsx
@@ -7,6 +7,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { EventAttendeesSection } from "./EventAttendeesSection";
 
+const rsvpMutate = vi.hoisted(() => vi.fn());
+
 vi.mock("@agent-native/core/client", () => ({
   cn: (...values: Array<string | undefined | false>) =>
     values.filter(Boolean).join(" "),
@@ -37,6 +39,18 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
   ),
 }));
 
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: ReactNode }) => children,
+  PopoverContent: ({
+    children,
+    onKeyDown,
+  }: {
+    children: ReactNode;
+    onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
+  }) => <div onKeyDown={onKeyDown}>{children}</div>,
+}));
+
 vi.mock("@/hooks/use-attendee-photos", () => ({
   useAttendeePhotos: () => ({ data: {} }),
 }));
@@ -47,7 +61,7 @@ vi.mock("@/hooks/use-attendee-timezones", () => ({
 }));
 
 vi.mock("@/hooks/use-events", () => ({
-  useRsvpEvent: () => ({ isPending: false, mutate: vi.fn() }),
+  useRsvpEvent: () => ({ isPending: false, mutate: rsvpMutate }),
 }));
 
 describe("EventAttendeesSection attendee controls", () => {
@@ -55,6 +69,7 @@ describe("EventAttendeesSection attendee controls", () => {
   let root: Root;
 
   beforeEach(() => {
+    rsvpMutate.mockReset();
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -109,5 +124,75 @@ describe("EventAttendeesSection attendee controls", () => {
     expect(guestOptions).toBeTruthy();
     expect(attendeeDetails!.contains(guestOptions)).toBe(false);
     expect(document.querySelector("button button")).toBeNull();
+  });
+
+  it("submits a recurring response with Cmd+Enter from the note", () => {
+    const event: CalendarEvent = {
+      id: "event-2",
+      title: "Planning",
+      description: "",
+      location: "",
+      start: "2026-07-10T16:00:00.000Z",
+      end: "2026-07-10T17:00:00.000Z",
+      allDay: false,
+      source: "google",
+      recurringEventId: "recurring-1",
+      createdAt: "2026-07-10T15:00:00.000Z",
+      updatedAt: "2026-07-10T15:00:00.000Z",
+      responseStatus: "accepted",
+      attendees: [
+        {
+          email: "me@example.com",
+          displayName: "Me",
+          responseStatus: "accepted",
+          self: true,
+        },
+      ],
+    };
+
+    act(() => {
+      root.render(<EventAttendeesSection event={event} />);
+    });
+
+    const maybeButton = Array.from(document.querySelectorAll("button")).find(
+      (button) => button.textContent === "eventForm.rsvpMaybe",
+    );
+    expect(maybeButton).toBeTruthy();
+
+    act(() => {
+      maybeButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const textarea = document.querySelector("textarea");
+    expect(textarea).toBeTruthy();
+    const setTextareaValue = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      "value",
+    )?.set;
+
+    act(() => {
+      setTextareaValue?.call(textarea, "Let's catch up async instead");
+      textarea!.dispatchEvent(new Event("input", { bubbles: true }));
+      textarea!.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Enter",
+          metaKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+
+    expect(rsvpMutate).toHaveBeenCalledWith(
+      {
+        id: "event-2",
+        status: "tentative",
+        accountEmail: undefined,
+        scope: "single",
+        note: "Let's catch up async instead",
+      },
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
+    expect(document.querySelector("textarea")).toBeNull();
   });
 });

--- a/templates/calendar/app/components/calendar/EventAttendeesSection.tsx
+++ b/templates/calendar/app/components/calendar/EventAttendeesSection.tsx
@@ -194,6 +194,12 @@ function RsvpControls({
     doRsvp(status, undefined, "");
   };
 
+  const savePendingResponse = () => {
+    if (!pendingStatus || mutation.isPending) return;
+    doRsvp(pendingStatus, isRecurring ? pendingScope : undefined);
+    closePopover();
+  };
+
   return (
     <Popover
       open={!!pendingStatus}
@@ -255,6 +261,13 @@ function RsvpControls({
         className="w-[22rem] max-w-[calc(100vw-2rem)] overflow-hidden p-0"
         onClick={(e) => e.stopPropagation()}
         onPointerDownCapture={(e) => e.stopPropagation()}
+        onKeyDown={(e) => {
+          if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+            e.preventDefault();
+            e.stopPropagation();
+            savePendingResponse();
+          }
+        }}
       >
         {pendingStatus && (
           <div>
@@ -336,8 +349,7 @@ function RsvpControls({
                 disabled={mutation.isPending}
                 onClick={(e) => {
                   e.stopPropagation();
-                  doRsvp(pendingStatus, isRecurring ? pendingScope : undefined);
-                  closePopover();
+                  savePendingResponse();
                 }}
               >
                 {t("eventForm.saveResponse")}

--- a/templates/calendar/changelog/2026-07-12-calendar-responses-can-now-be-saved-with-command-enter-or-ct.md
+++ b/templates/calendar/changelog/2026-07-12-calendar-responses-can-now-be-saved-with-command-enter-or-ct.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-12
+---
+
+Calendar responses can now be saved with Command+Enter or Ctrl+Enter, and delete confirmations focus the delete action for faster keyboard use.


### PR DESCRIPTION
## Summary\n- keep rrweb iframe, outer stage, responsive CSS, and pointer coordinates in the same corrected camera for malformed legacy viewport events\n- restore a stock arrow replay cursor while keeping the viewer's OS pointer visible; preserve recorded overlays and keep pointer-only activity out of inactivity skips\n- isolate recording identity per browser tab, arbitrate duplicated-tab claims, recover once from active non-final 409 conflicts, and emit content-free recovery telemetry\n- preserve signed load-bearing image/media/style/font URLs while continuing to scrub executable, embedded, navigation, and diagnostic secrets\n- avoid React maximum-depth loops by coalescing replay clock publication while rrweb continues rendering every frame\n- bypass CPU-heavy demo redaction for raw rrweb payloads; include concurrent Calendar keyboard/delete-dialog refinements and stabilize timing-sensitive tests\n\n## Root cause and canaries\nThe original , , and  stored streams have normal viewport data. The deployed player instead left rrweb's iframe at impossible widths ( / ) while correcting only the outer stage. This changed responsive breakpoints and put recorded cursor/click coordinates in a different camera. The fix re-applies rrweb sizing before the React same-state early return.\n\nA separate capture bug allowed same-origin tabs to share a replay identity through ; this PR moves it to per-tab storage and handles duplicated-tab conflicts so future recordings cannot interleave independent DOM streams.\n\n## Review follow-up\n- narrowed 3k legacy viewport recovery to the exact observed  shape; valid  remains exact\n- scoped signed URL preservation by element and attribute, including mutation-time reclassification\n- prevented explicit-stop/final-flush 409s from restarting recording\n- preserved accepted sampling and exact normalized capture limits during an active conflict recovery\n- preserved captured product toasts instead of suppressing selected libraries\n\n## Validation\n- 
> agentnative@1.0.0 prep /Users/steve/Projects/builder/agent-native/framework
> pnpm fmt && concurrently -n types,test,guard -c cyan,green,yellow "pnpm typecheck" "pnpm test:fast" "pnpm guards"


> agentnative@1.0.0 fmt /Users/steve/Projects/builder/agent-native/framework
> oxfmt --write .

Finished in 5355ms on 9913 files using 16 threads.
[test] 
[test] > agentnative@1.0.0 test:fast /Users/steve/Projects/builder/agent-native/framework
[test] > tsx scripts/workspace-run.ts test -- --exclude "**/*.db.test.ts" --exclude "**/*.integration.spec.ts" --exclude "**/*.integration.test.ts" --exclude "**/*.e2e.spec.ts" --exclude "**/*.e2e.test.ts"
[test] 
[guard] 
[guard] > agentnative@1.0.0 guards /Users/steve/Projects/builder/agent-native/framework
[guard] > tsx scripts/run-guards.ts
[guard] 
[types] 
[types] > agentnative@1.0.0 typecheck /Users/steve/Projects/builder/agent-native/framework
[types] > tsx scripts/workspace-run.ts typecheck
[types] 
[test] [workspace-run] test: workspace-concurrency=6
[guard] [guards] Running 22 checks with concurrency 6
[types] [workspace-run] typecheck: workspace-concurrency=10
[types] Scope: 37 of 38 workspace projects
[test] Scope: 37 of 38 workspace projects
[types] packages/agent-chrome-extension typecheck$ tsc --noEmit
[types] packages/migrate typecheck$ tsc --noEmit
[types] packages/shared-app-config typecheck$ tsc --noEmit
[types] templates/clips/desktop typecheck$ tsc --noEmit
[types] packages/toolkit typecheck$ tsc --noEmit
[types] templates/clips/chrome-extension typecheck$ tsc --noEmit
[types] packages/vscode-extension typecheck$ tsc --noEmit -p tsconfig.json
[test] packages/agent-chrome-extension test$ vitest run -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] packages/migrate test$ vitest --run -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] packages/toolkit test$ vitest --run --passWithNoTests -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] packages/vscode-extension test$ vitest --run src --passWithNoTests -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] templates/clips/desktop test$ vitest --run -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] templates/clips/chrome-extension test$ vitest --run -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[types] packages/shared-app-config typecheck: Done
[types] packages/migrate typecheck: Done
[types] packages/vscode-extension typecheck: Done
[types] packages/agent-chrome-extension typecheck: Done
[types] templates/clips/chrome-extension typecheck: Done
[types] packages/toolkit typecheck: Done
[test] packages/vscode-extension test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/packages/vscode-extension
[test] packages/migrate test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/packages/migrate
[test] packages/toolkit test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/packages/toolkit
[types] templates/clips/desktop typecheck: Done
[types] packages/core typecheck$ tsc --noEmit
[test] packages/agent-chrome-extension test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/packages/agent-chrome-extension
[test] templates/clips/chrome-extension test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/templates/clips/chrome-extension
[test] templates/clips/desktop test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/templates/clips/desktop
[test] packages/vscode-extension test:  Test Files  2 passed (2)
[test] packages/vscode-extension test:       Tests  10 passed (10)
[test] packages/vscode-extension test:    Start at  13:57:08
[test] packages/vscode-extension test:    Duration  360ms (transform 114ms, setup 0ms, import 254ms, tests 4ms, environment 0ms)
[test] packages/vscode-extension test: Done
[test] packages/agent-chrome-extension test:  Test Files  2 passed (2)
[test] packages/agent-chrome-extension test:       Tests  20 passed (20)
[test] packages/agent-chrome-extension test:    Start at  13:57:08
[test] packages/agent-chrome-extension test:    Duration  485ms (transform 191ms, setup 0ms, import 272ms, tests 55ms, environment 0ms)
[test] templates/clips/chrome-extension test:  Test Files  1 passed (1)
[test] templates/clips/chrome-extension test:       Tests  7 passed (7)
[test] templates/clips/chrome-extension test:    Start at  13:57:08
[test] templates/clips/chrome-extension test:    Duration  475ms (transform 135ms, setup 0ms, import 187ms, tests 17ms, environment 0ms)
[test] packages/agent-chrome-extension test: Done
[test] templates/clips/chrome-extension test: Done
[test] packages/toolkit test:  Test Files  6 passed (6)
[test] packages/toolkit test:       Tests  28 passed (28)
[test] packages/toolkit test:    Start at  13:57:07
[test] packages/toolkit test:    Duration  914ms (transform 1.05s, setup 0ms, import 3.92s, tests 38ms, environment 1ms)
[test] packages/toolkit test: Done
[test] packages/migrate test:  Test Files  5 passed (5)
[test] packages/migrate test:       Tests  23 passed (23)
[test] packages/migrate test:    Start at  13:57:07
[test] packages/migrate test:    Duration  1.05s (transform 1.53s, setup 0ms, import 3.93s, tests 182ms, environment 0ms)
[types] packages/core typecheck: Done
[types] packages/code-agents-ui typecheck$ tsc --noEmit
[types] packages/docs typecheck$ agent-native typecheck
[types] packages/dispatch typecheck$ tsc --noEmit
[types] packages/scheduling typecheck$ tsc --noEmit
[types] packages/pinpoint typecheck$ tsc --noEmit
[types] packages/skills typecheck$ tsc --noEmit
[types] packages/embedding typecheck$ tsc --noEmit
[types] templates/brain typecheck$ agent-native typecheck
[types] templates/analytics typecheck$ agent-native typecheck
[types] templates/assets typecheck$ agent-native typecheck
[test] packages/migrate test: Done
[types] packages/embedding typecheck: Done
[types] templates/chat typecheck$ agent-native typecheck
[types] packages/skills typecheck: Done
[types] templates/clips typecheck$ agent-native typecheck
[types] packages/code-agents-ui typecheck: Done
[types] templates/content typecheck$ agent-native typecheck
[types] packages/pinpoint typecheck: Done
[types] templates/forms typecheck$ agent-native typecheck
[test] templates/clips/desktop test:  Test Files  11 passed (11)
[test] templates/clips/desktop test:       Tests  52 passed (52)
[test] templates/clips/desktop test:    Start at  13:57:09
[test] templates/clips/desktop test:    Duration  647ms (transform 633ms, setup 0ms, import 1.26s, tests 48ms, environment 1ms)
[types] packages/scheduling typecheck: Done
[types] templates/macros typecheck$ agent-native typecheck
[test] templates/clips/desktop test: Done
[test] packages/core test$ vitest --run src --maxWorkers=25% -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[types] packages/dispatch typecheck: Done
[types] templates/mail typecheck$ agent-native typecheck
[test] packages/core test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/packages/core
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: ◇  App created!
[test] packages/core test: [?25h│
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd test-app
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm dev
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: ◇  App created!
[test] packages/core test: [?25h┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: │
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd legacy-app
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm dev
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: ◇  App created!
[test] packages/core test: [?25h◇  App created!
[test] packages/core test: [?25h│
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd test-app
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm dev
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: ◇  App created!
[test] packages/core test: [?25h│
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd test-app
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm dev
[types] templates/chat typecheck: Done
[types] templates/plan typecheck$ agent-native typecheck
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: ◇  App created!
[test] packages/core test: [?25h│
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd test-app
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm dev
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: ◇  App created!
[types] templates/macros typecheck: Done
[test] packages/core test: [?25h│
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd plan
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm dev
[types] templates/brain typecheck: Done
[types] templates/forms typecheck: Done
[types] templates/assets typecheck: Done
[types] packages/docs typecheck: Done
[test] packages/core test: │
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd test-app
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm dev
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: ◇  App created!
[types] templates/mail typecheck: Done
[test] packages/core test: [?25h┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[types] templates/analytics typecheck: Done
[test] packages/core test: │
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd test-app
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm dev
[types] templates/clips typecheck: Done
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: ◇  App created!
[test] packages/core test: [?25h◇  App created!
[types] templates/content typecheck: Done
[guard] 
[guard] [guard:no-localhost-fallback] output
[guard] 
[guard] > agentnative@1.0.0 guard:no-localhost-fallback /Users/steve/Projects/builder/agent-native/framework
[guard] > node scripts/guard-no-localhost-fallback.mjs
[guard] 
[guard] guard-no-localhost-fallback: clean (no "local@localhost" literals in production code).
[guard] [guards] PASS guard:no-localhost-fallback (11.4s)
[test] packages/core test: [?25h│
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd test-app
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm dev
[guard] 
[guard] [guard:google-auth-redirects] output
[guard] 
[guard] > agentnative@1.0.0 guard:google-auth-redirects /Users/steve/Projects/builder/agent-native/framework
[guard] > node scripts/guard-google-auth-redirects.mjs
[guard] 
[guard] guard-google-auth-redirects: clean (11 auth-url files checked).
[guard] [guards] PASS guard:google-auth-redirects (370ms)
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: ◇  App created!
[test] packages/core test: [?25h│
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd test-app
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm action hello --name Builder
[test] packages/core test:   pnpm agent "Call hello for Builder"
[test] packages/core test: Add a UI later by starting from the Chat template; `agent-native add` is reserved for integration blueprints.
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: ◇  App created!
[test] packages/core test: [?25h│
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd test-app
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm action hello --name Builder
[test] packages/core test:   pnpm agent "Call hello for Builder"
[test] packages/core test: Add a UI later by starting from the Chat template; `agent-native add` is reserved for integration blueprints.
[test] packages/core test: │
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd plan
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm dev
[guard] 
[guard] [guard:no-env-mutation] output
[guard] 
[guard] > agentnative@1.0.0 guard:no-env-mutation /Users/steve/Projects/builder/agent-native/framework
[guard] > node scripts/guard-no-env-mutation.mjs
[guard] 
[guard] guard-no-env-mutation: clean (no process.env mutations/deletions in production code).
[guard] [guards] PASS guard:no-env-mutation (13.3s)
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[guard] 
[guard] [guard:template-list] output
[guard] 
[guard] > agentnative@1.0.0 guard:template-list /Users/steve/Projects/builder/agent-native/framework
[guard] > node scripts/guard-template-list.mjs
[guard] 
[guard] guard-template-list: clean (13 public templates: analytics, assets, brain, calendar, chat, clips, content, design, dispatch, forms, mail, plan, slides).
[guard] [guards] PASS guard:template-list (326ms)
[types] templates/plan typecheck: Done
[types] packages/desktop-app typecheck$ tsc --noEmit
[types] templates/calendar typecheck$ agent-native typecheck
[types] templates/dispatch typecheck$ agent-native typecheck
[types] templates/design typecheck$ agent-native typecheck && pnpm exec tsc --noEmit -p app/components/design/bridge/tsconfig.json
[types] templates/slides typecheck$ agent-native typecheck
[test] packages/core test: ◇  App created!
[types] packages/desktop-app typecheck: Done
[test] packages/core test: [?25h│
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd plan
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm dev
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: ◇  App created!
[guard] 
[guard] [guard:db-tool-scoping] output
[guard] 
[guard] > agentnative@1.0.0 guard:db-tool-scoping /Users/steve/Projects/builder/agent-native/framework
[guard] > node scripts/guard-db-tool-scoping.mjs
[guard] 
[guard] guard-db-tool-scoping: clean (40 intentionally denied template table(s))
[guard] [guards] PASS guard:db-tool-scoping (6.6s)
[types] templates/dispatch typecheck: Done
[test] packages/core test: [?25h│
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd plan
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm dev
[types] templates/calendar typecheck: Done
[types] templates/slides typecheck: Done
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[guard] 
[guard] [guard:workspace-skills] output
[guard] 
[guard] > agentnative@1.0.0 guard:workspace-skills /Users/steve/Projects/builder/agent-native/framework
[guard] > tsx scripts/sync-workspace-core-skills.ts --check
[guard] 
[guard] Workspace-core, default-template, and template shared skills are in sync.
[guard] [guards] PASS guard:workspace-skills (1.1s)
[test] packages/core test: ◇  App created!
[guard] 
[guard] [guard:public-packages] output
[guard] 
[guard] > agentnative@1.0.0 guard:public-packages /Users/steve/Projects/builder/agent-native/framework
[guard] > tsx scripts/guard-public-packages.ts
[guard] 
[guard] OK Agent-Native package publish metadata is public.
[guard] [guards] PASS guard:public-packages (449ms)
[guard] 
[guard] [guard:no-generated-artifacts] output
[guard] 
[guard] > agentnative@1.0.0 guard:no-generated-artifacts /Users/steve/Projects/builder/agent-native/framework
[guard] > node scripts/guard-no-generated-artifacts.mjs
[guard] 
[guard] [guards] PASS guard:no-generated-artifacts (296ms)
[types] templates/design typecheck: Done
[types] pnpm typecheck exited with code 0
[test] packages/core test: [?25h│
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd plan
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm dev
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: ◇  App created!
[test] packages/core test: [?25h│
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd plan
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm dev
[guard] 
[guard] [guard:no-drizzle-push] output
[guard] 
[guard] > agentnative@1.0.0 guard:no-drizzle-push /Users/steve/Projects/builder/agent-native/framework
[guard] > node scripts/guard-no-drizzle-push.mjs
[guard] 
[guard] guard-no-drizzle-push: clean (no `drizzle-kit push` in any build/deploy path).
[guard] [guards] PASS guard:no-drizzle-push (23.2s)
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[guard] 
[guard] [guard:no-env-credentials] output
[guard] 
[guard] > agentnative@1.0.0 guard:no-env-credentials /Users/steve/Projects/builder/agent-native/framework
[guard] > node scripts/guard-no-env-credentials.mjs
[guard] 
[guard] guard-no-env-credentials: clean (no forbidden process.env reads in credential paths).
[guard] [guards] PASS guard:no-env-credentials (23.4s)
[guard] 
[guard] [guard:no-unscoped-credentials] output
[guard] 
[guard] > agentnative@1.0.0 guard:no-unscoped-credentials /Users/steve/Projects/builder/agent-native/framework
[guard] > node scripts/guard-no-unscoped-credentials.mjs
[guard] 
[guard] guard-no-unscoped-credentials: clean (every credential call passes context).
[guard] [guards] PASS guard:no-unscoped-credentials (23.4s)
[test] packages/core test: ◇  App created!
[guard] 
[guard] [guard:plan-skills] output
[guard] 
[guard] > agentnative@1.0.0 guard:plan-skills /Users/steve/Projects/builder/agent-native/framework
[guard] > tsx scripts/sync-plan-skills.ts --check
[guard] 
[guard] Exported app skills are in sync with skills.ts constants.
[guard] [guards] PASS guard:plan-skills (577ms)
[test] packages/core test: [?25h│
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd my-roadmap
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm dev
[guard] 
[guard] [guard:plan-marketplace] output
[guard] 
[guard] > agentnative@1.0.0 guard:plan-marketplace /Users/steve/Projects/builder/agent-native/framework
[guard] > tsx scripts/sync-plan-marketplace.ts --check
[guard] 
[guard] App marketplace bundles are in sync (agent-native-visual-plans 1.0.0+codex.7ab843ff8d5e, agent-native-design 1.0.0+codex.66dbb8d10905).
[guard] [guards] PASS guard:plan-marketplace (560ms)
[guard] 
[guard] [guard:extension-no-public] output
[guard] 
[guard] > agentnative@1.0.0 guard:extension-no-public /Users/steve/Projects/builder/agent-native/framework
[guard] > node scripts/guard-extension-no-public.mjs
[guard] 
[guard] [guard-extension-no-public] OK — scanned 12338 files, no violations.
[guard] [guards] PASS guard:extension-no-public (4.5s)
[test] packages/core test: ┌  Add an app to your workspace
[test] packages/core test: [?25l│
[guard] 
[guard] [guard:no-error-string-returns] output
[guard] 
[guard] > agentnative@1.0.0 guard:no-error-string-returns /Users/steve/Projects/builder/agent-native/framework
[guard] > node scripts/guard-no-error-string-returns.mjs
[guard] 
[guard] guard-no-error-string-returns: OK
[guard] [guards] PASS guard:no-error-string-returns (317ms)
[guard] 
[guard] [guard:no-action-twin-routes] output
[guard] 
[guard] > agentnative@1.0.0 guard:no-action-twin-routes /Users/steve/Projects/builder/agent-native/framework
[guard] > node scripts/guard-no-action-twin-routes.mjs
[guard] 
[guard] guard-no-action-twin-routes: OK (21 grandfathered twin routes remaining in baseline)
[guard] [guards] PASS guard:no-action-twin-routes (298ms)
[guard] 
[guard] [guard:agent-chat-context] output
[guard] 
[guard] > agentnative@1.0.0 guard:agent-chat-context /Users/steve/Projects/builder/agent-native/framework
[guard] > tsx scripts/guard-agent-chat-context.ts
[guard] 
[guard] [guard:agent-chat-context] packages/dispatch/src/server/plugins/agent-chat.ts: 21 starter tools
[guard] [guard:agent-chat-context] templates/analytics/server/plugins/agent-chat.ts: 36 starter tools
[guard] [guard:agent-chat-context] templates/assets/server/plugins/agent-chat.ts: 16 starter tools
[guard] [guard:agent-chat-context] templates/brain/server/plugins/agent-chat.ts: 22 starter tools
[guard] [guard:agent-chat-context] templates/calendar/server/plugins/agent-chat.ts: 20 starter tools
[guard] [guard:agent-chat-context] templates/chat/server/plugins/agent-chat.ts: 3 starter tools
[guard] [guard:agent-chat-context] templates/clips/server/plugins/agent-chat.ts: 18 starter tools
[guard] [guard:agent-chat-context] templates/content/server/plugins/agent-chat.ts: 16 starter tools
[guard] [guard:agent-chat-context] templates/design/server/plugins/agent-chat.ts: 25 starter tools
[guard] [guard:agent-chat-context] templates/forms/server/plugins/agent-chat.ts: 13 starter tools
[guard] [guard:agent-chat-context] templates/macros/server/plugins/agent-chat.ts: 9 starter tools
[guard] [guard:agent-chat-context] templates/mail/server/plugins/agent-chat.ts: 19 starter tools
[guard] [guard:agent-chat-context] templates/plan/server/plugins/agent-chat.ts: 12 starter tools
[guard] [guard:agent-chat-context] templates/slides/server/plugins/agent-chat.ts: 16 starter tools
[guard] [guard:agent-chat-context] clean (14 first-party agent chat plugins)
[guard] [guards] PASS guard:agent-chat-context (421ms)
[test] packages/core test: ◇  Scaffolded apps/roadmap.
[test] packages/core test: [?25h│
[test] packages/core test: └  Done!
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm dev
[test] packages/core test: The workspace gateway will detect apps/roadmap and serve it at /roadmap.
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: └  Directory "plan" already exists.
[test] packages/core test: └  Invalid name "Plan With Spaces!". Use lowercase letters, numbers, and hyphens (must start with a letter).
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: ◇  App created!
[test] packages/core test: [recap shot] Playwright browser unavailable; trying system Chrome at /usr/bin/google-chrome-stable
[test] packages/core test: [recap shot] Playwright browser unavailable; trying system Chrome at /usr/bin/google-chrome-stable
[test] packages/core test: [recap shot] system Chrome launch failed at /usr/bin/google-chrome-stable: missing shared library
[test] packages/core test: [recap shot] PNG is 5242881 bytes (cap 5242880) — retrying at CSS-pixel scale
[test] packages/core test: [recap shot] image upload failed: 500  upload failed
[test] packages/core test: [?25h│
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd local-chat
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm dev
[guard] 
[guard] [guard:no-one-off-mcp-app-html] output
[guard] 
[guard] > agentnative@1.0.0 guard:no-one-off-mcp-app-html /Users/steve/Projects/builder/agent-native/framework
[guard] > node scripts/guard-no-one-off-mcp-app-html.mjs
[guard] 
[guard] [guard-no-one-off-mcp-app-html] OK - scanned 4591 template source files.
[guard] [guards] PASS guard:no-one-off-mcp-app-html (3.2s)
[guard] 
[guard] [guard:netlify-private-env] output
[guard] 
[guard] > agentnative@1.0.0 guard:netlify-private-env /Users/steve/Projects/builder/agent-native/framework
[guard] > tsx scripts/guard-netlify-private-env.ts
[guard] 
[guard] guard-netlify-private-env: clean (no Builder private key in Netlify deploy config).
[guard] [guards] PASS guard:netlify-private-env (13.6s)
[guard] 
[guard] [guard:i18n-catalogs] output
[guard] 
[guard] > agentnative@1.0.0 guard:i18n-catalogs /Users/steve/Projects/builder/agent-native/framework
[guard] > tsx scripts/guard-i18n-catalogs.ts
[guard] 
[guard] [guard:i18n-catalogs] checked 16 catalog directories
[guard] [guards] PASS guard:i18n-catalogs (5.6s)
[test] packages/core test: [workspace] Default: http://127.0.0.1:64269/dispatch
[test] packages/core test: [workspace] Gateway: http://127.0.0.1:64269
[test] packages/core test: [workspace] Mode: lazy
[test] packages/core test: [workspace] dispatch: /dispatch -> 127.0.0.1:19100
[test] packages/core test: [workspace] starter: /starter -> 127.0.0.1:19101
[test] packages/core test: [workspace] Default: http://127.0.0.1:64274/dispatch
[test] packages/core test: [workspace] Gateway: http://127.0.0.1:64274
[test] packages/core test: [workspace] Mode: eager
[test] packages/core test: [workspace] dispatch: /dispatch -> 127.0.0.1:19100
[test] packages/core test: [workspace] starter: /starter -> 127.0.0.1:19101
[test] packages/core test: [workspace] todo: /todo -> 127.0.0.1:19102
[test] packages/core test: [workspace] Default: http://127.0.0.1:64275/dispatch
[test] packages/core test: [workspace] Gateway: http://127.0.0.1:64275
[test] packages/core test: [workspace] Mode: lazy
[test] packages/core test: [workspace] dispatch: /dispatch -> 127.0.0.1:19100
[test] packages/core test: [workspace] Default: http://127.0.0.1:64279/dispatch
[test] packages/core test: [workspace] Gateway: http://127.0.0.1:64279
[test] packages/core test: [workspace] Mode: lazy
[test] packages/core test: [workspace] dispatch: /dispatch -> 127.0.0.1:19100
[test] packages/core test: [workspace] Default: http://127.0.0.1:64283/dispatch
[test] packages/core test: [workspace] Gateway: http://127.0.0.1:64283
[test] packages/core test: [workspace] Mode: lazy
[test] packages/core test: [workspace] dispatch: /dispatch -> 127.0.0.1:19100
[test] packages/core test: [workspace] Default: http://127.0.0.1:64287/dispatch
[test] packages/core test: [workspace] Gateway: http://127.0.0.1:64287
[test] packages/core test: [workspace] Mode: lazy+prewarm
[test] packages/core test: [workspace] dispatch: /dispatch -> 127.0.0.1:19100
[test] packages/core test: [workspace] starter: /starter -> 127.0.0.1:19101
[test] packages/core test: [workspace] todo: /todo -> 127.0.0.1:19102
[test] packages/core test: [workspace] Prewarming 2 app(s) in the background (concurrency 2; pass --no-prewarm to disable)
[guard] 
[guard] [guard:request-storms] output
[guard] 
[guard] > agentnative@1.0.0 guard:request-storms /Users/steve/Projects/builder/agent-native/framework
[guard] > tsx scripts/guard-request-storms.ts
[guard] 
[guard] [guard:request-storms] clean (5943 maintained TypeScript files)
[guard] [guards] PASS guard:request-storms (5.4s)
[test] packages/core test: [workspace] Default: http://127.0.0.1:64292/dispatch
[test] packages/core test: [workspace] Gateway: http://127.0.0.1:64292
[test] packages/core test: [workspace] Mode: lazy
[test] packages/core test: [workspace] dispatch: /dispatch -> 127.0.0.1:19100
[test] packages/core test: [workspace] starter: /starter -> 127.0.0.1:19101
[test] packages/core test: [workspace] todo: /todo -> 127.0.0.1:19102
[test] packages/core test: [workspace] Default: http://127.0.0.1:64294/dispatch
[test] packages/core test: [workspace] Gateway: http://127.0.0.1:64294
[test] packages/core test: [workspace] Mode: lazy
[test] packages/core test: [workspace] dispatch: /dispatch -> 127.0.0.1:19100
[test] packages/core test: [workspace] Default: http://127.0.0.1:64295/dispatch
[test] packages/core test: [workspace] Gateway: http://127.0.0.1:64295
[test] packages/core test: [workspace] Mode: eager
[test] packages/core test: [workspace] dispatch: /dispatch -> 127.0.0.1:19100
[test] packages/core test: [workspace] portal: /portal -> 127.0.0.1:19101
[test] packages/core test: [workspace] Using polling file watchers (1000ms) to avoid remote-container inotify limits.
[test] packages/core test: [workspace] Default: http://127.0.0.1:64296/dispatch
[test] packages/core test: [workspace] Gateway: http://127.0.0.1:64296
[test] packages/core test: [workspace] Mode: lazy
[test] packages/core test: [workspace] dispatch: /dispatch -> 127.0.0.1:19100
[test] packages/core test: [workspace] Default: http://127.0.0.1:64297/dispatch
[test] packages/core test: [workspace] Gateway: http://127.0.0.1:64297
[test] packages/core test: [workspace] Mode: lazy
[test] packages/core test: [workspace] dispatch: /dispatch -> 127.0.0.1:19100
[test] packages/core test: [workspace] Default: http://127.0.0.1:64298/dispatch
[test] packages/core test: [workspace] Gateway: http://127.0.0.1:64298
[test] packages/core test: [workspace] Mode: lazy
[test] packages/core test: [workspace] dispatch: /dispatch -> 127.0.0.1:19100
[test] packages/core test: [workspace] Default: http://127.0.0.1:64299
[test] packages/core test: [workspace] Gateway: http://127.0.0.1:64299
[test] packages/core test: [workspace] Mode: lazy
[test] packages/core test: [workspace] starter: /starter -> 127.0.0.1:19100
[test] packages/core test: [workspace] Default: http://127.0.0.1:64301/dispatch
[test] packages/core test: [workspace] Gateway: http://127.0.0.1:64301
[test] packages/core test: [workspace] Mode: lazy
[test] packages/core test: [workspace] dispatch: /dispatch -> 127.0.0.1:19100
[test] packages/core test: [workspace] starter: /starter -> 127.0.0.1:19101
[test] packages/core test: [workspace] Default: http://127.0.0.1:64303
[test] packages/core test: [workspace] Gateway: http://127.0.0.1:64303
[test] packages/core test: [workspace] Mode: lazy
[test] packages/core test: [workspace] starter: /starter -> 127.0.0.1:19100
[test] packages/core test: [workspace] Detected new app: /todo
[test] packages/core test: [workspace] Default: http://127.0.0.1:64305/dispatch
[test] packages/core test: [workspace] Gateway: http://127.0.0.1:64305
[test] packages/core test: [workspace] Mode: lazy
[test] packages/core test: [workspace] dispatch: /dispatch -> 127.0.0.1:19100
[test] packages/core test: [workspace] Detected new app: /todo
[test] packages/core test: [workspace] Default: http://127.0.0.1:64309/dispatch
[test] packages/core test: [workspace] Gateway: http://127.0.0.1:64309
[test] packages/core test: [workspace] Mode: lazy
[test] packages/core test: [workspace] dispatch: /dispatch -> 127.0.0.1:19100
[test] packages/core test: [workspace] Default: http://127.0.0.1:64312/dispatch
[test] packages/core test: [workspace] Gateway: http://127.0.0.1:64312
[test] packages/core test: [workspace] Mode: lazy
[test] packages/core test: [workspace] dispatch: /dispatch -> 127.0.0.1:19100
[test] packages/core test: [workspace] Default: http://127.0.0.1:64318/dispatch
[test] packages/core test: [workspace] Gateway: http://127.0.0.1:64318
[test] packages/core test: [workspace] Mode: lazy
[test] packages/core test: [workspace] dispatch: /dispatch -> 127.0.0.1:19100
[test] packages/core test: [workspace] Detected new app: /todo
[test] packages/core test: [workspace] Installing dependencies before starting /todo
[test] packages/core test: [workspace] Default: http://127.0.0.1:64320/dispatch
[test] packages/core test: [workspace] Gateway: http://127.0.0.1:64320
[test] packages/core test: [workspace] Mode: lazy
[test] packages/core test: [workspace] dispatch: /dispatch -> 127.0.0.1:19100
[test] packages/core test: [dispatch] Error: Cannot find module '@agent-native/example'
[test] packages/core test: [dispatch] exited with code 1; retrying in 1s
[test] packages/core test: [workspace] Default: http://127.0.0.1:64325/dispatch
[test] packages/core test: [workspace] Gateway: http://127.0.0.1:64325
[test] packages/core test: [workspace] Mode: lazy
[test] packages/core test: [workspace] dispatch: /dispatch -> 127.0.0.1:19100
[test] packages/core test: ┌  Create a new agent-native workspace
[test] packages/core test: │
[test] packages/core test: ◇  About workspaces ───────────────────────────────────────────────────────────╮
[test] packages/core test: │                                                                              │
[test] packages/core test: │  You're creating a workspace named "my-ws". A workspace is a monorepo        │
[test] packages/core test: │  container — it isn't an app itself. Inside it you pick one or more apps     │
[test] packages/core test: │  (below), and each app gets its own route, agent, and UI. Apps in the        │
[test] packages/core test: │  same workspace share auth, database, and the agent chat. Add more apps      │
[test] packages/core test: │  later with `npx @agent-native/core@latest add-app`. Chat is the UI on-ramp  │
[test] packages/core test: │  for a minimal chat-first app with the browser shell already wired.          │
[test] packages/core test: │  Dispatch is always included as the workspace control plane —                │
[test] packages/core test: │  it owns shared secrets, messaging, approvals, and cross-app routing.        │
[test] packages/core test: │                                                                              │
[test] packages/core test: ├──────────────────────────────────────────────────────────────────────────────╯
[test] packages/core test: [?25l│
[test] packages/core test: ◇  Workspace scaffolded with 2 apps.
[test] packages/core test: [dispatch] Timed out waiting 50ms for /dispatch to return an HTTP response on 127.0.0.1:19100.; retrying in 1s
[test] packages/core test: [?25h│
[test] packages/core test: └  Created workspace "my-ws" with 2 apps:
[test] packages/core test:   my-ws/                    ← your workspace
[test] packages/core test:   ├─ apps/dispatch/              ← app
[test] packages/core test:   └─ apps/chat/                  ← app
[test] packages/core test: Next steps:
[test] packages/core test:   cd my-ws
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm dev          # starts Dispatch on http://localhost:8092
[test] packages/core test: Once running, open Dispatch — you'll see "Workspace: My Ws"
[test] packages/core test: at the top, with all your apps listed under it.
[test] packages/core test: Add another app later:        npx @agent-native/core@latest add-app
[test] packages/core test: Deploy the whole workspace:   pnpm exec agent-native deploy
[test] packages/core test: ┌  Create a new agent-native workspace
[test] packages/core test: │
[test] packages/core test: ◇  About workspaces ───────────────────────────────────────────────────────────╮
[test] packages/core test: │                                                                              │
[test] packages/core test: │  You're creating a workspace named "test-ws". A workspace is a monorepo      │
[test] packages/core test: │  container — it isn't an app itself. Inside it you pick one or more apps     │
[test] packages/core test: │  (below), and each app gets its own route, agent, and UI. Apps in the        │
[test] packages/core test: │  same workspace share auth, database, and the agent chat. Add more apps      │
[test] packages/core test: │  later with `npx @agent-native/core@latest add-app`. Chat is the UI on-ramp  │
[test] packages/core test: │  for a minimal chat-first app with the browser shell already wired.          │
[test] packages/core test: │  Dispatch is always included as the workspace control plane —                │
[test] packages/core test: │  it owns shared secrets, messaging, approvals, and cross-app routing.        │
[test] packages/core test: │                                                                              │
[test] packages/core test: ├──────────────────────────────────────────────────────────────────────────────╯
[test] packages/core test: [?25l│
[test] packages/core test: ◇  Workspace scaffolded with 3 apps.
[test] packages/core test: [?25h│
[test] packages/core test: └  Created workspace "test-ws" with 3 apps:
[test] packages/core test:   test-ws/                    ← your workspace
[test] packages/core test:   ├─ apps/dispatch/              ← app
[test] packages/core test:   ├─ apps/chat/                  ← app
[test] packages/core test:   └─ apps/forms/                 ← app
[test] packages/core test: Next steps:
[test] packages/core test:   cd test-ws
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm dev          # starts Dispatch on http://localhost:8092
[test] packages/core test: Once running, open Dispatch — you'll see "Workspace: Test Ws"
[test] packages/core test: at the top, with all your apps listed under it.
[test] packages/core test: Add another app later:        npx @agent-native/core@latest add-app
[test] packages/core test: Deploy the whole workspace:   pnpm exec agent-native deploy
[test] packages/core test: ┌  Add an app to your workspace
[test] packages/core test: [?25l│
[test] packages/core test: ◇  Scaffolded apps/dispatch.
[test] packages/core test: [?25h│
[test] packages/core test: └  Done!
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm dev
[test] packages/core test: The workspace gateway will detect apps/dispatch and serve it at /dispatch.
[test] packages/core test: ┌  Create a new agent-native workspace
[test] packages/core test: │
[test] packages/core test: ◇  About workspaces ───────────────────────────────────────────────────────────╮
[test] packages/core test: │                                                                              │
[test] packages/core test: │  You're creating a workspace named "my-ws". A workspace is a monorepo        │
[test] packages/core test: │  container — it isn't an app itself. Inside it you pick one or more apps     │
[test] packages/core test: │  (below), and each app gets its own route, agent, and UI. Apps in the        │
[test] packages/core test: │  same workspace share auth, database, and the agent chat. Add more apps      │
[test] packages/core test: │  later with `npx @agent-native/core@latest add-app`. Chat is the UI on-ramp  │
[test] packages/core test: │  for a minimal chat-first app with the browser shell already wired.          │
[test] packages/core test: │  Dispatch is always included as the workspace control plane —                │
[test] packages/core test: │  it owns shared secrets, messaging, approvals, and cross-app routing.        │
[test] packages/core test: │                                                                              │
[test] packages/core test: ├──────────────────────────────────────────────────────────────────────────────╯
[test] packages/core test: [?25l│
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: ◇  App created!
[test] packages/core test: [?25h◇  Workspace scaffolded with 2 apps.
[test] packages/core test: [?25h│
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd my-app
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm action hello --name Builder
[test] packages/core test:   pnpm agent "Call hello for Builder"
[test] packages/core test: Add a UI later by starting from the Chat template; `agent-native add` is reserved for integration blueprints.
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: ◇  App created!
[test] packages/core test: [?25h│
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd hello-world
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm action hello --name Builder
[test] packages/core test:   pnpm agent "Call hello for Builder"
[test] packages/core test: Add a UI later by starting from the Chat template; `agent-native add` is reserved for integration blueprints.
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: ◇  App created!
[test] packages/core test: [?25h│
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd my-app
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm action hello --name Builder
[test] packages/core test:   pnpm agent "Call hello for Builder"
[test] packages/core test: Add a UI later by starting from the Chat template; `agent-native add` is reserved for integration blueprints.
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: ◇  App created!
[test] packages/core test: [?25h│
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd my-cool-app
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm action hello --name Builder
[test] packages/core test:   pnpm agent "Call hello for Builder"
[test] packages/core test: Add a UI later by starting from the Chat template; `agent-native add` is reserved for integration blueprints.
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: ◇  App created!
[test] packages/core test: [?25h│
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd my-app
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm action hello --name Builder
[test] packages/core test:   pnpm agent "Call hello for Builder"
[test] packages/core test: Add a UI later by starting from the Chat template; `agent-native add` is reserved for integration blueprints.
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: ◇  App created!
[test] packages/core test: [?25h│
[test] packages/core test: └  Created workspace "my-ws" with 2 apps:
[test] packages/core test:   my-ws/                    ← your workspace
[test] packages/core test:   ├─ apps/dispatch/              ← app
[test] packages/core test:   └─ apps/chat/                  ← app
[test] packages/core test: Next steps:
[test] packages/core test:   cd my-ws
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm dev          # starts Dispatch on http://localhost:8092
[test] packages/core test: Once running, open Dispatch — you'll see "Workspace: My Ws"
[test] packages/core test: at the top, with all your apps listed under it.
[test] packages/core test: Add another app later:        npx @agent-native/core@latest add-app
[test] packages/core test: Deploy the whole workspace:   pnpm exec agent-native deploy
[test] packages/core test: ┌  Add an app to your workspace
[test] packages/core test: [?25l│
[test] packages/core test: ◇  Scaffolded apps/crm.
[test] packages/core test: [?25h│
[test] packages/core test: └  Done!
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm dev
[test] packages/core test: The workspace gateway will detect apps/crm and serve it at /crm.
[test] packages/core test: │
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd my-app
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm action hello --name Builder
[test] packages/core test:   pnpm agent "Call hello for Builder"
[test] packages/core test: Add a UI later by starting from the Chat template; `agent-native add` is reserved for integration blueprints.
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: ◇  App created!
[test] packages/core test: [?25h│
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd my-app
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm action hello --name Builder
[test] packages/core test:   pnpm agent "Call hello for Builder"
[test] packages/core test: Add a UI later by starting from the Chat template; `agent-native add` is reserved for integration blueprints.
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: ◇  App created!
[test] packages/core test: [?25h│
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd my-app
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm action hello --name Builder
[test] packages/core test:   pnpm agent "Call hello for Builder"
[test] packages/core test: Add a UI later by starting from the Chat template; `agent-native add` is reserved for integration blueprints.
[test] packages/core test: ┌  Create a new standalone agent-native app
[test] packages/core test: [?25l│
[test] packages/core test: ◇  App created!
[test] packages/core test: [?25h│
[test] packages/core test: └  Done! Next steps:
[test] packages/core test:   cd legacy-blank
[test] packages/core test:   pnpm install
[test] packages/core test:   pnpm action hello --name Builder
[test] packages/core test:   pnpm agent "Call hello for Builder"
[test] packages/core test: Add a UI later by starting from the Chat template; `agent-native add` is reserved for integration blueprints.
[test] packages/core test: └  The headless scaffold is standalone-only. Use `agent-native create my-app --headless`, or use the Chat template when adding a UI app to a workspace.
[test] packages/core test: ┌  Add an app to your workspace
[test] packages/core test: └  The headless scaffold is standalone-only. Use `agent-native create my-app --headless` outside a workspace, or use the Chat template when adding a UI app to a workspace.
[test] packages/core test: └  Invalid name "My_Invalid App!". Use lowercase letters, numbers, and hyphens (must start with a letter).
[test] packages/core test: Updated 1 skill folder.
[test] packages/core test: scaffold               current project/standalone managed (2 skills)
[test] packages/core test:   /var/folders/w3/pcrbtr3d3ps7cqq0793xcf0m0000gn/T/an-skills-h9g2w0/.agents/skills
[test] packages/core test: AggregateError: 
[test] packages/core test:     at internalConnectMultiple (node:net:1142:49)
[test] packages/core test:     at afterConnectMultiple (node:net:1723:7) {
[test] packages/core test:   code: 'ECONNREFUSED',
[test] packages/core test:   [errors]: [
[test] packages/core test:     Error: connect ECONNREFUSED ::1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '::1',
[test] packages/core test:       port: 3000
[test] packages/core test:     },
[test] packages/core test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '127.0.0.1',
[test] packages/core test:       port: 3000
[test] packages/core test:     }
[test] packages/core test:   ]
[test] packages/core test: }
[test] packages/core test: AggregateError: 
[test] packages/core test:     at internalConnectMultiple (node:net:1142:49)
[test] packages/core test:     at afterConnectMultiple (node:net:1723:7) {
[test] packages/core test:   code: 'ECONNREFUSED',
[test] packages/core test:   [errors]: [
[test] packages/core test:     Error: connect ECONNREFUSED ::1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '::1',
[test] packages/core test:       port: 3000
[test] packages/core test:     },
[test] packages/core test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '127.0.0.1',
[test] packages/core test:       port: 3000
[test] packages/core test:     }
[test] packages/core test:   ]
[test] packages/core test: }
[test] packages/core test: AggregateError: 
[test] packages/core test:     at internalConnectMultiple (node:net:1142:49)
[test] packages/core test:     at afterConnectMultiple (node:net:1723:7) {
[test] packages/core test:   code: 'ECONNREFUSED',
[test] packages/core test:   [errors]: [
[test] packages/core test:     Error: connect ECONNREFUSED ::1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '::1',
[test] packages/core test:       port: 3000
[test] packages/core test:     },
[test] packages/core test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '127.0.0.1',
[test] packages/core test:       port: 3000
[test] packages/core test:     }
[test] packages/core test:   ]
[test] packages/core test: }
[test] packages/core test: AggregateError: 
[test] packages/core test:     at internalConnectMultiple (node:net:1142:49)
[test] packages/core test:     at afterConnectMultiple (node:net:1723:7) {
[test] packages/core test:   code: 'ECONNREFUSED',
[test] packages/core test:   [errors]: [
[test] packages/core test:     Error: connect ECONNREFUSED ::1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '::1',
[test] packages/core test:       port: 3000
[test] packages/core test:     },
[test] packages/core test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '127.0.0.1',
[test] packages/core test:       port: 3000
[test] packages/core test:     }
[test] packages/core test:   ]
[test] packages/core test: }
[test] packages/core test: AggregateError: 
[test] packages/core test:     at internalConnectMultiple (node:net:1142:49)
[test] packages/core test:     at afterConnectMultiple (node:net:1723:7) {
[test] packages/core test:   code: 'ECONNREFUSED',
[test] packages/core test:   [errors]: [
[test] packages/core test:     Error: connect ECONNREFUSED ::1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '::1',
[test] packages/core test:       port: 3000
[test] packages/core test:     },
[test] packages/core test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '127.0.0.1',
[test] packages/core test:       port: 3000
[test] packages/core test:     }
[test] packages/core test:   ]
[test] packages/core test: }
[test] packages/core test: AggregateError: 
[test] packages/core test:     at internalConnectMultiple (node:net:1142:49)
[test] packages/core test:     at afterConnectMultiple (node:net:1723:7) {
[test] packages/core test:   code: 'ECONNREFUSED',
[test] packages/core test:   [errors]: [
[test] packages/core test:     Error: connect ECONNREFUSED ::1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '::1',
[test] packages/core test:       port: 3000
[test] packages/core test:     },
[test] packages/core test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '127.0.0.1',
[test] packages/core test:       port: 3000
[test] packages/core test:     }
[test] packages/core test:   ]
[test] packages/core test: }
[test] packages/core test: AggregateError: 
[test] packages/core test:     at internalConnectMultiple (node:net:1142:49)
[test] packages/core test:     at afterConnectMultiple (node:net:1723:7) {
[test] packages/core test:   code: 'ECONNREFUSED',
[test] packages/core test:   [errors]: [
[test] packages/core test:     Error: connect ECONNREFUSED ::1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '::1',
[test] packages/core test:       port: 3000
[test] packages/core test:     },
[test] packages/core test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '127.0.0.1',
[test] packages/core test:       port: 3000
[test] packages/core test:     }
[test] packages/core test:   ]
[test] packages/core test: }
[test] packages/core test: AggregateError: 
[test] packages/core test:     at internalConnectMultiple (node:net:1142:49)
[test] packages/core test:     at afterConnectMultiple (node:net:1723:7) {
[test] packages/core test:   code: 'ECONNREFUSED',
[test] packages/core test:   [errors]: [
[test] packages/core test:     Error: connect ECONNREFUSED ::1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '::1',
[test] packages/core test:       port: 3000
[test] packages/core test:     },
[test] packages/core test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '127.0.0.1',
[test] packages/core test:       port: 3000
[test] packages/core test:     }
[test] packages/core test:   ]
[test] packages/core test: }
[test] packages/core test: AggregateError: 
[test] packages/core test:     at internalConnectMultiple (node:net:1142:49)
[test] packages/core test:     at afterConnectMultiple (node:net:1723:7) {
[test] packages/core test:   code: 'ECONNREFUSED',
[test] packages/core test:   [errors]: [
[test] packages/core test:     Error: connect ECONNREFUSED ::1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '::1',
[test] packages/core test:       port: 3000
[test] packages/core test:     },
[test] packages/core test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '127.0.0.1',
[test] packages/core test:       port: 3000
[test] packages/core test:     }
[test] packages/core test:   ]
[test] packages/core test: }
[test] packages/core test: AggregateError: 
[test] packages/core test:     at internalConnectMultiple (node:net:1142:49)
[test] packages/core test:     at afterConnectMultiple (node:net:1723:7) {
[test] packages/core test:   code: 'ECONNREFUSED',
[test] packages/core test:   [errors]: [
[test] packages/core test:     Error: connect ECONNREFUSED ::1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '::1',
[test] packages/core test:       port: 3000
[test] packages/core test:     },
[test] packages/core test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '127.0.0.1',
[test] packages/core test:       port: 3000
[test] packages/core test:     }
[test] packages/core test:   ]
[test] packages/core test: }
[test] packages/core test: AggregateError: 
[test] packages/core test:     at internalConnectMultiple (node:net:1142:49)
[test] packages/core test:     at afterConnectMultiple (node:net:1723:7) {
[test] packages/core test:   code: 'ECONNREFUSED',
[test] packages/core test:   [errors]: [
[test] packages/core test:     Error: connect ECONNREFUSED ::1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '::1',
[test] packages/core test:       port: 3000
[test] packages/core test:     },
[test] packages/core test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '127.0.0.1',
[test] packages/core test:       port: 3000
[test] packages/core test:     }
[test] packages/core test:   ]
[test] packages/core test: }
[test] packages/core test: AggregateError: 
[test] packages/core test:     at internalConnectMultiple (node:net:1142:49)
[test] packages/core test:     at afterConnectMultiple (node:net:1723:7) {
[test] packages/core test:   code: 'ECONNREFUSED',
[test] packages/core test:   [errors]: [
[test] packages/core test:     Error: connect ECONNREFUSED ::1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '::1',
[test] packages/core test:       port: 3000
[test] packages/core test:     },
[test] packages/core test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] packages/core test:         at createConnectionError (node:net:1686:14)
[test] packages/core test:         at afterConnectMultiple (node:net:1716:16) {
[test] packages/core test:       errno: -61,
[test] packages/core test:       code: 'ECONNREFUSED',
[test] packages/core test:       syscall: 'connect',
[test] packages/core test:       address: '127.0.0.1',
[test] packages/core test:       port: 3000
[test] packages/core test:     }
[test] packages/core test:   ]
[test] packages/core test: }
[test] packages/core test: {
[test] packages/core test:   "ok": true,
[test] packages/core test:   "workspaceRoot": "/private/var/folders/w3/pcrbtr3d3ps7cqq0793xcf0m0000gn/T/an-visualize-repo-za9MNF",
[test] packages/core test:   "manifestPath": "/private/var/folders/w3/pcrbtr3d3ps7cqq0793xcf0m0000gn/T/an-visualize-repo-za9MNF/agent-native.json",
[test] packages/core test:   "docsRoot": "/private/var/folders/w3/pcrbtr3d3ps7cqq0793xcf0m0000gn/T/an-visualize-repo-za9MNF/.agent-native/visual-docs",
[test] packages/core test:   "planDir": "/private/var/folders/w3/pcrbtr3d3ps7cqq0793xcf0m0000gn/T/an-visualize-repo-za9MNF/docs/repo-map",
[test] packages/core test:   "planPath": "/private/var/folders/w3/pcrbtr3d3ps7cqq0793xcf0m0000gn/T/an-visualize-repo-za9MNF/docs/repo-map/plan.mdx",
[test] packages/core test:   "targets": [
[test] packages/core test:     {
[test] packages/core test:       "id": "docs",
[test] packages/core test:       "name": "Docs",
[test] packages/core test:       "kind": "area",
[test] packages/core test:       "include": [
[test] packages/core test:         "docs"
[test] packages/core test:       ],
[test] packages/core test:       "blocks": [
[test] packages/core test:         "file-tree",
[test] packages/core test:         "diagram",
[test] packages/core test:         "annotated-code"
[test] packages/core test:       ],
[test] packages/core test:       "policy": "seed"
[test] packages/core test:     }
[test] packages/core test:   ],
[test] packages/core test:   "created": false,
[test] packages/core test:   "validation": "lint-passed"
[test] packages/core test: }
[guard] 
[guard] [guard:no-unscoped-queries] output
[guard] 
[guard] > agentnative@1.0.0 guard:no-unscoped-queries /Users/steve/Projects/builder/agent-native/framework
[guard] > node scripts/guard-no-unscoped-queries.mjs
[guard] 
[guard] guard-no-unscoped-queries: clean (341 schema dirs scanned).
[guard] [guards] PASS guard:no-unscoped-queries (58.8s)
[guard] [guards] All checks passed
[guard] pnpm guards exited with code 0
[test] packages/core test:  Test Files  606 passed (606)
[test] packages/core test:       Tests  7799 passed | 1 skipped (7800)
[test] packages/core test:    Start at  13:57:10
[test] packages/core test:    Duration  72.84s (transform 16.91s, setup 0ms, import 89.15s, tests 145.10s, environment 12.64s)
[test] packages/core test: Done
[test] packages/docs test$ vitest run --passWithNoTests -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] packages/scheduling test$ vitest --run -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] packages/dispatch test$ vitest --run src --passWithNoTests -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] packages/pinpoint test$ vitest --run --passWithNoTests -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] packages/skills test$ vitest --run src --passWithNoTests -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] packages/embedding test$ vitest --run src -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] packages/scheduling test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/packages/scheduling
[test] packages/embedding test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/packages/embedding
[test] packages/pinpoint test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/packages/pinpoint
[test] packages/skills test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/packages/skills
[test] packages/dispatch test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/packages/dispatch
[test] packages/docs test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/packages/docs
[test] packages/embedding test:  Test Files  3 passed (3)
[test] packages/embedding test:       Tests  7 passed (7)
[test] packages/embedding test:    Start at  13:58:24
[test] packages/embedding test:    Duration  800ms (transform 235ms, setup 0ms, import 526ms, tests 8ms, environment 0ms)
[test] packages/embedding test: Done
[test] templates/analytics test$ vitest --run -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] packages/skills test: [?25l│
[test] packages/skills test: ◇  Installation complete [0s]
[test] packages/skills test: [?25h
[test] packages/skills test:  Test Files  8 passed (8)
[test] packages/skills test:       Tests  75 passed (75)
[test] packages/skills test:    Start at  13:58:24
[test] packages/skills test:    Duration  1.28s (transform 1.41s, setup 0ms, import 1.97s, tests 367ms, environment 14ms)
[test] packages/skills test: Done
[test] templates/assets test$ vitest --run -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] templates/analytics test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/templates/analytics
[test] templates/assets test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/templates/assets
[test] packages/pinpoint test:  Test Files  7 passed (7)
[test] packages/pinpoint test:       Tests  47 passed (47)
[test] packages/pinpoint test:    Start at  13:58:24
[test] packages/pinpoint test:    Duration  7.92s (transform 6.32s, setup 0ms, import 22.61s, tests 397ms, environment 0ms)
[test] packages/pinpoint test: Done
[test] templates/brain test$ vitest --run --config vitest.config.ts -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] templates/brain test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/templates/brain
[test] templates/assets test:  Test Files  36 passed (36)
[test] templates/assets test:       Tests  199 passed (199)
[test] templates/assets test:    Start at  13:58:26
[test] templates/assets test:    Duration  21.91s (transform 125.20s, setup 0ms, import 254.42s, tests 907ms, environment 3ms)
[test] templates/assets test: Done
[test] templates/chat test$ vitest --run --passWithNoTests -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] packages/scheduling test:  Test Files  9 passed (9)
[test] packages/scheduling test:       Tests  65 passed (65)
[test] packages/scheduling test:    Start at  13:58:24
[test] packages/scheduling test:    Duration  25.05s (transform 30.77s, setup 0ms, import 61.24s, tests 1.11s, environment 1ms)
[test] packages/scheduling test: Done
[test] templates/clips test$ vitest --run --passWithNoTests -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] templates/clips test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/templates/clips
[test] templates/brain test:  Test Files  8 passed (8)
[test] templates/brain test:       Tests  90 passed (90)
[test] templates/brain test:    Start at  13:58:34
[test] templates/brain test:    Duration  17.07s (transform 27.76s, setup 0ms, import 46.98s, tests 274ms, environment 0ms)
[test] templates/chat test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/templates/chat
[test] templates/brain test: Done
[test] templates/content test$ vitest --run -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] templates/chat test: ReferenceError: require is not defined
[test] templates/chat test:     at /Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/react-dom@19.2.7_react@19.2.7/node_modules/react-dom/server.browser.js:8:3
[test] templates/chat test:     at ESModulesEvaluator.runInlinedModule (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/vite@8.1.0_@types+node@24.13.2_esbuild@0.27.7_jiti@2.6.1_terser@5.46.1_tsx@4.21.0_yaml@2.9.0/node_modules/vite/dist/node/module-runner.js:1006:161)
[test] templates/chat test:     at ModuleRunner.directRequest (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/vite@8.1.0_@types+node@24.13.2_esbuild@0.27.7_jiti@2.6.1_terser@5.46.1_tsx@4.21.0_yaml@2.9.0/node_modules/vite/dist/node/module-runner.js:1259:80)
[test] templates/chat test:     at ModuleRunner.cachedRequest (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/vite@8.1.0_@types+node@24.13.2_esbuild@0.27.7_jiti@2.6.1_terser@5.46.1_tsx@4.21.0_yaml@2.9.0/node_modules/vite/dist/node/module-runner.js:1166:73)
[test] templates/content test: [vite:react-swc] We recommend switching to `@vitejs/plugin-react` for improved performance as no swc plugins are used. More information at https://vite.dev/rolldown
[test] templates/content test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/templates/content
[test] templates/chat test:  Test Files  3 passed (3)
[test] templates/chat test:       Tests  12 passed (12)
[test] templates/chat test:    Start at  13:58:51
[test] templates/chat test:    Duration  1.34s (transform 2.28s, setup 0ms, import 2.10s, tests 520ms, environment 0ms)
[test] packages/dispatch test:  Test Files  41 passed (41)
[test] packages/dispatch test:       Tests  233 passed (233)
[test] packages/dispatch test:    Start at  13:58:24
[test] packages/dispatch test:    Duration  30.11s (transform 146.61s, setup 0ms, import 273.83s, tests 46.31s, environment 10.20s)
[test] packages/dispatch test: Done
[test] templates/forms test$ vitest --run --config vitest.config.ts -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] templates/forms test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/templates/forms
[test] templates/chat test: ReferenceError: exports is not defined
[test] templates/chat test:     at eval (/Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/@opentelemetry+semantic-conventions@1.41.1/node_modules/@opentelemetry/semantic-conventions/build/src/index.js:22:23)
[test] templates/chat test:     at ESModulesEvaluator.runInlinedModule (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/vite@8.1.0_@types+node@24.13.2_esbuild@0.27.7_jiti@2.6.1_terser@5.46.1_tsx@4.21.0_yaml@2.9.0/node_modules/vite/dist/node/module-runner.js:1006:161)
[test] templates/chat test:     at ModuleRunner.directRequest (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/vite@8.1.0_@types+node@24.13.2_esbuild@0.27.7_jiti@2.6.1_terser@5.46.1_tsx@4.21.0_yaml@2.9.0/node_modules/vite/dist/node/module-runner.js:1259:80)
[test] templates/chat test:     at ModuleRunner.cachedRequest (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/vite@8.1.0_@types+node@24.13.2_esbuild@0.27.7_jiti@2.6.1_terser@5.46.1_tsx@4.21.0_yaml@2.9.0/node_modules/vite/dist/node/module-runner.js:1166:73)
[test] templates/chat test: close timed out after 10000ms
[test] templates/chat test: Tests closed successfully but something prevents Vite server from exiting
[test] templates/chat test: You can try to identify the cause by enabling "hanging-process" reporter. See https://vitest.dev/guide/reporters.html#hanging-process-reporter
[test] templates/chat test: Done
[test] templates/macros test$ vitest --run --passWithNoTests -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] templates/macros test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/templates/macros
[test] templates/macros test:  Test Files  1 passed (1)
[test] templates/macros test:       Tests  9 passed (9)
[test] templates/macros test:    Start at  13:59:03
[test] templates/macros test:    Duration  752ms (transform 160ms, setup 0ms, import 634ms, tests 3ms, environment 0ms)
[test] templates/macros test: Done
[test] templates/mail test$ vitest --run -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] packages/docs test:  Test Files  20 passed (20)
[test] packages/docs test:       Tests  110 passed (110)
[test] packages/docs test:    Start at  13:58:24
[test] packages/docs test:    Duration  39.71s (transform 266.98s, setup 0ms, import 414.02s, tests 38.31s, environment 4.24s)
[test] templates/mail test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/templates/mail
[test] packages/docs test: Done
[test] templates/plan test$ vitest --run -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] templates/plan test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/templates/plan
[test] templates/clips test:  Test Files  83 passed (83)
[test] templates/clips test:       Tests  440 passed (440)
[test] templates/clips test:    Start at  13:58:51
[test] templates/clips test:    Duration  14.96s (transform 53.57s, setup 0ms, import 84.37s, tests 3.09s, environment 1.57s)
[test] templates/clips test: Done
[test] templates/analytics test:  Test Files  98 passed (98)
[test] templates/analytics test:       Tests  746 passed (746)
[test] templates/analytics test:    Start at  13:58:25
[test] templates/analytics test:    Duration  40.73s (transform 214.83s, setup 0ms, import 514.08s, tests 7.35s, environment 5.12s)
[test] templates/analytics test: Done
[test] templates/forms test:  Test Files  19 passed (19)
[test] templates/forms test:       Tests  74 passed (74)
[test] templates/forms test:    Start at  13:58:55
[test] templates/forms test:    Duration  13.22s (transform 63.99s, setup 0ms, import 92.23s, tests 299ms, environment 2.34s)
[test] templates/forms test: Done
[test] templates/mail test:  Test Files  35 passed (35)
[test] templates/mail test:       Tests  219 passed (219)
[test] templates/mail test:    Start at  13:59:04
[test] templates/mail test:    Duration  10.74s (transform 36.54s, setup 0ms, import 62.91s, tests 653ms, environment 387ms)
[test] templates/mail test: Done
[test] templates/plan test: Error: Failed to execute 'startTask()' on 'AsyncTaskManager': The asynchronous task manager has been destroyed. This error can be thrown if scripts continue to run while a browser frame is closed.
[test] templates/plan test:     at AsyncTaskManager.startTask (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/async-task-manager/AsyncTaskManager.js:153:19)
[test] templates/plan test:     at file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:416:80
[test] templates/plan test:     at new Promise (<anonymous>)
[test] templates/plan test:     at Fetch.sendRequest (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:415:16)
[test] templates/plan test:     at Fetch.send (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:188:27)
[test] templates/plan test:     at processTicksAndRejections (node:internal/process/task_queues:104:5)
[test] templates/plan test:     at BrowserFrameNavigator.navigate (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/browser/utilities/BrowserFrameNavigator.js:202:24)
[test] templates/plan test:  Test Files  98 passed (98)
[test] templates/plan test:       Tests  1067 passed (1067)
[test] templates/plan test:    Start at  13:59:05
[test] templates/plan test:    Duration  20.67s (transform 89.98s, setup 0ms, import 194.50s, tests 71.29s, environment 6.28s)
[test] templates/plan test: Done
[test] templates/content test:  Test Files  115 passed | 1 skipped (116)
[test] templates/content test:       Tests  1412 passed | 3 expected fail | 5 skipped (1420)
[test] templates/content test:    Start at  13:58:52
[test] templates/content test:    Duration  35.55s (transform 77.68s, setup 0ms, import 206.24s, tests 57.41s, environment 4.59s)
[test] templates/content test: Done
[test] templates/dispatch test$ vitest --run --passWithNoTests -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] templates/slides test$ vitest --run -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] templates/calendar test$ vitest --run -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] templates/design test$ vitest --run -- --exclude '**/*.db.test.ts' --exclude '**/*.integration.spec.ts' --exclude '**/*.integration.test.ts' --exclude '**/*.e2e.spec.ts' --exclude '**/*.e2e.test.ts'
[test] templates/calendar test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/templates/calendar
[test] templates/design test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/templates/design
[test] templates/dispatch test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/templates/dispatch
[test] templates/slides test: [vite:react-swc] We recommend switching to `@vitejs/plugin-react` for improved performance as no swc plugins are used. More information at https://vite.dev/rolldown
[test] templates/slides test:  RUN  v4.1.9 /Users/steve/Projects/builder/agent-native/framework/templates/slides
[test] templates/dispatch test:  Test Files  2 passed (2)
[test] templates/dispatch test:       Tests  40 passed (40)
[test] templates/dispatch test:    Start at  13:59:28
[test] templates/dispatch test:    Duration  852ms (transform 655ms, setup 0ms, import 834ms, tests 23ms, environment 0ms)
[test] templates/dispatch test: Done
[test] templates/calendar test:  Test Files  41 passed (41)
[test] templates/calendar test:       Tests  230 passed (230)
[test] templates/calendar test:    Start at  13:59:28
[test] templates/calendar test:    Duration  14.18s (transform 63.40s, setup 0ms, import 107.90s, tests 4.29s, environment 4.20s)
[test] templates/calendar test: Done
[test] templates/design test: AggregateError: 
[test] templates/design test:     at internalConnectMultiple (node:net:1142:49)
[test] templates/design test:     at afterConnectMultiple (node:net:1723:7) {
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   [errors]: [
[test] templates/design test:     Error: connect ECONNREFUSED ::1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '::1',
[test] templates/design test:       port: 3000
[test] templates/design test:     },
[test] templates/design test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '127.0.0.1',
[test] templates/design test:       port: 3000
[test] templates/design test:     }
[test] templates/design test:   ]
[test] templates/design test: }
[test] templates/design test: AggregateError: 
[test] templates/design test:     at internalConnectMultiple (node:net:1142:49)
[test] templates/design test:     at afterConnectMultiple (node:net:1723:7) {
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   [errors]: [
[test] templates/design test:     Error: connect ECONNREFUSED ::1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '::1',
[test] templates/design test:       port: 3000
[test] templates/design test:     },
[test] templates/design test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '127.0.0.1',
[test] templates/design test:       port: 3000
[test] templates/design test:     }
[test] templates/design test:   ]
[test] templates/design test: }
[test] templates/design test: AggregateError: 
[test] templates/design test:     at internalConnectMultiple (node:net:1142:49)
[test] templates/design test:     at afterConnectMultiple (node:net:1723:7) {
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   [errors]: [
[test] templates/design test:     Error: connect ECONNREFUSED ::1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '::1',
[test] templates/design test:       port: 3000
[test] templates/design test:     },
[test] templates/design test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '127.0.0.1',
[test] templates/design test:       port: 3000
[test] templates/design test:     }
[test] templates/design test:   ]
[test] templates/design test: }
[test] templates/design test: AggregateError: 
[test] templates/design test:     at internalConnectMultiple (node:net:1142:49)
[test] templates/design test:     at afterConnectMultiple (node:net:1723:7) {
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   [errors]: [
[test] templates/design test:     Error: connect ECONNREFUSED ::1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '::1',
[test] templates/design test:       port: 3000
[test] templates/design test:     },
[test] templates/design test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '127.0.0.1',
[test] templates/design test:       port: 3000
[test] templates/design test:     }
[test] templates/design test:   ]
[test] templates/design test: }
[test] templates/design test: AggregateError: 
[test] templates/design test:     at internalConnectMultiple (node:net:1142:49)
[test] templates/design test:     at afterConnectMultiple (node:net:1723:7) {
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   [errors]: [
[test] templates/design test:     Error: connect ECONNREFUSED ::1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '::1',
[test] templates/design test:       port: 3000
[test] templates/design test:     },
[test] templates/design test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '127.0.0.1',
[test] templates/design test:       port: 3000
[test] templates/design test:     }
[test] templates/design test:   ]
[test] templates/design test: }
[test] templates/design test: AggregateError: 
[test] templates/design test:     at internalConnectMultiple (node:net:1142:49)
[test] templates/design test:     at afterConnectMultiple (node:net:1723:7) {
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   [errors]: [
[test] templates/design test:     Error: connect ECONNREFUSED ::1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '::1',
[test] templates/design test:       port: 3000
[test] templates/design test:     },
[test] templates/design test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '127.0.0.1',
[test] templates/design test:       port: 3000
[test] templates/design test:     }
[test] templates/design test:   ]
[test] templates/design test: }
[test] templates/design test: AggregateError: 
[test] templates/design test:     at internalConnectMultiple (node:net:1142:49)
[test] templates/design test:     at afterConnectMultiple (node:net:1723:7) {
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   [errors]: [
[test] templates/design test:     Error: connect ECONNREFUSED ::1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '::1',
[test] templates/design test:       port: 3000
[test] templates/design test:     },
[test] templates/design test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '127.0.0.1',
[test] templates/design test:       port: 3000
[test] templates/design test:     }
[test] templates/design test:   ]
[test] templates/design test: }
[test] templates/design test: AggregateError: 
[test] templates/design test:     at internalConnectMultiple (node:net:1142:49)
[test] templates/design test:     at afterConnectMultiple (node:net:1723:7) {
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   [errors]: [
[test] templates/design test:     Error: connect ECONNREFUSED ::1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '::1',
[test] templates/design test:       port: 3000
[test] templates/design test:     },
[test] templates/design test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '127.0.0.1',
[test] templates/design test:       port: 3000
[test] templates/design test:     }
[test] templates/design test:   ]
[test] templates/design test: }
[test] templates/design test: AggregateError: 
[test] templates/design test:     at internalConnectMultiple (node:net:1142:49)
[test] templates/design test:     at afterConnectMultiple (node:net:1723:7) {
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   [errors]: [
[test] templates/design test:     Error: connect ECONNREFUSED ::1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '::1',
[test] templates/design test:       port: 3000
[test] templates/design test:     },
[test] templates/design test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '127.0.0.1',
[test] templates/design test:       port: 3000
[test] templates/design test:     }
[test] templates/design test:   ]
[test] templates/design test: }
[test] templates/design test: AggregateError: 
[test] templates/design test:     at internalConnectMultiple (node:net:1142:49)
[test] templates/design test:     at afterConnectMultiple (node:net:1723:7) {
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   [errors]: [
[test] templates/design test:     Error: connect ECONNREFUSED ::1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '::1',
[test] templates/design test:       port: 3000
[test] templates/design test:     },
[test] templates/design test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '127.0.0.1',
[test] templates/design test:       port: 3000
[test] templates/design test:     }
[test] templates/design test:   ]
[test] templates/design test: }
[test] templates/design test: AggregateError: 
[test] templates/design test:     at internalConnectMultiple (node:net:1142:49)
[test] templates/design test:     at afterConnectMultiple (node:net:1723:7) {
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   [errors]: [
[test] templates/design test:     Error: connect ECONNREFUSED ::1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '::1',
[test] templates/design test:       port: 3000
[test] templates/design test:     },
[test] templates/design test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '127.0.0.1',
[test] templates/design test:       port: 3000
[test] templates/design test:     }
[test] templates/design test:   ]
[test] templates/design test: }
[test] templates/design test: AggregateError: 
[test] templates/design test:     at internalConnectMultiple (node:net:1142:49)
[test] templates/design test:     at afterConnectMultiple (node:net:1723:7) {
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   [errors]: [
[test] templates/design test:     Error: connect ECONNREFUSED ::1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '::1',
[test] templates/design test:       port: 3000
[test] templates/design test:     },
[test] templates/design test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '127.0.0.1',
[test] templates/design test:       port: 3000
[test] templates/design test:     }
[test] templates/design test:   ]
[test] templates/design test: }
[test] templates/design test: AggregateError: 
[test] templates/design test:     at internalConnectMultiple (node:net:1142:49)
[test] templates/design test:     at afterConnectMultiple (node:net:1723:7) {
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   [errors]: [
[test] templates/design test:     Error: connect ECONNREFUSED ::1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '::1',
[test] templates/design test:       port: 3000
[test] templates/design test:     },
[test] templates/design test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '127.0.0.1',
[test] templates/design test:       port: 3000
[test] templates/design test:     }
[test] templates/design test:   ]
[test] templates/design test: }
[test] templates/design test: AggregateError: 
[test] templates/design test:     at internalConnectMultiple (node:net:1142:49)
[test] templates/design test:     at afterConnectMultiple (node:net:1723:7) {
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   [errors]: [
[test] templates/design test:     Error: connect ECONNREFUSED ::1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '::1',
[test] templates/design test:       port: 3000
[test] templates/design test:     },
[test] templates/design test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '127.0.0.1',
[test] templates/design test:       port: 3000
[test] templates/design test:     }
[test] templates/design test:   ]
[test] templates/design test: }
[test] templates/design test: AggregateError: 
[test] templates/design test:     at internalConnectMultiple (node:net:1142:49)
[test] templates/design test:     at afterConnectMultiple (node:net:1723:7) {
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   [errors]: [
[test] templates/design test:     Error: connect ECONNREFUSED ::1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '::1',
[test] templates/design test:       port: 3000
[test] templates/design test:     },
[test] templates/design test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '127.0.0.1',
[test] templates/design test:       port: 3000
[test] templates/design test:     }
[test] templates/design test:   ]
[test] templates/design test: }
[test] templates/design test: AggregateError: 
[test] templates/design test:     at internalConnectMultiple (node:net:1142:49)
[test] templates/design test:     at afterConnectMultiple (node:net:1723:7) {
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   [errors]: [
[test] templates/design test:     Error: connect ECONNREFUSED ::1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '::1',
[test] templates/design test:       port: 3000
[test] templates/design test:     },
[test] templates/design test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '127.0.0.1',
[test] templates/design test:       port: 3000
[test] templates/design test:     }
[test] templates/design test:   ]
[test] templates/design test: }
[test] templates/design test: AggregateError: 
[test] templates/design test:     at internalConnectMultiple (node:net:1142:49)
[test] templates/design test:     at afterConnectMultiple (node:net:1723:7) {
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   [errors]: [
[test] templates/design test:     Error: connect ECONNREFUSED ::1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '::1',
[test] templates/design test:       port: 3000
[test] templates/design test:     },
[test] templates/design test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '127.0.0.1',
[test] templates/design test:       port: 3000
[test] templates/design test:     }
[test] templates/design test:   ]
[test] templates/design test: }
[test] templates/design test: AggregateError: 
[test] templates/design test:     at internalConnectMultiple (node:net:1142:49)
[test] templates/design test:     at afterConnectMultiple (node:net:1723:7) {
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   [errors]: [
[test] templates/design test:     Error: connect ECONNREFUSED ::1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '::1',
[test] templates/design test:       port: 3000
[test] templates/design test:     },
[test] templates/design test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '127.0.0.1',
[test] templates/design test:       port: 3000
[test] templates/design test:     }
[test] templates/design test:   ]
[test] templates/design test: }
[test] templates/design test: AggregateError: 
[test] templates/design test:     at internalConnectMultiple (node:net:1142:49)
[test] templates/design test:     at afterConnectMultiple (node:net:1723:7) {
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   [errors]: [
[test] templates/design test:     Error: connect ECONNREFUSED ::1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '::1',
[test] templates/design test:       port: 3000
[test] templates/design test:     },
[test] templates/design test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '127.0.0.1',
[test] templates/design test:       port: 3000
[test] templates/design test:     }
[test] templates/design test:   ]
[test] templates/design test: }
[test] templates/design test: AggregateError: 
[test] templates/design test:     at internalConnectMultiple (node:net:1142:49)
[test] templates/design test:     at afterConnectMultiple (node:net:1723:7) {
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   [errors]: [
[test] templates/design test:     Error: connect ECONNREFUSED ::1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '::1',
[test] templates/design test:       port: 3000
[test] templates/design test:     },
[test] templates/design test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '127.0.0.1',
[test] templates/design test:       port: 3000
[test] templates/design test:     }
[test] templates/design test:   ]
[test] templates/design test: }
[test] templates/design test: AggregateError: 
[test] templates/design test:     at internalConnectMultiple (node:net:1142:49)
[test] templates/design test:     at afterConnectMultiple (node:net:1723:7) {
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   [errors]: [
[test] templates/design test:     Error: connect ECONNREFUSED ::1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '::1',
[test] templates/design test:       port: 3000
[test] templates/design test:     },
[test] templates/design test:     Error: connect ECONNREFUSED 127.0.0.1:3000
[test] templates/design test:         at createConnectionError (node:net:1686:14)
[test] templates/design test:         at afterConnectMultiple (node:net:1716:16) {
[test] templates/design test:       errno: -61,
[test] templates/design test:       code: 'ECONNREFUSED',
[test] templates/design test:       syscall: 'connect',
[test] templates/design test:       address: '127.0.0.1',
[test] templates/design test:       port: 3000
[test] templates/design test:     }
[test] templates/design test:   ]
[test] templates/design test: }
[test] templates/design test: Error: connect ECONNREFUSED 127.0.0.1:7331
[test] templates/design test:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1645:16) {
[test] templates/design test:   errno: -61,
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   syscall: 'connect',
[test] templates/design test:   address: '127.0.0.1',
[test] templates/design test:   port: 7331
[test] templates/design test: }
[test] templates/design test: DOMException [NetworkError]: Failed to execute "fetch()" on "Window" with URL "http://127.0.0.1:7331/live-edit?url=http%3A%2F%2Flocalhost%3A5173%2Fforms&previewToken=preview-token&bridgeKey=376286%3A3010835940": connect ECONNREFUSED 127.0.0.1:7331
[test] templates/design test:     at Fetch.onError (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:540:21)
[test] templates/design test:     at ClientRequest.emit (node:events:508:28)
[test] templates/design test:     at emitErrorEvent (node:_http_client:108:11)
[test] templates/design test:     at Socket.socketErrorListener (node:_http_client:575:5)
[test] templates/design test:     at Socket.emit (node:events:508:28)
[test] templates/design test:     at emitErrorNT (node:internal/streams/destroy:170:8)
[test] templates/design test:     at emitErrorCloseNT (node:internal/streams/destroy:129:3)
[test] templates/design test:     at processTicksAndRejections (node:internal/process/task_queues:90:21)
[test] templates/design test: Error: connect ECONNREFUSED 127.0.0.1:7331
[test] templates/design test:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1645:16) {
[test] templates/design test:   errno: -61,
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   syscall: 'connect',
[test] templates/design test:   address: '127.0.0.1',
[test] templates/design test:   port: 7331
[test] templates/design test: }
[test] templates/design test: DOMException [NetworkError]: Failed to execute "fetch()" on "Window" with URL "http://127.0.0.1:7331/live-edit?url=http%3A%2F%2Flocalhost%3A5173%2Fforms&previewToken=preview-token&bridgeKey=376286%3A3010835940": connect ECONNREFUSED 127.0.0.1:7331
[test] templates/design test:     at Fetch.onError (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:540:21)
[test] templates/design test:     at ClientRequest.emit (node:events:508:28)
[test] templates/design test:     at emitErrorEvent (node:_http_client:108:11)
[test] templates/design test:     at Socket.socketErrorListener (node:_http_client:575:5)
[test] templates/design test:     at Socket.emit (node:events:508:28)
[test] templates/design test:     at emitErrorNT (node:internal/streams/destroy:170:8)
[test] templates/design test:     at emitErrorCloseNT (node:internal/streams/destroy:129:3)
[test] templates/design test:     at processTicksAndRejections (node:internal/process/task_queues:90:21)
[test] templates/design test: DOMException [AbortError]: The operation was aborted.
[test] templates/design test:     at Fetch.onAsyncTaskManagerAbort (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:546:23)
[test] templates/design test:     at Object.<anonymous> (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:416:101)
[test] templates/design test:     at AsyncTaskManager.abortAll (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/async-task-manager/AsyncTaskManager.js:292:30)
[test] templates/design test:     at AsyncTaskManager.destroy (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/async-task-manager/AsyncTaskManager.js:64:21)
[test] templates/design test:     at file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/browser/utilities/BrowserFrameFactory.js:43:22
[test] templates/design test:     at new Promise (<anonymous>)
[test] templates/design test:     at BrowserFrameFactory.destroyFrame (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/browser/utilities/BrowserFrameFactory.js:30:16)
[test] templates/design test:     at HTMLIFrameElement.#unloadPage (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/nodes/html-iframe-element/HTMLIFrameElement.js:363:33)
[test] templates/design test:     at HTMLIFrameElement.[disconnectedFromDocument] (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/nodes/html-iframe-element/HTMLIFrameElement.js:238:25)
[test] templates/design test:     at HTMLIFrameElement.[disconnectedFromNode] (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/nodes/node/Node.js:822:58)
[test] templates/design test: DOMException [NetworkError]: Failed to execute "fetch()" on "Window" with URL "http://127.0.0.1:64715/live-edit?url=http%3A%2F%2Flocalhost%3A5173%2Faccount&previewToken=verification-preview-token&bridgeKey=376292%3A1312884952": The operation was aborted.
[test] templates/design test:     at Fetch.onError (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:540:21)
[test] templates/design test:     at ClientRequest.emit (node:events:508:28)
[test] templates/design test:     at emitErrorEvent (node:_http_client:108:11)
[test] templates/design test:     at Socket.socketErrorListener (node:_http_client:575:5)
[test] templates/design test:     at Socket.emit (node:events:508:28)
[test] templates/design test:     at emitErrorNT (node:internal/streams/destroy:170:8)
[test] templates/design test:     at emitErrorCloseNT (node:internal/streams/destroy:129:3)
[test] templates/design test:     at processTicksAndRejections (node:internal/process/task_queues:90:21)
[test] templates/design test: Error: connect ECONNREFUSED 127.0.0.1:7331
[test] templates/design test:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1645:16) {
[test] templates/design test:   errno: -61,
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   syscall: 'connect',
[test] templates/design test:   address: '127.0.0.1',
[test] templates/design test:   port: 7331
[test] templates/design test: }
[test] templates/design test: DOMException [NetworkError]: Failed to execute "fetch()" on "Window" with URL "http://127.0.0.1:7331/live-edit?url=http%3A%2F%2Flocalhost%3A5173%2Fforms&previewToken=preview-token&bridgeKey=376286%3A3010835940": connect ECONNREFUSED 127.0.0.1:7331
[test] templates/design test:     at Fetch.onError (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:540:21)
[test] templates/design test:     at ClientRequest.emit (node:events:508:28)
[test] templates/design test:     at emitErrorEvent (node:_http_client:108:11)
[test] templates/design test:     at Socket.socketErrorListener (node:_http_client:575:5)
[test] templates/design test:     at Socket.emit (node:events:508:28)
[test] templates/design test:     at emitErrorNT (node:internal/streams/destroy:170:8)
[test] templates/design test:     at emitErrorCloseNT (node:internal/streams/destroy:129:3)
[test] templates/design test:     at processTicksAndRejections (node:internal/process/task_queues:90:21)
[test] templates/design test: DOMException [AbortError]: The operation was aborted.
[test] templates/design test:     at Fetch.onAsyncTaskManagerAbort (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:546:23)
[test] templates/design test:     at Object.<anonymous> (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:416:101)
[test] templates/design test:     at AsyncTaskManager.abortAll (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/async-task-manager/AsyncTaskManager.js:292:30)
[test] templates/design test:     at AsyncTaskManager.destroy (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/async-task-manager/AsyncTaskManager.js:64:21)
[test] templates/design test:     at file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/browser/utilities/BrowserFrameFactory.js:43:22
[test] templates/design test:     at new Promise (<anonymous>)
[test] templates/design test:     at BrowserFrameFactory.destroyFrame (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/browser/utilities/BrowserFrameFactory.js:30:16)
[test] templates/design test:     at HTMLIFrameElement.#unloadPage (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/nodes/html-iframe-element/HTMLIFrameElement.js:363:33)
[test] templates/design test:     at HTMLIFrameElement.[disconnectedFromDocument] (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/nodes/html-iframe-element/HTMLIFrameElement.js:238:25)
[test] templates/design test:     at HTMLIFrameElement.[connectedToNode] (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/nodes/node/Node.js:797:58)
[test] templates/design test: DOMException [NetworkError]: Failed to execute "fetch()" on "Window" with URL "http://127.0.0.1:64715/live-edit?url=http%3A%2F%2Flocalhost%3A5173%2Faccount&previewToken=verification-preview-token&bridgeKey=376292%3A1312884952": The operation was aborted.
[test] templates/design test:     at Fetch.onError (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:540:21)
[test] templates/design test:     at ClientRequest.emit (node:events:508:28)
[test] templates/design test:     at emitErrorEvent (node:_http_client:108:11)
[test] templates/design test:     at Socket.socketErrorListener (node:_http_client:575:5)
[test] templates/design test:     at Socket.emit (node:events:508:28)
[test] templates/design test:     at emitErrorNT (node:internal/streams/destroy:170:8)
[test] templates/design test:     at emitErrorCloseNT (node:internal/streams/destroy:129:3)
[test] templates/design test:     at processTicksAndRejections (node:internal/process/task_queues:90:21)
[test] templates/design test:     at runNextTicks (node:internal/process/task_queues:69:3)
[test] templates/design test:     at processImmediate (node:internal/timers:472:9)
[test] templates/design test: Error: connect ECONNREFUSED 127.0.0.1:7331
[test] templates/design test:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1645:16) {
[test] templates/design test:   errno: -61,
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   syscall: 'connect',
[test] templates/design test:   address: '127.0.0.1',
[test] templates/design test:   port: 7331
[test] templates/design test: }
[test] templates/design test: DOMException [NetworkError]: Failed to execute "fetch()" on "Window" with URL "http://127.0.0.1:7331/live-edit?url=http%3A%2F%2Flocalhost%3A5173%2Fforms&previewToken=preview-token&bridgeKey=376286%3A3010835940": connect ECONNREFUSED 127.0.0.1:7331
[test] templates/design test:     at Fetch.onError (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:540:21)
[test] templates/design test:     at ClientRequest.emit (node:events:508:28)
[test] templates/design test:     at emitErrorEvent (node:_http_client:108:11)
[test] templates/design test:     at Socket.socketErrorListener (node:_http_client:575:5)
[test] templates/design test:     at Socket.emit (node:events:508:28)
[test] templates/design test:     at emitErrorNT (node:internal/streams/destroy:170:8)
[test] templates/design test:     at emitErrorCloseNT (node:internal/streams/destroy:129:3)
[test] templates/design test:     at processTicksAndRejections (node:internal/process/task_queues:90:21)
[test] templates/design test: DOMException [AbortError]: The operation was aborted.
[test] templates/design test:     at Fetch.onAsyncTaskManagerAbort (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:546:23)
[test] templates/design test:     at Object.<anonymous> (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:416:101)
[test] templates/design test:     at AsyncTaskManager.abortAll (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/async-task-manager/AsyncTaskManager.js:292:30)
[test] templates/design test:     at AsyncTaskManager.destroy (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/async-task-manager/AsyncTaskManager.js:64:21)
[test] templates/design test:     at file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/browser/utilities/BrowserFrameFactory.js:43:22
[test] templates/design test:     at new Promise (<anonymous>)
[test] templates/design test:     at BrowserFrameFactory.destroyFrame (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/browser/utilities/BrowserFrameFactory.js:30:16)
[test] templates/design test:     at HTMLIFrameElement.#unloadPage (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/nodes/html-iframe-element/HTMLIFrameElement.js:363:33)
[test] templates/design test:     at HTMLIFrameElement.[disconnectedFromDocument] (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/nodes/html-iframe-element/HTMLIFrameElement.js:238:25)
[test] templates/design test:     at HTMLIFrameElement.[connectedToNode] (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/nodes/node/Node.js:797:58)
[test] templates/design test: DOMException [NetworkError]: Failed to execute "fetch()" on "Window" with URL "http://127.0.0.1:64723/live-edit?url=http%3A%2F%2Flocalhost%3A5173%2Fchat&previewToken=handoff-preview-token&bridgeKey=376289%3A972104035": The operation was aborted.
[test] templates/design test:     at Fetch.onError (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:540:21)
[test] templates/design test:     at ClientRequest.emit (node:events:508:28)
[test] templates/design test:     at emitErrorEvent (node:_http_client:108:11)
[test] templates/design test:     at Socket.socketErrorListener (node:_http_client:575:5)
[test] templates/design test:     at Socket.emit (node:events:508:28)
[test] templates/design test:     at emitErrorNT (node:internal/streams/destroy:170:8)
[test] templates/design test:     at emitErrorCloseNT (node:internal/streams/destroy:129:3)
[test] templates/design test:     at processTicksAndRejections (node:internal/process/task_queues:90:21)
[test] templates/design test: Error: connect ECONNREFUSED 127.0.0.1:7331
[test] templates/design test:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1645:16) {
[test] templates/design test:   errno: -61,
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   syscall: 'connect',
[test] templates/design test:   address: '127.0.0.1',
[test] templates/design test:   port: 7331
[test] templates/design test: }
[test] templates/design test: DOMException [NetworkError]: Failed to execute "fetch()" on "Window" with URL "http://127.0.0.1:7331/live-edit?url=http%3A%2F%2Flocalhost%3A5173%2Fforms&previewToken=preview-token&bridgeKey=376286%3A3010835940": connect ECONNREFUSED 127.0.0.1:7331
[test] templates/design test:     at Fetch.onError (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:540:21)
[test] templates/design test:     at ClientRequest.emit (node:events:508:28)
[test] templates/design test:     at emitErrorEvent (node:_http_client:108:11)
[test] templates/design test:     at Socket.socketErrorListener (node:_http_client:575:5)
[test] templates/design test:     at Socket.emit (node:events:508:28)
[test] templates/design test:     at emitErrorNT (node:internal/streams/destroy:170:8)
[test] templates/design test:     at emitErrorCloseNT (node:internal/streams/destroy:129:3)
[test] templates/design test:     at processTicksAndRejections (node:internal/process/task_queues:90:21)
[test] templates/design test: Error: connect ECONNREFUSED 127.0.0.1:7331
[test] templates/design test:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1645:16) {
[test] templates/design test:   errno: -61,
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   syscall: 'connect',
[test] templates/design test:   address: '127.0.0.1',
[test] templates/design test:   port: 7331
[test] templates/design test: }
[test] templates/design test: DOMException [NetworkError]: Failed to execute "fetch()" on "Window" with URL "http://127.0.0.1:7331/live-edit?url=http%3A%2F%2Flocalhost%3A5173%2Fforms&previewToken=preview-token&bridgeKey=376286%3A3010835940": connect ECONNREFUSED 127.0.0.1:7331
[test] templates/design test:     at Fetch.onError (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:540:21)
[test] templates/design test:     at ClientRequest.emit (node:events:508:28)
[test] templates/design test:     at emitErrorEvent (node:_http_client:108:11)
[test] templates/design test:     at Socket.socketErrorListener (node:_http_client:575:5)
[test] templates/design test:     at Socket.emit (node:events:508:28)
[test] templates/design test:     at emitErrorNT (node:internal/streams/destroy:170:8)
[test] templates/design test:     at emitErrorCloseNT (node:internal/streams/destroy:129:3)
[test] templates/design test:     at processTicksAndRejections (node:internal/process/task_queues:90:21)
[test] templates/design test: Error: connect ECONNREFUSED 127.0.0.1:7331
[test] templates/design test:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1645:16) {
[test] templates/design test:   errno: -61,
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   syscall: 'connect',
[test] templates/design test:   address: '127.0.0.1',
[test] templates/design test:   port: 7331
[test] templates/design test: }
[test] templates/design test: DOMException [NetworkError]: Failed to execute "fetch()" on "Window" with URL "http://127.0.0.1:7331/live-edit?url=http%3A%2F%2Flocalhost%3A5173%2Fforms&previewToken=preview-token&bridgeKey=376286%3A3010835940": connect ECONNREFUSED 127.0.0.1:7331
[test] templates/design test:     at Fetch.onError (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:540:21)
[test] templates/design test:     at ClientRequest.emit (node:events:508:28)
[test] templates/design test:     at emitErrorEvent (node:_http_client:108:11)
[test] templates/design test:     at Socket.socketErrorListener (node:_http_client:575:5)
[test] templates/design test:     at Socket.emit (node:events:508:28)
[test] templates/design test:     at emitErrorNT (node:internal/streams/destroy:170:8)
[test] templates/design test:     at emitErrorCloseNT (node:internal/streams/destroy:129:3)
[test] templates/design test:     at processTicksAndRejections (node:internal/process/task_queues:90:21)
[test] templates/design test: Error: connect ECONNREFUSED 127.0.0.1:7331
[test] templates/design test:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1645:16) {
[test] templates/design test:   errno: -61,
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   syscall: 'connect',
[test] templates/design test:   address: '127.0.0.1',
[test] templates/design test:   port: 7331
[test] templates/design test: }
[test] templates/design test: DOMException [NetworkError]: Failed to execute "fetch()" on "Window" with URL "http://127.0.0.1:7331/live-edit?url=http%3A%2F%2Flocalhost%3A5173%2Fforms&previewToken=preview-token&bridgeKey=376286%3A3010835940": connect ECONNREFUSED 127.0.0.1:7331
[test] templates/design test:     at Fetch.onError (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:540:21)
[test] templates/design test:     at ClientRequest.emit (node:events:508:28)
[test] templates/design test:     at emitErrorEvent (node:_http_client:108:11)
[test] templates/design test:     at Socket.socketErrorListener (node:_http_client:575:5)
[test] templates/design test:     at Socket.emit (node:events:508:28)
[test] templates/design test:     at emitErrorNT (node:internal/streams/destroy:170:8)
[test] templates/design test:     at emitErrorCloseNT (node:internal/streams/destroy:129:3)
[test] templates/design test:     at processTicksAndRejections (node:internal/process/task_queues:90:21)
[test] templates/design test: DOMException [NotSupportedError]: Failed to load module "/src/main.tsx". JavaScript file loading is disabled.
[test] templates/design test:     at HTMLScriptElement.#loadModule (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/nodes/html-script-element/HTMLScriptElement.js:484:31)
[test] templates/design test:     at HTMLScriptElement.[connectedToDocument] (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/nodes/html-script-element/HTMLScriptElement.js:312:33)
[test] templates/design test:     at HTMLScriptElement.[connectedToNode] (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/nodes/node/Node.js:794:53)
[test] templates/design test:     at HTMLBodyElement.[appendChild] (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/nodes/node/Node.js:413:45)
[test] templates/design test:     at HTMLBodyElement.[appendChild] (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/nodes/element/Element.js:1028:62)
[test] templates/design test:     at HTMLParser.parseRawTextElementContent (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/html-parser/HTMLParser.js:654:61)
[test] templates/design test:     at HTMLParser.parse (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/html-parser/HTMLParser.js:244:30)
[test] templates/design test:     at HTMLDocument.write (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/nodes/document/Document.js:1225:16)
[test] templates/design test:     at HTMLIFrameElement.#loadPage (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/nodes/html-iframe-element/HTMLIFrameElement.js:319:42)
[test] templates/design test:     at HTMLIFrameElement.[connectedToDocument] (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/nodes/html-iframe-element/HTMLIFrameElement.js:230:23)
[test] templates/design test: Error: connect ECONNREFUSED 127.0.0.1:7331
[test] templates/design test:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1645:16) {
[test] templates/design test:   errno: -61,
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   syscall: 'connect',
[test] templates/design test:   address: '127.0.0.1',
[test] templates/design test:   port: 7331
[test] templates/design test: }
[test] templates/design test: DOMException [NetworkError]: Failed to execute "fetch()" on "Window" with URL "http://127.0.0.1:7331/live-edit?url=http%3A%2F%2Flocalhost%3A5173%2Fforms&previewToken=preview-token&bridgeKey=376286%3A3010835940": connect ECONNREFUSED 127.0.0.1:7331
[test] templates/design test:     at Fetch.onError (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:540:21)
[test] templates/design test:     at ClientRequest.emit (node:events:508:28)
[test] templates/design test:     at emitErrorEvent (node:_http_client:108:11)
[test] templates/design test:     at Socket.socketErrorListener (node:_http_client:575:5)
[test] templates/design test:     at Socket.emit (node:events:508:28)
[test] templates/design test:     at emitErrorNT (node:internal/streams/destroy:170:8)
[test] templates/design test:     at emitErrorCloseNT (node:internal/streams/destroy:129:3)
[test] templates/design test:     at processTicksAndRejections (node:internal/process/task_queues:90:21)
[test] templates/design test: Error: connect ECONNREFUSED 127.0.0.1:7331
[test] templates/design test:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1645:16) {
[test] templates/design test:   errno: -61,
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   syscall: 'connect',
[test] templates/design test:   address: '127.0.0.1',
[test] templates/design test:   port: 7331
[test] templates/design test: }
[test] templates/design test: DOMException [NetworkError]: Failed to execute "fetch()" on "Window" with URL "http://127.0.0.1:7331/live-edit?url=http%3A%2F%2Flocalhost%3A5173%2Fforms&previewToken=preview-token&bridgeKey=376286%3A3010835940": connect ECONNREFUSED 127.0.0.1:7331
[test] templates/design test:     at Fetch.onError (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:540:21)
[test] templates/design test:     at ClientRequest.emit (node:events:508:28)
[test] templates/design test:     at emitErrorEvent (node:_http_client:108:11)
[test] templates/design test:     at Socket.socketErrorListener (node:_http_client:575:5)
[test] templates/design test:     at Socket.emit (node:events:508:28)
[test] templates/design test:     at emitErrorNT (node:internal/streams/destroy:170:8)
[test] templates/design test:     at emitErrorCloseNT (node:internal/streams/destroy:129:3)
[test] templates/design test:     at processTicksAndRejections (node:internal/process/task_queues:90:21)
[test] templates/design test: Error: connect ECONNREFUSED 127.0.0.1:7331
[test] templates/design test:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1645:16) {
[test] templates/design test:   errno: -61,
[test] templates/design test:   code: 'ECONNREFUSED',
[test] templates/design test:   syscall: 'connect',
[test] templates/design test:   address: '127.0.0.1',
[test] templates/design test:   port: 7331
[test] templates/design test: }
[test] templates/design test: DOMException [NetworkError]: Failed to execute "fetch()" on "Window" with URL "http://127.0.0.1:7331/live-edit?url=http%3A%2F%2Flocalhost%3A5173%2Fforms&previewToken=preview-token&bridgeKey=376286%3A3010835940": connect ECONNREFUSED 127.0.0.1:7331
[test] templates/design test:     at Fetch.onError (file:///Users/steve/Projects/builder/agent-native/framework/node_modules/.pnpm/happy-dom@20.10.6/node_modules/happy-dom/lib/fetch/Fetch.js:540:21)
[test] templates/design test:     at ClientRequest.emit (node:events:508:28)
[test] templates/design test:     at emitErrorEvent (node:_http_client:108:11)
[test] templates/design test:     at Socket.socketErrorListener (node:_http_client:575:5)
[test] templates/design test:     at Socket.emit (node:events:508:28)
[test] templates/design test:     at emitErrorNT (node:internal/streams/destroy:170:8)
[test] templates/design test:     at emitErrorCloseNT (node:internal/streams/destroy:129:3)
[test] templates/design test:     at processTicksAndRejections (node:internal/process/task_queues:90:21)
[test] templates/slides test:  Test Files  58 passed (58)
[test] templates/slides test:       Tests  301 passed (301)
[test] templates/slides test:    Start at  13:59:28
[test] templates/slides test:    Duration  19.19s (transform 111.15s, setup 0ms, import 213.02s, tests 8.90s, environment 9.12s)
[test] templates/slides test: Done
[test] templates/design test:  Test Files  331 passed (331)
[test] templates/design test:       Tests  4116 passed (4116)
[test] templates/design test:    Start at  13:59:28
[test] templates/design test:    Duration  49.03s (transform 133.19s, setup 0ms, import 427.41s, tests 86.33s, environment 14.30s)
[test] templates/design test: Done
[test] pnpm test:fast exited with code 0 — all workspace typechecks, all 22 guards, and all fast-test workspaces passed\n- Core fast suite: 606 files / 7,799 passed / 1 skipped\n- Analytics: 98 files / 746 passed\n- Core replay-focused: 70 passed\n- Dispatch: 233 passed\n- generated-worker stabilization: 66 passed\n- browser/raw-event verification across , , and \n\n## Tradeoffs\n- Historically interleaved recordings cannot be generically repaired because stored events have no tab identity; heuristic warning UI was intentionally not added due false positives.\n- Progressive playback before all chunks load was researched against rrweb 2.1 and  but deferred after its first lifecycle integration proved risky.\n- External recorded fonts/styles remain live resources; Analytics currently sends no restrictive style/font CSP. Signed load-bearing resource URLs are preserved so capture-time redaction does not break them.\n