### PR TITLE
Keep registry editor adapter on Core

### DIFF
--- a/.changeset/calm-cats-smile.md
+++ b/.changeset/calm-cats-smile.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Correct the prepublished registry editor migration so the framework-wired data provider remains on Core's blocks entry.

--- a/packages/core/migration-manifest.json
+++ b/packages/core/migration-manifest.json
@@ -374,7 +374,7 @@
           "status": "planned"
         },
         "RegistryBlockDataProvider": {
-          "to": "@agent-native/toolkit/editor",
+          "to": "@agent-native/core/blocks",
           "status": "planned"
         },
         "RegistryBlockDataValue": {
@@ -1311,7 +1311,10 @@
         "UseCollabReconcileResult": "UseCollabReconcileResult",
         "createRegistryBlockNode": "createRegistryBlockNode",
         "RegistryBlockNodeView": "RegistryBlockNodeView",
-        "RegistryBlockDataProvider": "RegistryBlockDataProvider",
+        "RegistryBlockDataProvider": {
+          "to": "@agent-native/core/blocks",
+          "status": "planned"
+        },
         "useRegistryBlockData": "useRegistryBlockData",
         "CreateRegistryBlockNodeOptions": "CreateRegistryBlockNodeOptions",
         "RegistryBlockDataValue": "RegistryBlockDataValue",
@@ -1382,7 +1385,10 @@
         "UseCollabReconcileResult": "UseCollabReconcileResult",
         "createRegistryBlockNode": "createRegistryBlockNode",
         "RegistryBlockNodeView": "RegistryBlockNodeView",
-        "RegistryBlockDataProvider": "RegistryBlockDataProvider",
+        "RegistryBlockDataProvider": {
+          "to": "@agent-native/core/blocks",
+          "status": "planned"
+        },
         "useRegistryBlockData": "useRegistryBlockData",
         "CreateRegistryBlockNodeOptions": "CreateRegistryBlockNodeOptions",
         "RegistryBlockDataValue": "RegistryBlockDataValue",

--- a/packages/core/src/package-lifecycle/deprecated-imports.spec.ts
+++ b/packages/core/src/package-lifecycle/deprecated-imports.spec.ts
@@ -101,6 +101,14 @@ describe("scanDeprecatedImports", () => {
         to: "@agent-native/core/client/uploads",
         status: "planned",
       });
+      expect(
+        move
+          ? resolveMigrationSymbolMove(move, "RegistryBlockDataProvider")
+          : null,
+      ).toMatchObject({
+        to: "@agent-native/core/blocks",
+        status: "planned",
+      });
     }
     expect(
       manifest?.moves["@agent-native/core/testing"]?.symbols?.DragHandle,


### PR DESCRIPTION
## Summary

- correct the prepublished registry editor migration before the breaking Toolkit flip
- keep `RegistryBlockDataProvider` on `@agent-native/core/blocks`, where the framework block registry is wired
- continue moving the generic Tiptap registry node and other portable editor symbols to Toolkit

This is a manifest-only release-gate correction. It does not change runtime exports.

## Validation

- `corepack pnpm --filter @agent-native/core exec vitest --run src/package-lifecycle/deprecated-imports.spec.ts`
- `corepack pnpm guard:migration-manifest`
- `git diff --check`