### PR TITLE
Smooth streaming for thinking blocks

### DIFF
--- a/.changeset/fast-chat-template-download.md
+++ b/.changeset/fast-chat-template-download.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Bundle the Chat template in the CLI package and download GitHub fallbacks directly from codeload for faster, more reliable scaffolding.

--- a/.changeset/quiet-chat-sidebar-header.md
+++ b/.changeset/quiet-chat-sidebar-header.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Polish the chat sidebar header by hiding mode tabs and moving full-view navigation into the icon row.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
     "tsconfig.base.json",
     "src/templates/default",
     "src/templates/headless",
+    "src/templates/chat",
     "src/templates/workspace-core",
     "src/templates/workspace-root"
   ],
@@ -249,7 +250,8 @@
     "dev": "tsc --watch",
     "typecheck": "tsc --noEmit",
     "test": "vitest --run src --maxWorkers=25%",
-    "prepack": "tsx ../../scripts/sync-workspace-core-skills.ts --check && npm run build && cp ../../README.md ./README.md",
+    "prepack": "tsx ../../scripts/sync-core-first-party-templates.ts && tsx ../../scripts/sync-workspace-core-skills.ts --check && npm run build && cp ../../README.md ./README.md",
+    "postpack": "tsx ../../scripts/sync-core-first-party-templates.ts --clean",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -34,6 +34,7 @@ import {
   _getGitHubTemplateRef,
   _getGitHubTemplateRefCandidates,
   _githubTarballUrl,
+  _findLocalTemplateFrom,
   _shouldSkipScaffoldEntry,
   _tarExtractArgs,
 } from "./create.js";
@@ -244,6 +245,24 @@ describe("standalone scaffold — chat template", { timeout: 60000 }, () => {
     await createApp("test-app", { template: "chat" });
     const pkg = readPkg(path.join(tmpDir, "test-app"));
     expect(pkg.dependencies?.postgres).toBeDefined();
+  });
+});
+
+describe("installed package template discovery", () => {
+  it("finds source templates included in an installed core package", () => {
+    const packageRoot = path.join(
+      tmpDir,
+      "node_modules",
+      "@agent-native",
+      "core",
+    );
+    const sourceTemplate = path.join(packageRoot, "src", "templates", "chat");
+    const compiledCli = path.join(packageRoot, "dist", "cli");
+    fs.mkdirSync(sourceTemplate, { recursive: true });
+    fs.mkdirSync(compiledCli, { recursive: true });
+    fs.writeFileSync(path.join(sourceTemplate, "package.json"), "{}\n");
+
+    expect(_findLocalTemplateFrom(compiledCli, "chat")).toBe(sourceTemplate);
   });
 });
 

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -33,6 +33,7 @@ import {
   _getToolkitDependencyVersion,
   _getGitHubTemplateRef,
   _getGitHubTemplateRefCandidates,
+  _githubTarballUrl,
   _shouldSkipScaffoldEntry,
   _tarExtractArgs,
 } from "./create.js";
