### PR TITLE
 Fix meeting notification close button requiring a click before it shows

### DIFF
--- a/templates/clips/desktop/src-tauri/src/notifications.rs
+++ b/templates/clips/desktop/src-tauri/src/notifications.rs
@@ -6,8 +6,13 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
-use tauri::{AppHandle, Emitter, Manager, PhysicalPosition, PhysicalSize, WebviewWindowBuilder};
+use std::time::Duration;
+use tauri::{
+    AppHandle, Emitter, Manager, PhysicalPosition, PhysicalSize, WebviewWindow,
+    WebviewWindowBuilder,
+};
 
 use crate::dlog;
 use crate::util::{
@@ -54,6 +59,59 @@ fn notification_rect(app: &AppHandle) -> (u32, u32, i32, i32) {
     (w, h, x, top.max(0))
 }
 
+static MEETING_NOTIF_HOVER_TRACKING: AtomicBool = AtomicBool::new(false);
+
+/// True when the global cursor sits inside the notification window's frame.
+/// Mirrors `cursor_inside_pill_frame` in `recording_indicator.rs`: cursor and
+/// frame both come from Tauri (physical px, desktop top-left origin), so the
+/// test is a plain point-in-rect with no AppKit hop.
+fn cursor_inside_notification_frame(window: &WebviewWindow) -> bool {
+    let (Ok(c), Ok(p), Ok(s)) = (
+        window.cursor_position(),
+        window.outer_position(),
+        window.outer_size(),
+    ) else {
+        return false;
+    };
+    c.x >= p.x as f64
+        && c.x <= (p.x + s.width as i32) as f64
+        && c.y >= p.y as f64
+        && c.y <= (p.y + s.height as i32) as f64
+}
+
+/// Poll the cursor against the notification frame and emit
+/// `meetings:notification-hover` on transitions. The window never becomes key
+/// (`show_without_activation` uses `orderFrontRegardless`, not
+/// `makeKeyAndOrderFront:`), so CSS `:hover`/`onMouseEnter` only fires once
+/// the user's first click makes it key — this poll is the fallback that
+/// reveals the close button on real hover before that click, same pattern as
+/// `start_pill_hover_tracking`. Idempotent — a second call is a no-op while a
+/// loop is already running.
+fn start_meeting_notification_hover_tracking(app: &AppHandle) {
+    if MEETING_NOTIF_HOVER_TRACKING.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let mut prev = false;
+        while MEETING_NOTIF_HOVER_TRACKING.load(Ordering::Relaxed) {
+            let Some(win) = app.get_webview_window(MEETING_NOTIFICATION_LABEL) else {
+                break;
+            };
+            let inside = cursor_inside_notification_frame(&win);
+            if inside != prev {
+                prev = inside;
+                let _ = win.emit(
+                    "meetings:notification-hover",
+                    serde_json::json!({ "hovered": inside }),
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(80)).await;
+        }
+        MEETING_NOTIF_HOVER_TRACKING.store(false, Ordering::SeqCst);
+    });
+}
+
 pub fn show_meeting_notification_window(app: &AppHandle) -> Result<(), String> {
     let (w, h, x, y) = notification_rect(app);
     if let Some(existing) = app.get_webview_window(MEETING_NOTIFICATION_LABEL) {
@@ -61,6 +119,7 @@ pub fn show_meeting_notification_window(app: &AppHandle) -> Result<(), String> {
         let _ = existing.set_position(PhysicalPosition::new(x, y));
         configure_overlay_behavior(&existing);
         show_without_activation(&existing);
+        start_meeting_notification_hover_tracking(&app);
         return Ok(());
     }
 
@@ -97,6 +156,7 @@ pub fn show_meeting_notification_window(app: &AppHandle) -> Result<(), String> {
     // own recording chrome is still excluded elsewhere so it won't leak.)
     configure_overlay_behavior(&win);
     show_without_activation(&win);
+    start_meeting_notification_hover_tracking(&app);
     Ok(())
 }
 

--- a/templates/clips/desktop/src-tauri/src/notifications.rs
+++ b/templates/clips/desktop/src-tauri/src/notifications.rs
@@ -98,6 +98,22 @@ fn start_meeting_notification_hover_tracking(app: &AppHandle) {
             let Some(win) = app.get_webview_window(MEETING_NOTIFICATION_LABEL) else {
                 break;
             };
+            // The window is reused across notifications (hidden/shown from
+            // the frontend, never destroyed), so this loop runs for the rest
+            // of the app session. Skip the cursor/frame queries entirely
+            // while hidden — no notification is on screen to hover — and
+            // back off to a slower idle tick until it's shown again.
+            if !win.is_visible().unwrap_or(false) {
+                if prev {
+                    prev = false;
+                    let _ = win.emit(
+                        "meetings:notification-hover",
+                        serde_json::json!({ "hovered": false }),
+                    );
+                }
+                tokio::time::sleep(Duration::from_millis(250)).await;
+                continue;
+            }
             let inside = cursor_inside_notification_frame(&win);
             if inside != prev {
                 prev = inside;

--- a/templates/clips/desktop/src/overlays/meeting-notification.tsx
+++ b/templates/clips/desktop/src/overlays/meeting-notification.tsx
@@ -128,6 +128,16 @@ export function MeetingNotification() {
   const [pending, setPending] = useState(false);
   const autoHideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const dataRef = useRef<NotificationData | null>(null);
+  // Real DOM hover only fires while this overlay window is key, which macOS
+  // won't grant it without a click (`show_without_activation` never
+  // activates). `polledHovered` mirrors the Rust-side global cursor poll
+  // (`meetings:notification-hover`, see `start_meeting_notification_hover_tracking`
+  // in notifications.rs) so the X still reveals on hover while another app is
+  // focused — same fallback pattern as the recording pill's `clips:pill-hover`.
+  const [domHovered, setDomHovered] = useState(false);
+  const [polledHovered, setPolledHovered] = useState(false);
+  const hovered = domHovered || polledHovered;
+  const prevHoveredRef = useRef(false);
 
   useEffect(() => {
     dataRef.current = data;
@@ -149,6 +159,22 @@ export function MeetingNotification() {
       win.hide().catch(() => {});
     }
   }, [data]);
+
+  useEffect(() => {
+    if (!data) {
+      prevHoveredRef.current = false;
+      return;
+    }
+    if (hovered === prevHoveredRef.current) return;
+    prevHoveredRef.current = hovered;
+    setShowClose(hovered);
+    if (hovered) {
+      clearAutoHide();
+    } else {
+      setMenuOpen(false);
+      resumeAutoHide();
+    }
+  }, [data, hovered]);
 
   function showNotification(
     payload: NotificationData,
@@ -188,6 +214,12 @@ export function MeetingNotification() {
     trackListen(
       listen<NotificationData>("meetings:show-notification", (ev) => {
         showNotification(ev.payload);
+      }),
+    );
+
+    trackListen(
+      listen<{ hovered: boolean }>("meetings:notification-hover", (ev) => {
+        setPolledHovered(ev.payload.hovered);
       }),
     );
 
@@ -329,15 +361,8 @@ export function MeetingNotification() {
     <div className="meeting-notification-root">
       <div
         className="meeting-notification"
-        onMouseEnter={() => {
-          setShowClose(true);
-          clearAutoHide();
-        }}
-        onMouseLeave={() => {
-          setShowClose(false);
-          setMenuOpen(false);
-          resumeAutoHide();
-        }}
+        onMouseEnter={() => setDomHovered(true)}
+        onMouseLeave={() => setDomHovered(false)}
       >
         <div
           className={`meeting-notification-bar ${isCalendar ? "meeting-notification-bar-calendar" : "meeting-notification-bar-adhoc"}`}

--- a/templates/clips/desktop/src/overlays/meeting-notification.tsx
+++ b/templates/clips/desktop/src/overlays/meeting-notification.tsx
@@ -162,7 +162,15 @@ export function MeetingNotification() {
 
   useEffect(() => {
     if (!data) {
+      // Dismissing doesn't guarantee mouseleave/hovered:false fires first
+      // (e.g. dismissed while the cursor is still over the card), so clear
+      // every hover source here — otherwise the next notification can
+      // inherit hovered === true and open with its close button already
+      // showing and auto-hide already cancelled.
       prevHoveredRef.current = false;
+      setDomHovered(false);
+      setPolledHovered(false);
+      setShowClose(false);
       return;
     }
     if (hovered === prevHoveredRef.current) return;


### PR DESCRIPTION
The desktop app now also tracks the cursor position natively and tells the notification card when the mouse is over it, regardless of whether the window is focused. This is the same approach already used for the recording pill overlay, so the two overlays now behave consistently.
