### PR TITLE
Harden shared chat and template workflows

### DIFF
--- a/.changeset/fix-clips-qa-feedback.md
+++ b/.changeset/fix-clips-qa-feedback.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Improve MCP connection status and make provider connection errors actionable.

--- a/.changeset/queue-and-assets-picker-fixes.md
+++ b/.changeset/queue-and-assets-picker-fixes.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep queued chat follow-ups draining after fast turns and route cross-origin Assets pickers through a top-level sign-in-safe handoff.

--- a/.changeset/steady-panel-recovery.md
+++ b/.changeset/steady-panel-recovery.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Recover the Agent panel when a stale lazy-loaded chat chunk fails to load.

--- a/.changeset/visible-builder-handoff.md
+++ b/.changeset/visible-builder-handoff.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep the Builder source-change handoff card visible outside the collapsed chat work summary.

--- a/packages/core/src/client/AgentPanel.header.spec.ts
+++ b/packages/core/src/client/AgentPanel.header.spec.ts
@@ -1,5 +1,7 @@
 // @vitest-environment happy-dom
 
+import { readFileSync } from "node:fs";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -148,6 +150,33 @@ describe("AgentPanel mode and full-view visibility", () => {
     );
     expect(shouldShowAgentPanelFullViewAction(undefined, "settings")).toBe(
       false,
+    );
+  });
+});
+
+describe("AgentPanel stale lazy chunk recovery", () => {
+  it("uses the guarded reload path before the panel reset fallback", () => {
+    const source = readFileSync("src/client/AgentPanel.tsx", {
+      encoding: "utf8",
+    });
+    const componentDidCatch = source.slice(
+      source.indexOf("componentDidCatch(error: Error"),
+      source.indexOf(
+        "componentDidUpdate(",
+        source.indexOf("componentDidCatch"),
+      ),
+    );
+
+    expect(source).toContain(
+      'import { recoverFromStaleChunkError } from "./route-chunk-recovery.js";',
+    );
+    expect(componentDidCatch).toContain(
+      "if (recoverFromStaleChunkError(error))",
+    );
+    expect(
+      componentDidCatch.indexOf("recoverFromStaleChunkError(error)"),
+    ).toBeLessThan(
+      componentDidCatch.indexOf("assistantUiRecoverableRenderErrorKind(error)"),
     );
   });
 });

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -110,6 +110,7 @@ import type {
   MultiTabAssistantChatHeaderProps,
   MultiTabAssistantChatProps,
 } from "./MultiTabAssistantChat.js";
+import { recoverFromStaleChunkError } from "./route-chunk-recovery.js";
 import { AgentNativeRouteWarmup } from "./route-warmup.js";
 import { withBuilderConnectTrackingParams } from "./settings/useBuilderStatus.js";
 import { useScreenRefreshKey } from "./use-db-sync.js";
@@ -2371,6 +2372,12 @@ class AgentPanelErrorBoundary extends React.Component<
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    if (recoverFromStaleChunkError(error)) {
+      console.warn(
+        "[agent-native] Recovering agent panel after stale chunk error",
+      );
+      return;
+    }
     const recoverableKind = assistantUiRecoverableRenderErrorKind(error);
     if (recoverableKind) {
       console.warn(

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -1648,6 +1648,25 @@ describe("chat submit and stop hardening", () => {
     expect(helperSource).toContain("includeActivity: true");
     expect(helperSource).toContain("settleVisibleInterruptedTools()");
   });
+
+  it("wakes the dequeue loop after its startup guard expires", () => {
+    const source = readFileSync("src/client/AssistantChat.tsx", {
+      encoding: "utf8",
+    });
+    const start = source.indexOf("// Auto-dequeue:");
+    const end = source.indexOf(
+      "// Clear frozen reconnect content + forceStopped",
+    );
+    const dequeueSource = source.slice(start, end);
+
+    expect(source).toContain(
+      "const [queueWakeVersion, setQueueWakeVersion] = useState(0);",
+    );
+    expect(dequeueSource).toContain(
+      "setQueueWakeVersion((version) => version + 1);",
+    );
+    expect(dequeueSource).toContain("queueWakeVersion,");
+  });
 });
 
 describe("waitForThreadRunToClear", () => {

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -2354,6 +2354,11 @@ const AssistantChatInner = forwardRef<
   } | null>(null);
   const [authSessionAvailable, setAuthSessionAvailable] = useState(false);
   const [queuedMessages, setQueuedMessages] = useState<QueuedMessage[]>([]);
+  // The dequeue guard briefly stays locked after appending a queued turn so
+  // the adapter has time to claim the run. Wake the effect when that guard
+  // expires; otherwise a fast-completing turn can leave the remaining queue
+  // pending with no state transition left to trigger another dequeue.
+  const [queueWakeVersion, setQueueWakeVersion] = useState(0);
   const queuedMessagesRef = useRef<QueuedMessage[]>([]);
   const queueDirtyRef = useRef(false);
   const queueMutationVersionRef = useRef(0);
@@ -4041,6 +4046,7 @@ const AssistantChatInner = forwardRef<
           if (appended) {
             window.setTimeout(() => {
               dequeueInFlightRef.current = false;
+              setQueueWakeVersion((version) => version + 1);
             }, 500);
           } else {
             dequeueInFlightRef.current = false;
@@ -4062,6 +4068,7 @@ const AssistantChatInner = forwardRef<
     applyLocalQueuedMessages,
     isRestoring,
     isRunning,
+    queueWakeVersion,
     queuedMessages,
     threadId,
   ]);

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -3392,7 +3392,13 @@ export function createAgentChatAdapter(
                   text: formatChatErrorText(
                     message,
                     preservedError?.upgradeUrl,
-                    errorCode,
+                    // `message` is already user-facing here: either a
+                    // recovery-specific explanation from exhaustedRecoveryMessage
+                    // or a normalized gateway message from errorInfo. Passing
+                    // the fallback connection_error code back through the
+                    // formatter would replace the useful recovery guidance
+                    // with the generic interruption copy.
+                    preservedError ? errorCode : undefined,
                   ),
                 });
                 yield {

--- a/packages/core/src/client/chat/message-components.spec.tsx
+++ b/packages/core/src/client/chat/message-components.spec.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   assistantMessageHasUnresolvedTool,
+  isCollapsibleAssistantWorkPart,
   shouldShowAssistantWorkSummary,
   shouldShowAssistantMessageFooter,
   ThinkingIndicator,
@@ -137,6 +138,27 @@ describe("shouldShowAssistantWorkSummary", () => {
         hasUnresolvedTool: true,
       }),
     ).toBe(false);
+  });
+});
+
+describe("isCollapsibleAssistantWorkPart", () => {
+  it("keeps the Builder handoff card outside collapsed work", () => {
+    expect(
+      isCollapsibleAssistantWorkPart({
+        type: "tool-call",
+        toolName: "connect-builder",
+      }),
+    ).toBe(false);
+  });
+
+  it("still groups ordinary work and reasoning", () => {
+    expect(
+      isCollapsibleAssistantWorkPart({
+        type: "tool-call",
+        toolName: "read-file",
+      }),
+    ).toBe(true);
+    expect(isCollapsibleAssistantWorkPart({ type: "reasoning" })).toBe(true);
   });
 });
 

--- a/packages/core/src/client/chat/message-components.tsx
+++ b/packages/core/src/client/chat/message-components.tsx
@@ -909,10 +909,24 @@ function ReasoningMessagePart() {
   );
 }
 
