### PR TITLE
Keep formatting when copying a chat message

### DIFF
--- a/.changeset/rich-clipboard-copy.md
+++ b/.changeset/rich-clipboard-copy.md
@@ -1,0 +1,8 @@
+---
+"@agent-native/core": patch
+---
+
+Copying an assistant message now preserves formatting when pasting into apps
+that read rich clipboard content (e.g. Slack), while still pasting as markdown
+in editors like Notion. Falls back to plain-text copy where the browser does
+not support rich clipboard writes.

--- a/packages/core/src/client/chat/markdown-renderer.tsx
+++ b/packages/core/src/client/chat/markdown-renderer.tsx
@@ -47,20 +47,30 @@ type ReactMarkdownModule = {
   defaultUrlTransform: typeof DefaultUrlTransformType;
 };
 
+type RenderToStaticMarkupFn = (node: React.ReactElement) => string;
+
 export let markdownModule: ReactMarkdownModule | null = null;
 export let remarkGfmFn: typeof remarkGfmType | null = null;
+let renderToStaticMarkupFn: RenderToStaticMarkupFn | null = null;
 const markdownListeners = new Set<() => void>();
 
 export function loadMarkdown(): void {
   if (markdownModule !== null) return; // already loaded
-  Promise.all([import("react-markdown"), import("remark-gfm")]).then(
-    ([md, gfm]) => {
-      markdownModule = md as ReactMarkdownModule;
-      remarkGfmFn = gfm.default;
-      markdownListeners.forEach((fn) => fn());
-      markdownListeners.clear();
-    },
-  );
+  Promise.all([
+    import("react-markdown"),
+    import("remark-gfm"),
+    // react-dom/server powers the synchronous markdown→HTML string used for
+    // rich clipboard copy; loaded alongside so readiness stays a single gate.
+    import("react-dom/server"),
+  ]).then(([md, gfm, server]) => {
+    markdownModule = md as ReactMarkdownModule;
+    remarkGfmFn = gfm.default;
+    renderToStaticMarkupFn = (
+      server as { renderToStaticMarkup: RenderToStaticMarkupFn }
+    ).renderToStaticMarkup;
+    markdownListeners.forEach((fn) => fn());
+    markdownListeners.clear();
+  });
 }
 
 export function onMarkdownReady(fn: () => void): () => void {
@@ -285,6 +295,42 @@ export const markdownComponents = {
     return <pre {...rest}>{children}</pre>;
   },
 };
+
+// ─── Clipboard HTML rendering ─────────────────────────────────────────────────
+// A stripped component set for the `text/html` clipboard flavor: plain <a> and
+// <pre>/<code> with no in-app buttons, iframes, or syntax-highlight markup, so
+// pasted output is portable structure (bold, lists, links, code) rather than
+// app-specific chrome that receiving apps (Slack, Notion) discard anyway.
+
+const clipboardMarkdownComponents = {
+  a(props: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
+    const { href, children } = props;
+    if (href === NEW_CHAT_ACTION_HREF || !href) return <span>{children}</span>;
+    return <a href={href}>{children}</a>;
+  },
+  pre(props: React.HTMLAttributes<HTMLPreElement>) {
+    return <pre>{props.children}</pre>;
+  },
+};
+
+// Renders joined message markdown to an HTML string for rich clipboard copy.
+// Returns null when the lazy markdown/react-dom-server modules haven't landed
+// yet; callers fall back to plain-text copy in that case.
+export function renderMarkdownToClipboardHtml(markdown: string): string | null {
+  const ReactMarkdown = markdownModule?.default;
+  const gfm = remarkGfmFn;
+  const renderToStaticMarkup = renderToStaticMarkupFn;
+  if (!ReactMarkdown || !gfm || !renderToStaticMarkup) return null;
+  return renderToStaticMarkup(
+    <ReactMarkdown
+      remarkPlugins={[gfm]}
+      components={clipboardMarkdownComponents}
+      urlTransform={markdownUrlTransform}
+    >
+      {markdown}
+    </ReactMarkdown>,
+  );
+}
 
 // ─── Smooth streaming ─────────────────────────────────────────────────────────
 

--- a/packages/core/src/client/chat/message-components.tsx
+++ b/packages/core/src/client/chat/message-components.tsx
@@ -64,7 +64,10 @@ import { PastedTextChip } from "../composer/PastedTextChip.js";
 import { ThumbsFeedback } from "../observability/ThumbsFeedback.js";
 import type { ContentPart } from "../sse-event-processor.js";
 import { cn } from "../utils.js";
