### PR TITLE
Calendar: render out-of-office behind events

### DIFF
--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/hooks/use-view-preferences";
 import { partitionAllDayEvents } from "@/lib/all-day-layout";
 import { getEventDisplayColor, allOtherDeclined } from "@/lib/event-colors";
+import { isOutOfOfficeEvent } from "@/lib/out-of-office";
 import {
   shouldSuppressAfterPopoverClose,
   shouldSuppressCreatePointerDown,
@@ -44,6 +45,7 @@ import {
 } from "@/lib/working-location";
 
 import { EventDetailPopover } from "./EventDetailPopover";
+import { OutOfOfficeEvent } from "./OutOfOfficeEvent";
 
 interface DayViewProps {
   events: CalendarEvent[];
@@ -230,6 +232,7 @@ interface DayEventCardProps {
   onDraftUpdate?: DayViewProps["onDraftUpdate"];
   onDraftCreate?: DayViewProps["onDraftCreate"];
   onDraftDiscard?: DayViewProps["onDraftDiscard"];
+  onPopoverOpenChange: (event: CalendarEvent, open: boolean) => void;
 }
 
 /**
@@ -262,6 +265,7 @@ const DayEventCard = memo(function DayEventCard({
   onDraftUpdate,
   onDraftCreate,
   onDraftDiscard,
+  onPopoverOpenChange,
 }: DayEventCardProps) {
   const t = useT();
   const workingLocationLabels = createWorkingLocationDisplayLabels(t);
@@ -488,6 +492,7 @@ const DayEventCard = memo(function DayEventCard({
       onDraftUpdate={onDraftUpdate}
       onDraftCreate={onDraftCreate}
       onDraftDiscard={onDraftDiscard}
+      onOpenChange={(open) => onPopoverOpenChange(event, open)}
     >
       {eventButton}
     </EventDetailPopover>
@@ -543,6 +548,7 @@ export const DayView = memo(function DayView({
   const { prefs } = useViewPreferences();
   const [now, setNow] = useState(new Date());
   const [focusedEventId, setFocusedEventId] = useState<string | null>(null);
+  const focusedEventIdRef = useRef<string | null>(null);
   const currentTimeRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
@@ -550,6 +556,7 @@ export const DayView = memo(function DayView({
   useEffect(() => {
     function handleKey(e: KeyboardEvent) {
       if (e.key === "Escape") {
+        focusedEventIdRef.current = null;
         setFocusedEventId(null);
         setFocusedEvent(null);
       }
@@ -594,7 +601,14 @@ export const DayView = memo(function DayView({
     () => partitionAllDayEvents(allDayEvents),
     [allDayEvents],
   );
-  const timedEvents = useMemo(() => events.filter((e) => !e.allDay), [events]);
+  const outOfOfficeEvents = useMemo(
+    () => events.filter((event) => !event.allDay && isOutOfOfficeEvent(event)),
+    [events],
+  );
+  const timedEvents = useMemo(
+    () => events.filter((event) => !event.allDay && !isOutOfOfficeEvent(event)),
+    [events],
+  );
   const layout = useMemo(() => computeLayout(timedEvents), [timedEvents]);
 
   // Timezone label: prefer the short generic name (e.g. "PT", "ET")
@@ -666,8 +680,25 @@ export const DayView = memo(function DayView({
 
   const canDrag = !!onEventTimeChange;
 
+  const handleEventPopoverOpenChange = useCallback(
+    (event: CalendarEvent, open: boolean) => {
+      if (open) {
+        focusedEventIdRef.current = event.id;
+        setFocusedEventId(event.id);
+        setFocusedEvent(event);
+        return;
+      }
+      if (focusedEventIdRef.current !== event.id) return;
+      focusedEventIdRef.current = null;
+      setFocusedEventId(null);
+      setFocusedEvent(null);
+    },
+    [setFocusedEvent],
+  );
+
   const handleEventPointerDown = useCallback(
     (e: React.PointerEvent, event: CalendarEvent, isStart: boolean) => {
+      focusedEventIdRef.current = event.id;
       setFocusedEventId(event.id);
       setFocusedEvent(event);
       if (
@@ -999,6 +1030,33 @@ export const DayView = memo(function DayView({
             </div>
           )}
 
+          {/* Native Google out-of-office context sits behind meetings. */}
+          {!isLoading &&
+            outOfOfficeEvents.map((event, markerIndex) => (
+              <OutOfOfficeEvent
+                key={event._tempId ?? event.id}
+                event={event}
+                day={date}
+                hourHeight={HOUR_HEIGHT}
+                color={
+                  getEventDisplayColor(event, prefs) ?? "hsl(var(--primary))"
+                }
+                label={t("eventForm.outOfOffice")}
+                markerIndex={markerIndex}
+                onDelete={onDeleteEvent}
+                isDraft={draftEventIds.includes(event.id)}
+                defaultOpen={quickEditEventId === event.id}
+                onTitleSave={onQuickEditSave}
+                onDismissNew={onQuickEditCancel}
+                onDraftUpdate={onDraftUpdate}
+                onDraftCreate={onDraftCreate}
+                onDraftDiscard={onDraftDiscard}
+                onOpenChange={(open) =>
+                  handleEventPopoverOpenChange(event, open)
+                }
+              />
+            ))}
+
           {/* Skeleton events when loading */}
           {isLoading &&
             DAY_SKELETONS.map(
@@ -1053,6 +1111,7 @@ export const DayView = memo(function DayView({
                   onDraftUpdate={onDraftUpdate}
                   onDraftCreate={onDraftCreate}
                   onDraftDiscard={onDraftDiscard}
+                  onPopoverOpenChange={handleEventPopoverOpenChange}
                 />
               );
             })}

--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -1032,30 +1032,50 @@ export const DayView = memo(function DayView({
 
           {/* Native Google out-of-office context sits behind meetings. */}
           {!isLoading &&
-            outOfOfficeEvents.map((event, markerIndex) => (
-              <OutOfOfficeEvent
-                key={event._tempId ?? event.id}
-                event={event}
-                day={date}
-                hourHeight={HOUR_HEIGHT}
-                color={
-                  getEventDisplayColor(event, prefs) ?? "hsl(var(--primary))"
-                }
-                label={t("eventForm.outOfOffice")}
-                markerIndex={markerIndex}
-                onDelete={onDeleteEvent}
-                isDraft={draftEventIds.includes(event.id)}
-                defaultOpen={quickEditEventId === event.id}
-                onTitleSave={onQuickEditSave}
-                onDismissNew={onQuickEditCancel}
-                onDraftUpdate={onDraftUpdate}
-                onDraftCreate={onDraftCreate}
-                onDraftDiscard={onDraftDiscard}
-                onOpenChange={(open) =>
-                  handleEventPopoverOpenChange(event, open)
-                }
-              />
-            ))}
+            outOfOfficeEvents.map((event, markerIndex) => {
+              const isBeingDragged = dragEventId === event.id;
+              const overrides = getDragOverrides(event.id);
+              return (
+                <OutOfOfficeEvent
+                  key={event._tempId ?? event.id}
+                  event={event}
+                  day={date}
+                  hourHeight={HOUR_HEIGHT}
+                  color={
+                    getEventDisplayColor(event, prefs) ?? "hsl(var(--primary))"
+                  }
+                  label={t("eventForm.outOfOffice")}
+                  markerIndex={markerIndex}
+                  canDrag={canDrag}
+                  isBeingDragged={isBeingDragged}
+                  isDragging={isDragging}
+                  isDragTargetDay={isBeingDragged}
+                  overrideTop={overrides?.top ?? null}
+                  overrideHeight={overrides?.height ?? null}
+                  onMovePointerDown={(pointerEvent, startsOnDay) =>
+                    handleEventPointerDown(pointerEvent, event, startsOnDay)
+                  }
+                  onResizeTopPointerDown={(pointerEvent) =>
+                    handleResizeTopPointerDown(pointerEvent, event.id)
+                  }
+                  onResizeBottomPointerDown={(pointerEvent) =>
+                    handleResizeBottomPointerDown(pointerEvent, event.id)
+                  }
+                  shouldSuppressClick={shouldSuppressClick}
+                  onDelete={onDeleteEvent}
+                  isDraft={draftEventIds.includes(event.id)}
+                  defaultOpen={quickEditEventId === event.id}
+                  onTitleSave={onQuickEditSave}
+                  onDismissNew={onQuickEditCancel}
+                  onDraftUpdate={onDraftUpdate}
+                  onDraftCreate={onDraftCreate}
+                  onDraftDiscard={onDraftDiscard}
+                  onOpenChange={(open) =>
+                    handleEventPopoverOpenChange(event, open)
+                  }
+                />
+              );
+            })}
 
           {/* Skeleton events when loading */}
           {isLoading &&

--- a/templates/calendar/app/components/calendar/EventCard.tsx
+++ b/templates/calendar/app/components/calendar/EventCard.tsx
@@ -1,12 +1,13 @@
 import { useT } from "@agent-native/core/client";
 import type { CalendarEvent } from "@shared/api";
-import { IconAlertTriangleFilled } from "@tabler/icons-react";
+import { IconAlertTriangleFilled, IconCalendarOff } from "@tabler/icons-react";
 
 import {
   getEventDisplayColor,
   allOtherDeclined,
   type CalendarColorPreferences,
 } from "@/lib/event-colors";
+import { isOutOfOfficeEvent } from "@/lib/out-of-office";
 import { EventStatusIcon } from "@/lib/rsvp-status";
 import { cn } from "@/lib/utils";
 import {
@@ -44,6 +45,7 @@ export function EventCard({
   const title = getWorkingLocationChipLabel(event, workingLocationLabels);
   const ariaTitle = getWorkingLocationTitle(event, workingLocationLabels);
   const isWorkingLocation = isWorkingLocationEvent(event);
+  const isOutOfOffice = isOutOfOfficeEvent(event);
 
   const handleDragStart = (e: React.DragEvent) => {
     e.dataTransfer.setData("text/plain", event.id);
@@ -73,7 +75,13 @@ export function EventCard({
           backgroundColor: `${accentColor}25`,
         }}
       >
-        {allOtherDeclined(event) ? (
+        {isOutOfOffice ? (
+          <IconCalendarOff
+            aria-hidden="true"
+            className="size-3 shrink-0"
+            style={{ color: accentColor }}
+          />
+        ) : allOtherDeclined(event) ? (
           <IconAlertTriangleFilled
             size={10}
             className="shrink-0 text-current opacity-70"
@@ -89,6 +97,11 @@ export function EventCard({
         {isWorkingLocation && (
           <span className="hidden shrink-0 text-[10px] font-normal text-foreground/65 sm:inline">
             {t("eventForm.workingLocation")}
+          </span>
+        )}
+        {isOutOfOffice && (
+          <span className="hidden shrink-0 text-[10px] font-normal text-foreground/65 sm:inline">
+            {t("eventForm.outOfOffice")}
           </span>
         )}
         {event.ownerColor && (
@@ -123,7 +136,14 @@ export function EventCard({
       }}
     >
       <div className="flex items-center gap-1 truncate">
-        {allOtherDeclined(event) && (
+        {isOutOfOffice && (
+          <IconCalendarOff
+            aria-hidden="true"
+            className="size-3 shrink-0"
+            style={{ color: accentColor }}
+          />
+        )}
+        {!isOutOfOffice && allOtherDeclined(event) && (
           <IconAlertTriangleFilled
             size={12}
             className="shrink-0 text-current opacity-70"
@@ -135,6 +155,11 @@ export function EventCard({
       {isWorkingLocation && (
         <span className="truncate text-foreground/70">
           {t("eventForm.workingLocation")}
+        </span>
+      )}
+      {isOutOfOffice && (
+        <span className="truncate text-foreground/70">
+          {t("eventForm.outOfOffice")}
         </span>
       )}
       {!event.allDay && (

--- a/templates/calendar/app/components/calendar/EventDetailPanel.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPanel.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useUpdateEvent } from "@/hooks/use-events";
 import { useViewPreferences } from "@/hooks/use-view-preferences";
+import { isOutOfOfficeEvent } from "@/lib/out-of-office";
 import { cn } from "@/lib/utils";
 import {
   buildWorkingLocationUpdate,
@@ -135,6 +136,7 @@ export function EventDetailPanel({
     useGuestNotificationPrompt();
   const isOverlay = !!event?.overlayEmail;
   const isWorkingLocation = event ? isWorkingLocationEvent(event) : false;
+  const isOutOfOffice = event ? isOutOfOfficeEvent(event) : false;
   const isRecurringEvent = !!(
     event?.recurringEventId || event?.recurrence?.length
   );
@@ -293,7 +295,9 @@ export function EventDetailPanel({
                 <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
                   {isWorkingLocation
                     ? t("eventForm.workingLocation")
-                    : t("eventForm.event")}
+                    : isOutOfOffice
+                      ? t("eventForm.outOfOffice")
+                      : t("eventForm.event")}
                 </span>
                 <div className="flex items-center gap-0.5">
                   <Tooltip>

--- a/templates/calendar/app/components/calendar/EventDetailPopover.test.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.test.tsx
@@ -15,6 +15,7 @@ const { updateEventMutate } = vi.hoisted(() => ({
 const { calendarContext } = vi.hoisted(() => ({
   calendarContext: {
     eventDetailSidebar: false,
+    sidebarEvent: null as CalendarEvent | null,
     setEventDetailSidebar: vi.fn(),
     setSidebarEvent: vi.fn(),
     setFocusedEvent: vi.fn(),
@@ -210,6 +211,7 @@ describe("EventDetailPopover characterization", () => {
     unmounted = false;
     updateEventMutate.mockClear();
     calendarContext.eventDetailSidebar = false;
+    calendarContext.sidebarEvent = null;
     calendarContext.setEventDetailSidebar.mockClear();
     calendarContext.setSidebarEvent.mockClear();
     calendarContext.setFocusedEvent.mockClear();
@@ -333,6 +335,43 @@ describe("EventDetailPopover characterization", () => {
     // visibly opened.
     expect(findByExactText("button", "Open")).toBeUndefined();
     expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("notifies parents when sidebar details open and close", () => {
+    const event = baseEvent();
+    const onOpenChange = vi.fn();
+    calendarContext.eventDetailSidebar = true;
+    calendarContext.sidebarEvent = event;
+
+    act(() => {
+      root.render(
+        <EventDetailPopover
+          event={event}
+          onDelete={() => undefined}
+          onOpenChange={onOpenChange}
+        >
+          <button type="button">Open</button>
+        </EventDetailPopover>,
+      );
+    });
+
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+
+    calendarContext.sidebarEvent = null;
+    act(() => {
+      root.render(
+        <EventDetailPopover
+          event={event}
+          onDelete={() => undefined}
+          onOpenChange={onOpenChange}
+        >
+          <button type="button">Open</button>
+        </EventDetailPopover>,
+      );
+    });
+
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+    expect(onOpenChange).toHaveBeenCalledTimes(2);
   });
 
   it("resyncs unedited fields from the event prop but preserves an in-progress edit on the actively edited field", () => {

--- a/templates/calendar/app/components/calendar/EventDetailPopover.test.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.test.tsx
@@ -271,6 +271,26 @@ describe("EventDetailPopover characterization", () => {
     expect(onOpenChange).toHaveBeenCalledTimes(2);
   });
 
+  it("notifies parents when default-open makes the popover visible", () => {
+    const onOpenChange = vi.fn();
+
+    act(() => {
+      root.render(
+        <EventDetailPopover
+          event={baseEvent()}
+          defaultOpen
+          onDelete={() => undefined}
+          onOpenChange={onOpenChange}
+        >
+          <button type="button">Open</button>
+        </EventDetailPopover>,
+      );
+    });
+
+    expect(onOpenChange).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+
   it("does not notify a popover open request suppressed by sidebar mode", () => {
     calendarContext.eventDetailSidebar = true;
     const onOpenChange = vi.fn();

--- a/templates/calendar/app/components/calendar/EventDetailPopover.test.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.test.tsx
@@ -12,6 +12,15 @@ const { updateEventMutate } = vi.hoisted(() => ({
   updateEventMutate: vi.fn(),
 }));
 
+const { calendarContext } = vi.hoisted(() => ({
+  calendarContext: {
+    eventDetailSidebar: false,
+    setEventDetailSidebar: vi.fn(),
+    setSidebarEvent: vi.fn(),
+    setFocusedEvent: vi.fn(),
+  },
+}));
+
 vi.mock("@agent-native/core/client", () => ({
   cn: (...values: Array<string | undefined | false>) =>
     values.filter(Boolean).join(" "),
@@ -46,6 +55,10 @@ vi.mock("@/components/calendar/FindTimePanel", () => ({
   FindTimeTakeover: () => null,
 }));
 
+vi.mock("@/components/layout/AppLayout", () => ({
+  useCalendarContext: () => calendarContext,
+}));
+
 // Data hooks backed by react-query: mock so the popover doesn't need a
 // QueryClientProvider in the test tree.
 vi.mock("@/hooks/use-events", () => ({
@@ -66,8 +79,25 @@ vi.mock("@/hooks/use-zoom-auth", () => ({
 // nested popovers (e.g. TimezoneCombobox) that default to closed stay out of
 // the DOM, matching how these primitives are mocked elsewhere in this repo.
 vi.mock("@/components/ui/popover", () => ({
-  Popover: ({ open, children }: { open?: boolean; children?: ReactNode }) =>
-    open ? <>{children}</> : null,
+  Popover: ({
+    open,
+    onOpenChange,
+    children,
+  }: {
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+    children?: ReactNode;
+  }) => (
+    <div>
+      <button type="button" onClick={() => onOpenChange?.(true)}>
+        Mock open popover
+      </button>
+      <button type="button" onClick={() => onOpenChange?.(false)}>
+        Mock close popover
+      </button>
+      {open ? children : null}
+    </div>
+  ),
   PopoverTrigger: ({ children }: { children?: ReactNode }) => <>{children}</>,
   PopoverContent: ({ children }: { children?: ReactNode }) => (
     <div>{children}</div>
@@ -179,6 +209,10 @@ describe("EventDetailPopover characterization", () => {
     root = createRoot(container);
     unmounted = false;
     updateEventMutate.mockClear();
+    calendarContext.eventDetailSidebar = false;
+    calendarContext.setEventDetailSidebar.mockClear();
+    calendarContext.setSidebarEvent.mockClear();
+    calendarContext.setFocusedEvent.mockClear();
   });
 
   afterEach(() => {
@@ -206,6 +240,61 @@ describe("EventDetailPopover characterization", () => {
     expect(
       findByExactText("span", "Halifax (America/Halifax)"),
     ).toBeUndefined();
+  });
+
+  it("notifies parents when the visible popover opens and closes", () => {
+    const onOpenChange = vi.fn();
+
+    act(() => {
+      root.render(
+        <EventDetailPopover
+          event={baseEvent()}
+          onDelete={() => undefined}
+          onOpenChange={onOpenChange}
+        >
+          <button type="button">Open</button>
+        </EventDetailPopover>,
+      );
+    });
+
+    const openButton = findByExactText("button", "Mock open popover");
+    act(() => {
+      (openButton as HTMLElement).click();
+    });
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+
+    const closeButton = findByExactText("button", "Mock close popover");
+    act(() => {
+      (closeButton as HTMLElement).click();
+    });
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+    expect(onOpenChange).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not notify a popover open request suppressed by sidebar mode", () => {
+    calendarContext.eventDetailSidebar = true;
+    const onOpenChange = vi.fn();
+
+    act(() => {
+      root.render(
+        <EventDetailPopover
+          event={baseEvent()}
+          onDelete={() => undefined}
+          onOpenChange={onOpenChange}
+        >
+          <button type="button">Open</button>
+        </EventDetailPopover>,
+      );
+    });
+
+    const openButton = findByExactText("button", "Mock open popover");
+    act(() => {
+      (openButton as HTMLElement).click();
+    });
+
+    // Sidebar mode consumes this interaction, so the popover never becomes
+    // visible and parents must not receive a misleading open notification.
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 
   it("resyncs unedited fields from the event prop but preserves an in-progress edit on the actively edited field", () => {

--- a/templates/calendar/app/components/calendar/EventDetailPopover.test.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.test.tsx
@@ -295,6 +295,24 @@ describe("EventDetailPopover characterization", () => {
     // Sidebar mode consumes this interaction, so the popover never becomes
     // visible and parents must not receive a misleading open notification.
     expect(onOpenChange).not.toHaveBeenCalled();
+
+    calendarContext.eventDetailSidebar = false;
+    act(() => {
+      root.render(
+        <EventDetailPopover
+          event={baseEvent()}
+          onDelete={() => undefined}
+          onOpenChange={onOpenChange}
+        >
+          <button type="button">Open</button>
+        </EventDetailPopover>,
+      );
+    });
+
+    // Disabling sidebar mode later must not reveal a popover that was never
+    // visibly opened.
+    expect(findByExactText("button", "Open")).toBeUndefined();
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 
   it("resyncs unedited fields from the event prop but preserves an in-progress edit on the actively edited field", () => {

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -1322,9 +1322,6 @@ export function EventDetailPopover({
         isNewEventRef.current = false;
       }
       setOpen(newOpen);
-      if (newOpen !== open) {
-        onOpenChange?.(newOpen);
-      }
     },
     [
       open,
@@ -1334,7 +1331,6 @@ export function EventDetailPopover({
       event.accountEmail,
       onTitleSave,
       onDismissNew,
-      onOpenChange,
       editingField,
       handleSaveDescription,
       handleSaveLocation,
@@ -1349,6 +1345,13 @@ export function EventDetailPopover({
 
   const popoverOpen =
     eventDetailSidebar && !isNewEventRef.current && !isDraft ? false : open;
+  const previousPopoverOpenRef = useRef(false);
+
+  useEffect(() => {
+    if (previousPopoverOpenRef.current === popoverOpen) return;
+    previousPopoverOpenRef.current = popoverOpen;
+    onOpenChange?.(popoverOpen);
+  }, [onOpenChange, popoverOpen]);
 
   useEffect(() => {
     const token = popoverTokenRef.current;

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -524,6 +524,7 @@ export function EventDetailPopover({
   }
   const {
     eventDetailSidebar,
+    sidebarEvent,
     setEventDetailSidebar,
     setSidebarEvent,
     setFocusedEvent,
@@ -1345,13 +1346,20 @@ export function EventDetailPopover({
 
   const popoverOpen =
     eventDetailSidebar && !isNewEventRef.current && !isDraft ? false : open;
-  const previousPopoverOpenRef = useRef(false);
+  const sidebarDetailsOpen =
+    eventDetailSidebar &&
+    !isNewEventRef.current &&
+    !isDraft &&
+    sidebarEvent?.id === event.id &&
+    sidebarEvent.accountEmail === event.accountEmail;
+  const detailsOpen = popoverOpen || sidebarDetailsOpen;
+  const previousDetailsOpenRef = useRef(false);
 
   useEffect(() => {
-    if (previousPopoverOpenRef.current === popoverOpen) return;
-    previousPopoverOpenRef.current = popoverOpen;
-    onOpenChange?.(popoverOpen);
-  }, [onOpenChange, popoverOpen]);
+    if (previousDetailsOpenRef.current === detailsOpen) return;
+    previousDetailsOpenRef.current = detailsOpen;
+    onOpenChange?.(detailsOpen);
+  }, [detailsOpen, onOpenChange]);
 
   useEffect(() => {
     const token = popoverTokenRef.current;

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -1281,6 +1281,7 @@ export function EventDetailPopover({
     (newOpen: boolean) => {
       const isPopoverSuppressed =
         eventDetailSidebar && !isNewEventRef.current && !isDraft;
+      if (newOpen && isPopoverSuppressed) return;
       if (!newOpen && open) {
         const trimmedTitle = editingTitle.trim();
         let savedPendingChange = false;
@@ -1321,7 +1322,7 @@ export function EventDetailPopover({
         isNewEventRef.current = false;
       }
       setOpen(newOpen);
-      if (!isPopoverSuppressed && newOpen !== open) {
+      if (newOpen !== open) {
         onOpenChange?.(newOpen);
       }
     },

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -97,6 +97,7 @@ import {
   type ReminderMode,
   validateAttachmentDrafts,
 } from "@/lib/event-form-utils";
+import { isOutOfOfficeEvent } from "@/lib/out-of-office";
 import {
   createEventDetailPopoverToken,
   markPopoverInteractOutside,
@@ -473,6 +474,8 @@ interface EventDetailPopoverProps {
   onTitleSave?: (eventId: string, title: string, accountEmail?: string) => void;
   /** Called when the popover is dismissed for a new event (to clean up if no title was set) */
   onDismissNew?: (eventId: string, accountEmail?: string) => void;
+  /** Called after the popover's visible open state changes through its normal lifecycle. */
+  onOpenChange?: (open: boolean) => void;
   onDraftUpdate?: (
     eventId: string,
     updates: Partial<CalendarEvent> & {
@@ -500,6 +503,7 @@ export function EventDetailPopover({
   defaultOpen = false,
   onTitleSave,
   onDismissNew,
+  onOpenChange,
   onDraftUpdate,
   onDraftCreate,
   onDraftDiscard,
@@ -525,6 +529,7 @@ export function EventDetailPopover({
     setFocusedEvent,
   } = useCalendarContext();
   const isWorkingLocation = isWorkingLocationEvent(event);
+  const isOutOfOffice = isOutOfOfficeEvent(event);
   const isSingleDayWorkingLocation = isWorkingLocation && event.allDay;
   const editableLocationValue = event.location || "";
 
@@ -1274,6 +1279,8 @@ export function EventDetailPopover({
       (isRecurringEvent ? t("eventForm.repeats") : null);
   const handleOpenChange = useCallback(
     (newOpen: boolean) => {
+      const isPopoverSuppressed =
+        eventDetailSidebar && !isNewEventRef.current && !isDraft;
       if (!newOpen && open) {
         const trimmedTitle = editingTitle.trim();
         let savedPendingChange = false;
@@ -1314,6 +1321,9 @@ export function EventDetailPopover({
         isNewEventRef.current = false;
       }
       setOpen(newOpen);
+      if (!isPopoverSuppressed && newOpen !== open) {
+        onOpenChange?.(newOpen);
+      }
     },
     [
       open,
@@ -1323,6 +1333,7 @@ export function EventDetailPopover({
       event.accountEmail,
       onTitleSave,
       onDismissNew,
+      onOpenChange,
       editingField,
       handleSaveDescription,
       handleSaveLocation,
@@ -1330,6 +1341,8 @@ export function EventDetailPopover({
       handleSaveMeetingLink,
       handleSaveReminders,
       handleSaveAttachments,
+      eventDetailSidebar,
+      isDraft,
     ],
   );
 
@@ -1386,9 +1399,11 @@ export function EventDetailPopover({
               <span>
                 {isWorkingLocation
                   ? t("eventForm.workingLocation")
-                  : isDraft
-                    ? t("eventForm.draftEvent")
-                    : t("eventForm.event")}
+                  : isOutOfOffice
+                    ? t("eventForm.outOfOffice")
+                    : isDraft
+                      ? t("eventForm.draftEvent")
+                      : t("eventForm.event")}
               </span>
             </div>
             <div className="flex items-center gap-0.5">

--- a/templates/calendar/app/components/calendar/OutOfOfficeEvent.tsx
+++ b/templates/calendar/app/components/calendar/OutOfOfficeEvent.tsx
@@ -62,22 +62,28 @@ export function OutOfOfficeEvent({
   const title = event.title || label;
 
   return (
-    <div
-      data-out-of-office-event={event.id}
-      className="pointer-events-none absolute inset-x-0 z-0"
-      style={{ top: `${top}px`, height: `${height}px` }}
-    >
+    <>
       <div
-        aria-hidden="true"
-        className="absolute inset-0"
+        data-out-of-office-event={event.id}
+        className="pointer-events-none absolute inset-x-0 z-0"
+        style={{ top: `${top}px`, height: `${height}px` }}
+      >
+        <div
+          aria-hidden="true"
+          className="absolute inset-0"
+          style={{
+            backgroundColor: `color-mix(in srgb, ${color} 7%, transparent)`,
+            boxShadow: `inset 2px 0 0 color-mix(in srgb, ${color} 28%, transparent)`,
+          }}
+        />
+      </div>
+      <div
+        data-out-of-office-trigger={event.id}
+        className="pointer-events-auto absolute right-1 z-40"
         style={{
-          backgroundColor: `color-mix(in srgb, ${color} 7%, transparent)`,
-          boxShadow: `inset 2px 0 0 color-mix(in srgb, ${color} 28%, transparent)`,
+          top: `${top + 4}px`,
+          left: `${4 + markerIndex * 12}px`,
         }}
-      />
-      <div
-        className="pointer-events-auto absolute right-1 top-1 z-10"
-        style={{ left: `${4 + markerIndex * 12}px` }}
       >
         <EventDetailPopover
           event={event}
@@ -108,6 +114,6 @@ export function OutOfOfficeEvent({
           </button>
         </EventDetailPopover>
       </div>
-    </div>
+    </>
   );
 }

--- a/templates/calendar/app/components/calendar/OutOfOfficeEvent.tsx
+++ b/templates/calendar/app/components/calendar/OutOfOfficeEvent.tsx
@@ -12,6 +12,7 @@ interface OutOfOfficeEventProps {
   color: string;
   label: string;
   markerIndex?: number;
+  compactMarker?: boolean;
   onDelete: (eventId: string) => void;
   isDraft: boolean;
   defaultOpen: boolean;
@@ -44,6 +45,7 @@ export function OutOfOfficeEvent({
   color,
   label,
   markerIndex = 0,
+  compactMarker = false,
   onDelete,
   isDraft,
   defaultOpen,
@@ -79,10 +81,11 @@ export function OutOfOfficeEvent({
       </div>
       <div
         data-out-of-office-trigger={event.id}
-        className="pointer-events-auto absolute right-1 z-40"
+        className="pointer-events-auto absolute z-40"
         style={{
           top: `${top + 4}px`,
-          left: `${4 + markerIndex * 12}px`,
+          right: `${4 + (compactMarker ? markerIndex * 24 : 0)}px`,
+          left: compactMarker ? undefined : `${4 + markerIndex * 12}px`,
         }}
       >
         <EventDetailPopover
@@ -98,7 +101,11 @@ export function OutOfOfficeEvent({
           onOpenChange={onOpenChange}
         >
           <button
-            className="flex h-5 max-w-full items-center gap-1 truncate rounded-sm px-1.5 text-left text-[10px] font-medium text-foreground outline-none transition-[filter,box-shadow] hover:brightness-110 focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1"
+            className={`flex h-5 max-w-full items-center truncate rounded-sm text-[10px] font-medium text-foreground outline-none transition-[filter,box-shadow] hover:brightness-110 focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 ${
+              compactMarker
+                ? "w-5 justify-center px-0"
+                : "gap-1 px-1.5 text-left"
+            }`}
             aria-label={`${label}: ${title}`}
             style={{
               backgroundColor: `color-mix(in srgb, ${color} 20%, hsl(var(--background)))`,
@@ -110,7 +117,7 @@ export function OutOfOfficeEvent({
               className="size-3 shrink-0"
               style={{ color }}
             />
-            <span className="truncate">{title}</span>
+            {!compactMarker && <span className="truncate">{title}</span>}
           </button>
         </EventDetailPopover>
       </div>

--- a/templates/calendar/app/components/calendar/OutOfOfficeEvent.tsx
+++ b/templates/calendar/app/components/calendar/OutOfOfficeEvent.tsx
@@ -167,29 +167,29 @@ export function OutOfOfficeEvent({
           </button>
         </EventDetailPopover>
       </div>
+      {canManipulate && (
+        <div
+          data-resize-handle="true"
+          data-out-of-office-resize="top"
+          onPointerDown={(pointerEvent) => {
+            pointerEvent.stopPropagation();
+            onResizeTopPointerDown?.(pointerEvent);
+          }}
+          className="pointer-events-auto absolute right-1 z-40 h-1.5 w-5 cursor-n-resize"
+          style={{ top: `${top}px`, touchAction: "none" }}
+        />
+      )}
       {canManipulate && endsOnDay && (
-        <>
-          <div
-            data-resize-handle="true"
-            data-out-of-office-resize="top"
-            onPointerDown={(pointerEvent) => {
-              pointerEvent.stopPropagation();
-              onResizeTopPointerDown?.(pointerEvent);
-            }}
-            className="pointer-events-auto absolute right-1 z-40 h-1.5 w-5 cursor-n-resize"
-            style={{ top: `${top}px`, touchAction: "none" }}
-          />
-          <div
-            data-resize-handle="true"
-            data-out-of-office-resize="bottom"
-            onPointerDown={(pointerEvent) => {
-              pointerEvent.stopPropagation();
-              onResizeBottomPointerDown?.(pointerEvent);
-            }}
-            className="pointer-events-auto absolute right-1 z-40 h-1.5 w-5 cursor-s-resize"
-            style={{ top: `${top + height - 6}px`, touchAction: "none" }}
-          />
-        </>
+        <div
+          data-resize-handle="true"
+          data-out-of-office-resize="bottom"
+          onPointerDown={(pointerEvent) => {
+            pointerEvent.stopPropagation();
+            onResizeBottomPointerDown?.(pointerEvent);
+          }}
+          className="pointer-events-auto absolute right-1 z-40 h-1.5 w-5 cursor-s-resize"
+          style={{ top: `${top + height - 6}px`, touchAction: "none" }}
+        />
       )}
     </>
   );

--- a/templates/calendar/app/components/calendar/OutOfOfficeEvent.tsx
+++ b/templates/calendar/app/components/calendar/OutOfOfficeEvent.tsx
@@ -1,0 +1,113 @@
+import type { CalendarEvent } from "@shared/api";
+import { IconCalendarOff } from "@tabler/icons-react";
+
+import { getOutOfOfficeSegment } from "@/lib/out-of-office";
+
+import { EventDetailPopover } from "./EventDetailPopover";
+
+interface OutOfOfficeEventProps {
+  event: CalendarEvent;
+  day: Date;
+  hourHeight: number;
+  color: string;
+  label: string;
+  markerIndex?: number;
+  onDelete: (eventId: string) => void;
+  isDraft: boolean;
+  defaultOpen: boolean;
+  onTitleSave?: (eventId: string, title: string, accountEmail?: string) => void;
+  onDismissNew?: (eventId: string, accountEmail?: string) => void;
+  onDraftUpdate?: (
+    eventId: string,
+    updates: Partial<CalendarEvent> & {
+      addGoogleMeet?: boolean;
+      addZoom?: boolean;
+      workingLocationType?: "homeOffice" | "officeLocation" | "customLocation";
+      workingLocationLabel?: string;
+    },
+  ) => void;
+  onDraftCreate?: (
+    eventId: string,
+    updates?: Partial<CalendarEvent> & {
+      addGoogleMeet?: boolean;
+      addZoom?: boolean;
+    },
+  ) => void;
+  onDraftDiscard?: (eventId: string) => void;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function OutOfOfficeEvent({
+  event,
+  day,
+  hourHeight,
+  color,
+  label,
+  markerIndex = 0,
+  onDelete,
+  isDraft,
+  defaultOpen,
+  onTitleSave,
+  onDismissNew,
+  onDraftUpdate,
+  onDraftCreate,
+  onDraftDiscard,
+  onOpenChange,
+}: OutOfOfficeEventProps) {
+  const segment = getOutOfOfficeSegment(event, day);
+  if (!segment) return null;
+
+  const top = (segment.topMinutes / 60) * hourHeight;
+  const height = (segment.durationMinutes / 60) * hourHeight;
+  const title = event.title || label;
+
+  return (
+    <div
+      data-out-of-office-event={event.id}
+      className="pointer-events-none absolute inset-x-0 z-0"
+      style={{ top: `${top}px`, height: `${height}px` }}
+    >
+      <div
+        aria-hidden="true"
+        className="absolute inset-0"
+        style={{
+          backgroundColor: `color-mix(in srgb, ${color} 7%, transparent)`,
+          boxShadow: `inset 2px 0 0 color-mix(in srgb, ${color} 28%, transparent)`,
+        }}
+      />
+      <div
+        className="pointer-events-auto absolute right-1 top-1 z-10"
+        style={{ left: `${4 + markerIndex * 12}px` }}
+      >
+        <EventDetailPopover
+          event={event}
+          onDelete={onDelete}
+          isDraft={isDraft}
+          defaultOpen={defaultOpen}
+          onTitleSave={onTitleSave}
+          onDismissNew={onDismissNew}
+          onDraftUpdate={onDraftUpdate}
+          onDraftCreate={onDraftCreate}
+          onDraftDiscard={onDraftDiscard}
+          onOpenChange={onOpenChange}
+        >
+          <button
+            className="flex h-5 max-w-full items-center gap-1 truncate rounded-sm px-1.5 text-left text-[10px] font-medium text-foreground outline-none transition-[filter,box-shadow] hover:brightness-110 focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1"
+            aria-label={`${label}: ${title}`}
+            style={{
+              backgroundColor: `color-mix(in srgb, ${color} 20%, hsl(var(--background)))`,
+              boxShadow: `0 0 0 1px color-mix(in srgb, ${color} 34%, transparent)`,
+            }}
+          >
+            <IconCalendarOff
+              aria-hidden="true"
+              className="size-3 shrink-0"
+              style={{ color }}
+            />
+            <span className="truncate">{title}</span>
+          </button>
+        </EventDetailPopover>
+      </div>
+    </div>
+  );
+}

--- a/templates/calendar/app/components/calendar/OutOfOfficeEvent.tsx
+++ b/templates/calendar/app/components/calendar/OutOfOfficeEvent.tsx
@@ -13,6 +13,16 @@ interface OutOfOfficeEventProps {
   label: string;
   markerIndex?: number;
   compactMarker?: boolean;
+  canDrag?: boolean;
+  isBeingDragged?: boolean;
+  isDragging?: boolean;
+  isDragTargetDay?: boolean;
+  overrideTop?: number | null;
+  overrideHeight?: number | null;
+  onMovePointerDown?: (event: React.PointerEvent, startsOnDay: boolean) => void;
+  onResizeTopPointerDown?: (event: React.PointerEvent) => void;
+  onResizeBottomPointerDown?: (event: React.PointerEvent) => void;
+  shouldSuppressClick?: () => boolean;
   onDelete: (eventId: string) => void;
   isDraft: boolean;
   defaultOpen: boolean;
@@ -46,6 +56,16 @@ export function OutOfOfficeEvent({
   label,
   markerIndex = 0,
   compactMarker = false,
+  canDrag = false,
+  isBeingDragged = false,
+  isDragging = false,
+  isDragTargetDay = false,
+  overrideTop = null,
+  overrideHeight = null,
+  onMovePointerDown,
+  onResizeTopPointerDown,
+  onResizeBottomPointerDown,
+  shouldSuppressClick,
   onDelete,
   isDraft,
   defaultOpen,
@@ -57,11 +77,24 @@ export function OutOfOfficeEvent({
   onOpenChange,
 }: OutOfOfficeEventProps) {
   const segment = getOutOfOfficeSegment(event, day);
-  if (!segment) return null;
+  const hasDragOverride =
+    isBeingDragged &&
+    isDragTargetDay &&
+    overrideTop !== null &&
+    overrideHeight !== null;
+  if (isBeingDragged && !isDragTargetDay) return null;
+  if (!segment && !hasDragOverride) return null;
 
-  const top = (segment.topMinutes / 60) * hourHeight;
-  const height = (segment.durationMinutes / 60) * hourHeight;
+  const top = hasDragOverride
+    ? overrideTop
+    : ((segment?.topMinutes ?? 0) / 60) * hourHeight;
+  const height = hasDragOverride
+    ? overrideHeight
+    : ((segment?.durationMinutes ?? 1) / 60) * hourHeight;
   const title = event.title || label;
+  const startsOnDay = hasDragOverride || segment?.startsOnDay === true;
+  const endsOnDay = hasDragOverride || segment?.endsOnDay === true;
+  const canManipulate = canDrag && startsOnDay;
 
   return (
     <>
@@ -81,7 +114,9 @@ export function OutOfOfficeEvent({
       </div>
       <div
         data-out-of-office-trigger={event.id}
-        className="pointer-events-auto absolute z-40"
+        className={`pointer-events-auto absolute ${
+          isBeingDragged && isDragging ? "z-[100]" : "z-40"
+        }`}
         style={{
           top: `${top + 4}px`,
           right: `${4 + (compactMarker ? markerIndex * 24 : 0)}px`,
@@ -101,10 +136,21 @@ export function OutOfOfficeEvent({
           onOpenChange={onOpenChange}
         >
           <button
+            onPointerDown={(pointerEvent) =>
+              onMovePointerDown?.(pointerEvent, startsOnDay)
+            }
+            onClick={(clickEvent) => {
+              if (shouldSuppressClick?.()) {
+                clickEvent.preventDefault();
+                clickEvent.stopPropagation();
+              }
+            }}
             className={`flex h-5 max-w-full items-center truncate rounded-sm text-[10px] font-medium text-foreground outline-none transition-[filter,box-shadow] hover:brightness-110 focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 ${
               compactMarker
                 ? "w-5 justify-center px-0"
                 : "gap-1 px-1.5 text-left"
+            } ${canManipulate ? "cursor-grab" : ""} ${
+              isBeingDragged && isDragging ? "cursor-grabbing shadow-lg" : ""
             }`}
             aria-label={`${label}: ${title}`}
             style={{
@@ -121,6 +167,30 @@ export function OutOfOfficeEvent({
           </button>
         </EventDetailPopover>
       </div>
+      {canManipulate && endsOnDay && (
+        <>
+          <div
+            data-resize-handle="true"
+            data-out-of-office-resize="top"
+            onPointerDown={(pointerEvent) => {
+              pointerEvent.stopPropagation();
+              onResizeTopPointerDown?.(pointerEvent);
+            }}
+            className="pointer-events-auto absolute right-1 z-40 h-1.5 w-5 cursor-n-resize"
+            style={{ top: `${top}px`, touchAction: "none" }}
+          />
+          <div
+            data-resize-handle="true"
+            data-out-of-office-resize="bottom"
+            onPointerDown={(pointerEvent) => {
+              pointerEvent.stopPropagation();
+              onResizeBottomPointerDown?.(pointerEvent);
+            }}
+            className="pointer-events-auto absolute right-1 z-40 h-1.5 w-5 cursor-s-resize"
+            style={{ top: `${top + height - 6}px`, touchAction: "none" }}
+          />
+        </>
+      )}
     </>
   );
 }

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -45,6 +45,7 @@ import {
 import { getEventDisplayColor, allOtherDeclined } from "@/lib/event-colors";
 import {
   getFirstVisibleOutOfOfficeDayIndex,
+  getOutOfOfficeSegment,
   isOutOfOfficeEvent,
 } from "@/lib/out-of-office";
 import {
@@ -1297,6 +1298,16 @@ export const WeekView = memo(function WeekView({
               }
             }
 
+            const visibleOutOfOfficeEvents = outOfOfficeEvents.filter(
+              (event) => {
+                const overrides = getDragOverrides(event.id);
+                return (
+                  getOutOfOfficeSegment(event, day) !== null ||
+                  (dragEventId === event.id && overrides?.dayIndex === dayIndex)
+                );
+              },
+            );
+
             return (
               <div
                 key={day.toISOString()}
@@ -1375,7 +1386,7 @@ export const WeekView = memo(function WeekView({
 
                 {/* Native Google out-of-office context sits behind meetings. */}
                 {!isLoading &&
-                  outOfOfficeEvents.map((event, markerIndex) => {
+                  visibleOutOfOfficeEvents.map((event, markerIndex) => {
                     const isBeingDragged = dragEventId === event.id;
                     const overrides = getDragOverrides(event.id);
                     const canonicalDayIndex =

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -1384,6 +1384,7 @@ export const WeekView = memo(function WeekView({
                       }
                       label={t("eventForm.outOfOffice")}
                       markerIndex={markerIndex}
+                      compactMarker
                       onDelete={onDeleteEvent}
                       isDraft={draftEventIds.includes(event.id)}
                       defaultOpen={quickEditEventId === event.id}

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -43,6 +43,7 @@ import {
   partitionAllDayEvents,
 } from "@/lib/all-day-layout";
 import { getEventDisplayColor, allOtherDeclined } from "@/lib/event-colors";
+import { isOutOfOfficeEvent } from "@/lib/out-of-office";
 import {
   shouldSuppressAfterPopoverClose,
   shouldSuppressCreatePointerDown,
@@ -56,6 +57,7 @@ import {
 } from "@/lib/working-location";
 
 import { EventDetailPopover } from "./EventDetailPopover";
+import { OutOfOfficeEvent } from "./OutOfOfficeEvent";
 import { shouldRenderWeekDragSegment } from "./week-drag-segment";
 
 interface WeekViewProps {
@@ -285,6 +287,7 @@ interface WeekEventCardProps {
   onDraftUpdate?: WeekViewProps["onDraftUpdate"];
   onDraftCreate?: WeekViewProps["onDraftCreate"];
   onDraftDiscard?: WeekViewProps["onDraftDiscard"];
+  onPopoverOpenChange: (event: CalendarEvent, open: boolean) => void;
 }
 
 /**
@@ -320,6 +323,7 @@ const WeekEventCard = memo(function WeekEventCard({
   onDraftUpdate,
   onDraftCreate,
   onDraftDiscard,
+  onPopoverOpenChange,
 }: WeekEventCardProps) {
   const t = useT();
   const li = layout.get(event.id) ?? {
@@ -558,6 +562,7 @@ const WeekEventCard = memo(function WeekEventCard({
       onDraftUpdate={onDraftUpdate}
       onDraftCreate={onDraftCreate}
       onDraftDiscard={onDraftDiscard}
+      onOpenChange={(open) => onPopoverOpenChange(event, open)}
     >
       {eventButton}
     </EventDetailPopover>
@@ -618,6 +623,7 @@ export const WeekView = memo(function WeekView({
   const GUTTER_WIDTH = isMobile ? MOBILE_GUTTER_WIDTH : DESKTOP_GUTTER_WIDTH;
   const [now, setNow] = useState(new Date());
   const [focusedEventId, setFocusedEventId] = useState<string | null>(null);
+  const focusedEventIdRef = useRef<string | null>(null);
   const currentTimeRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const allDayContainerRef = useRef<HTMLDivElement>(null);
@@ -628,6 +634,7 @@ export const WeekView = memo(function WeekView({
   useEffect(() => {
     function handleKey(e: KeyboardEvent) {
       if (e.key === "Escape") {
+        focusedEventIdRef.current = null;
         setFocusedEventId(null);
         setFocusedEvent(null);
       }
@@ -675,7 +682,15 @@ export const WeekView = memo(function WeekView({
   // Separate all-day and timed events
   const allDayEvents = useMemo(() => events.filter((e) => e.allDay), [events]);
 
-  const timedEvents = useMemo(() => events.filter((e) => !e.allDay), [events]);
+  const outOfOfficeEvents = useMemo(
+    () => events.filter((event) => !event.allDay && isOutOfOfficeEvent(event)),
+    [events],
+  );
+
+  const timedEvents = useMemo(
+    () => events.filter((event) => !event.allDay && !isOutOfOfficeEvent(event)),
+    [events],
+  );
 
   const { workingLocations, regularEvents } = useMemo(
     () => partitionAllDayEvents(allDayEvents),
@@ -849,6 +864,22 @@ export const WeekView = memo(function WeekView({
 
   const canDrag = !!onEventTimeChange;
 
+  const handleEventPopoverOpenChange = useCallback(
+    (event: CalendarEvent, open: boolean) => {
+      if (open) {
+        focusedEventIdRef.current = event.id;
+        setFocusedEventId(event.id);
+        setFocusedEvent(event);
+        return;
+      }
+      if (focusedEventIdRef.current !== event.id) return;
+      focusedEventIdRef.current = null;
+      setFocusedEventId(null);
+      setFocusedEvent(null);
+    },
+    [setFocusedEvent],
+  );
+
   const handleEventPointerDown = useCallback(
     (
       e: React.PointerEvent,
@@ -856,6 +887,7 @@ export const WeekView = memo(function WeekView({
       isStart: boolean,
       dayIndex: number,
     ) => {
+      focusedEventIdRef.current = event.id;
       setFocusedEventId(event.id);
       setFocusedEvent(event);
       if (
@@ -1338,6 +1370,34 @@ export const WeekView = memo(function WeekView({
                   </div>
                 )}
 
+                {/* Native Google out-of-office context sits behind meetings. */}
+                {!isLoading &&
+                  outOfOfficeEvents.map((event, markerIndex) => (
+                    <OutOfOfficeEvent
+                      key={`${event._tempId ?? event.id}:${day.toISOString()}`}
+                      event={event}
+                      day={day}
+                      hourHeight={HOUR_HEIGHT}
+                      color={
+                        getEventDisplayColor(event, prefs) ??
+                        "hsl(var(--primary))"
+                      }
+                      label={t("eventForm.outOfOffice")}
+                      markerIndex={markerIndex}
+                      onDelete={onDeleteEvent}
+                      isDraft={draftEventIds.includes(event.id)}
+                      defaultOpen={quickEditEventId === event.id}
+                      onTitleSave={onQuickEditSave}
+                      onDismissNew={onQuickEditCancel}
+                      onDraftUpdate={onDraftUpdate}
+                      onDraftCreate={onDraftCreate}
+                      onDraftDiscard={onDraftDiscard}
+                      onOpenChange={(open) =>
+                        handleEventPopoverOpenChange(event, open)
+                      }
+                    />
+                  ))}
+
                 {/* Skeleton events when loading */}
                 {isLoading &&
                   WEEK_SKELETONS[dayIndex]?.map(
@@ -1402,6 +1462,7 @@ export const WeekView = memo(function WeekView({
                         onDraftUpdate={onDraftUpdate}
                         onDraftCreate={onDraftCreate}
                         onDraftDiscard={onDraftDiscard}
+                        onPopoverOpenChange={handleEventPopoverOpenChange}
                       />
                     );
                   })}

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -43,7 +43,10 @@ import {
   partitionAllDayEvents,
 } from "@/lib/all-day-layout";
 import { getEventDisplayColor, allOtherDeclined } from "@/lib/event-colors";
-import { isOutOfOfficeEvent } from "@/lib/out-of-office";
+import {
+  getFirstVisibleOutOfOfficeDayIndex,
+  isOutOfOfficeEvent,
+} from "@/lib/out-of-office";
 import {
   shouldSuppressAfterPopoverClose,
   shouldSuppressCreatePointerDown,
@@ -1372,32 +1375,70 @@ export const WeekView = memo(function WeekView({
 
                 {/* Native Google out-of-office context sits behind meetings. */}
                 {!isLoading &&
-                  outOfOfficeEvents.map((event, markerIndex) => (
-                    <OutOfOfficeEvent
-                      key={`${event._tempId ?? event.id}:${day.toISOString()}`}
-                      event={event}
-                      day={day}
-                      hourHeight={HOUR_HEIGHT}
-                      color={
-                        getEventDisplayColor(event, prefs) ??
-                        "hsl(var(--primary))"
-                      }
-                      label={t("eventForm.outOfOffice")}
-                      markerIndex={markerIndex}
-                      compactMarker
-                      onDelete={onDeleteEvent}
-                      isDraft={draftEventIds.includes(event.id)}
-                      defaultOpen={quickEditEventId === event.id}
-                      onTitleSave={onQuickEditSave}
-                      onDismissNew={onQuickEditCancel}
-                      onDraftUpdate={onDraftUpdate}
-                      onDraftCreate={onDraftCreate}
-                      onDraftDiscard={onDraftDiscard}
-                      onOpenChange={(open) =>
-                        handleEventPopoverOpenChange(event, open)
-                      }
-                    />
-                  ))}
+                  outOfOfficeEvents.map((event, markerIndex) => {
+                    const isBeingDragged = dragEventId === event.id;
+                    const overrides = getDragOverrides(event.id);
+                    const canonicalDayIndex =
+                      getFirstVisibleOutOfOfficeDayIndex(event, days);
+                    return (
+                      <OutOfOfficeEvent
+                        key={`${event._tempId ?? event.id}:${day.toISOString()}`}
+                        event={event}
+                        day={day}
+                        hourHeight={HOUR_HEIGHT}
+                        color={
+                          getEventDisplayColor(event, prefs) ??
+                          "hsl(var(--primary))"
+                        }
+                        label={t("eventForm.outOfOffice")}
+                        markerIndex={markerIndex}
+                        compactMarker
+                        canDrag={canDrag}
+                        isBeingDragged={isBeingDragged}
+                        isDragging={isDragging}
+                        isDragTargetDay={overrides?.dayIndex === dayIndex}
+                        overrideTop={overrides?.top ?? null}
+                        overrideHeight={overrides?.height ?? null}
+                        onMovePointerDown={(pointerEvent, startsOnDay) =>
+                          handleEventPointerDown(
+                            pointerEvent,
+                            event,
+                            startsOnDay,
+                            dayIndex,
+                          )
+                        }
+                        onResizeTopPointerDown={(pointerEvent) =>
+                          handleResizeTopPointerDown(
+                            pointerEvent,
+                            event.id,
+                            dayIndex,
+                          )
+                        }
+                        onResizeBottomPointerDown={(pointerEvent) =>
+                          handleResizeBottomPointerDown(
+                            pointerEvent,
+                            event.id,
+                            dayIndex,
+                          )
+                        }
+                        shouldSuppressClick={shouldSuppressClick}
+                        onDelete={onDeleteEvent}
+                        isDraft={draftEventIds.includes(event.id)}
+                        defaultOpen={
+                          quickEditEventId === event.id &&
+                          dayIndex === canonicalDayIndex
+                        }
+                        onTitleSave={onQuickEditSave}
+                        onDismissNew={onQuickEditCancel}
+                        onDraftUpdate={onDraftUpdate}
+                        onDraftCreate={onDraftCreate}
+                        onDraftDiscard={onDraftDiscard}
+                        onOpenChange={(open) =>
+                          handleEventPopoverOpenChange(event, open)
+                        }
+                      />
+                    );
+                  })}
 
                 {/* Skeleton events when loading */}
                 {isLoading &&

--- a/templates/calendar/app/lib/out-of-office.test.ts
+++ b/templates/calendar/app/lib/out-of-office.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import { getOutOfOfficeSegment, isOutOfOfficeEvent } from "./out-of-office";
 
+function localIso(day: number, hour: number): string {
+  return new Date(2026, 6, day, hour).toISOString();
+}
+
 describe("out-of-office display", () => {
   it("recognizes native Google out-of-office events", () => {
     expect(isOutOfOfficeEvent({ eventType: "outOfOffice" })).toBe(true);
@@ -12,10 +16,10 @@ describe("out-of-office display", () => {
     expect(
       getOutOfOfficeSegment(
         {
-          start: "2026-07-22T09:00:00-04:00",
-          end: "2026-07-22T17:00:00-04:00",
+          start: localIso(22, 9),
+          end: localIso(22, 17),
         },
-        new Date("2026-07-22T12:00:00-04:00"),
+        new Date(2026, 6, 22, 12),
       ),
     ).toEqual({
       topMinutes: 9 * 60,
@@ -29,10 +33,10 @@ describe("out-of-office display", () => {
     expect(
       getOutOfOfficeSegment(
         {
-          start: "2026-07-21T12:00:00-04:00",
-          end: "2026-07-23T12:00:00-04:00",
+          start: localIso(21, 12),
+          end: localIso(23, 12),
         },
-        new Date("2026-07-22T12:00:00-04:00"),
+        new Date(2026, 6, 22, 12),
       ),
     ).toEqual({
       topMinutes: 0,
@@ -46,10 +50,10 @@ describe("out-of-office display", () => {
     expect(
       getOutOfOfficeSegment(
         {
-          start: "2026-07-22T09:00:00-04:00",
-          end: "2026-07-22T17:00:00-04:00",
+          start: localIso(22, 9),
+          end: localIso(22, 17),
         },
-        new Date("2026-07-23T12:00:00-04:00"),
+        new Date(2026, 6, 23, 12),
       ),
     ).toBeNull();
   });

--- a/templates/calendar/app/lib/out-of-office.test.ts
+++ b/templates/calendar/app/lib/out-of-office.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { getOutOfOfficeSegment, isOutOfOfficeEvent } from "./out-of-office";
+import {
+  getFirstVisibleOutOfOfficeDayIndex,
+  getOutOfOfficeSegment,
+  isOutOfOfficeEvent,
+} from "./out-of-office";
 
 function localIso(day: number, hour: number): string {
   return new Date(2026, 6, day, hour).toISOString();
@@ -56,5 +60,15 @@ describe("out-of-office display", () => {
         new Date(2026, 6, 23, 12),
       ),
     ).toBeNull();
+  });
+
+  it("selects one canonical visible segment for multi-day details", () => {
+    const event = {
+      start: localIso(21, 12),
+      end: localIso(24, 12),
+    };
+    const days = [22, 23, 24].map((day) => new Date(2026, 6, day, 12));
+
+    expect(getFirstVisibleOutOfOfficeDayIndex(event, days)).toBe(0);
   });
 });

--- a/templates/calendar/app/lib/out-of-office.test.ts
+++ b/templates/calendar/app/lib/out-of-office.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { getOutOfOfficeSegment, isOutOfOfficeEvent } from "./out-of-office";
+
+describe("out-of-office display", () => {
+  it("recognizes native Google out-of-office events", () => {
+    expect(isOutOfOfficeEvent({ eventType: "outOfOffice" })).toBe(true);
+    expect(isOutOfOfficeEvent({ eventType: "default" })).toBe(false);
+  });
+
+  it("returns the visible portion of a partial-day event", () => {
+    expect(
+      getOutOfOfficeSegment(
+        {
+          start: "2026-07-22T09:00:00-04:00",
+          end: "2026-07-22T17:00:00-04:00",
+        },
+        new Date("2026-07-22T12:00:00-04:00"),
+      ),
+    ).toEqual({
+      topMinutes: 9 * 60,
+      durationMinutes: 8 * 60,
+      startsOnDay: true,
+      endsOnDay: true,
+    });
+  });
+
+  it("caps multi-day segments at day boundaries", () => {
+    expect(
+      getOutOfOfficeSegment(
+        {
+          start: "2026-07-21T12:00:00-04:00",
+          end: "2026-07-23T12:00:00-04:00",
+        },
+        new Date("2026-07-22T12:00:00-04:00"),
+      ),
+    ).toEqual({
+      topMinutes: 0,
+      durationMinutes: 24 * 60,
+      startsOnDay: false,
+      endsOnDay: false,
+    });
+  });
+
+  it("returns null outside the event range", () => {
+    expect(
+      getOutOfOfficeSegment(
+        {
+          start: "2026-07-22T09:00:00-04:00",
+          end: "2026-07-22T17:00:00-04:00",
+        },
+        new Date("2026-07-23T12:00:00-04:00"),
+      ),
+    ).toBeNull();
+  });
+});

--- a/templates/calendar/app/lib/out-of-office.ts
+++ b/templates/calendar/app/lib/out-of-office.ts
@@ -36,3 +36,10 @@ export function getOutOfOfficeSegment(
     endsOnDay: eventEnd > dayStart && eventEnd <= dayEnd,
   };
 }
+
+export function getFirstVisibleOutOfOfficeDayIndex(
+  event: Pick<CalendarEvent, "start" | "end">,
+  days: Date[],
+): number {
+  return days.findIndex((day) => getOutOfOfficeSegment(event, day) !== null);
+}

--- a/templates/calendar/app/lib/out-of-office.ts
+++ b/templates/calendar/app/lib/out-of-office.ts
@@ -1,0 +1,38 @@
+import type { CalendarEvent } from "@shared/api";
+import { addDays, differenceInMinutes, parseISO, startOfDay } from "date-fns";
+
+export interface OutOfOfficeSegment {
+  topMinutes: number;
+  durationMinutes: number;
+  startsOnDay: boolean;
+  endsOnDay: boolean;
+}
+
+export function isOutOfOfficeEvent(
+  event: Pick<CalendarEvent, "eventType">,
+): boolean {
+  return event.eventType === "outOfOffice";
+}
+
+/** Return the portion of a timed out-of-office event visible on one day. */
+export function getOutOfOfficeSegment(
+  event: Pick<CalendarEvent, "start" | "end">,
+  day: Date,
+): OutOfOfficeSegment | null {
+  const eventStart = parseISO(event.start);
+  const eventEnd = parseISO(event.end);
+  const dayStart = startOfDay(day);
+  const dayEnd = addDays(dayStart, 1);
+
+  if (eventStart >= dayEnd || eventEnd <= dayStart) return null;
+
+  const segmentStart = eventStart > dayStart ? eventStart : dayStart;
+  const segmentEnd = eventEnd < dayEnd ? eventEnd : dayEnd;
+
+  return {
+    topMinutes: Math.max(0, differenceInMinutes(segmentStart, dayStart)),
+    durationMinutes: Math.max(1, differenceInMinutes(segmentEnd, segmentStart)),
+    startsOnDay: eventStart >= dayStart && eventStart < dayEnd,
+    endsOnDay: eventEnd > dayStart && eventEnd <= dayEnd,
+  };
+}

--- a/templates/calendar/changelog/2026-07-14-out-of-office-blocks-now-sit-behind-meetings-and-event-stack.md
+++ b/templates/calendar/changelog/2026-07-14-out-of-office-blocks-now-sit-behind-meetings-and-event-stack.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-14
+---
+
+Out-of-office blocks now sit behind meetings, and event stacking resets after closing details.


### PR DESCRIPTION
## Summary
- Render native Google out-of-office blocks beneath ordinary event cards in day and week views.
- Preserve readable out-of-office detail presentation and avoid duplicate event-card treatment.
- Cover day-boundary segmentation and out-of-office detail behavior with targeted tests.

## Verification
- `pnpm --filter calendar exec vitest --run app/lib/out-of-office.test.ts app/components/calendar/EventDetailPopover.test.tsx` (the first four out-of-office assertions ran; Vitest did not exit before the local runner timeout while continuing into the popover suite).
- Full CI will run on this existing implementation commit.

No merge requested.