### PR TITLE
Fix kit name truncation in library selector

### DIFF
--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -1011,7 +1011,7 @@ function LibraryKitSelector({
             type="button"
             className="-ml-1.5 inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-md px-1.5 py-1 text-left text-xl font-semibold leading-tight tracking-tight transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           >
-            <span className="block min-w-0 max-w-[min(48rem,calc(100vw-7rem))] truncate sm:max-w-none">
+            <span className="block min-w-0 break-words">
               {triggerLabel ?? selectedLibrary?.title ?? t("library.allAssets")}
             </span>
             <IconChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />


### PR DESCRIPTION
### Summary
Updates the library kit selector label styling so the full kit name is shown instead of being cut off.

### Problem
The kit name displayed in the `LibraryKitSelector` trigger was constrained to a fixed max width and truncated with an ellipsis, causing longer kit names to be cut off and not fully readable.

### Solution
Removed the max-width truncation constraint on the label and allowed the text to wrap instead of truncating.

### Key Changes
- In `templates/assets/app/routes/library.tsx`, replaced the `max-w-[min(48rem,calc(100vw-7rem))] truncate sm:max-w-none` classes on the kit name `span` with `break-words`, so the full label wraps and remains visible instead of being truncated.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/canvas-capsule-bu6pbdrk"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-canvas-capsule-bu6pbdrk.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2205`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>canvas-capsule-bu6pbdrk</branchName>-->