### PR TITLE
Redesign generation results as library-style asset grid

### DIFF
--- a/templates/assets/app/components/generation/GenerationResults.tsx
+++ b/templates/assets/app/components/generation/GenerationResults.tsx
@@ -537,6 +537,9 @@ function GenerationPreviewDialog({
   };
   const sources = slot ? assetPreviewSources(slot, "preview") : [];
   const src = sources[0];
+  const title = libraryTitle
+    ? `${libraryTitle}${prompt ? ` / ${prompt}` : ""}`
+    : prompt || t("library.readyToSave");
   return (
     <Dialog open={Boolean(slot)} onOpenChange={onOpenChange}>
       {slot ? (
@@ -546,7 +549,7 @@ function GenerationPreviewDialog({
             if (event.key === "ArrowLeft") showPreviousSlot();
             if (event.key === "ArrowRight") showNextSlot();
           }}
-          className="max-w-4xl border-0 bg-transparent p-0 shadow-none"
+          className="flex max-h-[85vh] w-[calc(100vw-24px)] max-w-4xl flex-col gap-0 overflow-hidden p-0"
         >
           <DialogTitle className="sr-only">
             {libraryTitle || t("library.noBrandKit")}
@@ -554,10 +557,13 @@ function GenerationPreviewDialog({
           <DialogDescription className="sr-only">
             {prompt || t("library.readyToSave")}
           </DialogDescription>
-          <div className="relative">
-            <div className="absolute right-2 top-2 z-10 flex items-center gap-2">
+
+          <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border/80 px-4 py-3">
+            <p className="min-w-0 truncate text-sm text-muted-foreground">
+              {title}
+            </p>
+            <div className="flex shrink-0 items-center gap-2">
               <Button
-                variant="secondary"
                 size="sm"
                 disabled={isSaving || !slot.assetId}
                 onClick={() => onSave(slot)}
@@ -583,16 +589,19 @@ function GenerationPreviewDialog({
               ) : null}
               <DialogClose
                 aria-label={t("library.closePreview")}
-                className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition hover:bg-accent hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
-                <IconX className="h-5 w-5" />
+                <IconX className="h-4 w-4" />
               </DialogClose>
             </div>
+          </div>
+
+          <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto bg-muted/20 p-4 sm:p-6">
             {src ? (
               <img
                 src={src}
                 alt={prompt || ""}
-                className="max-h-[85vh] w-full rounded-lg bg-black object-contain"
+                className="max-h-full max-w-full rounded-lg bg-black object-contain"
               />
             ) : (
               <div className="flex h-64 w-full items-center justify-center rounded-lg bg-muted">
@@ -600,14 +609,15 @@ function GenerationPreviewDialog({
               </div>
             )}
           </div>
+
           {hasPrev || hasNext ? (
-            <div className="mt-5 flex justify-center gap-2">
+            <div className="flex shrink-0 items-center justify-center gap-2 border-t border-border/80 py-3">
               <button
                 type="button"
                 aria-label={t("library.previousImage")}
                 onClick={showPreviousSlot}
                 disabled={!hasPrev}
-                className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white disabled:cursor-not-allowed disabled:opacity-40"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-full text-foreground transition hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-40"
               >
                 <IconChevronLeft className="h-5 w-5" />
               </button>
@@ -616,7 +626,7 @@ function GenerationPreviewDialog({
                 aria-label={t("library.nextImage")}
                 onClick={showNextSlot}
                 disabled={!hasNext}
-                className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white disabled:cursor-not-allowed disabled:opacity-40"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-full text-foreground transition hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-40"
               >
                 <IconChevronRight className="h-5 w-5" />
               </button>

--- a/templates/assets/app/components/generation/GenerationResults.tsx
+++ b/templates/assets/app/components/generation/GenerationResults.tsx
@@ -299,6 +299,7 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
         prompt={variants.prompt}
         libraryTitle={libraryTitle}
         isSaving={saveGenerated.isPending}
+        isDismissing={dismissSlot.isPending}
         onOpenChange={(open) => {
           if (!open) setPreviewSlotId(null);
         }}
@@ -308,6 +309,9 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
           refineSlot(slot, variantNumber);
           setPreviewSlotId(null);
         }}
+        onDismiss={(slot) =>
+          dismissSlotById(slot, () => setPreviewSlotId(null))
+        }
       />
 
       <section className="mx-auto mb-4 w-full max-w-[760px] px-4">
@@ -490,7 +494,7 @@ function GenerationDraftCard({
               event.stopPropagation();
               onDismiss();
             }}
-            className="absolute right-2 top-2 z-10 inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/90 text-muted-foreground opacity-0 shadow-sm transition hover:bg-destructive hover:text-destructive-foreground focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100 disabled:opacity-60"
+            className="absolute right-2 top-2 z-10 inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/90 text-muted-foreground shadow-sm transition hover:bg-destructive hover:text-destructive-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
           >
             <IconTrash className="h-4 w-4" />
           </button>
@@ -509,20 +513,24 @@ function GenerationPreviewDialog({
   prompt,
   libraryTitle,
   isSaving,
+  isDismissing,
   onOpenChange,
   onSelect,
   onSave,
   onRefine,
+  onDismiss,
 }: {
   slot: VariantSlot | null;
   slots: VariantSlot[];
   prompt: string;
   libraryTitle: string | null;
   isSaving: boolean;
+  isDismissing: boolean;
   onOpenChange: (open: boolean) => void;
   onSelect: (slotId: string) => void;
   onSave: (slot: VariantSlot) => void;
   onRefine: (slot: VariantSlot, variantNumber: number) => void;
+  onDismiss: (slot: VariantSlot) => void;
 }) {
   const t = useT();
   const previewableSlots = useMemo(
@@ -590,11 +598,28 @@ function GenerationPreviewDialog({
               </Button>
               {slot.assetId ? (
                 <Button asChild variant="outline" size="sm">
-                  <Link to={`/asset/${encodeURIComponent(slot.assetId)}`}>
+                  <Link
+                    to={`/asset/${encodeURIComponent(slot.assetId)}`}
+                    onClick={() => onOpenChange(false)}
+                  >
                     {t("library.viewDetails")}
                   </Link>
                 </Button>
               ) : null}
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-8 w-8 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                disabled={isDismissing}
+                onClick={() => onDismiss(slot)}
+                aria-label={t("library.deleteCandidate")}
+              >
+                {isDismissing ? (
+                  <Spinner className="h-4 w-4" />
+                ) : (
+                  <IconTrash className="h-4 w-4" />
+                )}
+              </Button>
               <DialogClose
                 aria-label={t("library.closePreview")}
                 className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition hover:bg-accent hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"

--- a/templates/assets/app/components/generation/GenerationResults.tsx
+++ b/templates/assets/app/components/generation/GenerationResults.tsx
@@ -6,6 +6,8 @@ import {
   useT,
 } from "@agent-native/core/client";
 import {
+  IconChevronLeft,
+  IconChevronRight,
   IconDeviceFloppy,
   IconMessageCircle,
   IconPhoto,
@@ -289,12 +291,14 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
 
       <GenerationPreviewDialog
         slot={previewSlot}
+        slots={slots}
         prompt={variants.prompt}
         libraryTitle={libraryTitle}
         isSaving={saveGenerated.isPending}
         onOpenChange={(open) => {
           if (!open) setPreviewSlotId(null);
         }}
+        onSelect={setPreviewSlotId}
         onSave={(slot) => saveSlot(slot, () => setPreviewSlotId(null))}
         onRefine={refineSlot}
       />
@@ -492,22 +496,45 @@ function GenerationDraftCard({
 
 function GenerationPreviewDialog({
   slot,
+  slots,
   prompt,
   libraryTitle,
   isSaving,
   onOpenChange,
+  onSelect,
   onSave,
   onRefine,
 }: {
   slot: VariantSlot | null;
+  slots: VariantSlot[];
   prompt: string;
   libraryTitle: string | null;
   isSaving: boolean;
   onOpenChange: (open: boolean) => void;
+  onSelect: (slotId: string) => void;
   onSave: (slot: VariantSlot) => void;
   onRefine: (slot: VariantSlot) => void;
 }) {
   const t = useT();
+  const previewableSlots = useMemo(
+    () =>
+      slots.filter(
+        (item) => item.status === "ready" && Boolean(item.assetId),
+      ),
+    [slots],
+  );
+  const previewIndex = slot
+    ? previewableSlots.findIndex((item) => item.slotId === slot.slotId)
+    : -1;
+  const hasPrev = previewIndex > 0;
+  const hasNext =
+    previewIndex >= 0 && previewIndex < previewableSlots.length - 1;
+  const showPreviousSlot = () => {
+    if (hasPrev) onSelect(previewableSlots[previewIndex - 1].slotId);
+  };
+  const showNextSlot = () => {
+    if (hasNext) onSelect(previewableSlots[previewIndex + 1].slotId);
+  };
   const sources = slot ? assetPreviewSources(slot, "preview") : [];
   const src = sources[0];
   return (
@@ -515,6 +542,10 @@ function GenerationPreviewDialog({
       {slot ? (
         <DialogContent
           hideClose
+          onKeyDown={(event) => {
+            if (event.key === "ArrowLeft") showPreviousSlot();
+            if (event.key === "ArrowRight") showNextSlot();
+          }}
           className="max-w-4xl border-0 bg-transparent p-0 shadow-none"
         >
           <DialogTitle className="sr-only">
@@ -569,6 +600,28 @@ function GenerationPreviewDialog({
               </div>
             )}
           </div>
+          {hasPrev || hasNext ? (
+            <div className="mt-5 flex justify-center gap-2">
+              <button
+                type="button"
+                aria-label={t("library.previousImage")}
+                onClick={showPreviousSlot}
+                disabled={!hasPrev}
+                className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                <IconChevronLeft className="h-5 w-5" />
+              </button>
+              <button
+                type="button"
+                aria-label={t("library.nextImage")}
+                onClick={showNextSlot}
+                disabled={!hasNext}
+                className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                <IconChevronRight className="h-5 w-5" />
+              </button>
+            </div>
+          ) : null}
         </DialogContent>
       ) : null}
     </Dialog>

--- a/templates/assets/app/components/generation/GenerationResults.tsx
+++ b/templates/assets/app/components/generation/GenerationResults.tsx
@@ -5,9 +5,16 @@ import {
   useActionQuery,
   useT,
 } from "@agent-native/core/client";
-import { IconMessageCircle, IconPhoto, IconTrash } from "@tabler/icons-react";
+import {
+  IconDeviceFloppy,
+  IconMessageCircle,
+  IconPhoto,
+  IconTrash,
+  IconX,
+} from "@tabler/icons-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { Link } from "react-router";
 import { toast } from "sonner";
 
 import {
@@ -22,7 +29,20 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { assetPreviewSources } from "@/lib/asset-preview-sources";
 
 import type {
@@ -33,6 +53,8 @@ import type {
 type LibraryListResult = {
   libraries?: ImageLibrarySummary[];
 };
+
+type VariantSlot = AssetVariantState["slots"][number];
 
 function variantStateKey(threadId: string | null) {
   return threadId ? `asset-variants:${threadId}` : "asset-variants";
@@ -46,15 +68,13 @@ function variantStateKey(threadId: string | null) {
 // its finished image arrives.
 const STALE_PENDING_RUN_MS = 10 * 60 * 1000;
 
-function slotTime(slot: AssetVariantState["slots"][number]): number {
+function slotTime(slot: VariantSlot): number {
   const raw = slot.createdAt ?? slot.updatedAt ?? "";
   const time = Date.parse(raw);
   return Number.isNaN(time) ? 0 : time;
 }
 
-function stalePendingRunId(
-  slot: AssetVariantState["slots"][number],
-): string | null {
+function stalePendingRunId(slot: VariantSlot): string | null {
   if (slot.status !== "pending") return null;
   if (!slot.runId) return null;
   const timestamp = slotTime(slot);
@@ -66,6 +86,7 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
   const t = useT();
   const queryClient = useQueryClient();
   const [clearAllOpen, setClearAllOpen] = useState(false);
+  const [previewSlotId, setPreviewSlotId] = useState<string | null>(null);
   const stateKey = variantStateKey(threadId);
   const stateQueryKey = useMemo(() => ["app-state", stateKey], [stateKey]);
   const { data: variants } = useQuery({
@@ -137,6 +158,11 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
     );
   }, [belongsToThread, queryClient, refreshGeneration, slots, stateQueryKey]);
 
+  const previewSlot = useMemo(
+    () => slots.find((slot) => slot.slotId === previewSlotId) ?? null,
+    [previewSlotId, slots],
+  );
+
   if (!belongsToThread || !variants) return null;
   if (slots.length === 0) return null;
 
@@ -167,6 +193,61 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
           toast.error(error.message || t("library.couldNotClearCandidates")),
       },
     );
+  }
+
+  function saveSlot(slot: VariantSlot, onDone?: () => void) {
+    if (!slot.assetId && !slot.slotId) return;
+    saveGenerated.mutate(
+      {
+        ...(slot.assetId ? { assetId: slot.assetId } : {}),
+        ...(slot.slotId ? { slotId: slot.slotId } : {}),
+        threadId,
+      },
+      {
+        onSuccess: () => {
+          toast.success(t("library.savedGeneratedAsset"));
+          void queryClient.invalidateQueries({ queryKey: stateQueryKey });
+          void queryClient.invalidateQueries({
+            queryKey: ["action", "get-library"],
+          });
+          onDone?.();
+        },
+        onError: (error) =>
+          toast.error(error.message || t("library.couldNotSaveCandidate")),
+      },
+    );
+  }
+
+  function dismissSlotById(slot: VariantSlot, onDone?: () => void) {
+    dismissSlot.mutate(
+      { slotId: slot.slotId, threadId },
+      {
+        onSuccess: () => {
+          void queryClient.invalidateQueries({ queryKey: stateQueryKey });
+          onDone?.();
+        },
+        onError: (error) =>
+          toast.error(error.message || t("library.couldNotDismissCandidate")),
+      },
+    );
+  }
+
+  function refineSlot(slot: VariantSlot) {
+    sendToAgentChat({
+      message: `Refine generated asset ${slot.assetId}: `,
+      context: [
+        "## Assets candidate",
+        `Asset ID: ${slot.assetId}`,
+        `Run ID: ${slot.runId ?? "unknown"}`,
+        `Prompt: ${variants?.prompt ?? ""}`,
+        libraryTitle ? `Brand kit: ${libraryTitle}` : "",
+        "Use refine-image with assetId when the user describes the change.",
+      ]
+        .filter(Boolean)
+        .join("\n"),
+      submit: false,
+      openSidebar: true,
+    });
   }
 
   return (
@@ -206,6 +287,18 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
         </AlertDialogContent>
       </AlertDialog>
 
+      <GenerationPreviewDialog
+        slot={previewSlot}
+        prompt={variants.prompt}
+        libraryTitle={libraryTitle}
+        isSaving={saveGenerated.isPending}
+        onOpenChange={(open) => {
+          if (!open) setPreviewSlotId(null);
+        }}
+        onSave={(slot) => saveSlot(slot, () => setPreviewSlotId(null))}
+        onRefine={refineSlot}
+      />
+
       <section className="mx-auto mb-4 w-full max-w-[760px] px-4">
         <div className="overflow-hidden rounded-xl border border-border bg-card shadow-sm">
           <div className="flex items-start justify-between gap-3 border-b border-border/80 px-3 py-3">
@@ -244,64 +337,19 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
           </div>
 
           <div className="max-h-[min(640px,52vh)] overflow-y-auto p-3">
-            <div
-              className={
-                slots.length === 1
-                  ? "grid grid-cols-1 gap-3"
-                  : "grid grid-cols-1 gap-3 sm:grid-cols-2"
-              }
-            >
-              {slots.map((slot, index) => (
-                <GenerationResultItem
+            <div className="assets-library-grid grid grid-cols-2 gap-3 sm:grid-cols-3">
+              {slots.map((slot) => (
+                <GenerationDraftCard
                   key={slot.slotId}
                   slot={slot}
-                  index={index}
                   prompt={variants.prompt}
                   libraryTitle={libraryTitle}
                   isSaving={saveGenerated.isPending}
                   isDismissing={dismissSlot.isPending}
-                  onSave={() => {
-                    if (!slot.assetId && !slot.slotId) return;
-                    saveGenerated.mutate(
-                      {
-                        ...(slot.assetId ? { assetId: slot.assetId } : {}),
-                        ...(slot.slotId ? { slotId: slot.slotId } : {}),
-                        threadId,
-                      },
-                      {
-                        onSuccess: () => {
-                          toast.success(t("library.savedGeneratedAsset"));
-                          void queryClient.invalidateQueries({
-                            queryKey: stateQueryKey,
-                          });
-                          void queryClient.invalidateQueries({
-                            queryKey: ["action", "get-library"],
-                          });
-                        },
-                        onError: (error) =>
-                          toast.error(
-                            error.message || t("library.couldNotSaveCandidate"),
-                          ),
-                      },
-                    );
-                  }}
-                  onDismiss={() => {
-                    dismissSlot.mutate(
-                      { slotId: slot.slotId, threadId },
-                      {
-                        onSuccess: () => {
-                          void queryClient.invalidateQueries({
-                            queryKey: stateQueryKey,
-                          });
-                        },
-                        onError: (error) =>
-                          toast.error(
-                            error.message ||
-                              t("library.couldNotDismissCandidate"),
-                          ),
-                      },
-                    );
-                  }}
+                  onPreview={() => setPreviewSlotId(slot.slotId)}
+                  onSave={() => saveSlot(slot)}
+                  onRefine={() => refineSlot(slot)}
+                  onDismiss={() => dismissSlotById(slot)}
                 />
               ))}
             </div>
@@ -312,117 +360,233 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
   );
 }
 
-function GenerationResultItem({
+function GenerationDraftCard({
   slot,
-  index,
   prompt,
   libraryTitle,
   isSaving,
   isDismissing,
+  onPreview,
   onSave,
+  onRefine,
   onDismiss,
 }: {
-  slot: AssetVariantState["slots"][number];
-  index: number;
+  slot: VariantSlot;
   prompt: string;
   libraryTitle: string | null;
   isSaving: boolean;
   isDismissing: boolean;
+  onPreview: () => void;
   onSave: () => void;
+  onRefine: () => void;
   onDismiss: () => void;
 }) {
-  const ready = slot.status === "ready" && Boolean(slot.assetId);
   const t = useT();
+  const ready = slot.status === "ready" && Boolean(slot.assetId);
+  const title = libraryTitle
+    ? `${libraryTitle}${prompt ? ` / ${prompt}` : ""}`
+    : prompt || t("library.readyToSave");
   return (
-    <article className="overflow-hidden rounded-lg border border-border/80 bg-background/70">
-      <div className="relative aspect-[16/10] overflow-hidden bg-muted/40">
-        <GenerationSlotPreview slot={slot} />
-        <div className="absolute left-2 top-2 flex items-center gap-1 rounded-full border border-border/70 bg-background/90 px-2 py-1 text-[11px] font-medium shadow-sm">
+    <div className="group relative overflow-hidden rounded-lg border border-border/80 bg-background transition hover:border-foreground/25 hover:bg-muted/10 focus-within:ring-2 focus-within:ring-ring">
+      <button
+        type="button"
+        aria-label={t("library.selectAsset", { title })}
+        title={title}
+        onClick={() => {
+          if (ready) onPreview();
+        }}
+        className="block w-full text-left focus-visible:outline-none"
+      >
+        <div className="aspect-[4/3] bg-muted/40">
+          <GenerationSlotPreview slot={slot} />
+        </div>
+      </button>
+
+      {slot.status !== "ready" ? (
+        <div className="absolute left-2 top-2 z-10 flex items-center gap-1 rounded-full border border-border/70 bg-background/90 px-2 py-1 text-[11px] font-medium shadow-sm">
           {slot.status === "pending" ? <Spinner className="h-3 w-3" /> : null}
           <span>
             {slot.status === "pending"
               ? t("library.generating")
-              : slot.status === "ready"
-                ? t("library.candidateWithNumber", { number: index + 1 })
-                : t("library.failed")}
+              : t("library.failed")}
           </span>
         </div>
-      </div>
-      <div className="space-y-2 p-2.5">
-        <div className="min-w-0 text-xs">
-          <div className="truncate font-medium">
-            {slot.status === "ready"
-              ? t("library.readyToSave")
-              : slot.status === "pending"
-                ? t("library.stillRendering")
-                : t("library.generationFailed")}
+      ) : null}
+
+      {ready ? (
+        <TooltipProvider>
+          <div className="absolute right-2 top-2 z-10 flex items-center gap-1.5 opacity-0 transition group-hover:opacity-100 focus-within:opacity-100">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label={t("library.save")}
+                  disabled={isSaving}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onSave();
+                  }}
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/90 text-foreground shadow-sm transition hover:bg-primary hover:text-primary-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+                >
+                  {isSaving ? (
+                    <Spinner className="h-4 w-4" />
+                  ) : (
+                    <IconDeviceFloppy className="h-4 w-4" />
+                  )}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>{t("library.save")}</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label={t("library.refine")}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onRefine();
+                  }}
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/90 text-foreground shadow-sm transition hover:bg-primary hover:text-primary-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <IconMessageCircle className="h-4 w-4" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>{t("library.refine")}</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label={t("library.deleteCandidate")}
+                  disabled={isDismissing}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onDismiss();
+                  }}
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/90 text-foreground shadow-sm transition hover:bg-destructive hover:text-destructive-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+                >
+                  <IconTrash className="h-4 w-4" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>{t("library.deleteCandidate")}</TooltipContent>
+            </Tooltip>
           </div>
-          <div className="mt-0.5 truncate text-muted-foreground">
-            {libraryTitle || t("library.noBrandKit")}
-            {prompt ? ` / ${prompt}` : null}
-          </div>
-        </div>
-        <div className="flex flex-wrap items-center gap-1.5">
-          <Button
-            size="sm"
-            className="h-7 px-2 text-xs"
-            disabled={!ready || isSaving}
-            onClick={onSave}
-          >
-            {isSaving ? <Spinner className="h-3 w-3" /> : t("library.save")}
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-7 gap-1 px-2 text-xs"
-            disabled={!slot.assetId}
-            onClick={() =>
-              sendToAgentChat({
-                message: `Refine generated asset ${slot.assetId}: `,
-                context: [
-                  "## Assets candidate",
-                  `Asset ID: ${slot.assetId}`,
-                  `Run ID: ${slot.runId ?? "unknown"}`,
-                  `Prompt: ${prompt}`,
-                  libraryTitle ? `Brand kit: ${libraryTitle}` : "",
-                  "Use refine-image with assetId when the user describes the change.",
-                ]
-                  .filter(Boolean)
-                  .join("\n"),
-                submit: false,
-                openSidebar: true,
-              })
-            }
-          >
-            <IconMessageCircle className="h-3.5 w-3.5" />
-            {t("library.refine")}
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-7 w-7 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-            disabled={isDismissing}
-            onClick={onDismiss}
-            aria-label={t("library.deleteCandidate")}
-          >
-            <IconTrash className="h-3.5 w-3.5" />
-          </Button>
-        </div>
-      </div>
-    </article>
+        </TooltipProvider>
+      ) : (
+        <button
+          type="button"
+          aria-label={t("library.deleteCandidate")}
+          disabled={isDismissing}
+          onClick={(event) => {
+            event.stopPropagation();
+            onDismiss();
+          }}
+          className="absolute right-2 top-2 z-10 inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/90 text-muted-foreground opacity-0 shadow-sm transition hover:bg-destructive hover:text-destructive-foreground focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100 disabled:opacity-60"
+        >
+          <IconTrash className="h-4 w-4" />
+        </button>
+      )}
+    </div>
   );
 }
 
-function GenerationSlotPreview({
+function GenerationPreviewDialog({
   slot,
+  prompt,
+  libraryTitle,
+  isSaving,
+  onOpenChange,
+  onSave,
+  onRefine,
 }: {
-  slot: AssetVariantState["slots"][number];
+  slot: VariantSlot | null;
+  prompt: string;
+  libraryTitle: string | null;
+  isSaving: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: (slot: VariantSlot) => void;
+  onRefine: (slot: VariantSlot) => void;
 }) {
+  const t = useT();
+  const sources = slot ? assetPreviewSources(slot, "preview") : [];
+  const src = sources[0];
+  return (
+    <Dialog open={Boolean(slot)} onOpenChange={onOpenChange}>
+      {slot ? (
+        <DialogContent
+          hideClose
+          className="max-w-4xl border-0 bg-transparent p-0 shadow-none"
+        >
+          <DialogTitle className="sr-only">
+            {libraryTitle || t("library.noBrandKit")}
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            {prompt || t("library.readyToSave")}
+          </DialogDescription>
+          <div className="relative">
+            <div className="absolute right-2 top-2 z-10 flex items-center gap-2">
+              <Button
+                variant="secondary"
+                size="sm"
+                disabled={isSaving || !slot.assetId}
+                onClick={() => onSave(slot)}
+              >
+                {isSaving ? <Spinner className="h-4 w-4" /> : t("library.save")}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-1"
+                disabled={!slot.assetId}
+                onClick={() => onRefine(slot)}
+              >
+                <IconMessageCircle className="h-4 w-4" />
+                {t("library.refine")}
+              </Button>
+              {slot.assetId ? (
+                <Button asChild variant="outline" size="sm">
+                  <Link to={`/asset/${encodeURIComponent(slot.assetId)}`}>
+                    {t("library.viewDetails")}
+                  </Link>
+                </Button>
+              ) : null}
+              <DialogClose
+                aria-label={t("library.closePreview")}
+                className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+              >
+                <IconX className="h-5 w-5" />
+              </DialogClose>
+            </div>
+            {src ? (
+              <img
+                src={src}
+                alt={prompt || ""}
+                className="max-h-[85vh] w-full rounded-lg bg-black object-contain"
+              />
+            ) : (
+              <div className="flex h-64 w-full items-center justify-center rounded-lg bg-muted">
+                <IconPhoto className="h-8 w-8 text-muted-foreground" />
+              </div>
+            )}
+          </div>
+        </DialogContent>
+      ) : null}
+    </Dialog>
+  );
+}
+
+function GenerationSlotPreview({ slot }: { slot: VariantSlot }) {
   const t = useT();
   const sources = assetPreviewSources(slot, "thumbnail");
   const src = sources[0];
   if (src) {
-    return <img src={src} alt="" className="h-full w-full object-contain" />;
+    return (
+      <img
+        src={src}
+        alt=""
+        className="h-full w-full object-contain transition group-hover:scale-[1.02]"
+      />
+    );
   }
   if (slot.status === "failed") {
     return (

--- a/templates/assets/app/components/generation/GenerationResults.tsx
+++ b/templates/assets/app/components/generation/GenerationResults.tsx
@@ -1,6 +1,6 @@
 import {
   readClientAppState,
-  sendToAgentChat,
+  setAgentChatContextItem,
   useActionMutation,
   useActionQuery,
   useT,
@@ -235,8 +235,10 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
   }
 
   function refineSlot(slot: VariantSlot) {
-    sendToAgentChat({
-      message: `Refine generated asset ${slot.assetId}: `,
+    if (!slot.assetId) return;
+    setAgentChatContextItem({
+      key: `refine-asset:${slot.assetId}`,
+      title: t("library.refine"),
       context: [
         "## Assets candidate",
         `Asset ID: ${slot.assetId}`,
@@ -247,7 +249,6 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
       ]
         .filter(Boolean)
         .join("\n"),
-      submit: false,
       openSidebar: true,
     });
   }

--- a/templates/assets/app/components/generation/GenerationResults.tsx
+++ b/templates/assets/app/components/generation/GenerationResults.tsx
@@ -301,7 +301,10 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
         }}
         onSelect={setPreviewSlotId}
         onSave={(slot) => saveSlot(slot, () => setPreviewSlotId(null))}
-        onRefine={refineSlot}
+        onRefine={(slot) => {
+          refineSlot(slot);
+          setPreviewSlotId(null);
+        }}
       />
 
       <section className="mx-auto mb-4 w-full max-w-[760px] px-4">

--- a/templates/assets/app/components/generation/GenerationResults.tsx
+++ b/templates/assets/app/components/generation/GenerationResults.tsx
@@ -234,11 +234,14 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
     );
   }
 
-  function refineSlot(slot: VariantSlot) {
+  function refineSlot(slot: VariantSlot, variantNumber: number) {
     if (!slot.assetId) return;
+    const variantLabel = t("library.variantWithNumber", {
+      number: variantNumber,
+    });
     setAgentChatContextItem({
-      key: `refine-asset:${slot.assetId}`,
-      title: t("library.refine"),
+      key: "refine-asset:" + slot.assetId,
+      title: t("library.refine") + " : " + variantLabel,
       context: [
         "## Assets candidate",
         `Asset ID: ${slot.assetId}`,
@@ -301,8 +304,8 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
         }}
         onSelect={setPreviewSlotId}
         onSave={(slot) => saveSlot(slot, () => setPreviewSlotId(null))}
-        onRefine={(slot) => {
-          refineSlot(slot);
+        onRefine={(slot, variantNumber) => {
+          refineSlot(slot, variantNumber);
           setPreviewSlotId(null);
         }}
       />
@@ -346,17 +349,16 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
 
           <div className="max-h-[min(640px,52vh)] overflow-y-auto p-3">
             <div className="assets-library-grid grid grid-cols-2 gap-3 sm:grid-cols-3">
-              {slots.map((slot) => (
+              {slots.map((slot, index) => (
                 <GenerationDraftCard
                   key={slot.slotId}
                   slot={slot}
-                  prompt={variants.prompt}
-                  libraryTitle={libraryTitle}
+                  variantNumber={index + 1}
                   isSaving={saveGenerated.isPending}
                   isDismissing={dismissSlot.isPending}
                   onPreview={() => setPreviewSlotId(slot.slotId)}
                   onSave={() => saveSlot(slot)}
-                  onRefine={() => refineSlot(slot)}
+                  onRefine={() => refineSlot(slot, index + 1)}
                   onDismiss={() => dismissSlotById(slot)}
                 />
               ))}
@@ -370,8 +372,7 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
 
 function GenerationDraftCard({
   slot,
-  prompt,
-  libraryTitle,
+  variantNumber,
   isSaving,
   isDismissing,
   onPreview,
@@ -380,8 +381,7 @@ function GenerationDraftCard({
   onDismiss,
 }: {
   slot: VariantSlot;
-  prompt: string;
-  libraryTitle: string | null;
+  variantNumber: number;
   isSaving: boolean;
   isDismissing: boolean;
   onPreview: () => void;
@@ -391,109 +391,114 @@ function GenerationDraftCard({
 }) {
   const t = useT();
   const ready = slot.status === "ready" && Boolean(slot.assetId);
-  const title = libraryTitle
-    ? `${libraryTitle}${prompt ? ` / ${prompt}` : ""}`
-    : prompt || t("library.readyToSave");
+  const variantLabel = t("library.variantWithNumber", {
+    number: variantNumber,
+  });
   return (
-    <div className="group relative overflow-hidden rounded-lg border border-border/80 bg-background transition hover:border-foreground/25 hover:bg-muted/10 focus-within:ring-2 focus-within:ring-ring">
-      <button
-        type="button"
-        aria-label={t("library.selectAsset", { title })}
-        title={title}
-        onClick={() => {
-          if (ready) onPreview();
-        }}
-        className="block w-full text-left focus-visible:outline-none"
-      >
-        <div className="aspect-[4/3] bg-muted/40">
-          <GenerationSlotPreview slot={slot} />
-        </div>
-      </button>
-
-      {slot.status !== "ready" ? (
-        <div className="absolute left-2 top-2 z-10 flex items-center gap-1 rounded-full border border-border/70 bg-background/90 px-2 py-1 text-[11px] font-medium shadow-sm">
-          {slot.status === "pending" ? <Spinner className="h-3 w-3" /> : null}
-          <span>
-            {slot.status === "pending"
-              ? t("library.generating")
-              : t("library.failed")}
-          </span>
-        </div>
-      ) : null}
-
-      {ready ? (
-        <TooltipProvider>
-          <div className="absolute right-2 top-2 z-10 flex items-center gap-1.5 opacity-0 transition group-hover:opacity-100 focus-within:opacity-100">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  aria-label={t("library.save")}
-                  disabled={isSaving}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onSave();
-                  }}
-                  className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/90 text-foreground shadow-sm transition hover:bg-primary hover:text-primary-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
-                >
-                  {isSaving ? (
-                    <Spinner className="h-4 w-4" />
-                  ) : (
-                    <IconDeviceFloppy className="h-4 w-4" />
-                  )}
-                </button>
-              </TooltipTrigger>
-              <TooltipContent>{t("library.save")}</TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  aria-label={t("library.refine")}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onRefine();
-                  }}
-                  className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/90 text-foreground shadow-sm transition hover:bg-primary hover:text-primary-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                >
-                  <IconMessageCircle className="h-4 w-4" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent>{t("library.refine")}</TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  aria-label={t("library.deleteCandidate")}
-                  disabled={isDismissing}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onDismiss();
-                  }}
-                  className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/90 text-foreground shadow-sm transition hover:bg-destructive hover:text-destructive-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
-                >
-                  <IconTrash className="h-4 w-4" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent>{t("library.deleteCandidate")}</TooltipContent>
-            </Tooltip>
-          </div>
-        </TooltipProvider>
-      ) : (
+    <div className="overflow-hidden rounded-lg border border-border/80 bg-background transition hover:border-foreground/25 hover:bg-muted/10">
+      <div className="group relative">
         <button
           type="button"
-          aria-label={t("library.deleteCandidate")}
-          disabled={isDismissing}
-          onClick={(event) => {
-            event.stopPropagation();
-            onDismiss();
+          aria-label={t("library.selectAsset", { title: variantLabel })}
+          title={variantLabel}
+          onClick={() => {
+            if (ready) onPreview();
           }}
-          className="absolute right-2 top-2 z-10 inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/90 text-muted-foreground opacity-0 shadow-sm transition hover:bg-destructive hover:text-destructive-foreground focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100 disabled:opacity-60"
+          className="block w-full text-left focus-visible:outline-none"
         >
-          <IconTrash className="h-4 w-4" />
+          <div className="aspect-[4/3] bg-muted/40">
+            <GenerationSlotPreview slot={slot} />
+          </div>
         </button>
-      )}
+
+        {slot.status !== "ready" ? (
+          <div className="absolute left-2 top-2 z-10 flex items-center gap-1 rounded-full border border-border/70 bg-background/90 px-2 py-1 text-[11px] font-medium shadow-sm">
+            {slot.status === "pending" ? <Spinner className="h-3 w-3" /> : null}
+            <span>
+              {slot.status === "pending"
+                ? t("library.generating")
+                : t("library.failed")}
+            </span>
+          </div>
+        ) : null}
+
+        {ready ? (
+          <TooltipProvider>
+            <div className="absolute right-2 top-2 z-10 flex items-center gap-1.5 opacity-0 transition group-hover:opacity-100 focus-within:opacity-100">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={t("library.save")}
+                    disabled={isSaving}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onSave();
+                    }}
+                    className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/90 text-foreground shadow-sm transition hover:bg-primary hover:text-primary-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+                  >
+                    {isSaving ? (
+                      <Spinner className="h-4 w-4" />
+                    ) : (
+                      <IconDeviceFloppy className="h-4 w-4" />
+                    )}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>{t("library.save")}</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={t("library.refine")}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onRefine();
+                    }}
+                    className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/90 text-foreground shadow-sm transition hover:bg-primary hover:text-primary-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    <IconMessageCircle className="h-4 w-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>{t("library.refine")}</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={t("library.deleteCandidate")}
+                    disabled={isDismissing}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onDismiss();
+                    }}
+                    className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/90 text-foreground shadow-sm transition hover:bg-destructive hover:text-destructive-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+                  >
+                    <IconTrash className="h-4 w-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>{t("library.deleteCandidate")}</TooltipContent>
+              </Tooltip>
+            </div>
+          </TooltipProvider>
+        ) : (
+          <button
+            type="button"
+            aria-label={t("library.deleteCandidate")}
+            disabled={isDismissing}
+            onClick={(event) => {
+              event.stopPropagation();
+              onDismiss();
+            }}
+            className="absolute right-2 top-2 z-10 inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/90 text-muted-foreground opacity-0 shadow-sm transition hover:bg-destructive hover:text-destructive-foreground focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100 disabled:opacity-60"
+          >
+            <IconTrash className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+      <div className="px-2 py-1.5 text-center text-xs font-medium text-muted-foreground">
+        {variantLabel}
+      </div>
     </div>
   );
 }
@@ -517,14 +522,12 @@ function GenerationPreviewDialog({
   onOpenChange: (open: boolean) => void;
   onSelect: (slotId: string) => void;
   onSave: (slot: VariantSlot) => void;
-  onRefine: (slot: VariantSlot) => void;
+  onRefine: (slot: VariantSlot, variantNumber: number) => void;
 }) {
   const t = useT();
   const previewableSlots = useMemo(
     () =>
-      slots.filter(
-        (item) => item.status === "ready" && Boolean(item.assetId),
-      ),
+      slots.filter((item) => item.status === "ready" && Boolean(item.assetId)),
     [slots],
   );
   const previewIndex = slot
@@ -541,9 +544,12 @@ function GenerationPreviewDialog({
   };
   const sources = slot ? assetPreviewSources(slot, "preview") : [];
   const src = sources[0];
-  const title = libraryTitle
-    ? `${libraryTitle}${prompt ? ` / ${prompt}` : ""}`
-    : prompt || t("library.readyToSave");
+  const variantNumber = slot
+    ? slots.findIndex((item) => item.slotId === slot.slotId) + 1
+    : 0;
+  const variantLabel = t("library.variantWithNumber", {
+    number: variantNumber,
+  });
   return (
     <Dialog open={Boolean(slot)} onOpenChange={onOpenChange}>
       {slot ? (
@@ -555,16 +561,14 @@ function GenerationPreviewDialog({
           }}
           className="flex max-h-[85vh] w-[calc(100vw-24px)] max-w-4xl flex-col gap-0 overflow-hidden p-0"
         >
-          <DialogTitle className="sr-only">
-            {libraryTitle || t("library.noBrandKit")}
-          </DialogTitle>
+          <DialogTitle className="sr-only">{variantLabel}</DialogTitle>
           <DialogDescription className="sr-only">
             {prompt || t("library.readyToSave")}
           </DialogDescription>
 
           <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border/80 px-4 py-3">
-            <p className="min-w-0 truncate text-sm text-muted-foreground">
-              {title}
+            <p className="min-w-0 truncate text-sm font-medium">
+              {variantLabel}
             </p>
             <div className="flex shrink-0 items-center gap-2">
               <Button
@@ -579,7 +583,7 @@ function GenerationPreviewDialog({
                 size="sm"
                 className="gap-1"
                 disabled={!slot.assetId}
-                onClick={() => onRefine(slot)}
+                onClick={() => onRefine(slot, variantNumber)}
               >
                 <IconMessageCircle className="h-4 w-4" />
                 {t("library.refine")}

--- a/templates/assets/app/i18n-data.ts
+++ b/templates/assets/app/i18n-data.ts
@@ -812,6 +812,7 @@ const enUS = {
     candidates: "Candidates",
     candidateActions: "Candidate actions",
     candidateWithNumber: "Candidate {{number}}",
+    variantWithNumber: "Variant {{number}}",
     checkingImageLibraries: "Checking image libraries...",
     checking: "Checking",
     checkingUpload: "Checking upload",

--- a/templates/assets/app/i18n/zh-TW.ts
+++ b/templates/assets/app/i18n/zh-TW.ts
@@ -774,6 +774,7 @@ const messages = {
     candidates: "候選項",
     candidateActions: "候選項操作",
     candidateWithNumber: "候選項 {{number}}",
+    variantWithNumber: "變體 {{number}}",
     checkingImageLibraries: "正在檢查圖片資料庫...",
     checking: "正在檢查",
     checkingUpload: "正在檢查上傳",


### PR DESCRIPTION
### Summary
Reworks the in-chat generation results UI to match the drafts grid used in the Library section, replacing the old list-style candidate cards with a hover-driven asset grid and a full preview dialog.

### Problem
The previous generation results view showed candidates as stacked cards with always-visible action buttons and text labels, which was inconsistent with the drafts UI already used in the Library, and lacked a way to preview a generated asset before deciding to save it.

### Solution
Introduced a `GenerationDraftCard` grid layout consistent with the library drafts UI, along with a `GenerationPreviewDialog` for viewing an individual generated asset within the chat, keeping scope limited to assets generated in that thread.

https://clips.agent-native.com/share/uTC0NI2V0KEA?ref=clip_share

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/e8c88334-3aa7-483f-b7c6-eac39318ce77" />

![Uploading image.png…]()


### Key Changes
- Replaced `GenerationResultItem` list cards with `GenerationDraftCard`, rendered in a responsive `assets-library-grid` (2/3 columns) instead of the previous 1/2-column list layout.
- Added hover-revealed action buttons (save, refine, delete) with tooltips on each draft card, matching the library drafts interaction pattern.
- Added `GenerationPreviewDialog` (using `Dialog`/`DialogContent`) to open a full-size preview of a slot, with save, refine, view details, and close actions.
- Extracted shared `saveSlot`, `dismissSlotById`, and `refineSlot` handlers used by both the grid cards and the preview dialog to avoid duplicated mutation logic.
- Added `VariantSlot` type alias for `AssetVariantState["slots"][number]` to simplify typing across the file.
- Updated `GenerationSlotPreview` thumbnail to add a subtle hover scale transition.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/wool-seed-c94wlnkp"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-wool-seed-c94wlnkp.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2115`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>wool-seed-c94wlnkp</branchName>-->