### PR TITLE
Clips Bug fixes

### DIFF
--- a/templates/clips/app/components/dictate/vocabulary-section.tsx
+++ b/templates/clips/app/components/dictate/vocabulary-section.tsx
@@ -66,6 +66,7 @@ export function VocabularySection() {
   const removeTerm = useActionMutation<unknown, { id: string }>(
     "remove-vocabulary-term",
     {
+      method: "DELETE",
       onMutate: async (vars) => {
         await queryClient.cancelQueries({ queryKey: QUERY_KEY });
         const prev = queryClient.getQueryData(QUERY_KEY);

--- a/templates/clips/app/components/library/folder-tree.tsx
+++ b/templates/clips/app/components/library/folder-tree.tsx
@@ -182,23 +182,29 @@ function FolderItem({
                 ) : (
                   <IconFolder className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                 )}
-                <span className="truncate">{node.name}</span>
+                <span className="truncate" title={node.name}>
+                  {node.name}
+                </span>
               </NavLink>
             </div>
           </ContextMenuTrigger>
           <ContextMenuContent>
             <ContextMenuItem
               onSelect={() => {
-                setRenameValue(node.name);
-                setRenameOpen(true);
+                setTimeout(() => {
+                  setRenameValue(node.name);
+                  setRenameOpen(true);
+                }, 0);
               }}
             >
               <IconEdit className="h-3.5 w-3.5 me-2" /> {t("folderTree.rename")}
             </ContextMenuItem>
             <ContextMenuItem
               onSelect={() => {
-                setNewValue("");
-                setNewOpen(true);
+                setTimeout(() => {
+                  setNewValue("");
+                  setNewOpen(true);
+                }, 0);
               }}
             >
               <IconFolderPlus className="h-3.5 w-3.5 me-2" />{" "}
@@ -206,7 +212,7 @@ function FolderItem({
             </ContextMenuItem>
             <ContextMenuSeparator />
             <ContextMenuItem
-              onSelect={() => setConfirmDelete(true)}
+              onSelect={() => setTimeout(() => setConfirmDelete(true), 0)}
               className="text-destructive"
             >
               <IconTrash className="h-3.5 w-3.5 me-2" />{" "}
@@ -263,7 +269,6 @@ function FolderItem({
                         ),
                     },
                   );
-                  setRenameOpen(false);
                 }}
               >
                 {t("common.save")}
@@ -311,7 +316,6 @@ function FolderItem({
                         ),
                     },
                   );
-                  setNewOpen(false);
                 }}
               >
                 {t("common.create")}
@@ -346,7 +350,6 @@ function FolderItem({
                         ),
                     },
                   );
-                  setConfirmDelete(false);
                 }}
               >
                 {t("folderTree.delete")}

--- a/templates/clips/app/components/library/library-layout.tsx
+++ b/templates/clips/app/components/library/library-layout.tsx
@@ -665,7 +665,6 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
                   },
                 );
                 setNewFolderName("");
-                setNewFolderOpen(false);
               }}
             >
               {t("common.create")}

