### PR TITLE
Add optional label gate for PR Visual Recap

### DIFF
--- a/.changeset/quiet-recaps-label-gate.md
+++ b/.changeset/quiet-recaps-label-gate.md
@@ -1,0 +1,7 @@
+---
+"@agent-native/recap-cli": minor
+"@agent-native/core": patch
+"@agent-native/skills": patch
+---
+
+Add `VISUAL_RECAP_REQUIRED_LABELS` so PR Visual Recap can run only when a pull request has an opt-in label.

--- a/.github/workflows/pr-visual-recap-reusable.yml
+++ b/.github/workflows/pr-visual-recap-reusable.yml
@@ -15,7 +15,7 @@ name: PR Visual Recap (reusable)
 #
 # IMPORTANT: callers must trigger on the same pull_request event types as this
 # file declares in its on.workflow_call section (opened, synchronize, reopened,
-# ready_for_review, closed).  The workflow_call trigger inherits the CALLER's event
+# ready_for_review, labeled, closed).  The workflow_call trigger inherits the CALLER's event
 # context, so `github.event.pull_request.*` expressions here work correctly only
 # when the caller fires on pull_request.
 
@@ -97,6 +97,11 @@ on:
         required: false
         type: string
         default: "ubuntu-latest"
+      required-labels:
+        description: "Comma-separated PR labels; when set, recaps only run when the PR has at least one listed label"
+        required: false
+        type: string
+        default: ""
     secrets:
       # Required: bearer token minted by `agent-native connect`.  Authorizes
       # publishing the recap plan and the screenshot upload.
@@ -126,6 +131,7 @@ concurrency:
 jobs:
   gate:
     name: Gate
+    if: github.event.action != 'labeled' || inputs.required-labels != ''
     # A custom plain-label runner is allowed only for trusted same-repo authors.
     # Fork and untrusted PRs are forced onto GitHub-hosted ubuntu-latest before
     # any step starts. The only fromJSON input is this static association list.
@@ -152,6 +158,7 @@ jobs:
           VISUAL_RECAP_MODEL: ${{ inputs.model }}
           VISUAL_RECAP_RUNS_ON: ${{ inputs.runs-on }}
           VISUAL_RECAP_BASE_URL: ${{ inputs.base-url }}
+          VISUAL_RECAP_REQUIRED_LABELS: ${{ inputs.required-labels }}
           VISUAL_RECAP_SKILL_SOURCE: ${{ inputs.skill-source || 'auto' }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         with:
@@ -163,6 +170,19 @@ jobs:
             if (pr && pr.draft) reasons.push('draft PR');
             if (pr && context.payload.action === 'closed' && !pr.merged) {
               reasons.push('closed without merge');
+            }
+            const requiredLabels = (process.env.VISUAL_RECAP_REQUIRED_LABELS || '')
+              .split(',')
+              .map((label) => label.trim().toLowerCase())
+              .filter(Boolean);
+            if (pr && requiredLabels.length > 0) {
+              const prLabels = new Set((Array.isArray(pr.labels) ? pr.labels : [])
+                .map((label) => typeof label === 'string' ? label : label && label.name)
+                .filter(Boolean)
+                .map((label) => String(label).toLowerCase()));
+              if (!requiredLabels.some((label) => prLabels.has(label))) {
+                reasons.push(`missing required recap label (${requiredLabels.join(', ')})`);
+              }
             }
 
             // Fork PRs only receive repo secrets when the org/repo opts into

--- a/.github/workflows/pr-visual-recap.yml
+++ b/.github/workflows/pr-visual-recap.yml
@@ -6,7 +6,7 @@ name: PR Visual Recap
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, closed]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, closed]
 
 permissions:
   contents: read
@@ -18,12 +18,14 @@ concurrency:
 env:
   VISUAL_RECAP_AGENT: ${{ vars.VISUAL_RECAP_AGENT || 'claude' }}
   VISUAL_RECAP_BASE_URL: ${{ vars.VISUAL_RECAP_BASE_URL || '' }}
+  VISUAL_RECAP_REQUIRED_LABELS: ${{ vars.VISUAL_RECAP_REQUIRED_LABELS || '' }}
   VISUAL_RECAP_SKILL_SOURCE: ${{ vars.VISUAL_RECAP_SKILL_SOURCE || 'auto' }}
   VISUAL_RECAP_SECRET_SCAN: ${{ vars.VISUAL_RECAP_SECRET_SCAN || 'high-confidence' }}
 
 jobs:
   gate:
     name: Gate
+    if: github.event.action != 'labeled' || vars.VISUAL_RECAP_REQUIRED_LABELS != ''
     # A custom plain-label runner is allowed only for trusted same-repo authors.
     # Fork and untrusted PRs are forced onto GitHub-hosted ubuntu-latest before
     # any step starts. The only fromJSON input is this static association list.
@@ -50,6 +52,7 @@ jobs:
           VISUAL_RECAP_BASE_URL: ${{ env.VISUAL_RECAP_BASE_URL }}
           VISUAL_RECAP_MODEL: ${{ vars.VISUAL_RECAP_MODEL }}
           VISUAL_RECAP_RUNS_ON: ${{ vars.VISUAL_RECAP_RUNS_ON || '"ubuntu-latest"' }}
+          VISUAL_RECAP_REQUIRED_LABELS: ${{ env.VISUAL_RECAP_REQUIRED_LABELS }}
           VISUAL_RECAP_SKILL_SOURCE: ${{ env.VISUAL_RECAP_SKILL_SOURCE }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         with:
@@ -61,6 +64,19 @@ jobs:
             if (pr && pr.draft) reasons.push('draft PR');
             if (pr && context.payload.action === 'closed' && !pr.merged) {
               reasons.push('closed without merge');
+            }
+            const requiredLabels = (process.env.VISUAL_RECAP_REQUIRED_LABELS || '')
+              .split(',')
+              .map((label) => label.trim().toLowerCase())
+              .filter(Boolean);
+            if (pr && requiredLabels.length > 0) {
+              const prLabels = new Set((Array.isArray(pr.labels) ? pr.labels : [])
+                .map((label) => typeof label === 'string' ? label : label && label.name)
+                .filter(Boolean)
+                .map((label) => String(label).toLowerCase()));
+              if (!requiredLabels.some((label) => prLabels.has(label))) {
+                reasons.push(`missing required recap label (${requiredLabels.join(', ')})`);
+              }
             }
 
             // Fork PRs only receive repo secrets when the org/repo opts into

--- a/packages/core/docs/content/locales/ar-SA/pr-visual-recap.mdx
+++ b/packages/core/docs/content/locales/ar-SA/pr-visual-recap.mdx
@@ -180,7 +180,7 @@ npx @agent-native/recap-cli@latest recap doctor
 - **ثبّت نموذجًا أرخص.** بالنسبة لـ Claude، اضبط `VISUAL_RECAP_MODEL=claude-haiku-4-5` للمستودعات البسيطة أو الصغيرة — إنه أرخص فئة من Claude؛ `claude-sonnet-5` (الافتراضي) هو الفئة المتوازنة.
 - **انتقل إلى Codex بنموذج أرخص.** اضبط `VISUAL_RECAP_AGENT=codex` مع `VISUAL_RECAP_MODEL=gpt-5.6-luna` (أرخص فئة من GPT-5.6) أو `gpt-5.6-terra` (فئة متوسطة)، واضبط `VISUAL_RECAP_REASONING=low` لخفض إنفاق رموز الاستدلال أكثر. يُطبَّق عمق الاستدلال على Codex فقط.
 - **وجّهه إلى مزود متوافق مع OpenAI أرخص.** اضبط `VISUAL_RECAP_AGENT=openai-compatible` مع `VISUAL_RECAP_BASE_URL`/`VISUAL_RECAP_MODEL`/`VISUAL_RECAP_API_KEY` مستهدفًا DeepSeek أو Kimi أو أي نقطة نهاية أخرى متوافقة مع OpenAI.
-- **قلّل من تكرار الملخصات.** عدّل `on.pull_request.types` في سير العمل المثبّت من `[opened, synchronize, reopened, ready_for_review, closed]` إلى `[opened, ready_for_review, closed]` بحيث يتم إنشاء الملخّص فقط عند فتح طلب السحب وعند دمجه، بدلاً من كل دفعة.
+- **قلّل من تكرار الملخصات.** عدّل `on.pull_request.types` في سير العمل المثبّت من `[opened, synchronize, reopened, ready_for_review, labeled, closed]` إلى `[opened, ready_for_review, closed]` بحيث يتم إنشاء الملخّص فقط عند فتح طلب السحب وعند دمجه، بدلاً من كل دفعة.
 
 يسجّل كل تشغيل ما أنفقه فعليًا: تُرفق خطوة `recap usage` في سير العمل استخدام الرموز والتكلفة بالخطة المنشورة، حتى تتمكن من الاطلاع على الإنفاق الفعلي لكل تشغيل بدلاً من التخمين.
 
@@ -479,10 +479,11 @@ name: PR Visual Recap
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, closed]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, closed]
 
 jobs:
   visual-recap:
