### PR TITLE
fix(core): harden manifest migration upgrades

### DIFF
--- a/.changeset/migrate-starter-source-imports.md
+++ b/.changeset/migrate-starter-source-imports.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Apply active import migrations to starter-owned source and install newly introduced migration dependencies before rewriting imports.

--- a/.github/workflows/sync-builder-starter.yml
+++ b/.github/workflows/sync-builder-starter.yml
@@ -8,6 +8,7 @@ on:
       # paths actually drift. Toolchain file list lives in sync-builder-starter-manifest.ts.
       - "templates/chat/**"
       - "pnpm-workspace.yaml"
+      - "packages/core/migration-manifest.json"
       - "packages/core/src/cli/create.ts"
       - "packages/core/src/cli/sync-builder-starter-manifest*"
       - "scripts/sync-builder-starter-manifest.ts"

--- a/packages/core/src/cli/migration-codemod.spec.ts
+++ b/packages/core/src/cli/migration-codemod.spec.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import type { MigrationManifest } from "../package-lifecycle/migration-manifest.js";
 import {
+  createMigrationPlanningTargetResolver,
   formatMigrationCodemodDiff,
   runMigrationCodemods,
 } from "./migration-codemod.js";
@@ -200,6 +201,134 @@ describe("runMigrationCodemods", () => {
       expect.arrayContaining([
         expect.stringContaining("not exported by an installed package"),
       ]),
+    );
+  });
+
+  it("plans a moved import and dependency when the target package is missing", () => {
+    const { root, source, packageFile } = fixture();
+    fs.writeFileSync(
+      source,
+      'import { Editor } from "@agent-native/core/client/editor";\nvoid Editor;\n',
+    );
+
+    const result = runMigrationCodemods({
+      root,
+      manifests: [
+        {
+          sinceVersion: "0.110.0",
+          moves: {
+            "@agent-native/core/client/editor": {
+              to: "@agent-native/toolkit/editor",
+            },
+          },
+        },
+      ],
+      targetExists: createMigrationPlanningTargetResolver(root),
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes.map((change) => change.file)).toEqual([
+      source,
+      packageFile,
+    ]);
+    expect(result.changes[0]?.after).toContain(
+      'from "@agent-native/toolkit/editor"',
+    );
+    expect(result.changes[1]?.after).toContain(
+      '"@agent-native/toolkit": "latest"',
+    );
+  });
+
+  it("skips a missing subpath when the target package is installed", () => {
+    const { root, source } = fixture();
+    fs.writeFileSync(
+      source,
+      'import { Editor } from "@agent-native/core/client/editor";\nvoid Editor;\n',
+    );
+    const toolkitDir = path.join(root, "node_modules/@agent-native/toolkit");
+    fs.mkdirSync(toolkitDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(toolkitDir, "package.json"),
+      `${JSON.stringify({
+        name: "@agent-native/toolkit",
+        exports: { ".": "./index.js" },
+      })}\n`,
+    );
+    fs.writeFileSync(path.join(toolkitDir, "index.js"), "export {};\n");
+
+    const result = runMigrationCodemods({
+      root,
+      manifests: [
+        {
+          sinceVersion: "0.110.0",
+          moves: {
+            "@agent-native/core/client/editor": {
+              to: "@agent-native/toolkit/editor",
+            },
+          },
+        },
+      ],
+      targetExists: createMigrationPlanningTargetResolver(root),
+    });
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([
+      expect.stringContaining("not exported by an installed package"),
+    ]);
+  });
+
+  it("resolves migration targets from the owning workspace package", () => {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), "an-codemod-workspace-"),
+    );
+    roots.push(root);
+    fs.writeFileSync(
+      path.join(root, "package.json"),
+      `${JSON.stringify({ private: true, workspaces: ["apps/*"] })}\n`,
+    );
+    const appRoot = path.join(root, "apps/chat");
+    const source = path.join(appRoot, "src/index.tsx");
+    fs.mkdirSync(path.dirname(source), { recursive: true });
+    fs.writeFileSync(
+      path.join(appRoot, "package.json"),
+      `${JSON.stringify({
+        name: "chat",
+        dependencies: { "@agent-native/core": "0.110.2" },
+      })}\n`,
+    );
+    fs.writeFileSync(
+      source,
+      'import { Editor } from "@agent-native/core/client/editor";\nvoid Editor;\n',
+    );
+    const toolkitDir = path.join(appRoot, "node_modules/@agent-native/toolkit");
+    fs.mkdirSync(toolkitDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(toolkitDir, "package.json"),
+      `${JSON.stringify({
+        name: "@agent-native/toolkit",
+        exports: { "./editor": "./editor.js" },
+      })}\n`,
+    );
+    fs.writeFileSync(path.join(toolkitDir, "editor.js"), "export {};\n");
+
+    const result = runMigrationCodemods({
+      root,
+      manifests: [
+        {
+          sinceVersion: "0.110.0",
+          moves: {
+            "@agent-native/core/client/editor": {
+              to: "@agent-native/toolkit/editor",
+            },
+          },
+        },
+      ],
+      apply: true,
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(fs.readFileSync(source, "utf-8")).toContain(
+      'from "@agent-native/toolkit/editor"',
     );
   });
 });

