### PR TITLE
fix(core): refresh migration target resolution

### DIFF
--- a/.changeset/fresh-migration-target-resolution.md
+++ b/.changeset/fresh-migration-target-resolution.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Re-scan installed package exports after dependency installation before applying manifest import migrations.

--- a/packages/core/src/cli/migration-codemod.spec.ts
+++ b/packages/core/src/cli/migration-codemod.spec.ts
@@ -299,6 +299,53 @@ describe("runMigrationCodemods", () => {
     );
   });
 
+  it("forwards custom export conditions to fresh target resolution", () => {
+    const { root, source } = fixture();
+    fs.writeFileSync(
+      source,
+      'import { Editor } from "@agent-native/core/client/editor";\nvoid Editor;\n',
+    );
+    const toolkitDir = path.join(root, "node_modules/@agent-native/toolkit");
+    fs.mkdirSync(toolkitDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(toolkitDir, "package.json"),
+      `${JSON.stringify({
+        name: "@agent-native/toolkit",
+        exports: {
+          "./editor": {
+            "agent-native-test": "./editor.js",
+          },
+        },
+      })}\n`,
+    );
+    fs.writeFileSync(path.join(toolkitDir, "editor.js"), "export {};\n");
+    const originalExecArgv = [...process.execArgv];
+    process.execArgv.push("--conditions=agent-native-test");
+    try {
+      const result = runMigrationCodemods({
+        root,
+        manifests: [
+          {
+            sinceVersion: "0.110.0",
+            moves: {
+              "@agent-native/core/client/editor": {
+                to: "@agent-native/toolkit/editor",
+              },
+            },
+          },
+        ],
+        apply: true,
+      });
+
+      expect(result.warnings).toEqual([]);
+      expect(fs.readFileSync(source, "utf-8")).toContain(
+        'from "@agent-native/toolkit/editor"',
+      );
+    } finally {
+      process.execArgv.splice(0, process.execArgv.length, ...originalExecArgv);
+    }
+  });
+
   it("skips a missing subpath when the target package is installed", () => {
     const { root, source } = fixture();
     fs.writeFileSync(

--- a/packages/core/src/cli/migration-codemod.spec.ts
+++ b/packages/core/src/cli/migration-codemod.spec.ts
@@ -239,6 +239,66 @@ describe("runMigrationCodemods", () => {
     );
   });
 
+  it("resolves a target installed after planning in the same process", () => {
+    const { root, source } = fixture();
+    fs.writeFileSync(
+      source,
+      'import { Editor } from "@agent-native/core/client/editor";\nvoid Editor;\n',
+    );
+    const moveManifest: MigrationManifest = {
+      sinceVersion: "0.110.0",
+      moves: {
+        "@agent-native/core/client/editor": {
+          to: "@agent-native/toolkit/editor",
+        },
+      },
+    };
+    const toolkitDir = path.join(root, "node_modules/@agent-native/toolkit");
+    fs.mkdirSync(toolkitDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(toolkitDir, "package.json"),
+      `${JSON.stringify({
+        name: "@agent-native/toolkit",
+        exports: { ".": "./index.js" },
+      })}\n`,
+    );
+    fs.writeFileSync(path.join(toolkitDir, "index.js"), "export {};\n");
+    const planningResolver = createMigrationPlanningTargetResolver(root);
+    expect(planningResolver("@agent-native/toolkit/editor", source)).toBe(
+      false,
+    );
+
+    fs.writeFileSync(
+      path.join(toolkitDir, "package.json"),
+      `${JSON.stringify({
+        name: "@agent-native/toolkit",
+        exports: {
+          "./editor": {
+            types: "./dist/editor/index.d.ts",
+            import: "./dist/editor/index.js",
+            default: "./dist/editor/index.js",
+          },
+        },
+      })}\n`,
+    );
+    fs.mkdirSync(path.join(toolkitDir, "dist/editor"), { recursive: true });
+    fs.writeFileSync(
+      path.join(toolkitDir, "dist/editor/index.js"),
+      "export {};\n",
+    );
+
+    const result = runMigrationCodemods({
+      root,
+      manifests: [moveManifest],
+      apply: true,
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(fs.readFileSync(source, "utf-8")).toContain(
+      'from "@agent-native/toolkit/editor"',
+    );
+  });
+
   it("skips a missing subpath when the target package is installed", () => {
     const { root, source } = fixture();
     fs.writeFileSync(

--- a/packages/core/src/cli/migration-codemod.ts
+++ b/packages/core/src/cli/migration-codemod.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
@@ -129,6 +130,37 @@ export function createMigrationPlanningTargetResolver(
         packageName && !isPackageInstalled(requireFromSource, packageName),
       );
     }
+  };
+}
+
+const FRESH_RESOLVE_SCRIPT = [
+  'const { createRequire } = require("node:module");',
+  "try {",
+  "  createRequire(process.argv[1]).resolve(process.argv[2]);",
+  "} catch {",
+  "  process.exitCode = 1;",
+  "}",
+].join("\n");
+
+function createFreshMigrationTargetResolver(
+  projectRoot: string,
+): (specifier: string, sourceFile?: string) => boolean {
+  const fallbackPath = path.join(path.resolve(projectRoot), "package.json");
+  const cache = new Map<string, boolean>();
+  return (specifier: string, sourceFile = fallbackPath): boolean => {
+    const resolutionBase =
+      nearestPackageFile(sourceFile, projectRoot) ?? sourceFile;
+    const key = `${resolutionBase}\0${specifier}`;
+    const cached = cache.get(key);
+    if (cached !== undefined) return cached;
+    const resolved =
+      spawnSync(
+        process.execPath,
+        ["-e", FRESH_RESOLVE_SCRIPT, resolutionBase, specifier],
+        { stdio: "ignore" },
+      ).status === 0;
+    cache.set(key, resolved);
+    return resolved;
   };
 }
 
@@ -498,15 +530,7 @@ export function runMigrationCodemods(
   const manifests = options.manifests ?? loadMigrationManifests(root);
   const moves = mergeManifestMoves(manifests);
   const targetExists =
-    options.targetExists ??
-    ((specifier: string, sourceFile = path.join(root, "package.json")) => {
-      try {
-        createRequire(sourceFile).resolve(specifier);
-        return true;
-      } catch {
-        return false;
-      }
-    });
+    options.targetExists ?? createFreshMigrationTargetResolver(root);
   const project = new Project({
     skipAddingFilesFromTsConfig: true,
     manipulationSettings: { quoteKind: QuoteKind.Double },

--- a/packages/core/src/cli/migration-codemod.ts
+++ b/packages/core/src/cli/migration-codemod.ts
@@ -142,6 +142,26 @@ const FRESH_RESOLVE_SCRIPT = [
   "}",
 ].join("\n");
 
+function nodeConditionArgs(): string[] {
+  const conditions: string[] = [];
+  for (let index = 0; index < process.execArgv.length; index += 1) {
+    const argument = process.execArgv[index];
+    if (argument === "--conditions" || argument === "-C") {
+      const value = process.execArgv[index + 1];
+      if (value) {
+        conditions.push(argument, value);
+        index += 1;
+      }
+    } else if (
+      argument.startsWith("--conditions=") ||
+      argument.startsWith("-C=")
+    ) {
+      conditions.push(argument);
+    }
+  }
+  return conditions;
+}
+
 function createFreshMigrationTargetResolver(
   projectRoot: string,
 ): (specifier: string, sourceFile?: string) => boolean {
@@ -156,7 +176,13 @@ function createFreshMigrationTargetResolver(
     const resolved =
       spawnSync(
         process.execPath,
-        ["-e", FRESH_RESOLVE_SCRIPT, resolutionBase, specifier],
+        [
+          ...nodeConditionArgs(),
+          "-e",
+          FRESH_RESOLVE_SCRIPT,
+          resolutionBase,
+          specifier,
+        ],
         { stdio: "ignore" },
       ).status === 0;
     cache.set(key, resolved);


### PR DESCRIPTION
## Summary

- resolve post-install migration targets in a fresh Node process so package/export metadata cached before install cannot produce a false unresolved warning
- memoize resolution by owning package and target specifier while preserving Node export-condition semantics
- cover an installed old package whose export map changes during the upgrade

## Why

Post-release verification of Core 0.111.3 reproduced the full 0.110.2 → 0.111.3 upgrade. Dependency introduction and install worked, but the long-lived CLI process retained stale package export metadata and refused the source rewrite. A fresh Node process resolved the newly installed `@agent-native/toolkit/editor` immediately.

## Validation

- migration + upgrade specs: 26/26 passed
- Core typecheck passed
- Core build and dist import checks passed
- 27/27 repository guards passed
- rebuilt-dist E2E from Core 0.110.2 with no direct Toolkit dependency: added Toolkit, installed Core 0.111.3 / Toolkit 0.6.0, rewrote `RichMarkdownEditor` to `@agent-native/toolkit/editor`, and resolved the installed export

## Browser scope

No browser runtime code changes; validation is against the packaged CLI and a real scratch app dependency install.