### PR TITLE
Fix play button not restarting ended clip

### DIFF
--- a/templates/clips/app/components/player/video-player.test.tsx
+++ b/templates/clips/app/components/player/video-player.test.tsx
@@ -172,6 +172,32 @@ describe("VideoPlayer playback", () => {
     expect(video.paused).toBe(false);
   });
 
+  it("replays from the start when the surface is clicked after the clip ended", () => {
+    const surface = getPlayerSurface();
+    const video = getVideo();
+
+    act(() => {
+      surface.click();
+    });
+    expect(video.paused).toBe(false);
+
+    // Reaching end of stream can fire "ended" while the browser leaves paused
+    // false (MSE end-of-stream / DB-duration mismatch). The play button must
+    // still restart from the beginning rather than pausing a finished clip.
+    video.currentTime = 10;
+    Object.defineProperty(video, "ended", { configurable: true, value: true });
+    act(() => {
+      video.dispatchEvent(new Event("ended"));
+    });
+
+    act(() => {
+      surface.click();
+    });
+
+    expect(video.currentTime).toBe(0);
+    expect(video.paused).toBe(false);
+  });
+
   it("suppresses the synthetic click that follows a touch tap instead of double-toggling playback", () => {
     const surface = getPlayerSurface();
     const video = getVideo();

--- a/templates/clips/app/components/player/video-player.tsx
+++ b/templates/clips/app/components/player/video-player.tsx
@@ -598,10 +598,10 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
     const togglePlayback = useCallback(() => {
       const v = videoRef.current;
       if (!v) return;
-      if (!v.paused || isPlaying) {
-        pauseVideo();
-        return;
-      }
+      // A finished clip must always replay from the start, even when the browser
+      // left `paused` false at end of stream (MSE end-of-stream / DB-duration
+      // mismatch) or `isPlaying` is stale — otherwise the toggle below would
+      // pause an already-ended element and the play button appears to do nothing.
       if (v.ended) {
         try {
           v.currentTime = 0;
@@ -609,6 +609,12 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
         } catch {
           // Let the normal play attempt report a media error if the seek fails.
         }
+        requestPlay();
+        return;
+      }
+      if (!v.paused || isPlaying) {
+        pauseVideo();
+        return;
       }
       requestPlay();
     }, [isPlaying, pauseVideo, requestPlay]);


### PR DESCRIPTION
### Summary
Fixes the play/pause toggle in the clips video player so clicking play after a clip finishes always restarts playback from the beginning.

### Problem
When a clip finished playing, clicking the play button did nothing. This happened because the browser can leave `video.paused` as `false` (or `isPlaying` stale) at end of stream due to MSE end-of-stream / DB-duration mismatches, causing the toggle logic to treat the click as a "pause" action on an already-ended element instead of replaying it.

### Solution
Reordered the toggle logic in `togglePlayback` to check `video.ended` first, before checking `paused`/`isPlaying`. This ensures a finished clip is always reset to the start and replayed, regardless of the browser's reported paused state.

### Key Changes
- `video-player.tsx`: Moved the `v.ended` check ahead of the `!v.paused || isPlaying` check in `togglePlayback`, so an ended clip resets `currentTime` to 0 and calls `requestPlay()` instead of being paused again.
- `video-player.test.tsx`: Added a test simulating an "ended" event where `paused` remains `false`, verifying that clicking the player surface afterward resets `currentTime` to 0 and resumes playback.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/vortex-jewel-ndsjqvru"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-vortex-jewel-ndsjqvru.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2261`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>vortex-jewel-ndsjqvru</branchName>-->