### PR TITLE
Use owner credentials for delegated agent runs

### DIFF
--- a/.changeset/hosted-ask-app-owner-key.md
+++ b/.changeset/hosted-ask-app-owner-key.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Resolve the authenticated owner's active provider key for A2A and MCP ask-agent runs, matching the interactive chat engine path.

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -1252,9 +1252,12 @@ export function createAgentChatPlugin(
 
           // Use the SAME agent setup as the interactive chat — identical tools,
           // prompt, and capabilities. The A2A agent IS the app's agent.
+          const { getOwnerActiveApiKey } =
+            await import("../agent/production-agent.js");
+          const ownerApiKey = await getOwnerActiveApiKey(userEmail);
           const a2aEngine = await resolveEngine({
             engineOption: options?.engine,
-            apiKey: options?.apiKey,
+            apiKey: ownerApiKey ?? options?.apiKey,
             appId: options?.appId,
           });
 
@@ -1524,9 +1527,15 @@ export function createAgentChatPlugin(
             ? { externalAgents: options.externalAgents }
             : {}),
           askAgent: async (message: string) => {
+            const ownerEmail = getRequestUserEmail();
+            const { getOwnerActiveApiKey } =
+              await import("../agent/production-agent.js");
+            const ownerApiKey = ownerEmail
+              ? await getOwnerActiveApiKey(ownerEmail)
+              : undefined;
             const mcpEngine = await resolveEngine({
               engineOption: options?.engine,
-              apiKey: options?.apiKey,
+              apiKey: ownerApiKey ?? options?.apiKey,
               appId: options?.appId,
             });
             const mcpModelCandidate =


### PR DESCRIPTION
## Summary\n- resolve the authenticated owner's active provider key before A2A agent engine creation\n- apply the same owner-key precedence to the MCP ask-agent fallback\n- keep delegated MCP/A2A runs aligned with interactive chat credential resolution\n\n## Validation\n- core A2A + production-agent tests (177 passing)\n- Analytics guard tests (13 passing)\n- core build\n- Analytics build\n- git diff --check