### PR TITLE
Electron app store logs in a file

### DIFF
--- a/packages/desktop-app/package.json
+++ b/packages/desktop-app/package.json
@@ -35,6 +35,7 @@
     "@sentry/electron": "^7.14.0",
     "@tabler/icons-react": "^3.40.0",
     "@tanstack/react-query": "5.101.2",
+    "electron-log": "5.4.4",
     "electron-updater": "^6.8.3",
     "sonner": "^2.0.7",
     "zod": "^4.4.3"

--- a/packages/desktop-app/src/main/desktop-logger.ts
+++ b/packages/desktop-app/src/main/desktop-logger.ts
@@ -1,0 +1,69 @@
+import path from "path";
+
+import { app, shell } from "electron";
+import type ElectronLog from "electron-log";
+import log from "electron-log/main";
+
+import { redactLogValue, redactLogString } from "./log-redaction";
+
+const LOG_MAX_SIZE = 5 * 1024 * 1024;
+const WEBVIEW_LOG_LEVELS: Record<number, ElectronLog.LogLevel> = {
+  0: "verbose",
+  1: "info",
+  2: "warn",
+  3: "error",
+};
+
+let initialized = false;
+
+export function initializeDesktopLogger(): void {
+  if (initialized) return;
+  initialized = true;
+
+  // --- File transport: rotate at 5 MB, keep one old file ---
+  log.transports.file.maxSize = LOG_MAX_SIZE;
+  log.transports.file.resolvePathFn = (vars) =>
+    path.join(vars.libraryDefaultDir, "main.log");
+
+  // --- Redact every log message before it reaches any transport ---
+  log.hooks.push((message) => {
+    message.data = message.data.map((item) => {
+      if (typeof item === "string") return redactLogString(item);
+      return redactLogValue(item);
+    });
+    return message;
+  });
+
+  // --- Mirror console.* to the log file in packaged builds ---
+  if (app.isPackaged) {
+    Object.assign(console, log.functions);
+  }
+}
+
+/**
+ * Wire the console-message event from a specific WebContents into the log
+ * file.  Call this in web-contents-created / before any webview is shown so
+ * that renderer logs (including Clips recording errors) are captured even
+ * when DevTools is closed.
+ */
+export function captureWebviewLogs(
+  contents: Electron.WebContents,
+  label: string,
+): void {
+  const scope = log.scope(label);
+  contents.on("console-message", (_event, level, message) => {
+    const logLevel: ElectronLog.LogLevel = WEBVIEW_LOG_LEVELS[level] ?? "debug";
+    scope[logLevel](redactLogString(message ?? ""));
+  });
+}
+
+/** Reveal the log folder in Finder / Explorer. */
+export function revealLogFolder(): void {
+  const file = log.transports.file.getFile();
+  shell.showItemInFolder(file.path);
+}
+
+/** Returns the path to the current log file so it can be displayed to the user. */
+export function getLogFilePath(): string {
+  return log.transports.file.getFile().path;
+}

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -150,6 +150,12 @@ import {
   SwiftDesktopHelperClient,
 } from "./computer-control";
 import { DesktopDesignPreviewManager } from "./design-preview-manager";
+import {
+  captureWebviewLogs,
+  initializeDesktopLogger,
+  revealLogFolder,
+  getLogFilePath,
+} from "./desktop-logger";
 import { registerAppsIpc } from "./ipc/apps";
 import { registerCodeAgentsIpc } from "./ipc/code-agents";
 import { registerContentFilesIpc } from "./ipc/content-files";
@@ -170,6 +176,7 @@ import {
 } from "./sentry";
 
 initializeDesktopSentry();
+initializeDesktopLogger();
 
 // ---------- stdout/stderr pipe resilience ----------
 // The main process logs spawned dev-server / code-agent child output via
