### PR TITLE
Rebuild core before Analytics production bundling

### DIFF
--- a/templates/analytics/changelog/2026-07-13-ask-app-now-uses-the-current-core-agent-loop-and-response-gu.md
+++ b/templates/analytics/changelog/2026-07-13-ask-app-now-uses-the-current-core-agent-loop-and-response-gu.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-13
+---
+
+Ask app now uses the current core agent loop and response guards in production MCP runs.

--- a/templates/analytics/netlify.toml
+++ b/templates/analytics/netlify.toml
@@ -1,6 +1,10 @@
 [build]
 ignore = "node ./scripts/netlify-ignore-build.mjs analytics"
-command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && NITRO_PRESET=netlify pnpm --filter analytics build"
+# The workspace package dist folders are ignored/generated artifacts. Rebuild
+# core explicitly here so a cached Netlify install cannot bundle an older agent
+# loop into Analytics' server functions (including A2A/MCP final-response
+# guards).
+command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && pnpm --filter @agent-native/core build && NITRO_PRESET=netlify pnpm --filter analytics build"
 publish = "templates/analytics/dist"
 functions = "templates/analytics/.netlify/functions-internal"
 


### PR DESCRIPTION
The Analytics Netlify build currently installs workspace dependencies and bundles the app without rebuilding the ignored/generated @agent-native/core dist output. This can ship stale A2A/MCP agent-loop behavior even when source fixes are merged.

This explicitly builds core before Analytics and records the user-visible ask_app production fix in the Analytics changelog.

Verification:
- pnpm --filter @agent-native/core build
- pnpm --filter analytics build
- git diff --check