### PR TITLE
Trim duplicate locales from the Core package

### DIFF
--- a/.changeset/trim-core-reference-locales.md
+++ b/.changeset/trim-core-reference-locales.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Trim non-English reference locales from the published source corpus.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,7 @@
     "corpus",
     "dist",
     "docs",
+    "!docs/content/locales/**",
     "migration-manifest.json",
     "tsconfig.base.json",
     "src/templates/default",

--- a/packages/core/scripts/materialize-source-corpus.mjs
+++ b/packages/core/scripts/materialize-source-corpus.mjs
@@ -147,6 +147,23 @@ function shouldSkipRelativePath(relativePath) {
   return shouldSkipFile(name);
 }
 
+export function shouldIncludeCorpusSourceFile(rootRel, sourcePath) {
+  const normalizedPath = sourcePath.split("\\").join("/");
+  if (
+    rootRel === "packages/core" &&
+    normalizedPath.startsWith("packages/core/docs/content/locales/")
+  ) {
+    return false;
+  }
+  if (rootRel !== "templates") return true;
+
+  const localeCatalog =
+    /^templates\/[^/]+\/app\/i18n\/([a-z]{2,3}-[A-Z]{2,4})\.[cm]?[jt]sx?$/.exec(
+      normalizedPath,
+    );
+  return !localeCatalog || localeCatalog[1] === "en-US";
+}
+
 function hasTextLikeName(relativePath) {
   const name = basename(relativePath);
   if (textFileNames.has(name)) return true;
@@ -227,7 +244,10 @@ function sourceFilesFor(rootRel) {
     tracked ?? listFilesystemFiles(join(repoRoot, rootRel), rootRel);
   return files
     .filter(
-      (file) => !shouldSkipRelativePath(file) && shouldIncludeSourceFile(file),
+      (file) =>
+        shouldIncludeCorpusSourceFile(rootRel, file) &&
+        !shouldSkipRelativePath(file) &&
+        shouldIncludeSourceFile(file),
     )
     .sort();
 }

--- a/packages/core/scripts/materialize-source-corpus.test.mjs
+++ b/packages/core/scripts/materialize-source-corpus.test.mjs
@@ -32,6 +32,7 @@ import { describe, it, afterEach } from "node:test";
 
 import {
   looksLikeMaterializedCorpus,
+  shouldIncludeCorpusSourceFile,
   swapCorpusDirIntoPlace,
 } from "./materialize-source-corpus.mjs";
 
@@ -48,6 +49,66 @@ afterEach(() => {
     const dir = scratchDirs.pop();
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+describe("shouldIncludeCorpusSourceFile", () => {
+  it("excludes localized Core docs from the published corpus", () => {
+    assert.equal(
+      shouldIncludeCorpusSourceFile(
+        "packages/core",
+        "packages/core/docs/content/locales/de-DE/workspace.mdx",
+      ),
+      false,
+    );
+    assert.equal(
+      shouldIncludeCorpusSourceFile(
+        "packages/core",
+        "packages/core/docs/content/workspace.mdx",
+      ),
+      true,
+    );
+  });
+
+  it("keeps only the English example among template locale catalogs", () => {
+    assert.equal(
+      shouldIncludeCorpusSourceFile(
+        "templates",
+        "templates/plan/app/i18n/de-DE.ts",
+      ),
+      false,
+    );
+    assert.equal(
+      shouldIncludeCorpusSourceFile(
+        "templates",
+        "templates/plan/app/i18n/en-US.ts",
+      ),
+      true,
+    );
+    assert.equal(
+      shouldIncludeCorpusSourceFile(
+        "templates",
+        "templates/plan/app/i18n/index.ts",
+      ),
+      true,
+    );
+    assert.equal(
+      shouldIncludeCorpusSourceFile(
+        "templates",
+        "templates/plan/app/i18n/formatters.ts",
+      ),
+      true,
+    );
+  });
+
+  it("does not filter functional scaffold locales from Core source", () => {
+    assert.equal(
+      shouldIncludeCorpusSourceFile(
+        "packages/core",
+        "packages/core/src/templates/default/app/i18n/de-DE.ts",
+      ),
+      true,
+    );
+  });
 });
 
 describe("looksLikeMaterializedCorpus", () => {


### PR DESCRIPTION
## Summary

- exclude `docs/content/locales/**` from the published Core files list
- omit localized Core docs and non-English template catalogs from the reference-only source corpus
- retain English corpus examples, i18n index/helper files, and every functional scaffold locale
- add focused path-selection tests and a Core patch changeset

## Package impact

Measured against the published `@agent-native/core@0.111.0` tarball with the same prepack flow:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Package entries | 14,705 | 12,803 | -1,902 (-12.9%) |
| Tarball size | 38,523,915 B | 28,275,417 B | -10,248,498 B (-26.6%) |
| Unpacked size | 144,872,999 B | 107,122,100 B | -37,750,899 B (-26.1%) |

The removed reference payload is 881 direct docs locale files (17,743,414 B), the same 881 files duplicated in the corpus, and 140 non-English corpus template catalogs (2,265,037 B). Pack inspection confirms zero files remain in those three excluded groups, while all 14 `en-US.ts` corpus examples, all 14 corpus `i18n/index.ts` files, and the packaged functional scaffold locale catalogs remain.

## Validation

- `node --test packages/core/scripts/materialize-source-corpus.test.mjs` (10/10)
- `pnpm --filter @agent-native/core build`
- `pnpm --filter @agent-native/core test` (638 files; 8,294 passed, 1 skipped)
- `pnpm guards` (27/27)
- `pnpm prep`
- real prepack + `npm pack --dry-run --json --ignore-scripts` artifact inspection

This is a reference-only packaging trim; scaffold sources under `packages/core/src/templates/**` and runtime behavior are unchanged.