### PR TITLE
Fix chart tooltip clipping by portaling it to document body

### DIFF
--- a/templates/analytics/app/components/dashboard/SqlChart.tooltip.spec.tsx
+++ b/templates/analytics/app/components/dashboard/SqlChart.tooltip.spec.tsx
@@ -41,7 +41,7 @@ describe("ChartTooltip", () => {
     vi.unstubAllGlobals();
   });
 
-  it("keeps the visible tooltip inside the chart tree", async () => {
+  it("portals the visible tooltip to the document body so scrollable ancestors can't clip it", async () => {
     await act(async () => {
       root.render(
         <ChartTooltip
@@ -52,7 +52,7 @@ describe("ChartTooltip", () => {
       );
     });
 
-    expect(container.querySelectorAll('[role="tooltip"]')).toHaveLength(1);
+    expect(container.querySelectorAll('[role="tooltip"]')).toHaveLength(0);
     expect(document.body.querySelectorAll('[role="tooltip"]')).toHaveLength(1);
   });
 

--- a/templates/analytics/app/components/dashboard/SqlChart.tsx
+++ b/templates/analytics/app/components/dashboard/SqlChart.tsx
@@ -898,6 +898,7 @@ export function ChartTooltip({
   active,
   payload,
   label,
+  coordinate,
   labelFormatter,
   seriesNameFormatter,
   valueFormatter,
@@ -910,6 +911,7 @@ export function ChartTooltip({
     value?: unknown;
   }>;
   label?: unknown;
+  coordinate?: { x?: number; y?: number };
   labelFormatter?: (value: string) => string;
   seriesNameFormatter?: (value: string) => string;
   valueFormatter?: (value: number) => string;
@@ -923,7 +925,10 @@ export function ChartTooltip({
     [payload],
   );
   const isVisible = Boolean(active) && items.length > 0;
-  const { anchorRef, boxRef } = useChartTooltipPortalPosition(isVisible);
+  const { anchorRef, boxRef } = useChartTooltipPortalPosition(
+    isVisible,
+    coordinate,
+  );
 
   const labelText =
     label == null

--- a/templates/analytics/app/components/dashboard/SqlChart.tsx
+++ b/templates/analytics/app/components/dashboard/SqlChart.tsx
@@ -26,6 +26,7 @@ import {
   type CSSProperties,
   type ReactNode,
 } from "react";
+import { createPortal } from "react-dom";
 import { Link } from "react-router";
 import {
   Area,
@@ -60,7 +61,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useChartTooltipFlip } from "@/hooks/use-chart-tooltip-flip";
+import { useChartTooltipPortalPosition } from "@/hooks/use-chart-tooltip-portal";
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
 import { createDemoChartTrendRows } from "@/lib/demo-chart-trend";
@@ -913,7 +914,6 @@ export function ChartTooltip({
   seriesNameFormatter?: (value: string) => string;
   valueFormatter?: (value: number) => string;
 }) {
-  const tooltipRef = useChartTooltipFlip<HTMLDivElement>(active);
   const items = useMemo(
     () =>
       sortTooltipPayloadItems(
@@ -922,6 +922,8 @@ export function ChartTooltip({
       ),
     [payload],
   );
+  const isVisible = Boolean(active) && items.length > 0;
+  const { anchorRef, boxRef } = useChartTooltipPortalPosition(isVisible);
 
   const labelText =
     label == null
@@ -930,13 +932,13 @@ export function ChartTooltip({
         ? labelFormatter(String(label))
         : String(label);
 
-  if (!active || items.length === 0) return null;
+  if (!isVisible) return null;
 
   const tooltip = (
     <div
-      ref={tooltipRef}
+      ref={boxRef}
       role="tooltip"
-      className="min-w-40 max-w-[280px] rounded-md border border-border bg-card px-3 py-2 text-xs text-foreground shadow-lg"
+      className="fixed z-[9999] min-w-40 max-w-[280px] rounded-md border border-border bg-card px-3 py-2 text-xs text-foreground shadow-lg pointer-events-none"
     >
       {labelText && (
         <div className="mb-1.5 truncate font-medium text-foreground">
@@ -971,7 +973,12 @@ export function ChartTooltip({
     </div>
   );
 
-  return tooltip;
+  return (
+    <>
+      <span ref={anchorRef} aria-hidden="true" />
+      {createPortal(tooltip, document.body)}
+    </>
+  );
 }
 
 function detectKeys(

--- a/templates/analytics/app/components/dashboard/SqlChart.tsx
+++ b/templates/analytics/app/components/dashboard/SqlChart.tsx
@@ -86,7 +86,7 @@ const DEFAULT_COLORS = [
 ];
 
 const CHART_TOOLTIP_WRAPPER_STYLE: CSSProperties = {
-  zIndex: 60,
+  zIndex: 9999,
   pointerEvents: "none",
 };
 

--- a/templates/analytics/app/hooks/use-chart-tooltip-portal.ts
+++ b/templates/analytics/app/hooks/use-chart-tooltip-portal.ts
@@ -1,70 +1,60 @@
-import { useEffect, useRef } from "react";
+import { useLayoutEffect, useRef } from "react";
 
-const VIEWPORT_GUTTER_PADDING = 12;
+const CHART_EDGE_PADDING = 8;
+const CURSOR_OFFSET = 14;
+
+type TooltipCoordinate = { x?: number; y?: number } | undefined;
 
 /**
  * Ancestors of a dashboard chart (the scrollable app shell, the dashboard
  * grid's inline-size container) clip any content that overflows their box,
- * including a Recharts tooltip positioned near a chart's edge or corner —
- * raising its z-index does not help because clipping is independent of
- * stacking order. Read the Recharts wrapper's live (transform-based) screen
- * position off an invisible marker rendered in its place, then let the
- * caller render the real tooltip through a portal to `document.body` at
- * that position, clamped to the viewport, so it always escapes overflow
- * ancestors entirely instead of being clipped at a container edge.
+ * so the tooltip content is rendered through a portal to `document.body`.
+ * Recharts positions its own tooltip wrapper by measuring that wrapper's
+ * child content size — with the real content portaled away the wrapper has
+ * no size to measure and never gets a transform, so we can't read a live
+ * position off it. Instead, position the portaled box ourselves from the
+ * `coordinate` Recharts already passes to custom tooltip content (the exact
+ * pixel the cursor is over, relative to the chart) plus the chart's own
+ * `.recharts-wrapper` rect, and clamp against that same rect so the tooltip
+ * tracks the cursor but never crosses the chart's own edges.
  */
-export function useChartTooltipPortalPosition(active: boolean) {
+export function useChartTooltipPortalPosition(
+  isVisible: boolean,
+  coordinate: TooltipCoordinate,
+) {
   const anchorRef = useRef<HTMLSpanElement | null>(null);
   const boxRef = useRef<HTMLDivElement | null>(null);
 
-  useEffect(() => {
-    if (!active) return;
+  useLayoutEffect(() => {
+    if (!isVisible) return;
     const anchor = anchorRef.current;
-    const wrapper = anchor?.parentElement;
-    if (!anchor || !wrapper) return;
+    const box = boxRef.current;
+    if (!anchor || !box) return;
+    const chartEl = anchor.closest(".recharts-wrapper");
+    if (!chartEl) return;
 
-    const apply = () => {
-      const box = boxRef.current;
-      if (!box) return;
-      const anchorRect = anchor.getBoundingClientRect();
+    const chartRect = chartEl.getBoundingClientRect();
+    const boxRect = box.getBoundingClientRect();
 
-      box.style.left = `${anchorRect.left}px`;
-      box.style.top = `${anchorRect.top}px`;
+    const pointX = chartRect.left + (coordinate?.x ?? 0);
+    const pointY = chartRect.top + (coordinate?.y ?? 0);
 
-      const rect = box.getBoundingClientRect();
-      if (rect.width === 0) return;
+    const minLeft = chartRect.left + CHART_EDGE_PADDING;
+    const maxLeft = chartRect.right - CHART_EDGE_PADDING - boxRect.width;
+    let left = pointX + CURSOR_OFFSET;
+    if (left > maxLeft) left = pointX - CURSOR_OFFSET - boxRect.width;
+    left = Math.min(Math.max(left, minLeft), Math.max(minLeft, maxLeft));
 
-      const sidebar = document.querySelector(".agent-sidebar-panel");
-      const sidebarRect = sidebar?.getBoundingClientRect();
-      const rightEdge =
-        sidebarRect && sidebarRect.width > 0 && sidebarRect.left > 0
-          ? sidebarRect.left
-          : window.innerWidth;
+    const minTop = chartRect.top + CHART_EDGE_PADDING;
+    const maxTop = chartRect.bottom - CHART_EDGE_PADDING - boxRect.height;
+    const top = Math.min(
+      Math.max(pointY - boxRect.height / 2, minTop),
+      Math.max(minTop, maxTop),
+    );
 
-      let left = anchorRect.left;
-      if (left + rect.width > rightEdge - VIEWPORT_GUTTER_PADDING) {
-        left = rightEdge - VIEWPORT_GUTTER_PADDING - rect.width;
-      }
-      if (left < VIEWPORT_GUTTER_PADDING) left = VIEWPORT_GUTTER_PADDING;
-
-      let top = anchorRect.top;
-      if (top + rect.height > window.innerHeight - VIEWPORT_GUTTER_PADDING) {
-        top = window.innerHeight - VIEWPORT_GUTTER_PADDING - rect.height;
-      }
-      if (top < VIEWPORT_GUTTER_PADDING) top = VIEWPORT_GUTTER_PADDING;
-
-      box.style.left = `${left}px`;
-      box.style.top = `${top}px`;
-    };
-
-    apply();
-    const observer = new MutationObserver(apply);
-    observer.observe(wrapper, {
-      attributes: true,
-      attributeFilter: ["style"],
-    });
-    return () => observer.disconnect();
-  }, [active]);
+    box.style.left = `${left}px`;
+    box.style.top = `${top}px`;
+  }, [isVisible, coordinate?.x, coordinate?.y]);
 
   return { anchorRef, boxRef };
 }

--- a/templates/analytics/app/hooks/use-chart-tooltip-portal.ts
+++ b/templates/analytics/app/hooks/use-chart-tooltip-portal.ts
@@ -1,0 +1,70 @@
+import { useEffect, useRef } from "react";
+
+const VIEWPORT_GUTTER_PADDING = 12;
+
+/**
+ * Ancestors of a dashboard chart (the scrollable app shell, the dashboard
+ * grid's inline-size container) clip any content that overflows their box,
+ * including a Recharts tooltip positioned near a chart's edge or corner —
+ * raising its z-index does not help because clipping is independent of
+ * stacking order. Read the Recharts wrapper's live (transform-based) screen
+ * position off an invisible marker rendered in its place, then let the
+ * caller render the real tooltip through a portal to `document.body` at
+ * that position, clamped to the viewport, so it always escapes overflow
+ * ancestors entirely instead of being clipped at a container edge.
+ */
+export function useChartTooltipPortalPosition(active: boolean) {
+  const anchorRef = useRef<HTMLSpanElement | null>(null);
+  const boxRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    const anchor = anchorRef.current;
+    const wrapper = anchor?.parentElement;
+    if (!anchor || !wrapper) return;
+
+    const apply = () => {
+      const box = boxRef.current;
+      if (!box) return;
+      const anchorRect = anchor.getBoundingClientRect();
+
+      box.style.left = `${anchorRect.left}px`;
+      box.style.top = `${anchorRect.top}px`;
+
+      const rect = box.getBoundingClientRect();
+      if (rect.width === 0) return;
+
+      const sidebar = document.querySelector(".agent-sidebar-panel");
+      const sidebarRect = sidebar?.getBoundingClientRect();
+      const rightEdge =
+        sidebarRect && sidebarRect.width > 0 && sidebarRect.left > 0
+          ? sidebarRect.left
+          : window.innerWidth;
+
+      let left = anchorRect.left;
+      if (left + rect.width > rightEdge - VIEWPORT_GUTTER_PADDING) {
+        left = rightEdge - VIEWPORT_GUTTER_PADDING - rect.width;
+      }
+      if (left < VIEWPORT_GUTTER_PADDING) left = VIEWPORT_GUTTER_PADDING;
+
+      let top = anchorRect.top;
+      if (top + rect.height > window.innerHeight - VIEWPORT_GUTTER_PADDING) {
+        top = window.innerHeight - VIEWPORT_GUTTER_PADDING - rect.height;
+      }
+      if (top < VIEWPORT_GUTTER_PADDING) top = VIEWPORT_GUTTER_PADDING;
+
+      box.style.left = `${left}px`;
+      box.style.top = `${top}px`;
+    };
+
+    apply();
+    const observer = new MutationObserver(apply);
+    observer.observe(wrapper, {
+      attributes: true,
+      attributeFilter: ["style"],
+    });
+    return () => observer.disconnect();
+  }, [active]);
+
+  return { anchorRef, boxRef };
+}

--- a/templates/analytics/app/routes/chart.tsx
+++ b/templates/analytics/app/routes/chart.tsx
@@ -105,7 +105,7 @@ export default function ChartRoute() {
   }
 
   return (
-    <div className="flex h-screen w-screen flex-col overflow-hidden bg-transparent p-2">
+    <div className="flex h-screen w-screen flex-col overflow-visible bg-transparent p-2">
       {result.title && (
         <div className="mb-1 px-1 text-xs font-medium text-muted-foreground">
           {result.title}


### PR DESCRIPTION
### Summary
Fixes chart tooltips getting clipped by scrollable/overflow ancestors by rendering them through a React portal to `document.body`, positioned manually to track the cursor while staying within the chart's bounds.

### Problem
The chart tooltip was clipped whenever it reached the edge of a scrollable container or the corner of the chart, since it was rendered inline inside ancestors with `overflow` clipping. This affected all chart types except the extension chart type.

### Solution
Instead of relying on Recharts' default tooltip wrapper positioning (which measures the wrapper element and applies a CSS transform within the clipped DOM tree), the tooltip content is now portaled to `document.body`. A new hook computes the tooltip's fixed screen position from the `coordinate` Recharts provides plus the chart wrapper's bounding rect, then clamps it so the tooltip tracks the cursor but never overflows the chart's edges.


## Before

<img width="1506" height="800" alt="image" src="https://github.com/user-attachments/assets/359eb252-a01b-4205-b52a-2d7114e0eb79" />



## After
<img width="1512" height="900" alt="image" src="https://github.com/user-attachments/assets/8fd67587-817e-45f6-a0ee-9569aba8e924" />


### Key Changes
- Added `useChartTooltipPortalPosition` hook (`use-chart-tooltip-portal.ts`) that computes and clamps the tooltip's `left`/`top` position relative to the `.recharts-wrapper` element, using the cursor `coordinate` and edge padding/cursor offset constants.
- Updated `ChartTooltip` in `SqlChart.tsx` to accept `coordinate`, use the new hook instead of `useChartTooltipFlip`, and render via `createPortal` to `document.body` with a hidden anchor span used to locate the chart wrapper.
- Changed the tooltip's className to `fixed` positioning with a much higher `z-[9999]` (also bumped `CHART_TOOLTIP_WRAPPER_STYLE.zIndex` to `9999`) to ensure it renders above all other content.
- Updated `chart.tsx` route container to `overflow-visible` so the portaled tooltip isn't clipped at the route level.
- Updated the tooltip spec to assert the tooltip is portaled to `document.body` instead of remaining inside the chart tree.


---

<a href="https://builder.io/app/projects/ae8cb7b8045d4c21b2a343e11036d454/liquid-hand-x8biwyjx"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ae8cb7b8045d4c21b2a343e11036d454-liquid-hand-x8biwyjx.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2271`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ae8cb7b8045d4c21b2a343e11036d454</projectId>-->
<!--<branchName>liquid-hand-x8biwyjx</branchName>-->