### PR TITLE
Fix Slack reply recovery after successful mutations

### DIFF
--- a/.changeset/quiet-slack-receipts.md
+++ b/.changeset/quiet-slack-receipts.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Retry messaging replies without repeating successful agent mutations, and deliver verified A2A artifact checkpoints as soon as they are durable.

--- a/packages/core/src/a2a/artifact-response.spec.ts
+++ b/packages/core/src/a2a/artifact-response.spec.ts
@@ -148,6 +148,45 @@ describe("appendA2AArtifactLinks", () => {
     ).toEqual([]);
   });
 
+  it("signs and verifies persisted artifacts with an explicit organization secret", () => {
+    vi.stubEnv("A2A_SECRET", "");
+    const orgSecret = "org-only-a2a-secret-for-artifact-provenance";
+    const downstream = appendA2AArtifactLinks(
+      "Filed the design ask.",
+      [
+        {
+          tool: "submit-content-database-form",
+          result: JSON.stringify({
+            createdDocumentId: "request_org_123",
+            urlPath: "/page/request_org_123",
+            verification: { found: true },
+          }),
+        },
+      ],
+      {
+        includePersistedArtifactMarker: true,
+        persistedArtifactSecret: orgSecret,
+      },
+    );
+
+    expect(
+      extractA2AArtifactIdentities(
+        [{ tool: "call-agent", result: downstream }],
+        { persistedArtifactSecrets: [orgSecret] },
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        id: "request_org_123",
+        sourceAction: "call-agent",
+      }),
+    ]);
+    expect(
+      extractA2AArtifactIdentities([
+        { tool: "call-agent", result: downstream },
+      ]),
+    ).toEqual([]);
+  });
+
   it("keeps nested mutation receipts on the target app origin", () => {
     vi.stubEnv("A2A_SECRET", "test-a2a-secret-for-nested-mutation-receipts");
     const downstream = appendA2AArtifactLinks(

--- a/packages/core/src/a2a/artifact-response.spec.ts
+++ b/packages/core/src/a2a/artifact-response.spec.ts
@@ -187,6 +187,47 @@ describe("appendA2AArtifactLinks", () => {
     ).toEqual([]);
   });
 
+  it("carries organization-signed nested artifacts into the outer checkpoint", () => {
+    vi.stubEnv("A2A_SECRET", "");
+    const orgSecret = "org-only-a2a-secret-for-nested-artifact-provenance";
+    const inner = appendA2AArtifactLinks(
+      "Filed the design ask.",
+      [
+        {
+          tool: "submit-content-database-form",
+          result: JSON.stringify({
+            createdDocumentId: "request_nested_org_123",
+            urlPath: "/page/request_nested_org_123",
+            verification: { found: true },
+          }),
+        },
+      ],
+      {
+        includePersistedArtifactMarker: true,
+        persistedArtifactSecret: orgSecret,
+      },
+    );
+    const outer = appendA2AArtifactLinks(
+      "The delegated agent finished.",
+      [{ tool: "call-agent", result: inner }],
+      {
+        includePersistedArtifactMarker: true,
+        persistedArtifactSecret: orgSecret,
+      },
+    );
+
+    expect(
+      extractA2AArtifactIdentities([{ tool: "call-agent", result: outer }], {
+        persistedArtifactSecrets: [orgSecret],
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        id: "request_nested_org_123",
+        sourceAction: "call-agent",
+      }),
+    ]);
+  });
+
   it("uses the global secret when no artifact signing override is provided", () => {
     const globalSecret = "global-a2a-secret-for-artifact-provenance";
     vi.stubEnv("A2A_SECRET", globalSecret);

--- a/packages/core/src/a2a/artifact-response.spec.ts
+++ b/packages/core/src/a2a/artifact-response.spec.ts
@@ -187,6 +187,36 @@ describe("appendA2AArtifactLinks", () => {
     ).toEqual([]);
   });
 
+  it("uses the global secret when no artifact signing override is provided", () => {
+    const globalSecret = "global-a2a-secret-for-artifact-provenance";
+    vi.stubEnv("A2A_SECRET", globalSecret);
+    const downstream = appendA2AArtifactLinks(
+      "Filed the design ask.",
+      [
+        {
+          tool: "submit-content-database-form",
+          result: JSON.stringify({
+            createdDocumentId: "request_global_123",
+            urlPath: "/page/request_global_123",
+            verification: { found: true },
+          }),
+        },
+      ],
+      { includePersistedArtifactMarker: true },
+    );
+
+    expect(
+      extractA2AArtifactIdentities([
+        { tool: "call-agent", result: downstream },
+      ]),
+    ).toEqual([
+      expect.objectContaining({
+        id: "request_global_123",
+        sourceAction: "call-agent",
+      }),
+    ]);
+  });
+
   it("keeps nested mutation receipts on the target app origin", () => {
     vi.stubEnv("A2A_SECRET", "test-a2a-secret-for-nested-mutation-receipts");
     const downstream = appendA2AArtifactLinks(

--- a/packages/core/src/a2a/artifact-response.ts
+++ b/packages/core/src/a2a/artifact-response.ts
@@ -126,7 +126,13 @@ function withPersistedArtifactMarker(
   toolResults: A2AToolResultSummary[],
   secret = process.env.A2A_SECRET,
 ): string {
-  const identities = extractA2AArtifactIdentities(toolResults).slice(0, 12);
+  const verificationSecrets = [secret, process.env.A2A_SECRET].filter(
+    (value, index, values): value is string =>
+      !!value && values.indexOf(value) === index,
+  );
+  const identities = extractA2AArtifactIdentities(toolResults, {
+    persistedArtifactSecrets: verificationSecrets,
+  }).slice(0, 12);
   if (identities.length === 0 || !secret) return text;
   const payload = Buffer.from(JSON.stringify(identities)).toString("base64url");
   const signature = createHmac("sha256", secret).update(payload).digest("hex");

--- a/packages/core/src/a2a/artifact-response.ts
+++ b/packages/core/src/a2a/artifact-response.ts
@@ -11,6 +11,11 @@ export interface A2AArtifactResponseOptions {
   baseUrl?: string;
   includeReferencedArtifacts?: boolean;
   includePersistedArtifactMarker?: boolean;
+  persistedArtifactSecret?: string;
+}
+
+export interface A2AArtifactIdentityOptions {
+  persistedArtifactSecrets?: readonly string[];
 }
 
 export interface A2AArtifactIdentity {
@@ -74,21 +79,26 @@ const ARTIFACT_RESOURCE_TYPES = new Set<A2AArtifactIdentity["resourceType"]>([
 
 function persistedArtifactIdentitiesFromMarker(
   result: string,
+  secrets: readonly string[] = process.env.A2A_SECRET
+    ? [process.env.A2A_SECRET]
+    : [],
 ): A2AArtifactIdentity[] {
-  const secret = process.env.A2A_SECRET;
-  if (!secret) return [];
+  if (secrets.length === 0) return [];
   const match = result.match(
     /<!--\s*agent-native:persisted-artifacts=([A-Za-z0-9_-]+)\.([a-f0-9]{64})\s*-->/,
   );
   if (!match) return [];
   try {
     const payload = match[1];
-    const expected = createHmac("sha256", secret).update(payload).digest();
     const supplied = Buffer.from(match[2], "hex");
-    if (
-      supplied.length !== expected.length ||
-      !timingSafeEqual(supplied, expected)
-    ) {
+    const verified = secrets.some((secret) => {
+      const expected = createHmac("sha256", secret).update(payload).digest();
+      return (
+        supplied.length === expected.length &&
+        timingSafeEqual(supplied, expected)
+      );
+    });
+    if (!verified) {
       return [];
     }
     const parsed = JSON.parse(Buffer.from(payload, "base64url").toString());
@@ -114,9 +124,9 @@ function persistedArtifactIdentitiesFromMarker(
 function withPersistedArtifactMarker(
   text: string,
   toolResults: A2AToolResultSummary[],
+  secret = process.env.A2A_SECRET,
 ): string {
   const identities = extractA2AArtifactIdentities(toolResults).slice(0, 12);
-  const secret = process.env.A2A_SECRET;
   if (identities.length === 0 || !secret) return text;
   const payload = Buffer.from(JSON.stringify(identities)).toString("base64url");
   const signature = createHmac("sha256", secret).update(payload).digest("hex");
@@ -881,6 +891,7 @@ function collectArtifacts(results: A2AToolResultSummary[]): {
  */
 export function extractA2AArtifactIdentities(
   results: A2AToolResultSummary[],
+  options: A2AArtifactIdentityOptions = {},
 ): A2AArtifactIdentity[] {
   const identities = new Map<string, A2AArtifactIdentity>();
 
@@ -894,6 +905,7 @@ export function extractA2AArtifactIdentities(
     if (result.tool === "call-agent") {
       for (const identity of persistedArtifactIdentitiesFromMarker(
         result.result,
+        options.persistedArtifactSecrets,
       )) {
         remember({ ...identity, sourceAction: "call-agent" });
       }
@@ -1387,7 +1399,11 @@ export function appendA2AArtifactLinks(
     options.includeReferencedArtifacts ?? false;
   const finalize = (value: string) =>
     options.includePersistedArtifactMarker
-      ? withPersistedArtifactMarker(value, toolResults)
+      ? withPersistedArtifactMarker(
+          value,
+          toolResults,
+          options.persistedArtifactSecret,
+        )
       : value;
   const {
     documents,

--- a/packages/core/src/a2a/artifact-response.ts
+++ b/packages/core/src/a2a/artifact-response.ts
@@ -1402,7 +1402,7 @@ export function appendA2AArtifactLinks(
       ? withPersistedArtifactMarker(
           value,
           toolResults,
-          options.persistedArtifactSecret,
+          options.persistedArtifactSecret ?? process.env.A2A_SECRET,
         )
       : value;
   const {

--- a/packages/core/src/integrations/a2a-continuation-processor.spec.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.spec.ts
@@ -1244,6 +1244,65 @@ describe("A2A continuation processor", () => {
     expect(rescheduleA2AContinuationMock).not.toHaveBeenCalled();
   });
 
+  it("verifies recoverable checkpoints with an organization-only A2A secret", async () => {
+    vi.useFakeTimers();
+    delete process.env.A2A_SECRET;
+    const orgSecret = "org-only-a2a-secret-for-signed-checkpoints";
+    vi.doMock("../org/context.js", () => ({
+      getOrgDomain: vi.fn(async () => "builder.io"),
+      getOrgA2ASecret: vi.fn(async () => orgSecret),
+    }));
+    const toolResults = [
+      {
+        tool: "submit-content-database-form",
+        result: JSON.stringify({
+          createdDocumentId: "request_org_checkpoint",
+          urlPath: "/page/request_org_checkpoint",
+          verification: { found: true },
+        }),
+      },
+    ];
+    const checkpointMessage = buildA2ARecoverableArtifactMessage(toolResults);
+    const checkpoint = appendA2AArtifactLinks(checkpointMessage!, toolResults, {
+      includePersistedArtifactMarker: true,
+      persistedArtifactSecret: orgSecret,
+    });
+    getTaskMock.mockResolvedValue({
+      id: "a2a-task-1",
+      status: {
+        state: "working",
+        message: {
+          role: "agent",
+          metadata: { agentNativeRecoverableArtifacts: true },
+          parts: [{ type: "text", text: checkpoint }],
+        },
+        timestamp: new Date().toISOString(),
+      },
+    });
+    claimA2AContinuationMock.mockResolvedValueOnce(
+      continuation({ attempts: 30, orgId: "builder_io" }),
+    );
+    const sendResponse = vi.fn(async () => ({ status: "delivered" as const }));
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    const processing = processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+    await vi.advanceTimersByTimeAsync(10_000);
+    await processing;
+
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining("request_org_checkpoint"),
+      }),
+      expect.any(Object),
+      { placeholderRef: undefined },
+    );
+    expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
+    expect(rescheduleA2AContinuationMock).not.toHaveBeenCalled();
+  });
+
   it("treats aborted task polling as transient while attempts remain", async () => {
     const sendResponse = vi.fn(async () => ({ status: "delivered" as const }));
     claimA2AContinuationMock.mockResolvedValueOnce(continuation());

--- a/packages/core/src/integrations/a2a-continuation-processor.spec.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.spec.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { appendA2AArtifactLinks } from "../a2a/artifact-response.js";
+import {
+  appendA2AArtifactLinks,
+  buildA2ARecoverableArtifactMessage,
+} from "../a2a/artifact-response.js";
 import type { A2AContinuation } from "./a2a-continuations-store.js";
 import type { PlatformAdapter } from "./types.js";
 
@@ -1094,6 +1097,151 @@ describe("A2A continuation processor", () => {
       }),
     );
     expect(failA2AContinuationMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps polling past checkpoint A so a later final artifact B wins", async () => {
+    vi.useFakeTimers();
+    process.env.A2A_SECRET = "test-a2a-secret-for-signed-checkpoints";
+    const checkpointAToolResults = [
+      {
+        tool: "submit-content-database-form",
+        result: JSON.stringify({
+          createdDocumentId: "request_checkpoint_a",
+          urlPath: "/page/request_checkpoint_a",
+          verification: { found: true },
+        }),
+      },
+    ];
+    const checkpointAMessage = buildA2ARecoverableArtifactMessage(
+      checkpointAToolResults,
+    );
+    const checkpointA = appendA2AArtifactLinks(
+      checkpointAMessage!,
+      checkpointAToolResults,
+      { includePersistedArtifactMarker: true },
+    );
+    const finalBToolResults = [
+      {
+        tool: "submit-content-database-form",
+        result: JSON.stringify({
+          createdDocumentId: "request_final_b",
+          urlPath: "/page/request_final_b",
+          verification: { found: true },
+        }),
+      },
+    ];
+    const finalB = appendA2AArtifactLinks(
+      "Final artifact B",
+      finalBToolResults,
+      {
+        includePersistedArtifactMarker: true,
+      },
+    );
+    getTaskMock
+      .mockResolvedValueOnce({
+        id: "a2a-task-1",
+        status: {
+          state: "working",
+          message: {
+            role: "agent",
+            metadata: { agentNativeRecoverableArtifacts: true },
+            parts: [{ type: "text", text: checkpointA }],
+          },
+          timestamp: new Date().toISOString(),
+        },
+      })
+      .mockResolvedValueOnce({
+        id: "a2a-task-1",
+        status: {
+          state: "completed",
+          message: {
+            role: "agent",
+            parts: [{ type: "text", text: finalB }],
+          },
+          timestamp: new Date().toISOString(),
+        },
+      });
+    claimA2AContinuationMock.mockResolvedValueOnce(continuation());
+    const sendResponse = vi.fn(async () => ({ status: "delivered" as const }));
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    const processing = processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+    await vi.advanceTimersByTimeAsync(2_000);
+    await processing;
+
+    expect(getTaskMock).toHaveBeenCalledTimes(2);
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining("request_final_b"),
+      }),
+      expect.any(Object),
+      { placeholderRef: undefined },
+    );
+    expect(sendResponse.mock.calls[0][0].text).not.toContain(
+      "request_checkpoint_a",
+    );
+    expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
+    expect(rescheduleA2AContinuationMock).not.toHaveBeenCalled();
+  });
+
+  it("delivers the latest signed checkpoint only when remote polling is exhausted", async () => {
+    vi.useFakeTimers();
+    process.env.A2A_SECRET = "test-a2a-secret-for-signed-checkpoints";
+    const toolResults = [
+      {
+        tool: "submit-content-database-form",
+        result: JSON.stringify({
+          createdDocumentId: "request_checkpoint_retry",
+          urlPath: "/page/request_checkpoint_retry",
+          verification: { found: true },
+        }),
+      },
+    ];
+    const checkpointMessage = buildA2ARecoverableArtifactMessage(toolResults);
+    const checkpoint = appendA2AArtifactLinks(checkpointMessage!, toolResults, {
+      includePersistedArtifactMarker: true,
+    });
+    getTaskMock.mockResolvedValue({
+      id: "a2a-task-1",
+      status: {
+        state: "working",
+        message: {
+          role: "agent",
+          metadata: { agentNativeRecoverableArtifacts: true },
+          parts: [{ type: "text", text: checkpoint! }],
+        },
+        timestamp: new Date().toISOString(),
+      },
+    });
+    claimA2AContinuationMock.mockResolvedValueOnce(
+      continuation({ attempts: 30 }),
+    );
+    const sendResponse = vi.fn(async () => ({ status: "delivered" as const }));
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    const processing = processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+    await vi.advanceTimersByTimeAsync(10_000);
+    await processing;
+
+    expect(sendResponse).toHaveBeenCalledOnce();
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining("request_checkpoint_retry"),
+      }),
+      expect.any(Object),
+      { placeholderRef: undefined },
+    );
+    expect(sendResponse.mock.calls[0][0].text).toContain(
+      "did not finish its full response",
+    );
+    expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
+    expect(rescheduleA2AContinuationMock).not.toHaveBeenCalled();
   });
 
   it("treats aborted task polling as transient while attempts remain", async () => {

--- a/packages/core/src/integrations/a2a-continuation-processor.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.ts
@@ -171,6 +171,8 @@ async function processClaimedContinuation(
     ...(auth.apiKeyFallbacks ? { fallbackApiKeys: auth.apiKeyFallbacks } : {}),
   });
   const deadline = Date.now() + PROCESSOR_WAIT_MS;
+  const recoverableArtifactSecrets =
+    await resolveContinuationArtifactSecrets(continuation);
   let task: Task | null = null;
   let latestRecoverableArtifactText: string | null = null;
 
@@ -180,6 +182,7 @@ async function processClaimedContinuation(
       const recoverableArtifactText = extractVerifiedRecoverableArtifactText(
         task,
         continuation.agentUrl,
+        recoverableArtifactSecrets,
       );
       if (recoverableArtifactText) {
         latestRecoverableArtifactText = recoverableArtifactText;
@@ -428,6 +431,8 @@ async function deliverAndCompleteA2AContinuation(
       `${deliveryContinuation.platform} response delivery timed out`,
     );
     let persistenceError: unknown;
+    const artifactSecrets =
+      await resolveContinuationArtifactSecrets(deliveryContinuation);
     for (let attempt = 0; attempt < 3; attempt += 1) {
       try {
         await persistA2AContinuationDelivery(
@@ -435,6 +440,7 @@ async function deliverAndCompleteA2AContinuation(
           outgoing,
           deliveryReceipt,
           text,
+          artifactSecrets,
         );
         persistenceError = undefined;
         break;
@@ -509,6 +515,7 @@ async function persistA2AContinuationDelivery(
   outgoing: OutgoingMessage,
   receipt: PlatformDeliveryReceipt,
   artifactText: string,
+  artifactSecrets: readonly string[],
 ): Promise<void> {
   const mapping = await getThreadMapping(
     continuation.platform,
@@ -526,9 +533,12 @@ async function persistA2AContinuationDelivery(
   }
   if (!Array.isArray(repo.messages)) repo.messages = [];
 
-  const artifacts = extractA2AArtifactIdentities([
-    { tool: "call-agent", result: artifactText },
-  ]);
+  const artifacts = extractA2AArtifactIdentities(
+    [{ tool: "call-agent", result: artifactText }],
+    {
+      persistedArtifactSecrets: artifactSecrets,
+    },
+  );
   const metadata: Record<string, unknown> = {
     integrationDeliveryAttempted: true,
     integrationDelivery: {
@@ -772,6 +782,24 @@ async function signFreshContinuationTokens(
   return tokens;
 }
 
+async function resolveContinuationArtifactSecrets(
+  continuation: A2AContinuation,
+): Promise<string[]> {
+  const secrets: string[] = [];
+  const add = (secret: string | null | undefined) => {
+    const value = secret?.trim();
+    if (value && !secrets.includes(value)) secrets.push(value);
+  };
+  add(process.env.A2A_SECRET);
+  if (continuation.orgId) {
+    try {
+      const { getOrgA2ASecret } = await import("../org/context.js");
+      add(await getOrgA2ASecret(continuation.orgId));
+    } catch {}
+  }
+  return secrets;
+}
+
 function isLikelyJwt(token: string): boolean {
   return token.split(".").length === 3;
 }
@@ -789,6 +817,7 @@ function extractTaskText(task: Task): string {
 function extractVerifiedRecoverableArtifactText(
   task: Task,
   agentUrl: string,
+  artifactSecrets: readonly string[],
 ): string | null {
   if (task.status.message?.metadata?.agentNativeRecoverableArtifacts !== true) {
     return null;
@@ -799,9 +828,12 @@ function extractVerifiedRecoverableArtifactText(
 
   // Require the signed identity ledger so arbitrary peer progress prose cannot
   // prematurely complete the continuation.
-  const artifacts = extractA2AArtifactIdentities([
-    { tool: "call-agent", result: text },
-  ]);
+  const artifacts = extractA2AArtifactIdentities(
+    [{ tool: "call-agent", result: text }],
+    {
+      persistedArtifactSecrets: artifactSecrets,
+    },
+  );
   return artifacts.length > 0 ? text : null;
 }
 

--- a/packages/core/src/integrations/a2a-continuation-processor.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.ts
@@ -172,10 +172,18 @@ async function processClaimedContinuation(
   });
   const deadline = Date.now() + PROCESSOR_WAIT_MS;
   let task: Task | null = null;
+  let latestRecoverableArtifactText: string | null = null;
 
   try {
     while (Date.now() < deadline) {
       task = await client.getTask(continuation.a2aTaskId);
+      const recoverableArtifactText = extractVerifiedRecoverableArtifactText(
+        task,
+        continuation.agentUrl,
+      );
+      if (recoverableArtifactText) {
+        latestRecoverableArtifactText = recoverableArtifactText;
+      }
       if (TERMINAL_STATES.has(task.status.state)) break;
       await reportA2AContinuationProgress(continuation, progress, task);
       await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
@@ -183,6 +191,17 @@ async function processClaimedContinuation(
   } catch (err) {
     if (isTransientA2APollError(err)) {
       if (shouldStopPollingRemoteTask(continuation)) {
+        if (latestRecoverableArtifactText) {
+          await deliverAndCompleteA2AContinuation(
+            continuation,
+            adapter,
+            formatRecoverableArtifactFallbackText(
+              latestRecoverableArtifactText,
+            ),
+            progress,
+          );
+          return;
+        }
         await notifyAndFailA2AContinuation(
           continuation,
           adapter,
@@ -209,6 +228,15 @@ async function processClaimedContinuation(
 
   if (!task || !TERMINAL_STATES.has(task.status.state)) {
     if (shouldStopPollingRemoteTask(continuation)) {
+      if (latestRecoverableArtifactText) {
+        await deliverAndCompleteA2AContinuation(
+          continuation,
+          adapter,
+          formatRecoverableArtifactFallbackText(latestRecoverableArtifactText),
+          progress,
+        );
+        return;
+      }
       await notifyAndFailA2AContinuation(
         continuation,
         adapter,
@@ -222,6 +250,15 @@ async function processClaimedContinuation(
   }
 
   if (task.status.state !== "completed") {
+    if (latestRecoverableArtifactText) {
+      await deliverAndCompleteA2AContinuation(
+        continuation,
+        adapter,
+        formatRecoverableArtifactFallbackText(latestRecoverableArtifactText),
+        progress,
+      );
+      return;
+    }
     const reason =
       extractTaskText(task) ||
       `Remote A2A task ${continuation.a2aTaskId} ended with state ${task.status.state}`;
@@ -234,6 +271,15 @@ async function processClaimedContinuation(
     continuation.agentUrl,
   );
   if (!text.trim()) {
+    if (latestRecoverableArtifactText) {
+      await deliverAndCompleteA2AContinuation(
+        continuation,
+        adapter,
+        formatRecoverableArtifactFallbackText(latestRecoverableArtifactText),
+        progress,
+      );
+      return;
+    }
     await notifyAndFailA2AContinuation(
       continuation,
       adapter,
@@ -738,6 +784,32 @@ function extractTaskText(task: Task): string {
     })
     .map((part) => part.text)
     .join("\n");
+}
+
+function extractVerifiedRecoverableArtifactText(
+  task: Task,
+  agentUrl: string,
+): string | null {
+  if (task.status.message?.metadata?.agentNativeRecoverableArtifacts !== true) {
+    return null;
+  }
+
+  const text = formatContinuationArtifactText(extractTaskText(task), agentUrl);
+  if (!text.trim()) return null;
+
+  // Require the signed identity ledger so arbitrary peer progress prose cannot
+  // prematurely complete the continuation.
+  const artifacts = extractA2AArtifactIdentities([
+    { tool: "call-agent", result: text },
+  ]);
+  return artifacts.length > 0 ? text : null;
+}
+
+function formatRecoverableArtifactFallbackText(text: string): string {
+  return text.replace(
+    "The agent is still working on the full response, but these verified artifacts already exist:",
+    "The downstream agent did not finish its full response, but these verified artifacts already exist:",
+  );
 }
 
 function formatContinuationArtifactText(

--- a/packages/core/src/integrations/pending-tasks-store.spec.ts
+++ b/packages/core/src/integrations/pending-tasks-store.spec.ts
@@ -62,6 +62,12 @@ describe("integration pending task store", () => {
         sql: expect.stringContaining("WHERE id = ? AND status = 'pending'"),
       }),
     );
+    expect((updateCall?.[0] as { sql: string }).sql).toContain(
+      "earlier.status = 'pending'",
+    );
+    expect((updateCall?.[0] as { sql: string }).sql).toContain(
+      "earlier.created_at < integration_pending_tasks.created_at",
+    );
   });
 
   it("does not claim terminal failed tasks", async () => {
@@ -320,5 +326,14 @@ describe("integration pending task store", () => {
       "{}",
       "slack-task",
     ]);
+  });
+
+  it("fails loud when the terminal delivery transition loses its race", async () => {
+    executeMock.mockResolvedValue({ rows: [], rowsAffected: 0 });
+    const { failTaskDeliveryTransition } = await loadStore();
+
+    await expect(
+      failTaskDeliveryTransition("raced-task", "atomic transition failed"),
+    ).rejects.toThrow("lost its race");
   });
 });

--- a/packages/core/src/integrations/pending-tasks-store.spec.ts
+++ b/packages/core/src/integrations/pending-tasks-store.spec.ts
@@ -312,6 +312,7 @@ describe("integration pending task store", () => {
           typeof query !== "string" && query.sql.includes("payload = ?"),
       );
     expect(update?.sql).toContain("WHERE id = ? AND status = 'processing'");
+    expect(update?.sql).not.toContain("external_event_key = NULL");
     expect(update?.args).toEqual([
       "failed",
       expect.any(Number),

--- a/packages/core/src/integrations/pending-tasks-store.spec.ts
+++ b/packages/core/src/integrations/pending-tasks-store.spec.ts
@@ -235,4 +235,89 @@ describe("integration pending task store", () => {
       "discord-task-retry",
     ]);
   });
+
+  it("atomically replaces a claimed task with a delivery-only payload", async () => {
+    executeMock.mockResolvedValue({ rows: [], rowsAffected: 1 });
+    const { stageTaskDeliveryPayload } = await loadStore();
+    const payload = JSON.stringify({
+      kind: "response-delivery",
+      message: { text: "Done", platformContext: {} },
+    });
+
+    await stageTaskDeliveryPayload("slack-task", payload);
+
+    const update = executeMock.mock.calls
+      .map(([query]) => query)
+      .find(
+        (query): query is { sql: string; args: unknown[] } =>
+          typeof query !== "string" &&
+          query.sql.includes("SET payload = ?, updated_at = ?"),
+      );
+    expect(update?.sql).toContain("WHERE id = ? AND status = 'processing'");
+    expect(update?.args).toEqual([payload, expect.any(Number), "slack-task"]);
+  });
+
+  it("fails closed when a delivery payload loses the processing-task race", async () => {
+    executeMock.mockResolvedValue({ rows: [], rowsAffected: 0 });
+    const { stageTaskDeliveryPayload } = await loadStore();
+
+    await expect(
+      stageTaskDeliveryPayload("raced-task", '{"kind":"response-delivery"}'),
+    ).rejects.toThrow("no longer claimable");
+  });
+
+  it("atomically requeues the enriched delivery payload", async () => {
+    executeMock.mockResolvedValue({ rows: [], rowsAffected: 1 });
+    const { markTaskDeliveryRetryable } = await loadStore();
+    const payload = JSON.stringify({
+      kind: "response-delivery",
+      deliveryReceipt: { status: "delivered" },
+      userMessageId: "user-1",
+      assistantMessageId: "assistant-1",
+    });
+
+    await markTaskDeliveryRetryable(
+      "slack-task",
+      payload,
+      "history checkpoint failed",
+    );
+
+    const update = executeMock.mock.calls
+      .map(([query]) => query)
+      .find(
+        (query): query is { sql: string; args: unknown[] } =>
+          typeof query !== "string" &&
+          query.sql.includes("SET status = ?, payload = ?"),
+      );
+    expect(update?.sql).toContain("WHERE id = ? AND status = 'processing'");
+    expect(update?.args).toEqual([
+      "pending",
+      payload,
+      expect.any(Number),
+      "history checkpoint failed",
+      "slack-task",
+    ]);
+  });
+
+  it("fails a broken delivery transition without overwriting another state", async () => {
+    executeMock.mockResolvedValue({ rows: [], rowsAffected: 1 });
+    const { failTaskDeliveryTransition } = await loadStore();
+
+    await failTaskDeliveryTransition("slack-task", "atomic transition failed");
+
+    const update = executeMock.mock.calls
+      .map(([query]) => query)
+      .find(
+        (query): query is { sql: string; args: unknown[] } =>
+          typeof query !== "string" && query.sql.includes("payload = ?"),
+      );
+    expect(update?.sql).toContain("WHERE id = ? AND status = 'processing'");
+    expect(update?.args).toEqual([
+      "failed",
+      expect.any(Number),
+      "atomic transition failed",
+      "{}",
+      "slack-task",
+    ]);
+  });
 });

--- a/packages/core/src/integrations/pending-tasks-store.spec.ts
+++ b/packages/core/src/integrations/pending-tasks-store.spec.ts
@@ -103,6 +103,25 @@ describe("integration pending task store", () => {
     await expect(claimPendingTask("task-failed")).resolves.toBeNull();
   });
 
+  it("dispatches same-millisecond thread tasks by stable id order", async () => {
+    executeMock.mockResolvedValue({ rows: [{ id: "task-a" }] });
+    const { getNextPendingTaskIdForThread } = await loadStore();
+
+    await expect(
+      getNextPendingTaskIdForThread("slack", "thread-1"),
+    ).resolves.toBe("task-a");
+
+    const select = executeMock.mock.calls
+      .map(([query]) => query)
+      .find(
+        (query): query is { sql: string; args: unknown[] } =>
+          typeof query !== "string" &&
+          query.sql.includes("SELECT id FROM integration_pending_tasks"),
+      );
+    expect(select?.sql).toContain("ORDER BY created_at ASC, id ASC");
+    expect(select?.args).toEqual(["slack", "thread-1"]);
+  });
+
   it("returns null when a SQLite claim loses the conditional update race", async () => {
     const { claimPendingTask } = await loadStore();
     executeMock.mockImplementation(async (query: string | { sql: string }) => {

--- a/packages/core/src/integrations/pending-tasks-store.ts
+++ b/packages/core/src/integrations/pending-tasks-store.ts
@@ -272,6 +272,19 @@ export async function claimPendingTask(
                AND active.status = 'processing'
                AND active.id <> integration_pending_tasks.id
            )
+           AND NOT EXISTS (
+             SELECT 1 FROM integration_pending_tasks earlier
+             WHERE earlier.platform = integration_pending_tasks.platform
+               AND earlier.external_thread_id = integration_pending_tasks.external_thread_id
+               AND earlier.status = 'pending'
+               AND (
+                 earlier.created_at < integration_pending_tasks.created_at
+                 OR (
+                   earlier.created_at = integration_pending_tasks.created_at
+                   AND earlier.id < integration_pending_tasks.id
+                 )
+               )
+           )
          RETURNING id, platform, external_thread_id, payload, owner_email, org_id, status, attempts, error_message, created_at, updated_at, completed_at`
       : `UPDATE integration_pending_tasks
          SET status = ?, attempts = attempts + 1, updated_at = ?
@@ -282,6 +295,19 @@ export async function claimPendingTask(
                AND active.external_thread_id = integration_pending_tasks.external_thread_id
                AND active.status = 'processing'
                AND active.id <> integration_pending_tasks.id
+           )
+           AND NOT EXISTS (
+             SELECT 1 FROM integration_pending_tasks earlier
+             WHERE earlier.platform = integration_pending_tasks.platform
+               AND earlier.external_thread_id = integration_pending_tasks.external_thread_id
+               AND earlier.status = 'pending'
+               AND (
+                 earlier.created_at < integration_pending_tasks.created_at
+                 OR (
+                   earlier.created_at = integration_pending_tasks.created_at
+                   AND earlier.id < integration_pending_tasks.id
+                 )
+               )
            )`,
     args: ["processing", now, id],
   });
@@ -407,12 +433,22 @@ export async function failTaskDeliveryTransition(
   errorMessage: string,
 ): Promise<void> {
   await ensureTable();
-  await getDbExec().execute({
+  const result = await getDbExec().execute({
     sql: `UPDATE integration_pending_tasks
           SET status = ?, updated_at = ?, error_message = ?, payload = ?
           WHERE id = ? AND status = 'processing'`,
     args: ["failed", Date.now(), errorMessage.slice(0, 2000), "{}", id],
   });
+  const affected = Number(
+    (result as { rowsAffected?: number }).rowsAffected ??
+      (result as { rowCount?: number }).rowCount ??
+      0,
+  );
+  if (affected === 0) {
+    throw new Error(
+      "Integration task delivery failure transition lost its race",
+    );
+  }
 }
 
 /** Mark a task as failed and stash an error message. */

--- a/packages/core/src/integrations/pending-tasks-store.ts
+++ b/packages/core/src/integrations/pending-tasks-store.ts
@@ -354,6 +354,67 @@ export async function markTaskRetryable(
   });
 }
 
+export async function stageTaskDeliveryPayload(
+  id: string,
+  payload: string,
+): Promise<void> {
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+  const result = await client.execute({
+    sql: `UPDATE integration_pending_tasks
+          SET payload = ?, updated_at = ?
+          WHERE id = ? AND status = 'processing'`,
+    args: [payload, now, id],
+  });
+  const affected = Number(
+    (result as { rowsAffected?: number }).rowsAffected ??
+      (result as { rowCount?: number }).rowCount ??
+      0,
+  );
+  if (affected === 0) {
+    throw new Error("Integration task is no longer claimable for delivery");
+  }
+}
+
+export async function markTaskDeliveryRetryable(
+  id: string,
+  payload: string,
+  errorMessage: string,
+): Promise<void> {
+  await ensureTable();
+  const client = getDbExec();
+  const result = await client.execute({
+    sql: `UPDATE integration_pending_tasks
+          SET status = ?, payload = ?, updated_at = ?, error_message = ?
+          WHERE id = ? AND status = 'processing'`,
+    args: ["pending", payload, Date.now(), errorMessage.slice(0, 2000), id],
+  });
+  const affected = Number(
+    (result as { rowsAffected?: number }).rowsAffected ??
+      (result as { rowCount?: number }).rowCount ??
+      0,
+  );
+  if (affected === 0) {
+    throw new Error(
+      "Integration task is no longer claimable for delivery retry",
+    );
+  }
+}
+
+export async function failTaskDeliveryTransition(
+  id: string,
+  errorMessage: string,
+): Promise<void> {
+  await ensureTable();
+  await getDbExec().execute({
+    sql: `UPDATE integration_pending_tasks
+          SET status = ?, updated_at = ?, error_message = ?, payload = ?, external_event_key = NULL
+          WHERE id = ? AND status = 'processing'`,
+    args: ["failed", Date.now(), errorMessage.slice(0, 2000), "{}", id],
+  });
+}
+
 /** Mark a task as failed and stash an error message. */
 export async function markTaskFailed(
   id: string,

--- a/packages/core/src/integrations/pending-tasks-store.ts
+++ b/packages/core/src/integrations/pending-tasks-store.ts
@@ -409,7 +409,7 @@ export async function failTaskDeliveryTransition(
   await ensureTable();
   await getDbExec().execute({
     sql: `UPDATE integration_pending_tasks
-          SET status = ?, updated_at = ?, error_message = ?, payload = ?, external_event_key = NULL
+          SET status = ?, updated_at = ?, error_message = ?, payload = ?
           WHERE id = ? AND status = 'processing'`,
     args: ["failed", Date.now(), errorMessage.slice(0, 2000), "{}", id],
   });

--- a/packages/core/src/integrations/pending-tasks-store.ts
+++ b/packages/core/src/integrations/pending-tasks-store.ts
@@ -338,7 +338,7 @@ export async function getNextPendingTaskIdForThread(
   const { rows } = await getDbExec().execute({
     sql: `SELECT id FROM integration_pending_tasks
       WHERE platform = ? AND external_thread_id = ? AND status = 'pending'
-      ORDER BY created_at ASC LIMIT 1`,
+      ORDER BY created_at ASC, id ASC LIMIT 1`,
     args: [platform, externalThreadId],
   });
   return rows[0]?.id ? String(rows[0].id) : null;

--- a/packages/core/src/integrations/plugin.spec.ts
+++ b/packages/core/src/integrations/plugin.spec.ts
@@ -20,6 +20,7 @@ const getIntegrationConfigMock = vi.hoisted(() =>
 );
 const saveIntegrationConfigMock = vi.hoisted(() => vi.fn());
 const processIntegrationTaskMock = vi.hoisted(() => vi.fn());
+const recordIntegrationResponseDeliveryMock = vi.hoisted(() => vi.fn());
 const handleWebhookMock = vi.hoisted(() =>
   vi.fn(async () => ({ status: 200, body: "ok" })),
 );
@@ -110,6 +111,7 @@ vi.mock("./webhook-handler.js", async () => {
     ...actual,
     handleWebhook: handleWebhookMock,
     processIntegrationTask: processIntegrationTaskMock,
+    recordIntegrationResponseDelivery: recordIntegrationResponseDeliveryMock,
   };
 });
 
@@ -787,6 +789,48 @@ describe("integrations plugin routes", () => {
     expect(sendResponse).not.toHaveBeenCalled();
     expect(processIntegrationTaskMock).not.toHaveBeenCalled();
     expect(markTaskCompletedMock).toHaveBeenCalledWith(task.id);
+  });
+
+  it("keeps a confirmed delivery receipt retryable after history retries exhaust", async () => {
+    process.env.NODE_ENV = "development";
+    const sendResponse = vi.fn();
+    const deliveryAdapter: PlatformAdapter = { ...adapter, sendResponse };
+    const task = claimedTask(3);
+    const incoming = JSON.parse(task.payload).incoming;
+    const deliveryPayload = {
+      kind: "response-delivery" as const,
+      incoming,
+      message: { text: "Updated /page/request_123", platformContext: {} },
+      deliveryReceipt: {
+        status: "delivered" as const,
+        messageRefs: ["reply-already-sent"],
+      },
+      deliveredAt: "2026-07-17T15:00:00.000Z",
+    };
+    task.payload = JSON.stringify(deliveryPayload);
+    claimPendingTaskMock.mockResolvedValueOnce(task);
+    recordIntegrationResponseDeliveryMock.mockRejectedValueOnce(
+      new Error("history database unavailable"),
+    );
+    const nitroApp = createNitroApp();
+    await createIntegrationsPlugin({ adapters: [deliveryAdapter] })(nitroApp);
+
+    const result = await dispatch(
+      nitroApp,
+      "/_agent-native/integrations/process-task",
+      "POST",
+      { taskId: task.id },
+    );
+
+    expect(result.status).toBe(202);
+    expect(sendResponse).not.toHaveBeenCalled();
+    expect(markTaskDeliveryRetryableMock).toHaveBeenCalledWith(
+      task.id,
+      JSON.stringify(deliveryPayload),
+      expect.stringContaining("history database unavailable"),
+    );
+    expect(markTaskFailedMock).not.toHaveBeenCalled();
+    expect(markTaskCompletedMock).not.toHaveBeenCalled();
   });
 
   it("delivers persisted system notices from the fresh task processor", async () => {

--- a/packages/core/src/integrations/plugin.spec.ts
+++ b/packages/core/src/integrations/plugin.spec.ts
@@ -833,6 +833,34 @@ describe("integrations plugin routes", () => {
     expect(markTaskCompletedMock).not.toHaveBeenCalled();
   });
 
+  it("contains a failed confirmed-delivery requeue transition", async () => {
+    process.env.NODE_ENV = "development";
+    const task = claimedTask(3);
+    const incoming = JSON.parse(task.payload).incoming;
+    task.payload = JSON.stringify({
+      kind: "response-delivery",
+      incoming,
+      message: { text: "Updated /page/request_123", platformContext: {} },
+      deliveryReceipt: { status: "delivered", messageRefs: ["reply-sent"] },
+    });
+    claimPendingTaskMock.mockResolvedValueOnce(task);
+    recordIntegrationResponseDeliveryMock.mockRejectedValueOnce(
+      new Error("history database unavailable"),
+    );
+    markTaskDeliveryRetryableMock.mockRejectedValueOnce(
+      new Error("retry transition unavailable"),
+    );
+    const nitroApp = createNitroApp();
+    await createIntegrationsPlugin({ adapters: [adapter] })(nitroApp);
+
+    await expect(
+      dispatch(nitroApp, "/_agent-native/integrations/process-task", "POST", {
+        taskId: task.id,
+      }),
+    ).resolves.toMatchObject({ status: 500 });
+    expect(markTaskFailedMock).not.toHaveBeenCalled();
+  });
+
   it("delivers persisted system notices from the fresh task processor", async () => {
     process.env.NODE_ENV = "development";
     const sendSystemNotice = vi.fn(async () => {});

--- a/packages/core/src/integrations/plugin.spec.ts
+++ b/packages/core/src/integrations/plugin.spec.ts
@@ -28,9 +28,12 @@ const resourceListMock = vi.hoisted(() => vi.fn(async () => []));
 const resourceListAccessibleMock = vi.hoisted(() => vi.fn(async () => []));
 const resourceGetMock = vi.hoisted(() => vi.fn(async () => null));
 const claimPendingTaskMock = vi.hoisted(() => vi.fn());
+const failTaskDeliveryTransitionMock = vi.hoisted(() => vi.fn());
 const markTaskCompletedMock = vi.hoisted(() => vi.fn());
 const markTaskFailedMock = vi.hoisted(() => vi.fn());
 const markTaskRetryableMock = vi.hoisted(() => vi.fn());
+const markTaskDeliveryRetryableMock = vi.hoisted(() => vi.fn());
+const stageTaskDeliveryPayloadMock = vi.hoisted(() => vi.fn());
 const insertPendingTaskMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../deploy/route-discovery.js", () => ({
@@ -87,6 +90,7 @@ vi.mock("../resources/store.js", () => ({
 vi.mock("./pending-tasks-store.js", () => ({
   MAX_PENDING_TASK_ATTEMPTS: 3,
   claimPendingTask: claimPendingTaskMock,
+  failTaskDeliveryTransition: failTaskDeliveryTransitionMock,
   getPendingTask: vi.fn(),
   getNextPendingTaskIdForThread: vi.fn(async () => null),
   insertPendingTask: insertPendingTaskMock,
@@ -94,6 +98,8 @@ vi.mock("./pending-tasks-store.js", () => ({
   markTaskCompleted: markTaskCompletedMock,
   markTaskFailed: markTaskFailedMock,
   markTaskRetryable: markTaskRetryableMock,
+  markTaskDeliveryRetryable: markTaskDeliveryRetryableMock,
+  stageTaskDeliveryPayload: stageTaskDeliveryPayloadMock,
 }));
 
 vi.mock("./webhook-handler.js", async () => {
@@ -545,6 +551,242 @@ describe("integrations plugin routes", () => {
       },
       expect.any(Function),
     );
+  });
+
+  it("checkpoints a failed reply for delivery-only retry without rerunning the agent", async () => {
+    process.env.NODE_ENV = "development";
+    const task = claimedTask(1);
+    const deliveryPayload = {
+      kind: "response-delivery" as const,
+      incoming: JSON.parse(task.payload).incoming,
+      message: { text: "Updated /page/request_123", platformContext: {} },
+    };
+    claimPendingTaskMock.mockResolvedValueOnce(task);
+    processIntegrationTaskMock.mockResolvedValueOnce({
+      status: "delivery-pending",
+      payload: deliveryPayload,
+      errorMessage: "Slack response delivery failed",
+    });
+    const nitroApp = createNitroApp();
+    await createIntegrationsPlugin({ adapters: [adapter] })(nitroApp);
+
+    const result = await dispatch(
+      nitroApp,
+      "/_agent-native/integrations/process-task",
+      "POST",
+      { taskId: task.id },
+    );
+
+    expect(result.status).toBe(202);
+    expect(markTaskDeliveryRetryableMock).toHaveBeenCalledWith(
+      task.id,
+      JSON.stringify(deliveryPayload),
+      "Slack response delivery failed",
+    );
+    expect(stageTaskDeliveryPayloadMock).not.toHaveBeenCalled();
+    expect(markTaskRetryableMock).not.toHaveBeenCalled();
+    expect(markTaskCompletedMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed instead of requeuing stale payload when the atomic delivery transition fails", async () => {
+    process.env.NODE_ENV = "development";
+    const task = claimedTask(1);
+    const deliveryPayload = {
+      kind: "response-delivery" as const,
+      incoming: JSON.parse(task.payload).incoming,
+      message: { text: "Updated /page/request_123", platformContext: {} },
+      deliveryReceipt: { status: "delivered" as const },
+      userMessageId: "user-1",
+      assistantMessageId: "assistant-1",
+    };
+    claimPendingTaskMock.mockResolvedValueOnce(task);
+    processIntegrationTaskMock.mockResolvedValueOnce({
+      status: "delivery-pending",
+      payload: deliveryPayload,
+      errorMessage: "history checkpoint failed",
+    });
+    markTaskDeliveryRetryableMock.mockRejectedValueOnce(
+      new Error("database transition failed"),
+    );
+    const nitroApp = createNitroApp();
+    await createIntegrationsPlugin({ adapters: [adapter] })(nitroApp);
+
+    const result = await dispatch(
+      nitroApp,
+      "/_agent-native/integrations/process-task",
+      "POST",
+      { taskId: task.id },
+    );
+
+    expect(result.status).toBe(500);
+    expect(failTaskDeliveryTransitionMock).toHaveBeenCalledWith(
+      task.id,
+      expect.stringContaining("database transition failed"),
+    );
+    expect(markTaskRetryableMock).not.toHaveBeenCalled();
+    expect(markTaskCompletedMock).not.toHaveBeenCalled();
+  });
+
+  it("delivers a response checkpoint without rerunning the mutation", async () => {
+    process.env.NODE_ENV = "development";
+    const sendResponse = vi.fn(async () => ({
+      status: "delivered" as const,
+      messageRefs: ["reply-1"],
+    }));
+    const deliveryAdapter: PlatformAdapter = { ...adapter, sendResponse };
+    const task = claimedTask(2);
+    const incoming = JSON.parse(task.payload).incoming;
+    task.payload = JSON.stringify({
+      kind: "response-delivery",
+      incoming,
+      message: { text: "Updated /page/request_123", platformContext: {} },
+    });
+    claimPendingTaskMock.mockResolvedValueOnce(task);
+    const nitroApp = createNitroApp();
+    await createIntegrationsPlugin({ adapters: [deliveryAdapter] })(nitroApp);
+
+    const result = await dispatch(
+      nitroApp,
+      "/_agent-native/integrations/process-task",
+      "POST",
+      { taskId: task.id },
+    );
+
+    expect(result.status).toBe(200);
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Updated /page/request_123" }),
+      expect.objectContaining({ externalThreadId: "fake-thread" }),
+      {},
+    );
+    expect(processIntegrationTaskMock).not.toHaveBeenCalled();
+    expect(markTaskCompletedMock).toHaveBeenCalledWith(task.id);
+  });
+
+  it("atomically preserves a provider receipt when delivery checkpointing fails", async () => {
+    process.env.NODE_ENV = "development";
+    const sendResponse = vi.fn(async () => ({
+      status: "delivered" as const,
+      messageRefs: ["reply-sent-once"],
+    }));
+    const deliveryAdapter: PlatformAdapter = { ...adapter, sendResponse };
+    const task = claimedTask(1);
+    const incoming = JSON.parse(task.payload).incoming;
+    task.payload = JSON.stringify({
+      kind: "response-delivery",
+      incoming,
+      message: { text: "Updated /page/request_123", platformContext: {} },
+    });
+    claimPendingTaskMock.mockResolvedValueOnce(task);
+    stageTaskDeliveryPayloadMock.mockRejectedValueOnce(
+      new Error("receipt checkpoint unavailable"),
+    );
+    const nitroApp = createNitroApp();
+    await createIntegrationsPlugin({ adapters: [deliveryAdapter] })(nitroApp);
+
+    const firstResult = await dispatch(
+      nitroApp,
+      "/_agent-native/integrations/process-task",
+      "POST",
+      { taskId: task.id },
+    );
+
+    expect(firstResult.status).toBe(202);
+    expect(sendResponse).toHaveBeenCalledOnce();
+    const retryPayload = markTaskDeliveryRetryableMock.mock.calls.at(-1)?.[1];
+    expect(typeof retryPayload).toBe("string");
+    if (typeof retryPayload !== "string") {
+      throw new Error("Expected an enriched delivery retry payload");
+    }
+    expect(JSON.parse(retryPayload)).toMatchObject({
+      kind: "response-delivery",
+      deliveryReceipt: {
+        status: "delivered",
+        messageRefs: ["reply-sent-once"],
+      },
+    });
+    expect(markTaskRetryableMock).not.toHaveBeenCalled();
+    expect(markTaskCompletedMock).not.toHaveBeenCalled();
+
+    claimPendingTaskMock.mockResolvedValueOnce({
+      ...task,
+      attempts: 2,
+      payload: retryPayload,
+    });
+    const secondResult = await dispatch(
+      nitroApp,
+      "/_agent-native/integrations/process-task",
+      "POST",
+      { taskId: task.id },
+    );
+
+    expect(secondResult.status).toBe(200);
+    expect(sendResponse).toHaveBeenCalledOnce();
+    expect(processIntegrationTaskMock).not.toHaveBeenCalled();
+    expect(markTaskCompletedMock).toHaveBeenCalledWith(task.id);
+  });
+
+  it("keeps an unconfirmed response checkpoint retryable", async () => {
+    process.env.NODE_ENV = "development";
+    const sendResponse = vi.fn(async () => undefined);
+    const deliveryAdapter: PlatformAdapter = { ...adapter, sendResponse };
+    const task = claimedTask(2);
+    const incoming = JSON.parse(task.payload).incoming;
+    task.payload = JSON.stringify({
+      kind: "response-delivery",
+      incoming,
+      message: { text: "Updated /page/request_123", platformContext: {} },
+    });
+    claimPendingTaskMock.mockResolvedValueOnce(task);
+    const nitroApp = createNitroApp();
+    await createIntegrationsPlugin({ adapters: [deliveryAdapter] })(nitroApp);
+
+    const result = await dispatch(
+      nitroApp,
+      "/_agent-native/integrations/process-task",
+      "POST",
+      { taskId: task.id },
+    );
+
+    expect(result.status).toBe(500);
+    expect(processIntegrationTaskMock).not.toHaveBeenCalled();
+    expect(markTaskRetryableMock).toHaveBeenCalledWith(
+      task.id,
+      "fake response completed without delivery proof",
+    );
+    expect(markTaskCompletedMock).not.toHaveBeenCalled();
+  });
+
+  it("finishes a provider-confirmed checkpoint without posting it twice", async () => {
+    process.env.NODE_ENV = "development";
+    const sendResponse = vi.fn();
+    const deliveryAdapter: PlatformAdapter = { ...adapter, sendResponse };
+    const task = claimedTask(2);
+    const incoming = JSON.parse(task.payload).incoming;
+    task.payload = JSON.stringify({
+      kind: "response-delivery",
+      incoming,
+      message: { text: "Updated /page/request_123", platformContext: {} },
+      deliveryReceipt: {
+        status: "delivered",
+        messageRefs: ["reply-already-sent"],
+      },
+      deliveredAt: "2026-07-17T15:00:00.000Z",
+    });
+    claimPendingTaskMock.mockResolvedValueOnce(task);
+    const nitroApp = createNitroApp();
+    await createIntegrationsPlugin({ adapters: [deliveryAdapter] })(nitroApp);
+
+    const result = await dispatch(
+      nitroApp,
+      "/_agent-native/integrations/process-task",
+      "POST",
+      { taskId: task.id },
+    );
+
+    expect(result.status).toBe(200);
+    expect(sendResponse).not.toHaveBeenCalled();
+    expect(processIntegrationTaskMock).not.toHaveBeenCalled();
+    expect(markTaskCompletedMock).toHaveBeenCalledWith(task.id);
   });
 
   it("delivers persisted system notices from the fresh task processor", async () => {

--- a/packages/core/src/integrations/plugin.ts
+++ b/packages/core/src/integrations/plugin.ts
@@ -1628,6 +1628,7 @@ export function createIntegrationsPlugin(
         let deliveryRetryRecovery:
           | { payload: string; errorMessage: string }
           | undefined;
+        let confirmedDeliveryRetryPayload: string | undefined;
         try {
           const adapter = adapterMap.get(task.platform);
           if (!adapter) {
@@ -1697,9 +1698,11 @@ export function createIntegrationsPlugin(
                       deliveryReceipt: receipt,
                       deliveredAt: new Date().toISOString(),
                     };
+                confirmedDeliveryRetryPayload =
+                  JSON.stringify(deliveredPayload);
                 if (!taskPayload.deliveryReceipt) {
                   deliveryRetryRecovery = {
-                    payload: JSON.stringify(deliveredPayload),
+                    payload: confirmedDeliveryRetryPayload,
                     errorMessage:
                       "Provider delivery was confirmed but its receipt checkpoint failed",
                   };
@@ -1802,6 +1805,15 @@ export function createIntegrationsPlugin(
                 `Could not safely checkpoint the delivery receipt: ${transitionMessage}`,
               );
             }
+          } else if (confirmedDeliveryRetryPayload) {
+            await markTaskDeliveryRetryable(
+              taskId,
+              confirmedDeliveryRetryPayload,
+              `Provider delivery was confirmed but history persistence failed: ${errorMessage}`,
+            );
+            console.error("[integrations] process-task failure:", err);
+            setResponseStatus(event, 202);
+            return { ok: true, taskId, retrying: "response-delivery" };
           } else if (deliveryRetryTransitionStarted) {
             await failTaskDeliveryTransition(
               taskId,

--- a/packages/core/src/integrations/plugin.ts
+++ b/packages/core/src/integrations/plugin.ts
@@ -1803,22 +1803,39 @@ export function createIntegrationsPlugin(
               await failTaskDeliveryTransition(
                 taskId,
                 `Could not safely checkpoint the delivery receipt: ${transitionMessage}`,
-              );
+              ).catch((failureTransitionError) => {
+                console.error(
+                  "[integrations] Failed to contain delivery receipt transition failure:",
+                  failureTransitionError,
+                );
+              });
             }
           } else if (confirmedDeliveryRetryPayload) {
-            await markTaskDeliveryRetryable(
-              taskId,
-              confirmedDeliveryRetryPayload,
-              `Provider delivery was confirmed but history persistence failed: ${errorMessage}`,
-            );
-            console.error("[integrations] process-task failure:", err);
-            setResponseStatus(event, 202);
-            return { ok: true, taskId, retrying: "response-delivery" };
+            try {
+              await markTaskDeliveryRetryable(
+                taskId,
+                confirmedDeliveryRetryPayload,
+                `Provider delivery was confirmed but history persistence failed: ${errorMessage}`,
+              );
+              console.error("[integrations] process-task failure:", err);
+              setResponseStatus(event, 202);
+              return { ok: true, taskId, retrying: "response-delivery" };
+            } catch (transitionError) {
+              console.error(
+                "[integrations] Failed to requeue confirmed delivery history:",
+                transitionError,
+              );
+            }
           } else if (deliveryRetryTransitionStarted) {
             await failTaskDeliveryTransition(
               taskId,
               `Could not safely checkpoint the delivery retry: ${errorMessage}`,
-            );
+            ).catch((transitionError) => {
+              console.error(
+                "[integrations] Failed to contain delivery retry transition failure:",
+                transitionError,
+              );
+            });
           } else if (task.attempts >= MAX_PENDING_TASK_ATTEMPTS) {
             await markTaskFailed(taskId, errorMessage);
           } else {

--- a/packages/core/src/integrations/plugin.ts
+++ b/packages/core/src/integrations/plugin.ts
@@ -78,13 +78,16 @@ import {
 import { startPendingTasksRetryJob } from "./pending-tasks-retry-job.js";
 import {
   claimPendingTask,
+  failTaskDeliveryTransition,
   getNextPendingTaskIdForThread,
   insertPendingTask,
   isDuplicateEventError,
   MAX_PENDING_TASK_ATTEMPTS,
   markTaskCompleted,
+  markTaskDeliveryRetryable,
   markTaskFailed,
   markTaskRetryable,
+  stageTaskDeliveryPayload,
 } from "./pending-tasks-store.js";
 import {
   claimNextComputerCommand,
@@ -142,12 +145,18 @@ import type {
   IntegrationStatus,
   IntegrationExecutionContext,
   IncomingMessage,
+  PlatformDeliveryReceipt,
 } from "./types.js";
 import {
   listIntegrationUsageBudgets,
   saveIntegrationUsageBudget,
 } from "./usage-budget-store.js";
-import { handleWebhook, processIntegrationTask } from "./webhook-handler.js";
+import {
+  handleWebhook,
+  processIntegrationTask,
+  recordIntegrationResponseDelivery,
+  type IntegrationResponseDeliveryTaskPayload,
+} from "./webhook-handler.js";
 
 type NitroPluginDef = (nitroApp: any) => void | Promise<void>;
 
@@ -1615,6 +1624,10 @@ export function createIntegrationsPlugin(
           return { ok: true, skipped: "already-claimed-or-missing" };
         }
 
+        let deliveryRetryTransitionStarted = false;
+        let deliveryRetryRecovery:
+          | { payload: string; errorMessage: string }
+          | undefined;
         try {
           const adapter = adapterMap.get(task.platform);
           if (!adapter) {
@@ -1622,7 +1635,7 @@ export function createIntegrationsPlugin(
             setResponseStatus(event, 404);
             return { error: "Unknown platform" };
           }
-          await runWithRequestContext(
+          const processingResult = await runWithRequestContext(
             {
               userEmail: task.ownerEmail,
               ...(task.orgId ? { orgId: task.orgId } : {}),
@@ -1631,6 +1644,7 @@ export function createIntegrationsPlugin(
             async () => {
               const taskPayload = JSON.parse(task.payload) as
                 | IntegrationSystemNoticeTaskPayload
+                | IntegrationResponseDeliveryTaskPayload
                 | { kind?: undefined };
               if (taskPayload.kind === "system-notice") {
                 if (!adapter.sendSystemNotice) {
@@ -1657,13 +1671,57 @@ export function createIntegrationsPlugin(
                 );
                 return;
               }
+              if (taskPayload.kind === "response-delivery") {
+                let receipt: void | PlatformDeliveryReceipt =
+                  taskPayload.deliveryReceipt;
+                if (!receipt) {
+                  receipt = await adapter.sendResponse(
+                    taskPayload.message,
+                    taskPayload.incoming,
+                    {
+                      ...(taskPayload.placeholderRef
+                        ? { placeholderRef: taskPayload.placeholderRef }
+                        : {}),
+                    },
+                  );
+                }
+                if (receipt?.status !== "delivered") {
+                  throw new Error(
+                    `${task.platform} response completed without delivery proof`,
+                  );
+                }
+                const deliveredPayload = taskPayload.deliveryReceipt
+                  ? taskPayload
+                  : {
+                      ...taskPayload,
+                      deliveryReceipt: receipt,
+                      deliveredAt: new Date().toISOString(),
+                    };
+                if (!taskPayload.deliveryReceipt) {
+                  deliveryRetryRecovery = {
+                    payload: JSON.stringify(deliveredPayload),
+                    errorMessage:
+                      "Provider delivery was confirmed but its receipt checkpoint failed",
+                  };
+                  await stageTaskDeliveryPayload(
+                    task.id,
+                    deliveryRetryRecovery.payload,
+                  );
+                  deliveryRetryRecovery = undefined;
+                }
+                await recordIntegrationResponseDelivery(
+                  deliveredPayload,
+                  receipt,
+                );
+                return;
+              }
               const resources = await loadResourcesForPrompt(
                 task.ownerEmail,
                 true,
                 options?.appId,
                 task.orgId,
               );
-              await processIntegrationTask(task, {
+              const result = await processIntegrationTask(task, {
                 adapter,
                 systemPrompt: baseSystemPrompt + resources,
                 actions,
@@ -1674,8 +1732,22 @@ export function createIntegrationsPlugin(
                 ownerEmail: task.ownerEmail,
                 appId: options?.appId,
               });
+              if (result?.status === "delivery-pending") {
+                deliveryRetryTransitionStarted = true;
+                await markTaskDeliveryRetryable(
+                  task.id,
+                  JSON.stringify(result.payload),
+                  result.errorMessage,
+                );
+                return "delivery-retry" as const;
+              }
+              return "completed" as const;
             },
           );
+          if (processingResult === "delivery-retry") {
+            setResponseStatus(event, 202);
+            return { ok: true, taskId, retrying: "response-delivery" };
+          }
           await markTaskCompleted(taskId);
           const nextTaskId = await getNextPendingTaskIdForThread(
             task.platform,
@@ -1711,7 +1783,31 @@ export function createIntegrationsPlugin(
           const errorMessage = err?.message
             ? String(err.message).slice(0, 1000)
             : "processor failed";
-          if (task.attempts >= MAX_PENDING_TASK_ATTEMPTS) {
+          if (deliveryRetryRecovery) {
+            try {
+              await markTaskDeliveryRetryable(
+                taskId,
+                deliveryRetryRecovery.payload,
+                `${deliveryRetryRecovery.errorMessage}: ${errorMessage}`,
+              );
+              setResponseStatus(event, 202);
+              return { ok: true, taskId, retrying: "response-delivery" };
+            } catch (transitionError) {
+              const transitionMessage =
+                transitionError instanceof Error
+                  ? transitionError.message
+                  : String(transitionError);
+              await failTaskDeliveryTransition(
+                taskId,
+                `Could not safely checkpoint the delivery receipt: ${transitionMessage}`,
+              );
+            }
+          } else if (deliveryRetryTransitionStarted) {
+            await failTaskDeliveryTransition(
+              taskId,
+              `Could not safely checkpoint the delivery retry: ${errorMessage}`,
+            );
+          } else if (task.attempts >= MAX_PENDING_TASK_ATTEMPTS) {
             await markTaskFailed(taskId, errorMessage);
           } else {
             await markTaskRetryable(taskId, errorMessage);

--- a/packages/core/src/integrations/webhook-handler-engine.spec.ts
+++ b/packages/core/src/integrations/webhook-handler-engine.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { appendA2AArtifactLinks } from "../a2a/artifact-response.js";
 import type { PendingTask } from "./pending-tasks-store.js";
 import type { PlatformAdapter } from "./types.js";
 
@@ -9,6 +10,7 @@ const createThreadMock = vi.hoisted(() => vi.fn());
 const getThreadMock = vi.hoisted(() => vi.fn());
 const updateThreadDataMock = vi.hoisted(() => vi.fn());
 const resolveOrgIdForEmailMock = vi.hoisted(() => vi.fn());
+const getOrgA2ASecretMock = vi.hoisted(() => vi.fn());
 const getOwnerActiveApiKeyMock = vi.hoisted(() => vi.fn());
 const getOwnerApiKeyMock = vi.hoisted(() => vi.fn());
 const runAgentLoopMock = vi.hoisted(() => vi.fn());
@@ -51,6 +53,7 @@ vi.mock("../chat-threads/store.js", () => ({
 }));
 
 vi.mock("../org/context.js", () => ({
+  getOrgA2ASecret: getOrgA2ASecretMock,
   resolveOrgIdForEmail: resolveOrgIdForEmailMock,
 }));
 
@@ -242,6 +245,7 @@ describe("integration webhook handler engine resolution", () => {
     getThreadMock.mockResolvedValue({ threadData: "{}" });
     updateThreadDataMock.mockResolvedValue(undefined);
     resolveOrgIdForEmailMock.mockResolvedValue("org-qa");
+    getOrgA2ASecretMock.mockResolvedValue(null);
     getOwnerActiveApiKeyMock.mockResolvedValue(undefined);
     getOwnerApiKeyMock.mockResolvedValue(undefined);
     isLocalDatabaseMock.mockReturnValue(true);
@@ -588,6 +592,67 @@ describe("integration webhook handler engine resolution", () => {
       );
     },
   );
+
+  it("retains organization-signed artifact identity in delivery and thread checkpoints", async () => {
+    const { processIntegrationTask } = await import("./webhook-handler.js");
+    const orgSecret = "org-only-a2a-secret-for-webhook-artifacts";
+    vi.stubEnv("A2A_SECRET", "");
+    getOrgA2ASecretMock.mockResolvedValue(orgSecret);
+    const downstream = appendA2AArtifactLinks(
+      "Filed the design ask.",
+      [
+        {
+          tool: "submit-content-database-form",
+          result: JSON.stringify({
+            createdDocumentId: "request_org_123",
+            urlPath: "/page/request_org_123",
+            verification: { found: true },
+          }),
+        },
+      ],
+      {
+        includePersistedArtifactMarker: true,
+        persistedArtifactSecret: orgSecret,
+      },
+    );
+    runAgentLoopMock.mockImplementationOnce(async ({ send }) => {
+      send({ type: "tool_start", id: "delegate", tool: "call-agent" });
+      send({
+        type: "tool_done",
+        id: "delegate",
+        tool: "call-agent",
+        result: downstream,
+      });
+      send({ type: "text", text: "The Content agent filed the ask." });
+    });
+
+    await processIntegrationTask(pendingTask(), {
+      adapter: createAdapter(
+        vi.fn(async () => ({ status: "delivered" as const })),
+      ),
+      systemPrompt: "system",
+      actions: {},
+      apiKey: "test-key",
+      ownerEmail: "dispatch+qa@integration.local",
+      orgId: "org-qa",
+      principalType: "service",
+    });
+
+    const staged = JSON.parse(stageTaskDeliveryPayloadMock.mock.calls[0][1]);
+    expect(staged.artifacts).toEqual([
+      expect.objectContaining({
+        id: "request_org_123",
+        sourceAction: "call-agent",
+      }),
+    ]);
+    const persisted = JSON.parse(updateThreadDataMock.mock.calls.at(-1)?.[1]);
+    expect(persisted.messages.at(-1).metadata.integrationArtifacts).toEqual([
+      expect.objectContaining({
+        id: "request_org_123",
+        sourceAction: "call-agent",
+      }),
+    ]);
+  });
 
   it(
     "preserves a successful mutation and returns a delivery-only checkpoint when receipt proof is missing",

--- a/packages/core/src/integrations/webhook-handler-engine.spec.ts
+++ b/packages/core/src/integrations/webhook-handler-engine.spec.ts
@@ -26,12 +26,23 @@ const settleIntegrationUsageBudgetMock = vi.hoisted(() => vi.fn());
 const setIntegrationAwaitingInputMock = vi.hoisted(() => vi.fn());
 const clearIntegrationAwaitingInputMock = vi.hoisted(() => vi.fn());
 const startRunMock = vi.hoisted(() => vi.fn());
+const stageTaskDeliveryPayloadMock = vi.hoisted(() => vi.fn());
 const originalNodeEnv = process.env.NODE_ENV;
 
 vi.mock("./thread-mapping-store.js", () => ({
   getThreadMapping: getThreadMappingMock,
   saveThreadMapping: saveThreadMappingMock,
 }));
+
+vi.mock("./pending-tasks-store.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("./pending-tasks-store.js")
+  >("./pending-tasks-store.js");
+  return {
+    ...actual,
+    stageTaskDeliveryPayload: stageTaskDeliveryPayloadMock,
+  };
+});
 
 vi.mock("../chat-threads/store.js", () => ({
   createThread: createThreadMock,
@@ -579,7 +590,7 @@ describe("integration webhook handler engine resolution", () => {
   );
 
   it(
-    "does not persist participant-visible history without a delivery receipt",
+    "preserves a successful mutation and returns a delivery-only checkpoint when receipt proof is missing",
     { timeout: 15_000 },
     async () => {
       const { processIntegrationTask } = await import("./webhook-handler.js");
@@ -596,9 +607,10 @@ describe("integration webhook handler engine resolution", () => {
         });
         send({ type: "text", text: "Created, but delivery failed." });
       });
+      const sendResponse = vi.fn(async () => undefined);
 
-      await processIntegrationTask(pendingTask(), {
-        adapter: createAdapter(vi.fn(async () => undefined)),
+      const result = await processIntegrationTask(pendingTask(), {
+        adapter: createAdapter(sendResponse),
         systemPrompt: "system",
         actions: {},
         apiKey: "test-key",
@@ -607,9 +619,176 @@ describe("integration webhook handler engine resolution", () => {
         principalType: "service",
       });
 
+      expect(result).toMatchObject({
+        status: "delivery-pending",
+        payload: {
+          kind: "response-delivery",
+          incoming: { externalThreadId: "thread-qa" },
+          message: { text: expect.stringContaining("delivery failed") },
+          internalThreadId: "thread-qa",
+          assistantMessageId: expect.any(String),
+        },
+      });
+      expect(stageTaskDeliveryPayloadMock).toHaveBeenCalledWith(
+        "task-qa",
+        expect.stringContaining('"kind":"response-delivery"'),
+      );
+      expect(
+        stageTaskDeliveryPayloadMock.mock.invocationCallOrder[0],
+      ).toBeLessThan(sendResponse.mock.invocationCallOrder[0]);
+      expect(updateThreadDataMock).toHaveBeenCalledOnce();
+      const persisted = JSON.parse(updateThreadDataMock.mock.calls[0][1]);
+      const assistant = persisted.messages.at(-1);
+      expect(assistant.metadata.integrationDeliveryAttempted).toBe(true);
+      expect(assistant.metadata.integrationDelivery).toBeUndefined();
+      expect(assistant.metadata.integrationArtifacts).toEqual([
+        expect.objectContaining({
+          id: "hidden_request",
+          url: "/page/hidden_request",
+        }),
+      ]);
+    },
+  );
+
+  it(
+    "retries history only when receipt checkpointing fails after provider delivery",
+    { timeout: 15_000 },
+    async () => {
+      const { processIntegrationTask } = await import("./webhook-handler.js");
+      runAgentLoopMock.mockImplementationOnce(async ({ send }) => {
+        send({ type: "text", text: "Updated /page/request_123" });
+      });
+      const sendResponse = vi.fn(async () => ({
+        status: "delivered" as const,
+        messageRefs: ["provider-reply-1"],
+      }));
+      stageTaskDeliveryPayloadMock
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error("checkpoint database unavailable"));
+
+      const result = await processIntegrationTask(pendingTask(), {
+        adapter: createAdapter(sendResponse),
+        systemPrompt: "system",
+        actions: {},
+        apiKey: "test-key",
+        ownerEmail: "dispatch+qa@integration.local",
+        orgId: "org-qa",
+        principalType: "service",
+      });
+
+      expect(result).toMatchObject({
+        status: "delivery-pending",
+        payload: {
+          kind: "response-delivery",
+          deliveryReceipt: {
+            status: "delivered",
+            messageRefs: ["provider-reply-1"],
+          },
+        },
+        errorMessage: "checkpoint database unavailable",
+      });
+      expect(sendResponse).toHaveBeenCalledOnce();
       expect(updateThreadDataMock).not.toHaveBeenCalled();
     },
   );
+
+  it("records a confirmed delivery retry as participant-visible context", async () => {
+    const { recordIntegrationResponseDelivery } =
+      await import("./webhook-handler.js");
+    getThreadMock.mockResolvedValueOnce({
+      title: "Slack thread",
+      preview: "",
+      threadData: JSON.stringify({
+        messages: [
+          {
+            id: "assistant-checkpoint",
+            role: "assistant",
+            content: [{ type: "text", text: "Updated /page/request_123" }],
+            metadata: { integrationDeliveryAttempted: true },
+          },
+        ],
+      }),
+    });
+
+    await recordIntegrationResponseDelivery(
+      {
+        kind: "response-delivery",
+        incoming: {
+          platform: "slack",
+          externalThreadId: "slack-thread",
+          text: "Update it",
+          platformContext: {},
+          timestamp: 1001,
+        },
+        message: {
+          text: "Updated /page/request_123",
+          platformContext: {},
+        },
+        internalThreadId: "thread-qa",
+        assistantMessageId: "assistant-checkpoint",
+        deliveredAt: "2026-07-17T15:00:00.000Z",
+      },
+      { status: "delivered", messageRefs: ["slack-reply-1"] },
+    );
+
+    const persisted = JSON.parse(updateThreadDataMock.mock.calls.at(-1)?.[1]);
+    expect(persisted.messages[0].metadata.integrationDelivery).toEqual({
+      platform: "slack",
+      status: "delivered",
+      text: "Updated /page/request_123",
+      deliveredAt: "2026-07-17T15:00:00.000Z",
+      messageRefs: ["slack-reply-1"],
+    });
+  });
+
+  it("reconstructs delivered conversation context after a pre-send crash", async () => {
+    const { recordIntegrationResponseDelivery } =
+      await import("./webhook-handler.js");
+    getThreadMock.mockResolvedValueOnce({
+      title: "Slack thread",
+      preview: "",
+      threadData: "{}",
+    });
+
+    await recordIntegrationResponseDelivery(
+      {
+        kind: "response-delivery",
+        incoming: {
+          platform: "slack",
+          externalThreadId: "slack-thread",
+          text: "Update the same Design Ask",
+          platformContext: {},
+          timestamp: 1001,
+        },
+        message: {
+          text: "Updated /page/request_123",
+          platformContext: {},
+        },
+        internalThreadId: "thread-qa",
+        artifacts: [
+          {
+            resourceType: "document",
+            id: "request_123",
+            sourceAction: "set-document-property",
+            url: "/page/request_123",
+          },
+        ],
+      },
+      { status: "delivered", messageRefs: ["slack-reply-2"] },
+    );
+
+    const persisted = JSON.parse(updateThreadDataMock.mock.calls.at(-1)?.[1]);
+    expect(persisted.messages.map((message: any) => message.role)).toEqual([
+      "user",
+      "assistant",
+    ]);
+    expect(persisted.messages[1].metadata.integrationArtifacts[0].id).toBe(
+      "request_123",
+    );
+    expect(persisted.messages[1].metadata.integrationDelivery.status).toBe(
+      "delivered",
+    );
+  });
 
   it(
     "uses the explicit engine provider when resolving owner API keys",
@@ -1438,6 +1617,61 @@ describe("integration webhook handler engine resolution", () => {
         ([event]) => event.type === "agent_call_progress",
       ),
     ).toBe(false);
+  });
+
+  it("preserves a queued parent reply receipt when checkpointing fails", async () => {
+    const { processIntegrationTask } = await import("./webhook-handler.js");
+    const { A2A_CONTINUATION_QUEUED_MARKER } =
+      await import("./a2a-continuation-marker.js");
+    const sendResponse = vi.fn(async () => ({
+      status: "delivered" as const,
+      messageRefs: ["queued-parent-reply"],
+    }));
+    const fail = vi.fn(async () => undefined);
+    const adapter = {
+      ...createAdapter(sendResponse),
+      startRunProgress: async () => ({
+        ref: { kind: "slack-stream", streamTs: "1719000000.000003" },
+        onEvent: vi.fn(async () => undefined),
+        complete: vi.fn(async () => undefined),
+        fail,
+      }),
+    };
+    stageTaskDeliveryPayloadMock
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("checkpoint database unavailable"));
+    runAgentLoopMock.mockImplementationOnce(async ({ send }) => {
+      send({
+        type: "tool_done",
+        tool: "call-agent",
+        result: `${A2A_CONTINUATION_QUEUED_MARKER}\nThe Analytics agent is still working.`,
+      });
+      send({ type: "text", text: "371 pageview events were recorded." });
+    });
+
+    const result = await processIntegrationTask(
+      pendingTask({ id: "task-queued-parent-checkpoint-failure" }),
+      {
+        adapter,
+        systemPrompt: "system",
+        actions: {},
+        model: "claude-sonnet-4-6",
+        apiKey: "",
+        ownerEmail: "dispatch+qa@integration.local",
+      },
+    );
+
+    expect(result).toMatchObject({
+      status: "delivery-pending",
+      payload: {
+        deliveryReceipt: {
+          status: "delivered",
+          messageRefs: ["queued-parent-reply"],
+        },
+      },
+    });
+    expect(sendResponse).toHaveBeenCalledOnce();
+    expect(fail).not.toHaveBeenCalled();
   });
 
   it("sends substantive partial answers without closing a queued continuation stream", async () => {

--- a/packages/core/src/integrations/webhook-handler-engine.spec.ts
+++ b/packages/core/src/integrations/webhook-handler-engine.spec.ts
@@ -680,6 +680,8 @@ describe("integration webhook handler engine resolution", () => {
         status: "delivery-pending",
         payload: {
           kind: "response-delivery",
+          userMessageId: expect.any(String),
+          assistantMessageId: expect.any(String),
           deliveryReceipt: {
             status: "delivered",
             messageRefs: ["provider-reply-1"],
@@ -691,6 +693,91 @@ describe("integration webhook handler engine resolution", () => {
       expect(updateThreadDataMock).not.toHaveBeenCalled();
     },
   );
+
+  it(
+    "retains stable history identity when a confirmed delivery history write fails",
+    { timeout: 15_000 },
+    async () => {
+      const { processIntegrationTask } = await import("./webhook-handler.js");
+      runAgentLoopMock.mockImplementationOnce(async ({ send }) => {
+        send({ type: "text", text: "Updated /page/request_123" });
+      });
+      const sendResponse = vi.fn(async () => ({
+        status: "delivered" as const,
+        messageRefs: ["provider-reply-history"],
+      }));
+      updateThreadDataMock.mockRejectedValueOnce(
+        new Error("history database response lost"),
+      );
+
+      const result = await processIntegrationTask(pendingTask(), {
+        adapter: createAdapter(sendResponse),
+        systemPrompt: "system",
+        actions: {},
+        apiKey: "test-key",
+        ownerEmail: "dispatch+qa@integration.local",
+        orgId: "org-qa",
+        principalType: "service",
+      });
+
+      expect(result).toMatchObject({
+        status: "delivery-pending",
+        payload: {
+          deliveryReceipt: {
+            status: "delivered",
+            messageRefs: ["provider-reply-history"],
+          },
+          userMessageId: expect.stringContaining("integration-fake:thread-qa"),
+          assistantMessageId: expect.stringContaining(
+            "integration-fake:thread-qa",
+          ),
+        },
+        errorMessage: "Integration response history checkpoint failed",
+      });
+      expect(sendResponse).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("retains a confirmed budget-limit receipt when checkpointing fails", async () => {
+    const { processIntegrationTask } = await import("./webhook-handler.js");
+    listIntegrationUsageBudgetsMock.mockResolvedValue([
+      { id: "budget-org", subjectType: "org", subjectId: "org-qa" },
+    ]);
+    reserveIntegrationUsageBudgetMock.mockResolvedValueOnce({
+      allowed: false,
+      status: "exhausted",
+    });
+    const sendResponse = vi.fn(async () => ({
+      status: "delivered" as const,
+      messageRefs: ["budget-limit-reply"],
+    }));
+    stageTaskDeliveryPayloadMock
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("budget receipt checkpoint failed"));
+
+    const result = await processIntegrationTask(pendingTask(), {
+      adapter: createAdapter(sendResponse),
+      systemPrompt: "system",
+      actions: {},
+      apiKey: "test-key",
+      ownerEmail: "dispatch+qa@integration.local",
+      orgId: "org-qa",
+      principalType: "service",
+    });
+
+    expect(result).toMatchObject({
+      status: "delivery-pending",
+      payload: {
+        deliveryReceipt: {
+          status: "delivered",
+          messageRefs: ["budget-limit-reply"],
+        },
+      },
+      errorMessage: "budget receipt checkpoint failed",
+    });
+    expect(sendResponse).toHaveBeenCalledOnce();
+    expect(runAgentLoopMock).not.toHaveBeenCalled();
+  });
 
   it("records a confirmed delivery retry as participant-visible context", async () => {
     const { recordIntegrationResponseDelivery } =
@@ -788,6 +875,95 @@ describe("integration webhook handler engine resolution", () => {
     expect(persisted.messages[1].metadata.integrationDelivery.status).toBe(
       "delivered",
     );
+  });
+
+  it("reuses deterministic reconstructed history IDs across delivery retries", async () => {
+    const { recordIntegrationResponseDelivery } =
+      await import("./webhook-handler.js");
+    const payload = {
+      kind: "response-delivery" as const,
+      incoming: {
+        platform: "slack",
+        externalThreadId: "slack-thread",
+        text: "Update the same Design Ask",
+        platformContext: { messageTs: "1001.0001" },
+        timestamp: 1001,
+      },
+      message: {
+        text: "Updated /page/request_123",
+        platformContext: {},
+      },
+      internalThreadId: "thread-qa",
+    };
+    const receipt = {
+      status: "delivered" as const,
+      messageRefs: ["slack-reply-stable"],
+    };
+    getThreadMock.mockResolvedValueOnce({
+      title: "Slack thread",
+      preview: "",
+      threadData: "{}",
+    });
+
+    await recordIntegrationResponseDelivery(payload, receipt);
+    const firstPersisted = JSON.parse(
+      updateThreadDataMock.mock.calls.at(-1)?.[1],
+    );
+    getThreadMock.mockResolvedValueOnce({
+      title: "Slack thread",
+      preview: "",
+      threadData: JSON.stringify(firstPersisted),
+    });
+
+    await recordIntegrationResponseDelivery(payload, receipt);
+    const secondPersisted = JSON.parse(
+      updateThreadDataMock.mock.calls.at(-1)?.[1],
+    );
+
+    expect(secondPersisted.messages).toHaveLength(2);
+    expect(secondPersisted.messages.map((message: any) => message.id)).toEqual(
+      firstPersisted.messages.map((message: any) => message.id),
+    );
+  });
+
+  it("reconstructs the exact staged history IDs when the original write did not commit", async () => {
+    const { recordIntegrationResponseDelivery } =
+      await import("./webhook-handler.js");
+    getThreadMock.mockResolvedValueOnce({
+      title: "Slack thread",
+      preview: "",
+      threadData: "{}",
+    });
+
+    await recordIntegrationResponseDelivery(
+      {
+        kind: "response-delivery",
+        incoming: {
+          platform: "slack",
+          externalThreadId: "slack-thread",
+          text: "Update the same Design Ask",
+          platformContext: { messageTs: "1001.0001" },
+          timestamp: 1001,
+        },
+        message: {
+          text: "Updated /page/request_123",
+          platformContext: {},
+        },
+        internalThreadId: "thread-qa",
+        userMessageId: "staged-user-id",
+        assistantMessageId: "staged-assistant-id",
+      },
+      {
+        status: "delivered",
+        messageRefs: ["slack-reply-staged"],
+      },
+    );
+
+    const persisted = JSON.parse(updateThreadDataMock.mock.calls.at(-1)?.[1]);
+    expect(persisted.messages.map((message: any) => message.id)).toEqual([
+      "staged-user-id",
+      "staged-assistant-id",
+    ]);
   });
 
   it(

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -44,7 +44,7 @@ import { attachToolSearch } from "../agent/tool-search.js";
 import { createThread, getThread } from "../chat-threads/store.js";
 import { updateThreadData } from "../chat-threads/store.js";
 import { isLocalDatabase } from "../db/client.js";
-import { resolveOrgIdForEmail } from "../org/context.js";
+import { getOrgA2ASecret, resolveOrgIdForEmail } from "../org/context.js";
 import { withConfiguredAppBasePath } from "../server/app-base-path.js";
 import { FRAMEWORK_ROUTE_PREFIX } from "../server/core-routes-plugin.js";
 import {
@@ -859,11 +859,13 @@ async function processIncomingMessage(
   // A2A delegation. Without this, getRequestOrgId() returns undefined and
   // call-agent can't look up the org's a2a_secret or org_domain.
   let orgId: string | null | undefined;
+  let artifactSecrets: string[];
   let runnableActions: Record<string, ActionEntry>;
   let tools: ReturnType<typeof actionsToEngineTools>;
   let availableTools: ReturnType<typeof actionsToEngineTools>;
   try {
     orgId = opts.orgId ?? (await resolveOrgIdForEmail(ownerEmail));
+    artifactSecrets = await resolveIntegrationArtifactSecrets(orgId);
     // Attach tool-search on a shallow copy so framework additions merged in
     // by `createIntegrationsPlugin` (integration memory, `call-agent`) can be
     // deferred behind it without mutating the plugin's long-lived registry.
@@ -1121,7 +1123,9 @@ async function processIncomingMessage(
                 : {}),
               internalThreadId: threadId,
               ...buildDeliveryHistoryMessageIds(incoming),
-              artifacts: extractA2AArtifactIdentities(toolResults),
+              artifacts: extractA2AArtifactIdentities(toolResults, {
+                persistedArtifactSecrets: artifactSecrets,
+              }),
             };
             if (opts.taskId) {
               await stageTaskDeliveryPayload(
@@ -1230,6 +1234,7 @@ async function processIncomingMessage(
             deliveredResponse,
             toolResults,
             stagedDeliveryPayload,
+            artifactSecrets,
           );
           if (outgoingForDelivery && stagedDeliveryPayload) {
             if (!threadCheckpoint) {
@@ -1283,6 +1288,7 @@ async function processIncomingMessage(
                 undefined,
                 collectToolResultSummaries(completedRun),
                 stagedDeliveryPayload,
+                artifactSecrets,
               );
             }
             if (usage) {
@@ -1769,6 +1775,7 @@ async function persistThreadData(
     IntegrationResponseDeliveryTaskPayload,
     "userMessageId" | "assistantMessageId"
   >,
+  artifactSecrets: readonly string[] = [],
 ): Promise<{ userMessageId: string; assistantMessageId?: string } | undefined> {
   try {
     let repo: any;
@@ -1803,7 +1810,9 @@ async function persistThreadData(
     const assistantMsg = existingAssistantMsg ?? builtAssistantMsg;
     if (assistantMsg) {
       assistantMsg.metadata.integrationDeliveryAttempted = true;
-      const artifactIdentities = extractA2AArtifactIdentities(toolResults);
+      const artifactIdentities = extractA2AArtifactIdentities(toolResults, {
+        persistedArtifactSecrets: artifactSecrets,
+      });
       if (artifactIdentities.length > 0) {
         assistantMsg.metadata.integrationArtifacts = artifactIdentities;
       }
@@ -1835,6 +1844,23 @@ async function persistThreadData(
     // Best-effort persistence
     return undefined;
   }
+}
+
+async function resolveIntegrationArtifactSecrets(
+  orgId: string | null | undefined,
+): Promise<string[]> {
+  const secrets: string[] = [];
+  const add = (secret: string | null | undefined) => {
+    const value = secret?.trim();
+    if (value && !secrets.includes(value)) secrets.push(value);
+  };
+  add(process.env.A2A_SECRET);
+  if (orgId) {
+    try {
+      add(await getOrgA2ASecret(orgId));
+    } catch {}
+  }
+  return secrets;
 }
 
 export async function recordIntegrationResponseDelivery(

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -4,6 +4,7 @@ import {
   appendA2AArtifactLinks,
   buildA2AVerifiedMutationReceipt,
   extractA2AArtifactIdentities,
+  type A2AArtifactIdentity,
   type A2AToolResultSummary,
 } from "../a2a/artifact-response.js";
 import { collectFinalResponseTextFromAgentEvents } from "../a2a/response-text.js";
@@ -62,6 +63,7 @@ import { signInternalToken } from "./internal-token.js";
 import {
   insertPendingTask,
   isDuplicateEventError,
+  stageTaskDeliveryPayload,
   type PendingTask,
 } from "./pending-tasks-store.js";
 import { integrationScopeSubjectKey } from "./scope-store.js";
@@ -69,6 +71,7 @@ import { getThreadMapping, saveThreadMapping } from "./thread-mapping-store.js";
 import type {
   PlatformAdapter,
   IncomingMessage,
+  OutgoingMessage,
   PlatformDeliveryReceipt,
 } from "./types.js";
 import {
@@ -91,6 +94,27 @@ type ToolDoneEvent = {
   isError?: boolean;
   completedSideEffect?: boolean;
 };
+
+export type IntegrationResponseDeliveryTaskPayload = {
+  kind: "response-delivery";
+  incoming: IncomingMessage;
+  message: OutgoingMessage;
+  placeholderRef?: string;
+  internalThreadId?: string;
+  userMessageId?: string;
+  assistantMessageId?: string;
+  deliveryReceipt?: PlatformDeliveryReceipt;
+  deliveredAt?: string;
+  artifacts?: A2AArtifactIdentity[];
+};
+
+export type ProcessIntegrationTaskResult =
+  | { status: "completed" }
+  | {
+      status: "delivery-pending";
+      payload: IntegrationResponseDeliveryTaskPayload;
+      errorMessage: string;
+    };
 
 /**
  * Build a stable per-event dedup key from the incoming message. The same
@@ -546,7 +570,7 @@ export function resolveBaseUrl(event: H3Event): string {
 export async function processIntegrationTask(
   task: PendingTask,
   options: WebhookHandlerOptions,
-): Promise<void> {
+): Promise<ProcessIntegrationTaskResult> {
   const parsed = JSON.parse(task.payload) as {
     incoming: IncomingMessage;
     placeholderRef?: string;
@@ -555,7 +579,7 @@ export async function processIntegrationTask(
 
   await recordInboundIntegrationAudit(task, parsed.incoming);
 
-  await processIncomingMessage(parsed.incoming, options, {
+  return processIncomingMessage(parsed.incoming, options, {
     taskId: task.id,
     attempts: task.attempts,
     placeholderRef: parsed.placeholderRef,
@@ -615,7 +639,7 @@ async function processIncomingMessage(
     orgId?: string;
     principalType?: "user" | "service";
   } = {},
-): Promise<void> {
+): Promise<ProcessIntegrationTaskResult> {
   const {
     adapter,
     systemPrompt,
@@ -698,10 +722,48 @@ async function processIncomingMessage(
     const outgoing = adapter.formatAgentResponse(
       "This channel or requester has reached its configured AI usage budget. An admin can review the budget in Messaging settings.",
     );
-    await adapter.sendResponse(outgoing, incoming, {
-      placeholderRef: opts.placeholderRef,
-    });
-    return;
+    const deliveryPayload: IntegrationResponseDeliveryTaskPayload = {
+      kind: "response-delivery",
+      incoming,
+      message: outgoing,
+      ...(opts.placeholderRef ? { placeholderRef: opts.placeholderRef } : {}),
+    };
+    try {
+      if (opts.taskId) {
+        await stageTaskDeliveryPayload(
+          opts.taskId,
+          JSON.stringify(deliveryPayload),
+        );
+      }
+      const receipt = await adapter.sendResponse(outgoing, incoming, {
+        placeholderRef: opts.placeholderRef,
+      });
+      if (receipt?.status !== "delivered") {
+        throw new Error(
+          `${incoming.platform} response completed without delivery proof`,
+        );
+      }
+      if (opts.taskId) {
+        await stageTaskDeliveryPayload(
+          opts.taskId,
+          JSON.stringify({
+            ...deliveryPayload,
+            deliveryReceipt: receipt,
+            deliveredAt: new Date().toISOString(),
+          }),
+        );
+      }
+      return { status: "completed" };
+    } catch (error) {
+      return {
+        status: "delivery-pending",
+        payload: deliveryPayload,
+        errorMessage:
+          error instanceof Error
+            ? error.message.slice(0, 1000)
+            : `${incoming.platform} response delivery failed`,
+      };
+    }
   }
 
   let threadId: string;
@@ -811,7 +873,7 @@ async function processIncomingMessage(
 
   // Wait for the run to complete inside this fresh function execution.
   // We use a Promise so the processor endpoint can await the full lifecycle.
-  await new Promise<void>((resolve) => {
+  return new Promise<ProcessIntegrationTaskResult>((resolve) => {
     startRun(
       runId,
       threadId,
@@ -921,6 +983,14 @@ async function processIncomingMessage(
       async (completedRun: ActiveRun) => {
         let keepSlackInputWindow = false;
         let queuedA2AContinuation = false;
+        let outgoingForDelivery: OutgoingMessage | undefined;
+        let stagedDeliveryPayload:
+          | IntegrationResponseDeliveryTaskPayload
+          | undefined;
+        let threadCheckpoint:
+          | { userMessageId: string; assistantMessageId?: string }
+          | undefined;
+        let outcome: ProcessIntegrationTaskResult = { status: "completed" };
         try {
           queuedA2AContinuation = hasQueuedA2AContinuation(completedRun);
           const slackInputRequest =
@@ -1029,6 +1099,23 @@ async function processIncomingMessage(
             const outgoing = adapter.formatAgentResponse(responseText, {
               threadDeepLinkUrl,
             });
+            outgoingForDelivery = outgoing;
+            stagedDeliveryPayload = {
+              kind: "response-delivery",
+              incoming,
+              message: outgoing,
+              ...(opts.placeholderRef
+                ? { placeholderRef: opts.placeholderRef }
+                : {}),
+              internalThreadId: threadId,
+              artifacts: extractA2AArtifactIdentities(toolResults),
+            };
+            if (opts.taskId) {
+              await stageTaskDeliveryPayload(
+                opts.taskId,
+                JSON.stringify(stagedDeliveryPayload),
+              );
+            }
             let deliveryReceipt: void | PlatformDeliveryReceipt;
             if (queuedA2AContinuation && progress?.ref) {
               // Post substantive parent results as a normal thread reply while
@@ -1054,24 +1141,33 @@ async function processIncomingMessage(
                 placeholderRef: opts.placeholderRef,
               });
             }
-            const delivered = deliveryReceipt?.status === "delivered";
-            if (!delivered) {
+            if (deliveryReceipt?.status !== "delivered") {
               throw new Error(
                 `${incoming.platform} response completed without delivery proof`,
               );
             }
-            if (delivered) {
-              deliveredResponse = {
-                platform: incoming.platform,
-                status: "delivered",
-                text: outgoing.text,
-                deliveredAt: new Date().toISOString(),
-                ...(deliveryReceipt?.messageRefs?.length
-                  ? { messageRefs: deliveryReceipt.messageRefs }
-                  : {}),
-              };
+            const deliveredAt = new Date().toISOString();
+            stagedDeliveryPayload = {
+              ...stagedDeliveryPayload,
+              deliveryReceipt,
+              deliveredAt,
+            };
+            if (opts.taskId) {
+              await stageTaskDeliveryPayload(
+                opts.taskId,
+                JSON.stringify(stagedDeliveryPayload),
+              );
             }
-            if (slackInputRequest && delivered && incoming.senderId) {
+            deliveredResponse = {
+              platform: incoming.platform,
+              status: "delivered",
+              text: outgoing.text,
+              deliveredAt,
+              ...(deliveryReceipt.messageRefs?.length
+                ? { messageRefs: deliveryReceipt.messageRefs }
+                : {}),
+            };
+            if (slackInputRequest && incoming.senderId) {
               await setIntegrationAwaitingInput({
                 platform: "slack",
                 externalThreadId: incoming.externalThreadId,
@@ -1113,7 +1209,7 @@ async function processIncomingMessage(
           }
 
           // Persist thread data
-          await persistThreadData(
+          threadCheckpoint = await persistThreadData(
             threadId,
             incoming.text,
             completedRun,
@@ -1121,6 +1217,24 @@ async function processIncomingMessage(
             deliveredResponse,
             toolResults,
           );
+          if (outgoingForDelivery && stagedDeliveryPayload) {
+            if (!threadCheckpoint) {
+              throw new Error("Integration response history checkpoint failed");
+            }
+            stagedDeliveryPayload = {
+              ...stagedDeliveryPayload,
+              userMessageId: threadCheckpoint.userMessageId,
+              ...(threadCheckpoint.assistantMessageId
+                ? { assistantMessageId: threadCheckpoint.assistantMessageId }
+                : {}),
+            };
+            if (opts.taskId) {
+              await stageTaskDeliveryPayload(
+                opts.taskId,
+                JSON.stringify(stagedDeliveryPayload),
+              );
+            }
+          }
           await recordIntegrationUsage({
             usage,
             ownerEmail,
@@ -1141,9 +1255,62 @@ async function processIncomingMessage(
             `[integrations] Error sending response to ${incoming.platform}:`,
             err,
           );
+          if (outgoingForDelivery) {
+            const errorMessage =
+              err instanceof Error
+                ? err.message.slice(0, 1000)
+                : `${incoming.platform} response delivery failed`;
+            if (!stagedDeliveryPayload?.deliveryReceipt) {
+              threadCheckpoint = await persistThreadData(
+                threadId,
+                incoming.text,
+                completedRun,
+                thread,
+                undefined,
+                collectToolResultSummaries(completedRun),
+              );
+            }
+            if (usage) {
+              await recordIntegrationUsage({
+                usage,
+                ownerEmail,
+                appId: options.appId,
+                runId,
+                threadId,
+                taskId: opts.taskId,
+                orgId: orgId ?? undefined,
+                incoming,
+              }).catch(() => {});
+              try {
+                await settleApplicableIntegrationBudgets(
+                  budgetReservations.reservations,
+                  usage,
+                );
+                budgetsSettled = true;
+              } catch {}
+            }
+            outcome = {
+              status: "delivery-pending",
+              payload: {
+                ...(stagedDeliveryPayload ?? {
+                  kind: "response-delivery",
+                  incoming,
+                  message: outgoingForDelivery,
+                  internalThreadId: threadId,
+                }),
+                ...(threadCheckpoint?.userMessageId
+                  ? { userMessageId: threadCheckpoint.userMessageId }
+                  : {}),
+                ...(threadCheckpoint?.assistantMessageId
+                  ? { assistantMessageId: threadCheckpoint.assistantMessageId }
+                  : {}),
+              },
+              errorMessage,
+            };
+            return;
+          }
           // A queued continuation owns the final platform response. Later
-          // bookkeeping failures (for example, persisting this parent run)
-          // must not close its resumable native stream with a false failure.
+          // bookkeeping failures must not close its stream with a false failure.
           if (queuedA2AContinuation) return;
           // Last-ditch: try to post a brief apology so the thread isn't silent.
           try {
@@ -1170,7 +1337,7 @@ async function processIncomingMessage(
               budgetReservations.reservations,
             );
           }
-          resolve();
+          resolve(outcome);
         }
       },
       // Integration workers are ordinary self-dispatched serverless requests,
@@ -1583,7 +1750,7 @@ async function persistThreadData(
     messageRefs?: string[];
   },
   toolResults: A2AToolResultSummary[] = [],
-): Promise<void> {
+): Promise<{ userMessageId: string; assistantMessageId?: string } | undefined> {
   try {
     let repo: any;
     try {
@@ -1608,12 +1775,12 @@ async function persistThreadData(
     );
     if (assistantMsg) {
       assistantMsg.metadata.integrationDeliveryAttempted = true;
+      const artifactIdentities = extractA2AArtifactIdentities(toolResults);
+      if (artifactIdentities.length > 0) {
+        assistantMsg.metadata.integrationArtifacts = artifactIdentities;
+      }
       if (deliveredResponse) {
         assistantMsg.metadata.integrationDelivery = deliveredResponse;
-        const artifactIdentities = extractA2AArtifactIdentities(toolResults);
-        if (artifactIdentities.length > 0) {
-          assistantMsg.metadata.integrationArtifacts = artifactIdentities;
-        }
       }
     }
 
@@ -1630,7 +1797,98 @@ async function persistThreadData(
       meta.preview || thread?.preview || "",
       repo.messages.length,
     );
+    return {
+      userMessageId: userMsg.id,
+      ...(assistantMsg?.id ? { assistantMessageId: assistantMsg.id } : {}),
+    };
   } catch {
     // Best-effort persistence
+    return undefined;
   }
+}
+
+export async function recordIntegrationResponseDelivery(
+  payload: IntegrationResponseDeliveryTaskPayload,
+  receipt: PlatformDeliveryReceipt,
+): Promise<void> {
+  if (!payload.internalThreadId) return;
+  const thread = await getThread(payload.internalThreadId);
+  if (!thread) throw new Error("Integration delivery thread was not found");
+
+  let repo: any;
+  try {
+    repo = JSON.parse(thread.threadData || "{}");
+  } catch {
+    throw new Error("Integration delivery thread data is invalid");
+  }
+  if (!Array.isArray(repo.messages)) {
+    if (payload.userMessageId || payload.assistantMessageId) {
+      throw new Error("Integration delivery thread has no message history");
+    }
+    repo.messages = [];
+  }
+  const userMsg = payload.userMessageId
+    ? repo.messages.find(
+        (message: any) => message?.id === payload.userMessageId,
+      )
+    : undefined;
+  if (payload.userMessageId && !userMsg) {
+    throw new Error(
+      "Integration delivery checkpoint user message was not found",
+    );
+  }
+  let assistantMsg = payload.assistantMessageId
+    ? repo.messages.find(
+        (message: any) => message?.id === payload.assistantMessageId,
+      )
+    : undefined;
+  if (payload.assistantMessageId && !assistantMsg) {
+    throw new Error("Integration delivery checkpoint message was not found");
+  }
+  if (!assistantMsg) {
+    const createdAt = payload.deliveredAt ?? new Date().toISOString();
+    if (!userMsg) {
+      repo.messages.push({
+        id: `msg-${Date.now()}-user-delivery-retry`,
+        role: "user",
+        content: [{ type: "text", text: payload.incoming.text }],
+        createdAt,
+      });
+    }
+    assistantMsg = {
+      id: `msg-${Date.now()}-assistant-delivery-retry`,
+      role: "assistant",
+      content: [{ type: "text", text: payload.message.text }],
+      createdAt,
+      metadata: {
+        integrationDeliveryAttempted: true,
+        ...(payload.artifacts?.length
+          ? { integrationArtifacts: payload.artifacts }
+          : {}),
+      },
+    };
+    repo.messages.push(assistantMsg);
+  }
+  if (!assistantMsg.metadata || typeof assistantMsg.metadata !== "object") {
+    assistantMsg.metadata = {};
+  }
+  assistantMsg.metadata.integrationDeliveryAttempted = true;
+  assistantMsg.metadata.integrationDelivery = {
+    platform: payload.incoming.platform,
+    status: "delivered",
+    text: payload.message.text,
+    deliveredAt: payload.deliveredAt ?? new Date().toISOString(),
+    ...(receipt.messageRefs?.length
+      ? { messageRefs: receipt.messageRefs }
+      : {}),
+  };
+
+  const meta = extractThreadMeta(repo);
+  await updateThreadData(
+    payload.internalThreadId,
+    JSON.stringify(repo),
+    meta.title || thread.title || "Integration Chat",
+    meta.preview || thread.preview || "",
+    repo.messages.length,
+  );
 }

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -148,6 +148,17 @@ function buildEventDedupKey(incoming: IncomingMessage): string {
   return `${incoming.platform}:${incoming.externalThreadId}:${eventReference}`;
 }
 
+function buildDeliveryHistoryMessageIds(incoming: IncomingMessage): {
+  userMessageId: string;
+  assistantMessageId: string;
+} {
+  const eventKey = buildEventDedupKey(incoming);
+  return {
+    userMessageId: `integration-${eventKey}-user`,
+    assistantMessageId: `integration-${eventKey}-assistant`,
+  };
+}
+
 export interface WebhookHandlerOptions {
   adapter: PlatformAdapter;
   /** Resolved system prompt string */
@@ -722,7 +733,7 @@ async function processIncomingMessage(
     const outgoing = adapter.formatAgentResponse(
       "This channel or requester has reached its configured AI usage budget. An admin can review the budget in Messaging settings.",
     );
-    const deliveryPayload: IntegrationResponseDeliveryTaskPayload = {
+    let deliveryPayload: IntegrationResponseDeliveryTaskPayload = {
       kind: "response-delivery",
       incoming,
       message: outgoing,
@@ -743,14 +754,15 @@ async function processIncomingMessage(
           `${incoming.platform} response completed without delivery proof`,
         );
       }
+      deliveryPayload = {
+        ...deliveryPayload,
+        deliveryReceipt: receipt,
+        deliveredAt: new Date().toISOString(),
+      };
       if (opts.taskId) {
         await stageTaskDeliveryPayload(
           opts.taskId,
-          JSON.stringify({
-            ...deliveryPayload,
-            deliveryReceipt: receipt,
-            deliveredAt: new Date().toISOString(),
-          }),
+          JSON.stringify(deliveryPayload),
         );
       }
       return { status: "completed" };
@@ -1108,6 +1120,7 @@ async function processIncomingMessage(
                 ? { placeholderRef: opts.placeholderRef }
                 : {}),
               internalThreadId: threadId,
+              ...buildDeliveryHistoryMessageIds(incoming),
               artifacts: extractA2AArtifactIdentities(toolResults),
             };
             if (opts.taskId) {
@@ -1216,6 +1229,7 @@ async function processIncomingMessage(
             thread,
             deliveredResponse,
             toolResults,
+            stagedDeliveryPayload,
           );
           if (outgoingForDelivery && stagedDeliveryPayload) {
             if (!threadCheckpoint) {
@@ -1268,6 +1282,7 @@ async function processIncomingMessage(
                 thread,
                 undefined,
                 collectToolResultSummaries(completedRun),
+                stagedDeliveryPayload,
               );
             }
             if (usage) {
@@ -1750,6 +1765,10 @@ async function persistThreadData(
     messageRefs?: string[];
   },
   toolResults: A2AToolResultSummary[] = [],
+  messageIds?: Pick<
+    IntegrationResponseDeliveryTaskPayload,
+    "userMessageId" | "assistantMessageId"
+  >,
 ): Promise<{ userMessageId: string; assistantMessageId?: string } | undefined> {
   try {
     let repo: any;
@@ -1762,17 +1781,26 @@ async function persistThreadData(
 
     // Add user message
     const userMsg = {
-      id: `msg-${Date.now()}-user`,
+      id: messageIds?.userMessageId ?? `msg-${Date.now()}-user`,
       role: "user",
       content: [{ type: "text", text: userText }],
       createdAt: new Date().toISOString(),
     };
 
     // Build assistant message from run events
-    const assistantMsg = buildAssistantMessage(
+    const builtAssistantMsg = buildAssistantMessage(
       completedRun.events ?? [],
       completedRun.runId,
     );
+    if (builtAssistantMsg && messageIds?.assistantMessageId) {
+      builtAssistantMsg.id = messageIds.assistantMessageId;
+    }
+    const existingAssistantMsg = builtAssistantMsg
+      ? repo.messages.find(
+          (message: any) => message?.id === builtAssistantMsg.id,
+        )
+      : undefined;
+    const assistantMsg = existingAssistantMsg ?? builtAssistantMsg;
     if (assistantMsg) {
       assistantMsg.metadata.integrationDeliveryAttempted = true;
       const artifactIdentities = extractA2AArtifactIdentities(toolResults);
@@ -1784,9 +1812,11 @@ async function persistThreadData(
       }
     }
 
-    repo.messages.push(userMsg);
-    if (assistantMsg) {
-      repo.messages.push(assistantMsg);
+    if (!repo.messages.some((message: any) => message?.id === userMsg.id)) {
+      repo.messages.push(userMsg);
+    }
+    if (builtAssistantMsg && !existingAssistantMsg) {
+      repo.messages.push(builtAssistantMsg);
     }
 
     const meta = extractThreadMeta(repo);
@@ -1822,41 +1852,30 @@ export async function recordIntegrationResponseDelivery(
     throw new Error("Integration delivery thread data is invalid");
   }
   if (!Array.isArray(repo.messages)) {
-    if (payload.userMessageId || payload.assistantMessageId) {
-      throw new Error("Integration delivery thread has no message history");
-    }
     repo.messages = [];
   }
-  const userMsg = payload.userMessageId
-    ? repo.messages.find(
-        (message: any) => message?.id === payload.userMessageId,
-      )
+  const stableMessageIds = buildDeliveryHistoryMessageIds(payload.incoming);
+  const userMessageId = payload.userMessageId ?? stableMessageIds.userMessageId;
+  const assistantMessageId =
+    payload.assistantMessageId ?? stableMessageIds.assistantMessageId;
+  const userMsg = userMessageId
+    ? repo.messages.find((message: any) => message?.id === userMessageId)
     : undefined;
-  if (payload.userMessageId && !userMsg) {
-    throw new Error(
-      "Integration delivery checkpoint user message was not found",
-    );
-  }
-  let assistantMsg = payload.assistantMessageId
-    ? repo.messages.find(
-        (message: any) => message?.id === payload.assistantMessageId,
-      )
+  let assistantMsg = assistantMessageId
+    ? repo.messages.find((message: any) => message?.id === assistantMessageId)
     : undefined;
-  if (payload.assistantMessageId && !assistantMsg) {
-    throw new Error("Integration delivery checkpoint message was not found");
+  const createdAt = payload.deliveredAt ?? new Date().toISOString();
+  if (!userMsg) {
+    repo.messages.push({
+      id: userMessageId,
+      role: "user",
+      content: [{ type: "text", text: payload.incoming.text }],
+      createdAt,
+    });
   }
   if (!assistantMsg) {
-    const createdAt = payload.deliveredAt ?? new Date().toISOString();
-    if (!userMsg) {
-      repo.messages.push({
-        id: `msg-${Date.now()}-user-delivery-retry`,
-        role: "user",
-        content: [{ type: "text", text: payload.incoming.text }],
-        createdAt,
-      });
-    }
     assistantMsg = {
-      id: `msg-${Date.now()}-assistant-delivery-retry`,
+      id: assistantMessageId,
       role: "assistant",
       content: [{ type: "text", text: payload.message.text }],
       createdAt,

--- a/packages/core/src/server/agent-chat-plugin.a2a.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin.a2a.spec.ts
@@ -6,11 +6,26 @@ import {
   buildPublicAgentA2ASkills,
   createA2AEngineToolSurface,
   createSerializedA2ATaskStatusWriter,
+  resolveA2ARecoverableArtifactSecret,
   runMCPAgentLoop,
   runA2AAgentLoop,
 } from "./agent-chat-plugin.js";
 
 describe("delegated A2A recoverable artifact checkpoints", () => {
+  it("uses an organization A2A secret when no global secret is configured", async () => {
+    vi.stubEnv("A2A_SECRET", "");
+    vi.doMock("../org/context.js", () => ({
+      getOrgA2ASecret: vi.fn(async () => "org-only-a2a-secret"),
+    }));
+
+    await expect(resolveA2ARecoverableArtifactSecret("org-qa")).resolves.toBe(
+      "org-only-a2a-secret",
+    );
+
+    vi.doUnmock("../org/context.js");
+    vi.unstubAllEnvs();
+  });
+
   it("serializes status writes and flushes the latest checkpoint", async () => {
     let releaseFirst!: () => void;
     let releaseSecond!: () => void;

--- a/packages/core/src/server/agent-chat-plugin.a2a.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin.a2a.spec.ts
@@ -5,9 +5,93 @@ import {
   assembleA2AFinalResponse,
   buildPublicAgentA2ASkills,
   createA2AEngineToolSurface,
+  createSerializedA2ATaskStatusWriter,
   runMCPAgentLoop,
   runA2AAgentLoop,
 } from "./agent-chat-plugin.js";
+
+describe("delegated A2A recoverable artifact checkpoints", () => {
+  it("serializes status writes and flushes the latest checkpoint", async () => {
+    let releaseFirst!: () => void;
+    let releaseSecond!: () => void;
+    const firstWrite = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const secondWrite = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    const writeStatus = vi
+      .fn()
+      .mockImplementationOnce(() => firstWrite)
+      .mockImplementationOnce(() => secondWrite);
+    const writer = createSerializedA2ATaskStatusWriter(
+      "task-checkpoint",
+      writeStatus,
+    );
+
+    writer.enqueue({
+      role: "agent",
+      parts: [{ type: "text", text: "first checkpoint" }],
+    });
+    writer.enqueue({
+      role: "agent",
+      parts: [{ type: "text", text: "latest checkpoint" }],
+    });
+    await vi.waitFor(() => expect(writeStatus).toHaveBeenCalledTimes(1));
+
+    let flushed = false;
+    const flush = writer.flush().then(() => {
+      flushed = true;
+    });
+    await Promise.resolve();
+    expect(flushed).toBe(false);
+    expect(writeStatus).toHaveBeenNthCalledWith(
+      1,
+      "task-checkpoint",
+      expect.objectContaining({
+        parts: [{ type: "text", text: "first checkpoint" }],
+      }),
+    );
+
+    releaseFirst();
+    await vi.waitFor(() => expect(writeStatus).toHaveBeenCalledTimes(2));
+    expect(flushed).toBe(false);
+    expect(writeStatus).toHaveBeenNthCalledWith(
+      2,
+      "task-checkpoint",
+      expect.objectContaining({
+        parts: [{ type: "text", text: "latest checkpoint" }],
+      }),
+    );
+
+    releaseSecond();
+    await flush;
+    expect(flushed).toBe(true);
+  });
+
+  it("retries a failed latest checkpoint and rejects flush when it is not durable", async () => {
+    const writeError = new Error("database unavailable");
+    const writeStatus = vi.fn(async () => {
+      throw writeError;
+    });
+    const onError = vi.fn();
+    const writer = createSerializedA2ATaskStatusWriter(
+      "task-checkpoint-failure",
+      writeStatus,
+      onError,
+    );
+
+    writer.enqueue({
+      role: "agent",
+      parts: [{ type: "text", text: "must become durable" }],
+    });
+
+    await expect(writer.flush()).rejects.toBe(writeError);
+    expect(writeStatus).toHaveBeenCalledTimes(3);
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError).toHaveBeenCalledWith(writeError);
+  });
+});
 
 describe("delegated A2A final response guards", () => {
   it("runs an Analytics-style real-data guard for delegated turns", async () => {

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -331,6 +331,20 @@ export function createSerializedA2ATaskStatusWriter(
   };
 }
 
+export async function resolveA2ARecoverableArtifactSecret(
+  orgId: string | null | undefined = getRequestOrgId(),
+): Promise<string | undefined> {
+  const globalSecret = process.env.A2A_SECRET?.trim();
+  if (globalSecret) return globalSecret;
+  if (!orgId) return undefined;
+  try {
+    const { getOrgA2ASecret } = await import("../org/context.js");
+    return (await getOrgA2ASecret(orgId))?.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function buildLeanRunPolicyPrompt(
   codeEditingSurfaceRestriction: string,
   prodCodeExecPromptNote: string,
@@ -1524,6 +1538,8 @@ export function createAgentChatPlugin(
           const a2aEvents: AgentChatEvent[] = [];
           const a2aToolResults: A2AToolResultSummary[] = [];
           let lastRecoverableArtifactText = "";
+          const recoverableArtifactSecret =
+            await resolveA2ARecoverableArtifactSecret();
           const recoverableArtifactStatusWriter =
             createSerializedA2ATaskStatusWriter(context.taskId);
           const controller = new AbortController();
@@ -1574,6 +1590,7 @@ export function createAgentChatPlugin(
                         {
                           baseUrl: artifactBaseUrl,
                           includePersistedArtifactMarker: true,
+                          persistedArtifactSecret: recoverableArtifactSecret,
                         },
                       )
                     : null;

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -14,6 +14,7 @@ import {
 } from "h3";
 
 import {
+  appendA2AArtifactLinks,
   buildA2ARecoverableArtifactMessage,
   type A2AToolResultSummary,
 } from "../a2a/artifact-response.js";
@@ -27,6 +28,7 @@ import {
   createA2AApproval,
   updateTaskStatusMessage,
 } from "../a2a/task-store.js";
+import type { Message as A2AMessage } from "../a2a/types.js";
 import type { ActionHttpConfig } from "../action.js";
 import {
   canUpdateAgentAppModelDefaultSettings,
@@ -274,6 +276,60 @@ export { shouldBlockInProductCodeEditingSurface };
 export { loadRunCodeToolEntries };
 export { shouldDisableRecurringJobsRuntime };
 export { finalizeClaimedAgentChatProcessRunFailure };
+
+export function createSerializedA2ATaskStatusWriter(
+  taskId: string,
+  writeStatus: (
+    taskId: string,
+    message: A2AMessage,
+  ) => Promise<void> = updateTaskStatusMessage,
+  onError: (error: unknown) => void = (error) => {
+    console.error(
+      `[A2A] Failed to persist recoverable artifact message for task ${taskId}:`,
+      error,
+    );
+  },
+): {
+  enqueue: (message: A2AMessage) => void;
+  flush: () => Promise<void>;
+} {
+  const maxAttempts = 3;
+  let latestWrite: Promise<void> = Promise.resolve();
+
+  const persistWithRetry = async (message: A2AMessage): Promise<void> => {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      try {
+        await writeStatus(taskId, message);
+        return;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    try {
+      onError(lastError);
+    } catch {
+      // The durable-write error below remains the authoritative failure.
+    }
+    throw lastError;
+  };
+
+  return {
+    enqueue(message) {
+      // A newer checkpoint supersedes an earlier failed checkpoint, so keep
+      // the queue moving. flush() still rejects when the latest write itself
+      // cannot be made durable after bounded retries.
+      latestWrite = latestWrite
+        .catch(() => undefined)
+        .then(() => {
+          return persistWithRetry(message);
+        });
+    },
+    flush() {
+      return latestWrite;
+    },
+  };
+}
 
 export function buildLeanRunPolicyPrompt(
   codeEditingSurfaceRestriction: string,
@@ -1468,6 +1524,8 @@ export function createAgentChatPlugin(
           const a2aEvents: AgentChatEvent[] = [];
           const a2aToolResults: A2AToolResultSummary[] = [];
           let lastRecoverableArtifactText = "";
+          const recoverableArtifactStatusWriter =
+            createSerializedA2ATaskStatusWriter(context.taskId);
           const controller = new AbortController();
 
           console.log(
@@ -1504,16 +1562,27 @@ export function createAgentChatPlugin(
                     isError: event.isError,
                     completedSideEffect: event.completedSideEffect,
                   });
-                  const recoverableArtifactText =
+                  const artifactBaseUrl = resolveArtifactBaseUrl(context.event);
+                  const recoverableArtifactMessage =
                     buildA2ARecoverableArtifactMessage(a2aToolResults, {
-                      baseUrl: resolveArtifactBaseUrl(context.event),
+                      baseUrl: artifactBaseUrl,
                     });
+                  const recoverableArtifactText = recoverableArtifactMessage
+                    ? appendA2AArtifactLinks(
+                        recoverableArtifactMessage,
+                        a2aToolResults,
+                        {
+                          baseUrl: artifactBaseUrl,
+                          includePersistedArtifactMarker: true,
+                        },
+                      )
+                    : null;
                   if (
                     recoverableArtifactText &&
                     recoverableArtifactText !== lastRecoverableArtifactText
                   ) {
                     lastRecoverableArtifactText = recoverableArtifactText;
-                    updateTaskStatusMessage(context.taskId, {
+                    recoverableArtifactStatusWriter.enqueue({
                       role: "agent",
                       metadata: { agentNativeRecoverableArtifacts: true },
                       parts: [
@@ -1522,11 +1591,6 @@ export function createAgentChatPlugin(
                           text: recoverableArtifactText,
                         },
                       ],
-                    }).catch((err) => {
-                      console.error(
-                        `[A2A] Failed to persist recoverable artifact message for task ${context.taskId}:`,
-                        err,
-                      );
                     });
                   }
                 } else if (event.type === "error") {
@@ -1547,6 +1611,10 @@ export function createAgentChatPlugin(
                 isInBackgroundFunctionRuntime(),
             },
           );
+
+          // The continuation can observe terminal output immediately, so make
+          // its latest mutation checkpoint durable first.
+          await recoverableArtifactStatusWriter.flush();
 
           const approval = [...a2aEvents]
             .reverse()


### PR DESCRIPTION
## Summary

- preserve verified A2A artifact checkpoints while delegated work continues, preferring a later final result and using the checkpoint only as a truthful terminal fallback
- persist formatted integration replies before provider delivery and retry delivery only, without rerunning successful mutations or allowing later thread turns to overtake recovery
- atomically carry provider receipts and deterministic conversation message IDs across retry transitions so retries preserve one conversation-history identity
- make recoverable A2A checkpoint persistence ordered, boundedly retried, fail loud when it cannot become durable, and support verified organization-only A2A secrets

## Why

A Slack correction could successfully update the existing Content record but leave the thread silent. Retrying the whole integration task would risk replaying the mutation. This change separates mutation truth from delivery truth: the stable Content identity is retained, while only the missing provider reply is retried.

Provider posting remains at-least-once when acceptance is ambiguous before a receipt is returned. Slack does not expose a generic exactly-once primitive for this reply path, so an accepted post followed by a lost provider response can still produce a duplicate reply. The durable guarantee here is that recovery preserves exact conversation-history identity and never reruns the successful Content mutation.

## Verification

- 204 focused tests across A2A artifact provenance and continuations, checkpoint persistence, pending-task storage, processor routing, webhook delivery, and integration-history replay
- `@agent-native/core` TypeScript 7 typecheck
- oxfmt check on all modified source and test files
- changeset validation
- `git diff --check`
- independent final code reviews: no remaining code blockers

## QA

No preview Slack bot or integration environment exists. Real Slack-to-Content QA remains intentionally deferred until this PR is merged and deployed. The frozen deployed story is: rename the Content record, correct unrelated fields in the same Slack thread, preserve the stable ID and live title, create no duplicate Content record, and receive one truthful confirmation on the clean provider path.