+    if: github.event.action != 'labeled' || vars.VISUAL_RECAP_REQUIRED_LABELS != ''
     permissions:
       actions: write
       contents: read
@@ -502,6 +503,7 @@ jobs:
       skill-source: ${{ vars.VISUAL_RECAP_SKILL_SOURCE || 'auto' }}
       runs-on: ${{ vars.VISUAL_RECAP_RUNS_ON || '"ubuntu-latest"' }}
       gate-runs-on: ${{ vars.VISUAL_RECAP_GATE_RUNS_ON || 'ubuntu-latest' }}
+      required-labels: ${{ vars.VISUAL_RECAP_REQUIRED_LABELS || '' }}
       # cli-version: "latest"  # pin to a specific @agent-native/recap-cli version
 ```
 

--- a/packages/core/docs/content/locales/de-DE/pr-visual-recap.mdx
+++ b/packages/core/docs/content/locales/de-DE/pr-visual-recap.mdx
@@ -180,7 +180,7 @@ So senken Sie die Kosten:
 - **Pinnen Sie ein günstigeres Modell.** Setzen Sie für Claude `VISUAL_RECAP_MODEL=claude-haiku-4-5` bei einfachen oder kleinen Repositorys – das ist die günstigste Claude-Stufe; `claude-sonnet-5` (die Standardeinstellung) ist die ausgewogene Stufe.
 - **Wechseln Sie zu Codex mit einem günstigeren Modell.** Setzen Sie `VISUAL_RECAP_AGENT=codex` zusammen mit `VISUAL_RECAP_MODEL=gpt-5.6-luna` (die günstigste GPT-5.6-Stufe) oder `gpt-5.6-terra` (mittlere Stufe), und setzen Sie `VISUAL_RECAP_REASONING=low`, um die Ausgaben für Argumentations-Token weiter zu senken. Die Argumentationstiefe gilt nur für Codex.
 - **Nutzen Sie einen günstigeren OpenAI-kompatiblen Anbieter.** Setzen Sie `VISUAL_RECAP_AGENT=openai-compatible` zusammen mit `VISUAL_RECAP_BASE_URL`/`VISUAL_RECAP_MODEL`/`VISUAL_RECAP_API_KEY`, die auf DeepSeek, Kimi oder einen anderen OpenAI-kompatiblen Endpunkt verweisen.
-- **Fassen Sie seltener zusammen.** Bearbeiten Sie `on.pull_request.types` des installierten Workflows von `[opened, synchronize, reopened, ready_for_review, closed]` zu `[opened, ready_for_review, closed]`, sodass nur beim Öffnen und beim Mergen eines PR zusammengefasst wird, statt bei jedem Push.
+- **Fassen Sie seltener zusammen.** Bearbeiten Sie `on.pull_request.types` des installierten Workflows von `[opened, synchronize, reopened, ready_for_review, labeled, closed]` zu `[opened, ready_for_review, closed]`, sodass nur beim Öffnen und beim Mergen eines PR zusammengefasst wird, statt bei jedem Push.
 
 Jeder Lauf zeichnet auf, was er tatsächlich gekostet hat: Der `recap usage`-Schritt des Workflows fügt dem veröffentlichten Plan Token- und Kostennutzung hinzu, sodass Sie die tatsächlichen Ausgaben pro Lauf einsehen können, statt zu raten.
 
@@ -479,10 +479,11 @@ name: PR Visual Recap
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, closed]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, closed]
 
 jobs:
   visual-recap:
+    if: github.event.action != 'labeled' || vars.VISUAL_RECAP_REQUIRED_LABELS != ''
     permissions:
       actions: write
       contents: read
@@ -502,6 +503,7 @@ jobs:
       skill-source: ${{ vars.VISUAL_RECAP_SKILL_SOURCE || 'auto' }}
       runs-on: ${{ vars.VISUAL_RECAP_RUNS_ON || '"ubuntu-latest"' }}
       gate-runs-on: ${{ vars.VISUAL_RECAP_GATE_RUNS_ON || 'ubuntu-latest' }}
+      required-labels: ${{ vars.VISUAL_RECAP_REQUIRED_LABELS || '' }}
       # cli-version: "latest"  # pin to a specific @agent-native/recap-cli version
 ```
 

--- a/packages/core/docs/content/locales/es-ES/pr-visual-recap.mdx
+++ b/packages/core/docs/content/locales/es-ES/pr-visual-recap.mdx
@@ -180,7 +180,7 @@ Para reducir el costo:
 - **Fije un modelo más económico.** Para Claude, configure `VISUAL_RECAP_MODEL=claude-haiku-4-5` para repositorios simples o pequeños — es el nivel más económico de Claude; `claude-sonnet-5` (el predeterminado) es el nivel equilibrado.
 - **Cambie a Codex con un modelo más económico.** Configure `VISUAL_RECAP_AGENT=codex` con `VISUAL_RECAP_MODEL=gpt-5.6-luna` (el nivel más económico de GPT-5.6) o `gpt-5.6-terra` (nivel intermedio), y configure `VISUAL_RECAP_REASONING=low` para reducir aún más el gasto en tokens de razonamiento. La profundidad de razonamiento solo se aplica a Codex.
 - **Apunte a un proveedor compatible con OpenAI más económico.** Configure `VISUAL_RECAP_AGENT=openai-compatible` con `VISUAL_RECAP_BASE_URL`/`VISUAL_RECAP_MODEL`/`VISUAL_RECAP_API_KEY` apuntando a DeepSeek, Kimi o cualquier otro endpoint compatible con OpenAI.
-- **Resuma con menos frecuencia.** Edite el `on.pull_request.types` del flujo de trabajo instalado de `[opened, synchronize, reopened, ready_for_review, closed]` a `[opened, ready_for_review, closed]` para que solo genere resúmenes cuando un PR se abre y cuando se fusiona, en lugar de en cada push.
+- **Resuma con menos frecuencia.** Edite el `on.pull_request.types` del flujo de trabajo instalado de `[opened, synchronize, reopened, ready_for_review, labeled, closed]` a `[opened, ready_for_review, closed]` para que solo genere resúmenes cuando un PR se abre y cuando se fusiona, en lugar de en cada push.
 
 Cada ejecución registra lo que realmente gastó: el paso `recap usage` del flujo de trabajo adjunta el uso de tokens y costo al plan publicado, para que pueda ver el gasto real por ejecución en lugar de adivinar.
 
@@ -479,10 +479,11 @@ name: PR Visual Recap
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, closed]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, closed]
 
 jobs:
   visual-recap:
+    if: github.event.action != 'labeled' || vars.VISUAL_RECAP_REQUIRED_LABELS != ''
     permissions:
       actions: write
       contents: read
@@ -502,6 +503,7 @@ jobs:
       skill-source: ${{ vars.VISUAL_RECAP_SKILL_SOURCE || 'auto' }}
       runs-on: ${{ vars.VISUAL_RECAP_RUNS_ON || '"ubuntu-latest"' }}
       gate-runs-on: ${{ vars.VISUAL_RECAP_GATE_RUNS_ON || 'ubuntu-latest' }}
