### PR TITLE
Fix whisper hallucinations and meetings popover layout

### DIFF
--- a/templates/clips/desktop/src-tauri/src/whisper_speech.rs
+++ b/templates/clips/desktop/src-tauri/src/whisper_speech.rs
@@ -495,14 +495,22 @@ mod macos {
         let mut out = Vec::new();
         for segment in state.as_iter() {
             let text = segment.to_string();
-            if is_speech(&text) && segment.no_speech_probability() < MAX_NO_SPEECH_PROBABILITY {
-                // whisper timestamps are in centiseconds → ms.
-                out.push((
-                    segment.start_timestamp() * 10,
-                    segment.end_timestamp() * 10,
-                    text,
-                ));
+            if !is_speech(&text) || segment.no_speech_probability() >= MAX_NO_SPEECH_PROBABILITY {
+                continue;
             }
+            // Low average token confidence means whisper was guessing —
+            // typically a mis-detected-language hallucination that reads
+            // fluently but scores poorly. Drop it.
+            let confidence = segment_confidence(&segment);
+            if confidence < MIN_AVG_TOKEN_PROBABILITY {
+                continue;
+            }
+            // whisper timestamps are in centiseconds → ms.
+            out.push((
+                segment.start_timestamp() * 10,
+                segment.end_timestamp() * 10,
+                text,
+            ));
         }
         out
     }
@@ -530,6 +538,40 @@ mod macos {
     const VOICE_RMS_THRESHOLD: f32 = 0.006;
     /// A second, model-level gate for ambient/no-speech Whisper segments.
     const MAX_NO_SPEECH_PROBABILITY: f32 = 0.72;
+    /// Minimum average per-token probability for a segment to count as real
+    /// speech. On noisy/near-silent audio whisper mis-detects the language and
+    /// decodes fluent-looking gibberish in another language — but those tokens
+    /// are low-confidence under the hood. Dropping segments below this cutoff
+    /// removes that wrong-language garbage while keeping genuine multilingual
+    /// speech (which decodes with high confidence).
+    const MIN_AVG_TOKEN_PROBABILITY: f32 = 0.55;
+
+    /// Average the model's per-token probability across a segment. Returns 0.0
+    /// for an empty segment so it is treated as low-confidence. Special tokens
+    /// (timestamps, `[_BEG_]`, …) render as `[_…]` and are skipped so they
+    /// don't skew the average toward the text tokens we actually care about.
+    fn segment_confidence(segment: &whisper_rs::WhisperSegment<'_>) -> f32 {
+        let mut sum = 0.0f32;
+        let mut count = 0u32;
+        for i in 0..segment.n_tokens() {
+            let Some(token) = segment.get_token(i) else {
+                continue;
+            };
+            let is_special = token
+                .to_str_lossy()
+                .map(|t| t.starts_with("[_"))
+                .unwrap_or(false);
+            if is_special {
+                continue;
+            }
+            sum += token.token_probability();
+            count += 1;
+        }
+        if count == 0 {
+            return 0.0;
+        }
+        sum / count as f32
+    }
 
     fn partial_inference_due(
         emit_partials: bool,

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -1220,6 +1220,28 @@ body[data-clips-route="recording-pill"] #root {
   flex-direction: column;
   gap: 6px;
   margin-bottom: 4px;
+  max-height: 280px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
+  padding-right: 2px;
+}
+
+.popover-list::-webkit-scrollbar {
+  width: 4px;
+}
+
+.popover-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.popover-list::-webkit-scrollbar-thumb {
+  background: var(--border-strong);
+  border-radius: 999px;
+}
+
+.popover-list::-webkit-scrollbar-thumb:hover {
+  background: var(--fg-subtle);
 }
 
 .popover-list-item {
@@ -1471,7 +1493,7 @@ body[data-clips-route="recording-pill"] #root {
    content isn't flush with the panel edge. Must follow `.setup` so it wins
    over the shorthand padding above. */
 .setup.popover-view {
-  padding-bottom: 26px;
+  padding-bottom: 16px;
 }
 
 .setup h2 {


### PR DESCRIPTION
**Whisper hallucination filter** — Whisper sometimes picks up near-silence or ambient noise and decodes it as fluent-looking text in the wrong language. This adds a confidence check on top of the existing no-speech gate: segments where the average per-token confidence is too low get dropped before they reach the transcript. This cuts the most common class of garbage output (wrong-language gibberish) without touching real multilingual speech, which scores high confidence even on short phrases.

**Meetings popover scrolling** — When a user has many upcoming meetings, the list now scrolls instead of overflowing off the bottom of the popover. The list is capped at 280px with a thin scrollbar that matches the dark theme.