### PR TITLE
Fix recording pill bugs in Clips desktop

### DIFF
--- a/templates/clips/desktop/src-tauri/src/recording_indicator.rs
+++ b/templates/clips/desktop/src-tauri/src/recording_indicator.rs
@@ -543,6 +543,7 @@ pub async fn recording_pill_set_detached(app: AppHandle, detached: bool) -> Resu
         // by the time we hit `anchored_rect` below, the new flag has
         // already taken effect and we get the right size + position for
         // the destination mode. (The atomic was flipped above.)
+        PILL_EXPANDED.store(false, Ordering::SeqCst);
         let (w, h, x, y) = anchored_rect(&app, false, None);
         let _ = window.set_size(tauri::Size::Physical(PhysicalSize::new(w, h)));
         let _ = window.set_position(PhysicalPosition::new(x, y));

--- a/templates/clips/desktop/src-tauri/src/recording_indicator.rs
+++ b/templates/clips/desktop/src-tauri/src/recording_indicator.rs
@@ -49,6 +49,12 @@ const PILL_LABEL: &str = "recording-pill";
 /// it through every command.
 static PILL_DETACHED: AtomicBool = AtomicBool::new(false);
 static PILL_RIGHT_SIDE: AtomicBool = AtomicBool::new(false);
+/// Mirrors the renderer's `expanded` React state so a re-show of an already
+/// open pill (e.g. after the tray icon toggles the popover) resizes the
+/// native window to match what's actually rendered instead of snapping it
+/// back to the collapsed size while the webview still renders the expanded
+/// layout.
+static PILL_EXPANDED: AtomicBool = AtomicBool::new(false);
 
 /// Hover-tracking loop control. macOS only feeds mouse-moved / hover events to
 /// the *key* window, so the background pill's CSS `:hover` never fires while
@@ -360,7 +366,8 @@ pub async fn recording_pill_show(
             (Some(p), Some(s)) => Some((p.x, p.y, s.width, s.height)),
             _ => None,
         };
-        let (w, h, x, y) = anchored_rect(&app, false, previous);
+        let expanded = PILL_EXPANDED.load(Ordering::Relaxed);
+        let (w, h, x, y) = anchored_rect(&app, expanded, previous);
         let _ = existing.set_size(tauri::Size::Physical(PhysicalSize::new(w, h)));
         let _ = existing.set_position(PhysicalPosition::new(x, y));
         use tauri::Emitter;
@@ -377,6 +384,7 @@ pub async fn recording_pill_show(
         return Ok(());
     }
 
+    PILL_EXPANDED.store(false, Ordering::SeqCst);
     let (w, h, x, y) = anchored_rect(&app, false, None);
 
     let url = build_overlay_url("recording-pill");
@@ -465,6 +473,7 @@ fn stop_pill_hover_tracking() {
 
 #[tauri::command]
 pub async fn recording_pill_expand(app: AppHandle, expanded: bool) -> Result<(), String> {
+    PILL_EXPANDED.store(expanded, Ordering::SeqCst);
     let Some(window) = app.get_webview_window(PILL_LABEL) else {
         return Ok(());
     };

--- a/templates/clips/desktop/src-tauri/src/whisper_speech.rs
+++ b/templates/clips/desktop/src-tauri/src/whisper_speech.rs
@@ -480,7 +480,7 @@ mod macos {
         language: Option<&str>,
     ) -> Vec<(i64, i64, String)> {
         let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
-        params.set_n_threads(4);
+        params.set_n_threads(2);
         params.set_language(language);
         params.set_translate(false);
         params.set_no_context(true);

--- a/templates/clips/desktop/src/overlays/recording-pill.tsx
+++ b/templates/clips/desktop/src/overlays/recording-pill.tsx
@@ -108,8 +108,18 @@ export function RecordingPill() {
           meetingId: ev.payload?.meetingId ?? null,
           mode: ev.payload?.mode ?? "clip",
         };
+        const prev = ctxRef.current;
+        const isSameSession =
+          prev.meetingId === next.meetingId && prev.mode === next.mode;
         ctxRef.current = next;
         setCtx(next);
+        // The Rust side re-shows (and re-emits this event for) the same pill
+        // window whenever the tray icon re-triggers `recording_pill_show`
+        // (e.g. toggling the popover) while a meeting is already in progress.
+        // Only reset session state below when the meeting/mode actually
+        // changed — otherwise an in-progress meeting's timer, transcript, and
+        // notes would wipe out on every tray click.
+        if (isSameSession) return;
         // Reset timer on new context.
         startedAtRef.current = Date.now();
         setElapsed(0);


### PR DESCRIPTION
**Reduced the number of threads used for on-device transcription** from 4 to 2. This should lower the CPU resources Clips uses while transcribing. I checked locally and didn't notice any performance loses  

**The recording pill broke when you clicked the tray icon while it was expanded.** The pill window would shrink back to its collapsed size, but its content still showed the expanded layout, making it look squished and broken. The pill now stays the correct size no matter how many times the tray icon is clicked.

<img width="175" height="166" alt="image" src="https://github.com/user-attachments/assets/c4e932d9-a1c8-434c-9f22-f59f0c379a8b" />


**The recording pill reset itself every time you clicked the tray icon during a meeting.** The timer jumped back to 0 and the live transcript disappeared, even though the meeting was still recording. The pill now only resets when a new meeting actually starts, so an in-progress meeting keeps its timer, transcript, and notes intact.
