### PR TITLE
fix: selection outline bounce on fast clicks in design editor

### DIFF
--- a/templates/design/.generated/bridge/editor-chrome.generated.ts
+++ b/templates/design/.generated/bridge/editor-chrome.generated.ts
@@ -7357,7 +7357,9 @@ export const editorChromeBridgeScript: string = `"use strict";
         selectedEl = target;
         positionOverlay(selectionOverlay, target);
         if (hoveredEl === selectedEl) highlightOverlay.style.display = "none";
-        if (selectionChangedByHost) postElementSelect(target);
+        if (selectionChangedByHost) {
+          postElementSelect(target);
+        }
         return;
       }
       if (e.data.type === "hover-element") {

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -2334,6 +2334,40 @@ export function DesignCanvas({
         return;
       }
       if (e.data.type === "element-select") {
+        const reported = e.data.payload as
+          | { selector?: string; sourceId?: string }
+          | undefined;
+        const reportedCandidates: string[] = [];
+        if (reported?.selector) reportedCandidates.push(reported.selector);
+        if (reported?.sourceId) {
+          reportedCandidates.push(
+            `[data-agent-native-node-id="${reported.sourceId}"]`,
+          );
+        }
+        if (e.data.intent) {
+          // A genuine user click inside the iframe: it already shows this
+          // selection locally, so record it and skip mirroring the upcoming
+          // host commit straight back down (that echo is the fast-click
+          // bounce). Only user gestures carry `intent`; intent-less echoes are
+          // host-mirror replays and must never suppress a mirror.
+          suppressMirrorSelectorsRef.current =
+            reportedCandidates.length > 0 ? reportedCandidates : null;
+        } else if (
+          selectedSelectorRef.current &&
+          reportedCandidates.length > 0 &&
+          !reportedCandidates.includes(selectedSelectorRef.current) &&
+          !(selectedSelectorCandidatesRef.current ?? []).some((c) =>
+            reportedCandidates.includes(c),
+          )
+        ) {
+          // Intent-less echo that disagrees with the committed selection: a
+          // stale mirror overwrote the iframe's real selection (it drifted).
+          // The host guard drops this echo, and the advanced dedup signature
+          // would otherwise block a corrective mirror — so force a resync to
+          // snap the iframe back to the committed selection.
+          forceSelectionMirrorResyncRef.current = true;
+          replayIframeEditorStateRef.current?.();
+        }
         onElementSelect(e.data.payload, e.data.intent);
         return;
       }
@@ -2797,6 +2831,35 @@ export function DesignCanvas({
     postOneShotBridgeMessage,
   ]);
 
+  // Selection-mirror dedup. replayIframeEditorState re-runs on many unrelated
+  // input changes (hover, tweaks, scale/pan mode, layer states…) and used to
+  // re-post `select-element` every time. That storm of stale mirrors of the
+  // PREVIOUS selection stayed in flight and, on a fast click, briefly
+  // re-highlighted the old element before the host caught up ("small dance").
+  // Only post the selection message when it actually changed, forcing a
+  // resync on (re)load since a freshly mounted document has no selection.
+  const lastSelectionMirrorSignatureRef = useRef<string | null>(null);
+  const forceSelectionMirrorResyncRef = useRef(true);
+  // When a selection ORIGINATES from this iframe (the user clicked inside it),
+  // the iframe already shows that selection locally. Mirroring it back down is
+  // redundant and, on a fast click, the echoed-back mirror of the PREVIOUS
+  // click lands after the NEXT click and yanks the outline back for a frame
+  // (the "quick bounce"). We record the selector(s) the iframe just reported
+  // and skip mirroring exactly that selection back once.
+  const suppressMirrorSelectorsRef = useRef<string[] | null>(null);
+  // Latest replayIframeEditorState, callable from the message handler (which is
+  // defined earlier in this component). Used to force a corrective resync when
+  // the iframe drifts off the committed selection (see the element-select
+  // drift branch below).
+  const replayIframeEditorStateRef = useRef<(() => void) | null>(null);
+  // Render-synced mirrors of the committed selection so the message handler can
+  // compare against the CURRENT selection without adding it to the listener's
+  // dependency array (which would re-bind the window listener every selection).
+  const selectedSelectorRef = useRef(selectedSelector);
+  selectedSelectorRef.current = selectedSelector;
+  const selectedSelectorCandidatesRef = useRef(selectedSelectorCandidates);
+  selectedSelectorCandidatesRef.current = selectedSelectorCandidates;
+
   const replayIframeEditorState = useCallback(() => {
     const iframe = iframeRef.current;
     if (!iframe) return;
@@ -2819,16 +2882,44 @@ export function DesignCanvas({
       { type: "scale-tool-mode", enabled: scaleMode },
       "*",
     );
-    iframe.contentWindow?.postMessage(
-      selectedSelector
-        ? {
-            type: "select-element",
-            selector: selectedSelector,
-            selectorCandidates: selectedSelectorCandidates,
-          }
-        : { type: "clear-selection" },
-      "*",
-    );
+    // Mirror the selection DOWN only when it actually changed (or a reload
+    // forced a resync). This is what prevents the fast-click flicker: without
+    // it, every unrelated re-render re-posted the current selector, so stale
+    // mirrors of the previous selection raced the user's next click.
+    const selectionMirrorSignature = JSON.stringify({
+      selector: selectedSelector ?? null,
+      candidates: selectedSelectorCandidates ?? [],
+    });
+    // If this selection is the one the iframe just reported, it already shows
+    // it — don't echo it back (prevents the fast-click bounce). One-shot: a
+    // reload forces a resync, and any later external selection clears it.
+    const isIframeOriginatedEcho =
+      !forceSelectionMirrorResyncRef.current &&
+      !!selectedSelector &&
+      (suppressMirrorSelectorsRef.current?.includes(selectedSelector) ?? false);
+    if (isIframeOriginatedEcho) {
+      lastSelectionMirrorSignatureRef.current = selectionMirrorSignature;
+      suppressMirrorSelectorsRef.current = null;
+    } else if (
+      forceSelectionMirrorResyncRef.current ||
+      selectionMirrorSignature !== lastSelectionMirrorSignatureRef.current
+    ) {
+      iframe.contentWindow?.postMessage(
+        selectedSelector
+          ? {
+              type: "select-element",
+              selector: selectedSelector,
+              selectorCandidates: selectedSelectorCandidates,
+            }
+          : { type: "clear-selection" },
+        "*",
+      );
+      lastSelectionMirrorSignatureRef.current = selectionMirrorSignature;
+      forceSelectionMirrorResyncRef.current = false;
+      // An authoritative (external) selection just went down; any pending
+      // iframe-origin suppression is now stale.
+      suppressMirrorSelectorsRef.current = null;
+    }
     iframe.contentWindow?.postMessage(
       {
         type: "select-elements",
@@ -2913,10 +3004,17 @@ export function DesignCanvas({
   // selection/layer state here, the freshly mounted document looks deselected.
   useEffect(() => {
     const iframe = iframeRef.current;
+    replayIframeEditorStateRef.current = replayIframeEditorState;
     if (!iframe) return;
+    // A (re)loaded document starts with no selection, so force the next
+    // mirror to post even if the selector is unchanged from before the load.
+    const replayAfterLoad = () => {
+      forceSelectionMirrorResyncRef.current = true;
+      replayIframeEditorState();
+    };
     replayIframeEditorState();
-    iframe.addEventListener("load", replayIframeEditorState);
-    return () => iframe.removeEventListener("load", replayIframeEditorState);
+    iframe.addEventListener("load", replayAfterLoad);
+    return () => iframe.removeEventListener("load", replayAfterLoad);
   }, [replayIframeEditorState]);
 
   // A real top-level focus loss (Cmd+Tab, switching windows, browser chrome)

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -2345,9 +2345,8 @@ export function DesignCanvas({
           );
         }
         if (e.data.intent) {
-          // User click (only gestures carry `intent`): the iframe already
-          // shows it, so suppress mirroring the host commit back down (the
-          // fast-click bounce). Intent-less echoes must never suppress.
+          // User click (carries intent): iframe already shows it — suppress the
+          // echo-back to avoid the fast-click bounce.
           suppressMirrorSelectorsRef.current =
             reportedCandidates.length > 0 ? reportedCandidates : null;
         } else if (
@@ -2358,9 +2357,8 @@ export function DesignCanvas({
             reportedCandidates.includes(c),
           )
         ) {
-          // Intent-less echo disagreeing with the committed selection = the
-          // iframe drifted (a stale mirror overwrote it). Force a resync since
-          // the dedup signature would otherwise block the corrective mirror.
+          // Intent-less echo ≠ committed selection: iframe drifted; force a
+          // resync (dedup would otherwise block the corrective mirror).
           forceSelectionMirrorResyncRef.current = true;
           replayIframeEditorStateRef.current?.();
         }
@@ -2827,20 +2825,18 @@ export function DesignCanvas({
     postOneShotBridgeMessage,
   ]);
 
-  // Mirror the selection down only when it changes (replayIframeEditorState
-  // re-runs on many unrelated inputs). Re-posting an unchanged selector let
-  // stale mirrors race a fast click and re-highlight the old element.
+  // Mirror the selection down only when it changes, so stale re-posts can't
+  // race a fast click and re-highlight the old element.
   const lastSelectionMirrorSignatureRef = useRef<string | null>(null);
   const forceSelectionMirrorResyncRef = useRef(true);
-  // Selectors the iframe just reported from a user click. It already shows that
-  // selection, so we skip mirroring it back once — otherwise the echo lands
-  // after the next click and bounces the outline back for a frame.
+  // Selectors from the iframe's own click; skip mirroring them back once to
+  // avoid the fast-click bounce.
   const suppressMirrorSelectorsRef = useRef<string[] | null>(null);
-  // Latest replayIframeEditorState, callable from the (earlier-defined) message
-  // handler to force a corrective resync when the iframe drifts (see below).
+  // Latest replayIframeEditorState, synced during render (below) so the message
+  // handler can force a corrective resync without a stale closure.
   const replayIframeEditorStateRef = useRef<(() => void) | null>(null);
-  // Render-synced committed selection, so the message handler can read the
-  // current value without re-binding the window listener on every selection.
+  // Render-synced committed selection so the message handler reads current
+  // values without re-binding the window listener on every selection.
   const selectedSelectorRef = useRef(selectedSelector);
   selectedSelectorRef.current = selectedSelector;
   const selectedSelectorCandidatesRef = useRef(selectedSelectorCandidates);
@@ -2868,10 +2864,6 @@ export function DesignCanvas({
       { type: "scale-tool-mode", enabled: scaleMode },
       "*",
     );
-    // Mirror the selection DOWN only when it actually changed (or a reload
-    // forced a resync). This is what prevents the fast-click flicker: without
-    // it, every unrelated re-render re-posted the current selector, so stale
-    // mirrors of the previous selection raced the user's next click.
     const selectionMirrorSignature = JSON.stringify({
       selector: selectedSelector ?? null,
       candidates: selectedSelectorCandidates ?? [],
@@ -2982,13 +2974,15 @@ export function DesignCanvas({
     statePreviewTarget,
     tweakValues,
   ]);
+  // Sync during render (not in an effect) so a drift echo can't invoke a stale
+  // closure that reposts the previous selection.
+  replayIframeEditorStateRef.current = replayIframeEditorState;
 
   // Replay the editor state whenever it changes OR the iframe (re)loads. The
   // load case matters for screen switches and mode changes; without replaying
   // selection/layer state here, the freshly mounted document looks deselected.
   useEffect(() => {
     const iframe = iframeRef.current;
-    replayIframeEditorStateRef.current = replayIframeEditorState;
     if (!iframe) return;
     // A (re)loaded document starts with no selection, so force the next
     // mirror to post even if the selector is unchanged from before the load.

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -2345,11 +2345,9 @@ export function DesignCanvas({
           );
         }
         if (e.data.intent) {
-          // A genuine user click inside the iframe: it already shows this
-          // selection locally, so record it and skip mirroring the upcoming
-          // host commit straight back down (that echo is the fast-click
-          // bounce). Only user gestures carry `intent`; intent-less echoes are
-          // host-mirror replays and must never suppress a mirror.
+          // User click (only gestures carry `intent`): the iframe already
+          // shows it, so suppress mirroring the host commit back down (the
+          // fast-click bounce). Intent-less echoes must never suppress.
           suppressMirrorSelectorsRef.current =
             reportedCandidates.length > 0 ? reportedCandidates : null;
         } else if (
@@ -2360,11 +2358,9 @@ export function DesignCanvas({
             reportedCandidates.includes(c),
           )
         ) {
-          // Intent-less echo that disagrees with the committed selection: a
-          // stale mirror overwrote the iframe's real selection (it drifted).
-          // The host guard drops this echo, and the advanced dedup signature
-          // would otherwise block a corrective mirror — so force a resync to
-          // snap the iframe back to the committed selection.
+          // Intent-less echo disagreeing with the committed selection = the
+          // iframe drifted (a stale mirror overwrote it). Force a resync since
+          // the dedup signature would otherwise block the corrective mirror.
           forceSelectionMirrorResyncRef.current = true;
           replayIframeEditorStateRef.current?.();
         }
@@ -2831,30 +2827,20 @@ export function DesignCanvas({
     postOneShotBridgeMessage,
   ]);
 
-  // Selection-mirror dedup. replayIframeEditorState re-runs on many unrelated
-  // input changes (hover, tweaks, scale/pan mode, layer states…) and used to
-  // re-post `select-element` every time. That storm of stale mirrors of the
-  // PREVIOUS selection stayed in flight and, on a fast click, briefly
-  // re-highlighted the old element before the host caught up ("small dance").
-  // Only post the selection message when it actually changed, forcing a
-  // resync on (re)load since a freshly mounted document has no selection.
+  // Mirror the selection down only when it changes (replayIframeEditorState
+  // re-runs on many unrelated inputs). Re-posting an unchanged selector let
+  // stale mirrors race a fast click and re-highlight the old element.
   const lastSelectionMirrorSignatureRef = useRef<string | null>(null);
   const forceSelectionMirrorResyncRef = useRef(true);
-  // When a selection ORIGINATES from this iframe (the user clicked inside it),
-  // the iframe already shows that selection locally. Mirroring it back down is
-  // redundant and, on a fast click, the echoed-back mirror of the PREVIOUS
-  // click lands after the NEXT click and yanks the outline back for a frame
-  // (the "quick bounce"). We record the selector(s) the iframe just reported
-  // and skip mirroring exactly that selection back once.
+  // Selectors the iframe just reported from a user click. It already shows that
+  // selection, so we skip mirroring it back once — otherwise the echo lands
+  // after the next click and bounces the outline back for a frame.
   const suppressMirrorSelectorsRef = useRef<string[] | null>(null);
-  // Latest replayIframeEditorState, callable from the message handler (which is
-  // defined earlier in this component). Used to force a corrective resync when
-  // the iframe drifts off the committed selection (see the element-select
-  // drift branch below).
+  // Latest replayIframeEditorState, callable from the (earlier-defined) message
+  // handler to force a corrective resync when the iframe drifts (see below).
   const replayIframeEditorStateRef = useRef<(() => void) | null>(null);
-  // Render-synced mirrors of the committed selection so the message handler can
-  // compare against the CURRENT selection without adding it to the listener's
-  // dependency array (which would re-bind the window listener every selection).
+  // Render-synced committed selection, so the message handler can read the
+  // current value without re-binding the window listener on every selection.
   const selectedSelectorRef = useRef(selectedSelector);
   selectedSelectorRef.current = selectedSelector;
   const selectedSelectorCandidatesRef = useRef(selectedSelectorCandidates);
@@ -2890,9 +2876,8 @@ export function DesignCanvas({
       selector: selectedSelector ?? null,
       candidates: selectedSelectorCandidates ?? [],
     });
-    // If this selection is the one the iframe just reported, it already shows
-    // it — don't echo it back (prevents the fast-click bounce). One-shot: a
-    // reload forces a resync, and any later external selection clears it.
+    // Skip echoing back a selection the iframe just reported (fast-click
+    // bounce). One-shot: reload forces a resync; external selection clears it.
     const isIframeOriginatedEcho =
       !forceSelectionMirrorResyncRef.current &&
       !!selectedSelector &&
@@ -2916,8 +2901,7 @@ export function DesignCanvas({
       );
       lastSelectionMirrorSignatureRef.current = selectionMirrorSignature;
       forceSelectionMirrorResyncRef.current = false;
-      // An authoritative (external) selection just went down; any pending
-      // iframe-origin suppression is now stale.
+      // An external selection just went down; pending suppression is now stale.
       suppressMirrorSelectorsRef.current = null;
     }
     iframe.contentWindow?.postMessage(

--- a/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
+++ b/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
@@ -63,6 +63,7 @@ declare var __RUNTIME_LAYER_SNAPSHOT_ENABLED__: boolean;
     Number(__DESIGN_CANVAS_CONTENT_OFFSET_Y__) || 0;
   var runtimeLayerSnapshotEnabled = !!__RUNTIME_LAYER_SNAPSHOT_ENABLED__;
   var scaleToolEnabled = false;
+
   // Interaction-state forced preview (phase 2 — see shared/interaction-states.ts's
   // "Forced-preview mechanism" doc comment). Keep the actual element rather
   // than only its node id: localhost React layers can resolve through runtime
@@ -10896,7 +10897,9 @@ declare var __RUNTIME_LAYER_SNAPSHOT_ENABLED__: boolean;
       // changes only — the `selectionChangedByHost` guard above already
       // keeps this a no-op on the ~1-2s poll-tick replay so it can't turn
       // into a message-spam loop.
-      if (selectionChangedByHost) postElementSelect(target);
+      if (selectionChangedByHost) {
+        postElementSelect(target);
+      }
       return;
     }
     if (e.data.type === "hover-element") {

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -2063,14 +2063,10 @@ function DesignEditor() {
   const [selectedElement, setSelectedElement] = useState<ElementInfo | null>(
     null,
   );
-  // Fresh mirror of the committed selection for synchronous reads inside the
-  // iframe `element-select` message handler (see handleIframeElementSelect's
-  // echo-loop guard). Assigned during render (not in an effect) so it reflects
-  // the latest committed value for EVERY setSelectedElement path — including
-  // the ~dozens of direct callers (layers panel, drag, structure moves) — with
-  // no post-commit lag. A lagging ref could otherwise make the guard reject the
-  // first valid intent-less echo after a host-driven selection, dropping the
-  // runtime inspector payload the iframe sends back.
+  // Current committed selection for synchronous reads in the echo-loop guard
+  // (handleIframeElementSelect). Assigned during render (not an effect) so it
+  // covers every setSelectedElement path with no lag; a lagging ref would let
+  // the guard reject the first valid echo after a host-driven selection.
   const selectedElementRef = useRef(selectedElement);
   selectedElementRef.current = selectedElement;
   // Vector-edit mode (P5 integration): active while the user is editing a
@@ -12000,9 +11996,7 @@ function DesignEditor() {
       const screenId = activeFile?.id ?? activeFileId;
       if (screenId) {
         // Same echo-loop guard as handleIframeElementSelect: the focused
-        // single-screen canvas rounds selections through here, so without
-        // this it would still commit stale intent-less echoes and reintroduce
-        // the quick-click race in the primary editing mode.
+        // single-screen canvas routes through here too.
         if (
           !intent &&
           isSupersededSelectionEcho(info, selectedElementRef.current)
@@ -12029,19 +12023,12 @@ function DesignEditor() {
     ],
   );
 
-  // Iframe→host selection boundary with an echo-loop guard.
-  //
-  // The host mirrors the committed selection DOWN to the iframe on every
-  // render (replayIframeEditorState). The bridge's select-element handler
-  // echoes that selection back UP as an `element-select` message with NO
-  // `intent` — a genuine user gesture always carries one. When two elements
-  // are selected in quick succession, their two mirror streams race over the
-  // iframe's single selection, so each intent-less echo disagrees with the
-  // previous commit; re-committing it re-mirrors and the selection "dances"
-  // between the two until reload. Drop an intent-less echo whose element
-  // differs from the current committed selection — it is a stale replay of a
-  // superseded mirror, never a user action. Matching echoes (layers-panel
-  // payload sync, post-drag reselect) still pass so the inspector populates.
+  // Iframe→host selection boundary with an echo-loop guard. The host mirrors
+  // the selection down; the bridge echoes it back up with NO `intent` (user
+  // gestures always carry one). On rapid clicks these echoes race and the
+  // selection "dances". Drop an intent-less echo that differs from the current
+  // selection (a stale mirror replay); matching echoes still pass so the
+  // inspector payload populates.
   const handleIframeElementSelect = useCallback(
     (
       screenId: string,

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -1927,6 +1927,29 @@ function DesignBottomToolbar({
 }
 
 /**
+ * Selection-echo identity check for the iframe→host boundary. Returns true
+ * only when we can AUTHORITATIVELY tell the incoming (intent-less) selection
+ * refers to a DIFFERENT element than the currently-committed one — a stable
+ * `data-agent-native-node-id` (sourceId) match wins, falling back to the CSS
+ * selector when neither side carries an id. When identity can't be compared
+ * we return false so a selection is never dropped.
+ */
+function isSupersededSelectionEcho(
+  incoming: ElementInfo,
+  current: ElementInfo | null,
+): boolean {
+  if (!current) return false;
+  const incomingId = incoming.sourceId?.trim();
+  const currentId = current.sourceId?.trim();
+  if (incomingId && currentId) return incomingId !== currentId;
+  const incomingSelector = incoming.selector?.trim();
+  const currentSelector = current.selector?.trim();
+  if (incomingSelector && currentSelector)
+    return incomingSelector !== currentSelector;
+  return false;
+}
+
+/**
  * React Router reuses the same route component when only `:id` changes. Key
  * the stateful editor by design id so pending refs, collaboration docs, tools,
  * selections, and per-screen caches from one design can never leak into the
@@ -2040,6 +2063,16 @@ function DesignEditor() {
   const [selectedElement, setSelectedElement] = useState<ElementInfo | null>(
     null,
   );
+  // Fresh mirror of the committed selection for synchronous reads inside the
+  // iframe `element-select` message handler (see handleIframeElementSelect's
+  // echo-loop guard). Assigned during render (not in an effect) so it reflects
+  // the latest committed value for EVERY setSelectedElement path — including
+  // the ~dozens of direct callers (layers panel, drag, structure moves) — with
+  // no post-commit lag. A lagging ref could otherwise make the guard reject the
+  // first valid intent-less echo after a host-driven selection, dropping the
+  // runtime inspector payload the iframe sends back.
+  const selectedElementRef = useRef(selectedElement);
+  selectedElementRef.current = selectedElement;
   // Vector-edit mode (P5 integration): active while the user is editing a
   // committed pen path's anchors/handles on the overview canvas. `path` is
   // the LIVE working copy (path-local coordinates, matching pen-path.ts);
@@ -11966,6 +11999,16 @@ function DesignEditor() {
     (info: ElementInfo, intent?: ElementSelectionIntent) => {
       const screenId = activeFile?.id ?? activeFileId;
       if (screenId) {
+        // Same echo-loop guard as handleIframeElementSelect: the focused
+        // single-screen canvas rounds selections through here, so without
+        // this it would still commit stale intent-less echoes and reintroduce
+        // the quick-click race in the primary editing mode.
+        if (
+          !intent &&
+          isSupersededSelectionEcho(info, selectedElementRef.current)
+        ) {
+          return;
+        }
         handleScreenElementSelect(screenId, info, intent);
         return;
       }
@@ -11984,6 +12027,40 @@ function DesignEditor() {
       focusDesignInspectorForSelection,
       handleScreenElementSelect,
     ],
+  );
+
+  // Iframe→host selection boundary with an echo-loop guard.
+  //
+  // The host mirrors the committed selection DOWN to the iframe on every
+  // render (replayIframeEditorState). The bridge's select-element handler
+  // echoes that selection back UP as an `element-select` message with NO
+  // `intent` — a genuine user gesture always carries one. When two elements
+  // are selected in quick succession, their two mirror streams race over the
+  // iframe's single selection, so each intent-less echo disagrees with the
+  // previous commit; re-committing it re-mirrors and the selection "dances"
+  // between the two until reload. Drop an intent-less echo whose element
+  // differs from the current committed selection — it is a stale replay of a
+  // superseded mirror, never a user action. Matching echoes (layers-panel
+  // payload sync, post-drag reselect) still pass so the inspector populates.
+  const handleIframeElementSelect = useCallback(
+    (
+      screenId: string,
+      info: ElementInfo,
+      intent?: ElementSelectionIntent,
+      options: {
+        persistPendingNodeId?: boolean;
+        breakpointWidthPx?: number;
+      } = {},
+    ) => {
+      if (
+        !intent &&
+        isSupersededSelectionEcho(info, selectedElementRef.current)
+      ) {
+        return;
+      }
+      handleScreenElementSelect(screenId, info, intent, options);
+    },
+    [handleScreenElementSelect],
   );
 
   const handleScreenElementDblClickText = useCallback(
@@ -26562,7 +26639,7 @@ function DesignEditor() {
           hiddenSelectors={getLayerSelectorsForFile(screen.id, hiddenLayerIds)}
           onElementSelect={(info, intent) => {
             activateResponsiveScope();
-            handleScreenElementSelect(screen.id, info, intent, {
+            handleIframeElementSelect(screen.id, info, intent, {
               breakpointWidthPx,
             });
           }}
@@ -26657,7 +26734,7 @@ function DesignEditor() {
       runtimeStructureVerificationRequest,
       contentRenderRevision,
       handleScreenExternalContentSnapshot,
-      handleScreenRuntimeLayerSnapshot,
+      getRuntimeLayerSnapshotCallback,
       getRuntimeVerificationSnapshotCallback,
       designFusionUrl,
       handleComponentSourceJump,
@@ -26683,7 +26760,7 @@ function DesignEditor() {
       getLayerSelectorsForFile,
       lockedLayerIds,
       hiddenLayerIds,
-      handleScreenElementSelect,
+      handleIframeElementSelect,
       handleScreenElementMarqueeSelect,
       handleScreenElementHover,
       handleEditorDragStateChange,
@@ -26738,9 +26815,9 @@ function DesignEditor() {
   >(
     (info, intent) => {
       if (!boardFileId) return;
-      handleScreenElementSelect(boardFileId, info, intent);
+      handleIframeElementSelect(boardFileId, info, intent);
     },
-    [boardFileId, handleScreenElementSelect],
+    [boardFileId, handleIframeElementSelect],
   );
   const handleBoardElementMarqueeSelect = useCallback<
     NonNullable<

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -1927,12 +1927,10 @@ function DesignBottomToolbar({
 }
 
 /**
- * Selection-echo identity check for the iframe→host boundary. Returns true
- * only when we can AUTHORITATIVELY tell the incoming (intent-less) selection
- * refers to a DIFFERENT element than the currently-committed one — a stable
- * `data-agent-native-node-id` (sourceId) match wins, falling back to the CSS
- * selector when neither side carries an id. When identity can't be compared
- * we return false so a selection is never dropped.
+ * True only when the incoming (intent-less) selection authoritatively refers to
+ * a different element than the committed one (sourceId match wins, else CSS
+ * selector). Returns false when identity can't be compared, so a real selection
+ * is never dropped.
  */
 function isSupersededSelectionEcho(
   incoming: ElementInfo,
@@ -2063,10 +2061,8 @@ function DesignEditor() {
   const [selectedElement, setSelectedElement] = useState<ElementInfo | null>(
     null,
   );
-  // Current committed selection for synchronous reads in the echo-loop guard
-  // (handleIframeElementSelect). Assigned during render (not an effect) so it
-  // covers every setSelectedElement path with no lag; a lagging ref would let
-  // the guard reject the first valid echo after a host-driven selection.
+  // Committed selection for synchronous reads in the echo-loop guard. Synced
+  // during render (not an effect) so it has no lag on any setSelectedElement path.
   const selectedElementRef = useRef(selectedElement);
   selectedElementRef.current = selectedElement;
   // Vector-edit mode (P5 integration): active while the user is editing a
@@ -2304,6 +2300,11 @@ function DesignEditor() {
     string | null
   >(null);
   const [activeFileId, setActiveFileId] = useState<string | null>(null);
+  // Screen that owns the committed selection. node ids/selectors are only
+  // unique within a screen, so the echo guard uses this to reject stale
+  // intent-less echoes arriving from a different screen. Render-synced.
+  const activeFileIdRef = useRef(activeFileId);
+  activeFileIdRef.current = activeFileId;
   const [contentRenderRevision, setContentRenderRevision] = useState(0);
   const [activeInspectorTab, setActiveInspectorTab] =
     useState<InspectorTab>("design");
@@ -12023,12 +12024,11 @@ function DesignEditor() {
     ],
   );
 
-  // Iframe→host selection boundary with an echo-loop guard. The host mirrors
-  // the selection down; the bridge echoes it back up with NO `intent` (user
-  // gestures always carry one). On rapid clicks these echoes race and the
-  // selection "dances". Drop an intent-less echo that differs from the current
-  // selection (a stale mirror replay); matching echoes still pass so the
-  // inspector payload populates.
+  // Iframe→host selection boundary with an echo-loop guard. The bridge echoes
+  // mirrored selections back with no `intent` (user gestures always carry one);
+  // on rapid clicks these race and the selection "dances". Drop an intent-less
+  // echo that differs from the committed selection or comes from another screen;
+  // matching echoes still pass so the inspector payload populates.
   const handleIframeElementSelect = useCallback(
     (
       screenId: string,
@@ -12041,7 +12041,9 @@ function DesignEditor() {
     ) => {
       if (
         !intent &&
-        isSupersededSelectionEcho(info, selectedElementRef.current)
+        (isSupersededSelectionEcho(info, selectedElementRef.current) ||
+          (activeFileIdRef.current !== null &&
+            screenId !== activeFileIdRef.current))
       ) {
         return;
       }

--- a/templates/design/changelog/2026-07-13-clicking-quickly-between-overlapping-elements-no-longer-bounc.md
+++ b/templates/design/changelog/2026-07-13-clicking-quickly-between-overlapping-elements-no-longer-bounc.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-13
+---
+
+Clicking quickly between overlapping elements no longer makes the selection outline bounce before settling


### PR DESCRIPTION
going back and forth bw elements seems to make them dance the selection bw them. Clicking quickly between overlapping elements made the selection outline bounce before settling. This fixes it and hardens the host <-> iframe selection sync.

https://clips.agent-native.com/r/B73635PAksdq