--- a/templates/clips/app/components/library/library-layout.tsx
+++ b/templates/clips/app/components/library/library-layout.tsx
@@ -11,7 +11,7 @@ import { ExtensionsSidebarSection } from "@agent-native/core/client/extensions";
 import {
   InvitationBanner,
   OrgSwitcher,
-  useOrg,
+  useOrgRole,
 } from "@agent-native/core/client/org";
 import {
   IconInbox,
@@ -115,7 +115,7 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
   const { shouldShowPromo, shouldShowSidebarLink, dismiss } = useDesktopPromo();
   usePrefetchVideoStorageStatus();
 
-  const { data: org } = useOrg();
+  const { org, canManageOrg } = useOrgRole();
   const hasActiveOrg = Boolean(org?.orgId);
   const { data: organizations } = useOrganizations({ enabled: hasActiveOrg });
   const currentOrganizationId =
@@ -466,19 +466,23 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
                     <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
                       {t("navigation.spaces")}
                     </span>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          aria-label={t("navigation.spaces")}
-                          className="rounded p-1 text-muted-foreground hover:bg-accent"
-                          onClick={() => setNewSpaceOpen(true)}
-                        >
-                          <IconPlus className="h-3.5 w-3.5" />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent>{t("navigation.spaces")}</TooltipContent>
-                    </Tooltip>
+                    {canManageOrg && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            aria-label={t("navigation.spaces")}
+                            className="rounded p-1 text-muted-foreground hover:bg-accent"
+                            onClick={() => setNewSpaceOpen(true)}
+                          >
+                            <IconPlus className="h-3.5 w-3.5" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {t("navigation.spaces")}
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
                   </div>
                   <ul className="space-y-0.5">
                     {(spaces?.spaces ?? []).map((s: any) => {

--- a/templates/clips/app/routes/_app.spaces._index.tsx
+++ b/templates/clips/app/routes/_app.spaces._index.tsx
@@ -1,4 +1,5 @@
 import { useT } from "@agent-native/core/client";
+import { useOrgRole } from "@agent-native/core/client/org";
 import { IconPlus, IconUsersGroup } from "@tabler/icons-react";
 import { useState } from "react";
 
@@ -29,6 +30,7 @@ function Skeleton() {
 export default function SpacesIndexRoute() {
   const t = useT();
   const [createOpen, setCreateOpen] = useState(false);
+  const { canManageOrg } = useOrgRole();
   const { data: organizations } = useOrganizations();
   const currentOrganizationId =
     organizations?.currentId ?? organizations?.organizations?.[0]?.id;
@@ -53,15 +55,17 @@ export default function SpacesIndexRoute() {
             {t("navigation.spaces")}
           </h1>
         </div>
-        <div className="ml-auto">
-          <Button
-            size="sm"
-            className="gap-1.5 bg-primary text-primary-foreground hover:bg-primary/90"
-            onClick={() => setCreateOpen(true)}
-          >
-            <IconPlus className="h-4 w-4" /> {t("createSpaceDialog.newSpace")}
-          </Button>
-        </div>
+        {canManageOrg && (
+          <div className="ml-auto">
+            <Button
+              size="sm"
+              className="gap-1.5 bg-primary text-primary-foreground hover:bg-primary/90"
+              onClick={() => setCreateOpen(true)}
+            >
+              <IconPlus className="h-4 w-4" /> {t("createSpaceDialog.newSpace")}
+            </Button>
+          </div>
+        )}
       </PageHeader>
 
       <div className="flex-1 overflow-y-auto p-5">

--- a/templates/clips/changelog/2026-07-15-folders-and-sidebar-links-are-clickable-again-immediately-af.md
+++ b/templates/clips/changelog/2026-07-15-folders-and-sidebar-links-are-clickable-again-immediately-af.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-15
+---
+
+Folders and sidebar links are clickable again immediately after creating or renaming a folder.

--- a/templates/clips/changelog/2026-07-15-hovering-a-truncated-folder-name-now-shows-the-full-name.md
+++ b/templates/clips/changelog/2026-07-15-hovering-a-truncated-folder-name-now-shows-the-full-name.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-15
+---
+
+Hovering a truncated folder name now shows the full name.

--- a/templates/clips/changelog/2026-07-15-space-creation-controls-are-now-shown-only-to-organization-a.md
+++ b/templates/clips/changelog/2026-07-15-space-creation-controls-are-now-shown-only-to-organization-a.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-15
+---
+
+Space creation controls are now shown only to organization admins and owners.

--- a/templates/clips/changelog/2026-07-15-vocabulary-terms-can-now-be-deleted-from-the-dictation-dicti.md
+++ b/templates/clips/changelog/2026-07-15-vocabulary-terms-can-now-be-deleted-from-the-dictation-dicti.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-15
+---
+
+Vocabulary terms can now be deleted from the dictation dictionary.

--- a/templates/clips/server/lib/recordings.ts
+++ b/templates/clips/server/lib/recordings.ts
@@ -6,7 +6,7 @@ import {
   getRequestOrgId,
 } from "@agent-native/core/server/request-context";
 import { and, desc, eq, sql } from "drizzle-orm";
-import type { H3Event } from "h3";
+import { HTTPError, type H3Event } from "h3";
 
 import { getDb, schema } from "../db/index.js";
 
@@ -120,7 +120,10 @@ export async function requireOrganizationAccess(
   const email = getCurrentOwnerEmail();
   const role = await getOrganizationRoleForEmail(resolvedOrganizationId, email);
   if (!role || !organizationRoleAllowed(role, allowedRoles)) {
-    throw new Error("Organization not found or access denied");
+    throw new HTTPError({
+      statusCode: 403,
+      statusMessage: "Organization not found or access denied",
+    });
   }
   return { organizationId: resolvedOrganizationId, email, role };
 }


### PR DESCRIPTION
**Space creation is now admin-only**
The "New space" button in the sidebar and on the Spaces page is now hidden for organization members who are not admins or owners. The server already blocked non-admins from creating spaces; this makes the UI consistent with that.

**Denied organization access returns a clear error instead of "Internal server error"**
When a user tries an action they are not allowed (for example, creating a space as a plain member), the response now shows "Organization not found or access denied" instead of a generic server error.

**Sidebar stays interactive after creating or renaming a folder**
After confirming a folder create or rename dialog, clicking anything in the left sidebar no longer required a page refresh to work again.

**Folder names are no longer permanently hidden when truncated**
Long folder names that don't fit in the sidebar now show the full name on hover.

**Vocabulary term deletion works**
The trash button on dictionary terms in the Dictate page was silently failing. It now correctly deletes the term.