+      required-labels: ${{ vars.VISUAL_RECAP_REQUIRED_LABELS || '' }}
       # cli-version: "latest"  # pin to a specific @agent-native/recap-cli version
 ```
 

--- a/packages/core/docs/content/locales/fr-FR/pr-visual-recap.mdx
+++ b/packages/core/docs/content/locales/fr-FR/pr-visual-recap.mdx
@@ -180,7 +180,7 @@ Pour réduire le coût :
 - **Épinglez un modèle moins cher.** Pour Claude, définissez `VISUAL_RECAP_MODEL=claude-haiku-4-5` pour les dépôts simples ou petits — c'est le niveau Claude le moins cher ; `claude-sonnet-5` (la valeur par défaut) est le niveau équilibré.
 - **Passez à Codex avec un modèle moins cher.** Définissez `VISUAL_RECAP_AGENT=codex` avec `VISUAL_RECAP_MODEL=gpt-5.6-luna` (le niveau GPT-5.6 le moins cher) ou `gpt-5.6-terra` (niveau intermédiaire), et définissez `VISUAL_RECAP_REASONING=low` pour réduire encore la dépense en jetons de raisonnement. La profondeur de raisonnement ne s'applique qu'à Codex.
 - **Pointez vers un fournisseur compatible OpenAI moins cher.** Définissez `VISUAL_RECAP_AGENT=openai-compatible` avec `VISUAL_RECAP_BASE_URL`/`VISUAL_RECAP_MODEL`/`VISUAL_RECAP_API_KEY` ciblant DeepSeek, Kimi ou tout autre point de terminaison compatible OpenAI.
-- **Récapitulez moins souvent.** Modifiez le `on.pull_request.types` du flux de travail installé de `[opened, synchronize, reopened, ready_for_review, closed]` à `[opened, ready_for_review, closed]` afin qu'il ne récapitule que lorsqu'une PR s'ouvre et lorsqu'elle est fusionnée, au lieu de le faire à chaque poussée.
+- **Récapitulez moins souvent.** Modifiez le `on.pull_request.types` du flux de travail installé de `[opened, synchronize, reopened, ready_for_review, labeled, closed]` à `[opened, ready_for_review, closed]` afin qu'il ne récapitule que lorsqu'une PR s'ouvre et lorsqu'elle est fusionnée, au lieu de le faire à chaque poussée.
 
 Chaque exécution enregistre ce qu'elle a réellement dépensé : l'étape `recap usage` du flux de travail associe l'utilisation de jetons et de coût au plan publié, afin que vous puissiez consulter la dépense réelle par exécution plutôt que de deviner.
 
@@ -480,10 +480,11 @@ name: PR Visual Recap
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, closed]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, closed]
 
 jobs:
   visual-recap:
+    if: github.event.action != 'labeled' || vars.VISUAL_RECAP_REQUIRED_LABELS != ''
     permissions:
       actions: write
       contents: read
@@ -503,6 +504,7 @@ jobs:
       skill-source: ${{ vars.VISUAL_RECAP_SKILL_SOURCE || 'auto' }}
       runs-on: ${{ vars.VISUAL_RECAP_RUNS_ON || '"ubuntu-latest"' }}
       gate-runs-on: ${{ vars.VISUAL_RECAP_GATE_RUNS_ON || 'ubuntu-latest' }}
+      required-labels: ${{ vars.VISUAL_RECAP_REQUIRED_LABELS || '' }}
       # cli-version: "latest"  # pin to a specific @agent-native/recap-cli version
 ```
 

--- a/packages/core/docs/content/locales/hi-IN/pr-visual-recap.mdx
+++ b/packages/core/docs/content/locales/hi-IN/pr-visual-recap.mdx
@@ -180,7 +180,7 @@ npx @agent-native/recap-cli@latest recap doctor
 - **एक सस्ता मॉडल पिन करें।** Claude के लिए, सरल या छोटे रिपॉज़िटरी के लिए `VISUAL_RECAP_MODEL=claude-haiku-4-5` सेट करें — यह सबसे सस्ता Claude स्तर है; `claude-sonnet-5` (डिफ़ॉल्ट) संतुलित स्तर है।
 - **सस्ते मॉडल के साथ Codex पर स्विच करें।** `VISUAL_RECAP_AGENT=codex` को `VISUAL_RECAP_MODEL=gpt-5.6-luna` (सबसे सस्ता GPT-5.6 स्तर) या `gpt-5.6-terra` (मध्य-स्तर) के साथ सेट करें, और रीज़निंग-टोकन खर्च को और कम करने के लिए `VISUAL_RECAP_REASONING=low` सेट करें। रीज़निंग गहराई केवल Codex पर लागू होती है।
 - **किसी सस्ते OpenAI-संगत प्रदाता की ओर इंगित करें।** DeepSeek, Kimi, या किसी अन्य OpenAI-संगत एंडपॉइंट को लक्षित करते हुए `VISUAL_RECAP_BASE_URL`/`VISUAL_RECAP_MODEL`/`VISUAL_RECAP_API_KEY` के साथ `VISUAL_RECAP_AGENT=openai-compatible` सेट करें।
-- **रिकैप कम बार करें।** इंस्टॉल किए गए वर्कफ़्लो के `on.pull_request.types` को `[opened, synchronize, reopened, ready_for_review, closed]` से बदलकर `[opened, ready_for_review, closed]` करें ताकि यह हर पुश पर नहीं, बल्कि केवल तब रिकैप करे जब कोई PR खुले और जब वह मर्ज हो।
+- **रिकैप कम बार करें।** इंस्टॉल किए गए वर्कफ़्लो के `on.pull_request.types` को `[opened, synchronize, reopened, ready_for_review, labeled, closed]` से बदलकर `[opened, ready_for_review, closed]` करें ताकि यह हर पुश पर नहीं, बल्कि केवल तब रिकैप करे जब कोई PR खुले और जब वह मर्ज हो।
 
 हर रन यह रिकॉर्ड करता है कि वास्तव में कितना खर्च हुआ: वर्कफ़्लो का `recap usage` चरण टोकन और लागत उपयोग को प्रकाशित योजना से जोड़ देता है, ताकि आप अनुमान लगाने के बजाय प्रति रन वास्तविक खर्च देख सकें।
 
@@ -480,10 +480,11 @@ name: PR Visual Recap
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, closed]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, closed]
 
 jobs:
   visual-recap:
+    if: github.event.action != 'labeled' || vars.VISUAL_RECAP_REQUIRED_LABELS != ''
     permissions:
       actions: write
       contents: read
@@ -503,6 +504,7 @@ jobs:
       skill-source: ${{ vars.VISUAL_RECAP_SKILL_SOURCE || 'auto' }}
       runs-on: ${{ vars.VISUAL_RECAP_RUNS_ON || '"ubuntu-latest"' }}
       gate-runs-on: ${{ vars.VISUAL_RECAP_GATE_RUNS_ON || 'ubuntu-latest' }}
+      required-labels: ${{ vars.VISUAL_RECAP_REQUIRED_LABELS || '' }}
       # cli-version: "latest"  # pin to a specific @agent-native/recap-cli version
 ```
 

--- a/packages/core/docs/content/locales/ja-JP/pr-visual-recap.mdx
+++ b/packages/core/docs/content/locales/ja-JP/pr-visual-recap.mdx
@@ -180,7 +180,7 @@ npx @agent-native/recap-cli@latest recap doctor
 - **より安価なモデルを固定します。** Claude の場合、シンプルまたは小規模なリポジトリには `VISUAL_RECAP_MODEL=claude-haiku-4-5` を設定してください — 最も安価な Claude ティアです。`claude-sonnet-5` (デフォルト) はバランス型のティアです。
 - **より安価なモデルで Codex に切り替えます。** `VISUAL_RECAP_AGENT=codex` と `VISUAL_RECAP_MODEL=gpt-5.6-luna` (最も安価な GPT-5.6 ティア) または `gpt-5.6-terra` (中間ティア) を設定し、推論トークンの消費をさらに削減するには `VISUAL_RECAP_REASONING=low` を設定してください。推論の深さは Codex にのみ適用されます。
 - **より安価な OpenAI 互換プロバイダーを指定します。** `VISUAL_RECAP_AGENT=openai-compatible` を、DeepSeek、Kimi、またはその他の OpenAI 互換エンドポイントを対象とする `VISUAL_RECAP_BASE_URL`/`VISUAL_RECAP_MODEL`/`VISUAL_RECAP_API_KEY` とともに設定してください。
-- **要約の頻度を減らします。** インストール済みワークフローの `on.pull_request.types` を `[opened, synchronize, reopened, ready_for_review, closed]` から `[opened, ready_for_review, closed]` に編集すると、プッシュのたびにではなく、PR が開かれたときとマージされたときにのみ要約されるようになります。
+- **要約の頻度を減らします。** インストール済みワークフローの `on.pull_request.types` を `[opened, synchronize, reopened, ready_for_review, labeled, closed]` から `[opened, ready_for_review, closed]` に編集すると、プッシュのたびにではなく、PR が開かれたときとマージされたときにのみ要約されるようになります。
 
 各実行は実際に消費した内容を記録します。ワークフローの `recap usage` ステップが、公開されたプランにトークンとコストの使用状況を添付するため、推測ではなく実際の消費量を実行ごとに確認できます。
 
@@ -477,10 +477,11 @@ name: PR Visual Recap
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, closed]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, closed]
 
 jobs:
   visual-recap:
+    if: github.event.action != 'labeled' || vars.VISUAL_RECAP_REQUIRED_LABELS != ''
     permissions:
       actions: write
       contents: read
@@ -500,6 +501,7 @@ jobs:
       skill-source: ${{ vars.VISUAL_RECAP_SKILL_SOURCE || 'auto' }}
       runs-on: ${{ vars.VISUAL_RECAP_RUNS_ON || '"ubuntu-latest"' }}
       gate-runs-on: ${{ vars.VISUAL_RECAP_GATE_RUNS_ON || 'ubuntu-latest' }}
+      required-labels: ${{ vars.VISUAL_RECAP_REQUIRED_LABELS || '' }}
       # cli-version: "latest"  # pin to a specific @agent-native/recap-cli version
 ```
 

