### PR TITLE
Harden agent tool retries and webhook allowlists

### DIFF
--- a/.changeset/dedupe-opt-out-volatile-reads.md
+++ b/.changeset/dedupe-opt-out-volatile-reads.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Opt the built-in `run-code`, `get-code-execution`, and `refresh-screen` tools out of the duplicate read-only tool-call guard via the new `dedupe: false` action option, since polling an execution by id or re-refreshing on-screen state is expected to return a different result on an identical repeat call. Also raise `get-extension` and `get-extension-history-version`'s result cap to 200,000 characters so the generic 50k truncation no longer slices mid-content and corrupts source reads for large extensions.
+Opt the dedicated `get-code-execution` and `refresh-screen` volatile reads out of the duplicate read-only tool-call guard via the new `dedupe: false` action option while retaining default duplicate protection for normal `run-code` executions. Also raise `get-extension` and `get-extension-history-version` result caps to 500,000 and 2,000,000 characters respectively so JSON serialization overhead cannot slice mid-content and corrupt source reads for large extensions or their history.

--- a/.changeset/dedupe-opt-out-volatile-reads.md
+++ b/.changeset/dedupe-opt-out-volatile-reads.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Opt the built-in `run-code`, `get-code-execution`, and `refresh-screen` tools out of the duplicate read-only tool-call guard via the new `dedupe: false` action option, since polling an execution by id or re-refreshing on-screen state is expected to return a different result on an identical repeat call. Also raise `get-extension` and `get-extension-history-version`'s result cap to 200,000 characters so the generic 50k truncation no longer slices mid-content and corrupts source reads for large extensions.

--- a/.changeset/harden-core-agent-and-webhooks.md
+++ b/.changeset/harden-core-agent-and-webhooks.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Prevent repeated read-only tool loops while preserving trimmed results, allow volatile reads to opt out of deduping, and enforce notification webhook allowlists at the scope that supplied each secret.

--- a/packages/core/src/action.spec.ts
+++ b/packages/core/src/action.spec.ts
@@ -83,6 +83,17 @@ describe("defineAction", () => {
     expect(action.parallelSafe).toBe(true);
   });
 
