### PR TITLE
fix: infinite call dreams page

### DIFF
--- a/.changeset/fix-header-render-loop.md
+++ b/.changeset/fix-header-render-loop.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/dispatch": patch
+"@agent-native/toolkit": patch
+---
+
+fix(header): prevent infinite render loops and accidental state clearing in HeaderActions

--- a/packages/dispatch/src/components/dispatch-shell.tsx
+++ b/packages/dispatch/src/components/dispatch-shell.tsx
@@ -1,6 +1,6 @@
 import { useT } from "@agent-native/core/client";
 import { IconInfoCircle } from "@tabler/icons-react";
-import { type ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 
 import { useSetPageTitle } from "./layout/HeaderActions";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
@@ -10,6 +10,10 @@ import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
  * description popover) into the global header via the HeaderActions store.
  * The actual chrome (sidebar, AgentSidebar, header bar with AgentToggleButton)
  * is provided by `Layout` mounted in `root.tsx`.
+ *
+ * The title node is memoised so that useSetPageTitle receives a stable
+ * reference across re-renders, preventing the notify() → re-render →
+ * new-JSX-reference → notify() loop.
  */
 export function DispatchShell({
   title,
@@ -21,33 +25,37 @@ export function DispatchShell({
   children: ReactNode;
 }) {
   const t = useT();
-  useSetPageTitle(
-    <div className="flex items-center gap-2 min-w-0">
-      <h1 className="text-lg font-semibold tracking-tight truncate text-foreground">
-        {title}
-      </h1>
-      {description ? (
-        <Popover>
-          <PopoverTrigger asChild>
-            <button
-              type="button"
-              className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground/70 hover:bg-accent hover:text-foreground cursor-pointer"
-              aria-label={t("dispatch.sidebar.aboutPage", { title })}
+  const titleNode = useMemo(
+    () => (
+      <div className="flex items-center gap-2 min-w-0">
+        <h1 className="text-lg font-semibold tracking-tight truncate text-foreground">
+          {title}
+        </h1>
+        {description ? (
+          <Popover>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground/70 hover:bg-accent hover:text-foreground cursor-pointer"
+                aria-label={t("dispatch.sidebar.aboutPage", { title })}
+              >
+                <IconInfoCircle className="h-3.5 w-3.5" />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent
+              side="bottom"
+              align="start"
+              className="max-w-72 text-xs leading-relaxed"
             >
-              <IconInfoCircle className="h-3.5 w-3.5" />
-            </button>
-          </PopoverTrigger>
-          <PopoverContent
-            side="bottom"
-            align="start"
-            className="max-w-72 text-xs leading-relaxed"
-          >
-            {description}
-          </PopoverContent>
-        </Popover>
-      ) : null}
-    </div>,
+              {description}
+            </PopoverContent>
+          </Popover>
+        ) : null}
+      </div>
+    ),
+    [title, description, t],
   );
+  useSetPageTitle(titleNode);
 
   return <>{children}</>;
 }

--- a/packages/dispatch/src/components/layout/HeaderActions.tsx
+++ b/packages/dispatch/src/components/layout/HeaderActions.tsx
@@ -59,16 +59,25 @@ export const HeaderActionsProvider: FC<{ children: ReactNode }> = ({
   children,
 }) => <>{children}</>;
 
-/** Mount a custom title into the app header. Cleans up on unmount. */
+/**
+ * Mount a custom title into the app header. Cleans up on unmount.
+ *
+ * Pass a memoised node (useMemo / stable reference) to avoid triggering
+ * notify() on every render. Inline JSX creates a new reference each render
+ * which defeats the identity guard and can cause update loops.
+ */
 export function useSetPageTitle(node: ReactNode) {
   useEffect(() => {
     currentTitle = node;
     notify();
     return () => {
-      currentTitle = null;
-      notify();
+      if (currentTitle === node) {
+        currentTitle = null;
+        notify();
+      }
     };
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [node]);
 }
 
 /** Mount ReactNode into the header's actions slot. Cleans up on unmount. */
@@ -77,8 +86,11 @@ export function useSetHeaderActions(node: ReactNode) {
     currentActions = node;
     notify();
     return () => {
-      currentActions = null;
-      notify();
+      if (currentActions === node) {
+        currentActions = null;
+        notify();
+      }
     };
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [node]);
 }

--- a/packages/toolkit/src/app-shell/header-actions.tsx
+++ b/packages/toolkit/src/app-shell/header-actions.tsx
@@ -59,16 +59,25 @@ export const HeaderActionsProvider: FC<{ children: ReactNode }> = ({
   children,
 }) => <>{children}</>;
 
-/** Mount a custom title into the app header. Cleans up on unmount. */
+/**
+ * Mount a custom title into the app header. Cleans up on unmount.
+ *
+ * Pass a memoised node (useMemo / stable reference) to avoid triggering
+ * notify() on every render. Inline JSX creates a new reference each render
+ * which defeats the identity guard and can cause update loops.
+ */
 export function useSetPageTitle(node: ReactNode) {
   useEffect(() => {
     currentTitle = node;
     notify();
     return () => {
-      currentTitle = null;
-      notify();
+      if (currentTitle === node) {
+        currentTitle = null;
+        notify();
+      }
     };
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [node]);
 }
 
 /** Mount ReactNode into the header's actions slot. Cleans up on unmount. */
@@ -77,8 +86,11 @@ export function useSetHeaderActions(node: ReactNode) {
     currentActions = node;
     notify();
     return () => {
-      currentActions = null;
-      notify();
+      if (currentActions === node) {
+        currentActions = null;
+        notify();
+      }
     };
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [node]);
 }

--- a/templates/mail/app/components/layout/HeaderActions.tsx
+++ b/templates/mail/app/components/layout/HeaderActions.tsx
@@ -48,27 +48,25 @@ export function useSetPageTitle(node: ReactNode) {
     currentTitle = node;
     notify();
     return () => {
-      currentTitle = null;
-      notify();
+      if (currentTitle === node) {
+        currentTitle = null;
+        notify();
+      }
     };
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [node]);
 }
 
 export function useSetHeaderActions(node: ReactNode) {
   useEffect(() => {
-    // Callers may pass a fresh-but-equivalent node (e.g. `null` from a
-    // conditional) on every render; only broadcast when the reference the
-    // store holds actually changes so unrelated re-renders of the caller
-    // don't force every header subscriber to re-render too.
-    if (currentActions !== node) {
-      currentActions = node;
-      notify();
-    }
+    currentActions = node;
+    notify();
     return () => {
       if (currentActions === node) {
         currentActions = null;
         notify();
       }
     };
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [node]);
 }


### PR DESCRIPTION
# fix: prevent infinite render loops and accidental state clearing in HeaderActions

## Description

This PR fixes two major issues with the global header page title and actions state management:
1. **Infinite Render/Update Loops**: Inside the [useSetPageTitle](file:///home/phenom/Projects/agent-native/packages/dispatch/src/components/layout/HeaderActions.tsx#L68) and [useSetHeaderActions](file:///home/phenom/Projects/agent-native/packages/dispatch/src/components/layout/HeaderActions.tsx#L85) hooks, the `useEffect` lacked a dependency array. This caused updates and `notify()` to trigger on every single render. Since callers often pass new JSX object references (e.g. in [DispatchShell](file:///home/phenom/Projects/agent-native/packages/dispatch/src/components/dispatch-shell.tsx#L14)), this resulted in an infinite re-render loop (`notify() -> re-render -> new JSX reference -> notify()`).
2. **Accidental State Erasure**: The cleanup function in the hooks unconditionally reset the shared page title or actions to `null`. If a newly mounted component had already set a new title/action, the unmounting component would mistakenly clear it out.

## Proposed Changes

### Core Hook Adjustments
* **Add Dependency Arrays**: Added `[node]` as a dependency to the `useEffect` blocks in both `HeaderActions` implementations to run effects only when the node reference changes.
* **Identity check on Cleanup**: Modified cleanup functions to only reset `currentTitle` or `currentActions` to `null` if the reference still matches the node registered by that specific hook instance.

### Component Adjustments
* **Memoize Titles/Actions**: Wrapped the custom header elements in [DispatchShell](file:///home/phenom/Projects/agent-native/packages/dispatch/src/components/dispatch-shell.tsx#L14) with `useMemo` to ensure a stable node reference is passed down.

---

### Affected Files
* [packages/dispatch/src/components/dispatch-shell.tsx](file:///home/phenom/Projects/agent-native/packages/dispatch/src/components/dispatch-shell.tsx)
* [packages/dispatch/src/components/layout/HeaderActions.tsx](file:///home/phenom/Projects/agent-native/packages/dispatch/src/components/layout/HeaderActions.tsx)
* [packages/toolkit/src/app-shell/header-actions.tsx](file:///home/phenom/Projects/agent-native/packages/toolkit/src/app-shell/header-actions.tsx)
* [templates/mail/app/components/layout/HeaderActions.tsx](file:///home/phenom/Projects/agent-native/templates/mail/app/components/layout/HeaderActions.tsx)


### Manual Verification
- Navigated through the different pages in the application and verified that no infinite re-render loops occur.
- Verified that headers transition correctly between pages without the title getting cleared out to `null` unexpectedly.

<img width="1005" height="584" alt="brave_screenshot_dispatch agent-native com" src="https://github.com/user-attachments/assets/62dec4d2-4d48-443a-ae19-dd456d59b988" />