--- a/packages/core/docs/content/locales/ko-KR/pr-visual-recap.mdx
+++ b/packages/core/docs/content/locales/ko-KR/pr-visual-recap.mdx
@@ -180,7 +180,7 @@ npx @agent-native/recap-cli@latest recap doctor
 - **더 저렴한 모델을 고정하세요.** Claude의 경우, 간단하거나 작은 저장소에는 `VISUAL_RECAP_MODEL=claude-haiku-4-5`를 설정하세요 — 가장 저렴한 Claude 등급입니다. `claude-sonnet-5`(기본값)는 균형 잡힌 등급입니다.
 - **더 저렴한 모델로 Codex로 전환하세요.** `VISUAL_RECAP_AGENT=codex`와 `VISUAL_RECAP_MODEL=gpt-5.6-luna`(가장 저렴한 GPT-5.6 등급) 또는 `gpt-5.6-terra`(중간 등급)를 설정하고, 추론 토큰 비용을 더 줄이려면 `VISUAL_RECAP_REASONING=low`를 설정하세요. 추론 깊이는 Codex에만 적용됩니다.
 - **더 저렴한 OpenAI 호환 제공업체를 지정하세요.** `VISUAL_RECAP_AGENT=openai-compatible`을 DeepSeek, Kimi 또는 다른 OpenAI 호환 엔드포인트를 대상으로 하는 `VISUAL_RECAP_BASE_URL`/`VISUAL_RECAP_MODEL`/`VISUAL_RECAP_API_KEY`와 함께 설정하세요.
-- **요약 빈도를 줄이세요.** 설치된 워크플로의 `on.pull_request.types`를 `[opened, synchronize, reopened, ready_for_review, closed]`에서 `[opened, ready_for_review, closed]`로 편집하면, 모든 푸시가 아니라 PR이 열릴 때와 병합될 때만 요약이 실행됩니다.
+- **요약 빈도를 줄이세요.** 설치된 워크플로의 `on.pull_request.types`를 `[opened, synchronize, reopened, ready_for_review, labeled, closed]`에서 `[opened, ready_for_review, closed]`로 편집하면, 모든 푸시가 아니라 PR이 열릴 때와 병합될 때만 요약이 실행됩니다.
 
 각 실행은 실제로 소비한 비용을 기록합니다. 워크플로의 `recap usage` 단계가 게시된 계획에 토큰 및 비용 사용량을 첨부하므로, 추측하는 대신 실행별 실제 지출을 확인할 수 있습니다.
 
@@ -479,10 +479,11 @@ name: PR Visual Recap
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, closed]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, closed]
 
 jobs:
   visual-recap:
+    if: github.event.action != 'labeled' || vars.VISUAL_RECAP_REQUIRED_LABELS != ''
     permissions:
       actions: write
       contents: read
@@ -502,6 +503,7 @@ jobs:
       skill-source: ${{ vars.VISUAL_RECAP_SKILL_SOURCE || 'auto' }}
       runs-on: ${{ vars.VISUAL_RECAP_RUNS_ON || '"ubuntu-latest"' }}
       gate-runs-on: ${{ vars.VISUAL_RECAP_GATE_RUNS_ON || 'ubuntu-latest' }}
+      required-labels: ${{ vars.VISUAL_RECAP_REQUIRED_LABELS || '' }}
       # cli-version: "latest"  # pin to a specific @agent-native/recap-cli version
 ```
 

--- a/packages/core/docs/content/locales/pt-BR/pr-visual-recap.mdx
+++ b/packages/core/docs/content/locales/pt-BR/pr-visual-recap.mdx
@@ -180,7 +180,7 @@ Para reduzir o custo:
 - **Fixe um modelo mais barato.** Para Claude, defina `VISUAL_RECAP_MODEL=claude-haiku-4-5` para repositórios simples ou pequenos — é o nível Claude mais barato; `claude-sonnet-5` (o padrão) é o nível equilibrado.
 - **Mude para Codex com um modelo mais barato.** Defina `VISUAL_RECAP_AGENT=codex` com `VISUAL_RECAP_MODEL=gpt-5.6-luna` (o nível GPT-5.6 mais barato) ou `gpt-5.6-terra` (nível intermediário), e defina `VISUAL_RECAP_REASONING=low` para reduzir ainda mais o gasto com tokens de raciocínio. A profundidade de raciocínio só se aplica ao Codex.
 - **Aponte para um provedor mais barato compatível com OpenAI.** Defina `VISUAL_RECAP_AGENT=openai-compatible` com `VISUAL_RECAP_BASE_URL`/`VISUAL_RECAP_MODEL`/`VISUAL_RECAP_API_KEY` direcionados ao DeepSeek, Kimi ou qualquer outro endpoint compatível com OpenAI.
-- **Recapitule com menos frequência.** Edite o `on.pull_request.types` do fluxo de trabalho instalado de `[opened, synchronize, reopened, ready_for_review, closed]` para `[opened, ready_for_review, closed]` para que ele só recapitule quando um PR é aberto e quando é mesclado, em vez de a cada push.
+- **Recapitule com menos frequência.** Edite o `on.pull_request.types` do fluxo de trabalho instalado de `[opened, synchronize, reopened, ready_for_review, labeled, closed]` para `[opened, ready_for_review, closed]` para que ele só recapitule quando um PR é aberto e quando é mesclado, em vez de a cada push.
 
 Cada execução registra o que realmente foi gasto: a etapa `recap usage` do fluxo de trabalho anexa o uso de tokens e custo ao plano publicado, para que você possa ver o gasto real por execução em vez de adivinhar.
 
@@ -479,10 +479,11 @@ name: PR Visual Recap
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, closed]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, closed]
 
 jobs:
   visual-recap:
+    if: github.event.action != 'labeled' || vars.VISUAL_RECAP_REQUIRED_LABELS != ''
     permissions:
       actions: write
       contents: read
@@ -502,6 +503,7 @@ jobs:
       skill-source: ${{ vars.VISUAL_RECAP_SKILL_SOURCE || 'auto' }}
       runs-on: ${{ vars.VISUAL_RECAP_RUNS_ON || '"ubuntu-latest"' }}
       gate-runs-on: ${{ vars.VISUAL_RECAP_GATE_RUNS_ON || 'ubuntu-latest' }}
+      required-labels: ${{ vars.VISUAL_RECAP_REQUIRED_LABELS || '' }}
       # cli-version: "latest"  # pin to a specific @agent-native/recap-cli version
 ```
 

--- a/packages/core/docs/content/locales/zh-CN/pr-visual-recap.mdx
+++ b/packages/core/docs/content/locales/zh-CN/pr-visual-recap.mdx
@@ -180,7 +180,7 @@ npx @agent-native/recap-cli@latest recap doctor
 - **固定使用更便宜的模型。** 对于 Claude，为简单或小型仓库设置 `VISUAL_RECAP_MODEL=claude-haiku-4-5` — 这是最便宜的 Claude 层级；`claude-sonnet-5`（默认值）是均衡层级。
 - **切换到使用更便宜模型的 Codex。** 设置 `VISUAL_RECAP_AGENT=codex` 并配合 `VISUAL_RECAP_MODEL=gpt-5.6-luna`（最便宜的 GPT-5.6 层级）或 `gpt-5.6-terra`（中间层级），并设置 `VISUAL_RECAP_REASONING=low` 以进一步减少推理 token 花费。推理深度仅适用于 Codex。
 - **指向更便宜的 OpenAI 兼容提供商。** 设置 `VISUAL_RECAP_AGENT=openai-compatible`，并配合指向 DeepSeek、Kimi 或任何其他 OpenAI 兼容端点的 `VISUAL_RECAP_BASE_URL`/`VISUAL_RECAP_MODEL`/`VISUAL_RECAP_API_KEY`。
