### PR TITLE
fix(design): preserve overview canvas background

### DIFF
--- a/templates/design/app/components/design/MultiScreenCanvas.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.tsx
@@ -7522,6 +7522,7 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
                   deviceFrame="none"
                   boardSurface
                   embeddedFrameBackground={BOARD_SURFACE_BACKGROUND}
+                  transparentBackground
                   embeddedFrame={{
                     viewportWidth: Math.max(1, Math.round(boardW)),
                     viewportHeight: Math.max(1, Math.round(boardH)),

--- a/templates/design/changelog/2026-07-13-adding-shapes-preserves-canvas-background.md
+++ b/templates/design/changelog/2026-07-13-adding-shapes-preserves-canvas-background.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-13
+---
+
+Adding a shape to the overview canvas no longer changes the canvas background color.

--- a/templates/design/e2e/canvas-tools.spec.ts
+++ b/templates/design/e2e/canvas-tools.spec.ts
@@ -2684,6 +2684,11 @@ test("rectangle drawn left of the first screen persists on the board", async ({
       timeout: 20_000,
     })
     .toBe(boardRectanglesBefore + 1);
+  await expect(
+    page.locator(
+      "[data-board-surface-layer] iframe[data-design-preview-iframe]",
+    ),
+  ).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
   await expect
     .poll(async () => {
       const positions = await primitiveLeftPositions(


### PR DESCRIPTION
adding a rectangle to the design canvas used to change the bg to black

fixes this: 
<img width="1036" height="750" alt="image" src="https://github.com/user-attachments/assets/44fc08ea-41ec-4ba4-9eae-8d0761dd6dca" />

<img width="712" height="640" alt="image" src="https://github.com/user-attachments/assets/e4386764-ec30-4c48-a84c-48632f66658c" />
