### PR TITLE
Run final guards for streamed text responses

### DIFF
--- a/.changeset/guard-streamed-final-text.md
+++ b/.changeset/guard-streamed-final-text.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Run final-response guards even when an engine completes with streamed text but no normalized assistant-content event.

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -5572,6 +5572,65 @@ describe("runAgentLoop", () => {
     expect(events.at(-1)).toEqual({ type: "done" });
   });
 
+  it("runs the final-response guard when an engine only emits text deltas", async () => {
+    let streamCalls = 0;
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: false,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        yield {
+          type: "text-delta",
+          text: streamCalls === 1 ? "unclear" : "grounded",
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    const guard = vi.fn((context: AgentLoopFinalResponseGuardContext) =>
+      context.text === "unclear"
+        ? {
+            retryMessage: "Retry with grounded evidence.",
+            fallbackMessage: "No grounded result.",
+          }
+        : null,
+    );
+    const events: AgentChatEvent[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {},
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+      finalResponseGuard: guard,
+    });
+
+    expect(streamCalls).toBe(2);
+    expect(guard).toHaveBeenCalledTimes(2);
+    expect(guard.mock.calls.map(([context]) => context.text)).toEqual([
+      "unclear",
+      "grounded",
+    ]);
+    expect(events).toEqual([
+      { type: "text", text: "unclear" },
+      { type: "clear" },
+      { type: "text", text: "grounded" },
+      { type: "done" },
+    ]);
+  });
+
   it("clears streamed final-answer text when the guard throws", async () => {
     const engine: AgentEngine = {
       name: "test",

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -3553,6 +3553,13 @@ export async function runAgentLoop(opts: {
       assistantContent = [];
     }
 
+    if (!assistantContent && streamedAssistantText.trim()) {
+      // Some delegated/custom engine streams emit text deltas and a terminal
+      // stop without the normalized assistant-content event. Preserve the
+      // streamed text so final-response guards still run; otherwise an app
+      // guard (for example Analytics' real-data guard) is silently bypassed.
+      assistantContent = [{ type: "text", text: streamedAssistantText }];
+    }
     if (!assistantContent) {
       // No content — done
       break;


### PR DESCRIPTION
Some engines can end a text-only stream without emitting the normalized assistant-content event. The shared loop now synthesizes assistant content from streamed text before deciding the turn is complete, ensuring app final-response guards still run for delegated A2A/MCP turns.

Verification:
- @agent-native/core production-agent specs (167 passed)
- oxfmt and git diff --check