### PR TITLE
Fix hosted deploys and recording durations

### DIFF
--- a/.changeset/calm-streams-recover.md
+++ b/.changeset/calm-streams-recover.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep chat responsive while replaying dense agent event bursts, and surface safe cancellation when a live background run has gone quiet.

--- a/.changeset/quiet-pandas-bundle.md
+++ b/.changeset/quiet-pandas-bundle.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Bundle one complete Yjs runtime into serverless deploy output so SSR starts without missing named exports.

--- a/packages/core/src/client/RunStuckBanner.spec.tsx
+++ b/packages/core/src/client/RunStuckBanner.spec.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RunStuckBanner } from "./RunStuckBanner.js";
+import { useRunStuckDetection } from "./use-run-stuck-detection.js";
 
 vi.mock("./analytics.js", () => ({
   trackEvent: vi.fn(),
@@ -20,6 +21,18 @@ function jsonResponse(body: unknown, ok = true) {
     status: ok ? 200 : 500,
     json: async () => body,
   } as Response;
+}
+
+function RunStuckProbe({
+  liveBackgroundStuckThresholdMs,
+}: {
+  liveBackgroundStuckThresholdMs: number;
+}) {
+  const state = useRunStuckDetection({
+    threadId: "thread-1",
+    liveBackgroundStuckThresholdMs,
+  });
+  return <div>{state.isStuck ? "stuck" : "healthy"}</div>;
 }
 
 describe("RunStuckBanner", () => {
@@ -103,7 +116,7 @@ describe("RunStuckBanner", () => {
     ).toHaveLength(1);
   });
 
-  it("does not flag a heartbeating durable worker during its bounded tool window", async () => {
+  it("shows informational status and Cancel for a quiet heartbeating durable worker", async () => {
     const onRetry = vi.fn();
     const fetchSpy = vi.fn(async (url: string) => {
       if (url.includes("/runs/active")) {
@@ -130,7 +143,13 @@ describe("RunStuckBanner", () => {
       await vi.advanceTimersByTimeAsync(2_000);
     });
 
-    expect(container.textContent ?? "").toBe("");
+    expect(container.textContent).toContain("The agent is still working.");
+    expect(container.textContent).toContain(
+      "The background worker is still alive",
+    );
+    expect(container.textContent).toContain("Cancel");
+    expect(container.textContent).not.toContain("Retry");
+    expect(container.textContent).not.toContain("Retrying automatically now.");
     expect(onRetry).not.toHaveBeenCalled();
     expect(
       fetchSpy.mock.calls.some(
@@ -141,7 +160,7 @@ describe("RunStuckBanner", () => {
     ).toBe(false);
   });
 
-  it("shows the fallback after a heartbeating durable worker exceeds its recovery window", async () => {
+  it("keeps overdue heartbeating worker status informational", async () => {
     const fetchSpy = vi.fn(async (url: string) => {
       if (url.includes("/runs/active")) {
         return jsonResponse({
@@ -169,7 +188,74 @@ describe("RunStuckBanner", () => {
     expect(container.textContent).toContain(
       "The background worker is still alive",
     );
+    expect(container.textContent).toContain("Cancel");
+    expect(container.textContent).not.toContain("Retry");
+  });
+
+  it("restores Retry when a fresh heartbeat expires during failed polls", async () => {
+    let activePollCount = 0;
+    const fetchSpy = vi.fn(async (url: string) => {
+      if (url.includes("/runs/active")) {
+        activePollCount += 1;
+        if (activePollCount > 1) throw new Error("poll unavailable");
+        return jsonResponse({
+          active: true,
+          runId: "run-background-expiring",
+          status: "running",
+          dispatchMode: "background-processing",
+          heartbeatAt: 295_000,
+          lastProgressAt: 10_000,
+          serverNow: 300_000,
+        });
+      }
+      return jsonResponse({ error: "unexpected" }, false);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await act(async () => {
+      root.render(<RunStuckBanner threadId="thread-1" autoRetry />);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+
+    expect(container.textContent).toContain("The agent is still working.");
+    expect(container.textContent).not.toContain("Retry");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(25_001);
+    });
+
+    expect(activePollCount).toBeGreaterThan(1);
+    expect(container.textContent).toContain("This chat looks stuck.");
     expect(container.textContent).toContain("Retry");
+  });
+
+  it("allows the live-worker threshold to request an earlier notice", async () => {
+    const fetchSpy = vi.fn(async (url: string) => {
+      if (url.includes("/runs/active")) {
+        return jsonResponse({
+          active: true,
+          runId: "run-background-early-notice",
+          status: "running",
+          dispatchMode: "background-processing",
+          heartbeatAt: 99_000,
+          lastProgressAt: 10_000,
+          serverNow: 100_000,
+        });
+      }
+      return jsonResponse({ error: "unexpected" }, false);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await act(async () => {
+      root.render(<RunStuckProbe liveBackgroundStuckThresholdMs={60_000} />);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+
+    expect(container.textContent).toBe("stuck");
   });
 
   it("never auto-retries a background-dispatched run even with a stale heartbeat", async () => {

--- a/packages/core/src/client/RunStuckBanner.spec.tsx
+++ b/packages/core/src/client/RunStuckBanner.spec.tsx
@@ -192,7 +192,7 @@ describe("RunStuckBanner", () => {
     expect(container.textContent).not.toContain("Retry");
   });
 
-  it("restores Retry when a fresh heartbeat expires during failed polls", async () => {
+  it("recomputes stuck state when a fresh heartbeat expires during failed polls", async () => {
     let activePollCount = 0;
     const fetchSpy = vi.fn(async (url: string) => {
       if (url.includes("/runs/active")) {
@@ -204,7 +204,8 @@ describe("RunStuckBanner", () => {
           status: "running",
           dispatchMode: "background-processing",
           heartbeatAt: 295_000,
-          lastProgressAt: 10_000,
+          // Just below the 180s background threshold at observation time.
+          lastProgressAt: 121_000,
           serverNow: 300_000,
         });
       }
@@ -219,8 +220,7 @@ describe("RunStuckBanner", () => {
       await vi.advanceTimersByTimeAsync(2_000);
     });
 
-    expect(container.textContent).toContain("The agent is still working.");
-    expect(container.textContent).not.toContain("Retry");
+    expect(container.textContent).toBe("");
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(25_001);
@@ -229,6 +229,7 @@ describe("RunStuckBanner", () => {
     expect(activePollCount).toBeGreaterThan(1);
     expect(container.textContent).toContain("This chat looks stuck.");
     expect(container.textContent).toContain("Retry");
+    expect(container.textContent).toContain("Cancel");
   });
 
   it("allows the live-worker threshold to request an earlier notice", async () => {

--- a/packages/core/src/client/RunStuckBanner.spec.tsx
+++ b/packages/core/src/client/RunStuckBanner.spec.tsx
@@ -232,6 +232,51 @@ describe("RunStuckBanner", () => {
     expect(container.textContent).toContain("Cancel");
   });
 
+  it("schedules a later stuck transition after heartbeat expiry", async () => {
+    let activePollCount = 0;
+    const fetchSpy = vi.fn(async (url: string) => {
+      if (url.includes("/runs/active")) {
+        activePollCount += 1;
+        if (activePollCount > 1) throw new Error("poll unavailable");
+        return jsonResponse({
+          active: true,
+          runId: "run-background-later-stuck",
+          status: "running",
+          dispatchMode: "background-processing",
+          heartbeatAt: 99_000,
+          // Far enough below 180s that heartbeat freshness expires first.
+          lastProgressAt: 10_000,
+          serverNow: 100_000,
+        });
+      }
+      return jsonResponse({ error: "unexpected" }, false);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await act(async () => {
+      root.render(<RunStuckBanner threadId="thread-1" autoRetry />);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+
+    expect(container.textContent).toBe("");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(89_999);
+    });
+    expect(container.textContent).toBe("");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2);
+    });
+
+    expect(activePollCount).toBeGreaterThan(1);
+    expect(container.textContent).toContain("This chat looks stuck.");
+    expect(container.textContent).toContain("Retry");
+    expect(container.textContent).toContain("Cancel");
+  });
+
   it("allows the live-worker threshold to request an earlier notice", async () => {
     const fetchSpy = vi.fn(async (url: string) => {
       if (url.includes("/runs/active")) {

--- a/packages/core/src/client/RunStuckBanner.tsx
+++ b/packages/core/src/client/RunStuckBanner.tsx
@@ -323,10 +323,17 @@ export function RunStuckBanner({
   };
 
   const handleRetry = async () => {
-    // Defense in depth: the button is hidden while `inFlightWork` is true
-    // (see render below), but guard the handler itself too so an abort can
-    // never be triggered against live work through this path.
-    if (!state.runId || busy.type !== "none" || inFlightWork) return;
+    // Defense in depth: Retry is hidden while a background worker is still
+    // heartbeating or work is explicitly in flight (see render below). Guard
+    // the handler too so this path cannot abort a run the server says is alive.
+    if (
+      !state.runId ||
+      busy.type !== "none" ||
+      backgroundWorkerStillAlive ||
+      inFlightWork
+    ) {
+      return;
+    }
     const runId = state.runId;
     setBusy({ type: "retry", runId });
     trackEvent("agent_chat_stuck_retry", {
@@ -380,7 +387,7 @@ export function RunStuckBanner({
           </span>
         </div>
         <div className="flex flex-wrap items-center gap-2">
-          {inFlightWork ? null : (
+          {stillWorking ? null : (
             <button
               type="button"
               onClick={handleRetry}

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -578,6 +578,103 @@ async function drain(iterable: AsyncIterable<unknown>) {
   return results;
 }
 
+describe("SSE replay render pacing", () => {
+  it("yields to the browser event loop during a dense replay burst", async () => {
+    const textEvents = Array.from({ length: 60 }, (_, index) => ({
+      type: "text",
+      text: `${index}|`,
+    }));
+    const results: any[] = [];
+    let eventLoopAdvanced = false;
+    let firstResultAfterEventLoopAdvance: number | null = null;
+    const eventLoopTurn = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        eventLoopAdvanced = true;
+        resolve();
+      }, 0);
+    });
+
+    for await (const result of readSSEStream(
+      eventStream([...textEvents, { type: "done" }]),
+      [],
+      { value: 0 },
+      undefined,
+    )) {
+      results.push(result);
+      if (eventLoopAdvanced && firstResultAfterEventLoopAdvance === null) {
+        firstResultAfterEventLoopAdvance = results.length - 1;
+      }
+    }
+    await eventLoopTurn;
+
+    expect(firstResultAfterEventLoopAdvance).not.toBeNull();
+    expect(firstResultAfterEventLoopAdvance!).toBeLessThan(textEvents.length);
+    expect(results).toHaveLength(textEvents.length + 1);
+    expect(results.at(-1)?.content).toEqual([
+      {
+        type: "text",
+        text: textEvents.map((event) => event.text).join(""),
+      },
+    ]);
+  });
+
+  it("preserves event order and tool content across cooperative yields", async () => {
+    const before = Array.from({ length: 24 }, (_, index) => ({
+      type: "text",
+      text: `before-${index}|`,
+    }));
+    const after = Array.from({ length: 24 }, (_, index) => ({
+      type: "text",
+      text: `after-${index}|`,
+    }));
+    const events = [
+      ...before,
+      {
+        type: "tool_start",
+        id: "tool-1",
+        tool: "query-data",
+        input: { query: "select 1" },
+      },
+      {
+        type: "tool_done",
+        id: "tool-1",
+        tool: "query-data",
+        result: "one row",
+      },
+      ...after,
+      { type: "done" },
+    ].map((event, seq) => ({ ...event, seq }));
+    const seenSeq: number[] = [];
+
+    const results = (await drain(
+      readSSEStream(eventStream(events), [], { value: 0 }, undefined, (seq) =>
+        seenSeq.push(seq),
+      ),
+    )) as any[];
+
+    expect(seenSeq).toEqual(events.map((event) => event.seq));
+    expect(results).toHaveLength(events.length);
+    expect(results.at(-1)?.content).toEqual([
+      {
+        type: "text",
+        text: before.map((event) => event.text).join(""),
+      },
+      {
+        type: "tool-call",
+        toolCallId: "tool-1",
+        toolName: "query-data",
+        argsText: JSON.stringify({ query: "select 1" }),
+        args: { query: "select 1" },
+        result: "one row",
+      },
+      {
+        type: "text",
+        text: after.map((event) => event.text).join(""),
+      },
+    ]);
+  });
+});
+
 describe("SSE event processor no-progress recovery", () => {
   afterEach(() => {
     vi.useRealTimers();

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -112,6 +112,20 @@ const INTERRUPTED_TOOL_RESULT =
   "Interrupted before this tool returned a result.";
 const INTERRUPTED_ACTIVITY_RESULT = "Stopped before this action started.";
 
+/**
+ * Maximum number of assistant-ui repository updates we deliver in one browser
+ * event-loop turn. Durable-run replay can put hundreds of SSE frames into the
+ * stream queue before the client attaches; draining all of them through
+ * assistant-ui without a macrotask boundary synchronously nests React external
+ * store notifications until React throws "Maximum update depth exceeded."
+ *
+ * A timer scheduled on the first result resets the count when the stream is
+ * naturally idle between network chunks. We only await it when results are
+ * arriving densely enough to hit this bound, so normal live token streaming
+ * keeps its existing latency while replay bursts yield cooperatively.
+ */
+const SSE_RENDER_UPDATES_PER_EVENT_LOOP_TURN = 20;
+
 export function settleInterruptedToolCalls(
   content: ContentPart[],
   result = INTERRUPTED_TOOL_RESULT,
@@ -1609,6 +1623,24 @@ export async function* readSSEStream(
     completedToolsAfterLastAssistantText: new Set(),
     streamProgressDispatched: false,
   };
+  let renderUpdatesThisTurn = 0;
+  let nextEventLoopTurn: Promise<void> | null = null;
+
+  const paceRenderUpdate = async (): Promise<void> => {
+    renderUpdatesThisTurn += 1;
+    if (!nextEventLoopTurn) {
+      nextEventLoopTurn = new Promise<void>((resolve) => {
+        setTimeout(() => {
+          renderUpdatesThisTurn = 0;
+          nextEventLoopTurn = null;
+          resolve();
+        }, 0);
+      });
+    }
+    if (renderUpdatesThisTurn >= SSE_RENDER_UPDATES_PER_EVENT_LOOP_TURN) {
+      await nextEventLoopTurn;
+    }
+  };
 
   const withStreamMetadata = (r: ChatModelRunResult): ChatModelRunResult => {
     if (!runId && activityTrail.length === 0) return r;
@@ -1726,7 +1758,10 @@ export async function* readSSEStream(
           processEventState,
         );
 
-        if (result) yield withStreamMetadata(result);
+        if (result) {
+          await paceRenderUpdate();
+          yield withStreamMetadata(result);
+        }
         if (
           hasStalledPreparingAction(
             preparingActionState,

--- a/packages/core/src/client/use-run-stuck-detection.ts
+++ b/packages/core/src/client/use-run-stuck-detection.ts
@@ -127,18 +127,10 @@ export function useRunStuckDetection({
     const base = apiUrl ?? agentNativePath("/_agent-native/agent-chat");
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
-    let heartbeatExpiryTimer: ReturnType<typeof setTimeout> | null = null;
+    let snapshotTransitionTimer: ReturnType<typeof setTimeout> | null = null;
+    let snapshotVersion = 0;
 
-    const scheduleHeartbeatExpiry = ({
-      active,
-      runId,
-      status,
-      lastProgressAt,
-      stuckSinceMs,
-      heartbeatAt,
-      heartbeatSinceMs,
-      dispatchMode,
-    }: {
+    type RunHealthSnapshot = {
       active: boolean;
       runId: string | null;
       status: string | null;
@@ -147,63 +139,112 @@ export function useRunStuckDetection({
       heartbeatAt: number | null;
       heartbeatSinceMs: number | null;
       dispatchMode: string | null;
-    }) => {
-      if (heartbeatExpiryTimer) clearTimeout(heartbeatExpiryTimer);
-      heartbeatExpiryTimer = null;
+    };
+
+    const effectiveThresholdFor = (
+      dispatchMode: string | null,
+      heartbeatSinceMs: number | null,
+    ) => {
+      const liveBackgroundWorker =
+        dispatchMode === "background-processing" &&
+        heartbeatSinceMs != null &&
+        heartbeatSinceMs >= 0 &&
+        heartbeatSinceMs < FRESH_BACKGROUND_HEARTBEAT_MS;
+      const serverContinued =
+        dispatchMode === "foreground-self-chain" ||
+        dispatchMode?.startsWith("background") === true;
+      return liveBackgroundWorker
+        ? Math.min(backgroundStuckThresholdMs, liveBackgroundStuckThresholdMs)
+        : serverContinued
+          ? backgroundStuckThresholdMs
+          : stuckThresholdMs;
+    };
+
+    const scheduleSnapshotTransition = (
+      snapshot: RunHealthSnapshot,
+      observedAtMs: number,
+      version: number,
+    ) => {
+      if (snapshotTransitionTimer) clearTimeout(snapshotTransitionTimer);
+      snapshotTransitionTimer = null;
       if (
-        runId == null ||
-        heartbeatAt == null ||
-        heartbeatSinceMs == null ||
-        heartbeatSinceMs < 0 ||
-        heartbeatSinceMs >= FRESH_BACKGROUND_HEARTBEAT_MS
+        cancelled ||
+        version !== snapshotVersion ||
+        !snapshot.active ||
+        snapshot.status !== "running" ||
+        snapshot.runId == null
       ) {
         return;
       }
 
-      // `heartbeatSinceMs` is computed from the server clock, but it is only a
-      // snapshot. Expire that snapshot against elapsed local time so a hung or
-      // failing follow-up poll cannot claim the worker is alive forever and
-      // indefinitely hide Retry. Comparing a duration is safe from client/server
-      // clock skew; a later successful poll replaces this timer with fresh data.
-      const observedAtMs = Date.now();
-      const expiresInMs = FRESH_BACKGROUND_HEARTBEAT_MS - heartbeatSinceMs + 1;
-      heartbeatExpiryTimer = setTimeout(() => {
-        if (cancelled) return;
+      const currentElapsedMs = Math.max(0, Date.now() - observedAtMs);
+      const currentHeartbeatSinceMs =
+        snapshot.heartbeatSinceMs == null
+          ? null
+          : snapshot.heartbeatSinceMs + currentElapsedMs;
+      const currentStuckSinceMs =
+        snapshot.stuckSinceMs == null
+          ? null
+          : snapshot.stuckSinceMs + currentElapsedMs;
+      const effectiveThresholdMs = effectiveThresholdFor(
+        snapshot.dispatchMode,
+        currentHeartbeatSinceMs,
+      );
+      const currentlyStuck = Boolean(
+        currentStuckSinceMs != null &&
+        currentStuckSinceMs > effectiveThresholdMs,
+      );
+      const transitionDelaysMs: number[] = [];
+      if (
+        currentHeartbeatSinceMs != null &&
+        currentHeartbeatSinceMs >= 0 &&
+        currentHeartbeatSinceMs < FRESH_BACKGROUND_HEARTBEAT_MS
+      ) {
+        transitionDelaysMs.push(
+          FRESH_BACKGROUND_HEARTBEAT_MS - currentHeartbeatSinceMs + 1,
+        );
+      }
+      if (currentStuckSinceMs != null && !currentlyStuck) {
+        transitionDelaysMs.push(
+          Math.max(1, effectiveThresholdMs - currentStuckSinceMs + 1),
+        );
+      }
+      if (transitionDelaysMs.length === 0) return;
+
+      // Both ages originate from the server clock. Advance those snapshots by
+      // only a local elapsed duration, which remains safe when client/server
+      // wall clocks differ. Wake at the earlier semantic boundary, then
+      // reschedule if the other boundary is still ahead.
+      const delayMs = Math.max(1, Math.min(...transitionDelaysMs));
+      snapshotTransitionTimer = setTimeout(() => {
+        snapshotTransitionTimer = null;
+        if (cancelled || version !== snapshotVersion) return;
         const elapsedSinceObservationMs = Math.max(
           0,
           Date.now() - observedAtMs,
         );
         const nextHeartbeatSinceMs =
-          heartbeatSinceMs + elapsedSinceObservationMs;
-        const nextStuckSinceMs =
-          stuckSinceMs == null
+          snapshot.heartbeatSinceMs == null
             ? null
-            : stuckSinceMs + elapsedSinceObservationMs;
-        const liveBackgroundWorker =
-          dispatchMode === "background-processing" &&
-          nextHeartbeatSinceMs >= 0 &&
-          nextHeartbeatSinceMs < FRESH_BACKGROUND_HEARTBEAT_MS;
-        const serverContinued =
-          dispatchMode === "foreground-self-chain" ||
-          dispatchMode?.startsWith("background") === true;
-        const effectiveThresholdMs = liveBackgroundWorker
-          ? Math.min(backgroundStuckThresholdMs, liveBackgroundStuckThresholdMs)
-          : serverContinued
-            ? backgroundStuckThresholdMs
-            : stuckThresholdMs;
+            : snapshot.heartbeatSinceMs + elapsedSinceObservationMs;
+        const nextStuckSinceMs =
+          snapshot.stuckSinceMs == null
+            ? null
+            : snapshot.stuckSinceMs + elapsedSinceObservationMs;
+        const nextEffectiveThresholdMs = effectiveThresholdFor(
+          snapshot.dispatchMode,
+          nextHeartbeatSinceMs,
+        );
         const nextIsStuck = Boolean(
-          active &&
-          status === "running" &&
           nextStuckSinceMs != null &&
-          nextStuckSinceMs > effectiveThresholdMs,
+          nextStuckSinceMs > nextEffectiveThresholdMs,
         );
         setState((current) => {
           if (
-            current.runId !== runId ||
-            current.lastProgressAt !== lastProgressAt ||
-            current.heartbeatAt !== heartbeatAt ||
-            current.heartbeatSinceMs == null ||
-            current.heartbeatSinceMs >= FRESH_BACKGROUND_HEARTBEAT_MS
+            version !== snapshotVersion ||
+            current.runId !== snapshot.runId ||
+            current.lastProgressAt !== snapshot.lastProgressAt ||
+            current.heartbeatAt !== snapshot.heartbeatAt
           ) {
             return current;
           }
@@ -214,7 +255,8 @@ export function useRunStuckDetection({
             heartbeatSinceMs: nextHeartbeatSinceMs,
           };
         });
-      }, expiresInMs);
+        scheduleSnapshotTransition(snapshot, observedAtMs, version);
+      }, delayMs);
     };
 
     const poll = async () => {
@@ -242,47 +284,38 @@ export function useRunStuckDetection({
             heartbeatAt != null ? nowMs - heartbeatAt : null;
           const dispatchMode =
             typeof data.dispatchMode === "string" ? data.dispatchMode : null;
-          // Server-continued runs get the wider threshold: the server's own
-          // recovery (150s no-progress backstop + chained continuations) must
-          // get its chance before the user sees a "stuck" affordance.
-          const serverContinued =
-            dispatchMode === "foreground-self-chain" ||
-            dispatchMode?.startsWith("background") === true;
           // A claimed durable worker with a fresh heartbeat can legitimately
           // be waiting on a bounded long-running tool/sub-agent call. Still
           // surface informational status at the normal background threshold;
           // RunStuckBanner uses the fresh heartbeat to withhold Retry while
           // keeping an explicit Cancel available. The legacy live-worker
           // threshold may make that notice earlier, but never later.
-          const liveBackgroundWorker =
-            dispatchMode === "background-processing" &&
-            heartbeatSinceMs != null &&
-            heartbeatSinceMs >= 0 &&
-            heartbeatSinceMs < FRESH_BACKGROUND_HEARTBEAT_MS;
-          const effectiveThresholdMs = liveBackgroundWorker
-            ? Math.min(
-                backgroundStuckThresholdMs,
-                liveBackgroundStuckThresholdMs,
-              )
-            : serverContinued
-              ? backgroundStuckThresholdMs
-              : stuckThresholdMs;
+          const effectiveThresholdMs = effectiveThresholdFor(
+            dispatchMode,
+            heartbeatSinceMs,
+          );
           const isStuck = Boolean(
             data.active &&
             data.status === "running" &&
             stuckSinceMs != null &&
             stuckSinceMs > effectiveThresholdMs,
           );
-          scheduleHeartbeatExpiry({
-            active: data.active,
-            runId: data.runId ?? null,
-            status: data.status ?? null,
-            lastProgressAt,
-            stuckSinceMs,
-            heartbeatAt,
-            heartbeatSinceMs,
-            dispatchMode,
-          });
+          const observedAtMs = Date.now();
+          const version = ++snapshotVersion;
+          scheduleSnapshotTransition(
+            {
+              active: data.active,
+              runId: data.runId ?? null,
+              status: data.status ?? null,
+              lastProgressAt,
+              stuckSinceMs,
+              heartbeatAt,
+              heartbeatSinceMs,
+              dispatchMode,
+            },
+            observedAtMs,
+            version,
+          );
           setState({
             isStuck,
             runId: data.runId ?? null,
@@ -319,8 +352,9 @@ export function useRunStuckDetection({
 
     return () => {
       cancelled = true;
+      snapshotVersion += 1;
       if (timer) clearTimeout(timer);
-      if (heartbeatExpiryTimer) clearTimeout(heartbeatExpiryTimer);
+      if (snapshotTransitionTimer) clearTimeout(snapshotTransitionTimer);
     };
   }, [
     threadId,

--- a/packages/core/src/client/use-run-stuck-detection.ts
+++ b/packages/core/src/client/use-run-stuck-detection.ts
@@ -63,10 +63,10 @@ export interface UseRunStuckDetectionOptions {
    */
   backgroundStuckThresholdMs?: number;
   /**
-   * Threshold for a claimed durable background worker that is still sending
-   * fresh process heartbeats. These workers can legitimately spend up to the
-   * 12-minute tool/no-progress window on large Design, Plan, or Assets work.
-   * Default 13 minutes, matching the durable chunk handoff boundary.
+   * Legacy upper bound for a claimed durable background worker that is still
+   * sending fresh process heartbeats. Informational quiet-run UI is never
+   * delayed past `backgroundStuckThresholdMs`; this option can only request an
+   * earlier notice for live workers. Default 13 minutes.
    */
   liveBackgroundStuckThresholdMs?: number;
   /** Poll interval. Default 5_000ms. */
@@ -127,6 +127,49 @@ export function useRunStuckDetection({
     const base = apiUrl ?? agentNativePath("/_agent-native/agent-chat");
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
+    let heartbeatExpiryTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const scheduleHeartbeatExpiry = (
+      runId: string | null,
+      heartbeatAt: number | null,
+      heartbeatSinceMs: number | null,
+    ) => {
+      if (heartbeatExpiryTimer) clearTimeout(heartbeatExpiryTimer);
+      heartbeatExpiryTimer = null;
+      if (
+        runId == null ||
+        heartbeatAt == null ||
+        heartbeatSinceMs == null ||
+        heartbeatSinceMs < 0 ||
+        heartbeatSinceMs >= FRESH_BACKGROUND_HEARTBEAT_MS
+      ) {
+        return;
+      }
+
+      // `heartbeatSinceMs` is computed from the server clock, but it is only a
+      // snapshot. Expire that snapshot against elapsed local time so a hung or
+      // failing follow-up poll cannot claim the worker is alive forever and
+      // indefinitely hide Retry. Comparing a duration is safe from client/server
+      // clock skew; a later successful poll replaces this timer with fresh data.
+      const expiresInMs = FRESH_BACKGROUND_HEARTBEAT_MS - heartbeatSinceMs + 1;
+      heartbeatExpiryTimer = setTimeout(() => {
+        if (cancelled) return;
+        setState((current) => {
+          if (
+            current.runId !== runId ||
+            current.heartbeatAt !== heartbeatAt ||
+            current.heartbeatSinceMs == null ||
+            current.heartbeatSinceMs >= FRESH_BACKGROUND_HEARTBEAT_MS
+          ) {
+            return current;
+          }
+          return {
+            ...current,
+            heartbeatSinceMs: FRESH_BACKGROUND_HEARTBEAT_MS,
+          };
+        });
+      }, expiresInMs);
+    };
 
     const poll = async () => {
       if (cancelled) return;
@@ -160,18 +203,21 @@ export function useRunStuckDetection({
             dispatchMode === "foreground-self-chain" ||
             dispatchMode?.startsWith("background") === true;
           // A claimed durable worker with a fresh heartbeat can legitimately
-          // be waiting on a bounded long-running tool/sub-agent call. Showing
-          // Retry at the generic 3-minute continuation threshold aborts healthy
-          // work and starts the same call again. Let the worker's own 12-minute
-          // watchdog act first; a dead/stale heartbeat still gets the earlier
-          // background fallback below.
+          // be waiting on a bounded long-running tool/sub-agent call. Still
+          // surface informational status at the normal background threshold;
+          // RunStuckBanner uses the fresh heartbeat to withhold Retry while
+          // keeping an explicit Cancel available. The legacy live-worker
+          // threshold may make that notice earlier, but never later.
           const liveBackgroundWorker =
             dispatchMode === "background-processing" &&
             heartbeatSinceMs != null &&
             heartbeatSinceMs >= 0 &&
             heartbeatSinceMs < FRESH_BACKGROUND_HEARTBEAT_MS;
           const effectiveThresholdMs = liveBackgroundWorker
-            ? liveBackgroundStuckThresholdMs
+            ? Math.min(
+                backgroundStuckThresholdMs,
+                liveBackgroundStuckThresholdMs,
+              )
             : serverContinued
               ? backgroundStuckThresholdMs
               : stuckThresholdMs;
@@ -180,6 +226,11 @@ export function useRunStuckDetection({
             data.status === "running" &&
             stuckSinceMs != null &&
             stuckSinceMs > effectiveThresholdMs,
+          );
+          scheduleHeartbeatExpiry(
+            data.runId ?? null,
+            heartbeatAt,
+            heartbeatSinceMs,
           );
           setState({
             isStuck,
@@ -218,6 +269,7 @@ export function useRunStuckDetection({
     return () => {
       cancelled = true;
       if (timer) clearTimeout(timer);
+      if (heartbeatExpiryTimer) clearTimeout(heartbeatExpiryTimer);
     };
   }, [
     threadId,

--- a/packages/core/src/client/use-run-stuck-detection.ts
+++ b/packages/core/src/client/use-run-stuck-detection.ts
@@ -129,11 +129,25 @@ export function useRunStuckDetection({
     let timer: ReturnType<typeof setTimeout> | null = null;
     let heartbeatExpiryTimer: ReturnType<typeof setTimeout> | null = null;
 
-    const scheduleHeartbeatExpiry = (
-      runId: string | null,
-      heartbeatAt: number | null,
-      heartbeatSinceMs: number | null,
-    ) => {
+    const scheduleHeartbeatExpiry = ({
+      active,
+      runId,
+      status,
+      lastProgressAt,
+      stuckSinceMs,
+      heartbeatAt,
+      heartbeatSinceMs,
+      dispatchMode,
+    }: {
+      active: boolean;
+      runId: string | null;
+      status: string | null;
+      lastProgressAt: number | null;
+      stuckSinceMs: number | null;
+      heartbeatAt: number | null;
+      heartbeatSinceMs: number | null;
+      dispatchMode: string | null;
+    }) => {
       if (heartbeatExpiryTimer) clearTimeout(heartbeatExpiryTimer);
       heartbeatExpiryTimer = null;
       if (
@@ -151,12 +165,42 @@ export function useRunStuckDetection({
       // failing follow-up poll cannot claim the worker is alive forever and
       // indefinitely hide Retry. Comparing a duration is safe from client/server
       // clock skew; a later successful poll replaces this timer with fresh data.
+      const observedAtMs = Date.now();
       const expiresInMs = FRESH_BACKGROUND_HEARTBEAT_MS - heartbeatSinceMs + 1;
       heartbeatExpiryTimer = setTimeout(() => {
         if (cancelled) return;
+        const elapsedSinceObservationMs = Math.max(
+          0,
+          Date.now() - observedAtMs,
+        );
+        const nextHeartbeatSinceMs =
+          heartbeatSinceMs + elapsedSinceObservationMs;
+        const nextStuckSinceMs =
+          stuckSinceMs == null
+            ? null
+            : stuckSinceMs + elapsedSinceObservationMs;
+        const liveBackgroundWorker =
+          dispatchMode === "background-processing" &&
+          nextHeartbeatSinceMs >= 0 &&
+          nextHeartbeatSinceMs < FRESH_BACKGROUND_HEARTBEAT_MS;
+        const serverContinued =
+          dispatchMode === "foreground-self-chain" ||
+          dispatchMode?.startsWith("background") === true;
+        const effectiveThresholdMs = liveBackgroundWorker
+          ? Math.min(backgroundStuckThresholdMs, liveBackgroundStuckThresholdMs)
+          : serverContinued
+            ? backgroundStuckThresholdMs
+            : stuckThresholdMs;
+        const nextIsStuck = Boolean(
+          active &&
+          status === "running" &&
+          nextStuckSinceMs != null &&
+          nextStuckSinceMs > effectiveThresholdMs,
+        );
         setState((current) => {
           if (
             current.runId !== runId ||
+            current.lastProgressAt !== lastProgressAt ||
             current.heartbeatAt !== heartbeatAt ||
             current.heartbeatSinceMs == null ||
             current.heartbeatSinceMs >= FRESH_BACKGROUND_HEARTBEAT_MS
@@ -165,7 +209,9 @@ export function useRunStuckDetection({
           }
           return {
             ...current,
-            heartbeatSinceMs: FRESH_BACKGROUND_HEARTBEAT_MS,
+            isStuck: nextIsStuck,
+            stuckSinceMs: nextStuckSinceMs,
+            heartbeatSinceMs: nextHeartbeatSinceMs,
           };
         });
       }, expiresInMs);
@@ -227,11 +273,16 @@ export function useRunStuckDetection({
             stuckSinceMs != null &&
             stuckSinceMs > effectiveThresholdMs,
           );
-          scheduleHeartbeatExpiry(
-            data.runId ?? null,
+          scheduleHeartbeatExpiry({
+            active: data.active,
+            runId: data.runId ?? null,
+            status: data.status ?? null,
+            lastProgressAt,
+            stuckSinceMs,
             heartbeatAt,
             heartbeatSinceMs,
-          );
+            dispatchMode,
+          });
           setState({
             isStuck,
             runId: data.runId ?? null,

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -12,6 +12,7 @@ import {
 import {
   addImmutableAssetRouteRulesForClientBuild,
   assertSingleTemplateNetlifyBuildOutput,
+  bundleYjsRuntimeForServerlessOutput,
   CLOUDFLARE_WORKER_ESBUILD_EXTERNALS,
   CLOUDFLARE_WORKER_NODE_BUILTIN_STUB_MODULES,
   CLOUDFLARE_WORKER_STUB_MODULES,
@@ -26,7 +27,7 @@ import {
   isDurableBackgroundDeployEnabled,
   NITRO_RUNTIME_IGNORE_PATTERNS,
   nitroNoExternalsForPreset,
-  rewriteBareYjsImportsForServerlessOutput,
+  resolveNitroBundledYjsEntry,
   runNitroBuildPipeline,
   sanitizeServerlessFunctionPackageManifest,
   shouldBundleFfmpegStaticForServerless,
@@ -41,16 +42,26 @@ const DEFAULT_SSR_NETLIFY_CDN_CACHE_CONTROL = DEFAULT_SSR_CACHE_CONTROL;
 const tempDirs: string[] = [];
 
 describe("nitroNoExternalsForPreset", () => {
-  it("bundles Yjs in Node/serverless output", () => {
-    expect(nitroNoExternalsForPreset("netlify")).toEqual(["yjs"]);
-    expect(nitroNoExternalsForPreset("vercel")).toEqual(["yjs"]);
-    expect(nitroNoExternalsForPreset("aws-lambda")).toEqual(["yjs"]);
+  it("leaves Yjs external for the controlled serverless bundling pass", () => {
+    expect(nitroNoExternalsForPreset("netlify")).toEqual([]);
+    expect(nitroNoExternalsForPreset("vercel")).toEqual([]);
+    expect(nitroNoExternalsForPreset("aws-lambda")).toEqual([]);
     expect(nitroNoExternalsForPreset("node-server")).toEqual(["yjs"]);
   });
 
   it("bundles every dependency for edge output", () => {
     expect(nitroNoExternalsForPreset("cloudflare-pages")).toBe(true);
     expect(nitroNoExternalsForPreset("deno-deploy")).toBe(true);
+  });
+});
+
+describe("resolveNitroBundledYjsEntry", () => {
+  it("resolves the complete core-owned ESM export surface", () => {
+    const entry = resolveNitroBundledYjsEntry();
+    expect(entry).toMatch(/[/\\]yjs[/\\]dist[/\\]yjs\.mjs$/);
+    expect(fs.readFileSync(entry, "utf-8")).toMatch(
+      /YText as Text[\s\S]*UndoManager[\s\S]*YXmlElement as XmlElement/,
+    );
   });
 });
 
@@ -1696,7 +1707,29 @@ describe("durable-background Netlify function emit (single-template, flag-gated)
     );
   });
 
-  it("rewrites bare Yjs imports to the bundled server copy", () => {
+  it("fails deploy output wired to Nitro's private tree-shaken Yjs chunk", () => {
+    const cwd = setupNetlifyOutput();
+    prepareSingleTemplateNetlifyOutput(cwd);
+    const serverChunk = path.join(
+      cwd,
+      ".netlify",
+      "functions-internal",
+      "server",
+      "_chunks",
+      "server3.mjs",
+    );
+    fs.mkdirSync(path.dirname(serverChunk), { recursive: true });
+    fs.writeFileSync(
+      serverChunk,
+      'import { Text } from "../_libs/yjs.mjs";\nexport { Text };\n',
+    );
+
+    expect(() => assertSingleTemplateNetlifyBuildOutput(cwd)).toThrow(
+      /internal tree-shaken _libs\/yjs\.mjs/,
+    );
+  });
+
+  it("bundles one complete Yjs runtime for every serverless consumer", async () => {
     const cwd = setupNetlifyOutput();
     const serverDir = path.join(
       cwd,
@@ -1705,18 +1738,39 @@ describe("durable-background Netlify function emit (single-template, flag-gated)
       "server",
     );
     const collabChunk = path.join(serverDir, "_chunks", "collab.mjs");
+    const editorChunk = path.join(serverDir, "_chunks", "editor.mjs");
     fs.mkdirSync(path.dirname(collabChunk), { recursive: true });
     fs.writeFileSync(
       collabChunk,
-      'import * as Y from "yjs";\nconst dynamic = import("yjs");\nexport { Y, dynamic };\n',
+      'import * as Y from "yjs";\nexport { Y };\nexport const doc = new Y.Doc();\n',
+    );
+    fs.writeFileSync(
+      editorChunk,
+      'import { Text, UndoManager } from "yjs";\nexport { Text, UndoManager };\n',
     );
 
-    expect(rewriteBareYjsImportsForServerlessOutput(serverDir)).toEqual([
+    expect(bundleYjsRuntimeForServerlessOutput(serverDir)).toEqual([
       collabChunk,
+      editorChunk,
     ]);
-    const rewritten = fs.readFileSync(collabChunk, "utf-8");
-    expect(rewritten).toContain('from "../_libs/yjs.mjs"');
-    expect(rewritten).toContain('import("../_libs/yjs.mjs")');
+    const runtime = fs.readFileSync(
+      path.join(serverDir, "_libs", "yjs-runtime.mjs"),
+      "utf-8",
+    );
+    expect(runtime).toMatch(/Text/);
+    expect(runtime).toMatch(/UndoManager/);
+    expect(fs.readFileSync(collabChunk, "utf-8")).toContain(
+      'from "../_libs/yjs-runtime.mjs"',
+    );
+    expect(fs.readFileSync(editorChunk, "utf-8")).toContain(
+      'from "../_libs/yjs-runtime.mjs"',
+    );
+    const [collab, editor] = await Promise.all([
+      import(`${pathToFileURL(collabChunk).href}?t=${Date.now()}`),
+      import(`${pathToFileURL(editorChunk).href}?t=${Date.now()}`),
+    ]);
+    expect(collab.Y.Text).toBe(editor.Text);
+    expect(collab.doc.getText("x")).toBeInstanceOf(editor.Text);
     prepareSingleTemplateNetlifyOutput(cwd);
     expect(() => assertSingleTemplateNetlifyBuildOutput(cwd)).not.toThrow();
   });
@@ -1736,7 +1790,7 @@ describe("durable-background Netlify function emit (single-template, flag-gated)
       'import * as Y from "yjs/src/index.js";\nexport { Y };\n',
     );
 
-    expect(() => rewriteBareYjsImportsForServerlessOutput(serverDir)).toThrow(
+    expect(() => bundleYjsRuntimeForServerlessOutput(serverDir)).toThrow(
       /unsupported yjs subpath imports/,
     );
   });

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -1749,7 +1749,7 @@ describe("durable-background Netlify function emit (single-template, flag-gated)
       'import { Text, UndoManager } from "yjs";\nexport { Text, UndoManager };\n',
     );
 
-    expect(bundleYjsRuntimeForServerlessOutput(serverDir)).toEqual([
+    expect(bundleYjsRuntimeForServerlessOutput(serverDir, cwd)).toEqual([
       collabChunk,
       editorChunk,
     ]);
@@ -1790,7 +1790,7 @@ describe("durable-background Netlify function emit (single-template, flag-gated)
       'import * as Y from "yjs/src/index.js";\nexport { Y };\n',
     );
 
-    expect(() => bundleYjsRuntimeForServerlessOutput(serverDir)).toThrow(
+    expect(() => bundleYjsRuntimeForServerlessOutput(serverDir, cwd)).toThrow(
       /unsupported yjs subpath imports/,
     );
   });

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -2543,6 +2543,7 @@ function walkServerJavaScriptFiles(
  */
 export function bundleYjsRuntimeForServerlessOutput(
   serverDir: string,
+  projectCwd: string,
 ): string[] {
   const bareImports: string[] = [];
   const unsupportedSubpathImports: string[] = [];
@@ -2577,7 +2578,7 @@ export function bundleYjsRuntimeForServerlessOutput(
       "--minify",
       `--outfile=${bundledYjsPath}`,
     ],
-    { cwd, stdio: "pipe" },
+    { cwd: projectCwd, stdio: "pipe" },
   );
 
   for (const filePath of bareImports) {
@@ -3406,7 +3407,7 @@ export default bundle;
     copyInstalledResvgPackages(nitro.options.output.serverDir);
     copyInstalledFfmpegStaticPackage(nitro.options.output.serverDir);
     sanitizeServerlessFunctionPackageManifest(nitro.options.output.serverDir);
-    bundleYjsRuntimeForServerlessOutput(nitro.options.output.serverDir);
+    bundleYjsRuntimeForServerlessOutput(nitro.options.output.serverDir, cwd);
   }
 
   // Durable background agent runs (default-OFF / opt-in; enable with a truthy

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -2535,17 +2535,17 @@ function walkServerJavaScriptFiles(
 }
 
 /**
- * Nitro can preserve Vite's `yjs` external in a split server chunk even when
- * its own server build has emitted `_libs/yjs.mjs`. Netlify does not install
- * that bare package at runtime, so make every emitted server chunk use the
- * bundled copy before its function is packaged.
+ * Nitro receives the React Router SSR build as prebuilt chunks, so its normal
+ * dependency resolver cannot reliably fold the preserved bare `yjs` imports
+ * into the same module instance used by core's server collaboration code.
+ * Keep Yjs external through Nitro, bundle its complete public ESM surface once,
+ * then point every emitted server chunk at that one portable runtime module.
  */
-export function rewriteBareYjsImportsForServerlessOutput(
+export function bundleYjsRuntimeForServerlessOutput(
   serverDir: string,
 ): string[] {
   const bareImports: string[] = [];
   const unsupportedSubpathImports: string[] = [];
-  const bundledYjsPath = path.join(serverDir, "_libs", "yjs.mjs");
 
   walkServerJavaScriptFiles(serverDir, (filePath) => {
     const source = fs.readFileSync(filePath, "utf-8");
@@ -2563,11 +2563,22 @@ export function rewriteBareYjsImportsForServerlessOutput(
     );
   }
   if (bareImports.length === 0) return [];
-  if (!fs.existsSync(bundledYjsPath)) {
-    throw new Error(
-      `[deploy] Serverless output left yjs as a runtime import but did not emit ${bundledYjsPath}`,
-    );
-  }
+
+  const bundledYjsPath = path.join(serverDir, "_libs", "yjs-runtime.mjs");
+  fs.mkdirSync(path.dirname(bundledYjsPath), { recursive: true });
+  execFileSync(
+    findEsbuild(),
+    [
+      resolveNitroBundledYjsEntry(),
+      "--bundle",
+      "--format=esm",
+      "--platform=node",
+      "--target=node22",
+      "--minify",
+      `--outfile=${bundledYjsPath}`,
+    ],
+    { cwd, stdio: "pipe" },
+  );
 
   for (const filePath of bareImports) {
     const bundledImport = path
@@ -2699,6 +2710,26 @@ export function assertSingleTemplateNetlifyBuildOutput(
   if (bareYjsImports.length > 0) {
     failures.push(
       `Netlify server bundle leaves yjs as a runtime import: ${bareYjsImports.join(", ")}`,
+    );
+  }
+
+  // Nitro's `_libs/yjs.mjs` is a private tree-shaken chunk, not a package
+  // facade. Repointing a prebuilt SSR chunk at it can request public exports
+  // (notably `Text`) that the private chunk did not retain. The controlled
+  // serverless pass must instead target the complete `yjs-runtime.mjs` bundle.
+  const privateYjsImports: string[] = [];
+  walkServerJavaScriptFiles(serverDir, (filePath) => {
+    if (
+      /\b(?:from\s*|import\s*\(\s*|import\s*)(["'])[^"']*_libs\/yjs\.mjs\1/.test(
+        fs.readFileSync(filePath, "utf-8"),
+      )
+    ) {
+      privateYjsImports.push(path.relative(projectCwd, filePath));
+    }
+  });
+  if (privateYjsImports.length > 0) {
+    failures.push(
+      `Netlify server bundle imports Nitro's internal tree-shaken _libs/yjs.mjs: ${privateYjsImports.join(", ")}`,
     );
   }
 
@@ -3153,17 +3184,26 @@ const BROWSER_ONLY_SERVER_LIBS = [
 ];
 
 /**
- * Dependencies that must be bundled into every Nitro server output instead of
- * being left as runtime package imports.
- *
- * `yjs` is a direct core dependency, but it is deliberately externalized from
- * the intermediate Vite SSR graph so that Vite and Nitro do not create two
- * incompatible Yjs constructors. On file-traced serverless presets, leaving it
- * external at Nitro's final build can emit `import "yjs"` into a function
- * chunk without placing the package in that function's `node_modules`. Bundle
- * it in Nitro's final output so every template receives the one portable copy.
+ * Dependencies Nitro itself must bundle outside the controlled serverless
+ * output pass. Netlify, Vercel, and Lambda keep Yjs external through Nitro;
+ * `bundleYjsRuntimeForServerlessOutput` then creates their one portable copy.
  */
 export const NITRO_SERVER_RUNTIME_BUNDLED_DEPS = ["yjs"] as const;
+
+/**
+ * Locate the core-owned ESM entry used by the controlled serverless bundling
+ * pass. Resolving from this module keeps the build independent of whether a
+ * template exposes core's transitive Yjs dependency at its own package root.
+ */
+export function resolveNitroBundledYjsEntry(): string {
+  const requireFromCore = createRequire(import.meta.url);
+  const packageDir = path.dirname(requireFromCore.resolve("yjs/package.json"));
+  const entry = path.join(packageDir, "dist", "yjs.mjs");
+  if (!fs.existsSync(entry)) {
+    throw new Error(`[build] Could not resolve the Yjs ESM entry at ${entry}`);
+  }
+  return entry;
+}
 
 /**
  * Edge runtimes have no node_modules, while Node/serverless outputs only need
@@ -3175,7 +3215,11 @@ export function nitroNoExternalsForPreset(
   return targetPreset.startsWith("cloudflare") ||
     targetPreset.startsWith("deno")
     ? true
-    : NITRO_SERVER_RUNTIME_BUNDLED_DEPS;
+    : targetPreset === "netlify" ||
+        targetPreset === "vercel" ||
+        targetPreset === "aws-lambda"
+      ? []
+      : NITRO_SERVER_RUNTIME_BUNDLED_DEPS;
 }
 
 /**
@@ -3327,6 +3371,14 @@ export default bundle;
     // (ReferenceError: window is not defined → every request 502s). Mirrors the
     // Vite `ssrStubPlugin`, which only covers the `build/server` step.
     rollupConfig: {
+      // Nitro treats the intermediate React Router SSR files as prebuilt
+      // chunks, while core's server collaboration files participate in the
+      // final Rolldown graph. Externalize Yjs consistently on serverless so
+      // both graphs retain their public import shapes; the controlled
+      // post-build pass below bundles and rewrites them to one module.
+      ...(preset === "netlify" || preset === "vercel" || preset === "aws-lambda"
+        ? { external: ["yjs"] }
+        : {}),
       plugins: [createBrowserOnlyServerStubPlugin()],
     },
     ...(providedPluginsNitroPlugin
@@ -3334,9 +3386,9 @@ export default bundle;
       : {}),
     routeRules: mcpEmbedStaticAssetRouteRules(appBasePath),
     // Edge presets (cloudflare, deno) bundle all deps because node_modules are
-    // unavailable at runtime. Node/serverless presets also bundle Yjs: Nitro's
-    // file tracer otherwise leaves a bare import that Netlify function bundles
-    // cannot resolve under pnpm.
+    // unavailable at runtime. Ordinary Node presets bundle Yjs through Nitro.
+    // Controlled serverless presets externalize it above, then emit one full
+    // runtime module after Nitro has preserved every consumer's public imports.
     noExternals: nitroNoExternalsForPreset(preset),
   } as any);
 
@@ -3354,7 +3406,7 @@ export default bundle;
     copyInstalledResvgPackages(nitro.options.output.serverDir);
     copyInstalledFfmpegStaticPackage(nitro.options.output.serverDir);
     sanitizeServerlessFunctionPackageManifest(nitro.options.output.serverDir);
-    rewriteBareYjsImportsForServerlessOutput(nitro.options.output.serverDir);
+    bundleYjsRuntimeForServerlessOutput(nitro.options.output.serverDir);
   }
 
   // Durable background agent runs (default-OFF / opt-in; enable with a truthy

--- a/templates/chat/changelog/2026-07-14-chat-opens-reliably-on-hosted-deployments-instead-of-failing.md
+++ b/templates/chat/changelog/2026-07-14-chat-opens-reliably-on-hosted-deployments-instead-of-failing.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-14
+---
+
+Chat opens reliably on hosted deployments instead of failing during startup

--- a/templates/clips/app/components/player/media-duration.test.ts
+++ b/templates/clips/app/components/player/media-duration.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveMediaDurationMs } from "./media-duration";
+
+describe("resolveMediaDurationMs", () => {
+  it("uses playable media duration when stored metadata counted a pause", () => {
+    expect(resolveMediaDurationMs(461_772, 80.576)).toBe(80_576);
+  });
+
+  it("keeps recorder metadata within normal MediaRecorder drift", () => {
+    expect(resolveMediaDurationMs(80_000, 78.4)).toBe(80_000);
+  });
+
+  it("falls back to whichever valid duration is available", () => {
+    expect(resolveMediaDurationMs(0, 12.345)).toBe(12_345);
+    expect(resolveMediaDurationMs(12_345, Number.POSITIVE_INFINITY)).toBe(
+      12_345,
+    );
+  });
+});

--- a/templates/clips/app/components/player/media-duration.ts
+++ b/templates/clips/app/components/player/media-duration.ts
@@ -1,0 +1,24 @@
+const MEDIARECORDER_DURATION_DRIFT_MS = 3_000;
+
+function finitePositiveMs(value: number): number {
+  return Number.isFinite(value) && value > 0 ? Math.round(value) : 0;
+}
+
+/**
+ * Prefer recorder metadata for normal MediaRecorder timeslice drift, but use
+ * the playable media's duration when the two values clearly describe
+ * different timelines (for example, metadata that accidentally counted a
+ * long pause).
+ */
+export function resolveMediaDurationMs(
+  recordedDurationMs: number,
+  mediaDurationSeconds: number,
+): number {
+  const recordedMs = finitePositiveMs(recordedDurationMs);
+  const mediaMs = finitePositiveMs(mediaDurationSeconds * 1000);
+  if (mediaMs === 0) return recordedMs;
+  if (recordedMs === 0) return mediaMs;
+  return Math.abs(recordedMs - mediaMs) > MEDIARECORDER_DURATION_DRIFT_MS
+    ? mediaMs
+    : recordedMs;
+}

--- a/templates/clips/app/components/player/video-player.tsx
+++ b/templates/clips/app/components/player/video-player.tsx
@@ -19,6 +19,7 @@ import {
   useState,
 } from "react";
 
+import { resolveMediaDurationMs } from "@/components/player/media-duration";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -824,22 +825,16 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       durationProbedRef.current = false;
     }, [activeVideoSrc, durationMs]);
 
-    // The recorder's elapsed-time counter (durationMs prop) is the most
-    // trustworthy length we have. A MediaRecorder WebM's own duration is
-    // cluster-estimated and lands short by up to one timeslice, so we never
-    // let it overwrite a real prop — doing so makes the scrubber jump to a
-    // shorter length than the actual recording on first watch.
-    const hasReliableDurationProp =
-      Number.isFinite(durationMs) && durationMs > 0;
-
+    // Prefer the recorder's elapsed-time counter for ordinary WebM timeslice
+    // drift, but let clearly different playable-media metadata win. This also
+    // repairs playback controls for older clips whose stored duration counted
+    // time spent paused.
     const probeDurationIfNeeded = useCallback(
       (v: HTMLVideoElement) => {
         if (durationProbedRef.current) return;
         if (Number.isFinite(v.duration) && v.duration > 0) {
           durationProbedRef.current = true;
-          if (!hasReliableDurationProp) {
-            setResolvedDurationMs(Math.round(v.duration * 1000));
-          }
+          setResolvedDurationMs(resolveMediaDurationMs(durationMs, v.duration));
           return;
         }
         if (playAttemptPendingRef.current || !v.paused) return;
@@ -855,7 +850,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
           // picks up the real duration.
         }
       },
-      [hasReliableDurationProp],
+      [durationMs],
     );
 
     // Resolve the WebM-duration-is-Infinity Chrome quirk: when a video created
@@ -873,11 +868,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
 
       const onDurationChange = () => {
         if (Number.isFinite(v.duration) && v.duration > 0) {
-          // Don't downgrade a trustworthy recorder duration to the
-          // cluster-estimated WebM duration; only adopt it as a fallback.
-          if (!hasReliableDurationProp) {
-            setResolvedDurationMs(Math.round(v.duration * 1000));
-          }
+          setResolvedDurationMs(resolveMediaDurationMs(durationMs, v.duration));
           // After we've resolved the real duration, rewind back to 0 so the
           // user isn't sitting at the end of the clip.
           if (durationProbedRef.current && v.currentTime > v.duration) {
@@ -900,7 +891,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
         v.removeEventListener("loadedmetadata", onLoadedMetadata);
         v.removeEventListener("durationchange", onDurationChange);
       };
-    }, [activeVideoSrc, hasReliableDurationProp, probeDurationIfNeeded]);
+    }, [activeVideoSrc, durationMs, probeDurationIfNeeded]);
 
     // Reset the thumbnail-capture flag when the source changes (e.g. the
     // player is reused for a different recording via React Router).

--- a/templates/clips/changelog/2026-07-14-paused-time-no-longer-counts-toward-chrome-extension-recordi.md
+++ b/templates/clips/changelog/2026-07-14-paused-time-no-longer-counts-toward-chrome-extension-recordi.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-14
+---
+
+Paused time no longer counts toward Chrome extension recording durations.

--- a/templates/clips/chrome-extension/src/offscreen.ts
+++ b/templates/clips/chrome-extension/src/offscreen.ts
@@ -36,6 +36,13 @@ import {
 import { MAX_UPLOAD_BYTES } from "@shared/upload-limits";
 
 import { waitForReadyRecordingAfterFinalizeError } from "./finalize-recovery";
+import {
+  createRecordingDurationState,
+  pauseRecordingDuration,
+  resumeRecordingDuration,
+  startRecordingDuration,
+  type RecordingDurationState,
+} from "./recording-duration";
 import { captureExtensionError, initExtensionSentry } from "./sentry";
 
 initExtensionSentry("offscreen");
@@ -187,6 +194,7 @@ type ActiveRecording = {
   authToken: string | null;
   mode: CaptureMode;
   startedAtMs: number;
+  duration: RecordingDurationState;
   mimeType: string;
   recorder: MediaRecorder;
   outputStream: MediaStream;
@@ -1218,6 +1226,7 @@ async function begin(message: BeginMessage): Promise<{
     authToken: message.authToken ?? null,
     mode: ready.mode,
     startedAtMs: 0,
+    duration: createRecordingDurationState(),
     mimeType,
     recorder,
     outputStream,
@@ -1350,6 +1359,7 @@ function startRecorderNow(recording: ActiveRecording): void {
     playStartChime();
     recording.recorder.start(2000);
     recording.startedAtMs = Date.now();
+    recording.duration = startRecordingDuration(recording.startedAtMs);
     console.log("[clips-offscreen] recorder.start ok");
     reportStatus(recording.sessionId, "recording", {
       recordingId: recording.recordingId,
@@ -1446,6 +1456,11 @@ async function finalizeStop(recording: ActiveRecording): Promise<void> {
     recording.resolveStopped({ ok: true, status: "cancelled" });
     return;
   }
+  // Freeze the media duration as soon as MediaRecorder stops. Waiting for
+  // outstanding uploads below must not make the clip appear longer, and time
+  // spent paused is excluded by pauseRecordingDuration().
+  recording.duration = pauseRecordingDuration(recording.duration, Date.now());
+  const durationMs = recording.duration.elapsedMs;
   reportStatus(recording.sessionId, "uploading", {
     recordingId: recording.recordingId,
   });
@@ -1460,7 +1475,6 @@ async function finalizeStop(recording: ActiveRecording): Promise<void> {
         ? rejected.reason
         : new Error(String(rejected.reason));
     }
-    const durationMs = Math.max(0, Date.now() - recording.startedAtMs);
     // Surface WHY a finalize might fail before the server's cryptic "No chunks
     // found": 0 chunks means the recorder emitted no non-empty data (empty
     // capture / never started), which is a different problem than an auth 401.
@@ -1549,7 +1563,7 @@ async function finalizeStop(recording: ActiveRecording): Promise<void> {
         recordingId: recording.recordingId,
         chunkCount: recording.chunkIndex,
         mimeType: recording.mimeType,
-        durationMs: Math.max(0, Date.now() - recording.startedAtMs),
+        durationMs,
       },
     });
     // The upload failed — save the buffered recording to disk so it isn't lost.
@@ -1574,7 +1588,13 @@ async function finalizeStop(recording: ActiveRecording): Promise<void> {
 function pause(message: SimpleMessage): { ok: boolean } {
   const recording = activeRecording;
   if (recording && recording.sessionId === message.sessionId) {
-    if (recording.recorder.state === "recording") recording.recorder.pause();
+    if (recording.recorder.state === "recording") {
+      recording.recorder.pause();
+      recording.duration = pauseRecordingDuration(
+        recording.duration,
+        Date.now(),
+      );
+    }
     reportStatus(recording.sessionId, "paused", {
       recordingId: recording.recordingId,
     });
@@ -1585,7 +1605,13 @@ function pause(message: SimpleMessage): { ok: boolean } {
 function resume(message: SimpleMessage): { ok: boolean } {
   const recording = activeRecording;
   if (recording && recording.sessionId === message.sessionId) {
-    if (recording.recorder.state === "paused") recording.recorder.resume();
+    if (recording.recorder.state === "paused") {
+      recording.recorder.resume();
+      recording.duration = resumeRecordingDuration(
+        recording.duration,
+        Date.now(),
+      );
+    }
     reportStatus(recording.sessionId, "recording", {
       recordingId: recording.recordingId,
     });

--- a/templates/clips/chrome-extension/src/recording-duration.test.ts
+++ b/templates/clips/chrome-extension/src/recording-duration.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createRecordingDurationState,
+  pauseRecordingDuration,
+  resumeRecordingDuration,
+  startRecordingDuration,
+} from "./recording-duration";
+
+describe("recording duration", () => {
+  it("excludes time spent paused", () => {
+    let state = startRecordingDuration(1_000);
+    state = pauseRecordingDuration(state, 31_000);
+    state = resumeRecordingDuration(state, 391_000);
+    state = pauseRecordingDuration(state, 441_000);
+
+    expect(state).toEqual({ elapsedMs: 80_000, activeSinceMs: null });
+  });
+
+  it("freezes duration when recording stops so upload time is excluded", () => {
+    let state = startRecordingDuration(1_000);
+    state = pauseRecordingDuration(state, 81_000);
+
+    const afterUploadDrain = pauseRecordingDuration(state, 111_000);
+    expect(afterUploadDrain.elapsedMs).toBe(80_000);
+  });
+
+  it("keeps the elapsed duration when stopping while already paused", () => {
+    let state = startRecordingDuration(1_000);
+    state = pauseRecordingDuration(state, 41_000);
+
+    state = pauseRecordingDuration(state, 401_000);
+    expect(state.elapsedMs).toBe(40_000);
+  });
+
+  it("ignores duplicate transitions and backward clock movement", () => {
+    let state = createRecordingDurationState();
+    state = resumeRecordingDuration(state, 2_000);
+    state = resumeRecordingDuration(state, 3_000);
+    state = pauseRecordingDuration(state, 1_000);
+
+    expect(state).toEqual({ elapsedMs: 0, activeSinceMs: null });
+  });
+});

--- a/templates/clips/chrome-extension/src/recording-duration.ts
+++ b/templates/clips/chrome-extension/src/recording-duration.ts
@@ -1,0 +1,32 @@
+export type RecordingDurationState = {
+  elapsedMs: number;
+  activeSinceMs: number | null;
+};
+
+export function createRecordingDurationState(): RecordingDurationState {
+  return { elapsedMs: 0, activeSinceMs: null };
+}
+
+export function startRecordingDuration(nowMs: number): RecordingDurationState {
+  return { elapsedMs: 0, activeSinceMs: nowMs };
+}
+
+export function pauseRecordingDuration(
+  state: RecordingDurationState,
+  nowMs: number,
+): RecordingDurationState {
+  if (state.activeSinceMs === null) return state;
+  return {
+    elapsedMs:
+      state.elapsedMs + Math.max(0, Math.round(nowMs - state.activeSinceMs)),
+    activeSinceMs: null,
+  };
+}
+
+export function resumeRecordingDuration(
+  state: RecordingDurationState,
+  nowMs: number,
+): RecordingDurationState {
+  if (state.activeSinceMs !== null) return state;
+  return { ...state, activeSinceMs: nowMs };
+}

--- a/templates/slides/actions/_uploaded-files.test.ts
+++ b/templates/slides/actions/_uploaded-files.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockExistsSync = vi.hoisted(() => vi.fn());
+const mockReadFile = vi.hoisted(() => vi.fn());
+const mockReadUploadedReferenceBlob = vi.hoisted(() => vi.fn());
+
+vi.mock("fs", () => ({
+  default: {
+    existsSync: (...args: unknown[]) => mockExistsSync(...args),
+    promises: {
+      readFile: (...args: unknown[]) => mockReadFile(...args),
+    },
+  },
+}));
+
+vi.mock("@agent-native/core/server/request-context", () => ({
+  getRequestUserEmail: () => "owner@example.com",
+}));
+
+vi.mock("../server/lib/tenant-files.js", () => ({
+  tenantUploadDir: () => "/uploads/owner",
+}));
+
+vi.mock("../server/lib/uploaded-reference-storage.js", () => ({
+  readUploadedReferenceBlob: (...args: unknown[]) =>
+    mockReadUploadedReferenceBlob(...args),
+}));
+
+import { readUserUploadedFile } from "./_uploaded-files";
+
+describe("readUserUploadedFile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReadUploadedReferenceBlob.mockResolvedValue(null);
+  });
+
+  it("returns durable hosted upload bytes without touching local files", async () => {
+    mockReadUploadedReferenceBlob.mockResolvedValue({
+      data: Buffer.from("pptx"),
+      filename: "deck.pptx",
+    });
+
+    await expect(
+      readUserUploadedFile("slides-upload:v1:opaque"),
+    ).resolves.toEqual({ data: Buffer.from("pptx"), filename: "deck.pptx" });
+    expect(mockExistsSync).not.toHaveBeenCalled();
+  });
+
+  it("reads an authenticated user's local upload", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFile.mockResolvedValue(Buffer.from("local"));
+
+    await expect(
+      readUserUploadedFile("/uploads/owner/deck.pptx"),
+    ).resolves.toEqual({ data: Buffer.from("local"), filename: "deck.pptx" });
+  });
+
+  it("rejects local path traversal before reading", async () => {
+    await expect(
+      readUserUploadedFile("/uploads/other/deck.pptx"),
+    ).rejects.toThrow("Access denied");
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+});

--- a/templates/slides/actions/_uploaded-files.ts
+++ b/templates/slides/actions/_uploaded-files.ts
@@ -4,10 +4,18 @@ import path from "path";
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 
 import { tenantUploadDir } from "../server/lib/tenant-files.js";
+import { readUploadedReferenceBlob } from "../server/lib/uploaded-reference-storage.js";
 
-export function resolveUserUploadedFile(filePath: string): string {
+export async function readUserUploadedFile(
+  filePath: string,
+): Promise<{ data: Buffer; filename: string }> {
   const email = getRequestUserEmail();
   if (!email) throw new Error("no authenticated user");
+
+  const privateUpload = await readUploadedReferenceBlob(filePath, email);
+  if (privateUpload) {
+    return privateUpload;
+  }
 
   const allowedDir = tenantUploadDir(email);
   const absPath = path.isAbsolute(filePath)
@@ -23,5 +31,8 @@ export function resolveUserUploadedFile(filePath: string): string {
   if (!fs.existsSync(resolved)) {
     throw new Error(`File not found: ${filePath}`);
   }
-  return resolved;
+  return {
+    data: await fs.promises.readFile(resolved),
+    filename: path.basename(resolved),
+  };
 }

--- a/templates/slides/actions/import-docx.ts
+++ b/templates/slides/actions/import-docx.ts
@@ -1,11 +1,9 @@
-import fs from "fs";
-
 import { defineAction } from "@agent-native/core";
 import { z } from "zod";
 
 import { parseDocx } from "../server/handlers/import/docx-parser.js";
 import { convertSectionsToSlides } from "../server/handlers/import/html-converter.js";
-import { resolveUserUploadedFile } from "./_uploaded-files.js";
+import { readUserUploadedFile } from "./_uploaded-files.js";
 
 export default defineAction({
   description:
@@ -16,9 +14,7 @@ export default defineAction({
   schema: z.object({
     filePath: z
       .string()
-      .describe(
-        "Server path to the uploaded DOCX file (e.g. data/uploads/document.docx)",
-      ),
+      .describe("Uploaded DOCX path or opaque hosted upload reference"),
     convertToSlides: z
       .boolean()
       .optional()
@@ -28,9 +24,7 @@ export default defineAction({
       ),
   }),
   run: async ({ filePath, convertToSlides }) => {
-    const absPath = resolveUserUploadedFile(filePath);
-
-    const fileBuffer = await fs.promises.readFile(absPath);
+    const { data: fileBuffer } = await readUserUploadedFile(filePath);
     const doc = await parseDocx(fileBuffer);
 
     const result: Record<string, unknown> = {

--- a/templates/slides/actions/import-file.test.ts
+++ b/templates/slides/actions/import-file.test.ts
@@ -1,25 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockReadFile = vi.hoisted(() => vi.fn());
+const mockReadUserUploadedFile = vi.hoisted(() => vi.fn());
 const mockPdfText = vi.hoisted(() => vi.fn());
 const mockStartBuilderDesignSystemIndex = vi.hoisted(() => vi.fn());
 const mockGetRequestUserEmail = vi.hoisted(() => vi.fn());
 const mockGetRequestOrgId = vi.hoisted(() => vi.fn());
 const mockUpsertBuilderProxyDesignSystem = vi.hoisted(() => vi.fn());
-
-vi.mock("fs", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("fs")>();
-  return {
-    ...actual,
-    default: {
-      ...actual.default,
-      promises: {
-        ...actual.default.promises,
-        readFile: (...args: unknown[]) => mockReadFile(...args),
-      },
-    },
-  };
-});
 
 vi.mock("pdf-parse", () => ({
   PDFParse: class {
@@ -30,7 +16,8 @@ vi.mock("pdf-parse", () => ({
 }));
 
 vi.mock("./_uploaded-files.js", () => ({
-  resolveUserUploadedFile: (filePath: string) => `/uploads/${filePath}`,
+  readUserUploadedFile: (...args: unknown[]) =>
+    mockReadUserUploadedFile(...args),
 }));
 
 vi.mock("../server/db/index.js", () => ({
@@ -69,7 +56,10 @@ import action from "./import-file";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockReadFile.mockResolvedValue(Buffer.from("%PDF-1.7\n"));
+  mockReadUserUploadedFile.mockImplementation(async (filePath: string) => ({
+    data: Buffer.from("%PDF-1.7\n"),
+    filename: filePath,
+  }));
   mockStartBuilderDesignSystemIndex.mockResolvedValue({
     ok: true,
     source: "builder",
@@ -153,7 +143,10 @@ describe("import-file PDF source extraction", () => {
     const figBuffer = Buffer.from([
       0x66, 0x69, 0x67, 0x2d, 0x6b, 0x69, 0x77, 0x69, 0, 0, 0, 0,
     ]);
-    mockReadFile.mockResolvedValue(figBuffer);
+    mockReadUserUploadedFile.mockResolvedValue({
+      data: figBuffer,
+      filename: "brand.fig",
+    });
 
     const result = (await action.run({
       filePath: "brand.fig",

--- a/templates/slides/actions/import-file.ts
+++ b/templates/slides/actions/import-file.ts
@@ -1,4 +1,3 @@
-import fs from "fs";
 import path from "path";
 
 import { defineAction } from "@agent-native/core";
@@ -15,7 +14,7 @@ import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { notifyClients } from "../server/handlers/decks.js";
 import { upsertBuilderProxyDesignSystem } from "../server/lib/builder-design-system-proxy.js";
-import { resolveUserUploadedFile } from "./_uploaded-files.js";
+import { readUserUploadedFile } from "./_uploaded-files.js";
 
 const DEFAULT_MAX_SOURCE_CHARS = 60_000;
 
@@ -30,9 +29,7 @@ export default defineAction({
   schema: z.object({
     filePath: z
       .string()
-      .describe(
-        "Server path to the uploaded file (e.g. data/uploads/file.pptx)",
-      ),
+      .describe("Uploaded file path or opaque hosted upload reference"),
     format: z
       .enum(["pptx", "docx", "pdf", "fig", "auto"])
       .optional()
@@ -60,15 +57,15 @@ export default defineAction({
       ),
   }),
   run: async ({ filePath, format, deckId, importIntoDeck, maxChars }) => {
-    const absPath = resolveUserUploadedFile(filePath);
+    const uploaded = await readUserUploadedFile(filePath);
     const sourceLimit = maxChars ?? DEFAULT_MAX_SOURCE_CHARS;
-
-    const fileBuffer = await fs.promises.readFile(absPath);
+    const fileBuffer = uploaded.data;
+    const filename = uploaded.filename;
 
     // Detect format from extension if auto
     let detectedFormat = format;
     if (detectedFormat === "auto") {
-      const ext = path.extname(absPath).toLowerCase();
+      const ext = path.extname(filename).toLowerCase();
       if (ext === ".pptx") detectedFormat = "pptx";
       else if (ext === ".docx") detectedFormat = "docx";
       else if (ext === ".pdf") detectedFormat = "pdf";
@@ -86,12 +83,12 @@ export default defineAction({
           "Figma .fig imports start Builder design-system indexing, not slide replacements. Re-run without importIntoDeck.",
         );
       }
-      const title = titleFromPath(absPath);
+      const title = titleFromPath(filename);
       const result = await startBuilderDesignSystemIndex({
         projectName: title,
         files: [
           {
-            name: path.basename(absPath),
+            name: path.basename(filename),
             data: fileBuffer,
             mimeType: "application/octet-stream",
           },
@@ -126,7 +123,7 @@ export default defineAction({
       const { convertToSlideHtml } =
         await import("../server/handlers/import/html-converter.js");
       const presentation = await parsePptx(fileBuffer);
-      const title = presentation.title || titleFromPath(absPath);
+      const title = presentation.title || titleFromPath(filename);
 
       if (importIntoDeck) {
         if (!deckId) throw new Error("deckId is required to import into deck");
@@ -172,7 +169,7 @@ export default defineAction({
         await import("../server/handlers/import/html-converter.js");
       const doc = await parseDocx(fileBuffer);
       const slideHtmlArray = convertSectionsToSlides(doc.sections);
-      const title = doc.title || titleFromPath(absPath);
+      const title = doc.title || titleFromPath(filename);
 
       if (importIntoDeck) {
         if (!deckId) throw new Error("deckId is required to import into deck");
@@ -221,7 +218,7 @@ export default defineAction({
       const result = await pdf.getText();
       const pages = normalizePdfPages(result);
       const textPages = pages.filter((p) => p.text.trim());
-      const title = titleFromPath(absPath);
+      const title = titleFromPath(filename);
 
       if (textPages.length === 0) {
         throw new Error(

--- a/templates/slides/actions/import-pptx.ts
+++ b/templates/slides/actions/import-pptx.ts
@@ -1,5 +1,3 @@
-import fs from "fs";
-
 import { defineAction } from "@agent-native/core";
 import { writeAppState } from "@agent-native/core/application-state";
 import {
@@ -15,7 +13,7 @@ import { notifyClients } from "../server/handlers/decks.js";
 import { convertToSlideHtml } from "../server/handlers/import/html-converter.js";
 import { parsePptx } from "../server/handlers/import/pptx-parser.js";
 import { getDeckUrl } from "./_app-url.js";
-import { resolveUserUploadedFile } from "./_uploaded-files.js";
+import { readUserUploadedFile } from "./_uploaded-files.js";
 
 export default defineAction({
   description:
@@ -26,9 +24,7 @@ export default defineAction({
   schema: z.object({
     filePath: z
       .string()
-      .describe(
-        "Server path to the uploaded PPTX file (e.g. data/uploads/presentation.pptx)",
-      ),
+      .describe("Uploaded PPTX path or opaque hosted upload reference"),
     deckId: z
       .string()
       .optional()
@@ -43,9 +39,7 @@ export default defineAction({
       ),
   }),
   run: async ({ filePath, deckId, title }) => {
-    const absPath = resolveUserUploadedFile(filePath);
-
-    const fileBuffer = await fs.promises.readFile(absPath);
+    const { data: fileBuffer } = await readUserUploadedFile(filePath);
     const presentation = await parsePptx(fileBuffer);
 
     const deckTitle = title || presentation.title || "Imported Presentation";

--- a/templates/slides/changelog/2026-07-14-powerpoint-template-uploads-now-work-in-hosted-slides-deploy.md
+++ b/templates/slides/changelog/2026-07-14-powerpoint-template-uploads-now-work-in-hosted-slides-deploy.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-14
+---
+
+PowerPoint template uploads now work in hosted Slides deployments.

--- a/templates/slides/server/handlers/uploads.test.ts
+++ b/templates/slides/server/handlers/uploads.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockMkdir = vi.hoisted(() => vi.fn(async () => undefined));
 const mockWriteFile = vi.hoisted(() => vi.fn(async () => undefined));
+const mockIsHostedSlidesRuntime = vi.hoisted(() => vi.fn(() => false));
+const mockStoreUploadedReferenceBlob = vi.hoisted(() => vi.fn());
 
 vi.mock("fs", () => ({
   default: {
@@ -14,6 +16,12 @@ vi.mock("fs", () => ({
 
 vi.mock("../lib/tenant-files.js", () => ({
   tenantUploadDir: () => "/tmp/slides-test-uploads",
+}));
+
+vi.mock("../lib/uploaded-reference-storage.js", () => ({
+  isHostedSlidesRuntime: () => mockIsHostedSlidesRuntime(),
+  storeUploadedReferenceBlob: (...args: unknown[]) =>
+    mockStoreUploadedReferenceBlob(...args),
 }));
 
 vi.mock("./assets.js", () => ({
@@ -32,6 +40,8 @@ describe("Slides reference upload limits", () => {
   beforeEach(() => {
     mockMkdir.mockClear();
     mockWriteFile.mockClear();
+    mockIsHostedSlidesRuntime.mockReturnValue(false);
+    mockStoreUploadedReferenceBlob.mockReset();
   });
 
   it("allows larger .fig files than ordinary references", () => {
@@ -78,5 +88,55 @@ describe("Slides reference upload limits", () => {
     ).rejects.toThrow("File contents do not match .fig upload type");
 
     expect(mockWriteFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("stores hosted reference uploads in durable private blob storage", async () => {
+    mockIsHostedSlidesRuntime.mockReturnValue(true);
+    mockStoreUploadedReferenceBlob.mockResolvedValue(
+      "slides-upload:v1:scoped-handle",
+    );
+    const pptx = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
+
+    await expect(
+      saveUploadedReferenceFile({
+        email: "owner@example.com",
+        orgId: "org-1",
+        originalName: "deck.pptx",
+        data: pptx,
+        type: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      }),
+    ).resolves.toMatchObject({
+      path: "slides-upload:v1:scoped-handle",
+      originalName: "deck.pptx",
+    });
+
+    expect(mockStoreUploadedReferenceBlob).toHaveBeenCalledWith({
+      data: pptx,
+      email: "owner@example.com",
+      orgId: "org-1",
+      filename: expect.stringMatching(/\.pptx$/),
+      mimeType:
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    });
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when hosted private file storage is unavailable", async () => {
+    mockIsHostedSlidesRuntime.mockReturnValue(true);
+    mockStoreUploadedReferenceBlob.mockResolvedValue(null);
+
+    await expect(
+      saveUploadedReferenceFile({
+        email: "owner@example.com",
+        originalName: "deck.pptx",
+        data: Buffer.from([0x50, 0x4b, 0x03, 0x04]),
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining(
+        "Private file storage is not configured",
+      ),
+      statusCode: 503,
+    });
+    expect(mockWriteFile).not.toHaveBeenCalled();
   });
 });

--- a/templates/slides/server/handlers/uploads.test.ts
+++ b/templates/slides/server/handlers/uploads.test.ts
@@ -139,4 +139,23 @@ describe("Slides reference upload limits", () => {
     });
     expect(mockWriteFile).not.toHaveBeenCalled();
   });
+
+  it("reports hosted private storage failures as service errors", async () => {
+    mockIsHostedSlidesRuntime.mockReturnValue(true);
+    mockStoreUploadedReferenceBlob.mockRejectedValue(
+      new Error("provider unavailable"),
+    );
+
+    await expect(
+      saveUploadedReferenceFile({
+        email: "owner@example.com",
+        originalName: "deck.pptx",
+        data: Buffer.from([0x50, 0x4b, 0x03, 0x04]),
+      }),
+    ).rejects.toMatchObject({
+      message: "Private file storage failed while saving the upload.",
+      statusCode: 503,
+    });
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
 });

--- a/templates/slides/server/handlers/uploads.test.ts
+++ b/templates/slides/server/handlers/uploads.test.ts
@@ -4,6 +4,17 @@ const mockMkdir = vi.hoisted(() => vi.fn(async () => undefined));
 const mockWriteFile = vi.hoisted(() => vi.fn(async () => undefined));
 const mockIsHostedSlidesRuntime = vi.hoisted(() => vi.fn(() => false));
 const mockStoreUploadedReferenceBlob = vi.hoisted(() => vi.fn());
+const mockReadMultipartFormData = vi.hoisted(() => vi.fn());
+const mockSetResponseStatus = vi.hoisted(() => vi.fn());
+const mockResolveSlidesRequestAuthContext = vi.hoisted(() => vi.fn());
+const mockWithSlidesRequestContext = vi.hoisted(() => vi.fn());
+
+vi.mock("h3", () => ({
+  defineEventHandler: (handler: unknown) => handler,
+  readMultipartFormData: (...args: unknown[]) =>
+    mockReadMultipartFormData(...args),
+  setResponseStatus: (...args: unknown[]) => mockSetResponseStatus(...args),
+}));
 
 vi.mock("fs", () => ({
   default: {
@@ -29,11 +40,19 @@ vi.mock("./assets.js", () => ({
   uploadImageAsset: vi.fn(),
 }));
 
+vi.mock("./request-auth-context.js", () => ({
+  resolveSlidesRequestAuthContext: (...args: unknown[]) =>
+    mockResolveSlidesRequestAuthContext(...args),
+  withSlidesRequestContext: (...args: unknown[]) =>
+    mockWithSlidesRequestContext(...args),
+}));
+
 import {
   MAX_FIG_REFERENCE_FILE_BYTES,
   MAX_REFERENCE_FILE_BYTES,
   maxReferenceFileBytes,
   saveUploadedReferenceFile,
+  uploadFiles,
 } from "./uploads";
 
 describe("Slides reference upload limits", () => {
@@ -42,6 +61,19 @@ describe("Slides reference upload limits", () => {
     mockWriteFile.mockClear();
     mockIsHostedSlidesRuntime.mockReturnValue(false);
     mockStoreUploadedReferenceBlob.mockReset();
+    mockReadMultipartFormData.mockReset();
+    mockSetResponseStatus.mockReset();
+    mockResolveSlidesRequestAuthContext.mockResolvedValue({
+      email: "owner@example.com",
+      orgId: "active-org",
+    });
+    mockWithSlidesRequestContext.mockImplementation(
+      async (
+        _event: unknown,
+        callback: (context: { email?: string; orgId?: string }) => unknown,
+        context: { email?: string; orgId?: string },
+      ) => callback(context),
+    );
   });
 
   it("allows larger .fig files than ordinary references", () => {
@@ -119,6 +151,40 @@ describe("Slides reference upload limits", () => {
         "application/vnd.openxmlformats-officedocument.presentationml.presentation",
     });
     expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("uses the live active organization when the upload route saves files", async () => {
+    mockIsHostedSlidesRuntime.mockReturnValue(true);
+    mockStoreUploadedReferenceBlob.mockResolvedValue(
+      "slides-upload:v1:scoped-handle",
+    );
+    const pptx = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
+    mockReadMultipartFormData.mockResolvedValue([
+      {
+        name: "files",
+        filename: "deck.pptx",
+        type: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        data: pptx,
+      },
+    ]);
+    const event = {} as any;
+
+    await expect(uploadFiles(event)).resolves.toEqual([
+      expect.objectContaining({ path: "slides-upload:v1:scoped-handle" }),
+    ]);
+
+    expect(mockResolveSlidesRequestAuthContext).toHaveBeenCalledWith(event);
+    expect(mockWithSlidesRequestContext).toHaveBeenCalledWith(
+      event,
+      expect.any(Function),
+      { email: "owner@example.com", orgId: "active-org" },
+    );
+    expect(mockStoreUploadedReferenceBlob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "owner@example.com",
+        orgId: "active-org",
+      }),
+    );
   });
 
   it("fails closed when hosted private file storage is unavailable", async () => {

--- a/templates/slides/server/handlers/uploads.ts
+++ b/templates/slides/server/handlers/uploads.ts
@@ -134,13 +134,21 @@ export async function saveUploadedReferenceFile(args: {
   }
   let uploadedPath: string;
   if (isHostedSlidesRuntime()) {
-    const reference = await storeUploadedReferenceBlob({
-      email: args.email,
-      orgId: args.orgId,
-      data: args.data,
-      filename,
-      mimeType: args.type || "application/octet-stream",
-    });
+    let reference: string | null;
+    try {
+      reference = await storeUploadedReferenceBlob({
+        email: args.email,
+        orgId: args.orgId,
+        data: args.data,
+        filename,
+        mimeType: args.type || "application/octet-stream",
+      });
+    } catch {
+      throw Object.assign(
+        new Error("Private file storage failed while saving the upload."),
+        { statusCode: 503 },
+      );
+    }
     if (!reference) {
       throw Object.assign(
         new Error(

--- a/templates/slides/server/handlers/uploads.ts
+++ b/templates/slides/server/handlers/uploads.ts
@@ -14,6 +14,10 @@ import {
   isSlidesReferenceFileExtension,
 } from "../../shared/upload-types";
 import { tenantUploadDir } from "../lib/tenant-files.js";
+import {
+  isHostedSlidesRuntime,
+  storeUploadedReferenceBlob,
+} from "../lib/uploaded-reference-storage.js";
 import { canSaveAsUploadedAsset, uploadImageAsset } from "./assets.js";
 
 export const MAX_REFERENCE_FILE_BYTES = 50 * 1024 * 1024;
@@ -113,6 +117,7 @@ function pathForAgent(absPath: string): string {
 
 export async function saveUploadedReferenceFile(args: {
   email: string;
+  orgId?: string | null;
   originalName: string;
   data: Uint8Array;
   type?: string;
@@ -127,14 +132,35 @@ export async function saveUploadedReferenceFile(args: {
   if (!hasExpectedSignature(ext, args.data)) {
     throw new Error(`File contents do not match ${ext} upload type`);
   }
-  const uploadDir = tenantUploadDir(args.email);
-  await fs.promises.mkdir(uploadDir, { recursive: true });
-  const destPath = path.join(uploadDir, filename);
-  await fs.promises.writeFile(destPath, args.data);
-  // For images, also push to the file-upload provider so the agent can embed
-  // a hosted URL (in slide HTML, chat replies, etc.). For non-image reference
-  // files (PPTX, DOCX, PDF), the on-disk path is what the agent uses via
-  // shell — no provider URL is required.
+  let uploadedPath: string;
+  if (isHostedSlidesRuntime()) {
+    const reference = await storeUploadedReferenceBlob({
+      email: args.email,
+      orgId: args.orgId,
+      data: args.data,
+      filename,
+      mimeType: args.type || "application/octet-stream",
+    });
+    if (!reference) {
+      throw Object.assign(
+        new Error(
+          "Private file storage is not configured. Connect Builder.io or another file provider before uploading reference files in a hosted Slides deployment.",
+        ),
+        { statusCode: 503 },
+      );
+    }
+    uploadedPath = reference;
+  } else {
+    const uploadDir = tenantUploadDir(args.email);
+    await fs.promises.mkdir(uploadDir, { recursive: true });
+    const destPath = path.join(uploadDir, filename);
+    await fs.promises.writeFile(destPath, args.data);
+    uploadedPath = pathForAgent(destPath);
+  }
+  // For images, also push to the public file-upload provider so the agent can
+  // embed a hosted URL (in slide HTML, chat replies, etc.). The `path` above
+  // remains the private import source: a tenant path locally and an encrypted,
+  // owner-scoped blob reference in hosted deployments.
   let url: string | undefined;
   if (
     canSaveAsUploadedAsset({
@@ -159,7 +185,7 @@ export async function saveUploadedReferenceFile(args: {
     }
   }
   return {
-    path: pathForAgent(destPath),
+    path: uploadedPath,
     url,
     originalName: args.originalName,
     filename,
@@ -208,6 +234,7 @@ export const uploadFiles = defineEventHandler(async (event) => {
       fileParts.map(async (part) => {
         return saveUploadedReferenceFile({
           email: session.email,
+          orgId: session.orgId,
           originalName: part.filename || "upload",
           data: part.data,
           type: part.type,
@@ -215,7 +242,11 @@ export const uploadFiles = defineEventHandler(async (event) => {
       }),
     );
   } catch (err) {
-    setResponseStatus(event, 400);
+    const statusCode =
+      typeof (err as { statusCode?: unknown })?.statusCode === "number"
+        ? (err as { statusCode: number }).statusCode
+        : 400;
+    setResponseStatus(event, statusCode);
     return { error: err instanceof Error ? err.message : "Invalid upload" };
   }
 

--- a/templates/slides/server/handlers/uploads.ts
+++ b/templates/slides/server/handlers/uploads.ts
@@ -1,7 +1,6 @@
 import fs from "fs";
 import path from "path";
 
-import { getSession } from "@agent-native/core/server";
 import {
   defineEventHandler,
   setResponseStatus,
@@ -19,6 +18,10 @@ import {
   storeUploadedReferenceBlob,
 } from "../lib/uploaded-reference-storage.js";
 import { canSaveAsUploadedAsset, uploadImageAsset } from "./assets.js";
+import {
+  resolveSlidesRequestAuthContext,
+  withSlidesRequestContext,
+} from "./request-auth-context.js";
 
 export const MAX_REFERENCE_FILE_BYTES = 50 * 1024 * 1024;
 export const MAX_FIG_REFERENCE_FILE_BYTES = 200 * 1024 * 1024;
@@ -204,59 +207,67 @@ export async function saveUploadedReferenceFile(args: {
 
 // Upload one or more files
 export const uploadFiles = defineEventHandler(async (event) => {
-  const session = await getSession(event).catch(() => null);
-  if (!session?.email) {
+  const authContext = await resolveSlidesRequestAuthContext(event);
+  const email = authContext.email;
+  if (!email) {
     setResponseStatus(event, 401);
     return { error: "Unauthorized" };
   }
 
-  const parts = await readMultipartFormData(event);
-  const fileParts =
-    parts?.filter((p) => (p.name === "files" || p.name === "file") && p.data) ??
-    [];
+  return withSlidesRequestContext(
+    event,
+    async ({ orgId }) => {
+      const parts = await readMultipartFormData(event);
+      const fileParts =
+        parts?.filter(
+          (p) => (p.name === "files" || p.name === "file") && p.data,
+        ) ?? [];
 
-  if (fileParts.length === 0) {
-    setResponseStatus(event, 400);
-    return { error: "No files uploaded" };
-  }
+      if (fileParts.length === 0) {
+        setResponseStatus(event, 400);
+        return { error: "No files uploaded" };
+      }
 
-  const MAX_FILES = 20;
+      const MAX_FILES = 20;
 
-  if (fileParts.length > MAX_FILES) {
-    setResponseStatus(event, 413);
-    return { error: `Too many files (max ${MAX_FILES})` };
-  }
+      if (fileParts.length > MAX_FILES) {
+        setResponseStatus(event, 413);
+        return { error: `Too many files (max ${MAX_FILES})` };
+      }
 
-  const oversized = fileParts.find(
-    (p) => p.data.length > maxReferenceFileBytes(p.filename),
+      const oversized = fileParts.find(
+        (p) => p.data.length > maxReferenceFileBytes(p.filename),
+      );
+      if (oversized) {
+        const limit = maxReferenceFileBytes(oversized.filename);
+        setResponseStatus(event, 413);
+        return { error: `File too large (max ${formatMaxFileSize(limit)})` };
+      }
+
+      let results;
+      try {
+        results = await Promise.all(
+          fileParts.map(async (part) => {
+            return saveUploadedReferenceFile({
+              email,
+              orgId,
+              originalName: part.filename || "upload",
+              data: part.data,
+              type: part.type,
+            });
+          }),
+        );
+      } catch (err) {
+        const statusCode =
+          typeof (err as { statusCode?: unknown })?.statusCode === "number"
+            ? (err as { statusCode: number }).statusCode
+            : 400;
+        setResponseStatus(event, statusCode);
+        return { error: err instanceof Error ? err.message : "Invalid upload" };
+      }
+
+      return results;
+    },
+    authContext,
   );
-  if (oversized) {
-    const limit = maxReferenceFileBytes(oversized.filename);
-    setResponseStatus(event, 413);
-    return { error: `File too large (max ${formatMaxFileSize(limit)})` };
-  }
-
-  let results;
-  try {
-    results = await Promise.all(
-      fileParts.map(async (part) => {
-        return saveUploadedReferenceFile({
-          email: session.email,
-          orgId: session.orgId,
-          originalName: part.filename || "upload",
-          data: part.data,
-          type: part.type,
-        });
-      }),
-    );
-  } catch (err) {
-    const statusCode =
-      typeof (err as { statusCode?: unknown })?.statusCode === "number"
-        ? (err as { statusCode: number }).statusCode
-        : 400;
-    setResponseStatus(event, statusCode);
-    return { error: err instanceof Error ? err.message : "Invalid upload" };
-  }
-
-  return results;
 });

--- a/templates/slides/server/lib/tenant-files.test.ts
+++ b/templates/slides/server/lib/tenant-files.test.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { describe, expect, it } from "vitest";
 
 import {
+  isHostedSlidesRuntime,
   tenantExportDir,
   tenantFileKey,
   tenantUploadDir,
@@ -34,10 +35,35 @@ describe("Slides tenant file storage", () => {
 
   it("uses writable temp storage for same-request hosted exports", () => {
     const key = tenantFileKey("owner@example.com");
+    const expected = path.join(
+      os.tmpdir(),
+      "agent-native-slides",
+      "exports",
+      key,
+    );
+
+    for (const env of [
+      { NETLIFY: "true" },
+      { VERCEL_ENV: "production" },
+      { CF_PAGES: "1" },
+      { RENDER: "true" },
+      { FLY_APP_NAME: "slides" },
+      { K_SERVICE: "slides" },
+    ]) {
+      expect(
+        tenantExportDir("owner@example.com", "/workspace/slides", env),
+      ).toBe(expected);
+    }
+  });
+
+  it("shares hosted-runtime detection with upload storage", () => {
+    expect(isHostedSlidesRuntime("/workspace/slides", EMPTY_ENV)).toBe(false);
     expect(
-      tenantExportDir("owner@example.com", "/workspace/slides", {
+      isHostedSlidesRuntime("/workspace/slides", {
         NETLIFY: "true",
+        NETLIFY_LOCAL: "true",
       }),
-    ).toBe(path.join(os.tmpdir(), "agent-native-slides", "exports", key));
+    ).toBe(false);
+    expect(isHostedSlidesRuntime("/var/task", EMPTY_ENV)).toBe(true);
   });
 });

--- a/templates/slides/server/lib/tenant-files.test.ts
+++ b/templates/slides/server/lib/tenant-files.test.ts
@@ -1,0 +1,43 @@
+import os from "os";
+import path from "path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  tenantExportDir,
+  tenantFileKey,
+  tenantUploadDir,
+} from "./tenant-files";
+
+const EMPTY_ENV = {} as NodeJS.ProcessEnv;
+
+describe("Slides tenant file storage", () => {
+  it("keeps local uploads and exports under the app data directory", () => {
+    const cwd = "/workspace/slides";
+    const key = tenantFileKey("owner@example.com");
+
+    expect(tenantUploadDir("owner@example.com", cwd)).toBe(
+      path.join(cwd, "data", "uploads", key),
+    );
+    expect(tenantExportDir("owner@example.com", cwd, EMPTY_ENV)).toBe(
+      path.join(cwd, "data", "exports", key),
+    );
+  });
+
+  it("keeps upload paths tenant-scoped for local file compatibility", () => {
+    const key = tenantFileKey("owner@example.com");
+
+    expect(tenantUploadDir("owner@example.com", "/workspace/slides")).toBe(
+      path.join("/workspace/slides", "data", "uploads", key),
+    );
+  });
+
+  it("uses writable temp storage for same-request hosted exports", () => {
+    const key = tenantFileKey("owner@example.com");
+    expect(
+      tenantExportDir("owner@example.com", "/workspace/slides", {
+        NETLIFY: "true",
+      }),
+    ).toBe(path.join(os.tmpdir(), "agent-native-slides", "exports", key));
+  });
+});

--- a/templates/slides/server/lib/tenant-files.ts
+++ b/templates/slides/server/lib/tenant-files.ts
@@ -10,26 +10,33 @@ export function tenantFileKey(email: string): string {
     .slice(0, 24);
 }
 
-export function tenantUploadDir(email: string): string {
-  return path.join(process.cwd(), "data", "uploads", tenantFileKey(email));
+export function tenantUploadDir(email: string, cwd = process.cwd()): string {
+  return path.join(cwd, "data", "uploads", tenantFileKey(email));
 }
 
-function exportRootDir(): string {
+function exportRootDir(
+  cwd = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env,
+): string {
   if (
-    process.env.NETLIFY ||
-    process.env.VERCEL ||
-    process.env.AWS_LAMBDA_FUNCTION_NAME ||
-    process.cwd() === "/var/task" ||
-    process.cwd().startsWith("/var/task/")
+    env.NETLIFY ||
+    env.VERCEL ||
+    env.AWS_LAMBDA_FUNCTION_NAME ||
+    cwd === "/var/task" ||
+    cwd.startsWith("/var/task/")
   ) {
     return path.join(os.tmpdir(), "agent-native-slides", "exports");
   }
 
-  return path.join(process.cwd(), "data", "exports");
+  return path.join(cwd, "data", "exports");
 }
 
-export function tenantExportDir(email: string): string {
-  return path.join(exportRootDir(), tenantFileKey(email));
+export function tenantExportDir(
+  email: string,
+  cwd = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return path.join(exportRootDir(cwd, env), tenantFileKey(email));
 }
 
 export function safeGeneratedFilename(title: string, ext: ".html" | ".pptx") {

--- a/templates/slides/server/lib/tenant-files.ts
+++ b/templates/slides/server/lib/tenant-files.ts
@@ -14,17 +14,37 @@ export function tenantUploadDir(email: string, cwd = process.cwd()): string {
   return path.join(cwd, "data", "uploads", tenantFileKey(email));
 }
 
+export function isHostedSlidesRuntime(
+  cwd = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (env.NETLIFY && env.NETLIFY !== "false" && env.NETLIFY_LOCAL !== "true") {
+    return true;
+  }
+  if (
+    (env.AWS_LAMBDA_FUNCTION_NAME ||
+      env.LAMBDA_TASK_ROOT ||
+      cwd === "/var/task" ||
+      cwd.startsWith("/var/task/")) &&
+    env.NETLIFY_LOCAL !== "true"
+  ) {
+    return true;
+  }
+  return Boolean(
+    env.VERCEL ||
+    env.VERCEL_ENV ||
+    env.CF_PAGES ||
+    env.RENDER ||
+    env.FLY_APP_NAME ||
+    env.K_SERVICE,
+  );
+}
+
 function exportRootDir(
   cwd = process.cwd(),
   env: NodeJS.ProcessEnv = process.env,
 ): string {
-  if (
-    env.NETLIFY ||
-    env.VERCEL ||
-    env.AWS_LAMBDA_FUNCTION_NAME ||
-    cwd === "/var/task" ||
-    cwd.startsWith("/var/task/")
-  ) {
+  if (isHostedSlidesRuntime(cwd, env)) {
     return path.join(os.tmpdir(), "agent-native-slides", "exports");
   }
 

--- a/templates/slides/server/lib/uploaded-reference-storage.test.ts
+++ b/templates/slides/server/lib/uploaded-reference-storage.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPutPrivateBlob = vi.hoisted(() => vi.fn());
+const mockReadPrivateBlob = vi.hoisted(() => vi.fn());
+const mockRunWithRequestContext = vi.hoisted(() => vi.fn());
+
+vi.mock("@agent-native/core/private-blob", () => ({
+  putPrivateBlob: (...args: unknown[]) => mockPutPrivateBlob(...args),
+  readPrivateBlob: (...args: unknown[]) => mockReadPrivateBlob(...args),
+}));
+
+vi.mock("@agent-native/core/secrets/crypto", () => ({
+  encryptSecretValue: (value: string) =>
+    Buffer.from(value, "utf8").toString("base64url"),
+  decryptSecretValue: (value: string) =>
+    Buffer.from(value, "base64url").toString("utf8"),
+}));
+
+vi.mock("@agent-native/core/server/request-context", () => ({
+  getRequestContext: () => ({ orgId: "existing-org", timezone: "UTC" }),
+  getRequestOrgId: () => "fallback-org",
+  runWithRequestContext: (...args: unknown[]) =>
+    mockRunWithRequestContext(...args),
+}));
+
+import {
+  isHostedSlidesRuntime,
+  readUploadedReferenceBlob,
+  storeUploadedReferenceBlob,
+} from "./uploaded-reference-storage";
+
+const HANDLE = {
+  id: "blob-1",
+  provider: "test",
+  opaque: true as const,
+  encrypted: true,
+};
+
+describe("Slides uploaded reference storage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPutPrivateBlob.mockResolvedValue(HANDLE);
+    mockReadPrivateBlob.mockResolvedValue({
+      data: new Uint8Array([1, 2, 3]),
+      handle: HANDLE,
+    });
+    mockRunWithRequestContext.mockImplementation(
+      (_context: unknown, fn: () => unknown) => fn(),
+    );
+  });
+
+  it("recognizes hosted runtimes without treating local development as hosted", () => {
+    expect(isHostedSlidesRuntime("/workspace/slides", {})).toBe(false);
+    expect(isHostedSlidesRuntime("/var/task", {})).toBe(true);
+    expect(
+      isHostedSlidesRuntime("/workspace/slides", { NETLIFY: "true" }),
+    ).toBe(true);
+    expect(
+      isHostedSlidesRuntime("/workspace/slides", {
+        NETLIFY: "true",
+        NETLIFY_LOCAL: "true",
+      }),
+    ).toBe(false);
+    expect(
+      isHostedSlidesRuntime("/workspace/slides", { NETLIFY: "false" }),
+    ).toBe(false);
+    expect(isHostedSlidesRuntime("/workspace/slides", { RENDER: "true" })).toBe(
+      true,
+    );
+    expect(
+      isHostedSlidesRuntime("/workspace/slides", { K_SERVICE: "slides" }),
+    ).toBe(true);
+  });
+
+  it("stores and reads an encrypted owner-scoped private blob reference", async () => {
+    const reference = await storeUploadedReferenceBlob({
+      email: "owner@example.com",
+      filename: "deck.pptx",
+      data: new Uint8Array([1, 2, 3]),
+      mimeType:
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    });
+
+    expect(reference).toMatch(/^slides-upload:v1:/);
+    expect(mockPutPrivateBlob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ownerEmail: "owner@example.com",
+        filename: "deck.pptx",
+      }),
+    );
+    expect(mockRunWithRequestContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userEmail: "owner@example.com",
+        orgId: "existing-org",
+        timezone: "UTC",
+      }),
+      expect.any(Function),
+    );
+    await expect(
+      readUploadedReferenceBlob(reference!, "owner@example.com"),
+    ).resolves.toEqual({
+      data: Buffer.from([1, 2, 3]),
+      filename: "deck.pptx",
+    });
+  });
+
+  it("uses an explicitly supplied org for org-scoped upload providers", async () => {
+    await storeUploadedReferenceBlob({
+      email: "owner@example.com",
+      orgId: "session-org",
+      filename: "deck.pptx",
+      data: new Uint8Array([1]),
+      mimeType: "application/octet-stream",
+    });
+
+    expect(mockRunWithRequestContext).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: "session-org" }),
+      expect.any(Function),
+    );
+  });
+
+  it("rejects another user's reference before reading the provider", async () => {
+    const reference = await storeUploadedReferenceBlob({
+      email: "owner@example.com",
+      filename: "deck.pptx",
+      data: new Uint8Array([1]),
+      mimeType: "application/octet-stream",
+    });
+    mockReadPrivateBlob.mockClear();
+
+    await expect(
+      readUploadedReferenceBlob(reference!, "other@example.com"),
+    ).rejects.toThrow("Access denied");
+    expect(mockReadPrivateBlob).not.toHaveBeenCalled();
+  });
+
+  it("rejects tampered references", async () => {
+    await expect(
+      readUploadedReferenceBlob(
+        "slides-upload:v1:not-valid",
+        "owner@example.com",
+      ),
+    ).rejects.toThrow("Invalid uploaded file reference");
+  });
+});

--- a/templates/slides/server/lib/uploaded-reference-storage.test.ts
+++ b/templates/slides/server/lib/uploaded-reference-storage.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockPutPrivateBlob = vi.hoisted(() => vi.fn());
 const mockReadPrivateBlob = vi.hoisted(() => vi.fn());
 const mockRunWithRequestContext = vi.hoisted(() => vi.fn());
+const mockGetRequestContext = vi.hoisted(() => vi.fn());
+const mockGetRequestOrgId = vi.hoisted(() => vi.fn());
 
 vi.mock("@agent-native/core/private-blob", () => ({
   putPrivateBlob: (...args: unknown[]) => mockPutPrivateBlob(...args),
@@ -17,8 +19,8 @@ vi.mock("@agent-native/core/secrets/crypto", () => ({
 }));
 
 vi.mock("@agent-native/core/server/request-context", () => ({
-  getRequestContext: () => ({ orgId: "existing-org", timezone: "UTC" }),
-  getRequestOrgId: () => "fallback-org",
+  getRequestContext: (...args: unknown[]) => mockGetRequestContext(...args),
+  getRequestOrgId: (...args: unknown[]) => mockGetRequestOrgId(...args),
   runWithRequestContext: (...args: unknown[]) =>
     mockRunWithRequestContext(...args),
 }));
@@ -44,6 +46,11 @@ describe("Slides uploaded reference storage", () => {
       data: new Uint8Array([1, 2, 3]),
       handle: HANDLE,
     });
+    mockGetRequestContext.mockReturnValue({
+      orgId: "existing-org",
+      timezone: "UTC",
+    });
+    mockGetRequestOrgId.mockReturnValue("existing-org");
     mockRunWithRequestContext.mockImplementation(
       (_context: unknown, fn: () => unknown) => fn(),
     );
@@ -105,7 +112,7 @@ describe("Slides uploaded reference storage", () => {
   });
 
   it("uses an explicitly supplied org for org-scoped upload providers", async () => {
-    await storeUploadedReferenceBlob({
+    const reference = await storeUploadedReferenceBlob({
       email: "owner@example.com",
       orgId: "session-org",
       filename: "deck.pptx",
@@ -117,6 +124,14 @@ describe("Slides uploaded reference storage", () => {
       expect.objectContaining({ orgId: "session-org" }),
       expect.any(Function),
     );
+
+    mockGetRequestOrgId.mockReturnValue("session-org");
+    await expect(
+      readUploadedReferenceBlob(reference!, "owner@example.com"),
+    ).resolves.toEqual({
+      data: Buffer.from([1, 2, 3]),
+      filename: "deck.pptx",
+    });
   });
 
   it("rejects another user's reference before reading the provider", async () => {
@@ -130,6 +145,49 @@ describe("Slides uploaded reference storage", () => {
 
     await expect(
       readUploadedReferenceBlob(reference!, "other@example.com"),
+    ).rejects.toThrow("Access denied");
+    expect(mockReadPrivateBlob).not.toHaveBeenCalled();
+  });
+
+  it("rejects another organization's reference before reading the provider", async () => {
+    const reference = await storeUploadedReferenceBlob({
+      email: "owner@example.com",
+      orgId: "org-one",
+      filename: "deck.pptx",
+      data: new Uint8Array([1]),
+      mimeType: "application/octet-stream",
+    });
+    mockReadPrivateBlob.mockClear();
+    mockGetRequestOrgId.mockReturnValue("org-two");
+
+    await expect(
+      readUploadedReferenceBlob(reference!, "owner@example.com"),
+    ).rejects.toThrow("Access denied");
+    expect(mockReadPrivateBlob).not.toHaveBeenCalled();
+  });
+
+  it("keeps personal uploads outside organization scopes", async () => {
+    mockGetRequestContext.mockReturnValue({ timezone: "UTC" });
+    mockGetRequestOrgId.mockReturnValue(undefined);
+    const reference = await storeUploadedReferenceBlob({
+      email: "owner@example.com",
+      orgId: null,
+      filename: "deck.pptx",
+      data: new Uint8Array([1]),
+      mimeType: "application/octet-stream",
+    });
+
+    await expect(
+      readUploadedReferenceBlob(reference!, "owner@example.com"),
+    ).resolves.toEqual({
+      data: Buffer.from([1, 2, 3]),
+      filename: "deck.pptx",
+    });
+
+    mockReadPrivateBlob.mockClear();
+    mockGetRequestOrgId.mockReturnValue("org-one");
+    await expect(
+      readUploadedReferenceBlob(reference!, "owner@example.com"),
     ).rejects.toThrow("Access denied");
     expect(mockReadPrivateBlob).not.toHaveBeenCalled();
   });

--- a/templates/slides/server/lib/uploaded-reference-storage.ts
+++ b/templates/slides/server/lib/uploaded-reference-storage.ts
@@ -17,40 +17,17 @@ import {
 
 import { tenantFileKey } from "./tenant-files.js";
 
+export { isHostedSlidesRuntime } from "./tenant-files.js";
+
 const UPLOADED_REFERENCE_PREFIX = "slides-upload:v1:";
 
 interface UploadedReferenceDescriptor {
   kind: "slides-upload";
   version: 1;
   ownerKey: string;
+  orgId: string | null;
   filename: string;
   handle: PrivateBlobHandle;
-}
-
-export function isHostedSlidesRuntime(
-  cwd = process.cwd(),
-  env: NodeJS.ProcessEnv = process.env,
-): boolean {
-  if (env.NETLIFY && env.NETLIFY !== "false" && env.NETLIFY_LOCAL !== "true") {
-    return true;
-  }
-  if (
-    (env.AWS_LAMBDA_FUNCTION_NAME ||
-      env.LAMBDA_TASK_ROOT ||
-      cwd === "/var/task" ||
-      cwd.startsWith("/var/task/")) &&
-    env.NETLIFY_LOCAL !== "true"
-  ) {
-    return true;
-  }
-  return Boolean(
-    env.VERCEL ||
-    env.VERCEL_ENV ||
-    env.CF_PAGES ||
-    env.RENDER ||
-    env.FLY_APP_NAME ||
-    env.K_SERVICE,
-  );
 }
 
 export async function storeUploadedReferenceBlob(args: {
@@ -61,11 +38,15 @@ export async function storeUploadedReferenceBlob(args: {
   mimeType: string;
 }): Promise<string | null> {
   const existingContext = getRequestContext();
+  const orgId =
+    args.orgId !== undefined
+      ? args.orgId
+      : (existingContext?.orgId ?? getRequestOrgId() ?? null);
   const handle = await runWithRequestContext(
     {
       ...existingContext,
       userEmail: args.email,
-      orgId: args.orgId ?? existingContext?.orgId ?? getRequestOrgId(),
+      orgId: orgId ?? undefined,
     },
     async () =>
       putPrivateBlob({
@@ -82,6 +63,7 @@ export async function storeUploadedReferenceBlob(args: {
     kind: "slides-upload",
     version: 1,
     ownerKey: tenantFileKey(args.email),
+    orgId,
     filename: path.basename(args.filename),
     handle,
   };
@@ -109,6 +91,7 @@ export async function readUploadedReferenceBlob(
     descriptor?.kind !== "slides-upload" ||
     descriptor.version !== 1 ||
     descriptor.ownerKey !== tenantFileKey(email) ||
+    descriptor.orgId !== (getRequestOrgId() ?? null) ||
     typeof descriptor.filename !== "string" ||
     descriptor.filename !== path.basename(descriptor.filename) ||
     typeof descriptor.handle?.id !== "string" ||
@@ -116,7 +99,7 @@ export async function readUploadedReferenceBlob(
     descriptor.handle.opaque !== true
   ) {
     throw new Error(
-      "Access denied: uploaded file reference is not valid for this user",
+      "Access denied: uploaded file reference is not valid for this user or organization",
     );
   }
 

--- a/templates/slides/server/lib/uploaded-reference-storage.ts
+++ b/templates/slides/server/lib/uploaded-reference-storage.ts
@@ -1,0 +1,125 @@
+import path from "path";
+
+import {
+  putPrivateBlob,
+  readPrivateBlob,
+  type PrivateBlobHandle,
+} from "@agent-native/core/private-blob";
+import {
+  decryptSecretValue,
+  encryptSecretValue,
+} from "@agent-native/core/secrets/crypto";
+import {
+  getRequestContext,
+  getRequestOrgId,
+  runWithRequestContext,
+} from "@agent-native/core/server/request-context";
+
+import { tenantFileKey } from "./tenant-files.js";
+
+const UPLOADED_REFERENCE_PREFIX = "slides-upload:v1:";
+
+interface UploadedReferenceDescriptor {
+  kind: "slides-upload";
+  version: 1;
+  ownerKey: string;
+  filename: string;
+  handle: PrivateBlobHandle;
+}
+
+export function isHostedSlidesRuntime(
+  cwd = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (env.NETLIFY && env.NETLIFY !== "false" && env.NETLIFY_LOCAL !== "true") {
+    return true;
+  }
+  if (
+    (env.AWS_LAMBDA_FUNCTION_NAME ||
+      env.LAMBDA_TASK_ROOT ||
+      cwd === "/var/task" ||
+      cwd.startsWith("/var/task/")) &&
+    env.NETLIFY_LOCAL !== "true"
+  ) {
+    return true;
+  }
+  return Boolean(
+    env.VERCEL ||
+    env.VERCEL_ENV ||
+    env.CF_PAGES ||
+    env.RENDER ||
+    env.FLY_APP_NAME ||
+    env.K_SERVICE,
+  );
+}
+
+export async function storeUploadedReferenceBlob(args: {
+  email: string;
+  orgId?: string | null;
+  filename: string;
+  data: Uint8Array;
+  mimeType: string;
+}): Promise<string | null> {
+  const existingContext = getRequestContext();
+  const handle = await runWithRequestContext(
+    {
+      ...existingContext,
+      userEmail: args.email,
+      orgId: args.orgId ?? existingContext?.orgId ?? getRequestOrgId(),
+    },
+    async () =>
+      putPrivateBlob({
+        data: args.data,
+        filename: args.filename,
+        mimeType: args.mimeType,
+        ownerEmail: args.email,
+        metadata: { kind: "slides-reference-upload" },
+      }),
+  );
+  if (!handle) return null;
+
+  const descriptor: UploadedReferenceDescriptor = {
+    kind: "slides-upload",
+    version: 1,
+    ownerKey: tenantFileKey(args.email),
+    filename: path.basename(args.filename),
+    handle,
+  };
+  return `${UPLOADED_REFERENCE_PREFIX}${encryptSecretValue(
+    JSON.stringify(descriptor),
+  )}`;
+}
+
+export async function readUploadedReferenceBlob(
+  reference: string,
+  email: string,
+): Promise<{ data: Buffer; filename: string } | null> {
+  if (!reference.startsWith(UPLOADED_REFERENCE_PREFIX)) return null;
+
+  let descriptor: UploadedReferenceDescriptor;
+  try {
+    descriptor = JSON.parse(
+      decryptSecretValue(reference.slice(UPLOADED_REFERENCE_PREFIX.length)),
+    ) as UploadedReferenceDescriptor;
+  } catch {
+    throw new Error("Invalid uploaded file reference");
+  }
+
+  if (
+    descriptor?.kind !== "slides-upload" ||
+    descriptor.version !== 1 ||
+    descriptor.ownerKey !== tenantFileKey(email) ||
+    typeof descriptor.filename !== "string" ||
+    descriptor.filename !== path.basename(descriptor.filename) ||
+    typeof descriptor.handle?.id !== "string" ||
+    typeof descriptor.handle?.provider !== "string" ||
+    descriptor.handle.opaque !== true
+  ) {
+    throw new Error(
+      "Access denied: uploaded file reference is not valid for this user",
+    );
+  }
+
+  const blob = await readPrivateBlob(descriptor.handle);
+  return { data: Buffer.from(blob.data), filename: descriptor.filename };
+}


### PR DESCRIPTION
## Summary\n\n- bundle a complete shared Yjs runtime into serverless output so hosted SSR starts reliably\n- exclude paused and upload-drain time from Clips recording duration while repairing older clip playback metadata\n- persist hosted Slides reference uploads as encrypted, user-and-organization-scoped private blobs with durable provider storage\n- keep chat responsive during dense SSE replay bursts and show safe informational status and cancellation for quiet live background runs\n\n## Validation\n\n- focused Core deploy tests (68 passing)\n- focused Core run recovery and SSE processor tests (91 passing)\n- focused Clips and Chrome extension duration tests (7 passing)\n- focused Slides upload/import/storage tests (23 passing)\n- Core, Clips, Clips extension, and Slides typechecks\n- all 23 repository guards\n- Chat and Slides Netlify production builds\n- changeset coverage, formatting, and diff checks