@@ -942,6 +943,18 @@ describe("template/core version compatibility", () => {
     // Never fall back to mutable `main`: it can be newer than the installed
     // core package and produce a scaffold that fails during SSR startup.
     expect(candidates).not.toContain("main");
+  });
+
+  it("downloads GitHub tarballs from codeload instead of the GitHub API", () => {
+    expect(
+      _githubTarballUrl(
+        "BuilderIO/agent-native",
+        "@agent-native/core@0.101.13",
+        "tag",
+      ),
+    ).toBe(
+      "https://codeload.github.com/BuilderIO/agent-native/tar.gz/refs/tags/%40agent-native%2Fcore%400.101.13",
+    );
   });
 });
 

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -785,7 +785,8 @@ function cleanupOnFailure(targetDir: string): void {
  * Scaffold a single app template into `targetDir`. Resolves:
  *   - "headless" / legacy "blank" → bundled action-first template
  *   - "github:user/repo" → download the whole repo
- *   - first-party template name → download that subdir from BuilderIO/agent-native
+ *   - first-party template name → use a bundled copy or download its subdir
+ *     from BuilderIO/agent-native
  */
 async function scaffoldAppTemplate(
   targetDir: string,
@@ -842,8 +843,9 @@ function templateSourceName(name: string): string {
 }
 
 /**
- * When developing the framework itself, prefer the sibling templates/<name>
- * directory. Returns undefined when running as a published package.
+ * Prefer a nearby templates/<name> directory. This covers the framework
+ * checkout and the dist/templates copy bundled into published CLI packages;
+ * packages that do not bundle a template fall back to GitHub.
  */
 function findLocalTemplate(name: string): string | undefined {
   let dir = path.resolve(__dirname);
@@ -1332,6 +1334,7 @@ export {
   getToolkitDependencyVersion as _getToolkitDependencyVersion,
   getGitHubTemplateRef as _getGitHubTemplateRef,
   getGitHubTemplateRefCandidates as _getGitHubTemplateRefCandidates,
+  githubTarballUrl as _githubTarballUrl,
   workspaceAppNameForTemplateSelection as _workspaceAppNameForTemplateSelection,
   shouldSkipScaffoldEntry as _shouldSkipScaffoldEntry,
   tarExtractArgs as _tarExtractArgs,
@@ -1405,7 +1408,7 @@ async function downloadAndExtract(
       "10",
       "--max-time",
       "120",
-      "-sL",
+      "-sSL",
       url,
     ],
     { maxBuffer: 100 * 1024 * 1024 },
@@ -1435,7 +1438,7 @@ async function downloadGitHubSubdir(
   }
   const errors: string[] = [];
   for (const ref of refs) {
-    const tarUrl = `https://api.github.com/repos/${repo}/tarball/${encodeURIComponent(ref)}`;
+    const tarUrl = githubTarballUrl(repo, ref, "tag");
     const tmpDir = path.join(
       targetDir,
       "..",
@@ -1471,8 +1474,16 @@ async function downloadGitHubRepo(
   targetDir: string,
 ): Promise<void> {
   validateRepoName(repo);
-  const tarUrl = `https://api.github.com/repos/${repo}/tarball/main`;
+  const tarUrl = githubTarballUrl(repo, "main", "branch");
   await downloadAndExtract(tarUrl, targetDir);
+}
+
+function githubTarballUrl(
+  repo: string,
+  ref: string,
+  kind: "branch" | "tag",
+): string {
+  return `https://codeload.github.com/${repo}/tar.gz/refs/${kind === "tag" ? "tags" : "heads"}/${encodeURIComponent(ref)}`;
 }
 
 /* ─────────────────────────────────────────────────────────────────────────

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -843,16 +843,26 @@ function templateSourceName(name: string): string {
 }
 
 /**
- * Prefer a nearby templates/<name> directory. This covers the framework
- * checkout and the dist/templates copy bundled into published CLI packages;
+ * Prefer a nearby templates/<name> or src/templates/<name> directory. This
+ * covers the framework checkout, the dist/templates copy bundled into
+ * published CLI packages, and source templates included in package files;
  * packages that do not bundle a template fall back to GitHub.
  */
 function findLocalTemplate(name: string): string | undefined {
-  let dir = path.resolve(__dirname);
+  return findLocalTemplateFrom(path.resolve(__dirname), name);
+}
+
+function findLocalTemplateFrom(
+  startDir: string,
+  name: string,
+): string | undefined {
+  let dir = path.resolve(startDir);
   for (let i = 0; i < 10; i++) {
-    const candidate = path.join(dir, "templates", name);
-    if (fs.existsSync(path.join(candidate, "package.json"))) {
-      return candidate;
+    for (const templatesDir of ["templates", "src/templates"]) {
+      const candidate = path.join(dir, templatesDir, name);
+      if (fs.existsSync(path.join(candidate, "package.json"))) {
+        return candidate;
+      }
     }
     const parent = path.dirname(dir);
     if (parent === dir) break;
@@ -1335,6 +1345,7 @@ export {
   getGitHubTemplateRef as _getGitHubTemplateRef,
   getGitHubTemplateRefCandidates as _getGitHubTemplateRefCandidates,
   githubTarballUrl as _githubTarballUrl,
+  findLocalTemplateFrom as _findLocalTemplateFrom,
   workspaceAppNameForTemplateSelection as _workspaceAppNameForTemplateSelection,
   shouldSkipScaffoldEntry as _shouldSkipScaffoldEntry,
   tarExtractArgs as _tarExtractArgs,

--- a/packages/core/src/client/AgentPanel.header.spec.ts
+++ b/packages/core/src/client/AgentPanel.header.spec.ts
@@ -8,9 +8,11 @@ import {
   resolveAgentPanelChatSurface,
   shouldAllowAgentChatSurfaceSettingsMode,
   shouldDefaultAgentChatSurfacePageNewChatButton,
+  shouldShowAgentPanelFullViewAction,
   shouldShowAgentPanelPageNewChatButton,
   shouldShowAgentPanelChatTabBar,
   shouldShowAgentPanelCliTabBar,
+  shouldShowAgentPanelModeButtons,
 } from "./AgentPanel.js";
 
 describe("resolveAgentPanelChatSurface", () => {
@@ -121,6 +123,33 @@ describe("AgentPanel header tab visibility", () => {
     );
     expect(normalizeAgentPanelModeForSurface("resources", false)).toBe(
       "resources",
+    );
+  });
+});
+
+describe("AgentPanel mode and full-view visibility", () => {
+  it("hides mode buttons in the sidebar and shows them on the full page", () => {
+    expect(shouldShowAgentPanelModeButtons(true)).toBe(false);
+    expect(shouldShowAgentPanelModeButtons(false)).toBe(true);
+  });
+
+  it("shows the full-view action for resources and settings when a page href exists", () => {
+    expect(shouldShowAgentPanelFullViewAction("/agent", "resources")).toBe(
+      true,
+    );
+    expect(shouldShowAgentPanelFullViewAction("/agent", "settings")).toBe(
+      true,
+    );
+  });
+
+  it("hides the full-view action for chat, CLI, or a missing page href", () => {
+    expect(shouldShowAgentPanelFullViewAction("/agent", "chat")).toBe(false);
+    expect(shouldShowAgentPanelFullViewAction("/agent", "cli")).toBe(false);
+    expect(shouldShowAgentPanelFullViewAction(undefined, "resources")).toBe(
+      false,
+    );
+    expect(shouldShowAgentPanelFullViewAction(undefined, "settings")).toBe(
+      false,
     );
   });
 });

--- a/packages/core/src/client/AgentPanel.header.spec.ts
+++ b/packages/core/src/client/AgentPanel.header.spec.ts
@@ -137,9 +137,7 @@ describe("AgentPanel mode and full-view visibility", () => {
     expect(shouldShowAgentPanelFullViewAction("/agent", "resources")).toBe(
       true,
     );
-    expect(shouldShowAgentPanelFullViewAction("/agent", "settings")).toBe(
-      true,
-    );
+    expect(shouldShowAgentPanelFullViewAction("/agent", "settings")).toBe(true);
   });
 
   it("hides the full-view action for chat, CLI, or a missing page href", () => {

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -437,6 +437,19 @@ export function shouldShowAgentPanelCliTabBar(cliTabs: string[]) {
   return cliTabs.length > 1;
 }
 
+export function shouldShowAgentPanelModeButtons(isSidebar: boolean) {
+  return !isSidebar;
+}
+
+export function shouldShowAgentPanelFullViewAction(
+  agentPageHref: string | undefined,
+  mode: PanelMode,
+) {
+  return (
+    Boolean(agentPageHref) && (mode === "resources" || mode === "settings")
+  );
+}
+
 // ─── AgentPanel ─────────────────────────────────────────────────────────────
 
 export interface AgentPanelCodeAccess {
@@ -1171,33 +1184,34 @@ function AgentPanelInner({
       | "toggleHistory"
     > & { activeChatSessionId?: string }) => (
       <div className="relative flex shrink-0 items-center gap-0.5">
-        {SHOW_ONBOARDING && (
+        {!onCollapse && SHOW_ONBOARDING && (
           <Suspense fallback={null}>
             <SetupButton />
           </Suspense>
         )}
-        {(() => {
-          const activeTab =
-            mode === "chat" && activeChatSessionId
-              ? tabs.find((tab) => tab.id === activeChatSessionId)
-              : undefined;
-          if (
-            !activeTab ||
-            (activeTabMessageCount <= 0 && activeTab.status === "idle")
-          ) {
-            return null;
-          }
-          return (
-            <ShareButton
-              resourceType="chat_thread"
-              resourceId={activeTab.id}
-              resourceTitle={activeTab.label || "Chat"}
-              shareUrl={getChatThreadShareUrl(activeTab.id)}
-              trigger="icon"
-              triggerClassName="h-7 w-7"
-            />
-          );
-        })()}
+        {!onCollapse &&
+          (() => {
+            const activeTab =
+              mode === "chat" && activeChatSessionId
+                ? tabs.find((tab) => tab.id === activeChatSessionId)
+                : undefined;
+            if (
+              !activeTab ||
+              (activeTabMessageCount <= 0 && activeTab.status === "idle")
+            ) {
+              return null;
+            }
+            return (
+              <ShareButton
+                resourceType="chat_thread"
+                resourceId={activeTab.id}
+                resourceTitle={activeTab.label || "Chat"}
+                shareUrl={getChatThreadShareUrl(activeTab.id)}
+                trigger="icon"
+                triggerClassName="h-7 w-7"
+              />
+            );
+          })()}
         <FeedbackButton
           variant="icon"
           side="bottom"
@@ -1215,7 +1229,7 @@ function AgentPanelInner({
             />
           }
         />
-        {mode === "chat" && (
+        {!onCollapse && mode === "chat" && (
           <IconTooltip content={t("agentPanel.newChat")}>
             <button
               onClick={addTab}
@@ -1226,7 +1240,7 @@ function AgentPanelInner({
             </button>
           </IconTooltip>
         )}
-        {mode === "cli" && canUseCodeTools && (
+        {!onCollapse && mode === "cli" && canUseCodeTools && (
           <IconTooltip content={t("agentPanel.newTerminal")}>
             <button
               onClick={addCliTab}
@@ -1235,6 +1249,17 @@ function AgentPanelInner({
             >
               <IconPlus size={14} />
             </button>
+          </IconTooltip>
+        )}
+        {shouldShowAgentPanelFullViewAction(agentPageHref, mode) && (
+          <IconTooltip content={t("agentPanel.openFullView")}>
+            <Link
+              to={agentPageHref!}
+              aria-label={t("agentPanel.openFullView")}
+              className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+            >
+              <IconArrowsMaximize size={14} />
+            </Link>
           </IconTooltip>
         )}
         <DropdownMenu open={headerMenuOpen} onOpenChange={setHeaderMenuOpen}>
@@ -1430,6 +1455,7 @@ function AgentPanelInner({
       headerMenuOpen,
       isFullscreen,
       mode,
+      agentPageHref,
       onCollapse,
       onToggleFullscreen,
       openRunThread,
@@ -1547,7 +1573,9 @@ function AgentPanelInner({
           style={AGENT_PANEL_HEADER_STYLE}
         >
           <div className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
-            {renderModeButtons(mode)}
+            {shouldShowAgentPanelModeButtons(Boolean(onCollapse))
+              ? renderModeButtons(mode)
+              : null}
           </div>
           <div className="flex items-center gap-0.5">
             {renderHeaderActions({
@@ -1939,17 +1967,6 @@ function AgentPanelInner({
       {/* Resources view */}
       {mode === "resources" && (
         <div className="flex flex-1 flex-col min-h-0">
-          {agentPageHref && (
-            <div className="flex shrink-0 justify-end border-b border-border px-3 py-1.5">
-              <Link
-                to={agentPageHref}
-                className="inline-flex cursor-pointer items-center gap-1 text-[11px] font-medium text-muted-foreground hover:text-foreground"
-              >
-                {t("agentPanel.openFullView")}
-                <IconExternalLink className="h-3 w-3" />
-              </Link>
-            </div>
-          )}
           <Suspense
             fallback={
               <div className="flex h-full flex-col min-h-0">
@@ -1970,17 +1987,6 @@ function AgentPanelInner({
       {/* Settings / Setup view */}
       {mode === "settings" && (
         <div className="flex flex-col flex-1 min-h-0">
-          {agentPageHref && (
-            <div className="flex shrink-0 justify-end border-b border-border px-3 py-1.5">
-              <Link
-                to={agentPageHref}
-                className="inline-flex cursor-pointer items-center gap-1 text-[11px] font-medium text-muted-foreground hover:text-foreground"
-              >
-                {t("agentPanel.openFullView")}
-                <IconExternalLink className="h-3 w-3" />
-              </Link>
-            </div>
-          )}
           <Suspense
             fallback={
               <div className="p-3 space-y-2">

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -1251,17 +1251,18 @@ function AgentPanelInner({
             </button>
           </IconTooltip>
         )}
-        {shouldShowAgentPanelFullViewAction(agentPageHref, mode) && (
-          <IconTooltip content={t("agentPanel.openFullView")}>
-            <Link
-              to={agentPageHref!}
-              aria-label={t("agentPanel.openFullView")}
-              className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-            >
-              <IconArrowsMaximize size={14} />
-            </Link>
-          </IconTooltip>
-        )}
+        {agentPageHref &&
+          shouldShowAgentPanelFullViewAction(agentPageHref, mode) && (
+            <IconTooltip content={t("agentPanel.openFullView")}>
+              <Link
+                to={agentPageHref}
+                aria-label={t("agentPanel.openFullView")}
+                className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+              >
+                <IconArrowsMaximize size={14} />
+              </Link>
+            </IconTooltip>
+          )}
         <DropdownMenu open={headerMenuOpen} onOpenChange={setHeaderMenuOpen}>
           <DropdownMenuTrigger asChild>
             <button
@@ -1290,6 +1291,12 @@ function AgentPanelInner({
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
               </>
+            )}
+            {onCollapse && mode === "chat" && (
+              <DropdownMenuItem onSelect={addTab}>
+                <IconPlus size={14} className="shrink-0" />
+                {t("agentPanel.newChat")}
+              </DropdownMenuItem>
             )}
             {mode === "chat" && toggleHistory && (
               <DropdownMenuItem onSelect={toggleHistory}>

--- a/packages/core/src/client/chat/message-components.tsx
+++ b/packages/core/src/client/chat/message-components.tsx
@@ -901,6 +901,7 @@ function ReasoningMessagePart() {
     <ReasoningCell
       text={part.text}
       isStreaming={isStreaming}
+      resetKey={`message-reasoning-${partIndex}`}
       durationMs={durationMs}
       defaultOpen={partIndex === latestReasoningPartIndex}
       collapseWhenReplaced={partIndex < latestReasoningPartIndex}

--- a/packages/core/src/client/chat/tool-call-display.spec.tsx
+++ b/packages/core/src/client/chat/tool-call-display.spec.tsx
@@ -759,6 +759,16 @@ describe("ToolCallDisplay native renderers", () => {
       thoughtButtons.map((button) => button.getAttribute("aria-expanded")),
     ).toEqual(["false", "true"]);
     expect(container.textContent).not.toContain("First thought");
+    expect(container.textContent).not.toContain("Current thought");
+
+    act(() => {
+      root.render(
+        <ChatRunningContext.Provider value={false}>
+          <ReconnectStreamMessage content={content} />
+        </ChatRunningContext.Provider>,
+      );
+    });
+
     expect(container.textContent).toContain("Current thought");
   });
 });
@@ -865,6 +875,22 @@ describe("ReasoningCell", () => {
     expect(container.textContent).toContain("Thinking");
     const shimmer = container.querySelector(".agent-thinking-indicator__text");
     expect(shimmer?.textContent).toBe("Thinking");
+  });
+
+  it("smoothly reveals reasoning text while streaming and completes it when done", () => {
+    const text = "Weighing options carefully.";
+
+    act(() => {
+      root.render(<ReasoningCell text={text} isStreaming />);
+    });
+
+    expect(container.textContent).not.toContain(text);
+
+    act(() => {
+      root.render(<ReasoningCell text={text} isStreaming={false} />);
+    });
+
+    expect(container.textContent).toContain(text);
   });
 
   it('falls back to a plain "Thought" label with no live timing', () => {

--- a/packages/core/src/client/chat/tool-call-display.tsx
+++ b/packages/core/src/client/chat/tool-call-display.tsx
@@ -52,6 +52,7 @@ import {
   markdownModule,
   remarkGfmFn,
   markdownUrlTransform,
+  useSmoothStreamingText,
 } from "./markdown-renderer.js";
 import { resolveToolRenderer } from "./tool-render-registry.js";
 import {
@@ -929,6 +930,7 @@ export function ReconnectStreamMessage({
                 key={`reconnect-reasoning-${i}`}
                 text={part.text}
                 isStreaming={chatRunning && i === streamingReasoningPartIndex}
+                resetKey={`reconnect-reasoning-${i}`}
                 defaultOpen={i === latestReasoningPartIndex}
                 collapseWhenReplaced={i < latestReasoningPartIndex}
               />
@@ -973,6 +975,7 @@ const WorkSummaryContentContext = React.createContext(false);
 export function ReasoningCell({
   text,
   isStreaming = false,
+  resetKey,
   defaultOpen,
   autoCollapse = false,
   collapseWhenReplaced = false,
@@ -980,6 +983,8 @@ export function ReasoningCell({
 }: {
   text: string;
   isStreaming?: boolean;
+  /** Stable identity used to restart the reveal when a new reasoning part mounts. */
+  resetKey?: string;
   defaultOpen?: boolean;
   /** Animate closed when a live reasoning segment finishes during a run. */
   autoCollapse?: boolean;
@@ -998,6 +1003,11 @@ export function ReasoningCell({
   const wasStreamingRef = useRef(isStreaming);
   const wasReplacedRef = useRef(collapseWhenReplaced);
   const trimmed = text.trim();
+  const visibleText = useSmoothStreamingText(
+    trimmed,
+    isStreaming,
+    resetKey ?? "reasoning",
+  );
 
   useEffect(() => {
     if (autoCollapse && wasStreamingRef.current && !isStreaming) {
@@ -1018,7 +1028,7 @@ export function ReasoningCell({
   if (embeddedInWorkSummary) {
     return (
       <div className="pb-1 pl-5 text-[13px] leading-relaxed text-muted-foreground whitespace-pre-wrap">
-        {trimmed || (isStreaming ? "…" : "")}
+        {visibleText || (isStreaming ? "…" : "")}
       </div>
     );
   }
@@ -1055,7 +1065,7 @@ export function ReasoningCell({
       <AnimatedCollapse open={open}>
         <div className={cn("pl-5 pb-1", showTail && "reasoning-cell-tail")}>
           <div className="text-[13px] leading-relaxed text-muted-foreground whitespace-pre-wrap">
-            {trimmed || (isStreaming ? "…" : "")}
+            {visibleText || (isStreaming ? "…" : "")}
           </div>
         </div>
       </AnimatedCollapse>

--- a/scripts/sync-core-first-party-templates.ts
+++ b/scripts/sync-core-first-party-templates.ts
@@ -1,0 +1,60 @@
+import { execFileSync } from "node:child_process";
+import {
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const rootDir = resolve(scriptDir, "..");
+const sourceRoot = join(rootDir, "templates", "chat");
+const targetRoot = join(
+  rootDir,
+  "packages",
+  "core",
+  "src",
+  "templates",
+  "chat",
+);
+
+if (process.argv.includes("--clean")) {
+  rmSync(targetRoot, { recursive: true, force: true });
+  process.exit(0);
+}
+
+const trackedFiles = execFileSync(
+  "git",
+  ["ls-files", "-z", "--", "templates/chat"],
+  { cwd: rootDir },
+)
+  .toString()
+  .split("\0")
+  .filter(Boolean);
+
+if (trackedFiles.length === 0) {
+  throw new Error(`No tracked files found under ${sourceRoot}.`);
+}
+
+rmSync(targetRoot, { recursive: true, force: true });
+mkdirSync(targetRoot, { recursive: true });
+
+for (const trackedPath of trackedFiles) {
+  const relativePath = relative("templates/chat", trackedPath);
+  const sourcePath = join(rootDir, trackedPath);
+  const targetPath = join(targetRoot, relativePath);
+  const stat = lstatSync(sourcePath);
+
+  mkdirSync(dirname(targetPath), { recursive: true });
+  if (stat.isSymbolicLink()) {
+    symlinkSync(readlinkSync(sourcePath), targetPath);
+    continue;
+  }
+
+  writeFileSync(targetPath, readFileSync(sourcePath));
+}

--- a/templates/clips/app/components/player/share-dialog.test.ts
+++ b/templates/clips/app/components/player/share-dialog.test.ts
@@ -19,7 +19,9 @@ describe("recording share popover", () => {
   it("keeps human and agent links visible for every visibility", () => {
     const shareDialogSource = readSource("./share-dialog.tsx");
 
-    expect(shareDialogSource).toContain('label={t("shareDialog.shareLink")}');
+    expect(shareDialogSource).toContain(
+      'label={t("shareDialog.shareWithHumans")}',
+    );
     expect(shareDialogSource).toContain(
       'label={t("shareDialog.shareWithAgents")}',
     );

--- a/templates/clips/app/components/player/share-dialog.tsx
+++ b/templates/clips/app/components/player/share-dialog.tsx
@@ -380,7 +380,7 @@ function LinkTab({
       )}
 
       <CopyField
-        label={t("shareDialog.shareLink")}
+        label={t("shareDialog.shareWithHumans")}
         value={shareUrl}
         disabled={
           visibilityPending || !sharesLoaded || (!isPublic && canManage)

--- a/templates/clips/app/i18n/ar-SA.ts
+++ b/templates/clips/app/i18n/ar-SA.ts
@@ -444,6 +444,7 @@ const messages = {
     invite: "دعوة",
     embed: "تضمين",
     shareLink: "رابط المشاركة",
+    shareWithHumans: "مشاركة مع الأشخاص",
     shareWithAgents: "شارك مع الوكلاء",
     copyAgentPrompt: "نسخ مطالبة الوكيل",
     agentPrompt:

--- a/templates/clips/app/i18n/de-DE.ts
+++ b/templates/clips/app/i18n/de-DE.ts
@@ -457,6 +457,7 @@ const messages = {
     invite: "Einladen",
     embed: "Einbetten",
     shareLink: "Teillink",
+    shareWithHumans: "Mit Menschen teilen",
     shareWithAgents: "Mit Agenten teilen",
     copyAgentPrompt: "Agent-Prompt kopieren",
     agentPrompt:

--- a/templates/clips/app/i18n/en-US.ts
+++ b/templates/clips/app/i18n/en-US.ts
@@ -440,6 +440,7 @@ const messages = {
     invite: "Invite",
     embed: "Embed",
     shareLink: "Share link",
+    shareWithHumans: "Share with humans",
     shareWithAgents: "Share with agents",
     copyAgentPrompt: "Copy agent prompt",
     agentPrompt:

--- a/templates/clips/app/i18n/es-ES.ts
+++ b/templates/clips/app/i18n/es-ES.ts
@@ -454,6 +454,7 @@ const messages = {
     invite: "Invitar",
     embed: "Insertar",
     shareLink: "Enlace para compartir",
+    shareWithHumans: "Compartir con personas",
     shareWithAgents: "Compartir con agentes",
     copyAgentPrompt: "Copiar indicación para agente",
     agentPrompt:

--- a/templates/clips/app/i18n/fr-FR.ts
+++ b/templates/clips/app/i18n/fr-FR.ts
@@ -454,6 +454,7 @@ const messages = {
     invite: "Inviter",
     embed: "Intégrer",
     shareLink: "Lien de partage",
+    shareWithHumans: "Partager avec des personnes",
     shareWithAgents: "Partager avec les agents",
     copyAgentPrompt: "Copier le prompt pour agent",
     agentPrompt:

--- a/templates/clips/app/i18n/hi-IN.ts
+++ b/templates/clips/app/i18n/hi-IN.ts
@@ -437,6 +437,7 @@ const messages = {
     invite: "आमंत्रित करें",
     embed: "एम्बेड",
     shareLink: "शेयर लिंक",
+    shareWithHumans: "लोगों के साथ साझा करें",
     shareWithAgents: "एजेंटों के साथ साझा करें",
     copyAgentPrompt: "एजेंट प्रॉम्प्ट कॉपी करें",
     agentPrompt:

--- a/templates/clips/app/i18n/ja-JP.ts
+++ b/templates/clips/app/i18n/ja-JP.ts
@@ -449,6 +449,7 @@ const messages = {
     invite: "招待",
     embed: "埋め込み",
     shareLink: "共有リンク",
+    shareWithHumans: "人と共有する",
     shareWithAgents: "エージェントと共有する",
     copyAgentPrompt: "エージェント用プロンプトをコピー",
     agentPrompt:

--- a/templates/clips/app/i18n/ko-KR.ts
+++ b/templates/clips/app/i18n/ko-KR.ts
@@ -442,6 +442,7 @@ const messages = {
     invite: "초대",
     embed: "임베드",
     shareLink: "공유 링크",
+    shareWithHumans: "사람과 공유",
     shareWithAgents: "상담원과 공유",
     copyAgentPrompt: "에이전트 프롬프트 복사",
     agentPrompt:

--- a/templates/clips/app/i18n/pt-BR.ts
+++ b/templates/clips/app/i18n/pt-BR.ts
@@ -451,6 +451,7 @@ const messages = {
     invite: "Convidar",
     embed: "Incorporar",
     shareLink: "Link de compartilhamento",
+    shareWithHumans: "Compartilhe com pessoas",
     shareWithAgents: "Compartilhe com agentes",
     copyAgentPrompt: "Copiar prompt para agente",
     agentPrompt:

--- a/templates/clips/app/i18n/zh-CN.ts
+++ b/templates/clips/app/i18n/zh-CN.ts
@@ -424,6 +424,7 @@ const messages = {
     invite: "邀请",
     embed: "嵌入",
     shareLink: "分享链接",
+    shareWithHumans: "与人分享",
     shareWithAgents: "与代理商分享",
     copyAgentPrompt: "复制代理提示",
     agentPrompt:

--- a/templates/clips/app/i18n/zh-TW.ts
+++ b/templates/clips/app/i18n/zh-TW.ts
@@ -424,6 +424,7 @@ const messages = {
     invite: "邀請",
     embed: "嵌入",
     shareLink: "分享連結",
+    shareWithHumans: "與人分享",
     shareWithAgents: "與 Agent 分享",
     copyAgentPrompt: "複製 Agent 提示",
     agentPrompt:

--- a/templates/clips/changelog/2026-07-15-public-clip-links-are-labeled-share-with-humans-for-clarity.md
+++ b/templates/clips/changelog/2026-07-15-public-clip-links-are-labeled-share-with-humans-for-clarity.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-15
+---
+
+Public clip links are labeled Share with humans for clarity.

--- a/templates/forms/actions/delete-form.ts
+++ b/templates/forms/actions/delete-form.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import { invalidatePublicFormCache } from "../server/lib/public-form-ssr.js";
 
 export default defineAction({
   description:
@@ -37,6 +38,7 @@ export default defineAction({
         .delete(schema.responses)
         .where(eq(schema.responses.formId, args.id));
       await db.delete(schema.forms).where(eq(schema.forms.id, args.id));
+      invalidatePublicFormCache(existing);
       return { success: true, purged: true };
     }
 
@@ -45,6 +47,8 @@ export default defineAction({
       .update(schema.forms)
       .set({ deletedAt: now, updatedAt: now })
       .where(eq(schema.forms.id, args.id));
+
+    invalidatePublicFormCache(existing);
 
     return { success: true, purged: false, deletedAt: now };
   },

--- a/templates/forms/actions/patch-form-fields.concurrency.test.ts
+++ b/templates/forms/actions/patch-form-fields.concurrency.test.ts
@@ -16,6 +16,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 type Row = { id: string; status: string; fields: string };
 
 const mockAssertAccess = vi.hoisted(() => vi.fn(async () => {}));
+const mockInvalidatePublicFormCache = vi.hoisted(() => vi.fn());
 
 const store = vi.hoisted(() => new Map<string, Row>());
 const selectDelay = vi.hoisted(() => ({ ms: 0 }));
@@ -27,6 +28,10 @@ vi.mock("@agent-native/core", () => ({
 
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: (...args: unknown[]) => mockAssertAccess(...args),
+}));
+
+vi.mock("../server/lib/public-form-ssr.js", () => ({
+  invalidatePublicFormCache: mockInvalidatePublicFormCache,
 }));
 
 vi.mock("drizzle-orm", () => ({

--- a/templates/forms/actions/patch-form-fields.spec.ts
+++ b/templates/forms/actions/patch-form-fields.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockAssertAccess = vi.hoisted(() => vi.fn());
 const mockUpdate = vi.hoisted(() => vi.fn());
+const mockInvalidatePublicFormCache = vi.hoisted(() => vi.fn());
 const state = vi.hoisted(() => ({
   existing: {
     id: "form-example",
@@ -34,6 +35,10 @@ vi.mock("@agent-native/core", () => ({
 
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: (...args: unknown[]) => mockAssertAccess(...args),
+}));
+
+vi.mock("../server/lib/public-form-ssr.js", () => ({
+  invalidatePublicFormCache: mockInvalidatePublicFormCache,
 }));
 
 vi.mock("drizzle-orm", () => ({

--- a/templates/forms/actions/patch-form-fields.ts
+++ b/templates/forms/actions/patch-form-fields.ts
@@ -23,6 +23,7 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { applyFieldOps } from "../server/lib/merge-fields.js";
+import { invalidatePublicFormCache } from "../server/lib/public-form-ssr.js";
 import { assertValidFields } from "../server/lib/validate-fields.js";
 import type { FormField } from "../shared/types.js";
 import { assertPublishableForm } from "./lib/assert-publishable-form.js";
@@ -138,6 +139,8 @@ export default defineAction({
         .update(schema.forms)
         .set({ fields: JSON.stringify(nextFields), updatedAt: now })
         .where(eq(schema.forms.id, args.id));
+
+      invalidatePublicFormCache(existing);
 
       return { id: args.id, fields: nextFields, updatedAt: now };
     });

--- a/templates/forms/actions/restore-form.ts
+++ b/templates/forms/actions/restore-form.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import { invalidatePublicFormCache } from "../server/lib/public-form-ssr.js";
 
 export default defineAction({
   description:
@@ -30,6 +31,8 @@ export default defineAction({
       .update(schema.forms)
       .set({ deletedAt: null, updatedAt: now })
       .where(eq(schema.forms.id, args.id));
+
+    invalidatePublicFormCache(existing);
 
     return { success: true };
   },

--- a/templates/forms/actions/update-form.ts
+++ b/templates/forms/actions/update-form.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { assertIntegrationUrlsAllowed } from "../server/lib/integrations.js";
+import { invalidatePublicFormCache } from "../server/lib/public-form-ssr.js";
 import { assertValidFields } from "../server/lib/validate-fields.js";
 import type { FormField, FormSettings } from "../shared/types.js";
 import { assertPublishableForm } from "./lib/assert-publishable-form.js";
@@ -135,6 +136,8 @@ export default defineAction({
       .from(schema.forms)
       .where(eq(schema.forms.id, args.id))
       .limit(1);
+
+    invalidatePublicFormCache(existing, row);
 
     return {
       id: row!.id,

--- a/templates/forms/app/pages/FormBuilderPage.tsx
+++ b/templates/forms/app/pages/FormBuilderPage.tsx
@@ -1468,10 +1468,10 @@ function ResultsContent({ formId, form }: { formId: string; form: any }) {
                   key={response.id}
                   className="border-b border-border hover:bg-muted/20"
                 >
-                  <td className="px-4 py-2.5 text-xs text-muted-foreground">
+                  <td className="px-4 py-2.5 align-top text-xs text-muted-foreground">
                     {responses.length - idx}
                   </td>
-                  <td className="min-w-36 px-4 py-2.5 text-xs text-muted-foreground whitespace-nowrap">
+                  <td className="min-w-36 px-4 py-2.5 align-top text-xs text-muted-foreground whitespace-nowrap">
                     {format(new Date(response.submittedAt), "MMM d, h:mm a")}
                   </td>
                   {hasSubmitterEmail && (

--- a/templates/forms/app/pages/ResponsesPage.tsx
+++ b/templates/forms/app/pages/ResponsesPage.tsx
@@ -428,10 +428,10 @@ export function ResponsesPage() {
                     key={response.id}
                     className="border-b border-border transition-[background-color] duration-150 hover:bg-muted/20 motion-reduce:transition-none"
                   >
-                    <td className="px-4 py-2.5 text-xs text-muted-foreground">
+                    <td className="px-4 py-2.5 align-top text-xs text-muted-foreground">
                       {filteredSorted.length - idx}
                     </td>
-                    <td className="min-w-36 px-4 py-2.5 text-xs text-muted-foreground whitespace-nowrap">
+                    <td className="min-w-36 px-4 py-2.5 align-top text-xs text-muted-foreground whitespace-nowrap">
                       {formatDate(response.submittedAt, {
                         month: "short",
                         day: "numeric",

--- a/templates/forms/changelog/2026-07-15-published-forms-now-reflect-field-updates-immediately-at-the.md
+++ b/templates/forms/changelog/2026-07-15-published-forms-now-reflect-field-updates-immediately-at-the.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-15
+---
+
+Published forms now reflect field updates immediately at their shared links

--- a/templates/forms/changelog/2026-07-15-response-rows-now-keep-every-column-aligned-to-the-top-for-c.md
+++ b/templates/forms/changelog/2026-07-15-response-rows-now-keep-every-column-aligned-to-the-top-for-c.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-15
+---
+
+Response rows now keep every column aligned to the top for consistent scanning

--- a/templates/forms/server/handlers/forms.ts
+++ b/templates/forms/server/handlers/forms.ts
@@ -53,6 +53,7 @@ export const getPublicForm = defineEventHandler(async (event: H3Event) => {
   const settings = JSON.parse(row.settings) as FormSettings;
   const result = {
     id: row.id,
+    updatedAt: row.updatedAt,
     title: row.title,
     description: row.description,
     fields: JSON.parse(row.fields),

--- a/templates/forms/server/lib/public-form-ssr.test.ts
+++ b/templates/forms/server/lib/public-form-ssr.test.ts
@@ -15,7 +15,7 @@ vi.mock("h3", () => ({
 }));
 
 vi.mock("drizzle-orm", () => ({
-  eq: vi.fn(),
+  eq: vi.fn((column: unknown, value: unknown) => ({ column, value })),
 }));
 
 vi.mock("../db/index.js", () => ({
@@ -38,7 +38,16 @@ function createDbWithRows(rows: unknown[]) {
   return {
     select: vi.fn(() => ({
       from: vi.fn(() => ({
-        where: vi.fn(() => Promise.resolve(rows)),
+        where: vi.fn((condition: { column: unknown; value: unknown }) => {
+          const key = condition.column === "forms.id" ? "id" : "slug";
+          return Promise.resolve(
+            rows.filter(
+              (row) =>
+                (row as { id?: unknown; slug?: unknown })[key] ===
+                condition.value,
+            ),
+          );
+        }),
       })),
     })),
   };
@@ -129,11 +138,18 @@ describe("public form SSR", () => {
       { id: "form-cache-123", slug: "new-cache-slug" },
     );
 
+    await expect(getPublicFormBySlugOrId("old-cache-slug")).resolves.toBeNull();
     await expect(
-      getPublicFormBySlugOrId("old-cache-slug"),
+      getPublicFormBySlugOrId("new-cache-slug"),
     ).resolves.toMatchObject({ title: "After update", slug: "new-cache-slug" });
     await expect(
       getPublicFormBySlugOrId("form-cache-123"),
     ).resolves.toMatchObject({ title: "After update", slug: "new-cache-slug" });
+
+    rows[0] = { ...rows[0], title: "After second update" };
+    invalidatePublicFormCache({ id: "form-cache-123", slug: "new-cache-slug" });
+    await expect(
+      getPublicFormBySlugOrId("new-cache-slug"),
+    ).resolves.toMatchObject({ title: "After second update" });
   });
 });

--- a/templates/forms/server/lib/public-form-ssr.test.ts
+++ b/templates/forms/server/lib/public-form-ssr.test.ts
@@ -31,6 +31,7 @@ vi.mock("../db/index.js", () => ({
 import {
   getPublicFormBySlugOrId,
   invalidatePublicFormCache,
+  renderPublicFormHtml,
   renderPublicForm,
 } from "./public-form-ssr";
 
@@ -151,5 +152,48 @@ describe("public form SSR", () => {
     await expect(
       getPublicFormBySlugOrId("new-cache-slug"),
     ).resolves.toMatchObject({ title: "After second update" });
+  });
+
+  it("uses the version query in the SSR cache key and embeds revalidation", async () => {
+    const rows = [
+      {
+        id: "form-versioned-123",
+        slug: "versioned-cache-slug",
+        title: "Before version bump",
+        description: null,
+        ownerEmail: "owner@example.test",
+        updatedAt: "2026-07-14T12:00:00.000Z",
+        fields: "[]",
+        settings: "{}",
+        status: "published",
+        deletedAt: null,
+      },
+    ];
+    mockGetDb.mockReturnValue(createDbWithRows(rows));
+
+    const first = await renderPublicFormHtml(
+      "https://forms.example.test/f/versioned-cache-slug",
+    );
+    expect(first.html).toContain("<title>Before version bump</title>");
+    expect(first.html).toContain(
+      'var FORM_VERSION = "2026-07-14T12:00:00.000Z";',
+    );
+    expect(first.html).toContain(
+      'fetch(PUBLIC_FORM_API, { cache: "no-store" })',
+    );
+
+    rows[0] = {
+      ...rows[0],
+      title: "After version bump",
+      updatedAt: "2026-07-14T12:01:00.000Z",
+    };
+
+    const refreshed = await renderPublicFormHtml(
+      "https://forms.example.test/f/versioned-cache-slug?v=2026-07-14T12%3A01%3A00.000Z",
+    );
+    expect(refreshed.html).toContain("<title>After version bump</title>");
+    expect(refreshed.html).toContain(
+      'var FORM_VERSION = "2026-07-14T12:01:00.000Z";',
+    );
   });
 });

--- a/templates/forms/server/lib/public-form-ssr.test.ts
+++ b/templates/forms/server/lib/public-form-ssr.test.ts
@@ -28,7 +28,11 @@ vi.mock("../db/index.js", () => ({
   },
 }));
 
-import { renderPublicForm } from "./public-form-ssr";
+import {
+  getPublicFormBySlugOrId,
+  invalidatePublicFormCache,
+  renderPublicForm,
+} from "./public-form-ssr";
 
 function createDbWithRows(rows: unknown[]) {
   return {
@@ -89,5 +93,47 @@ describe("public form SSR", () => {
     expect(html).toContain(
       "/api/forms/og/customer-intake-123/og.png?v=2026-07-14T12%3A00%3A00.000Z",
     );
+  });
+
+  it("refreshes cached forms after invalidating old and new lookup keys", async () => {
+    const rows = [
+      {
+        id: "form-cache-123",
+        slug: "old-cache-slug",
+        title: "Before update",
+        description: null,
+        ownerEmail: "owner@example.test",
+        updatedAt: "2026-07-14T12:00:00.000Z",
+        fields: "[]",
+        settings: "{}",
+        status: "published",
+        deletedAt: null,
+      },
+    ];
+    mockGetDb.mockReturnValue(createDbWithRows(rows));
+
+    await expect(
+      getPublicFormBySlugOrId("old-cache-slug"),
+    ).resolves.toMatchObject({ title: "Before update" });
+    await expect(
+      getPublicFormBySlugOrId("form-cache-123"),
+    ).resolves.toMatchObject({ title: "Before update" });
+
+    rows[0] = {
+      ...rows[0],
+      slug: "new-cache-slug",
+      title: "After update",
+    };
+    invalidatePublicFormCache(
+      { id: "form-cache-123", slug: "old-cache-slug" },
+      { id: "form-cache-123", slug: "new-cache-slug" },
+    );
+
+    await expect(
+      getPublicFormBySlugOrId("old-cache-slug"),
+    ).resolves.toMatchObject({ title: "After update", slug: "new-cache-slug" });
+    await expect(
+      getPublicFormBySlugOrId("form-cache-123"),
+    ).resolves.toMatchObject({ title: "After update", slug: "new-cache-slug" });
   });
 });

--- a/templates/forms/server/lib/public-form-ssr.ts
+++ b/templates/forms/server/lib/public-form-ssr.ts
@@ -22,6 +22,20 @@ import { getDb, schema } from "../db/index.js";
 const cache = new Map<string, { data: any; ts: number }>();
 const TTL = 60_000;
 
+type PublicFormCacheKeys = {
+  id?: string | null;
+  slug?: string | null;
+};
+
+export function invalidatePublicFormCache(
+  ...forms: Array<PublicFormCacheKeys | null | undefined>
+) {
+  for (const form of forms) {
+    if (form?.id) cache.delete(form.id);
+    if (form?.slug) cache.delete(form.slug);
+  }
+}
+
 function getCached(key: string) {
   const entry = cache.get(key);
   if (entry && Date.now() - entry.ts < TTL) return entry.data;

--- a/templates/forms/server/lib/public-form-ssr.ts
+++ b/templates/forms/server/lib/public-form-ssr.ts
@@ -31,8 +31,14 @@ export function invalidatePublicFormCache(
   ...forms: Array<PublicFormCacheKeys | null | undefined>
 ) {
   for (const form of forms) {
-    if (form?.id) cache.delete(form.id);
-    if (form?.slug) cache.delete(form.slug);
+    for (const key of [form?.id, form?.slug]) {
+      if (!key) continue;
+      cache.delete(key);
+      const versionPrefix = `${key}?v=`;
+      for (const cachedKey of cache.keys()) {
+        if (cachedKey.startsWith(versionPrefix)) cache.delete(cachedKey);
+      }
+    }
   }
 }
 
@@ -42,8 +48,12 @@ function getCached(key: string) {
   return null;
 }
 
-export async function getPublicFormBySlugOrId(slugOrId: string) {
-  const cached = getCached(slugOrId);
+export async function getPublicFormBySlugOrId(
+  slugOrId: string,
+  version?: string,
+) {
+  const cacheKey = version ? `${slugOrId}?v=${version}` : slugOrId;
+  const cached = getCached(cacheKey);
   if (cached) return cached;
 
   const db = getDb();
@@ -80,7 +90,7 @@ export async function getPublicFormBySlugOrId(slugOrId: string) {
     settings: toPublicFormSettings(settings),
   };
 
-  cache.set(slugOrId, { data: result, ts: Date.now() });
+  cache.set(cacheKey, { data: result, ts: Date.now() });
   return result;
 }
 
@@ -117,6 +127,7 @@ const FALLBACK_PUBLIC_FORM_ORIGIN = "http://agent-native.local";
 function parsePublicFormUrl(url: string): {
   pathname: string;
   origin?: string;
+  version?: string;
 } {
   try {
     const parsed = new URL(url, FALLBACK_PUBLIC_FORM_ORIGIN);
@@ -124,6 +135,7 @@ function parsePublicFormUrl(url: string): {
     return {
       pathname: parsed.pathname,
       origin: isAbsolute ? parsed.origin : undefined,
+      version: parsed.searchParams.get("v") || undefined,
     };
   } catch {
     return { pathname: url.split("?")[0] || "/" };
@@ -275,7 +287,9 @@ export async function renderPublicFormHtml(
       ? pathname.slice(basePath.length)
       : pathname;
   const slugOrId = decodeURIComponent(pathWithoutBase.replace(/^\/f\//, ""));
-  const form = slugOrId ? await getPublicFormBySlugOrId(slugOrId) : null;
+  const form = slugOrId
+    ? await getPublicFormBySlugOrId(slugOrId, parsedUrl.version)
+    : null;
 
   if (!form) {
     return { html: notFoundPage(parsedUrl.origin), status: 404 };
@@ -416,9 +430,24 @@ function renderFormPage(
 <script>
 (function(){
   var FORM_ID = ${JSON.stringify(form.id)};
+  var FORM_VERSION = ${JSON.stringify(form.updatedAt || "")};
+  var PUBLIC_FORM_API = ${JSON.stringify(`${appBasePath}/api/forms/public/${encodeURIComponent(form.slug || form.id)}`)};
   var REDIRECT = ${JSON.stringify(safeRedirectUrl(settings.redirectUrl))};
   var TURNSTILE_KEY = ${JSON.stringify(turnstileSiteKey)};
   var FIELDS = ${JSON.stringify(fields.map((f) => ({ id: f.id, type: f.type, required: f.required, validation: f.validation, label: f.label, conditional: f.conditional })))};
+
+  function revalidateFormVersion() {
+    fetch(PUBLIC_FORM_API, { cache: "no-store" })
+      .then(function(response) { return response.ok ? response.json() : null; })
+      .then(function(latest) {
+        if (!latest || typeof latest.updatedAt !== "string" || !latest.updatedAt || latest.updatedAt === FORM_VERSION) return;
+        var currentUrl = new URL(window.location.href);
+        currentUrl.searchParams.set("v", latest.updatedAt);
+        window.location.replace(currentUrl.toString());
+      })
+      .catch(function() {});
+  }
+  revalidateFormVersion();
 
   // Theme toggle
   var html = document.documentElement;

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -24,6 +24,7 @@ import {
   useRef,
   useEffect,
   type MouseEvent as ReactMouseEvent,
+  type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
 
@@ -475,111 +476,175 @@ function SameSlidePresenceIndicator({ users }: { users: CollabUser[] }) {
 }
 
 /** Selection outline rendered over a selected image */
-function ImageSelectionOutline({ rect }: { rect: DOMRect }) {
-  const pad = 2;
-  return createPortal(
-    <div
-      style={{
-        position: "fixed",
-        top: rect.top - pad,
-        left: rect.left - pad,
-        width: rect.width + pad * 2,
-        height: rect.height + pad * 2,
-        pointerEvents: "none",
-        zIndex: 50,
-        border: "2px solid #609FF8",
-        borderRadius: 2,
-      }}
-    />,
-    document.body,
-  );
-}
+function SelectionOverlayPortal({
+  viewportRect,
+  zIndex,
+  children,
+}: {
+  viewportRect: DOMRect | null;
+  zIndex: number;
+  children: ReactNode;
+}) {
+  if (!viewportRect) return null;
 
-function ElementSelectionOutline({ rect }: { rect: DOMRect }) {
-  const pad = 2;
-  const handle = 7;
-  const handleClass =
-    "absolute size-[7px] rounded-sm border border-background bg-[#609FF8] shadow-sm";
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+  const top = Math.max(0, Math.min(viewportHeight, viewportRect.top));
+  const right = Math.max(
+    0,
+    Math.min(viewportWidth, viewportWidth - viewportRect.right),
+  );
+  const bottom = Math.max(
+    0,
+    Math.min(viewportHeight, viewportHeight - viewportRect.bottom),
+  );
+  const left = Math.max(0, Math.min(viewportWidth, viewportRect.left));
+
   return createPortal(
     <div
       style={{
         position: "fixed",
-        top: rect.top - pad,
-        left: rect.left - pad,
-        width: rect.width + pad * 2,
-        height: rect.height + pad * 2,
+        inset: 0,
+        overflow: "hidden",
         pointerEvents: "none",
-        zIndex: 51,
-        border: "1.5px solid #609FF8",
-        borderRadius: 3,
-        boxShadow: "0 0 0 1px rgba(96, 159, 248, 0.2)",
+        zIndex,
+        // Selection rects use viewport coordinates, so keep the portal for
+        // accurate zoom/scroll tracking while clipping it to the canvas
+        // viewport. This prevents outlines from painting over either sidebar.
+        clipPath: `inset(${top}px ${right}px ${bottom}px ${left}px)`,
       }}
     >
-      <span
-        className={handleClass}
-        style={{ left: -handle / 2, top: -handle / 2 }}
-      />
-      <span
-        className={handleClass}
-        style={{ right: -handle / 2, top: -handle / 2 }}
-      />
-      <span
-        className={handleClass}
-        style={{ left: -handle / 2, bottom: -handle / 2 }}
-      />
-      <span
-        className={handleClass}
-        style={{ right: -handle / 2, bottom: -handle / 2 }}
-      />
+      {children}
     </div>,
     document.body,
   );
 }
 
+function ImageSelectionOutline({
+  rect,
+  viewportRect,
+}: {
+  rect: DOMRect;
+  viewportRect: DOMRect | null;
+}) {
+  const pad = 2;
+  return (
+    <SelectionOverlayPortal viewportRect={viewportRect} zIndex={50}>
+      <div
+        style={{
+          position: "absolute",
+          top: rect.top - pad,
+          left: rect.left - pad,
+          width: rect.width + pad * 2,
+          height: rect.height + pad * 2,
+          pointerEvents: "none",
+          border: "2px solid #609FF8",
+          borderRadius: 2,
+        }}
+      />
+    </SelectionOverlayPortal>
+  );
+}
+
+function ElementSelectionOutline({
+  rect,
+  viewportRect,
+}: {
+  rect: DOMRect;
+  viewportRect: DOMRect | null;
+}) {
+  const pad = 2;
+  const handle = 7;
+  const handleClass =
+    "absolute size-[7px] rounded-sm border border-background bg-[#609FF8] shadow-sm";
+  return (
+    <SelectionOverlayPortal viewportRect={viewportRect} zIndex={51}>
+      <div
+        style={{
+          position: "absolute",
+          top: rect.top - pad,
+          left: rect.left - pad,
+          width: rect.width + pad * 2,
+          height: rect.height + pad * 2,
+          pointerEvents: "none",
+          border: "1.5px solid #609FF8",
+          borderRadius: 3,
+          boxShadow: "0 0 0 1px rgba(96, 159, 248, 0.2)",
+        }}
+      >
+        <span
+          className={handleClass}
+          style={{ left: -handle / 2, top: -handle / 2 }}
+        />
+        <span
+          className={handleClass}
+          style={{ right: -handle / 2, top: -handle / 2 }}
+        />
+        <span
+          className={handleClass}
+          style={{ left: -handle / 2, bottom: -handle / 2 }}
+        />
+        <span
+          className={handleClass}
+          style={{ right: -handle / 2, bottom: -handle / 2 }}
+        />
+      </div>
+    </SelectionOverlayPortal>
+  );
+}
+
 /** Outline rendered around a multi-select element */
-function MultiSelectOutline({ rect }: { rect: DOMRect }) {
+function MultiSelectOutline({
+  rect,
+  viewportRect,
+}: {
+  rect: DOMRect;
+  viewportRect: DOMRect | null;
+}) {
   const pad = 1;
-  return createPortal(
-    <div
-      style={{
-        position: "fixed",
-        top: rect.top - pad,
-        left: rect.left - pad,
-        width: rect.width + pad * 2,
-        height: rect.height + pad * 2,
-        pointerEvents: "none",
-        zIndex: 49,
-        border: "2px solid #609FF8",
-        borderRadius: 2,
-        boxShadow: "0 0 0 1px rgba(96, 159, 248, 0.25)",
-      }}
-    />,
-    document.body,
+  return (
+    <SelectionOverlayPortal viewportRect={viewportRect} zIndex={49}>
+      <div
+        style={{
+          position: "absolute",
+          top: rect.top - pad,
+          left: rect.left - pad,
+          width: rect.width + pad * 2,
+          height: rect.height + pad * 2,
+          pointerEvents: "none",
+          border: "2px solid #609FF8",
+          borderRadius: 2,
+          boxShadow: "0 0 0 1px rgba(96, 159, 248, 0.25)",
+        }}
+      />
+    </SelectionOverlayPortal>
   );
 }
 
 /** Translucent rectangle drawn while marquee-dragging */
 function MarqueeRect({
   rect,
+  viewportRect,
 }: {
   rect: { x: number; y: number; w: number; h: number };
+  viewportRect: DOMRect | null;
 }) {
-  return createPortal(
-    <div
-      style={{
-        position: "fixed",
-        top: rect.y,
-        left: rect.x,
-        width: rect.w,
-        height: rect.h,
-        pointerEvents: "none",
-        zIndex: 48,
-        background: "rgba(96, 159, 248, 0.12)",
-        border: "1px solid #609FF8",
-        borderRadius: 1,
-      }}
-    />,
-    document.body,
+  return (
+    <SelectionOverlayPortal viewportRect={viewportRect} zIndex={48}>
+      <div
+        style={{
+          position: "absolute",
+          top: rect.y,
+          left: rect.x,
+          width: rect.w,
+          height: rect.h,
+          pointerEvents: "none",
+          background: "rgba(96, 159, 248, 0.12)",
+          border: "1px solid #609FF8",
+          borderRadius: 1,
+        }}
+      />
+    </SelectionOverlayPortal>
   );
 }
 

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -755,6 +755,8 @@ export default function SlideEditor({
   } | null>(null);
   const [selectedImg, setSelectedImg] = useState<HTMLImageElement | null>(null);
   const [selectionRect, setSelectionRect] = useState<DOMRect | null>(null);
+  const [selectionViewportRect, setSelectionViewportRect] =
+    useState<DOMRect | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   // Wraps the rendered slide; used as the positioning container for the
@@ -848,6 +850,34 @@ export default function SlideEditor({
     min: MIN_CANVAS_ZOOM,
     max: MAX_CANVAS_ZOOM,
   });
+
+  // Selection outlines are portaled to the document so their viewport
+  // coordinates stay aligned with the zoomed/scrolling slide. Keep a live
+  // viewport rect so that portal can clip itself to the central canvas when
+  // either sidebar or the style inspector changes the available width.
+  useEffect(() => {
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer) return;
+
+    const updateViewportRect = () => {
+      setSelectionViewportRect(scrollContainer.getBoundingClientRect());
+    };
+
+    updateViewportRect();
+    const observer =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(updateViewportRect);
+    observer?.observe(scrollContainer);
+    window.addEventListener("resize", updateViewportRect);
+    window.addEventListener("scroll", updateViewportRect, true);
+
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener("resize", updateViewportRect);
+      window.removeEventListener("scroll", updateViewportRect, true);
+    };
+  }, []);
 
   useEffect(() => {
     const scrollContainer = scrollContainerRef.current;
@@ -2046,19 +2076,31 @@ export default function SlideEditor({
         slideCount={slideCount}
       />
 
-      {selectionRect && <ImageSelectionOutline rect={selectionRect} />}
+      {selectionRect && (
+        <ImageSelectionOutline
+          rect={selectionRect}
+          viewportRect={selectionViewportRect}
+        />
+      )}
       {selectedElementRect && (
-        <ElementSelectionOutline rect={selectedElementRect} />
+        <ElementSelectionOutline
+          rect={selectedElementRect}
+          viewportRect={selectionViewportRect}
+        />
       )}
 
       {/* Multi-select outlines */}
       {Array.from(multiSelectionRects.entries()).map(([id, v]) => (
-        <MultiSelectOutline key={id} rect={v.rect} />
+        <MultiSelectOutline
+          key={id}
+          rect={v.rect}
+          viewportRect={selectionViewportRect}
+        />
       ))}
 
       {/* Active marquee rectangle */}
       {marquee && (marquee.w > 1 || marquee.h > 1) && (
-        <MarqueeRect rect={marquee} />
+        <MarqueeRect rect={marquee} viewportRect={selectionViewportRect} />
       )}
 
       {/* Floating "N selected" chip */}

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -2054,7 +2054,7 @@ export default function SlideEditor({
         </div>
 
         {selectedStyleSnapshot && !readOnly && (
-          <div className="hidden h-full w-[17rem] shrink-0 border-l border-border/70 bg-background/95 lg:block">
+          <div className="relative z-[70] hidden h-full w-[17rem] shrink-0 border-l border-border/70 bg-background/95 lg:block">
             <SlideStyleInspector
               snapshot={selectedStyleSnapshot}
               designSystem={designSystem}

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -875,7 +875,7 @@ export default function DeckEditor() {
               className="md:hidden fixed inset-0 bg-black/50 z-30"
               onClick={() => setSidebarOpen(false)}
             />
-            <div className="absolute z-40 h-full min-h-0 md:relative">
+            <div className="absolute z-[70] h-full min-h-0 md:relative">
               <DndContext
                 sensors={sensors}
                 collisionDetection={closestCenter}


### PR DESCRIPTION
## What changed

Thinking/reasoning blocks now use the same grapheme-aware smooth streaming behavior as normal assistant text, including reconnect rendering.

## Why

The transport already delivered reasoning deltas incrementally, but `ReasoningCell` rendered the full accumulated string immediately on each update. This made thinking text jump in chunks instead of revealing smoothly.

## Validation

- `./node_modules/.bin/vitest --run src/shared/streaming-text-smoothing.spec.ts src/client/chat/tool-call-display.spec.tsx src/client/chat/message-components.spec.tsx`
- 76 tests passed
- `corepack pnpm --dir packages/core typecheck`
- `git diff --check`