### PR TITLE
Add visible border to asset selection checkboxes

### DIFF
--- a/templates/assets/app/routes/brand-kits.$id.tsx
+++ b/templates/assets/app/routes/brand-kits.$id.tsx
@@ -2866,7 +2866,7 @@ function AssetCardsView({ items }: { items: LaneGalleryItem[] }) {
                     aria-label={t("library.selectAsset", {
                       title: item.title,
                     })}
-                    className="border-background bg-background/90 shadow-sm"
+                    className="border-2 border-foreground/40 bg-background/90 shadow-sm"
                   />
                 ) : null}
               </div>
@@ -3393,7 +3393,7 @@ function AssetLaneTile({
           onCheckedChange={(checked) => onToggle(checked === true)}
           aria-label={t("library.selectAsset", { title: displayTitle })}
           className={[
-            "border-background bg-background/90 shadow-sm opacity-100 transition sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100",
+            "border-2 border-foreground/40 bg-background/90 shadow-sm opacity-100 transition sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100",
             selected ? "sm:opacity-100" : "",
           ].join(" ")}
         />


### PR DESCRIPTION
### Summary
Updates the styling of asset selection checkboxes so they have a clearly visible border against the background.

### Problem
The selection checkboxes on brand kit asset cards and lane tiles used a border color matching the background, making them hard to notice at a glance.

### Solution
Changed the checkbox border styling to use a thicker, higher-contrast border so it stands out immediately regardless of the underlying image or background.

### Key Changes
- In `AssetCardsView`, updated checkbox `className` from `border-background` to `border-2 border-foreground/40`.
- In `AssetLaneTile`, updated checkbox `className` from `border-background` to `border-2 border-foreground/40`, keeping existing opacity/hover/focus-visible behavior intact.

---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/oracle-lane-d3q1j1d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-oracle-lane-d3q1j1d1.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2214`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>oracle-lane-d3q1j1d1</branchName>-->