### PR TITLE
Preserve current Content state in Slack corrections

### DIFF
--- a/.changeset/calm-slack-receipts.md
+++ b/.changeset/calm-slack-receipts.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Return a verified artifact receipt when an integration mutation succeeds without a final model summary.

--- a/packages/core/src/a2a/artifact-response.spec.ts
+++ b/packages/core/src/a2a/artifact-response.spec.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   appendA2AArtifactLinks,
   buildA2ARecoverableArtifactMessage,
+  buildA2AVerifiedMutationReceipt,
   extractA2AArtifactIdentities,
   stripA2APersistedArtifactMarkers,
 } from "./artifact-response.js";
@@ -145,6 +146,48 @@ describe("appendA2AArtifactLinks", () => {
         },
       ]),
     ).toEqual([]);
+  });
+
+  it("keeps nested mutation receipts on the target app origin", () => {
+    vi.stubEnv("A2A_SECRET", "test-a2a-secret-for-nested-mutation-receipts");
+    const downstream = appendA2AArtifactLinks(
+      "Updated the existing row.",
+      [
+        {
+          tool: "set-document-property",
+          result: JSON.stringify({ documentId: "request_123" }),
+          completedSideEffect: true,
+        },
+      ],
+      {
+        baseUrl: "https://content.agent.test",
+        includeReferencedArtifacts: true,
+        includePersistedArtifactMarker: true,
+      },
+    );
+    const callAgentResult = {
+      tool: "call-agent",
+      result: downstream,
+      completedSideEffect: true,
+    };
+
+    const receipt = buildA2AVerifiedMutationReceipt([callAgentResult], {
+      baseUrl: "https://dispatch.agent.test",
+    });
+    expect(receipt).toContain("Document ID: request_123");
+    expect(receipt).not.toContain(
+      "https://dispatch.agent.test/page/request_123",
+    );
+
+    const delivered = appendA2AArtifactLinks(receipt ?? "", [callAgentResult], {
+      baseUrl: "https://dispatch.agent.test",
+    });
+    expect(delivered).toContain(
+      "https://content.agent.test/page/request_123 (ID: request_123)",
+    );
+    expect(delivered).not.toContain(
+      "https://dispatch.agent.test/page/request_123",
+    );
   });
 
   it("excludes lookup artifacts from the stable identity ledger", () => {
@@ -323,6 +366,101 @@ describe("appendA2AArtifactLinks", () => {
     expect(text).toContain(
       '- Document "Homepage refresh": https://content.agent.test/page/request_456 (ID: request_456)',
     );
+  });
+
+  it("builds an identity-only receipt for a verified document update", () => {
+    const text = buildA2AVerifiedMutationReceipt(
+      [
+        {
+          tool: "update-document",
+          result: JSON.stringify({
+            id: "request_456",
+            title: "Historical title must not be repeated",
+            urlPath: "/page/request_456",
+          }),
+        },
+      ],
+      { baseUrl: "https://content.agent.test/" },
+    );
+
+    expect(text).toContain("A verified change was saved");
+    expect(text).toContain(
+      "- Document: https://content.agent.test/page/request_456 (ID: request_456)",
+    );
+    expect(text).not.toContain("Historical title must not be repeated");
+  });
+
+  it("does not treat read-only or failed action results as mutation receipts", () => {
+    expect(
+      buildA2AVerifiedMutationReceipt([
+        {
+          tool: "get-document",
+          result: JSON.stringify({
+            id: "request_456",
+            urlPath: "/page/request_456",
+          }),
+        },
+      ]),
+    ).toBeNull();
+    expect(
+      buildA2AVerifiedMutationReceipt([
+        {
+          tool: "update-document",
+          result: "Error: update rejected",
+        },
+      ]),
+    ).toBeNull();
+  });
+
+  it("builds a document receipt for a sparse property correction", () => {
+    const text = buildA2AVerifiedMutationReceipt(
+      [
+        {
+          tool: "set-document-property",
+          result: JSON.stringify({ documentId: "request_456" }),
+          completedSideEffect: true,
+        },
+      ],
+      { baseUrl: "https://content.agent.test/" },
+    );
+
+    expect(text).toContain(
+      "- Document: https://content.agent.test/page/request_456 (ID: request_456)",
+    );
+  });
+
+  it("rejects conflicts and explicitly incomplete write events", () => {
+    expect(
+      buildA2AVerifiedMutationReceipt([
+        {
+          tool: "update-document",
+          result: JSON.stringify({
+            conflict: true,
+            id: "request_456",
+            document: { id: "request_456" },
+          }),
+          completedSideEffect: true,
+        },
+      ]),
+    ).toBeNull();
+    expect(
+      buildA2AVerifiedMutationReceipt([
+        {
+          tool: "set-document-property",
+          result: JSON.stringify({ documentId: "request_456" }),
+          completedSideEffect: false,
+        },
+      ]),
+    ).toBeNull();
+    expect(
+      buildA2AVerifiedMutationReceipt([
+        {
+          tool: "set-document-property",
+          result: JSON.stringify({ documentId: "request_456" }),
+          isError: true,
+        },
+      ]),
+    ).toBeNull();
   });
 
   it("ignores a mismatched Content submission URL and uses the canonical page route", () => {

--- a/packages/core/src/a2a/artifact-response.ts
+++ b/packages/core/src/a2a/artifact-response.ts
@@ -548,6 +548,8 @@ function collectArtifacts(results: A2AToolResultSummary[]): {
   const forms = new Map<string, CreatedFormArtifact>();
 
   for (const toolResult of results) {
+    if (toolResult.isError === true || toolResult.completedSideEffect === false)
+      continue;
     if (toolResult.tool === "call-agent") {
       for (const artifact of parseDownstreamArtifactBlock(toolResult.result)) {
         if (artifact.kind === "deck") {

--- a/packages/core/src/a2a/artifact-response.ts
+++ b/packages/core/src/a2a/artifact-response.ts
@@ -3,6 +3,8 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 export interface A2AToolResultSummary {
   tool: string;
   result: string;
+  isError?: boolean;
+  completedSideEffect?: boolean;
 }
 
 export interface A2AArtifactResponseOptions {
@@ -34,6 +36,7 @@ const ARTIFACT_IDENTITY_WRITE_TOOLS = new Set([
   "add-database-item",
   "create-document",
   "update-document",
+  "set-document-property",
   "create-deck",
   "duplicate-deck",
   "add-slide",
@@ -632,11 +635,23 @@ function collectArtifacts(results: A2AToolResultSummary[]): {
       toolResult.tool === "create-document" ||
       toolResult.tool === "update-document"
     ) {
+      if (parsed.conflict === true) continue;
       const id = stringValue(parsed.id);
       if (id) {
         documents.set(id, {
           id,
           title: stringValue(parsed.title),
+          url: stringValue(parsed.url) ?? stringValue(parsed.urlPath),
+        });
+      }
+      continue;
+    }
+
+    if (toolResult.tool === "set-document-property") {
+      const id = stringValue(parsed.documentId);
+      if (id) {
+        documents.set(id, {
+          id,
           url: stringValue(parsed.url) ?? stringValue(parsed.urlPath),
         });
       }
@@ -872,6 +887,8 @@ export function extractA2AArtifactIdentities(
   };
 
   for (const result of results) {
+    if (result.isError === true || result.completedSideEffect === false)
+      continue;
     if (result.tool === "call-agent") {
       for (const identity of persistedArtifactIdentitiesFromMarker(
         result.result,
@@ -1537,6 +1554,71 @@ export function buildA2ARecoverableArtifactMessage(
     "The agent is still working on the full response, but these verified artifacts already exist:",
     "",
     "Artifacts:",
+    ...lines,
+  ].join("\n");
+}
+
+function mutationReceiptUrl(
+  identity: A2AArtifactIdentity,
+  baseUrl: string | undefined,
+): string | undefined {
+  if (
+    identity.sourceAction === "call-agent" &&
+    (!identity.url || identity.url.startsWith("/"))
+  ) {
+    return undefined;
+  }
+  if (identity.url) {
+    return identity.url.startsWith("/")
+      ? artifactUrl(baseUrl, identity.url)
+      : identity.url;
+  }
+
+  const path =
+    identity.resourceType === "document"
+      ? `/page/${identity.id}`
+      : identity.resourceType === "deck"
+        ? `/deck/${identity.id}`
+        : identity.resourceType === "dashboard"
+          ? `/adhoc/${identity.id}`
+          : identity.resourceType === "analysis"
+            ? `/analyses/${identity.id}`
+            : identity.resourceType === "image"
+              ? `/image/${identity.id}`
+              : identity.resourceType === "design"
+                ? `/design/${identity.id}`
+                : undefined;
+  return path ? artifactUrl(baseUrl, path) : undefined;
+}
+
+/**
+ * Build a bounded participant-facing receipt from authenticated artifact writes.
+ * Unlike generic artifact recovery, this only trusts identities extracted from
+ * successful write actions (or a signed downstream write ledger), so a read or
+ * an unverified URL cannot be rounded up to a successful mutation.
+ */
+export function buildA2AVerifiedMutationReceipt(
+  toolResults: A2AToolResultSummary[],
+  options: A2AArtifactResponseOptions = {},
+): string | null {
+  const baseUrl = normalizeBaseUrl(options.baseUrl);
+  const identities = extractA2AArtifactIdentities(toolResults);
+  if (identities.length === 0) return null;
+
+  const lines = identities.map((identity) => {
+    const label =
+      identity.resourceType.charAt(0).toUpperCase() +
+      identity.resourceType.slice(1);
+    const url = mutationReceiptUrl(identity, baseUrl);
+    return url
+      ? `- ${label}: ${url} (ID: ${identity.id})`
+      : `- ${label} ID: ${identity.id}`;
+  });
+
+  return [
+    "A verified change was saved, but I couldn't generate the detailed summary.",
+    "",
+    "Saved artifacts:",
     ...lines,
   ].join("\n");
 }

--- a/packages/core/src/agent/thread-data-builder.engine-messages.spec.ts
+++ b/packages/core/src/agent/thread-data-builder.engine-messages.spec.ts
@@ -97,6 +97,8 @@ describe("threadDataToEngineMessages", () => {
     expect(text.text).toContain("What Slack participants saw");
     expect(text.text).toContain("request_123");
     expect(text.text).toContain("IDs remain stable");
+    expect(text.text).toContain("titleAtAction are historical aliases");
+    expect(text.text).toContain("omit fields the user did not explicitly ask");
     expect(text.text).not.toContain("raw result must not be replayed");
     expect(text.text).not.toContain("Raw model response");
   });

--- a/packages/core/src/agent/thread-data-builder.ts
+++ b/packages/core/src/agent/thread-data-builder.ts
@@ -719,7 +719,7 @@ export function threadMessageTextForEngine(message: any): string {
 
   const context = [
     "<integration_artifact_context>",
-    "Trusted action history for this conversation. Resource IDs remain stable if participants rename the resource. Use these IDs when a follow-up refers to an earlier artifact, while still deciding from the request whether to update, add, supersede, or create.",
+    "Trusted action history for this conversation. Resource IDs remain stable if participants rename the resource. Fields such as titleAtAction are historical aliases from the time of that action, not current resource state. Use stable IDs to locate an earlier artifact, read its current state before changing it, and omit fields the user did not explicitly ask to change while still deciding whether to update, add, supersede, or create.",
     promptSafeJson(artifacts),
     "</integration_artifact_context>",
   ].join("\n");

--- a/packages/core/src/integrations/webhook-handler-engine.spec.ts
+++ b/packages/core/src/integrations/webhook-handler-engine.spec.ts
@@ -1619,6 +1619,45 @@ describe("integration webhook handler engine resolution", () => {
     expect(sendResponse.mock.calls[0][0].text).not.toContain("deck-guessed");
   });
 
+  it("does not append an artifact link from a failed or incomplete write", async () => {
+    const { processIntegrationTask } = await import("./webhook-handler.js");
+    const previousAppUrl = process.env.APP_URL;
+    process.env.APP_URL = "https://content.agent.test";
+    const sendResponse = vi.fn(async () => ({ status: "delivered" as const }));
+    runAgentLoopMock.mockImplementationOnce(async ({ send }) => {
+      send({
+        type: "tool_done",
+        tool: "update-document",
+        isError: true,
+        completedSideEffect: false,
+        result: JSON.stringify({
+          id: "request_failed",
+          urlPath: "/page/request_failed",
+        }),
+      });
+    });
+
+    try {
+      await processIntegrationTask(pendingTask({ id: "task-failed-write" }), {
+        adapter: createAdapter(sendResponse),
+        systemPrompt: "system",
+        actions: {},
+        model: "claude-sonnet-4-6",
+        apiKey: "",
+        ownerEmail: "dispatch+qa@integration.local",
+      });
+    } finally {
+      if (previousAppUrl === undefined) delete process.env.APP_URL;
+      else process.env.APP_URL = previousAppUrl;
+    }
+
+    const deliveredText = sendResponse.mock.calls[0][0].text;
+    expect(deliveredText).toContain(
+      "The model finished without a visible answer",
+    );
+    expect(deliveredText).not.toContain("request_failed");
+  });
+
   it("surfaces a verified mutation receipt when a sparse correction finishes without final text", async () => {
     const { processIntegrationTask } = await import("./webhook-handler.js");
     const previousAppUrl = process.env.APP_URL;

--- a/packages/core/src/integrations/webhook-handler-engine.spec.ts
+++ b/packages/core/src/integrations/webhook-handler-engine.spec.ts
@@ -1619,6 +1619,58 @@ describe("integration webhook handler engine resolution", () => {
     expect(sendResponse.mock.calls[0][0].text).not.toContain("deck-guessed");
   });
 
+  it("surfaces a verified mutation receipt when a sparse correction finishes without final text", async () => {
+    const { processIntegrationTask } = await import("./webhook-handler.js");
+    const previousAppUrl = process.env.APP_URL;
+    process.env.APP_URL = "https://content.agent.test";
+    const sendResponse = vi.fn(async () => ({ status: "delivered" as const }));
+    runAgentLoopMock.mockImplementationOnce(async ({ send }) => {
+      send({
+        type: "tool_start",
+        tool: "set-document-property",
+        input: {
+          documentId: "request_456",
+          propertyId: "priority",
+          value: "P1 High",
+        },
+      });
+      send({
+        type: "tool_done",
+        tool: "set-document-property",
+        completedSideEffect: true,
+        result: JSON.stringify({
+          documentId: "request_456",
+          properties: [{ propertyId: "priority", value: "P1 High" }],
+        }),
+      });
+    });
+
+    try {
+      await processIntegrationTask(pendingTask({ id: "task-written-empty" }), {
+        adapter: createAdapter(sendResponse),
+        systemPrompt: "system",
+        actions: {},
+        model: "claude-sonnet-4-6",
+        apiKey: "",
+        ownerEmail: "dispatch+qa@integration.local",
+      });
+    } finally {
+      if (previousAppUrl === undefined) delete process.env.APP_URL;
+      else process.env.APP_URL = previousAppUrl;
+    }
+
+    const deliveredText = sendResponse.mock.calls[0][0].text;
+    expect(deliveredText).toContain("A verified change was saved");
+    expect(deliveredText).toContain(
+      "https://content.agent.test/page/request_456",
+    );
+    expect(deliveredText).toContain("ID: request_456");
+    expect(deliveredText).not.toContain(
+      "The model finished without a visible answer",
+    );
+    expect(deliveredText).not.toContain("P1 High");
+  });
+
   it("links Slack-style replies directly to the Dispatch chat thread", async () => {
     const { processIntegrationTask } = await import("./webhook-handler.js");
     const previousAppUrl = process.env.APP_URL;

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -211,7 +211,12 @@ function collectToolResultSummaries(
   return completedRun.events
     .map((runEvent) => runEvent.event)
     .filter((event): event is ToolDoneEvent => event.type === "tool_done")
-    .map((event) => ({ tool: event.tool, result: event.result }));
+    .map((event) => ({
+      tool: event.tool,
+      result: event.result,
+      isError: event.isError,
+      completedSideEffect: event.completedSideEffect,
+    }));
 }
 
 function collectCompletedMutationToolResultSummaries(

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -2,6 +2,7 @@ import type { H3Event } from "h3";
 
 import {
   appendA2AArtifactLinks,
+  buildA2AVerifiedMutationReceipt,
   extractA2AArtifactIdentities,
   type A2AToolResultSummary,
 } from "../a2a/artifact-response.js";
@@ -83,7 +84,13 @@ const DEFERRED_RESPONSE_MAX_HANDLER_MS = 2_500;
 const EMPTY_INTEGRATION_RESPONSE_MESSAGE =
   "The model finished without a visible answer. Try again, or open the thread in Dispatch to inspect the run.";
 
-type ToolDoneEvent = { type: "tool_done"; tool: string; result: string };
+type ToolDoneEvent = {
+  type: "tool_done";
+  tool: string;
+  result: string;
+  isError?: boolean;
+  completedSideEffect?: boolean;
+};
 
 /**
  * Build a stable per-event dedup key from the incoming message. The same
@@ -204,6 +211,20 @@ function collectToolResultSummaries(
   return completedRun.events
     .map((runEvent) => runEvent.event)
     .filter((event): event is ToolDoneEvent => event.type === "tool_done")
+    .map((event) => ({ tool: event.tool, result: event.result }));
+}
+
+function collectCompletedMutationToolResultSummaries(
+  completedRun: ActiveRun,
+): A2AToolResultSummary[] {
+  return completedRun.events
+    .map((runEvent) => runEvent.event)
+    .filter(
+      (event): event is ToolDoneEvent =>
+        event.type === "tool_done" &&
+        event.completedSideEffect === true &&
+        event.isError !== true,
+    )
     .map((event) => ({ tool: event.tool, result: event.result }));
 }
 
@@ -923,6 +944,18 @@ async function processIncomingMessage(
             queuedA2AContinuation &&
             isQueuedA2AContinuationDeferral(responseText);
 
+          // Compute trusted tool receipts before choosing the empty-answer
+          // fallback. A completed write must not be reported as though nothing
+          // happened merely because the model ran out of time before its prose
+          // summary. Read-only and unverified tool results do not qualify.
+          const baseUrl = process.env.APP_URL || process.env.URL || "";
+          const appBaseUrl = baseUrl ? withConfiguredAppBasePath(baseUrl) : "";
+          const toolResults = collectToolResultSummaries(completedRun);
+          const verifiedMutationReceipt = buildA2AVerifiedMutationReceipt(
+            collectCompletedMutationToolResultSummaries(completedRun),
+            { baseUrl: appBaseUrl || undefined },
+          );
+
           // If the run errored OR produced no text, post a graceful fallback so
           // the user isn't left wondering whether the bot saw their message.
           // Common case: an A2A delegation timed out and the agent loop bailed
@@ -953,7 +986,8 @@ async function processIncomingMessage(
                 "If it was a complex analytics question, opening the analytics app " +
                 "directly is the most reliable way to get an answer right now.";
             } else {
-              responseText = EMPTY_INTEGRATION_RESPONSE_MESSAGE;
+              responseText =
+                verifiedMutationReceipt ?? EMPTY_INTEGRATION_RESPONSE_MESSAGE;
             }
           }
           if (approval?.type === "approval_required") {
@@ -965,9 +999,6 @@ async function processIncomingMessage(
           // platforms with rich blocks (Slack) can render a button instead
           // of inlining a `<url|text>` link that auto-unfurls into a giant
           // preview card.
-          const baseUrl = process.env.APP_URL || process.env.URL || "";
-          const appBaseUrl = baseUrl ? withConfiguredAppBasePath(baseUrl) : "";
-          const toolResults = collectToolResultSummaries(completedRun);
           if (!suppressPlatformReply) {
             responseText = appendA2AArtifactLinks(responseText, toolResults, {
               baseUrl: appBaseUrl || undefined,

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -13,7 +13,10 @@ import {
   type H3Event,
 } from "h3";
 
-import { buildA2ARecoverableArtifactMessage } from "../a2a/artifact-response.js";
+import {
+  buildA2ARecoverableArtifactMessage,
+  type A2AToolResultSummary,
+} from "../a2a/artifact-response.js";
 import {
   hasConfiguredA2ASecret,
   isLoopbackAddress,
@@ -1457,7 +1460,7 @@ export function createAgentChatPlugin(
           // Run the SAME agent loop, then extract the final answer from the
           // event stream so pre-tool narration never leaks as the A2A result.
           const a2aEvents: AgentChatEvent[] = [];
-          const a2aToolResults: Array<{ tool: string; result: string }> = [];
+          const a2aToolResults: A2AToolResultSummary[] = [];
           let lastRecoverableArtifactText = "";
           const controller = new AbortController();
 
@@ -1492,6 +1495,8 @@ export function createAgentChatPlugin(
                   a2aToolResults.push({
                     tool: event.tool,
                     result: event.result,
+                    isError: event.isError,
+                    completedSideEffect: event.completedSideEffect,
                   });
                   const recoverableArtifactText =
                     buildA2ARecoverableArtifactMessage(a2aToolResults, {

--- a/templates/content/.agents/skills/content/SKILL.md
+++ b/templates/content/.agents/skills/content/SKILL.md
@@ -125,9 +125,12 @@ For a correction to an existing artifact, treat Slack history as identity and
 intent context, not as the current record state. A title captured when the row
 was created is a historical title: it may help locate the stable document ID,
 but it is not authoritative after the row has been renamed in Content. Once the
-stable ID is known, read the canonical row from Content immediately before
-building the update. Content is authoritative for every field the correction
-does not explicitly change.
+stable ID is known, an external Slack or A2A correction must call
+`pull-document` first to flush any open collaborative editor state; fail closed
+if that flush/read cannot complete. Then read the canonical database row from
+Content immediately before building the update. Treat those freshly read
+values as authoritative for every field the correction does not explicitly
+change.
 
 Build corrections as sparse patches:
 
@@ -142,10 +145,12 @@ Build corrections as sparse patches:
 - Never reconstruct a full-row update from the original Slack request. Derive
   the patch from the correction message and the freshly read canonical row,
   while preserving the stable document ID.
-- After the mutation, read the row again and verify both sides of the contract:
-  requested fields changed, and omitted fields retained their pre-mutation live
-  values. If concurrent edits make that impossible, report the conflict rather
-  than silently overwriting them.
+- After the mutation, read the row again and verify that the requested fields
+  changed and the mutation did not include omitted fields. Post-write
+  verification is not compare-and-swap: it can reveal an unexpected result but
+  cannot prevent a concurrent edit between the read and a blind metadata or
+  property write. Report an action-provided conflict when one exists; otherwise
+  keep the patch minimal and do not claim the write was conflict-safe.
 
 Apply people fields from verified identity and intent, not from convenient
 guesswork:

--- a/templates/content/.agents/skills/content/SKILL.md
+++ b/templates/content/.agents/skills/content/SKILL.md
@@ -121,6 +121,32 @@ intent:
   explicitly asks for a new artifact. Do not blindly submit another row merely
   because a new Slack message arrived.
 
+For a correction to an existing artifact, treat Slack history as identity and
+intent context, not as the current record state. A title captured when the row
+was created is a historical title: it may help locate the stable document ID,
+but it is not authoritative after the row has been renamed in Content. Once the
+stable ID is known, read the canonical row from Content immediately before
+building the update. Content is authoritative for every field the correction
+does not explicitly change.
+
+Build corrections as sparse patches:
+
+- Include only fields the user explicitly asks to change. "Keep," "preserve,"
+  "leave as is," and "unchanged" are constraints, not new values; omit those
+  fields from the mutation so a newer Content-side value cannot be overwritten
+  by stale Slack context.
+- Omission and clearing are different operations. An omitted field keeps its
+  live Content value. Clear a field only when the user explicitly asks to
+  remove, unset, or clear it, and use the empty representation accepted by the
+  current database schema.
+- Never reconstruct a full-row update from the original Slack request. Derive
+  the patch from the correction message and the freshly read canonical row,
+  while preserving the stable document ID.
+- After the mutation, read the row again and verify both sides of the contract:
+  requested fields changed, and omitted fields retained their pre-mutation live
+  values. If concurrent edits make that impossible, report the conflict rather
+  than silently overwriting them.
+
 Apply people fields from verified identity and intent, not from convenient
 guesswork:
 

--- a/templates/content/changelog/2026-07-16-slack-corrections-now-preserve-newer-content-values-unless-y.md
+++ b/templates/content/changelog/2026-07-16-slack-corrections-now-preserve-newer-content-values-unless-y.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-16
+---
+
+Slack corrections now preserve newer Content values unless you explicitly change or clear them.

--- a/templates/content/parity/__tests__/content-skill-correction-semantics.test.ts
+++ b/templates/content/parity/__tests__/content-skill-correction-semantics.test.ts
@@ -41,10 +41,14 @@ describe("Content skill correction semantics", () => {
       /A title captured when the row\s+was created is a historical title/,
     );
     expect(skill).toMatch(
-      /read the canonical row from Content immediately before\s+building the update/,
+      /must call\s+`pull-document` first to flush any open collaborative editor state/,
+    );
+    expect(skill).toMatch(/fail closed\s+if that flush\/read cannot complete/);
+    expect(skill).toMatch(
+      /read the canonical database row from\s+Content immediately before building the update/,
     );
     expect(skill).toMatch(
-      /Content is authoritative for every field the correction\s+does not explicitly change/,
+      /freshly read\s+values as authoritative for every field the correction does not explicitly\s+change/,
     );
     expect(skill).toContain("Build corrections as sparse patches");
     expect(skill).toMatch(
@@ -63,10 +67,9 @@ describe("Content skill correction semantics", () => {
       /Clear a field only when the user explicitly asks to\s+remove, unset, or clear it/,
     );
     expect(skill).toMatch(
-      /requested fields changed, and omitted fields retained their pre-mutation live\s+values/,
+      /requested fields\s+changed and the mutation did not include omitted fields/,
     );
-    expect(skill).toMatch(
-      /report the conflict rather\s+than silently overwriting them/,
-    );
+    expect(skill).toMatch(/Post-write\s+verification is not compare-and-swap/);
+    expect(skill).toMatch(/do not claim the write was conflict-safe/);
   });
 });

--- a/templates/content/parity/__tests__/content-skill-correction-semantics.test.ts
+++ b/templates/content/parity/__tests__/content-skill-correction-semantics.test.ts
@@ -32,4 +32,41 @@ describe("Content skill correction semantics", () => {
       "never omit, downgrade, or silently drop the person",
     );
   });
+
+  it("uses live Content state and sparse patches for corrections", () => {
+    expect(skill).toMatch(
+      /treat Slack history as identity and\s+intent context, not as the current record state/,
+    );
+    expect(skill).toMatch(
+      /A title captured when the row\s+was created is a historical title/,
+    );
+    expect(skill).toMatch(
+      /read the canonical row from Content immediately before\s+building the update/,
+    );
+    expect(skill).toMatch(
+      /Content is authoritative for every field the correction\s+does not explicitly change/,
+    );
+    expect(skill).toContain("Build corrections as sparse patches");
+    expect(skill).toMatch(
+      /"Keep," "preserve,"\s+"leave as is," and "unchanged" are constraints, not new values/,
+    );
+    expect(skill).toMatch(/omit those\s+fields from the mutation/);
+    expect(skill).toMatch(
+      /Never reconstruct a full-row update from the original Slack request/,
+    );
+  });
+
+  it("distinguishes omitted fields from explicit clears and verifies the result", () => {
+    expect(skill).toContain("Omission and clearing are different operations");
+    expect(skill).toMatch(/An omitted field keeps its\s+live Content value/);
+    expect(skill).toMatch(
+      /Clear a field only when the user explicitly asks to\s+remove, unset, or clear it/,
+    );
+    expect(skill).toMatch(
+      /requested fields changed, and omitted fields retained their pre-mutation live\s+values/,
+    );
+    expect(skill).toMatch(
+      /report the conflict rather\s+than silently overwriting them/,
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- treat persisted artifact titles as historical aliases and make Slack corrections sparse patches against live Content state
- return an identity-only verified receipt when a mutation succeeds without a final integration summary
- reject failed, incomplete, conflicted, and read-only actions from mutation receipts

## Verification

- `vitest` focused suite: 116 tests passed
- `pnpm --filter @agent-native/core typecheck`
- `git diff --check`

## QA

Alice approved post-merge real Slack QA because this integration has no preview bot/environment. The frozen test is: rename a Slack-created record in Content, correct unrelated fields in the original Slack thread, and verify the same ID remains, the live title is preserved, no duplicate is created, and Slack posts one truthful confirmation.