### PR TITLE
fix: design app local dev server crash

### DIFF
--- a/.agents/skills/feature-flags/SKILL.md
+++ b/.agents/skills/feature-flags/SKILL.md
@@ -37,7 +37,7 @@ Keep definitions in a shared TypeScript module so server and client code use the
 same stable key. Flags are boolean and default-off.
 
 ```ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/.changeset/browser-safe-feature-flag-registry.md
+++ b/.changeset/browser-safe-feature-flag-registry.md
@@ -1,0 +1,24 @@
+---
+"@agent-native/core": patch
+---
+
+fix(core): keep feature-flag definitions out of the browser server graph
+
+App-shared config that imported feature-flag definitions from
+`@agent-native/core/feature-flags` pulled the barrel's server re-exports
+(`store` → `settings/store` → `db/client` → request telemetry) into the client
+dev graph. Vite's dev server does not tree-shake, so the browser evaluated that
+server chain and `request-telemetry`'s top-level `new AsyncLocalStorage()` threw
+against the externalized `node:async_hooks` stub, breaking app load in dev
+(production tree-shakes it away and was unaffected).
+
+- Add a client-safe `@agent-native/core/feature-flags/registry` entry for
+  `defineFeatureFlag` / `defineFeatureFlags` / `registerFeatureFlags` so shared
+  config no longer imports the server barrel.
+- Make `db/request-telemetry` and `settings/store` resolve `AsyncLocalStorage` /
+  `EventEmitter` lazily via `process.getBuiltinModule` (matching
+  `server/request-context`) instead of a top-level value import, so the modules
+  can be evaluated in any runtime without tripping the browser stub.
+- Add a regression guard asserting the client-safe registry entry never reaches
+  the server layer and that those modules never statically value-import the
+  builtins.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -159,6 +159,7 @@
     "./application-state": "./dist/application-state/index.js",
     "./settings": "./dist/settings/index.js",
     "./feature-flags": "./dist/feature-flags/index.js",
+    "./feature-flags/registry": "./dist/feature-flags/registry.js",
     "./feature-flags/actions/get-feature-flags": "./dist/feature-flags/actions/get-feature-flags.js",
     "./feature-flags/actions/list-feature-flags": "./dist/feature-flags/actions/list-feature-flags.js",
     "./feature-flags/actions/set-feature-flag": "./dist/feature-flags/actions/set-feature-flag.js",

--- a/packages/core/src/db/request-telemetry.ts
+++ b/packages/core/src/db/request-telemetry.ts
@@ -1,4 +1,4 @@
-import { AsyncLocalStorage } from "node:async_hooks";
+import { getAsyncLocalStorageCtor } from "../shared/optional-node-builtins.js";
 
 export type DatabaseOperationKind = "connect" | "query";
 
@@ -30,15 +30,39 @@ interface StartupDatabaseTelemetryState {
   claimed: boolean;
   telemetry: DatabaseRequestTelemetry;
 }
+interface TelemetryStorage {
+  getStore(): DatabaseRequestTelemetry | undefined;
+  run<T>(store: DatabaseRequestTelemetry, fn: () => T): T;
+  enterWith(store: DatabaseRequestTelemetry): void;
+}
+
 type GlobalWithDatabaseTelemetry = typeof globalThis & {
-  [STORAGE_KEY]?: AsyncLocalStorage<DatabaseRequestTelemetry>;
+  [STORAGE_KEY]?: TelemetryStorage;
   [STARTUP_STATE_KEY]?: StartupDatabaseTelemetryState;
 };
 
 const globalRef = globalThis as GlobalWithDatabaseTelemetry;
-const storage =
-  globalRef[STORAGE_KEY] ??
-  (globalRef[STORAGE_KEY] = new AsyncLocalStorage<DatabaseRequestTelemetry>());
+
+// AsyncLocalStorage is resolved lazily, never at module load: this module can
+// land in the browser dev graph, where a top-level `new AsyncLocalStorage()`
+// would throw against Vite's externalized `node:async_hooks` stub. On non-Node
+// runtimes telemetry no-ops.
+const NOOP_STORAGE: TelemetryStorage = {
+  getStore: () => undefined,
+  run: (_store, fn) => fn(),
+  enterWith: () => {},
+};
+
+function getStorage(): TelemetryStorage {
+  const existing = globalRef[STORAGE_KEY];
+  if (existing) return existing;
+  const Ctor = getAsyncLocalStorageCtor();
+  const created: TelemetryStorage = Ctor
+    ? new Ctor<DatabaseRequestTelemetry>()
+    : NOOP_STORAGE;
+  globalRef[STORAGE_KEY] = created;
+  return created;
+}
 
 export function createDatabaseRequestTelemetry(): DatabaseRequestTelemetry {
   return {
@@ -66,7 +90,7 @@ const startupState =
   });
 
 function currentDatabaseTelemetry(): DatabaseRequestTelemetry | undefined {
-  const requestTelemetry = storage.getStore();
+  const requestTelemetry = getStorage().getStore();
   if (requestTelemetry) return requestTelemetry;
   if (!startupState.claimed && Date.now() <= startupState.captureUntil) {
     return startupState.telemetry;
@@ -86,13 +110,13 @@ export function runWithDatabaseRequestTelemetry<T>(
   telemetry: DatabaseRequestTelemetry,
   fn: () => T,
 ): T {
-  return storage.run(telemetry, fn);
+  return getStorage().run(telemetry, fn);
 }
 
 export function enterDatabaseRequestTelemetry(
   telemetry: DatabaseRequestTelemetry,
 ): void {
-  storage.enterWith(telemetry);
+  getStorage().enterWith(telemetry);
 }
 
 export function beginDatabaseOperation(

--- a/packages/core/src/feature-flags/browser-safe.guard.spec.ts
+++ b/packages/core/src/feature-flags/browser-safe.guard.spec.ts
@@ -1,0 +1,194 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression guard for the dev-only "server code in the browser" crash.
+ *
+ * Root cause history: `@agent-native/core/feature-flags` (the server barrel)
+ * value-re-exports `store.ts`, which reaches `settings/store` → `db/client` →
+ * `request-telemetry`. When app-shared config (imported by client routes)
+ * pulled definitions from that barrel, Vite's dev server (no tree-shaking)
+ * evaluated the whole server chain in the browser. `request-telemetry`'s
+ * top-level `new AsyncLocalStorage()` and `settings/store`'s top-level
+ * `new EventEmitter()` then threw against Vite's externalized node-builtin
+ * stubs and broke the app on load.
+ *
+ * Two invariants keep it fixed:
+ *  1. `feature-flags/registry.ts` (the client-safe definition entry that
+ *     app-shared config imports) must never statically reach the server layer
+ *     (`db/`, `settings/`, `server/`, or the feature-flags server modules) or a
+ *     Node builtin.
+ *  2. The modules that legitimately touch Node builtins in a possibly-browser
+ *     graph must not statically value-import them (only `import type`), so the
+ *     module can be evaluated anywhere without tripping the externalized stub.
+ */
+
+const SRC_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const NODE_BUILTINS = new Set([
+  "assert",
+  "async_hooks",
+  "buffer",
+  "child_process",
+  "cluster",
+  "console",
+  "crypto",
+  "dgram",
+  "dns",
+  "events",
+  "fs",
+  "fs/promises",
+  "http",
+  "http2",
+  "https",
+  "module",
+  "net",
+  "os",
+  "path",
+  "perf_hooks",
+  "process",
+  "querystring",
+  "readline",
+  "stream",
+  "string_decoder",
+  "timers",
+  "tls",
+  "tty",
+  "url",
+  "util",
+  "v8",
+  "vm",
+  "worker_threads",
+  "zlib",
+]);
+
+function isNodeBuiltin(spec: string): boolean {
+  if (spec.startsWith("node:")) return true;
+  return NODE_BUILTINS.has(spec);
+}
+
+/**
+ * Runtime (non-type) static import / re-export specifiers. Whole-statement
+ * `import type` / `export type` is skipped (erased at build); dynamic
+ * `import()` is intentionally skipped (it does not force eager evaluation).
+ */
+function staticSpecifiers(code: string): string[] {
+  const specs: string[] = [];
+  const fromRe =
+    /(?:^|\n)[ \t]*(?:import|export)\b([^;'"]*?)\bfrom[ \t\n]*["']([^"']+)["']/g;
+  let m: RegExpExecArray | null;
+  while ((m = fromRe.exec(code))) {
+    const clause = m[1] ?? "";
+    if (/^\s*type\b/.test(clause)) continue;
+    specs.push(m[2]);
+  }
+  const sideEffectRe = /(?:^|\n)[ \t]*import[ \t]*["']([^"']+)["']/g;
+  while ((m = sideEffectRe.exec(code))) specs.push(m[1]);
+  return specs;
+}
+
+function resolveRelative(fromFile: string, spec: string): string | null {
+  if (!spec.startsWith(".")) return null;
+  const base = resolve(dirname(fromFile), spec);
+  const candidates = [
+    base,
+    base.replace(/\.js$/, ".ts"),
+    base.replace(/\.js$/, ".tsx"),
+    `${base}.ts`,
+    `${base}.tsx`,
+    join(base, "index.ts"),
+    join(base, "index.tsx"),
+  ];
+  for (const c of candidates) {
+    if (existsSync(c) && statSync(c).isFile()) return c;
+  }
+  return null;
+}
+
+interface WalkResult {
+  visited: Set<string>;
+  builtinHits: { file: string; spec: string }[];
+}
+
+function walkGraph(entry: string): WalkResult {
+  const visited = new Set<string>();
+  const builtinHits: { file: string; spec: string }[] = [];
+  const stack = [entry];
+  while (stack.length) {
+    const file = stack.pop()!;
+    if (visited.has(file)) continue;
+    visited.add(file);
+    const code = readFileSync(file, "utf8");
+    for (const spec of staticSpecifiers(code)) {
+      if (isNodeBuiltin(spec)) {
+        builtinHits.push({ file, spec });
+        continue;
+      }
+      const resolved = resolveRelative(file, spec);
+      if (resolved) stack.push(resolved);
+      // Bare npm specifiers are out of scope: the guard protects our own src
+      // graph and any direct `node:` import, not third-party transitive deps.
+    }
+  }
+  return { visited, builtinHits };
+}
+
+const rel = (file: string) => file.slice(SRC_DIR.length + 1);
+
+const FORBIDDEN_SERVER_SEGMENTS = [
+  `${sep}db${sep}`,
+  `${sep}settings${sep}`,
+  `${sep}server${sep}`,
+];
+const FORBIDDEN_FF_SERVER = [
+  join(SRC_DIR, "feature-flags", "store.ts"),
+  join(SRC_DIR, "feature-flags", "plugin.ts"),
+  join(SRC_DIR, "feature-flags", "a2a-action-route.ts"),
+];
+
+describe("feature-flags/registry is a browser-safe leaf", () => {
+  const entry = join(SRC_DIR, "feature-flags", "registry.ts");
+
+  it("never statically reaches the server layer", () => {
+    const { visited } = walkGraph(entry);
+    const leaked = [...visited].filter(
+      (f) =>
+        f !== entry &&
+        (FORBIDDEN_SERVER_SEGMENTS.some((s) => f.includes(s)) ||
+          FORBIDDEN_FF_SERVER.includes(f)),
+    );
+    expect(
+      leaked.map(rel),
+      "registry.ts must not pull server modules into the client graph",
+    ).toEqual([]);
+  });
+
+  it("never statically imports a Node builtin", () => {
+    const { builtinHits } = walkGraph(entry);
+    expect(
+      builtinHits.map((h) => `${rel(h.file)} -> ${h.spec}`),
+      "registry.ts must stay free of node: builtins",
+    ).toEqual([]);
+  });
+});
+
+describe("possibly-browser modules access Node builtins lazily", () => {
+  const VALUE_IMPORT_RE =
+    /(?:^|\n)[ \t]*import[ \t]+(?!type\b)[^;]*from[ \t\n]*["'](?:node:)?(?:async_hooks|events)["']/;
+  const files = [
+    join(SRC_DIR, "db", "request-telemetry.ts"),
+    join(SRC_DIR, "settings", "store.ts"),
+  ];
+  for (const file of files) {
+    it(`${rel(file)} does not statically value-import async_hooks/events`, () => {
+      const code = readFileSync(file, "utf8");
+      expect(
+        VALUE_IMPORT_RE.test(code),
+        `${rel(file)} must use process.getBuiltinModule via shared/optional-node-builtins, not a top-level value import`,
+      ).toBe(false);
+    });
+  }
+});

--- a/packages/core/src/settings/store.ts
+++ b/packages/core/src/settings/store.ts
@@ -1,9 +1,10 @@
-import { EventEmitter } from "events";
+import type { EventEmitter } from "node:events";
 
 import { getDbExec, isPostgres, intType } from "../db/client.js";
 import { ensureIndexExists, ensureTableExists } from "../db/ddl-guard.js";
 import { widenIntColumnsToBigInt } from "../db/widen-columns.js";
 import { getRequestContext } from "../server/request-context.js";
+import { createEventEmitter } from "../shared/optional-node-builtins.js";
 
 let _initPromise: Promise<void> | undefined;
 
@@ -29,10 +30,18 @@ function requestSettingsCache(): Map<string, string | null> | null {
   return cache;
 }
 
-const _emitter = new EventEmitter();
+// Created lazily so this module can be evaluated in the browser dev graph
+// without a top-level `new EventEmitter()` tripping Vite's externalized
+// `node:events` stub. The emitter drives server-side SSE fan-out only.
+let _emitter: EventEmitter | undefined;
+
+function settingsEmitter(): EventEmitter {
+  if (!_emitter) _emitter = createEventEmitter();
+  return _emitter;
+}
 
 export function getSettingsEmitter(): EventEmitter {
-  return _emitter;
+  return settingsEmitter();
 }
 
 function settingsTable(): string {
@@ -174,7 +183,7 @@ export async function mutateSetting(
           });
     if (result.rowsAffected === 0) continue;
     requestSettingsCache()?.set(key, nextRaw);
-    _emitter.emit("settings", {
+    settingsEmitter().emit("settings", {
       source: "settings",
       type: "change",
       key,
@@ -200,7 +209,7 @@ export async function putSetting(
     args: [key, JSON.stringify(value), Date.now()],
   });
   requestSettingsCache()?.set(key, JSON.stringify(value));
-  _emitter.emit("settings", {
+  settingsEmitter().emit("settings", {
     source: "settings",
     type: "change",
     key,
@@ -221,7 +230,7 @@ export async function deleteSetting(
   });
   requestSettingsCache()?.set(key, null);
   if (result.rowsAffected > 0) {
-    _emitter.emit("settings", {
+    settingsEmitter().emit("settings", {
       source: "settings",
       type: "delete",
       key,

--- a/packages/core/src/shared/optional-node-builtins.ts
+++ b/packages/core/src/shared/optional-node-builtins.ts
@@ -1,0 +1,66 @@
+/**
+ * Browser-safe accessors for optional Node builtins.
+ *
+ * `node:async_hooks` and `node:events` are server-only, but the modules that
+ * use them (db telemetry, settings/resource emitters) can land in the browser
+ * dev graph before tree-shaking runs. A static `import { X } from "node:..."`
+ * resolves to Vite's externalized stub and throws the instant the value is
+ * touched at module load. We read the builtin through `process.getBuiltinModule`
+ * instead — the same guard `server/request-context.ts` uses — so there is no
+ * static `node:` import to evaluate in the browser, and callers fall back to a
+ * no-op on non-Node runtimes (browser, or Node without getBuiltinModule).
+ */
+import type { AsyncLocalStorage } from "node:async_hooks";
+import type { EventEmitter } from "node:events";
+
+type BuiltinProcess = {
+  versions?: { node?: string };
+  getBuiltinModule?: (name: string) => unknown;
+};
+
+function nodeBuiltin<T>(name: string): T | undefined {
+  const proc =
+    typeof process === "undefined" ? undefined : (process as BuiltinProcess);
+  if (
+    typeof window !== "undefined" ||
+    !proc ||
+    !proc.versions?.node ||
+    typeof proc.getBuiltinModule !== "function"
+  ) {
+    return undefined;
+  }
+  return proc.getBuiltinModule(name) as T | undefined;
+}
+
+export type AsyncLocalStorageCtor = new <T>() => AsyncLocalStorage<T>;
+
+export function getAsyncLocalStorageCtor(): AsyncLocalStorageCtor | undefined {
+  return nodeBuiltin<{ AsyncLocalStorage: AsyncLocalStorageCtor }>(
+    "node:async_hooks",
+  )?.AsyncLocalStorage;
+}
+
+type EventEmitterCtor = new () => EventEmitter;
+
+/**
+ * Returns a real Node EventEmitter on Node, or a no-op emitter elsewhere. The
+ * emitters that use this drive server-side SSE fan-out; nothing subscribes in
+ * the browser, so the no-op fallback is inert rather than wrong.
+ */
+export function createEventEmitter(): EventEmitter {
+  const Ctor = nodeBuiltin<{ EventEmitter: EventEmitterCtor }>(
+    "node:events",
+  )?.EventEmitter;
+  if (Ctor) return new Ctor();
+  const noop = {
+    on: () => noop,
+    off: () => noop,
+    once: () => noop,
+    addListener: () => noop,
+    removeListener: () => noop,
+    removeAllListeners: () => noop,
+    setMaxListeners: () => noop,
+    emit: () => false,
+  };
+  return noop as unknown as EventEmitter;
+}

--- a/packages/core/src/templates/default/.agents/skills/feature-flags/SKILL.md
+++ b/packages/core/src/templates/default/.agents/skills/feature-flags/SKILL.md
@@ -37,7 +37,7 @@ Keep definitions in a shared TypeScript module so server and client code use the
 same stable key. Flags are boolean and default-off.
 
 ```ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/packages/core/src/templates/headless/.agents/skills/feature-flags/SKILL.md
