### PR TITLE
Expose observability reads to Analytics agent

### DIFF
--- a/templates/analytics/changelog/2026-07-12-named-session-incident-investigations-now-start-with-session.md
+++ b/templates/analytics/changelog/2026-07-12-named-session-incident-investigations-now-start-with-session.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-12
+---
+
+Named session incident investigations now start with session, replay, and error evidence

--- a/templates/analytics/server/lib/agent-chat-plan-mode.ts
+++ b/templates/analytics/server/lib/agent-chat-plan-mode.ts
@@ -6,14 +6,11 @@ export const INITIAL_TOOL_NAMES = [
   // Keep the first-party observability workflow on the initial surface so a
   // named user's session/error question does not depend on an indirect
   // tool-search round before the agent can inspect its evidence.
-  "create-session-replay-agent-link",
   "get-error-issue",
-  "get-session-replay-events",
   "get-session-replay-summary",
   "get-session-replay-timeline",
   "list-error-issues",
   "list-session-recordings",
-  "match-error-issues",
   "list-analyses",
   "get-analysis",
   "save-analysis",
@@ -46,7 +43,6 @@ export const INITIAL_TOOL_NAMES = [
   "slack-messages",
   "sentry",
   "list-data-dictionary",
-  "save-data-dictionary-entry",
   "navigate",
 ];
 

--- a/templates/analytics/server/lib/agent-chat-plan-mode.ts
+++ b/templates/analytics/server/lib/agent-chat-plan-mode.ts
@@ -3,6 +3,17 @@ import type { ActionEntry } from "@agent-native/core/server";
 export const INITIAL_TOOL_NAMES = [
   "view-screen",
   "data-source-status",
+  // Keep the first-party observability workflow on the initial surface so a
+  // named user's session/error question does not depend on an indirect
+  // tool-search round before the agent can inspect its evidence.
+  "create-session-replay-agent-link",
+  "get-error-issue",
+  "get-session-replay-events",
+  "get-session-replay-summary",
+  "get-session-replay-timeline",
+  "list-error-issues",
+  "list-session-recordings",
+  "match-error-issues",
   "list-analyses",
   "get-analysis",
   "save-analysis",

--- a/templates/analytics/server/plugins/agent-chat.spec.ts
+++ b/templates/analytics/server/plugins/agent-chat.spec.ts
@@ -135,6 +135,21 @@ describe("Analytics agent Plan mode policy", () => {
       ]),
     );
   });
+
+  it("keeps named-session incident evidence on the initial tool surface", () => {
+    expect(INITIAL_TOOL_NAMES).toEqual(
+      expect.arrayContaining([
+        "create-session-replay-agent-link",
+        "get-error-issue",
+        "get-session-replay-events",
+        "get-session-replay-summary",
+        "get-session-replay-timeline",
+        "list-error-issues",
+        "list-session-recordings",
+        "match-error-issues",
+      ]),
+    );
+  });
 });
 
 function userMessage(

--- a/templates/analytics/server/plugins/agent-chat.spec.ts
+++ b/templates/analytics/server/plugins/agent-chat.spec.ts
@@ -139,14 +139,11 @@ describe("Analytics agent Plan mode policy", () => {
   it("keeps named-session incident evidence on the initial tool surface", () => {
     expect(INITIAL_TOOL_NAMES).toEqual(
       expect.arrayContaining([
-        "create-session-replay-agent-link",
         "get-error-issue",
-        "get-session-replay-events",
         "get-session-replay-summary",
         "get-session-replay-timeline",
         "list-error-issues",
         "list-session-recordings",
-        "match-error-issues",
       ]),
     );
   });


### PR DESCRIPTION
## Summary
- keep first-party session, replay, and error actions on Analytics agent initial tool surface
- make named-user incident investigations work without an indirect tool-search round
- add regression coverage and a user-facing Analytics changelog entry

## Validation
- `corepack pnpm --filter analytics exec vitest --run server/plugins/agent-chat.spec.ts server/lib/real-data-actions.spec.ts --maxWorkers=1`
- `corepack pnpm --filter analytics typecheck`

## Production finding
After PR #2070 deployed, the live ask_app path still fell back because these actions were instructed but not initially exposed. Direct MCP reads were already working; this closes the default ask_app path gap.