### PR TITLE
Fix Content description wrapping

### DIFF
--- a/templates/content/app/components/editor/DescriptionField.test.tsx
+++ b/templates/content/app/components/editor/DescriptionField.test.tsx
@@ -63,6 +63,14 @@ describe("DescriptionField behavior", () => {
     expect(descriptionFieldEscapeDraft(undefined)).toBe("");
   });
 
+  it("starts at one row and grows with softly wrapped content", () => {
+    render();
+
+    expect(textareaProps.rows).toBe(1);
+    expect(textareaProps.wrap).toBe("soft");
+    expect(textareaProps.style).toEqual({ fieldSizing: "content" });
+  });
+
   it("does not save the canceled draft when Escape immediately blurs", () => {
     const onSave = render();
     act(() => {
@@ -78,6 +86,26 @@ describe("DescriptionField behavior", () => {
 
     expect(onSave).not.toHaveBeenCalled();
     expect(textareaProps.value).toBe("Stable guidance");
+  });
+
+  it("saves the wrapped description when Enter blurs the field", async () => {
+    const onSave = render();
+    const preventDefault = vi.fn();
+    act(() => {
+      textareaProps.onChange({ target: { value: "Updated guidance" } });
+    });
+
+    await act(async () => {
+      textareaProps.onKeyDown({
+        key: "Enter",
+        preventDefault,
+        currentTarget: { blur: () => textareaProps.onBlur() },
+      });
+      await Promise.resolve();
+    });
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(onSave).toHaveBeenCalledWith("Updated guidance");
   });
 
   it("restores the stored value when a blur save fails", async () => {

--- a/templates/content/app/components/editor/DescriptionField.test.tsx
+++ b/templates/content/app/components/editor/DescriptionField.test.tsx
@@ -98,6 +98,8 @@ describe("DescriptionField behavior", () => {
     await act(async () => {
       textareaProps.onKeyDown({
         key: "Enter",
+        nativeEvent: { isComposing: false },
+        keyCode: 13,
         preventDefault,
         currentTarget: { blur: () => textareaProps.onBlur() },
       });
@@ -106,6 +108,27 @@ describe("DescriptionField behavior", () => {
 
     expect(preventDefault).toHaveBeenCalledOnce();
     expect(onSave).toHaveBeenCalledWith("Updated guidance");
+  });
+
+  it("does not blur or save when Enter is committing IME composition", () => {
+    const onSave = render();
+    const preventDefault = vi.fn();
+    const blur = vi.fn();
+
+    act(() => {
+      textareaProps.onChange({ target: { value: "Composing guidance" } });
+      textareaProps.onKeyDown({
+        key: "Enter",
+        nativeEvent: { isComposing: true },
+        keyCode: 229,
+        preventDefault,
+        currentTarget: { blur },
+      });
+    });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(blur).not.toHaveBeenCalled();
+    expect(onSave).not.toHaveBeenCalled();
   });
 
   it("restores the stored value when a blur save fails", async () => {

--- a/templates/content/app/components/editor/DescriptionField.tsx
+++ b/templates/content/app/components/editor/DescriptionField.tsx
@@ -107,6 +107,7 @@ export function DescriptionField({
       }}
       onKeyDown={(event) => {
         if (event.key === "Enter") {
+          if (event.nativeEvent.isComposing || event.keyCode === 229) return;
           event.preventDefault();
           event.currentTarget.blur();
           return;

--- a/templates/content/app/components/editor/DescriptionField.tsx
+++ b/templates/content/app/components/editor/DescriptionField.tsx
@@ -91,7 +91,8 @@ export function DescriptionField({
   return (
     <Textarea
       aria-label={label}
-      rows={editing || draft ? 2 : 1}
+      rows={1}
+      wrap="soft"
       value={draft}
       placeholder={placeholder}
       onFocus={() => setEditing(true)}
@@ -105,6 +106,11 @@ export function DescriptionField({
         void save();
       }}
       onKeyDown={(event) => {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          event.currentTarget.blur();
+          return;
+        }
         if (event.key === "Escape") {
           event.preventDefault();
           skipNextBlurSaveRef.current = true;
@@ -112,8 +118,9 @@ export function DescriptionField({
           event.currentTarget.blur();
         }
       }}
+      style={{ fieldSizing: "content" } as any}
       className={cn(
-        "mt-2 block w-full resize-none overflow-hidden rounded border-0 bg-transparent px-0 py-0 text-sm leading-6 text-muted-foreground outline-none placeholder:text-muted-foreground/45 hover:bg-muted/30 focus:bg-muted/30 focus:px-1 focus:outline-none focus:ring-1 focus:ring-ring",
+        "mt-2 min-h-6 w-full resize-none overflow-hidden rounded-none border-0 bg-transparent px-0 py-0 text-sm leading-6 text-muted-foreground shadow-none outline-none placeholder:text-muted-foreground/45 focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 focus-visible:ring-offset-0",
         className,
       )}
     />

--- a/templates/content/changelog/2026-07-15-page-and-database-descriptions-now-use-a-clean-single-line-f.md
+++ b/templates/content/changelog/2026-07-15-page-and-database-descriptions-now-use-a-clean-single-line-f.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-15
+---
+
+Page and database descriptions now start compactly and wrap naturally as they grow.


### PR DESCRIPTION
## Summary

- keep page and database descriptions compact at one row by default
- let longer descriptions wrap and grow naturally instead of clipping horizontally
- remove the gray hover and focus-box treatment so description editing matches the title and body surfaces
- preserve Enter-to-save, Escape-to-cancel, queued saves, and rollback behavior

## Validation

- pnpm exec oxfmt --check templates/content/app/components/editor/DescriptionField.tsx templates/content/app/components/editor/DescriptionField.test.tsx
- pnpm --filter content exec vitest --run app/components/editor/DescriptionField.test.tsx (8 tests)
- pnpm --filter content typecheck
- implementer browser verification: wrapped textarea height matched scroll height, overflow stayed hidden, hover background stayed transparent, and browser console had no errors

## Independent human QA

Status: BLOCKED before H1; no acceptance criterion was bypassed.

Frozen story: create a disposable page, verify the compact transparent empty description, enter a long description and verify wrapping/no clipping, press Enter, reload, and verify persistence.

- Local isolated browser: redirected to sign-in with no usable dev auto-login.
- Healthy authenticated local session: New -> Page wrote an untitled local file but did not open the new-page editor; the disposable file was removed.
- CI Content preview: https://deploy-preview-2154--agent-native-content.netlify.app redirects to /_agent-native/sign-in?return=%2F, which returns HTTP 404.

The PR must not be declared handoff-ready until the preview authentication route is reachable or an authenticated preview entrypoint is provided and the unchanged H1-H4 story passes.