### PR TITLE
Increase Files tab height for better content visibility

### DIFF
--- a/.changeset/files-tab-taller-scroll.md
+++ b/.changeset/files-tab-taller-scroll.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Make the Agent Files tab taller and viewport-responsive, and let file previews fill the panel height with natural scrolling.

--- a/packages/core/src/client/agent-page/AgentTabsPage.tsx
+++ b/packages/core/src/client/agent-page/AgentTabsPage.tsx
@@ -152,7 +152,7 @@ function EmptySlot({ label }: { label: string }) {
 
 function FilesTab({ scope }: AgentPageTabProps) {
   return (
-    <div className="h-full min-h-[360px]">
+    <div className="h-[calc(100vh-14rem)] min-h-[480px]">
       <ResourcesPanel
         key={scope}
         showMcpServers={false}

--- a/packages/core/src/client/agent-page/AgentTabsPage.tsx
+++ b/packages/core/src/client/agent-page/AgentTabsPage.tsx
@@ -1,6 +1,4 @@
 import {
-  IconArrowsDiagonal,
-  IconArrowsDiagonalMinimize2,
   IconBrain,
   IconClock,
   IconExternalLink,
@@ -153,58 +151,13 @@ function EmptySlot({ label }: { label: string }) {
 }
 
 function FilesTab({ scope }: AgentPageTabProps) {
-  const [expanded, setExpanded] = useState(false);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [expanded]);
-
-  const panel = (
-    <ResourcesPanel
-      key={scope}
-      showMcpServers={false}
-      scope={scope === "org" ? "shared" : "personal"}
-    />
-  );
-
-  if (expanded) {
-    return (
-      <div className="fixed inset-0 z-50 flex flex-col bg-background p-4 sm:p-6">
-        <div className="mb-2 flex shrink-0 items-center justify-between">
-          <span className="text-sm font-medium text-foreground">Files</span>
-          <button
-            type="button"
-            onClick={() => setExpanded(false)}
-            className="flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-[12px] font-medium text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-          >
-            <IconArrowsDiagonalMinimize2 className="size-3.5" />
-            Collapse
-          </button>
-        </div>
-        <div className="min-h-0 flex-1 overflow-hidden rounded-lg border border-border">
-          {panel}
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="relative h-[calc(100vh-14rem)] min-h-[480px]">
-      <button
-        type="button"
-        onClick={() => setExpanded(true)}
-        aria-label="Expand files"
-        className="absolute -top-9 right-0 z-10 flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-[12px] font-medium text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-      >
-        <IconArrowsDiagonal className="size-3.5" />
-        Expand
-      </button>
-      {panel}
+    <div className="h-[calc(100vh-14rem)] min-h-[480px]">
+      <ResourcesPanel
+        key={scope}
+        showMcpServers={false}
+        scope={scope === "org" ? "shared" : "personal"}
+      />
     </div>
   );
 }

--- a/packages/core/src/client/agent-page/AgentTabsPage.tsx
+++ b/packages/core/src/client/agent-page/AgentTabsPage.tsx
@@ -1,4 +1,6 @@
 import {
+  IconArrowsDiagonal,
+  IconArrowsDiagonalMinimize2,
   IconBrain,
   IconClock,
   IconExternalLink,
@@ -151,13 +153,58 @@ function EmptySlot({ label }: { label: string }) {
 }
 
 function FilesTab({ scope }: AgentPageTabProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    if (!expanded) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setExpanded(false);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [expanded]);
+
+  const panel = (
+    <ResourcesPanel
+      key={scope}
+      showMcpServers={false}
+      scope={scope === "org" ? "shared" : "personal"}
+    />
+  );
+
+  if (expanded) {
+    return (
+      <div className="fixed inset-0 z-50 flex flex-col bg-background p-4 sm:p-6">
+        <div className="mb-2 flex shrink-0 items-center justify-between">
+          <span className="text-sm font-medium text-foreground">Files</span>
+          <button
+            type="button"
+            onClick={() => setExpanded(false)}
+            className="flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-[12px] font-medium text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+          >
+            <IconArrowsDiagonalMinimize2 className="size-3.5" />
+            Collapse
+          </button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-hidden rounded-lg border border-border">
+          {panel}
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="h-[calc(100vh-14rem)] min-h-[480px]">
-      <ResourcesPanel
-        key={scope}
-        showMcpServers={false}
-        scope={scope === "org" ? "shared" : "personal"}
-      />
+    <div className="relative h-[calc(100vh-14rem)] min-h-[480px]">
+      <button
+        type="button"
+        onClick={() => setExpanded(true)}
+        aria-label="Expand files"
+        className="absolute -top-9 right-0 z-10 flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-[12px] font-medium text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+      >
+        <IconArrowsDiagonal className="size-3.5" />
+        Expand
+      </button>
+      {panel}
     </div>
   );
 }

--- a/packages/core/src/client/resources/ResourceEditor.tsx
+++ b/packages/core/src/client/resources/ResourceEditor.tsx
@@ -1,5 +1,5 @@
-import Link from "@tiptap/extension-link";
 import { IconChevronDown, IconChevronUp } from "@tabler/icons-react";
+import Link from "@tiptap/extension-link";
 import Placeholder from "@tiptap/extension-placeholder";
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";

--- a/packages/core/src/client/resources/ResourceEditor.tsx
+++ b/packages/core/src/client/resources/ResourceEditor.tsx
@@ -1319,12 +1319,10 @@ export function ResourceEditor({
   );
 }
 
-const COLLAPSED_MAX_HEIGHT = 420;
-
 /**
- * Plain-text editor that opens at a capped height and offers a "Show more"
- * toggle to reveal the full file. When expanded it grows to fit all content
- * and the surrounding container scrolls.
+ * Plain-text editor that fills the available panel height and offers a
+ * "Show more" toggle to reveal the full file. When expanded it grows to fit
+ * all content and the surrounding container scrolls.
  */
 function AutoGrowTextarea({
   content,
@@ -1342,22 +1340,26 @@ function AutoGrowTextarea({
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
-    el.style.height = "auto";
-    const full = el.scrollHeight;
-    setOverflowing(full > COLLAPSED_MAX_HEIGHT);
-    el.style.height = expanded
-      ? `${full}px`
-      : `${Math.min(full, COLLAPSED_MAX_HEIGHT)}px`;
+    if (expanded) {
+      el.style.height = "auto";
+      el.style.height = `${el.scrollHeight}px`;
+    } else {
+      el.style.height = "";
+      setOverflowing(el.scrollHeight > el.clientHeight + 1);
+    }
   }, [content, expanded]);
 
   return (
-    <div className="flex flex-col">
+    <div className={cn("flex flex-col", !expanded && "h-full")}>
       <textarea
         ref={ref}
         value={content}
         onChange={(e) => onChange(e.target.value)}
         readOnly={readOnly}
-        className="block w-full resize-none bg-transparent p-3 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50"
+        className={cn(
+          "block w-full resize-none bg-transparent p-3 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50",
+          expanded ? "shrink-0" : "min-h-0 flex-1",
+        )}
         style={{
           fontFamily:
             'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
@@ -1366,7 +1368,7 @@ function AutoGrowTextarea({
         }}
         spellCheck={false}
       />
-      {overflowing && (
+      {(overflowing || expanded) && (
         <div className="flex justify-center border-t border-border/60 py-1.5">
           <button
             type="button"

--- a/packages/core/src/client/resources/ResourceEditor.tsx
+++ b/packages/core/src/client/resources/ResourceEditor.tsx
@@ -1306,20 +1306,54 @@ export function ResourceEditor({
           readOnly={readOnly}
         />
       ) : (
-        <textarea
-          value={content}
-          onChange={(e) => handleChange(e.target.value)}
-          readOnly={readOnly}
-          className="flex-1 min-h-0 resize-none bg-transparent p-3 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50"
-          style={{
-            fontFamily:
-              'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
-            lineHeight: 1.6,
-          }}
-          spellCheck={false}
-        />
+        <div className="flex-1 min-h-0 overflow-auto">
+          <AutoGrowTextarea
+            content={content}
+            onChange={handleChange}
+            readOnly={readOnly}
+          />
+        </div>
       )}
     </div>
+  );
+}
+
+/**
+ * Plain-text editor that grows to fit its full content so the entire file is
+ * visible; the surrounding container scrolls instead of the textarea.
+ */
+function AutoGrowTextarea({
+  content,
+  onChange,
+  readOnly,
+}: {
+  content: string;
+  onChange: (value: string) => void;
+  readOnly?: boolean;
+}) {
+  const ref = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [content]);
+
+  return (
+    <textarea
+      ref={ref}
+      value={content}
+      onChange={(e) => onChange(e.target.value)}
+      readOnly={readOnly}
+      className="block w-full resize-none overflow-hidden bg-transparent p-3 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50"
+      style={{
+        fontFamily:
+          'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+        lineHeight: 1.6,
+      }}
+      spellCheck={false}
+    />
   );
 }
 

--- a/packages/core/src/client/resources/ResourceEditor.tsx
+++ b/packages/core/src/client/resources/ResourceEditor.tsx
@@ -1,4 +1,3 @@
-import { IconChevronDown, IconChevronUp } from "@tabler/icons-react";
 import Link from "@tiptap/extension-link";
 import Placeholder from "@tiptap/extension-placeholder";
 import { useEditor, EditorContent } from "@tiptap/react";
@@ -1307,87 +1306,18 @@ export function ResourceEditor({
           readOnly={readOnly}
         />
       ) : (
-        <div className="flex-1 min-h-0 overflow-auto">
-          <AutoGrowTextarea
-            content={content}
-            onChange={handleChange}
-            readOnly={readOnly}
-          />
-        </div>
-      )}
-    </div>
-  );
-}
-
-/**
- * Plain-text editor that fills the available panel height and offers a
- * "Show more" toggle to reveal the full file. When expanded it grows to fit
- * all content and the surrounding container scrolls.
- */
-function AutoGrowTextarea({
-  content,
-  onChange,
-  readOnly,
-}: {
-  content: string;
-  onChange: (value: string) => void;
-  readOnly?: boolean;
-}) {
-  const ref = useRef<HTMLTextAreaElement | null>(null);
-  const [expanded, setExpanded] = useState(false);
-  const [overflowing, setOverflowing] = useState(false);
-
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    if (expanded) {
-      el.style.height = "auto";
-      el.style.height = `${el.scrollHeight}px`;
-    } else {
-      el.style.height = "";
-      setOverflowing(el.scrollHeight > el.clientHeight + 1);
-    }
-  }, [content, expanded]);
-
-  return (
-    <div className={cn("flex flex-col", !expanded && "h-full")}>
-      <textarea
-        ref={ref}
-        value={content}
-        onChange={(e) => onChange(e.target.value)}
-        readOnly={readOnly}
-        className={cn(
-          "block w-full resize-none bg-transparent p-3 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50",
-          expanded ? "shrink-0" : "min-h-0 flex-1",
-        )}
-        style={{
-          fontFamily:
-            'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
-          lineHeight: 1.6,
-          overflowY: expanded ? "hidden" : "auto",
-        }}
-        spellCheck={false}
-      />
-      {(overflowing || expanded) && (
-        <div className="flex justify-center border-t border-border/60 py-1.5">
-          <button
-            type="button"
-            onClick={() => setExpanded((value) => !value)}
-            className="flex items-center gap-1 rounded-md px-2 py-1 text-[12px] font-medium text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-          >
-            {expanded ? (
-              <>
-                <IconChevronUp className="size-3.5" />
-                Show less
-              </>
-            ) : (
-              <>
-                <IconChevronDown className="size-3.5" />
-                Show more
-              </>
-            )}
-          </button>
-        </div>
+        <textarea
+          value={content}
+          onChange={(e) => handleChange(e.target.value)}
+          readOnly={readOnly}
+          className="flex-1 min-h-0 resize-none bg-transparent p-3 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50"
+          style={{
+            fontFamily:
+              'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+            lineHeight: 1.6,
+          }}
+          spellCheck={false}
+        />
       )}
     </div>
   );

--- a/packages/core/src/client/resources/ResourceEditor.tsx
+++ b/packages/core/src/client/resources/ResourceEditor.tsx
@@ -1,4 +1,5 @@
 import Link from "@tiptap/extension-link";
+import { IconChevronDown, IconChevronUp } from "@tabler/icons-react";
 import Placeholder from "@tiptap/extension-placeholder";
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
@@ -1318,9 +1319,12 @@ export function ResourceEditor({
   );
 }
 
+const COLLAPSED_MAX_HEIGHT = 420;
+
 /**
- * Plain-text editor that grows to fit its full content so the entire file is
- * visible; the surrounding container scrolls instead of the textarea.
+ * Plain-text editor that opens at a capped height and offers a "Show more"
+ * toggle to reveal the full file. When expanded it grows to fit all content
+ * and the surrounding container scrolls.
  */
 function AutoGrowTextarea({
   content,
@@ -1332,28 +1336,58 @@ function AutoGrowTextarea({
   readOnly?: boolean;
 }) {
   const ref = useRef<HTMLTextAreaElement | null>(null);
+  const [expanded, setExpanded] = useState(false);
+  const [overflowing, setOverflowing] = useState(false);
 
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
     el.style.height = "auto";
-    el.style.height = `${el.scrollHeight}px`;
-  }, [content]);
+    const full = el.scrollHeight;
+    setOverflowing(full > COLLAPSED_MAX_HEIGHT);
+    el.style.height = expanded
+      ? `${full}px`
+      : `${Math.min(full, COLLAPSED_MAX_HEIGHT)}px`;
+  }, [content, expanded]);
 
   return (
-    <textarea
-      ref={ref}
-      value={content}
-      onChange={(e) => onChange(e.target.value)}
-      readOnly={readOnly}
-      className="block w-full resize-none overflow-hidden bg-transparent p-3 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50"
-      style={{
-        fontFamily:
-          'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
-        lineHeight: 1.6,
-      }}
-      spellCheck={false}
-    />
+    <div className="flex flex-col">
+      <textarea
+        ref={ref}
+        value={content}
+        onChange={(e) => onChange(e.target.value)}
+        readOnly={readOnly}
+        className="block w-full resize-none bg-transparent p-3 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50"
+        style={{
+          fontFamily:
+            'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+          lineHeight: 1.6,
+          overflowY: expanded ? "hidden" : "auto",
+        }}
+        spellCheck={false}
+      />
+      {overflowing && (
+        <div className="flex justify-center border-t border-border/60 py-1.5">
+          <button
+            type="button"
+            onClick={() => setExpanded((value) => !value)}
+            className="flex items-center gap-1 rounded-md px-2 py-1 text-[12px] font-medium text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+          >
+            {expanded ? (
+              <>
+                <IconChevronUp className="size-3.5" />
+                Show less
+              </>
+            ) : (
+              <>
+                <IconChevronDown className="size-3.5" />
+                Show more
+              </>
+            )}
+          </button>
+        </div>
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
### Summary
Increases the height of the Files tab panel so more file content (e.g. CSV exports) is visible without needing excessive scrolling.

this was hard to read:
<img width="2926" height="1414" alt="image" src="https://github.com/user-attachments/assets/05bf4e47-4572-4eb0-93a6-207f4410696f" />

now:
<img width="2126" height="1560" alt="image" src="https://github.com/user-attachments/assets/4b8e4cf8-8ce9-4254-8980-3428e9cfd95c" />


### Problem
The Files tab was constrained to a small fixed minimum height (`min-h-[360px]`), making it hard to view file contents like CSV exports that can contain a lot of text/rows. Users had to scroll extensively within a small viewport to review file contents.

### Solution
Updated the container height for the Files tab to be relative to the viewport, giving it significantly more vertical space to display content.

### Key Changes
- Changed `FilesTab` container class in `AgentTabsPage.tsx` from `h-full min-h-[360px]` to `h-[calc(100vh-14rem)] min-h-[480px]`, increasing the visible area for the resources panel.

---

<a href="https://builder.io/app/projects/ae8cb7b8045d4c21b2a343e11036d454/lime-conduit-kj5dopwt"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ae8cb7b8045d4c21b2a343e11036d454-lime-conduit-kj5dopwt.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2171`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ae8cb7b8045d4c21b2a343e11036d454</projectId>-->
<!--<branchName>lime-conduit-kj5dopwt</branchName>-->