### PR TITLE
Fix agent guard discarding successful dashboard edits

### DIFF
--- a/templates/analytics/changelog/2026-07-15-fixed-the-agent-discarding-a-successful-dashboard-edit-and-r.md
+++ b/templates/analytics/changelog/2026-07-15-fixed-the-agent-discarding-a-successful-dashboard-edit-and-r.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-15
+---
+
+Fixed the agent discarding a successful dashboard edit and replacing it with an unrelated data-source message

--- a/templates/analytics/server/lib/real-data-actions.ts
+++ b/templates/analytics/server/lib/real-data-actions.ts
@@ -76,6 +76,20 @@ export const DASHBOARD_CONSTRUCTION_ACTIONS = new Set([
   "get-extension",
 ]);
 
+// Dashboard authoring/save actions. Unlike the read actions above, running one
+// of these is proof the turn actually edited or built a dashboard/extension —
+// which is a legitimate non-query completion. A saved SQL panel the user runs
+// themselves is not a fabricated metric, so the guard only needs to keep
+// blocking drafts that state invented numbers (draftClaimsAnalyticsMetrics).
+export const DASHBOARD_MUTATION_ACTIONS = new Set([
+  "mutate-dashboard",
+  "update-dashboard",
+  "compose-dashboard",
+  "install-dashboard-template",
+  "create-extension",
+  "update-extension",
+]);
+
 const RUN_CODE_BRIDGE_TOOLS_USED = /^bridgeToolsUsed:\s*(.+)$/im;
 
 const MCP_DATA_SOURCE_TOKENS = [
@@ -120,11 +134,15 @@ function isDashboardConstructionActionName(name: string): boolean {
   return DASHBOARD_CONSTRUCTION_ACTIONS.has(normalizeActionToolName(name));
 }
 
+function isDashboardMutationActionName(name: string): boolean {
+  return DASHBOARD_MUTATION_ACTIONS.has(normalizeActionToolName(name));
+}
+
 // "Build/clone/template" language targeting a dashboard/extension/panel is
 // dashboard construction, distinct from an analytics-result question. Turns
 // like this may inspect and clone a template without running a metric query.
 const DASHBOARD_CONSTRUCTION_INTENT_TERMS =
-  /\b(build|create|make|clone|copy|duplicate|adapt|template|based (?:off|on)|using .{1,80}? as a template)\b/i;
+  /\b(build|create|make|clone|copy|duplicate|adapt|update|edit|change|modify|rename|adjust|simplify|switch|template|based (?:off|on)|using .{1,80}? as a template)\b/i;
 
 const DASHBOARD_CONSTRUCTION_TARGET_TERMS =
   /\b(dashboard|extension|panel|widget)\b/i;
@@ -148,6 +166,17 @@ export function hasDashboardConstructionAttempt(
   return (toolResults ?? []).some((result) => {
     if (result.isError) return false;
     return isDashboardConstructionActionName(String(result.name ?? ""));
+  });
+}
+
+export function hasDashboardMutationAttempt(
+  toolResults:
+    | Array<{ name?: string; isError?: boolean; content?: string }>
+    | undefined,
+): boolean {
+  return (toolResults ?? []).some((result) => {
+    if (result.isError) return false;
+    return isDashboardMutationActionName(String(result.name ?? ""));
   });
 }
 

--- a/templates/analytics/server/plugins/agent-chat.dashboard-edit.spec.ts
+++ b/templates/analytics/server/plugins/agent-chat.dashboard-edit.spec.ts
@@ -1,0 +1,67 @@
+import type { AgentLoopFinalResponseGuardContext } from "@agent-native/core/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../.generated/actions-registry.js", () => ({ default: {} }));
+
+import { realDataFinalGuard } from "./agent-chat";
+
+function userMessage(
+  text: string,
+): AgentLoopFinalResponseGuardContext["messages"][number] {
+  return { role: "user", content: [{ type: "text", text }] };
+}
+
+function guardContext(params: {
+  userText: string;
+  draftText: string;
+  toolResults?: AgentLoopFinalResponseGuardContext["toolResults"];
+}): AgentLoopFinalResponseGuardContext {
+  const context: AgentLoopFinalResponseGuardContext & { requestText?: string } =
+    {
+      messages: [userMessage(params.userText)],
+      requestText: params.userText,
+      assistantContent: [],
+      text: params.draftText,
+      toolCalls: [],
+      toolResults: params.toolResults ?? [],
+      retryCount: 0,
+      executionMode: "act",
+    };
+  return context;
+}
+
+describe("realDataFinalGuard dashboard edits", () => {
+  it("accepts a dashboard edit that saved a mutation without a data query", () => {
+    const result = realDataFinalGuard(
+      guardContext({
+        userText:
+          "update the classification logic in both panels to use only DUAL_TRACK and IMPLEMENTATION deals",
+        draftText:
+          "Updated both panels to use only DUAL_TRACK and IMPLEMENTATION classifications as requested.",
+        toolResults: [
+          { name: "get-sql-dashboard", isError: false, content: "ok" },
+          { name: "mutate-dashboard", isError: false, content: "ok" },
+        ],
+      }),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("still retries a dashboard edit whose draft states invented metrics", () => {
+    const result = realDataFinalGuard(
+      guardContext({
+        userText:
+          "update the classification logic in both panels to use only DUAL_TRACK and IMPLEMENTATION deals",
+        draftText:
+          "Done. DUAL_TRACK deals now have a 62 percent win rate versus 41 percent for IMPLEMENTATION.",
+        toolResults: [
+          { name: "get-sql-dashboard", isError: false, content: "ok" },
+          { name: "mutate-dashboard", isError: false, content: "ok" },
+        ],
+      }),
+    );
+
+    expect(result).not.toBeNull();
+  });
+});

--- a/templates/analytics/server/plugins/agent-chat.ts
+++ b/templates/analytics/server/plugins/agent-chat.ts
@@ -17,6 +17,7 @@ import {
   draftClaimsAnalyticsMetrics,
   failedDataQueryAttemptMessage,
   hasDashboardConstructionAttempt,
+  hasDashboardMutationAttempt,
   hasExplicitPartialDisclosure,
   hasFailedCorpusWorkflowEvidence,
   hasDataQueryAttempt,
@@ -524,6 +525,20 @@ export function realDataFinalGuard(
       fallbackMessage:
         "I can't make a confident exhaustive analytics claim yet because part of the source evidence was aborted, truncated, or still paginated. I need to recover the missing coverage or state the answer as partial with the inspected sample size.",
     };
+  }
+  // Dashboard EDIT turns: the user asked to change an existing dashboard and
+  // the agent actually saved a mutation (mutate-dashboard/update-dashboard/
+  // etc.). This is a legitimate non-query completion regardless of how the
+  // request was phrased ("update the panels" does not match the construction
+  // intent regex), so it must not be steered into a data-source query. Anchor
+  // on tool evidence, not user wording, and still block any draft that states
+  // invented numbers via draftClaimsAnalyticsMetrics. A saved SQL panel the
+  // user runs themselves is not a fabricated metric.
+  if (
+    hasDashboardMutationAttempt(context.toolResults) &&
+    !draftClaimsAnalyticsMetrics(context.text)
+  ) {
+    return null;
   }
   // Dashboard construction/template-clone turns may inspect and clone an
   // existing dashboard/extension without running a metric query, as long as


### PR DESCRIPTION
### Summary
Fixes the agent's final-response guard incorrectly rejecting drafts that successfully edited a dashboard, redirecting them into an unrelated data-source query instead.

### Problem
When a user asked the agent to update/edit an existing dashboard (e.g. "update the classification logic in both panels..."), the guard's construction-intent regex didn't recognize edit-style phrasing (`update`, `edit`, `change`, `modify`, etc.). As a result, even after the agent successfully saved the mutation via tools like `mutate-dashboard`, the guard treated the turn as an unanswered analytics query and discarded the successful edit, steering the response toward a fabricated data-source message.

### Solution
Instead of relying solely on user wording to detect dashboard construction intent, the guard now also checks for actual tool evidence that a dashboard/extension mutation was saved. If such a mutation occurred and the draft doesn't claim fabricated analytics metrics, the turn is accepted as a legitimate non-query completion.

### Key Changes
- Added `DASHBOARD_MUTATION_ACTIONS` set (`mutate-dashboard`, `update-dashboard`, `compose-dashboard`, `install-dashboard-template`, `create-extension`, `update-extension`) and `isDashboardMutationActionName` helper in `real-data-actions.ts`.
- Added `hasDashboardMutationAttempt` function to detect successful dashboard/extension mutation tool calls in tool results.
- Expanded `DASHBOARD_CONSTRUCTION_INTENT_TERMS` regex to also match edit-style verbs (`update`, `edit`, `change`, `modify`, `rename`, `adjust`, `simplify`, `switch`).
- Updated `realDataFinalGuard` in `agent-chat.ts` to short-circuit and accept the draft when `hasDashboardMutationAttempt` is true and `draftClaimsAnalyticsMetrics` is false, anchoring the decision on tool evidence rather than user phrasing.
- Added unit tests (`agent-chat.dashboard-edit.spec.ts`) covering acceptance of a successful dashboard-edit draft and continued rejection of drafts that state invented metrics.
- Added changelog entry documenting the fix.


---

<a href="https://builder.io/app/projects/ae8cb7b8045d4c21b2a343e11036d454/apex-volt-ce4lv573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ae8cb7b8045d4c21b2a343e11036d454-apex-volt-ce4lv573.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2161`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ae8cb7b8045d4c21b2a343e11036d454</projectId>-->
<!--<branchName>apex-volt-ce4lv573</branchName>-->