### PR TITLE
Keep delegated agent turns explicitly scoped

### DIFF
--- a/.changeset/explicit-a2a-scope.md
+++ b/.changeset/explicit-a2a-scope.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep delegated A2A and MCP agent turns explicitly bound to the authenticated owner/org scope and Act execution mode.

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -1371,6 +1371,13 @@ export function createAgentChatPlugin(
               availableTools: a2aToolSurface.availableTools,
               messages: a2aMessages,
               actions: a2aActions,
+              // A2A already establishes these values in request context. Pass
+              // them explicitly too so delegated tool execution and template
+              // final-response guards cannot lose the authenticated caller's
+              // scope when a processor hop or alternate runner is involved.
+              ownerEmail: userEmail,
+              orgId: getRequestOrgId() ?? null,
+              executionMode: "act",
               send: (event) => {
                 a2aEvents.push(event);
                 if (event.type === "tool_start") {
@@ -1640,6 +1647,9 @@ export function createAgentChatPlugin(
                   },
                 ],
                 actions: mcpActions,
+                ownerEmail: getRequestUserEmail(),
+                orgId: getRequestOrgId() ?? null,
+                executionMode: "act",
                 send: (event) => {
                   accumulatedText = applyAgentTextEventToBuffer(
                     accumulatedText,


### PR DESCRIPTION
A2A and MCP-delegated agent loops now pass the authenticated owner/org and explicit Act execution mode into the shared run loop. This prevents processor hops or alternate runners from losing data scope or being treated as Plan mode.

Verification:
- @agent-native/core build
- Analytics guard tests
- MCP/A2A regression tests
- oxfmt and git diff --check