+  it("preserves explicit duplicate-read opt-out metadata", () => {
+    const action = defineAction({
+      description: "volatile polling read",
+      parameters: { id: { type: "string" } },
+      readOnly: true,
+      dedupe: false,
+      run: async () => "ok",
+    });
+    expect(action.dedupe).toBe(false);
+  });
+
   it("preserves per-tool timeout and result limits", () => {
     const action = defineAction({
       description: "slow provider call",

--- a/packages/core/src/action.ts
+++ b/packages/core/src/action.ts
@@ -373,6 +373,14 @@ interface DefineActionWithSchema<
    *  Only set this for mutating actions that are internally concurrency-safe
    *  and order-independent for same-turn execution. */
   parallelSafe?: boolean;
+  /** Set false to exempt a read-only tool from the agent loop's duplicate
+   *  read-only call guard (per-turn result cache + "Skipped duplicate..."
+   *  repeat detection). Default true (deduped). Use this for volatile/polling
+   *  reads where an identical call is expected to return a different result
+   *  each time — e.g. polling a code-execution status by id, or re-fetching
+   *  current on-screen state. Has no effect on non-read-only actions, which
+   *  are never deduped in the first place. */
+  dedupe?: boolean;
   /** Whether this action may be invoked from the tools (Alpine iframe) bridge
    *  via `appAction(name, params)` — see `packages/core/docs/content/actions.mdx`
    *  ("Tools Callability"). **Default-allow opt-out**: undefined / `true` both
@@ -493,6 +501,9 @@ interface DefineActionWithParams<
   /** If true, the agent may execute this action concurrently with other
    *  read-only or parallel-safe tool calls emitted in the same model turn. */
   parallelSafe?: boolean;
+  /** Set false to exempt a read-only tool from the duplicate read-only call
+   *  guard. Default true. See the schema overload above. */
+  dedupe?: boolean;
   /** Whether this action may be invoked from the tools (Alpine iframe) bridge
    *  via `appAction(name, params)`. See the schema overload above for details
    *  and the `toolCallable` section in actions.md. */
@@ -557,6 +568,7 @@ export interface ActionDefinition<TInput, TReturn> {
   readonly readOnly?: boolean;
   readonly allowInPlanMode?: boolean;
   readonly parallelSafe?: boolean;
+  readonly dedupe?: boolean;
   readonly toolCallable?: boolean;
   readonly publicAgent?: PublicAgentActionConfig;
   readonly link?: ActionLinkBuilder;
@@ -752,6 +764,8 @@ export function defineAction(options: any) {
     typeof options.parallelSafe === "boolean"
       ? options.parallelSafe
       : undefined;
+  const dedupe: boolean | undefined =
+    typeof options.dedupe === "boolean" ? options.dedupe : undefined;
   const publicAgent: PublicAgentActionConfig | undefined =
     options.publicAgent &&
     typeof options.publicAgent === "object" &&
@@ -806,6 +820,7 @@ export function defineAction(options: any) {
       ? { allowInPlanMode: options.allowInPlanMode }
       : {}),
     ...(typeof parallelSafe === "boolean" ? { parallelSafe } : {}),
+    ...(typeof dedupe === "boolean" ? { dedupe } : {}),
     ...(typeof toolCallable === "boolean" ? { toolCallable } : {}),
     ...(publicAgent ? { publicAgent } : {}),
     ...(link ? { link } : {}),

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -3470,6 +3470,123 @@ describe("runAgentLoop", () => {
     });
   });
 
+  it("stops after the third visible duplicate across continuation invocations", async () => {
+    const messages: EngineMessage[] = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "read the document" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            id: "original-call",
+            name: "get-document",
+            input: { id: "doc-1" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "original-call",
+            toolName: "get-document",
+            toolInput: '{"id":"doc-1"}',
+            content: "the document",
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: AGENT_INTERNAL_CONTINUE_PROMPT }],
+      },
+    ];
+    const readAction = vi.fn(async () => "fresh document");
+
+    const runContinuation = async (chunk: number) => {
+      let streamCalls = 0;
+      const events: any[] = [];
+      const engine: AgentEngine = {
+        name: "test",
+        label: "Test",
+        defaultModel: "test-model",
+        supportedModels: ["test-model"],
+        capabilities: {
+          thinking: false,
+          promptCaching: false,
+          vision: false,
+          computerUse: false,
+          parallelToolCalls: true,
+        },
+        async *stream(): AsyncIterable<EngineEvent> {
+          streamCalls += 1;
+          if (streamCalls === 1) {
+            yield {
+              type: "assistant-content",
+              parts: [
+                {
+                  type: "tool-call" as const,
+                  id: `repeat-${chunk}`,
+                  name: "get-document",
+                  input: { id: "doc-1" },
+                },
+              ],
+            };
+            yield { type: "stop", reason: "tool_use" };
+            return;
+          }
+          yield {
+            type: "assistant-content",
+            parts: [{ type: "text" as const, text: `chunk ${chunk} done` }],
+          };
+          yield { type: "stop", reason: "end_turn" };
+        },
+      };
+
+      await runAgentLoop({
+        engine,
+        model: "test-model",
+        systemPrompt: "system",
+        tools: [],
+        messages,
+        actions: {
+          "get-document": {
+            ...actionEntry({ readOnly: true }),
+            run: readAction,
+          },
+        },
+        send: (event) => events.push(event),
+        signal: new AbortController().signal,
+      });
+
+      return { events, streamCalls };
+    };
+
+    const first = await runContinuation(1);
+    messages.push({
+      role: "user",
+      content: [{ type: "text", text: AGENT_INTERNAL_CONTINUE_PROMPT }],
+    });
+    const second = await runContinuation(2);
+    messages.push({
+      role: "user",
+      content: [{ type: "text", text: AGENT_INTERNAL_CONTINUE_PROMPT }],
+    });
+    const third = await runContinuation(3);
+
+    expect(readAction).not.toHaveBeenCalled();
+    expect(first.streamCalls).toBe(2);
+    expect(second.streamCalls).toBe(2);
+    expect(third.streamCalls).toBe(1);
+    expect(third.events).toContainEqual({
+      type: "text",
+      text: "I stopped because the agent kept asking for the same read-only context it already had. Please send the request again if you want me to retry from a fresh turn.",
+    });
+  });
+
   it("does not cache repeated reads when the action opts out of deduping", async () => {
     let streamCalls = 0;
     const engine: AgentEngine = {

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -14,6 +14,7 @@ import {
 import type {
   AgentEngine,
   EngineEvent,
+  EngineMessage,
   EngineStreamOptions,
 } from "./engine/types.js";
 import { EngineError } from "./engine/types.js";
@@ -26,6 +27,7 @@ import {
   claimBackgroundWorkerRunEarly,
   createPlanModeActionRegistry,
   isPlanModeToolCallAllowed,
+  isCachedToolResultVisibleInContext,
   isContextTooLongError,
   isRetryableError,
   actionsToEngineTools,
@@ -3404,6 +3406,464 @@ describe("runAgentLoop", () => {
     });
   });
 
+  it("stops the run after 3 duplicate repeats of a visible read-only result", async () => {
+    let streamCalls = 0;
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        // The model keeps asking for the exact same read-only context on
+        // every iteration — the result stays visible in `contextMessages`
+        // the whole time (no threadId is passed, so contextMessages ===
+        // messages), so every repeat past the first should strike-count.
+        yield {
+          type: "assistant-content",
+          parts: [
+            {
+              type: "tool-call" as const,
+              id: `call-${streamCalls}`,
+              name: "get-document",
+              input: { id: "doc-1" },
+            },
+          ],
+        };
+        yield { type: "stop", reason: "tool_use" };
+      },
+    };
+    const readAction = vi.fn(async () => "the document");
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {
+        "get-document": {
+          ...actionEntry({ readOnly: true }),
+          run: readAction,
+        },
+      },
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    // Iteration 1 executes for real; iterations 2-4 are duplicates (repeats
+    // 1, 2, 3) and the 3rd repeat triggers the stop — the engine must not be
+    // called a 5th time.
+    expect(readAction).toHaveBeenCalledTimes(1);
+    expect(streamCalls).toBe(4);
+    expect(events).toContainEqual({
+      type: "text",
+      text: "I stopped because the agent kept asking for the same read-only context it already had. Please send the request again if you want me to retry from a fresh turn.",
+    });
+  });
+
+  it("does not cache repeated reads when the action opts out of deduping", async () => {
+    let streamCalls = 0;
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        if (streamCalls <= 2) {
+          yield {
+            type: "assistant-content",
+            parts: [
+              {
+                type: "tool-call" as const,
+                id: `poll-${streamCalls}`,
+                name: "poll-run",
+                input: { id: "run-1" },
+              },
+            ],
+          };
+          yield { type: "stop", reason: "tool_use" };
+          return;
+        }
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "text" as const, text: "complete" }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    const pollAction = vi
+      .fn()
+      .mockResolvedValueOnce({ status: "running" })
+      .mockResolvedValueOnce({ status: "complete" });
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "wait" }] }],
+      actions: {
+        "poll-run": {
+          ...actionEntry({ readOnly: true }),
+          dedupe: false,
+          run: pollAction,
+        },
+      },
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    expect(pollAction).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(events)).not.toContain("Skipped duplicate read-only");
+    expect(events).toContainEqual({ type: "text", text: "complete" });
+  });
+
+  it("does not treat a suffix collision as the visible cached read result", () => {
+    const contextMessages: EngineMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            id: "matching-call",
+            name: "get-document",
+            input: { id: "doc-1" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "matching-call",
+            toolName: "get-document",
+            toolInput: '{"id":"doc-1"}',
+            content: "not ok",
+          },
+        ],
+      },
+    ];
+
+    expect(
+      isCachedToolResultVisibleInContext(
+        contextMessages,
+        { name: "get-document", input: { id: "doc-1" } },
+        "ok",
+      ),
+    ).toBe(false);
+  });
+
+  it("re-serves a duplicate read-only result without a strike once it is trimmed out of the model's visible context", async () => {
+    let streamCalls = 0;
+    const PADDING_ITERATIONS = 8;
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        if (streamCalls === 1) {
+          yield {
+            type: "assistant-content",
+            parts: [
+              {
+                type: "tool-call" as const,
+                id: "orig-call",
+                name: "get-document",
+                input: { id: "doc-1" },
+              },
+            ],
+          };
+          yield { type: "stop", reason: "tool_use" };
+          return;
+        }
+        // Pad the transcript with unrelated read-only calls so the ORIGINAL
+        // get-document tool-result (message index 2) falls outside
+        // trimOldToolResults' protected tail window and gets stubbed out the
+        // next time a context-length-exceeded recovery runs.
+        if (streamCalls <= 1 + PADDING_ITERATIONS) {
+          yield {
+            type: "assistant-content",
+            parts: [
+              {
+                type: "tool-call" as const,
+                id: `pad-${streamCalls}`,
+                name: "get-other",
+                input: { n: streamCalls },
+              },
+            ],
+          };
+          yield { type: "stop", reason: "tool_use" };
+          return;
+        }
+        if (streamCalls === 2 + PADDING_ITERATIONS) {
+          // Simulate the provider rejecting this attempt as too-long — the
+          // one-shot recovery in runAgentLoop trims old tool results from
+          // contextMessages and retries.
+          throw new Error("context_length_exceeded: too many tokens");
+        }
+        if (streamCalls === 3 + PADDING_ITERATIONS) {
+          // Retry after trim: the model asks for the exact same read-only
+          // context again. Its earlier result is no longer visible in
+          // contextMessages (it was stubbed by the trim above).
+          yield {
+            type: "assistant-content",
+            parts: [
+              {
+                type: "tool-call" as const,
+                id: "dup-call",
+                name: "get-document",
+                input: { id: "doc-1" },
+              },
+            ],
+          };
+          yield { type: "stop", reason: "tool_use" };
+          return;
+        }
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "text" as const, text: "done" }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    const readAction = vi.fn(async () => "ORIGINAL_RESULT_TEXT");
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {
+        "get-document": {
+          ...actionEntry({ readOnly: true }),
+          run: readAction,
+        },
+        "get-other": actionEntry({ readOnly: true }),
+      },
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    // The tool ran fresh exactly once — the later repeat was re-served from
+    // cache, not re-executed.
+    expect(readAction).toHaveBeenCalledTimes(1);
+    // No kill: the repeat wasn't visible in context, so it isn't a strike.
+    expect(JSON.stringify(events)).not.toContain(
+      "I stopped because the agent kept asking",
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_done",
+        tool: "get-document",
+        result: expect.stringContaining(
+          "Its earlier result is no longer in view",
+        ),
+      }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_done",
+        tool: "get-document",
+        result: expect.stringContaining("ORIGINAL_RESULT_TEXT"),
+      }),
+    );
+  });
+
+  it("keeps the original cached body across a continuation with a pointer-only duplicate result", async () => {
+    let streamCalls = 0;
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        if (streamCalls === 1) {
+          throw new Error("context_length_exceeded: too many tokens");
+        }
+        if (streamCalls === 2) {
+          yield {
+            type: "assistant-content",
+            parts: [
+              {
+                type: "tool-call" as const,
+                id: "continuation-repeat",
+                name: "get-document",
+                input: { id: "doc-1" },
+              },
+            ],
+          };
+          yield { type: "stop", reason: "tool_use" };
+          return;
+        }
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "text" as const, text: "done" }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    const readAction = vi.fn(async () => "fresh result");
+    const events: any[] = [];
+    const paddingMessages: EngineMessage[] = Array.from(
+      { length: 8 },
+      (_, index): EngineMessage[] => [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              id: `padding-call-${index}`,
+              name: "get-other",
+              input: { index },
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: `padding-call-${index}`,
+              toolName: "get-other",
+              toolInput: JSON.stringify({ index }),
+              content: `padding result ${index}`,
+            },
+          ],
+        },
+      ],
+    ).flat();
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "summarize this doc" }],
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              id: "original-call",
+              name: "get-document",
+              input: { id: "doc-1" },
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "original-call",
+              toolName: "get-document",
+              toolInput: '{"id":"doc-1"}',
+              content: "ORIGINAL_RESULT_TEXT",
+            },
+          ],
+        },
+        ...paddingMessages,
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              id: "pointer-call",
+              name: "get-document",
+              input: { id: "doc-1" },
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "pointer-call",
+              toolName: "get-document",
+              toolInput: '{"id":"doc-1"}',
+              content:
+                "Skipped duplicate read-only call to get-document: identical input already ran in this turn. Use the previous result already in the conversation instead of calling this tool again.",
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: AGENT_INTERNAL_CONTINUE_PROMPT }],
+        },
+      ],
+      actions: {
+        "get-document": {
+          ...actionEntry({ readOnly: true }),
+          run: readAction,
+        },
+        "get-other": actionEntry({ readOnly: true }),
+      },
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    expect(readAction).not.toHaveBeenCalled();
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_done",
+        tool: "get-document",
+        result: expect.stringContaining(
+          "Its earlier result is no longer in view",
+        ),
+      }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_done",
+        tool: "get-document",
+        result: expect.stringContaining("ORIGINAL_RESULT_TEXT"),
+      }),
+    );
+  });
+
   it("adds stop-and-report guidance to provider rate-limit tool errors", async () => {
     let streamCalls = 0;
     const engine: AgentEngine = {
@@ -3916,6 +4376,249 @@ describe("runAgentLoop", () => {
         result: expect.stringContaining(
           "Invalid action parameters for get-extension",
         ),
+      }),
+    );
+  });
+
+  it("does not treat a read-only call from a PRIOR turn as a seeded duplicate", async () => {
+    let streamCalls = 0;
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        if (streamCalls === 1) {
+          yield {
+            type: "assistant-content",
+            parts: [
+              {
+                type: "tool-call" as const,
+                id: "turn2-call",
+                name: "get-document",
+                input: { id: "doc-1" },
+              },
+            ],
+          };
+          yield { type: "stop", reason: "tool_use" };
+          return;
+        }
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "text" as const, text: "answered fresh" }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    const readAction = vi.fn(async () => "fresh document for turn 2");
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [
+        // Turn 1: real user prompt, a read, and a final answer.
+        {
+          role: "user",
+          content: [{ type: "text", text: "read the doc" }],
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              id: "turn1-call",
+              name: "get-document",
+              input: { id: "doc-1" },
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "turn1-call",
+              toolName: "get-document",
+              toolInput: '{"id":"doc-1"}',
+              content: "doc content from turn 1",
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Here it is." }],
+        },
+        // Turn 2: a NEW real user prompt (not a continuation of turn 1),
+        // followed by an internal-continue prompt for this request.
+        {
+          role: "user",
+          content: [{ type: "text", text: "read it again" }],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: AGENT_INTERNAL_CONTINUE_PROMPT }],
+        },
+      ],
+      actions: {
+        "get-document": {
+          ...actionEntry({ readOnly: true }),
+          run: readAction,
+        },
+      },
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    // The prior turn's read must not seed the duplicate-skip cache for a
+    // request that starts a new turn — the tool must run fresh.
+    expect(readAction).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(events)).not.toContain("Skipped duplicate read-only");
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_done",
+        tool: "get-document",
+        result: "fresh document for turn 2",
+      }),
+    );
+  });
+
+  it("does not treat a read-only call seeded before an intervening write as a duplicate", async () => {
+    let streamCalls = 0;
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        if (streamCalls === 1) {
+          yield {
+            type: "assistant-content",
+            parts: [
+              {
+                type: "tool-call" as const,
+                id: "read-again",
+                name: "get-document",
+                input: { id: "doc-1" },
+              },
+            ],
+          };
+          yield { type: "stop", reason: "tool_use" };
+          return;
+        }
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "text" as const, text: "done" }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    const readAction = vi.fn(async () => "fresh document after write");
+    const writeAction = vi.fn(async () => "updated");
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "update the doc" }],
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              id: "read-1",
+              name: "get-document",
+              input: { id: "doc-1" },
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "read-1",
+              toolName: "get-document",
+              toolInput: '{"id":"doc-1"}',
+              content: "doc content before write",
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              id: "write-1",
+              name: "update-document",
+              input: { id: "doc-1", text: "new text" },
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "write-1",
+              toolName: "update-document",
+              toolInput: '{"id":"doc-1","text":"new text"}',
+              content: "updated",
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: AGENT_INTERNAL_CONTINUE_PROMPT }],
+        },
+      ],
+      actions: {
+        "get-document": {
+          ...actionEntry({ readOnly: true }),
+          run: readAction,
+        },
+        "update-document": {
+          ...actionEntry({ readOnly: false }),
+          run: writeAction,
+        },
+      },
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    // The successful write between the seeded read and the continuation
+    // invalidates the seeded cache, so the repeat read must run fresh.
+    expect(readAction).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(events)).not.toContain("Skipped duplicate read-only");
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_done",
+        tool: "get-document",
+        result: "fresh document after write",
       }),
     );
   });
