### PR TITLE
Keep Context X-Ray panel on Core

### DIFF
--- a/.changeset/calm-context-panels.md
+++ b/.changeset/calm-context-panels.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep the framework-wired Context X-Ray panel on its existing Core entrypoint instead of suggesting an incompatible Toolkit view migration.

--- a/packages/core/migration-manifest.json
+++ b/packages/core/migration-manifest.json
@@ -1490,9 +1490,6 @@
     },
     "@agent-native/core/client/visual-style-controls": {
       "to": "@agent-native/toolkit/design-tweaks"
-    },
-    "@agent-native/core/client/context-xray/ContextXRayPanel": {
-      "to": "@agent-native/toolkit/context-ui"
     }
   }
 }


### PR DESCRIPTION
## Summary
- remove the incompatible Context X-Ray panel migration from the published manifest
- keep the framework-wired Core panel distinct from Toolkit's portable view
- publish a Core patch so upgrade tooling matches the breaking flip before it merges

## Validation
- parsed the updated manifest as JSON
- verified the diff contains only the manifest correction and patch changeset