### PR TITLE
Design: Improves commenting for signed-in design viewers who do not have edit access

### DIFF
--- a/.changeset/review-composer-context.md
+++ b/.changeset/review-composer-context.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Allow review hosts to attach a composer target, anchor, metadata, and visible context while independently controlling agent dispatch.
+Allow review hosts to attach a composer target, anchor, metadata, and visible context while independently controlling agent dispatch, and keep comment-only composers human-routed.

--- a/.changeset/review-composer-context.md
+++ b/.changeset/review-composer-context.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow review hosts to attach a composer target, anchor, metadata, and visible context while independently controlling agent dispatch.

--- a/packages/core/src/client/review/ReviewCommentComposer.tsx
+++ b/packages/core/src/client/review/ReviewCommentComposer.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@agent-native/toolkit/ui/button";
 import { Spinner } from "@agent-native/toolkit/ui/spinner";
 import { Textarea } from "@agent-native/toolkit/ui/textarea";
-import { IconMessageCircle, IconSend } from "@tabler/icons-react";
+import { IconFocus2, IconMessageCircle, IconSend } from "@tabler/icons-react";
 
 import type { ReviewResolutionTarget } from "../../review/types.js";
 import { cn } from "../utils.js";
@@ -16,6 +16,7 @@ export interface ReviewCommentComposerProps {
   placeholder?: string;
   commentLabel?: string;
   agentLabel?: string;
+  contextLabel?: string;
   autoFocus?: boolean;
   submitOnEnter?: boolean;
   onEscape?: () => void;
@@ -32,6 +33,7 @@ export function ReviewCommentComposer({
   placeholder = "Add a comment...",
   commentLabel = "Comment",
   agentLabel = "Send to agent",
+  contextLabel,
   autoFocus = false,
   submitOnEnter = false,
   onEscape,
@@ -51,6 +53,12 @@ export function ReviewCommentComposer({
         submit("human");
       }}
     >
+      {contextLabel ? (
+        <div className="mb-2 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+          <IconFocus2 className="size-3.5 shrink-0" />
+          <span className="truncate">{contextLabel}</span>
+        </div>
+      ) : null}
       <Textarea
         autoFocus={autoFocus}
         value={value}

--- a/packages/core/src/client/review/ReviewThreadPanel.spec.tsx
+++ b/packages/core/src/client/review/ReviewThreadPanel.spec.tsx
@@ -193,6 +193,40 @@ describe("ReviewThreadPanel sidebar layout", () => {
     ).not.toBeNull();
   });
 
+  it("routes the plain comment action to a human when agent dispatch is hidden", () => {
+    act(() => {
+      root.render(
+        <ReviewThreadPanel
+          resourceType="design"
+          resourceId="design-1"
+          targetId="screen-1"
+          showHeader={false}
+          placeholder="Leave feedback"
+        />,
+      );
+    });
+
+    const composer = container.querySelector<HTMLTextAreaElement>(
+      'textarea[placeholder="Leave feedback"]',
+    );
+    expect(composer).not.toBeNull();
+    setTextareaValue(composer!, "Human review note");
+    const commentButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "Comment",
+    );
+    act(() => commentButton?.click());
+
+    expect(mutate).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        targetId: "screen-1",
+        body: "Human review note",
+        resolutionTarget: "human",
+      }),
+      expect.any(Object),
+    );
+    expect(container.textContent).not.toContain("Send to agent");
+  });
+
   it("fails closed when reply, resolve, and delete capabilities are omitted", () => {
     act(() => {
       root.render(

--- a/packages/core/src/client/review/ReviewThreadPanel.spec.tsx
+++ b/packages/core/src/client/review/ReviewThreadPanel.spec.tsx
@@ -98,6 +98,13 @@ describe("ReviewThreadPanel sidebar layout", () => {
           resourceType="design"
           resourceId="design-1"
           targetId="screen-1"
+          composerTargetId="screen-2"
+          composerAnchor={{
+            nodeId: "hero-title",
+            point: { xPct: 50, yPct: 20 },
+          }}
+          composerMetadata={{ layerName: "Hero title", tagName: "H1" }}
+          composerContextLabel="Commenting on Hero title"
           showHeader={false}
           variant="plain"
           canReply
@@ -121,6 +128,7 @@ describe("ReviewThreadPanel sidebar layout", () => {
     expect(section?.className).not.toContain("rounded-lg");
     expect(container.textContent).not.toContain("Draft");
     expect(container.textContent).toContain("Make the heading clearer");
+    expect(container.textContent).toContain("Commenting on Hero title");
     expect(container.querySelector('[role="radiogroup"]')).toBeNull();
     expect(
       Array.from(container.querySelectorAll("button")).some(
@@ -147,7 +155,15 @@ describe("ReviewThreadPanel sidebar layout", () => {
     );
     act(() => commentButton?.click());
     expect(mutate).toHaveBeenLastCalledWith(
-      expect.objectContaining({ resolutionTarget: "human" }),
+      expect.objectContaining({
+        targetId: "screen-2",
+        anchor: {
+          nodeId: "hero-title",
+          point: { xPct: 50, yPct: 20 },
+        },
+        metadata: { layerName: "Hero title", tagName: "H1" },
+        resolutionTarget: "human",
+      }),
       expect.any(Object),
     );
     act(() => agentButton?.click());

--- a/packages/core/src/client/review/ReviewThreadPanel.tsx
+++ b/packages/core/src/client/review/ReviewThreadPanel.tsx
@@ -52,6 +52,14 @@ export interface ReviewThreadPanelProps {
   resourceType: string;
   resourceId: string;
   targetId?: string | null;
+  /** Persist new comments against this target while targetId continues to filter the list. */
+  composerTargetId?: string | null;
+  /** Optional element/point anchor attached to new comments from the composer. */
+  composerAnchor?: unknown | null;
+  /** Host metadata attached to new comments from the composer. */
+  composerMetadata?: Record<string, unknown>;
+  /** Visible label describing the element currently targeted by the composer. */
+  composerContextLabel?: string;
   title?: string;
   className?: string;
   includeResolved?: boolean;
@@ -89,6 +97,10 @@ export function ReviewThreadPanel({
   resourceType,
   resourceId,
   targetId,
+  composerTargetId,
+  composerAnchor,
+  composerMetadata,
+  composerContextLabel,
   title = "Review",
   className,
   includeResolved = true,
@@ -145,7 +157,9 @@ export function ReviewThreadPanel({
       {
         resourceType,
         resourceId,
-        targetId,
+        targetId: composerTargetId === undefined ? targetId : composerTargetId,
+        ...(composerAnchor !== undefined ? { anchor: composerAnchor } : {}),
+        ...(composerMetadata ? { metadata: composerMetadata } : {}),
         body,
         ...(showComposerTargetPicker ? { resolutionTarget } : {}),
       },
@@ -194,6 +208,7 @@ export function ReviewThreadPanel({
           placeholder={placeholder}
           commentLabel={composerCommentLabel}
           agentLabel={composerAgentLabel}
+          contextLabel={composerContextLabel}
         />
       ) : null}
 

--- a/packages/core/src/client/review/ReviewThreadPanel.tsx
+++ b/packages/core/src/client/review/ReviewThreadPanel.tsx
@@ -161,7 +161,7 @@ export function ReviewThreadPanel({
         ...(composerAnchor !== undefined ? { anchor: composerAnchor } : {}),
         ...(composerMetadata ? { metadata: composerMetadata } : {}),
         body,
-        ...(showComposerTargetPicker ? { resolutionTarget } : {}),
+        resolutionTarget: showComposerTargetPicker ? resolutionTarget : "human",
       },
       {
         onSuccess: (comment) => {

--- a/templates/design/app/components/design/ReadOnlyDesignBanner.spec.tsx
+++ b/templates/design/app/components/design/ReadOnlyDesignBanner.spec.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@agent-native/core/client", () => ({
+  cn: (...values: Array<string | false | null | undefined>) =>
+    values.filter(Boolean).join(" "),
+  useT: () => (key: string) =>
+    key === "designEditor.stopPinningComments"
+      ? "Stop pinning comments"
+      : "Pin comment",
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children?: ReactNode }) => children,
+  TooltipTrigger: ({ children }: { children?: ReactNode }) => children,
+  TooltipContent: ({ children }: { children?: ReactNode }) => children,
+}));
+
+import { ReadOnlyDesignBanner } from "./ReadOnlyDesignBanner";
+
+describe("ReadOnlyDesignBanner", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("stays informational when commenting is unavailable", () => {
+    act(() => root.render(<ReadOnlyDesignBanner />));
+
+    expect(container.textContent).toContain(
+      "You don't have access to edit this design",
+    );
+    expect(container.querySelector("button")).toBeNull();
+  });
+
+  it("integrates the viewer comment toggle into the notice", () => {
+    const onCommentPin = vi.fn();
+    act(() =>
+      root.render(<ReadOnlyDesignBanner onCommentPin={onCommentPin} />),
+    );
+
+    const button = container.querySelector("button");
+    expect(button?.getAttribute("aria-label")).toBe("Pin comment");
+    expect(button?.getAttribute("aria-pressed")).toBe("false");
+    act(() => button?.click());
+    expect(onCommentPin).toHaveBeenCalledOnce();
+
+    act(() =>
+      root.render(<ReadOnlyDesignBanner pinMode onCommentPin={onCommentPin} />),
+    );
+    expect(container.querySelector("button")?.getAttribute("aria-label")).toBe(
+      "Stop pinning comments",
+    );
+    expect(
+      container.querySelector("button")?.getAttribute("aria-pressed"),
+    ).toBe("true");
+  });
+});

--- a/templates/design/app/components/design/ReadOnlyDesignBanner.tsx
+++ b/templates/design/app/components/design/ReadOnlyDesignBanner.tsx
@@ -1,21 +1,66 @@
-import { IconInfoCircle } from "@tabler/icons-react";
+import { useT } from "@agent-native/core/client";
+import { IconInfoCircle, IconMessage } from "@tabler/icons-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
 
 /**
  * Slim, non-blocking banner shown below the canvas when the current user only
  * has viewer access to the design (Figma-style "you can't edit this" notice).
- * Purely informational — editing affordances are already disabled elsewhere
- * via `canEditDesign`; this just tells the viewer why.
+ * Editing affordances are disabled elsewhere via `canEditDesign`; signed-in
+ * viewers get their one canvas action integrated into the same quiet notice.
  */
-export function ReadOnlyDesignBanner() {
+export function ReadOnlyDesignBanner({
+  pinMode = false,
+  onCommentPin,
+}: {
+  pinMode?: boolean;
+  onCommentPin?: () => void;
+}) {
+  const t = useT();
+  const commentLabel = pinMode
+    ? t("designEditor.stopPinningComments")
+    : t("designEditor.pinComment");
+
   return (
-    <div className="pointer-events-none absolute inset-x-0 bottom-0 z-30 flex items-center justify-center px-3 pb-2">
-      <div className="flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1.5 text-xs text-blue-600 shadow-sm backdrop-blur-sm dark:text-blue-400">
+    <div
+      data-read-only-design-banner
+      className="pointer-events-none absolute inset-x-0 bottom-0 z-[50] flex items-center justify-center px-3 pb-2"
+    >
+      <div className="flex max-w-full items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 py-1 pe-1 ps-3 text-xs text-blue-600 shadow-sm backdrop-blur-sm dark:text-blue-400">
         <IconInfoCircle className="size-3.5 shrink-0" />
-        <span className="truncate">
+        <span className="min-w-0 truncate">
           {
             "You don't have access to edit this design" /* i18n-ignore Figma-style read-only notice */
           }
         </span>
+        {onCommentPin ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className={cn(
+                  "pointer-events-auto size-7 shrink-0 rounded-full text-blue-600 hover:bg-blue-500/15 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300",
+                  pinMode &&
+                    "bg-blue-500/20 text-blue-700 dark:bg-blue-400/20 dark:text-blue-300",
+                )}
+                aria-label={commentLabel}
+                aria-pressed={pinMode}
+                onClick={onCommentPin}
+              >
+                <IconMessage className="size-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top">{commentLabel}</TooltipContent>
+          </Tooltip>
+        ) : null}
       </div>
     </div>
   );

--- a/templates/design/app/components/design/ReviewCommentsPanel.spec.tsx
+++ b/templates/design/app/components/design/ReviewCommentsPanel.spec.tsx
@@ -1,0 +1,97 @@
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  latestPanelProps: null as Record<string, unknown> | null,
+}));
+
+vi.mock("@agent-native/core/client", () => ({
+  cn: (...values: Array<string | false | null | undefined>) =>
+    values.filter(Boolean).join(" "),
+  ReviewThreadPanel: (props: Record<string, unknown>) => {
+    mocks.latestPanelProps = props;
+    return <div data-review-thread-panel />;
+  },
+  useT: () => (key: string) => key,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children }: { children?: ReactNode }) => children,
+}));
+
+vi.mock("@/components/ui/spinner", () => ({
+  Spinner: () => null,
+}));
+
+vi.mock("@/components/ui/tabs", () => ({
+  Tabs: ({ children }: { children?: ReactNode }) => children,
+  TabsList: ({ children }: { children?: ReactNode }) => children,
+  TabsTrigger: ({ children }: { children?: ReactNode }) => children,
+}));
+
+import { ReviewCommentsPanel } from "./ReviewCommentsPanel";
+
+describe("ReviewCommentsPanel capabilities", () => {
+  beforeEach(() => {
+    mocks.latestPanelProps = null;
+  });
+
+  it("targets a selected layer without exposing agent controls to viewers", () => {
+    const dispatch = vi.fn();
+    const anchor = {
+      nodeId: "hero-title",
+      point: { xPct: 25, yPct: 30 },
+    };
+    const metadata = { layerName: "Hero title", tagName: "h1" };
+
+    renderToStaticMarkup(
+      <ReviewCommentsPanel
+        designId="design-1"
+        activeFileId="screen-1"
+        commentAnchor={anchor}
+        commentMetadata={metadata}
+        commentContextLabel="Commenting on Hero title"
+        canComment
+        canResolve={false}
+        canDispatchToAgent={false}
+        onDispatchCommentToAgent={dispatch}
+      />,
+    );
+
+    expect(mocks.latestPanelProps).toMatchObject({
+      targetId: "screen-1",
+      composerTargetId: "screen-1",
+      composerAnchor: anchor,
+      composerMetadata: metadata,
+      composerContextLabel: "Commenting on Hero title",
+      canResolve: false,
+      showComposerTargetPicker: false,
+    });
+    expect(mocks.latestPanelProps?.renderThreadActions).toBeUndefined();
+
+    const onCommentCreated = mocks.latestPanelProps
+      ?.onCommentCreated as (comment: { resolutionTarget: "agent" }) => void;
+    onCommentCreated({ resolutionTarget: "agent" });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("shows agent routing only when the caller grants dispatch capability", () => {
+    renderToStaticMarkup(
+      <ReviewCommentsPanel
+        designId="design-1"
+        activeFileId="screen-1"
+        canComment
+        canResolve
+        canDispatchToAgent
+        onSendThreadToAgent={vi.fn()}
+      />,
+    );
+
+    expect(mocks.latestPanelProps).toMatchObject({
+      canResolve: true,
+      showComposerTargetPicker: true,
+    });
+    expect(mocks.latestPanelProps?.renderThreadActions).toBeTypeOf("function");
+  });
+});

--- a/templates/design/app/components/design/ReviewCommentsPanel.spec.tsx
+++ b/templates/design/app/components/design/ReviewCommentsPanel.spec.tsx
@@ -30,7 +30,43 @@ vi.mock("@/components/ui/tabs", () => ({
   TabsTrigger: ({ children }: { children?: ReactNode }) => children,
 }));
 
-import { ReviewCommentsPanel } from "./ReviewCommentsPanel";
+import {
+  ReviewCommentsPanel,
+  resolveReviewComposerTargetId,
+} from "./ReviewCommentsPanel";
+
+describe("resolveReviewComposerTargetId", () => {
+  it("targets the active screen in This screen scope", () => {
+    expect(
+      resolveReviewComposerTargetId({
+        scope: "screen",
+        activeFileId: "screen-1",
+      }),
+    ).toBe("screen-1");
+  });
+
+  it("keeps unanchored All screens comments design-wide", () => {
+    expect(
+      resolveReviewComposerTargetId({
+        scope: "all",
+        activeFileId: "screen-1",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("targets the active screen for an anchored layer in All screens scope", () => {
+    expect(
+      resolveReviewComposerTargetId({
+        scope: "all",
+        activeFileId: "screen-1",
+        commentAnchor: {
+          nodeId: "hero-title",
+          point: { xPct: 25, yPct: 30 },
+        },
+      }),
+    ).toBe("screen-1");
+  });
+});
 
 describe("ReviewCommentsPanel capabilities", () => {
   beforeEach(() => {

--- a/templates/design/app/components/design/ReviewCommentsPanel.tsx
+++ b/templates/design/app/components/design/ReviewCommentsPanel.tsx
@@ -33,6 +33,21 @@ export interface ReviewCommentsPanelProps {
   className?: string;
 }
 
+type ReviewCommentsScope = "screen" | "all";
+
+export function resolveReviewComposerTargetId({
+  scope,
+  activeFileId,
+  commentAnchor,
+}: {
+  scope: ReviewCommentsScope;
+  activeFileId?: string | null;
+  commentAnchor?: unknown | null;
+}): string | null | undefined {
+  if (commentAnchor != null) return activeFileId;
+  return scope === "screen" ? activeFileId : undefined;
+}
+
 export function ReviewCommentsPanel({
   designId,
   activeFileId,
@@ -52,8 +67,13 @@ export function ReviewCommentsPanel({
   className,
 }: ReviewCommentsPanelProps) {
   const t = useT();
-  const [scope, setScope] = useState<"screen" | "all">("screen");
+  const [scope, setScope] = useState<ReviewCommentsScope>("screen");
   const targetId = scope === "screen" ? activeFileId : undefined;
+  const composerTargetId = resolveReviewComposerTargetId({
+    scope,
+    activeFileId,
+    commentAnchor,
+  });
 
   return (
     <div
@@ -93,7 +113,7 @@ export function ReviewCommentsPanel({
           resourceType="design"
           resourceId={designId}
           targetId={targetId}
-          composerTargetId={activeFileId}
+          composerTargetId={composerTargetId}
           composerAnchor={commentAnchor}
           composerMetadata={commentMetadata}
           composerContextLabel={commentContextLabel}

--- a/templates/design/app/components/design/ReviewCommentsPanel.tsx
+++ b/templates/design/app/components/design/ReviewCommentsPanel.tsx
@@ -15,6 +15,9 @@ import { cn } from "@/lib/utils";
 export interface ReviewCommentsPanelProps {
   designId: string;
   activeFileId?: string | null;
+  commentAnchor?: unknown | null;
+  commentMetadata?: Record<string, unknown>;
+  commentContextLabel?: string;
   canComment: boolean;
   /** Caller-derived editor capability for resolving threads. */
   canResolve?: boolean;
@@ -33,6 +36,9 @@ export interface ReviewCommentsPanelProps {
 export function ReviewCommentsPanel({
   designId,
   activeFileId,
+  commentAnchor,
+  commentMetadata,
+  commentContextLabel,
   canComment,
   canResolve,
   canDeleteComment,
@@ -87,6 +93,10 @@ export function ReviewCommentsPanel({
           resourceType="design"
           resourceId={designId}
           targetId={targetId}
+          composerTargetId={activeFileId}
+          composerAnchor={commentAnchor}
+          composerMetadata={commentMetadata}
+          composerContextLabel={commentContextLabel}
           title={t("review.panelTitle")}
           placeholder={t("review.placeholder")}
           emptyState={t("review.emptyState")}
@@ -104,13 +114,15 @@ export function ReviewCommentsPanel({
           variant="plain"
           showComposer={canComment && showComposer}
           canReply={canComment}
-          canResolve={canResolve ?? canDispatchToAgent}
+          canResolve={canResolve ?? false}
           canDeleteComment={canDeleteComment}
-          showComposerTargetPicker={canComment && showComposer}
+          showComposerTargetPicker={
+            canComment && showComposer && canDispatchToAgent
+          }
           composerCommentLabel={t("review.commentMode")}
           composerAgentLabel={t("review.sendToAgent")}
           onCommentCreated={(comment) => {
-            if (comment.resolutionTarget === "agent") {
+            if (canDispatchToAgent && comment.resolutionTarget === "agent") {
               onDispatchCommentToAgent?.(comment);
             }
           }}

--- a/templates/design/app/components/visual-editor/ReviewCanvasPins.spec.tsx
+++ b/templates/design/app/components/visual-editor/ReviewCanvasPins.spec.tsx
@@ -50,6 +50,7 @@ vi.mock("@agent-native/core/client", () => ({
     value: string;
     onChange: (value: string) => void;
     onSubmit: (target: "human" | "agent") => void;
+    showAgentAction?: boolean;
   }) => (
     <div>
       <button
@@ -62,6 +63,9 @@ vi.mock("@agent-native/core/client", () => ({
         data-review-test-submit
         onClick={() => props.onSubmit("human")}
       />
+      {props.showAgentAction ? (
+        <button type="button" data-review-test-agent-action />
+      ) : null}
     </div>
   ),
   cn: (...values: Array<string | false | null | undefined>) =>
@@ -196,6 +200,9 @@ describe("ReviewCanvasPins persisted thread popover", () => {
 
     expect(document.querySelectorAll("[data-review-pin]")).toHaveLength(2);
     expect(mocks.createMutate).not.toHaveBeenCalled();
+    expect(
+      document.querySelector("[data-review-test-agent-action]"),
+    ).toBeNull();
 
     await act(async () => {
       document
@@ -214,6 +221,40 @@ describe("ReviewCanvasPins persisted thread popover", () => {
       anchor: { point: { xPct: 37.5, yPct: 40 } },
       resolutionTarget: "human",
     });
+  });
+
+  it("shows agent dispatch only when the host provides that capability", async () => {
+    await act(async () => {
+      root.render(
+        <ReviewCanvasPins
+          active
+          onClose={vi.fn()}
+          canvasSelector=".review-test-canvas"
+          resourceType="design"
+          resourceId="design-1"
+          targetId="screen-1"
+          canPost
+          canResolve
+          onDispatchCommentToAgent={vi.fn()}
+        />,
+      );
+    });
+
+    await act(async () => {
+      document
+        .querySelector<HTMLElement>("[data-review-click-plane]")
+        ?.dispatchEvent(
+          new MouseEvent("click", {
+            bubbles: true,
+            clientX: 200,
+            clientY: 180,
+          }),
+        );
+    });
+
+    expect(
+      document.querySelector("[data-review-test-agent-action]"),
+    ).not.toBeNull();
   });
 
   it("enriches opaque iframe clicks with a bridge-resolved node anchor", async () => {

--- a/templates/design/app/components/visual-editor/ReviewCanvasPins.tsx
+++ b/templates/design/app/components/visual-editor/ReviewCanvasPins.tsx
@@ -777,6 +777,7 @@ export function ReviewCanvasPins({
                 postDraft({ ...draftPin, resolutionTarget });
               }}
               resolutionTarget={draftPin.resolutionTarget}
+              showAgentAction={Boolean(onDispatchCommentToAgent)}
               placement={getReviewPopoverPlacement(draftPinPosition.point)}
               submitting={createComment.isPending}
             />
@@ -843,6 +844,7 @@ function DraftComposer({
   onCancel,
   onSubmit,
   resolutionTarget,
+  showAgentAction,
   placement,
   submitting,
 }: {
@@ -851,6 +853,7 @@ function DraftComposer({
   onCancel: () => void;
   onSubmit: (target: "agent" | "human") => void;
   resolutionTarget: "agent" | "human";
+  showAgentAction: boolean;
   placement: ReviewPopoverPlacement;
   submitting: boolean;
 }) {
@@ -886,7 +889,7 @@ function DraftComposer({
         onChange={onChange}
         onSubmit={onSubmit}
         submittingTarget={submitting ? resolutionTarget : null}
-        showAgentAction
+        showAgentAction={showAgentAction}
         placeholder={t("review.placeholder")}
         commentLabel={t("review.commentMode")}
         agentLabel={t("review.sendToAgent")}

--- a/templates/design/app/i18n/ar-SA.ts
+++ b/templates/design/app/i18n/ar-SA.ts
@@ -12,6 +12,7 @@ const messages = {
     signInToComment: "سجّل الدخول للتعليق",
     panelTitle: "الملاحظات",
     placeholder: "اترك ملاحظاتك…",
+    commentingOn: "التعليق على {{name}}",
     emptyState: "لا توجد تعليقات مراجعة بعد.",
     clickToPin: "انقر في أي مكان لتثبيت ملاحظة",
     escToExit: "اضغط Esc للخروج",

--- a/templates/design/app/i18n/de-DE.ts
+++ b/templates/design/app/i18n/de-DE.ts
@@ -12,6 +12,7 @@ const messages = {
     signInToComment: "Zum Kommentieren anmelden",
     panelTitle: "Feedback",
     placeholder: "Feedback hinterlassen…",
+    commentingOn: "Kommentar zu {{name}}",
     emptyState: "Noch keine Prüfkommentare.",
     clickToPin: "Klicke an eine beliebige Stelle, um Feedback anzuheften",
     escToExit: "Esc zum Beenden",

--- a/templates/design/app/i18n/en-US.ts
+++ b/templates/design/app/i18n/en-US.ts
@@ -12,6 +12,7 @@ const messages = {
     signInToComment: "Sign in to comment",
     panelTitle: "Feedback",
     placeholder: "Leave feedback…",
+    commentingOn: "Commenting on {{name}}",
     emptyState: "No review comments yet.",
     clickToPin: "Click anywhere to pin feedback",
     escToExit: "Esc to exit",

--- a/templates/design/app/i18n/es-ES.ts
+++ b/templates/design/app/i18n/es-ES.ts
@@ -12,6 +12,7 @@ const messages = {
     signInToComment: "Inicia sesión para comentar",
     panelTitle: "Opiniones",
     placeholder: "Deja tus comentarios…",
+    commentingOn: "Comentando en {{name}}",
     emptyState: "Aún no hay comentarios de revisión.",
     clickToPin: "Haz clic en cualquier lugar para fijar un comentario",
     escToExit: "Pulsa Esc para salir",

--- a/templates/design/app/i18n/fr-FR.ts
+++ b/templates/design/app/i18n/fr-FR.ts
@@ -12,6 +12,7 @@ const messages = {
     signInToComment: "Connectez-vous pour commenter",
     panelTitle: "Retours",
     placeholder: "Laissez un commentaire…",
+    commentingOn: "Commentaire sur {{name}}",
     emptyState: "Aucun commentaire de révision pour le moment.",
     clickToPin: "Cliquez n’importe où pour épingler un commentaire",
     escToExit: "Appuyez sur Esc pour quitter",

--- a/templates/design/app/i18n/hi-IN.ts
+++ b/templates/design/app/i18n/hi-IN.ts
@@ -12,6 +12,7 @@ const messages = {
     signInToComment: "टिप्पणी करने के लिए साइन इन करें",
     panelTitle: "प्रतिक्रिया",
     placeholder: "अपनी प्रतिक्रिया दें…",
+    commentingOn: "{{name}} पर टिप्पणी",
     emptyState: "अभी तक कोई समीक्षा टिप्पणी नहीं है।",
     clickToPin: "प्रतिक्रिया पिन करने के लिए कहीं भी क्लिक करें",
     escToExit: "बाहर निकलने के लिए Esc दबाएँ",

--- a/templates/design/app/i18n/ja-JP.ts
+++ b/templates/design/app/i18n/ja-JP.ts
@@ -12,6 +12,7 @@ const messages = {
     signInToComment: "コメントするにはサインイン",
     panelTitle: "フィードバック",
     placeholder: "フィードバックを入力…",
+    commentingOn: "{{name}} にコメント",
     emptyState: "レビューコメントはまだありません。",
     clickToPin: "任意の場所をクリックしてフィードバックを固定",
     escToExit: "Esc で終了",

--- a/templates/design/app/i18n/ko-KR.ts
+++ b/templates/design/app/i18n/ko-KR.ts
@@ -12,6 +12,7 @@ const messages = {
     signInToComment: "댓글을 작성하려면 로그인",
     panelTitle: "피드백",
     placeholder: "피드백을 남겨 주세요…",
+    commentingOn: "{{name}}에 댓글 작성",
     emptyState: "아직 검토 댓글이 없습니다.",
     clickToPin: "아무 곳이나 클릭하여 피드백 고정",
     escToExit: "Esc를 눌러 종료",

--- a/templates/design/app/i18n/pt-BR.ts
+++ b/templates/design/app/i18n/pt-BR.ts
@@ -12,6 +12,7 @@ const messages = {
     signInToComment: "Entre para comentar",
     panelTitle: "Feedback",
     placeholder: "Deixe seu feedback…",
+    commentingOn: "Comentando em {{name}}",
     emptyState: "Ainda não há comentários de revisão.",
     clickToPin: "Clique em qualquer lugar para fixar o feedback",
     escToExit: "Pressione Esc para sair",

--- a/templates/design/app/i18n/zh-CN.ts
+++ b/templates/design/app/i18n/zh-CN.ts
@@ -12,6 +12,7 @@ const messages = {
     signInToComment: "登录后评论",
     panelTitle: "反馈",
     placeholder: "留下反馈…",
+    commentingOn: "正在评论 {{name}}",
     emptyState: "暂无审阅评论。",
     clickToPin: "点击任意位置固定反馈",
     escToExit: "按 Esc 退出",

--- a/templates/design/app/i18n/zh-TW.ts
+++ b/templates/design/app/i18n/zh-TW.ts
@@ -53,6 +53,7 @@ const messages = {
     signInToComment: "登入後評論",
     panelTitle: "意見回饋",
     placeholder: "留下意見…",
+    commentingOn: "正在評論 {{name}}",
     emptyState: "目前沒有審閱評論。",
     clickToPin: "點選任意位置以固定意見",
     escToExit: "按 Esc 退出",

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -110,6 +110,7 @@ import {
   breakpointUpperBoundPx,
   utilityStem,
 } from "@shared/responsive-classes";
+import { createElementReviewAnchor } from "@shared/review-anchor";
 import { readDesignReviewSummary } from "@shared/review-summary";
 import { normalizeDesignSourceType } from "@shared/source-mode";
 import { sourceContentHash } from "@shared/source-workspace";
@@ -784,6 +785,7 @@ import {
 } from "./design-editor/text-edit-utils";
 import {
   getDesignToolActivationState,
+  getDesignBottomToolbarMode,
   getMoveGroupToolPresentation,
   getSingleScreenCreationTool,
   isSingleScreenAnnotationTool,
@@ -1589,6 +1591,7 @@ function DesignModeTab({
 }
 
 function DesignBottomToolbar({
+  commentOnly = false,
   mode,
   pinMode,
   drawMode,
@@ -1607,6 +1610,7 @@ function DesignBottomToolbar({
   onModeChange,
   shortcutsPanelOpen,
 }: {
+  commentOnly?: boolean;
   mode: EditorMode;
   pinMode: boolean;
   drawMode: boolean;
@@ -1897,6 +1901,9 @@ function DesignBottomToolbar({
       onClick: () => onModeChange("interact"),
     },
   ];
+  const visibleTools = commentOnly
+    ? tools.filter((tool) => tool.key === "comment")
+    : tools;
 
   return (
     <div
@@ -1905,7 +1912,7 @@ function DesignBottomToolbar({
       style={{ bottom: shortcutsPanelOpen ? 257 : 16 }}
     >
       <div className="flex min-w-0 items-center gap-0.5">
-        {tools.map((tool) => (
+        {visibleTools.map((tool) => (
           <DesignToolbarTool
             key={tool.key}
             active={tool.active}
@@ -1917,19 +1924,23 @@ function DesignBottomToolbar({
         ))}
       </div>
 
-      <div className="h-9 w-px shrink-0 bg-white/15" />
+      {!commentOnly ? (
+        <>
+          <div className="h-9 w-px shrink-0 bg-white/15" />
 
-      <div className="flex shrink-0 items-center gap-0.5 rounded-md bg-white/10 p-0.5">
-        {modes.map((item) => (
-          <DesignModeTab
-            key={item.key}
-            active={item.active}
-            label={item.label}
-            icon={item.icon}
-            onClick={item.onClick}
-          />
-        ))}
-      </div>
+          <div className="flex shrink-0 items-center gap-0.5 rounded-md bg-white/10 p-0.5">
+            {modes.map((item) => (
+              <DesignModeTab
+                key={item.key}
+                active={item.active}
+                label={item.label}
+                icon={item.icon}
+                onClick={item.onClick}
+              />
+            ))}
+          </div>
+        </>
+      ) : null}
     </div>
   );
 }
@@ -5838,6 +5849,11 @@ function DesignEditor() {
 
   const activeFile =
     files.find((f) => f.id === activeFileId) ?? defaultActiveFile;
+  const designBottomToolbarMode = getDesignBottomToolbarMode({
+    isSignedIn,
+    canEditDesign,
+    hasActiveFile: Boolean(activeFile),
+  });
   activeFileIdForUndoRef.current = activeFile?.id ?? null;
   // Kept current every render (mirrors activeFileIdForUndoRef just above) so
   // handleGeometryCommit/recordContentHistoryEntry/recordLocalContentHistoryEntry
@@ -10473,6 +10489,55 @@ function DesignEditor() {
     });
   }, []);
 
+  const selectedReviewLayerContext = useMemo(() => {
+    if (!activeFile?.id || !selectedElement) return null;
+
+    const selectedScreen = overviewScreens.find(
+      (screen) => screen.id === activeFile.id,
+    );
+    const frameGeometry = canvasFrameGeometryById[activeFile.id];
+    const nodeId =
+      selectedCodeLayerNode?.dataAttributes[
+        "data-agent-native-node-id"
+      ]?.trim() ||
+      selectedElement.sourceId?.trim() ||
+      selectedCodeLayerNode?.id.trim() ||
+      null;
+    const anchor = createElementReviewAnchor({
+      nodeId,
+      rect: selectedElement.boundingRect,
+      viewportWidth:
+        activeBreakpointWidthState ??
+        frameGeometry?.width ??
+        selectedScreen?.width ??
+        activeScreenBaseWidthPx,
+      viewportHeight: frameGeometry?.height ?? selectedScreen?.height,
+    });
+    if (!anchor) return null;
+
+    const layerName =
+      selectedCodeLayerNode?.layerName.trim() ||
+      selectedElement.componentName?.trim() ||
+      selectedElement.id?.trim() ||
+      selectedElement.tagName.toLowerCase();
+    return {
+      anchor,
+      label: layerName,
+      metadata: {
+        layerName,
+        tagName: selectedElement.tagName.toLowerCase(),
+      },
+    };
+  }, [
+    activeBreakpointWidthState,
+    activeFile?.id,
+    activeScreenBaseWidthPx,
+    canvasFrameGeometryById,
+    overviewScreens,
+    selectedCodeLayerNode,
+    selectedElement,
+  ]);
+
   const reviewCommentsPanelProps = useMemo<
     ReviewCommentsPanelProps | undefined
   >(
@@ -10481,6 +10546,13 @@ function DesignEditor() {
         ? {
             designId: id,
             activeFileId: activeFile?.id,
+            commentAnchor: selectedReviewLayerContext?.anchor,
+            commentMetadata: selectedReviewLayerContext?.metadata,
+            commentContextLabel: selectedReviewLayerContext
+              ? t("review.commentingOn", {
+                  name: selectedReviewLayerContext.label,
+                })
+              : undefined,
             canComment: isSignedIn,
             canResolve: canEditDesign,
             canDeleteComment: (comment) =>
@@ -10490,8 +10562,12 @@ function DesignEditor() {
             signInHref: signInToCommentHref,
             canDispatchToAgent: canEditDesign,
             sendingThreadId: reviewSendingThreadId,
-            onDispatchCommentToAgent: handleDispatchCommentToAgent,
-            onSendThreadToAgent: handleSendReviewThreadToAgent,
+            onDispatchCommentToAgent: canEditDesign
+              ? handleDispatchCommentToAgent
+              : undefined,
+            onSendThreadToAgent: canEditDesign
+              ? handleSendReviewThreadToAgent
+              : undefined,
             onSelectThread: handleReviewThreadSelect,
           }
         : undefined,
@@ -10504,8 +10580,10 @@ function DesignEditor() {
       isSignedIn,
       canEditDesign,
       reviewSendingThreadId,
+      selectedReviewLayerContext,
       session?.email,
       signInToCommentHref,
+      t,
     ],
   );
 
@@ -27725,7 +27803,7 @@ function DesignEditor() {
         </DropdownMenuSub>
         <DropdownMenuItem
           onClick={handlePinToolToggle}
-          disabled={!activeFile || viewMode === "overview" || !isSignedIn}
+          disabled={!activeFile || !isSignedIn}
         >
           <IconPin className="mr-2 h-4 w-4" />
           {pinMode
@@ -27953,20 +28031,6 @@ function DesignEditor() {
         </div>
 
         <div className="flex shrink-0 items-center gap-1">
-          {isSignedIn && !canEditDesign && activeFile ? (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="h-8 gap-1 rounded-md px-2 text-xs"
-              onClick={handlePinToolToggle}
-            >
-              <IconMessageCircle className="size-3.5" />
-              {pinMode
-                ? t("designEditor.stopPinningComments")
-                : t("designEditor.pinComment")}
-            </Button>
-          ) : null}
           {canEditDesign && reviewAgentQueueCount > 0 ? (
             <Button
               type="button"
@@ -28520,10 +28584,11 @@ function DesignEditor() {
 
         {!embedded &&
           !uiHidden &&
-          canEditDesign &&
+          designBottomToolbarMode !== "hidden" &&
           activeFile &&
           !questionFlowActive && (
             <DesignBottomToolbar
+              commentOnly={designBottomToolbarMode === "commenter"}
               mode={mode}
               pinMode={pinMode}
               drawMode={drawMode}

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -769,6 +769,7 @@ import {
   resolveEscapePopSelectionAction,
   sameStringIds,
   shouldClearBridgeSelectionOnEmptyMarquee,
+  shouldClearSelectionForReviewThreadTarget,
   shouldEscapeToOverview,
   shouldIgnoreOverviewLayerCreationEcho,
   shouldLimitEditorChromeUntilContentReady,
@@ -10462,22 +10463,37 @@ function DesignEditor() {
     ],
   );
 
-  const handleReviewThreadSelect = useCallback((thread: ReviewThread) => {
-    const targetId = thread.root.targetId;
-    if (targetId) {
-      viewModeRef.current = "single";
-      setViewMode("single");
-      setScreenZoom(FOCUSED_SCREEN_ZOOM);
-      setActiveFileId(targetId);
-    }
-    setActiveInspectorTab("comments");
-    reviewFocusNonceRef.current += 1;
-    setReviewFocusRequest({
-      nonce: reviewFocusNonceRef.current,
-      anchor: thread.root.anchor,
-      targetId: targetId ?? undefined,
-    });
-  }, []);
+  const handleReviewThreadSelect = useCallback(
+    (thread: ReviewThread) => {
+      const targetId = thread.root.targetId;
+      if (
+        shouldClearSelectionForReviewThreadTarget({
+          activeFileId: activeFile?.id,
+          targetId,
+        })
+      ) {
+        setSelectedElement(null);
+        setSelectedLayerIdsState([]);
+        setHoveredElement(null);
+        setHoveredElementScreenId(null);
+        setOverviewClearSelectionRequest((request) => request + 1);
+      }
+      if (targetId) {
+        viewModeRef.current = "single";
+        setViewMode("single");
+        setScreenZoom(FOCUSED_SCREEN_ZOOM);
+        setActiveFileId(targetId);
+      }
+      setActiveInspectorTab("comments");
+      reviewFocusNonceRef.current += 1;
+      setReviewFocusRequest({
+        nonce: reviewFocusNonceRef.current,
+        anchor: thread.root.anchor,
+        targetId: targetId ?? undefined,
+      });
+    },
+    [activeFile?.id],
+  );
 
   const selectedReviewLayerContext = useMemo(() => {
     if (!activeFile?.id || !selectedElement) return null;

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -1591,7 +1591,6 @@ function DesignModeTab({
 }
 
 function DesignBottomToolbar({
-  commentOnly = false,
   mode,
   pinMode,
   drawMode,
@@ -1610,7 +1609,6 @@ function DesignBottomToolbar({
   onModeChange,
   shortcutsPanelOpen,
 }: {
-  commentOnly?: boolean;
   mode: EditorMode;
   pinMode: boolean;
   drawMode: boolean;
@@ -1901,10 +1899,6 @@ function DesignBottomToolbar({
       onClick: () => onModeChange("interact"),
     },
   ];
-  const visibleTools = commentOnly
-    ? tools.filter((tool) => tool.key === "comment")
-    : tools;
-
   return (
     <div
       data-design-bottom-toolbar
@@ -1912,7 +1906,7 @@ function DesignBottomToolbar({
       style={{ bottom: shortcutsPanelOpen ? 257 : 16 }}
     >
       <div className="flex min-w-0 items-center gap-0.5">
-        {visibleTools.map((tool) => (
+        {tools.map((tool) => (
           <DesignToolbarTool
             key={tool.key}
             active={tool.active}
@@ -1924,23 +1918,19 @@ function DesignBottomToolbar({
         ))}
       </div>
 
-      {!commentOnly ? (
-        <>
-          <div className="h-9 w-px shrink-0 bg-white/15" />
+      <div className="h-9 w-px shrink-0 bg-white/15" />
 
-          <div className="flex shrink-0 items-center gap-0.5 rounded-md bg-white/10 p-0.5">
-            {modes.map((item) => (
-              <DesignModeTab
-                key={item.key}
-                active={item.active}
-                label={item.label}
-                icon={item.icon}
-                onClick={item.onClick}
-              />
-            ))}
-          </div>
-        </>
-      ) : null}
+      <div className="flex shrink-0 items-center gap-0.5 rounded-md bg-white/10 p-0.5">
+        {modes.map((item) => (
+          <DesignModeTab
+            key={item.key}
+            active={item.active}
+            label={item.label}
+            icon={item.icon}
+            onClick={item.onClick}
+          />
+        ))}
+      </div>
     </div>
   );
 }
@@ -28584,11 +28574,10 @@ function DesignEditor() {
 
         {!embedded &&
           !uiHidden &&
-          designBottomToolbarMode !== "hidden" &&
+          designBottomToolbarMode === "editor" &&
           activeFile &&
           !questionFlowActive && (
             <DesignBottomToolbar
-              commentOnly={designBottomToolbarMode === "commenter"}
               mode={mode}
               pinMode={pinMode}
               drawMode={drawMode}
@@ -28874,7 +28863,18 @@ function DesignEditor() {
                   {/* Figma-style notice for viewers who can't edit this
                       design. Only shown once accessRole has actually
                       resolved to "viewer" to avoid flashing during load. */}
-                  {designAccessRole === "viewer" && <ReadOnlyDesignBanner />}
+                  {designAccessRole === "viewer" && (
+                    <ReadOnlyDesignBanner
+                      pinMode={pinMode}
+                      onCommentPin={
+                        !embedded &&
+                        !uiHidden &&
+                        designBottomToolbarMode === "commenter"
+                          ? handlePinToolToggle
+                          : undefined
+                      }
+                    />
+                  )}
                   {/* Full-app building status/controls. Renders only for
                       designs backed by a fusion app (see readFusionApp) and
                       only while the flag is on — the fusion actions the

--- a/templates/design/app/pages/design-editor/selection-state.spec.ts
+++ b/templates/design/app/pages/design-editor/selection-state.spec.ts
@@ -6,6 +6,7 @@ import {
   isDocumentShellCodeLayerNode,
   pendingEditTargetsSelectedElement,
   resolveEscapePopSelectionAction,
+  shouldClearSelectionForReviewThreadTarget,
   shouldEscapeToOverview,
 } from "./selection-state";
 
@@ -107,6 +108,32 @@ describe("resolveEscapePopSelectionAction", () => {
         viewMode: "overview",
       }),
     ).toEqual({ kind: "deselect" });
+  });
+});
+
+describe("shouldClearSelectionForReviewThreadTarget", () => {
+  it("clears stale layer context when thread focus changes screens", () => {
+    expect(
+      shouldClearSelectionForReviewThreadTarget({
+        activeFileId: "screen-a",
+        targetId: "screen-b",
+      }),
+    ).toBe(true);
+  });
+
+  it("preserves selection for same-screen and design-wide threads", () => {
+    expect(
+      shouldClearSelectionForReviewThreadTarget({
+        activeFileId: "screen-a",
+        targetId: "screen-a",
+      }),
+    ).toBe(false);
+    expect(
+      shouldClearSelectionForReviewThreadTarget({
+        activeFileId: "screen-a",
+        targetId: null,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/templates/design/app/pages/design-editor/selection-state.ts
+++ b/templates/design/app/pages/design-editor/selection-state.ts
@@ -483,6 +483,14 @@ export function shouldClearBridgeSelectionOnEmptyMarquee(args: {
   return args.resolvedCount === 0 && !args.additive;
 }
 
+/** Clear element context only when a selected review thread changes screens. */
+export function shouldClearSelectionForReviewThreadTarget(args: {
+  activeFileId?: string | null;
+  targetId?: string | null;
+}): boolean {
+  return Boolean(args.targetId && args.targetId !== args.activeFileId);
+}
+
 /**
  * PICK-RACE: MultiScreenCanvas's `onPick` prop is `(id: string) => void` — no
  * modifier/event info — even though a shift-click there already toggled a

--- a/templates/design/app/pages/design-editor/tool-state.spec.ts
+++ b/templates/design/app/pages/design-editor/tool-state.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { getDesignBottomToolbarMode } from "./tool-state";
+
+describe("getDesignBottomToolbarMode", () => {
+  it("keeps all tools for editors", () => {
+    expect(
+      getDesignBottomToolbarMode({
+        isSignedIn: true,
+        canEditDesign: true,
+        hasActiveFile: true,
+      }),
+    ).toBe("editor");
+  });
+
+  it("shows a comment-only toolbar to signed-in viewers", () => {
+    expect(
+      getDesignBottomToolbarMode({
+        isSignedIn: true,
+        canEditDesign: false,
+        hasActiveFile: true,
+      }),
+    ).toBe("commenter");
+  });
+
+  it("hides the toolbar without a session or active file", () => {
+    expect(
+      getDesignBottomToolbarMode({
+        isSignedIn: false,
+        canEditDesign: false,
+        hasActiveFile: true,
+      }),
+    ).toBe("hidden");
+    expect(
+      getDesignBottomToolbarMode({
+        isSignedIn: true,
+        canEditDesign: false,
+        hasActiveFile: false,
+      }),
+    ).toBe("hidden");
+  });
+});

--- a/templates/design/app/pages/design-editor/tool-state.ts
+++ b/templates/design/app/pages/design-editor/tool-state.ts
@@ -102,6 +102,17 @@ export function shouldAutoEnableDrawOverlay(args: {
   );
 }
 
+export type DesignBottomToolbarMode = "editor" | "commenter" | "hidden";
+
+export function getDesignBottomToolbarMode(args: {
+  isSignedIn: boolean;
+  canEditDesign: boolean;
+  hasActiveFile: boolean;
+}): DesignBottomToolbarMode {
+  if (!args.isSignedIn || !args.hasActiveFile) return "hidden";
+  return args.canEditDesign ? "editor" : "commenter";
+}
+
 export function getSingleScreenCreationTool(args: {
   activeTool: DesignTool;
   viewMode: "single" | "overview";

--- a/templates/design/changelog/2026-07-14-reviewers-can-now-pin-comments-from-the-canvas-toolbar-targe.md
+++ b/templates/design/changelog/2026-07-14-reviewers-can-now-pin-comments-from-the-canvas-toolbar-targe.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-14
+---
+
+Reviewers can now pin comments from the canvas toolbar, target selected layers, and only see actions they can use.

--- a/templates/design/changelog/2026-07-15-viewer-comment-controls-now-sit-inside-the-read-only-notice-.md
+++ b/templates/design/changelog/2026-07-15-viewer-comment-controls-now-sit-inside-the-read-only-notice-.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-15
+---
+
+Viewer comment controls now sit inside the read-only notice instead of floating over the canvas.

--- a/templates/design/shared/review-anchor.spec.ts
+++ b/templates/design/shared/review-anchor.spec.ts
@@ -63,4 +63,26 @@ describe("review anchors", () => {
     });
     expect(createElementReviewAnchor({})).toBeNull();
   });
+
+  it("ignores zero-sized synthetic bounds when creating a fallback point", () => {
+    const syntheticBounds = { x: 0, y: 0, width: 0, height: 0 };
+    expect(
+      createElementReviewAnchor({
+        nodeId: "hero-title",
+        rect: syntheticBounds,
+        viewportWidth: 1_000,
+        viewportHeight: 500,
+      }),
+    ).toEqual({
+      nodeId: "hero-title",
+      point: { xPct: 50, yPct: 50 },
+    });
+    expect(
+      createElementReviewAnchor({
+        rect: syntheticBounds,
+        viewportWidth: 1_000,
+        viewportHeight: 500,
+      }),
+    ).toBeNull();
+  });
 });

--- a/templates/design/shared/review-anchor.spec.ts
+++ b/templates/design/shared/review-anchor.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { parseReviewAnchor, resolveReviewAnchor } from "./review-anchor";
+import {
+  createElementReviewAnchor,
+  parseReviewAnchor,
+  resolveReviewAnchor,
+} from "./review-anchor";
 
 describe("review anchors", () => {
   const point = { xPct: 24, yPct: 68 };
@@ -36,5 +40,27 @@ describe("review anchors", () => {
     expect(
       resolveReviewAnchor({ point: { xPct: "nope", yPct: 20 } }, () => null),
     ).toBeNull();
+  });
+
+  it("anchors a selected layer at its visible center", () => {
+    expect(
+      createElementReviewAnchor({
+        nodeId: "hero-title",
+        rect: { x: 100, y: 80, width: 200, height: 40 },
+        viewportWidth: 1_000,
+        viewportHeight: 500,
+      }),
+    ).toEqual({
+      nodeId: "hero-title",
+      point: { xPct: 20, yPct: 20 },
+    });
+  });
+
+  it("keeps a node anchor when viewport geometry is unavailable", () => {
+    expect(createElementReviewAnchor({ nodeId: "hero-title" })).toEqual({
+      nodeId: "hero-title",
+      point: { xPct: 50, yPct: 50 },
+    });
+    expect(createElementReviewAnchor({})).toBeNull();
   });
 });

--- a/templates/design/shared/review-anchor.ts
+++ b/templates/design/shared/review-anchor.ts
@@ -27,7 +27,9 @@ export function createElementReviewAnchor(input: {
     Number.isFinite(rect.x) &&
     Number.isFinite(rect.y) &&
     Number.isFinite(rect.width) &&
+    rect.width > 0 &&
     Number.isFinite(rect.height) &&
+    rect.height > 0 &&
     typeof input.viewportWidth === "number" &&
     Number.isFinite(input.viewportWidth) &&
     input.viewportWidth > 0 &&

--- a/templates/design/shared/review-anchor.ts
+++ b/templates/design/shared/review-anchor.ts
@@ -14,6 +14,52 @@ export interface ResolvedReviewAnchor {
   source: "node" | "point";
 }
 
+export function createElementReviewAnchor(input: {
+  nodeId?: string | null;
+  rect?: { x: number; y: number; width: number; height: number } | null;
+  viewportWidth?: number | null;
+  viewportHeight?: number | null;
+}): DesignReviewAnchor | null {
+  const nodeId = input.nodeId?.trim() ?? "";
+  const rect = input.rect;
+  const hasRect = Boolean(
+    rect &&
+    Number.isFinite(rect.x) &&
+    Number.isFinite(rect.y) &&
+    Number.isFinite(rect.width) &&
+    Number.isFinite(rect.height) &&
+    typeof input.viewportWidth === "number" &&
+    Number.isFinite(input.viewportWidth) &&
+    input.viewportWidth > 0 &&
+    typeof input.viewportHeight === "number" &&
+    Number.isFinite(input.viewportHeight) &&
+    input.viewportHeight > 0,
+  );
+  if (!nodeId && !hasRect) return null;
+
+  const point = hasRect
+    ? {
+        xPct:
+          finitePercentage(
+            (((rect?.x ?? 0) + (rect?.width ?? 0) / 2) /
+              (input.viewportWidth as number)) *
+              100,
+          ) ?? 50,
+        yPct:
+          finitePercentage(
+            (((rect?.y ?? 0) + (rect?.height ?? 0) / 2) /
+              (input.viewportHeight as number)) *
+              100,
+          ) ?? 50,
+      }
+    : { xPct: 50, yPct: 50 };
+
+  return {
+    ...(nodeId ? { nodeId } : {}),
+    point,
+  };
+}
+
 function finitePercentage(value: unknown): number | null {
   if (typeof value !== "number" || !Number.isFinite(value)) return null;
   return Math.min(100, Math.max(0, value));


### PR DESCRIPTION
Improves commenting for signed-in design viewers who do not have edit access.
What changed
Added a comment-only canvas toolbar for viewers.
Enabled point-and-click pinned comments without exposing editing tools.
Associated Comments-tab feedback with the selected layer using a stable node anchor, fallback coordinates, and layer metadata.
Added a visible “Commenting on…” context label.
Hid “Send to agent” and resolution controls unless the user can edit.
Extended Core review composers to support independent targets, anchors, metadata, and context labels.
Added localized copy, changelog entry, changeset, and regression coverage.