-- **减少回顾频率。** 将已安装工作流的 `on.pull_request.types` 从 `[opened, synchronize, reopened, ready_for_review, closed]` 编辑为 `[opened, ready_for_review, closed]`，使其仅在 PR 打开和合并时回顾，而不是每次推送都回顾。
+- **减少回顾频率。** 将已安装工作流的 `on.pull_request.types` 从 `[opened, synchronize, reopened, ready_for_review, labeled, closed]` 编辑为 `[opened, ready_for_review, closed]`，使其仅在 PR 打开和合并时回顾，而不是每次推送都回顾。
 
 每次运行都会记录实际花费：工作流的 `recap usage` 步骤会将 token 和成本使用情况附加到已发布的计划中，因此你可以查看每次运行的实际花费，而不是靠猜测。
 
@@ -477,10 +477,11 @@ name: PR Visual Recap
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, closed]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, closed]
 
 jobs:
   visual-recap:
+    if: github.event.action != 'labeled' || vars.VISUAL_RECAP_REQUIRED_LABELS != ''
     permissions:
       actions: write
       contents: read
@@ -500,6 +501,7 @@ jobs:
       skill-source: ${{ vars.VISUAL_RECAP_SKILL_SOURCE || 'auto' }}
       runs-on: ${{ vars.VISUAL_RECAP_RUNS_ON || '"ubuntu-latest"' }}
       gate-runs-on: ${{ vars.VISUAL_RECAP_GATE_RUNS_ON || 'ubuntu-latest' }}
+      required-labels: ${{ vars.VISUAL_RECAP_REQUIRED_LABELS || '' }}
       # cli-version: "latest"  # pin to a specific @agent-native/recap-cli version
 ```
 

--- a/packages/core/docs/content/locales/zh-TW/pr-visual-recap.mdx
+++ b/packages/core/docs/content/locales/zh-TW/pr-visual-recap.mdx
@@ -180,7 +180,7 @@ npx @agent-native/recap-cli@latest recap doctor
 - **固定使用較便宜的模型。** 對於 Claude，為簡單或小型儲存庫設定 `VISUAL_RECAP_MODEL=claude-haiku-4-5` — 這是最便宜的 Claude 層級；`claude-sonnet-5`（預設值）是均衡層級。
 - **切換到使用較便宜模型的 Codex。** 設定 `VISUAL_RECAP_AGENT=codex` 並搭配 `VISUAL_RECAP_MODEL=gpt-5.6-luna`（最便宜的 GPT-5.6 層級）或 `gpt-5.6-terra`（中間層級），並設定 `VISUAL_RECAP_REASONING=low` 以進一步減少推理 token 花費。推理深度僅適用於 Codex。
 - **指向較便宜的 OpenAI 相容供應商。** 設定 `VISUAL_RECAP_AGENT=openai-compatible`，並搭配指向 DeepSeek、Kimi 或任何其他 OpenAI 相容端點的 `VISUAL_RECAP_BASE_URL`/`VISUAL_RECAP_MODEL`/`VISUAL_RECAP_API_KEY`。
-- **降低回顧頻率。** 將已安裝工作流程的 `on.pull_request.types` 從 `[opened, synchronize, reopened, ready_for_review, closed]` 編輯為 `[opened, ready_for_review, closed]`，使其僅在 PR 開啟和合併時回顧，而不是每次推送都回顧。
+- **降低回顧頻率。** 將已安裝工作流程的 `on.pull_request.types` 從 `[opened, synchronize, reopened, ready_for_review, labeled, closed]` 編輯為 `[opened, ready_for_review, closed]`，使其僅在 PR 開啟和合併時回顧，而不是每次推送都回顧。
 
 每次執行都會記錄實際花費：工作流程的 `recap usage` 步驟會將 token 和成本使用情況附加到已發布的計畫中，因此你可以查看每次執行的實際花費，而不是靠猜測。
 
@@ -477,10 +477,11 @@ name: PR Visual Recap
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, closed]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, closed]
 
 jobs:
   visual-recap:
+    if: github.event.action != 'labeled' || vars.VISUAL_RECAP_REQUIRED_LABELS != ''
     permissions:
       actions: write
       contents: read
@@ -500,6 +501,7 @@ jobs:
       skill-source: ${{ vars.VISUAL_RECAP_SKILL_SOURCE || 'auto' }}
       runs-on: ${{ vars.VISUAL_RECAP_RUNS_ON || '"ubuntu-latest"' }}
       gate-runs-on: ${{ vars.VISUAL_RECAP_GATE_RUNS_ON || 'ubuntu-latest' }}
+      required-labels: ${{ vars.VISUAL_RECAP_REQUIRED_LABELS || '' }}
       # cli-version: "latest"  # pin to a specific @agent-native/recap-cli version
 ```
 

--- a/packages/core/docs/content/pr-visual-recap.mdx
+++ b/packages/core/docs/content/pr-visual-recap.mdx
@@ -209,7 +209,8 @@ To reduce cost:
 - **Pin a cheaper model.** For Claude, set `VISUAL_RECAP_MODEL=claude-haiku-4-5` for simple or small repos — it's the cheapest Claude tier; `claude-sonnet-5` (the default) is the balanced tier.
 - **Switch to Codex with a cheaper model.** Set `VISUAL_RECAP_AGENT=codex` with `VISUAL_RECAP_MODEL=gpt-5.6-luna` (the cheapest GPT-5.6 tier) or `gpt-5.6-terra` (mid-tier), and set `VISUAL_RECAP_REASONING=low` to cut reasoning-token spend further. Reasoning depth only applies to Codex.
 - **Point at a cheaper OpenAI-compatible provider.** Set `VISUAL_RECAP_AGENT=openai-compatible` with `VISUAL_RECAP_BASE_URL`/`VISUAL_RECAP_MODEL`/`VISUAL_RECAP_API_KEY` targeting DeepSeek, Kimi, or any other OpenAI-compatible endpoint.
-- **Recap less often.** Edit the installed workflow's `on.pull_request.types` from `[opened, synchronize, reopened, ready_for_review, closed]` to `[opened, ready_for_review, closed]` so it recaps only when a PR opens and when it merges, instead of on every push.
+- **Require an explicit PR label.** Set `VISUAL_RECAP_REQUIRED_LABELS=visual recap` to keep the workflow installed but skip recaps until a PR has that label. Use a comma-separated list, such as `visual recap,recap`, when several labels should opt in. Applying a listed label wakes the workflow immediately.
+- **Recap less often.** Edit the installed workflow's `on.pull_request.types` from `[opened, synchronize, reopened, ready_for_review, labeled, closed]` to `[opened, ready_for_review, closed]` so it recaps only when a PR opens and when it merges, instead of on every push.
 
 Every run records what it actually spent: the workflow's `recap usage` step attaches token and cost usage to the published plan, so you can look at real spend per run instead of guessing.
 
@@ -256,16 +257,17 @@ real token.
 
 ### Optional (only if you change defaults)
 