@@ -1567,8 +1574,19 @@ function isTrustedPermissionRequest(
   const appConfig = loadAppsForAuthContext().find(
     (candidate) => candidate.id === targetAppId && candidate.enabled !== false,
   );
-  const trustedOrigin = appConfig ? getAppOrigin(appConfig) : null;
-  if (!trustedOrigin) return false;
+  if (!appConfig) return false;
+
+  // In dev mode, first-party templates load through the frame
+  // (http://localhost:FRAME_PORT), so the actual document origin differs from
+  // the resolved app base origin (dev port or template gateway). Trust the
+  // frame origin only in dev; production loads the real app URL directly.
+  const appOrigin = getAppOrigin(appConfig);
+  const frameOrigin =
+    appConfig.mode === "dev" ? `http://localhost:${FRAME_PORT}` : null;
+  const trustedOrigins = new Set(
+    [appOrigin, frameOrigin].filter((value): value is string => Boolean(value)),
+  );
+  if (trustedOrigins.size === 0) return false;
 
   const detailUrl = isObject(details)
     ? firstStringValue(details.requestingUrl, details.embeddingOrigin)
@@ -1577,10 +1595,10 @@ function isTrustedPermissionRequest(
     originFromUrl(requestingOrigin) ??
     originFromUrl(detailUrl) ??
     originFromUrl(contents?.getURL());
-  if (requestOrigin !== trustedOrigin) return false;
+  if (!requestOrigin || !trustedOrigins.has(requestOrigin)) return false;
 
   const contentsOrigin = originFromUrl(contents?.getURL());
-  return !contentsOrigin || contentsOrigin === trustedOrigin;
+  return !contentsOrigin || trustedOrigins.has(contentsOrigin);
 }
 
 function remoteDeviceConfigPath(): string {
@@ -8843,10 +8861,19 @@ function installApplicationMenu() {
     ],
   };
 
+  const openLogsMenuItem: Electron.MenuItemConstructorOptions = {
+    label: "Open Logs Folder",
+    click: () => revealLogFolder(),
+  };
+
   const helpMenu: Electron.MenuItemConstructorOptions = {
     role: "help" as const,
     submenu: isMac
-      ? [buildCurrentVersionMenuItem()]
+      ? [
+          buildCurrentVersionMenuItem(),
+          { type: "separator" as const },
+          openLogsMenuItem,
+        ]
       : [
           buildUpdateMenuItem(),
           buildCurrentVersionMenuItem(),
@@ -8855,6 +8882,8 @@ function installApplicationMenu() {
             label: "Learn More",
             click: () => void shell.openExternal("https://agent-native.com"),
           },
+          { type: "separator" as const },
+          openLogsMenuItem,
         ],
   };
 
@@ -8936,14 +8965,21 @@ function configurePermissionHandlers(
   );
 
   if (targetAppId === "clips") {
+    console.info("[display-capture] registering clips display media handler", {
+      platform: process.platform,
+      osRelease: os.release(),
+    });
     sess.setDisplayMediaRequestHandler(
       (_request, callback) => {
-        // The handler is only reached when Electron cannot provide the trusted
-        // system picker. Never choose a display without explicit user selection.
+        // Only reached when Electron cannot provide the system picker. Log as a
+        // warning because it means native screen selection did not engage.
+        console.warn(
+          "[display-capture] system picker did not engage — denying capture request",
+        );
         callback({});
       },
       {
-        // Electron currently supports its native display picker on macOS 15+.
+        // Uses the OS-native screen picker (macOS 15+ / ScreenCaptureKit).
         useSystemPicker: process.platform === "darwin",
       },
     );
@@ -9049,9 +9085,14 @@ app.whenReady().then(async () => {
       } catch {}
     }
     configureWebviewSession(wc.session, id);
+    // Capture renderer console messages to the log file so they survive
+    // across sessions without DevTools needing to be open.
+    captureWebviewLogs(wc, id ?? "webview");
   });
 
   installApplicationMenu();
+
+  console.info("[main] log file:", getLogFilePath());
 
   reconcileInterruptedCodeAgentRuns("startup");
   registerDesktopShortcutBindings();

--- a/packages/desktop-app/src/main/log-redaction.ts
+++ b/packages/desktop-app/src/main/log-redaction.ts
@@ -4,12 +4,37 @@ const MAX_STRING_LENGTH = 20_000;
 const MAX_COLLECTION_ITEMS = 50;
 const MAX_DEPTH = 4;
 
-const SENSITIVE_KEY =
-  /^(?:authorization|cookie|password|passphrase|secret|token|accessToken|refreshToken|apiKey|privateKey|bearerToken)$/i;
-const SENSITIVE_ASSIGNMENT =
-  /((?:authorization|cookie|password|passphrase|secret|token|access[_-]?token|refresh[_-]?token|api[_-]?key|private[_-]?key|bearer[_-]?token)\s*[=:]\s*)([^\s,;]+)/gi;
+// Substrings checked against a normalized (letters/digits only, lowercased)
+// key name. Matching on substrings — instead of an exact-name allow-list —
+// catches compound and snake_case/camelCase variants like access_token,
+// clientSecret, secretAccessKey, and credentials without listing every
+// spelling individually.
+const SENSITIVE_KEY_TERMS = [
+  "authorization",
+  "cookie",
+  "password",
+  "passphrase",
+  "secret",
+  "token",
+  "apikey",
+  "privatekey",
+  "credential",
+  "signingkey",
+  "accesskey",
+];
+const ASSIGNMENT_PATTERN =
+  /([A-Za-z][A-Za-z0-9_-]*)(\s*[=:]\s*)("[^"]*"|'[^']*'|[^\s,;}]+)/g;
 const BEARER_TOKEN = /(Bearer\s+)[A-Za-z0-9._~+\/-]+=*/gi;
 const JWT = /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g;
