### PR TITLE
Fix dreams infinite render loops

### DIFF
--- a/.changeset/fix-dreams-infinite-render-loop.md
+++ b/.changeset/fix-dreams-infinite-render-loop.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Fix infinite render loop in DreamsRoute caused by the `useEffect` fallback clearing `selectedDreamId` to `null` while `dreams` was still loading. Added a `dreamsQuery.isLoading` guard to prevent the fallback from running before data resolves.

--- a/packages/dispatch/src/routes/pages/dreams.tsx
+++ b/packages/dispatch/src/routes/pages/dreams.tsx
@@ -1249,11 +1249,17 @@ export default function DreamsRoute() {
       return;
     }
     if (dreamsQuery.isLoading) return;
-    const nextId = dreams[0]?.id ?? urlDreamId;
+    const nextId = dreams[0]?.id ?? null;
     setSelectedDreamId(nextId);
     if (nextId && nextId !== urlDreamId) {
       const next = new URLSearchParams(searchParams);
       next.set("dreamId", nextId);
+      setSearchParams(next, { replace: true });
+    } else if (!nextId && urlDreamId) {
+      // List settled with no rows — remove the stale URL param so
+      // dreamDetailQuery does not fire for an ID that cannot be found.
+      const next = new URLSearchParams(searchParams);
+      next.delete("dreamId");
       setSearchParams(next, { replace: true });
     }
   }, [

--- a/packages/dispatch/src/routes/pages/dreams.tsx
+++ b/packages/dispatch/src/routes/pages/dreams.tsx
@@ -1242,16 +1242,27 @@ export default function DreamsRoute() {
       setSelectedDreamId(urlDreamId);
       return;
     }
-    if (selectedDreamId && dreams.some((dream) => dream.id === selectedDreamId))
+    if (
+      selectedDreamId &&
+      dreams.some((dream) => dream.id === selectedDreamId)
+    ) {
       return;
-    const nextId = dreams[0]?.id ?? null;
+    }
+    if (dreamsQuery.isLoading) return;
+    const nextId = dreams[0]?.id ?? urlDreamId;
     setSelectedDreamId(nextId);
     if (nextId && nextId !== urlDreamId) {
       const next = new URLSearchParams(searchParams);
       next.set("dreamId", nextId);
       setSearchParams(next, { replace: true });
     }
-  }, [dreams, searchParams, selectedDreamId, setSearchParams]);
+  }, [
+    dreams,
+    dreamsQuery.isLoading,
+    searchParams,
+    selectedDreamId,
+    setSearchParams,
+  ]);
 
   function selectDream(dreamId: string) {
     setSelectedDreamId(dreamId);
@@ -1403,8 +1414,8 @@ export default function DreamsRoute() {
       description="Review agent runs, propose memory improvements, and apply evidence-backed learning changes."
     >
       <div className="space-y-4">
-        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-          <div className="grid flex-1 gap-2 sm:grid-cols-2 xl:grid-cols-4">
+        <div className="grid gap-3 grid-cols-1 lg:grid-cols-2 xl:grid-cols-[1fr_auto] items-center w-full">
+          <div className="grid gap-2 grid-cols-2 sm:grid-cols-4 w-full">
             <StatTile
               label="Dream passes"
               value={dreams.length}
@@ -1426,7 +1437,7 @@ export default function DreamsRoute() {
               icon={IconCheck}
             />
           </div>
-          <div className="flex shrink-0 flex-wrap gap-2">
+          <div className="flex flex-wrap items-center gap-2 w-full lg:justify-end">
             {dreamSettings ? (
               <Badge variant="outline" className="h-9 px-3">
                 {dreamSettings.enabled ? "Enabled" : "Paused"} ·{" "}

--- a/packages/dispatch/src/routes/pages/dreams.tsx
+++ b/packages/dispatch/src/routes/pages/dreams.tsx
@@ -1414,8 +1414,8 @@ export default function DreamsRoute() {
       description="Review agent runs, propose memory improvements, and apply evidence-backed learning changes."
     >
       <div className="space-y-4">
-        <div className="grid gap-3 grid-cols-1 lg:grid-cols-2 xl:grid-cols-[1fr_auto] items-center w-full">
-          <div className="grid gap-2 grid-cols-2 sm:grid-cols-4 w-full">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div className="grid flex-1 gap-2 sm:grid-cols-2 xl:grid-cols-4">
             <StatTile
               label="Dream passes"
               value={dreams.length}
@@ -1437,7 +1437,7 @@ export default function DreamsRoute() {
               icon={IconCheck}
             />
           </div>
-          <div className="flex flex-wrap items-center gap-2 w-full lg:justify-end">
+          <div className="flex shrink-0 flex-wrap gap-2">
             {dreamSettings ? (
               <Badge variant="outline" className="h-9 px-3">
                 {dreamSettings.enabled ? "Enabled" : "Paused"} ·{" "}

--- a/packages/dispatch/src/routes/pages/dreams.tsx
+++ b/packages/dispatch/src/routes/pages/dreams.tsx
@@ -1249,6 +1249,10 @@ export default function DreamsRoute() {
       return;
     }
     if (dreamsQuery.isLoading) return;
+    // If the query failed, normalizeArray returns [] but the list is not
+    // confirmed empty — preserve the current selection so dreamDetailQuery
+    // can still load the detail from the URL param.
+    if (dreamsQuery.error) return;
     const nextId = dreams[0]?.id ?? null;
     setSelectedDreamId(nextId);
     if (nextId && nextId !== urlDreamId) {
@@ -1256,8 +1260,8 @@ export default function DreamsRoute() {
       next.set("dreamId", nextId);
       setSearchParams(next, { replace: true });
     } else if (!nextId && urlDreamId) {
-      // List settled with no rows — remove the stale URL param so
-      // dreamDetailQuery does not fire for an ID that cannot be found.
+      // List settled successfully with no rows — remove the stale URL param
+      // so dreamDetailQuery does not fire for an ID that cannot be found.
       const next = new URLSearchParams(searchParams);
       next.delete("dreamId");
       setSearchParams(next, { replace: true });
@@ -1265,6 +1269,7 @@ export default function DreamsRoute() {
   }, [
     dreams,
     dreamsQuery.isLoading,
+    dreamsQuery.error,
     searchParams,
     selectedDreamId,
     setSearchParams,


### PR DESCRIPTION
# fix: prevent infinite render loop in dreams route selection

## Problem: Infinite Render Loop
When the component mounts or refetches, `dreams` is temporarily empty (`[]`). This triggers a state-synchronization conflict:
1. Since `dreams` is empty, the validator checks fail, and the effect falls back to setting `selectedDreamId` to `null`.
2. On the next render, the effect detects that `selectedDreamId` (`null`) doesn't match the URL `dreamId` (e.g., `af9e...`) and sets the state back to the URL value.
3. This creates a perpetual loop between setting the selection state to `null` and setting it back to the URL ID.

## Solution
We restore the early return check for `dreamsQuery.isLoading`. 
- When the query is still loading, the effect exits early and avoids clearing the selection to `null`.
- This keeps the local state stable while waiting for the data to resolve.

## Changes
- Restored the `dreamsQuery.isLoading` check to gate the fallback selection logic.
- Maintained exhaustive dependencies to ensure clean, stale-free updates.
- Verified file formatting using `oxfmt`.

<img width="1005" height="584" alt="brave_screenshot_dispatch agent-native com" src="https://github.com/user-attachments/assets/46ed8d12-2a21-4bce-879d-758b15c4db35" />