### PR TITLE
Keep MCP ask_app on the guarded agent loop

### DIFF
--- a/.changeset/quiet-ask-app-guard.md
+++ b/.changeset/quiet-ask-app-guard.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep MCP-local `ask_app` turns on the same app-level final-response guard as A2A turns.

--- a/packages/core/src/server/agent-chat-plugin.a2a.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin.a2a.spec.ts
@@ -5,6 +5,7 @@ import {
   assembleA2AFinalResponse,
   buildPublicAgentA2ASkills,
   createA2AEngineToolSurface,
+  runMCPAgentLoop,
   runA2AAgentLoop,
 } from "./agent-chat-plugin.js";
 
@@ -71,6 +72,42 @@ describe("delegated A2A final response guards", () => {
       expect.objectContaining({ finalResponseGuard: analyticsGuard }),
       12_345,
       { backgroundFunction: true },
+    );
+  });
+
+  it("keeps the MCP-local ask_app loop on the same guard contract", async () => {
+    const guard = vi.fn(() => null);
+    const runner = vi.fn(async (options: any) => {
+      expect(options.finalResponseGuard).toBe(guard);
+      return {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        model: "test-model",
+      };
+    });
+
+    await runMCPAgentLoop(
+      {
+        engine: {} as any,
+        model: "test-model",
+        systemPrompt: "system",
+        tools: [],
+        messages: [],
+        actions: {},
+        send: () => {},
+        signal: new AbortController().signal,
+      },
+      { finalResponseGuard: guard as any, runSoftTimeoutMs: 1_000 },
+      { backgroundFunction: false },
+      runner as any,
+    );
+
+    expect(runner).toHaveBeenCalledWith(
+      expect.objectContaining({ finalResponseGuard: guard }),
+      1_000,
+      { backgroundFunction: false },
     );
   });
 });

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -57,7 +57,6 @@ import {
   subscribeToRun,
   type ActionEntry,
 } from "../agent/production-agent.js";
-import { runAgentLoopDirectWithSoftTimeout } from "../agent/run-loop-with-resume.js";
 import {
   callerHasRunAccess,
   callerHasThreadAccess,

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -202,6 +202,7 @@ import {
   filterReadOnlyActions,
   resolveInitialToolNames,
   runA2AAgentLoop,
+  runMCPAgentLoop,
   assembleA2AFinalResponse,
   buildPublicAgentA2ASkills,
   resolveArtifactBaseUrl,
@@ -257,6 +258,7 @@ export { buildPublicAgentA2ASkills };
 export { assembleA2AFinalResponse };
 export type { AgentChatPluginOptions };
 export { runA2AAgentLoop };
+export { runMCPAgentLoop };
 export { createA2AEngineToolSurface };
 export { shouldBlockInProductCodeEditingSurface };
 export { loadRunCodeToolEntries };
@@ -1618,7 +1620,7 @@ export function createAgentChatPlugin(
             let accumulatedText = "";
             const controller = new AbortController();
 
-            await runAgentLoopDirectWithSoftTimeout(
+            await runMCPAgentLoop(
               {
                 engine: mcpEngine,
                 model,
@@ -1647,7 +1649,10 @@ export function createAgentChatPlugin(
                 },
                 signal: controller.signal,
               },
-              options?.runSoftTimeoutMs,
+              {
+                finalResponseGuard: options?.finalResponseGuard,
+                runSoftTimeoutMs: options?.runSoftTimeoutMs,
+              },
               {
                 backgroundFunction:
                   options?.durableBackgroundRuns === true &&

--- a/packages/core/src/server/agent-chat/action-filters-a2a.ts
+++ b/packages/core/src/server/agent-chat/action-filters-a2a.ts
@@ -148,6 +148,25 @@ function formatA2ATerminalError(
 
 type A2AAgentLoopRunner = typeof runAgentLoopDirectWithSoftTimeout;
 
+function runDelegatedAgentLoop(
+  runOptions: Parameters<A2AAgentLoopRunner>[0],
+  pluginOptions: Pick<
+    AgentChatPluginOptions,
+    "finalResponseGuard" | "runSoftTimeoutMs"
+  >,
+  timeoutOptions: Parameters<A2AAgentLoopRunner>[2],
+  runner: A2AAgentLoopRunner,
+) {
+  return runner(
+    {
+      ...runOptions,
+      finalResponseGuard: pluginOptions.finalResponseGuard,
+    },
+    pluginOptions.runSoftTimeoutMs,
+    timeoutOptions,
+  );
+}
+
 /**
  * Run an A2A-delegated agent turn with the same final-response guard used by
  * the app's interactive chat surface.
@@ -165,13 +184,33 @@ export function runA2AAgentLoop(
   timeoutOptions: Parameters<A2AAgentLoopRunner>[2],
   runner: A2AAgentLoopRunner = runAgentLoopDirectWithSoftTimeout,
 ) {
-  return runner(
-    {
-      ...runOptions,
-      finalResponseGuard: pluginOptions.finalResponseGuard,
-    },
-    pluginOptions.runSoftTimeoutMs,
+  return runDelegatedAgentLoop(
+    runOptions,
+    pluginOptions,
     timeoutOptions,
+    runner,
+  );
+}
+
+/**
+ * Run the MCP-local ask_app turn with the same app-level response guard as
+ * A2A. Keeping this seam shared prevents hosted MCP callers from bypassing
+ * template guarantees when the request cannot use the self-A2A route.
+ */
+export function runMCPAgentLoop(
+  runOptions: Parameters<A2AAgentLoopRunner>[0],
+  pluginOptions: Pick<
+    AgentChatPluginOptions,
+    "finalResponseGuard" | "runSoftTimeoutMs"
+  >,
+  timeoutOptions: Parameters<A2AAgentLoopRunner>[2],
+  runner: A2AAgentLoopRunner = runAgentLoopDirectWithSoftTimeout,
+) {
+  return runDelegatedAgentLoop(
+    runOptions,
+    pluginOptions,
+    timeoutOptions,
+    runner,
   );
 }
 


### PR DESCRIPTION
## Summary
- run MCP-local ask_app through the same final-response guard as A2A
- preserve Analytics real-data and non-Analytics fallback guarantees for every hosted path
- add regression coverage and a core patch changeset

## Verification
- core delegated/MCP tests
- core cross-app MCP tests
- oxfmt check
- git diff --check