-| Secret / variable        | Default                                                       | When you need it                                                                                                                                                                                                                                         |
-| ------------------------ | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `OPENAI_API_KEY`         | —                                                             | Secret. Set together with `VISUAL_RECAP_AGENT=codex` to run the recap with Codex instead.                                                                                                                                                                |
-| `VISUAL_RECAP_API_KEY`   | —                                                             | Secret. Set with `VISUAL_RECAP_AGENT=openai-compatible` for DeepSeek, Kimi, or another OpenAI-compatible provider.                                                                                                                                       |
-| `VISUAL_RECAP_AGENT`     | `claude`                                                      | Variable. Selects the coding-agent backend (`claude`, `codex`, or `openai-compatible`).                                                                                                                                                                  |
-| `VISUAL_RECAP_BASE_URL`  | required for compatible backend                               | Variable. HTTP(S) base URL for the OpenAI-compatible backend; credentials are rejected.                                                                                                                                                                  |
-| `VISUAL_RECAP_MODEL`     | `claude-sonnet-5` for Claude; required for compatible backend | Variable. Provider model id for OpenAI-compatible backends (required there). For Claude, unset now defaults to `claude-sonnet-5` — set it to override, e.g. `claude-haiku-4-5` for the cheapest tier. For Codex, unset uses the Codex CLI's own default. |
-| `VISUAL_RECAP_REASONING` | each model's default                                          | Variable. Reasoning depth: `none`, `minimal`, `low`, `medium`, `high`, or `xhigh`. Applies to the Codex backend.                                                                                                                                         |
-| `RECAP_CLI_VERSION`      | `latest`                                                      | Variable. Pins the `@agent-native/recap-cli` version the workflow installs — e.g. `1.5.0`. See [Version pinning](#version-pinning-copy-variant).                                                                                                         |
-| `PLAN_RECAP_APP_URL`     | `https://plan.agent-native.com`                               | Secret. Only when self-hosting the Plans app at a different origin.                                                                                                                                                                                      |
+| Secret / variable              | Default                                                       | When you need it                                                                                                                                                                                                                                         |
+| ------------------------------ | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OPENAI_API_KEY`               | —                                                             | Secret. Set together with `VISUAL_RECAP_AGENT=codex` to run the recap with Codex instead.                                                                                                                                                                |
+| `VISUAL_RECAP_API_KEY`         | —                                                             | Secret. Set with `VISUAL_RECAP_AGENT=openai-compatible` for DeepSeek, Kimi, or another OpenAI-compatible provider.                                                                                                                                       |
+| `VISUAL_RECAP_AGENT`           | `claude`                                                      | Variable. Selects the coding-agent backend (`claude`, `codex`, or `openai-compatible`).                                                                                                                                                                  |
+| `VISUAL_RECAP_BASE_URL`        | required for compatible backend                               | Variable. HTTP(S) base URL for the OpenAI-compatible backend; credentials are rejected.                                                                                                                                                                  |
+| `VISUAL_RECAP_MODEL`           | `claude-sonnet-5` for Claude; required for compatible backend | Variable. Provider model id for OpenAI-compatible backends (required there). For Claude, unset now defaults to `claude-sonnet-5` — set it to override, e.g. `claude-haiku-4-5` for the cheapest tier. For Codex, unset uses the Codex CLI's own default. |
+| `VISUAL_RECAP_REASONING`       | each model's default                                          | Variable. Reasoning depth: `none`, `minimal`, `low`, `medium`, `high`, or `xhigh`. Applies to the Codex backend.                                                                                                                                         |
+| `VISUAL_RECAP_REQUIRED_LABELS` | —                                                             | Variable. Comma-separated PR labels. When set, the gate skips until the PR has at least one listed label, for example `visual recap`.                                                                                                                    |
+| `RECAP_CLI_VERSION`            | `latest`                                                      | Variable. Pins the `@agent-native/recap-cli` version the workflow installs — e.g. `1.5.0`. See [Version pinning](#version-pinning-copy-variant).                                                                                                         |
+| `PLAN_RECAP_APP_URL`           | `https://plan.agent-native.com`                               | Secret. Only when self-hosting the Plans app at a different origin.                                                                                                                                                                                      |
 
 The workflow auto-detects how to invoke its helper CLI (local source inside this monorepo, the published `@agent-native/recap-cli` elsewhere), so there is no `RECAP_CLI` variable to set.
 
@@ -510,10 +512,11 @@ name: PR Visual Recap
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, closed]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, closed]
 
 jobs:
   visual-recap:
+    if: github.event.action != 'labeled' || vars.VISUAL_RECAP_REQUIRED_LABELS != ''
     permissions:
       actions: write
       contents: read
@@ -535,10 +538,11 @@ jobs:
       skill-source: ${{ vars.VISUAL_RECAP_SKILL_SOURCE || 'auto' }}
       runs-on: ${{ vars.VISUAL_RECAP_RUNS_ON || '"ubuntu-latest"' }}
       gate-runs-on: ${{ vars.VISUAL_RECAP_GATE_RUNS_ON || 'ubuntu-latest' }}