+++ b/packages/core/src/templates/headless/.agents/skills/feature-flags/SKILL.md
@@ -37,7 +37,7 @@ Keep definitions in a shared TypeScript module so server and client code use the
 same stable key. Flags are boolean and default-off.
 
 ```ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/packages/core/src/templates/workspace-core/.agents/skills/feature-flags/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/feature-flags/SKILL.md
@@ -37,7 +37,7 @@ Keep definitions in a shared TypeScript module so server and client code use the
 same stable key. Flags are boolean and default-off.
 
 ```ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -805,6 +805,7 @@ const CORE_CLIENT_SUBPATHS = [
   "@agent-native/core/client/components/RemoteSelectionRings",
   "@agent-native/core/client/visual-style-controls",
   "@agent-native/core/client/feature-flags",
+  "@agent-native/core/feature-flags/registry",
   "@agent-native/core/client/hooks",
   "@agent-native/core/client/host",
   "@agent-native/core/client/i18n",
@@ -1157,6 +1158,10 @@ function getCoreSourceAliases(
     "@agent-native/core/client/feature-flags": path.join(
       coreSrc,
       "client/feature-flags/index.ts",
+    ),
+    "@agent-native/core/feature-flags/registry": path.join(
+      coreSrc,
+      "feature-flags/registry.ts",
     ),
     "@agent-native/core/client/hooks": path.join(
       coreSrc,

--- a/templates/analytics/.agents/skills/feature-flags/SKILL.md
+++ b/templates/analytics/.agents/skills/feature-flags/SKILL.md
@@ -37,7 +37,7 @@ Keep definitions in a shared TypeScript module so server and client code use the
 same stable key. Flags are boolean and default-off.
 
 ```ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/templates/assets/.agents/skills/feature-flags/SKILL.md
+++ b/templates/assets/.agents/skills/feature-flags/SKILL.md
@@ -37,7 +37,7 @@ Keep definitions in a shared TypeScript module so server and client code use the
 same stable key. Flags are boolean and default-off.
 
 ```ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/templates/brain/.agents/skills/feature-flags/SKILL.md
+++ b/templates/brain/.agents/skills/feature-flags/SKILL.md
@@ -37,7 +37,7 @@ Keep definitions in a shared TypeScript module so server and client code use the
 same stable key. Flags are boolean and default-off.
 
 ```ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/templates/calendar/.agents/skills/feature-flags/SKILL.md
+++ b/templates/calendar/.agents/skills/feature-flags/SKILL.md
@@ -37,7 +37,7 @@ Keep definitions in a shared TypeScript module so server and client code use the
 same stable key. Flags are boolean and default-off.
 
 ```ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/templates/chat/.agents/skills/feature-flags/SKILL.md
+++ b/templates/chat/.agents/skills/feature-flags/SKILL.md
@@ -37,7 +37,7 @@ Keep definitions in a shared TypeScript module so server and client code use the
 same stable key. Flags are boolean and default-off.
 
 ```ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/templates/clips/.agents/skills/feature-flags/SKILL.md
+++ b/templates/clips/.agents/skills/feature-flags/SKILL.md
@@ -37,7 +37,7 @@ Keep definitions in a shared TypeScript module so server and client code use the
 same stable key. Flags are boolean and default-off.
 
 ```ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/templates/clips/shared/feature-flags.ts
+++ b/templates/clips/shared/feature-flags.ts
@@ -1,7 +1,7 @@
 import {
   defineFeatureFlag,
   defineFeatureFlags,
-} from "@agent-native/core/feature-flags";
+} from "@agent-native/core/feature-flags/registry";
 
 /**
  * Desktop app: use the custom ScreenCaptureKit (SCK) capture pipeline

--- a/templates/content/.agents/skills/feature-flags/SKILL.md
+++ b/templates/content/.agents/skills/feature-flags/SKILL.md
@@ -37,7 +37,7 @@ Keep definitions in a shared TypeScript module so server and client code use the
 same stable key. Flags are boolean and default-off.
 
 ```ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/templates/design/.agents/skills/feature-flags/SKILL.md
+++ b/templates/design/.agents/skills/feature-flags/SKILL.md
@@ -37,7 +37,7 @@ Keep definitions in a shared TypeScript module so server and client code use the
 same stable key. Flags are boolean and default-off.
 
 ```ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/templates/design/shared/full-app.ts
+++ b/templates/design/shared/full-app.ts
@@ -13,7 +13,7 @@
  * a design as app-backed.
  */
 
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 /**
  * Runtime rollout for full app building in the Design app. Builder

--- a/templates/dispatch/.agents/skills/feature-flags/SKILL.md
+++ b/templates/dispatch/.agents/skills/feature-flags/SKILL.md
@@ -37,7 +37,7 @@ Keep definitions in a shared TypeScript module so server and client code use the
 same stable key. Flags are boolean and default-off.
 
 ```ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/templates/forms/.agents/skills/feature-flags/SKILL.md
+++ b/templates/forms/.agents/skills/feature-flags/SKILL.md
@@ -37,7 +37,7 @@ Keep definitions in a shared TypeScript module so server and client code use the
 same stable key. Flags are boolean and default-off.
 
 ```ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/templates/macros/.agents/skills/feature-flags/SKILL.md
+++ b/templates/macros/.agents/skills/feature-flags/SKILL.md
@@ -37,7 +37,7 @@ Keep definitions in a shared TypeScript module so server and client code use the
 same stable key. Flags are boolean and default-off.
 
 ```ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/templates/mail/.agents/skills/feature-flags/SKILL.md
+++ b/templates/mail/.agents/skills/feature-flags/SKILL.md
@@ -37,7 +37,7 @@ Keep definitions in a shared TypeScript module so server and client code use the
 same stable key. Flags are boolean and default-off.
 
 ```ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/templates/plan/.agents/skills/feature-flags/SKILL.md
+++ b/templates/plan/.agents/skills/feature-flags/SKILL.md
@@ -37,7 +37,7 @@ Keep definitions in a shared TypeScript module so server and client code use the
 same stable key. Flags are boolean and default-off.
 
 ```ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/templates/slides/.agents/skills/feature-flags/SKILL.md
+++ b/templates/slides/.agents/skills/feature-flags/SKILL.md
@@ -37,7 +37,7 @@ Keep definitions in a shared TypeScript module so server and client code use the
 same stable key. Flags are boolean and default-off.
 
 ```ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/templates/tasks/.agents/skills/feature-flags/SKILL.md
+++ b/templates/tasks/.agents/skills/feature-flags/SKILL.md
@@ -37,7 +37,7 @@ Keep definitions in a shared TypeScript module so server and client code use the
 same stable key. Flags are boolean and default-off.
 
 ```ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",


### PR DESCRIPTION
Fixes a dev-only crash where importing feature-flag definitions dragged the server DB chain (and node:async_hooks) into the browser.

recap: https://plan.agent-native.com/plans/recap-4131b8d83824489d