### PR TITLE
Fix hosted organization-space database creation

### DIFF
--- a/templates/content/actions/_content-space-access.ts
+++ b/templates/content/actions/_content-space-access.ts
@@ -1,24 +1,8 @@
 import { getDbExec } from "@agent-native/core/db";
-import { table, text } from "@agent-native/core/db/schema";
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 import { and, eq, sql } from "drizzle-orm";
 
 import { getDb, schema } from "../server/db/index.js";
-
-// Keep these lightweight table references local. Importing the public org
-// barrel also initializes auth's long-lived cleanup timer, which breaks test
-// suites that intentionally drain fake timers.
-const organizations = table("organizations", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  createdBy: text("created_by").notNull(),
-});
-
-const orgMembers = table("org_members", {
-  orgId: text("org_id").notNull(),
-  email: text("email").notNull(),
-  role: text("role").notNull(),
-});
 
 export type ContentSpaceRole = "viewer" | "editor" | "owner";
 
@@ -40,6 +24,13 @@ export async function getContentOrganizationMembership(
   options: { db?: any } = {},
 ): Promise<{ role: string; name: string; createdBy: string } | null> {
   if (options.db) {
+    // Import the canonical org tables only when this transaction-scoped path
+    // actually runs. A top-level import initializes auth's cleanup timer and
+    // breaks suites that intentionally drain fake timers; duplicating these
+    // dialect-aware tables locally can produce the wrong table metadata in a
+    // hosted Postgres runtime.
+    const { organizations, orgMembers } =
+      await import("@agent-native/core/org");
     const [row] = await options.db
       .select({
         role: orgMembers.role,


### PR DESCRIPTION
## Summary

- lazily load the canonical organization schema for transaction-scoped Content space authorization
- avoid initializing the auth cleanup timer in unrelated fake-timer test suites
- remove locally duplicated dialect-aware organization table definitions that fail on the hosted organization-space path

## Production reproduction

After PR #2211 deployed, creating a database in the Builder.io Content workspace returned HTTP 500 from create-content-database in 553 ms and created no artifact. Personal/local creation remained green.

## Verification

- 58 focused tests passed across organization-space creation, hosted transaction authorization, and Notion fake-timer coverage
- TypeScript passed
- production H1 will be rerun after merge and deploy

- Codex AI