+      required-labels: ${{ vars.VISUAL_RECAP_REQUIRED_LABELS || '' }}
       # cli-version: "latest"  # pin to a specific @agent-native/recap-cli version
 ```
 
-The same secrets and variables described in [Secrets and variables](#secrets-and-variables) apply — set them in your repo settings the same way as for the copy variant. The reusable caller forwards `VISUAL_RECAP_RUNS_ON` through its JSON `runs-on` input for the full recap job and `VISUAL_RECAP_GATE_RUNS_ON` through its plain-label `gate-runs-on` input for the metadata-only gate. The latter is used only for trusted same-repository authors; other PRs use GitHub-hosted `ubuntu-latest`. Omitting either input preserves its `ubuntu-latest` default.
+The same secrets and variables described in [Secrets and variables](#secrets-and-variables) apply — set them in your repo settings the same way as for the copy variant. The reusable caller forwards `VISUAL_RECAP_RUNS_ON` through its JSON `runs-on` input for the full recap job, `VISUAL_RECAP_GATE_RUNS_ON` through its plain-label `gate-runs-on` input for the metadata-only gate, and `VISUAL_RECAP_REQUIRED_LABELS` through `required-labels` for optional PR-label gating. The gate runner input is used only for trusted same-repository authors; other PRs use GitHub-hosted `ubuntu-latest`. Omitting the runner inputs preserves their `ubuntu-latest` defaults; omitting required labels preserves automatic recap behavior.
 
 ### Installing via the CLI
 

--- a/packages/core/src/cli/recap.spec.ts
+++ b/packages/core/src/cli/recap.spec.ts
@@ -2883,7 +2883,10 @@ describe("bundled PR visual recap workflow", () => {
     expect(PR_VISUAL_RECAP_WORKFLOW_YML).toContain("Publish recap source");
     expect(PR_VISUAL_RECAP_WORKFLOW_YML).toContain("recap publish");
     expect(PR_VISUAL_RECAP_WORKFLOW_YML).toContain(
-      "types: [opened, synchronize, reopened, ready_for_review, closed]",
+      "types: [opened, synchronize, reopened, ready_for_review, labeled, closed]",
+    );
+    expect(PR_VISUAL_RECAP_WORKFLOW_YML).toContain(
+      "VISUAL_RECAP_REQUIRED_LABELS",
     );
     expect(PR_VISUAL_RECAP_WORKFLOW_YML).toContain("closed without merge");
     expect(PR_VISUAL_RECAP_WORKFLOW_YML).toContain("PR_MERGED_AT");
@@ -3396,7 +3399,7 @@ describe("reusable caller workflow builder", () => {
     const yml = buildReusableCallerWorkflow();
     // Trigger: same event types as the canonical workflow.
     expect(yml).toContain(
-      "types: [opened, synchronize, reopened, ready_for_review, closed]",
+      "types: [opened, synchronize, reopened, ready_for_review, labeled, closed]",
     );
     // Uses the reusable workflow in the agent-native repo.
     expect(yml).toContain(
@@ -3416,6 +3419,9 @@ describe("reusable caller workflow builder", () => {
     expect(yml).toContain("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}");
     expect(yml).toContain(
       "VISUAL_RECAP_API_KEY: ${{ secrets.VISUAL_RECAP_API_KEY }}",
+    );
+    expect(yml).toContain(
+      "required-labels: ${{ vars.VISUAL_RECAP_REQUIRED_LABELS || '' }}",
     );
     expect(yml).toContain(
       "PLAN_RECAP_APP_URL: ${{ secrets.PLAN_RECAP_APP_URL }}",

--- a/packages/recap-cli/src/pr-visual-recap-workflow.spec.ts
+++ b/packages/recap-cli/src/pr-visual-recap-workflow.spec.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import { PR_VISUAL_RECAP_WORKFLOW_YML } from "./pr-visual-recap-workflow.js";
+import { buildReusableCallerWorkflow } from "./recap.js";
 
 const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -16,6 +17,27 @@ describe("the recap installer workflow", () => {
     expect(PR_VISUAL_RECAP_WORKFLOW_YML).toContain(
       "    defaults:\n      run:\n        shell: bash",
     );
+  });
+
+  it("wakes label-gated recaps when a PR label is applied", () => {
+    expect(PR_VISUAL_RECAP_WORKFLOW_YML).toContain(
+      "types: [opened, synchronize, reopened, ready_for_review, labeled, closed]",
+    );
+  });
+
+  it("forwards label gates from reusable callers", () => {
+    expect(buildReusableCallerWorkflow()).toContain(
+      "required-labels: ${{ vars.VISUAL_RECAP_REQUIRED_LABELS || '' }}",
+    );
+  });
+
+  it("wakes labeled events when reusable callers configure labels directly", () => {
+    const workflow = buildReusableCallerWorkflow({
+      requiredLabels: "visual recap",
+    });
+
+    expect(workflow).toContain("if: github.event.action != 'labeled' || true");
+    expect(workflow).toContain('required-labels: "visual recap"');
   });
 
   it("bundles the canonical workflow byte for byte", () => {

--- a/packages/recap-cli/src/recap-gate.spec.ts
+++ b/packages/recap-cli/src/recap-gate.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluateRecapGate, type RecapGateInput } from "./recap.js";
+
+function validGateInput(
+  overrides: Partial<RecapGateInput> = {},
+): RecapGateInput {
+  return {
+    pr: {
+      number: 123,
+      draft: false,
+      author_association: "MEMBER",
+      head: { repo: { full_name: "owner/repo" } },
+      user: { login: "alice", type: "User" },
+      labels: [],
+    },
+    repository: "owner/repo",
+    repositoryPrivate: true,
+    hasPlan: true,
+    hasAnthropic: true,
+    hasOpenai: false,
+    hasOpenaiCompatible: false,
+    agentRaw: "claude",
+    model: undefined,
+    baseUrl: undefined,
+    skillSource: "auto",
+    changedFiles: [],
+    ...overrides,
+  };
+}
+
+describe("evaluateRecapGate", () => {
+  it("skips when configured labels are missing", () => {
+    const decision = evaluateRecapGate(
+      validGateInput({ requiredLabels: "visual recap" }),
+    );
+
+    expect(decision.run).toBe(false);
+    expect(decision.reasons).toContain(
+      "missing required recap label (visual recap)",
+    );
+  });
+
+  it("runs when the PR has any configured label", () => {
+    const decision = evaluateRecapGate(
+      validGateInput({
+        requiredLabels: "visual recap, expensive",
+        pr: {
+          number: 123,
+          draft: false,
+          author_association: "MEMBER",
+          head: { repo: { full_name: "owner/repo" } },
+          user: { login: "alice", type: "User" },
+          labels: [{ name: "Visual Recap" }],
+        },
+      }),
+    );
+
+    expect(decision.run).toBe(true);
+    expect(decision.reasons).toEqual([]);
+  });
+});

--- a/packages/recap-cli/src/recap.ts
+++ b/packages/recap-cli/src/recap.ts
@@ -109,6 +109,7 @@ export const PR_VISUAL_RECAP_SETUP: string[] = [
   "  VISUAL_RECAP_REASONING (variable) — reasoning depth (none|minimal|low|medium|high|xhigh; Codex only)",
   '  VISUAL_RECAP_RUNS_ON (variable) — JSON hosted label or self-hosted label array; defaults to "ubuntu-latest"',
   "  VISUAL_RECAP_GATE_RUNS_ON (variable) — trusted same-repo authors only; plain single gate label; defaults to ubuntu-latest",
+  "  VISUAL_RECAP_REQUIRED_LABELS (variable) — comma-separated PR labels; when set, recaps run only when the PR has at least one listed label",
   "  VISUAL_RECAP_SKILL_SOURCE=repo (variable) — pin CI to the repo-local visual-recap skill instead of latest bundled guidance",
   "  VISUAL_RECAP_SECRET_SCAN=off|high-confidence|strict (variable) — default high-confidence; strict restores generic TOKEN/SECRET assignment suppression",
   "  PLAN_RECAP_APP_URL (secret) — only when self-hosting the plan app (defaults to https://plan.agent-native.com)",
@@ -166,7 +167,8 @@ export function writePrVisualRecapWorkflow(
  *
  * Callers must trigger on the same `pull_request` event types so that
  * `github.event.pull_request.*` expressions in the reusable workflow resolve
- * correctly (workflow_call inherits the caller's event context).
+ * correctly (workflow_call inherits the caller's event context). The `labeled`
+ * event lets required-label configurations run as soon as a maintainer opts in.
  *
  * @param options.cliVersion  Semver or tag to pin (default "main" / latest).
  * @param options.ref         Git ref to pin the reusable workflow to (default "@main").
@@ -178,6 +180,7 @@ export function buildReusableCallerWorkflow(
     model?: string;
     runsOn?: string;
     gateRunsOn?: string;
+    requiredLabels?: string;
   } = {},
 ): string {
   const ref = (options.ref ?? "main").replace(/^@/, "");
@@ -192,6 +195,16 @@ export function buildReusableCallerWorkflow(
     options.gateRunsOn === undefined
       ? "${{ vars.VISUAL_RECAP_GATE_RUNS_ON || 'ubuntu-latest' }}"
       : JSON.stringify(options.gateRunsOn);
+  const requiredLabelsValue =
+    options.requiredLabels === undefined
+      ? "${{ vars.VISUAL_RECAP_REQUIRED_LABELS || '' }}"
+      : JSON.stringify(options.requiredLabels);
+  const labeledEventEnabled =
+    options.requiredLabels === undefined
+      ? "vars.VISUAL_RECAP_REQUIRED_LABELS != ''"
+      : options.requiredLabels.trim()
+        ? "true"
+        : "false";
   return (
     `name: PR Visual Recap\n` +
     `\n` +
@@ -202,10 +215,11 @@ export function buildReusableCallerWorkflow(
     `\n` +
     `on:\n` +
     `  pull_request:\n` +
-    `    types: [opened, synchronize, reopened, ready_for_review, closed]\n` +
+    `    types: [opened, synchronize, reopened, ready_for_review, labeled, closed]\n` +
     `\n` +
     `jobs:\n` +
     `  visual-recap:\n` +
+    `    if: github.event.action != 'labeled' || ${labeledEventEnabled}\n` +
     `    permissions:\n` +
     `      actions: write\n` +
     `      contents: read\n` +
@@ -230,6 +244,7 @@ export function buildReusableCallerWorkflow(
     `      core-cli-version: \${{ vars.CORE_CLI_VERSION || 'latest' }}\n` +
     `      runs-on: ${runsOnValue}\n` +
     `      gate-runs-on: ${gateRunsOnValue}\n` +
+    `      required-labels: ${requiredLabelsValue}\n` +
     `      # Pin recap-cli and core-cli independently when using the openai-compatible backend.\n` +
     ``
   );