@@ -6979,6 +7682,144 @@ describe("trimOldToolResults", () => {
       i % 2 === 0 ? userTextMsg(`u${i}`) : assistantTextMsg(`a${i}`),
     );
     expect(trimOldToolResults(messages, 10)).toBeNull();
+  });
+});
+
+describe("isCachedToolResultVisibleInContext", () => {
+  const cachedToolCall = {
+    name: "get-document",
+    input: { id: "doc-1" },
+  };
+
+  function contextWithMatchingToolResult(content: string): EngineMessage[] {
+    return [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            id: "tc1",
+            ...cachedToolCall,
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tc1",
+            toolName: cachedToolCall.name,
+            toolInput: JSON.stringify(cachedToolCall.input),
+            content,
+          },
+        ],
+      },
+    ];
+  }
+
+  it("is visible when a user tool-result part exactly matches the cached result", () => {
+    const messages = contextWithMatchingToolResult("the document body");
+    expect(
+      isCachedToolResultVisibleInContext(
+        messages,
+        cachedToolCall,
+        "the document body",
+      ),
+    ).toBe(true);
+  });
+
+  it("is visible when the matching result contains the exact re-serve wrapper", () => {
+    const wrapped =
+      "Skipped duplicate read-only call to get-document: identical input already ran in this turn. " +
+      "Its earlier result is no longer in view, so here it is again:\n\nthe document body";
+    const messages = contextWithMatchingToolResult(wrapped);
+    expect(
+      isCachedToolResultVisibleInContext(
+        messages,
+        cachedToolCall,
+        "the document body",
+      ),
+    ).toBe(true);
+  });
+
+  it("is not visible when no tool-result part matches (evicted or summarized placeholder)", () => {
+    const messages = contextWithMatchingToolResult(
+      "[older tool results trimmed to save context]",
+    );
+    expect(
+      isCachedToolResultVisibleInContext(
+        messages,
+        cachedToolCall,
+        "the document body",
+      ),
+    ).toBe(false);
+  });
+
+  it("treats an empty cached result as always visible", () => {
+    expect(isCachedToolResultVisibleInContext([], cachedToolCall, "")).toBe(
+      true,
+    );
+  });
+
+  it("ignores tool-result-shaped content on assistant-role messages", () => {
+    const messages: EngineMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            id: "tc1",
+            ...cachedToolCall,
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tc1",
+            toolName: "get-document",
+            toolInput: "{}",
+            content: "the document body",
+          },
+        ],
+      },
+    ];
+    expect(
+      isCachedToolResultVisibleInContext(
+        messages,
+        cachedToolCall,
+        "the document body",
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores non-tool-result parts even when the text matches", () => {
+    const messages: EngineMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            id: "tc1",
+            ...cachedToolCall,
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "the document body" }],
+      },
+    ];
+    expect(
+      isCachedToolResultVisibleInContext(
+        messages,
+        cachedToolCall,
+        "the document body",
+      ),
+    ).toBe(false);
   });
 });
 

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -2223,6 +2223,94 @@ function seedReadOnlyToolResultsFromHistory(
   return cache;
 }
 
+function visibleDuplicateReadOnlyToolResult(toolName: string): string {
+  return (
+    `Skipped duplicate read-only call to ${toolName}: identical input already ran in this turn. ` +
+    `Use the previous result already in the conversation instead of calling this tool again.`
+  );
+}
+
+function resurfacedDuplicateReadOnlyToolResultPrefix(toolName: string): string {
+  return (
+    `Skipped duplicate read-only call to ${toolName}: identical input already ran in this turn. ` +
+    `Its earlier result is no longer in view, so here it is again:\n\n`
+  );
+}
+
+function resurfacedDuplicateReadOnlyToolResult(
+  toolName: string,
+  cachedResult: string,
+): string {
+  return `${resurfacedDuplicateReadOnlyToolResultPrefix(toolName)}${cachedResult}`;
+}
+
+/** Restore visible-repeat strike counts for this continuation's active turn. */
+function seedDuplicateReadOnlyToolCallsFromHistory(
+  messages: EngineMessage[],
+  actions: Record<string, ActionEntry>,
+): Map<string, number> {
+  const repeats = new Map<string, number>();
+  if (!isInternalContinuationTurn(messages)) return repeats;
+
+  const turnStart = findCurrentTurnStartForContinuation(messages);
+  const pendingToolCalls = new Map<
+    string,
+    { name: string; input: unknown; readOnly: boolean; dedupe: boolean }
+  >();
+  const reusableReadKeys = new Set<string>();
+
+  for (const message of messages.slice(turnStart)) {
+    if (message.role === "assistant") {
+      for (const part of message.content) {
+        if (part.type !== "tool-call") continue;
+        const entry = actions[part.name];
+        pendingToolCalls.set(part.id, {
+          name: part.name,
+          input: part.input,
+          readOnly: entry?.readOnly === true,
+          dedupe: entry?.dedupe !== false,
+        });
+      }
+      continue;
+    }
+
+    for (const part of message.content) {
+      if (part.type !== "tool-result") continue;
+      const call = pendingToolCalls.get(part.toolCallId);
+      if (!call) continue;
+      if (!call.readOnly) {
+        if (part.isError !== true) {
+          repeats.clear();
+          reusableReadKeys.clear();
+        }
+        continue;
+      }
+      if (!call.dedupe || part.isError === true) continue;
+
+      const cacheKey = toolCallCacheKey(call.name, call.input);
+      if (part.content === visibleDuplicateReadOnlyToolResult(call.name)) {
+        if (reusableReadKeys.has(cacheKey)) {
+          repeats.set(cacheKey, (repeats.get(cacheKey) ?? 0) + 1);
+        }
+        continue;
+      }
+      if (
+        part.content.startsWith(
+          resurfacedDuplicateReadOnlyToolResultPrefix(call.name),
+        )
+      ) {
+        if (reusableReadKeys.has(cacheKey)) repeats.set(cacheKey, 0);
+        continue;
+      }
+      if (isReusableReadOnlyToolResult(part)) {
+        reusableReadKeys.add(cacheKey);
+      }
+    }
+  }
+
+  return repeats;
+}
+
 function isReusableReadOnlyToolResult(part: EngineToolResultPart): boolean {
   if (part.isError) return false;
   const lower = part.content.trim().toLowerCase();
@@ -2271,9 +2359,10 @@ export function isCachedToolResultVisibleInContext(
     }
   }
 
