### PR TITLE
fix: make dreams page responsive across all screen sizes

### DIFF
--- a/.changeset/fix-dreams-responsive-layout.md
+++ b/.changeset/fix-dreams-responsive-layout.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Make dreams page responsive across all screen sizes: stat tile labels now truncate instead of clipping, stats render as a full-width grid (2-col on mobile, 4-col on md+), action buttons wrap on their own row, and the three-panel content grid stacks on mobile, goes 2-col on lg, and 3-col on xl.

--- a/packages/dispatch/src/routes/pages/dreams.tsx
+++ b/packages/dispatch/src/routes/pages/dreams.tsx
@@ -556,16 +556,16 @@ function StatTile({
 }) {
   return (
     <div className="rounded-lg border bg-card px-3 py-2.5">
-      <div className="flex items-center justify-between gap-3">
-        <div>
-          <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
             {label}
           </div>
           <div className="mt-1 text-xl font-semibold tabular-nums text-foreground">
             {value}
           </div>
         </div>
-        <Icon size={18} className="text-muted-foreground" />
+        <Icon size={18} className="shrink-0 text-muted-foreground" />
       </div>
     </div>
   );
@@ -1425,8 +1425,8 @@ export default function DreamsRoute() {
       description="Review agent runs, propose memory improvements, and apply evidence-backed learning changes."
     >
       <div className="space-y-4">
-        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-          <div className="grid flex-1 gap-2 sm:grid-cols-2 xl:grid-cols-4">
+        <div className="flex flex-col gap-3">
+          <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
             <StatTile
               label="Dream passes"
               value={dreams.length}
@@ -1448,9 +1448,9 @@ export default function DreamsRoute() {
               icon={IconCheck}
             />
           </div>
-          <div className="flex shrink-0 flex-wrap gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             {dreamSettings ? (
-              <Badge variant="outline" className="h-9 px-3">
+              <Badge variant="outline" className="h-9 max-w-full truncate px-3">
                 {dreamSettings.enabled ? "Enabled" : "Paused"} ·{" "}
                 {dreamSettings.allSources
                   ? "All sources"
@@ -1516,7 +1516,7 @@ export default function DreamsRoute() {
           </div>
         </div>
 
-        <div className="grid gap-4 xl:grid-cols-[280px_minmax(0,1fr)_380px]">
+        <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-[280px_minmax(0,1fr)_380px]">
           <section className="rounded-lg border bg-card">
             <div className="border-b px-4 py-3">
               <div className="text-sm font-semibold text-foreground">


### PR DESCRIPTION
- Stats tile labels now truncate instead of clipping mid-word
- Icon marked shrink-0 to prevent squeezing in flex containers
- Stats always render as full-width grid (2-col mobile, 4-col md+)
- Action buttons moved to their own wrapping row below stats
- Three-panel content grid: single-col on mobile, 2-col on lg, 3-col on xl