### PR TITLE
fix(clips): report truthful Rewind capture status

### DIFF
--- a/templates/clips/changelog/2026-07-20-rewind-capture-status.md
+++ b/templates/clips/changelog/2026-07-20-rewind-capture-status.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+date: 2026-07-20
+---
+Rewind now reports the same live capture status on Home and in Settings without mistaking an idle moment for a permission problem.

--- a/templates/clips/changelog/2026-07-20-rewind-capture-status.md
+++ b/templates/clips/changelog/2026-07-20-rewind-capture-status.md
@@ -2,4 +2,5 @@
 type: fixed
 date: 2026-07-20
 ---
+
 Rewind now reports the same live capture status on Home and in Settings without mistaking an idle moment for a permission problem.

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -3171,8 +3171,13 @@ export function App() {
           },
         },
       });
-      const status = await invoke<ScreenMemoryStatus>("screen_memory_status");
-      setHomeScreenMemoryStatus(status);
+      // The native producer can take a moment to finish pausing. Do not keep
+      // the Home switch locked while that status request waits; the existing
+      // change event and bounded poll will reconcile it, and this best-effort
+      // refresh can do the same without blocking the next resume action.
+      void invoke<ScreenMemoryStatus>("screen_memory_status")
+        .then(setHomeScreenMemoryStatus)
+        .catch(() => {});
     } catch (err) {
       console.error(
         "[clips-tray] update Rewind remembering state failed:",

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -86,6 +86,7 @@ import {
   type RecorderStopResult,
 } from "./lib/recorder";
 import { REWIND_AGENT_PROMPT } from "./lib/rewind-agent-prompt";
+import { getRewindStatusPresentation } from "./lib/rewind-status";
 import {
   loadBool,
   loadString,
@@ -946,6 +947,11 @@ export function App() {
   const isRecording = recorder !== null;
   // Whether the popover window is shown; driven by the visibility effect below.
   const [popoverVisible, setPopoverVisible] = useState(false);
+  const homeRewindPresentation = getRewindStatusPresentation({
+    status: homeScreenMemoryStatus,
+    config: featureConfig?.screenMemory ?? DEFAULT_SCREEN_MEMORY_CONFIG,
+    clipRecordingActive: isRecording || recordingFlowActive,
+  });
   useEffect(() => {
     if (featureConfig?.screenMemory?.enabled !== true) {
       setHomeScreenMemoryStatus(null);
@@ -961,9 +967,20 @@ export function App() {
     };
     refresh();
     const timer = window.setInterval(refresh, popoverVisible ? 5_000 : 30_000);
+    let unlisten: (() => void) | undefined;
+    listen("clips:screen-memory-changed", refresh)
+      .then((stopListening) => {
+        if (cancelled) {
+          stopListening();
+          return;
+        }
+        unlisten = stopListening;
+      })
+      .catch(() => {});
     return () => {
       cancelled = true;
       window.clearInterval(timer);
+      unlisten?.();
     };
   }, [featureConfig?.screenMemory?.enabled, popoverVisible]);
   const recordShortcutHandlerRef = useRef<() => void>(() => {});
@@ -3633,34 +3650,12 @@ export function App() {
         <section className="rewind-home-card" aria-label="Rewind status">
           <div className="rewind-home-status">
             <span
-              className={`rewind-home-dot ${
-                featureConfig?.screenMemory?.enabled === true &&
-                featureConfig.screenMemory.paused !== true &&
-                homeScreenMemoryStatus?.state === "recording"
-                  ? "is-live"
-                  : ""
-              }`}
+              className={`rewind-home-dot ${homeRewindPresentation.isLive ? "is-live" : ""}`}
             />
             <div>
-              <strong>
-                {featureConfig?.screenMemory?.enabled !== true
-                  ? "Rewind is off"
-                  : featureConfig.screenMemory.paused === true
-                    ? "Rewind is paused"
-                    : homeScreenMemoryStatus?.exclusionActive
-                      ? "Rewind is protecting a private moment"
-                      : "Rewind is remembering"}
-              </strong>
-              {featureConfig?.screenMemory?.enabled !== true ||
-              featureConfig.screenMemory.paused ||
-              homeScreenMemoryStatus?.exclusionActive ? (
-                <p>
-                  {featureConfig?.screenMemory?.enabled !== true
-                    ? "Private memory for moments you may need later."
-                    : featureConfig.screenMemory.paused
-                      ? "Existing local memory is still available."
-                      : "An excluded app is being skipped."}
-                </p>
+              <strong>{homeRewindPresentation.title}</strong>
+              {!homeRewindPresentation.isLive ? (
+                <p>{homeRewindPresentation.detail}</p>
               ) : null}
             </div>
             <div className="rewind-home-controls">
@@ -4976,7 +4971,11 @@ function Setup({
     (sum, segment) => sum + segment.bytes,
     0,
   );
-  const screenMemoryRecording = screenMemoryStatus?.state === "recording";
+  const rewindStatusPresentation = getRewindStatusPresentation({
+    status: screenMemoryStatus,
+    config: screenMemory,
+    clipRecordingActive: recordingActive,
+  });
   const captureControlsLocked = recordingActive;
 
   useEffect(() => {
@@ -5431,6 +5430,7 @@ function Setup({
         .catch(() => {});
     };
     refresh();
+    const timer = window.setInterval(refresh, 5_000);
     const unlistens: Array<() => void> = [];
     const track = (p: Promise<() => void>) => {
       p.then((u) => {
@@ -5448,6 +5448,7 @@ function Setup({
     track(listen("clips:screen-memory-changed", refresh));
     return () => {
       cancelled = true;
+      window.clearInterval(timer);
       unlistens.forEach((u) => {
         try {
           u();
@@ -6044,17 +6045,13 @@ function Setup({
             </div>
             <div className="rewind-settings-status">
               <span
-                className={`rewind-home-dot ${screenMemoryRecording ? "is-live" : ""}`}
+                className={`rewind-home-dot ${rewindStatusPresentation.isLive ? "is-live" : ""}`}
               />
               <span>
-                {screenMemoryStatus?.exclusionActive
-                  ? screenMemoryStatus.coverage
-                  : screenMemoryRecording
-                    ? `${screenMemorySegments.length} retained segment${screenMemorySegments.length === 1 ? "" : "s"} · ${formatStorageBytes(screenMemoryTotalBytes)}`
-                    : screenMemory.paused
-                      ? "Paused. Existing memory remains available."
-                      : screenMemoryStatus?.lastError ||
-                        "Waiting for screen-recording permission."}
+                {rewindStatusPresentation.kind === "recording" &&
+                !rewindStatusPresentation.hasError
+                  ? `${screenMemorySegments.length} retained segment${screenMemorySegments.length === 1 ? "" : "s"} · ${formatStorageBytes(screenMemoryTotalBytes)}`
+                  : rewindStatusPresentation.detail}
               </span>
             </div>
             <div className="setup-section-heading">Privacy</div>
@@ -6550,17 +6547,11 @@ function Setup({
       <div className="setup-section rewind-settings-entry">
         <div className="rewind-settings-entry-main">
           <span
-            className={`rewind-home-dot ${screenMemoryRecording ? "is-live" : ""}`}
+            className={`rewind-home-dot ${rewindStatusPresentation.isLive ? "is-live" : ""}`}
           />
           <div>
             <strong>Rewind</strong>
-            <p className="setup-hint">
-              {!screenMemory.enabled
-                ? "Off"
-                : screenMemory.paused
-                  ? "Paused · existing local memory is still available"
-                  : "Remembering locally"}
-            </p>
+            <p className="setup-hint">{rewindStatusPresentation.title}</p>
           </div>
         </div>
         <button type="button" className="secondary" onClick={onOpenRewind}>
@@ -6738,21 +6729,16 @@ function Setup({
               bundle ID cannot be detected.
             </p>
             <div className="whisper-status">
-              {screenMemoryRecording ? (
+              {rewindStatusPresentation.isLive ? (
                 <IconCircleCheck size={13} className="whisper-status-icon" />
               ) : (
                 <IconAlertTriangle size={13} className="whisper-status-icon" />
               )}
               <span>
-                {screenMemoryStatus?.exclusionActive
-                  ? screenMemoryStatus.coverage
-                  : screenMemoryRecording
-                    ? `Rewind is retaining local coverage: ${screenMemorySegments.length} segment${screenMemorySegments.length === 1 ? "" : "s"}, ${formatStorageBytes(screenMemoryTotalBytes)}.`
-                    : screenMemory.paused
-                      ? "Capture paused. Existing local coverage remains available."
-                      : screenMemoryStatus?.lastError
-                        ? screenMemoryStatus.lastError
-                        : "Capture status is waiting for screen-recording permission."}
+                {rewindStatusPresentation.kind === "recording" &&
+                !rewindStatusPresentation.hasError
+                  ? `Rewind is retaining local coverage: ${screenMemorySegments.length} segment${screenMemorySegments.length === 1 ? "" : "s"}, ${formatStorageBytes(screenMemoryTotalBytes)}.`
+                  : rewindStatusPresentation.detail}
               </span>
             </div>
             {screenMemorySegments[0] ? (

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -894,6 +894,7 @@ export function App() {
   const [homeScreenMemoryStatus, setHomeScreenMemoryStatus] =
     useState<ScreenMemoryStatus | null>(null);
   const [homeScreenMemoryBusy, setHomeScreenMemoryBusy] = useState(false);
+  const homeScreenMemoryRefreshVersionRef = useRef(0);
   const [rewindAgentPromptCopied, setRewindAgentPromptCopied] = useState(false);
   const [agentHandoff, setAgentHandoff] =
     useState<RewindAgentHandoffRequest | null>(null);
@@ -952,18 +953,25 @@ export function App() {
     config: featureConfig?.screenMemory ?? DEFAULT_SCREEN_MEMORY_CONFIG,
     clipRecordingActive: isRecording || recordingFlowActive,
   });
+  const refreshHomeScreenMemoryStatus = useCallback(() => {
+    const version = ++homeScreenMemoryRefreshVersionRef.current;
+    invoke<ScreenMemoryStatus>("screen_memory_status")
+      .then((status) => {
+        if (version === homeScreenMemoryRefreshVersionRef.current) {
+          setHomeScreenMemoryStatus(status);
+        }
+      })
+      .catch(() => {});
+  }, []);
   useEffect(() => {
     if (featureConfig?.screenMemory?.enabled !== true) {
+      homeScreenMemoryRefreshVersionRef.current += 1;
       setHomeScreenMemoryStatus(null);
       return;
     }
     let cancelled = false;
     const refresh = () => {
-      invoke<ScreenMemoryStatus>("screen_memory_status")
-        .then((status) => {
-          if (!cancelled) setHomeScreenMemoryStatus(status);
-        })
-        .catch(() => {});
+      if (!cancelled) refreshHomeScreenMemoryStatus();
     };
     refresh();
     const timer = window.setInterval(refresh, popoverVisible ? 5_000 : 30_000);
@@ -979,10 +987,15 @@ export function App() {
       .catch(() => {});
     return () => {
       cancelled = true;
+      homeScreenMemoryRefreshVersionRef.current += 1;
       window.clearInterval(timer);
       unlisten?.();
     };
-  }, [featureConfig?.screenMemory?.enabled, popoverVisible]);
+  }, [
+    featureConfig?.screenMemory?.enabled,
+    popoverVisible,
+    refreshHomeScreenMemoryStatus,
+  ]);
   const recordShortcutHandlerRef = useRef<() => void>(() => {});
   // Mirrors `bubbleActive` (assigned below once it is computed) so device
   // probes can synchronously tell whether the camera bubble owns the grant.
@@ -3175,9 +3188,7 @@ export function App() {
       // the Home switch locked while that status request waits; the existing
       // change event and bounded poll will reconcile it, and this best-effort
       // refresh can do the same without blocking the next resume action.
-      void invoke<ScreenMemoryStatus>("screen_memory_status")
-        .then(setHomeScreenMemoryStatus)
-        .catch(() => {});
+      refreshHomeScreenMemoryStatus();
     } catch (err) {
       console.error(
         "[clips-tray] update Rewind remembering state failed:",
@@ -3659,7 +3670,8 @@ export function App() {
             />
             <div>
               <strong>{homeRewindPresentation.title}</strong>
-              {!homeRewindPresentation.isLive ? (
+              {!homeRewindPresentation.isLive ||
+              homeRewindPresentation.hasError ? (
                 <p>{homeRewindPresentation.detail}</p>
               ) : null}
             </div>
@@ -4941,6 +4953,7 @@ function Setup({
   );
   const [screenMemoryStatus, setScreenMemoryStatus] =
     useState<ScreenMemoryStatus | null>(null);
+  const screenMemoryStatusRefreshVersionRef = useRef(0);
   const [screenMemoryMessage, setScreenMemoryMessage] = useState<{
     kind: "ok" | "error";
     text: string;
@@ -5176,11 +5189,16 @@ function Setup({
     }
   }
 
-  function refreshScreenMemoryStatus() {
+  const refreshScreenMemoryStatus = useCallback(() => {
+    const version = ++screenMemoryStatusRefreshVersionRef.current;
     invoke<ScreenMemoryStatus>("screen_memory_status")
-      .then(setScreenMemoryStatus)
+      .then((status) => {
+        if (version === screenMemoryStatusRefreshVersionRef.current) {
+          setScreenMemoryStatus(status);
+        }
+      })
       .catch(() => {});
-  }
+  }, []);
 
   function refreshRewindEgressLog() {
     invoke<RewindEgressEvent[]>("rewind_list_evidence_egress", { limit: 20 })
@@ -5261,6 +5279,7 @@ function Setup({
       const status = await invoke<ScreenMemoryStatus>(
         "screen_memory_delete_all",
       );
+      screenMemoryStatusRefreshVersionRef.current += 1;
       setScreenMemoryStatus(status);
       setScreenMemoryMessage({ kind: "ok", text: "Rewind cleared." });
     } catch (err) {
@@ -5428,11 +5447,7 @@ function Setup({
   useEffect(() => {
     let cancelled = false;
     const refresh = () => {
-      invoke<ScreenMemoryStatus>("screen_memory_status")
-        .then((status) => {
-          if (!cancelled) setScreenMemoryStatus(status);
-        })
-        .catch(() => {});
+      if (!cancelled) refreshScreenMemoryStatus();
     };
     refresh();
     const timer = window.setInterval(refresh, 5_000);
@@ -5453,6 +5468,7 @@ function Setup({
     track(listen("clips:screen-memory-changed", refresh));
     return () => {
       cancelled = true;
+      screenMemoryStatusRefreshVersionRef.current += 1;
       window.clearInterval(timer);
       unlistens.forEach((u) => {
         try {
@@ -5462,7 +5478,7 @@ function Setup({
         }
       });
     };
-  }, []);
+  }, [refreshScreenMemoryStatus]);
 
   // Load model status on mount and keep it current via events.
   useEffect(() => {

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -6068,11 +6068,14 @@ function Setup({
               <span
                 className={`rewind-home-dot ${rewindStatusPresentation.isLive ? "is-live" : ""}`}
               />
-              <span>
-                {rewindStatusPresentation.kind === "recording" &&
-                !rewindStatusPresentation.hasError
-                  ? `${screenMemorySegments.length} retained segment${screenMemorySegments.length === 1 ? "" : "s"} · ${formatStorageBytes(screenMemoryTotalBytes)}`
-                  : rewindStatusPresentation.detail}
+              <span className="rewind-settings-status-copy">
+                <strong>{rewindStatusPresentation.title}</strong>
+                <span>
+                  {rewindStatusPresentation.kind === "recording" &&
+                  !rewindStatusPresentation.hasError
+                    ? `${screenMemorySegments.length} retained segment${screenMemorySegments.length === 1 ? "" : "s"} · ${formatStorageBytes(screenMemoryTotalBytes)}`
+                    : rewindStatusPresentation.detail}
+                </span>
               </span>
             </div>
             <div className="setup-section-heading">Privacy</div>

--- a/templates/clips/desktop/src/lib/rewind-status.test.ts
+++ b/templates/clips/desktop/src/lib/rewind-status.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+
+import type { ScreenMemoryConfig, ScreenMemoryStatus } from "../shared/config";
+import { getRewindStatusPresentation } from "./rewind-status";
+
+const config: ScreenMemoryConfig = {
+  enabled: true,
+  paused: false,
+  retentionHours: 8,
+  maxBytes: 5 * 1024 * 1024 * 1024,
+  segmentSeconds: 300,
+  sampleIntervalSeconds: 5,
+  captureMode: "visuals",
+  reviewBeforeSending: true,
+  autoPreviewBeforeSending: true,
+  agentClipRetention: "forever",
+  excludedBundleIds: [],
+  excludePrivateWindows: true,
+};
+
+function status(patch: Partial<ScreenMemoryStatus> = {}): ScreenMemoryStatus {
+  return {
+    available: true,
+    state: "recording",
+    config,
+    storageDir: "/tmp/rewind",
+    activeSegment: null,
+    recentSegments: [],
+    lastError: null,
+    exclusionActive: false,
+    coverage: "Rewind is retaining local media coverage.",
+    ...patch,
+  };
+}
+
+describe("getRewindStatusPresentation", () => {
+  it.each([
+    {
+      name: "disabled",
+      input: status({
+        state: "disabled",
+        config: { ...config, enabled: false },
+      }),
+      kind: "off",
+      title: "Rewind is off",
+    },
+    {
+      name: "paused",
+      input: status({ state: "paused", config: { ...config, paused: true } }),
+      kind: "paused",
+      title: "Rewind is paused",
+    },
+    {
+      name: "recording",
+      input: status(),
+      kind: "recording",
+      title: "Rewind is remembering",
+    },
+    {
+      name: "excluded",
+      input: status({ exclusionActive: true }),
+      kind: "excluded",
+      title: "Rewind is protecting a private moment",
+    },
+    {
+      name: "idle",
+      input: status({ state: "idle", activeSegment: null }),
+      kind: "idle",
+      title: "Rewind is enabled but not currently capturing",
+    },
+    {
+      name: "unavailable",
+      input: status({ available: false, state: "idle" }),
+      kind: "unavailable",
+      title: "Rewind is unavailable",
+    },
+  ])("maps $name from native runtime truth", ({ input, kind, title }) => {
+    const presentation = getRewindStatusPresentation({
+      status: input,
+      config,
+    });
+
+    expect(presentation.kind).toBe(kind);
+    expect(presentation.title).toBe(title);
+    expect(presentation.isLive).toBe(kind === "recording");
+  });
+
+  it("does not call an unexplained idle state a permission failure", () => {
+    const presentation = getRewindStatusPresentation({
+      status: status({ state: "idle" }),
+      config,
+    });
+
+    expect(presentation.detail).toBe(
+      "No new local coverage is being retained right now.",
+    );
+    expect(presentation.detail.toLowerCase()).not.toContain("permission");
+  });
+
+  it("explains idle while a Clip owns capture without claiming Rewind is live", () => {
+    const presentation = getRewindStatusPresentation({
+      status: status({ state: "idle" }),
+      config,
+      clipRecordingActive: true,
+    });
+
+    expect(presentation.detail).toBe("Rewind will resume when this Clip ends.");
+    expect(presentation.isLive).toBe(false);
+  });
+
+  it("shows the concrete native permission error without guessing from idle", () => {
+    const error =
+      "Screen Recording permission denied. Open System Settings > Privacy & Security > Screen Recording, enable Clips, then try again.";
+    const presentation = getRewindStatusPresentation({
+      status: status({ state: "idle", lastError: error }),
+      config,
+    });
+
+    expect(presentation.kind).toBe("error");
+    expect(presentation.title).toBe("Rewind needs attention");
+    expect(presentation.detail).toBe(error);
+    expect(presentation.isLive).toBe(false);
+  });
+
+  it("keeps live capture truthful while surfacing an auxiliary error", () => {
+    const error = "Could not write visual index metadata.";
+    const presentation = getRewindStatusPresentation({
+      status: status({ state: "recording", lastError: error }),
+      config,
+    });
+
+    expect(presentation.kind).toBe("recording");
+    expect(presentation.title).toBe("Rewind is remembering");
+    expect(presentation.detail).toBe(error);
+    expect(presentation.isLive).toBe(true);
+    expect(presentation.hasError).toBe(true);
+  });
+
+  it("uses native config when status and observed config disagree", () => {
+    const presentation = getRewindStatusPresentation({
+      status: status({ state: "paused", config: { ...config, paused: true } }),
+      config,
+    });
+
+    expect(presentation.kind).toBe("paused");
+  });
+
+  it("uses observed intent while the first native status is loading", () => {
+    const presentation = getRewindStatusPresentation({
+      status: null,
+      config,
+    });
+
+    expect(presentation.kind).toBe("idle");
+    expect(presentation.isLive).toBe(false);
+  });
+});

--- a/templates/clips/desktop/src/lib/rewind-status.ts
+++ b/templates/clips/desktop/src/lib/rewind-status.ts
@@ -1,0 +1,103 @@
+import type { ScreenMemoryConfig, ScreenMemoryStatus } from "../shared/config";
+
+export type RewindPresentationKind =
+  | "off"
+  | "paused"
+  | "recording"
+  | "excluded"
+  | "idle"
+  | "error"
+  | "unavailable";
+
+export interface RewindStatusPresentation {
+  kind: RewindPresentationKind;
+  title: string;
+  detail: string;
+  isLive: boolean;
+  hasError: boolean;
+}
+
+export function getRewindStatusPresentation({
+  status,
+  config,
+  clipRecordingActive = false,
+}: {
+  status: ScreenMemoryStatus | null;
+  config: ScreenMemoryConfig;
+  clipRecordingActive?: boolean;
+}): RewindStatusPresentation {
+  const runtimeConfig = status?.config ?? config;
+
+  if (!runtimeConfig.enabled || status?.state === "disabled") {
+    return {
+      kind: "off",
+      title: "Rewind is off",
+      detail: "Private memory for moments you may need later.",
+      isLive: false,
+      hasError: false,
+    };
+  }
+
+  if (runtimeConfig.paused || status?.state === "paused") {
+    return {
+      kind: "paused",
+      title: "Rewind is paused",
+      detail: "Existing local memory is still available.",
+      isLive: false,
+      hasError: false,
+    };
+  }
+
+  if (status?.exclusionActive) {
+    return {
+      kind: "excluded",
+      title: "Rewind is protecting a private moment",
+      detail: status.coverage || "An excluded app is being skipped.",
+      isLive: false,
+      hasError: false,
+    };
+  }
+
+  if (status?.available === false) {
+    return {
+      kind: "unavailable",
+      title: "Rewind is unavailable",
+      detail: "Rewind capture is not available on this device.",
+      isLive: false,
+      hasError: false,
+    };
+  }
+
+  if (status?.state === "recording") {
+    return {
+      kind: "recording",
+      title: "Rewind is remembering",
+      detail:
+        status.lastError ||
+        status.coverage ||
+        "Rewind is retaining local coverage.",
+      isLive: true,
+      hasError: Boolean(status.lastError),
+    };
+  }
+
+  if (status?.lastError) {
+    return {
+      kind: "error",
+      title: "Rewind needs attention",
+      detail: status.lastError,
+      isLive: false,
+      hasError: true,
+    };
+  }
+
+  return {
+    kind: "idle",
+    title: "Rewind is enabled but not currently capturing",
+    detail: clipRecordingActive
+      ? "Rewind will resume when this Clip ends."
+      : "No new local coverage is being retained right now.",
+    isLive: false,
+    hasError: false,
+  };
+}

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -1707,6 +1707,16 @@ body[data-clips-route="recording-pill"] #root {
   margin: -4px 0 0;
 }
 
+.rewind-settings-status-copy {
+  display: grid;
+  gap: 1px;
+}
+
+.rewind-settings-status-copy strong {
+  color: var(--fg);
+  font-weight: 600;
+}
+
 .rewind-agent-row {
   border-bottom: none;
 }


### PR DESCRIPTION
## Summary

- derive Rewind copy and live indicators from one native-status presentation mapper
- keep Home, Recording Settings, and detailed Rewind Settings consistent across recording, paused, idle, excluded, error, and unavailable states
- refresh Home and Settings from the existing native change event plus bounded polling
- release the Home pause/resume control without blocking on a follow-up native status refresh

## Verification

- `pnpm --dir templates/clips/desktop test -- --run` — 20 files, 90 tests passed
- `pnpm --dir templates/clips/desktop typecheck`
- `pnpm --dir templates/clips/desktop build:alpha`
- fresh ad-hoc-signed `/Applications/Clips Alpha.app` install
- independent native-app QA H1–H6: Home, Recording Settings, and detailed Rewind Settings agreed while recording and paused; pause and resume settled successfully; Rewind and microphone restored on; no Clip or upload created

The first independent pass exposed a Home toggle lock after pausing. Commit `47661beab` fixes that blocker; a fresh independent rerun verified pause and resume end to end.

## Governing brief

`teenylilthoughts/briefs/Agent-Native Clips Rewind truthful capture status.md`

Architecture fingerprint: `rewind-truthful-capture-status-r1`
