### PR TITLE
style: update LayersPanel layout styles

### DIFF
--- a/templates/design/app/components/design/LayersPanel.tsx
+++ b/templates/design/app/components/design/LayersPanel.tsx
@@ -2234,7 +2234,7 @@ const LayerRow = memo(function LayerRow({
             </button>
 
             {(lockable || hideable) && (
-              <div className="sticky right-0 z-10 ml-auto flex shrink-0 items-center gap-1 bg-inherit pl-2 pr-1">
+              <div className="sticky right-0 z-10 ml-auto flex shrink-0 items-center gap-1  pl-2 pr-1">
                 {lockable ? (
                   <Tooltip>
                     <TooltipTrigger asChild>

--- a/templates/design/app/components/design/LayersPanel.tsx
+++ b/templates/design/app/components/design/LayersPanel.tsx
@@ -11,9 +11,9 @@ import {
   IconFrame,
   IconLayersSubtract,
   IconLayersUnion,
+  IconLayoutGrid,
   IconLock,
   IconLockOpen,
-  IconLayoutGrid,
   IconPencil,
   IconPlus,
   IconSearch,
@@ -30,8 +30,8 @@ import {
   useMemo,
   useRef,
   useState,
-  type KeyboardEvent,
   type DragEvent,
+  type KeyboardEvent,
   type MouseEvent,
   type ReactNode,
   type Ref,
@@ -1481,17 +1481,13 @@ function LayersPanelImpl(
 
         <div
           ref={scrollContainerRef}
-          className="min-h-0 flex-1 overflow-auto overscroll-contain py-2"
+          className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden overscroll-contain py-2"
           onDragOver={handleRowsDragOver}
           onDrop={stopAutoScroll}
           onDragEnd={stopAutoScroll}
         >
           {visibleRows.length ? (
-            <div
-              className="w-max min-w-full px-2"
-              role="tree"
-              aria-label={labels.title}
-            >
+            <div className="w-full px-2" role="tree" aria-label={labels.title}>
               {visibleRows.map((row) => {
                 // Per-row primitives computed here (not inside LayerRow) so the
                 // row only receives booleans/strings it needs — no whole-tree
@@ -2047,7 +2043,7 @@ const LayerRow = memo(function LayerRow({
           aria-expanded={hasChildren ? isExpanded : undefined}
           aria-level={depth + 1}
           aria-selected={selectable ? isSelected : undefined}
-          className="relative min-w-full"
+          className="relative w-full min-w-0"
           draggable={draggable}
           onDragStart={handleDragStart}
           onDragOver={handleDragOver}
@@ -2087,7 +2083,7 @@ const LayerRow = memo(function LayerRow({
           ) : null}
           <div
             className={cn(
-              "group flex h-8 min-w-full items-center gap-1 rounded-[5px] pr-1 text-[12px]",
+              "group flex h-8 w-full min-w-0 items-center gap-1 rounded-[5px] pr-1 text-[12px]",
               activeDrop === "inside" &&
                 "ring-1 ring-inset ring-[var(--design-editor-accent-color)]",
               isSelected &&

--- a/templates/design/app/components/design/LayersPanel.tsx
+++ b/templates/design/app/components/design/LayersPanel.tsx
@@ -2234,7 +2234,7 @@ const LayerRow = memo(function LayerRow({
             </button>
 
             {(lockable || hideable) && (
-              <div className="sticky right-0 z-10 ml-auto flex shrink-0 items-center gap-1  pl-2 pr-1">
+              <div className="sticky right-0 z-10 ml-auto flex shrink-0 items-center gap-1 bg-inherit pl-2 pr-1">
                 {lockable ? (
                   <Tooltip>
                     <TooltipTrigger asChild>

--- a/templates/design/app/components/design/LayersPanel.tsx
+++ b/templates/design/app/components/design/LayersPanel.tsx
@@ -2087,7 +2087,7 @@ const LayerRow = memo(function LayerRow({
           ) : null}
           <div
             className={cn(
-              "group flex h-8 w-max min-w-full items-center gap-1 rounded-[5px] pr-1 text-[12px] bg-[var(--design-editor-panel-bg)]",
+              "group flex h-7 w-max min-w-full items-center gap-1 rounded-[5px] pr-1 text-[12px] bg-[var(--design-editor-panel-bg)]",
               activeDrop === "inside" &&
                 "ring-1 ring-inset ring-[var(--design-editor-accent-color)]",
               isSelected &&
@@ -2235,6 +2235,8 @@ const LayerRow = memo(function LayerRow({
 
             {(lockable || hideable) && (
               <div className="sticky right-0 z-10 ml-auto flex shrink-0 items-center gap-1 bg-inherit pl-2 pr-1">
+                {/* Solid backdrop to prevent scrolling text from showing through semi-transparent row backgrounds */}
+                <div className="absolute inset-0 -z-10 bg-[var(--design-editor-panel-bg)] rounded-r-[5px]" />
                 {lockable ? (
                   <Tooltip>
                     <TooltipTrigger asChild>

--- a/templates/design/app/components/design/LayersPanel.tsx
+++ b/templates/design/app/components/design/LayersPanel.tsx
@@ -1481,13 +1481,17 @@ function LayersPanelImpl(
 
         <div
           ref={scrollContainerRef}
-          className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden overscroll-contain py-2"
+          className="min-h-0 flex-1 overflow-auto overscroll-contain py-2"
           onDragOver={handleRowsDragOver}
           onDrop={stopAutoScroll}
           onDragEnd={stopAutoScroll}
         >
           {visibleRows.length ? (
-            <div className="w-full px-2" role="tree" aria-label={labels.title}>
+            <div
+              className="w-max min-w-full px-2"
+              role="tree"
+              aria-label={labels.title}
+            >
               {visibleRows.map((row) => {
                 // Per-row primitives computed here (not inside LayerRow) so the
                 // row only receives booleans/strings it needs — no whole-tree
@@ -2043,7 +2047,7 @@ const LayerRow = memo(function LayerRow({
           aria-expanded={hasChildren ? isExpanded : undefined}
           aria-level={depth + 1}
           aria-selected={selectable ? isSelected : undefined}
-          className="relative w-full min-w-0"
+          className="relative w-max min-w-full"
           draggable={draggable}
           onDragStart={handleDragStart}
           onDragOver={handleDragOver}
@@ -2083,7 +2087,7 @@ const LayerRow = memo(function LayerRow({
           ) : null}
           <div
             className={cn(
-              "group flex h-8 w-full min-w-0 items-center gap-1 rounded-[5px] pr-1 text-[12px]",
+              "group flex h-8 w-max min-w-full items-center gap-1 rounded-[5px] pr-1 text-[12px] bg-[var(--design-editor-panel-bg)]",
               activeDrop === "inside" &&
                 "ring-1 ring-inset ring-[var(--design-editor-accent-color)]",
               isSelected &&
@@ -2229,67 +2233,71 @@ const LayerRow = memo(function LayerRow({
               ) : null}
             </button>
 
-            {lockable ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className={cn(
-                      "size-5 shrink-0 rounded-sm p-0 text-muted-foreground opacity-0 hover:bg-transparent hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100",
-                      node.locked && "opacity-100",
-                      isSelected && "text-foreground",
-                    )}
-                    aria-label={node.locked ? labels.unlock : labels.lock}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onToggleLocked?.(node.id, !node.locked);
-                    }}
-                  >
-                    {node.locked ? (
-                      <IconLock className="size-3" />
-                    ) : (
-                      <IconLockOpen className="size-3" />
-                    )}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {node.locked ? labels.unlock : labels.lock}
-                </TooltipContent>
-              </Tooltip>
-            ) : null}
+            {(lockable || hideable) && (
+              <div className="sticky right-0 z-10 ml-auto flex shrink-0 items-center gap-1 bg-inherit pl-2 pr-1">
+                {lockable ? (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className={cn(
+                          "size-5 shrink-0 rounded-sm p-0 text-muted-foreground opacity-0 hover:bg-transparent hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100",
+                          node.locked && "opacity-100",
+                          isSelected && "text-foreground",
+                        )}
+                        aria-label={node.locked ? labels.unlock : labels.lock}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onToggleLocked?.(node.id, !node.locked);
+                        }}
+                      >
+                        {node.locked ? (
+                          <IconLock className="size-3" />
+                        ) : (
+                          <IconLockOpen className="size-3" />
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {node.locked ? labels.unlock : labels.lock}
+                    </TooltipContent>
+                  </Tooltip>
+                ) : null}
 
-            {hideable ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className={cn(
-                      "size-5 shrink-0 rounded-sm p-0 text-muted-foreground opacity-0 hover:bg-transparent hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100",
-                      node.hidden && "opacity-100",
-                      isSelected && "text-foreground",
-                    )}
-                    aria-label={node.hidden ? labels.show : labels.hide}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onToggleHidden?.(node.id, !node.hidden);
-                    }}
-                  >
-                    {node.hidden ? (
-                      <IconEyeOff className="size-3" />
-                    ) : (
-                      <IconEye className="size-3" />
-                    )}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {node.hidden ? labels.show : labels.hide}
-                </TooltipContent>
-              </Tooltip>
-            ) : null}
+                {hideable ? (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className={cn(
+                          "size-5 shrink-0 rounded-sm p-0 text-muted-foreground opacity-0 hover:bg-transparent hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100",
+                          node.hidden && "opacity-100",
+                          isSelected && "text-foreground",
+                        )}
+                        aria-label={node.hidden ? labels.show : labels.hide}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onToggleHidden?.(node.id, !node.hidden);
+                        }}
+                      >
+                        {node.hidden ? (
+                          <IconEyeOff className="size-3" />
+                        ) : (
+                          <IconEye className="size-3" />
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {node.hidden ? labels.show : labels.hide}
+                    </TooltipContent>
+                  </Tooltip>
+                ) : null}
+              </div>
+            )}
           </div>
         </div>
       </ContextMenuTrigger>

--- a/templates/design/app/components/design/LayersPanel.tsx
+++ b/templates/design/app/components/design/LayersPanel.tsx
@@ -2234,9 +2234,16 @@ const LayerRow = memo(function LayerRow({
             </button>
 
             {(lockable || hideable) && (
-              <div className="sticky right-0 z-10 ml-auto flex shrink-0 items-center gap-1 bg-inherit pl-2 pr-1">
-                {/* Solid backdrop to prevent scrolling text from showing through semi-transparent row backgrounds */}
-                <div className="absolute inset-0 -z-10 bg-[var(--design-editor-panel-bg)] rounded-r-[5px]" />
+              <div
+                className={cn(
+                  "sticky right-0 z-10 ml-auto flex shrink-0 items-center gap-1 bg-inherit",
+                  node.locked || node.hidden
+                    ? "w-auto overflow-visible pl-2 pr-1"
+                    : "w-0 overflow-hidden pl-0 pr-0 group-hover:w-auto group-hover:overflow-visible group-hover:pl-2 group-hover:pr-1",
+                )}
+              >
+                <div className="absolute inset-0 -z-20 bg-[var(--design-editor-panel-bg)]" />
+                <div className="absolute inset-0 -z-10 bg-inherit" />
                 {lockable ? (
                   <Tooltip>
                     <TooltipTrigger asChild>

--- a/templates/design/app/components/design/LayersPanel.tsx
+++ b/templates/design/app/components/design/LayersPanel.tsx
@@ -2239,7 +2239,7 @@ const LayerRow = memo(function LayerRow({
                   "sticky right-0 z-10 ml-auto flex shrink-0 items-center gap-1 bg-inherit",
                   node.locked || node.hidden
                     ? "w-auto overflow-visible pl-2 pr-1"
-                    : "w-0 overflow-hidden pl-0 pr-0 group-hover:w-auto group-hover:overflow-visible group-hover:pl-2 group-hover:pr-1",
+                    : "w-0 overflow-hidden pl-0 pr-0 group-hover:w-auto group-hover:overflow-visible group-hover:pl-2 group-hover:pr-1 focus-within:w-auto focus-within:overflow-visible focus-within:pl-2 focus-within:pr-1",
                 )}
               >
                 <div className="absolute inset-0 -z-20 bg-[var(--design-editor-panel-bg)]" />


### PR DESCRIPTION
# Description

🗂️ **Layers Panel UI Layout & Scroll Improvements**
- **Horizontal Scroll Support**: Restored horizontal scroll capabilities by keeping the tree and row wrappers at `w-max min-w-full`. This ensures that deeply nested layers can be inspected without being cut off.
- **Sticky Actions**: Wrapped the lock and hide buttons in a sticky container (`sticky right-0 z-10 ml-auto bg-inherit pl-2 pr-1`). These buttons now stay anchored on the right edge of the viewport and remain visible even when scrolling horizontally, matching Figma's exact behavior.
- **Visual Integrity**: Applied `bg-[var(--design-editor-panel-bg)]` to the row inner `div` to ensure that scrolling text is cleanly hidden beneath the sticky buttons block as it scrolls by.


### Before
<img width="281" height="254" alt="brave_screenshot_localhost (6)" src="https://github.com/user-attachments/assets/bc4f53bc-1a64-4d76-b729-c2f28ef1dc7a" />
<img width="346" height="389" alt="brave_screenshot_localhost (7)" src="https://github.com/user-attachments/assets/d3d8c46d-5e3d-483e-87f9-c89e5702ea32" />


### After
<img width="243" height="353" alt="brave_screenshot_localhost (8)" src="https://github.com/user-attachments/assets/d1043b5f-6f90-434e-a97d-c48176534ffa" />
