### PR TITLE
Expose structured read results over MCP

### DIFF
--- a/.changeset/mcp-read-result-payloads.md
+++ b/.changeset/mcp-read-result-payloads.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Preserve structured payloads from read-only MCP actions so external agents can inspect detailed records and replay data directly.

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -512,24 +512,53 @@ function routePathFromOpenUrl(value: string): string | null {
  * `mcpApp.resource` (the resource path already strips them via
  * `mcpAppStructuredContent`).
  *
- * Depth-capped to avoid pathological / circular structures. Strings that
- * embed an `isEmbedStartUrl` substring (e.g. a longer message that includes
- * the URL) are replaced with `[hidden embed URL]`.
+ * Circular structures are replaced with a marker. Strings that embed an
+ * `isEmbedStartUrl` substring (e.g. a longer message that includes the URL)
+ * are replaced with `[hidden embed URL]`. Credential-like `ticket` fields are
+ * removed only inside an embed-signaled object/branch, so ordinary business
+ * fields from unrelated read actions remain faithful.
  */
 const EMBED_RESULT_SENSITIVE_KEYS = new Set([
   "embedTargetPath",
   "embedExpiresAt",
-  "ticket",
   "embedTicket",
 ]);
 
-function isSensitiveEmbedResultKey(key: string): boolean {
-  return EMBED_RESULT_SENSITIVE_KEYS.has(key) || /Ticket$/.test(key);
+function isEmbedCredentialKey(key: string): boolean {
+  return key === "ticket" || /Ticket$/.test(key);
+}
+
+function containsEmbedRoutingSignal(
+  value: unknown,
+  seen = new WeakSet<object>(),
+): boolean {
+  if (typeof value === "string") return isEmbedStartUrl(value);
+  if (!value || typeof value !== "object") return false;
+  if (seen.has(value)) return false;
+  seen.add(value);
+  if (Array.isArray(value)) {
+    const result = value.some((item) => containsEmbedRoutingSignal(item, seen));
+    seen.delete(value);
+    return result;
+  }
+  for (const [key, val] of Object.entries(value)) {
+    if (EMBED_RESULT_SENSITIVE_KEYS.has(key)) {
+      seen.delete(value);
+      return true;
+    }
+    if (containsEmbedRoutingSignal(val, seen)) {
+      seen.delete(value);
+      return true;
+    }
+  }
+  seen.delete(value);
+  return false;
 }
 
 function purgeEmbedStartUrls(
   value: unknown,
   seen = new WeakSet<object>(),
+  embedContext = false,
 ): unknown {
   if (typeof value === "string") {
     return isEmbedStartUrl(value) ? "[hidden embed URL]" : value;
@@ -537,22 +566,41 @@ function purgeEmbedStartUrls(
   if (Array.isArray(value)) {
     if (seen.has(value)) return "[circular result]";
     seen.add(value);
-    const out = value.map((item) => purgeEmbedStartUrls(item, seen));
+    const out = value.map((item) =>
+      purgeEmbedStartUrls(
+        item,
+        seen,
+        embedContext || containsEmbedRoutingSignal(item),
+      ),
+    );
     seen.delete(value);
     return out;
   }
   if (value && typeof value === "object") {
     if (seen.has(value)) return "[circular result]";
     seen.add(value);
+    const entries = Object.entries(value as Record<string, unknown>);
+    const localEmbedContext =
+      embedContext ||
+      entries.some(
+        ([key, val]) =>
+          EMBED_RESULT_SENSITIVE_KEYS.has(key) ||
+          (typeof val === "string" && isEmbedStartUrl(val)),
+      );
     const out: Record<string, unknown> = {};
-    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
-      if (isSensitiveEmbedResultKey(key)) continue;
+    for (const [key, val] of entries) {
+      if (
+        EMBED_RESULT_SENSITIVE_KEYS.has(key) ||
+        (localEmbedContext && isEmbedCredentialKey(key))
+      ) {
+        continue;
+      }
       if (typeof val === "string" && isEmbedStartUrl(val)) {
         // Drop the key entirely for object-typed inputs so a tool result like
         // `{ embedStartUrl: "..." }` does not appear at all in the LLM text.
         continue;
       }
-      out[key] = purgeEmbedStartUrls(val, seen);
+      out[key] = purgeEmbedStartUrls(val, seen, localEmbedContext);
     }
     seen.delete(value);
     return out;

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -1275,12 +1275,25 @@ function isSuccessOnlyResult(value: Record<string, unknown>): boolean {
   });
 }
 
-function conciseToolResultText(name: string, result: unknown): string {
+function conciseToolResultText(
+  name: string,
+  result: unknown,
+  options?: { preserveObjectResult?: boolean },
+): string {
   const purged = purgeEmbedStartUrls(result);
   if (typeof purged === "string") return truncateToolText(purged);
   if (purged === true || purged == null) return `${name} completed.`;
   if (purged && typeof purged === "object" && !Array.isArray(purged)) {
     const record = purged as Record<string, unknown>;
+    // Read-only actions are data reads, not mutations. Keep their object
+    // payload available to MCP clients in the text fallback too; the
+    // structuredContent branch below is the lossless path for clients that
+    // support it. Mutating/action-style results retain the concise status
+    // text so we do not unexpectedly dump write results into conversations.
+    if (options?.preserveObjectResult) {
+      const text = JSON.stringify(purged);
+      return text === undefined ? `${name} completed.` : truncateToolText(text);
+    }
     const message = record.message ?? record.summary;
     if (typeof message === "string" && message.trim()) {
       return truncateToolText(message.trim());
@@ -1711,10 +1724,17 @@ export async function createMCPServerForRequest(
               typeof rawResult === "object" &&
               !Array.isArray(rawResult)
             ? (rawResult as Record<string, unknown>)
-            : undefined;
+            : entry.readOnly === true &&
+                rawResult &&
+                typeof rawResult === "object" &&
+                !Array.isArray(rawResult)
+              ? mcpAppStructuredContent(rawResultForClient, responseMeta)
+              : undefined;
         const text = mcpAppResource
           ? conciseMcpAppToolText(name, resultForClient, structuredContent!)
-          : conciseToolResultText(name, resultForClient);
+          : conciseToolResultText(name, resultForClient, {
+              preserveObjectResult: entry.readOnly === true,
+            });
         const content: any[] = [{ type: "text", text }];
         if (block) content.push(block);
         return {

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -516,24 +516,45 @@ function routePathFromOpenUrl(value: string): string | null {
  * embed an `isEmbedStartUrl` substring (e.g. a longer message that includes
  * the URL) are replaced with `[hidden embed URL]`.
  */
-function purgeEmbedStartUrls(value: unknown, depth = 0): unknown {
-  if (depth > 5) return value;
+const EMBED_RESULT_SENSITIVE_KEYS = new Set([
+  "embedTargetPath",
+  "embedExpiresAt",
+  "ticket",
+  "embedTicket",
+]);
+
+function isSensitiveEmbedResultKey(key: string): boolean {
+  return EMBED_RESULT_SENSITIVE_KEYS.has(key) || /Ticket$/.test(key);
+}
+
+function purgeEmbedStartUrls(
+  value: unknown,
+  seen = new WeakSet<object>(),
+): unknown {
   if (typeof value === "string") {
     return isEmbedStartUrl(value) ? "[hidden embed URL]" : value;
   }
   if (Array.isArray(value)) {
-    return value.map((item) => purgeEmbedStartUrls(item, depth + 1));
+    if (seen.has(value)) return "[circular result]";
+    seen.add(value);
+    const out = value.map((item) => purgeEmbedStartUrls(item, seen));
+    seen.delete(value);
+    return out;
   }
   if (value && typeof value === "object") {
+    if (seen.has(value)) return "[circular result]";
+    seen.add(value);
     const out: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      if (isSensitiveEmbedResultKey(key)) continue;
       if (typeof val === "string" && isEmbedStartUrl(val)) {
         // Drop the key entirely for object-typed inputs so a tool result like
         // `{ embedStartUrl: "..." }` does not appear at all in the LLM text.
         continue;
       }
-      out[key] = purgeEmbedStartUrls(val, depth + 1);
+      out[key] = purgeEmbedStartUrls(val, seen);
     }
+    seen.delete(value);
     return out;
   }
   return value;
@@ -1195,11 +1216,12 @@ function mcpAppStructuredContent(
   result: unknown,
   meta: Record<string, unknown> | undefined,
 ): Record<string, unknown> {
+  const purged = purgeEmbedStartUrls(result);
   const out: Record<string, unknown> =
-    result && typeof result === "object" && !Array.isArray(result)
-      ? { ...(result as Record<string, unknown>) }
-      : primitiveValue(result)
-        ? { result }
+    purged && typeof purged === "object" && !Array.isArray(purged)
+      ? { ...(purged as Record<string, unknown>) }
+      : primitiveValue(purged)
+        ? { result: purged }
         : {};
   for (const key of ["embedStartUrl", "startUrl"]) {
     const value = out[key];
@@ -1213,17 +1235,6 @@ function mcpAppStructuredContent(
   // LLM). `embedTargetPath` reveals the exact route + thread/draft id the user
   // is looking at; `embedExpiresAt` is an unintended timestamp; ticket-bearing
   // fields are single-use credentials. Drop all of them unconditionally.
-  for (const key of [
-    "embedTargetPath",
-    "embedExpiresAt",
-    "ticket",
-    "embedTicket",
-  ]) {
-    delete out[key];
-  }
-  for (const key of Object.keys(out)) {
-    if (/Ticket$/.test(key)) delete out[key];
-  }
   const openLink = meta?.["agent-native/openLink"];
   if (openLink && typeof openLink === "object" && !Array.isArray(openLink)) {
     const webUrl = (openLink as Record<string, unknown>).webUrl;

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -580,13 +580,7 @@ function purgeEmbedStartUrls(
     if (seen.has(value)) return "[circular result]";
     seen.add(value);
     const entries = Object.entries(value as Record<string, unknown>);
-    const localEmbedContext =
-      embedContext ||
-      entries.some(
-        ([key, val]) =>
-          EMBED_RESULT_SENSITIVE_KEYS.has(key) ||
-          (typeof val === "string" && isEmbedStartUrl(val)),
-      );
+    const localEmbedContext = embedContext || containsEmbedRoutingSignal(value);
     const out: Record<string, unknown> = {};
     for (const [key, val] of entries) {
       if (

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -2753,6 +2753,49 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.result.content[0].text).not.toContain("should-be-hidden");
   });
 
+  it("surfaces sanitized structured payloads for model-visible read-only tools", async () => {
+    const readConfig = {
+      ...config,
+      actions: {
+        "read-detail": {
+          tool: { description: "Read a detail record" },
+          http: { method: "GET" as const },
+          readOnly: true,
+          run: async () => ({
+            id: "record-42",
+            status: "failed",
+            message: "The request failed",
+            url: "/_agent-native/embed/start?ticket=must-not-leak",
+            steps: [{ kind: "network", status: 404 }],
+          }),
+        },
+      },
+    };
+
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 162,
+        method: "tools/call",
+        params: { name: "read-detail", arguments: {} },
+      },
+      {
+        headers: { "x-agent-native-mcp-full-catalog": "1" },
+        config: readConfig,
+      },
+    );
+
+    expect(out.error).toBeUndefined();
+    expect(out.result.structuredContent).toEqual({
+      id: "record-42",
+      status: "failed",
+      message: "The request failed",
+      steps: [{ kind: "network", status: 404 }],
+    });
+    expect(out.result.content[0].text).toContain('"record-42"');
+    expect(out.result.content[0].text).not.toContain("must-not-leak");
+  });
+
   it("strips embedTargetPath, embedExpiresAt, and ticket fields from structuredContent", async () => {
     // Regression: internal embed-routing fields are carried in
     // `_meta["agent-native/embedStart"]` for the embed runtime. They must NOT

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -2819,6 +2819,47 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.result.content[0].text).not.toContain("private/thread/42");
   });
 
+  it("preserves ordinary ticket fields on unrelated read-only payloads", async () => {
+    const readConfig = {
+      ...config,
+      actions: {
+        "read-business-record": {
+          tool: { description: "Read a business record" },
+          http: { method: "GET" as const },
+          readOnly: true,
+          run: async () => ({
+            id: "order-42",
+            ticket: "customer-support-ticket-42",
+            receiptTicket: "receipt-ticket-42",
+            nested: { ticket: "nested-business-ticket-42" },
+          }),
+        },
+      },
+    };
+
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 163,
+        method: "tools/call",
+        params: { name: "read-business-record", arguments: {} },
+      },
+      {
+        headers: { "x-agent-native-mcp-full-catalog": "1" },
+        config: readConfig,
+      },
+    );
+
+    expect(out.error).toBeUndefined();
+    expect(out.result.structuredContent).toEqual({
+      id: "order-42",
+      ticket: "customer-support-ticket-42",
+      receiptTicket: "receipt-ticket-42",
+      nested: { ticket: "nested-business-ticket-42" },
+    });
+    expect(out.result.content[0].text).toContain("customer-support-ticket-42");
+  });
+
   it("strips embedTargetPath, embedExpiresAt, and ticket fields from structuredContent", async () => {
     // Regression: internal embed-routing fields are carried in
     // `_meta["agent-native/embedStart"]` for the embed runtime. They must NOT

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -2766,7 +2766,21 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
             status: "failed",
             message: "The request failed",
             url: "/_agent-native/embed/start?ticket=must-not-leak",
-            steps: [{ kind: "network", status: 404 }],
+            ticket: "top-level-ticket-must-not-leak",
+            embedTargetPath: "/private/thread/42",
+            embedExpiresAt: 1735689600,
+            uploadTicket: "nested-upload-ticket-must-not-leak",
+            steps: [
+              {
+                kind: "network",
+                status: 404,
+                details: {
+                  ticket: "nested-ticket-must-not-leak",
+                  embedTargetPath: "/private/nested",
+                  safe: "keep this detail",
+                },
+              },
+            ],
           }),
         },
       },
@@ -2790,10 +2804,19 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       id: "record-42",
       status: "failed",
       message: "The request failed",
-      steps: [{ kind: "network", status: 404 }],
+      steps: [
+        {
+          kind: "network",
+          status: 404,
+          details: { safe: "keep this detail" },
+        },
+      ],
     });
     expect(out.result.content[0].text).toContain('"record-42"');
     expect(out.result.content[0].text).not.toContain("must-not-leak");
+    expect(out.result.content[0].text).not.toContain("top-level-ticket");
+    expect(out.result.content[0].text).not.toContain("nested-ticket");
+    expect(out.result.content[0].text).not.toContain("private/thread/42");
   });
 
   it("strips embedTargetPath, embedExpiresAt, and ticket fields from structuredContent", async () => {

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -2860,6 +2860,49 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.result.content[0].text).toContain("customer-support-ticket-42");
   });
 
+  it("propagates embed sanitization to credential siblings", async () => {
+    const readConfig = {
+      ...config,
+      actions: {
+        "read-nested-embed-record": {
+          tool: { description: "Read a nested embed record" },
+          http: { method: "GET" as const },
+          readOnly: true,
+          run: async () => ({
+            id: "record-with-nested-embed",
+            ticket: "sibling-ticket-must-not-leak",
+            details: {
+              embedTargetPath: "/private/thread/42",
+              safe: "keep this detail",
+            },
+          }),
+        },
+      },
+    };
+
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 164,
+        method: "tools/call",
+        params: { name: "read-nested-embed-record", arguments: {} },
+      },
+      {
+        headers: { "x-agent-native-mcp-full-catalog": "1" },
+        config: readConfig,
+      },
+    );
+
+    expect(out.error).toBeUndefined();
+    expect(out.result.structuredContent).toEqual({
+      id: "record-with-nested-embed",
+      details: { safe: "keep this detail" },
+    });
+    expect(out.result.content[0].text).not.toContain(
+      "sibling-ticket-must-not-leak",
+    );
+  });
+
   it("strips embedTargetPath, embedExpiresAt, and ticket fields from structuredContent", async () => {
     // Regression: internal embed-routing fields are carried in
     // `_meta["agent-native/embedStart"]` for the embed runtime. They must NOT


### PR DESCRIPTION
## Summary
- preserve sanitized structured payloads for model-visible read-only MCP actions
- keep mutating action results concise
- add regression coverage for replay/detail-style payloads and embed-ticket redaction

## Validation
- `corepack pnpm --filter @agent-native/core test`
- `corepack pnpm --filter @agent-native/core typecheck`
- `corepack pnpm --filter @agent-native/core build`
- `corepack pnpm prep` (full fast tests and typechecks passed; initial guard saw a test-generated temporary corpus artifact, rerun passed)

Includes a patch changeset for `@agent-native/core`.