--- a/packages/core/src/cli/migration-codemod.ts
+++ b/packages/core/src/cli/migration-codemod.ts
@@ -48,7 +48,7 @@ export interface RunMigrationCodemodsOptions {
   root: string;
   manifests?: MigrationManifest[];
   apply?: boolean;
-  targetExists?: (specifier: string) => boolean;
+  targetExists?: (specifier: string, sourceFile?: string) => boolean;
 }
 
 interface PendingDependency {
@@ -102,6 +102,34 @@ function packageNameFromSpecifier(specifier: string): string | null {
   }
   const [name] = specifier.split("/");
   return name && !name.startsWith(".") ? name : null;
+}
+
+function isPackageInstalled(
+  requireFromProject: ReturnType<typeof createRequire>,
+  packageName: string,
+): boolean {
+  const searchPaths = requireFromProject.resolve.paths(packageName) ?? [];
+  return searchPaths.some((searchPath) =>
+    fs.existsSync(path.join(searchPath, packageName, "package.json")),
+  );
+}
+
+export function createMigrationPlanningTargetResolver(
+  projectRoot: string,
+): (specifier: string, sourceFile?: string) => boolean {
+  const fallbackPath = path.join(path.resolve(projectRoot), "package.json");
+  return (specifier: string, sourceFile = fallbackPath): boolean => {
+    const requireFromSource = createRequire(sourceFile);
+    try {
+      requireFromSource.resolve(specifier);
+      return true;
+    } catch {
+      const packageName = packageNameFromSpecifier(specifier);
+      return Boolean(
+        packageName && !isPackageInstalled(requireFromSource, packageName),
+      );
+    }
+  };
 }
 
 function nearestPackageFile(file: string, root: string): string | null {
@@ -175,7 +203,7 @@ function rewriteImportDeclaration(
   root: string,
   pendingDependencies: PendingDependency[],
   warnings: string[],
-  targetExists: (specifier: string) => boolean,
+  targetExists: (specifier: string, sourceFile?: string) => boolean,
 ): boolean {
   const originalSpecifier = declaration.getModuleSpecifierValue();
   const sourceFile = declaration.getSourceFile();
@@ -186,7 +214,7 @@ function rewriteImportDeclaration(
       warnSkippedTarget(warnings, sourceFile.getFilePath(), move.to, "planned");
       return false;
     }
-    if (!targetExists(move.to)) {
+    if (!targetExists(move.to, sourceFile.getFilePath())) {
       warnSkippedTarget(
         warnings,
         sourceFile.getFilePath(),
@@ -228,7 +256,7 @@ function rewriteImportDeclaration(
       );
       continue;
     }
-    if (!targetExists(resolved.to)) {
+    if (!targetExists(resolved.to, sourceFile.getFilePath())) {
       warnSkippedTarget(
         warnings,
         sourceFile.getFilePath(),
@@ -286,7 +314,7 @@ function rewriteExportDeclarations(
   root: string,
   pendingDependencies: PendingDependency[],
   warnings: string[],
-  targetExists: (specifier: string) => boolean,
+  targetExists: (specifier: string, sourceFile?: string) => boolean,
 ): void {
   for (const declaration of [...sourceFile.getExportDeclarations()]) {
     const originalSpecifier = declaration.getModuleSpecifierValue();
@@ -305,7 +333,7 @@ function rewriteExportDeclarations(
         );
         continue;
       }
-      if (!targetExists(move.to)) {
+      if (!targetExists(move.to, sourceFile.getFilePath())) {
         warnSkippedTarget(
           warnings,
           sourceFile.getFilePath(),
@@ -349,7 +377,7 @@ function rewriteExportDeclarations(
         );
         continue;
       }
-      if (!targetExists(resolved.to)) {
+      if (!targetExists(resolved.to, sourceFile.getFilePath())) {
         warnSkippedTarget(
           warnings,
           sourceFile.getFilePath(),
@@ -469,12 +497,11 @@ export function runMigrationCodemods(
   const root = path.resolve(options.root);
   const manifests = options.manifests ?? loadMigrationManifests(root);
   const moves = mergeManifestMoves(manifests);
-  const requireFromProject = createRequire(path.join(root, "package.json"));
   const targetExists =
     options.targetExists ??
-    ((specifier: string): boolean => {
+    ((specifier: string, sourceFile = path.join(root, "package.json")) => {
       try {
-        requireFromProject.resolve(specifier);
+        createRequire(sourceFile).resolve(specifier);
         return true;
       } catch {
         return false;

--- a/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
@@ -13,6 +13,9 @@ import {
   generateStandaloneChatManifest,
   listStarterSyncPaths,
   mergeStarterManifest,
+  migrateStarterSources,
+  resolveStarterCoreVersion,
+  STARTER_SOURCE_MIGRATION_PATHS,
   STARTER_TOOLCHAIN_SYNC_PATHS,
   syncStarterManifestFiles,
   workspaceFileSyncChanged,
@@ -101,6 +104,12 @@ describe("sync-builder-starter-manifest", () => {
 
   it("includes pnpm-lock.yaml in starter CI staging paths", () => {
     expect(listStarterSyncPaths()).toContain("pnpm-lock.yaml");
+  });
+
+  it("includes source pathspecs for manifest-driven migrations", () => {
+    expect(listStarterSyncPaths()).toEqual(
+      expect.arrayContaining([...STARTER_SOURCE_MIGRATION_PATHS]),
+    );
   });
 
   it(
@@ -220,6 +229,109 @@ describe("sync-builder-starter-manifest", () => {
         fs.rmSync(tempDir, { recursive: true, force: true });
       }
     });
+
+    it(
+      "applies active import migrations to starter-owned source",
+      () => {
+        tempDir = fs.mkdtempSync(
+          path.join(os.tmpdir(), "an-starter-sync-spec-"),
+        );
+        const { packageJson, pnpmWorkspaceYaml } =
+          generateStandaloneChatManifest(repoRoot);
+        fs.writeFileSync(
+          path.join(tempDir, "package.json"),
+          `${JSON.stringify(packageJson, null, 2)}\n`,
+        );
+        if (pnpmWorkspaceYaml) {
+          fs.writeFileSync(
+            path.join(tempDir, "pnpm-workspace.yaml"),
+            pnpmWorkspaceYaml,
+          );
+        }
+        const routePath = path.join(tempDir, "app/routes/_index.tsx");
+        fs.mkdirSync(path.dirname(routePath), { recursive: true });
+        fs.writeFileSync(
+          routePath,
+          [
+            'import { PromptComposer, openAgentSidebar, sendToAgentChat } from "@agent-native/core/client";',
+            "void PromptComposer;",
+            "void openAgentSidebar;",
+            "void sendToAgentChat;",
+            "",
+          ].join("\n"),
+        );
+
+        const result = syncStarterManifestFiles({
+          starterDir: tempDir,
+          repoRoot,
+          write: true,
+        });
+        const migrated = fs.readFileSync(routePath, "utf-8");
+
+        expect(result.changedSourceMigrationPaths).toContain(
+          "app/routes/_index.tsx",
+        );
+        expect(result.sourceMigrationWarnings).toEqual([]);
+        expect(migrated).toContain(
+          'from "@agent-native/core/client/agent-chat"',
+        );
+        expect(migrated).toContain('from "@agent-native/core/client/composer"');
+        expect(migrated).toContain(
+          'from "@agent-native/core/client/navigation"',
+        );
+        expect(migrated).not.toContain('from "@agent-native/core/client"');
+
+        expect(
+          migrateStarterSources({
+            starterDir: tempDir,
+            repoRoot,
+            coreVersion: resolveStarterCoreVersion(packageJson, repoRoot),
+            write: true,
+          }).changedPaths,
+        ).toEqual([]);
+      },
+      STARTER_MANIFEST_TIMEOUT_MS,
+    );
+
+    it(
+      "leaves source untouched when the starter predates the migration manifest",
+      () => {
+        tempDir = fs.mkdtempSync(
+          path.join(os.tmpdir(), "an-starter-sync-spec-"),
+        );
+        const { packageJson, pnpmWorkspaceYaml } =
+          generateStandaloneChatManifest(repoRoot);
+        const oldPackageJson = structuredClone(packageJson) as {
+          dependencies: Record<string, string>;
+        };
+        oldPackageJson.dependencies["@agent-native/core"] = "0.109.9";
+        fs.writeFileSync(
+          path.join(tempDir, "package.json"),
+          `${JSON.stringify(oldPackageJson, null, 2)}\n`,
+        );
+        if (pnpmWorkspaceYaml) {
+          fs.writeFileSync(
+            path.join(tempDir, "pnpm-workspace.yaml"),
+            pnpmWorkspaceYaml,
+          );
+        }
+        const routePath = path.join(tempDir, "app/routes/_index.tsx");
+        fs.mkdirSync(path.dirname(routePath), { recursive: true });
+        const original =
+          'import { PromptComposer } from "@agent-native/core/client";\n';
+        fs.writeFileSync(routePath, original);
+
+        const result = syncStarterManifestFiles({
+          starterDir: tempDir,
+          repoRoot,
+          write: true,
+        });
+
+        expect(result.changedSourceMigrationPaths).toEqual([]);
+        expect(fs.readFileSync(routePath, "utf-8")).toBe(original);
+      },
+      STARTER_MANIFEST_TIMEOUT_MS,
+    );
 
     it(
       "reports no changes when starter already matches the canonical manifest",

--- a/packages/core/src/cli/sync-builder-starter-manifest.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.ts
@@ -3,7 +3,12 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  isMigrationManifestActive,
+  readMigrationManifest,
+} from "../package-lifecycle/migration-manifest.js";
 import { _postProcessStandalone } from "./create.js";
+import { runMigrationCodemods } from "./migration-codemod.js";
 
 export const STARTER_APP_NAME = "builder-agent-native-starter";
 export const CHAT_TEMPLATE = "chat";
@@ -23,6 +28,11 @@ export const STARTER_TOOLCHAIN_SYNC_PATHS = [
   "components.json",
   ".oxfmtrc.json",
   "netlify.toml",
+] as const;
+
+export const STARTER_SOURCE_MIGRATION_PATHS = [
+  ":(glob)**/*.ts",
+  ":(glob)**/*.tsx",
 ] as const;
 
 const STANDALONE_SNAPSHOT_EXCLUDED_TOP_LEVEL = new Set([
@@ -58,7 +68,77 @@ export function listStarterSyncPaths(): string[] {
     "pnpm-lock.yaml",
     "pnpm-workspace.yaml",
     ...STARTER_TOOLCHAIN_SYNC_PATHS,
+    ...STARTER_SOURCE_MIGRATION_PATHS,
   ];
+}
+
+export function migrateStarterSources(options: {
+  starterDir: string;
+  repoRoot: string;
+  coreVersion: string | null;
+  write?: boolean;
+}): { changedPaths: string[]; warnings: string[] } {
+  const manifestPath = path.join(
+    options.repoRoot,
+    "packages/core/migration-manifest.json",
+  );
+  const manifest = readMigrationManifest(manifestPath);
+  if (!manifest) {
+    throw new Error(`Could not read migration manifest at ${manifestPath}.`);
+  }
+  if (!isMigrationManifestActive(manifest, options.coreVersion)) {
+    return { changedPaths: [], warnings: [] };
+  }
+
+  const result = runMigrationCodemods({
+    root: options.starterDir,
+    manifests: [manifest],
+    apply: options.write,
+    // Checked-in migration targets are validated by the manifest guard before
+    // this source sync runs; starter dependencies are installed afterward.
+    targetExists: () => true,
+  });
+
+  return {
+    changedPaths: [
+      ...new Set(
+        result.changes.map((change) =>
+          path.relative(options.starterDir, change.file),
+        ),
+      ),
+    ].sort(),
+    warnings: result.warnings,
+  };
+}
+
+export function resolveStarterCoreVersion(
+  starterPackageJson: PackageJson,
+  repoRoot: string,
+): string | null {
+  const dependencies = starterPackageJson.dependencies;
+  if (dependencies && typeof dependencies === "object") {
+    const declared = (dependencies as Record<string, unknown>)[
+      "@agent-native/core"
+    ];
+    if (typeof declared === "string") {
+      const version = declared.match(/\d+\.\d+\.\d+/)?.[0];
+      if (version) return version;
+    }
+  }
+
+  try {
+    const corePackageJson = JSON.parse(
+      fs.readFileSync(
+        path.join(repoRoot, "packages/core/package.json"),
+        "utf-8",
+      ),
+    ) as { version?: unknown };
+    return typeof corePackageJson.version === "string"
+      ? corePackageJson.version
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 export function findAgentNativeRoot(startDir = process.cwd()): string {
@@ -296,6 +376,8 @@ export type SyncStarterManifestResult = {
   pnpmWorkspaceYaml: string | null;
   toolchainChanges: StarterToolchainSyncChange[];
   changedToolchainPaths: StarterToolchainSyncPath[];
+  changedSourceMigrationPaths: string[];
+  sourceMigrationWarnings: string[];
 };
 
 export function resolveStarterPaths(options: {
@@ -345,6 +427,19 @@ export function syncStarterManifestFiles(options: {
   const snapshot = createStandaloneChatSnapshot(options.repoRoot);
 
   try {
+    const repoRoot = options.repoRoot ?? findAgentNativeRoot();
+    const initialStarterPackageJson = JSON.parse(
+      fs.readFileSync(starterPackageJsonPath, "utf-8"),
+    ) as PackageJson;
+    const sourceMigration = migrateStarterSources({
+      starterDir,
+      repoRoot,
+      coreVersion: resolveStarterCoreVersion(
+        initialStarterPackageJson,
+        repoRoot,
+      ),
+      write: options.write,
+    });
     const starterPackageJson = JSON.parse(
       fs.readFileSync(starterPackageJsonPath, "utf-8"),
     ) as PackageJson;
@@ -371,7 +466,10 @@ export function syncStarterManifestFiles(options: {
       .filter((change) => change.changed)
       .map((change) => change.relativePath);
     const changed =
-      packageChanged || workspaceChanged || changedToolchainPaths.length > 0;
+      packageChanged ||
+      workspaceChanged ||
+      changedToolchainPaths.length > 0 ||
+      sourceMigration.changedPaths.length > 0;
 
     if (options.write && changed) {
       if (packageChanged) {
@@ -396,6 +494,8 @@ export function syncStarterManifestFiles(options: {
       pnpmWorkspaceYaml: snapshot.pnpmWorkspaceYaml,
       toolchainChanges,
       changedToolchainPaths,
+      changedSourceMigrationPaths: sourceMigration.changedPaths,
+      sourceMigrationWarnings: sourceMigration.warnings,
     };
   } finally {
     snapshot.cleanup();
@@ -494,11 +594,18 @@ export function runSyncStarterManifestCli(argv: string[]): number {
     write: args.write,
   });
 
+  for (const warning of result.sourceMigrationWarnings) {
+    console.warn(`[starter migration] ${warning}`);
+  }
+
   if (result.changed) {
     const updatedPaths = [
-      ...(result.packageChanged ? ["package.json"] : []),
-      ...(result.workspaceChanged ? ["pnpm-workspace.yaml"] : []),
-      ...result.changedToolchainPaths,
+      ...new Set([
+        ...(result.packageChanged ? ["package.json"] : []),
+        ...(result.workspaceChanged ? ["pnpm-workspace.yaml"] : []),
+        ...result.changedToolchainPaths,
+        ...result.changedSourceMigrationPaths,
+      ]),
     ];
     const summary = updatedPaths.length ? ` (${updatedPaths.join(", ")})` : "";
     console.log(

--- a/packages/core/src/cli/upgrade.spec.ts
+++ b/packages/core/src/cli/upgrade.spec.ts
@@ -339,6 +339,244 @@ describe("runUpgrade", () => {
     expect(pkg.dependencies["@agent-native/core"]).toBe("latest");
   });
 
+  it("adds a missing migration dependency before install and applies source afterward", async () => {
+    const root = makeTempProject({
+      rootPkg: {
+        name: "old-app",
+        dependencies: { "@agent-native/core": "0.110.2" },
+      },
+    });
+    const source = path.join(root, "src/index.tsx");
+    fs.mkdirSync(path.dirname(source), { recursive: true });
+    fs.writeFileSync(
+      source,
+      'import { RichMarkdownEditor } from "@agent-native/core/client/editor";\nvoid RichMarkdownEditor;\n',
+    );
+    const installDependencies: Array<Record<string, string>> = [];
+    const { io } = captureIo({
+      spawn: (_command, args) => {
+        if (args.includes("install")) {
+          expect(fs.readFileSync(source, "utf-8")).toContain(
+            'from "@agent-native/core/client/editor"',
+          );
+          const packageJson = JSON.parse(
+            fs.readFileSync(path.join(root, "package.json"), "utf-8"),
+          ) as { dependencies: Record<string, string> };
+          installDependencies.push({ ...packageJson.dependencies });
+          const toolkitDir = path.join(
+            root,
+            "node_modules/@agent-native/toolkit",
+          );
+          fs.mkdirSync(toolkitDir, { recursive: true });
+          fs.writeFileSync(
+            path.join(toolkitDir, "package.json"),
+            `${JSON.stringify({
+              name: "@agent-native/toolkit",
+              exports: { "./editor": "./editor.js" },
+            })}\n`,
+          );
+          fs.writeFileSync(
+            path.join(toolkitDir, "editor.js"),
+            "export const RichMarkdownEditor = {};\n",
+          );
+        }
+        return {
+          status: 0,
+          pid: 1,
+          output: [],
+          stdout: "",
+          stderr: "",
+          signal: null,
+        };
+      },
+    });
+
+    const code = await runUpgrade(
+      ["--cwd", root, "--codemods", "--yes", "--skip-skills", "--skip-verify"],
+      io,
+    );
+
+    expect(code).toBe(0);
+    expect(installDependencies).toEqual([
+      expect.objectContaining({
+        "@agent-native/core": "latest",
+        "@agent-native/toolkit": "latest",
+      }),
+    ]);
+    expect(fs.readFileSync(source, "utf-8")).toContain(
+      'from "@agent-native/toolkit/editor"',
+    );
+  });
+
+  it("keeps an installed but unresolved migration subpath unchanged", async () => {
+    const root = makeTempProject({
+      rootPkg: {
+        name: "old-app",
+        dependencies: {
+          "@agent-native/core": "0.110.2",
+          "@agent-native/toolkit": "0.5.1",
+        },
+      },
+    });
+    const source = path.join(root, "src/index.tsx");
+    fs.mkdirSync(path.dirname(source), { recursive: true });
+    const original =
+      'import { RichMarkdownEditor } from "@agent-native/core/client/editor";\nvoid RichMarkdownEditor;\n';
+    fs.writeFileSync(source, original);
+    const toolkitDir = path.join(root, "node_modules/@agent-native/toolkit");
+    fs.mkdirSync(toolkitDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(toolkitDir, "package.json"),
+      `${JSON.stringify({
+        name: "@agent-native/toolkit",
+        exports: { ".": "./index.js" },
+      })}\n`,
+    );
+    fs.writeFileSync(path.join(toolkitDir, "index.js"), "export {};\n");
+    const { io, err } = captureIo();
+
+    const code = await runUpgrade(
+      ["--cwd", root, "--codemods", "--yes", "--skip-skills", "--skip-verify"],
+      io,
+    );
+
+    expect(code).toBe(0);
+    expect(fs.readFileSync(source, "utf-8")).toBe(original);
+    expect(err.join("\n")).toContain("not exported by an installed package");
+  });
+
+  it("reports only changes applied after post-install target verification", async () => {
+    const root = makeTempProject({
+      rootPkg: {
+        name: "old-app",
+        dependencies: { "@agent-native/core": "0.110.2" },
+      },
+    });
+    const source = path.join(root, "src/index.tsx");
+    fs.mkdirSync(path.dirname(source), { recursive: true });
+    const original =
+      'import { RichMarkdownEditor } from "@agent-native/core/client/editor";\nvoid RichMarkdownEditor;\n';
+    fs.writeFileSync(source, original);
+    const { io, out, err } = captureIo({
+      spawn: (_command, args) => {
+        if (args.includes("install")) {
+          const toolkitDir = path.join(
+            root,
+            "node_modules/@agent-native/toolkit",
+          );
+          fs.mkdirSync(toolkitDir, { recursive: true });
+          fs.writeFileSync(
+            path.join(toolkitDir, "package.json"),
+            `${JSON.stringify({
+              name: "@agent-native/toolkit",
+              exports: { ".": "./index.js" },
+            })}\n`,
+          );
+          fs.writeFileSync(path.join(toolkitDir, "index.js"), "export {};\n");
+        }
+        return {
+          status: 0,
+          pid: 1,
+          output: [],
+          stdout: "",
+          stderr: "",
+          signal: null,
+        };
+      },
+    });
+
+    const code = await runUpgrade(
+      ["--cwd", root, "--codemods", "--yes", "--skip-skills", "--skip-verify"],
+      io,
+    );
+
+    expect(code).toBe(0);
+    expect(fs.readFileSync(source, "utf-8")).toBe(original);
+    expect(out.join("\n")).not.toContain("+++ b/src/index.tsx");
+    expect(err.join("\n")).toContain("not exported by an installed package");
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(root, "package.json"), "utf-8"),
+    ) as { dependencies: Record<string, string> };
+    expect(pkg.dependencies["@agent-native/toolkit"]).toBe("latest");
+  });
+
+  it("reports dependency changes when installation fails before source rewrites", async () => {
+    const root = makeTempProject({
+      rootPkg: {
+        name: "old-app",
+        dependencies: { "@agent-native/core": "0.110.2" },
+      },
+    });
+    const source = path.join(root, "src/index.tsx");
+    fs.mkdirSync(path.dirname(source), { recursive: true });
+    const original =
+      'import { RichMarkdownEditor } from "@agent-native/core/client/editor";\nvoid RichMarkdownEditor;\n';
+    fs.writeFileSync(source, original);
+    const { io, err } = captureIo({
+      spawn: () => ({
+        status: 1,
+        pid: 1,
+        output: [],
+        stdout: "",
+        stderr: "boom",
+        signal: null,
+      }),
+    });
+
+    const code = await runUpgrade(
+      [
+        "--cwd",
+        root,
+        "--codemods",
+        "--yes",
+        "--json",
+        "--skip-skills",
+        "--skip-verify",
+      ],
+      io,
+    );
+
+    expect(code).toBe(1);
+    expect(fs.readFileSync(source, "utf-8")).toBe(original);
+    const result = JSON.parse(err.join("\n")) as {
+      codemod: { files: string[]; diff: string };
+    };
+    expect(result.codemod.files).toEqual(["package.json"]);
+    expect(result.codemod.diff).toContain('"@agent-native/toolkit": "latest"');
+  });
+
+  it("reports codemods applied while dependency installation is skipped", async () => {
+    const root = makeTempProject({
+      rootPkg: {
+        name: "old-app",
+        dependencies: { "@agent-native/core": "0.110.2" },
+      },
+    });
+    const source = path.join(root, "src/index.tsx");
+    fs.mkdirSync(path.dirname(source), { recursive: true });
+    fs.writeFileSync(
+      source,
+      'import { RichMarkdownEditor } from "@agent-native/core/client/editor";\nvoid RichMarkdownEditor;\n',
+    );
+    const { io, out } = captureIo();
+
+    const code = await runUpgrade(
+      [
+        "--cwd",
+        root,
+        "--codemods",
+        "--yes",
+        "--skip-install",
+        "--skip-skills",
+        "--skip-verify",
+      ],
+      io,
+    );
+
+    expect(code).toBe(0);
+    expect(out.join("\n")).toContain("without installing dependencies");
+  });
+
   it("prints failure guidance when install fails", async () => {
     const root = makeTempProject({
       rootPkg: {

--- a/packages/core/src/cli/upgrade.ts
+++ b/packages/core/src/cli/upgrade.ts
@@ -18,6 +18,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import type { MigrationCodemodResult } from "./migration-codemod.js";
+
 const AGENT_NATIVE_SCOPE = "@agent-native/";
 const PINNABLE_VERSION = "latest";
 
@@ -541,6 +543,19 @@ const FAILURE_GUIDANCE = [
   "  npx @agent-native/core@latest upgrade",
 ].join("\n");
 
+function applyCodemodDependencyPlan(
+  codemodResult: MigrationCodemodResult,
+): MigrationCodemodResult["changes"] {
+  const dependencyFiles = new Set(codemodResult.dependencyFiles);
+  const applied: MigrationCodemodResult["changes"] = [];
+  for (const change of codemodResult.changes) {
+    if (!dependencyFiles.has(change.file)) continue;
+    fs.writeFileSync(change.file, change.after);
+    applied.push(change);
+  }
+  return applied;
+}
+
 export async function runUpgrade(
   argv: string[],
   io: UpgradeIo = defaultIo,
@@ -659,39 +674,57 @@ export async function runUpgrade(
     });
   }
 
+  let codemodPlan:
+    | {
+        module: typeof import("./migration-codemod.js");
+        dependencyChanges: MigrationCodemodResult["changes"];
+      }
+    | undefined;
+
   if (opts.codemods) {
-    const { formatMigrationCodemodDiff, runMigrationCodemods } =
-      await import("./migration-codemod.js");
-    const codemodResult = runMigrationCodemods({
+    const codemodModule = await import("./migration-codemod.js");
+    const codemodResult = codemodModule.runMigrationCodemods({
       root: project.root,
-      apply: !dryRun,
-    });
-    const diff = formatMigrationCodemodDiff(codemodResult, project.root);
-    result.codemod = {
-      files: codemodResult.changes.map((change) =>
-        relativeTo(project.root, change.file),
+      targetExists: codemodModule.createMigrationPlanningTargetResolver(
+        project.root,
       ),
-      warnings: codemodResult.warnings,
-      diff,
-    };
-    result.steps.push({
-      id: "codemods",
-      status:
-        codemodResult.changes.length === 0
-          ? "skipped"
-          : dryRun
-            ? "planned"
-            : "ok",
-      detail:
-        codemodResult.changes.length === 0
-          ? "No manifest migrations found"
-          : `${dryRun ? "Would update" : "Updated"} ${codemodResult.changes.length} file(s)`,
     });
-    if (!opts.json && diff) {
+    const diff = codemodModule.formatMigrationCodemodDiff(
+      codemodResult,
+      project.root,
+    );
+    const dependencyChanges = dryRun
+      ? []
+      : applyCodemodDependencyPlan(codemodResult);
+    codemodPlan = {
+      module: codemodModule,
+      dependencyChanges,
+    };
+
+    if (dryRun) {
+      result.codemod = {
+        files: codemodResult.changes.map((change) =>
+          relativeTo(project.root, change.file),
+        ),
+        warnings: codemodResult.warnings,
+        diff,
+      };
+    }
+    if (dryRun) {
+      result.steps.push({
+        id: "codemods",
+        status: codemodResult.changes.length === 0 ? "skipped" : "planned",
+        detail:
+          codemodResult.changes.length === 0
+            ? "No manifest migrations found"
+            : `Would update ${codemodResult.changes.length} file(s)`,
+      });
+    }
+    if (dryRun && !opts.json && diff) {
       io.log(diff);
       io.log("");
     }
-    if (!opts.json) {
+    if (dryRun && !opts.json) {
       for (const warning of codemodResult.warnings) {
         io.err(`[codemods] ${warning}`);
       }
@@ -721,6 +754,30 @@ export async function runUpgrade(
       result.ok = false;
       result.exitCode = spawned.status ?? 1;
       result.message = `${pm} install failed`;
+      if (codemodPlan && codemodPlan.dependencyChanges.length > 0) {
+        const dependencyResult: MigrationCodemodResult = {
+          changes: codemodPlan.dependencyChanges,
+          dependencyFiles: codemodPlan.dependencyChanges.map(
+            (change) => change.file,
+          ),
+          warnings: [],
+        };
+        const diff = codemodPlan.module.formatMigrationCodemodDiff(
+          dependencyResult,
+          project.root,
+        );
+        result.codemod = {
+          files: dependencyResult.changes.map((change) =>
+            relativeTo(project.root, change.file),
+          ),
+          warnings: [],
+          diff,
+        };
+        if (!opts.json && diff) {
+          io.log(diff);
+          io.log("");
+        }
+      }
       result.steps.push({
         id: "install",
         status: "failed",
@@ -730,6 +787,51 @@ export async function runUpgrade(
       return result.exitCode;
     }
     result.steps.push({ id: "install", status: "ok", detail: `${pm} install` });
+  }
+
+  if (codemodPlan && !dryRun) {
+    const applied = codemodPlan.module.runMigrationCodemods({
+      root: project.root,
+      apply: true,
+    });
+    const actualResult: MigrationCodemodResult = {
+      changes: [...codemodPlan.dependencyChanges, ...applied.changes],
+      dependencyFiles: codemodPlan.dependencyChanges.map(
+        (change) => change.file,
+      ),
+      warnings: applied.warnings,
+    };
+    const diff = codemodPlan.module.formatMigrationCodemodDiff(
+      actualResult,
+      project.root,
+    );
+    const files = [
+      ...new Set(actualResult.changes.map((change) => change.file)),
+    ];
+    result.codemod = {
+      files: files.map((file) => relativeTo(project.root, file)),
+      warnings: actualResult.warnings,
+      diff,
+    };
+    result.steps.push({
+      id: "codemods",
+      status: files.length === 0 ? "skipped" : "ok",
+      detail:
+        files.length === 0
+          ? "No resolvable manifest migrations found"
+          : opts.skipInstall
+            ? `Updated ${files.length} file(s) without installing dependencies`
+            : `Updated ${files.length} file(s) after dependency installation`,
+    });
+    if (!opts.json && diff) {
+      io.log(diff);
+      io.log("");
+    }
+    if (!opts.json) {
+      for (const warning of actualResult.warnings) {
+        io.err(`[codemods] ${warning}`);
+      }
+    }
   }
 
   // Skills refresh.


### PR DESCRIPTION
## Summary

- stage migration-introduced dependencies before install, then verify and apply source rewrites against the installed target
- distinguish missing packages from installed packages with invalid export subpaths, including package-local resolution in workspaces
- migrate active manifest imports in the Builder starter sync so package bumps cannot leave tombstoned imports behind
- trigger the starter sync whenever the Core migration manifest changes

## Validation

- focused migration, upgrade, and starter-sync specs: 43/43 passed
- Core typecheck passed
- 27/27 repository guards passed
- all workspace typechecks passed
- real registry E2E from Core 0.110.2 with no Toolkit dependency: Toolkit was added before install, then `RichMarkdownEditor` rewrote to `@agent-native/toolkit/editor` and resolved from the installed package
- external starter scratch builds passed with both preserved pins (Core 0.110.3 / Toolkit 0.5.1) and current published pins (Core 0.111.2 / Toolkit 0.6.0)
- full `pnpm prep` repeated one unrelated `create-e2e.spec.ts` local-pin assertion failure (`workspace:*` observed instead of `file://`); the exact test passes in isolation

## Browser scope

No browser runtime code changes here. The Composer flip was browser-smoked in #2240; this follow-up exercises upgraded apps through real production builds.