+
+function normalizeKey(key: string): string {
+  return key.replace(/[^a-z0-9]/gi, "").toLowerCase();
+}
+
+function isSensitiveKey(key: string): boolean {
+  const normalized = normalizeKey(key);
+  return SENSITIVE_KEY_TERMS.some((term) => normalized.includes(term));
+}
 
 export function redactLogString(value: string): string {
   const truncated =
@@ -17,7 +42,9 @@ export function redactLogString(value: string): string {
       ? `${value.slice(0, MAX_STRING_LENGTH)}${TRUNCATED}`
       : value;
   return truncated
-    .replace(SENSITIVE_ASSIGNMENT, `$1${REDACTED}`)
+    .replace(ASSIGNMENT_PATTERN, (match, key: string, sep: string) =>
+      isSensitiveKey(key) ? `${key}${sep}${REDACTED}` : match,
+    )
     .replace(BEARER_TOKEN, `$1${REDACTED}`)
     .replace(JWT, REDACTED);
 }
@@ -66,7 +93,7 @@ export function redactLogValue(
   const entries = Object.entries(value).slice(0, MAX_COLLECTION_ITEMS);
   const redacted: Record<string, unknown> = {};
   for (const [key, item] of entries) {
-    redacted[key] = SENSITIVE_KEY.test(key)
+    redacted[key] = isSensitiveKey(key)
       ? REDACTED
       : redactLogValue(item, depth + 1, seen);
   }

--- a/packages/desktop-app/src/main/log-redaction.ts
+++ b/packages/desktop-app/src/main/log-redaction.ts
@@ -1,0 +1,77 @@
+const REDACTED = "[REDACTED]";
+const TRUNCATED = "[TRUNCATED]";
+const MAX_STRING_LENGTH = 20_000;
+const MAX_COLLECTION_ITEMS = 50;
+const MAX_DEPTH = 4;
+
+const SENSITIVE_KEY =
+  /^(?:authorization|cookie|password|passphrase|secret|token|accessToken|refreshToken|apiKey|privateKey|bearerToken)$/i;
+const SENSITIVE_ASSIGNMENT =
+  /((?:authorization|cookie|password|passphrase|secret|token|access[_-]?token|refresh[_-]?token|api[_-]?key|private[_-]?key|bearer[_-]?token)\s*[=:]\s*)([^\s,;]+)/gi;
+const BEARER_TOKEN = /(Bearer\s+)[A-Za-z0-9._~+\/-]+=*/gi;
+const JWT = /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g;
+
+export function redactLogString(value: string): string {
+  const truncated =
+    value.length > MAX_STRING_LENGTH
+      ? `${value.slice(0, MAX_STRING_LENGTH)}${TRUNCATED}`
+      : value;
+  return truncated
+    .replace(SENSITIVE_ASSIGNMENT, `$1${REDACTED}`)
+    .replace(BEARER_TOKEN, `$1${REDACTED}`)
+    .replace(JWT, REDACTED);
+}
+
+export function redactLogValue(
+  value: unknown,
+  depth = 0,
+  seen = new WeakSet<object>(),
+): unknown {
+  if (typeof value === "string") return redactLogString(value);
+  if (
+    value === null ||
+    value === undefined ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint"
+  ) {
+    return value;
+  }
+  if (typeof value === "function" || typeof value === "symbol") {
+    return String(value);
+  }
+  if (depth >= MAX_DEPTH) return TRUNCATED;
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: redactLogString(value.message),
+      stack: value.stack ? redactLogString(value.stack) : undefined,
+    };
+  }
+  if (value instanceof Uint8Array) {
+    return `[${value.constructor.name} ${value.byteLength} bytes]`;
+  }
+  if (typeof value !== "object") return String(value);
+  if (seen.has(value)) return "[CIRCULAR]";
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    const items = value
+      .slice(0, MAX_COLLECTION_ITEMS)
+      .map((item) => redactLogValue(item, depth + 1, seen));
+    if (value.length > MAX_COLLECTION_ITEMS) items.push(TRUNCATED);
+    return items;
+  }
+
+  const entries = Object.entries(value).slice(0, MAX_COLLECTION_ITEMS);
+  const redacted: Record<string, unknown> = {};
+  for (const [key, item] of entries) {
+    redacted[key] = SENSITIVE_KEY.test(key)
+      ? REDACTED
+      : redactLogValue(item, depth + 1, seen);
+  }
+  if (Object.keys(value).length > MAX_COLLECTION_ITEMS) {
+    redacted.__truncated__ = true;
+  }
+  return redacted;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -606,6 +606,9 @@ importers:
       '@tanstack/react-query':
         specifier: 5.101.2
         version: 5.101.2(react@19.2.7)
