### PR TITLE
Fix selected Builder review timeouts

### DIFF
--- a/templates/content/actions/_database-source-utils.ts
+++ b/templates/content/actions/_database-source-utils.ts
@@ -3017,6 +3017,7 @@ export async function getContentDatabaseSourceSnapshotById(
 export async function getContentDatabaseSourceSnapshotForWrite(
   database: ContentDatabaseRow | ContentDatabase,
   sourceId?: string | null,
+  documentIds?: string[],
 ): Promise<ContentDatabaseSource | null> {
   const db = getDb();
   if (sourceId) {
@@ -3032,6 +3033,7 @@ export async function getContentDatabaseSourceSnapshotForWrite(
     return source
       ? loadSourceSnapshot(source, database, {
           includeHeavyBuilderBodyValues: true,
+          documentIds,
         })
       : null;
   }
@@ -3046,6 +3048,7 @@ export async function getContentDatabaseSourceSnapshotForWrite(
   return source
     ? loadSourceSnapshot(source, database, {
         includeHeavyBuilderBodyValues: true,
+        documentIds,
       })
     : null;
 }
@@ -3086,8 +3089,12 @@ async function readSourceSnapshotRowsOnce(args: {
   database: ContentDatabaseRow | ContentDatabase;
   isBuilderSource: boolean;
   includeHeavyBuilderBodyValues: boolean;
+  documentIds?: string[];
 }) {
   const db = getDb();
+  const documentScope = args.documentIds?.length
+    ? new Set(args.documentIds)
+    : null;
   const rowRows = await db
     .select(
       sourceSnapshotRowSelection({
@@ -3096,7 +3103,16 @@ async function readSourceSnapshotRowsOnce(args: {
       }),
     )
     .from(schema.contentDatabaseSourceRows)
-    .where(eq(schema.contentDatabaseSourceRows.sourceId, args.source.id))
+    .where(
+      documentScope
+        ? and(
+            eq(schema.contentDatabaseSourceRows.sourceId, args.source.id),
+            inArray(schema.contentDatabaseSourceRows.documentId, [
+              ...documentScope,
+            ]),
+          )
+        : eq(schema.contentDatabaseSourceRows.sourceId, args.source.id),
+    )
     .orderBy(asc(schema.contentDatabaseSourceRows.createdAt));
   // For Builder sources, load ALL database items (not just synced source rows)
   // so brand-new local rows (no source link) can become create_draft change-sets.
@@ -3112,6 +3128,13 @@ async function readSourceSnapshotRowsOnce(args: {
           and(
             eq(schema.contentDatabaseItems.databaseId, args.database.id),
             eq(schema.contentDatabaseItems.ownerEmail, args.source.ownerEmail),
+            ...(documentScope
+              ? [
+                  inArray(schema.contentDatabaseItems.documentId, [
+                    ...documentScope,
+                  ]),
+                ]
+              : []),
           ),
         )
     : [];
@@ -3180,8 +3203,12 @@ async function sourceSnapshotConsistencyMarker(args: {
   database: ContentDatabaseRow | ContentDatabase;
   isBuilderSource: boolean;
   includeHeavyBuilderBodyValues: boolean;
+  documentIds?: string[];
 }) {
   const db = getDb();
+  const documentScope = args.documentIds?.length
+    ? new Set(args.documentIds)
+    : null;
   const [rows] = await db
     .select({
       count: sql<number>`COUNT(*)`,
@@ -3190,7 +3217,16 @@ async function sourceSnapshotConsistencyMarker(args: {
       >`MAX(${schema.contentDatabaseSourceRows.updatedAt})`,
     })
     .from(schema.contentDatabaseSourceRows)
-    .where(eq(schema.contentDatabaseSourceRows.sourceId, args.source.id));
+    .where(
+      documentScope
+        ? and(
+            eq(schema.contentDatabaseSourceRows.sourceId, args.source.id),
+            inArray(schema.contentDatabaseSourceRows.documentId, [
+              ...documentScope,
+            ]),
+          )
+        : eq(schema.contentDatabaseSourceRows.sourceId, args.source.id),
+    );
   const [items] = args.isBuilderSource
     ? await db
         .select({
@@ -3204,6 +3240,13 @@ async function sourceSnapshotConsistencyMarker(args: {
           and(
             eq(schema.contentDatabaseItems.databaseId, args.database.id),
             eq(schema.contentDatabaseItems.ownerEmail, args.source.ownerEmail),
+            ...(documentScope
+              ? [
+                  inArray(schema.contentDatabaseItems.documentId, [
+                    ...documentScope,
+                  ]),
+                ]
+              : []),
           ),
         )
     : [{ count: 0, maxUpdatedAt: null }];
@@ -3232,6 +3275,7 @@ async function loadSourceSnapshotRowsOptimistically(args: {
   database: ContentDatabaseRow | ContentDatabase;
   isBuilderSource: boolean;
   includeHeavyBuilderBodyValues: boolean;
+  documentIds?: string[];
 }) {
   let latest: Awaited<ReturnType<typeof readSourceSnapshotRowsOnce>> | null =
     null;
@@ -3247,7 +3291,7 @@ async function loadSourceSnapshotRowsOptimistically(args: {
 async function loadSourceSnapshot(
   source: ContentDatabaseSourceRowDb,
   database: ContentDatabaseRow | ContentDatabase,
-  options: { includeHeavyBuilderBodyValues: boolean },
+  options: { includeHeavyBuilderBodyValues: boolean; documentIds?: string[] },
 ): Promise<ContentDatabaseSource> {
   const db = getDb();
   const [fieldRows, changeRows, reviewRows, executionRows, propertyDefs] =
@@ -3260,7 +3304,17 @@ async function loadSourceSnapshot(
       db
         .select()
         .from(schema.contentDatabaseSourceChangeSets)
-        .where(eq(schema.contentDatabaseSourceChangeSets.sourceId, source.id))
+        .where(
+          options.documentIds?.length
+            ? and(
+                eq(schema.contentDatabaseSourceChangeSets.sourceId, source.id),
+                inArray(
+                  schema.contentDatabaseSourceChangeSets.documentId,
+                  options.documentIds,
+                ),
+              )
+            : eq(schema.contentDatabaseSourceChangeSets.sourceId, source.id),
+        )
         .orderBy(asc(schema.contentDatabaseSourceChangeSets.createdAt)),
       db
         .select()
@@ -3341,6 +3395,7 @@ async function loadSourceSnapshot(
     database,
     isBuilderSource,
     includeHeavyBuilderBodyValues: options.includeHeavyBuilderBodyValues,
+    documentIds: options.documentIds,
   });
   const rows = rowRows.map((row) =>
     serializeSourceRowRecord(row, {

--- a/templates/content/actions/builder-source-review-gates.db.test.ts
+++ b/templates/content/actions/builder-source-review-gates.db.test.ts
@@ -19,6 +19,7 @@ const heavySnapshotReads = vi.hoisted(() => ({
   target: 0,
   allSources: 0,
   omitTargetRows: false,
+  documentScopes: [] as Array<string[] | null>,
 }));
 vi.mock("./_database-source-utils.js", async (importOriginal) => {
   const original =
@@ -31,6 +32,7 @@ vi.mock("./_database-source-utils.js", async (importOriginal) => {
       >
     ) => {
       heavySnapshotReads.target += 1;
+      heavySnapshotReads.documentScopes.push(args[2] ? [...args[2]] : null);
       const snapshot = await original.getContentDatabaseSourceSnapshotForWrite(
         ...args,
       );
@@ -252,6 +254,7 @@ describe("Builder source review execution gates", () => {
     const seeded = await seedBuilderSource({
       sourceTable: BUILDER_CMS_SAFE_WRITE_MODEL,
     });
+    heavySnapshotReads.documentScopes = [];
     heavySnapshotReads.omitTargetRows = true;
     try {
       const response = await asOwner(() =>
@@ -259,6 +262,7 @@ describe("Builder source review execution gates", () => {
           documentId: seeded.databaseDocumentId,
           sourceId: seeded.sourceId,
           changeSetIds: [seeded.changeSetId],
+          documentIds: [seeded.rowDocumentId],
           pushModeConfirmation: "autosave",
         }),
       );
@@ -283,6 +287,10 @@ describe("Builder source review execution gates", () => {
         documentId: expect.stringMatching(/^doc_row_/),
       });
       expect(JSON.parse(execution.payloadJson).request.method).toBe("PATCH");
+      expect(heavySnapshotReads.documentScopes).toEqual([
+        [seeded.rowDocumentId],
+        [seeded.rowDocumentId],
+      ]);
     } finally {
       heavySnapshotReads.omitTargetRows = false;
     }

--- a/templates/content/actions/cancel-prepared-builder-source-update.db.test.ts
+++ b/templates/content/actions/cancel-prepared-builder-source-update.db.test.ts
@@ -411,6 +411,79 @@ describe("cancel-prepared-builder-source-update", () => {
     expect(persisted.claims).toHaveLength(1);
   });
 
+  it("bounds heavy Builder write snapshots to selected documents", async () => {
+    const seeded = await seed();
+    const now = "2026-07-15T16:00:00.000Z";
+    const selectedDocumentId = `selected_${seeded.documentId}`;
+    const selectedItemId = `selected_item_${seeded.documentId}`;
+    const otherDocumentId = `other_${seeded.documentId}`;
+    const otherItemId = `other_item_${seeded.documentId}`;
+
+    await getDb()
+      .insert(schema.documents)
+      .values([
+        {
+          id: selectedDocumentId,
+          ownerEmail: OWNER,
+          parentId: seeded.documentId,
+          title: "Selected local draft",
+          content: "Selected rich Builder body.",
+          createdAt: now,
+          updatedAt: now,
+        },
+        {
+          id: otherDocumentId,
+          ownerEmail: OWNER,
+          parentId: seeded.documentId,
+          title: "Unselected local draft",
+          content: "This body must not enter the selected heavy snapshot.",
+          createdAt: now,
+          updatedAt: now,
+        },
+      ]);
+    await getDb()
+      .insert(schema.contentDatabaseItems)
+      .values([
+        {
+          id: selectedItemId,
+          ownerEmail: OWNER,
+          databaseId: seeded.databaseId,
+          documentId: selectedDocumentId,
+          createdAt: now,
+          updatedAt: now,
+        },
+        {
+          id: otherItemId,
+          ownerEmail: OWNER,
+          databaseId: seeded.databaseId,
+          documentId: otherDocumentId,
+          createdAt: now,
+          updatedAt: now,
+        },
+      ]);
+
+    const snapshot = await getWriteSnapshot(
+      {
+        id: seeded.databaseId,
+        documentId: seeded.documentId,
+      } as any,
+      seeded.sourceId,
+      [selectedDocumentId],
+    );
+
+    expect(snapshot?.rows).toEqual([]);
+    expect(snapshot?.changeSets).toEqual([
+      expect.objectContaining({
+        databaseItemId: selectedItemId,
+        documentId: selectedDocumentId,
+        localOnly: true,
+        bodyChange: expect.objectContaining({
+          proposedContent: "Selected rich Builder body.",
+        }),
+      }),
+    ]);
+  });
+
   it("suppresses only the identical cancelled diff and resurfaces local or remote changes", async () => {
     const seeded = await seed({
       titleDiff: { remote: "Remote title", local: "Local title" },

--- a/templates/content/actions/content-database-source-actions.test.ts
+++ b/templates/content/actions/content-database-source-actions.test.ts
@@ -575,6 +575,7 @@ describe("content database source actions", () => {
     expect(
       prepareReview.schema.parse({
         documentId: "database-page",
+        documentIds: ["document-1"],
         changeSetIds: ["change-set"],
         pushModeConfirmation: "publish",
         transitions: {
@@ -586,6 +587,7 @@ describe("content database source actions", () => {
       }),
     ).toEqual({
       documentId: "database-page",
+      documentIds: ["document-1"],
       changeSetIds: ["change-set"],
       pushModeConfirmation: "publish",
       transitions: {

--- a/templates/content/actions/prepare-builder-source-review.ts
+++ b/templates/content/actions/prepare-builder-source-review.ts
@@ -618,6 +618,13 @@ export default defineAction({
         .max(BUILDER_SOURCE_REVIEW_PREPARE_LIMIT)
         .optional()
         .describe("Optional bounded set of Builder change-set IDs to prepare"),
+      documentIds: z
+        .array(z.string())
+        .max(BUILDER_SOURCE_REVIEW_PREPARE_LIMIT)
+        .optional()
+        .describe(
+          "Optional document IDs that bound heavy Builder snapshot loading",
+        ),
       pushModeConfirmation: z
         .enum(["autosave", "draft", "publish"])
         .optional()
@@ -663,6 +670,7 @@ export default defineAction({
           const snapshot = await getContentDatabaseSourceSnapshotForWrite(
             database,
             args.sourceId,
+            args.documentIds,
           );
           return { database, snapshot };
         },
@@ -765,6 +773,7 @@ export default defineAction({
           reviewedSnapshot: await getContentDatabaseSourceSnapshotForWrite(
             database,
             args.sourceId,
+            args.documentIds,
           ),
           response: await getContentDatabaseResponse(database.id),
         }),

--- a/templates/content/actions/preview-builder-source-review.ts
+++ b/templates/content/actions/preview-builder-source-review.ts
@@ -40,18 +40,20 @@ export default defineAction({
     if (!database) throw new Error("Database not found.");
     await assertAccess("document", database.documentId, "editor");
 
+    const selectedDocumentIds = new Set(args.documentIds ?? []);
+    if (args.scope === "selected" && selectedDocumentIds.size === 0) {
+      throw new Error("Select at least one Builder row before reviewing it.");
+    }
+
     const source = await getContentDatabaseSourceSnapshotForWrite(
       database,
       args.sourceId,
+      args.scope === "selected" ? args.documentIds : undefined,
     );
     if (!source || source.sourceType !== "builder-cms") {
       throw new Error("Attach a Builder CMS source before reviewing updates.");
     }
 
-    const selectedDocumentIds = new Set(args.documentIds ?? []);
-    if (args.scope === "selected" && selectedDocumentIds.size === 0) {
-      throw new Error("Select at least one Builder row before reviewing it.");
-    }
     const allReviewableChanges = source.changeSets.filter((changeSet) => {
       if (
         changeSet.direction !== "outbound" ||

--- a/templates/content/app/components/editor/database/DatabaseView.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.tsx
@@ -1720,6 +1720,10 @@ function DatabaseTable({
           documentId: document.id,
           sourceId: session.sourceId,
           changeSetIds: selectedChangeSetIds,
+          documentIds:
+            selectedItemIds.length > 0
+              ? selectedItems.map((item) => item.document.id)
+              : undefined,
           pushModeConfirmation:
             activeBuilderReview.pushMode === "none"
               ? undefined

--- a/templates/content/changelog/2026-07-15-selected-builder-reviews-now-load-only-the-chosen-rows-avoid.md
+++ b/templates/content/changelog/2026-07-15-selected-builder-reviews-now-load-only-the-chosen-rows-avoid.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-15
+---
+
+Selected Builder reviews now load only the chosen rows, avoiding production timeouts on large collections.

--- a/templates/content/shared/api.ts
+++ b/templates/content/shared/api.ts
@@ -1018,6 +1018,7 @@ export interface PrepareBuilderSourceReviewRequest {
   documentId?: string;
   sourceId?: string;
   changeSetIds?: string[];
+  documentIds?: string[];
   pushModeConfirmation?: ContentDatabaseSourcePushMode;
   publicationTransition?: BuilderCmsPublicationTransitionIntent;
   confirmUnpublish?: boolean;


### PR DESCRIPTION
## Summary

- scope heavy Builder write snapshots to the selected Content document IDs
- validate empty selected reviews before loading a source snapshot
- cover a selected unsourced rich draft while excluding an unselected draft

## Production evidence

The merged BuilderSync flow reached the safe `agent-native-blog-article-test` model, selected exactly one new Content row, and then `preview-builder-source-review` returned HTTP 502 after building a source-wide heavy snapshot across a 775-row database. No Builder write occurred.

## Verification

- `pnpm vitest run actions/cancel-prepared-builder-source-update.db.test.ts actions/content-database-source-actions.test.ts` (52 passed)
- `pnpm exec tsc --noEmit --pretty false`
- production QA will resume against the same selected Content row after deploy