### PR TITLE
Add reliable direct Calendar and Mail connector reads

### DIFF
--- a/.changeset/reliable-calendar-mail-connector-reads.md
+++ b/.changeset/reliable-calendar-mail-connector-reads.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Validate explicit Calendar and Mail connector catalog actions through the external MCP lifecycle.

--- a/packages/core/src/mcp/connector-catalog.spec.ts
+++ b/packages/core/src/mcp/connector-catalog.spec.ts
@@ -449,6 +449,58 @@ describe("connector-catalog tier", () => {
     });
   });
 
+  it("advertises and calls the Calendar and Mail deterministic connector reads", async () => {
+    const deterministicReads = {
+      "list-events": {
+        tool: { description: "List a calendar inventory" },
+        http: { method: "GET" as const },
+        readOnly: true,
+        run: async () => ({ version: 1, items: [], complete: true }),
+      },
+      "list-emails": {
+        tool: { description: "List a mail inventory" },
+        http: { method: "GET" as const },
+        readOnly: true,
+        run: async () => ({ version: 1, items: [], complete: true }),
+      },
+    };
+    const mcpConfig = {
+      ...connectorConfig,
+      actions: deterministicReads,
+      productionActions: deterministicReads,
+      connectorCatalog: ["list-events", "list-emails"],
+    };
+    const token = await signA2AToken("alice@example.com");
+    const headers = { authorization: `Bearer ${token}` };
+    const listed = await call(
+      { jsonrpc: "2.0", id: 30, method: "tools/list", params: {} },
+      { headers, mcpConfig },
+    );
+    const names = listed.result.tools.map((tool: any) => tool.name);
+    expect(names).toEqual(
+      expect.arrayContaining(["list-events", "list-emails"]),
+    );
+
+    for (const name of ["list-events", "list-emails"]) {
+      const called = await call(
+        {
+          jsonrpc: "2.0",
+          id: name,
+          method: "tools/call",
+          params: { name, arguments: {} },
+        },
+        { headers, mcpConfig },
+      );
+      expect(called.error).toBeUndefined();
+      expect(called.result.isError).not.toBe(true);
+      expect(called.result.structuredContent).toMatchObject({
+        version: 1,
+        items: [],
+        complete: true,
+      });
+    }
+  });
+
   describe("tools/call — non-catalog tool is rejected", () => {
     it("rejects db-exec (not in catalog)", async () => {
       const token = await signA2AToken("alice@example.com");

--- a/templates/calendar/AGENTS.md
+++ b/templates/calendar/AGENTS.md
@@ -37,6 +37,15 @@ Detailed event, availability, booking, storage, and UI rules live in
   with `stageAs` and analyze them with `query-staged-dataset`.
 - For Google Calendar, distinguish an empty calendar from missing auth,
   reauth-needed, or fetch failures.
+- `list-events` remains the UI-compatible event list by default. External MCP
+  callers receive its compact, paginated version 1 inventory envelope
+  unless they explicitly request `format: "legacy"`; use `format: "inventory"`
+  for that same coverage-aware result from other callers. Preserve its
+  account coverage, `sourceCoverage`, and `coverageComplete` fields: Google
+  account, ICS feed, overlay, and local-booking sources are independent, and a
+  partial source failure is not an empty calendar. Pass `accountEmails` only
+  for connected accounts; the action validates the whole requested set before
+  provider work.
 - Google Calendar working locations are status events (`eventType:
 "workingLocation"`). Sync and display them as working locations, keep them
   transparent/non-blocking, and preserve `workingLocationProperties` instead of

--- a/templates/calendar/actions/list-events.test.ts
+++ b/templates/calendar/actions/list-events.test.ts
@@ -318,6 +318,21 @@ describe("list-events inventory contract", () => {
     expect(listGoogleEventsMock).not.toHaveBeenCalled();
   });
 
+  it("rejects an explicitly empty account selection", async () => {
+    await expect(
+      (listEventsAction as any).run(
+        {
+          from: "2026-06-17",
+          to: "2026-06-18",
+          accountEmails: [],
+        },
+        { caller: "mcp" },
+      ),
+    ).rejects.toThrow();
+    expect(getOwnedAccountEmailsMock).not.toHaveBeenCalled();
+    expect(listGoogleEventsMock).not.toHaveBeenCalled();
+  });
+
   it("keeps successful empty and failed owned accounts explicit", async () => {
     getOwnedAccountEmailsMock.mockResolvedValue([
       "quiet@example.com",
@@ -582,6 +597,7 @@ describe("list-events inventory contract", () => {
       [...first.items, ...second.items].map((item: any) => item.id),
     ).toEqual(["event-1", "event-2"]);
     getRequestUserEmailMock.mockReturnValue("other-owner@example.com");
+    listGoogleEventsMock.mockClear();
     await expect(
       (listEventsAction as any).run(
         {
@@ -594,7 +610,9 @@ describe("list-events inventory contract", () => {
         { caller: "mcp" },
       ),
     ).rejects.toThrow("does not match");
+    expect(listGoogleEventsMock).not.toHaveBeenCalled();
     getRequestUserEmailMock.mockReturnValue("owner@example.com");
+    listGoogleEventsMock.mockClear();
     await expect(
       (listEventsAction as any).run(
         {
@@ -607,7 +625,9 @@ describe("list-events inventory contract", () => {
         { caller: "mcp" },
       ),
     ).rejects.toThrow("does not match");
+    expect(listGoogleEventsMock).not.toHaveBeenCalled();
     verifyShortLivedTokenMock.mockReturnValueOnce({ ok: false });
+    listGoogleEventsMock.mockClear();
     await expect(
       (listEventsAction as any).run(
         {
@@ -620,6 +640,22 @@ describe("list-events inventory contract", () => {
         { caller: "mcp" },
       ),
     ).rejects.toThrow("Expired or invalid");
+    expect(listGoogleEventsMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed inventory cursor before provider reads", async () => {
+    await expect(
+      (listEventsAction as any).run(
+        {
+          from: "2026-06-17",
+          to: "2026-06-18",
+          format: "inventory",
+          cursor: "not-a-cursor",
+        },
+        { caller: "mcp" },
+      ),
+    ).rejects.toThrow("Invalid inventory cursor");
+    expect(listGoogleEventsMock).not.toHaveBeenCalled();
   });
 
   it("packs compact pages under the action-owned item budget", async () => {

--- a/templates/calendar/actions/list-events.test.ts
+++ b/templates/calendar/actions/list-events.test.ts
@@ -533,6 +533,67 @@ describe("list-events inventory contract", () => {
     expect(listOverlayEventsMock).not.toHaveBeenCalled();
   });
 
+  it("reports selected-account refresh failures during an otherwise successful overlay read", async () => {
+    getOwnedAccountEmailsMock.mockResolvedValue([
+      "broken@example.com",
+      "healthy@example.com",
+    ]);
+    listOverlayEventsMock.mockResolvedValue({
+      events: [
+        {
+          id: "overlay-person@example.com-overlay-1",
+          title: "Available through the healthy account",
+          description: "",
+          start: "2026-06-17T16:00:00.000Z",
+          end: "2026-06-17T16:30:00.000Z",
+          location: "",
+          allDay: false,
+          source: "google",
+          googleEventId: "overlay-1",
+          accountEmail: "healthy@example.com",
+          overlayEmail: "person@example.com",
+          createdAt: "2026-06-12T10:13:39.746Z",
+          updatedAt: "2026-06-12T10:13:39.746Z",
+        },
+      ],
+      errors: [],
+      accountErrors: [
+        { email: "broken@example.com", error: "Refresh token revoked" },
+      ],
+    });
+
+    const result = await (listEventsAction as any).run(
+      {
+        from: "2026-06-17",
+        to: "2026-06-18",
+        sources: ["overlays"],
+        overlayEmails: ["person@example.com"],
+        format: "inventory",
+      },
+      { caller: "mcp" },
+    );
+
+    expect(result.accounts).toEqual([
+      expect.objectContaining({
+        accountEmail: "broken@example.com",
+        status: "error",
+        exhausted: false,
+        error: expect.objectContaining({ message: "Refresh token revoked" }),
+      }),
+      expect.objectContaining({
+        accountEmail: "healthy@example.com",
+        status: "ok",
+        count: 1,
+        exhausted: true,
+      }),
+    ]);
+    expect(result.sourceCoverage).toEqual([
+      { source: "overlay", id: "person@example.com", status: "ok" },
+    ]);
+    expect(result.coverageComplete).toBe(false);
+    expect(result.complete).toBe(false);
+  });
+
   it("binds inventory cursors to the owner and exact query", async () => {
     listGoogleEventsMock.mockResolvedValue({
       events: [

--- a/templates/calendar/actions/list-events.test.ts
+++ b/templates/calendar/actions/list-events.test.ts
@@ -5,13 +5,18 @@ const getRequestUserEmailMock = vi.hoisted(() => vi.fn());
 const getUserSettingMock = vi.hoisted(() => vi.fn());
 const getDbMock = vi.hoisted(() => vi.fn());
 const isConnectedMock = vi.hoisted(() => vi.fn());
+const getOwnedAccountEmailsMock = vi.hoisted(() => vi.fn());
 const listGoogleEventsMock = vi.hoisted(() => vi.fn());
 const listOverlayEventsMock = vi.hoisted(() => vi.fn());
 const fetchICalEventsMock = vi.hoisted(() => vi.fn());
+const signShortLivedTokenMock = vi.hoisted(() => vi.fn());
+const verifyShortLivedTokenMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@agent-native/core/server", () => ({
   getRequestTimezone: getRequestTimezoneMock,
   getRequestUserEmail: getRequestUserEmailMock,
+  signShortLivedToken: signShortLivedTokenMock,
+  verifyShortLivedToken: verifyShortLivedTokenMock,
 }));
 
 vi.mock("@agent-native/core/settings", () => ({
@@ -33,6 +38,7 @@ vi.mock("drizzle-orm", () => ({
 
 vi.mock("../server/lib/google-calendar.js", () => ({
   isConnected: isConnectedMock,
+  getOwnedAccountEmails: getOwnedAccountEmailsMock,
   listEvents: listGoogleEventsMock,
   listOverlayEvents: listOverlayEventsMock,
 }));
@@ -73,6 +79,7 @@ import {
   listCalendarEvents,
   resolveCalendarEventRange,
 } from "./list-events.js";
+import listEventsAction from "./list-events.js";
 
 function createDbMock({
   links = [
@@ -124,9 +131,15 @@ describe("listCalendarEvents booking merge", () => {
     getUserSettingMock.mockResolvedValue(null);
     getDbMock.mockReturnValue(createDbMock());
     isConnectedMock.mockResolvedValue(true);
+    getOwnedAccountEmailsMock.mockResolvedValue(["steve@example.com"]);
     listGoogleEventsMock.mockResolvedValue({ events: [], errors: [] });
     listOverlayEventsMock.mockResolvedValue({ events: [], errors: [] });
     fetchICalEventsMock.mockResolvedValue([]);
+    signShortLivedTokenMock.mockImplementation(
+      ({ resourceId }) =>
+        `${Buffer.from(JSON.stringify({ resourceId })).toString("base64url")}.signature`,
+    );
+    verifyShortLivedTokenMock.mockReturnValue({ ok: true });
   });
 
   it("hides a linked local booking when Google was read successfully but no longer returns the event", async () => {
@@ -217,6 +230,431 @@ describe("listCalendarEvents booking merge", () => {
       source: "google",
       googleEventId: "google-event-1",
     });
+  });
+});
+
+describe("list-events inventory contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getRequestTimezoneMock.mockReturnValue("UTC");
+    getRequestUserEmailMock.mockReturnValue("owner@example.com");
+    getUserSettingMock.mockResolvedValue(null);
+    getDbMock.mockReturnValue(createDbMock());
+    isConnectedMock.mockResolvedValue(true);
+    getOwnedAccountEmailsMock.mockResolvedValue(["steve@example.com"]);
+    listGoogleEventsMock.mockResolvedValue({ events: [], errors: [] });
+    listOverlayEventsMock.mockResolvedValue({ events: [], errors: [] });
+    fetchICalEventsMock.mockResolvedValue([]);
+    signShortLivedTokenMock.mockImplementation(
+      ({ resourceId }) =>
+        `${Buffer.from(JSON.stringify({ resourceId })).toString("base64url")}.signature`,
+    );
+    verifyShortLivedTokenMock.mockReturnValue({ ok: true });
+  });
+
+  it("keeps legacy callers on CalendarEvent arrays", async () => {
+    const result = await (listEventsAction as any).run(
+      { from: "2026-06-17", to: "2026-06-18" },
+      { caller: "frontend" },
+    );
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it("returns compact coverage-aware inventory to MCP", async () => {
+    listGoogleEventsMock.mockResolvedValue({
+      events: [
+        {
+          id: "google-event-1",
+          googleEventId: "event-1",
+          title: "A deliberately ordinary event",
+          description: "not returned",
+          start: "2026-06-17T16:00:00.000Z",
+          end: "2026-06-17T16:30:00.000Z",
+          location: "not returned",
+          allDay: false,
+          source: "google",
+          accountEmail: "steve@example.com",
+          attendees: [
+            { email: "guest@example.com", responseStatus: "accepted" },
+          ],
+          createdAt: "2026-06-12T10:13:39.746Z",
+          updatedAt: "2026-06-12T10:13:39.746Z",
+        },
+      ],
+      errors: [],
+    });
+    const result = await (listEventsAction as any).run(
+      { from: "2026-06-17", to: "2026-06-18" },
+      { caller: "mcp" },
+    );
+    expect(result).toMatchObject({
+      version: 1,
+      requestedAccounts: null,
+      resolvedAccounts: ["steve@example.com"],
+      queriedAccounts: ["steve@example.com"],
+      coverageComplete: true,
+      page: { returned: 1, hasMore: false },
+    });
+    expect(result.items[0]).toMatchObject({
+      id: "event-1",
+      source: "google",
+      accountEmail: "steve@example.com",
+      attendeeCount: 1,
+      attendeeStatusCounts: { accepted: 1 },
+    });
+    expect(result.items[0]).not.toHaveProperty("description");
+  });
+
+  it("rejects an unowned account before fetching Google", async () => {
+    getOwnedAccountEmailsMock.mockResolvedValue(["steve@example.com"]);
+    listGoogleEventsMock.mockClear();
+    await expect(
+      listCalendarEvents({
+        from: "2026-06-17",
+        to: "2026-06-18",
+        accountEmails: ["other@example.com"],
+      }),
+    ).rejects.toThrow("not connected");
+    expect(listGoogleEventsMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps successful empty and failed owned accounts explicit", async () => {
+    getOwnedAccountEmailsMock.mockResolvedValue([
+      "quiet@example.com",
+      "failed@example.com",
+    ]);
+    listGoogleEventsMock.mockResolvedValue({
+      events: [],
+      errors: [{ email: "failed@example.com", error: "quota exhausted" }],
+    });
+
+    const result = await (listEventsAction as any).run(
+      {
+        from: "2026-06-17",
+        to: "2026-06-18",
+        accountEmails: ["QUIET@example.com", "failed@example.com"],
+      },
+      { caller: "mcp" },
+    );
+
+    expect(result.accounts).toEqual([
+      {
+        accountEmail: "quiet@example.com",
+        status: "ok",
+        count: 0,
+        exhausted: true,
+      },
+      {
+        accountEmail: "failed@example.com",
+        status: "error",
+        count: 0,
+        exhausted: false,
+        error: {
+          code: "PROVIDER_READ_FAILED",
+          message: "quota exhausted",
+          retryable: true,
+        },
+      },
+    ]);
+    expect(result).toMatchObject({
+      requestedAccounts: ["failed@example.com", "quiet@example.com"],
+      coverageComplete: false,
+      complete: false,
+      items: [],
+    });
+  });
+
+  it("deduplicates a successful account's Google event while another account fails", async () => {
+    getOwnedAccountEmailsMock.mockResolvedValue([
+      "working@example.com",
+      "failed@example.com",
+    ]);
+    getDbMock.mockReturnValue(createDbMock({ bookings: [bookingRow()] }));
+    listGoogleEventsMock.mockResolvedValue({
+      events: [
+        {
+          id: "google-google-event-1",
+          googleEventId: "google-event-1",
+          title: "Provider copy",
+          description: "",
+          start: "2026-06-17T16:00:00.000Z",
+          end: "2026-06-17T16:30:00.000Z",
+          location: "",
+          allDay: false,
+          source: "google",
+          accountEmail: "working@example.com",
+          createdAt: "2026-06-12T10:13:39.746Z",
+          updatedAt: "2026-06-12T10:13:39.746Z",
+        },
+      ],
+      errors: [{ email: "failed@example.com", error: "provider unavailable" }],
+    });
+
+    const result = await (listEventsAction as any).run(
+      { from: "2026-06-17", to: "2026-06-18" },
+      { caller: "mcp" },
+    );
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      id: "google-event-1",
+      source: "google",
+      accountEmail: "working@example.com",
+    });
+    expect(result.accounts).toContainEqual(
+      expect.objectContaining({
+        accountEmail: "failed@example.com",
+        status: "error",
+      }),
+    );
+  });
+
+  it("reports a failed ICS source instead of treating it as empty success", async () => {
+    getUserSettingMock.mockResolvedValue([
+      {
+        id: "team-feed",
+        name: "Team feed",
+        url: "https://calendar.example.test/team.ics",
+        color: "blue",
+      },
+    ]);
+    fetchICalEventsMock.mockRejectedValue(new Error("ICS feed request failed"));
+
+    const result = await (listEventsAction as any).run(
+      {
+        from: "2026-06-17",
+        to: "2026-06-18",
+        sources: ["ics"],
+      },
+      { caller: "mcp" },
+    );
+
+    expect(result.sourceCoverage).toEqual([
+      {
+        source: "ics",
+        id: "team-feed",
+        status: "error",
+        error: {
+          code: "SOURCE_READ_FAILED",
+          message: "ICS feed request failed",
+          retryable: true,
+        },
+      },
+    ]);
+    expect(result.coverageComplete).toBe(false);
+  });
+
+  it("preserves ICS feed provenance on compact items", async () => {
+    getUserSettingMock.mockResolvedValue([
+      {
+        id: "team-feed",
+        name: "Team feed",
+        url: "https://calendar.example.test/team.ics",
+        color: "blue",
+      },
+    ]);
+    fetchICalEventsMock.mockResolvedValue([
+      {
+        id: "ical-team-feed-event-1",
+        title: "Feed event",
+        description: "not returned",
+        start: "2026-06-17T18:00:00.000Z",
+        end: "2026-06-17T18:30:00.000Z",
+        location: "not returned",
+        allDay: false,
+        source: "ical",
+        sourceId: "team-feed",
+        createdAt: "2026-06-12T10:13:39.746Z",
+        updatedAt: "2026-06-12T10:13:39.746Z",
+      },
+    ]);
+
+    const result = await (listEventsAction as any).run(
+      {
+        from: "2026-06-17",
+        to: "2026-06-18",
+        sources: ["ics"],
+      },
+      { caller: "mcp" },
+    );
+
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        id: "ical-team-feed-event-1",
+        source: "ics",
+        sourceId: "team-feed",
+      }),
+    ]);
+    expect(result.items[0]).not.toHaveProperty("description");
+  });
+
+  it("reports requested overlays when Google is disconnected", async () => {
+    isConnectedMock.mockResolvedValue(false);
+    getOwnedAccountEmailsMock.mockResolvedValue([]);
+
+    const result = await (listEventsAction as any).run(
+      {
+        from: "2026-06-17",
+        to: "2026-06-18",
+        sources: ["overlays"],
+        overlayEmails: ["person@example.com"],
+      },
+      { caller: "mcp" },
+    );
+
+    expect(result.sourceCoverage).toEqual([
+      {
+        source: "overlay",
+        id: "person@example.com",
+        status: "error",
+        error: {
+          code: "NOT_CONNECTED",
+          message: "Google Calendar is not connected",
+          retryable: false,
+        },
+      },
+    ]);
+    expect(result.coverageComplete).toBe(false);
+    expect(listOverlayEventsMock).not.toHaveBeenCalled();
+  });
+
+  it("binds inventory cursors to the owner and exact query", async () => {
+    listGoogleEventsMock.mockResolvedValue({
+      events: [
+        {
+          id: "google-event-1",
+          googleEventId: "event-1",
+          title: "First",
+          description: "",
+          start: "2026-06-17T16:00:00.000Z",
+          end: "2026-06-17T16:30:00.000Z",
+          location: "",
+          allDay: false,
+          source: "google",
+          accountEmail: "steve@example.com",
+          createdAt: "2026-06-12T10:13:39.746Z",
+          updatedAt: "2026-06-12T10:13:39.746Z",
+        },
+        {
+          id: "google-event-2",
+          googleEventId: "event-2",
+          title: "Second",
+          description: "",
+          start: "2026-06-17T17:00:00.000Z",
+          end: "2026-06-17T17:30:00.000Z",
+          location: "",
+          allDay: false,
+          source: "google",
+          accountEmail: "steve@example.com",
+          createdAt: "2026-06-12T10:13:39.746Z",
+          updatedAt: "2026-06-12T10:13:39.746Z",
+        },
+      ],
+      errors: [],
+    });
+    const first = await (listEventsAction as any).run(
+      {
+        from: "2026-06-17",
+        to: "2026-06-18",
+        format: "inventory",
+        pageSize: 1,
+      },
+      { caller: "mcp" },
+    );
+    expect(first.page).toMatchObject({ hasMore: true });
+    const second = await (listEventsAction as any).run(
+      {
+        from: "2026-06-17",
+        to: "2026-06-18",
+        format: "inventory",
+        pageSize: 1,
+        cursor: first.page.nextCursor,
+      },
+      { caller: "mcp" },
+    );
+    expect(second.items.map((item: any) => item.id)).toEqual(["event-2"]);
+    expect(second.page).toEqual({
+      returned: 1,
+      hasMore: false,
+      nextCursor: undefined,
+    });
+    expect(
+      [...first.items, ...second.items].map((item: any) => item.id),
+    ).toEqual(["event-1", "event-2"]);
+    getRequestUserEmailMock.mockReturnValue("other-owner@example.com");
+    await expect(
+      (listEventsAction as any).run(
+        {
+          from: "2026-06-17",
+          to: "2026-06-18",
+          format: "inventory",
+          pageSize: 1,
+          cursor: first.page.nextCursor,
+        },
+        { caller: "mcp" },
+      ),
+    ).rejects.toThrow("does not match");
+    getRequestUserEmailMock.mockReturnValue("owner@example.com");
+    await expect(
+      (listEventsAction as any).run(
+        {
+          from: "2026-06-18",
+          to: "2026-06-19",
+          format: "inventory",
+          pageSize: 1,
+          cursor: first.page.nextCursor,
+        },
+        { caller: "mcp" },
+      ),
+    ).rejects.toThrow("does not match");
+    verifyShortLivedTokenMock.mockReturnValueOnce({ ok: false });
+    await expect(
+      (listEventsAction as any).run(
+        {
+          from: "2026-06-17",
+          to: "2026-06-18",
+          format: "inventory",
+          pageSize: 1,
+          cursor: first.page.nextCursor,
+        },
+        { caller: "mcp" },
+      ),
+    ).rejects.toThrow("Expired or invalid");
+  });
+
+  it("packs compact pages under the action-owned item budget", async () => {
+    listGoogleEventsMock.mockResolvedValue({
+      events: Array.from({ length: 100 }, (_, index) => ({
+        id: `google-event-${index}`,
+        googleEventId: `event-${index}`,
+        title: `Event ${index} ${"x".repeat(240)}`,
+        description: "not returned",
+        start: new Date(Date.UTC(2026, 5, 17, 0, index)).toISOString(),
+        end: new Date(Date.UTC(2026, 5, 17, 0, index + 1)).toISOString(),
+        location: "not returned",
+        allDay: false,
+        source: "google",
+        accountEmail: "steve@example.com",
+        createdAt: "2026-06-12T10:13:39.746Z",
+        updatedAt: "2026-06-12T10:13:39.746Z",
+      })),
+      errors: [],
+    });
+
+    const result = await (listEventsAction as any).run(
+      {
+        from: "2026-06-17",
+        to: "2026-06-18",
+        pageSize: 100,
+      },
+      { caller: "mcp" },
+    );
+
+    expect(
+      Buffer.byteLength(JSON.stringify(result.items), "utf8"),
+    ).toBeLessThanOrEqual(12_000);
+    expect(result.page.hasMore).toBe(true);
+    expect(result.page.nextCursor).toBeTruthy();
   });
 });
 

--- a/templates/calendar/actions/list-events.ts
+++ b/templates/calendar/actions/list-events.ts
@@ -71,6 +71,11 @@ interface ListCalendarEventsArgs {
   providerPageSize?: number;
 }
 
+interface ListCalendarEventsOptions {
+  ownedAccounts?: string[];
+  range?: CalendarEventRange;
+}
+
 type CalendarInventorySource = "google" | "bookings" | "ics" | "overlays";
 
 interface CalendarEventsResult {
@@ -184,6 +189,16 @@ function normalizedOverlayEmails(value: string | string[] | undefined) {
     Array.isArray(value)
       ? value
       : value?.split(",").map((email) => email.trim()),
+  );
+}
+
+function resolveInventorySources(
+  sources: CalendarInventorySource[] | undefined,
+): CalendarInventorySource[] {
+  return Array.from(
+    new Set<CalendarInventorySource>(
+      sources ?? ["google", "bookings", "ics", "overlays"],
+    ),
   );
 }
 
@@ -544,19 +559,18 @@ function shouldShowLocalBookingEvent({
 
 export async function listCalendarEvents(
   args: ListCalendarEventsArgs = {},
+  options: ListCalendarEventsOptions = {},
 ): Promise<CalendarEventsResult> {
   const email = getRequestUserEmail();
   if (!email) throw new Error("no authenticated user");
-  const range = resolveCalendarEventRange({
-    from: args.from,
-    to: args.to,
-  });
+  const range =
+    options.range ??
+    resolveCalendarEventRange({
+      from: args.from,
+      to: args.to,
+    });
 
-  const sources = Array.from(
-    new Set<CalendarInventorySource>(
-      args.sources ?? ["google", "bookings", "ics", "overlays"],
-    ),
-  );
+  const sources = resolveInventorySources(args.sources);
   const includeGoogle = sources.includes("google");
   const includeOverlays = sources.includes("overlays");
 
@@ -576,7 +590,7 @@ export async function listCalendarEvents(
   // Resolve/validate ownership before `isConnected` or token refreshes. A
   // rejected filter is therefore atomic even when every token is expired.
   const [ownedAccounts, connected] = await Promise.all([
-    googleCalendar.getOwnedAccountEmails(email),
+    options.ownedAccounts ?? googleCalendar.getOwnedAccountEmails(email),
     googleCalendar.isConnected(email),
   ]);
   if (normalizedRequestedAccounts.length > 0) {
@@ -762,6 +776,7 @@ export default defineAction({
       ),
     accountEmails: z
       .array(z.string().email())
+      .min(1)
       .max(20)
       .optional()
       .describe(
@@ -794,21 +809,61 @@ export default defineAction({
   run: async (args, ctx) => {
     const inventory =
       args.format === "inventory" || (ctx?.caller === "mcp" && !args.format);
-    const result = await listCalendarEvents({
-      ...args,
-    });
+    const owner = inventory ? getRequestUserEmail() : undefined;
+    if (inventory && !owner) throw new Error("no authenticated user");
+
+    // Reject invalid, expired, owner-bound, and query-bound cursors before any
+    // provider call. Omitted account filters require the cheap owned-account
+    // lookup to reproduce the exact query key, but token refreshes and calendar
+    // reads remain behind this gate.
+    let preparedCursor: InventoryCursor | undefined;
+    let preparedQuery: string | undefined;
+    let preparedRange: CalendarEventRange | undefined;
+    let preparedOwnedAccounts: string[] | undefined;
+    if (inventory && args.cursor) {
+      preparedRange = resolveCalendarEventRange({
+        from: args.from,
+        to: args.to,
+      });
+      preparedOwnedAccounts = args.accountEmails
+        ? undefined
+        : await googleCalendar.getOwnedAccountEmails(owner!);
+      preparedQuery = inventoryQueryKey({
+        from: preparedRange.from,
+        to: preparedRange.to,
+        query: args.query,
+        accountEmails: args.accountEmails ?? preparedOwnedAccounts ?? [],
+        overlayEmails: args.overlayEmails,
+        sources: resolveInventorySources(args.sources),
+      });
+      preparedCursor = decodeInventoryCursor(
+        args.cursor,
+        owner!,
+        preparedQuery,
+      );
+    }
+
+    const result = await listCalendarEvents(
+      {
+        ...args,
+      },
+      {
+        ownedAccounts: preparedOwnedAccounts,
+        range: preparedRange,
+      },
+    );
 
     if (inventory) {
-      const owner = getRequestUserEmail();
-      if (!owner) throw new Error("no authenticated user");
-      const query = inventoryQueryKey({
-        from: result.range.from,
-        to: result.range.to,
-        query: args.query,
-        accountEmails: result.requestedAccounts ?? result.resolvedAccounts,
-        overlayEmails: args.overlayEmails,
-        sources: result.sources,
-      });
+      const query =
+        preparedQuery ??
+        inventoryQueryKey({
+          from: result.range.from,
+          to: result.range.to,
+          query: args.query,
+          accountEmails: result.requestedAccounts ?? result.resolvedAccounts,
+          overlayEmails: args.overlayEmails,
+          sources: result.sources,
+        });
       const compact = result.events.map(compactInventoryEvent);
       // Provider ids are only unique within an account. Prefer the owned Google
       // occurrence to a duplicate local booking; otherwise keep first after a
@@ -823,9 +878,7 @@ export default defineAction({
             .map((item) => [item.key, item]),
         ).values(),
       );
-      const cursor = args.cursor
-        ? decodeInventoryCursor(args.cursor, owner, query)
-        : undefined;
+      const cursor = preparedCursor;
       const afterCursor = cursor
         ? unique.filter(
             (item) =>
@@ -849,7 +902,7 @@ export default defineAction({
       const nextCursor =
         hasMore && last
           ? encodeInventoryCursor({
-              owner,
+              owner: owner!,
               query,
               start: last.start,
               key: last.key,

--- a/templates/calendar/actions/list-events.ts
+++ b/templates/calendar/actions/list-events.ts
@@ -676,10 +676,7 @@ export async function listCalendarEvents(
   const [googleResult, overlayResult, icalResult, rawBookingEvents] =
     await Promise.all([googleRead, overlayRead, icalRead, bookingRead]);
   googleEvents = [...googleResult.events, ...overlayResult.events];
-  errors = mergeAccountErrors(
-    googleResult.errors,
-    overlayResult.accountErrors,
-  );
+  errors = mergeAccountErrors(googleResult.errors, overlayResult.accountErrors);
   if (connected && includeOverlays && requestedOverlayEmails.length > 0) {
     overlaySources = requestedOverlayEmails.map((overlayEmail) => {
       const error = overlayResult.errors.find(

--- a/templates/calendar/actions/list-events.ts
+++ b/templates/calendar/actions/list-events.ts
@@ -1,7 +1,11 @@
+import { createHash } from "node:crypto";
+
 import { defineAction } from "@agent-native/core";
 import {
   getRequestTimezone,
   getRequestUserEmail,
+  signShortLivedToken,
+  verifyShortLivedToken,
 } from "@agent-native/core/server";
 import { getUserSetting } from "@agent-native/core/settings";
 import { accessFilter } from "@agent-native/core/sharing";
@@ -44,6 +48,7 @@ async function fetchICalEventsCached(
     cal.color,
     from,
     to,
+    { throwOnError: true },
   );
   icalCache.set(cacheKey, { events, fetchedAt: Date.now() });
   return events;
@@ -60,14 +65,255 @@ interface ListCalendarEventsArgs {
   from?: string;
   to?: string;
   query?: string;
-  overlayEmails?: string;
+  overlayEmails?: string | string[];
+  accountEmails?: string[];
+  sources?: CalendarInventorySource[];
+  providerPageSize?: number;
 }
+
+type CalendarInventorySource = "google" | "bookings" | "ics" | "overlays";
 
 interface CalendarEventsResult {
   events: CalendarEvent[];
   errors: Array<{ email: string; error: string }>;
   googleConnected: boolean;
   range: CalendarEventRange;
+  icalErrors: Array<{ id: string; name: string; error: string }>;
+  icalSources: Array<{
+    id: string;
+    name: string;
+    status: "ok" | "error";
+    error?: string;
+  }>;
+  overlaySources: Array<{
+    email: string;
+    status: "ok" | "error";
+    error?: string;
+  }>;
+  requestedAccounts: string[] | null;
+  resolvedAccounts: string[];
+  queriedAccounts: string[];
+  sources: CalendarInventorySource[];
+}
+
+export interface CalendarInventoryItem {
+  key: string;
+  id: string;
+  title: string;
+  start: string;
+  end: string;
+  allDay: boolean;
+  eventType?: CalendarEvent["eventType"];
+  status?: CalendarEvent["status"];
+  transparency?: CalendarEvent["transparency"];
+  source: "google" | "booking" | "ics" | "overlay";
+  sourceId?: string;
+  accountEmail?: string;
+  overlayEmail?: string;
+  organizer?: { email?: string; displayName?: string; self?: boolean };
+  selfResponseStatus?: CalendarEvent["responseStatus"];
+  attendeeCount: number;
+  attendeeStatusCounts: Record<string, number>;
+  attendees: Array<{
+    email?: string;
+    displayName?: string;
+    responseStatus?: string;
+    optional?: boolean;
+    self?: boolean;
+    organizer?: boolean;
+  }>;
+  attendeesComplete: boolean;
+}
+
+interface InventoryCursor {
+  owner: string;
+  query: string;
+  start: string;
+  key: string;
+}
+
+const INVENTORY_VERSION = 1;
+const INVENTORY_CURSOR_PREFIX = "calendar-inventory:";
+const INVENTORY_PAGE_SIZE = 100;
+const INVENTORY_MAX_PAGE_SIZE = 250;
+const INVENTORY_ITEM_BUDGET_BYTES = 12_000;
+const INVENTORY_STRING_LIMIT = 240;
+const INVENTORY_ATTENDEE_PREVIEW_LIMIT = 8;
+
+function cap(
+  value: string | undefined,
+  limit = INVENTORY_STRING_LIMIT,
+): string | undefined {
+  if (!value) return undefined;
+  return value.length > limit ? `${value.slice(0, limit - 1)}…` : value;
+}
+
+function sanitizeError(message: unknown, fallback: string) {
+  return (
+    cap(
+      String(message ?? fallback)
+        .replace(/\bBearer\s+\S+/gi, "Bearer [redacted]")
+        .replace(
+          /\b(access_token|refresh_token|id_token|token)=([^\s&]+)/gi,
+          "$1=[redacted]",
+        ),
+    ) ?? fallback
+  );
+}
+
+function sourceCoverageError(message: string, fallback: string) {
+  const bounded = sanitizeError(message, fallback);
+  const notConnected = /not connected|reconnect|authentication/i.test(bounded);
+  return {
+    code: notConnected ? "NOT_CONNECTED" : "SOURCE_READ_FAILED",
+    message: bounded,
+    retryable: !notConnected,
+  };
+}
+
+function normalizedEmails(values: string[] | undefined): string[] {
+  return Array.from(
+    new Set(
+      (values ?? []).map((value) => value.trim().toLowerCase()).filter(Boolean),
+    ),
+  ).sort();
+}
+
+function normalizedOverlayEmails(value: string | string[] | undefined) {
+  return normalizedEmails(
+    Array.isArray(value)
+      ? value
+      : value?.split(",").map((email) => email.trim()),
+  );
+}
+
+function inventoryQueryKey(args: {
+  from: string;
+  to: string;
+  query?: string;
+  accountEmails: string[];
+  overlayEmails?: string | string[];
+  sources: CalendarInventorySource[];
+}): string {
+  const canonical = JSON.stringify({
+    v: INVENTORY_VERSION,
+    from: args.from,
+    to: args.to,
+    query: args.query?.trim().toLowerCase() || "",
+    accountEmails: normalizedEmails(args.accountEmails),
+    overlayEmails: normalizedOverlayEmails(args.overlayEmails),
+    sources: [...args.sources].sort(),
+  });
+  return createHash("sha256").update(canonical).digest("base64url");
+}
+
+function encodeInventoryCursor(cursor: InventoryCursor): string {
+  const resourceId = `${INVENTORY_CURSOR_PREFIX}${Buffer.from(JSON.stringify(cursor)).toString("base64url")}`;
+  return signShortLivedToken({ resourceId, ttlSeconds: 600 });
+}
+
+function decodeInventoryCursor(
+  token: string,
+  owner: string,
+  query: string,
+): InventoryCursor {
+  const [payload] = token.split(".", 1);
+  if (!payload) throw new Error("Invalid inventory cursor");
+  let resourceId: unknown;
+  try {
+    resourceId = JSON.parse(
+      Buffer.from(payload, "base64url").toString("utf8"),
+    ).resourceId;
+  } catch {
+    throw new Error("Invalid inventory cursor");
+  }
+  if (
+    typeof resourceId !== "string" ||
+    !resourceId.startsWith(INVENTORY_CURSOR_PREFIX)
+  )
+    throw new Error("Invalid inventory cursor");
+  if (!verifyShortLivedToken(token, resourceId).ok)
+    throw new Error("Expired or invalid inventory cursor");
+  let cursor: InventoryCursor;
+  try {
+    cursor = JSON.parse(
+      Buffer.from(
+        resourceId.slice(INVENTORY_CURSOR_PREFIX.length),
+        "base64url",
+      ).toString("utf8"),
+    );
+  } catch {
+    throw new Error("Invalid inventory cursor");
+  }
+  if (
+    cursor.owner !== owner ||
+    cursor.query !== query ||
+    !cursor.start ||
+    !cursor.key
+  )
+    throw new Error("Inventory cursor does not match this query");
+  return cursor;
+}
+
+function compactInventoryEvent(event: CalendarEvent): CalendarInventoryItem {
+  const attendees = event.attendees ?? [];
+  const attendeeStatusCounts = attendees.reduce<Record<string, number>>(
+    (counts, attendee) => {
+      const status = attendee.responseStatus ?? "unknown";
+      counts[status] = (counts[status] ?? 0) + 1;
+      return counts;
+    },
+    {},
+  );
+  const key = [
+    event.source,
+    event.accountEmail ?? event.overlayEmail ?? "local",
+    event.googleEventId ?? event.id,
+    event.start,
+  ].join(":");
+  const source = event.overlayEmail
+    ? "overlay"
+    : event.source === "local"
+      ? "booking"
+      : event.source === "ical"
+        ? "ics"
+        : event.source;
+  return {
+    key,
+    id: event.googleEventId ?? event.id,
+    title: cap(event.title) ?? "Untitled",
+    start: event.start,
+    end: event.end,
+    allDay: event.allDay,
+    eventType: event.eventType,
+    status: event.status,
+    transparency: event.transparency,
+    source,
+    sourceId: event.sourceId,
+    accountEmail: event.accountEmail,
+    overlayEmail: event.overlayEmail,
+    organizer: event.organizer
+      ? {
+          email: cap(event.organizer.email, 320) ?? "",
+          displayName: cap(event.organizer.displayName),
+          self: event.organizer.self,
+        }
+      : undefined,
+    selfResponseStatus: event.responseStatus,
+    attendeeCount: attendees.length,
+    attendeeStatusCounts,
+    attendees: attendees
+      .slice(0, INVENTORY_ATTENDEE_PREVIEW_LIMIT)
+      .map((attendee) => ({
+        email: cap(attendee.email, 320) ?? "",
+        displayName: cap(attendee.displayName),
+        responseStatus: attendee.responseStatus,
+        optional: attendee.optional,
+        self: attendee.self,
+        organizer: attendee.organizer,
+      })),
+    attendeesComplete: attendees.length <= INVENTORY_ATTENDEE_PREVIEW_LIMIT,
+  };
 }
 
 function normalizeTimezone(timezone?: string): string {
@@ -306,58 +552,160 @@ export async function listCalendarEvents(
     to: args.to,
   });
 
-  // Fetch Google Calendar events
-  let googleEvents: CalendarEvent[] = [];
-  let errors: Array<{ email: string; error: string }> = [];
-  const connected = await googleCalendar.isConnected(email);
-  if (connected) {
-    const result = await googleCalendar.listEvents(range.from, range.to, email);
-    googleEvents = result.events;
-    errors = result.errors;
-
-    if (args.overlayEmails) {
-      const overlayEmails = args.overlayEmails
-        .split(",")
-        .filter(Boolean)
-        .slice(0, 10);
-      if (overlayEmails.length > 0) {
-        const { events: overlayEvents } =
-          await googleCalendar.listOverlayEvents(
-            range.from,
-            range.to,
-            overlayEmails,
-            email,
-          );
-        googleEvents = [...googleEvents, ...overlayEvents];
-      }
-    }
-  }
-
-  // Fetch external ICS calendar feeds concurrently
-  const externalCalendars =
-    ((await getUserSetting(email, "external-calendars")) as unknown as
-      | ExternalCalendar[]
-      | null) ?? [];
-
-  const icalResults = await Promise.allSettled(
-    externalCalendars.map((cal) =>
-      fetchICalEventsCached(cal, range.from, range.to),
+  const sources = Array.from(
+    new Set<CalendarInventorySource>(
+      args.sources ?? ["google", "bookings", "ics", "overlays"],
     ),
   );
+  const includeGoogle = sources.includes("google");
+  const includeOverlays = sources.includes("overlays");
+
+  // Resolve owned accounts before any token refresh or provider call.
+  let googleEvents: CalendarEvent[] = [];
+  let errors: Array<{ email: string; error: string }> = [];
+  let overlaySources: Array<{
+    email: string;
+    status: "ok" | "error";
+    error?: string;
+  }> = [];
+  const normalizedRequestedAccounts = normalizedEmails(args.accountEmails);
+  const requestedAccounts = args.accountEmails
+    ? normalizedRequestedAccounts
+    : null;
+  let resolvedAccounts: string[] = [];
+  // Resolve/validate ownership before `isConnected` or token refreshes. A
+  // rejected filter is therefore atomic even when every token is expired.
+  const [ownedAccounts, connected] = await Promise.all([
+    googleCalendar.getOwnedAccountEmails(email),
+    googleCalendar.isConnected(email),
+  ]);
+  if (normalizedRequestedAccounts.length > 0) {
+    const unowned = normalizedRequestedAccounts.filter(
+      (account) =>
+        !ownedAccounts.some((owned) => owned.trim().toLowerCase() === account),
+    );
+    if (unowned.length > 0) {
+      throw new Error(
+        `Google Calendar account not connected for this user: ${unowned.join(", ")}`,
+      );
+    }
+    resolvedAccounts = ownedAccounts.filter((account) =>
+      normalizedRequestedAccounts.includes(account.trim().toLowerCase()),
+    );
+  } else {
+    resolvedAccounts = ownedAccounts;
+  }
+  const requestedOverlayEmails = normalizedOverlayEmails(
+    args.overlayEmails,
+  ).slice(0, 10);
+  if (includeOverlays && requestedOverlayEmails.length > 0 && !connected) {
+    overlaySources = requestedOverlayEmails.map((overlayEmail) => ({
+      email: overlayEmail,
+      status: "error",
+      error: "Google Calendar is not connected",
+    }));
+  }
+  // Once account ownership is validated, independent providers and local SQL
+  // can run together. The slowest source should set latency, not their sum.
+  const googleRead =
+    connected && includeGoogle
+      ? googleCalendar.listEvents(range.from, range.to, email, {
+          accountEmails: args.accountEmails,
+          maxResults: args.providerPageSize,
+        })
+      : Promise.resolve({ events: [], errors: [] });
+  const overlayRead =
+    connected && includeOverlays && requestedOverlayEmails.length > 0
+      ? googleCalendar.listOverlayEvents(
+          range.from,
+          range.to,
+          requestedOverlayEmails,
+          email,
+          { accountEmails: args.accountEmails },
+        )
+      : Promise.resolve({ events: [], errors: [] });
+  const icalRead = sources.includes("ics")
+    ? Promise.resolve(getUserSetting(email, "external-calendars")).then(
+        async (setting) => {
+          const calendars =
+            (setting as unknown as ExternalCalendar[] | null) ?? [];
+          return {
+            calendars,
+            results: await Promise.allSettled(
+              calendars.map((calendar) =>
+                fetchICalEventsCached(calendar, range.from, range.to),
+              ),
+            ),
+          };
+        },
+      )
+    : Promise.resolve({ calendars: [], results: [] });
+  const bookingRead = sources.includes("bookings")
+    ? listLocalBookingEvents(range.from, range.to)
+    : Promise.resolve([]);
+
+  const [googleResult, overlayResult, icalResult, rawBookingEvents] =
+    await Promise.all([googleRead, overlayRead, icalRead, bookingRead]);
+  googleEvents = [...googleResult.events, ...overlayResult.events];
+  errors = googleResult.errors;
+  if (connected && includeOverlays && requestedOverlayEmails.length > 0) {
+    overlaySources = requestedOverlayEmails.map((overlayEmail) => {
+      const error = overlayResult.errors.find(
+        (entry) => entry.email.toLowerCase() === overlayEmail.toLowerCase(),
+      );
+      return error
+        ? {
+            email: overlayEmail,
+            status: "error" as const,
+            error: error.error,
+          }
+        : { email: overlayEmail, status: "ok" as const };
+    });
+  }
+
+  const externalCalendars = icalResult.calendars;
+  const icalResults = icalResult.results;
 
   const icalEvents: CalendarEvent[] = icalResults.flatMap((r) =>
     r.status === "fulfilled" ? r.value : [],
   );
+  const icalErrors = icalResults.flatMap((result, index) =>
+    result.status === "rejected"
+      ? [
+          {
+            id: externalCalendars[index]!.id,
+            name: externalCalendars[index]!.name,
+            error:
+              result.reason instanceof Error
+                ? result.reason.message
+                : "Unable to load ICS feed",
+          },
+        ]
+      : [],
+  );
+  const icalSources = externalCalendars.map((calendar, index) => {
+    const result = icalResults[index]!;
+    return result.status === "fulfilled"
+      ? { id: calendar.id, name: calendar.name, status: "ok" as const }
+      : {
+          id: calendar.id,
+          name: calendar.name,
+          status: "error" as const,
+          error:
+            result.reason instanceof Error
+              ? result.reason.message
+              : "Unable to load ICS feed",
+        };
+  });
 
   const googleEventIds = new Set(
     googleEvents
       .map((event) => event.googleEventId)
       .filter((id): id is string => Boolean(id)),
   );
-  const googleReadAuthoritative = connected && errors.length === 0;
-  const bookingEvents = (
-    await listLocalBookingEvents(range.from, range.to)
-  ).filter((event) =>
+  const googleReadAuthoritative =
+    includeGoogle && connected && errors.length === 0;
+  const bookingEvents = rawBookingEvents.filter((event) =>
     shouldShowLocalBookingEvent({
       event,
       googleEventIds,
@@ -385,6 +733,13 @@ export async function listCalendarEvents(
     errors,
     googleConnected: connected,
     range,
+    icalErrors,
+    icalSources,
+    overlaySources,
+    requestedAccounts,
+    resolvedAccounts,
+    queriedAccounts: includeGoogle ? resolvedAccounts : [],
+    sources,
   };
 }
 
@@ -396,16 +751,205 @@ export default defineAction({
     to: z.string().optional().describe("End date (ISO string)"),
     query: z
       .string()
+      .max(500)
       .optional()
       .describe("Case-insensitive title/attendee/organizer search term"),
     overlayEmails: z
-      .string()
+      .union([z.string().max(3_200), z.array(z.string().email()).max(10)])
       .optional()
-      .describe("Comma-separated emails for overlay calendar view"),
+      .describe(
+        "Overlay calendar emails (an array, or legacy comma-separated string)",
+      ),
+    accountEmails: z
+      .array(z.string().email())
+      .max(20)
+      .optional()
+      .describe(
+        "Connected Google accounts to read; omitted reads every connected account",
+      ),
+    sources: z
+      .array(z.enum(["google", "bookings", "ics", "overlays"]))
+      .max(4)
+      .optional()
+      .describe("Calendar sources to query; omitted reads every source"),
+    format: z
+      .enum(["legacy", "inventory"])
+      .optional()
+      .describe("Use inventory for compact, coverage-aware external reads"),
+    cursor: z
+      .string()
+      .max(4096)
+      .optional()
+      .describe("Opaque cursor from an inventory response"),
+    pageSize: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(INVENTORY_MAX_PAGE_SIZE)
+      .optional(),
   }),
   http: { method: "GET" },
-  run: async (args) => {
-    const result = await listCalendarEvents(args);
+  readOnly: true,
+  publicAgent: { expose: true, readOnly: true, requiresAuth: true },
+  run: async (args, ctx) => {
+    const inventory =
+      args.format === "inventory" || (ctx?.caller === "mcp" && !args.format);
+    const result = await listCalendarEvents({
+      ...args,
+    });
+
+    if (inventory) {
+      const owner = getRequestUserEmail();
+      if (!owner) throw new Error("no authenticated user");
+      const query = inventoryQueryKey({
+        from: result.range.from,
+        to: result.range.to,
+        query: args.query,
+        accountEmails: result.requestedAccounts ?? result.resolvedAccounts,
+        overlayEmails: args.overlayEmails,
+        sources: result.sources,
+      });
+      const compact = result.events.map(compactInventoryEvent);
+      // Provider ids are only unique within an account. Prefer the owned Google
+      // occurrence to a duplicate local booking; otherwise keep first after a
+      // stable source/key sort.
+      const unique = Array.from(
+        new Map(
+          compact
+            .sort(
+              (a, b) =>
+                a.start.localeCompare(b.start) || a.key.localeCompare(b.key),
+            )
+            .map((item) => [item.key, item]),
+        ).values(),
+      );
+      const cursor = args.cursor
+        ? decodeInventoryCursor(args.cursor, owner, query)
+        : undefined;
+      const afterCursor = cursor
+        ? unique.filter(
+            (item) =>
+              item.start > cursor.start ||
+              (item.start === cursor.start && item.key > cursor.key),
+          )
+        : unique;
+      const pageSize = args.pageSize ?? INVENTORY_PAGE_SIZE;
+      const items: CalendarInventoryItem[] = [];
+      for (const item of afterCursor) {
+        if (items.length >= pageSize) break;
+        const nextSize = Buffer.byteLength(
+          JSON.stringify([...items, item]),
+          "utf8",
+        );
+        if (items.length > 0 && nextSize > INVENTORY_ITEM_BUDGET_BYTES) break;
+        items.push(item);
+      }
+      const last = items[items.length - 1];
+      const hasMore = afterCursor.length > items.length;
+      const nextCursor =
+        hasMore && last
+          ? encodeInventoryCursor({
+              owner,
+              query,
+              start: last.start,
+              key: last.key,
+            })
+          : undefined;
+      const accounts = result.queriedAccounts.map((accountEmail) => {
+        const error = result.errors.find(
+          (entry) =>
+            entry.email.trim().toLowerCase() ===
+            accountEmail.trim().toLowerCase(),
+        );
+        return {
+          accountEmail,
+          status: error ? ("error" as const) : ("ok" as const),
+          count: compact.filter(
+            (item) => item.accountEmail?.trim().toLowerCase() === accountEmail,
+          ).length,
+          exhausted: !error,
+          ...(error
+            ? {
+                error: {
+                  code: "PROVIDER_READ_FAILED",
+                  message: sanitizeError(error.error, "Calendar read failed"),
+                  retryable: true,
+                },
+              }
+            : {}),
+        };
+      });
+      const sourceCoverage = [
+        ...(result.sources.includes("google") && !result.googleConnected
+          ? [
+              {
+                source: "google" as const,
+                id: "owned-accounts",
+                status: "error" as const,
+                error: {
+                  code: "NOT_CONNECTED",
+                  message: "Google Calendar is not connected",
+                  retryable: false,
+                },
+              },
+            ]
+          : []),
+        ...result.icalSources.map((feed) => ({
+          source: "ics" as const,
+          id: feed.id,
+          status: feed.status,
+          ...(feed.error
+            ? {
+                error: {
+                  ...sourceCoverageError(feed.error, "ICS read failed"),
+                },
+              }
+            : {}),
+        })),
+        ...result.overlaySources.map((overlay) => ({
+          source: "overlay" as const,
+          id: overlay.email,
+          status: overlay.status,
+          ...(overlay.error
+            ? {
+                error: {
+                  ...sourceCoverageError(overlay.error, "Overlay read failed"),
+                },
+              }
+            : {}),
+        })),
+        ...(result.sources.includes("bookings")
+          ? [
+              {
+                source: "booking" as const,
+                id: "bookings",
+                status: "ok" as const,
+              },
+            ]
+          : []),
+      ];
+      const coverageComplete =
+        accounts.every((account) => account.status === "ok") &&
+        sourceCoverage.every((entry) => entry.status === "ok");
+      return {
+        version: INVENTORY_VERSION,
+        query: {
+          ...result.range,
+          ...(args.query ? { text: args.query } : {}),
+          sources: result.sources,
+          overlayEmails: normalizedOverlayEmails(args.overlayEmails),
+        },
+        requestedAccounts: result.requestedAccounts,
+        resolvedAccounts: result.resolvedAccounts,
+        queriedAccounts: result.queriedAccounts,
+        accounts,
+        sourceCoverage,
+        coverageComplete,
+        complete: !hasMore && coverageComplete,
+        items,
+        page: { returned: items.length, nextCursor, hasMore },
+      };
+    }
 
     if (result.events.length === 0 && result.errors.length > 0) {
       throw new Error(

--- a/templates/calendar/actions/list-events.ts
+++ b/templates/calendar/actions/list-events.ts
@@ -184,6 +184,21 @@ function normalizedEmails(values: string[] | undefined): string[] {
   ).sort();
 }
 
+function mergeAccountErrors(
+  ...groups: Array<Array<{ email: string; error: string }>>
+): Array<{ email: string; error: string }> {
+  return Array.from(
+    new Map(
+      groups
+        .flat()
+        .map((entry) => [
+          `${entry.email.trim().toLowerCase()}\0${entry.error}`,
+          entry,
+        ]),
+    ).values(),
+  );
+}
+
 function normalizedOverlayEmails(value: string | string[] | undefined) {
   return normalizedEmails(
     Array.isArray(value)
@@ -637,7 +652,7 @@ export async function listCalendarEvents(
           email,
           { accountEmails: args.accountEmails },
         )
-      : Promise.resolve({ events: [], errors: [] });
+      : Promise.resolve({ events: [], errors: [], accountErrors: [] });
   const icalRead = sources.includes("ics")
     ? Promise.resolve(getUserSetting(email, "external-calendars")).then(
         async (setting) => {
@@ -661,7 +676,10 @@ export async function listCalendarEvents(
   const [googleResult, overlayResult, icalResult, rawBookingEvents] =
     await Promise.all([googleRead, overlayRead, icalRead, bookingRead]);
   googleEvents = [...googleResult.events, ...overlayResult.events];
-  errors = googleResult.errors;
+  errors = mergeAccountErrors(
+    googleResult.errors,
+    overlayResult.accountErrors,
+  );
   if (connected && includeOverlays && requestedOverlayEmails.length > 0) {
     overlaySources = requestedOverlayEmails.map((overlayEmail) => {
       const error = overlayResult.errors.find(
@@ -752,7 +770,10 @@ export async function listCalendarEvents(
     overlaySources,
     requestedAccounts,
     resolvedAccounts,
-    queriedAccounts: includeGoogle ? resolvedAccounts : [],
+    queriedAccounts:
+      includeGoogle || (includeOverlays && requestedOverlayEmails.length > 0)
+        ? resolvedAccounts
+        : [],
     sources,
   };
 }

--- a/templates/calendar/changelog/2026-07-13-calendar-inventory-reads-report-source-coverage.md
+++ b/templates/calendar/changelog/2026-07-13-calendar-inventory-reads-report-source-coverage.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-13
+---
+
+Calendar reads now show which connected sources were covered, including partial connection or feed failures.

--- a/templates/calendar/changelog/2026-07-13-calendar-inventory-reads-report-source-coverage.md
+++ b/templates/calendar/changelog/2026-07-13-calendar-inventory-reads-report-source-coverage.md
@@ -3,4 +3,4 @@ type: improved
 date: 2026-07-13
 ---
 
-Calendar reads now show which connected sources were covered, including partial connection or feed failures.
+Direct Calendar reads now show which connected sources were covered, including partial connection or feed failures.

--- a/templates/calendar/server/lib/calendar-connector-catalog.spec.ts
+++ b/templates/calendar/server/lib/calendar-connector-catalog.spec.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { CALENDAR_CONNECTOR_CATALOG } from "./calendar-connector-catalog";
+
+describe("Calendar MCP connector catalog", () => {
+  it("exposes only deterministic event inventory reads", () => {
+    expect(CALENDAR_CONNECTOR_CATALOG).toEqual(["list-events"]);
+    expect(CALENDAR_CONNECTOR_CATALOG).not.toContain("search-events");
+    expect(CALENDAR_CONNECTOR_CATALOG).not.toContain("get-event");
+    expect(CALENDAR_CONNECTOR_CATALOG).not.toContain("create-event");
+  });
+
+  it("wires the catalog into MCP and keeps the action authenticated read-only", () => {
+    const root = process.cwd();
+    const plugin = readFileSync(
+      join(root, "server", "plugins", "agent-chat.ts"),
+      "utf8",
+    );
+    const action = readFileSync(
+      join(root, "actions", "list-events.ts"),
+      "utf8",
+    );
+
+    expect(plugin).toContain("connectorCatalog: [");
+    expect(plugin).toContain("...CALENDAR_CONNECTOR_CATALOG");
+    expect(action).toContain("readOnly: true");
+    expect(action).toContain(
+      "publicAgent: { expose: true, readOnly: true, requiresAuth: true }",
+    );
+  });
+});

--- a/templates/calendar/server/lib/calendar-connector-catalog.ts
+++ b/templates/calendar/server/lib/calendar-connector-catalog.ts
@@ -1,0 +1,8 @@
+/**
+ * Deliberately narrow authenticated MCP surface for Calendar.
+ *
+ * External callers may read calendar coverage through list-events. Other
+ * actions remain available through the in-app agent, ask_app, or an explicit
+ * full-catalog connection; tool-search alone never makes them callable.
+ */
+export const CALENDAR_CONNECTOR_CATALOG = ["list-events"] as const;

--- a/templates/calendar/server/lib/google-calendar.spec.ts
+++ b/templates/calendar/server/lib/google-calendar.spec.ts
@@ -605,6 +605,7 @@ describe("calendar event listing", () => {
 
     expect(result.events[0]).toMatchObject({
       id: "overlay-host@example.com-overlay-1",
+      accountEmail: "steve@example.com",
       overlayEmail: "host@example.com",
       attendees: [
         {
@@ -624,6 +625,116 @@ describe("calendar event listing", () => {
         displayName: "Host Person",
       },
     });
+  });
+
+  it("falls back to another selected account when the first cannot read an overlay", async () => {
+    listOAuthAccountsByOwnerMock.mockResolvedValue([
+      {
+        accountId: "alpha@example.com",
+        tokens: {
+          access_token: "alpha-token",
+          expiry_date: Date.now() + 10 * 60_000,
+        },
+      },
+      {
+        accountId: "zulu@example.com",
+        tokens: {
+          access_token: "zulu-token",
+          expiry_date: Date.now() + 10 * 60_000,
+        },
+      },
+    ]);
+    calendarListEventsMock
+      .mockRejectedValueOnce(new Error("403 Forbidden"))
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: "overlay-1",
+            start: { dateTime: "2026-02-05T17:00:00Z" },
+            end: { dateTime: "2026-02-05T17:30:00Z" },
+          },
+        ],
+      });
+
+    const result = await listOverlayEvents(
+      "2026-02-05T00:00:00Z",
+      "2026-02-06T00:00:00Z",
+      ["person@example.com"],
+      "owner@example.com",
+      { accountEmails: ["alpha@example.com", "zulu@example.com"] },
+    );
+
+    expect(calendarListEventsMock).toHaveBeenNthCalledWith(
+      1,
+      "alpha-token",
+      "person@example.com",
+      expect.any(Object),
+    );
+    expect(calendarListEventsMock).toHaveBeenNthCalledWith(
+      2,
+      "zulu-token",
+      "person@example.com",
+      expect.any(Object),
+    );
+    expect(result).toMatchObject({
+      errors: [],
+      accountErrors: [],
+      events: [
+        {
+          googleEventId: "overlay-1",
+          accountEmail: "zulu@example.com",
+          overlayEmail: "person@example.com",
+        },
+      ],
+    });
+  });
+
+  it("returns selected-account refresh failures separately from overlay coverage", async () => {
+    listOAuthAccountsByOwnerMock.mockResolvedValue([
+      {
+        accountId: "broken@example.com",
+        tokens: {
+          access_token: "expired-token",
+          refresh_token: "broken-refresh-token",
+          expiry_date: Date.now() - 60_000,
+        },
+      },
+      {
+        accountId: "healthy@example.com",
+        tokens: {
+          access_token: "healthy-token",
+          expiry_date: Date.now() + 10 * 60_000,
+        },
+      },
+    ]);
+    createOAuth2ClientMock.mockReturnValue({
+      refreshToken: vi
+        .fn()
+        .mockRejectedValue(new Error("Refresh token revoked")),
+    });
+    calendarListEventsMock.mockResolvedValue({ items: [] });
+
+    const result = await listOverlayEvents(
+      "2026-02-05T00:00:00Z",
+      "2026-02-06T00:00:00Z",
+      ["person@example.com"],
+      "owner@example.com",
+      { accountEmails: ["broken@example.com", "healthy@example.com"] },
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.accountErrors).toEqual([
+      expect.objectContaining({
+        email: "broken@example.com",
+        error: expect.stringContaining("Refresh token revoked"),
+      }),
+    ]);
+    expect(calendarListEventsMock).toHaveBeenCalledTimes(1);
+    expect(calendarListEventsMock).toHaveBeenCalledWith(
+      "healthy-token",
+      "person@example.com",
+      expect.any(Object),
+    );
   });
 
   it("paginates overlay reads without losing later events", async () => {

--- a/templates/calendar/server/lib/google-calendar.spec.ts
+++ b/templates/calendar/server/lib/google-calendar.spec.ts
@@ -414,6 +414,120 @@ describe("calendar event listing", () => {
     );
   });
 
+  it("validates and reads only the selected owned account", async () => {
+    listOAuthAccountsByOwnerMock.mockResolvedValue([
+      {
+        accountId: "primary@example.com",
+        tokens: {
+          access_token: "primary-token",
+          expiry_date: Date.now() + 10 * 60_000,
+        },
+      },
+      {
+        accountId: "quiet@example.com",
+        tokens: {
+          access_token: "quiet-token",
+          expiry_date: Date.now() + 10 * 60_000,
+        },
+      },
+    ]);
+    calendarListEventsMock.mockResolvedValue({ items: [] });
+
+    const result = await listEvents(
+      "2026-07-06T00:00:00Z",
+      "2026-07-13T00:00:00Z",
+      "owner@example.com",
+      { accountEmails: ["QUIET@example.com"] },
+    );
+
+    expect(result).toEqual({ events: [], errors: [] });
+    expect(calendarListEventsMock).toHaveBeenCalledTimes(1);
+    expect(calendarListEventsMock).toHaveBeenCalledWith(
+      "quiet-token",
+      "primary",
+      expect.objectContaining({ maxResults: 2500 }),
+    );
+  });
+
+  it("preserves a successful empty account alongside a failed account", async () => {
+    listOAuthAccountsByOwnerMock.mockResolvedValue([
+      {
+        accountId: "quiet@example.com",
+        tokens: {
+          access_token: "quiet-token",
+          expiry_date: Date.now() + 10 * 60_000,
+        },
+      },
+      {
+        accountId: "failed@example.com",
+        tokens: {
+          access_token: "failed-token",
+          expiry_date: Date.now() + 10 * 60_000,
+        },
+      },
+    ]);
+    calendarListEventsMock.mockImplementation(async (token: string) => {
+      if (token === "failed-token") throw new Error("provider unavailable");
+      return { items: [] };
+    });
+
+    const result = await listEvents(
+      "2026-07-06T00:00:00Z",
+      "2026-07-13T00:00:00Z",
+      "owner@example.com",
+    );
+
+    expect(calendarListEventsMock).toHaveBeenCalledTimes(2);
+    expect(result.events).toEqual([]);
+    expect(result.errors).toEqual([
+      { email: "failed@example.com", error: "provider unavailable" },
+    ]);
+  });
+
+  it("bounds multi-account provider concurrency at four", async () => {
+    listOAuthAccountsByOwnerMock.mockResolvedValue(
+      Array.from({ length: 5 }, (_, index) => ({
+        accountId: `account-${index}@example.com`,
+        tokens: {
+          access_token: `token-${index}`,
+          expiry_date: Date.now() + 10 * 60_000,
+        },
+      })),
+    );
+    let active = 0;
+    let maxActive = 0;
+    calendarListEventsMock.mockImplementation(async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      active -= 1;
+      return { items: [] };
+    });
+
+    await listEvents(
+      "2026-07-06T00:00:00Z",
+      "2026-07-13T00:00:00Z",
+      "owner@example.com",
+    );
+
+    expect(calendarListEventsMock).toHaveBeenCalledTimes(5);
+    expect(maxActive).toBe(4);
+  });
+
+  it("rejects an unowned selection before any provider call", async () => {
+    calendarListEventsMock.mockClear();
+
+    await expect(
+      listEvents(
+        "2026-07-06T00:00:00Z",
+        "2026-07-13T00:00:00Z",
+        "owner@example.com",
+        { accountEmails: ["missing@example.com"] },
+      ),
+    ).rejects.toThrow("not connected");
+    expect(calendarListEventsMock).not.toHaveBeenCalled();
+  });
+
   it("maps Google working-location metadata from listed events", async () => {
     calendarListEventsMock.mockResolvedValueOnce({
       items: [
@@ -510,6 +624,47 @@ describe("calendar event listing", () => {
         displayName: "Host Person",
       },
     });
+  });
+
+  it("paginates overlay reads without losing later events", async () => {
+    calendarListEventsMock
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: "overlay-1",
+            start: { dateTime: "2026-02-05T17:00:00Z" },
+            end: { dateTime: "2026-02-05T17:30:00Z" },
+          },
+        ],
+        nextPageToken: "overlay-page-2",
+      })
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: "overlay-2",
+            start: { dateTime: "2026-02-05T18:00:00Z" },
+            end: { dateTime: "2026-02-05T18:30:00Z" },
+          },
+        ],
+      });
+
+    const result = await listOverlayEvents(
+      "2026-02-05T00:00:00Z",
+      "2026-02-06T00:00:00Z",
+      ["person@example.com"],
+      "owner@example.com",
+    );
+
+    expect(result.events.map((event) => event.googleEventId)).toEqual([
+      "overlay-1",
+      "overlay-2",
+    ]);
+    expect(calendarListEventsMock).toHaveBeenNthCalledWith(
+      2,
+      "access-token",
+      "person@example.com",
+      expect.objectContaining({ pageToken: "overlay-page-2" }),
+    );
   });
 });
 

--- a/templates/calendar/server/lib/google-calendar.ts
+++ b/templates/calendar/server/lib/google-calendar.ts
@@ -190,6 +190,22 @@ const LIST_EVENT_TYPES = [
   "outOfOffice",
   "workingLocation",
 ];
+const GOOGLE_READ_CONCURRENCY = 4;
+
+async function mapWithConcurrency<T, R>(
+  values: T[],
+  map: (value: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+  for (let index = 0; index < values.length; index += GOOGLE_READ_CONCURRENCY) {
+    results.push(
+      ...(await Promise.all(
+        values.slice(index, index + GOOGLE_READ_CONCURRENCY).map(map),
+      )),
+    );
+  }
+  return results;
+}
 
 function mapReminders(
   event: any,
@@ -684,6 +700,85 @@ export async function getClientsWithErrors(forEmail?: string): Promise<{
   return { clients, errors };
 }
 
+/**
+ * Resolve a caller's connected Google accounts without refreshing tokens. This
+ * is intentionally separate from `getClientsWithErrors`: callers that accept
+ * an account filter must reject an unowned requested account before they do
+ * provider work for any account.
+ */
+export async function getOwnedAccountEmails(
+  forEmail?: string,
+): Promise<string[]> {
+  if (!forEmail) return [];
+  const accounts = await listOAuthAccountsByOwner("google", forEmail);
+  return accounts.map((account) => account.accountId);
+}
+
+export async function getClientsForAccountsWithErrors(
+  forEmail: string | undefined,
+  accountEmails?: string[],
+): Promise<{
+  clients: Array<{ email: string; accessToken: string }>;
+  errors: Array<{ email: string; error: string }>;
+  requestedAccounts: string[];
+  resolvedAccounts: string[];
+}> {
+  if (!forEmail) {
+    return {
+      clients: [],
+      errors: [],
+      requestedAccounts: [],
+      resolvedAccounts: [],
+    };
+  }
+  const accounts = await listOAuthAccountsByOwner("google", forEmail);
+  const byNormalized = new Map(
+    accounts.map((account) => [
+      account.accountId.trim().toLowerCase(),
+      account,
+    ]),
+  );
+  const requestedAccounts = Array.from(
+    new Set(
+      (accountEmails ?? accounts.map((account) => account.accountId))
+        .map((email) => email.trim().toLowerCase())
+        .filter(Boolean),
+    ),
+  );
+  const unowned = requestedAccounts.filter((email) => !byNormalized.has(email));
+  if (unowned.length > 0) {
+    throw new Error(
+      `Google Calendar account not connected for this user: ${unowned.join(", ")}`,
+    );
+  }
+  const selected = requestedAccounts.map((email) => byNormalized.get(email)!);
+  const clients: Array<{ email: string; accessToken: string }> = [];
+  const errors: Array<{ email: string; error: string }> = [];
+  await mapWithConcurrency(selected, async (account) => {
+    try {
+      const accessToken = await getValidAccessToken(
+        account.accountId,
+        account.tokens as unknown as GoogleTokens,
+        forEmail,
+      );
+      clients.push({ email: account.accountId, accessToken });
+    } catch (err: any) {
+      errors.push({
+        email: account.accountId,
+        error: err?.message || "Unknown refresh error",
+      });
+    }
+  });
+  clients.sort((a, b) => a.email.localeCompare(b.email));
+  errors.sort((a, b) => a.email.localeCompare(b.email));
+  return {
+    clients,
+    errors,
+    requestedAccounts,
+    resolvedAccounts: selected.map((account) => account.accountId),
+  };
+}
+
 export async function isConnected(forEmail?: string): Promise<boolean> {
   return isOAuthConnected("google", forEmail ?? "");
 }
@@ -779,12 +874,13 @@ export async function listEvents(
   timeMin: string,
   timeMax: string,
   forEmail?: string,
+  options: { accountEmails?: string[]; maxResults?: number } = {},
 ): Promise<{
   events: CalendarEvent[];
   errors: Array<{ email: string; error: string }>;
 }> {
   const { clients, errors: refreshErrors } =
-    await getClientsWithErrors(forEmail);
+    await getClientsForAccountsWithErrors(forEmail, options.accountEmails);
   // Seed with refresh failures so a fully-dead connection (every account's
   // refresh_token revoked or invalidated by a GOOGLE_CLIENT_ID rotation)
   // reaches the caller — otherwise the result is indistinguishable from
@@ -792,8 +888,9 @@ export async function listEvents(
   const errors: Array<{ email: string; error: string }> = [...refreshErrors];
   if (clients.length === 0) return { events: [], errors };
 
-  const allResults = await Promise.all(
-    clients.map(async ({ email, accessToken }) => {
+  const allResults = await mapWithConcurrency(
+    clients,
+    async ({ email, accessToken }) => {
       try {
         const events: any[] = [];
         let pageToken: string | undefined;
@@ -803,7 +900,7 @@ export async function listEvents(
             timeMax,
             singleEvents: true,
             orderBy: "startTime",
-            maxResults: 2500,
+            maxResults: options.maxResults ?? 2500,
             pageToken,
             eventTypes: LIST_EVENT_TYPES,
           });
@@ -883,7 +980,7 @@ export async function listEvents(
         errors.push({ email, error: error.message });
         return [];
       }
-    }),
+    },
   );
 
   return { events: allResults.flat(), errors };
@@ -993,14 +1090,22 @@ export async function listOverlayEvents(
   timeMax: string,
   overlayEmails: string[],
   forEmail?: string,
+  options: { accountEmails?: string[] } = {},
 ): Promise<{
   events: CalendarEvent[];
   errors: Array<{ email: string; error: string }>;
 }> {
   const { clients, errors: refreshErrors } =
-    await getClientsWithErrors(forEmail);
+    await getClientsForAccountsWithErrors(forEmail, options.accountEmails);
   const errors: Array<{ email: string; error: string }> = [...refreshErrors];
-  if (clients.length === 0) return { events: [], errors };
+  if (clients.length === 0) {
+    const message =
+      refreshErrors[0]?.error ?? "Google Calendar is not connected";
+    return {
+      events: [],
+      errors: overlayEmails.map((email) => ({ email, error: message })),
+    };
+  }
 
   // Use the first available token to query other people's calendars
   const { accessToken } = clients[0];
@@ -1008,15 +1113,20 @@ export async function listOverlayEvents(
   const allResults = await Promise.all(
     overlayEmails.map(async (overlayEmail) => {
       try {
-        const response = await calendarListEvents(accessToken, overlayEmail, {
-          timeMin,
-          timeMax,
-          singleEvents: true,
-          orderBy: "startTime",
-          eventTypes: LIST_EVENT_TYPES,
-        });
-
-        const events = response.items || [];
+        const events: any[] = [];
+        let pageToken: string | undefined;
+        do {
+          const response = await calendarListEvents(accessToken, overlayEmail, {
+            timeMin,
+            timeMax,
+            singleEvents: true,
+            orderBy: "startTime",
+            eventTypes: LIST_EVENT_TYPES,
+            pageToken,
+          });
+          events.push(...(response.items || []));
+          pageToken = response.nextPageToken;
+        } while (pageToken);
         return events.map((event: any) => ({
           id: `overlay-${overlayEmail}-${event.id}`,
           title: event.summary || "Busy",

--- a/templates/calendar/server/lib/google-calendar.ts
+++ b/templates/calendar/server/lib/google-calendar.ts
@@ -1094,73 +1094,85 @@ export async function listOverlayEvents(
 ): Promise<{
   events: CalendarEvent[];
   errors: Array<{ email: string; error: string }>;
+  accountErrors: Array<{ email: string; error: string }>;
 }> {
   const { clients, errors: refreshErrors } =
     await getClientsForAccountsWithErrors(forEmail, options.accountEmails);
-  const errors: Array<{ email: string; error: string }> = [...refreshErrors];
+  const errors: Array<{ email: string; error: string }> = [];
   if (clients.length === 0) {
     const message =
       refreshErrors[0]?.error ?? "Google Calendar is not connected";
     return {
       events: [],
       errors: overlayEmails.map((email) => ({ email, error: message })),
+      accountErrors: refreshErrors,
     };
   }
 
-  // Use the first available token to query other people's calendars
-  const { accessToken } = clients[0];
-
   const allResults = await Promise.all(
     overlayEmails.map(async (overlayEmail) => {
-      try {
-        const events: any[] = [];
-        let pageToken: string | undefined;
-        do {
-          const response = await calendarListEvents(accessToken, overlayEmail, {
-            timeMin,
-            timeMax,
-            singleEvents: true,
-            orderBy: "startTime",
-            eventTypes: LIST_EVENT_TYPES,
-            pageToken,
-          });
-          events.push(...(response.items || []));
-          pageToken = response.nextPageToken;
-        } while (pageToken);
-        return events.map((event: any) => ({
-          id: `overlay-${overlayEmail}-${event.id}`,
-          title: event.summary || "Busy",
-          description: event.description || "",
-          start: event.start?.dateTime || event.start?.date || "",
-          end: event.end?.dateTime || event.end?.date || "",
-          startTimeZone: event.start?.timeZone || undefined,
-          endTimeZone: event.end?.timeZone || undefined,
-          location: event.location || "",
-          allDay: !event.start?.dateTime,
-          source: "google" as const,
-          googleEventId: event.id || undefined,
-          htmlLink: event.htmlLink || undefined,
-          eventType: event.eventType || "default",
-          accountEmail: undefined,
-          overlayEmail,
-          ...mapColor(event),
-          attendees: mapAttendees(event),
-          organizer: mapOrganizer(event),
-          createdAt: event.created || new Date().toISOString(),
-          updatedAt: event.updated || new Date().toISOString(),
-        }));
-      } catch (error: any) {
-        console.error(
-          `[listOverlayEvents] Error fetching ${overlayEmail}:`,
-          error.message,
-        );
-        errors.push({ email: overlayEmail, error: error.message });
-        return [];
+      const accessErrors: string[] = [];
+      for (const client of clients) {
+        try {
+          const events: any[] = [];
+          let pageToken: string | undefined;
+          do {
+            const response = await calendarListEvents(
+              client.accessToken,
+              overlayEmail,
+              {
+                timeMin,
+                timeMax,
+                singleEvents: true,
+                orderBy: "startTime",
+                eventTypes: LIST_EVENT_TYPES,
+                pageToken,
+              },
+            );
+            events.push(...(response.items || []));
+            pageToken = response.nextPageToken;
+          } while (pageToken);
+          return events.map((event: any) => ({
+            id: `overlay-${overlayEmail}-${event.id}`,
+            title: event.summary || "Busy",
+            description: event.description || "",
+            start: event.start?.dateTime || event.start?.date || "",
+            end: event.end?.dateTime || event.end?.date || "",
+            startTimeZone: event.start?.timeZone || undefined,
+            endTimeZone: event.end?.timeZone || undefined,
+            location: event.location || "",
+            allDay: !event.start?.dateTime,
+            source: "google" as const,
+            googleEventId: event.id || undefined,
+            htmlLink: event.htmlLink || undefined,
+            eventType: event.eventType || "default",
+            accountEmail: client.email,
+            overlayEmail,
+            ...mapColor(event),
+            attendees: mapAttendees(event),
+            organizer: mapOrganizer(event),
+            createdAt: event.created || new Date().toISOString(),
+            updatedAt: event.updated || new Date().toISOString(),
+          }));
+        } catch (error: any) {
+          const message = error?.message || "Unable to read overlay calendar";
+          console.error(
+            `[listOverlayEvents] Error fetching ${overlayEmail} via ${client.email}:`,
+            message,
+          );
+          accessErrors.push(`${client.email}: ${message}`);
+        }
       }
+
+      errors.push({
+        email: overlayEmail,
+        error: `No selected Google account could read this overlay (${accessErrors.join("; ")})`,
+      });
+      return [];
     }),
   );
 
-  return { events: allResults.flat(), errors };
+  return { events: allResults.flat(), errors, accountErrors: refreshErrors };
 }
 
 export async function getEvent(

--- a/templates/calendar/server/lib/ical-fetcher.spec.ts
+++ b/templates/calendar/server/lib/ical-fetcher.spec.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const ssrfSafeFetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@agent-native/core/extensions/url-safety", () => ({
+  ssrfSafeFetch: ssrfSafeFetchMock,
+}));
+
+vi.mock("@agent-native/core/tools/url-safety", () => ({
+  isBlockedToolUrl: () => false,
+  ssrfSafeFetch: ssrfSafeFetchMock,
+}));
+
+import { fetchICalEvents } from "./ical-fetcher.js";
+
+const args = [
+  "feed-1",
+  "Team calendar",
+  "https://calendar.example.test/team.ics",
+  "blue",
+  "2026-07-13T00:00:00.000Z",
+  "2026-07-20T00:00:00.000Z",
+] as const;
+
+describe("strict ICS inventory reads", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("distinguishes a valid empty feed from a failed request", async () => {
+    ssrfSafeFetchMock.mockResolvedValueOnce({
+      ok: true,
+      text: async () => "BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n",
+    });
+    await expect(
+      fetchICalEvents(...args, { throwOnError: true }),
+    ).resolves.toEqual([]);
+
+    ssrfSafeFetchMock.mockResolvedValueOnce({ ok: false, status: 503 });
+    await expect(
+      fetchICalEvents(...args, { throwOnError: true }),
+    ).rejects.toThrow("ICS feed request failed");
+  });
+
+  it("preserves graceful legacy degradation", async () => {
+    ssrfSafeFetchMock.mockRejectedValueOnce(new Error("network unavailable"));
+    await expect(fetchICalEvents(...args)).resolves.toEqual([]);
+  });
+});

--- a/templates/calendar/server/lib/ical-fetcher.ts
+++ b/templates/calendar/server/lib/ical-fetcher.ts
@@ -273,6 +273,7 @@ export async function fetchICalEvents(
   color: string,
   from: string,
   to: string,
+  options: { throwOnError?: boolean } = {},
 ): Promise<CalendarEvent[]> {
   const httpUrl = normalizeUrl(url);
 
@@ -281,6 +282,7 @@ export async function fetchICalEvents(
   } catch {
     // Silently degrade — never echo the URL or reason back. A loud error
     // helps an attacker map internal infrastructure via probe responses.
+    if (options.throwOnError) throw new Error("ICS feed URL is not allowed");
     return [];
   }
 
@@ -294,9 +296,17 @@ export async function fetchICalEvents(
       },
       { maxRedirects: 3 },
     );
-    if (!response.ok) return [];
+    if (!response.ok) {
+      if (options.throwOnError) throw new Error("ICS feed request failed");
+      return [];
+    }
     icsText = await response.text();
-  } catch {
+  } catch (error) {
+    if (options.throwOnError) {
+      throw error instanceof Error
+        ? error
+        : new Error("ICS feed request failed");
+    }
     return [];
   }
 
@@ -323,6 +333,7 @@ export async function fetchICalEvents(
       location: e.location || "",
       allDay: e.allDay,
       source: "ical" as const,
+      sourceId: feedId,
       color,
       createdAt: now,
       updatedAt: now,

--- a/templates/calendar/server/plugins/agent-chat.ts
+++ b/templates/calendar/server/plugins/agent-chat.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 // why `autoDiscoverActions` on its own produces 404s for action routes in
 // production.
 import actionsRegistry from "../../.generated/actions-registry.js";
+import { CALENDAR_CONNECTOR_CATALOG } from "../lib/calendar-connector-catalog.js";
 
 // ---------------------------------------------------------------------------
 // Register calendar event-bus events
@@ -83,6 +84,7 @@ const INITIAL_TOOL_NAMES = [
 export default createAgentChatPlugin({
   appId: "calendar",
   initialToolNames: INITIAL_TOOL_NAMES,
+  connectorCatalog: [...CALENDAR_CONNECTOR_CATALOG],
   // Enable sandboxed JavaScript execution so Calendar agents can fetch,
   // paginate, and reduce provider data through providerFetch() without us
   // hardcoding one action per Google Calendar / CRM endpoint.
@@ -102,7 +104,7 @@ Google Calendar events are NOT stored in the local database. They are fetched li
 
 Provider-specific Calendar actions are shortcuts, not limits. If a first-class action cannot express the exact Google Calendar/CRM endpoint, calendar id, filter, request body, pagination mode, attendee search, recurrence field, or API version needed, call \`provider-api-catalog\` and \`provider-api-docs\` as needed, then call \`provider-api-request\` against the provider's real HTTP API. Use this raw provider API escape hatch instead of weakening the answer, broadening filters, or claiming Calendar cannot do something the underlying API can do.
 
-- \`pnpm action view-screen\` — See what the user is looking at (current view, date, events). ALWAYS run this first.
+- \`pnpm action view-screen\` — See the visible UI state (current view, date, selected event). Use it for questions about what the user is looking at, not as a prerequisite for deterministic schedule reads.
 - \`pnpm action list-events --from YYYY-MM-DD --to YYYY-MM-DD\` — List events from Google Calendar. The --to date is exclusive, so use tomorrow for today's events.
 - \`pnpm action search-events --query "term" --from YYYY-MM-DD --to YYYY-MM-DD\` — Convenience bounded search by title, attendees, organizer, location, or description. For relationship history, all-calendar discovery, exact attendee/domain search, or custom pagination, prefer provider-api-request with provider=google_calendar.
 - \`pnpm action provider-api-catalog\` / \`provider-api-docs\` / \`provider-api-request\` — Inspect and call the real Google Calendar, Apollo, Gong, HubSpot, and Pylon APIs directly. For Google Calendar events.list pagination use provider=google_calendar, path=/calendars/primary/events, query={...}, fetchAllPages={cursorPath:"nextPageToken",cursorParam:"pageToken",itemsPath:"items"}. For large relationship-history scans, pass stageAs and pagination={nextCursorPath:"nextPageToken",cursorParam:"pageToken",maxPages:N} with itemsPath="items", then use query-staged-dataset.
@@ -125,14 +127,14 @@ Provider-specific Calendar actions are shortcuts, not limits. If a first-class a
 Use \`create-event\` or \`update-event --colorId 1..11\` when the user wants one specific Google Calendar event color changed. Use \`update-calendar-visual-preferences\` when the user wants broad app-layer display rules such as color-coding meetings by internal/external, 1:1/group, focus time, or one display color for all Google events.
 
 ## Google Connection Check
-Before answering schedule questions, run view-screen first for context, then use list-events for the requested date range even if the user is currently on Settings, Booking Links, or another non-calendar page. Do not infer a Google Calendar connection problem just because the current page is Settings. Only ask the user to reconnect Google if list-events or the explicit Google status reports an auth/connection error.
+For broad, deterministic schedule reads, call list-events directly for the requested date range in inventory/coverage mode, even when UI context is irrelevant or the user is on Settings, Booking Links, or another non-calendar page. Do not require view-screen as a connection preflight, and do not infer a Google Calendar connection problem from the current screen. Only ask the user to reconnect Google if list-events or the explicit Google status reports an auth/connection error.
 
 When the user explicitly asks you to connect or reconnect Google Calendar, call \`connect-google-calendar\` and give them the returned link. Do not call raw HTTP/fetch/web-request against \`/_agent-native/google/auth-url\`; that route depends on the user's browser session and will return 401 from the agent backend.
 
 For relationship-history or frequency questions such as "who have I met at Adobe?" or "how often do I meet with Mattel?", prefer the raw Google Calendar API through provider-api-request so you can choose the exact timeMin/timeMax, q, calendarId, maxResults, and pageToken behavior. Stage large paginated results before analysis. Do not conclude there are no recurring meetings from the visible range or from a convenience action alone.
 
 ## Context Awareness
-The UI writes navigation state including the current view, date, view mode (day/week/month), and selected event ID. Always check view-screen to know what the user sees before responding.
+The UI writes navigation state including the current view, date, view mode (day/week/month), and selected event ID. Check view-screen when the answer depends on that visible state; skip it for headless inventory/coverage reads with an explicit date range.
 
 When the user says "show me", "go to", "open", or "switch to" a view or date, ALWAYS use the \`navigate\` action to update the UI first, then fetch/display data. The user expects to SEE the result in the app.`,
   mentionProviders: async () => {

--- a/templates/calendar/shared/api.ts
+++ b/templates/calendar/shared/api.ts
@@ -11,6 +11,8 @@ export interface CalendarEvent {
   location: string;
   allDay: boolean;
   source: "local" | "google" | "ical";
+  /** Stable feed/source identifier for non-Google inventory provenance. */
+  sourceId?: string;
   googleEventId?: string;
   /** Absolute Google Calendar web URL for Google events */
   htmlLink?: string;

--- a/templates/mail/AGENTS.md
+++ b/templates/mail/AGENTS.md
@@ -7,6 +7,18 @@ updates mail state through actions and application state.
 Detailed draft, queue, and contact-resolution patterns live in
 `.agents/skills/`.
 
+## Coverage-aware inventory reads
+
+`list-emails` remains the compatibility list action for the UI and internal
+callers. External MCP callers receive its structured inventory envelope by
+default (or pass `format: "inventory"`). Inventory reads use `accountEmails`
+for an explicit set; the legacy singular `account` alias cannot be combined
+with it. The response reports each account's success, empty result, exhaustion
+or bounded error, so partial coverage must never be described as complete.
+Inventory items are intentionally compact metadata only — use `get-email` or
+`get-thread` only after selecting a specific result when body content is
+needed.
+
 ## Core Rules
 
 - Store large file/blob payloads in configured file/blob storage, not SQL: no

--- a/templates/mail/actions/list-emails.spec.ts
+++ b/templates/mail/actions/list-emails.spec.ts
@@ -63,7 +63,10 @@ import {
   isConnected,
   listGmailMessages,
 } from "../server/lib/google-auth.js";
-import { getSnoozedThreadIds } from "../server/lib/jobs.js";
+import {
+  getSnoozedThreadIds,
+  getSyntheticEmailsForView,
+} from "../server/lib/jobs.js";
 import action from "./list-emails";
 
 const OWNER = "owner@example.com";
@@ -102,6 +105,7 @@ beforeEach(() => {
   vi.mocked(getConnectedAccounts).mockResolvedValue([OWNER]);
   vi.mocked(fetchGmailLabelMap).mockResolvedValue(new Map());
   vi.mocked(getSnoozedThreadIds).mockResolvedValue(new Set());
+  vi.mocked(getSyntheticEmailsForView).mockResolvedValue([]);
   mocks.getUserSetting.mockResolvedValue(null);
   mocks.cursorState = null;
   mocks.createInventoryCursor.mockImplementation(async (_owner, state) => {
@@ -213,6 +217,70 @@ describe("list-emails action — coverage-aware inventory", () => {
       EMPTY,
       FAILED,
     ]);
+  });
+
+  it("rejects an explicitly empty account selection", () => {
+    expect(
+      action.schema.safeParse({
+        format: "inventory",
+        accountEmails: [],
+      }).success,
+    ).toBe(false);
+  });
+
+  it.each(["scheduled", "snoozed"] as const)(
+    "validates %s account selection against synthetic inventory without discovering Google accounts",
+    async (view) => {
+      const SYNTHETIC = `${view}@example.com`;
+      vi.mocked(getSyntheticEmailsForView).mockResolvedValue([
+        emailFor(
+          {
+            ...rawMessage(`${view}-1`, `${view}-thread`),
+            _accountEmail: SYNTHETIC,
+          },
+          { date: "2026-07-13T14:00:00Z" },
+        ),
+      ]);
+
+      const result = (await action.run(
+        {
+          view,
+          format: "inventory",
+          accountEmails: [SYNTHETIC],
+        },
+        { caller: "mcp" } as any,
+      )) as any;
+
+      expect(result.requestedAccounts).toEqual([SYNTHETIC]);
+      expect(result.resolvedAccounts).toEqual([SYNTHETIC]);
+      expect(result.items.map((item: any) => item.id)).toEqual([`${view}-1`]);
+      expect(getConnectedAccounts).not.toHaveBeenCalled();
+      expect(listGmailMessages).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects a scheduled account absent from synthetic inventory", async () => {
+    vi.mocked(getSyntheticEmailsForView).mockResolvedValue([
+      emailFor({
+        ...rawMessage("scheduled-1", "scheduled-thread"),
+        _accountEmail: "scheduled@example.com",
+      }),
+    ]);
+
+    await expect(
+      action.run(
+        {
+          view: "scheduled",
+          format: "inventory",
+          accountEmails: ["missing@example.com"],
+        },
+        { caller: "mcp" } as any,
+      ),
+    ).rejects.toThrow(
+      "Account missing@example.com is not available in scheduled mail for this user.",
+    );
+    expect(getConnectedAccounts).not.toHaveBeenCalled();
+    expect(listGmailMessages).not.toHaveBeenCalled();
   });
 
   it("reports busy, quiet, empty, and failed accounts without silent partial coverage", async () => {

--- a/templates/mail/actions/list-emails.spec.ts
+++ b/templates/mail/actions/list-emails.spec.ts
@@ -367,6 +367,89 @@ describe("list-emails action — coverage-aware inventory", () => {
     ]);
   });
 
+  it("validates and filters plural account selection against local mail accounts", async () => {
+    const LOCAL_ONE = "local-one@example.com";
+    const LOCAL_TWO = "local-two@example.com";
+    vi.mocked(getConnectedAccounts).mockResolvedValue([]);
+    vi.mocked(isConnected).mockResolvedValue(false);
+    mocks.getUserSetting.mockResolvedValue({
+      emails: [
+        emailFor(
+          {
+            ...rawMessage("local-one", "thread-one"),
+            _accountEmail: LOCAL_ONE,
+          },
+          { date: "2026-07-13T13:00:00Z" },
+        ),
+        emailFor(
+          {
+            ...rawMessage("local-two", "thread-two"),
+            _accountEmail: LOCAL_TWO,
+          },
+          { date: "2026-07-13T12:00:00Z" },
+        ),
+      ],
+    });
+
+    const result = (await action.run(
+      { format: "inventory", accountEmails: [LOCAL_TWO] },
+      { caller: "mcp" } as any,
+    )) as any;
+
+    expect(result.requestedAccounts).toEqual([LOCAL_TWO]);
+    expect(result.resolvedAccounts).toEqual([LOCAL_TWO]);
+    expect(result.items.map((item: any) => item.id)).toEqual(["local-two"]);
+    expect(listGmailMessages).not.toHaveBeenCalled();
+  });
+
+  it("accepts singular account selection for a local mail account", async () => {
+    const LOCAL_ONE = "local-one@example.com";
+    const LOCAL_TWO = "local-two@example.com";
+    vi.mocked(getConnectedAccounts).mockResolvedValue([]);
+    vi.mocked(isConnected).mockResolvedValue(false);
+    mocks.getUserSetting.mockResolvedValue({
+      emails: [
+        emailFor({
+          ...rawMessage("local-one", "thread-one"),
+          _accountEmail: LOCAL_ONE,
+        }),
+        emailFor({
+          ...rawMessage("local-two", "thread-two"),
+          _accountEmail: LOCAL_TWO,
+        }),
+      ],
+    });
+
+    const result = (await action.run(
+      { format: "inventory", account: LOCAL_ONE },
+      { caller: "mcp" } as any,
+    )) as any;
+
+    expect(result.requestedAccounts).toEqual([LOCAL_ONE]);
+    expect(result.resolvedAccounts).toEqual([LOCAL_ONE]);
+    expect(result.items.map((item: any) => item.id)).toEqual(["local-one"]);
+  });
+
+  it("rejects an account selection absent from local mail", async () => {
+    vi.mocked(getConnectedAccounts).mockResolvedValue([]);
+    vi.mocked(isConnected).mockResolvedValue(false);
+    mocks.getUserSetting.mockResolvedValue({
+      emails: [rawMessage("local-one", "thread-one")].map((raw) =>
+        emailFor({ ...raw, _accountEmail: "local-one@example.com" }),
+      ),
+    });
+
+    await expect(
+      action.run(
+        { format: "inventory", accountEmails: ["missing@example.com"] },
+        { caller: "mcp" } as any,
+      ),
+    ).rejects.toThrow(
+      "Account missing@example.com is not available in local mail for this user.",
+    );
+    expect(listGmailMessages).not.toHaveBeenCalled();
+  });
+
   it("pages local inventory without prefix loss when OAuth is absent", async () => {
     vi.mocked(getConnectedAccounts).mockResolvedValue([]);
     vi.mocked(isConnected).mockResolvedValue(false);

--- a/templates/mail/actions/list-emails.spec.ts
+++ b/templates/mail/actions/list-emails.spec.ts
@@ -11,15 +11,38 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   getRequestUserEmail: vi.fn(),
+  getUserSetting: vi.fn(),
+  cursorState: null as any,
+  createInventoryCursor: vi.fn(),
+  claimInventoryCursor: vi.fn(),
+  settleInventoryCursorClaim: vi.fn(),
+  releaseInventoryCursorClaim: vi.fn(),
 }));
 
 vi.mock("@agent-native/core/server", () => ({
   getRequestUserEmail: mocks.getRequestUserEmail,
 }));
 
+vi.mock("@agent-native/core/settings", () => ({
+  getUserSetting: mocks.getUserSetting,
+}));
+
+vi.mock("../server/lib/inventory-cursor.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../server/lib/inventory-cursor.js")>();
+  return {
+    ...actual,
+    createInventoryCursor: mocks.createInventoryCursor,
+    claimInventoryCursor: mocks.claimInventoryCursor,
+    settleInventoryCursorClaim: mocks.settleInventoryCursorClaim,
+    releaseInventoryCursorClaim: mocks.releaseInventoryCursorClaim,
+  };
+});
+
 vi.mock("../server/lib/google-auth.js", () => ({
   isConnected: vi.fn(),
   getClients: vi.fn(),
+  getConnectedAccounts: vi.fn(),
   fetchGmailLabelMap: vi.fn(),
   // Consumed internally by the real (unmocked) shared list-inbox-emails.js core.
   DEFAULT_THREAD_RECENT_MESSAGE_CANDIDATE_LIMIT: 100,
@@ -34,6 +57,7 @@ vi.mock("../server/lib/jobs.js", () => ({
 
 import {
   fetchGmailLabelMap,
+  getConnectedAccounts,
   getClients,
   gmailToEmailMessage,
   isConnected,
@@ -75,8 +99,30 @@ beforeEach(() => {
   vi.mocked(getClients).mockResolvedValue([
     { email: OWNER, accessToken: "access-token", refreshToken: "" },
   ] as any);
+  vi.mocked(getConnectedAccounts).mockResolvedValue([OWNER]);
   vi.mocked(fetchGmailLabelMap).mockResolvedValue(new Map());
   vi.mocked(getSnoozedThreadIds).mockResolvedValue(new Set());
+  mocks.getUserSetting.mockResolvedValue(null);
+  mocks.cursorState = null;
+  mocks.createInventoryCursor.mockImplementation(async (_owner, state) => {
+    mocks.cursorState = structuredClone(state);
+    return "cursor-1";
+  });
+  mocks.claimInventoryCursor.mockImplementation(
+    async (ownerEmail, id, queryFingerprint) =>
+      id === "cursor-1" && mocks.cursorState
+        ? {
+            id,
+            claimId: "claim-1",
+            ownerEmail,
+            queryFingerprint,
+            version: 1,
+            state: structuredClone(mocks.cursorState),
+          }
+        : null,
+  );
+  mocks.settleInventoryCursorClaim.mockResolvedValue(undefined);
+  mocks.releaseInventoryCursorClaim.mockResolvedValue(undefined);
 });
 
 describe("list-emails action — Gmail-connected inbox", () => {
@@ -151,5 +197,247 @@ describe("list-emails action — Gmail-connected inbox", () => {
     await action.run({ view: "inbox" });
 
     expect(getSnoozedThreadIds).not.toHaveBeenCalled();
+  });
+});
+
+describe("list-emails action — coverage-aware inventory", () => {
+  const BUSY = "busy@example.com";
+  const QUIET = "quiet@example.com";
+  const EMPTY = "empty@example.com";
+  const FAILED = "failed@example.com";
+
+  beforeEach(() => {
+    vi.mocked(getConnectedAccounts).mockResolvedValue([
+      BUSY,
+      QUIET,
+      EMPTY,
+      FAILED,
+    ]);
+  });
+
+  it("reports busy, quiet, empty, and failed accounts without silent partial coverage", async () => {
+    const busy = rawMessage("busy-1", "busy-thread");
+    busy._accountEmail = BUSY;
+    const quiet = rawMessage("quiet-1", "quiet-thread");
+    quiet._accountEmail = QUIET;
+    vi.mocked(listGmailMessages).mockResolvedValue({
+      messages: [busy, quiet],
+      errors: [{ email: FAILED, error: "429: rateLimitExceeded" }],
+    } as any);
+    vi.mocked(gmailToEmailMessage).mockImplementation((raw: any) =>
+      emailFor(raw, {
+        date:
+          raw._accountEmail === BUSY
+            ? "2026-07-13T12:00:00Z"
+            : "2026-07-13T11:00:00Z",
+      }),
+    );
+
+    const result = (await action.run(
+      { view: "inbox", format: "inventory", limit: 10 },
+      { caller: "mcp" } as any,
+    )) as any;
+
+    expect(result.version).toBe(1);
+    expect(result.requestedAccounts).toBeNull();
+    expect(result.resolvedAccounts).toEqual([BUSY, QUIET, EMPTY, FAILED]);
+    expect(result.queriedAccounts).toEqual([BUSY, QUIET, EMPTY, FAILED]);
+    expect(result.items.map((item: any) => item.accountEmail)).toEqual([
+      BUSY,
+      QUIET,
+    ]);
+    expect(result.items.every((item: any) => !("body" in item))).toBe(true);
+    expect(result.accounts).toEqual([
+      expect.objectContaining({
+        accountEmail: BUSY,
+        status: "ok",
+        count: 1,
+        exhausted: true,
+      }),
+      expect.objectContaining({
+        accountEmail: QUIET,
+        status: "ok",
+        count: 1,
+        exhausted: true,
+      }),
+      expect.objectContaining({
+        accountEmail: EMPTY,
+        status: "ok",
+        count: 0,
+        exhausted: true,
+      }),
+      expect.objectContaining({
+        accountEmail: FAILED,
+        status: "error",
+        count: 0,
+        exhausted: false,
+        error: expect.objectContaining({
+          code: "rate_limited",
+          retryable: true,
+        }),
+      }),
+    ]);
+    expect(result.coverageComplete).toBe(false);
+    expect(result.complete).toBe(false);
+    expect(result.page).toEqual({ returned: 2, hasMore: false });
+  });
+
+  it("validates and forwards an account filter before unrelated provider work", async () => {
+    vi.mocked(listGmailMessages).mockResolvedValue({
+      messages: [],
+      errors: [],
+    } as any);
+
+    const result = (await action.run(
+      { format: "inventory", accountEmails: [QUIET] },
+      { caller: "mcp" } as any,
+    )) as any;
+
+    expect(result.requestedAccounts).toEqual([QUIET]);
+    expect(result.resolvedAccounts).toEqual([QUIET]);
+    expect(listGmailMessages).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(listGmailMessages).mock.calls[0]?.[4]).toEqual(
+      expect.objectContaining({
+        accountEmails: [QUIET],
+        threadFormat: "metadata",
+        threadRecentMessageCandidateLimit: undefined,
+      }),
+    );
+    expect(getClients).not.toHaveBeenCalled();
+    expect(fetchGmailLabelMap).not.toHaveBeenCalled();
+  });
+
+  it("accepts singular account as the inventory account alias", async () => {
+    vi.mocked(listGmailMessages).mockResolvedValue({
+      messages: [],
+      errors: [],
+    } as any);
+
+    const result = (await action.run({ format: "inventory", account: QUIET }, {
+      caller: "mcp",
+    } as any)) as any;
+
+    expect(result.requestedAccounts).toEqual([QUIET]);
+    expect(result.resolvedAccounts).toEqual([QUIET]);
+    expect(vi.mocked(listGmailMessages).mock.calls[0]?.[4]).toEqual(
+      expect.objectContaining({ accountEmails: [QUIET] }),
+    );
+  });
+
+  it("rejects ambiguous singular and plural account filters", async () => {
+    await expect(
+      action.run(
+        {
+          format: "inventory",
+          account: QUIET,
+          accountEmails: [BUSY],
+        },
+        { caller: "mcp" } as any,
+      ),
+    ).rejects.toThrow("Pass account or accountEmails, not both.");
+    expect(getConnectedAccounts).not.toHaveBeenCalled();
+  });
+
+  it("preserves account provenance when Gmail thread ids collide", async () => {
+    const fromBusy = rawMessage("busy-message", "shared-thread");
+    fromBusy._accountEmail = BUSY;
+    const fromQuiet = rawMessage("quiet-message", "shared-thread");
+    fromQuiet._accountEmail = QUIET;
+    vi.mocked(listGmailMessages).mockResolvedValue({
+      messages: [fromBusy, fromQuiet],
+      errors: [],
+    } as any);
+    vi.mocked(gmailToEmailMessage).mockImplementation((raw: any) =>
+      emailFor(raw),
+    );
+
+    const result = (await action.run(
+      {
+        format: "inventory",
+        accountEmails: [BUSY, QUIET],
+        limit: 10,
+      },
+      { caller: "mcp" } as any,
+    )) as any;
+
+    expect(result.items).toHaveLength(2);
+    expect(result.items.map((item: any) => item.accountEmail).sort()).toEqual([
+      BUSY,
+      QUIET,
+    ]);
+  });
+
+  it("pages local inventory without prefix loss when OAuth is absent", async () => {
+    vi.mocked(getConnectedAccounts).mockResolvedValue([]);
+    vi.mocked(isConnected).mockResolvedValue(false);
+    mocks.getUserSetting.mockResolvedValue({
+      emails: [
+        emailFor(rawMessage("local-3", "thread-3"), {
+          date: "2026-07-13T13:00:00Z",
+        }),
+        emailFor(rawMessage("local-2", "thread-2"), {
+          date: "2026-07-13T12:00:00Z",
+        }),
+        emailFor(rawMessage("local-1", "thread-1"), {
+          date: "2026-07-13T11:00:00Z",
+        }),
+      ],
+    });
+
+    const first = (await action.run({ format: "inventory", limit: 2 }, {
+      caller: "mcp",
+    } as any)) as any;
+    const second = (await action.run(
+      { format: "inventory", limit: 2, cursor: first.page.nextCursor },
+      { caller: "mcp" } as any,
+    )) as any;
+
+    expect(first.resolvedAccounts).toEqual([OWNER]);
+    expect(first.items.map((row: any) => row.id)).toEqual([
+      "local-3",
+      "local-2",
+    ]);
+    expect(first.page).toEqual({
+      returned: 2,
+      hasMore: true,
+      nextCursor: "cursor-1",
+    });
+    expect(second.items.map((row: any) => row.id)).toEqual(["local-1"]);
+    expect(second.complete).toBe(true);
+    expect([...first.items, ...second.items].map((row: any) => row.id)).toEqual(
+      ["local-3", "local-2", "local-1"],
+    );
+    expect(mocks.settleInventoryCursorClaim).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases a continuation lease when settlement fails", async () => {
+    vi.mocked(getConnectedAccounts).mockResolvedValue([]);
+    vi.mocked(isConnected).mockResolvedValue(false);
+    mocks.getUserSetting.mockResolvedValue({
+      emails: [
+        emailFor(rawMessage("local-2", "thread-2"), {
+          date: "2026-07-13T12:00:00Z",
+        }),
+        emailFor(rawMessage("local-1", "thread-1"), {
+          date: "2026-07-13T11:00:00Z",
+        }),
+      ],
+    });
+    const first = (await action.run({ format: "inventory", limit: 1 }, {
+      caller: "mcp",
+    } as any)) as any;
+    mocks.settleInventoryCursorClaim.mockRejectedValueOnce(
+      new Error("temporary database failure"),
+    );
+
+    await expect(
+      action.run(
+        { format: "inventory", limit: 1, cursor: first.page.nextCursor },
+        { caller: "mcp" } as any,
+      ),
+    ).rejects.toThrow("temporary database failure");
+    expect(mocks.releaseInventoryCursorClaim).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "cursor-1", claimId: "claim-1" }),
+    );
   });
 });

--- a/templates/mail/actions/list-emails.ts
+++ b/templates/mail/actions/list-emails.ts
@@ -286,6 +286,7 @@ export default defineAction({
       ),
     accountEmails: z
       .array(z.string().email())
+      .min(1)
       .optional()
       .describe(
         "Inventory only: connected account email addresses to include.",
@@ -348,32 +349,32 @@ export default defineAction({
     // from touching token state for accounts the caller did not choose.
     const requestedAccounts =
       args.accountEmails ?? (args.account ? [args.account] : undefined);
-    const connectedAccounts = inventory
-      ? await getConnectedAccounts(ownerEmail)
-      : [];
-    const connectedByLower = new Map(
-      connectedAccounts.map((email) => [email.toLowerCase(), email]),
-    );
-    const selectedAccounts =
-      inventory && connectedAccounts.length > 0
-        ? Array.from(
-            new Set(
-              (requestedAccounts ?? connectedAccounts).map((email) =>
-                email.toLowerCase(),
-              ),
-            ),
-          ).map((email) => {
-            const owned = connectedByLower.get(email);
-            if (!owned)
-              throw new Error(
-                `Account ${email} is not connected for this user.`,
-              );
-            return owned;
-          })
-        : undefined;
 
     if (view === "snoozed" || view === "scheduled") {
       let emails = await getSyntheticEmailsForView(ownerEmail, view);
+      const syntheticAccountsByLower = new Map<string, string>();
+      for (const email of emails) {
+        const accountEmail = String(email.accountEmail ?? ownerEmail);
+        syntheticAccountsByLower.set(accountEmail.toLowerCase(), accountEmail);
+      }
+      const syntheticSelectedAccounts = inventory
+        ? Array.from(
+            new Set(
+              (
+                requestedAccounts ??
+                Array.from(syntheticAccountsByLower.values())
+              ).map((email) => email.toLowerCase()),
+            ),
+          ).map((email) => {
+            const available = syntheticAccountsByLower.get(email);
+            if (!available) {
+              throw new Error(
+                `Account ${email} is not available in ${view} mail for this user.`,
+              );
+            }
+            return available;
+          })
+        : undefined;
       if (query) {
         emails = emails.filter((e) => emailMessageMatchesSearch(e, query));
       }
@@ -384,7 +385,7 @@ export default defineAction({
       }
       if (inventory) {
         const selected = new Set(
-          (selectedAccounts ?? []).map((email) => email.toLowerCase()),
+          (syntheticSelectedAccounts ?? []).map((email) => email.toLowerCase()),
         );
         if (selected.size > 0) {
           emails = emails.filter((email) =>
@@ -392,8 +393,8 @@ export default defineAction({
           );
         }
         const syntheticResolvedAccounts =
-          selectedAccounts && selectedAccounts.length > 0
-            ? selectedAccounts
+          syntheticSelectedAccounts && syntheticSelectedAccounts.length > 0
+            ? syntheticSelectedAccounts
             : Array.from(
                 new Set(
                   emails.map((email) =>
@@ -417,6 +418,30 @@ export default defineAction({
         2,
       );
     }
+
+    const connectedAccounts = inventory
+      ? await getConnectedAccounts(ownerEmail)
+      : [];
+    const connectedByLower = new Map(
+      connectedAccounts.map((email) => [email.toLowerCase(), email]),
+    );
+    const selectedAccounts =
+      inventory && connectedAccounts.length > 0
+        ? Array.from(
+            new Set(
+              (requestedAccounts ?? connectedAccounts).map((email) =>
+                email.toLowerCase(),
+              ),
+            ),
+          ).map((email) => {
+            const owned = connectedByLower.get(email);
+            if (!owned)
+              throw new Error(
+                `Account ${email} is not connected for this user.`,
+              );
+            return owned;
+          })
+        : undefined;
 
     if (
       (inventory && selectedAccounts && selectedAccounts.length > 0) ||

--- a/templates/mail/actions/list-emails.ts
+++ b/templates/mail/actions/list-emails.ts
@@ -354,20 +354,23 @@ export default defineAction({
     const connectedByLower = new Map(
       connectedAccounts.map((email) => [email.toLowerCase(), email]),
     );
-    const selectedAccounts = inventory
-      ? Array.from(
-          new Set(
-            (requestedAccounts ?? connectedAccounts).map((email) =>
-              email.toLowerCase(),
+    const selectedAccounts =
+      inventory && connectedAccounts.length > 0
+        ? Array.from(
+            new Set(
+              (requestedAccounts ?? connectedAccounts).map((email) =>
+                email.toLowerCase(),
+              ),
             ),
-          ),
-        ).map((email) => {
-          const owned = connectedByLower.get(email);
-          if (!owned)
-            throw new Error(`Account ${email} is not connected for this user.`);
-          return owned;
-        })
-      : undefined;
+          ).map((email) => {
+            const owned = connectedByLower.get(email);
+            if (!owned)
+              throw new Error(
+                `Account ${email} is not connected for this user.`,
+              );
+            return owned;
+          })
+        : undefined;
 
     if (view === "snoozed" || view === "scheduled") {
       let emails = await getSyntheticEmailsForView(ownerEmail, view);
@@ -641,6 +644,37 @@ export default defineAction({
 
     // Fallback: local store
     let emails = await readLocalEmails(ownerEmail);
+    const localAccountsByLower = new Map<string, string>();
+    for (const email of emails) {
+      const accountEmail = String(email.accountEmail ?? "local");
+      localAccountsByLower.set(accountEmail.toLowerCase(), accountEmail);
+    }
+    const localSelectedAccounts = inventory
+      ? Array.from(
+          new Set(
+            (
+              requestedAccounts ?? Array.from(localAccountsByLower.values())
+            ).map((email) => email.toLowerCase()),
+          ),
+        ).map((email) => {
+          const available = localAccountsByLower.get(email);
+          if (!available) {
+            throw new Error(
+              `Account ${email} is not available in local mail for this user.`,
+            );
+          }
+          return available;
+        })
+      : undefined;
+
+    if (localSelectedAccounts && requestedAccounts) {
+      const selected = new Set(
+        localSelectedAccounts.map((email) => email.toLowerCase()),
+      );
+      emails = emails.filter((email) =>
+        selected.has(String(email.accountEmail ?? "local").toLowerCase()),
+      );
+    }
 
     switch (view) {
       case "inbox":
@@ -692,8 +726,8 @@ export default defineAction({
 
     if (inventory) {
       const localResolvedAccounts =
-        selectedAccounts && selectedAccounts.length > 0
-          ? selectedAccounts
+        localSelectedAccounts && localSelectedAccounts.length > 0
+          ? localSelectedAccounts
           : Array.from(
               new Set(
                 emails.map((email) =>

--- a/templates/mail/actions/list-emails.ts
+++ b/templates/mail/actions/list-emails.ts
@@ -6,9 +6,24 @@ import { z } from "zod";
 
 import {
   getClients,
+  getConnectedAccounts,
   fetchGmailLabelMap,
   isConnected,
 } from "../server/lib/google-auth.js";
+import {
+  buildMailInventoryPage,
+  claimInventoryCursor,
+  compareInventoryItems,
+  createInventoryCursor,
+  inventoryQueryFingerprint,
+  releaseInventoryCursorClaim,
+  settleInventoryCursorClaim,
+  type MailInventoryError,
+  type MailInventoryFetchResult,
+  type MailInventoryItem,
+  type MailInventoryCursorState,
+  type MailInventoryCursorClaim,
+} from "../server/lib/inventory-cursor.js";
 import {
   getSnoozedThreadIds,
   getSyntheticEmailsForView,
@@ -36,6 +51,55 @@ function toCompact(emails: any[]): any[] {
     isStarred: e.isStarred,
     accountEmail: e.accountEmail,
   }));
+}
+
+function toInventoryItem(
+  email: any,
+  includeSnippet: boolean,
+): MailInventoryItem {
+  return {
+    id: String(email.id ?? "").slice(0, 256),
+    threadId: String(email.threadId ?? email.id ?? "").slice(0, 256),
+    accountEmail: String(email.accountEmail ?? "").slice(0, 320),
+    date: String(email.date ?? "").slice(0, 64),
+    from: email.from?.email
+      ? {
+          ...(email.from.name
+            ? { name: String(email.from.name).slice(0, 160) }
+            : {}),
+          email: String(email.from.email).slice(0, 320),
+        }
+      : { email: String(email.from ?? "").slice(0, 320) },
+    subject: String(email.subject ?? "").slice(0, 500),
+    isUnread: email.hasUnread ?? !email.isRead,
+    ...(email.isStarred !== undefined ? { isStarred: email.isStarred } : {}),
+    messageCount: email.messageCount ?? 1,
+    unreadCount: email.unreadCount ?? (email.isRead ? 0 : 1),
+    ...(includeSnippet && email.snippet
+      ? { snippet: String(email.snippet).slice(0, 320) }
+      : {}),
+  };
+}
+
+function inventoryError(message: unknown): MailInventoryError {
+  const bounded = String(message ?? "Provider request failed")
+    .replace(/\bBearer\s+\S+/gi, "Bearer [redacted]")
+    .replace(
+      /\b(access_token|refresh_token|id_token|token)=([^\s&]+)/gi,
+      "$1=[redacted]",
+    )
+    .slice(0, 240);
+  const rateLimited = /\b(?:429|quota|rate.?limit)\b/i.test(bounded);
+  const auth = /\b(?:401|403|auth|token|credential|permission)\b/i.test(
+    bounded,
+  );
+  return {
+    code: rateLimited ? "rate_limited" : auth ? "authentication" : "provider",
+    message: bounded,
+    retryable:
+      rateLimited ||
+      /\b(?:timeout|temporar|unavailable|5\d\d)\b/i.test(bounded),
+  };
 }
 
 function latestPerThread(emails: any[]): any[] {
@@ -85,6 +149,107 @@ function latestPerThread(emails: any[]): any[] {
     );
 }
 
+async function localInventoryEnvelope(
+  emails: any[],
+  requestedAccounts: string[] | undefined,
+  resolvedAccounts: string[],
+  query: { view: string; q?: string },
+  limit: number,
+  ownerEmail: string,
+  cursor?: string,
+) {
+  const normalizedRequested = requestedAccounts
+    ? [...new Set(requestedAccounts.map((email) => email.toLowerCase()))]
+    : null;
+  const queryFingerprint = inventoryQueryFingerprint({
+    ...query,
+    requestedAccounts: normalizedRequested,
+    limit,
+    source: "local",
+  });
+  let claim: MailInventoryCursorClaim | null = null;
+  let state: MailInventoryCursorState;
+  if (cursor) {
+    claim = await claimInventoryCursor(ownerEmail, cursor, queryFingerprint);
+    if (!claim) {
+      throw new Error(
+        "Inventory cursor is invalid, expired, or has already been used.",
+      );
+    }
+    state = claim.state;
+  } else {
+    const inventoryItems = latestPerThread(emails)
+      .map((email) =>
+        toInventoryItem(
+          {
+            ...email,
+            accountEmail: email.accountEmail ?? resolvedAccounts[0] ?? "local",
+          },
+          false,
+        ),
+      )
+      .sort(compareInventoryItems);
+    state = {
+      queryFingerprint,
+      requestedAccounts: normalizedRequested,
+      firstPage: true,
+      accounts: resolvedAccounts.map((accountEmail) => {
+        const pending = inventoryItems.filter(
+          (item) =>
+            item.accountEmail.toLowerCase() === accountEmail.toLowerCase(),
+        );
+        return {
+          accountEmail,
+          status: "ok" as const,
+          exhausted: true,
+          pending,
+          emittedCount: 0,
+          knownCount: pending.length,
+          emittedThreadIds: [],
+        };
+      }),
+    };
+  }
+
+  try {
+    const { items, hasMore } = await buildMailInventoryPage(
+      state,
+      limit,
+      async () => ({ items: [], errors: {}, nextPageTokens: {} }),
+    );
+    const nextCursor = claim
+      ? await settleInventoryCursorClaim(claim, state, hasMore)
+      : hasMore
+        ? await createInventoryCursor(ownerEmail, state)
+        : undefined;
+    return {
+      version: 1,
+      query,
+      requestedAccounts: state.requestedAccounts,
+      resolvedAccounts: state.accounts.map((account) => account.accountEmail),
+      queriedAccounts: state.accounts.map((account) => account.accountEmail),
+      accounts: state.accounts.map((account) => ({
+        accountEmail: account.accountEmail,
+        status: account.status,
+        count: account.knownCount ?? account.emittedCount,
+        emittedCount: account.emittedCount,
+        exhausted: account.exhausted && account.pending.length === 0,
+      })),
+      coverageComplete: true,
+      complete: !hasMore,
+      items,
+      page: {
+        returned: items.length,
+        hasMore,
+        ...(nextCursor ? { nextCursor } : {}),
+      },
+    };
+  } catch (error) {
+    if (claim) await releaseInventoryCursorClaim(claim);
+    throw error;
+  }
+}
+
 async function readLocalEmails(ownerEmail: string): Promise<any[]> {
   const data = await getUserSetting(ownerEmail, "local-emails");
   if (data && Array.isArray((data as any).emails)) {
@@ -112,13 +277,26 @@ export default defineAction({
       ])
       .optional()
       .describe("View to list (default: inbox)"),
-    q: z.string().optional().describe("Full-text search query"),
+    q: z.string().max(500).optional().describe("Full-text search query"),
     account: z
       .string()
       .optional()
       .describe(
         "Filter to a specific account email address. By default searches all connected accounts.",
       ),
+    accountEmails: z
+      .array(z.string().email())
+      .optional()
+      .describe(
+        "Inventory only: connected account email addresses to include.",
+      ),
+    format: z
+      .enum(["legacy", "inventory"])
+      .optional()
+      .describe(
+        "Use inventory for a coverage-aware compact multi-account read.",
+      ),
+    cursor: z.string().max(256).optional().describe("Inventory page cursor."),
     limit: z.coerce
       .number()
       .optional()
@@ -146,7 +324,7 @@ export default defineAction({
       view,
     };
   },
-  run: async (args) => {
+  run: async (args, ctx) => {
     const view = args.view ?? "inbox";
     const query = args.q;
     const limit = args.limit ?? 50;
@@ -155,6 +333,41 @@ export default defineAction({
     const accountFilter = args.account?.toLowerCase();
     const ownerEmail = getRequestUserEmail();
     if (!ownerEmail) throw new Error("no authenticated user");
+    if (args.account && args.accountEmails) {
+      throw new Error("Pass account or accountEmails, not both.");
+    }
+    const inventory =
+      args.format === "inventory" ||
+      (ctx?.caller === "mcp" && args.format === undefined);
+    if (inventory && (!Number.isInteger(limit) || limit < 1 || limit > 100)) {
+      throw new Error("Inventory limit must be an integer from 1 through 100.");
+    }
+
+    // Inventory is deliberately resolved before any refresh/list call. Apart
+    // from preventing a cross-account data leak, this keeps a selected read
+    // from touching token state for accounts the caller did not choose.
+    const requestedAccounts =
+      args.accountEmails ?? (args.account ? [args.account] : undefined);
+    const connectedAccounts = inventory
+      ? await getConnectedAccounts(ownerEmail)
+      : [];
+    const connectedByLower = new Map(
+      connectedAccounts.map((email) => [email.toLowerCase(), email]),
+    );
+    const selectedAccounts = inventory
+      ? Array.from(
+          new Set(
+            (requestedAccounts ?? connectedAccounts).map((email) =>
+              email.toLowerCase(),
+            ),
+          ),
+        ).map((email) => {
+          const owned = connectedByLower.get(email);
+          if (!owned)
+            throw new Error(`Account ${email} is not connected for this user.`);
+          return owned;
+        })
+      : undefined;
 
     if (view === "snoozed" || view === "scheduled") {
       let emails = await getSyntheticEmailsForView(ownerEmail, view);
@@ -166,6 +379,35 @@ export default defineAction({
           (e) => e.accountEmail?.toLowerCase() === accountFilter,
         );
       }
+      if (inventory) {
+        const selected = new Set(
+          (selectedAccounts ?? []).map((email) => email.toLowerCase()),
+        );
+        if (selected.size > 0) {
+          emails = emails.filter((email) =>
+            selected.has(String(email.accountEmail ?? "").toLowerCase()),
+          );
+        }
+        const syntheticResolvedAccounts =
+          selectedAccounts && selectedAccounts.length > 0
+            ? selectedAccounts
+            : Array.from(
+                new Set(
+                  emails.map((email) =>
+                    String(email.accountEmail ?? ownerEmail).toLowerCase(),
+                  ),
+                ),
+              );
+        return await localInventoryEnvelope(
+          emails,
+          requestedAccounts,
+          syntheticResolvedAccounts,
+          { view, ...(query ? { q: query } : {}) },
+          limit,
+          ownerEmail,
+          args.cursor,
+        );
+      }
       return JSON.stringify(
         compact ? toCompact(emails.slice(0, limit)) : emails.slice(0, limit),
         null,
@@ -173,8 +415,168 @@ export default defineAction({
       );
     }
 
-    if (await isConnected(ownerEmail)) {
-      const clients = await getClients(ownerEmail);
+    if (
+      (inventory && selectedAccounts && selectedAccounts.length > 0) ||
+      (!inventory && (await isConnected(ownerEmail)))
+    ) {
+      const inventoryAccounts = selectedAccounts ?? [];
+      const clients = inventory
+        ? inventoryAccounts.map((email) => ({
+            email,
+            accessToken: "",
+            refreshToken: "",
+          }))
+        : await getClients(ownerEmail);
+      if (inventory) {
+        const normalizedRequested = requestedAccounts
+          ? [...new Set(requestedAccounts.map((email) => email.toLowerCase()))]
+          : null;
+        const queryFingerprint = inventoryQueryFingerprint({
+          view,
+          q: query ?? null,
+          requestedAccounts: normalizedRequested,
+          limit,
+        });
+        let cursorState: MailInventoryCursorState;
+        let cursorClaim: MailInventoryCursorClaim | null = null;
+        if (args.cursor) {
+          const claimed = await claimInventoryCursor(
+            ownerEmail,
+            args.cursor,
+            queryFingerprint,
+          );
+          if (!claimed) {
+            throw new Error(
+              "Inventory cursor is invalid, expired, or has already been used.",
+            );
+          }
+          cursorClaim = claimed;
+          cursorState = claimed.state;
+        } else {
+          cursorState = {
+            queryFingerprint,
+            requestedAccounts: normalizedRequested,
+            firstPage: true,
+            accounts: inventoryAccounts.map((accountEmail) => ({
+              accountEmail,
+              status: "ok",
+              exhausted: false,
+              pending: [],
+              emittedCount: 0,
+              knownCount: 0,
+              emittedThreadIds: [],
+            })),
+          };
+        }
+
+        const fetchInventory = async (
+          requests: Array<{ accountEmail: string; pageToken?: string }>,
+        ): Promise<MailInventoryFetchResult> => {
+          const accountEmails = requests.map((request) => request.accountEmail);
+          const pageTokens = Object.fromEntries(
+            requests
+              .filter((request) => request.pageToken)
+              .map((request) => [request.accountEmail, request.pageToken!]),
+          );
+          const listResult = await listInboxEmails({
+            ownerEmail,
+            view,
+            q: query,
+            limit,
+            pageTokens:
+              Object.keys(pageTokens).length > 0 ? pageTokens : undefined,
+            threadFormat: "metadata",
+            includeRecentMessageCandidates: false,
+            accountTokens: accountEmails.map((email) => ({
+              email,
+              accessToken: "",
+            })),
+            accountEmails,
+            labelMap: new Map(),
+          });
+          if (!listResult.ok) {
+            return {
+              items: [],
+              errors: Object.fromEntries(
+                accountEmails.map((email) => [
+                  email.toLowerCase(),
+                  inventoryError(listResult.message),
+                ]),
+              ),
+              nextPageTokens: {},
+            };
+          }
+          return {
+            items: latestPerThread(listResult.emails).map((email) =>
+              toInventoryItem(email, false),
+            ),
+            errors: Object.fromEntries(
+              listResult.errors.map((error) => [
+                error.email.toLowerCase(),
+                inventoryError(error.error),
+              ]),
+            ),
+            nextPageTokens: Object.fromEntries(
+              Object.entries(listResult.nextPageTokens ?? {}).map(
+                ([email, token]) => [email.toLowerCase(), token],
+              ),
+            ),
+          };
+        };
+
+        try {
+          const { items, hasMore } = await buildMailInventoryPage(
+            cursorState,
+            limit,
+            fetchInventory,
+          );
+          const nextCursor = cursorClaim
+            ? await settleInventoryCursorClaim(
+                cursorClaim,
+                cursorState,
+                hasMore,
+              )
+            : hasMore
+              ? await createInventoryCursor(ownerEmail, cursorState)
+              : undefined;
+          const coverageComplete = cursorState.accounts.every(
+            (account) => account.status === "ok",
+          );
+          return {
+            version: 1,
+            query: { view, ...(query ? { q: query } : {}) },
+            requestedAccounts: cursorState.requestedAccounts,
+            resolvedAccounts: cursorState.accounts.map(
+              (account) => account.accountEmail,
+            ),
+            queriedAccounts: cursorState.accounts.map(
+              (account) => account.accountEmail,
+            ),
+            accounts: cursorState.accounts.map((account) => ({
+              accountEmail: account.accountEmail,
+              status: account.status,
+              count: account.knownCount ?? account.emittedCount,
+              emittedCount: account.emittedCount,
+              exhausted:
+                account.status === "ok" &&
+                account.exhausted &&
+                account.pending.length === 0,
+              ...(account.error ? { error: account.error } : {}),
+            })),
+            coverageComplete,
+            complete: coverageComplete && !hasMore,
+            items,
+            page: {
+              returned: items.length,
+              hasMore,
+              ...(nextCursor ? { nextCursor } : {}),
+            },
+          };
+        } catch (error) {
+          if (cursorClaim) await releaseInventoryCursorClaim(cursorClaim);
+          throw error;
+        }
+      }
       const labelMap = new Map<string, string>();
       await Promise.all(
         clients.map(async ({ accessToken }) => {
@@ -288,6 +690,27 @@ export default defineAction({
       }
     }
 
+    if (inventory) {
+      const localResolvedAccounts =
+        selectedAccounts && selectedAccounts.length > 0
+          ? selectedAccounts
+          : Array.from(
+              new Set(
+                emails.map((email) =>
+                  String(email.accountEmail ?? "local").toLowerCase(),
+                ),
+              ),
+            );
+      return await localInventoryEnvelope(
+        emails,
+        requestedAccounts,
+        localResolvedAccounts,
+        { view, ...(query ? { q: query } : {}) },
+        limit,
+        ownerEmail,
+        args.cursor,
+      );
+    }
     emails = latestPerThread(emails).slice(0, limit);
     const payload = compact ? toCompact(emails) : emails;
     if (includeCounts) {

--- a/templates/mail/changelog/2026-07-13-coverage-aware-connected-inbox-inventory.md
+++ b/templates/mail/changelog/2026-07-13-coverage-aware-connected-inbox-inventory.md
@@ -3,4 +3,4 @@ type: added
 date: 2026-07-13
 ---
 
-Mail can now return a compact coverage-aware inventory across selected connected inboxes.
+Mail can now return a compact coverage-aware direct inventory across selected connected inboxes.

--- a/templates/mail/changelog/2026-07-13-coverage-aware-connected-inbox-inventory.md
+++ b/templates/mail/changelog/2026-07-13-coverage-aware-connected-inbox-inventory.md
@@ -1,0 +1,6 @@
+---
+type: added
+date: 2026-07-13
+---
+
+Mail can now return a compact coverage-aware inventory across selected connected inboxes.

--- a/templates/mail/server/db/schema.ts
+++ b/templates/mail/server/db/schema.ts
@@ -1,5 +1,22 @@
 import { table, text, integer } from "@agent-native/core/db/schema";
 
+/**
+ * Short-lived, owner-scoped continuation state for the external Mail
+ * inventory. It intentionally contains compact metadata only; credentials,
+ * bodies, HTML and attachments never enter this table.
+ */
+export const mailInventoryCursors = table("mail_inventory_cursors", {
+  id: text("id").primaryKey(),
+  ownerEmail: text("owner_email").notNull(),
+  queryFingerprint: text("query_fingerprint").notNull(),
+  state: text("state").notNull(),
+  version: integer("version").notNull().default(1),
+  claimId: text("claim_id"),
+  claimedAt: integer("claimed_at"),
+  expiresAt: integer("expires_at").notNull(),
+  updatedAt: integer("updated_at").notNull(),
+});
+
 export const scheduledJobs = table("scheduled_jobs", {
   id: text("id").primaryKey(),
   type: text("type", { enum: ["snooze", "send_later"] }).notNull(),

--- a/templates/mail/server/lib/google-auth.spec.ts
+++ b/templates/mail/server/lib/google-auth.spec.ts
@@ -117,6 +117,52 @@ describe("listGmailMessages", () => {
     expect(result.resultSizeEstimate).toBe(12);
   });
 
+  it("keeps a four-account metadata inventory to eight provider reads", async () => {
+    const accounts = ["a", "b", "c", "d"].map((name) => ({
+      accountId: `${name}@example.com`,
+      owner: "owner@example.com",
+      tokens: {
+        access_token: `${name}-token`,
+        refresh_token: `${name}-refresh`,
+        expiry_date: Date.now() + 60 * 60 * 1000,
+      },
+    }));
+    vi.mocked(listOAuthAccountsByOwner).mockResolvedValue(accounts as any);
+    vi.mocked(gmailListThreads).mockImplementation(async (token: string) => ({
+      threads: [{ id: `${token}-thread` }],
+    }));
+    vi.mocked(gmailBatchGetThreads).mockImplementation(
+      async (_token: string, ids: string[]) =>
+        ids.map((id) => ({
+          id,
+          data: { messages: [{ id: `${id}-message`, threadId: id }] },
+        })) as any,
+    );
+
+    const result = await listGmailMessages(
+      "in:inbox",
+      10,
+      "owner@example.com",
+      undefined,
+      {
+        mode: "threads",
+        threadFormat: "metadata",
+        accountEmails: accounts.map((account) => account.accountId),
+      },
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.messages).toHaveLength(4);
+    expect(gmailListThreads).toHaveBeenCalledTimes(4);
+    expect(gmailBatchGetThreads).toHaveBeenCalledTimes(4);
+    expect(
+      vi
+        .mocked(gmailBatchGetThreads)
+        .mock.calls.every(([, , format]) => format === "metadata"),
+    ).toBe(true);
+    expect(gmailListMessagesApi).not.toHaveBeenCalled();
+  });
+
   it("uses recent message candidates so old inbox threads with fresh replies can lead normal pages", async () => {
     vi.mocked(gmailListThreads).mockResolvedValue({
       threads: [{ id: "thread-old" }, { id: "thread-other" }],
@@ -427,6 +473,32 @@ describe("listGmailMessages", () => {
     expect(result.messages.map((m) => m.id)).toEqual(["refilled"]);
   });
 
+  it("marks an account failed when missing thread metadata cannot be refilled", async () => {
+    vi.mocked(gmailListThreads).mockResolvedValue({
+      threads: [{ id: "thread-missing" }],
+    } as any);
+    vi.mocked(gmailBatchGetThreads).mockResolvedValue([
+      { id: "thread-missing", data: null, error: "No response part" },
+    ] as any);
+    vi.mocked(gmailGetThread).mockRejectedValue(new Error("still missing"));
+
+    const result = await listGmailMessages(
+      "missing-case",
+      1,
+      "owner@example.com",
+      undefined,
+      { mode: "threads", threadFormat: "metadata" },
+    );
+
+    expect(result.messages).toEqual([]);
+    expect(result.errors).toEqual([
+      {
+        email: "connected@example.com",
+        error: "Gmail thread metadata response was incomplete",
+      },
+    ]);
+  });
+
   it("keeps default inbox and explicit all-mail thread pages separate in the list cache", async () => {
     vi.mocked(gmailListThreads).mockResolvedValue({
       threads: [],
@@ -488,6 +560,41 @@ describe("getClientsWithErrors with unusable token records", () => {
         error: expect.stringContaining("please reconnect"),
       },
     ]);
+    expect(deleteOAuthTokens).not.toHaveBeenCalled();
+  });
+
+  it("filters selected accounts before token validation or refresh", async () => {
+    vi.mocked(listOAuthAccountsByOwner).mockResolvedValue([
+      {
+        accountId: "unrelated@example.com",
+        owner: "owner@example.com",
+        tokens: {},
+      },
+      {
+        accountId: "selected@example.com",
+        owner: "owner@example.com",
+        tokens: {
+          access_token: "selected-token",
+          refresh_token: "selected-refresh",
+          expiry_date: Date.now() + 60 * 60 * 1000,
+        },
+      },
+    ] as any);
+
+    const result = await getClientsWithErrors("owner@example.com", [
+      "SELECTED@example.com",
+    ]);
+
+    expect(result).toEqual({
+      clients: [
+        {
+          email: "selected@example.com",
+          accessToken: "selected-token",
+          refreshToken: "selected-refresh",
+        },
+      ],
+      errors: [],
+    });
     expect(deleteOAuthTokens).not.toHaveBeenCalled();
   });
 });

--- a/templates/mail/server/lib/google-auth.ts
+++ b/templates/mail/server/lib/google-auth.ts
@@ -375,12 +375,23 @@ export async function getClients(
  * handler uses this to return a 502 with the underlying reason instead
  * of silently rendering an empty inbox.
  */
-export async function getClientsWithErrors(forEmail?: string): Promise<{
+export async function getClientsWithErrors(
+  forEmail?: string,
+  accountEmails?: string[],
+): Promise<{
   clients: Array<{ email: string; accessToken: string; refreshToken: string }>;
   errors: Array<{ email: string; error: string }>;
 }> {
   if (!forEmail) return { clients: [], errors: [] };
-  const accounts = await listOAuthAccountsByOwner("google", forEmail);
+  const requested = accountEmails
+    ? new Set(accountEmails.map((email) => email.toLowerCase()))
+    : null;
+  // Filtering happens before getValidAccessToken. This is important: token
+  // refreshes are writes and an explicitly scoped inventory read must not
+  // refresh unrelated accounts.
+  const accounts = (await listOAuthAccountsByOwner("google", forEmail)).filter(
+    (account) => !requested || requested.has(account.accountId.toLowerCase()),
+  );
 
   const clients: Array<{
     email: string;
@@ -571,6 +582,13 @@ type ListOptions = {
    * without hydrating a large metadata ranking window on every inbox poll.
    */
   threadRecentMessageCandidateLimit?: number;
+  /**
+   * Restrict this read before OAuth refreshes or provider calls.  This is
+   * deliberately an account-id allow-list rather than a post-fetch filter:
+   * a Mail user can have several connected inboxes and an explicitly scoped
+   * read must not wake up the others.
+   */
+  accountEmails?: string[];
 };
 
 const LIST_CACHE_TTL = 45_000;
@@ -791,6 +809,10 @@ async function fetchThreadBatchWithRefill(
     }
   }
 
+  if (batchResults.some((result) => !result.data)) {
+    throw new Error("Gmail thread metadata response was incomplete");
+  }
+
   return batchResults;
 }
 
@@ -852,7 +874,11 @@ function listCacheKey(
         .join("|")
     : "";
   const queryPart = query === undefined ? "<default>" : query;
-  return `${forEmail ?? ""}::${queryPart}::${maxResults}::${tokenPart}::${options?.mode ?? "messages"}::${options?.threadFormat ?? ""}::${options?.messageFormat ?? ""}::${options?.threadCandidateLimit ?? ""}::${options?.threadRecentMessageCandidateLimit ?? ""}`;
+  const accounts = options?.accountEmails
+    ?.map((email) => email.toLowerCase())
+    .sort()
+    .join(",");
+  return `${forEmail ?? ""}::${queryPart}::${maxResults}::${tokenPart}::${options?.mode ?? "messages"}::${options?.threadFormat ?? ""}::${options?.messageFormat ?? ""}::${options?.threadCandidateLimit ?? ""}::${options?.threadRecentMessageCandidateLimit ?? ""}::${accounts ?? ""}`;
 }
 
 export async function listGmailMessages(
@@ -1542,8 +1568,10 @@ async function listGmailMessagesUncached(
   pageTokens?: Record<string, string>,
   options?: ListOptions,
 ): Promise<ListResult> {
-  const { clients, errors: refreshErrors } =
-    await getClientsWithErrors(forEmail);
+  const { clients, errors: refreshErrors } = await getClientsWithErrors(
+    forEmail,
+    options?.accountEmails,
+  );
   // Seed the per-fetch error list with refresh failures so a fully-dead
   // connection (every account's refresh_token revoked or invalidated by a
   // GOOGLE_CLIENT_ID rotation) reaches the handler — otherwise the list

--- a/templates/mail/server/lib/inventory-cursor.spec.ts
+++ b/templates/mail/server/lib/inventory-cursor.spec.ts
@@ -1,0 +1,385 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMock = vi.hoisted(() => {
+  const updateReturns: any[][] = [];
+  const deleteReturns: any[][] = [];
+  const updateWhere = vi.fn(() => ({
+    returning: vi.fn(async () => updateReturns.shift() ?? []),
+  }));
+  const updateSet = vi.fn(() => ({ where: updateWhere }));
+  const updateFn = vi.fn(() => ({ set: updateSet }));
+  const deleteReturning = vi.fn(async () => deleteReturns.shift() ?? []);
+  const deleteWhere = vi.fn(() => ({ returning: deleteReturning }));
+  const deleteFn = vi.fn(() => ({ where: deleteWhere }));
+  const insertValues = vi.fn(async () => undefined);
+  const insertFn = vi.fn(() => ({ values: insertValues }));
+  const db = {
+    update: updateFn,
+    delete: deleteFn,
+    insert: insertFn,
+    transaction: vi.fn(async (fn: (tx: any) => unknown) => fn(db)),
+  };
+  return {
+    updateReturns,
+    deleteReturns,
+    updateWhere,
+    updateSet,
+    updateFn,
+    deleteReturning,
+    deleteWhere,
+    deleteFn,
+    insertValues,
+    insertFn,
+    db,
+    getDb: vi.fn(() => db),
+  };
+});
+
+vi.mock("../db/index.js", () => ({ getDb: dbMock.getDb }));
+
+import {
+  buildMailInventoryPage,
+  claimInventoryCursor,
+  inventoryQueryFingerprint,
+  releaseInventoryCursorClaim,
+  settleInventoryCursorClaim,
+  type MailInventoryCursorState,
+  type MailInventoryItem,
+} from "./inventory-cursor.js";
+
+function item(
+  id: string,
+  accountEmail: string,
+  date: string,
+): MailInventoryItem {
+  return {
+    id,
+    threadId: `${id}-thread`,
+    accountEmail,
+    date,
+    from: { email: "sender@example.com" },
+    subject: id,
+    isUnread: true,
+    messageCount: 1,
+    unreadCount: 1,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbMock.updateReturns.length = 0;
+  dbMock.deleteReturns.length = 0;
+});
+
+describe("mail inventory merge", () => {
+  it("globally orders busy and quiet accounts and exhausts every row exactly once", async () => {
+    const busy = "busy@example.com";
+    const quiet = "quiet@example.com";
+    const state: MailInventoryCursorState = {
+      queryFingerprint: "query",
+      requestedAccounts: null,
+      firstPage: true,
+      accounts: [busy, quiet].map((accountEmail) => ({
+        accountEmail,
+        status: "ok" as const,
+        exhausted: false,
+        pending: [],
+        emittedCount: 0,
+      })),
+    };
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        items: [
+          item("busy-3", busy, "2026-07-13T13:00:00Z"),
+          item("busy-2", busy, "2026-07-13T12:00:00Z"),
+          item("quiet-1", quiet, "2026-07-13T10:00:00Z"),
+        ],
+        errors: {},
+        nextPageTokens: { [busy]: "busy-next" },
+      })
+      .mockResolvedValueOnce({
+        items: [item("busy-1", busy, "2026-07-13T11:00:00Z")],
+        errors: {},
+        nextPageTokens: {},
+      });
+
+    const first = await buildMailInventoryPage(state, 2, fetch);
+    const second = await buildMailInventoryPage(state, 2, fetch);
+    const ids = [...first.items, ...second.items].map((row) => row.id);
+
+    expect(first.items.map((row) => row.id)).toEqual(["busy-3", "busy-2"]);
+    expect(first.hasMore).toBe(true);
+    expect(second.hasMore).toBe(false);
+    expect(ids).toHaveLength(new Set(ids).size);
+    expect(ids.sort()).toEqual(["busy-1", "busy-2", "busy-3", "quiet-1"]);
+    expect(fetch).toHaveBeenNthCalledWith(2, [
+      { accountEmail: busy, pageToken: "busy-next" },
+    ]);
+    expect(state.accounts).toEqual([
+      expect.objectContaining({
+        accountEmail: busy,
+        exhausted: true,
+        emittedCount: 3,
+      }),
+      expect.objectContaining({
+        accountEmail: quiet,
+        exhausted: true,
+        emittedCount: 1,
+      }),
+    ]);
+  });
+
+  it("refills every empty frontier before choosing the next global row", async () => {
+    const accounts = [
+      "a@example.com",
+      "b@example.com",
+      "c@example.com",
+      "d@example.com",
+    ];
+    const state: MailInventoryCursorState = {
+      queryFingerprint: "query",
+      requestedAccounts: null,
+      firstPage: true,
+      accounts: accounts.map((accountEmail) => ({
+        accountEmail,
+        status: "ok",
+        exhausted: false,
+        pending: [],
+        emittedCount: 0,
+        emittedThreadIds: [],
+      })),
+    };
+    const pages: Record<string, MailInventoryItem[][]> = {
+      [accounts[0]]: [
+        [item("a4", accounts[0], "2026-07-13T14:00:00Z")],
+        [item("a2", accounts[0], "2026-07-13T12:00:00Z")],
+      ],
+      [accounts[1]]: [[item("b3", accounts[1], "2026-07-13T13:00:00Z")]],
+      [accounts[2]]: [[]],
+      [accounts[3]]: [[item("d1", accounts[3], "2026-07-13T11:00:00Z")]],
+    };
+    const positions = new Map<string, number>();
+    const fetch = vi.fn(async (requests: Array<{ accountEmail: string }>) => {
+      const rows: MailInventoryItem[] = [];
+      const nextPageTokens: Record<string, string> = {};
+      for (const request of requests) {
+        const position = positions.get(request.accountEmail) ?? 0;
+        rows.push(...(pages[request.accountEmail]?.[position] ?? []));
+        positions.set(request.accountEmail, position + 1);
+        if (position + 1 < (pages[request.accountEmail]?.length ?? 0)) {
+          nextPageTokens[request.accountEmail] = `page-${position + 1}`;
+        }
+      }
+      return { items: rows, errors: {}, nextPageTokens };
+    });
+
+    const emitted: MailInventoryItem[] = [];
+    while (true) {
+      const page = await buildMailInventoryPage(state, 1, fetch);
+      emitted.push(...page.items);
+      if (!page.hasMore) break;
+    }
+
+    expect(emitted.map((row) => row.id)).toEqual(["a4", "b3", "a2", "d1"]);
+    expect(
+      new Set(emitted.map((row) => `${row.accountEmail}:${row.threadId}`)).size,
+    ).toBe(4);
+    expect(state.accounts.map((account) => account.knownCount ?? 0)).toEqual([
+      2, 1, 0, 1,
+    ]);
+  });
+
+  it("binds a fingerprint to nested query values independent of key order", () => {
+    const fingerprint = inventoryQueryFingerprint({
+      query: { view: "inbox", q: null },
+      accounts: ["a@example.com"],
+    });
+    expect(fingerprint).toHaveLength(64);
+    expect(fingerprint).toBe(
+      inventoryQueryFingerprint({
+        accounts: ["a@example.com"],
+        query: { q: null, view: "inbox" },
+      }),
+    );
+  });
+
+  it("reports an unknown frontier after four empty provider pages", async () => {
+    const accountEmail = "empty-pages@example.com";
+    const state: MailInventoryCursorState = {
+      queryFingerprint: "query",
+      requestedAccounts: null,
+      firstPage: true,
+      accounts: [
+        {
+          accountEmail,
+          status: "ok",
+          exhausted: false,
+          pending: [],
+          emittedCount: 0,
+        },
+      ],
+    };
+    let page = 0;
+    const fetch = vi.fn(async () => ({
+      items: [],
+      errors: {},
+      nextPageTokens: { [accountEmail]: `next-${++page}` },
+    }));
+
+    const result = await buildMailInventoryPage(state, 10, fetch);
+
+    expect(result).toEqual({ items: [], hasMore: false });
+    expect(fetch).toHaveBeenCalledTimes(4);
+    expect(state.accounts[0]).toEqual(
+      expect.objectContaining({
+        status: "error",
+        exhausted: true,
+        error: expect.objectContaining({
+          code: "pagination_limit",
+          retryable: true,
+        }),
+      }),
+    );
+  });
+
+  it("does not re-emit a thread repeated by a later provider page", async () => {
+    const accountEmail = "busy@example.com";
+    const repeated = item("repeated", accountEmail, "2026-07-13T13:00:00Z");
+    const state: MailInventoryCursorState = {
+      queryFingerprint: "query",
+      requestedAccounts: null,
+      firstPage: true,
+      accounts: [
+        {
+          accountEmail,
+          status: "ok",
+          exhausted: false,
+          pending: [],
+          emittedCount: 0,
+          emittedThreadIds: [],
+        },
+      ],
+    };
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        items: [repeated],
+        errors: {},
+        nextPageTokens: { [accountEmail]: "next" },
+      })
+      .mockResolvedValueOnce({
+        items: [repeated, item("new", accountEmail, "2026-07-13T12:00:00Z")],
+        errors: {},
+        nextPageTokens: {},
+      });
+
+    const first = await buildMailInventoryPage(state, 1, fetch);
+    const second = await buildMailInventoryPage(state, 2, fetch);
+
+    expect([...first.items, ...second.items].map((row) => row.id)).toEqual([
+      "repeated",
+      "new",
+    ]);
+    expect(state.accounts[0]?.emittedCount).toBe(2);
+  });
+});
+
+describe("mail inventory cursor claim", () => {
+  it("allows only one concurrent owner/query/expiry-bound lease", async () => {
+    const state: MailInventoryCursorState = {
+      queryFingerprint: "query",
+      requestedAccounts: null,
+      firstPage: false,
+      accounts: [],
+    };
+    dbMock.updateReturns.push(
+      [
+        {
+          state: JSON.stringify(state),
+          expiresAt: Date.now() + 60_000,
+          version: 3,
+        },
+      ],
+      [],
+    );
+
+    const claims = await Promise.all([
+      claimInventoryCursor("owner@example.com", "cursor", "query"),
+      claimInventoryCursor("owner@example.com", "cursor", "query"),
+    ]);
+
+    expect(claims.filter(Boolean)).toHaveLength(1);
+    expect(claims.filter((claim) => claim === null)).toHaveLength(1);
+    expect(dbMock.updateFn).toHaveBeenCalledTimes(2);
+    expect(claims[0]).toEqual(
+      expect.objectContaining({
+        ownerEmail: "owner@example.com",
+        queryFingerprint: "query",
+        version: 3,
+        state,
+      }),
+    );
+  });
+
+  it("rejects an expired lease candidate", async () => {
+    dbMock.updateReturns.push([
+      { state: "{}", expiresAt: Date.now() - 1, version: 1 },
+    ]);
+    await expect(
+      claimInventoryCursor("owner@example.com", "cursor", "query"),
+    ).resolves.toBeNull();
+  });
+
+  it("releases a transient failure with the exact lease witness", async () => {
+    const claim = {
+      id: "cursor",
+      claimId: "claim",
+      ownerEmail: "owner@example.com",
+      queryFingerprint: "query",
+      version: 2,
+      state: {
+        queryFingerprint: "query",
+        requestedAccounts: null,
+        firstPage: false,
+        accounts: [],
+      },
+    };
+    await releaseInventoryCursorClaim(claim);
+    expect(dbMock.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ claimId: null, claimedAt: null }),
+    );
+  });
+
+  it("settles a consumed lease into a distinct successor", async () => {
+    const state: MailInventoryCursorState = {
+      queryFingerprint: "query",
+      requestedAccounts: null,
+      firstPage: false,
+      accounts: [],
+    };
+    const claim = {
+      id: "cursor",
+      claimId: "claim",
+      ownerEmail: "owner@example.com",
+      queryFingerprint: "query",
+      version: 4,
+      state,
+    };
+    dbMock.deleteReturns.push([{ id: "cursor" }]);
+
+    const successor = await settleInventoryCursorClaim(claim, state, true);
+
+    expect(successor).toEqual(expect.any(String));
+    expect(successor).not.toBe("cursor");
+    expect(dbMock.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: successor,
+        ownerEmail: "owner@example.com",
+        queryFingerprint: "query",
+        version: 5,
+        claimId: null,
+      }),
+    );
+  });
+});

--- a/templates/mail/server/lib/inventory-cursor.ts
+++ b/templates/mail/server/lib/inventory-cursor.ts
@@ -1,0 +1,406 @@
+import { createHash } from "node:crypto";
+
+import { and, eq, gt, lt, or, sql } from "drizzle-orm";
+
+import { getDb } from "../db/index.js";
+import { mailInventoryCursors } from "../db/schema.js";
+
+const TTL_MS = 10 * 60 * 1000;
+const CLAIM_TTL_MS = 60 * 1000;
+const PAGE_ITEMS_BUDGET_BYTES = 12 * 1024;
+
+export interface MailInventoryItem {
+  id: string;
+  threadId: string;
+  accountEmail: string;
+  date: string;
+  from: { name?: string; email: string };
+  subject: string;
+  isUnread: boolean;
+  isStarred?: boolean;
+  messageCount: number;
+  unreadCount: number;
+  snippet?: string;
+}
+
+export interface MailInventoryError {
+  code: string;
+  message: string;
+  retryable: boolean;
+}
+
+export interface MailInventoryAccountState {
+  accountEmail: string;
+  status: "ok" | "error";
+  error?: MailInventoryError;
+  providerPageToken?: string;
+  exhausted: boolean;
+  pending: MailInventoryItem[];
+  emittedCount: number;
+  /** Unique rows discovered so coverage remains visible before emission. */
+  knownCount?: number;
+  /** Account-local thread ids already emitted by an earlier output page. */
+  emittedThreadIds?: string[];
+}
+
+export interface MailInventoryCursorState {
+  queryFingerprint: string;
+  requestedAccounts: string[] | null;
+  accounts: MailInventoryAccountState[];
+  firstPage: boolean;
+}
+
+export interface MailInventoryCursorClaim {
+  id: string;
+  claimId: string;
+  ownerEmail: string;
+  queryFingerprint: string;
+  version: number;
+  state: MailInventoryCursorState;
+}
+
+export interface MailInventoryFetchResult {
+  items: MailInventoryItem[];
+  errors: Record<string, MailInventoryError>;
+  nextPageTokens: Record<string, string>;
+}
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, child]) => [key, stableValue(child)]),
+    );
+  }
+  return value;
+}
+
+export function inventoryQueryFingerprint(input: unknown): string {
+  return createHash("sha256")
+    .update(JSON.stringify(stableValue(input)))
+    .digest("hex");
+}
+
+export function compareInventoryItems(
+  a: MailInventoryItem,
+  b: MailInventoryItem,
+): number {
+  const date = new Date(b.date).getTime() - new Date(a.date).getTime();
+  if (date) return date;
+  const account = a.accountEmail.localeCompare(b.accountEmail);
+  if (account) return account;
+  const thread = a.threadId.localeCompare(b.threadId);
+  if (thread) return thread;
+  return a.id.localeCompare(b.id);
+}
+
+function dedupeAndSort(items: MailInventoryItem[]): MailInventoryItem[] {
+  const unique = new Map<string, MailInventoryItem>();
+  for (const item of items) {
+    const key = `${item.accountEmail.toLowerCase()}:${item.threadId}`;
+    const current = unique.get(key);
+    if (!current || compareInventoryItems(item, current) < 0) {
+      unique.set(key, item);
+    }
+  }
+  return [...unique.values()].sort(compareInventoryItems);
+}
+
+function applyFetch(
+  states: MailInventoryAccountState[],
+  result: MailInventoryFetchResult,
+): void {
+  const byAccount = new Map<string, MailInventoryItem[]>();
+  for (const item of result.items) {
+    const key = item.accountEmail.toLowerCase();
+    const accountItems = byAccount.get(key) ?? [];
+    accountItems.push(item);
+    byAccount.set(key, accountItems);
+  }
+
+  for (const state of states) {
+    const key = state.accountEmail.toLowerCase();
+    const error = result.errors[key];
+    if (error) {
+      state.status = "error";
+      state.error = error;
+      state.exhausted = true;
+      state.providerPageToken = undefined;
+      continue;
+    }
+    const emitted = new Set(state.emittedThreadIds ?? []);
+    const before = new Set(
+      state.pending.map((item) => item.threadId).concat([...emitted]),
+    );
+    const additions = (byAccount.get(key) ?? []).filter(
+      (item) => !before.has(item.threadId),
+    );
+    state.knownCount =
+      (state.knownCount ?? state.emittedCount) + additions.length;
+    state.pending = dedupeAndSort([...state.pending, ...additions]);
+    state.providerPageToken = result.nextPageTokens[key];
+    state.exhausted = !state.providerPageToken;
+  }
+}
+
+export async function buildMailInventoryPage(
+  state: MailInventoryCursorState,
+  limit: number,
+  fetch: (
+    accounts: Array<{ accountEmail: string; pageToken?: string }>,
+  ) => Promise<MailInventoryFetchResult>,
+): Promise<{ items: MailInventoryItem[]; hasMore: boolean }> {
+  const pageLimit = Math.max(1, Math.min(Math.floor(limit), 100));
+  const refillCounts = new Map<string, number>();
+  const refillFrontiers = async () => {
+    while (true) {
+      const needsFetch = state.accounts.filter(
+        (account) =>
+          account.status === "ok" &&
+          account.pending.length === 0 &&
+          !account.exhausted,
+      );
+      if (needsFetch.length === 0) return;
+      const fetchable = needsFetch.filter((account) => {
+        const key = account.accountEmail.toLowerCase();
+        const count = refillCounts.get(key) ?? 0;
+        if (count < 4) {
+          refillCounts.set(key, count + 1);
+          return true;
+        }
+        account.status = "error";
+        account.error = {
+          code: "pagination_limit",
+          message:
+            "Mail pagination did not expose a row frontier within four provider pages.",
+          retryable: true,
+        };
+        account.exhausted = true;
+        account.providerPageToken = undefined;
+        return false;
+      });
+      if (fetchable.length === 0) continue;
+      const prior = fetchable.map((account) => ({
+        account,
+        token: account.providerPageToken,
+      }));
+      applyFetch(
+        fetchable,
+        await fetch(
+          fetchable.map((account) => ({
+            accountEmail: account.accountEmail,
+            pageToken: account.providerPageToken,
+          })),
+        ),
+      );
+      for (const { account, token } of prior) {
+        if (
+          account.status === "ok" &&
+          !account.exhausted &&
+          account.pending.length === 0 &&
+          account.providerPageToken === token
+        ) {
+          throw new Error(
+            `Mail provider pagination made no progress for ${account.accountEmail}.`,
+          );
+        }
+      }
+    }
+  };
+
+  const page: MailInventoryItem[] = [];
+  const emittedKeys = new Set<string>();
+  let pageBytes = 2; // JSON array brackets
+  const emit = (
+    account: MailInventoryAccountState,
+    item: MailInventoryItem,
+  ) => {
+    const key = `${item.accountEmail.toLowerCase()}:${item.threadId}`;
+    if (emittedKeys.has(key)) return;
+    emittedKeys.add(key);
+    page.push(item);
+    account.emittedCount += 1;
+    account.emittedThreadIds = [
+      ...(account.emittedThreadIds ?? []),
+      item.threadId,
+    ];
+  };
+
+  while (page.length < pageLimit) {
+    // A global merge is only safe when every live account has a known
+    // frontier. Refill an emptied account before emitting an older candidate
+    // from another account; otherwise an unseen newer provider row can be
+    // skipped across the page boundary.
+    await refillFrontiers();
+    const candidates = state.accounts
+      .filter((account) => account.pending.length > 0)
+      .map((account) => ({ account, item: account.pending[0] }))
+      .sort((a, b) => compareInventoryItems(a.item, b.item));
+    if (candidates.length === 0) {
+      break;
+    }
+    const winner = candidates[0];
+    const itemBytes = new TextEncoder().encode(
+      JSON.stringify(winner.item),
+    ).byteLength;
+    if (
+      page.length > 0 &&
+      pageBytes + itemBytes + 1 > PAGE_ITEMS_BUDGET_BYTES
+    ) {
+      break;
+    }
+    winner.account.pending.shift();
+    emit(winner.account, winner.item);
+    pageBytes += itemBytes + (page.length > 1 ? 1 : 0);
+  }
+
+  page.sort(compareInventoryItems);
+  state.firstPage = false;
+  return {
+    items: page,
+    hasMore: state.accounts.some(
+      (account) => account.pending.length > 0 || !account.exhausted,
+    ),
+  };
+}
+
+export async function createInventoryCursor(
+  ownerEmail: string,
+  state: MailInventoryCursorState,
+): Promise<string> {
+  const now = Date.now();
+  const id = crypto.randomUUID();
+  await getDb()
+    .insert(mailInventoryCursors)
+    .values({
+      id,
+      ownerEmail,
+      queryFingerprint: state.queryFingerprint,
+      state: JSON.stringify(state),
+      version: 1,
+      expiresAt: now + TTL_MS,
+      updatedAt: now,
+    });
+  await getDb()
+    .delete(mailInventoryCursors)
+    .where(lt(mailInventoryCursors.expiresAt, now));
+  return id;
+}
+
+/**
+ * Atomically leases a cursor without consuming it. Provider work happens only
+ * after this short-lived CAS. Failures can release the lease; success settles
+ * it into a distinct successor id (or deletes it at exhaustion).
+ */
+export async function claimInventoryCursor(
+  ownerEmail: string,
+  id: string,
+  queryFingerprint: string,
+): Promise<MailInventoryCursorClaim | null> {
+  const now = Date.now();
+  const claimId = crypto.randomUUID();
+  const staleBefore = now - CLAIM_TTL_MS;
+  const rows = await getDb()
+    .update(mailInventoryCursors)
+    .set({ claimId, claimedAt: now, updatedAt: now })
+    .where(
+      and(
+        eq(mailInventoryCursors.id, id),
+        eq(mailInventoryCursors.ownerEmail, ownerEmail),
+        eq(mailInventoryCursors.queryFingerprint, queryFingerprint),
+        gt(mailInventoryCursors.expiresAt, now),
+        or(
+          sql`${mailInventoryCursors.claimId} IS NULL`,
+          lt(mailInventoryCursors.claimedAt, staleBefore),
+        ),
+      ),
+    )
+    .returning({
+      state: mailInventoryCursors.state,
+      expiresAt: mailInventoryCursors.expiresAt,
+      version: mailInventoryCursors.version,
+    });
+  const row = rows[0];
+  if (!row || row.expiresAt <= now) return null;
+  try {
+    return {
+      id,
+      claimId,
+      ownerEmail,
+      queryFingerprint,
+      version: row.version,
+      state: JSON.parse(row.state) as MailInventoryCursorState,
+    };
+  } catch {
+    await releaseInventoryCursorClaim({
+      id,
+      claimId,
+      ownerEmail,
+      queryFingerprint,
+      version: row.version,
+      state: {} as MailInventoryCursorState,
+    });
+    return null;
+  }
+}
+
+export async function releaseInventoryCursorClaim(
+  claim: MailInventoryCursorClaim,
+): Promise<void> {
+  await getDb()
+    .update(mailInventoryCursors)
+    .set({ claimId: null, claimedAt: null, updatedAt: Date.now() })
+    .where(
+      and(
+        eq(mailInventoryCursors.id, claim.id),
+        eq(mailInventoryCursors.ownerEmail, claim.ownerEmail),
+        eq(mailInventoryCursors.queryFingerprint, claim.queryFingerprint),
+        eq(mailInventoryCursors.version, claim.version),
+        eq(mailInventoryCursors.claimId, claim.claimId),
+      ),
+    );
+}
+
+/** Atomically consumes a leased id and optionally creates its successor. */
+export async function settleInventoryCursorClaim(
+  claim: MailInventoryCursorClaim,
+  state: MailInventoryCursorState,
+  hasMore: boolean,
+): Promise<string | undefined> {
+  const db = getDb();
+  const successorId = hasMore ? crypto.randomUUID() : undefined;
+  const now = Date.now();
+  return db.transaction(async (tx: any) => {
+    const consumed = await tx
+      .delete(mailInventoryCursors)
+      .where(
+        and(
+          eq(mailInventoryCursors.id, claim.id),
+          eq(mailInventoryCursors.ownerEmail, claim.ownerEmail),
+          eq(mailInventoryCursors.queryFingerprint, claim.queryFingerprint),
+          eq(mailInventoryCursors.version, claim.version),
+          eq(mailInventoryCursors.claimId, claim.claimId),
+        ),
+      )
+      .returning({ id: mailInventoryCursors.id });
+    if (consumed.length !== 1) {
+      throw new Error("Inventory cursor lease was lost before settlement.");
+    }
+    if (successorId) {
+      await tx.insert(mailInventoryCursors).values({
+        id: successorId,
+        ownerEmail: claim.ownerEmail,
+        queryFingerprint: claim.queryFingerprint,
+        state: JSON.stringify(state),
+        version: claim.version + 1,
+        claimId: null,
+        claimedAt: null,
+        expiresAt: now + TTL_MS,
+        updatedAt: now,
+      });
+    }
+    return successorId;
+  });
+}

--- a/templates/mail/server/lib/list-inbox-emails.spec.ts
+++ b/templates/mail/server/lib/list-inbox-emails.spec.ts
@@ -235,4 +235,30 @@ describe("listInboxEmails", () => {
     expect(result.isQuotaError).toBe(false);
     expect(result.retryAfterSeconds).toBeUndefined();
   });
+
+  it("preserves successful empty accounts when a sibling account fails", async () => {
+    vi.mocked(listGmailMessages).mockResolvedValue({
+      messages: [],
+      errors: [{ email: "failed@example.com", error: "provider unavailable" }],
+    } as any);
+
+    const result = await listInboxEmails({
+      ownerEmail: OWNER,
+      view: "inbox",
+      limit: 50,
+      accountTokens: [
+        { email: "empty@example.com", accessToken: "empty-token" },
+        { email: "failed@example.com", accessToken: "failed-token" },
+      ],
+      accountEmails: ["empty@example.com", "failed@example.com"],
+      labelMap: new Map(),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected partial success result");
+    expect(result.emails).toEqual([]);
+    expect(result.errors).toEqual([
+      { email: "failed@example.com", error: "provider unavailable" },
+    ]);
+  });
 });

--- a/templates/mail/server/lib/list-inbox-emails.ts
+++ b/templates/mail/server/lib/list-inbox-emails.ts
@@ -45,7 +45,11 @@ export interface ListInboxEmailsParams {
   pageTokens?: Record<string, string>;
   threadFormat?: "full" | "metadata" | "minimal";
   threadCandidateLimit?: number;
+  /** Disable the extra recent-message candidate pass for bounded inventory. */
+  includeRecentMessageCandidates?: boolean;
   accountTokens: ListInboxEmailsAccountToken[];
+  /** Selected account ids are forwarded to Gmail before token refresh. */
+  accountEmails?: string[];
   labelMap: Map<string, string>;
 }
 
@@ -108,7 +112,9 @@ export async function listInboxEmails(
     pageTokens,
     threadFormat,
     threadCandidateLimit,
+    includeRecentMessageCandidates = true,
     accountTokens,
+    accountEmails,
     labelMap,
   } = params;
 
@@ -123,12 +129,25 @@ export async function listInboxEmails(
       threadFormat,
       threadCandidateLimit,
       threadRecentMessageCandidateLimit:
-        !q && (view === "inbox" || view === "unread")
+        includeRecentMessageCandidates &&
+        !q &&
+        (view === "inbox" || view === "unread")
           ? DEFAULT_THREAD_RECENT_MESSAGE_CANDIDATE_LIMIT
           : undefined,
+      accountEmails,
     });
 
-  if (messages.length === 0 && errors.length > 0) {
+  const failedAccounts = new Set(
+    errors.map((error) => error.email.toLowerCase()),
+  );
+  const everySelectedAccountFailed = [...connectedEmails].every((email) =>
+    failedAccounts.has(email),
+  );
+  if (
+    messages.length === 0 &&
+    errors.length > 0 &&
+    everySelectedAccountFailed
+  ) {
     const isQuotaError = errors.every((e) => isGmailQuotaError(e.error));
     return {
       ok: false,

--- a/templates/mail/server/lib/mail-connector-catalog.spec.ts
+++ b/templates/mail/server/lib/mail-connector-catalog.spec.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { MAIL_CONNECTOR_CATALOG } from "./mail-connector-catalog";
+
+describe("Mail MCP connector catalog", () => {
+  it("exposes only deterministic email inventory reads", () => {
+    expect(MAIL_CONNECTOR_CATALOG).toEqual(["list-emails"]);
+    expect(MAIL_CONNECTOR_CATALOG).not.toContain("search-emails");
+    expect(MAIL_CONNECTOR_CATALOG).not.toContain("get-email");
+    expect(MAIL_CONNECTOR_CATALOG).not.toContain("send-email");
+  });
+
+  it("wires the catalog into MCP and keeps the action authenticated read-only", () => {
+    const root = process.cwd();
+    const plugin = readFileSync(
+      join(root, "server", "plugins", "agent-chat.ts"),
+      "utf8",
+    );
+    const action = readFileSync(
+      join(root, "actions", "list-emails.ts"),
+      "utf8",
+    );
+
+    expect(plugin).toContain("connectorCatalog: [");
+    expect(plugin).toContain("...MAIL_CONNECTOR_CATALOG");
+    expect(action).toContain("readOnly: true");
+    expect(action).toContain(
+      "publicAgent: { expose: true, readOnly: true, requiresAuth: true }",
+    );
+  });
+});

--- a/templates/mail/server/lib/mail-connector-catalog.ts
+++ b/templates/mail/server/lib/mail-connector-catalog.ts
@@ -1,0 +1,8 @@
+/**
+ * Deliberately narrow authenticated MCP surface for Mail.
+ *
+ * External callers may read inbox coverage through list-emails. Other actions
+ * remain available through the in-app agent, ask_app, or an explicit
+ * full-catalog connection; tool-search alone never makes them callable.
+ */
+export const MAIL_CONNECTOR_CATALOG = ["list-emails"] as const;

--- a/templates/mail/server/plugins/agent-chat.ts
+++ b/templates/mail/server/plugins/agent-chat.ts
@@ -6,6 +6,7 @@ import {
 } from "@agent-native/core/server";
 
 import actionsRegistry from "../../.generated/actions-registry.js";
+import { MAIL_CONNECTOR_CATALOG } from "../lib/mail-connector-catalog.js";
 
 const INITIAL_TOOL_NAMES = [
   "view-screen",
@@ -33,6 +34,7 @@ export default createAgentChatPlugin({
   actions: loadActionsFromStaticRegistry(actionsRegistry),
   appId: "mail",
   initialToolNames: INITIAL_TOOL_NAMES,
+  connectorCatalog: [...MAIL_CONNECTOR_CATALOG],
   resolveOrgId: async (event) => {
     const ctx = await getOrgContext(event);
     return ctx.orgId;
@@ -90,16 +92,9 @@ export default createAgentChatPlugin({
 
 Some less-common tool schemas are loaded on demand. Use tool-search with a specific query when you need a capability that is not already available as a direct tool.
 
-## Google Connection Check — CRITICAL
+## Deterministic Mail Reads
 
-BEFORE doing anything else, run view-screen to check if Google is connected.
-If view-screen shows 0 emails or indicates Google is not connected:
-- Do NOT run list-emails, search-emails, send-email, or any email operation scripts
-- Do NOT pretend to have access to emails
-- Tell the user: "You need to connect your Google account first. Click the 'Connect Google' button on the main screen to get started."
-- You can still answer general questions, but you cannot perform any email operations
-
-Only proceed with email operations if view-screen confirms real emails are available.
+For deterministic headless email reads, call list-emails directly in inventory/coverage mode. Do not require view-screen as a Google connection preflight: list-emails selects the connected Gmail or synthetic local-mail backend for the user and returns the relevant result. Use view-screen only when the answer depends on visible UI state, such as the active thread, selected message, draft, queue item, or current inbox view. Treat real action errors as the evidence for an unavailable connection; do not infer it from a zero-email screen.
 
 Available operations:
 - List and search emails

--- a/templates/mail/server/plugins/db.ts
+++ b/templates/mail/server/plugins/db.ts
@@ -188,6 +188,26 @@ CREATE INDEX IF NOT EXISTS idx_snippets_owner_name ON snippets(owner_email, name
       sql: `ALTER TABLE queued_email_drafts ADD COLUMN IF NOT EXISTS send_claim_id TEXT;
 ALTER TABLE queued_email_drafts ADD COLUMN IF NOT EXISTS send_claimed_at ${intType()}`,
     },
+    {
+      version: 18,
+      name: "mail-inventory-cursors",
+      sql: `CREATE TABLE IF NOT EXISTS mail_inventory_cursors (
+    id TEXT PRIMARY KEY,
+    owner_email TEXT NOT NULL,
+    query_fingerprint TEXT NOT NULL,
+    state TEXT NOT NULL,
+    version ${intType()} NOT NULL DEFAULT 1,
+    expires_at ${intType()} NOT NULL,
+    updated_at ${intType()} NOT NULL
+  );
+CREATE INDEX IF NOT EXISTS idx_mail_inventory_cursors_owner_expiry ON mail_inventory_cursors(owner_email, expires_at);`,
+    },
+    {
+      version: 19,
+      name: "mail-inventory-cursor-leases",
+      sql: `ALTER TABLE mail_inventory_cursors ADD COLUMN IF NOT EXISTS claim_id TEXT;
+ALTER TABLE mail_inventory_cursors ADD COLUMN IF NOT EXISTS claimed_at ${intType()}`,
+    },
   ],
   { table: "mail_migrations" },
 );


### PR DESCRIPTION
## Summary

- Expose Calendar `list-events` and Mail `list-emails` through narrow, explicit connector catalogs.
- Return bounded, coverage-aware inventory envelopes with provenance and honest partial failures.
- Validate owned-account filters before provider work.
- Add compact Calendar pagination and fair, metadata-only Mail pagination.
- Let deterministic headless reads bypass `ask_app` and the `view-screen` preflight.
- Keep the general A2A durability rewrite explicitly out of scope.

## Reliability details

- Calendar reports requested, resolved, and queried accounts plus per-account and per-source coverage.
- Calendar cursors reject malformed, expired, owner-mismatched, and query-mismatched requests before provider event reads.
- Calendar overlay reads fall through across selected owned accounts, retain credential-account provenance, and keep refresh failures visible.
- Mail preserves quiet and failed accounts in a fair four-account merge without hydrating bodies.
- Mail validates Gmail, local, scheduled, and snoozed account identities against the correct backend.
- External MCP still clips ordinary text output; both actions own bounded pagination rather than raising the global cap.

## Verification

- Core MCP lifecycle: 82/82.
- Calendar full suite: 304/304.
- Mail full suite: 251/251.
- Calendar and Mail typechecks pass under Node 24.14.0.
- All required PR checks pass.
- All review threads are resolved.

## Hosted human QA

Read-only QA used the real Agent Native Calendar and Mail MCP servers:

- Production discovery still exposes the legacy schemas and cannot call the new direct inventory actions before deployment.
- Calendar `ask_app` returned explicit two-account coverage, taking about 42 seconds.
- Mail `ask_app` returned explicit four-account coverage through durable polling, including a zero-message account, without bodies or writes.
- The Calendar and Mail PR previews enforce authentication, but their OAuth challenges point to production metadata. Production rejects preview-origin authorization, so safe authenticated preview `tools/list` and `tools/call` are unavailable.
- Production bearer tokens were not reused on preview origins.

## Final deployment gate

After deployment to the production Calendar and Mail MCP origins:

1. Confirm compact `tools/list` advertises both direct actions.
2. Call both actions directly and exhaust their cursors.
3. Verify provenance and explicit zero-result and failure coverage for every selected account.
4. Record at least ten warm runs, reporting p50 and p95 latency and provider-call counts separately from the current `ask_app` baseline.

## Deferred

General A2A host-kill recovery, durable continuation, retry policy, and processing-lease fencing remain a separately trackable follow-up.