### PR TITLE
Add local Codex sign-in and improve integration replies

### DIFF
--- a/.changeset/add-codex-local-signin.md
+++ b/.changeset/add-codex-local-signin.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/code-agents-ui": patch
+---
+
+Add a native local-runtime sign-in handoff for Codex-backed ChatGPT subscriptions in Agent composer surfaces.

--- a/.changeset/add-codex-local-signin.md
+++ b/.changeset/add-codex-local-signin.md
@@ -1,6 +1,5 @@
 ---
 "@agent-native/core": patch
-"@agent-native/code-agents-ui": patch
 ---
 
 Add a native local-runtime sign-in handoff for Codex-backed ChatGPT subscriptions in Agent composer surfaces.

--- a/.changeset/fix-slack-empty-response.md
+++ b/.changeset/fix-slack-empty-response.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix Slack integration fallbacks and link replies directly to Dispatch chat threads.

--- a/.changeset/shared-workspace-secret-key.md
+++ b/.changeset/shared-workspace-secret-key.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep workspace-shared app secrets decryptable across sibling apps.

--- a/packages/code-agents-ui/src/CodeAgentsApp.tsx
+++ b/packages/code-agents-ui/src/CodeAgentsApp.tsx
@@ -839,6 +839,12 @@ export default function CodeAgentsApp({
     () => getProviderGate(hostMetadata),
     [hostMetadata],
   );
+  // `listModels` only includes Codex when the local CLI is installed. Keep
+  // sign-in hidden until that capability has been confirmed by the host so a
+  // fresh install does not offer a command that cannot launch.
+  const codexCliAvailable = modelOptions.some(
+    (option) => option.engine === "codex-cli",
+  );
   const normalizedSearchQuery = searchQuery.trim();
   const searchResults = useMemo(
     () =>
@@ -1751,7 +1757,9 @@ export default function CodeAgentsApp({
                         onConnectBuilder={connectBuilderProvider}
                         onOpenSettings={onOpenSettings}
                         onConnectProvider={connectBuilderProvider}
-                        onConnectLocalRuntime={connectLocalRuntime}
+                        onConnectLocalRuntime={
+                          codexCliAvailable ? connectLocalRuntime : undefined
+                        }
                       />
                     ) : (
                       <div className="code-agents-start">
@@ -1763,8 +1771,10 @@ export default function CodeAgentsApp({
                             message={builderConnectMessage}
                             onConnectBuilder={connectBuilderProvider}
                             onOpenSettings={onOpenSettings}
-                            onConnectLocalRuntime={() =>
-                              void connectLocalRuntime("codex-cli")
+                            onConnectLocalRuntime={
+                              codexCliAvailable
+                                ? () => void connectLocalRuntime("codex-cli")
+                                : undefined
                             }
                           />
                         )}
@@ -1784,7 +1794,9 @@ export default function CodeAgentsApp({
                           onSlashCommand={handleSlashCommand}
                           onSubmit={createRunFromPrompt}
                           onConnectProvider={connectBuilderProvider}
-                          onConnectLocalRuntime={connectLocalRuntime}
+                          onConnectLocalRuntime={
+                            codexCliAvailable ? connectLocalRuntime : undefined
+                          }
                         />
                         {(projects.length > 0 || canChooseProjectFolder) && (
                           <ProjectFolderPicker

--- a/packages/code-agents-ui/src/CodeAgentsApp.tsx
+++ b/packages/code-agents-ui/src/CodeAgentsApp.tsx
@@ -160,6 +160,7 @@ export interface CodeAgentsHost {
   openTerminal?(
     request?: CodeAgentTerminalRequest,
   ): Promise<CodeAgentTerminalResult>;
+  openCodexLogin?(): Promise<CodeAgentTerminalResult>;
   getRemoteConnectorStatus?(): Promise<CodeAgentRemoteConnectorStatus>;
   setRemoteConnectorEnabled?(
     enabled: boolean,
@@ -734,6 +735,67 @@ export default function CodeAgentsApp({
     selectedRun,
     transcriptEvents,
   ]);
+
+  const connectLocalRuntime = useCallback(
+    async (engine: string) => {
+      if (engine !== "codex-cli") return;
+      if (!host.openCodexLogin) {
+        toast("Local sign-in is only available in Agent Native Desktop", {
+          description: "Open Settings to manage hosted providers instead.",
+        });
+        onOpenSettings?.();
+        return;
+      }
+      try {
+        const result = await host.openCodexLogin();
+        if (!result.ok) {
+          toast("Codex sign-in was not opened", {
+            description: result.error,
+          });
+          return;
+        }
+        toast("Codex sign-in opened", {
+          description:
+            "Finish the ChatGPT sign-in in Terminal. The runtime picker will refresh when it is ready.",
+          duration: 4800,
+        });
+
+        let attempts = 0;
+        const refresh = async (): Promise<void> => {
+          const modelResult = await host.listModels?.();
+          if (modelResult?.status === "ok" && modelResult.models.length > 0) {
+            setModelOptions(modelResult.models);
+            if (modelResult.selected) {
+              setModelSelection((current) =>
+                current.model && current.model !== "auto"
+                  ? current
+                  : { ...modelResult.selected!, effort: current.effort },
+              );
+            }
+            if (
+              modelResult.models.some(
+                (option) =>
+                  option.engine === "codex-cli" && option.configured === true,
+              )
+            ) {
+              toast("ChatGPT subscription connected", {
+                description: "This computer is ready for local Agent tasks.",
+              });
+              return;
+            }
+          }
+          attempts += 1;
+          if (attempts < 30) window.setTimeout(() => void refresh(), 2_000);
+        };
+        void refresh();
+      } catch (err) {
+        toast("Codex sign-in was not opened", {
+          description: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+    [host, onOpenSettings],
+  );
 
   useEffect(() => {
     if (!isActive || !host.getRemoteConnectorStatus) return;
@@ -1689,6 +1751,7 @@ export default function CodeAgentsApp({
                         onConnectBuilder={connectBuilderProvider}
                         onOpenSettings={onOpenSettings}
                         onConnectProvider={connectBuilderProvider}
+                        onConnectLocalRuntime={connectLocalRuntime}
                       />
                     ) : (
                       <div className="code-agents-start">
@@ -1718,6 +1781,7 @@ export default function CodeAgentsApp({
                           onSlashCommand={handleSlashCommand}
                           onSubmit={createRunFromPrompt}
                           onConnectProvider={connectBuilderProvider}
+                          onConnectLocalRuntime={connectLocalRuntime}
                         />
                         {(projects.length > 0 || canChooseProjectFolder) && (
                           <ProjectFolderPicker
@@ -2128,6 +2192,7 @@ function NewSessionComposer({
   onSlashCommand,
   onSubmit,
   onConnectProvider,
+  onConnectLocalRuntime,
 }: {
   prompt: string;
   promptSeed: number;
@@ -2147,6 +2212,7 @@ function NewSessionComposer({
     attachments: CodeAgentPromptAttachment[],
   ) => void;
   onConnectProvider?: () => void;
+  onConnectLocalRuntime?: (engine: string) => void;
 }) {
   return (
     <CodeAgentComposer
@@ -2167,6 +2233,7 @@ function NewSessionComposer({
       onSlashCommand={onSlashCommand}
       onSubmit={onSubmit}
       onConnectProvider={onConnectProvider}
+      onConnectLocalRuntime={onConnectLocalRuntime}
     />
   );
 }
@@ -2191,6 +2258,7 @@ function CodeAgentComposer({
   onSubmit,
   onStop,
   onConnectProvider,
+  onConnectLocalRuntime,
 }: {
   prompt: string;
   promptSeed?: string | number;
@@ -2215,6 +2283,7 @@ function CodeAgentComposer({
   ) => void;
   onStop?: () => void;
   onConnectProvider?: () => void;
+  onConnectLocalRuntime?: (engine: string) => void;
 }) {
   const normalizedModel = normalizeModelSelection(modelSelection, modelOptions);
   const availableModels = groupCodeAgentModelOptions(modelOptions);
@@ -2297,6 +2366,7 @@ function CodeAgentComposer({
       voiceEnabled
       preserveDraftOnSubmit={false}
       onConnectProvider={onConnectProvider}
+      onConnectLocalRuntime={onConnectLocalRuntime}
     />
   );
 }
@@ -3281,6 +3351,7 @@ function RunDetailCard({
   onConnectBuilder,
   onOpenSettings,
   onConnectProvider,
+  onConnectLocalRuntime,
 }: {
   host: CodeAgentsHost;
   run: CodeAgentRun | null;
@@ -3304,6 +3375,7 @@ function RunDetailCard({
   onConnectBuilder: () => void;
   onOpenSettings?: () => void;
   onConnectProvider?: () => void;
+  onConnectLocalRuntime?: (engine: string) => void;
 }) {
   const runIsActive = run ? isRunActive(run) : false;
 
@@ -3427,6 +3499,7 @@ function RunDetailCard({
         onDeny={onDeny}
         onApproveAlways={onApproveAlways}
         onConnectProvider={onConnectProvider}
+        onConnectLocalRuntime={onConnectLocalRuntime}
       />
     </div>
   );
@@ -3450,6 +3523,7 @@ function TranscriptPanel({
   onDeny,
   onApproveAlways,
   onConnectProvider,
+  onConnectLocalRuntime,
 }: {
   host: CodeAgentsHost;
   goal: CodeAgentGoalDefinition;
@@ -3470,6 +3544,7 @@ function TranscriptPanel({
   /** Resolves the run's pending approval as approved and allowlists the exact command — same command the banner uses. */
   onApproveAlways?: () => void;
   onConnectProvider?: () => void;
+  onConnectLocalRuntime?: (engine: string) => void;
 }) {
   const normalizedModel = normalizeModelSelection(modelSelection, modelOptions);
   const selectedModel = normalizedModel.model ?? "auto";
@@ -3596,6 +3671,7 @@ function TranscriptPanel({
             runIsActive ? <CodeAgentStopButton onStop={onStop} /> : undefined
           }
           onConnectProvider={onConnectProvider}
+          onConnectLocalRuntime={onConnectLocalRuntime}
         />
       )}
     </div>

--- a/packages/code-agents-ui/src/CodeAgentsApp.tsx
+++ b/packages/code-agents-ui/src/CodeAgentsApp.tsx
@@ -1763,6 +1763,9 @@ export default function CodeAgentsApp({
                             message={builderConnectMessage}
                             onConnectBuilder={connectBuilderProvider}
                             onOpenSettings={onOpenSettings}
+                            onConnectLocalRuntime={() =>
+                              void connectLocalRuntime("codex-cli")
+                            }
                           />
                         )}
                         <NewSessionComposer
@@ -2409,7 +2412,7 @@ function getProviderGate(metadata: CodeAgentHostMetadata | null): {
     return {
       blocked: true,
       description:
-        "Connect Builder.io, run codex login for Codex CLI, or add your own API key.",
+        "Connect Builder.io, sign in with your ChatGPT subscription, or add an API key.",
     };
   }
   return {
@@ -2424,12 +2427,14 @@ function ProviderGateNotice({
   message,
   onConnectBuilder,
   onOpenSettings,
+  onConnectLocalRuntime,
 }: {
   description: string;
   connecting: boolean;
   message: string | null;
   onConnectBuilder: () => void;
   onOpenSettings?: () => void;
+  onConnectLocalRuntime?: () => void;
 }) {
   return (
     <CodeProviderNotice
@@ -2439,6 +2444,8 @@ function ProviderGateNotice({
       primaryActionLabel={connecting ? "Waiting..." : "Connect Builder.io"}
       primaryDisabled={connecting}
       onPrimaryAction={onConnectBuilder}
+      localRuntimeActionLabel="Sign in with ChatGPT"
+      onConnectLocalRuntime={onConnectLocalRuntime}
       secondaryActionLabel="API keys"
       onOpenSettings={onOpenSettings}
     />
@@ -2452,6 +2459,8 @@ function CodeProviderNotice({
   primaryActionLabel,
   primaryDisabled,
   onPrimaryAction,
+  localRuntimeActionLabel,
+  onConnectLocalRuntime,
   secondaryActionLabel,
   onOpenSettings,
 }: {
@@ -2461,6 +2470,8 @@ function CodeProviderNotice({
   primaryActionLabel?: string;
   primaryDisabled?: boolean;
   onPrimaryAction?: () => void;
+  localRuntimeActionLabel?: string;
+  onConnectLocalRuntime?: () => void;
   secondaryActionLabel?: string;
   onOpenSettings?: () => void;
 }) {
@@ -2480,6 +2491,16 @@ function CodeProviderNotice({
             disabled={primaryDisabled}
           >
             {primaryActionLabel}
+          </button>
+        )}
+        {onConnectLocalRuntime && localRuntimeActionLabel && (
+          <button
+            type="button"
+            className="code-agents-button"
+            onClick={onConnectLocalRuntime}
+          >
+            <IconTerminal2 size={14} strokeWidth={1.8} />
+            {localRuntimeActionLabel}
           </button>
         )}
         {onOpenSettings && secondaryActionLabel && (
@@ -3437,6 +3458,12 @@ function RunDetailCard({
           }
           primaryDisabled={builderConnecting}
           onPrimaryAction={onConnectBuilder}
+          localRuntimeActionLabel="Sign in with ChatGPT"
+          onConnectLocalRuntime={
+            onConnectLocalRuntime
+              ? () => onConnectLocalRuntime("codex-cli")
+              : undefined
+          }
           secondaryActionLabel="API keys"
           onOpenSettings={onOpenSettings}
         />

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1813,6 +1813,8 @@ export interface AssistantChatProps {
   onForkChat?: () => void | boolean | Promise<void | boolean>;
   /** Override Builder/provider connect routing for embedded hosts. */
   onConnectProvider?: () => void;
+  /** Route local runtime setup through the host's native bridge. */
+  onConnectLocalRuntime?: (engine: string) => void;
   /**
    * Controls the shared composer + menu. Sidebar keeps the full menu by default;
    * hosts without the sidebar provider stack can use upload-only.
@@ -2177,6 +2179,7 @@ const AssistantChatInner = forwardRef<
     imageModelMenu,
     onForkChat,
     onConnectProvider,
+    onConnectLocalRuntime,
     plusMenuMode = "full",
     providerStatusChecksEnabled = true,
     loadHistoryRepository,
@@ -5529,6 +5532,7 @@ const AssistantChatInner = forwardRef<
                             onEffortChange={onEffortChange}
                             imageModelMenu={imageModelMenu}
                             onConnectProvider={onConnectProvider}
+                            onConnectLocalRuntime={onConnectLocalRuntime}
                             toolbarSlot={composerToolbarSlot}
                             contextItems={composerContextItems}
                             onRemoveContextItem={removeComposerContextItem}

--- a/packages/core/src/client/composer/PromptComposer.tsx
+++ b/packages/core/src/client/composer/PromptComposer.tsx
@@ -154,6 +154,8 @@ export interface PromptComposerProps {
    * Used by the Electron desktop app to route through the native IPC handler.
    */
   onConnectProvider?: () => void;
+  /** Called when a local runtime needs its native sign-in/setup flow. */
+  onConnectLocalRuntime?: (engine: string) => void;
   /** Imperative handle for focusing the composer. */
   composerRef?: Ref<TiptapComposerHandle>;
 }
@@ -474,6 +476,7 @@ function PromptComposerInner({
   modelStatusChecksEnabled,
   onTextChange,
   onConnectProvider,
+  onConnectLocalRuntime,
   composerRef,
 }: PromptComposerProps) {
   const localRef = useRef<TiptapComposerHandle>(null);
@@ -656,6 +659,7 @@ function PromptComposerInner({
           onEffortChange={handleEffortChange}
           providerConnectStatusEnabled={resolvedModelStatusChecksEnabled}
           onConnectProvider={onConnectProvider}
+          onConnectLocalRuntime={onConnectLocalRuntime}
         />
       </AgentComposerFrame>
     </>

--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -628,6 +628,8 @@ export interface TiptapComposerProps {
    * Used by the Electron desktop app to route through the native IPC handler.
    */
   onConnectProvider?: () => void;
+  /** Route local runtime setup through the host's native bridge. */
+  onConnectLocalRuntime?: (engine: string) => void;
   /**
    * Optional secondary model menu (e.g. an image-generation model) rendered as
    * an extra section inside the model picker. Opt-in; omit for chat-only apps.
@@ -807,6 +809,7 @@ function ModeSelector({
 
 const FRIENDLY_MODEL_NAMES: Record<string, string> = {
   auto: "Default model",
+  "codex-cli": "ChatGPT subscription",
   "claude-fable-5": "Fable 5",
   "kimi-k2-5": "Kimi K2.5",
   "deepseek-v3-1": "DeepSeek v3.1",
@@ -949,6 +952,7 @@ function ModelSelector({
   onEffortChange,
   providerConnectStatusEnabled = true,
   onConnectProvider,
+  onConnectLocalRuntime,
   imageModel,
 }: {
   model: string;
@@ -963,6 +967,7 @@ function ModelSelector({
   onEffortChange?: (effort: ReasoningEffort) => void;
   providerConnectStatusEnabled?: boolean;
   onConnectProvider?: () => void;
+  onConnectLocalRuntime?: (engine: string) => void;
   imageModel?: ComposerImageModelMenu;
 }) {
   const [open, setOpen] = useState(false);
@@ -1050,6 +1055,13 @@ function ModelSelector({
     window.dispatchEvent(new CustomEvent("agent-panel:open-settings"));
     setOpen(false);
   }, []);
+  const connectLocalRuntime = useCallback(
+    (engine: string) => {
+      onConnectLocalRuntime?.(engine);
+      setOpen(false);
+    },
+    [onConnectLocalRuntime],
+  );
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -1207,9 +1219,15 @@ function ModelSelector({
                   <button
                     type="button"
                     className="text-[10px] text-muted-foreground/60 hover:text-foreground cursor-pointer pe-3 py-1.5"
-                    onClick={openLlmSettings}
+                    onClick={() =>
+                      group.engine === "codex-cli" && onConnectLocalRuntime
+                        ? connectLocalRuntime(group.engine)
+                        : openLlmSettings()
+                    }
                   >
-                    needs API key
+                    {group.engine === "codex-cli" && onConnectLocalRuntime
+                      ? "sign in"
+                      : "needs API key"}
                   </button>
                 )}
               </div>
@@ -1220,7 +1238,14 @@ function ModelSelector({
                     type="button"
                     onClick={() => {
                       if (!group.configured) {
-                        openLlmSettings();
+                        if (
+                          group.engine === "codex-cli" &&
+                          onConnectLocalRuntime
+                        ) {
+                          connectLocalRuntime(group.engine);
+                        } else {
+                          openLlmSettings();
+                        }
                         return;
                       }
                       onChange(m, group.engine);
@@ -1339,6 +1364,7 @@ export function TiptapComposer({
   onEffortChange,
   providerConnectStatusEnabled,
   onConnectProvider,
+  onConnectLocalRuntime,
   imageModelMenu,
   draftScope,
   contextItems = [],
@@ -2740,6 +2766,7 @@ export function TiptapComposer({
             onEffortChange={onEffortChange}
             providerConnectStatusEnabled={providerConnectStatusEnabled}
             onConnectProvider={onConnectProvider}
+            onConnectLocalRuntime={onConnectLocalRuntime}
             imageModel={imageModelMenu}
           />
         )}

--- a/packages/core/src/integrations/webhook-handler-engine.spec.ts
+++ b/packages/core/src/integrations/webhook-handler-engine.spec.ts
@@ -164,7 +164,13 @@ vi.mock("../agent/run-manager.js", () => ({
   ),
 }));
 
-function createAdapter(sendResponse = vi.fn()): PlatformAdapter {
+function createAdapter(
+  sendResponse = vi.fn(),
+  formatAgentResponse: PlatformAdapter["formatAgentResponse"] = (text) => ({
+    text,
+    platformContext: {},
+  }),
+): PlatformAdapter {
   return {
     platform: "fake",
     label: "Fake",
@@ -173,7 +179,7 @@ function createAdapter(sendResponse = vi.fn()): PlatformAdapter {
     verifyWebhook: async () => true,
     parseIncomingMessage: async () => null,
     sendResponse,
-    formatAgentResponse: (text) => ({ text, platformContext: {} }),
+    formatAgentResponse,
     getStatus: async () => ({
       platform: "fake",
       label: "Fake",
@@ -1406,7 +1412,7 @@ describe("integration webhook handler engine resolution", () => {
     expect(sendResponse.mock.calls[0][0].text).not.toContain("design-empty");
   });
 
-  it("does not fall back to unmarked A2A tool URLs when no final text is emitted", async () => {
+  it("surfaces a useful fallback when no final text is emitted", async () => {
     const { processIntegrationTask } = await import("./webhook-handler.js");
     const sendResponse = vi.fn();
     runAgentLoopMock.mockImplementationOnce(async ({ send }) => {
@@ -1433,12 +1439,64 @@ describe("integration webhook handler engine resolution", () => {
 
     expect(sendResponse).toHaveBeenCalledWith(
       expect.objectContaining({
-        text: "(No response)",
+        text: expect.stringContaining(
+          "The model finished without a visible answer",
+        ),
       }),
       expect.any(Object),
       expect.objectContaining({ placeholderRef: undefined }),
     );
     expect(sendResponse.mock.calls[0][0].text).not.toContain("deck-guessed");
+  });
+
+  it("links Slack-style replies directly to the Dispatch chat thread", async () => {
+    const { processIntegrationTask } = await import("./webhook-handler.js");
+    const previousAppUrl = process.env.APP_URL;
+    const previousAppBasePath = process.env.APP_BASE_PATH;
+    process.env.APP_URL = "https://agent-workspace.builder.io";
+    process.env.APP_BASE_PATH = "/dispatch";
+    const sendResponse = vi.fn();
+    const formatAgentResponse = vi.fn(
+      (text: string, opts?: { threadDeepLinkUrl?: string }) => ({
+        text,
+        platformContext: opts ?? {},
+      }),
+    );
+    runAgentLoopMock.mockImplementationOnce(async ({ send }) => {
+      send({ type: "text", text: "I found the issue." });
+    });
+
+    try {
+      await processIntegrationTask(pendingTask({ id: "task-direct-thread" }), {
+        adapter: createAdapter(sendResponse, formatAgentResponse),
+        systemPrompt: "system",
+        actions: {},
+        model: "claude-sonnet-4-6",
+        apiKey: "",
+        ownerEmail: "dispatch+qa@integration.local",
+      });
+    } finally {
+      if (previousAppUrl === undefined) {
+        delete process.env.APP_URL;
+      } else {
+        process.env.APP_URL = previousAppUrl;
+      }
+      if (previousAppBasePath === undefined) {
+        delete process.env.APP_BASE_PATH;
+      } else {
+        process.env.APP_BASE_PATH = previousAppBasePath;
+      }
+    }
+
+    expect(formatAgentResponse).toHaveBeenCalledWith("I found the issue.", {
+      threadDeepLinkUrl:
+        "https://agent-workspace.builder.io/dispatch/chat/thread-qa",
+    });
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "I found the issue." }),
+      expect.any(Object),
+      expect.objectContaining({ placeholderRef: undefined }),
+    );
   });
 
   it("does not send hallucinated local design URLs to Slack-style integrations", async () => {

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -74,6 +74,8 @@ import {
 const PROCESSOR_DISPATCH_SETTLE_WAIT_MS = 1_500;
 const DEFERRED_RESPONSE_DISPATCH_SETTLE_WAIT_MS = 1_500;
 const DEFERRED_RESPONSE_MAX_HANDLER_MS = 2_500;
+const EMPTY_INTEGRATION_RESPONSE_MESSAGE =
+  "The model finished without a visible answer. Try again, or open the thread in Dispatch to inspect the run.";
 
 type ToolDoneEvent = { type: "tool_done"; tool: string; result: string };
 
@@ -972,7 +974,7 @@ async function processIncomingMessage(
                 "If it was a complex analytics question, opening the analytics app " +
                 "directly is the most reliable way to get an answer right now.";
             } else {
-              responseText = "(No response)";
+              responseText = EMPTY_INTEGRATION_RESPONSE_MESSAGE;
             }
           }
           if (approval?.type === "approval_required") {
@@ -995,7 +997,7 @@ async function processIncomingMessage(
           }
           const threadDeepLinkUrl =
             appBaseUrl && threadId
-              ? `${appBaseUrl}/?thread=${threadId}`
+              ? `${appBaseUrl}/chat/${encodeURIComponent(threadId)}`
               : undefined;
 
           // Format and send back to platform — update the "thinking…"

--- a/packages/core/src/secrets/crypto.spec.ts
+++ b/packages/core/src/secrets/crypto.spec.ts
@@ -129,6 +129,23 @@ describe("getSecretEncryptionKey", () => {
     expect(shared.equals(expected)).toBe(true);
   });
 
+  it("falls back to the app-scoped key when shared material is absent", () => {
+    process.env.NODE_ENV = "production";
+    process.env.APP_NAME = "analytics"; // guard:allow-env-credential — test configures a deploy-level app scope.
+    process.env.ANALYTICS_SECRETS_ENCRYPTION_KEY = "analytics-material"; // guard:allow-env-credential — test configures deploy-level app encryption material.
+    delete process.env.SECRETS_ENCRYPTION_KEY;
+    delete process.env.BETTER_AUTH_SECRET;
+
+    const fallback = getSharedSecretEncryptionKey();
+
+    delete process.env.APP_NAME; // guard:allow-env-credential — test removes the deploy-level app scope.
+    delete process.env.ANALYTICS_SECRETS_ENCRYPTION_KEY; // guard:allow-env-credential — test removes deploy-level app encryption material.
+    process.env.SECRETS_ENCRYPTION_KEY = "analytics-material";
+    const expected = getSharedSecretEncryptionKey();
+
+    expect(fallback.equals(expected)).toBe(true);
+  });
+
   it("derives a stable 32-byte AES key from the configured material", () => {
     process.env.SECRETS_ENCRYPTION_KEY = "stable-material";
     const a = getSecretEncryptionKey();

--- a/packages/core/src/secrets/crypto.spec.ts
+++ b/packages/core/src/secrets/crypto.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeAll, afterEach } from "vitest";
 import {
   encryptSecretValue,
   decryptSecretValue,
+  getSharedSecretEncryptionKey,
   getSecretEncryptionKey,
   isEncryptedSecretValue,
 } from "./crypto.js";
@@ -113,6 +114,19 @@ describe("getSecretEncryptionKey", () => {
     const expected = getSecretEncryptionKey();
 
     expect(appScoped.equals(expected)).toBe(true);
+  });
+
+  it("uses shared key material for workspace secrets", () => {
+    process.env.APP_NAME = "analytics"; // guard:allow-env-credential — test configures a deploy-level app scope.
+    process.env.ANALYTICS_SECRETS_ENCRYPTION_KEY = "analytics-material"; // guard:allow-env-credential — test configures deploy-level app encryption material.
+    process.env.SECRETS_ENCRYPTION_KEY = "shared-material";
+    const shared = getSharedSecretEncryptionKey();
+
+    delete process.env.APP_NAME; // guard:allow-env-credential — test removes the deploy-level app scope.
+    delete process.env.ANALYTICS_SECRETS_ENCRYPTION_KEY; // guard:allow-env-credential — test removes deploy-level app encryption material.
+    const expected = getSharedSecretEncryptionKey();
+
+    expect(shared.equals(expected)).toBe(true);
   });
 
   it("derives a stable 32-byte AES key from the configured material", () => {

--- a/packages/core/src/secrets/crypto.ts
+++ b/packages/core/src/secrets/crypto.ts
@@ -143,6 +143,11 @@ export function getSharedSecretEncryptionKey(): Buffer {
   );
 }
 
+/** Whether this deployment has stable workspace-shared key material. */
+export function hasSharedSecretEncryptionKeyMaterial(): boolean {
+  return Boolean(sharedEncryptionKeyMaterial());
+}
+
 function encryptWithKey(plaintext: string, key: Buffer): string {
   const { createCipheriv, randomBytes } = requireNodeCrypto();
   const iv = randomBytes(12);

--- a/packages/core/src/secrets/crypto.ts
+++ b/packages/core/src/secrets/crypto.ts
@@ -5,7 +5,10 @@
  * (`resolveCredential` / `saveCredential`, stored in `settings`), and other
  * column-level encrypted values. The `app_secrets` storage layer uses the
  * shared-key variant below because workspace-scoped vault rows are readable by
- * sibling apps in the same workspace.
+ * sibling apps in the same workspace. When a deployment has not been given
+ * shared key material yet, that variant falls back to the app-scoped key so
+ * existing single-app deployments can keep reading and writing secrets while
+ * they migrate to the shared key.
  *
  * The default encryption key is derived from
  * `<APP_NAME>_SECRETS_ENCRYPTION_KEY` when set, then `SECRETS_ENCRYPTION_KEY`,
@@ -123,17 +126,20 @@ export function getSecretEncryptionKey(): Buffer {
 }
 
 /**
- * Derive the workspace-shared key used by `app_secrets` rows. Unlike generic
- * column-level encryption, workspace vault data must decrypt in sibling apps,
- * so app-specific `<APP_NAME>_SECRETS_ENCRYPTION_KEY` values are excluded.
+ * Derive the preferred workspace-shared key used by `app_secrets` rows.
+ * Unlike generic column-level encryption, workspace vault data should decrypt
+ * in sibling apps, so `SECRETS_ENCRYPTION_KEY` / `BETTER_AUTH_SECRET` take
+ * precedence. The app-scoped key remains a compatibility fallback for
+ * deployments that have not configured shared material yet; once the shared
+ * key is configured, writes use it and reads still fall back to old rows.
  */
 export function getSharedSecretEncryptionKey(): Buffer {
   return deriveSecretEncryptionKey(
-    sharedEncryptionKeyMaterial(),
-    "[agent-native/secrets] Refusing to start in production without a shared encryption key for workspace secrets. " +
-      "Set SECRETS_ENCRYPTION_KEY or BETTER_AUTH_SECRET in every workspace app.",
-    "[agent-native/secrets] SECRETS_ENCRYPTION_KEY not set — using a machine-local fallback for workspace secrets. " +
-      "Set SECRETS_ENCRYPTION_KEY or BETTER_AUTH_SECRET in every workspace app.",
+    sharedEncryptionKeyMaterial() || appScopedEncryptionKey(),
+    "[agent-native/secrets] Refusing to start in production without encryption key material for workspace secrets. " +
+      "Set SECRETS_ENCRYPTION_KEY, BETTER_AUTH_SECRET, or the app-scoped *_SECRETS_ENCRYPTION_KEY in the deploy environment.",
+    "[agent-native/secrets] SECRETS_ENCRYPTION_KEY not set — using app-scoped or machine-local fallback for workspace secrets. " +
+      "Set SECRETS_ENCRYPTION_KEY or BETTER_AUTH_SECRET in every workspace app so sibling apps share vault rows.",
   );
 }
 

--- a/packages/core/src/secrets/crypto.ts
+++ b/packages/core/src/secrets/crypto.ts
@@ -1,17 +1,20 @@
 /**
  * Shared AES-256-GCM encryption for secret values at rest.
  *
- * Used by both the framework secrets vault (`app_secrets`) and per-user/per-org
- * credentials (`resolveCredential` / `saveCredential`, stored in `settings`) so
- * there is a single crypto implementation and a single key story.
+ * Used by the framework secrets vault, per-user/per-org credentials
+ * (`resolveCredential` / `saveCredential`, stored in `settings`), and other
+ * column-level encrypted values. The `app_secrets` storage layer uses the
+ * shared-key variant below because workspace-scoped vault rows are readable by
+ * sibling apps in the same workspace.
  *
- * The encryption key is derived from `<APP_NAME>_SECRETS_ENCRYPTION_KEY` when
- * set, then `SECRETS_ENCRYPTION_KEY`, then `BETTER_AUTH_SECRET`. The app-scoped
- * key lets a local multi-app workspace read one app's encrypted production data
- * without replacing the shared local auth secret. In production we refuse to
- * start without configured key material — a CWD-derived fallback would be
- * effectively static (e.g. `/var/task` on Lambda), so anyone with read access
- * to the DB could decrypt every secret.
+ * The default encryption key is derived from
+ * `<APP_NAME>_SECRETS_ENCRYPTION_KEY` when set, then `SECRETS_ENCRYPTION_KEY`,
+ * then `BETTER_AUTH_SECRET`. The app-scoped key lets a local multi-app
+ * workspace read one app's encrypted production data without replacing the
+ * shared local auth secret. In production we refuse to start without
+ * configured key material — a CWD-derived fallback would be effectively
+ * static (e.g. `/var/task` on Lambda), so anyone with read access to the DB
+ * could decrypt every secret.
  *
  * Encrypted values are tagged `v1:<iv-hex>:<ct-hex>:<tag-hex>`. The `v1:` prefix
  * lets readers distinguish ciphertext from legacy plaintext during migration.
@@ -67,45 +70,26 @@ function appScopedEncryptionKey(): string | undefined {
     : undefined;
 }
 
-/**
- * Derive a 32-byte AES key from the configured secret material via SHA-256.
- * Re-derived per call (cheap, stateless, and makes rotation easy).
- */
-export function getSecretEncryptionKey(): Buffer {
+function sharedEncryptionKeyMaterial(): string | undefined {
+  if (typeof process === "undefined") return undefined;
+  return process.env.SECRETS_ENCRYPTION_KEY || process.env.BETTER_AUTH_SECRET;
+}
+
+function deriveSecretEncryptionKey(
+  explicit: string | undefined,
+  errorMessage: string,
+  warningMessage: string,
+): Buffer {
   const { createHash } = requireNodeCrypto();
-  const explicit =
-    appScopedEncryptionKey() ||
-    (typeof process === "undefined"
-      ? undefined
-      : process.env.SECRETS_ENCRYPTION_KEY) ||
-    (typeof process === "undefined"
-      ? undefined
-      : process.env.BETTER_AUTH_SECRET);
 
   if (!explicit) {
     if (processNodeEnv() === "production") {
-      const appName =
-        typeof process === "undefined"
-          ? undefined
-          : process.env.APP_NAME?.trim() // guard:allow-env-credential — deploy-level app configuration selects the scoped encryption key.
-              .toUpperCase()
-              .replace(/[^A-Z0-9]+/g, "_")
-              .replace(/^_+|_+$/g, "");
-      throw new Error(
-        "[agent-native/secrets] Refusing to start in production without an encryption key. " +
-          `Set ${appName ? `${appName}_SECRETS_ENCRYPTION_KEY, ` : ""}SECRETS_ENCRYPTION_KEY, or BETTER_AUTH_SECRET in the deploy environment. ` +
-          "The previous CWD-derived fallback was effectively static (e.g. `/var/task` on Lambda), " +
-          "which means anyone with read access to the secrets table could decrypt every user's secrets.",
-      );
+      throw new Error(errorMessage);
     }
     if (!_warnedFallback) {
       _warnedFallback = true;
       // eslint-disable-next-line no-console
-      console.warn(
-        "[agent-native/secrets] SECRETS_ENCRYPTION_KEY not set — using a machine-local fallback. " +
-          "Set an app-scoped *_SECRETS_ENCRYPTION_KEY, SECRETS_ENCRYPTION_KEY, or BETTER_AUTH_SECRET for production. " +
-          "Production deploys without one of these env vars now hard-fail.",
-      );
+      console.warn(warningMessage);
     }
   }
 
@@ -113,10 +97,48 @@ export function getSecretEncryptionKey(): Buffer {
   return createHash("sha256").update(material).digest();
 }
 
-/** Encrypt a plain-text value. Returns `v1:<iv-hex>:<ct-hex>:<tag-hex>`. */
-export function encryptSecretValue(plaintext: string): string {
+/**
+ * Derive the key used by generic encrypted values such as credentials and
+ * OAuth tokens. App-specific key material is allowed for these app-local
+ * values.
+ */
+export function getSecretEncryptionKey(): Buffer {
+  const appName =
+    typeof process === "undefined"
+      ? undefined
+      : process.env.APP_NAME?.trim() // guard:allow-env-credential — deploy-level app configuration selects the scoped encryption key.
+          .toUpperCase()
+          .replace(/[^A-Z0-9]+/g, "_")
+          .replace(/^_+|_+$/g, "");
+  return deriveSecretEncryptionKey(
+    appScopedEncryptionKey() || sharedEncryptionKeyMaterial(),
+    "[agent-native/secrets] Refusing to start in production without an encryption key. " +
+      `Set ${appName ? `${appName}_SECRETS_ENCRYPTION_KEY, ` : ""}SECRETS_ENCRYPTION_KEY, or BETTER_AUTH_SECRET in the deploy environment. ` +
+      "The previous CWD-derived fallback was effectively static (e.g. `/var/task` on Lambda), " +
+      "which means anyone with read access to the DB could decrypt every secret.",
+    "[agent-native/secrets] SECRETS_ENCRYPTION_KEY not set — using a machine-local fallback. " +
+      "Set an app-scoped *_SECRETS_ENCRYPTION_KEY, SECRETS_ENCRYPTION_KEY, or BETTER_AUTH_SECRET for production. " +
+      "Production deploys without one of these env vars now hard-fail.",
+  );
+}
+
+/**
+ * Derive the workspace-shared key used by `app_secrets` rows. Unlike generic
+ * column-level encryption, workspace vault data must decrypt in sibling apps,
+ * so app-specific `<APP_NAME>_SECRETS_ENCRYPTION_KEY` values are excluded.
+ */
+export function getSharedSecretEncryptionKey(): Buffer {
+  return deriveSecretEncryptionKey(
+    sharedEncryptionKeyMaterial(),
+    "[agent-native/secrets] Refusing to start in production without a shared encryption key for workspace secrets. " +
+      "Set SECRETS_ENCRYPTION_KEY or BETTER_AUTH_SECRET in every workspace app.",
+    "[agent-native/secrets] SECRETS_ENCRYPTION_KEY not set — using a machine-local fallback for workspace secrets. " +
+      "Set SECRETS_ENCRYPTION_KEY or BETTER_AUTH_SECRET in every workspace app.",
+  );
+}
+
+function encryptWithKey(plaintext: string, key: Buffer): string {
   const { createCipheriv, randomBytes } = requireNodeCrypto();
-  const key = getSecretEncryptionKey();
   const iv = randomBytes(12);
   const cipher = createCipheriv("aes-256-gcm", key, iv);
   const ct = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
@@ -124,8 +146,7 @@ export function encryptSecretValue(plaintext: string): string {
   return `v1:${iv.toString("hex")}:${ct.toString("hex")}:${tag.toString("hex")}`;
 }
 
-/** Decrypt a value produced by `encryptSecretValue`. Throws on tampering. */
-export function decryptSecretValue(encrypted: string): string {
+function decryptWithKey(encrypted: string, key: Buffer): string {
   const { createDecipheriv } = requireNodeCrypto();
   if (!encrypted.startsWith("v1:")) {
     throw new Error("Unrecognised secret encoding");
@@ -134,7 +155,6 @@ export function decryptSecretValue(encrypted: string): string {
   if (!ivHex || !ctHex || !tagHex) {
     throw new Error("Corrupt secret payload");
   }
-  const key = getSecretEncryptionKey();
   const decipher = createDecipheriv(
     "aes-256-gcm",
     key,
@@ -146,6 +166,26 @@ export function decryptSecretValue(encrypted: string): string {
     decipher.final(),
   ]);
   return pt.toString("utf8");
+}
+
+/** Encrypt a plain-text value with the generic app-local key. */
+export function encryptSecretValue(plaintext: string): string {
+  return encryptWithKey(plaintext, getSecretEncryptionKey());
+}
+
+/** Decrypt a value produced by `encryptSecretValue`. Throws on tampering. */
+export function decryptSecretValue(encrypted: string): string {
+  return decryptWithKey(encrypted, getSecretEncryptionKey());
+}
+
+/** Encrypt a workspace-shared `app_secrets` value. */
+export function encryptSharedSecretValue(plaintext: string): string {
+  return encryptWithKey(plaintext, getSharedSecretEncryptionKey());
+}
+
+/** Decrypt a workspace-shared `app_secrets` value. */
+export function decryptSharedSecretValue(encrypted: string): string {
+  return decryptWithKey(encrypted, getSharedSecretEncryptionKey());
 }
 
 /**

--- a/packages/core/src/secrets/index.ts
+++ b/packages/core/src/secrets/index.ts
@@ -38,7 +38,8 @@ export { APP_SECRETS_CREATE_SQL, appSecrets } from "./schema.js";
 
 // AES-256-GCM helpers for column-level encryption of per-row secret values
 // (e.g. a per-record share password) that don't fit the keyed app_secrets /
-// credentials stores. Same key story as the vault.
+// credentials stores. These use the app-local key, unlike the workspace-shared
+// app_secrets storage layer.
 export {
   encryptSecretValue,
   decryptSecretValue,

--- a/packages/core/src/secrets/schema.ts
+++ b/packages/core/src/secrets/schema.ts
@@ -22,6 +22,8 @@ export const appSecrets = table("app_secrets", {
   key: text("key").notNull(),
   /** Encrypted value — never return this through any API. */
   encryptedValue: text("encrypted_value").notNull(),
+  /** Preferred workspace-shared ciphertext; nullable during key migration. */
+  sharedEncryptedValue: text("shared_encrypted_value"),
   /** Optional human-readable description (used for ad-hoc keys). */
   description: text("description"),
   /** JSON array of allowed URL origins. Null = allow all. */
@@ -41,6 +43,7 @@ export const APP_SECRETS_CREATE_SQL = `CREATE TABLE IF NOT EXISTS app_secrets (
   scope_id TEXT NOT NULL,
   key TEXT NOT NULL,
   encrypted_value TEXT NOT NULL,
+  shared_encrypted_value TEXT,
   description TEXT,
   url_allowlist TEXT,
   created_at INTEGER NOT NULL,

--- a/packages/core/src/secrets/storage.spec.ts
+++ b/packages/core/src/secrets/storage.spec.ts
@@ -9,6 +9,8 @@ import {
   vi,
 } from "vitest";
 
+import { decryptSharedSecretValue } from "./crypto.js";
+
 // A stable encryption key so values round-trip deterministically and the
 // crypto layer never falls through to the cwd-derived fallback (which would
 // warn on every run).
@@ -275,6 +277,65 @@ describe("secrets storage CRUD (real sqlite)", () => {
       if (originalSharedKey === undefined)
         delete process.env.SECRETS_ENCRYPTION_KEY;
       else process.env.SECRETS_ENCRYPTION_KEY = originalSharedKey;
+    }
+  });
+
+  it("keeps app-scoped-only production deployments writable", async () => {
+    const originalAppName = process.env.APP_NAME; // guard:allow-env-credential — test configures deploy-level app scope.
+    const originalAppKey = process.env.ANALYTICS_SECRETS_ENCRYPTION_KEY; // guard:allow-env-credential — test configures deploy-level app encryption material.
+    const originalSharedKey = process.env.SECRETS_ENCRYPTION_KEY;
+    const originalAuthSecret = process.env.BETTER_AUTH_SECRET;
+    const originalNodeEnv = process.env.NODE_ENV;
+
+    try {
+      process.env.NODE_ENV = "production";
+      process.env.APP_NAME = "analytics"; // guard:allow-env-credential — test configures deploy-level app scope.
+      process.env.ANALYTICS_SECRETS_ENCRYPTION_KEY = "analytics-only-material"; // guard:allow-env-credential — test configures deploy-level app encryption material.
+      delete process.env.SECRETS_ENCRYPTION_KEY;
+      delete process.env.BETTER_AUTH_SECRET;
+
+      await mod.writeAppSecret({
+        ...userRef,
+        value: "legacy-deployment-secret",
+      });
+      await expect(mod.readAppSecret(userRef)).resolves.toMatchObject({
+        value: "legacy-deployment-secret",
+      });
+
+      // Existing rows remain readable after the deployment adds the preferred
+      // workspace key; the storage read path falls back to the old app key.
+      const beforeMigration = sqlite
+        .prepare(`SELECT encrypted_value, updated_at FROM app_secrets`)
+        .get() as { encrypted_value: string; updated_at: number };
+      process.env.SECRETS_ENCRYPTION_KEY = "new-workspace-shared-material";
+      await expect(mod.readAppSecret(userRef)).resolves.toMatchObject({
+        value: "legacy-deployment-secret",
+      });
+      const afterMigration = sqlite
+        .prepare(`SELECT encrypted_value, updated_at FROM app_secrets`)
+        .get() as { encrypted_value: string; updated_at: number };
+      expect(afterMigration.encrypted_value).not.toBe(
+        beforeMigration.encrypted_value,
+      );
+      expect(afterMigration.updated_at).toBe(beforeMigration.updated_at);
+      expect(decryptSharedSecretValue(afterMigration.encrypted_value)).toBe(
+        "legacy-deployment-secret",
+      );
+    } finally {
+      if (originalAppName === undefined)
+        delete process.env.APP_NAME; // guard:allow-env-credential — test restores deploy-level app scope.
+      else process.env.APP_NAME = originalAppName; // guard:allow-env-credential — test restores deploy-level app scope.
+      if (originalAppKey === undefined)
+        delete process.env.ANALYTICS_SECRETS_ENCRYPTION_KEY; // guard:allow-env-credential — test restores deploy-level app encryption material.
+      else process.env.ANALYTICS_SECRETS_ENCRYPTION_KEY = originalAppKey; // guard:allow-env-credential — test restores deploy-level app encryption material.
+      if (originalSharedKey === undefined)
+        delete process.env.SECRETS_ENCRYPTION_KEY;
+      else process.env.SECRETS_ENCRYPTION_KEY = originalSharedKey;
+      if (originalAuthSecret === undefined)
+        delete process.env.BETTER_AUTH_SECRET;
+      else process.env.BETTER_AUTH_SECRET = originalAuthSecret;
+      if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = originalNodeEnv;
     }
   });
 

--- a/packages/core/src/secrets/storage.spec.ts
+++ b/packages/core/src/secrets/storage.spec.ts
@@ -87,7 +87,9 @@ describe("secrets storage bootstrap", () => {
 
     expect(execute).toHaveBeenCalledTimes(1);
     expect(execute.mock.calls[0]?.[0]).toMatchObject({
-      sql: expect.stringMatching(/^SELECT encrypted_value, updated_at/),
+      sql: expect.stringMatching(
+        /^SELECT encrypted_value, shared_encrypted_value/,
+      ),
     });
   });
 
@@ -114,11 +116,15 @@ describe("secrets storage bootstrap", () => {
     const allSql = execute.mock.calls.map(([input]) =>
       typeof input === "string" ? input : input.sql,
     );
-    expect(allSql[0]).toMatch(/^SELECT encrypted_value, updated_at/);
+    expect(allSql[0]).toMatch(
+      /^SELECT encrypted_value, shared_encrypted_value/,
+    );
     expect(allSql).toContainEqual(
       expect.stringContaining("CREATE TABLE IF NOT EXISTS app_secrets"),
     );
-    expect(allSql.at(-1)).toMatch(/^SELECT encrypted_value, updated_at/);
+    expect(allSql.at(-1)).toMatch(
+      /^SELECT encrypted_value, shared_encrypted_value/,
+    );
   });
 
   it("does not bootstrap for unrelated database failures", async () => {
@@ -305,21 +311,49 @@ describe("secrets storage CRUD (real sqlite)", () => {
       // Existing rows remain readable after the deployment adds the preferred
       // workspace key; the storage read path falls back to the old app key.
       const beforeMigration = sqlite
-        .prepare(`SELECT encrypted_value, updated_at FROM app_secrets`)
-        .get() as { encrypted_value: string; updated_at: number };
+        .prepare(
+          `SELECT encrypted_value, shared_encrypted_value, updated_at FROM app_secrets`,
+        )
+        .get() as {
+        encrypted_value: string;
+        shared_encrypted_value: string | null;
+        updated_at: number;
+      };
       process.env.SECRETS_ENCRYPTION_KEY = "new-workspace-shared-material";
       await expect(mod.readAppSecret(userRef)).resolves.toMatchObject({
         value: "legacy-deployment-secret",
       });
       const afterMigration = sqlite
-        .prepare(`SELECT encrypted_value, updated_at FROM app_secrets`)
-        .get() as { encrypted_value: string; updated_at: number };
-      expect(afterMigration.encrypted_value).not.toBe(
+        .prepare(
+          `SELECT encrypted_value, shared_encrypted_value, updated_at FROM app_secrets`,
+        )
+        .get() as {
+        encrypted_value: string;
+        shared_encrypted_value: string | null;
+        updated_at: number;
+      };
+      expect(afterMigration.encrypted_value).toBe(
         beforeMigration.encrypted_value,
       );
+      expect(afterMigration.shared_encrypted_value).not.toBeNull();
       expect(afterMigration.updated_at).toBe(beforeMigration.updated_at);
-      expect(decryptSharedSecretValue(afterMigration.encrypted_value)).toBe(
-        "legacy-deployment-secret",
+      expect(
+        decryptSharedSecretValue(afterMigration.shared_encrypted_value!),
+      ).toBe("legacy-deployment-secret");
+
+      // An older app version can update the legacy column while preserving
+      // the shared ciphertext written by a newer sibling.
+      const sharedBeforeLegacyWrite = afterMigration.shared_encrypted_value;
+      delete process.env.SECRETS_ENCRYPTION_KEY;
+      await mod.writeAppSecret({
+        ...userRef,
+        value: "updated-by-legacy-app",
+      });
+      const afterLegacyWrite = sqlite
+        .prepare(`SELECT shared_encrypted_value FROM app_secrets`)
+        .get() as { shared_encrypted_value: string | null };
+      expect(afterLegacyWrite.shared_encrypted_value).toBe(
+        sharedBeforeLegacyWrite,
       );
     } finally {
       if (originalAppName === undefined)
@@ -498,8 +532,10 @@ describe("secrets storage CRUD (real sqlite)", () => {
     // Simulate a tampered / key-rotated row by overwriting the ciphertext with
     // a syntactically-encrypted-but-undecryptable value.
     sqlite
-      .prepare(`UPDATE app_secrets SET encrypted_value = ?`)
-      .run("v1:dead:beef:cafe");
+      .prepare(
+        `UPDATE app_secrets SET encrypted_value = ?, shared_encrypted_value = ?`,
+      )
+      .run("v1:dead:beef:cafe", "v1:dead:beef:cafe");
 
     // readAppSecret swallows decryption errors and reports "missing" so the
     // ciphertext never escapes up the stack.

--- a/packages/core/src/secrets/storage.spec.ts
+++ b/packages/core/src/secrets/storage.spec.ts
@@ -233,6 +233,51 @@ describe("secrets storage CRUD (real sqlite)", () => {
     expect(read!.updatedAt).toBeGreaterThan(0);
   });
 
+  it("round-trips workspace secrets across app-scoped deployments", async () => {
+    const originalAppName = process.env.APP_NAME; // guard:allow-env-credential — test configures deploy-level app scope.
+    const originalDispatchKey = process.env.DISPATCH_SECRETS_ENCRYPTION_KEY; // guard:allow-env-credential — test configures deploy-level app encryption material.
+    const originalCoachKey = process.env.COACH_SECRETS_ENCRYPTION_KEY; // guard:allow-env-credential — test configures deploy-level app encryption material.
+    const originalSharedKey = process.env.SECRETS_ENCRYPTION_KEY;
+
+    try {
+      process.env.SECRETS_ENCRYPTION_KEY = "workspace-shared-material";
+      process.env.DISPATCH_SECRETS_ENCRYPTION_KEY = "dispatch-only-material"; // guard:allow-env-credential — test configures deploy-level app encryption material.
+      process.env.COACH_SECRETS_ENCRYPTION_KEY = "coach-only-material"; // guard:allow-env-credential — test configures deploy-level app encryption material.
+
+      process.env.APP_NAME = "dispatch"; // guard:allow-env-credential — test switches between deploy-level app scopes.
+      await mod.writeAppSecret({
+        scope: "org",
+        scopeId: "org_42",
+        key: "ACADEMY_CONVEX_SITE_URL",
+        value: "https://academy.example.test",
+      });
+
+      process.env.APP_NAME = "coach"; // guard:allow-env-credential — test switches between deploy-level app scopes.
+      await expect(
+        mod.readAppSecret({
+          scope: "org",
+          scopeId: "org_42",
+          key: "ACADEMY_CONVEX_SITE_URL",
+        }),
+      ).resolves.toMatchObject({
+        value: "https://academy.example.test",
+      });
+    } finally {
+      if (originalAppName === undefined)
+        delete process.env.APP_NAME; // guard:allow-env-credential — test restores deploy-level app scope.
+      else process.env.APP_NAME = originalAppName; // guard:allow-env-credential — test restores deploy-level app scope.
+      if (originalDispatchKey === undefined)
+        delete process.env.DISPATCH_SECRETS_ENCRYPTION_KEY; // guard:allow-env-credential — test restores deploy-level app encryption material.
+      else process.env.DISPATCH_SECRETS_ENCRYPTION_KEY = originalDispatchKey; // guard:allow-env-credential — test restores deploy-level app encryption material.
+      if (originalCoachKey === undefined)
+        delete process.env.COACH_SECRETS_ENCRYPTION_KEY; // guard:allow-env-credential — test restores deploy-level app encryption material.
+      else process.env.COACH_SECRETS_ENCRYPTION_KEY = originalCoachKey; // guard:allow-env-credential — test restores deploy-level app encryption material.
+      if (originalSharedKey === undefined)
+        delete process.env.SECRETS_ENCRYPTION_KEY;
+      else process.env.SECRETS_ENCRYPTION_KEY = originalSharedKey;
+    }
+  });
+
   it("reads several scoped secrets in one projected query", async () => {
     await mod.writeAppSecret({ ...userRef, value: "openai-example" });
     await mod.writeAppSecret({

--- a/packages/core/src/secrets/storage.ts
+++ b/packages/core/src/secrets/storage.ts
@@ -1,13 +1,13 @@
 /**
  * Storage layer for the framework secrets registry.
  *
- * Values are encrypted at rest with AES-256-GCM. The encryption key is
- * derived from `SECRETS_ENCRYPTION_KEY` (preferred) or the existing
- * `BETTER_AUTH_SECRET` env var (fallback so templates don't need a second
- * secret during development). If neither is set in production we fall back
- * to a machine-local key derived from the cwd — the secret is still only
- * readable on this machine, but consider setting `SECRETS_ENCRYPTION_KEY`
- * for a stable, rotatable key.
+ * Values are encrypted at rest with AES-256-GCM. The workspace-shared
+ * encryption key is derived from `SECRETS_ENCRYPTION_KEY` (preferred) or the
+ * existing `BETTER_AUTH_SECRET` env var (fallback so templates don't need a
+ * second secret during development). If neither is set in production we fall
+ * back to a machine-local key derived from the cwd — the secret is still only
+ * readable on this machine, but consider setting `SECRETS_ENCRYPTION_KEY` for
+ * a stable, rotatable key shared by every app in the workspace.
  *
  * Secret values are NEVER logged and NEVER returned from any route handler.
  */
@@ -17,8 +17,8 @@ import { randomUUID } from "node:crypto";
 import { getDbExec, isPostgres } from "../db/client.js";
 import { ensureColumnExists, ensureTableExists } from "../db/ddl-guard.js";
 import {
-  encryptSecretValue as encryptValue,
-  decryptSecretValue as decryptValue,
+  encryptSharedSecretValue as encryptValue,
+  decryptSharedSecretValue as decryptValue,
 } from "./crypto.js";
 import type { SecretScope } from "./register.js";
 import { APP_SECRETS_CREATE_SQL } from "./schema.js";

--- a/packages/core/src/secrets/storage.ts
+++ b/packages/core/src/secrets/storage.ts
@@ -17,9 +17,11 @@ import { randomUUID } from "node:crypto";
 import { getDbExec, isPostgres } from "../db/client.js";
 import { ensureColumnExists, ensureTableExists } from "../db/ddl-guard.js";
 import {
+  encryptSecretValue as encryptLegacyValue,
   encryptSharedSecretValue as encryptValue,
   decryptSharedSecretValue as decryptValue,
   decryptSecretValue as decryptLegacyValue,
+  hasSharedSecretEncryptionKeyMaterial,
 } from "./crypto.js";
 import type { SecretScope } from "./register.js";
 import { APP_SECRETS_CREATE_SQL } from "./schema.js";
@@ -62,6 +64,11 @@ async function ensureTable(): Promise<void> {
           "url_allowlist",
           `ALTER TABLE app_secrets ADD COLUMN IF NOT EXISTS url_allowlist TEXT`,
         );
+        await ensureColumnExists(
+          "app_secrets",
+          "shared_encrypted_value",
+          `ALTER TABLE app_secrets ADD COLUMN IF NOT EXISTS shared_encrypted_value TEXT`,
+        );
         return;
       }
 
@@ -87,6 +94,16 @@ async function ensureTable(): Promise<void> {
       } catch {
         // Column already exists — expected
       }
+
+      // Additive migration: workspace-shared ciphertext. Keep the legacy
+      // encrypted_value column so older app versions remain readable.
+      try {
+        await client.execute(
+          `ALTER TABLE app_secrets ADD COLUMN shared_encrypted_value TEXT`,
+        );
+      } catch {
+        // Column already exists — expected
+      }
     })().catch((err) => {
       _initPromise = undefined;
       throw err;
@@ -96,8 +113,9 @@ async function ensureTable(): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// Encryption — see ./crypto.ts. app_secrets uses the workspace-shared key so
-// rows can be read by any app granted access to the same workspace vault.
+// Encryption — see ./crypto.ts. Keep encrypted_value on the legacy app-key
+// format for mixed-version deployments, and add shared_encrypted_value when a
+// stable workspace key is configured so sibling apps can read the same row.
 // ---------------------------------------------------------------------------
 
 /**
@@ -143,7 +161,14 @@ export async function writeAppSecret(args: WriteSecretArgs): Promise<string> {
   }
   const client = getDbExec();
   const now = Date.now();
-  const encrypted = encryptValue(value);
+  // Dual-write during rollout: old readers continue using encrypted_value,
+  // while new readers prefer the nullable shared ciphertext. An app-only
+  // deployment leaves the shared column null; on an update, an existing
+  // shared ciphertext is preserved by the upsert below.
+  const encrypted = encryptLegacyValue(value);
+  const sharedEncrypted = hasSharedSecretEncryptionKeyMaterial()
+    ? encryptValue(value)
+    : null;
   const id = randomUUID();
 
   // Atomic upsert by (scope, scope_id, key). Previously this was a
@@ -157,10 +182,11 @@ export async function writeAppSecret(args: WriteSecretArgs): Promise<string> {
   // keeps its original id (any stored references stay stable); only a
   // genuinely new row gets the freshly generated `id`. This syntax is
   // portable across SQLite (UPSERT since 3.24) and Postgres.
-  const upsertSql = `INSERT INTO app_secrets (id, scope, scope_id, key, encrypted_value, description, url_allowlist, created_at, updated_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  const upsertSql = `INSERT INTO app_secrets (id, scope, scope_id, key, encrypted_value, shared_encrypted_value, description, url_allowlist, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT (scope, scope_id, key) DO UPDATE SET
       encrypted_value = excluded.encrypted_value,
+      shared_encrypted_value = COALESCE(excluded.shared_encrypted_value, app_secrets.shared_encrypted_value),
       description = excluded.description,
       url_allowlist = excluded.url_allowlist,
       updated_at = excluded.updated_at`;
@@ -170,6 +196,7 @@ export async function writeAppSecret(args: WriteSecretArgs): Promise<string> {
     scopeId,
     key,
     encrypted,
+    sharedEncrypted,
     description ?? null,
     urlAllowlist ?? null,
     now,
@@ -211,34 +238,65 @@ export interface ReadSecretResult {
  */
 interface DecryptedAppSecretValue {
   value: string;
+  /** True when the app-scoped fallback decrypted encrypted_value. */
   usedLegacyKey: boolean;
+  /** True when shared_encrypted_value was not the source of the plaintext. */
+  needsSharedCiphertext: boolean;
 }
 
-function decryptAppSecretValue(encrypted: string): DecryptedAppSecretValue {
+function decryptAppSecretValue(
+  encrypted: string,
+  sharedEncrypted?: string | null,
+): DecryptedAppSecretValue {
+  if (sharedEncrypted) {
+    try {
+      return {
+        value: decryptValue(sharedEncrypted),
+        usedLegacyKey: false,
+        needsSharedCiphertext: false,
+      };
+    } catch {
+      // Fall through to the legacy column. A partially migrated row may have
+      // a stale shared ciphertext while the old app-key value is valid.
+    }
+  }
   try {
-    return { value: decryptValue(encrypted), usedLegacyKey: false };
+    return {
+      value: decryptValue(encrypted),
+      usedLegacyKey: false,
+      needsSharedCiphertext: true,
+    };
   } catch {
-    return { value: decryptLegacyValue(encrypted), usedLegacyKey: true };
+    return {
+      value: decryptLegacyValue(encrypted),
+      usedLegacyKey: true,
+      needsSharedCiphertext: true,
+    };
   }
 }
 
 /**
- * Upgrade a row that was encrypted with the old app-scoped key. This is
+ * Populate the shared column without touching encrypted_value. This is
  * intentionally best-effort: a read must still succeed if a deployment's DB
- * role cannot update the row. The ciphertext predicate prevents a concurrent
- * write from being overwritten, and leaving `updated_at` untouched preserves
- * the row's user-visible ordering/metadata.
+ * role cannot update the row. The NULL predicate prevents a concurrent writer
+ * from overwriting newly-populated shared ciphertext, and leaving updated_at
+ * untouched preserves the row's user-visible ordering/metadata.
  */
-async function reencryptLegacyAppSecret(
+async function populateSharedAppSecret(
   id: unknown,
-  encrypted: string,
   value: string,
 ): Promise<void> {
-  if (id === undefined || id === null) return;
+  if (
+    id === undefined ||
+    id === null ||
+    !hasSharedSecretEncryptionKeyMaterial()
+  ) {
+    return;
+  }
   try {
     await getDbExec().execute({
-      sql: `UPDATE app_secrets SET encrypted_value = ? WHERE id = ? AND encrypted_value = ?`,
-      args: [encryptValue(value), id, encrypted],
+      sql: `UPDATE app_secrets SET shared_encrypted_value = ? WHERE id = ? AND shared_encrypted_value IS NULL`,
+      args: [encryptValue(value), id],
     });
   } catch {
     // Migration is opportunistic. Preserve the successful read if the update
@@ -289,15 +347,18 @@ export async function readAppSecret(
 ): Promise<ReadSecretResult | null> {
   const { key, scope, scopeId } = ref;
   const { rows } = await executeAppSecretsRead({
-    sql: `SELECT encrypted_value, updated_at, id FROM app_secrets WHERE scope = ? AND scope_id = ? AND key = ? LIMIT 1`,
+    sql: `SELECT encrypted_value, shared_encrypted_value, updated_at, id FROM app_secrets WHERE scope = ? AND scope_id = ? AND key = ? LIMIT 1`,
     args: [scope, scopeId, key],
   });
   if (rows.length === 0) return null;
   try {
     const encrypted = rows[0].encrypted_value as string;
-    const decrypted = decryptAppSecretValue(encrypted);
-    if (decrypted.usedLegacyKey) {
-      await reencryptLegacyAppSecret(rows[0].id, encrypted, decrypted.value);
+    const decrypted = decryptAppSecretValue(
+      encrypted,
+      rows[0].shared_encrypted_value as string | null,
+    );
+    if (decrypted.needsSharedCiphertext) {
+      await populateSharedAppSecret(rows[0].id, decrypted.value);
     }
     return {
       value: decrypted.value,
@@ -322,7 +383,7 @@ export async function readAppSecrets(args: {
 
   const placeholders = keys.map(() => "?").join(", ");
   const { rows } = await executeAppSecretsRead({
-    sql: `SELECT key, encrypted_value, updated_at, id FROM app_secrets WHERE scope = ? AND scope_id = ? AND key IN (${placeholders})`,
+    sql: `SELECT key, encrypted_value, shared_encrypted_value, updated_at, id FROM app_secrets WHERE scope = ? AND scope_id = ? AND key IN (${placeholders})`,
     args: [args.scope, args.scopeId, ...keys],
   });
   const results = new Map<string, ReadSecretResult>();
@@ -331,9 +392,12 @@ export async function readAppSecrets(args: {
     if (!key) continue;
     try {
       const encrypted = row.encrypted_value as string;
-      const decrypted = decryptAppSecretValue(encrypted);
-      if (decrypted.usedLegacyKey) {
-        await reencryptLegacyAppSecret(row.id, encrypted, decrypted.value);
+      const decrypted = decryptAppSecretValue(
+        encrypted,
+        row.shared_encrypted_value as string | null,
+      );
+      if (decrypted.needsSharedCiphertext) {
+        await populateSharedAppSecret(row.id, decrypted.value);
       }
       results.set(key, {
         value: decrypted.value,
@@ -383,7 +447,7 @@ export async function readAppSecretMeta(
   const { key, scope, scopeId } = ref;
   const client = getDbExec();
   const { rows } = await client.execute({
-    sql: `SELECT id, encrypted_value, description, url_allowlist, created_at, updated_at FROM app_secrets WHERE scope = ? AND scope_id = ? AND key = ? LIMIT 1`,
+    sql: `SELECT id, encrypted_value, shared_encrypted_value, description, url_allowlist, created_at, updated_at FROM app_secrets WHERE scope = ? AND scope_id = ? AND key = ? LIMIT 1`,
     args: [scope, scopeId, key],
   });
   if (rows.length === 0) return null;
@@ -391,9 +455,12 @@ export async function readAppSecretMeta(
   let last4Value = "";
   try {
     const encrypted = row.encrypted_value as string;
-    const decrypted = decryptAppSecretValue(encrypted);
-    if (decrypted.usedLegacyKey) {
-      await reencryptLegacyAppSecret(row.id, encrypted, decrypted.value);
+    const decrypted = decryptAppSecretValue(
+      encrypted,
+      row.shared_encrypted_value as string | null,
+    );
+    if (decrypted.needsSharedCiphertext) {
+      await populateSharedAppSecret(row.id, decrypted.value);
     }
     last4Value = last4(decrypted.value);
   } catch {
@@ -423,7 +490,7 @@ export async function listAppSecretsForScope(
   await ensureTable();
   const client = getDbExec();
   const { rows } = await client.execute({
-    sql: `SELECT id, key, encrypted_value, description, url_allowlist, created_at, updated_at FROM app_secrets WHERE scope = ? AND scope_id = ? ORDER BY updated_at DESC`,
+    sql: `SELECT id, key, encrypted_value, shared_encrypted_value, description, url_allowlist, created_at, updated_at FROM app_secrets WHERE scope = ? AND scope_id = ? ORDER BY updated_at DESC`,
     args: [scope, scopeId],
   });
   const results: SecretMeta[] = [];
@@ -431,9 +498,12 @@ export async function listAppSecretsForScope(
     let last4Value = "";
     try {
       const encrypted = row.encrypted_value as string;
-      const decrypted = decryptAppSecretValue(encrypted);
-      if (decrypted.usedLegacyKey) {
-        await reencryptLegacyAppSecret(row.id, encrypted, decrypted.value);
+      const decrypted = decryptAppSecretValue(
+        encrypted,
+        row.shared_encrypted_value as string | null,
+      );
+      if (decrypted.needsSharedCiphertext) {
+        await populateSharedAppSecret(row.id, decrypted.value);
       }
       last4Value = last4(decrypted.value);
     } catch {

--- a/packages/core/src/secrets/storage.ts
+++ b/packages/core/src/secrets/storage.ts
@@ -4,10 +4,10 @@
  * Values are encrypted at rest with AES-256-GCM. The workspace-shared
  * encryption key is derived from `SECRETS_ENCRYPTION_KEY` (preferred) or the
  * existing `BETTER_AUTH_SECRET` env var (fallback so templates don't need a
- * second secret during development). If neither is set in production we fall
- * back to a machine-local key derived from the cwd — the secret is still only
- * readable on this machine, but consider setting `SECRETS_ENCRYPTION_KEY` for
- * a stable, rotatable key shared by every app in the workspace.
+ * second secret during development). Deployments that only have the legacy
+ * app-scoped key continue to work until shared key material is configured;
+ * once configured, new rows use the shared key and reads retain a legacy-key
+ * fallback for existing rows.
  *
  * Secret values are NEVER logged and NEVER returned from any route handler.
  */
@@ -209,11 +209,40 @@ export interface ReadSecretResult {
  * fallback is only useful when the current app owns the old row; sibling apps
  * will receive shared-key ciphertext after the next vault sync or update.
  */
-function decryptAppSecretValue(encrypted: string): string {
+interface DecryptedAppSecretValue {
+  value: string;
+  usedLegacyKey: boolean;
+}
+
+function decryptAppSecretValue(encrypted: string): DecryptedAppSecretValue {
   try {
-    return decryptValue(encrypted);
+    return { value: decryptValue(encrypted), usedLegacyKey: false };
   } catch {
-    return decryptLegacyValue(encrypted);
+    return { value: decryptLegacyValue(encrypted), usedLegacyKey: true };
+  }
+}
+
+/**
+ * Upgrade a row that was encrypted with the old app-scoped key. This is
+ * intentionally best-effort: a read must still succeed if a deployment's DB
+ * role cannot update the row. The ciphertext predicate prevents a concurrent
+ * write from being overwritten, and leaving `updated_at` untouched preserves
+ * the row's user-visible ordering/metadata.
+ */
+async function reencryptLegacyAppSecret(
+  id: unknown,
+  encrypted: string,
+  value: string,
+): Promise<void> {
+  if (id === undefined || id === null) return;
+  try {
+    await getDbExec().execute({
+      sql: `UPDATE app_secrets SET encrypted_value = ? WHERE id = ? AND encrypted_value = ?`,
+      args: [encryptValue(value), id, encrypted],
+    });
+  } catch {
+    // Migration is opportunistic. Preserve the successful read if the update
+    // is unavailable due to a read-only role, transient DB failure, or race.
   }
 }
 
@@ -260,15 +289,19 @@ export async function readAppSecret(
 ): Promise<ReadSecretResult | null> {
   const { key, scope, scopeId } = ref;
   const { rows } = await executeAppSecretsRead({
-    sql: `SELECT encrypted_value, updated_at FROM app_secrets WHERE scope = ? AND scope_id = ? AND key = ? LIMIT 1`,
+    sql: `SELECT encrypted_value, updated_at, id FROM app_secrets WHERE scope = ? AND scope_id = ? AND key = ? LIMIT 1`,
     args: [scope, scopeId, key],
   });
   if (rows.length === 0) return null;
   try {
-    const value = decryptAppSecretValue(rows[0].encrypted_value as string);
+    const encrypted = rows[0].encrypted_value as string;
+    const decrypted = decryptAppSecretValue(encrypted);
+    if (decrypted.usedLegacyKey) {
+      await reencryptLegacyAppSecret(rows[0].id, encrypted, decrypted.value);
+    }
     return {
-      value,
-      last4: last4(value),
+      value: decrypted.value,
+      last4: last4(decrypted.value),
       updatedAt: Number(rows[0].updated_at ?? 0),
     };
   } catch {
@@ -289,7 +322,7 @@ export async function readAppSecrets(args: {
 
   const placeholders = keys.map(() => "?").join(", ");
   const { rows } = await executeAppSecretsRead({
-    sql: `SELECT key, encrypted_value, updated_at FROM app_secrets WHERE scope = ? AND scope_id = ? AND key IN (${placeholders})`,
+    sql: `SELECT key, encrypted_value, updated_at, id FROM app_secrets WHERE scope = ? AND scope_id = ? AND key IN (${placeholders})`,
     args: [args.scope, args.scopeId, ...keys],
   });
   const results = new Map<string, ReadSecretResult>();
@@ -297,10 +330,14 @@ export async function readAppSecrets(args: {
     const key = String(row.key ?? "");
     if (!key) continue;
     try {
-      const value = decryptAppSecretValue(row.encrypted_value as string);
+      const encrypted = row.encrypted_value as string;
+      const decrypted = decryptAppSecretValue(encrypted);
+      if (decrypted.usedLegacyKey) {
+        await reencryptLegacyAppSecret(row.id, encrypted, decrypted.value);
+      }
       results.set(key, {
-        value,
-        last4: last4(value),
+        value: decrypted.value,
+        last4: last4(decrypted.value),
         updatedAt: Number(row.updated_at ?? 0),
       });
     } catch {
@@ -346,15 +383,19 @@ export async function readAppSecretMeta(
   const { key, scope, scopeId } = ref;
   const client = getDbExec();
   const { rows } = await client.execute({
-    sql: `SELECT encrypted_value, description, url_allowlist, created_at, updated_at FROM app_secrets WHERE scope = ? AND scope_id = ? AND key = ? LIMIT 1`,
+    sql: `SELECT id, encrypted_value, description, url_allowlist, created_at, updated_at FROM app_secrets WHERE scope = ? AND scope_id = ? AND key = ? LIMIT 1`,
     args: [scope, scopeId, key],
   });
   if (rows.length === 0) return null;
   const row = rows[0];
   let last4Value = "";
   try {
-    const value = decryptAppSecretValue(row.encrypted_value as string);
-    last4Value = last4(value);
+    const encrypted = row.encrypted_value as string;
+    const decrypted = decryptAppSecretValue(encrypted);
+    if (decrypted.usedLegacyKey) {
+      await reencryptLegacyAppSecret(row.id, encrypted, decrypted.value);
+    }
+    last4Value = last4(decrypted.value);
   } catch {
     last4Value = "";
   }
@@ -382,18 +423,23 @@ export async function listAppSecretsForScope(
   await ensureTable();
   const client = getDbExec();
   const { rows } = await client.execute({
-    sql: `SELECT key, encrypted_value, description, url_allowlist, created_at, updated_at FROM app_secrets WHERE scope = ? AND scope_id = ? ORDER BY updated_at DESC`,
+    sql: `SELECT id, key, encrypted_value, description, url_allowlist, created_at, updated_at FROM app_secrets WHERE scope = ? AND scope_id = ? ORDER BY updated_at DESC`,
     args: [scope, scopeId],
   });
-  return rows.map((row) => {
+  const results: SecretMeta[] = [];
+  for (const row of rows) {
     let last4Value = "";
     try {
-      const value = decryptAppSecretValue(row.encrypted_value as string);
-      last4Value = last4(value);
+      const encrypted = row.encrypted_value as string;
+      const decrypted = decryptAppSecretValue(encrypted);
+      if (decrypted.usedLegacyKey) {
+        await reencryptLegacyAppSecret(row.id, encrypted, decrypted.value);
+      }
+      last4Value = last4(decrypted.value);
     } catch {
       last4Value = "";
     }
-    return {
+    results.push({
       key: row.key as string,
       scope,
       scopeId,
@@ -402,8 +448,9 @@ export async function listAppSecretsForScope(
       urlAllowlist: parseAllowlist(row.url_allowlist as string | null),
       createdAt: Number(row.created_at ?? 0),
       updatedAt: Number(row.updated_at ?? 0),
-    };
-  });
+    });
+  }
+  return results;
 }
 
 function parseAllowlist(raw: string | null): string[] | null {

--- a/packages/core/src/secrets/storage.ts
+++ b/packages/core/src/secrets/storage.ts
@@ -19,6 +19,7 @@ import { ensureColumnExists, ensureTableExists } from "../db/ddl-guard.js";
 import {
   encryptSharedSecretValue as encryptValue,
   decryptSharedSecretValue as decryptValue,
+  decryptSecretValue as decryptLegacyValue,
 } from "./crypto.js";
 import type { SecretScope } from "./register.js";
 import { APP_SECRETS_CREATE_SQL } from "./schema.js";
@@ -95,7 +96,8 @@ async function ensureTable(): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// Encryption — see ./crypto.ts (shared with per-user credentials)
+// Encryption — see ./crypto.ts. app_secrets uses the workspace-shared key so
+// rows can be read by any app granted access to the same workspace vault.
 // ---------------------------------------------------------------------------
 
 /**
@@ -201,6 +203,20 @@ export interface ReadSecretResult {
   updatedAt: number;
 }
 
+/**
+ * Read the shared-key format and retain compatibility with rows written before
+ * app_secrets moved to its workspace-shared encryption boundary. The legacy
+ * fallback is only useful when the current app owns the old row; sibling apps
+ * will receive shared-key ciphertext after the next vault sync or update.
+ */
+function decryptAppSecretValue(encrypted: string): string {
+  try {
+    return decryptValue(encrypted);
+  } catch {
+    return decryptLegacyValue(encrypted);
+  }
+}
+
 type AppSecretsReadQuery = { sql: string; args: unknown[] };
 
 /**
@@ -249,7 +265,7 @@ export async function readAppSecret(
   });
   if (rows.length === 0) return null;
   try {
-    const value = decryptValue(rows[0].encrypted_value as string);
+    const value = decryptAppSecretValue(rows[0].encrypted_value as string);
     return {
       value,
       last4: last4(value),
@@ -281,7 +297,7 @@ export async function readAppSecrets(args: {
     const key = String(row.key ?? "");
     if (!key) continue;
     try {
-      const value = decryptValue(row.encrypted_value as string);
+      const value = decryptAppSecretValue(row.encrypted_value as string);
       results.set(key, {
         value,
         last4: last4(value),
@@ -337,7 +353,7 @@ export async function readAppSecretMeta(
   const row = rows[0];
   let last4Value = "";
   try {
-    const value = decryptValue(row.encrypted_value as string);
+    const value = decryptAppSecretValue(row.encrypted_value as string);
     last4Value = last4(value);
   } catch {
     last4Value = "";
@@ -372,7 +388,7 @@ export async function listAppSecretsForScope(
   return rows.map((row) => {
     let last4Value = "";
     try {
-      const value = decryptValue(row.encrypted_value as string);
+      const value = decryptAppSecretValue(row.encrypted_value as string);
       last4Value = last4(value);
     } catch {
       last4Value = "";

--- a/packages/desktop-app/shared/ipc-channels.ts
+++ b/packages/desktop-app/shared/ipc-channels.ts
@@ -97,6 +97,7 @@ export const IPC = {
   CODE_AGENTS_CHOOSE_PROJECT: "code-agents:choose-project",
   CODE_AGENTS_LIST_MIGRATION_RUNS: "code-agents:list-migration-runs",
   CODE_AGENTS_OPEN_TERMINAL: "code-agents:open-terminal",
+  CODE_AGENTS_OPEN_CODEX_LOGIN: "code-agents:open-codex-login",
   CODE_AGENTS_REMOTE_CONNECTOR_GET_STATUS:
     "code-agents:remote-connector:get-status",
   CODE_AGENTS_REMOTE_CONNECTOR_SET_ENABLED:

--- a/packages/desktop-app/src/main/codex-login-launcher.test.ts
+++ b/packages/desktop-app/src/main/codex-login-launcher.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
 
-import { getCodexLoginLaunchSpec } from "./codex-login-launcher";
+import { describe, expect, it, vi } from "vitest";
+
+import { getCodexLoginLaunchSpec, spawnDetached } from "./codex-login-launcher";
 
 describe("getCodexLoginLaunchSpec", () => {
   it.each([
@@ -15,12 +17,33 @@ describe("getCodexLoginLaunchSpec", () => {
       ],
     ],
     ["win32", "cmd.exe", ["/d", "/k", "codex login"]],
-    ["linux", "x-terminal-emulator", ["-e", "codex", "login"]],
   ])("uses a fixed login command on %s", (platform, command, args) => {
     expect(getCodexLoginLaunchSpec(platform)).toEqual({
       ok: true,
       command,
       args,
+    });
+  });
+
+  it("selects the first available Linux terminal emulator", () => {
+    const unavailable = new Set(["x-terminal-emulator"]);
+    expect(
+      getCodexLoginLaunchSpec(
+        "linux",
+        (command) => !unavailable.has(command) && command === "gnome-terminal",
+      ),
+    ).toEqual({
+      ok: true,
+      command: "gnome-terminal",
+      args: ["--", "codex", "login"],
+    });
+  });
+
+  it("returns install guidance when Linux has no supported terminal", () => {
+    expect(getCodexLoginLaunchSpec("linux", () => false)).toEqual({
+      ok: false,
+      error:
+        "No supported terminal emulator was found. Install a terminal emulator and try again.",
     });
   });
 
@@ -44,5 +67,45 @@ describe("getCodexLoginLaunchSpec", () => {
       ok: false,
       error: "Opening a terminal is not supported on aix.",
     });
+  });
+
+  it("does not report success before the child emits spawn", async () => {
+    const child = new EventEmitter() as EventEmitter & {
+      unref: () => void;
+    };
+    child.unref = vi.fn();
+    const launch = spawnDetached(
+      "codex",
+      ["login"],
+      "/tmp",
+      () => child as never,
+    );
+
+    child.emit("spawn");
+
+    await expect(launch).resolves.toEqual({ ok: true, cwd: "/tmp" });
+    expect(child.unref).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a launch error when the child reports an asynchronous spawn failure", async () => {
+    const child = new EventEmitter() as EventEmitter & {
+      unref: () => void;
+    };
+    child.unref = vi.fn();
+    const launch = spawnDetached(
+      "missing-terminal",
+      [],
+      "/tmp",
+      () => child as never,
+    );
+
+    child.emit("error", new Error("spawn ENOENT"));
+
+    await expect(launch).resolves.toEqual({
+      ok: false,
+      cwd: "/tmp",
+      error: "spawn ENOENT",
+    });
+    expect(child.unref).not.toHaveBeenCalled();
   });
 });

--- a/packages/desktop-app/src/main/codex-login-launcher.test.ts
+++ b/packages/desktop-app/src/main/codex-login-launcher.test.ts
@@ -108,4 +108,47 @@ describe("getCodexLoginLaunchSpec", () => {
     });
     expect(child.unref).not.toHaveBeenCalled();
   });
+
+  it("waits for wrapper exit status when requested", async () => {
+    const child = new EventEmitter() as EventEmitter & {
+      unref: () => void;
+    };
+    child.unref = vi.fn();
+    const launch = spawnDetached(
+      "/usr/bin/osascript",
+      [],
+      "/tmp",
+      () => child as never,
+      { waitForExit: true },
+    );
+
+    child.emit("spawn");
+    child.emit("close", 0, null);
+
+    await expect(launch).resolves.toEqual({ ok: true, cwd: "/tmp" });
+    expect(child.unref).not.toHaveBeenCalled();
+  });
+
+  it("reports a wrapper's non-zero exit instead of claiming success", async () => {
+    const child = new EventEmitter() as EventEmitter & {
+      unref: () => void;
+    };
+    child.unref = vi.fn();
+    const launch = spawnDetached(
+      "/usr/bin/osascript",
+      [],
+      "/tmp",
+      () => child as never,
+      { waitForExit: true },
+    );
+
+    child.emit("spawn");
+    child.emit("close", 1, null);
+
+    await expect(launch).resolves.toEqual({
+      ok: false,
+      cwd: "/tmp",
+      error: "Process exited with code 1.",
+    });
+  });
 });

--- a/packages/desktop-app/src/main/codex-login-launcher.test.ts
+++ b/packages/desktop-app/src/main/codex-login-launcher.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { getCodexLoginLaunchSpec } from "./codex-login-launcher";
+
+describe("getCodexLoginLaunchSpec", () => {
+  it.each([
+    [
+      "darwin",
+      "/usr/bin/osascript",
+      [
+        "-e",
+        'tell application "Terminal" to do script "codex login"',
+        "-e",
+        'tell application "Terminal" to activate',
+      ],
+    ],
+    ["win32", "cmd.exe", ["/d", "/k", "codex login"]],
+    ["linux", "x-terminal-emulator", ["-e", "codex", "login"]],
+  ])("uses a fixed login command on %s", (platform, command, args) => {
+    expect(getCodexLoginLaunchSpec(platform)).toEqual({
+      ok: true,
+      command,
+      args,
+    });
+  });
+
+  it("does not interpolate renderer-controlled values into the command", () => {
+    const spec = getCodexLoginLaunchSpec("darwin");
+
+    expect(spec).toEqual({
+      ok: true,
+      command: "/usr/bin/osascript",
+      args: [
+        "-e",
+        'tell application "Terminal" to do script "codex login"',
+        "-e",
+        'tell application "Terminal" to activate',
+      ],
+    });
+  });
+
+  it("rejects unsupported platforms", () => {
+    expect(getCodexLoginLaunchSpec("aix")).toEqual({
+      ok: false,
+      error: "Opening a terminal is not supported on aix.",
+    });
+  });
+});

--- a/packages/desktop-app/src/main/codex-login-launcher.ts
+++ b/packages/desktop-app/src/main/codex-login-launcher.ts
@@ -1,3 +1,9 @@
+import {
+  spawn,
+  type ChildProcess,
+  type SpawnOptions,
+} from "node:child_process";
+
 export type CodexLoginLaunchSpec =
   | {
       ok: true;
@@ -9,8 +15,77 @@ export type CodexLoginLaunchSpec =
       error: string;
     };
 
+type CommandAvailable = (command: string) => boolean;
+
+export interface DetachedLaunchResult {
+  ok: boolean;
+  cwd: string;
+  error?: string;
+}
+
+type SpawnProcess = (
+  command: string,
+  args: string[],
+  options: SpawnOptions,
+) => ChildProcess;
+
+/** Spawn a detached process and resolve only after spawn or error is known. */
+export function spawnDetached(
+  command: string,
+  args: string[],
+  cwd: string,
+  spawnProcess: SpawnProcess = (nextCommand, nextArgs, options) =>
+    spawn(nextCommand, nextArgs, options),
+): Promise<DetachedLaunchResult> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result: DetachedLaunchResult) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+
+    try {
+      const child = spawnProcess(command, args, {
+        cwd,
+        detached: true,
+        stdio: "ignore",
+        windowsHide: false,
+      });
+      const onError = (err: Error) => {
+        finish({
+          ok: false,
+          cwd,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      };
+      child.once("spawn", () => {
+        child.removeListener("error", onError);
+        child.unref();
+        finish({ ok: true, cwd });
+      });
+      child.once("error", onError);
+    } catch (err) {
+      finish({
+        ok: false,
+        cwd,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  });
+}
+
+const LINUX_TERMINAL_CANDIDATES = [
+  { command: "x-terminal-emulator", args: ["-e", "codex", "login"] },
+  { command: "gnome-terminal", args: ["--", "codex", "login"] },
+  { command: "konsole", args: ["-e", "codex", "login"] },
+  { command: "xfce4-terminal", args: ["--command", "codex login"] },
+  { command: "xterm", args: ["-e", "codex", "login"] },
+] as const;
+
 export function getCodexLoginLaunchSpec(
   platform: string,
+  commandAvailable: CommandAvailable = () => true,
 ): CodexLoginLaunchSpec {
   if (platform === "darwin") {
     return {
@@ -32,10 +107,15 @@ export function getCodexLoginLaunchSpec(
     };
   }
   if (platform === "linux") {
+    const terminal = LINUX_TERMINAL_CANDIDATES.find((candidate) =>
+      commandAvailable(candidate.command),
+    );
+    if (terminal)
+      return { ok: true, command: terminal.command, args: [...terminal.args] };
     return {
-      ok: true,
-      command: "x-terminal-emulator",
-      args: ["-e", "codex", "login"],
+      ok: false,
+      error:
+        "No supported terminal emulator was found. Install a terminal emulator and try again.",
     };
   }
   return {

--- a/packages/desktop-app/src/main/codex-login-launcher.ts
+++ b/packages/desktop-app/src/main/codex-login-launcher.ts
@@ -29,6 +29,11 @@ type SpawnProcess = (
   options: SpawnOptions,
 ) => ChildProcess;
 
+export interface DetachedLaunchOptions {
+  /** Wait for wrapper commands (such as macOS osascript) to exit. */
+  waitForExit?: boolean;
+}
+
 /** Spawn a detached process and resolve only after spawn or error is known. */
 export function spawnDetached(
   command: string,
@@ -36,6 +41,7 @@ export function spawnDetached(
   cwd: string,
   spawnProcess: SpawnProcess = (nextCommand, nextArgs, options) =>
     spawn(nextCommand, nextArgs, options),
+  { waitForExit = false }: DetachedLaunchOptions = {},
 ): Promise<DetachedLaunchResult> {
   return new Promise((resolve) => {
     let settled = false;
@@ -59,7 +65,24 @@ export function spawnDetached(
           error: err instanceof Error ? err.message : String(err),
         });
       };
+      const onClose = (code: number | null, signal: NodeJS.Signals | null) => {
+        if (code === 0) {
+          finish({ ok: true, cwd });
+          return;
+        }
+        finish({
+          ok: false,
+          cwd,
+          error: `Process exited with ${
+            signal ? `signal ${signal}` : `code ${code ?? "unknown"}`
+          }.`,
+        });
+      };
       child.once("spawn", () => {
+        if (waitForExit) {
+          child.once("close", onClose);
+          return;
+        }
         child.removeListener("error", onError);
         child.unref();
         finish({ ok: true, cwd });

--- a/packages/desktop-app/src/main/codex-login-launcher.ts
+++ b/packages/desktop-app/src/main/codex-login-launcher.ts
@@ -1,0 +1,45 @@
+export type CodexLoginLaunchSpec =
+  | {
+      ok: true;
+      command: string;
+      args: string[];
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export function getCodexLoginLaunchSpec(
+  platform: string,
+): CodexLoginLaunchSpec {
+  if (platform === "darwin") {
+    return {
+      ok: true,
+      command: "/usr/bin/osascript",
+      args: [
+        "-e",
+        'tell application "Terminal" to do script "codex login"',
+        "-e",
+        'tell application "Terminal" to activate',
+      ],
+    };
+  }
+  if (platform === "win32") {
+    return {
+      ok: true,
+      command: "cmd.exe",
+      args: ["/d", "/k", "codex login"],
+    };
+  }
+  if (platform === "linux") {
+    return {
+      ok: true,
+      command: "x-terminal-emulator",
+      args: ["-e", "codex", "login"],
+    };
+  }
+  return {
+    ok: false,
+    error: `Opening a terminal is not supported on ${platform}.`,
+  };
+}

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -6760,7 +6760,9 @@ async function openCodexLoginTerminal(): Promise<CodeAgentTerminalResult> {
     process.platform === "linux" ? isCommandAvailable : undefined,
   );
   if (!launch.ok) return { ok: false, cwd, error: launch.error };
-  return spawnDetached(launch.command, launch.args, cwd);
+  return spawnDetached(launch.command, launch.args, cwd, undefined, {
+    waitForExit: process.platform === "darwin",
+  });
 }
 
 function readPackageMetadata(packagePath: string): {

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -136,6 +136,7 @@ import {
 import * as AppStore from "./app-store";
 import { BrowserControlLoopbackBridge } from "./browser-control/bridge";
 import { installBrowserNativeHost } from "./browser-control/native-host";
+import { getCodexLoginLaunchSpec } from "./codex-login-launcher.js";
 import {
   ComputerControlBroker,
   DesktopComputerMcpBridge,
@@ -6758,6 +6759,13 @@ function openTerminalForCodeAgents(request?: unknown): CodeAgentTerminalResult {
   };
 }
 
+function openCodexLoginTerminal(): CodeAgentTerminalResult {
+  const cwd = getHomeDirectory();
+  const launch = getCodexLoginLaunchSpec(process.platform);
+  if (!launch.ok) return { ok: false, cwd, error: launch.error };
+  return spawnDetached(launch.command, launch.args, cwd);
+}
+
 function readPackageMetadata(packagePath: string): {
   name?: string;
   version?: string;
@@ -7054,7 +7062,7 @@ function withLocalCodexProviderStatus(
   if (!codex.available) return settings;
   const provider = {
     id: "codex" as const,
-    label: "Codex CLI",
+    label: "ChatGPT subscription",
     configured: codex.authenticated,
     configuredKeys: [] as CodeAgentProviderCredentialKey[],
     missingKeys: [] as CodeAgentProviderCredentialKey[],
@@ -7180,11 +7188,11 @@ function getCodeAgentModelList(): CodeAgentModelListResult {
       if (codex.available) {
         models.push({
           engine: CODEX_CLI_ENGINE_NAME,
-          engineLabel: "Codex",
+          engineLabel: "This computer",
           model: CODEX_CLI_DEFAULT_MODEL,
           label: "Codex CLI default",
           description:
-            "Use the local Codex CLI and its signed-in ChatGPT/API auth.",
+            "Run locally through your signed-in ChatGPT subscription.",
           configured: codex.authenticated,
         });
       }
@@ -7591,6 +7599,7 @@ registerCodeAgentsIpc({
   readCodeAgentProjectsState,
   chooseCodeAgentProject,
   openTerminalForCodeAgents,
+  openCodeAgentCodexLogin: openCodexLoginTerminal,
   getRemoteConnectorStatus,
   setRemoteConnectorEnabled,
   pairRemoteCodeAgentConnector,

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -136,7 +136,10 @@ import {
 import * as AppStore from "./app-store";
 import { BrowserControlLoopbackBridge } from "./browser-control/bridge";
 import { installBrowserNativeHost } from "./browser-control/native-host";
-import { getCodexLoginLaunchSpec } from "./codex-login-launcher.js";
+import {
+  getCodexLoginLaunchSpec,
+  spawnDetached,
+} from "./codex-login-launcher.js";
 import {
   ComputerControlBroker,
   DesktopComputerMcpBridge,
@@ -4463,29 +4466,6 @@ function updateCodeAgentRun(input: unknown): CodeAgentUpdateRunResult {
   };
 }
 
-function spawnDetached(
-  command: string,
-  args: string[],
-  cwd: string,
-): CodeAgentTerminalResult {
-  try {
-    const child = spawn(command, args, {
-      cwd,
-      detached: true,
-      stdio: "ignore",
-      windowsHide: false,
-    });
-    child.unref();
-    return { ok: true, cwd };
-  } catch (err) {
-    return {
-      ok: false,
-      cwd,
-      error: err instanceof Error ? err.message : String(err),
-    };
-  }
-}
-
 function getHomeDirectory(): string {
   try {
     return app.getPath("home");
@@ -6733,7 +6713,9 @@ function quoteWindowsCmdPath(value: string): string {
   return `"${value.replaceAll('"', '""')}"`;
 }
 
-function openTerminalForCodeAgents(request?: unknown): CodeAgentTerminalResult {
+async function openTerminalForCodeAgents(
+  request?: unknown,
+): Promise<CodeAgentTerminalResult> {
   const cwd = resolveCodeAgentsTerminalCwd(request);
   if (process.platform === "darwin") {
     return spawnDetached("open", ["-a", "Terminal", cwd], cwd);
@@ -6759,9 +6741,24 @@ function openTerminalForCodeAgents(request?: unknown): CodeAgentTerminalResult {
   };
 }
 
-function openCodexLoginTerminal(): CodeAgentTerminalResult {
+function isCommandAvailable(command: string): boolean {
+  try {
+    return (
+      spawnSync("which", [command], {
+        stdio: "ignore",
+      }).status === 0
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function openCodexLoginTerminal(): Promise<CodeAgentTerminalResult> {
   const cwd = getHomeDirectory();
-  const launch = getCodexLoginLaunchSpec(process.platform);
+  const launch = getCodexLoginLaunchSpec(
+    process.platform,
+    process.platform === "linux" ? isCommandAvailable : undefined,
+  );
   if (!launch.ok) return { ok: false, cwd, error: launch.error };
   return spawnDetached(launch.command, launch.args, cwd);
 }

--- a/packages/desktop-app/src/main/ipc/code-agents.ts
+++ b/packages/desktop-app/src/main/ipc/code-agents.ts
@@ -96,6 +96,7 @@ export interface CodeAgentsIpcDeps {
   };
   chooseCodeAgentProject: () => Promise<CodeAgentProjectSelectResult>;
   openTerminalForCodeAgents: (request?: unknown) => CodeAgentTerminalResult;
+  openCodeAgentCodexLogin: () => CodeAgentTerminalResult;
   getRemoteConnectorStatus: () => CodeAgentRemoteConnectorStatus;
   setRemoteConnectorEnabled: (
     enabled: boolean,
@@ -142,6 +143,7 @@ export function registerCodeAgentsIpc(deps: CodeAgentsIpcDeps): void {
     readCodeAgentProjectsState,
     chooseCodeAgentProject,
     openTerminalForCodeAgents,
+    openCodeAgentCodexLogin,
     getRemoteConnectorStatus,
     setRemoteConnectorEnabled,
     pairRemoteCodeAgentConnector,
@@ -416,6 +418,11 @@ export function registerCodeAgentsIpc(deps: CodeAgentsIpcDeps): void {
     ): CodeAgentTerminalResult => {
       return openTerminalForCodeAgents(request);
     },
+  );
+
+  ipcMain.handle(
+    IPC.CODE_AGENTS_OPEN_CODEX_LOGIN,
+    (): CodeAgentTerminalResult => openCodeAgentCodexLogin(),
   );
 
   ipcMain.handle(

--- a/packages/desktop-app/src/main/ipc/code-agents.ts
+++ b/packages/desktop-app/src/main/ipc/code-agents.ts
@@ -95,8 +95,12 @@ export interface CodeAgentsIpcDeps {
     projects: CodeAgentProjectFolder[];
   };
   chooseCodeAgentProject: () => Promise<CodeAgentProjectSelectResult>;
-  openTerminalForCodeAgents: (request?: unknown) => CodeAgentTerminalResult;
-  openCodeAgentCodexLogin: () => CodeAgentTerminalResult;
+  openTerminalForCodeAgents: (
+    request?: unknown,
+  ) => CodeAgentTerminalResult | Promise<CodeAgentTerminalResult>;
+  openCodeAgentCodexLogin: () =>
+    | CodeAgentTerminalResult
+    | Promise<CodeAgentTerminalResult>;
   getRemoteConnectorStatus: () => CodeAgentRemoteConnectorStatus;
   setRemoteConnectorEnabled: (
     enabled: boolean,
@@ -412,17 +416,18 @@ export function registerCodeAgentsIpc(deps: CodeAgentsIpcDeps): void {
 
   ipcMain.handle(
     IPC.CODE_AGENTS_OPEN_TERMINAL,
-    (
+    async (
       _event: IpcMainInvokeEvent,
       request?: unknown,
-    ): CodeAgentTerminalResult => {
-      return openTerminalForCodeAgents(request);
+    ): Promise<CodeAgentTerminalResult> => {
+      return await openTerminalForCodeAgents(request);
     },
   );
 
   ipcMain.handle(
     IPC.CODE_AGENTS_OPEN_CODEX_LOGIN,
-    (): CodeAgentTerminalResult => openCodeAgentCodexLogin(),
+    async (): Promise<CodeAgentTerminalResult> =>
+      await openCodeAgentCodexLogin(),
   );
 
   ipcMain.handle(

--- a/packages/desktop-app/src/preload/index.ts
+++ b/packages/desktop-app/src/preload/index.ts
@@ -317,6 +317,8 @@ const electronAPI = {
       request?: CodeAgentTerminalRequest,
     ): Promise<CodeAgentTerminalResult> =>
       ipcRenderer.invoke(IPC.CODE_AGENTS_OPEN_TERMINAL, request),
+    openCodexLogin: (): Promise<CodeAgentTerminalResult> =>
+      ipcRenderer.invoke(IPC.CODE_AGENTS_OPEN_CODEX_LOGIN),
     getRemoteConnectorStatus: (): Promise<CodeAgentRemoteConnectorStatus> =>
       ipcRenderer.invoke(IPC.CODE_AGENTS_REMOTE_CONNECTOR_GET_STATUS),
     setRemoteConnectorEnabled: (

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -239,6 +239,17 @@ export default function CodeAgentsHub({
         }
         return api.openTerminal(request);
       },
+      async openCodexLogin() {
+        const api = window.electronAPI?.codeAgents;
+        if (!api?.openCodexLogin) {
+          return {
+            ok: false,
+            cwd: "",
+            error: "Desktop bridge is not available.",
+          };
+        }
+        return api.openCodexLogin();
+      },
       async getRemoteConnectorStatus() {
         const api = window.electronAPI?.codeAgents;
         if (!api?.getRemoteConnectorStatus) {

--- a/packages/desktop-app/src/renderer/components/CodeProviderSettings.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeProviderSettings.tsx
@@ -3,6 +3,7 @@ import {
   IconChevronRight,
   IconExternalLink,
   IconLoader2,
+  IconRefresh,
   IconTerminal2,
 } from "@tabler/icons-react";
 import { useCallback, useEffect, useState } from "react";
@@ -169,6 +170,8 @@ export function CodeProviderSettings({
   const [providerSavingId, setProviderSavingId] =
     useState<CodeAgentProviderId | null>(null);
   const [builderConnecting, setBuilderConnecting] = useState(false);
+  const [codexConnecting, setCodexConnecting] = useState(false);
+  const [codexRefreshing, setCodexRefreshing] = useState(false);
   const [providerMessage, setProviderMessage] = useState<string | null>(null);
 
   const builderProvider = settings.providers.find(
@@ -248,6 +251,50 @@ export function CodeProviderSettings({
     },
     [onProvidersChanged, onSettingsChanged],
   );
+
+  const handleConnectCodex = useCallback(async () => {
+    const api = window.electronAPI?.codeAgents;
+    if (!api?.openCodexLogin) {
+      setProviderMessage(
+        "Open Agent Native Desktop to sign in to your ChatGPT subscription.",
+      );
+      return;
+    }
+    setCodexConnecting(true);
+    setProviderMessage(
+      "Terminal opened. Finish `codex login`, then refresh this status.",
+    );
+    try {
+      const result = await api.openCodexLogin();
+      if (!result.ok)
+        setProviderMessage(result.error ?? "Terminal was not opened.");
+    } catch (err) {
+      setProviderMessage(err instanceof Error ? err.message : String(err));
+    } finally {
+      setCodexConnecting(false);
+    }
+  }, []);
+
+  const refreshCodexStatus = useCallback(async () => {
+    const api = window.electronAPI?.codeAgents;
+    if (!api?.getProviderSettings) return;
+    setCodexRefreshing(true);
+    try {
+      const nextSettings = await api.getProviderSettings();
+      onSettingsChanged(nextSettings);
+      onProvidersChanged?.();
+      setProviderMessage(
+        nextSettings.providers.find((provider) => provider.id === "codex")
+          ?.configured
+          ? "ChatGPT subscription is ready on this computer."
+          : "Codex is not signed in yet. Finish `codex login` in Terminal.",
+      );
+    } catch (err) {
+      setProviderMessage(err instanceof Error ? err.message : String(err));
+    } finally {
+      setCodexRefreshing(false);
+    }
+  }, [onProvidersChanged, onSettingsChanged]);
 
   useEffect(() => {
     if (!consumePendingBuilderConnectReload()) return;
@@ -389,23 +436,67 @@ export function CodeProviderSettings({
         }`}
       >
         <div className="settings-builder-connect-copy">
-          <span className="settings-builder-title">Codex CLI</span>
+          <span className="settings-builder-title">ChatGPT subscription</span>
           <span className="settings-builder-description">
             {codexConnected
-              ? `Using ${codexProvider?.label ?? "Codex CLI"} for Agent tasks.`
+              ? "Ready to run Agent tasks on this computer through Codex."
               : codexAvailable
-                ? "Run codex login in Terminal; Desktop will pick up the local session."
-                : "Install the OpenAI Codex CLI, then run codex login in Terminal."}
+                ? "Use your ChatGPT subscription locally through Codex."
+                : "Install the OpenAI Codex CLI to use your ChatGPT subscription locally."}
           </span>
         </div>
-        <span
-          className={`settings-codex-status${
-            codexConnected ? " settings-codex-status--ok" : ""
-          }`}
-        >
-          <IconTerminal2 size={13} />
-          {codexConnected ? "Ready" : codexAvailable ? "Sign in" : "Install"}
-        </span>
+        <div className="settings-builder-actions">
+          <span
+            className={`settings-codex-status${
+              codexConnected ? " settings-codex-status--ok" : ""
+            }`}
+          >
+            <IconTerminal2 size={13} />
+            {codexConnected
+              ? "Ready"
+              : codexAvailable
+                ? "Not signed in"
+                : "Install"}
+          </span>
+          {codexAvailable && !codexConnected && (
+            <button
+              type="button"
+              className="settings-builder-connect-button"
+              onClick={() => void handleConnectCodex()}
+              disabled={codexConnecting}
+            >
+              {codexConnecting ? (
+                <>
+                  <IconLoader2
+                    size={13}
+                    className="settings-codex-status-spinner"
+                  />
+                  Opening...
+                </>
+              ) : (
+                "Sign in"
+              )}
+            </button>
+          )}
+          {codexAvailable && (
+            <button
+              type="button"
+              className="settings-provider-text-button"
+              onClick={() => void refreshCodexStatus()}
+              disabled={codexRefreshing}
+            >
+              {codexRefreshing ? (
+                <IconLoader2
+                  size={13}
+                  className="settings-codex-status-spinner"
+                />
+              ) : (
+                <IconRefresh size={13} />
+              )}
+              Refresh
+            </button>
+          )}
+        </div>
       </div>
 
       <button

--- a/packages/desktop-app/src/renderer/global.d.ts
+++ b/packages/desktop-app/src/renderer/global.d.ts
@@ -735,6 +735,7 @@ interface ElectronAPI {
     openTerminal(
       request?: CodeAgentTerminalRequest,
     ): Promise<CodeAgentTerminalResult>;
+    openCodexLogin(): Promise<CodeAgentTerminalResult>;
     getRemoteConnectorStatus(): Promise<CodeAgentRemoteConnectorStatus>;
     setRemoteConnectorEnabled(
       enabled: boolean,

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -1198,6 +1198,10 @@ body {
   animation: spin 0.8s linear infinite;
 }
 
+.settings-codex-status-spinner {
+  animation: spin 0.8s linear infinite;
+}
+
 .settings-codex-status {
   display: inline-flex;
   align-items: center;

--- a/templates/assets/app/components/layout/Layout.tsx
+++ b/templates/assets/app/components/layout/Layout.tsx
@@ -67,7 +67,10 @@ export function Layout({ children }: LayoutProps) {
   useAgentChatHomeHandoffLinks({
     storageKey: ASSETS_CHAT_STORAGE_KEY,
     isChatPath: (pathname) => pathname === "/" || pathname.startsWith("/chat/"),
-    requireActiveHandoff: true,
+    // A direct /chat/:id link already names the thread and must preserve the
+    // normal chat-to-sidebar transition. Only the empty home chat needs the
+    // recent marker that proves an agent handoff is in flight.
+    requireActiveHandoff: location.pathname === "/",
   });
 
   useEffect(() => {

--- a/templates/assets/app/components/layout/Layout.tsx
+++ b/templates/assets/app/components/layout/Layout.tsx
@@ -67,6 +67,7 @@ export function Layout({ children }: LayoutProps) {
   useAgentChatHomeHandoffLinks({
     storageKey: ASSETS_CHAT_STORAGE_KEY,
     isChatPath: (pathname) => pathname === "/" || pathname.startsWith("/chat/"),
+    requireActiveHandoff: true,
   });
 
   useEffect(() => {

--- a/templates/assets/app/hooks/use-navigation-state.ts
+++ b/templates/assets/app/hooks/use-navigation-state.ts
@@ -1,4 +1,5 @@
 import {
+  isAgentChatHomeHandoffActive,
   markAgentChatHomeHandoff,
   useAgentRouteState,
   getBrowserTabId,
@@ -190,7 +191,8 @@ export function useNavigationState() {
     onNavigate: (_command, path) => {
       if (
         isCreatePath(location.pathname) &&
-        !isCreatePath(pathnameFromPath(path))
+        !isCreatePath(pathnameFromPath(path)) &&
+        isAgentChatHomeHandoffActive(ASSETS_CHAT_STORAGE_KEY)
       ) {
         markAgentChatHomeHandoff(ASSETS_CHAT_STORAGE_KEY);
       }

--- a/templates/assets/changelog/2026-07-13-assets-keeps-the-right-chat-sidebar-closed-when-the-full-pag.md
+++ b/templates/assets/changelog/2026-07-13-assets-keeps-the-right-chat-sidebar-closed-when-the-full-pag.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-13
+---
+
+Assets keeps the right chat sidebar closed when the full-page chat is empty.


### PR DESCRIPTION
## Summary
- add native Codex login handoff and local-runtime composer setup
- improve Slack/integration fallbacks and Dispatch thread deep links
- add focused desktop launcher coverage and release changesets

## Validation
- `corepack pnpm run prep`
- focused webhook, composer, desktop launcher, and privacy tests
- core, Code Agents UI, and Desktop typechecks