### PR TITLE
Fix slides org switching and form creation UX

### DIFF
--- a/templates/forms/app/components/layout/Sidebar.tsx
+++ b/templates/forms/app/components/layout/Sidebar.tsx
@@ -88,11 +88,9 @@ export function Sidebar() {
 
   function handleSkip() {
     setPopoverOpen(false);
-    const tempId = crypto.randomUUID().replace(/-/g, "").slice(0, 10);
-    navigate(`/forms/${tempId}`);
     createForm.mutate(
       { title: t("sidebar.untitledForm") },
-      { onSuccess: (form) => navigate(`/forms/${form.id}`, { replace: true }) },
+      { onSuccess: (form) => navigate(`/forms/${form.id}`) },
     );
   }
 
@@ -171,6 +169,7 @@ export function Sidebar() {
             size="sm"
             className="min-h-10 px-2 text-xs text-muted-foreground active:scale-[0.96] transition-[background-color,color,transform]"
             onClick={handleSkip}
+            disabled={createForm.isPending}
           >
             {t("sidebar.skipPrompt")}
           </Button>

--- a/templates/forms/app/components/layout/Sidebar.tsx
+++ b/templates/forms/app/components/layout/Sidebar.tsx
@@ -12,6 +12,7 @@ import { FeedbackButton } from "@agent-native/core/client/ui";
 import {
   IconArrowUp,
   IconPlus,
+  IconLoader2,
   IconMenu2,
   IconX,
   IconMessageCircle,
@@ -171,6 +172,9 @@ export function Sidebar() {
             onClick={handleSkip}
             disabled={createForm.isPending}
           >
+            {createForm.isPending && (
+              <IconLoader2 className="h-3 w-3 animate-spin" />
+            )}
             {t("sidebar.skipPrompt")}
           </Button>
           <span className="text-[11px] text-muted-foreground/70">

--- a/templates/forms/app/pages/FormBuilderPage.tsx
+++ b/templates/forms/app/pages/FormBuilderPage.tsx
@@ -634,7 +634,6 @@ export function FormBuilderPage() {
                   size="icon"
                   className="h-10 w-10 active:scale-[0.96] motion-reduce:active:scale-100"
                   onClick={copyShareLink}
-                  disabled={form.status !== "published"}
                   aria-label={
                     form.status === "published"
                       ? t("builder.copyPublicFormLink")

--- a/templates/forms/app/pages/FormBuilderPage.tsx
+++ b/templates/forms/app/pages/FormBuilderPage.tsx
@@ -626,19 +626,15 @@ export function FormBuilderPage() {
             </Tooltip>
           )}
 
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="inline-flex">
+          {form.status === "published" && (
+            <Tooltip>
+              <TooltipTrigger asChild>
                 <Button
                   variant="ghost"
                   size="icon"
                   className="h-10 w-10 active:scale-[0.96] motion-reduce:active:scale-100"
                   onClick={copyShareLink}
-                  aria-label={
-                    form.status === "published"
-                      ? t("builder.copyPublicFormLink")
-                      : t("builder.publishBeforeCopyPublicFormLink")
-                  }
+                  aria-label={t("builder.copyPublicFormLink")}
                 >
                   <span className="relative inline-flex h-4 w-4 items-center justify-center">
                     <IconCopy
@@ -659,16 +655,14 @@ export function FormBuilderPage() {
                     />
                   </span>
                 </Button>
-              </span>
-            </TooltipTrigger>
-            <TooltipContent>
-              {form.status === "published"
-                ? copied
+              </TooltipTrigger>
+              <TooltipContent>
+                {copied
                   ? t("builder.publicLinkCopied")
-                  : t("builder.copyPublishedPublicLink")
-                : t("builder.publishBeforeCopyPublicLink")}
-            </TooltipContent>
-          </Tooltip>
+                  : t("builder.copyPublishedPublicLink")}
+              </TooltipContent>
+            </Tooltip>
+          )}
 
           <Tooltip>
             <TooltipTrigger asChild>

--- a/templates/forms/app/pages/FormsListPage.tsx
+++ b/templates/forms/app/pages/FormsListPage.tsx
@@ -100,11 +100,9 @@ export function FormsListPage() {
   }, [forms]);
 
   function handleCreate() {
-    const tempId = crypto.randomUUID().replace(/-/g, "").slice(0, 10);
-    navigate(`/forms/${tempId}`);
     createForm.mutate(
       { title: t("forms.untitled") },
-      { onSuccess: (form) => navigate(`/forms/${form.id}`, { replace: true }) },
+      { onSuccess: (form) => navigate(`/forms/${form.id}`) },
     );
   }
 
@@ -114,6 +112,7 @@ export function FormsListPage() {
     () => (
       <Button
         onClick={handleCreate}
+        disabled={createForm.isPending}
         size="sm"
         className="min-h-10 shrink-0 cursor-pointer active:scale-[0.96] transition-[background-color,box-shadow,transform]"
       >
@@ -123,7 +122,7 @@ export function FormsListPage() {
       </Button>
     ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
+    [createForm.isPending],
   );
   useSetHeaderActions(headerActions);
 

--- a/templates/forms/app/pages/FormsListPage.tsx
+++ b/templates/forms/app/pages/FormsListPage.tsx
@@ -7,6 +7,7 @@ import {
 import { VisibilityBadge } from "@agent-native/toolkit/sharing";
 import {
   IconPlus,
+  IconLoader2,
   IconDots,
   IconTrash,
   IconCopy,
@@ -116,7 +117,11 @@ export function FormsListPage() {
         size="sm"
         className="min-h-10 shrink-0 cursor-pointer active:scale-[0.96] transition-[background-color,box-shadow,transform]"
       >
-        <IconPlus className="h-3.5 w-3.5" />
+        {createForm.isPending ? (
+          <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <IconPlus className="h-3.5 w-3.5" />
+        )}
         <span className="hidden sm:inline">{t("forms.newForm")}</span>
         <span className="sm:hidden">{t("forms.new")}</span>
       </Button>

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -460,15 +460,24 @@ function discardPendingDeckOps(deckId: string) {
 }
 
 // Cancels all debounced-but-not-yet-sent ops without sending them.
-// Used on provider unmount (e.g. org switch): by the time the provider
-// tears down the session already carries the new org, so flushing would
-// send ops to a session that fails access checks on the old-org decks.
-// Already-in-flight requests (inFlightSaves) are left to settle on their own.
 function cancelAllPendingOps() {
   for (const timer of pendingSaves.values()) clearTimeout(timer);
   pendingSaves.clear();
   pendingOpsQueue.clear();
   notifySaveListeners();
+}
+
+// Counter of DeckProvider unmounts that are caused by an org switch.
+// Incremented during render (before commit) by OrganizationScopedDeckProvider
+// so the cleanup can distinguish org-switch unmounts from ordinary navigation.
+let _pendingOrgSwitchUnmounts = 0;
+
+// Called by OrganizationScopedDeckProvider during render when the active org
+// scope changes. Setting this during render is intentional: React renders are
+// synchronous and the commit-phase cleanups run immediately after, so the flag
+// is guaranteed to be set before the affected DeckProvider cleanup executes.
+export function markOrgSwitchUnmount() {
+  _pendingOrgSwitchUnmounts++;
 }
 
 // ---------------------------------------------------------------------------
@@ -1536,11 +1545,17 @@ export function DeckProvider({ children }: { children: ReactNode }) {
     return () => {
       document.removeEventListener("visibilitychange", onHidden);
       window.removeEventListener("pagehide", onPageHide);
-      // Cancel debounced-but-not-yet-sent ops on unmount (e.g. org switch).
-      // Flushing here would race: the session already carries the new org by
-      // the time cleanup runs, so those requests would fail access checks on
-      // the old-org decks. Already-in-flight requests settle on their own.
-      cancelAllPendingOps();
+      if (_pendingOrgSwitchUnmounts > 0) {
+        // Org-switch unmount: cancel debounced ops rather than flushing.
+        // The session already carries the new org by the time cleanup runs,
+        // so flushing would send patch-deck requests that fail access checks
+        // on the old-org decks. In-flight requests settle on their own.
+        _pendingOrgSwitchUnmounts--;
+        cancelAllPendingOps();
+      } else {
+        // Ordinary navigation unmount: flush so edits are not lost.
+        flushPendingSaves();
+      }
     };
   }, []);
 

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -1524,6 +1524,9 @@ export function DeckProvider({ children }: { children: ReactNode }) {
     return () => {
       document.removeEventListener("visibilitychange", onHidden);
       window.removeEventListener("pagehide", onPageHide);
+      // Flush on unmount (e.g. org switch) so edits made in the previous org
+      // context are not silently dropped or sent under the wrong org.
+      flushPendingSaves();
     };
   }, []);
 

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -459,6 +459,18 @@ function discardPendingDeckOps(deckId: string) {
   notifySaveListeners();
 }
 
+// Cancels all debounced-but-not-yet-sent ops without sending them.
+// Used on provider unmount (e.g. org switch): by the time the provider
+// tears down the session already carries the new org, so flushing would
+// send ops to a session that fails access checks on the old-org decks.
+// Already-in-flight requests (inFlightSaves) are left to settle on their own.
+function cancelAllPendingOps() {
+  for (const timer of pendingSaves.values()) clearTimeout(timer);
+  pendingSaves.clear();
+  pendingOpsQueue.clear();
+  notifySaveListeners();
+}
+
 // ---------------------------------------------------------------------------
 // Local op application + inverse derivation (for inverse-op undo)
 // ---------------------------------------------------------------------------
@@ -1524,9 +1536,11 @@ export function DeckProvider({ children }: { children: ReactNode }) {
     return () => {
       document.removeEventListener("visibilitychange", onHidden);
       window.removeEventListener("pagehide", onPageHide);
-      // Flush on unmount (e.g. org switch) so edits made in the previous org
-      // context are not silently dropped or sent under the wrong org.
-      flushPendingSaves();
+      // Cancel debounced-but-not-yet-sent ops on unmount (e.g. org switch).
+      // Flushing here would race: the session already carries the new org by
+      // the time cleanup runs, so those requests would fail access checks on
+      // the old-org decks. Already-in-flight requests settle on their own.
+      cancelAllPendingOps();
     };
   }, []);
 

--- a/templates/slides/app/context/OrganizationScopedDeckProvider.test.tsx
+++ b/templates/slides/app/context/OrganizationScopedDeckProvider.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const testState = vi.hoisted(() => ({
+  mountCount: 0,
+  orgId: "org-a" as string | null,
+}));
+
+vi.mock("@agent-native/core/client/org", () => ({
+  useOrg: () => ({ data: { orgId: testState.orgId } }),
+}));
+
+vi.mock("@/context/DeckContext", async () => {
+  const React = await import("react");
+  return {
+    DeckProvider: ({ children }: { children: React.ReactNode }) => {
+      const [mountId] = React.useState(() => ++testState.mountCount);
+      return (
+        <div data-testid="deck-provider" data-mount-id={mountId}>
+          {children}
+        </div>
+      );
+    },
+  };
+});
+
+import { OrganizationScopedDeckProvider } from "./OrganizationScopedDeckProvider";
+
+afterEach(() => {
+  cleanup();
+  testState.mountCount = 0;
+  testState.orgId = "org-a";
+});
+
+describe("OrganizationScopedDeckProvider", () => {
+  it("remounts deck state when the active organization changes", () => {
+    const { rerender } = render(
+      <OrganizationScopedDeckProvider version={3}>
+        <span>Decks</span>
+      </OrganizationScopedDeckProvider>,
+    );
+    const initialMountId = screen
+      .getByTestId("deck-provider")
+      .getAttribute("data-mount-id");
+
+    testState.orgId = "org-b";
+    rerender(
+      <OrganizationScopedDeckProvider version={3}>
+        <span>Decks</span>
+      </OrganizationScopedDeckProvider>,
+    );
+
+    expect(
+      screen.getByTestId("deck-provider").getAttribute("data-mount-id"),
+    ).not.toBe(initialMountId);
+  });
+});

--- a/templates/slides/app/context/OrganizationScopedDeckProvider.test.tsx
+++ b/templates/slides/app/context/OrganizationScopedDeckProvider.test.tsx
@@ -15,6 +15,8 @@ vi.mock("@agent-native/core/client/org", () => ({
   }),
 }));
 
+const markOrgSwitchUnmountSpy = vi.hoisted(() => vi.fn());
+
 vi.mock("@/context/DeckContext", async () => {
   const React = await import("react");
   return {
@@ -26,6 +28,7 @@ vi.mock("@/context/DeckContext", async () => {
         </div>
       );
     },
+    markOrgSwitchUnmount: markOrgSwitchUnmountSpy,
   };
 });
 
@@ -36,6 +39,7 @@ afterEach(() => {
   testState.mountCount = 0;
   testState.orgId = "org-a";
   testState.isLoading = false;
+  markOrgSwitchUnmountSpy.mockClear();
 });
 
 describe("OrganizationScopedDeckProvider", () => {
@@ -65,9 +69,10 @@ describe("OrganizationScopedDeckProvider", () => {
       </OrganizationScopedDeckProvider>,
     );
     expect(testState.mountCount).toBe(1);
+    expect(markOrgSwitchUnmountSpy).not.toHaveBeenCalled();
   });
 
-  it("remounts deck state when the active organization changes", () => {
+  it("remounts DeckProvider when the active organization changes", () => {
     const { rerender } = render(
       <OrganizationScopedDeckProvider version={3}>
         <span>Decks</span>
@@ -87,5 +92,37 @@ describe("OrganizationScopedDeckProvider", () => {
     expect(
       screen.getByTestId("deck-provider").getAttribute("data-mount-id"),
     ).not.toBe(initialMountId);
+  });
+
+  it("signals org-switch before the key changes so cleanup can cancel instead of flush", () => {
+    const { rerender } = render(
+      <OrganizationScopedDeckProvider version={3}>
+        <span>Decks</span>
+      </OrganizationScopedDeckProvider>,
+    );
+    expect(markOrgSwitchUnmountSpy).not.toHaveBeenCalled();
+
+    testState.orgId = "org-b";
+    rerender(
+      <OrganizationScopedDeckProvider version={3}>
+        <span>Decks</span>
+      </OrganizationScopedDeckProvider>,
+    );
+
+    expect(markOrgSwitchUnmountSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not signal org-switch when re-rendering without an org change", () => {
+    const { rerender } = render(
+      <OrganizationScopedDeckProvider version={3}>
+        <span>Decks</span>
+      </OrganizationScopedDeckProvider>,
+    );
+    rerender(
+      <OrganizationScopedDeckProvider version={3}>
+        <span>Decks</span>
+      </OrganizationScopedDeckProvider>,
+    );
+    expect(markOrgSwitchUnmountSpy).not.toHaveBeenCalled();
   });
 });

--- a/templates/slides/app/context/OrganizationScopedDeckProvider.test.tsx
+++ b/templates/slides/app/context/OrganizationScopedDeckProvider.test.tsx
@@ -5,10 +5,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const testState = vi.hoisted(() => ({
   mountCount: 0,
   orgId: "org-a" as string | null,
+  isLoading: false,
 }));
 
 vi.mock("@agent-native/core/client/org", () => ({
-  useOrg: () => ({ data: { orgId: testState.orgId } }),
+  useOrg: () => ({
+    data: { orgId: testState.orgId },
+    isLoading: testState.isLoading,
+  }),
 }));
 
 vi.mock("@/context/DeckContext", async () => {
@@ -31,9 +35,38 @@ afterEach(() => {
   cleanup();
   testState.mountCount = 0;
   testState.orgId = "org-a";
+  testState.isLoading = false;
 });
 
 describe("OrganizationScopedDeckProvider", () => {
+  it("renders nothing while org is loading", () => {
+    testState.isLoading = true;
+    render(
+      <OrganizationScopedDeckProvider version={3}>
+        <span>Decks</span>
+      </OrganizationScopedDeckProvider>,
+    );
+    expect(screen.queryByTestId("deck-provider")).toBeNull();
+  });
+
+  it("mounts exactly once when org resolves from loading", () => {
+    testState.isLoading = true;
+    const { rerender } = render(
+      <OrganizationScopedDeckProvider version={3}>
+        <span>Decks</span>
+      </OrganizationScopedDeckProvider>,
+    );
+    expect(testState.mountCount).toBe(0);
+
+    testState.isLoading = false;
+    rerender(
+      <OrganizationScopedDeckProvider version={3}>
+        <span>Decks</span>
+      </OrganizationScopedDeckProvider>,
+    );
+    expect(testState.mountCount).toBe(1);
+  });
+
   it("remounts deck state when the active organization changes", () => {
     const { rerender } = render(
       <OrganizationScopedDeckProvider version={3}>

--- a/templates/slides/app/context/OrganizationScopedDeckProvider.tsx
+++ b/templates/slides/app/context/OrganizationScopedDeckProvider.tsx
@@ -10,9 +10,14 @@ export function OrganizationScopedDeckProvider({
   children: ReactNode;
   version: number;
 }) {
-  const { data: org } = useOrg();
-  const organizationScope = org?.orgId ?? "personal";
+  const { data: org, isLoading } = useOrg();
 
+  // Don't render until org is known — avoids mounting with a "personal"
+  // placeholder key that immediately changes once the org query resolves,
+  // which would double-mount DeckProvider and trigger duplicate deck fetches.
+  if (isLoading) return null;
+
+  const organizationScope = org?.orgId ?? "personal";
   return (
     <DeckProvider key={`${version}:${organizationScope}`}>
       {children}

--- a/templates/slides/app/context/OrganizationScopedDeckProvider.tsx
+++ b/templates/slides/app/context/OrganizationScopedDeckProvider.tsx
@@ -1,7 +1,7 @@
 import { useOrg } from "@agent-native/core/client/org";
-import type { ReactNode } from "react";
+import { useRef, type ReactNode } from "react";
 
-import { DeckProvider } from "@/context/DeckContext";
+import { DeckProvider, markOrgSwitchUnmount } from "@/context/DeckContext";
 
 export function OrganizationScopedDeckProvider({
   children,
@@ -18,6 +18,38 @@ export function OrganizationScopedDeckProvider({
   if (isLoading) return null;
 
   const organizationScope = org?.orgId ?? "personal";
+  return (
+    <OrgKeyedDeckProvider
+      version={version}
+      organizationScope={organizationScope}
+    >
+      {children}
+    </OrgKeyedDeckProvider>
+  );
+}
+
+// Separate component so the ref tracks the committed scope independent of the
+// parent's loading gate re-renders.
+function OrgKeyedDeckProvider({
+  children,
+  version,
+  organizationScope,
+}: {
+  children: ReactNode;
+  version: number;
+  organizationScope: string;
+}) {
+  const prevScopeRef = useRef(organizationScope);
+
+  if (prevScopeRef.current !== organizationScope) {
+    // Org scope changed: signal that the imminent DeckProvider unmount is an
+    // org switch so its cleanup cancels pending ops instead of flushing them.
+    // This runs during render (synchronously before React's commit phase), which
+    // guarantees the flag is set before the DeckProvider cleanup executes.
+    markOrgSwitchUnmount();
+    prevScopeRef.current = organizationScope;
+  }
+
   return (
     <DeckProvider key={`${version}:${organizationScope}`}>
       {children}

--- a/templates/slides/app/context/OrganizationScopedDeckProvider.tsx
+++ b/templates/slides/app/context/OrganizationScopedDeckProvider.tsx
@@ -1,0 +1,21 @@
+import { useOrg } from "@agent-native/core/client/org";
+import type { ReactNode } from "react";
+
+import { DeckProvider } from "@/context/DeckContext";
+
+export function OrganizationScopedDeckProvider({
+  children,
+  version,
+}: {
+  children: ReactNode;
+  version: number;
+}) {
+  const { data: org } = useOrg();
+  const organizationScope = org?.orgId ?? "personal";
+
+  return (
+    <DeckProvider key={`${version}:${organizationScope}`}>
+      {children}
+    </DeckProvider>
+  );
+}

--- a/templates/slides/app/root.tsx
+++ b/templates/slides/app/root.tsx
@@ -34,7 +34,7 @@ import type { LinksFunction } from "react-router";
 
 import { Layout as AppLayout } from "@/components/layout/Layout";
 import { AppToolkitProvider } from "@/components/ui/toolkit-provider";
-import { DeckProvider } from "@/context/DeckContext";
+import { OrganizationScopedDeckProvider } from "@/context/OrganizationScopedDeckProvider";
 import { useNavigationState } from "@/hooks/use-navigation-state";
 import { TAB_ID } from "@/lib/tab-id";
 
@@ -198,9 +198,9 @@ function AppContent() {
 
   if (isBare) {
     return (
-      <DeckProvider key={DECK_KEY}>
+      <OrganizationScopedDeckProvider version={DECK_KEY}>
         <Outlet />
-      </DeckProvider>
+      </OrganizationScopedDeckProvider>
     );
   }
 
@@ -234,11 +234,11 @@ function AppContent() {
           </CommandMenu.Item>
         </CommandMenu.Group>
       </CommandMenu>
-      <DeckProvider key={DECK_KEY}>
+      <OrganizationScopedDeckProvider version={DECK_KEY}>
         <AppLayout>
           <Outlet />
         </AppLayout>
-      </DeckProvider>
+      </OrganizationScopedDeckProvider>
     </>
   );
 }


### PR DESCRIPTION
### Summary
Fixes stale slide decks when switching organizations, and improves form creation UX with loading states and a corrected copy-link button.

### Problem
In `templates/slides`, switching organizations did not refresh the deck list — slides from the previous organization stayed visible until a manual page refresh. In `templates/forms`, creating a new form navigated to a randomly generated temporary ID before the form actually existed, causing a "Failed to load form" error page, and the copy-link button in the form builder toolbar was shown (but disabled/unclickable) for unpublished forms, which was confusing.

### Solution
- Introduced an `OrganizationScopedDeckProvider` that remounts the `DeckProvider` whenever the active organization changes, ensuring deck state is reset per-organization.
- Removed the temporary random ID navigation for form creation and instead navigate only after the form is successfully created, adding a loading indicator on the create buttons while the mutation is pending.
- Hid the copy-share-link button entirely until a form is published, instead of showing it disabled.

### Key Changes
- Added `OrganizationScopedDeckProvider.tsx` in `templates/slides/app/context`, which keys `DeckProvider` on `${version}:${organizationScope}` using `useOrg()` to force a remount on org change, plus a test verifying the remount behavior.
- Updated `templates/slides/app/root.tsx` to use `OrganizationScopedDeckProvider` instead of `DeckProvider` directly in both the bare and full app layouts.
- In `templates/forms/app/components/layout/Sidebar.tsx` and `templates/forms/app/pages/FormsListPage.tsx`: removed premature navigation using a random temp ID, navigate only in `onSuccess` of `createForm.mutate`, and added an `IconLoader2` spinner plus `disabled` state on the create button while `createForm.isPending`.
- In `templates/forms/app/pages/FormBuilderPage.tsx`: the copy public link button/tooltip is now only rendered when `form.status === "published"`, removing the disabled state and status-conditional labels/tooltips.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/spark-note-jftj0wox"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-spark-note-jftj0wox.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2285`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>spark-note-jftj0wox</branchName>-->