@@ -248,6 +263,7 @@ export function writePrVisualRecapReusableCallerWorkflow(
     model?: string;
     runsOn?: string;
     gateRunsOn?: string;
+    requiredLabels?: string;
   } = {},
 ): WriteWorkflowResult {
   const dir = path.resolve(baseDir, ".github", "workflows");
@@ -260,6 +276,7 @@ export function writePrVisualRecapReusableCallerWorkflow(
     model: options.model,
     runsOn: options.runsOn,
     gateRunsOn: options.gateRunsOn,
+    requiredLabels: options.requiredLabels,
   });
   if (fs.existsSync(file)) {
     const current = fs.readFileSync(file, "utf8");
@@ -745,6 +762,7 @@ export function buildRecapSetupPlan(input: {
   repo?: string;
   runsOn?: string;
   gateRunsOn?: string;
+  requiredLabels?: string;
   env?: NodeJS.ProcessEnv;
 }): RecapSetupPlan {
   const env = input.env ?? process.env;
@@ -771,6 +789,7 @@ export function buildRecapSetupPlan(input: {
     "VISUAL_RECAP_MODEL",
     "VISUAL_RECAP_REASONING",
     "VISUAL_RECAP_SKILL_SOURCE",
+    "VISUAL_RECAP_REQUIRED_LABELS",
   ]) {
     const value = envValue(env, key);
     if (value) variableValues[key] = value;
@@ -801,6 +820,10 @@ export function buildRecapSetupPlan(input: {
       variableValues.VISUAL_RECAP_GATE_RUNS_ON =
         parseRecapGateRunsOn(gateRunsOn);
   }
+  const requiredLabels =
+    input.requiredLabels ?? envValue(env, "VISUAL_RECAP_REQUIRED_LABELS");
+  if (requiredLabels)
+    variableValues.VISUAL_RECAP_REQUIRED_LABELS = requiredLabels;
   return {
     agent,
     appUrl,
@@ -841,6 +864,7 @@ function runSetup(args: Record<string, string | boolean>): void {
     repo,
     runsOn: optionalArg(args, "runs-on"),
     gateRunsOn: optionalArg(args, "gate-runs-on"),
+    requiredLabels: optionalArg(args, "required-labels"),
   });
   const runnerProblem = plan.variableProblems.find(
     (problem) =>
@@ -873,6 +897,7 @@ function runSetup(args: Record<string, string | boolean>): void {
       agent: plan.agent !== "claude" ? plan.agent : undefined,
       runsOn: plan.variableValues.VISUAL_RECAP_RUNS_ON,
       gateRunsOn: plan.variableValues.VISUAL_RECAP_GATE_RUNS_ON,
+      requiredLabels: plan.variableValues.VISUAL_RECAP_REQUIRED_LABELS,
     });
     if (result.status === "refused") {
       process.stderr.write(`recap setup: ${result.message}\n`);
@@ -3937,6 +3962,7 @@ export interface RecapGatePullRequest {
   author_association?: string | null;
   head?: { repo?: { full_name?: string | null } | null } | null;
   user?: { login?: string | null; type?: string | null } | null;
+  labels?: Array<string | { name?: string | null } | null> | null;
 }
 
 export interface RecapGateInput {
@@ -3962,6 +3988,8 @@ export interface RecapGateInput {
   baseUrl?: string;
   /** Raw VISUAL_RECAP_SKILL_SOURCE value (auto/latest/repo; may be undefined). */
   skillSource: string | undefined;
+  /** Comma-separated PR labels required before the recap runs. */
+  requiredLabels?: string;
   /** Filenames changed by the PR (for the self-modifying guard). */
   changedFiles: string[];
 }
@@ -3979,6 +4007,22 @@ function normalizeRecapSkillSourceMode(value: string | undefined): string {
 
 function isRepoPinnedRecapSkillSource(value: string | undefined): boolean {
   return normalizeRecapSkillSourceMode(value) === "repo";
+}
+
+function parseRequiredRecapLabels(value: string | undefined): string[] {
+  return (value || "")
+    .split(",")
+    .map((label) => label.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function pullRequestLabelNames(pr: RecapGatePullRequest): Set<string> {
+  return new Set(
+    (Array.isArray(pr.labels) ? pr.labels : [])
+      .map((label) => (typeof label === "string" ? label : label && label.name))
+      .filter((label): label is string => Boolean(label))
+      .map((label) => label.toLowerCase()),
+  );
 }
 
 export function isRecapSensitivePath(
@@ -4020,6 +4064,15 @@ export function evaluateRecapGate(input: RecapGateInput): {
 
   if (!pr) reasons.push("no pull_request payload");
   if (pr && pr.draft) reasons.push("draft PR");
+  const requiredLabels = parseRequiredRecapLabels(input.requiredLabels);
+  if (pr && requiredLabels.length > 0) {
+    const prLabels = pullRequestLabelNames(pr);
+    if (!requiredLabels.some((label) => prLabels.has(label))) {
+      reasons.push(
+        `missing required recap label (${requiredLabels.join(", ")})`,
+      );
+    }
+  }
 
   // Fork PRs only receive repo secrets when the org/repo opts into GitHub's
   // "Send secrets to workflows from pull requests" setting (common in private
@@ -4238,6 +4291,7 @@ async function runGate(): Promise<void> {
     model: process.env.VISUAL_RECAP_MODEL,
     baseUrl: process.env.VISUAL_RECAP_BASE_URL,
     skillSource: process.env.VISUAL_RECAP_SKILL_SOURCE,
+    requiredLabels: process.env.VISUAL_RECAP_REQUIRED_LABELS,
     changedFiles,
   });
 
@@ -5007,7 +5061,7 @@ function runAgentSummary(args: Record<string, string | boolean>): void {
 const HELP = `npx @agent-native/recap-cli@latest recap — PR visual recap helpers (used by the GitHub Action)
 
 Usage:
-  npx @agent-native/recap-cli@latest recap setup [--repo owner/name] [--agent claude|codex|openai-compatible] [--app-url <url>] [--runs-on <json>] [--gate-runs-on <label>] [--skip-secrets] [--dry-run] [--force]
+  npx @agent-native/recap-cli@latest recap setup [--repo owner/name] [--agent claude|codex|openai-compatible] [--app-url <url>] [--runs-on <json>] [--gate-runs-on <label>] [--required-labels <labels>] [--skip-secrets] [--dry-run] [--force]
   npx @agent-native/recap-cli@latest recap doctor [--repo owner/name] [--agent claude|codex|openai-compatible] [--app-url <url>]
   npx @agent-native/recap-cli@latest recap collect-diff --base <baseSha> --head <headSha> [--out recap.diff] [--stat recap.stat]
   npx @agent-native/recap-cli@latest recap block-reference [--app-url <url>] [--out recap-blocks.md]
@@ -5070,7 +5124,9 @@ Usage:
     MEMBER, or COLLABORATOR authors. The stock gate does not check out the PR
     tree; it evaluates workflow logic and PR metadata. Fork and untrusted PRs
     use GitHub-hosted ubuntu-latest instead, so they may remain unscheduled when
-    a repository disables GitHub-hosted runners.
+    a repository disables GitHub-hosted runners. Pass
+    --required-labels "visual recap" to run recaps only after a PR has a listed
+    label; comma-separated labels are OR-matched.
   npx @agent-native/recap-cli@latest recap doctor
     Check workflow presence/drift, local Plans publish-token availability, gh
     repo access, and required GitHub Actions secrets and variables for the

--- a/packages/skills/src/index.spec.ts
+++ b/packages/skills/src/index.spec.ts
@@ -1168,10 +1168,19 @@ describe("@agent-native/skills", () => {
       "pr-visual-recap-reusable.yml@main",
     );
     expect(fs.readFileSync(result.githubActionPath!, "utf-8")).toContain(
+      "types: [opened, synchronize, reopened, ready_for_review, labeled, closed]",
+    );
+    expect(fs.readFileSync(result.githubActionPath!, "utf-8")).toContain(
+      "if: github.event.action != 'labeled' || vars.VISUAL_RECAP_REQUIRED_LABELS != ''",
+    );
+    expect(fs.readFileSync(result.githubActionPath!, "utf-8")).toContain(
       `runs-on: \${{ vars.VISUAL_RECAP_RUNS_ON || '"ubuntu-latest"' }}`,
     );
     expect(fs.readFileSync(result.githubActionPath!, "utf-8")).toContain(
       `gate-runs-on: \${{ vars.VISUAL_RECAP_GATE_RUNS_ON || 'ubuntu-latest' }}`,
+    );
+    expect(fs.readFileSync(result.githubActionPath!, "utf-8")).toContain(
+      `required-labels: \${{ vars.VISUAL_RECAP_REQUIRED_LABELS || '' }}`,
     );
   });
 });

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -1619,7 +1619,7 @@ const PR_VISUAL_RECAP_REUSABLE_WORKFLOW = `name: PR Visual Recap
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, closed]
 
 permissions:
   contents: read
@@ -1630,6 +1630,7 @@ concurrency:
 
 jobs:
   visual-recap:
+    if: github.event.action != 'labeled' || vars.VISUAL_RECAP_REQUIRED_LABELS != ''
     permissions:
       checks: write
       contents: read
@@ -1640,6 +1641,7 @@ jobs:
       skill-source: repo
       runs-on: \${{ vars.VISUAL_RECAP_RUNS_ON || '"ubuntu-latest"' }}
       gate-runs-on: \${{ vars.VISUAL_RECAP_GATE_RUNS_ON || 'ubuntu-latest' }}
+      required-labels: \${{ vars.VISUAL_RECAP_REQUIRED_LABELS || '' }}
     secrets:
       PLAN_RECAP_TOKEN: \${{ secrets.PLAN_RECAP_TOKEN }}
       ANTHROPIC_API_KEY: \${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- add `VISUAL_RECAP_REQUIRED_LABELS` / reusable `required-labels` so recaps can be opt-in by PR label
- include the `labeled` pull_request event so applying an allowed label starts the recap immediately
- update setup/generated reusable caller docs, add gate tests, and add a recap-cli changeset

## Verification
- `pnpm --dir packages/recap-cli test`
- `pnpm --dir packages/recap-cli typecheck`
- `pnpm --dir packages/recap-cli build`
- `git diff --check`

## Notes
- English docs are updated; localized `pr-visual-recap.mdx` copies still need the new variable translated in a localization follow-up.