### PR TITLE
Fix camera and microphone in the desktop app

### DIFF
--- a/packages/desktop-app/electron-builder.yml
+++ b/packages/desktop-app/electron-builder.yml
@@ -34,6 +34,9 @@ mac:
   extendInfo:
     CFBundleIconName: agent-native
     NSMicrophoneUsageDescription: Agent Native uses your microphone for dictation and realtime voice conversations.
+    NSCameraUsageDescription: Agent Native uses your camera for video capture in apps like Clips.
+  entitlements: entitlements.mac.plist
+  entitlementsInherit: entitlements.mac.plist
   notarize: true
   target:
     - target: dmg

--- a/packages/desktop-app/entitlements.mac.plist
+++ b/packages/desktop-app/entitlements.mac.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
+  </dict>
+</plist>


### PR DESCRIPTION
The microphone and camera did not work in the released desktop app, even though they worked fine while developing locally. This meant screen and video recording in Clips (and other capture features) was broken for anyone using the installed app. This change fixes that.

After this change, the app can access the camera and microphone in production builds, and it shows up correctly under System Settings → Privacy → Camera and Microphone as "Agent Native".

## Changes

- Added the camera permission description to the app, so macOS allows camera access.
- Added a macOS entitlements file that grants the app microphone and camera access. This is required for signed, released builds.

## Testing

This bug only appears in signed, released builds — it cannot be reproduced while developing locally. Full testing needs the notarized release build from CI. To confirm: install the release, open Clips, and start a recording with the camera and microphone on. Both should prompt for permission and then work.