-import { MarkdownText } from "./markdown-renderer.js";
+import {
+  MarkdownText,
+  renderMarkdownToClipboardHtml,
+} from "./markdown-renderer.js";
 import {
   ToolCallFallback,
   FilesChangedSummary,
@@ -526,7 +529,10 @@ export function MessageActionsMenu({
       .filter((p) => p.type === "text")
       .map((p) => (p as { text: string }).text)
       .join("\n");
-    void writeClipboardText(text).then((ok) => {
+    // Rich flavor keeps formatting in targets that read text/html (e.g. Slack);
+    // null when the markdown renderer isn't ready yet, so we copy plain markdown.
+    const html = renderMarkdownToClipboardHtml(text);
+    void writeClipboardText(text, html ? { html } : undefined).then((ok) => {
       if (!ok) return;
       setCopied("message");
       setTimeout(() => {

--- a/packages/core/src/client/clipboard.spec.ts
+++ b/packages/core/src/client/clipboard.spec.ts
@@ -31,4 +31,59 @@ describe("writeClipboardText", () => {
     expect(writeText).toHaveBeenCalledWith("copy me");
     expect(browserWriteText).toHaveBeenCalledWith("copy me");
   });
+
+  it("writes a rich text/html flavor when html is provided", async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const items: unknown[] = [];
+    vi.stubGlobal(
+      "ClipboardItem",
+      class {
+        constructor(data: unknown) {
+          items.push(data);
+        }
+      },
+    );
+    vi.stubGlobal("navigator", { clipboard: { write, writeText } });
+
+    await expect(
+      writeClipboardText("**hi**", { html: "<strong>hi</strong>" }),
+    ).resolves.toBe(true);
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(writeText).not.toHaveBeenCalled();
+    expect(Object.keys(items[0] as Record<string, unknown>)).toEqual([
+      "text/plain",
+      "text/html",
+    ]);
+  });
+
+  it("falls back to plain text when ClipboardItem is unavailable", async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { write, writeText } });
+
+    await expect(
+      writeClipboardText("**hi**", { html: "<strong>hi</strong>" }),
+    ).resolves.toBe(true);
+    expect(write).not.toHaveBeenCalled();
+    expect(writeText).toHaveBeenCalledWith("**hi**");
+  });
+
+  it("falls back to plain text when the rich write rejects", async () => {
+    const write = vi.fn().mockRejectedValue(new Error("denied"));
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal(
+      "ClipboardItem",
+      class {
+        constructor() {}
+      },
+    );
+    vi.stubGlobal("navigator", { clipboard: { write, writeText } });
+
+    await expect(
+      writeClipboardText("**hi**", { html: "<strong>hi</strong>" }),
+    ).resolves.toBe(true);
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(writeText).toHaveBeenCalledWith("**hi**");
+  });
 });

--- a/packages/core/src/client/clipboard.ts
+++ b/packages/core/src/client/clipboard.ts
@@ -39,7 +39,15 @@ function writeWithExecCommand(text: string): boolean {
   }
 }
 
-export async function writeClipboardText(text: string): Promise<boolean> {
+export async function writeClipboardText(
+  text: string,
+  // Optional rich flavor. When provided and the browser supports ClipboardItem,
+  // both text/plain (this text) and text/html are written so pasted output keeps
+  // formatting in rich targets (Slack) while staying markdown in editors
+  // (Notion). The desktop bridge and execCommand fallbacks are plain-text only,
+  // so html is ignored there.
+  options?: { html?: string },
+): Promise<boolean> {
   for (const desktopClipboard of getDesktopClipboards()) {
     try {
       const result = await desktopClipboard.writeText?.(text);
@@ -50,6 +58,25 @@ export async function writeClipboardText(text: string): Promise<boolean> {
   }
 
   if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    const html = options?.html;
+    if (
+      html !== undefined &&
+      typeof ClipboardItem !== "undefined" &&
+      navigator.clipboard.write
+    ) {
+      try {
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            "text/plain": new Blob([text], { type: "text/plain" }),
+            "text/html": new Blob([html], { type: "text/html" }),
+          }),
+        ]);
+        return true;
+      } catch {
+        // Fall through to the plain-text paths below.
+      }
+    }
+
     try {
       await navigator.clipboard.writeText(text);
       return true;


### PR DESCRIPTION
Copying an assistant message now keeps its formatting in more places when you paste it. Paste into Slack and you get real bold text, lists, and links instead of raw markdown symbols.

Before this change, copying only put plain markdown text on the clipboard. Some apps, like Notion, read that markdown and turned it into formatted text, so copy already looked fine there. But Slack does not convert pasted markdown, so it showed the raw `**` and `-` characters. This change also copies a formatted (rich) version alongside the plain text, so apps like Slack can show the formatting too.

## Notes

- If a browser doesn't support rich copy, it quietly falls back to the old plain-text behavior, so nothing breaks.
- Formatting is preserved for browser copies only. The desktop app keeps using plain text for now.