+const ALWAYS_VISIBLE_ASSISTANT_TOOLS = new Set(["connect-builder"]);
+
+export function isCollapsibleAssistantWorkPart(part: {
+  type?: string;
+  toolName?: string;
+}): boolean {
+  if (part.type === "reasoning") return true;
+  return (
+    part.type === "tool-call" &&
+    !ALWAYS_VISIBLE_ASSISTANT_TOOLS.has(part.toolName ?? "")
+  );
+}
+
 function groupAssistantWorkParts(part: {
   type?: string;
+  toolName?: string;
 }): ["group-work"] | null {
-  if (part.type === "reasoning" || part.type === "tool-call") {
+  if (isCollapsibleAssistantWorkPart(part)) {
     return ["group-work"];
   }
   return null;
@@ -1044,8 +1058,8 @@ export function AssistantMessage() {
     Array.isArray(msgContent) &&
     msgContent.some(
       (p) =>
-        p.type === "reasoning" ||
-        (p.type === "tool-call" && p.activity !== true),
+        (p.type !== "tool-call" || p.activity !== true) &&
+        isCollapsibleAssistantWorkPart(p),
     );
 
   if (!hasRenderableContent) return null;

--- a/packages/core/src/client/composer/ComposerPlusMenu.tsx
+++ b/packages/core/src/client/composer/ComposerPlusMenu.tsx
@@ -42,6 +42,10 @@ import {
   type McpServerScope,
 } from "../resources/use-mcp-servers.js";
 import { cn } from "../utils.js";
+import {
+  isExternalAssetPickerUrl,
+  standaloneAssetPickerUrl,
+} from "./asset-picker-url.js";
 import type { ComposerMode } from "./types.js";
 
 interface ComposerPlusMenuProps {
@@ -744,6 +748,20 @@ function AssetsPickerModal({
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const [pickerReady, setPickerReady] = useState(false);
   const sourceUrl = useMemo(() => assetPickerUrl(), []);
+  const externalPicker = useMemo(
+    () =>
+      typeof window !== "undefined" &&
+      isExternalAssetPickerUrl(sourceUrl, window.location.origin),
+    [sourceUrl],
+  );
+  const standaloneUrl = useMemo(
+    () =>
+      standaloneAssetPickerUrl(
+        sourceUrl,
+        typeof window !== "undefined" ? window.location.href : undefined,
+      ),
+    [sourceUrl],
+  );
   const iframeUrl = useMemo(() => withEmbeddedParams(sourceUrl), [sourceUrl]);
   const targetOrigin = useMemo(() => assetPickerOrigin(iframeUrl), [iframeUrl]);
   const configurePicker = useCallback(() => {
@@ -842,7 +860,22 @@ function AssetsPickerModal({
             <IconX className="h-4 w-4" />
           </button>
         </div>
-        {targetOrigin ? (
+        {externalPicker ? (
+          <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
+            <div className="max-w-md text-sm text-muted-foreground">
+              Open Assets in a new tab to sign in and choose an image securely.
+            </div>
+            <a
+              href={standaloneUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => onOpenChange(false)}
+              className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              Open Assets image picker
+            </a>
+          </div>
+        ) : targetOrigin ? (
           <div className="relative min-h-0 flex-1 overflow-hidden bg-background">
             {!pickerReady && <AssetsPickerLoadingSkeleton />}
             <iframe

--- a/packages/core/src/client/composer/ComposerPlusMenu.tsx
+++ b/packages/core/src/client/composer/ComposerPlusMenu.tsx
@@ -43,6 +43,7 @@ import {
 } from "../resources/use-mcp-servers.js";
 import { cn } from "../utils.js";
 import {
+  createAssetPickerHandoffId,
   isExternalAssetPickerUrl,
   standaloneAssetPickerUrl,
 } from "./asset-picker-url.js";
@@ -77,6 +78,7 @@ interface EmbedEnvelope<TPayload = unknown> {
 
 interface AssetPickerPayload {
   assetId?: unknown;
+  handoffId?: unknown;
   url?: unknown;
   previewUrl?: unknown;
   downloadUrl?: unknown;
@@ -746,7 +748,11 @@ function AssetsPickerModal({
   onOpenChange: (open: boolean) => void;
 }) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const standaloneWindowRef = useRef<Window | null>(null);
   const [pickerReady, setPickerReady] = useState(false);
+  const [standaloneHandoffId, setStandaloneHandoffId] = useState<string | null>(
+    null,
+  );
   const sourceUrl = useMemo(() => assetPickerUrl(), []);
   const externalPicker = useMemo(
     () =>
@@ -759,8 +765,13 @@ function AssetsPickerModal({
       standaloneAssetPickerUrl(
         sourceUrl,
         typeof window !== "undefined" ? window.location.href : undefined,
+        {
+          handoffId: standaloneHandoffId ?? undefined,
+          returnOrigin:
+            typeof window !== "undefined" ? window.location.origin : undefined,
+        },
       ),
-    [sourceUrl],
+    [sourceUrl, standaloneHandoffId],
   );
   const iframeUrl = useMemo(() => withEmbeddedParams(sourceUrl), [sourceUrl]);
   const targetOrigin = useMemo(() => assetPickerOrigin(iframeUrl), [iframeUrl]);
@@ -776,14 +787,32 @@ function AssetsPickerModal({
   }, [targetOrigin]);
 
   useEffect(() => {
-    if (open) setPickerReady(false);
-  }, [iframeUrl, open]);
+    if (open) {
+      setPickerReady(false);
+      if (externalPicker) {
+        standaloneWindowRef.current = null;
+        setStandaloneHandoffId(createAssetPickerHandoffId());
+      } else {
+        setStandaloneHandoffId(null);
+      }
+      return;
+    }
+    if (!standaloneWindowRef.current) setStandaloneHandoffId(null);
+  }, [externalPicker, iframeUrl, open]);
 
   useEffect(() => {
-    if (!open || !targetOrigin) return;
+    if (
+      !targetOrigin ||
+      (!open && !standaloneWindowRef.current) ||
+      (externalPicker && !standaloneHandoffId)
+    )
+      return;
 
     const handleMessage = (event: MessageEvent) => {
-      if (event.source !== iframeRef.current?.contentWindow) return;
+      const expectedSource = externalPicker
+        ? standaloneWindowRef.current
+        : iframeRef.current?.contentWindow;
+      if (!expectedSource || event.source !== expectedSource) return;
       if (event.origin !== targetOrigin) return;
       if (!isEmbedEnvelope(event.data)) return;
 
@@ -794,6 +823,14 @@ function AssetsPickerModal({
       }
 
       if (event.data.type !== "message") return;
+      if (externalPicker) {
+        const payload = event.data.payload;
+        const handoffId =
+          payload && typeof payload === "object"
+            ? assetString((payload as AssetPickerPayload).handoffId)
+            : null;
+        if (handoffId !== standaloneHandoffId) return;
+      }
       if (event.data.name === "close") {
         onOpenChange(false);
         return;
@@ -816,6 +853,8 @@ function AssetsPickerModal({
         title: `Image: ${title}`,
         context: assetContext(event.data.payload, url),
       });
+      standaloneWindowRef.current = null;
+      setStandaloneHandoffId(null);
       onOpenChange(false);
     };
 
@@ -829,7 +868,26 @@ function AssetsPickerModal({
       window.removeEventListener("message", handleMessage);
       window.removeEventListener("keydown", handleKey);
     };
-  }, [configurePicker, onOpenChange, open, targetOrigin]);
+  }, [
+    configurePicker,
+    externalPicker,
+    onOpenChange,
+    open,
+    standaloneHandoffId,
+    targetOrigin,
+  ]);
+
+  const openStandalonePicker = useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement>) => {
+      if (!standaloneHandoffId) return;
+      event.preventDefault();
+      const pickerWindow = window.open(standaloneUrl, "_blank");
+      if (!pickerWindow) return;
+      standaloneWindowRef.current = pickerWindow;
+      onOpenChange(false);
+    },
+    [onOpenChange, standaloneHandoffId, standaloneUrl],
+  );
 
   if (!open || typeof document === "undefined") return null;
 
@@ -868,8 +926,7 @@ function AssetsPickerModal({
             <a
               href={standaloneUrl}
               target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => onOpenChange(false)}
+              onClick={openStandalonePicker}
               className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90"
             >
               Open Assets image picker

--- a/packages/core/src/client/composer/asset-picker-url.spec.ts
+++ b/packages/core/src/client/composer/asset-picker-url.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isExternalAssetPickerUrl,
+  standaloneAssetPickerUrl,
+} from "./asset-picker-url.js";
+
+describe("asset picker auth handoff", () => {
+  it("treats the hosted Assets picker as external to the host app", () => {
+    expect(
+      isExternalAssetPickerUrl(
+        "https://assets.agent-native.com/picker",
+        "https://clips.agent-native.com",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps same-origin pickers eligible for inline rendering", () => {
+    expect(
+      isExternalAssetPickerUrl("/picker", "https://clips.agent-native.com"),
+    ).toBe(false);
+  });
+
+  it("removes iframe flags from the top-level fallback URL", () => {
+    expect(
+      standaloneAssetPickerUrl(
+        "https://assets.agent-native.com/picker?embedded=1&__an_embed_token=fake-token",
+      ),
+    ).toBe("https://assets.agent-native.com/picker?mediaType=image");
+  });
+});

--- a/packages/core/src/client/composer/asset-picker-url.spec.ts
+++ b/packages/core/src/client/composer/asset-picker-url.spec.ts
@@ -28,4 +28,29 @@ describe("asset picker auth handoff", () => {
       ),
     ).toBe("https://assets.agent-native.com/picker?mediaType=image");
   });
+
+  it("adds a nonce-bound exact-origin callback to the top-level URL", () => {
+    expect(
+      standaloneAssetPickerUrl(
+        "https://assets.agent-native.com/picker?embedded=1",
+        "https://clips.agent-native.com",
+        {
+          handoffId: "handoff-123",
+          returnOrigin: "https://clips.agent-native.com/chat",
+        },
+      ),
+    ).toBe(
+      "https://assets.agent-native.com/picker?mediaType=image&__an_asset_picker_handoff=handoff-123&__an_asset_picker_return_origin=https%3A%2F%2Fclips.agent-native.com",
+    );
+  });
+
+  it("omits an invalid callback target", () => {
+    expect(
+      standaloneAssetPickerUrl(
+        "https://assets.agent-native.com/picker",
+        "https://clips.agent-native.com",
+        { handoffId: "handoff-123", returnOrigin: "javascript:alert(1)" },
+      ),
+    ).toBe("https://assets.agent-native.com/picker?mediaType=image");
+  });
 });

--- a/packages/core/src/client/composer/asset-picker-url.ts
+++ b/packages/core/src/client/composer/asset-picker-url.ts
@@ -1,5 +1,27 @@
 const FALLBACK_BASE_URL = "http://agent-native.invalid";
 
+export const ASSET_PICKER_HANDOFF_PARAM = "__an_asset_picker_handoff";
+export const ASSET_PICKER_RETURN_ORIGIN_PARAM =
+  "__an_asset_picker_return_origin";
+
+export interface StandaloneAssetPickerOptions {
+  handoffId?: string;
+  returnOrigin?: string;
+}
+
+export function createAssetPickerHandoffId(): string {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  if (typeof crypto !== "undefined" && crypto.getRandomValues) {
+    const bytes = crypto.getRandomValues(new Uint8Array(16));
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+      "",
+    );
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
 /**
  * Cross-origin Assets pages cannot inherit the host app's authenticated
  * session inside an iframe. Treat those URLs as link-out targets so provider
@@ -22,12 +44,35 @@ export function isExternalAssetPickerUrl(
 export function standaloneAssetPickerUrl(
   value: string,
   baseUrl = FALLBACK_BASE_URL,
+  options: StandaloneAssetPickerOptions = {},
 ): string {
   try {
     const parsed = new URL(value, baseUrl);
     parsed.searchParams.delete("embedded");
     parsed.searchParams.delete("__an_embed_token");
     parsed.searchParams.set("mediaType", "image");
+    let returnOrigin: string | null = null;
+    if (options.returnOrigin) {
+      try {
+        const parsedOrigin = new URL(options.returnOrigin);
+        if (
+          parsedOrigin.protocol === "http:" ||
+          parsedOrigin.protocol === "https:"
+        ) {
+          returnOrigin = parsedOrigin.origin;
+        }
+      } catch {
+        // Omit an invalid return target rather than emitting an unverified
+        // cross-origin callback URL.
+      }
+    }
+    if (options.handoffId && returnOrigin) {
+      parsed.searchParams.set(ASSET_PICKER_HANDOFF_PARAM, options.handoffId);
+      parsed.searchParams.set(ASSET_PICKER_RETURN_ORIGIN_PARAM, returnOrigin);
+    } else {
+      parsed.searchParams.delete(ASSET_PICKER_HANDOFF_PARAM);
+      parsed.searchParams.delete(ASSET_PICKER_RETURN_ORIGIN_PARAM);
+    }
     return parsed.toString();
   } catch {
     return value;

--- a/packages/core/src/client/composer/asset-picker-url.ts
+++ b/packages/core/src/client/composer/asset-picker-url.ts
@@ -1,0 +1,35 @@
+const FALLBACK_BASE_URL = "http://agent-native.invalid";
+
+/**
+ * Cross-origin Assets pages cannot inherit the host app's authenticated
+ * session inside an iframe. Treat those URLs as link-out targets so provider
+ * sign-in runs in a normal top-level browser context.
+ */
+export function isExternalAssetPickerUrl(
+  value: string,
+  currentOrigin: string,
+): boolean {
+  try {
+    return new URL(value, currentOrigin).origin !== currentOrigin;
+  } catch {
+    // A malformed configured URL should fail closed instead of being loaded in
+    // an iframe with an unknown auth boundary.
+    return true;
+  }
+}
+
+/** Build a top-level picker URL without iframe-only auth flags. */
+export function standaloneAssetPickerUrl(
+  value: string,
+  baseUrl = FALLBACK_BASE_URL,
+): string {
+  try {
+    const parsed = new URL(value, baseUrl);
+    parsed.searchParams.delete("embedded");
+    parsed.searchParams.delete("__an_embed_token");
+    parsed.searchParams.set("mediaType", "image");
+    return parsed.toString();
+  } catch {
+    return value;
+  }
+}

--- a/packages/core/src/client/error-format.spec.ts
+++ b/packages/core/src/client/error-format.spec.ts
@@ -143,4 +143,28 @@ describe("formatChatErrorText", () => {
       "Error: The model provider rejected the saved API key. Update the key in API Keys & Connections, then retry.",
     );
   });
+
+  it("normalizes provider network failures into an actionable retry message", () => {
+    const normalized = normalizeChatError(
+      "provider_network_error",
+      "provider_network_error",
+    );
+
+    expect(normalized.message).toBe(
+      "The model provider could not be reached. Check your connection and retry.",
+    );
+    expect(normalized.details).toBe("provider_network_error");
+  });
+
+  it("normalizes generic connection failures into an actionable retry message", () => {
+    const normalized = normalizeChatError(
+      "connection_error",
+      "connection_error",
+    );
+
+    expect(normalized.message).toBe(
+      "The agent connection was interrupted. Check your connection and retry.",
+    );
+    expect(normalized.details).toBe("connection_error");
+  });
 });

--- a/packages/core/src/client/error-format.ts
+++ b/packages/core/src/client/error-format.ts
@@ -102,6 +102,18 @@ function isProviderAuthenticationError(
   );
 }
 
+function isConnectionError(text: string, errorCode?: string): boolean {
+  const code = normalizeErrorCode(errorCode);
+  return (
+    code === "provider_network_error" ||
+    code === "connection_error" ||
+    code === "network_error" ||
+    /^(?:provider_network_error|connection_error|network_error)$/i.test(
+      text.trim(),
+    )
+  );
+}
+
 export function normalizeChatError(
   errorMessage: string,
   errorCode?: string,
@@ -122,6 +134,18 @@ export function normalizeChatError(
     return {
       message:
         "The model provider rejected the saved API key. Update the key in API Keys & Connections, then retry.",
+      details: text,
+    };
+  }
+
+  if (isConnectionError(text, errorCode)) {
+    const providerNetworkError =
+      normalizeErrorCode(errorCode) === "provider_network_error" ||
+      /provider_network_error/i.test(text);
+    return {
+      message: providerNetworkError
+        ? "The model provider could not be reached. Check your connection and retry."
+        : "The agent connection was interrupted. Check your connection and retry.",
       details: text,
     };
   }

--- a/packages/core/src/client/resources/McpIntegrationDialog.tsx
+++ b/packages/core/src/client/resources/McpIntegrationDialog.tsx
@@ -115,7 +115,14 @@ export function McpIntegrationDialog({
       ...(mcpServersQuery.data?.user ?? []),
       ...(mcpServersQuery.data?.org ?? []),
     ];
-    return new Set(servers.map((server) => compareUrl(server.url)));
+    // A saved server is not necessarily a working connection. The settings
+    // page reports failed and unknown health states separately, so only mark
+    // catalog entries as connected after the health probe succeeds.
+    return new Set(
+      servers
+        .filter((server) => server.status.state === "connected")
+        .map((server) => compareUrl(server.url)),
+    );
   }, [mcpServersQuery.data]);
 
   const filteredIntegrations = useMemo(

--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -16,6 +16,8 @@ import {
   writeClientAppState,
 } from "@agent-native/core/client";
 import {
+  AGENT_NATIVE_EMBED_MESSAGE_TYPES,
+  createAgentNativeEmbedEnvelope,
   createEmbeddedAppBridge,
   type EmbeddedAppBridge,
 } from "@agent-native/core/embedding";
@@ -241,6 +243,31 @@ function isEmbeddedWindow() {
     return window.self !== window.top;
   } catch {
     return true;
+  }
+}
+
+interface StandalonePickerHandoff {
+  handoffId: string;
+  returnOrigin: string;
+}
+
+function standalonePickerHandoff(): StandalonePickerHandoff | null {
+  if (typeof window === "undefined") return null;
+  const params = new URLSearchParams(window.location.search);
+  const handoffId = params.get("__an_asset_picker_handoff")?.trim();
+  const rawReturnOrigin = params.get("__an_asset_picker_return_origin")?.trim();
+  if (!handoffId || handoffId.length > 128 || !rawReturnOrigin) return null;
+  try {
+    const parsed = new URL(rawReturnOrigin);
+    if (
+      (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+      parsed.origin !== rawReturnOrigin
+    ) {
+      return null;
+    }
+    return { handoffId, returnOrigin: parsed.origin };
+  } catch {
+    return null;
   }
 }
 
@@ -2206,6 +2233,10 @@ export function AssetPickerSurface() {
       isEmbedAuthActive(),
     [searchParams],
   );
+  const standaloneHandoff = useMemo(
+    () => (embedded ? null : standalonePickerHandoff()),
+    [embedded],
+  );
   const pickerVariantScopeId = useMemo(
     () =>
       typeof window === "undefined" ? null : `picker:${getBrowserTabId()}`,
@@ -2552,6 +2583,35 @@ export function AssetPickerSurface() {
     [],
   );
 
+  const postStandaloneSelectionMessage = useCallback(
+    (payload: ReturnType<typeof assetPayload>) => {
+      if (
+        !standaloneHandoff ||
+        typeof window === "undefined" ||
+        !window.opener ||
+        window.opener.closed
+      ) {
+        return false;
+      }
+      try {
+        window.opener.postMessage(
+          createAgentNativeEmbedEnvelope(
+            AGENT_NATIVE_EMBED_MESSAGE_TYPES.MESSAGE,
+            {
+              name: "chooseAsset",
+              payload: { ...payload, handoffId: standaloneHandoff.handoffId },
+            },
+          ),
+          standaloneHandoff.returnOrigin,
+        );
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [standaloneHandoff],
+  );
+
   const chooseAsset = (asset: Asset) => {
     const payload = assetPayload(asset, mediaType);
     if (embedded) {
@@ -2572,6 +2632,15 @@ export function AssetPickerSurface() {
           toast.error(t("library.selectedAssetSendFailed"));
         }
       });
+      return;
+    }
+    if (postStandaloneSelectionMessage(payload)) {
+      toast.success(
+        t("assetPicker.selectedAsset", {
+          title: selectedAssetLabel(payload),
+        }),
+      );
+      window.setTimeout(() => window.close(), 0);
       return;
     }
     setStandaloneSelection(payload);

--- a/templates/assets/changelog/2026-07-15-fixed-top-level-image-picker-selections-returning-to-the-com.md
+++ b/templates/assets/changelog/2026-07-15-fixed-top-level-image-picker-selections-returning-to-the-com.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-15
+---
+
+Fixed top-level image picker selections returning to the composer

--- a/templates/clips/actions/disconnect-calendar.test.ts
+++ b/templates/clips/actions/disconnect-calendar.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  assertAccess: vi.fn(),
+  deleteAppSecret: vi.fn(),
+  getRequestUserEmail: vi.fn(),
+  lockCalendarAccount: vi.fn(),
+  readAppSecret: vi.fn(),
+  revokeToken: vi.fn(),
+  writeAppState: vi.fn(),
+}));
+
+const { operationOrder, schema } = vi.hoisted(() => ({
+  operationOrder: [] as string[],
+  schema: {
+    calendarAccounts: { id: "calendarAccounts.id" },
+    calendarEvents: {
+      id: "calendarEvents.id",
+      calendarAccountId: "calendarEvents.calendarAccountId",
+      meetingId: "calendarEvents.meetingId",
+    },
+    meetings: {
+      id: "meetings.id",
+      calendarEventId: "meetings.calendarEventId",
+      recordingId: "meetings.recordingId",
+      trashedAt: "meetings.trashedAt",
+    },
+  },
+}));
+
+const mockDb = vi.hoisted(() => ({
+  select: vi.fn(),
+  transaction: vi.fn(),
+}));
+
+vi.mock("@agent-native/core", () => ({
+  defineAction: (options: unknown) => options,
+}));
+
+vi.mock("@agent-native/core/application-state", () => ({
+  writeAppState: (...args: unknown[]) => mocks.writeAppState(...args),
+}));
+
+vi.mock("@agent-native/core/secrets", () => ({
+  deleteAppSecret: (...args: unknown[]) => mocks.deleteAppSecret(...args),
+  readAppSecret: (...args: unknown[]) => mocks.readAppSecret(...args),
+}));
+
+vi.mock("@agent-native/core/server/request-context", () => ({
+  getRequestUserEmail: () => mocks.getRequestUserEmail(),
+}));
+
+vi.mock("@agent-native/core/sharing", () => ({
+  assertAccess: (...args: unknown[]) => mocks.assertAccess(...args),
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: (...args: unknown[]) => ({ op: "and", args }),
+  eq: (column: unknown, value: unknown) => ({
+    op: "eq",
+    column,
+    value,
+  }),
+  inArray: (column: unknown, values: unknown[]) => ({
+    op: "inArray",
+    column,
+    values,
+  }),
+  isNull: (column: unknown) => ({ op: "isNull", column }),
+  or: (...args: unknown[]) => ({ op: "or", args }),
+}));
+
+vi.mock("../server/db/index.js", () => ({
+  getDb: () => mockDb,
+  schema,
+}));
+
+vi.mock("../server/lib/calendar-event-meetings.js", () => ({
+  lockCalendarAccount: (...args: unknown[]) => {
+    operationOrder.push("lock-account");
+    return mocks.lockCalendarAccount(...args);
+  },
+}));
+
+vi.mock("../server/lib/google-calendar-client.js", () => ({
+  revokeToken: (...args: unknown[]) => mocks.revokeToken(...args),
+}));
+
+import action from "./disconnect-calendar";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  operationOrder.length = 0;
+  mocks.assertAccess.mockResolvedValue(undefined);
+  mocks.deleteAppSecret.mockResolvedValue(undefined);
+  mocks.getRequestUserEmail.mockReturnValue("owner@example.com");
+  mocks.lockCalendarAccount.mockResolvedValue(true);
+  mocks.readAppSecret.mockResolvedValue(null);
+  mocks.revokeToken.mockResolvedValue(undefined);
+  mocks.writeAppState.mockResolvedValue(undefined);
+
+  const accountSelect = {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockResolvedValue([
+      {
+        id: "account_1",
+        ownerEmail: "owner@example.com",
+        accessTokenSecretRef: null,
+        refreshTokenSecretRef: null,
+      },
+    ]),
+  };
+  mockDb.select.mockReturnValue(accountSelect);
+
+  const tx = {
+    select: vi.fn(() => ({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn(async () => {
+        operationOrder.push("snapshot-events");
+        return [{ id: "event_1", meetingId: "meeting_1" }];
+      }),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn(async () => {
+        operationOrder.push("trash-meetings");
+      }),
+    })),
+    delete: vi.fn((table: unknown) => ({
+      where: vi.fn(async () => {
+        operationOrder.push(
+          table === schema.calendarEvents ? "delete-events" : "delete-account",
+        );
+      }),
+    })),
+  };
+  mockDb.transaction.mockImplementation(async (callback) => callback(tx));
+});
+
+describe("disconnect-calendar action", () => {
+  it("locks cleanup against materialization before snapshotting calendar events", async () => {
+    const result = await action.run({ id: "account_1" });
+
+    expect(result).toEqual({ id: "account_1", disconnected: true });
+    expect(mockDb.transaction).toHaveBeenCalledOnce();
+    expect(operationOrder).toEqual([
+      "lock-account",
+      "snapshot-events",
+      "trash-meetings",
+      "delete-events",
+      "delete-account",
+    ]);
+    expect(mocks.writeAppState).toHaveBeenCalledWith(
+      "refresh-signal",
+      expect.objectContaining({ ts: expect.any(Number) }),
+    );
+  });
+});

--- a/templates/clips/actions/disconnect-calendar.ts
+++ b/templates/clips/actions/disconnect-calendar.ts
@@ -17,6 +17,7 @@ import { and, eq, inArray, isNull, or } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import { lockCalendarAccount } from "../server/lib/calendar-event-meetings.js";
 import { revokeToken } from "../server/lib/google-calendar-client.js";
 
 export default defineAction({
@@ -90,52 +91,62 @@ export default defineAction({
       }).catch(() => {});
     }
 
-    // Preserve recorded meetings, but hide unrecorded calendar placeholders
-    // tied to this account. Without this cleanup, those materialized rows stay
-    // visible after the account and its calendar-event cache are removed.
-    const syncedEvents = await db
-      .select({
-        id: schema.calendarEvents.id,
-        meetingId: schema.calendarEvents.meetingId,
-      })
-      .from(schema.calendarEvents)
-      .where(eq(schema.calendarEvents.calendarAccountId, args.id));
-    const syncedCalendarEventIds = syncedEvents.map((event) => event.id);
-    const syncedMeetingIds = syncedEvents
-      .map((event) => event.meetingId)
-      .filter((meetingId): meetingId is string => Boolean(meetingId));
-    if (syncedCalendarEventIds.length > 0 || syncedMeetingIds.length > 0) {
-      await db
-        .update(schema.meetings)
-        .set({ trashedAt: new Date().toISOString() })
-        .where(
-          and(
-            or(
-              syncedMeetingIds.length > 0
-                ? inArray(schema.meetings.id, syncedMeetingIds)
-                : undefined,
-              syncedCalendarEventIds.length > 0
-                ? inArray(
-                    schema.meetings.calendarEventId,
-                    syncedCalendarEventIds,
-                  )
-                : undefined,
-            )!,
-            isNull(schema.meetings.recordingId),
-            isNull(schema.meetings.trashedAt),
-          ),
-        );
-    }
+    await db.transaction(async (tx) => {
+      // Materialization takes this same account-row write lock before it
+      // snapshots/claims an event and inserts a meeting. Taking it before
+      // this cleanup snapshot prevents a new unrecorded meeting from being
+      // inserted after the rows below have been inspected.
+      if (!(await lockCalendarAccount(tx, args.id, account.ownerEmail))) {
+        throw new Error(`Calendar account not found: ${args.id}`);
+      }
 
-    // Drop the synced events for this account so the meetings tab clears.
-    await db
-      .delete(schema.calendarEvents)
-      .where(eq(schema.calendarEvents.calendarAccountId, args.id));
+      // Preserve recorded meetings, but hide unrecorded calendar placeholders
+      // tied to this account. Without this cleanup, those materialized rows
+      // stay visible after the account and its event cache are removed.
+      const syncedEvents = await tx
+        .select({
+          id: schema.calendarEvents.id,
+          meetingId: schema.calendarEvents.meetingId,
+        })
+        .from(schema.calendarEvents)
+        .where(eq(schema.calendarEvents.calendarAccountId, args.id));
+      const syncedCalendarEventIds = syncedEvents.map((event) => event.id);
+      const syncedMeetingIds = syncedEvents
+        .map((event) => event.meetingId)
+        .filter((meetingId): meetingId is string => Boolean(meetingId));
+      if (syncedCalendarEventIds.length > 0 || syncedMeetingIds.length > 0) {
+        await tx
+          .update(schema.meetings)
+          .set({ trashedAt: new Date().toISOString() })
+          .where(
+            and(
+              or(
+                syncedMeetingIds.length > 0
+                  ? inArray(schema.meetings.id, syncedMeetingIds)
+                  : undefined,
+                syncedCalendarEventIds.length > 0
+                  ? inArray(
+                      schema.meetings.calendarEventId,
+                      syncedCalendarEventIds,
+                    )
+                  : undefined,
+              )!,
+              isNull(schema.meetings.recordingId),
+              isNull(schema.meetings.trashedAt),
+            ),
+          );
+      }
 
-    // Drop the account row itself.
-    await db
-      .delete(schema.calendarAccounts)
-      .where(eq(schema.calendarAccounts.id, args.id));
+      // Drop the synced events for this account so the meetings tab clears.
+      await tx
+        .delete(schema.calendarEvents)
+        .where(eq(schema.calendarEvents.calendarAccountId, args.id));
+
+      // Drop the account row itself.
+      await tx
+        .delete(schema.calendarAccounts)
+        .where(eq(schema.calendarAccounts.id, args.id));
+    });
 
     await writeAppState("refresh-signal", { ts: Date.now() });
     return { id: args.id, disconnected: true };

--- a/templates/clips/actions/disconnect-calendar.ts
+++ b/templates/clips/actions/disconnect-calendar.ts
@@ -13,7 +13,7 @@ import { writeAppState } from "@agent-native/core/application-state";
 import { deleteAppSecret, readAppSecret } from "@agent-native/core/secrets";
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 import { assertAccess } from "@agent-native/core/sharing";
-import { eq } from "drizzle-orm";
+import { and, eq, inArray, isNull, or } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
@@ -88,6 +88,43 @@ export default defineAction({
         scope: "user",
         scopeId: secretScopeEmail,
       }).catch(() => {});
+    }
+
+    // Preserve recorded meetings, but hide unrecorded calendar placeholders
+    // tied to this account. Without this cleanup, those materialized rows stay
+    // visible after the account and its calendar-event cache are removed.
+    const syncedEvents = await db
+      .select({
+        id: schema.calendarEvents.id,
+        meetingId: schema.calendarEvents.meetingId,
+      })
+      .from(schema.calendarEvents)
+      .where(eq(schema.calendarEvents.calendarAccountId, args.id));
+    const syncedCalendarEventIds = syncedEvents.map((event) => event.id);
+    const syncedMeetingIds = syncedEvents
+      .map((event) => event.meetingId)
+      .filter((meetingId): meetingId is string => Boolean(meetingId));
+    if (syncedCalendarEventIds.length > 0 || syncedMeetingIds.length > 0) {
+      await db
+        .update(schema.meetings)
+        .set({ trashedAt: new Date().toISOString() })
+        .where(
+          and(
+            or(
+              syncedMeetingIds.length > 0
+                ? inArray(schema.meetings.id, syncedMeetingIds)
+                : undefined,
+              syncedCalendarEventIds.length > 0
+                ? inArray(
+                    schema.meetings.calendarEventId,
+                    syncedCalendarEventIds,
+                  )
+                : undefined,
+            )!,
+            isNull(schema.meetings.recordingId),
+            isNull(schema.meetings.trashedAt),
+          ),
+        );
     }
 
     // Drop the synced events for this account so the meetings tab clears.

--- a/templates/clips/actions/generate-workflow.test.ts
+++ b/templates/clips/actions/generate-workflow.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  assertAccess: vi.fn(),
+  readAppState: vi.fn(),
+  writeAppState: vi.fn(),
+  readIncludeFullVideoInAi: vi.fn(),
+  withFullVideoAiInstructions: vi.fn(),
+  select: vi.fn(),
+}));
+
+vi.mock("@agent-native/core", () => ({
+  defineAction: (options: unknown) => options,
+}));
+
+vi.mock("@agent-native/core/application-state", () => ({
+  readAppState: (...args: unknown[]) => mocks.readAppState(...args),
+  writeAppState: (...args: unknown[]) => mocks.writeAppState(...args),
+}));
+
+vi.mock("@agent-native/core/sharing", () => ({
+  assertAccess: (...args: unknown[]) => mocks.assertAccess(...args),
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: (...args: unknown[]) => args,
+}));
+
+vi.mock("../server/db/index.js", () => ({
+  getDb: () => ({ select: mocks.select }),
+  schema: {
+    recordings: { id: "recordings.id" },
+    recordingTranscripts: { recordingId: "recordingTranscripts.recordingId" },
+  },
+}));
+
+vi.mock("../shared/clips-ai-prefs.js", () => ({
+  withFullVideoAiInstructions: (...args: unknown[]) =>
+    mocks.withFullVideoAiInstructions(...args),
+}));
+
+vi.mock("./lib/clips-ai-prefs.js", () => ({
+  readIncludeFullVideoInAi: (...args: unknown[]) =>
+    mocks.readIncludeFullVideoInAi(...args),
+}));
+
+import action from "./generate-workflow";
+
+function setupDatabase() {
+  let selectCount = 0;
+  mocks.select.mockImplementation(() => {
+    const rows =
+      selectCount++ === 0
+        ? [{ id: "rec_1", title: "Demo recording", description: "" }]
+        : [{ status: "complete", fullText: "Transcript" }];
+    return {
+      from() {
+        return this;
+      },
+      where() {
+        return this;
+      },
+      limit: async () => rows,
+    };
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setupDatabase();
+  mocks.assertAccess.mockResolvedValue(undefined);
+  mocks.readAppState.mockResolvedValue(null);
+  mocks.writeAppState.mockResolvedValue(undefined);
+  mocks.readIncludeFullVideoInAi.mockResolvedValue(false);
+  mocks.withFullVideoAiInstructions.mockImplementation(
+    (message: string) => message,
+  );
+});
+
+describe("generate-workflow action", () => {
+  it("single-flights concurrent requests for one recording", async () => {
+    let releaseRead!: () => void;
+    const readStarted = new Promise<void>((resolve) => {
+      const originalRead = mocks.readAppState.getMockImplementation();
+      mocks.readAppState.mockImplementation(async (key: string) => {
+        if (key === "clips-workflow-rec_1") {
+          resolve();
+          await new Promise<void>((release) => {
+            releaseRead = release;
+          });
+        }
+        return originalRead ? originalRead(key) : null;
+      });
+    });
+
+    const first = action.run({ recordingId: "rec_1", kind: "pr" });
+    await readStarted;
+
+    await expect(
+      action.run({ recordingId: "rec_1", kind: "pr" }),
+    ).resolves.toEqual({
+      queued: false,
+      duplicate: true,
+      recordingId: "rec_1",
+      kind: "pr",
+      stateKey: "clips-workflow-rec_1",
+    });
+
+    releaseRead();
+    await expect(first).resolves.toMatchObject({ queued: true });
+    expect(mocks.writeAppState).toHaveBeenCalledWith(
+      "clips-ai-request-rec_1",
+      expect.any(Object),
+    );
+  });
+});

--- a/templates/clips/actions/generate-workflow.ts
+++ b/templates/clips/actions/generate-workflow.ts
@@ -54,6 +54,11 @@ Output markdown.`,
 Keep it concise, warm, and professional.`,
 } as const;
 
+// Actions for the same recording can arrive concurrently when the player and
+// agent both retry a request. Keep the read-check-write/enqueue sequence
+// single-flight within this runtime so only one request can claim generation.
+const workflowGenerationLocks = new Set<string>();
+
 export default defineAction({
   description:
     "Ask the agent to generate a structured workflow doc (pr/sop/ticket/email) from this recording's transcript (and the full video when Include full video is enabled). The agent writes the result to clips-workflow-<recordingId> in application_state.",
@@ -64,87 +69,106 @@ export default defineAction({
   run: async (args) => {
     await assertAccess("recording", args.recordingId, "viewer");
 
-    const db = getDb();
-    const [rec] = await db
-      .select()
-      .from(schema.recordings)
-      .where(eq(schema.recordings.id, args.recordingId))
-      .limit(1);
-    if (!rec) throw new Error(`Recording not found: ${args.recordingId}`);
-
-    const [transcript] = await db
-      .select()
-      .from(schema.recordingTranscripts)
-      .where(eq(schema.recordingTranscripts.recordingId, args.recordingId))
-      .limit(1);
-
     const stateKey = `clips-workflow-${args.recordingId}`;
-    const includeFullVideoInAi = await readIncludeFullVideoInAi();
-
-    const existing = await readAppState(stateKey).catch(() => null);
-    if (existing?.status === "generating") {
-      const requestedAt = Date.parse(String(existing.requestedAt ?? ""));
-      const isRecent =
-        !Number.isFinite(requestedAt) || Date.now() - requestedAt < 10 * 60_000;
-      if (isRecent) {
-        return {
-          queued: false,
-          duplicate: true,
-          recordingId: args.recordingId,
-          kind: existing.kind ?? args.kind,
-          stateKey,
-        };
-      }
+    if (workflowGenerationLocks.has(stateKey)) {
+      return {
+        queued: false,
+        duplicate: true,
+        recordingId: args.recordingId,
+        kind: args.kind,
+        stateKey,
+      };
     }
+    workflowGenerationLocks.add(stateKey);
 
-    // Seed the output state with a "generating" placeholder so the UI can show
-    // a loading state immediately.
-    await writeAppState(stateKey, {
-      kind: args.kind,
-      status: "generating",
-      recordingId: args.recordingId,
-      requestedAt: new Date().toISOString(),
-    } as any);
+    try {
+      const db = getDb();
+      const [rec] = await db
+        .select()
+        .from(schema.recordings)
+        .where(eq(schema.recordings.id, args.recordingId))
+        .limit(1);
+      if (!rec) throw new Error(`Recording not found: ${args.recordingId}`);
 
-    const baseMessage =
-      `Generate a ${args.kind.toUpperCase()} workflow document from recording ${args.recordingId} ` +
-      `(title: "${rec.title}"). Read the transcript from this request's context. ` +
-      `${KIND_PROMPTS[args.kind]} ` +
-      `Then write the final markdown to application_state key "${stateKey}" as ` +
-      `\`{ kind: "${args.kind}", status: "ready", content: "...", recordingId: "${args.recordingId}" }\`. ` +
-      `Finish by replying in chat with the same generated markdown so the user can read it immediately.`;
+      const [transcript] = await db
+        .select()
+        .from(schema.recordingTranscripts)
+        .where(eq(schema.recordingTranscripts.recordingId, args.recordingId))
+        .limit(1);
 
-    const request = {
-      kind: "generate-workflow" as const,
-      workflowKind: args.kind,
-      recordingId: args.recordingId,
-      requestedAt: new Date().toISOString(),
-      recordingTitle: rec.title,
-      recordingDescription: rec.description,
-      transcriptStatus: transcript?.status ?? "pending",
-      transcriptText: transcript?.fullText ?? "",
-      stateKey,
-      instructions: KIND_PROMPTS[args.kind],
-      includeFullVideoInAi,
-      message: withFullVideoAiInstructions(
-        baseMessage,
-        args.recordingId,
+      const includeFullVideoInAi = await readIncludeFullVideoInAi();
+
+      const existing = await readAppState(stateKey).catch(() => null);
+      if (existing?.status === "generating") {
+        const requestedAt = Date.parse(String(existing.requestedAt ?? ""));
+        const isRecent =
+          !Number.isFinite(requestedAt) ||
+          Date.now() - requestedAt < 10 * 60_000;
+        if (isRecent) {
+          return {
+            queued: false,
+            duplicate: true,
+            recordingId: args.recordingId,
+            kind: existing.kind ?? args.kind,
+            stateKey,
+          };
+        }
+      }
+
+      // Seed the output state with a "generating" placeholder so the UI can show
+      // a loading state immediately.
+      await writeAppState(stateKey, {
+        kind: args.kind,
+        status: "generating",
+        recordingId: args.recordingId,
+        requestedAt: new Date().toISOString(),
+      } as any);
+
+      const baseMessage =
+        `Generate a ${args.kind.toUpperCase()} workflow document from recording ${args.recordingId} ` +
+        `(title: "${rec.title}"). Read the transcript from this request's context. ` +
+        `${KIND_PROMPTS[args.kind]} ` +
+        `Then write the final markdown to application_state key "${stateKey}" as ` +
+        `\`{ kind: "${args.kind}", status: "ready", content: "...", recordingId: "${args.recordingId}" }\`. ` +
+        `Finish by replying in chat with the same generated markdown so the user can read it immediately.`;
+
+      const request = {
+        kind: "generate-workflow" as const,
+        workflowKind: args.kind,
+        recordingId: args.recordingId,
+        requestedAt: new Date().toISOString(),
+        recordingTitle: rec.title,
+        recordingDescription: rec.description,
+        transcriptStatus: transcript?.status ?? "pending",
+        transcriptText: transcript?.fullText ?? "",
+        stateKey,
+        instructions: KIND_PROMPTS[args.kind],
         includeFullVideoInAi,
-      ),
-    };
+        message: withFullVideoAiInstructions(
+          baseMessage,
+          args.recordingId,
+          includeFullVideoInAi,
+        ),
+      };
 
-    await writeAppState(`clips-ai-request-${args.recordingId}`, request as any);
-    await writeAppState("refresh-signal", { ts: Date.now() });
+      await writeAppState(
+        `clips-ai-request-${args.recordingId}`,
+        request as any,
+      );
+      await writeAppState("refresh-signal", { ts: Date.now() });
 
-    console.log(
-      `Delegation queued: generate-workflow (${args.kind}) for ${args.recordingId}`,
-    );
-    return {
-      queued: true,
-      recordingId: args.recordingId,
-      kind: args.kind,
-      stateKey,
-      includeFullVideoInAi,
-    };
+      console.log(
+        `Delegation queued: generate-workflow (${args.kind}) for ${args.recordingId}`,
+      );
+      return {
+        queued: true,
+        recordingId: args.recordingId,
+        kind: args.kind,
+        stateKey,
+        includeFullVideoInAi,
+      };
+    } finally {
+      workflowGenerationLocks.delete(stateKey);
+    }
   },
 });

--- a/templates/clips/actions/generate-workflow.ts
+++ b/templates/clips/actions/generate-workflow.ts
@@ -15,7 +15,10 @@
  */
 
 import { defineAction } from "@agent-native/core";
-import { writeAppState } from "@agent-native/core/application-state";
+import {
+  readAppState,
+  writeAppState,
+} from "@agent-native/core/application-state";
 import { assertAccess } from "@agent-native/core/sharing";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
@@ -77,6 +80,22 @@ export default defineAction({
 
     const stateKey = `clips-workflow-${args.recordingId}`;
     const includeFullVideoInAi = await readIncludeFullVideoInAi();
+
+    const existing = await readAppState(stateKey).catch(() => null);
+    if (existing?.status === "generating") {
+      const requestedAt = Date.parse(String(existing.requestedAt ?? ""));
+      const isRecent =
+        !Number.isFinite(requestedAt) || Date.now() - requestedAt < 10 * 60_000;
+      if (isRecent) {
+        return {
+          queued: false,
+          duplicate: true,
+          recordingId: args.recordingId,
+          kind: existing.kind ?? args.kind,
+          stateKey,
+        };
+      }
+    }
 
     // Seed the output state with a "generating" placeholder so the UI can show
     // a loading state immediately.

--- a/templates/clips/actions/get-recording-player-data.test.ts
+++ b/templates/clips/actions/get-recording-player-data.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { MockForbiddenError } = vi.hoisted(() => {
+  class MockForbiddenError extends Error {}
+  return { MockForbiddenError };
+});
+
+const mockResolveAccess = vi.hoisted(() => vi.fn());
+const mockGetRequestUserEmail = vi.hoisted(() => vi.fn());
+const mockGetRequestOrgId = vi.hoisted(() => vi.fn());
+const mockShareLimit = vi.hoisted(() => vi.fn(async () => []));
+const mockShareQuery = vi.hoisted(() => {
+  const query = {
+    from: vi.fn(),
+    where: vi.fn(),
+    limit: mockShareLimit,
+  };
+  query.from.mockReturnValue(query);
+  query.where.mockReturnValue(query);
+  return query;
+});
+const mockDb = vi.hoisted(() => ({
+  select: vi.fn((selection?: unknown) => {
+    if (!selection) {
+      throw new Error("player data query reached before share verification");
+    }
+    return mockShareQuery;
+  }),
+}));
+
+vi.mock("@agent-native/core", () => ({
+  defineAction: (options: unknown) => options,
+  embedApp: (options: unknown) => options,
+}));
+
+vi.mock("@agent-native/core/application-state", () => ({
+  readAppState: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/server", () => ({
+  buildDeepLink: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/server/request-context", () => ({
+  getRequestOrgId: (...args: unknown[]) => mockGetRequestOrgId(...args),
+  getRequestUserEmail: (...args: unknown[]) => mockGetRequestUserEmail(...args),
+}));
+
+vi.mock("@agent-native/core/sharing", () => ({
+  ForbiddenError: MockForbiddenError,
+  resolveAccess: (...args: unknown[]) => mockResolveAccess(...args),
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: (...conditions: unknown[]) => ({ kind: "and", conditions }),
+  asc: vi.fn(),
+  eq: (column: unknown, value: unknown) => ({ kind: "eq", column, value }),
+  or: (...conditions: unknown[]) => ({ kind: "or", conditions }),
+  sql: vi.fn(),
+}));
+
+vi.mock("../server/db/index.js", () => ({
+  getDb: () => mockDb,
+  schema: {
+    recordingShares: {
+      id: "recordingShares.id",
+      principalType: "recordingShares.principalType",
+      principalId: "recordingShares.principalId",
+      resourceId: "recordingShares.resourceId",
+    },
+    recordingTranscripts: { recordingId: "recordingTranscripts.recordingId" },
+    recordingComments: {
+      recordingId: "recordingComments.recordingId",
+      videoTimestampMs: "recordingComments.videoTimestampMs",
+      createdAt: "recordingComments.createdAt",
+    },
+    recordingReactions: {
+      recordingId: "recordingReactions.recordingId",
+      createdAt: "recordingReactions.createdAt",
+    },
+    recordingCtas: {
+      recordingId: "recordingCtas.recordingId",
+      createdAt: "recordingCtas.createdAt",
+    },
+    recordingBrowserDiagnostics: {
+      recordingId: "recordingBrowserDiagnostics.recordingId",
+    },
+    recordingBugReports: { recordingId: "recordingBugReports.recordingId" },
+    meetings: {
+      id: "meetings.id",
+      title: "meetings.title",
+      recordingId: "meetings.recordingId",
+    },
+  },
+}));
+
+vi.mock("../server/lib/player-video-url.js", () => ({
+  resolvePlayerVideoUrl: vi.fn(),
+}));
+
+vi.mock("../server/lib/recordings.js", () => ({
+  parseSpaceIds: vi.fn(() => []),
+}));
+
+vi.mock("../shared/browser-diagnostics.js", () => ({
+  parseBrowserDiagnosticsRow: vi.fn(() => null),
+}));
+
+vi.mock("../shared/builder-credits.js", () => ({
+  CLIPS_BUILDER_CREDITS_STATE_KEY: "clips-builder-credits",
+  normalizeBuilderCreditsStatus: vi.fn(() => null),
+}));
+
+vi.mock("../shared/transcript-segments.js", () => ({
+  normalizeTranscriptSegments: vi.fn(() => []),
+  parseTranscriptSegments: vi.fn(() => []),
+}));
+
+vi.mock("../shared/transcript-status.js", () => ({
+  resolveTranscriptPresentation: vi.fn(() => ({
+    status: "pending",
+    failureReason: null,
+  })),
+}));
+
+import action from "./get-recording-player-data";
+
+describe("get-recording-player-data direct public access", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetRequestUserEmail.mockReturnValue("viewer@example.com");
+    mockGetRequestOrgId.mockReturnValue("org-1");
+    mockShareLimit.mockResolvedValue([]);
+  });
+
+  it.each(["admin", "editor", "viewer"] as const)(
+    "requires an explicit recording share for %s callers",
+    async (role) => {
+      mockResolveAccess.mockResolvedValue({
+        role,
+        resource: {
+          id: "rec-1",
+          visibility: "public",
+          password: null,
+          expiresAt: null,
+        },
+      });
+
+      await expect(action.run({ recordingId: "rec-1" })).rejects.toThrow(
+        "Open this recording from its share link instead of the direct recording URL",
+      );
+
+      expect(mockDb.select).toHaveBeenCalledWith({
+        id: "recordingShares.id",
+      });
+      expect(mockShareLimit).toHaveBeenCalledTimes(1);
+    },
+  );
+});

--- a/templates/clips/actions/get-recording-player-data.ts
+++ b/templates/clips/actions/get-recording-player-data.ts
@@ -20,12 +20,17 @@
 import { defineAction, embedApp } from "@agent-native/core";
 import { readAppState } from "@agent-native/core/application-state";
 import { buildDeepLink } from "@agent-native/core/server";
+import {
+  getRequestOrgId,
+  getRequestUserEmail,
+} from "@agent-native/core/server/request-context";
 import { resolveAccess, ForbiddenError } from "@agent-native/core/sharing";
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq, or, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { resolvePlayerVideoUrl } from "../server/lib/player-video-url.js";
+import { canOpenDirectRecordingPage } from "../server/lib/recording-page-access.js";
 import { parseSpaceIds } from "../server/lib/recordings.js";
 import { parseBrowserDiagnosticsRow } from "../shared/browser-diagnostics.js";
 import {
@@ -105,6 +110,57 @@ export default defineAction({
 
     const db = getDb();
     const rec: any = access.resource;
+
+    let hasExplicitShare = access.role !== "owner";
+    if (rec.visibility === "public" && access.role === "viewer") {
+      const userEmail = getRequestUserEmail()?.trim().toLowerCase();
+      const orgId = getRequestOrgId();
+      const principals = [];
+      if (userEmail) {
+        principals.push(
+          and(
+            eq(schema.recordingShares.principalType, "user"),
+            sql`lower(${schema.recordingShares.principalId}) = ${userEmail}`,
+          ),
+        );
+      }
+      if (orgId) {
+        principals.push(
+          and(
+            eq(schema.recordingShares.principalType, "org"),
+            eq(schema.recordingShares.principalId, orgId),
+          ),
+        );
+      }
+      if (principals.length > 0) {
+        const [share] = await db
+          .select({ id: schema.recordingShares.id })
+          .from(schema.recordingShares)
+          .where(
+            and(
+              eq(schema.recordingShares.resourceId, args.recordingId),
+              or(...principals),
+            ),
+          )
+          .limit(1);
+        hasExplicitShare = Boolean(share);
+      } else {
+        hasExplicitShare = false;
+      }
+    }
+
+    if (
+      !canOpenDirectRecordingPage({
+        role: access.role,
+        visibility: rec.visibility,
+        hasPassword: Boolean(rec.password),
+        hasExplicitShare,
+      })
+    ) {
+      throw new ForbiddenError(
+        "Open this recording from its share link instead of the direct recording URL",
+      );
+    }
 
     const [transcript] = await db
       .select()

--- a/templates/clips/actions/get-recording-player-data.ts
+++ b/templates/clips/actions/get-recording-player-data.ts
@@ -118,8 +118,8 @@ export default defineAction({
       throw new ForbiddenError("Recording has expired");
     }
 
-    let hasExplicitShare = access.role !== "owner";
-    if (rec.visibility === "public" && access.role === "viewer") {
+    let hasExplicitShare = access.role === "owner";
+    if (rec.visibility === "public" && access.role !== "owner") {
       const userEmail = getRequestUserEmail()?.trim().toLowerCase();
       const orgId = getRequestOrgId();
       const principals = [];

--- a/templates/clips/actions/get-recording-player-data.ts
+++ b/templates/clips/actions/get-recording-player-data.ts
@@ -30,7 +30,10 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { resolvePlayerVideoUrl } from "../server/lib/player-video-url.js";
-import { canOpenDirectRecordingPage } from "../server/lib/recording-page-access.js";
+import {
+  canOpenDirectRecordingPage,
+  isRecordingExpired,
+} from "../server/lib/recording-page-access.js";
 import { parseSpaceIds } from "../server/lib/recordings.js";
 import { parseBrowserDiagnosticsRow } from "../shared/browser-diagnostics.js";
 import {
@@ -110,6 +113,10 @@ export default defineAction({
 
     const db = getDb();
     const rec: any = access.resource;
+
+    if (isRecordingExpired(rec.expiresAt)) {
+      throw new ForbiddenError("Recording has expired");
+    }
 
     let hasExplicitShare = access.role !== "owner";
     if (rec.visibility === "public" && access.role === "viewer") {

--- a/templates/clips/actions/regenerate-summary.ts
+++ b/templates/clips/actions/regenerate-summary.ts
@@ -22,6 +22,12 @@ export default defineAction({
     "Ask the agent to regenerate this recording's description/summary based on its transcript (and the full video when Include full video is enabled).",
   schema: z.object({
     recordingId: z.string().describe("Recording ID"),
+    openInChat: z
+      .boolean()
+      .optional()
+      .describe(
+        "When true, focus the queued generation request in the agent chat instead of keeping it hidden.",
+      ),
   }),
   run: async (args) => {
     await assertAccess("recording", args.recordingId, "editor");
@@ -74,6 +80,7 @@ export default defineAction({
       transcriptStatus: transcript?.status ?? "pending",
       transcriptText: transcript?.fullText ?? "",
       includeFullVideoInAi,
+      openInChat: args.openInChat === true,
       message: withFullVideoAiInstructions(
         baseMessage,
         args.recordingId,

--- a/templates/clips/actions/regenerate-title.ts
+++ b/templates/clips/actions/regenerate-title.ts
@@ -59,7 +59,9 @@ function buildTitleContext({
 }): string | undefined {
   const parts: string[] = [];
   if (currentTitle && !isDefaultTitle(currentTitle)) {
-    parts.push(`Current title: ${currentTitle}`);
+    parts.push(
+      `Current title: ${currentTitle}\nWhen regenerating, do not return this title verbatim; choose a more specific alternative when the transcript supports one.`,
+    );
   }
   if (agentsContext) parts.push(agentsContext);
   return parts.length > 0 ? parts.join("\n\n") : undefined;
@@ -237,9 +239,14 @@ export default defineAction({
 
         if (!fresh) throw new Error(`Recording not found: ${args.recordingId}`);
 
+        const titleMatchesCurrent =
+          fresh.title?.trim().toLocaleLowerCase() ===
+          generatedTitle.trim().toLocaleLowerCase();
+
         if (
-          isAutoTitleReplaceable(fresh.title, fresh.titleSource) ||
-          fresh.title === rec.title
+          !titleMatchesCurrent &&
+          (isAutoTitleReplaceable(fresh.title, fresh.titleSource) ||
+            fresh.title === rec.title)
         ) {
           await db
             .update(schema.recordings)
@@ -272,12 +279,18 @@ export default defineAction({
           };
         }
 
-        return {
-          updated: false,
-          skipped: true,
-          reason: "Recording title changed before generation completed",
-          recordingId: args.recordingId,
-        };
+        if (!titleMatchesCurrent) {
+          return {
+            updated: false,
+            skipped: true,
+            reason: "Recording title changed before generation completed",
+            recordingId: args.recordingId,
+          };
+        }
+
+        console.warn(
+          `[clips] AI title regeneration returned the existing title for ${args.recordingId}; queueing a refinement instead`,
+        );
       }
     } catch (err) {
       builderCreditsPaused = isBuilderCreditsExhaustedMessage(
@@ -302,9 +315,14 @@ export default defineAction({
 
       if (!fresh) throw new Error(`Recording not found: ${args.recordingId}`);
 
+      const titleMatchesCurrent =
+        fresh.title?.trim().toLocaleLowerCase() ===
+        fallbackTitle.trim().toLocaleLowerCase();
+
       if (
-        isAutoTitleReplaceable(fresh.title, fresh.titleSource) ||
-        fresh.title === rec.title
+        !titleMatchesCurrent &&
+        (isAutoTitleReplaceable(fresh.title, fresh.titleSource) ||
+          fresh.title === rec.title)
       ) {
         await db
           .update(schema.recordings)

--- a/templates/clips/app/components/editor/editor-layout.tsx
+++ b/templates/clips/app/components/editor/editor-layout.tsx
@@ -63,6 +63,7 @@ import {
   parseEdits,
   getExcludedRanges,
   formatMs,
+  skipExcludedRange,
   type EditsJson,
 } from "@/lib/timestamp-mapping";
 import { cn } from "@/lib/utils";
@@ -435,10 +436,15 @@ export function EditorLayout({ recordingId, className }: EditorLayoutProps) {
   useEffect(() => {
     const v = videoRef.current;
     if (!v) return;
-    const onTime = () => setPlayheadMs(v.currentTime * 1000);
+    const onTime = () => {
+      const rawMs = v.currentTime * 1000;
+      const visibleMs = skipExcludedRange(rawMs, excludedRanges, durationMs);
+      if (visibleMs !== rawMs) v.currentTime = visibleMs / 1000;
+      setPlayheadMs(visibleMs);
+    };
     v.addEventListener("timeupdate", onTime);
     return () => v.removeEventListener("timeupdate", onTime);
-  }, [videoUrl]);
+  }, [durationMs, excludedRanges, videoUrl]);
 
   // Expose the in-editor state so the agent can read "the user is editing and scrubbed to X".
   useEffect(() => {
@@ -510,11 +516,15 @@ export function EditorLayout({ recordingId, className }: EditorLayoutProps) {
     [recordingId, trim],
   );
 
-  const seek = useCallback((ms: number) => {
-    const v = videoRef.current;
-    if (v) v.currentTime = ms / 1000;
-    setPlayheadMs(ms);
-  }, []);
+  const seek = useCallback(
+    (ms: number) => {
+      const visibleMs = skipExcludedRange(ms, excludedRanges, durationMs);
+      const v = videoRef.current;
+      if (v) v.currentTime = visibleMs / 1000;
+      setPlayheadMs(visibleMs);
+    },
+    [durationMs, excludedRanges],
+  );
 
   // --- keyboard shortcuts -------------------------------------------------
   useEffect(() => {
@@ -585,8 +595,8 @@ export function EditorLayout({ recordingId, className }: EditorLayoutProps) {
 
   // Default selection window so the TrimHandles have something to render.
   const effectiveSelection = selectionRange ?? {
-    startMs: Math.max(0, playheadMs - 1000),
-    endMs: Math.min(durationMs || 1_000, playheadMs + 1000),
+    startMs: 0,
+    endMs: durationMs || 1_000,
   };
 
   if (playerDataQuery.isLoading) {
@@ -684,7 +694,8 @@ export function EditorLayout({ recordingId, className }: EditorLayoutProps) {
                 playheadMs={playheadMs}
                 durationMs={durationMs}
                 excludedRanges={excludedRanges}
-                selectionRange={selectionRange}
+                selectionRange={effectiveSelection}
+                splitPoints={splitPoints}
                 activityRanges={transcriptSegments}
                 onSeek={seek}
                 scrollLeft={scrollLeft}
@@ -707,6 +718,7 @@ export function EditorLayout({ recordingId, className }: EditorLayoutProps) {
                     value={effectiveSelection}
                     onChange={setSelectionRange}
                     durationMs={durationMs}
+                    splitPoints={splitPoints}
                   />
                 </div>
               </div>
@@ -727,7 +739,6 @@ export function EditorLayout({ recordingId, className }: EditorLayoutProps) {
                   durationMs={durationMs}
                   playheadMs={playheadMs}
                   chapters={chapters}
-                  excludedRanges={excludedRanges}
                   splitPoints={splitPoints}
                   onSeek={seek}
                   onClickChapter={(c) => seek(c.startMs)}

--- a/templates/clips/app/components/editor/thumbnail-picker.tsx
+++ b/templates/clips/app/components/editor/thumbnail-picker.tsx
@@ -4,6 +4,7 @@ import {
   IconPhotoEdit,
   IconUpload,
   IconLoader2,
+  IconX,
 } from "@tabler/icons-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -55,6 +56,10 @@ export function ThumbnailPicker({
   const [gifDataUrl, setGifDataUrl] = useState<string | null>(null);
 
   const videoRef = useRef<HTMLVideoElement | null>(null);
+  const framePreviewRef = useRef<HTMLVideoElement | null>(null);
+  const gifVideoRef = useRef<HTMLVideoElement | null>(null);
+  const gifPreviewRef = useRef<HTMLVideoElement | null>(null);
+  const uploadInputRef = useRef<HTMLInputElement | null>(null);
 
   const mutation = useActionMutation("set-thumbnail");
 
@@ -65,6 +70,7 @@ export function ThumbnailPicker({
       setFrameDataUrl(null);
       setGifDataUrl(null);
       setGifProgress(null);
+      if (uploadInputRef.current) uploadInputRef.current.value = "";
     }
   }, [open]);
 
@@ -95,6 +101,18 @@ export function ThumbnailPicker({
     } catch (err) {
       console.error(err);
       toast.error(t("thumbnailPicker.failedCapture"));
+    }
+  };
+
+  const seekPreview = (video: HTMLVideoElement | null, timeMs: number) => {
+    if (!video || !Number.isFinite(timeMs)) return;
+    const apply = () => {
+      video.currentTime = Math.max(0, timeMs) / 1000;
+    };
+    if (video.readyState === HTMLMediaElement.HAVE_NOTHING) {
+      video.addEventListener("loadedmetadata", apply, { once: true });
+    } else {
+      apply();
     }
   };
 
@@ -187,6 +205,7 @@ export function ThumbnailPicker({
           <TabsContent value="upload" className="py-4 space-y-3">
             <Label>{t("thumbnailPicker.uploadImage")}</Label>
             <input
+              ref={uploadInputRef}
               type="file"
               accept="image/*"
               onChange={(e) => {
@@ -196,14 +215,39 @@ export function ThumbnailPicker({
                 reader.onload = () => setUploadDataUrl(reader.result as string);
                 reader.readAsDataURL(file);
               }}
-              className="text-sm"
+              className="sr-only"
             />
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => uploadInputRef.current?.click()}
+            >
+              <IconUpload className="mr-1 h-4 w-4" />
+              {t("shareDialog.chooseFile")}
+            </Button>
             {uploadDataUrl ? (
-              <img
-                src={uploadDataUrl}
-                alt={t("thumbnailPicker.uploadedPreview")}
-                className="max-h-60 rounded border border-border"
-              />
+              <div className="relative w-fit">
+                <img
+                  src={uploadDataUrl}
+                  alt={t("thumbnailPicker.uploadedPreview")}
+                  className="max-h-60 rounded border border-border"
+                />
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="icon"
+                  className="absolute right-1 top-1 h-7 w-7"
+                  aria-label={t("shareDialog.remove")}
+                  onClick={() => {
+                    setUploadDataUrl(null);
+                    if (uploadInputRef.current)
+                      uploadInputRef.current.value = "";
+                  }}
+                >
+                  <IconX className="h-4 w-4" />
+                </Button>
+              </div>
             ) : currentThumbnailUrl ? (
               <img
                 src={currentThumbnailUrl}
@@ -235,7 +279,13 @@ export function ThumbnailPicker({
                     max={Math.max(1000, durationMs)}
                     step={100}
                     value={[frameTime]}
-                    onValueChange={([v]) => setFrameTime(v)}
+                    onValueChange={([v]) => {
+                      const next = v ?? 0;
+                      setFrameTime(next);
+                      setFrameDataUrl(null);
+                      seekPreview(videoRef.current, next);
+                      seekPreview(framePreviewRef.current, next);
+                    }}
                   />
                   <Button
                     size="sm"
@@ -256,6 +306,15 @@ export function ThumbnailPicker({
                     alt={t("thumbnailPicker.capturedFrame")}
                     className="w-full rounded border border-border mt-1"
                   />
+                ) : videoUrl ? (
+                  <video
+                    ref={framePreviewRef}
+                    src={videoUrl}
+                    className="w-full rounded border border-border bg-black mt-1"
+                    crossOrigin="anonymous"
+                    preload="auto"
+                    muted
+                  />
                 ) : (
                   <div className="w-full aspect-video rounded border border-dashed border-border flex items-center justify-center text-xs text-muted-foreground mt-1">
                     {t("thumbnailPicker.capturePreview")}
@@ -269,6 +328,7 @@ export function ThumbnailPicker({
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <video
+                  ref={gifVideoRef}
                   src={videoUrl ?? undefined}
                   className="w-full rounded border border-border bg-black"
                   crossOrigin="anonymous"
@@ -287,7 +347,13 @@ export function ThumbnailPicker({
                       max={Math.max(0, durationMs - gifDuration)}
                       step={100}
                       value={[gifStart]}
-                      onValueChange={([v]) => setGifStart(v)}
+                      onValueChange={([v]) => {
+                        const next = v ?? 0;
+                        setGifStart(next);
+                        setGifDataUrl(null);
+                        seekPreview(gifVideoRef.current, next);
+                        seekPreview(gifPreviewRef.current, next);
+                      }}
                     />
                   </div>
                   <div>
@@ -301,7 +367,10 @@ export function ThumbnailPicker({
                       max={10000}
                       step={100}
                       value={[gifDuration]}
-                      onValueChange={([v]) => setGifDuration(v)}
+                      onValueChange={([v]) => {
+                        setGifDuration(v ?? 500);
+                        setGifDataUrl(null);
+                      }}
                     />
                   </div>
                   <Button
@@ -330,6 +399,15 @@ export function ThumbnailPicker({
                     src={gifDataUrl}
                     alt={t("thumbnailPicker.animatedPreview")}
                     className="w-full rounded border border-border mt-1"
+                  />
+                ) : videoUrl ? (
+                  <video
+                    ref={gifPreviewRef}
+                    src={videoUrl}
+                    className="w-full rounded border border-border bg-black mt-1"
+                    crossOrigin="anonymous"
+                    preload="auto"
+                    muted
                   />
                 ) : (
                   <div className="w-full aspect-video rounded border border-dashed border-border flex items-center justify-center text-xs text-muted-foreground mt-1">

--- a/templates/clips/app/components/editor/trim-handles.tsx
+++ b/templates/clips/app/components/editor/trim-handles.tsx
@@ -13,6 +13,7 @@ export interface TrimHandlesProps {
   /** Fires when the user releases the mouse after drag. */
   onCommit?: (value: { startMs: number; endMs: number }) => void;
   durationMs: number;
+  splitPoints?: number[];
   className?: string;
 }
 
@@ -44,6 +45,7 @@ export function TrimHandles({
   onChange,
   onCommit,
   durationMs,
+  splitPoints = [],
   className,
 }: TrimHandlesProps) {
   const rootRef = useRef<HTMLDivElement | null>(null);
@@ -111,6 +113,9 @@ export function TrimHandles({
 
   const startX = (value.startMs / Math.max(durationMs, 1)) * width;
   const endX = (value.endMs / Math.max(durationMs, 1)) * width;
+  const visibleSplitPoints = splitPoints.filter(
+    (ms) => ms > value.startMs && ms < value.endMs, // i18n-ignore numeric range predicate, not visible UI copy
+  );
 
   return (
     <div
@@ -133,6 +138,16 @@ export function TrimHandles({
         <div className="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-full bg-foreground text-background text-[10px] px-1.5 py-0.5 rounded font-mono whitespace-nowrap">
           {formatMs(value.endMs - value.startMs)}
         </div>
+        {visibleSplitPoints.map((splitMs) => (
+          <div
+            key={splitMs}
+            className="absolute top-0 h-full w-0.5 -translate-x-1/2 bg-rose-500/95"
+            style={{
+              left: `${((splitMs - value.startMs) / Math.max(value.endMs - value.startMs, 1)) * 100}%`,
+            }}
+            aria-hidden="true"
+          />
+        ))}
       </div>
 
       {/* Left handle */}

--- a/templates/clips/app/components/editor/waveform.tsx
+++ b/templates/clips/app/components/editor/waveform.tsx
@@ -18,6 +18,8 @@ export interface WaveformProps {
   durationMs: number;
   /** Excluded ranges (original time) — drawn as striped overlays. */
   excludedRanges?: Array<{ startMs: number; endMs: number }>;
+  /** Split markers (original time) — drawn over the active selection. */
+  splitPoints?: number[];
   /** Optional selection range (original time) highlighted in brand color. */
   selectionRange?: { startMs: number; endMs: number } | null;
   /** Transcript-backed activity ranges used when browser audio decoding fails. */
@@ -87,6 +89,7 @@ export function Waveform({
   playheadMs,
   durationMs,
   excludedRanges,
+  splitPoints = [],
   selectionRange,
   activityRanges = [],
   onSeek,
@@ -220,19 +223,28 @@ export function Waveform({
 
     // Selection overlay
     if (selectionRange) {
-      const xStart =
-        (Math.min(selectionRange.startMs, selectionRange.endMs) /
-          Math.max(durationMs, 1)) *
-        totalWidth;
-      const xEnd =
-        (Math.max(selectionRange.startMs, selectionRange.endMs) /
-          Math.max(durationMs, 1)) *
-        totalWidth;
+      const startMs = Math.min(selectionRange.startMs, selectionRange.endMs);
+      const endMs = Math.max(selectionRange.startMs, selectionRange.endMs);
+      const xStart = (startMs / Math.max(durationMs, 1)) * totalWidth;
+      const xEnd = (endMs / Math.max(durationMs, 1)) * totalWidth;
       ctx.fillStyle = getBrandColorAlpha(0.28);
       ctx.fillRect(xStart, 0, xEnd - xStart, height);
       ctx.strokeStyle = getBrandColor();
       ctx.lineWidth = 1;
       ctx.strokeRect(xStart + 0.5, 0.5, xEnd - xStart - 1, height - 1);
+
+      // Keep split markers visible on the selected track as well as on the
+      // ruler so a split is visibly actionable within the selection.
+      for (const splitMs of splitPoints) {
+        if (splitMs <= startMs || splitMs >= endMs) continue;
+        const splitX = (splitMs / Math.max(durationMs, 1)) * totalWidth;
+        ctx.strokeStyle = "rgba(244, 63, 94, 0.95)";
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(splitX, 0);
+        ctx.lineTo(splitX, height);
+        ctx.stroke();
+      }
     }
   }, [
     peaks,
@@ -240,6 +252,7 @@ export function Waveform({
     height,
     excludedRanges,
     selectionRange,
+    splitPoints,
     durationMs,
     activityRanges,
   ]);

--- a/templates/clips/app/components/library/folder-tree.tsx
+++ b/templates/clips/app/components/library/folder-tree.tsx
@@ -6,6 +6,7 @@ import {
   IconFolderPlus,
   IconTrash,
   IconEdit,
+  IconDots,
 } from "@tabler/icons-react";
 import { useMemo, useState } from "react";
 import { NavLink } from "react-router";
@@ -33,6 +34,13 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   useCreateFolder,
   useDeleteFolder,
@@ -186,6 +194,50 @@ function FolderItem({
                   {node.name}
                 </span>
               </NavLink>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={`${node.name}: ${t("root.commandActions")}`}
+                    title={`${node.name}: ${t("root.commandActions")}`}
+                    className="rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-hover:opacity-100 group-focus-within:opacity-100 data-[state=open]:opacity-100"
+                  >
+                    <IconDots className="h-3.5 w-3.5" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" side="right">
+                  <DropdownMenuItem
+                    onSelect={() => {
+                      setTimeout(() => {
+                        setRenameValue(node.name);
+                        setRenameOpen(true);
+                      }, 0);
+                    }}
+                  >
+                    <IconEdit className="h-3.5 w-3.5 me-2" />{" "}
+                    {t("folderTree.rename")}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onSelect={() => {
+                      setTimeout(() => {
+                        setNewValue("");
+                        setNewOpen(true);
+                      }, 0);
+                    }}
+                  >
+                    <IconFolderPlus className="h-3.5 w-3.5 me-2" />{" "}
+                    {t("folderTree.newSubfolder")}
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onSelect={() => setTimeout(() => setConfirmDelete(true), 0)}
+                    className="text-destructive"
+                  >
+                    <IconTrash className="h-3.5 w-3.5 me-2" />{" "}
+                    {t("folderTree.delete")}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
           </ContextMenuTrigger>
           <ContextMenuContent>

--- a/templates/clips/app/components/player/settings-panel.tsx
+++ b/templates/clips/app/components/player/settings-panel.tsx
@@ -361,6 +361,7 @@ function CtaEditor({
   // editing this card, so an agent edit to the CTA shows up live. `editing`
   // flips true while focus is anywhere inside the card.
   const editing = useRef(false);
+  const [collapsed, setCollapsed] = useState(true);
   const [label, setLabel] = useReconciledState(cta.label, {
     active: editing.current,
   });
@@ -387,52 +388,91 @@ function CtaEditor({
         }
       }}
     >
-      <Input
-        value={label}
-        onChange={(e) => setLabel(e.target.value)}
-        placeholder={t("playerSettings.buttonLabelPlaceholder")}
-      />
-      <Input
-        value={url}
-        onChange={(e) => setUrl(e.target.value)}
-        placeholder="https://…"
-      />
-      <div className="flex gap-2">
-        <input
-          type="color"
-          value={color}
-          onChange={(e) => setColor(e.target.value)}
-          className="h-9 w-12 rounded cursor-pointer border border-border"
-        />
-        <Select
-          value={placement}
-          onValueChange={(v) => setPlacement(v as "end" | "throughout")}
-        >
-          <SelectTrigger className="flex-1">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="throughout">
-              {t("playerSettings.placementThroughout")}
-            </SelectItem>
-            <SelectItem value="end">
-              {t("playerSettings.placementEnd")}
-            </SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-      <div className="flex gap-2">
-        <Button
-          size="sm"
-          className="bg-primary hover:bg-primary/90 text-primary-foreground"
-          onClick={() => onSave({ label, url, color, placement })}
-        >
-          {t("common.save")}
-        </Button>
-        <Button size="sm" variant="ghost" onClick={onDelete}>
-          {t("playerSettings.delete")}
-        </Button>
-      </div>
+      {collapsed ? (
+        <div className="flex items-center gap-2">
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium">{cta.label}</p>
+            <p className="text-xs text-muted-foreground">
+              {cta.placement === "throughout"
+                ? t("playerSettings.placementThroughout")
+                : t("playerSettings.placementEnd")}
+            </p>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            title={t("recordingPage.edit")}
+            onClick={() => setCollapsed(false)}
+          >
+            {t("recordingPage.edit")}
+          </Button>
+          <Button type="button" size="sm" variant="ghost" onClick={onDelete}>
+            {t("playerSettings.delete")}
+          </Button>
+        </div>
+      ) : (
+        <>
+          <Input
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder={t("playerSettings.buttonLabelPlaceholder")}
+          />
+          <Input
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://…"
+          />
+          <div className="flex gap-2">
+            <input
+              type="color"
+              value={color}
+              onChange={(e) => setColor(e.target.value)}
+              className="h-9 w-12 rounded cursor-pointer border border-border"
+            />
+            <Select
+              value={placement}
+              onValueChange={(v) => setPlacement(v as "end" | "throughout")}
+            >
+              <SelectTrigger className="flex-1">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="throughout">
+                  {t("playerSettings.placementThroughout")}
+                </SelectItem>
+                <SelectItem value="end">
+                  {t("playerSettings.placementEnd")}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              size="sm"
+              className="bg-primary text-primary-foreground hover:bg-primary/90"
+              onClick={() => {
+                onSave({ label, url, color, placement });
+                setCollapsed(true);
+              }}
+            >
+              {t("common.save")}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={() => setCollapsed(true)}
+            >
+              {t("recordingPage.done")}
+            </Button>
+            <Button type="button" size="sm" variant="ghost" onClick={onDelete}>
+              {t("playerSettings.delete")}
+            </Button>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/templates/clips/app/components/player/share-dialog.test.ts
+++ b/templates/clips/app/components/player/share-dialog.test.ts
@@ -16,18 +16,16 @@ describe("recording share popover", () => {
     expect(shareDialogSource).toContain("z-[260] w-[440px]");
   });
 
-  it("keeps human and agent links visible for every visibility", () => {
+  it("does not show the same public URL twice", () => {
     const shareDialogSource = readSource("./share-dialog.tsx");
 
     expect(shareDialogSource).toContain(
-      'label={t("shareDialog.shareWithHumans")}',
+      'isPublic\n            ? t("shareDialog.shareLink")',
     );
     expect(shareDialogSource).toContain(
       'label={t("shareDialog.shareWithAgents")}',
     );
-    expect(shareDialogSource).toContain(
-      "const agentLink = isPublic ? shareUrl : agentContextUrl",
-    );
+    expect(shareDialogSource).toContain("{!isPublic ? (");
     expect(shareDialogSource).toContain("if (!isPublic)");
     expect(shareDialogSource).not.toContain("Collapsible");
   });

--- a/templates/clips/app/components/player/share-dialog.tsx
+++ b/templates/clips/app/components/player/share-dialog.tsx
@@ -380,49 +380,55 @@ function LinkTab({
       )}
 
       <CopyField
-        label={t("shareDialog.shareWithHumans")}
+        label={
+          isPublic
+            ? t("shareDialog.shareLink")
+            : t("shareDialog.shareWithHumans")
+        }
         value={shareUrl}
         disabled={
           visibilityPending || !sharesLoaded || (!isPublic && canManage)
         }
       />
 
-      <div className="space-y-2">
-        <CopyField
-          label={t("shareDialog.shareWithAgents")}
-          value={agentLink}
-          disabled={agentShareDisabled}
-        />
-        {sharesLoaded && !isPublic ? (
-          <>
-            <p className="text-xs text-muted-foreground">
-              {t("shareDialog.agentTokenDescription")}
-            </p>
-            {agentLinkError ? (
-              <div className="flex items-center justify-between gap-2 rounded-md border border-border bg-muted/30 px-3 py-2">
-                <p className="text-xs text-muted-foreground">
-                  {t("shareDialog.agentLinkUnavailable")}
-                </p>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="h-7"
-                  onClick={() => void loadAgentContextUrl()}
-                  disabled={createAgentLink.isPending}
-                >
-                  {t("shareDialog.retryAgentLink")}
-                </Button>
-              </div>
-            ) : null}
-            <CopyField
-              label={t("shareDialog.copyAgentPrompt")}
-              value={agentPrompt}
-              disabled={agentShareDisabled}
-            />
-          </>
-        ) : null}
-      </div>
+      {!isPublic ? (
+        <div className="space-y-2">
+          <CopyField
+            label={t("shareDialog.shareWithAgents")}
+            value={agentLink}
+            disabled={agentShareDisabled}
+          />
+          {sharesLoaded ? (
+            <>
+              <p className="text-xs text-muted-foreground">
+                {t("shareDialog.agentTokenDescription")}
+              </p>
+              {agentLinkError ? (
+                <div className="flex items-center justify-between gap-2 rounded-md border border-border bg-muted/30 px-3 py-2">
+                  <p className="text-xs text-muted-foreground">
+                    {t("shareDialog.agentLinkUnavailable")}
+                  </p>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-7"
+                    onClick={() => void loadAgentContextUrl()}
+                    disabled={createAgentLink.isPending}
+                  >
+                    {t("shareDialog.retryAgentLink")}
+                  </Button>
+                </div>
+              ) : null}
+              <CopyField
+                label={t("shareDialog.copyAgentPrompt")}
+                value={agentPrompt}
+                disabled={agentShareDisabled}
+              />
+            </>
+          ) : null}
+        </div>
+      ) : null}
 
       {sharesLoaded && !isPublic && canManage ? (
         <MakePublicCard

--- a/templates/clips/app/components/player/video-player.tsx
+++ b/templates/clips/app/components/player/video-player.tsx
@@ -592,6 +592,14 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
         pauseVideo();
         return;
       }
+      if (v.ended) {
+        try {
+          v.currentTime = 0;
+          setCurrentMs(0);
+        } catch {
+          // Let the normal play attempt report a media error if the seek fails.
+        }
+      }
       requestPlay();
     }, [isPlaying, pauseVideo, requestPlay]);
 
@@ -1423,6 +1431,21 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
           </div>
         )}
 
+        {thumbnailUrl &&
+        !autoPlay &&
+        !hasPlaybackStarted &&
+        (!startMs || startMs <= 0) ? (
+          <img
+            src={resolveLocalUrl(thumbnailUrl)}
+            alt=""
+            aria-hidden="true"
+            className={cn(
+              "pointer-events-none absolute inset-0 z-[1] h-full w-full",
+              cover ? "object-cover" : "object-contain",
+            )}
+          />
+        ) : null}
+
         {centerOverlayMode ? (
           <CenterPlaybackOverlay
             mode={centerOverlayMode}
@@ -1462,7 +1485,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
 
         {/* Floating CTA (throughout placement) */}
         {showThroughoutCta ? (
-          <div data-player-ui className="absolute bottom-16 right-4 z-20">
+          <div data-player-ui className="absolute bottom-16 right-4 z-30">
             <CtaButton
               cta={cta!}
               onClick={() => onCtaClick?.(cta!.id)}
@@ -1484,6 +1507,27 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
                 onClick={() => onCtaClick?.(cta!.id)}
                 large
               />
+              <button
+                type="button"
+                data-player-ui
+                aria-label={t("videoPlayer.playClip")}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  const v = videoRef.current;
+                  if (!v) return;
+                  try {
+                    v.currentTime = 0;
+                    setCurrentMs(0);
+                  } catch {
+                    // The regular play path will surface any media error.
+                  }
+                  requestPlay();
+                }}
+                className="pointer-events-auto inline-flex items-center gap-2 rounded-md border border-white/30 bg-white/10 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+              >
+                <IconPlayerPlay className="h-4 w-4 fill-current" />
+                {t("videoPlayer.playClip")}
+              </button>
             </div>
           </div>
         ) : null}

--- a/templates/clips/app/i18n/ar-SA.ts
+++ b/templates/clips/app/i18n/ar-SA.ts
@@ -455,6 +455,8 @@ const messages = {
     retryAgentLink: "إعادة المحاولة",
     gifPreview: "معاينة GIF",
     openPlayer: "مشغل مفتوح",
+    chooseFile: "اختيار ملف",
+    remove: "إزالة",
     downloadMp4: "تحميل MP4",
     embedsNeedPublic: "التضمينات تحتاج إلى مقطع عام",
     embedPublicDescription:

--- a/templates/clips/app/i18n/de-DE.ts
+++ b/templates/clips/app/i18n/de-DE.ts
@@ -468,6 +468,8 @@ const messages = {
     retryAgentLink: "Erneut versuchen",
     gifPreview: "GIF-Vorschau",
     openPlayer: "Spieler öffnen",
+    chooseFile: "Datei auswählen",
+    remove: "Entfernen",
     downloadMp4: "Laden Sie MP4 herunter",
     embedsNeedPublic: "Für Einbettungen ist ein öffentlicher Clip erforderlich",
     embedPublicDescription:

--- a/templates/clips/app/i18n/en-US.ts
+++ b/templates/clips/app/i18n/en-US.ts
@@ -451,6 +451,8 @@ const messages = {
     retryAgentLink: "Retry",
     gifPreview: "GIF preview",
     openPlayer: "Open player",
+    chooseFile: "Choose file",
+    remove: "Remove",
     downloadMp4: "Download MP4",
     embedsNeedPublic: "Embeds need a public clip",
     embedPublicDescription:

--- a/templates/clips/app/i18n/es-ES.ts
+++ b/templates/clips/app/i18n/es-ES.ts
@@ -465,6 +465,8 @@ const messages = {
     retryAgentLink: "Reintentar",
     gifPreview: "vista previa de GIF",
     openPlayer: "jugador abierto",
+    chooseFile: "Elige el archivo",
+    remove: "Eliminar",
     downloadMp4: "Descargar MP4",
     embedsNeedPublic: "Los elementos insertados necesitan un clip público",
     embedPublicDescription:

--- a/templates/clips/app/i18n/fr-FR.ts
+++ b/templates/clips/app/i18n/fr-FR.ts
@@ -465,6 +465,8 @@ const messages = {
     retryAgentLink: "Réessayer",
     gifPreview: "aperçu de GIF",
     openPlayer: "Joueur ouvert",
+    chooseFile: "Choisir un fichier",
+    remove: "Retirer",
     downloadMp4: "Télécharger MP4",
     embedsNeedPublic: "Les intégrations nécessitent un clip public",
     embedPublicDescription:

--- a/templates/clips/app/i18n/hi-IN.ts
+++ b/templates/clips/app/i18n/hi-IN.ts
@@ -448,6 +448,8 @@ const messages = {
     retryAgentLink: "फिर से प्रयास करें",
     gifPreview: "GIF पूर्वावलोकन",
     openPlayer: "खुला खिलाड़ी",
+    chooseFile: "फ़ाइल चुनें",
+    remove: "हटाएं",
     downloadMp4: "MP4 डाउनलोड करें",
     embedsNeedPublic: "एंबेड को एक सार्वजनिक क्लिप की आवश्यकता है",
     embedPublicDescription:

--- a/templates/clips/app/i18n/ja-JP.ts
+++ b/templates/clips/app/i18n/ja-JP.ts
@@ -460,6 +460,8 @@ const messages = {
     retryAgentLink: "再試行",
     gifPreview: "GIF プレビュー",
     openPlayer: "プレーヤーを開く",
+    chooseFile: "ファイルを選択してください",
+    remove: "取り除く",
     downloadMp4: "ダウンロード",
     embedsNeedPublic: "埋め込みにはパブリッククリップが必要です",
     embedPublicDescription:

--- a/templates/clips/app/i18n/ko-KR.ts
+++ b/templates/clips/app/i18n/ko-KR.ts
@@ -453,6 +453,8 @@ const messages = {
     retryAgentLink: "다시 시도",
     gifPreview: "GIF 미리보기",
     openPlayer: "플레이어 열기",
+    chooseFile: "파일 선택",
+    remove: "제거",
     downloadMp4: "MP4 다운로드",
     embedsNeedPublic: "퍼가기에는 공개 클립이 필요합니다",
     embedPublicDescription:

--- a/templates/clips/app/i18n/pt-BR.ts
+++ b/templates/clips/app/i18n/pt-BR.ts
@@ -462,6 +462,8 @@ const messages = {
     retryAgentLink: "Tentar novamente",
     gifPreview: "visualização de GIF",
     openPlayer: "Jogador aberto",
+    chooseFile: "Escolher arquivo",
+    remove: "Remover",
     downloadMp4: "Baixar MP4",
     embedsNeedPublic: "As incorporações precisam de um clipe público",
     embedPublicDescription:

--- a/templates/clips/app/i18n/zh-CN.ts
+++ b/templates/clips/app/i18n/zh-CN.ts
@@ -435,6 +435,8 @@ const messages = {
     retryAgentLink: "重试",
     gifPreview: "GIF 预览",
     openPlayer: "开放玩家",
+    chooseFile: "选择文件",
+    remove: "消除",
     downloadMp4: "下载MP4",
     embedsNeedPublic: "嵌入需要公共剪辑",
     embedPublicDescription:

--- a/templates/clips/app/i18n/zh-TW.ts
+++ b/templates/clips/app/i18n/zh-TW.ts
@@ -435,6 +435,8 @@ const messages = {
     retryAgentLink: "重試",
     gifPreview: "GIF 預覽",
     openPlayer: "開啟播放器",
+    chooseFile: "選取檔案",
+    remove: "消除",
     downloadMp4: "下載 MP4",
     embedsNeedPublic: "嵌入需要公開剪輯",
     embedPublicDescription:

--- a/templates/clips/app/lib/timestamp-mapping.test.ts
+++ b/templates/clips/app/lib/timestamp-mapping.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { skipExcludedRange } from "./timestamp-mapping";
+
+describe("skipExcludedRange", () => {
+  const cuts = [
+    { startMs: 1_000, endMs: 2_000 },
+    { startMs: 3_000, endMs: 3_500 },
+  ];
+
+  it("leaves visible timestamps unchanged", () => {
+    expect(skipExcludedRange(500, cuts, 5_000)).toBe(500);
+    expect(skipExcludedRange(2_500, cuts, 5_000)).toBe(2_500);
+  });
+
+  it("jumps to the end of the cut", () => {
+    expect(skipExcludedRange(1_250, cuts, 5_000)).toBe(2_000);
+    expect(skipExcludedRange(3_100, cuts, 5_000)).toBe(3_500);
+  });
+
+  it("does not seek past the known duration", () => {
+    expect(
+      skipExcludedRange(4_900, [{ startMs: 4_000, endMs: 6_000 }], 5_000),
+    ).toBe(5_000);
+  });
+});

--- a/templates/clips/app/lib/timestamp-mapping.ts
+++ b/templates/clips/app/lib/timestamp-mapping.ts
@@ -198,6 +198,20 @@ export function getKeptRanges(
   return out;
 }
 
+/** Move a source timestamp to the first visible timestamp after a cut. */
+export function skipExcludedRange(
+  ms: number,
+  excludedRanges: Pick<TrimRange, "startMs" | "endMs">[],
+  durationMs: number,
+): number {
+  const range = excludedRanges.find(
+    (candidate) => ms >= candidate.startMs && ms < candidate.endMs,
+  );
+  if (!range) return ms;
+  const next = Math.max(ms, range.endMs);
+  return durationMs > 0 ? Math.min(next, durationMs) : next;
+}
+
 /**
  * Merge a new excluded range into the edits, collapsing adjacent/overlapping
  * entries. Preserves existing non-excluded (split) markers as-is.

--- a/templates/clips/app/routes/_app.library._index.tsx
+++ b/templates/clips/app/routes/_app.library._index.tsx
@@ -6,8 +6,7 @@ import { NavLink } from "react-router";
 import { LibraryGrid } from "@/components/library/library-grid";
 import { usePageHeaderLayout } from "@/components/library/page-header";
 
-const SEO_TITLE =
-  "Agent-Native Clips - Open Source, agent-friendly Loom alternative";
+const SEO_TITLE = "Agent-Native Clips - Open Source screen recorder";
 const SEO_DESCRIPTION =
   "Open Source screen recorder and meeting-notes app with AI transcripts, summaries, search, dictation, and agent-readable share links.";
 

--- a/templates/clips/app/routes/_index.tsx
+++ b/templates/clips/app/routes/_index.tsx
@@ -1,8 +1,7 @@
 import { DefaultSpinner } from "@agent-native/core/client";
 import { redirect, type LoaderFunctionArgs } from "react-router";
 
-const SEO_TITLE =
-  "Agent-Native Clips - Open Source, agent-friendly Loom alternative";
+const SEO_TITLE = "Agent-Native Clips - Open Source screen recorder";
 const SEO_DESCRIPTION =
   "Open Source screen recorder and meeting-notes app with AI transcripts, summaries, search, dictation, and agent-readable share links.";
 

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -205,6 +205,10 @@ function parseTimeParam(raw: string | null): number {
   return (hours * 3600 + minutes * 60 + seconds) * 1000;
 }
 
+function buildSignInHref(returnTo: string): string {
+  return `${agentNativePath("/_agent-native/sign-in")}?return=${encodeURIComponent(returnTo)}`;
+}
+
 export default function RecordingPage() {
   const t = useT();
   useAutoTitleBridge();
@@ -256,6 +260,7 @@ export default function RecordingPage() {
   );
   const lastPlayerStateWriteRef = useRef(0);
   const readyMediaPollRef = useRef<{ key: string; until: number } | null>(null);
+  const [metadataRefreshUntil, setMetadataRefreshUntil] = useState(0);
 
   useEffect(() => {
     if (
@@ -325,6 +330,7 @@ export default function RecordingPage() {
         // `update-recording` and we want the skeleton to swap in promptly.
         if (shouldShowGeneratedTitleSkeleton(rec, data?.transcript?.status))
           return 3000;
+        if (Date.now() < metadataRefreshUntil) return 2000;
         return false;
       },
     },
@@ -542,6 +548,8 @@ export default function RecordingPage() {
   });
   const regenerateTitle = useActionMutation("regenerate-title" as any, {
     onSuccess: (result: any) => {
+      setMetadataRefreshUntil(Date.now() + 60_000);
+      void playerDataQ.refetch();
       if (result?.updated) {
         toast.success(t("recordingPage.titleUpdated"));
       } else if (result?.reason === "builder_credits_paused") {
@@ -559,7 +567,11 @@ export default function RecordingPage() {
     onError: handleAiError,
   });
   const regenerateSummary = useActionMutation("regenerate-summary" as any, {
-    onSuccess: () => toast.success(t("recordingPage.descriptionQueued")),
+    onSuccess: () => {
+      setMetadataRefreshUntil(Date.now() + 60_000);
+      void playerDataQ.refetch();
+      toast.success(t("recordingPage.descriptionQueued"));
+    },
     onError: handleAiError,
   });
   const regenerateChapters = useActionMutation("regenerate-chapters" as any, {
@@ -614,16 +626,21 @@ export default function RecordingPage() {
   }
   function handleGenerateWorkflow(kind: WorkflowKind) {
     if (!recording) return;
+    if (generatedWorkflow?.status === "generating") return;
     setEditing(false);
     setPanel("agent");
     window.dispatchEvent(
       new CustomEvent("agent-panel:set-mode", { detail: { mode: "chat" } }),
     );
+    window.dispatchEvent(new Event("agent-panel:open"));
     generateWorkflow.mutate({
       recordingId: recording.id,
       kind,
     } as any);
   }
+
+  const workflowBusy =
+    generateWorkflow.isPending || generatedWorkflow?.status === "generating";
 
   useEffect(() => {
     if (recording && panel === "settings" && !canEdit) setPanel("agent");
@@ -709,18 +726,36 @@ export default function RecordingPage() {
   }
 
   if (playerDataQ.isError || !recording) {
+    const needsSignIn = !session;
+    const returnTo =
+      typeof window === "undefined"
+        ? `/r/${recordingId}`
+        : window.location.pathname + window.location.search;
     return (
       <div className="flex flex-col items-center justify-center h-screen w-full bg-background px-6">
         <h1 className="text-xl font-semibold mb-2">
-          {t("recordingPage.recordingNotFound")}
+          {needsSignIn
+            ? t("sharePage.clipUnavailable")
+            : t("recordingPage.recordingNotFound")}
         </h1>
         <p className="text-sm text-muted-foreground mb-4">
-          {(playerDataQ.error as Error | undefined)?.message ??
-            t("recordingPage.noAccess")}
+          {needsSignIn
+            ? t("sharePage.clipUnavailableMessage")
+            : ((playerDataQ.error as Error | undefined)?.message ??
+              t("recordingPage.noAccess"))}
         </p>
-        <Button asChild variant="outline">
-          <Link to="/">{t("recordingPage.backToLibrary")}</Link>
-        </Button>
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          {needsSignIn ? (
+            <Button asChild>
+              <a href={buildSignInHref(returnTo)}>{t("sharePage.signIn")}</a>
+            </Button>
+          ) : null}
+          <Button asChild variant="outline">
+            <Link to="/library" replace>
+              {t("recordingPage.backToLibrary")}
+            </Link>
+          </Button>
+        </div>
       </div>
     );
   }
@@ -784,7 +819,7 @@ export default function RecordingPage() {
               className="shrink-0"
               aria-label={t("recordingPage.back")}
             >
-              <Link to="/">
+              <Link to="/library" replace>
                 <IconArrowLeft className="h-4 w-4 rtl:-scale-x-100" />
               </Link>
             </Button>
@@ -956,7 +991,9 @@ export default function RecordingPage() {
               : t("recordingPage.checkAgain")}
           </Button>
           <Button asChild variant="ghost" size="sm">
-            <Link to="/">{t("recordingPage.backToLibrary")}</Link>
+            <Link to="/library" replace>
+              {t("recordingPage.backToLibrary")}
+            </Link>
           </Button>
         </div>
       </div>
@@ -1136,7 +1173,7 @@ export default function RecordingPage() {
             className="shrink-0"
             aria-label={t("recordingPage.back")}
           >
-            <Link to="/">
+            <Link to="/library" replace>
               <IconArrowLeft className="h-4 w-4 rtl:-scale-x-100" />
             </Link>
           </Button>
@@ -1174,7 +1211,7 @@ export default function RecordingPage() {
             </Button>
           ) : null}
 
-          {canEdit ? (
+          {canEdit && !editing ? (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
@@ -1221,6 +1258,7 @@ export default function RecordingPage() {
                   onSelect={() =>
                     regenerateSummary.mutate({
                       recordingId: recording.id,
+                      openInChat: true,
                     } as any)
                   }
                 >
@@ -1264,7 +1302,7 @@ export default function RecordingPage() {
                   const menuItem = (
                     <DropdownMenuItem
                       key={item.kind}
-                      disabled={generateWorkflow.isPending}
+                      disabled={workflowBusy}
                       onSelect={() => handleGenerateWorkflow(item.kind)}
                       className={
                         item.tooltipKey ? "justify-between gap-3" : undefined
@@ -1319,24 +1357,26 @@ export default function RecordingPage() {
             </DropdownMenu>
           ) : null}
 
-          <ShareRecordingPopover
-            recordingId={recording.id}
-            recordingTitle={recording.title}
-            initialVisibility={recording.visibility}
-            initialRole={role}
-            videoUrl={recording.videoUrl}
-            animatedThumbnailUrl={recording.animatedThumbnailUrl}
-            isLoomRecording={isLoomEmbedBacked}
-            hasPassword={Boolean(recording.hasPassword)}
-          >
-            <Button
-              className="shrink-0 gap-1.5 bg-primary text-primary-foreground hover:bg-primary/90"
-              size="sm"
+          {!editing ? (
+            <ShareRecordingPopover
+              recordingId={recording.id}
+              recordingTitle={recording.title}
+              initialVisibility={recording.visibility}
+              initialRole={role}
+              videoUrl={recording.videoUrl}
+              animatedThumbnailUrl={recording.animatedThumbnailUrl}
+              isLoomRecording={isLoomEmbedBacked}
+              hasPassword={Boolean(recording.hasPassword)}
             >
-              <IconShare3 className="h-4 w-4" />
-              {t("recordingPage.share")}
-            </Button>
-          </ShareRecordingPopover>
+              <Button
+                className="shrink-0 gap-1.5 bg-primary text-primary-foreground hover:bg-primary/90"
+                size="sm"
+              >
+                <IconShare3 className="h-4 w-4" />
+                {t("recordingPage.share")}
+              </Button>
+            </ShareRecordingPopover>
+          ) : null}
 
           {canDelete || canDownloadRecording ? (
             <RecordingOptionsMenu
@@ -1486,7 +1526,7 @@ export default function RecordingPage() {
                     ) : null}
                   </div>
                   {recording.description ? (
-                    <p className="mt-3 line-clamp-2 text-sm text-muted-foreground">
+                    <p className="mt-3 whitespace-pre-wrap break-words text-sm text-muted-foreground">
                       {recording.description}
                     </p>
                   ) : null}
@@ -1528,7 +1568,7 @@ function GeneratedWorkflowNotice({
   const status = workflow.status ?? (workflow.content ? "ready" : "generating");
   const content =
     typeof workflow.content === "string" ? workflow.content.trim() : "";
-  const isReady = status === "ready" && content.length > 0;
+  const isReady = status !== "failed" && content.length > 0;
   const isFailed = status === "failed";
   const title = workflowTitle(workflow.kind);
 

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -855,6 +855,8 @@ export default function ShareRoute() {
               <Button variant="ghost" size="sm" asChild>
                 <a
                   href={appPath("/")}
+                  target="_blank"
+                  rel="noopener noreferrer"
                   className="gap-1.5"
                   onClick={() => fireShareCtaClick("try_clips")}
                 >
@@ -965,7 +967,7 @@ export default function ShareRoute() {
                 </h2>
               )}
               {recording.description ? (
-                <p className="text-sm text-muted-foreground line-clamp-2">
+                <p className="whitespace-pre-wrap break-words text-sm text-muted-foreground">
                   {recording.description}
                 </p>
               ) : null}
@@ -1063,6 +1065,7 @@ export default function ShareRoute() {
                   t("recordingPage.draftQuestions"),
                 ]}
                 browserTabId={getBrowserTabId()}
+                showHeader={false}
               />
             ) : (
               <PublicAgentEmptyState

--- a/templates/clips/changelog/2026-07-15-ai-workflow-generation-now-stays-visible-avoids-duplicate-re.md
+++ b/templates/clips/changelog/2026-07-15-ai-workflow-generation-now-stays-visible-avoids-duplicate-re.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-15
+---
+
+AI workflow generation now stays visible, avoids duplicate requests, and reports completion correctly.

--- a/templates/clips/changelog/2026-07-15-clip-playback-and-cta-controls-remain-interactive-through-ed.md
+++ b/templates/clips/changelog/2026-07-15-clip-playback-and-cta-controls-remain-interactive-through-ed.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-15
+---
+
+Clip playback and CTA controls remain interactive through editing and replay.

--- a/templates/clips/changelog/2026-07-15-clip-titles-no-longer-describe-the-product-as-a-loom-alterna.md
+++ b/templates/clips/changelog/2026-07-15-clip-titles-no-longer-describe-the-product-as-a-loom-alterna.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-15
+---
+
+Clip titles no longer describe the product as a Loom alternative.

--- a/templates/clips/changelog/2026-07-15-description-regeneration-now-opens-the-agent-chat-so-progres.md
+++ b/templates/clips/changelog/2026-07-15-description-regeneration-now-opens-the-agent-chat-so-progres.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-15
+---
+
+Description regeneration now opens the agent chat so progress is easy to follow.

--- a/templates/clips/changelog/2026-07-15-direct-recording-urls-now-respect-share-link-and-password-ac.md
+++ b/templates/clips/changelog/2026-07-15-direct-recording-urls-now-respect-share-link-and-password-ac.md
@@ -1,0 +1,6 @@
+---
+type: security
+date: 2026-07-15
+---
+
+Direct recording URLs now respect share-link and password access controls

--- a/templates/clips/changelog/2026-07-15-disconnecting-a-calendar-now-clears-unrecorded-synced-meetin.md
+++ b/templates/clips/changelog/2026-07-15-disconnecting-a-calendar-now-clears-unrecorded-synced-meetin.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-15
+---
+
+Disconnecting a calendar now clears unrecorded synced meeting placeholders.

--- a/templates/clips/changelog/2026-07-15-folders-now-expose-rename-and-delete-actions-directly-in-the.md
+++ b/templates/clips/changelog/2026-07-15-folders-now-expose-rename-and-delete-actions-directly-in-the.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-15
+---
+
+Folders now expose rename and delete actions directly in the library sidebar

--- a/templates/clips/changelog/2026-07-15-recording-pages-now-explain-sign-in-access-and-avoid-showing.md
+++ b/templates/clips/changelog/2026-07-15-recording-pages-now-explain-sign-in-access-and-avoid-showing.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-15
+---
+
+Recording pages now explain sign-in access and avoid showing the same public link twice.

--- a/templates/clips/changelog/2026-07-15-the-clips-extension-quick-actions-toolbar-can-be-moved-out-o.md
+++ b/templates/clips/changelog/2026-07-15-the-clips-extension-quick-actions-toolbar-can-be-moved-out-o.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-15
+---
+
+The Clips extension quick-actions toolbar can be moved out of the way.

--- a/templates/clips/changelog/2026-07-15-the-editor-now-skips-cut-sections-during-preview-and-keeps-t.md
+++ b/templates/clips/changelog/2026-07-15-the-editor-now-skips-cut-sections-during-preview-and-keeps-t.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-15
+---
+
+The editor now skips cut sections during preview and keeps the full clip selection visible.

--- a/templates/clips/changelog/2026-07-15-thumbnail-capture-now-updates-previews-while-scrubbing-and-l.md
+++ b/templates/clips/changelog/2026-07-15-thumbnail-capture-now-updates-previews-while-scrubbing-and-l.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-15
+---
+
+Thumbnail capture now updates previews while scrubbing and lets uploaded files be removed.

--- a/templates/clips/changelog/2026-07-15-windows-permission-links-open-the-matching-settings-page.md
+++ b/templates/clips/changelog/2026-07-15-windows-permission-links-open-the-matching-settings-page.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-15
+---
+
+Windows permission links now open the matching system settings page.

--- a/templates/clips/chrome-extension/src/content-script.ts
+++ b/templates/clips/chrome-extension/src/content-script.ts
@@ -83,6 +83,17 @@
   let bubbleDragLayer: HTMLDivElement | null = null;
   let bubblePersistTimer: ReturnType<typeof setTimeout> | undefined;
 
+  // The quick-actions toolbar is also draggable. Keep its geometry in the
+  // content script because the iframe cannot position itself on the host page.
+  const TOOLBAR_WIDTH = 68;
+  const TOOLBAR_COLLAPSED_HEIGHT = 154;
+  const toolbarGeom: { left: number | null; top: number | null } = {
+    left: null,
+    top: null,
+  };
+  let toolbarDragLayer: HTMLDivElement | null = null;
+  let toolbarPersistTimer: ReturnType<typeof setTimeout> | undefined;
+
   function bubbleSizePx(): number {
     return BUBBLE_SIZES[bubbleGeom.size] ?? BUBBLE_SIZES.lg;
   }
@@ -128,6 +139,92 @@
         /* ignore */
       }
     }, 200);
+  }
+
+  function clampToolbar(
+    left: number,
+    top: number,
+    height: number,
+  ): { left: number; top: number } {
+    return {
+      left: Math.max(8, Math.min(left, window.innerWidth - TOOLBAR_WIDTH - 8)),
+      top: Math.max(8, Math.min(top, window.innerHeight - height - 8)),
+    };
+  }
+
+  function applyToolbarGeom(): void {
+    const frame = document.getElementById(
+      partFrameId("toolbar"),
+    ) as HTMLIFrameElement | null;
+    if (!frame) return;
+    const height =
+      frame.getBoundingClientRect().height || TOOLBAR_COLLAPSED_HEIGHT;
+    const base = clampToolbar(
+      toolbarGeom.left ?? 16,
+      toolbarGeom.top ?? window.innerHeight / 2 - TOOLBAR_COLLAPSED_HEIGHT / 2,
+      height,
+    );
+    Object.assign(frame.style, {
+      left: `${base.left}px`,
+      top: `${base.top}px`,
+      right: "auto",
+    });
+  }
+
+  function persistToolbarGeom(): void {
+    clearTimeout(toolbarPersistTimer);
+    toolbarPersistTimer = setTimeout(() => {
+      try {
+        chrome.storage.local.set({ toolbarGeom });
+      } catch {
+        /* ignore */
+      }
+    }, 200);
+  }
+
+  function startToolbarDrag(): void {
+    if (toolbarDragLayer) return;
+    const frame = document.getElementById(
+      partFrameId("toolbar"),
+    ) as HTMLIFrameElement | null;
+    if (!frame) return;
+
+    const layer = document.createElement("div");
+    Object.assign(layer.style, {
+      position: "fixed",
+      inset: "0",
+      zIndex: "2147483647",
+      cursor: "grabbing",
+    });
+    (document.documentElement || document.body).appendChild(layer);
+    toolbarDragLayer = layer;
+
+    const onMove = (e: PointerEvent): void => {
+      const rect = frame.getBoundingClientRect();
+      const next = clampToolbar(
+        rect.left + e.movementX,
+        rect.top + e.movementY,
+        rect.height || TOOLBAR_COLLAPSED_HEIGHT,
+      );
+      toolbarGeom.left = next.left;
+      toolbarGeom.top = next.top;
+      Object.assign(frame.style, {
+        left: `${next.left}px`,
+        top: `${next.top}px`,
+        right: "auto",
+      });
+    };
+    const onUp = (): void => {
+      layer.removeEventListener("pointermove", onMove);
+      layer.removeEventListener("pointerup", onUp);
+      layer.removeEventListener("pointercancel", onUp);
+      layer.remove();
+      toolbarDragLayer = null;
+      persistToolbarGeom();
+    };
+    layer.addEventListener("pointermove", onMove);
+    layer.addEventListener("pointerup", onUp);
+    layer.addEventListener("pointercancel", onUp);
   }
 
   function startBubbleDrag(): void {
@@ -177,7 +274,7 @@
   }
 
   try {
-    chrome.storage.local.get("bubbleGeom", (value) => {
+    chrome.storage.local.get(["bubbleGeom", "toolbarGeom"], (value) => {
       if (chrome.runtime.lastError) return;
       const g = value.bubbleGeom as
         | { size?: unknown; left?: unknown; top?: unknown }
@@ -188,12 +285,24 @@
         bubbleGeom.top = typeof g.top === "number" ? g.top : null;
       }
       applyBubbleGeom();
+      const toolbar = value.toolbarGeom as
+        | { left?: unknown; top?: unknown }
+        | undefined;
+      if (toolbar && typeof toolbar === "object") {
+        toolbarGeom.left =
+          typeof toolbar.left === "number" ? toolbar.left : null;
+        toolbarGeom.top = typeof toolbar.top === "number" ? toolbar.top : null;
+      }
+      applyToolbarGeom();
     });
   } catch {
     /* ignore */
   }
 
-  window.addEventListener("resize", () => applyBubbleGeom());
+  window.addEventListener("resize", () => {
+    applyBubbleGeom();
+    applyToolbarGeom();
+  });
 
   function readCurrentParts(
     callback: (parts: OverlayPart[] | null) => void,
@@ -338,6 +447,7 @@
     styleFrame(frame, part);
     container.appendChild(frame);
     if (part === "bubble") applyBubbleGeom();
+    if (part === "toolbar") applyToolbarGeom();
   }
 
   // Camera-ready gating + connecting spinner: while the camera connects we show a
@@ -520,6 +630,7 @@
       const frame = document.getElementById(partFrameId("toolbar"));
       if (frame && typeof data.height === "number") {
         frame.style.height = `${Math.round(data.height)}px`;
+        applyToolbarGeom();
       }
       return;
     }
@@ -535,6 +646,10 @@
     }
     if (data.kind === "bubble-drag-start") {
       startBubbleDrag();
+      return;
+    }
+    if (data.kind === "toolbar-drag-start") {
+      startToolbarDrag();
       return;
     }
     if (data.kind === "bubble-size") {

--- a/templates/clips/chrome-extension/src/overlay.ts
+++ b/templates/clips/chrome-extension/src/overlay.ts
@@ -84,6 +84,17 @@ function postToolbarSize(height: number): void {
   }
 }
 
+function postToolbarDragStart(): void {
+  try {
+    window.parent.postMessage(
+      { source: "clips-overlay", kind: "toolbar-drag-start", part: "toolbar" },
+      "*",
+    );
+  } catch {
+    /* parent gone */
+  }
+}
+
 function postCountdownFinished(): void {
   try {
     window.parent.postMessage(
@@ -406,6 +417,22 @@ function initCountdown(): void {
 function initToolbar(): void {
   const pill = document.createElement("div");
   pill.className = "toolbar-v";
+  pill.style.cursor = "grab";
+
+  // The content script owns iframe geometry, so ask it to capture the pointer
+  // page-wide when the user drags the toolbar outside its current bounds.
+  pill.addEventListener("pointerdown", (event) => {
+    if (event.button !== 0) return;
+    if ((event.target as HTMLElement).closest("button")) return;
+    event.preventDefault();
+    pill.style.cursor = "grabbing";
+    postToolbarDragStart();
+    const restore = (): void => {
+      pill.style.cursor = "grab";
+      window.removeEventListener("pointerup", restore);
+    };
+    window.addEventListener("pointerup", restore);
+  });
 
   const makeBtn = (
     cls: string,

--- a/templates/clips/desktop/src-tauri/tauri.conf.json
+++ b/templates/clips/desktop/src-tauri/tauri.conf.json
@@ -40,7 +40,7 @@
   },
   "plugins": {
     "shell": {
-      "open": "(((mailto:\\w+)|(tel:\\w+)|(https?://\\w+)).+|(zoommtg://([A-Za-z0-9-]+\\.)*zoom\\.us/join\\?.+))"
+      "open": "(((mailto:\\w+)|(tel:\\w+)|(https?://\\w+)).+|(zoommtg://([A-Za-z0-9-]+\\.)*zoom\\.us/join\\?.+)|(ms-settings:[A-Za-z0-9._?=&-]+))"
     },
     "updater": {
       "active": true,

--- a/templates/clips/desktop/src/lib/windows-privacy-settings.test.ts
+++ b/templates/clips/desktop/src/lib/windows-privacy-settings.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const tauriConfig = JSON.parse(
+  readFileSync(
+    new URL("../../src-tauri/tauri.conf.json", import.meta.url),
+    "utf8",
+  ),
+) as {
+  plugins?: {
+    shell?: {
+      open?: string;
+    };
+  };
+};
+
+describe("Windows privacy settings links", () => {
+  it("are allowed by the Tauri shell plugin", () => {
+    const pattern = tauriConfig.plugins?.shell?.open;
+    expect(pattern).toEqual(expect.any(String));
+
+    const allowlist = new RegExp(pattern as string);
+    for (const url of [
+      "ms-settings:privacy",
+      "ms-settings:privacy-microphone",
+      "ms-settings:privacy-webcam",
+      "ms-settings:privacy-speechtyping",
+      "ms-settings:easeofaccess",
+    ]) {
+      expect(allowlist.test(url), url).toBe(true);
+    }
+  });
+});

--- a/templates/clips/server/lib/calendar-event-meetings.ts
+++ b/templates/clips/server/lib/calendar-event-meetings.ts
@@ -274,6 +274,27 @@ export function calendarEventToMeetingView(args: {
   };
 }
 
+/**
+ * Acquire the calendar account's write lock inside a caller-owned transaction.
+ * Disconnect and materialization both take this lock before touching the
+ * account's calendar events, so cleanup cannot race a meeting insert.
+ */
+export async function lockCalendarAccount(
+  db: any,
+  accountId: string,
+  ownerEmail?: string | null,
+): Promise<boolean> {
+  const ownerFilter = ownerEmail
+    ? eq(schema.calendarAccounts.ownerEmail, ownerEmail)
+    : isNull(schema.calendarAccounts.ownerEmail);
+  const locked = await db
+    .update(schema.calendarAccounts)
+    .set({ updatedAt: new Date().toISOString() })
+    .where(and(eq(schema.calendarAccounts.id, accountId), ownerFilter))
+    .returning({ id: schema.calendarAccounts.id });
+  return locked.length > 0;
+}
+
 export async function fetchLiveCalendarEventFromId(virtualId: string) {
   const parsed = parseCalendarMeetingId(virtualId);
   if (!parsed) return null;
@@ -317,11 +338,14 @@ export async function fetchLiveCalendarEventFromId(virtualId: string) {
   }
 }
 
-export async function upsertCalendarEventSnapshot(args: {
-  account: CalendarAccountForEvents;
-  event: CalendarEvent;
-}) {
-  const db = getDb();
+export async function upsertCalendarEventSnapshot(
+  args: {
+    account: CalendarAccountForEvents;
+    event: CalendarEvent;
+  },
+  database: any = getDb(),
+) {
+  const db = database;
   const startIso = eventStartIso(args.event);
   const endIso = eventEndIso(args.event);
   if (!args.event.id || !startIso || !endIso) {
@@ -397,120 +421,134 @@ export async function materializeCalendarMeetingFromVirtualId(
   const live = await fetchLiveCalendarEventFromId(virtualId);
   if (!live) return null;
   const db = getDb();
-  const snapshot = await upsertCalendarEventSnapshot(live);
-
-  if (snapshot.meetingId) {
-    const [existingMeeting] = await db
-      .select()
-      .from(schema.meetings)
-      .where(eq(schema.meetings.id, snapshot.meetingId))
-      .limit(1);
-    if (existingMeeting) return { meeting: existingMeeting, created: false };
-  }
-
   const ownerEmail = getCurrentOwnerEmail();
   const orgId = (await getActiveOrganizationId().catch(() => null)) ?? null;
   const joinUrl = pickJoinUrl(live.event);
   const meetingId = nanoid();
   const nowIso = new Date().toISOString();
 
-  // Claim the calendar_events row atomically before inserting the meeting
-  // row, so two concurrent materialize calls for the same event can't both
-  // insert a `meetings` row (check-then-act TOCTOU). Only the caller whose
-  // UPDATE actually matched a row (meetingId still NULL) proceeds to insert;
-  // the loser re-reads and returns the winner's meeting instead.
-  const claimed = await db
-    .update(schema.calendarEvents)
-    .set({ meetingId, updatedAt: nowIso })
-    .where(
-      and(
-        eq(schema.calendarEvents.id, snapshot.id),
-        isNull(schema.calendarEvents.meetingId),
-      ),
+  return db.transaction(async (tx: any) => {
+    // Disconnect takes this same account-row write lock before it snapshots
+    // and deletes events. If disconnect wins, the account is gone by the time
+    // this transaction reaches the lock and materialization becomes a no-op.
+    if (
+      !(await lockCalendarAccount(tx, live.account.id, live.account.ownerEmail))
     )
-    .returning({ id: schema.calendarEvents.id });
+      return null;
 
-  if (!claimed.length) {
-    // Someone else claimed it first — re-read and return their meeting.
-    const [winnerEvent] = await db
-      .select({ meetingId: schema.calendarEvents.meetingId })
-      .from(schema.calendarEvents)
-      .where(eq(schema.calendarEvents.id, snapshot.id))
-      .limit(1);
-    if (winnerEvent?.meetingId) {
-      const [winnerMeeting] = await db
+    const snapshot = await upsertCalendarEventSnapshot(live, tx);
+
+    if (snapshot.meetingId) {
+      const [existingMeeting] = await tx
         .select()
         .from(schema.meetings)
-        .where(eq(schema.meetings.id, winnerEvent.meetingId))
+        .where(eq(schema.meetings.id, snapshot.meetingId))
         .limit(1);
-      if (winnerMeeting) return { meeting: winnerMeeting, created: false };
+      if (existingMeeting) {
+        return { meeting: existingMeeting, created: false };
+      }
     }
-    return null;
-  }
 
-  try {
-    await db.insert(schema.meetings).values({
-      id: meetingId,
-      organizationId: orgId ?? live.account.orgId ?? null,
-      title: live.event.summary || "Untitled meeting",
-      scheduledStart: eventStartIso(live.event),
-      scheduledEnd: eventEndIso(live.event),
-      actualStart: null,
-      actualEnd: null,
-      platform: detectPlatform(joinUrl),
-      joinUrl: joinUrl ?? null,
-      calendarEventId: snapshot.id,
-      recordingId: null,
-      transcriptStatus: "idle",
-      summaryMd: "",
-      bulletsJson: "[]",
-      actionItemsJson: "[]",
-      source: "calendar",
-      reminderFiredAt: null,
-      createdAt: nowIso,
-      updatedAt: nowIso,
-      ownerEmail,
-      orgId,
-      visibility: "private",
-    } as any);
-
-    const participants = calendarEventParticipants(live.event).filter(
-      (p) => p.email,
-    );
-    if (participants.length) {
-      await db.insert(schema.meetingParticipants).values(
-        participants.map((p) => ({
-          id: nanoid(),
-          meetingId,
-          email: p.email,
-          name: p.name ?? null,
-          isOrganizer: !!p.isOrganizer,
-          attendedAt: null,
-          createdAt: nowIso,
-        })) as any,
-      );
-    }
-  } catch (err) {
-    // Roll back the claim so a future call can retry — but only if it still
-    // points at our own meetingId (don't clobber a legitimate later claim).
-    await db
+    // Claim the calendar_events row atomically before inserting the meeting
+    // row, so two concurrent materialize calls for the same event can't both
+    // insert a `meetings` row (check-then-act TOCTOU). Only the caller whose
+    // UPDATE actually matched a row (meetingId still NULL) proceeds to insert;
+    // the loser re-reads and returns the winner's meeting instead.
+    const claimed = await tx
       .update(schema.calendarEvents)
-      .set({ meetingId: null, updatedAt: new Date().toISOString() })
+      .set({ meetingId, updatedAt: nowIso })
       .where(
         and(
           eq(schema.calendarEvents.id, snapshot.id),
-          eq(schema.calendarEvents.meetingId, meetingId),
+          isNull(schema.calendarEvents.meetingId),
         ),
       )
-      .catch(() => {});
-    throw err;
-  }
+      .returning({ id: schema.calendarEvents.id });
 
-  const [meeting] = await db
-    .select()
-    .from(schema.meetings)
-    .where(eq(schema.meetings.id, meetingId))
-    .limit(1);
+    if (!claimed.length) {
+      // Someone else claimed it first — re-read and return the winner.
+      const [winnerEvent] = await tx
+        .select({ meetingId: schema.calendarEvents.meetingId })
+        .from(schema.calendarEvents)
+        .where(eq(schema.calendarEvents.id, snapshot.id))
+        .limit(1);
+      if (winnerEvent?.meetingId) {
+        const [winnerMeeting] = await tx
+          .select()
+          .from(schema.meetings)
+          .where(eq(schema.meetings.id, winnerEvent.meetingId))
+          .limit(1);
+        if (winnerMeeting) {
+          return { meeting: winnerMeeting, created: false };
+        }
+      }
+      return null;
+    }
 
-  return { meeting, created: true };
+    try {
+      await tx.insert(schema.meetings).values({
+        id: meetingId,
+        organizationId: orgId ?? live.account.orgId ?? null,
+        title: live.event.summary || "Untitled meeting",
+        scheduledStart: eventStartIso(live.event),
+        scheduledEnd: eventEndIso(live.event),
+        actualStart: null,
+        actualEnd: null,
+        platform: detectPlatform(joinUrl),
+        joinUrl: joinUrl ?? null,
+        calendarEventId: snapshot.id,
+        recordingId: null,
+        transcriptStatus: "idle",
+        summaryMd: "",
+        bulletsJson: "[]",
+        actionItemsJson: "[]",
+        source: "calendar",
+        reminderFiredAt: null,
+        createdAt: nowIso,
+        updatedAt: nowIso,
+        ownerEmail,
+        orgId,
+        visibility: "private",
+      } as any);
+
+      const participants = calendarEventParticipants(live.event).filter(
+        (p) => p.email,
+      );
+      if (participants.length) {
+        await tx.insert(schema.meetingParticipants).values(
+          participants.map((p) => ({
+            id: nanoid(),
+            meetingId,
+            email: p.email,
+            name: p.name ?? null,
+            isOrganizer: !!p.isOrganizer,
+            attendedAt: null,
+            createdAt: nowIso,
+          })) as any,
+        );
+      }
+    } catch (err) {
+      // Roll back the claim so a future call can retry — but only if it still
+      // points at our own meetingId (don't clobber a legitimate later claim).
+      await tx
+        .update(schema.calendarEvents)
+        .set({ meetingId: null, updatedAt: new Date().toISOString() })
+        .where(
+          and(
+            eq(schema.calendarEvents.id, snapshot.id),
+            eq(schema.calendarEvents.meetingId, meetingId),
+          ),
+        )
+        .catch(() => {});
+      throw err;
+    }
+
+    const [meeting] = await tx
+      .select()
+      .from(schema.meetings)
+      .where(eq(schema.meetings.id, meetingId))
+      .limit(1);
+
+    return { meeting, created: true };
+  });
 }

--- a/templates/clips/server/lib/recording-page-access.test.ts
+++ b/templates/clips/server/lib/recording-page-access.test.ts
@@ -1,6 +1,28 @@
 import { describe, expect, it } from "vitest";
 
-import { canOpenDirectRecordingPage } from "./recording-page-access.js";
+import {
+  canOpenDirectRecordingPage,
+  isRecordingExpired,
+} from "./recording-page-access.js";
+
+describe("isRecordingExpired", () => {
+  const now = Date.parse("2026-07-15T12:00:00.000Z");
+
+  it("expires recordings whose finite date is in the past", () => {
+    expect(isRecordingExpired("2026-07-15T11:59:59.999Z", now)).toBe(true);
+  });
+
+  it("keeps recordings with a future finite date available", () => {
+    expect(isRecordingExpired("2026-07-15T12:00:00.001Z", now)).toBe(false);
+  });
+
+  it.each(["not-a-date", "", null, undefined])(
+    "ignores non-finite or unset expiry %s",
+    (expiresAt) => {
+      expect(isRecordingExpired(expiresAt, now)).toBe(false);
+    },
+  );
+});
 
 describe("canOpenDirectRecordingPage", () => {
   it("always allows the owner, including for password-protected recordings", () => {

--- a/templates/clips/server/lib/recording-page-access.test.ts
+++ b/templates/clips/server/lib/recording-page-access.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { canOpenDirectRecordingPage } from "./recording-page-access.js";
+
+describe("canOpenDirectRecordingPage", () => {
+  it("always allows the owner, including for password-protected recordings", () => {
+    expect(
+      canOpenDirectRecordingPage({
+        role: "owner",
+        visibility: "public",
+        hasPassword: true,
+        hasExplicitShare: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects non-owner access to password-protected recordings", () => {
+    expect(
+      canOpenDirectRecordingPage({
+        role: "viewer",
+        visibility: "public",
+        hasPassword: true,
+        hasExplicitShare: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects public-link-only access on the direct recording route", () => {
+    expect(
+      canOpenDirectRecordingPage({
+        role: "viewer",
+        visibility: "public",
+        hasPassword: false,
+        hasExplicitShare: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("allows an explicit public recording share without a password", () => {
+    expect(
+      canOpenDirectRecordingPage({
+        role: "viewer",
+        visibility: "public",
+        hasPassword: false,
+        hasExplicitShare: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("preserves direct access for non-public recordings already shared to the viewer", () => {
+    expect(
+      canOpenDirectRecordingPage({
+        role: "viewer",
+        visibility: "private",
+        hasPassword: false,
+        hasExplicitShare: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/templates/clips/server/lib/recording-page-access.ts
+++ b/templates/clips/server/lib/recording-page-access.ts
@@ -1,0 +1,20 @@
+export type RecordingPageAccessRole = "owner" | "admin" | "editor" | "viewer";
+
+/**
+ * Decide whether an authenticated request may use the editor/player route.
+ * Public visibility is intentionally a share-link concern; a direct `/r/*`
+ * request must either be the owner or have an explicit share grant.
+ * Password-protected recordings stay on the password-aware share flow for
+ * every non-owner so the authenticated action cannot mint a bypass token.
+ */
+export function canOpenDirectRecordingPage(input: {
+  role: RecordingPageAccessRole;
+  visibility: "private" | "org" | "public";
+  hasPassword: boolean;
+  hasExplicitShare: boolean;
+}): boolean {
+  if (input.role === "owner") return true;
+  if (input.hasPassword) return false;
+  if (input.visibility === "public") return input.hasExplicitShare;
+  return true;
+}

--- a/templates/clips/server/lib/recording-page-access.ts
+++ b/templates/clips/server/lib/recording-page-access.ts
@@ -1,6 +1,21 @@
 export type RecordingPageAccessRole = "owner" | "admin" | "editor" | "viewer";
 
 /**
+ * Match the public recording and video routes: only a finite expiry date can
+ * expire a recording, and the expiry is strict so the exact instant remains
+ * valid until time advances past it.
+ */
+export function isRecordingExpired(
+  expiresAt: string | null | undefined,
+  now = Date.now(),
+): boolean {
+  if (!expiresAt) return false;
+
+  const expires = new Date(expiresAt).getTime();
+  return Number.isFinite(expires) && expires < now;
+}
+
+/**
  * Decide whether an authenticated request may use the editor/player route.
  * Public visibility is intentionally a share-link concern; a direct `/r/*`
  * request must either be the owner or have an explicit share grant.

--- a/templates/design/app/components/design/DesignCanvas.embedded-frame.test.ts
+++ b/templates/design/app/components/design/DesignCanvas.embedded-frame.test.ts
@@ -216,6 +216,18 @@ window.__vite_plugin_react_preamble_installed__ = true;
 });
 
 describe("DesignCanvas iframe sandbox policy", () => {
+  it("allows prototype print and download controls in every preview mode", () => {
+    for (const args of [
+      { externalPreview: false, readOnly: false },
+      { externalPreview: false, readOnly: true },
+      { externalPreview: true, readOnly: true },
+    ]) {
+      const sandbox = getDesignCanvasIframeSandbox(args);
+      expect(sandbox).toContain("allow-modals");
+      expect(sandbox).toContain("allow-downloads");
+    }
+  });
+
   it("does not grant same-origin access to read-only inline previews", () => {
     const sandbox = getDesignCanvasIframeSandbox({
       externalPreview: false,

--- a/templates/design/app/components/design/design-canvas/external-preview.ts
+++ b/templates/design/app/components/design/design-canvas/external-preview.ts
@@ -110,12 +110,16 @@ export function sanitizeLocalhostSourceSnapshotHtml(html: string): string {
   );
 }
 
+// Prototypes are still sandboxed, but user-initiated print/download controls
+// need the browser permissions that make `window.print()` and download links
+// work inside an iframe. Without these tokens the browser silently ignores
+// the common "Download / Print PDF" pattern.
 const EXTERNAL_PREVIEW_IFRAME_SANDBOX =
-  "allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin";
+  "allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-downloads allow-modals allow-same-origin";
 const EDITABLE_INLINE_IFRAME_SANDBOX =
-  "allow-scripts allow-popups allow-popups-to-escape-sandbox allow-same-origin";
+  "allow-scripts allow-popups allow-popups-to-escape-sandbox allow-downloads allow-modals allow-same-origin";
 const READ_ONLY_INLINE_IFRAME_SANDBOX =
-  "allow-scripts allow-popups allow-popups-to-escape-sandbox";
+  "allow-scripts allow-popups allow-popups-to-escape-sandbox allow-downloads allow-modals";
 
 export function getDesignCanvasIframeSandbox(args: {
   externalPreview: boolean;

--- a/templates/design/changelog/2026-07-15-prototype-print-and-download-buttons-now-work-in-preview.md
+++ b/templates/design/changelog/2026-07-15-prototype-print-and-download-buttons-now-work-in-preview.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-15
+---
+
+Prototype print and download buttons now work in preview

--- a/templates/slides/actions/extract-pdf.ts
+++ b/templates/slides/actions/extract-pdf.ts
@@ -11,7 +11,7 @@ export default async function (args: string[]) {
   }
 
   const buf = fs.readFileSync(pdfPath);
-  const pdf = new PDFParse(new Uint8Array(buf));
+  const pdf = new PDFParse({ data: new Uint8Array(buf) });
   const result = await pdf.getText();
   const pages = result.pages || [];
   console.log("Total pages:", pages.length);

--- a/templates/slides/actions/import-file.test.ts
+++ b/templates/slides/actions/import-file.test.ts
@@ -6,9 +6,14 @@ const mockStartBuilderDesignSystemIndex = vi.hoisted(() => vi.fn());
 const mockGetRequestUserEmail = vi.hoisted(() => vi.fn());
 const mockGetRequestOrgId = vi.hoisted(() => vi.fn());
 const mockUpsertBuilderProxyDesignSystem = vi.hoisted(() => vi.fn());
+const mockPdfParseOptions = vi.hoisted(() => vi.fn());
 
 vi.mock("pdf-parse", () => ({
   PDFParse: class {
+    constructor(options: unknown) {
+      mockPdfParseOptions(options);
+    }
+
     async getText() {
       return mockPdfText();
     }
@@ -56,6 +61,7 @@ import action from "./import-file";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockPdfParseOptions.mockReset();
   mockReadUserUploadedFile.mockImplementation(async (filePath: string) => ({
     data: Buffer.from("%PDF-1.7\n"),
     filename: filePath,
@@ -99,6 +105,9 @@ describe("import-file PDF source extraction", () => {
     expect(result.pages[0].text).toBe(fullText);
     expect(result.pages[0].textPreview).toBe(fullText.slice(0, 500));
     expect(result.truncated).toBe(false);
+    expect(mockPdfParseOptions).toHaveBeenCalledWith({
+      data: expect.any(Uint8Array),
+    });
   });
 
   it("caps large PDF extraction output by default", async () => {

--- a/templates/slides/actions/import-file.ts
+++ b/templates/slides/actions/import-file.ts
@@ -214,7 +214,10 @@ export default defineAction({
       const { PDFParse } = await import("pdf-parse");
       const { convertSectionsToSlides } =
         await import("../server/handlers/import/html-converter.js");
-      const pdf = new PDFParse(new Uint8Array(fileBuffer));
+      // pdf-parse v2 expects a LoadParameters object. Passing the byte array
+      // directly uses the old v1 shape and can fail while pdf.js initializes
+      // in production (the reported DOMMatrix error).
+      const pdf = new PDFParse({ data: new Uint8Array(fileBuffer) });
       const result = await pdf.getText();
       const pages = normalizePdfPages(result);
       const textPages = pages.filter((p) => p.text.trim());

--- a/templates/slides/app/components/editor/ImageGenPanel.tsx
+++ b/templates/slides/app/components/editor/ImageGenPanel.tsx
@@ -69,7 +69,7 @@ export default function ImageGenPanel({
     const contextParts: string[] = [];
 
     contextParts.push(
-      "Generate 3 image variations using our image generation action (`pnpm action generate-image`).",
+      "Generate 3 image variations by calling the registered `generate-image-api` action three times with the same prompt.",
     );
     contextParts.push(
       "The deliverables must be actual generated image assets from the action. Do not create placeholder HTML/CSS, oversized icon compositions, inline SVGs, or text-only mockups.",

--- a/templates/slides/app/components/editor/ImageSearchPanel.tsx
+++ b/templates/slides/app/components/editor/ImageSearchPanel.tsx
@@ -1,4 +1,4 @@
-import { appBasePath, useT } from "@agent-native/core/client";
+import { callAction, useT } from "@agent-native/core/client";
 import { IconX, IconSearch, IconLoader2 } from "@tabler/icons-react";
 import { useState, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
@@ -61,18 +61,15 @@ export default function ImageSearchPanel({
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(
-        `${appBasePath()}/api/image-search?q=${encodeURIComponent(query)}`,
+      const data = await callAction<SearchResult[]>(
+        "search-images",
+        { q: query.trim() },
+        { method: "GET" },
       );
-      if (!res.ok) {
-        const data = await res.json();
-        setError(data.error || "Search failed");
-        setResults([]);
-      } else {
-        setResults(await res.json());
-      }
-    } catch {
-      setError("Search failed");
+      setResults(data);
+    } catch (error) {
+      setError(error instanceof Error ? error.message : t("raw.searchFailed"));
+      setResults([]);
     } finally {
       setLoading(false);
     }

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -1141,7 +1141,10 @@ export default function SlideEditor({
       const selector = getBuilderSelector(el);
       el.contentEditable = "true";
       el.setAttribute("data-editing-block", "true");
-      clearSelectedElement();
+      // Keep the inspector selection mounted while text is being edited. The
+      // inspector is a stable dock, so clearing it here would make the canvas
+      // resize and auto-fit again on the second click.
+      setSelectedElementRect(null);
       captureInlineEditDraft(slide.id);
       // Mark the deck dirty immediately so SSE/poll refreshes do not replace
       // the deck under an active contentEditable edit, even before the user
@@ -1167,13 +1170,7 @@ export default function SlideEditor({
         );
       }
     },
-    [
-      buildSelectionState,
-      captureInlineEditDraft,
-      clearSelectedElement,
-      onInlineEditStart,
-      slide.id,
-    ],
+    [buildSelectionState, captureInlineEditDraft, onInlineEditStart, slide.id],
   );
 
   // Exit edit mode when switching slides — save pending content first so
@@ -2053,18 +2050,29 @@ export default function SlideEditor({
           )}
         </div>
 
-        {selectedStyleSnapshot && !readOnly && (
-          <div className="relative z-[70] hidden h-full w-[17rem] shrink-0 border-l border-border/70 bg-background/95 lg:block">
-            <SlideStyleInspector
-              snapshot={selectedStyleSnapshot}
-              designSystem={designSystem}
-              className="h-full w-full rounded-none border-0 bg-transparent shadow-none"
-              onChange={applySelectedStylePatch}
-              onClose={() => {
-                clearSelectedElement();
-                syncSelectionToAppState(null);
-              }}
-            />
+        {!readOnly && (
+          <div
+            className="relative z-[70] hidden h-full w-[17rem] shrink-0 border-l border-border/70 bg-background/95 lg:block"
+            data-slide-style-dock="true"
+          >
+            {selectedStyleSnapshot ? (
+              <SlideStyleInspector
+                snapshot={selectedStyleSnapshot}
+                designSystem={designSystem}
+                className="h-full w-full rounded-none border-0 bg-transparent shadow-none"
+                onChange={applySelectedStylePatch}
+                onClose={() => {
+                  clearSelectedElement();
+                  syncSelectionToAppState(null);
+                }}
+              />
+            ) : (
+              <div className="flex h-11 items-center border-b border-border/70 px-3">
+                <span className="text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground/70">
+                  {t("styleInspector.title")}
+                </span>
+              </div>
+            )}
           </div>
         )}
       </div>
@@ -2082,7 +2090,7 @@ export default function SlideEditor({
           viewportRect={selectionViewportRect}
         />
       )}
-      {selectedElementRect && (
+      {selectedElementRect && !editingEl && (
         <ElementSelectionOutline
           rect={selectedElementRect}
           viewportRect={selectionViewportRect}

--- a/templates/slides/app/i18n/ar-SA.ts
+++ b/templates/slides/app/i18n/ar-SA.ts
@@ -103,6 +103,7 @@ const messages = {
     searchImagesPlaceholder: "Buscar imagens...",
     searchForLogosImagesIcons: "Buscar logos, imagens, ícones...",
     search: "بحث",
+    searchFailed: "فشل البحث",
     logoSearchTitle: "بحث عن الشعار",
     searchCompanyLogo: "Busque uma empresa para encontrar seu logo",
     searchCompanyPlaceholder: "Buscar nome da empresa (ex.: Intuit)",

--- a/templates/slides/app/i18n/de-DE.ts
+++ b/templates/slides/app/i18n/de-DE.ts
@@ -106,6 +106,7 @@ const messages = {
     searchImagesPlaceholder: "Nach Bildern suchen...",
     searchForLogosImagesIcons: "Nach Logos, Bildern, Icons suchen...",
     search: "Suchen",
+    searchFailed: "Suche fehlgeschlagen",
     logoSearchTitle: "Logo-Suche",
     searchCompanyLogo: "Suche nach einem Unternehmen, um sein Logo zu finden",
     searchCompanyPlaceholder: "Unternehmensname suchen (z. B. Intuit)",

--- a/templates/slides/app/i18n/en-US.ts
+++ b/templates/slides/app/i18n/en-US.ts
@@ -104,6 +104,7 @@ const messages = {
     searchImagesPlaceholder: "Search for images...",
     searchForLogosImagesIcons: "Search for logos, images, icons...",
     search: "Search",
+    searchFailed: "Search failed",
     logoSearchTitle: "Logo Search",
     searchCompanyLogo: "Search for a company to find their logo",
     searchCompanyPlaceholder: "Search company name (e.g. Intuit)",

--- a/templates/slides/app/i18n/es-ES.ts
+++ b/templates/slides/app/i18n/es-ES.ts
@@ -105,6 +105,7 @@ const messages = {
     searchImagesPlaceholder: "Buscar imágenes...",
     searchForLogosImagesIcons: "Buscar logos, imágenes, iconos...",
     search: "Buscar",
+    searchFailed: "Error al buscar",
     logoSearchTitle: "Búsqueda de logos",
     searchCompanyLogo: "Busca una empresa para encontrar su logo",
     searchCompanyPlaceholder: "Buscar nombre de empresa (p. ej. Intuit)",

--- a/templates/slides/app/i18n/fr-FR.ts
+++ b/templates/slides/app/i18n/fr-FR.ts
@@ -106,6 +106,7 @@ const messages = {
     searchImagesPlaceholder: "Rechercher des images...",
     searchForLogosImagesIcons: "Rechercher des logos, images, icônes...",
     search: "Rechercher",
+    searchFailed: "Échec de la recherche",
     logoSearchTitle: "Recherche de logo",
     searchCompanyLogo: "Recherchez une entreprise pour trouver son logo",
     searchCompanyPlaceholder: "Rechercher un nom d’entreprise (ex. Intuit)",

--- a/templates/slides/app/i18n/hi-IN.ts
+++ b/templates/slides/app/i18n/hi-IN.ts
@@ -103,6 +103,7 @@ const messages = {
     searchImagesPlaceholder: "Buscar imagens...",
     searchForLogosImagesIcons: "Buscar logos, imagens, ícones...",
     search: "खोजें",
+    searchFailed: "खोज विफल",
     logoSearchTitle: "लोगो खोज",
     searchCompanyLogo: "Busque uma empresa para encontrar seu logo",
     searchCompanyPlaceholder: "Buscar nome da empresa (ex.: Intuit)",

--- a/templates/slides/app/i18n/ja-JP.ts
+++ b/templates/slides/app/i18n/ja-JP.ts
@@ -104,6 +104,7 @@ const messages = {
     searchImagesPlaceholder: "画像を検索...",
     searchForLogosImagesIcons: "ロゴ、画像、アイコンを検索...",
     search: "検索",
+    searchFailed: "検索に失敗しました",
     logoSearchTitle: "ロゴ検索",
     searchCompanyLogo: "会社を検索してロゴを見つける",
     searchCompanyPlaceholder: "会社名を検索（例: Intuit）",

--- a/templates/slides/app/i18n/ko-KR.ts
+++ b/templates/slides/app/i18n/ko-KR.ts
@@ -104,6 +104,7 @@ const messages = {
     searchImagesPlaceholder: "画像を検索...",
     searchForLogosImagesIcons: "ロゴ、画像、アイコンを検索...",
     search: "검색",
+    searchFailed: "검색 실패",
     logoSearchTitle: "로고 검색",
     searchCompanyLogo: "会社を検索してロゴを見つける",
     searchCompanyPlaceholder: "会社名を検索（例: Intuit）",

--- a/templates/slides/app/i18n/pt-BR.ts
+++ b/templates/slides/app/i18n/pt-BR.ts
@@ -104,6 +104,7 @@ const messages = {
     searchImagesPlaceholder: "Buscar imagens...",
     searchForLogosImagesIcons: "Buscar logos, imagens, ícones...",
     search: "Buscar",
+    searchFailed: "Falha na pesquisa",
     logoSearchTitle: "Busca de logo",
     searchCompanyLogo: "Busque uma empresa para encontrar seu logo",
     searchCompanyPlaceholder: "Buscar nome da empresa (ex.: Intuit)",

--- a/templates/slides/app/i18n/zh-CN.ts
+++ b/templates/slides/app/i18n/zh-CN.ts
@@ -102,6 +102,7 @@ const messages = {
     searchImagesPlaceholder: "画像を検索...",
     searchForLogosImagesIcons: "ロゴ、画像、アイコンを検索...",
     search: "搜索",
+    searchFailed: "搜索失败",
     logoSearchTitle: "徽标搜索",
     searchCompanyLogo: "会社を検索してロゴを見つける",
     searchCompanyPlaceholder: "会社名を検索（例: Intuit）",

--- a/templates/slides/app/i18n/zh-TW.ts
+++ b/templates/slides/app/i18n/zh-TW.ts
@@ -100,6 +100,7 @@ const messages = {
     searchImagesPlaceholder: "搜尋圖片...",
     searchForLogosImagesIcons: "搜尋徽標、圖片、圖示...",
     search: "搜尋",
+    searchFailed: "搜尋失敗",
     logoSearchTitle: "徽標搜尋",
     searchCompanyLogo: "搜尋公司以尋找徽標",
     searchCompanyPlaceholder: "搜尋公司名稱（例如：Intuit）",

--- a/templates/slides/changelog/2026-07-15-image-search-and-generation-controls-now-use-the-registered-.md
+++ b/templates/slides/changelog/2026-07-15-image-search-and-generation-controls-now-use-the-registered-.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-15
+---
+
+Image search and generation controls now use the registered Slides actions

--- a/templates/slides/changelog/2026-07-15-pdf-deck-references-can-be-imported-for-slide-inspiration-ag.md
+++ b/templates/slides/changelog/2026-07-15-pdf-deck-references-can-be-imported-for-slide-inspiration-ag.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-15
+---
+
+PDF deck references can be imported for slide inspiration again

--- a/templates/slides/changelog/2026-07-15-stable-style-inspector-dock.md
+++ b/templates/slides/changelog/2026-07-15-stable-style-inspector-dock.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-15
+---
+
+The slide Style inspector now stays in a stable dock while selecting and editing elements, so the canvas no longer jumps or changes zoom.

--- a/templates/slides/server/agent-card.test.ts
+++ b/templates/slides/server/agent-card.test.ts
@@ -18,6 +18,8 @@ const REQUIRED_SLIDES_ACTIONS = [
   "list-decks",
   "update-slide",
   "navigate",
+  "search-images",
+  "generate-image-api",
 ];
 
 const ACTION_REGISTRY_TEST_TIMEOUT_MS = 30_000;


### PR DESCRIPTION
## Summary
- Harden shared core chat behavior, stale panel recovery, asset handoff, error formatting, and MCP connection UI.
- Fix Clips workflow generation, recording access, calendar cleanup, editor playback, sharing, extension, and desktop behavior.
- Fix Design preview and Slides import/editor behavior, with focused tests, synchronized i18n catalogs, core changesets, and template changelog entries.

## Validation
- `pnpm run guards`
- `pnpm fmt:check`
- Core, Clips, Design, and Slides focused Vitest suites
- Core, Clips, Design, Slides, Clips desktop, and Clips extension typechecks
- Tauri config JSON parse check