+      electron-log:
+        specifier: 5.4.4
+        version: 5.4.4
       electron-updater:
         specifier: ^6.8.3
         version: 6.8.9
@@ -13326,6 +13329,10 @@ packages:
     resolution: {integrity: sha512-a1KM5heqS3gQCZzizXEI8RjJy3QVogULPdeSknt76uLDpBIW/HDGsMg/XgP0riP6PI9COsRvFITKKGDqA8fJxA==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  electron-log@5.4.4:
+    resolution: {integrity: sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==}
+    engines: {node: '>= 14'}
 
   electron-publish@26.15.3:
     resolution: {integrity: sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==}
@@ -27428,6 +27435,8 @@ snapshots:
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
       - supports-color
+
+  electron-log@5.4.4: {}
 
   electron-publish@26.15.3:
     dependencies:

--- a/templates/clips/app/components/recorder/microphone-visualizer.tsx
+++ b/templates/clips/app/components/recorder/microphone-visualizer.tsx
@@ -41,6 +41,26 @@ function stopStream(stream: MediaStream | null): void {
 
 type MicrophonePermissionState = PermissionState | "unknown";
 
+function isDesktopShell(): boolean {
+  if (typeof window === "undefined") return false;
+  const w = window as typeof window & {
+    electronAPI?: unknown;
+    __TAURI_INTERNALS__?: unknown;
+    __TAURI__?: unknown;
+  };
+  if (w.electronAPI || w.__TAURI_INTERNALS__ || w.__TAURI__) return true;
+  return (
+    typeof navigator !== "undefined" && /Electron/i.test(navigator.userAgent)
+  );
+}
+
+function micBlockedMessage(): string {
+  if (isDesktopShell()) {
+    return "Microphone access is blocked for this app. Enable the microphone for the app in your system Privacy settings, then reopen the recorder.";
+  }
+  return "Your browser has blocked microphone access for this site, so it won't prompt. Allow the microphone in this site's settings, then reload.";
+}
+
 function isMicrophoneBlockedByPolicy(): boolean {
   const policy =
     (
@@ -96,7 +116,7 @@ export async function friendlyMicError(err: unknown): Promise<string> {
     return "Microphone prompts require HTTPS or localhost. Open this app on localhost or an HTTPS URL, then try again.";
   }
   if (permissionState === "denied") {
-    return "This site is blocked from using the microphone. Open the browser site settings, set Microphone to Allow, then reload.";
+    return micBlockedMessage();
   }
   if (/NotAllowedError|Permission denied|denied|blocked/i.test(combined)) {
     return "The browser or operating system denied microphone access. Check this site's microphone setting and your system privacy settings for this browser, then reload.";
@@ -328,8 +348,7 @@ export function MicrophoneVisualizer({
     const permissionState = await getMicrophonePermissionState();
     if (runIdRef.current !== runId) return;
     if (permissionState === "denied") {
-      const message =
-        "Brave already has Microphone set to Block for this site, so it will not show the popup. Click the lock/tune icon in the address bar → Site settings → Microphone → Allow, then reload.";
+      const message = micBlockedMessage();
       setError(message);
       setStatus("error");
       onStatusChange?.("error", { error: message });


### PR DESCRIPTION
This fixes microphone permission checks for Clips running in the desktop app during development and replaces the Brave-specific blocked microphone message with instructions that match the desktop app or browser.

Production builds now save desktop and embedded-app console output to rotating log files, with common credentials and tokens removed. Users can open the log folder from the Help menu and share the files when reporting recording problems. The logs also show whether screen capture was registered and whether the system picker failed to open.