### PR TITLE
Handle empty assistant content in final guards

### DIFF
--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -5572,7 +5572,7 @@ describe("runAgentLoop", () => {
     expect(events.at(-1)).toEqual({ type: "done" });
   });
 
-  it("runs the final-response guard when an engine only emits text deltas", async () => {
+  it("runs the final-response guard when an engine emits text with empty content", async () => {
     let streamCalls = 0;
     const engine: AgentEngine = {
       name: "test",
@@ -5592,6 +5592,7 @@ describe("runAgentLoop", () => {
           type: "text-delta",
           text: streamCalls === 1 ? "unclear" : "grounded",
         };
+        yield { type: "assistant-content", parts: [] };
         yield { type: "stop", reason: "end_turn" };
       },
     };

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -3553,7 +3553,10 @@ export async function runAgentLoop(opts: {
       assistantContent = [];
     }
 
-    if (!assistantContent && streamedAssistantText.trim()) {
+    if (
+      (!assistantContent || assistantContent.length === 0) &&
+      streamedAssistantText.trim()
+    ) {
       // Some delegated/custom engine streams emit text deltas and a terminal
       // stop without the normalized assistant-content event. Preserve the
       // streamed text so final-response guards still run; otherwise an app


### PR DESCRIPTION
Some production engine streams emit text deltas followed by an empty assistant-content array. Treat that as streamed assistant text so final-response guards still run instead of silently accepting an unguarded delegated response.

Verification:
- @agent-native/core production-agent specs (167 passed)
- oxfmt and git diff --check