### PR TITLE
Clips: redirect denied direct links, fix playback speed reset

### DIFF
--- a/templates/clips/app/components/editor/editor-layout.tsx
+++ b/templates/clips/app/components/editor/editor-layout.tsx
@@ -415,13 +415,20 @@ export function EditorLayout({ recordingId, className }: EditorLayoutProps) {
     if (!recording?.id) return;
     const next = readPlaybackSpeedPreference(defaultPreviewSpeed);
     setPlaybackSpeed(next);
-    if (videoRef.current) videoRef.current.playbackRate = next;
+    if (videoRef.current) {
+      videoRef.current.defaultPlaybackRate = next;
+      videoRef.current.playbackRate = next;
+    }
   }, [defaultPreviewSpeed, recording?.id]);
 
   // Keep the editor preview speed visible and in sync with the media element.
+  // `defaultPlaybackRate` is set too so a `videoUrl` source swap that resets
+  // `playbackRate` (some browsers do this on load) falls back to the chosen
+  // speed instead of 1x.
   useEffect(() => {
     const v = videoRef.current;
     if (!v) return;
+    v.defaultPlaybackRate = playbackSpeed;
     v.playbackRate = playbackSpeed;
   }, [playbackSpeed, videoUrl]);
 
@@ -429,7 +436,10 @@ export function EditorLayout({ recordingId, className }: EditorLayoutProps) {
     const next = parsePlaybackSpeed(rate) ?? 1.2;
     setPlaybackSpeed(next);
     savePlaybackSpeedPreference(next);
-    if (videoRef.current) videoRef.current.playbackRate = next;
+    if (videoRef.current) {
+      videoRef.current.defaultPlaybackRate = next;
+      videoRef.current.playbackRate = next;
+    }
   }, []);
 
   // Keep the playheadMs in sync with the element's currentTime.

--- a/templates/clips/app/components/player/video-player.tsx
+++ b/templates/clips/app/components/player/video-player.tsx
@@ -679,7 +679,10 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
           (isPlaying || playAttemptPendingRef.current || !v.paused),
         );
 
-        if (v) v.playbackRate = nextSpeed;
+        if (v) {
+          v.defaultPlaybackRate = nextSpeed;
+          v.playbackRate = nextSpeed;
+        }
         setSpeed(nextSpeed);
         savePlaybackSpeedPreference(nextSpeed);
         onSpeedChange?.(nextSpeed);
@@ -778,6 +781,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       const v = videoRef.current;
       if (!v) return;
       const initialSpeed = readPlaybackSpeedPreference(defaultSpeed);
+      v.defaultPlaybackRate = initialSpeed;
       v.playbackRate = initialSpeed;
       setSpeed(initialSpeed);
       onSpeedChange?.(initialSpeed);

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -20,6 +20,7 @@ import {
   isLoomEmbedBackedRecording,
   isLoomRecordingSource,
 } from "@shared/loom";
+import { CLIP_SHARE_REF, REF_PARAM } from "@shared/share-attribution";
 import {
   IconShare3,
   IconArrowLeft,
@@ -335,6 +336,31 @@ export default function RecordingPage() {
       },
     },
   );
+
+  const playerDataAccessStatus = playerDataQ.isError
+    ? (playerDataQ.error as { status?: number } | undefined)?.status
+    : undefined;
+  // Signed-out requests never even reach `resolveAccess` — the action route's
+  // default auth gate rejects them with 401 first. Authenticated viewers with
+  // no share grant (or a deleted/mismatched id) get 403 from `resolveAccess`
+  // inside `get-recording-player-data`. Both mean "can't open the direct
+  // owner/editor route here".
+  const playerDataForbidden =
+    playerDataAccessStatus === 401 || playerDataAccessStatus === 403;
+
+  // A direct `/r/:id` visit without edit/view access (signed out, no share
+  // grant, wrong org) can't do anything useful here — send the visitor to the
+  // public share flow instead, which knows how to prompt for sign-in or a
+  // password.
+  useEffect(() => {
+    if (!recordingId || !playerDataForbidden) return;
+    navigate(
+      `/share/${encodeURIComponent(recordingId)}?${REF_PARAM}=${CLIP_SHARE_REF}`,
+      {
+        replace: true,
+      },
+    );
+  }, [recordingId, playerDataForbidden, navigate]);
 
   const recording = playerDataQ.data?.recording;
   const role = playerDataQ.data?.role as
@@ -717,7 +743,7 @@ export default function RecordingPage() {
 
   if (!recordingId) return null;
 
-  if (playerDataQ.isLoading) {
+  if (playerDataQ.isLoading || playerDataForbidden) {
     return (
       <div className="flex items-center justify-center h-screen w-full bg-background">
         <Spinner className="h-8 w-8" />


### PR DESCRIPTION

## Redirect to the share page when a direct clip link fails

Opening a direct clip link like `/r/<clipId>` used to show a plain "no access" screen if the viewer wasn't signed in or didn't have permission to see it. Now they're redirected to the public share page (`/share/<clipId>?ref=clip_share`) instead, which already knows how to prompt for sign-in or a password and gives a much better experience.

## Fix playback speed not applying

Changing the playback speed (e.g. to 1.5x) showed the right speed in the player controls, but the video kept playing at 1x. This happened because the video would silently reset its speed back to normal whenever its source refreshed in the background (for example when a new video token loaded). The player now keeps the chosen speed applied even after these background refreshes, in both the main player and the clip editor.