-  const resurfacedResult =
-    `Skipped duplicate read-only call to ${toolCall.name}: identical input already ran in this turn. ` +
-    `Its earlier result is no longer in view, so here it is again:\n\n${cachedResult}`;
+  const resurfacedResult = resurfacedDuplicateReadOnlyToolResult(
+    toolCall.name,
+    cachedResult,
+  );
   for (const message of contextMessages) {
     if (message.role !== "user") continue;
     for (const part of message.content) {
@@ -3182,7 +3271,10 @@ export async function runAgentLoop(opts: {
     messages,
     actions,
   );
-  const duplicateReadOnlyToolCalls = new Map<string, number>();
+  const duplicateReadOnlyToolCalls = seedDuplicateReadOnlyToolCallsFromHistory(
+    messages,
+    actions,
+  );
   const writeToolInterruptions = seedWriteToolInterruptionsFromHistory(
     messages,
     actions,
@@ -4439,9 +4531,7 @@ export async function runAgentLoop(opts: {
         if (visible) {
           const repeats = (duplicateReadOnlyToolCalls.get(cacheKey) ?? 0) + 1;
           duplicateReadOnlyToolCalls.set(cacheKey, repeats);
-          result =
-            `Skipped duplicate read-only call to ${toolCall.name}: identical input already ran in this turn. ` +
-            `Use the previous result already in the conversation instead of calling this tool again.`;
+          result = visibleDuplicateReadOnlyToolResult(toolCall.name);
           if (repeats >= 3) {
             requestedActionStop ??= {
               message:
@@ -4455,9 +4545,10 @@ export async function runAgentLoop(opts: {
           // can't see the answer anymore. Re-serve it in full and don't
           // count a strike.
           duplicateReadOnlyToolCalls.set(cacheKey, 0);
-          result =
-            `Skipped duplicate read-only call to ${toolCall.name}: identical input already ran in this turn. ` +
-            `Its earlier result is no longer in view, so here it is again:\n\n${previousResult}`;
+          result = resurfacedDuplicateReadOnlyToolResult(
+            toolCall.name,
+            previousResult,
+          );
         }
         send({
           type: "tool_done",

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -583,6 +583,11 @@ export interface ActionEntry {
    *  read-only/parallel-safe tool calls. Only use for actions that handle
    *  their own write ordering and idempotency. */
   parallelSafe?: boolean;
+  /** Set false to exempt a read-only tool from the duplicate read-only
+   *  tool-call guard (per-turn result cache + repeat-kill). Default true. Use
+   *  for volatile/polling reads that are expected to return a different
+   *  result on each identical call. See `defineAction`'s `dedupe` option. */
+  dedupe?: boolean;
   /** Whether this action may be invoked from the tools-iframe bridge.
    *  **Default-allow opt-out**: only an explicit `false` returns 403.
    *  - `true` / `undefined` — allow.
@@ -2170,16 +2175,26 @@ function seedReadOnlyToolResultsFromHistory(
   const cache = new Map<string, string>();
   if (!isInternalContinuationTurn(messages)) return cache;
 
-  const pendingToolCalls = new Map<string, { name: string; input: unknown }>();
-  for (const message of messages) {
+  // Scoped to the current turn only (same slice as
+  // seedWriteToolInterruptionsFromHistory) — reads from a prior turn are no
+  // longer relevant context and must not seed skip-as-duplicate behavior.
+  const turnStart = findCurrentTurnStartForContinuation(messages);
+  const turnMessages = messages.slice(turnStart);
+
+  const pendingToolCalls = new Map<
+    string,
+    { name: string; input: unknown; readOnly: boolean; dedupe: boolean }
+  >();
+  for (const message of turnMessages) {
     if (message.role === "assistant") {
       for (const part of message.content) {
         if (part.type !== "tool-call") continue;
         const entry = actions[part.name];
-        if (entry?.readOnly !== true) continue;
         pendingToolCalls.set(part.id, {
           name: part.name,
           input: part.input,
+          readOnly: entry?.readOnly === true,
+          dedupe: entry?.dedupe !== false,
         });
       }
       continue;
@@ -2189,6 +2204,17 @@ function seedReadOnlyToolResultsFromHistory(
       if (part.type !== "tool-result") continue;
       const call = pendingToolCalls.get(part.toolCallId);
       if (!call) continue;
+      if (!call.readOnly) {
+        // Mirror the live loop: a successful write invalidates all cached
+        // reads (see the `readOnlyToolResultCache.clear()` call below), so a
+        // read seeded from before an intervening write must not be replayed
+        // as still-fresh.
+        if (part.isError !== true) cache.clear();
+        continue;
+      }
+      // dedupe:false read-only tools (volatile/polling reads) are never
+      // cached — every call must execute fresh, seeded or not.
+      if (!call.dedupe) continue;
       if (!isReusableReadOnlyToolResult(part)) continue;
       cache.set(toolCallCacheKey(call.name, call.input), part.content);
     }
@@ -2202,6 +2228,7 @@ function isReusableReadOnlyToolResult(part: EngineToolResultPart): boolean {
   const lower = part.content.trim().toLowerCase();
   if (!lower) return false;
   return !(
+    lower.startsWith("skipped duplicate read-only call to ") ||
     lower.startsWith("invalid action parameters for ") ||
     lower.startsWith("error running ") ||
     lower.includes("run aborted") ||
@@ -2209,6 +2236,55 @@ function isReusableReadOnlyToolResult(part: EngineToolResultPart): boolean {
     lower.includes("stale_run") ||
     lower.includes("connection_error")
   );
+}
+
+/**
+ * Whether a cached read-only tool result is still something the model can
+ * actually see in `contextMessages` — the trimmed/summarized view the engine
+ * is streamed (NOT the raw, ever-growing `messages` array the cache is keyed
+ * off of). Context-xray `evict` drops tool-result parts entirely, `summarize`
+ * replaces their content with a placeholder, and observational-memory
+ * trimming drops whole older messages once active. When the cached result
+ * has fallen out of that view, re-serving "use the previous result" is not
+ * actionable — the model has nothing to point back to.
+ *
+ * A visible result must belong to the same tool name + normalized input and
+ * contain either the exact cached body or the exact wrapper used when that
+ * body was re-served after trimming. Matching only by a content suffix is too
+ * loose: short results such as "ok" can also end unrelated tool output.
+ */
+export function isCachedToolResultVisibleInContext(
+  contextMessages: EngineMessage[],
+  toolCall: { name: string; input: unknown },
+  cachedResult: string,
+): boolean {
+  if (cachedResult.length === 0) return true;
+  const cacheKey = toolCallCacheKey(toolCall.name, toolCall.input);
+  const matchingToolCallIds = new Set<string>();
+  for (const message of contextMessages) {
+    if (message.role !== "assistant") continue;
+    for (const part of message.content) {
+      if (part.type !== "tool-call") continue;
+      if (toolCallCacheKey(part.name, part.input) === cacheKey) {
+        matchingToolCallIds.add(part.id);
+      }
+    }
+  }
+
+  const resurfacedResult =
+    `Skipped duplicate read-only call to ${toolCall.name}: identical input already ran in this turn. ` +
+    `Its earlier result is no longer in view, so here it is again:\n\n${cachedResult}`;
+  for (const message of contextMessages) {
+    if (message.role !== "user") continue;
+    for (const part of message.content) {
+      if (part.type !== "tool-result") continue;
+      if (!matchingToolCallIds.has(part.toolCallId)) continue;
+      if (part.content === cachedResult || part.content === resurfacedResult) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 /**
@@ -4339,18 +4415,50 @@ export async function runAgentLoop(opts: {
         };
       }
 
+      // dedupe: false opts a read-only tool out of the guard entirely — the
+      // cacheKey stays null so it never gets skipped-as-duplicate and never
+      // populates the cache (see the success handler below, which also
+      // leaves dedupe:false results uncached and un-cleared).
       const cacheKey =
-        actionEntry.readOnly === true
+        actionEntry.readOnly === true && actionEntry.dedupe !== false
           ? toolCallCacheKey(toolCall.name, toolCall.input)
           : null;
       if (cacheKey && readOnlyToolResultCache.has(cacheKey)) {
-        const repeats = (duplicateReadOnlyToolCalls.get(cacheKey) ?? 0) + 1;
-        duplicateReadOnlyToolCalls.set(cacheKey, repeats);
         const previousResult = readOnlyToolResultCache.get(cacheKey) ?? "";
-        const result =
-          `Skipped duplicate read-only call to ${toolCall.name}: identical input already ran in this turn. ` +
-          `Use the previous result already in the conversation instead of calling this tool again.\n\n` +
-          `Previous result:\n${previousResult}`;
+        // `contextMessages` (not `messages`) is what the model actually sees
+        // this iteration — context-xray eviction/summarization and
+        // observational-memory trimming can drop the earlier result from
+        // view even though it's still cached here. Only strike-count the
+        // repeat when the model could have looked back and found it itself.
+        const visible = isCachedToolResultVisibleInContext(
+          contextMessages,
+          toolCall,
+          previousResult,
+        );
+        let result: string;
+        if (visible) {
+          const repeats = (duplicateReadOnlyToolCalls.get(cacheKey) ?? 0) + 1;
+          duplicateReadOnlyToolCalls.set(cacheKey, repeats);
+          result =
+            `Skipped duplicate read-only call to ${toolCall.name}: identical input already ran in this turn. ` +
+            `Use the previous result already in the conversation instead of calling this tool again.`;
+          if (repeats >= 3) {
+            requestedActionStop ??= {
+              message:
+                "I stopped because the agent kept asking for the same read-only context it already had. Please send the request again if you want me to retry from a fresh turn.",
+              errorCode: "duplicate_read_only_tool",
+            };
+          }
+        } else {
+          // The earlier result was trimmed out of the model's visible
+          // context — this isn't a repetitive loop, the model legitimately
+          // can't see the answer anymore. Re-serve it in full and don't
+          // count a strike.
+          duplicateReadOnlyToolCalls.set(cacheKey, 0);
+          result =
+            `Skipped duplicate read-only call to ${toolCall.name}: identical input already ran in this turn. ` +
+            `Its earlier result is no longer in view, so here it is again:\n\n${previousResult}`;
+        }
         send({
           type: "tool_done",
           id: toolCall.id,
@@ -4360,13 +4468,6 @@ export async function runAgentLoop(opts: {
           completedSideEffect: false,
         });
         recordToolResult(result, false);
-        if (repeats >= 3) {
-          requestedActionStop ??= {
-            message:
-              "I stopped because the agent kept asking for the same read-only context it already had. Please send the request again if you want me to retry from a fresh turn.",
-            errorCode: "duplicate_read_only_tool",
-          };
-        }
         return {
           type: "tool-result" as const,
           toolCallId: toolCall.id,
@@ -4638,7 +4739,11 @@ export async function runAgentLoop(opts: {
       if (!isError) {
         if (cacheKey) {
           readOnlyToolResultCache.set(cacheKey, result);
-        } else {
+        } else if (actionEntry.readOnly !== true) {
+          // A genuine write invalidates all cached reads. A dedupe:false
+          // read-only tool also has a null cacheKey (see above) but must NOT
+          // clear the cache — it isn't a write and other tools' cached reads
+          // are still valid.
           readOnlyToolResultCache.clear();
           duplicateReadOnlyToolCalls.clear();
         }

--- a/packages/core/src/coding-tools/run-code.background.spec.ts
+++ b/packages/core/src/coding-tools/run-code.background.spec.ts
@@ -94,6 +94,7 @@ afterEach(() => {
 describe("run-code background param", () => {
   it("advertises background + executionId in the tool schema", () => {
     const entry = createRunCodeEntry(makeActions);
+    expect(entry.dedupe).toBeUndefined();
     expect(entry.tool.description).toContain("background: true");
     const props = (
       entry.tool.parameters as { properties: Record<string, unknown> }
@@ -255,6 +256,7 @@ describe("get-code-execution entry", () => {
     const runCode = createRunCodeEntry(makeActions);
     const getExec = createGetCodeExecutionEntry();
     expect(getExec.readOnly).toBe(true);
+    expect(getExec.dedupe).toBe(false);
 
     const enqueued = JSON.parse(
       (await runCode.run(

--- a/packages/core/src/coding-tools/run-code.ts
+++ b/packages/core/src/coding-tools/run-code.ts
@@ -107,6 +107,10 @@ export function createRunCodeEntry(
 
   return {
     readOnly: true,
+    // This tool doubles as the poll for a background execution (call again
+    // with only `executionId`) — identical input is expected to return a
+    // different result as the run progresses, so it must not be deduped.
+    dedupe: false,
     allowInPlanMode: false,
     // Allow a generous per-call timeout so large data-processing jobs don't hit
     // the agent-loop's default 60 s cap.
@@ -588,6 +592,9 @@ function formatTerminalSandboxExecution(row: SandboxExecutionRow): string {
 export function createGetCodeExecutionEntry(): ActionEntry {
   return {
     readOnly: true,
+    // Polling with an identical executionId is the intended usage — the
+    // status changes over time, so this must not be deduped.
+    dedupe: false,
     tool: {
       description:
         "Check a background run-code execution: returns its status (queued | running | succeeded | failed | timed_out) and, once finished, its stdout/stderr output. Executions are scoped to the user who started them. While one is queued or running, continue other useful work and poll every ~15-30 seconds instead of busy-waiting.",

--- a/packages/core/src/coding-tools/run-code.ts
+++ b/packages/core/src/coding-tools/run-code.ts
@@ -107,10 +107,6 @@ export function createRunCodeEntry(
 
   return {
     readOnly: true,
-    // This tool doubles as the poll for a background execution (call again
-    // with only `executionId`) — identical input is expected to return a
-    // different result as the run progresses, so it must not be deduped.
-    dedupe: false,
     allowInPlanMode: false,
     // Allow a generous per-call timeout so large data-processing jobs don't hit
     // the agent-loop's default 60 s cap.
@@ -143,7 +139,7 @@ export function createRunCodeEntry(
         "  - `workspaceList(prefix?)` — list workspace files, returns [{ path, sizeBytes, contentType, updatedAt }].",
         "Print results with `console.log()`; only stdout+stderr are returned.",
         "Timeout defaults to 120 s (max 600 s). Output is truncated to 50 000 chars by default (max 200 000).",
-        'For LONG compute — big cross-source joins, corpus-wide sweeps, scripts that could exceed ~30 s, or anything at risk of dying with the current chat run — pass `background: true`. That enqueues a durable execution and returns `{ executionId, status: "queued" }` immediately; the code runs out-of-band with a generous budget (default 10 min) and its result survives run timeouts. Continue other work, then poll by calling run-code again with just `{ executionId }` to get status and, once finished, the output. Keep quick scripts in the default foreground mode.',
+        'For LONG compute — big cross-source joins, corpus-wide sweeps, scripts that could exceed ~30 s, or anything at risk of dying with the current chat run — pass `background: true`. That enqueues a durable execution and returns `{ executionId, status: "queued" }` immediately; the code runs out-of-band with a generous budget (default 10 min) and its result survives run timeouts. Continue other work, then poll with `get-code-execution` when that dedicated tool is available; legacy hosts can call run-code again with just `{ executionId }`. Keep quick scripts in the default foreground mode.',
       ].join(" "),
       parameters: {
         type: "object",
@@ -164,12 +160,12 @@ export function createRunCodeEntry(
           background: {
             type: "boolean",
             description:
-              'Run as a durable background execution: returns { executionId, status: "queued" } immediately and the code executes out-of-band, surviving chat-run timeouts. Use for long compute (large joins, multi-page provider sweeps, heavy analysis). Poll with executionId for the result.',
+              'Run as a durable background execution: returns { executionId, status: "queued" } immediately and the code executes out-of-band, surviving chat-run timeouts. Use for long compute (large joins, multi-page provider sweeps, heavy analysis). Poll with get-code-execution when available.',
           },
           executionId: {
             type: "string",
             description:
-              "Poll a background execution started earlier: pass the executionId alone (no code) to get its status and, once finished, its output.",
+              "Legacy polling fallback for hosts without get-code-execution: pass the executionId alone (no code) to get status and output.",
           },
         },
         required: [],
@@ -586,8 +582,11 @@ function formatTerminalSandboxExecution(row: SandboxExecutionRow): string {
 /**
  * Standalone, access-scoped poll tool for background executions. Behaviorally
  * identical to calling `run-code` with only `executionId`; hosts that register
- * it as `get-code-execution` give the model a dedicated read tool (and the
- * enqueue guidance automatically points at it when present in the registry).
+ * it as `get-code-execution` give the model a dedicated volatile read tool (and
+ * the enqueue guidance automatically points at it when present in the
+ * registry). Keep the opt-out here rather than on `run-code`: repeated normal
+ * run-code calls may execute writes or outbound requests and must retain the
+ * agent loop's default duplicate-call protection.
  */
 export function createGetCodeExecutionEntry(): ActionEntry {
   return {

--- a/packages/core/src/extensions/actions.spec.ts
+++ b/packages/core/src/extensions/actions.spec.ts
@@ -197,6 +197,28 @@ describe("extensions/actions", () => {
     });
   });
 
+  it("declares serialization-safe result caps for extension source reads", async () => {
+    mockExtensionModules();
+
+    const { createExtensionActionEntries } = await import("./actions.js");
+    const actions = createExtensionActionEntries();
+    const jsonSensitiveSource = '"\\\n'
+      .repeat(Math.ceil(200_000 / 3))
+      .slice(0, 200_000);
+    const serializedSourceChars = JSON.stringify(jsonSensitiveSource).length;
+
+    expect(actions["get-extension"].maxResultChars).toBe(500_000);
+    expect(actions["get-extension"].maxResultChars).toBeGreaterThanOrEqual(
+      serializedSourceChars + 50_000,
+    );
+    expect(actions["get-extension-history-version"].maxResultChars).toBe(
+      2_000_000,
+    );
+    expect(
+      actions["get-extension-history-version"].maxResultChars,
+    ).toBeGreaterThanOrEqual(serializedSourceChars * 4 + 100_000);
+  });
+
   it("omits repeated unchanged extension content within one agent run", async () => {
     const getExtension = vi.fn(async () => ({
       ...extensionRow,

--- a/packages/core/src/extensions/actions.ts
+++ b/packages/core/src/extensions/actions.ts
@@ -185,6 +185,10 @@ export function createExtensionActionEntries(): Record<string, ActionEntry> {
           ),
         };
       },
+      // Result is JSON including the full Alpine content — the generic 50k
+      // default cap slices mid-content and corrupts source reads for large
+      // extensions. Mirrors render-inline-extension's override below.
+      maxResultChars: 200_000,
       readOnly: true,
     },
 
@@ -276,6 +280,9 @@ export function createExtensionActionEntries(): Record<string, ActionEntry> {
           ),
         };
       },
+      // Returns full historical content when includeContent is set — same
+      // truncation hazard as get-extension above.
+      maxResultChars: 200_000,
       readOnly: true,
     },
 

--- a/packages/core/src/extensions/actions.ts
+++ b/packages/core/src/extensions/actions.ts
@@ -44,6 +44,15 @@ import {
   type ExtensionRow,
 } from "./store.js";
 
+// A 200k extension body containing JSON-sensitive HTML/JS characters (quotes,
+// backslashes, and newlines) expands to about 400k characters when pretty-JSON
+// serialized by the agent loop. A history detail can carry the current and
+// previous bodies plus both bodies again in its line diff (about 1.6M chars in
+// the same worst-common-case fixture). These caps add roughly 25% headroom for
+// the surrounding metadata and indentation while still bounding tool context.
+const GET_EXTENSION_MAX_RESULT_CHARS = 500_000;
+const GET_EXTENSION_HISTORY_MAX_RESULT_CHARS = 2_000_000;
+
 export function createExtensionActionEntries(): Record<string, ActionEntry> {
   return {
     "list-extensions": {
@@ -185,10 +194,9 @@ export function createExtensionActionEntries(): Record<string, ActionEntry> {
           ),
         };
       },
-      // Result is JSON including the full Alpine content — the generic 50k
-      // default cap slices mid-content and corrupts source reads for large
-      // extensions. Mirrors render-inline-extension's override below.
-      maxResultChars: 200_000,
+      // Result is JSON including the full Alpine content; account for JSON
+      // escaping and envelope metadata instead of matching the source cap.
+      maxResultChars: GET_EXTENSION_MAX_RESULT_CHARS,
       readOnly: true,
     },
 
@@ -280,9 +288,9 @@ export function createExtensionActionEntries(): Record<string, ActionEntry> {
           ),
         };
       },
-      // Returns full historical content when includeContent is set — same
-      // truncation hazard as get-extension above.
-      maxResultChars: 200_000,
+      // With includeContent, history can contain current + previous source and
+      // repeat both in the diff, so it needs more headroom than get-extension.
+      maxResultChars: GET_EXTENSION_HISTORY_MAX_RESULT_CHARS,
       readOnly: true,
     },
 

--- a/packages/core/src/extensions/url-safety.spec.ts
+++ b/packages/core/src/extensions/url-safety.spec.ts
@@ -80,7 +80,7 @@ describe("isBlockedExtensionUrlWithDns (DNS rebinding guard)", () => {
   });
 });
 
-describe("ssrfSafeFetch httpsOnly", () => {
+describe("ssrfSafeFetch per-hop policies", () => {
   // Public IP literals skip the DNS lookup, so these tests stay offline.
   const httpsOrigin = "https://93.184.216.34/image.png";
   const httpOrigin = "http://93.184.216.34/image.png";
@@ -127,6 +127,39 @@ describe("ssrfSafeFetch httpsOnly", () => {
     expect(response.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledTimes(2);
     // The followed hop's body must be drained so its connection is released.
+    expect(redirectResponse.bodyUsed).toBe(true);
+  });
+
+  it("rejects a caller-disallowed redirect before forwarding sensitive request data", async () => {
+    const redirectUrl = "https://93.184.216.35/steal";
+    const redirectResponse = new Response("moved", {
+      status: 302,
+      headers: { location: redirectUrl },
+    });
+    const fetchMock = vi.fn(async () => redirectResponse);
+    const assertUrlAllowed = vi.fn((url: string) => {
+      if (url !== httpsOrigin) {
+        throw new Error(`URL ${url} is not in the credential allowlist`);
+      }
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      ssrfSafeFetch(
+        httpsOrigin,
+        {
+          method: "POST",
+          headers: { Authorization: "Bearer example-token" },
+          body: "sensitive payload",
+        },
+        { assertUrlAllowed },
+      ),
+    ).rejects.toThrow(/not in the credential allowlist/);
+
+    expect(assertUrlAllowed).toHaveBeenNthCalledWith(1, httpsOrigin);
+    expect(assertUrlAllowed).toHaveBeenNthCalledWith(2, redirectUrl);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(httpsOrigin);
     expect(redirectResponse.bodyUsed).toBe(true);
   });
 });

--- a/packages/core/src/extensions/url-safety.ts
+++ b/packages/core/src/extensions/url-safety.ts
@@ -251,17 +251,27 @@ export async function createSsrfSafeDispatcher(): Promise<unknown | null> {
  * `httpsOnly` extends the per-hop validation to the URL scheme: redirects are
  * followed only to `https:` targets, so an HTTPS-only caller cannot be
  * downgraded to plain HTTP by a 30x from the (untrusted) origin.
+ *
+ * `assertUrlAllowed` lets callers layer a stricter destination policy (for
+ * example, a credential's origin allowlist) on top of the SSRF checks. It runs
+ * before the initial request and before every redirect hop, so sensitive
+ * headers and bodies are never forwarded to a destination the caller rejects.
  */
 export async function ssrfSafeFetch(
   url: string,
   init: RequestInit = {},
-  options: { maxRedirects?: number; httpsOnly?: boolean } = {},
+  options: {
+    maxRedirects?: number;
+    httpsOnly?: boolean;
+    assertUrlAllowed?: (url: string) => void | Promise<void>;
+  } = {},
 ): Promise<Response> {
   const maxRedirects = options.maxRedirects ?? 3;
   const dispatcher = (await createSsrfSafeDispatcher()) ?? undefined;
 
   let currentUrl = url;
   for (let hop = 0; hop <= maxRedirects; hop++) {
+    await options.assertUrlAllowed?.(currentUrl);
     if (options.httpsOnly && new URL(currentUrl).protocol !== "https:") {
       throw new Error(
         `SSRF blocked: refusing to fetch non-HTTPS address (${currentUrl})`,

--- a/packages/core/src/notifications/channels.spec.ts
+++ b/packages/core/src/notifications/channels.spec.ts
@@ -307,6 +307,48 @@ describe("webhook notification channel", () => {
     expect(getResolvedKeyAllowlist).toHaveBeenCalledWith(authRef);
   });
 
+  it("rejects a redirect outside the auth key allowlist before forwarding the request", async () => {
+    process.env.NOTIFICATIONS_WEBHOOK_AUTH = "Bearer ${keys.HOOK_TOKEN}";
+    const authRef = {
+      name: "HOOK_TOKEN",
+      scope: "org" as const,
+      scopeId: "org-1",
+    };
+    resolveKeyReferencesWithRequestScopes.mockImplementation(
+      async (text: string) =>
+        text.includes("HOOK_TOKEN")
+          ? {
+              resolved: "Bearer example-token",
+              usedKeys: ["HOOK_TOKEN"],
+              secretValues: ["example-token"],
+              resolvedKeys: [authRef],
+            }
+          : {
+              resolved: text,
+              usedKeys: [],
+              secretValues: [],
+              resolvedKeys: [],
+            },
+    );
+    getResolvedKeyAllowlist.mockResolvedValue(["https://hooks.example.com"]);
+    validateUrlAllowlist.mockImplementation(
+      (url: string) => new URL(url).origin === "https://hooks.example.com",
+    );
+
+    const channel = (await loadWebhookChannel())!;
+    await channel.deliver(
+      { severity: "critical", title: "x" },
+      { owner: "alice@example.com" },
+    );
+
+    const options = fetchMock.mock.calls[0][2] as {
+      assertUrlAllowed: (url: string) => void;
+    };
+    expect(() =>
+      options.assertUrlAllowed("https://evil.example.com/steal"),
+    ).toThrow(/not in the allowlist/i);
+  });
+
   it("delivers when the resolved URL satisfies the allowlist", async () => {
     process.env.NOTIFICATIONS_WEBHOOK_URL = "${keys.HOOK_URL}";
     resolveKeyReferencesWithRequestScopes.mockImplementation(async () => ({

--- a/packages/core/src/notifications/channels.spec.ts
+++ b/packages/core/src/notifications/channels.spec.ts
@@ -12,6 +12,7 @@ import type { NotificationChannel } from "./types.js";
 const resolveKeyReferencesWithRequestScopes = vi.fn();
 const validateUrlAllowlist = vi.fn();
 const getKeyAllowlist = vi.fn();
+const getResolvedKeyAllowlist = vi.fn();
 const sendEmail = vi.fn();
 
 let fetchMock: ReturnType<typeof vi.fn>;
@@ -38,6 +39,8 @@ async function loadChannels(): Promise<NotificationChannel[]> {
       resolveKeyReferencesWithRequestScopes(...args),
     validateUrlAllowlist: (...args: unknown[]) => validateUrlAllowlist(...args),
     getKeyAllowlist: (...args: unknown[]) => getKeyAllowlist(...args),
+    getResolvedKeyAllowlist: (...args: unknown[]) =>
+      getResolvedKeyAllowlist(...args),
   }));
   vi.doMock("../extensions/url-safety.js", () => ({
     ssrfSafeFetch: (...args: unknown[]) => fetchMock(...args),
@@ -64,6 +67,7 @@ beforeEach(() => {
   );
   validateUrlAllowlist.mockReturnValue(true);
   getKeyAllowlist.mockResolvedValue(null);
+  getResolvedKeyAllowlist.mockResolvedValue(null);
   sendEmail.mockResolvedValue(undefined);
 });
 
@@ -228,6 +232,79 @@ describe("webhook notification channel", () => {
       "user",
       "alice@example.com",
     );
+  });
+
+  it("enforces an allowlist at the scope that supplied the webhook key", async () => {
+    process.env.NOTIFICATIONS_WEBHOOK_URL = "${keys.HOOK_URL}";
+    const resolvedRef = {
+      name: "HOOK_URL",
+      scope: "org" as const,
+      scopeId: "org-1",
+    };
+    resolveKeyReferencesWithRequestScopes.mockResolvedValue({
+      resolved: "https://evil.example.com/steal",
+      usedKeys: ["HOOK_URL"],
+      secretValues: [],
+      resolvedKeys: [resolvedRef],
+    });
+    getResolvedKeyAllowlist.mockResolvedValue(["https://hooks.example.com"]);
+    validateUrlAllowlist.mockReturnValue(false);
+
+    const channel = (await loadWebhookChannel())!;
+
+    await expect(
+      channel.deliver(
+        { severity: "critical", title: "x" },
+        { owner: "alice@example.com" },
+      ),
+    ).rejects.toThrow(/not in the allowlist/i);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(getResolvedKeyAllowlist).toHaveBeenCalledWith(resolvedRef);
+    expect(getKeyAllowlist).not.toHaveBeenCalled();
+  });
+
+  it("does not send an allowlisted auth key to a metadata-provided origin", async () => {
+    process.env.NOTIFICATIONS_WEBHOOK_AUTH = "Bearer ${keys.HOOK_TOKEN}";
+    const authRef = {
+      name: "HOOK_TOKEN",
+      scope: "org" as const,
+      scopeId: "org-1",
+    };
+    resolveKeyReferencesWithRequestScopes.mockImplementation(
+      async (text: string) =>
+        text.includes("HOOK_TOKEN")
+          ? {
+              resolved: "Bearer example-token",
+              usedKeys: ["HOOK_TOKEN"],
+              secretValues: ["example-token"],
+              resolvedKeys: [authRef],
+            }
+          : {
+              resolved: text,
+              usedKeys: [],
+              secretValues: [],
+              resolvedKeys: [],
+            },
+    );
+    getResolvedKeyAllowlist.mockResolvedValue(["https://hooks.example.com"]);
+    validateUrlAllowlist.mockReturnValue(false);
+
+    const channel = (await loadWebhookChannel())!;
+
+    await expect(
+      channel.deliver(
+        {
+          severity: "critical",
+          title: "x",
+          metadata: { webhookUrl: "https://evil.example.com/steal" },
+        },
+        { owner: "alice@example.com" },
+      ),
+    ).rejects.toThrow(/not in the allowlist/i);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(getResolvedKeyAllowlist).toHaveBeenCalledWith(authRef);
   });
 
   it("delivers when the resolved URL satisfies the allowlist", async () => {

--- a/packages/core/src/notifications/channels.ts
+++ b/packages/core/src/notifications/channels.ts
@@ -29,9 +29,10 @@
 
 import { ssrfSafeFetch } from "../extensions/url-safety.js";
 import {
+  getKeyAllowlist,
+  getResolvedKeyAllowlist,
   resolveKeyReferencesWithRequestScopes,
   validateUrlAllowlist,
-  getKeyAllowlist,
 } from "../secrets/substitution.js";
 import { sendEmail } from "../server/email.js";
 import { registerNotificationChannel } from "./registry.js";
@@ -229,39 +230,62 @@ async function resolveWebhookRequest(
   // strict superset of the previous user-scope-only behavior.
   // Missing keys throw — the error surfaces in logs and the channel is marked
   // un-delivered, but other channels still run.
-  const { resolved: url } = await resolveKeyReferencesWithRequestScopes(
+  const urlResult = await resolveKeyReferencesWithRequestScopes(
     urlTemplate,
     owner,
   );
+  const url = urlResult.resolved;
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
   };
+  let authResult:
+    | Awaited<ReturnType<typeof resolveKeyReferencesWithRequestScopes>>
+    | undefined;
   if (authTemplate) {
-    const { resolved: auth } = await resolveKeyReferencesWithRequestScopes(
+    authResult = await resolveKeyReferencesWithRequestScopes(
       authTemplate,
       owner,
     );
-    headers.Authorization = auth;
+    headers.Authorization = authResult.resolved;
   }
 
   // If the user set an allowlist on a referenced key, enforce it here —
   // origin-level check, same rule the automations fetch-tool applies.
-  // NOTE: this still checks the allowlist at user scope only (unlike the
-  // fetch tool's validateUrl, which now consults getResolvedKeyAllowlist at
-  // the scope the key actually resolved at — see agent-chat-plugin.ts). A
-  // key that resolves at org/workspace scope with an allowlist configured
-  // on that org/workspace row will not have it enforced here.
-  const keyNames = Array.from(
-    new Set(
-      Array.from(urlTemplate.matchAll(/\$\{keys\.([A-Za-z0-9_-]+)\}/g), (m) =>
-        String(m[1]),
-      ),
+  // Validate URL and Authorization keys independently so an allowlisted auth
+  // token cannot be sent to a metadata-provided destination. Keep scope in the
+  // dedupe key because the same key name can resolve at a different scope if a
+  // credential changes between the two substitutions.
+  type ResolvedKey = NonNullable<typeof urlResult.resolvedKeys>[number];
+  const keyUsages = new Map<
+    string,
+    { name: string; resolvedKey?: ResolvedKey }
+  >();
+  for (const result of authResult ? [urlResult, authResult] : [urlResult]) {
+    for (const name of result.usedKeys) {
+      const resolved = (result.resolvedKeys ?? []).filter(
+        (ref) => ref.name === name,
+      );
+      if (resolved.length === 0) {
+        keyUsages.set(`user:${owner}:${name}`, { name });
+        continue;
+      }
+      for (const resolvedKey of resolved) {
+        keyUsages.set(`${resolvedKey.scope}:${resolvedKey.scopeId}:${name}`, {
+          name,
+          resolvedKey,
+        });
+      }
+    }
+  }
+  const usages = Array.from(keyUsages.values());
+  const allowlists = await Promise.all(
+    usages.map(({ name, resolvedKey }) =>
+      resolvedKey
+        ? getResolvedKeyAllowlist(resolvedKey)
+        : getKeyAllowlist(name, "user", owner),
     ),
   );
-  const allowlists = await Promise.all(
-    keyNames.map((name) => getKeyAllowlist(name, "user", owner)),
-  );
-  keyNames.forEach((name, i) => {
+  usages.forEach(({ name }, i) => {
     if (!validateUrlAllowlist(url, allowlists[i])) {
       throw new Error(
         `[notifications] ${label} URL ${new URL(url).origin} is not in the allowlist for key "${name}"`,

--- a/packages/core/src/notifications/channels.ts
+++ b/packages/core/src/notifications/channels.ts
@@ -73,7 +73,7 @@ function createWebhookChannel(
       // No-op when neither a per-notification nor workspace URL is set —
       // mirrors email's empty-recipients behavior so notify-all stays quiet.
       if (!urlTemplate) return false;
-      const { url, headers } = await resolveWebhookRequest(
+      const { url, headers, assertUrlAllowed } = await resolveWebhookRequest(
         urlTemplate,
         overrideUrlTemplate ? undefined : authTemplate,
         meta.owner,
@@ -93,7 +93,7 @@ function createWebhookChannel(
             emittedAt: new Date().toISOString(),
           }),
         },
-        { maxRedirects: 3 },
+        { maxRedirects: 3, assertUrlAllowed },
       );
       if (!res.ok) {
         throw new Error(
@@ -122,7 +122,7 @@ function createSlackWebhookChannel(
         metadataString(input.metadata, "slackWebhookUrl") ??
         envUrlTemplate?.trim();
       if (!urlTemplate) return false;
-      const { url, headers } = await resolveWebhookRequest(
+      const { url, headers, assertUrlAllowed } = await resolveWebhookRequest(
         urlTemplate,
         overrideUrlTemplate ? undefined : authTemplate,
         meta.owner,
@@ -166,7 +166,7 @@ function createSlackWebhookChannel(
             ],
           }),
         },
-        { maxRedirects: 3 },
+        { maxRedirects: 3, assertUrlAllowed },
       );
       if (!res.ok) {
         throw new Error(
@@ -215,7 +215,11 @@ async function resolveWebhookRequest(
   authTemplate: string | undefined,
   owner: string,
   label: string,
-): Promise<{ url: string; headers: Record<string, string> }> {
+): Promise<{
+  url: string;
+  headers: Record<string, string>;
+  assertUrlAllowed: (url: string) => void;
+}> {
   // Resolve `${keys.NAME}` references through the same request-scope
   // cascade already used by extension fetches (extensions/routes.ts) and
   // automation connector headers (automation/index.ts): user scope first
@@ -285,14 +289,17 @@ async function resolveWebhookRequest(
         : getKeyAllowlist(name, "user", owner),
     ),
   );
-  usages.forEach(({ name }, i) => {
-    if (!validateUrlAllowlist(url, allowlists[i])) {
-      throw new Error(
-        `[notifications] ${label} URL ${new URL(url).origin} is not in the allowlist for key "${name}"`,
-      );
-    }
-  });
-  return { url, headers };
+  const assertUrlAllowed = (candidateUrl: string): void => {
+    usages.forEach(({ name }, i) => {
+      if (!validateUrlAllowlist(candidateUrl, allowlists[i])) {
+        throw new Error(
+          `[notifications] ${label} URL ${new URL(candidateUrl).origin} is not in the allowlist for key "${name}"`,
+        );
+      }
+    });
+  };
+  assertUrlAllowed(url);
+  return { url, headers, assertUrlAllowed };
 }
 
 function metadataString(

--- a/packages/core/src/server/action-discovery.spec.ts
+++ b/packages/core/src/server/action-discovery.spec.ts
@@ -92,6 +92,21 @@ describe("action discovery", () => {
     expect(registry["safe-write"].parallelSafe).toBe(true);
   });
 
+  it("preserves explicit duplicate-read opt-out metadata", () => {
+    const registry = loadActionsFromStaticRegistry({
+      "poll-run": {
+        default: {
+          tool: { description: "Poll run status", parameters: {} },
+          readOnly: true,
+          dedupe: false,
+          run: async () => ({ status: "running" }),
+        },
+      },
+    });
+
+    expect(registry["poll-run"].dedupe).toBe(false);
+  });
+
   it("preserves explicit allowInPlanMode false metadata", () => {
     const registry = loadActionsFromStaticRegistry({
       "act-only-read": {

--- a/packages/core/src/server/action-discovery.ts
+++ b/packages/core/src/server/action-discovery.ts
@@ -192,6 +192,9 @@ function preserveActionFlags(entry: Record<string, any>): Partial<ActionEntry> {
   if (typeof entry.parallelSafe === "boolean") {
     out.parallelSafe = entry.parallelSafe;
   }
+  if (typeof entry.dedupe === "boolean") {
+    out.dedupe = entry.dedupe;
+  }
   if (typeof entry.toolCallable === "boolean") {
     out.toolCallable = entry.toolCallable;
   }
@@ -716,7 +719,7 @@ export async function mergeCoreSharingActions(
           run: def.run,
           ...(def.http !== undefined ? { http: def.http } : {}),
           // Carry security-relevant flags (toolCallable, publicAgent, link,
-          // mcpApp) plus readOnly/parallelSafe. Without this, the sharing
+          // mcpApp) plus readOnly/parallelSafe/dedupe. Without this, the sharing
           // actions' `toolCallable: false` (audit-H5) is dropped and the
           // tools-iframe bridge 403 in action-routes.ts never fires.
           ...preserveActionFlags(def),

--- a/packages/core/src/server/agent-chat/context-tools.ts
+++ b/packages/core/src/server/agent-chat/context-tools.ts
@@ -241,6 +241,10 @@ export function createRefreshScreenEntry(): Record<string, ActionEntry> {
       // distinct `screen-refresh` poll event. Don't double-emit a generic
       // `action` event on top of that.
       readOnly: true,
+      // Refetching volatile on-screen state is the entire point of this
+      // tool — an identical repeat call (even with the same scope) is a
+      // legitimate re-refresh, not a redundant read to skip.
+      dedupe: false,
       tool: {
         description:
           "Manually refresh the user's current screen. The framework ALREADY auto-refreshes after any successful mutating action tool call (template actions and any enabled raw DB write tools) — you do NOT need to call this after a normal action. Use it only when (a) you mutated data via a path the framework can't detect (e.g. a direct write to an external system the app mirrors), or (b) you want to pass a `scope` hint so the UI narrows which queries to refetch. The UI re-fetches its queries without a full page reload.",


### PR DESCRIPTION
## Summary

- keep duplicate read-only tool caching scoped to the current continuation, re-serve results after context trimming, and stop only repeated visible calls
- let volatile polling tools opt out of deduping and preserve that metadata through action discovery
- preserve complete extension source/history results with a larger per-tool result limit
- enforce notification webhook allowlists at the user, organization, or workspace scope that supplied every URL or authorization secret

## Testing

- `corepack pnpm run prep`
- `corepack pnpm --filter @agent-native/core exec vitest --run src/action.spec.ts src/server/action-discovery.spec.ts src/agent/production-agent.spec.ts src/notifications/channels.spec.ts src/secrets/substitution.spec.ts --maxWorkers=25%`
- `corepack pnpm --filter @agent-native/core typecheck`
