### PR TITLE
Whisper model selection for Clips desktop

### DIFF
--- a/templates/clips/changelog/2026-07-21-choose-which-whisper-model-to-use-in-settings.md
+++ b/templates/clips/changelog/2026-07-21-choose-which-whisper-model-to-use-in-settings.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-21
+---
+
+You can now choose which Whisper model to use for offline transcription in Settings — from Tiny (fast, small) to Large v3 Turbo (most accurate) — and delete previously downloaded models you no longer need.

--- a/templates/clips/desktop/src-tauri/src/config.rs
+++ b/templates/clips/desktop/src-tauri/src/config.rs
@@ -135,6 +135,8 @@ pub struct FeatureConfig {
     pub onboarding_complete: bool,
     #[serde(default = "default_whisper_model_enabled")]
     pub whisper_model_enabled: bool,
+    #[serde(default = "default_whisper_model_id")]
+    pub whisper_model_id: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -168,6 +170,10 @@ fn default_show_meeting_widget_enabled() -> bool {
 
 fn default_whisper_model_enabled() -> bool {
     true
+}
+
+fn default_whisper_model_id() -> String {
+    "base".to_string()
 }
 
 fn default_screen_memory_retention_hours() -> u32 {
@@ -227,6 +233,7 @@ impl Default for FeatureConfig {
             screen_memory: ScreenMemoryConfig::default(),
             onboarding_complete: false,
             whisper_model_enabled: default_whisper_model_enabled(),
+            whisper_model_id: default_whisper_model_id(),
         }
     }
 }
@@ -333,6 +340,12 @@ pub async fn get_feature_config(app: AppHandle) -> Result<FeatureConfig, String>
 /// Save feature config to disk and emit a change event.
 #[tauri::command]
 pub async fn set_feature_config(app: AppHandle, config: FeatureConfig) -> Result<(), String> {
+    if !crate::whisper_model::is_supported_model_id(&config.whisper_model_id) {
+        return Err(format!(
+            "unsupported Whisper model: {}",
+            config.whisper_model_id
+        ));
+    }
     let previous = load_config(&app);
     if (crate::rewind_clip::is_active(&app) || crate::util::is_recording_active(&app))
         && rewind_capture_contract_changed(&previous.screen_memory, &config.screen_memory)
@@ -364,6 +377,12 @@ pub async fn set_feature_config(app: AppHandle, config: FeatureConfig) -> Result
         let _ = app.emit(
             "whisper:model-enabled-changed",
             serde_json::json!({ "enabled": config.whisper_model_enabled }),
+        );
+    }
+    if previous.whisper_model_id != config.whisper_model_id {
+        let _ = app.emit(
+            "whisper:model-selection-changed",
+            serde_json::json!({ "modelId": config.whisper_model_id }),
         );
     }
     crate::screen_memory::sync_from_config(&app, &config);
@@ -404,6 +423,19 @@ mod tests {
         assert!(config
             .excluded_bundle_ids
             .contains(&"com.1password.1password".to_string()));
+    }
+
+    #[test]
+    fn feature_config_defaults_to_base_whisper_model_for_legacy_json() {
+        let config: FeatureConfig = serde_json::from_value(serde_json::json!({
+            "clipsEnabled": true,
+            "meetingsEnabled": true,
+            "voiceEnabled": true,
+            "onboardingComplete": true
+        }))
+        .unwrap();
+
+        assert_eq!(config.whisper_model_id, "base");
     }
 
     #[test]

--- a/templates/clips/desktop/src-tauri/src/lib.rs
+++ b/templates/clips/desktop/src-tauri/src/lib.rs
@@ -231,8 +231,11 @@ pub fn run() {
             shortcuts::set_fn_shortcut_enabled,
             shortcuts::set_dictation_escape_active,
             // whisper model management
+            whisper_model::whisper_models,
             whisper_model::whisper_model_status,
             whisper_model::whisper_model_download,
+            whisper_model::whisper_downloaded_models,
+            whisper_model::whisper_model_delete,
             // permission status (silent checks for all TCC permissions)
             permission_status::check_permission_statuses,
             // persistent log file (production debugging)

--- a/templates/clips/desktop/src-tauri/src/whisper_model.rs
+++ b/templates/clips/desktop/src-tauri/src/whisper_model.rs
@@ -195,9 +195,6 @@ pub async fn whisper_model_status(app: AppHandle) -> Result<ModelStatus, String>
 
 #[tauri::command]
 pub async fn whisper_model_download(app: AppHandle) -> Result<(), String> {
-    if DOWNLOADING.load(Ordering::Acquire) {
-        return Ok(());
-    }
     let path = model_file(&app)?;
     if let Ok(meta) = std::fs::metadata(&path) {
         let config = crate::config::feature_config(&app);
@@ -247,7 +244,10 @@ pub async fn whisper_model_delete(app: AppHandle, model_id: String) -> Result<()
     if path.exists() {
         std::fs::remove_file(&path).map_err(|e| format!("delete model: {e}"))?;
     }
-    let _ = app.emit("whisper:model-deleted", serde_json::json!({ "modelId": model_id }));
+    let _ = app.emit(
+        "whisper:model-deleted",
+        serde_json::json!({ "modelId": model_id }),
+    );
     Ok(())
 }
 
@@ -284,7 +284,14 @@ pub(crate) async fn ensure_model(app: &AppHandle) -> Result<PathBuf, String> {
         );
     }
 
-    if DOWNLOADING.load(Ordering::SeqCst) {
+    loop {
+        if DOWNLOADING
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            break;
+        }
+
         eprintln!("[whisper] waiting for in-progress download…");
         while DOWNLOADING.load(Ordering::SeqCst) {
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -293,13 +300,6 @@ pub(crate) async fn ensure_model(app: &AppHandle) -> Result<PathBuf, String> {
             return Ok(path);
         }
     }
-
-    if DOWNLOADING
-        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-        .is_err()
-    {
-        return Err("Download already in progress — please wait.".to_string());
-    }
     DOWNLOADED_BYTES.store(0, Ordering::Relaxed);
 
     let result = do_download(app, &path, model).await;
@@ -307,14 +307,18 @@ pub(crate) async fn ensure_model(app: &AppHandle) -> Result<PathBuf, String> {
     result
 }
 
-async fn do_download(app: &AppHandle, path: &Path, model: &WhisperModel) -> Result<PathBuf, String> {
+async fn do_download(
+    app: &AppHandle,
+    path: &Path,
+    model: &WhisperModel,
+) -> Result<PathBuf, String> {
     eprintln!(
         "[whisper] downloading {} (~{} MB)",
         model.url, model.size_mb
     );
-    let mut response = reqwest::get(model.url).await.map_err(|e| {
-        format!("model download failed: {e}")
-    })?;
+    let mut response = reqwest::get(model.url)
+        .await
+        .map_err(|e| format!("model download failed: {e}"))?;
     if !response.status().is_success() {
         return Err(format!("model download HTTP {}", response.status()));
     }
@@ -323,13 +327,16 @@ async fn do_download(app: &AppHandle, path: &Path, model: &WhisperModel) -> Resu
     use std::io::Write as _;
 
     let tmp = path.with_extension("bin.tmp");
-    let mut file =
-        std::fs::File::create(&tmp).map_err(|e| format!("create tmp: {e}"))?;
+    let mut file = std::fs::File::create(&tmp).map_err(|e| format!("create tmp: {e}"))?;
     let mut hasher = Sha256::new();
     let mut total = 0_u64;
     let mut last_progress = 0_u64;
 
-    while let Some(chunk) = response.chunk().await.map_err(|e| format!("download body: {e}"))? {
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|e| format!("download body: {e}"))?
+    {
         hasher.update(&chunk);
         total += chunk.len() as u64;
         DOWNLOADED_BYTES.store(total, Ordering::Relaxed);
@@ -359,7 +366,11 @@ async fn do_download(app: &AppHandle, path: &Path, model: &WhisperModel) -> Resu
             model.size_bytes
         ));
     }
-    let digest: String = hasher.finalize().iter().map(|b| format!("{b:02x}")).collect();
+    let digest: String = hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect();
     if digest != model.sha256 {
         let _ = std::fs::remove_file(&tmp);
         return Err(format!(

--- a/templates/clips/desktop/src-tauri/src/whisper_model.rs
+++ b/templates/clips/desktop/src-tauri/src/whisper_model.rs
@@ -1,116 +1,208 @@
-//! Whisper model resolution + download for the local meeting transcription
-//! engine (`whisper_speech.rs`).
-//!
-//! Resolves where the `ggml-base.bin` model lives, downloads it from
-//! HuggingFace on first use, and verifies the download against a pinned
-//! SHA-256 + byte size so a corrupted, truncated, or tampered file is rejected
-//! rather than loaded
+//! Local Whisper model catalog, download, and integrity verification.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager};
 
-const MODEL_URL: &str = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin";
-const MODEL_FILENAME: &str = "ggml-base.bin";
-const MODEL_SHA256: &str = "60ed5bc3dd14eea856493d334349b405782ddcaf0028d4b5df4088345fba2efe";
-const MODEL_SIZE: u64 = 147_951_465;
-const MODEL_SIZE_MB: u64 = MODEL_SIZE / (1024 * 1024);
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WhisperModel {
+    pub id: &'static str,
+    pub title: &'static str,
+    pub description: &'static str,
+    pub url: &'static str,
+    pub filename: &'static str,
+    pub sha256: &'static str,
+    pub size_bytes: u64,
+    pub size_mb: u64,
+}
 
-// Global download-in-flight state so the status command and concurrent callers
-// can inspect without re-checking the filesystem.
+const TINY_MODEL: WhisperModel = WhisperModel {
+    id: "tiny",
+    title: "Tiny",
+    description: "Transcribes instantly and uses very little space. May miss some words or struggle with accents, but great if speed is all that matters.",
+    url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin",
+    filename: "ggml-tiny.bin",
+    sha256: "be07e048e1e599ad46341c8d2a135645097a538221678b7acdd1b1919c6e1b21",
+    size_bytes: 77_691_713,
+    size_mb: 74,
+};
+
+const BASE_MODEL: WhisperModel = WhisperModel {
+    id: "base",
+    title: "Base",
+    description: "A great everyday choice. Transcribes quickly and gets most things right for dictation and meetings.",
+    url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin",
+    filename: "ggml-base.bin",
+    sha256: "60ed5bc3dd14eea856493d334349b405782ddcaf0028d4b5df4088345fba2efe",
+    size_bytes: 147_951_465,
+    size_mb: 141,
+};
+
+const SMALL_MODEL: WhisperModel = WhisperModel {
+    id: "small",
+    title: "Small",
+    description: "More accurate than Base, especially with accents or background noise. Takes a bit longer and uses more space.",
+    url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin",
+    filename: "ggml-small.bin",
+    sha256: "1be3a9b2063867b937e64e2ec7483364a79917e157fa98c5d94b5c1fffea987b",
+    size_bytes: 487_601_967,
+    size_mb: 488,
+};
+
+const LARGE_V3_TURBO_MODEL: WhisperModel = WhisperModel {
+    id: "large-v3-turbo",
+    title: "Large v3 Turbo",
+    description: "The most accurate option. Catches subtle speech and complex vocabulary well. Best on newer Macs; requires a larger one-time download.",
+    url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin",
+    filename: "ggml-large-v3-turbo.bin",
+    sha256: "1fc70f774d38eb169993ac391eea357ef47c88757ef72ee5943879b7e8e2bc69",
+    size_bytes: 1_624_555_275,
+    size_mb: 1549,
+};
+
+const SUPPORTED_MODELS: &[WhisperModel] =
+    &[TINY_MODEL, BASE_MODEL, SMALL_MODEL, LARGE_V3_TURBO_MODEL];
+
 static DOWNLOADING: AtomicBool = AtomicBool::new(false);
 static DOWNLOADED_BYTES: AtomicU64 = AtomicU64::new(0);
 
-/// Whether the model path is overridden via `CLIPS_WHISPER_MODEL`. A custom
-/// model is exempt from checksum verification (it may legitimately be a
-/// different model, e.g. multilingual).
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
 pub(crate) fn custom_model_override() -> bool {
     std::env::var("CLIPS_WHISPER_MODEL")
         .map(|v| !v.trim().is_empty())
         .unwrap_or(false)
 }
 
-/// Resolve the model path. Honors `CLIPS_WHISPER_MODEL`, otherwise
-/// `<app_data_dir>/models/ggml-base.bin` (creating the dir).
-pub fn model_file(app: &AppHandle) -> Result<PathBuf, String> {
-    if let Ok(path) = std::env::var("CLIPS_WHISPER_MODEL") {
-        if !path.trim().is_empty() {
-            return Ok(PathBuf::from(path));
-        }
-    }
+pub(crate) fn is_supported_model_id(id: &str) -> bool {
+    SUPPORTED_MODELS.iter().any(|m| m.id == id)
+}
+
+fn find_model(id: &str) -> Result<&'static WhisperModel, String> {
+    SUPPORTED_MODELS
+        .iter()
+        .find(|m| m.id == id)
+        .ok_or_else(|| format!("unsupported Whisper model: {id}"))
+}
+
+/// Returns the directory where model files are stored, creating it if needed.
+fn models_dir(app: &AppHandle) -> Result<PathBuf, String> {
     let dir = app
         .path()
         .app_data_dir()
         .map_err(|e| format!("no app_data_dir: {e}"))?
         .join("models");
     std::fs::create_dir_all(&dir).map_err(|e| format!("mkdir models: {e}"))?;
-    Ok(dir.join(MODEL_FILENAME))
+    Ok(dir)
 }
 
-/// Model status returned to the frontend settings UI.
+/// Resolve the full path for a catalog model on disk.
+fn model_path(dir: &Path, model: &WhisperModel) -> PathBuf {
+    dir.join(model.filename)
+}
+
+fn is_complete_on_disk(path: &Path, model: &WhisperModel) -> bool {
+    std::fs::metadata(path)
+        .map(|m| m.len() == model.size_bytes)
+        .unwrap_or(false)
+}
+
+fn downloaded_mb(bytes: u64, model: &WhisperModel) -> u64 {
+    bytes.saturating_mul(model.size_mb) / model.size_bytes
+}
+
+// ---------------------------------------------------------------------------
+// Public: resolve model file path (honors CLIPS_WHISPER_MODEL env override)
+// ---------------------------------------------------------------------------
+
+pub fn model_file(app: &AppHandle) -> Result<PathBuf, String> {
+    if let Ok(path) = std::env::var("CLIPS_WHISPER_MODEL") {
+        if !path.trim().is_empty() {
+            return Ok(PathBuf::from(path));
+        }
+    }
+    let config = crate::config::feature_config(app);
+    let model = find_model(&config.whisper_model_id)?;
+    Ok(model_path(&models_dir(app)?, model))
+}
+
+// ---------------------------------------------------------------------------
+// Tauri commands
+// ---------------------------------------------------------------------------
+
+#[tauri::command]
+pub async fn whisper_models() -> Vec<WhisperModel> {
+    SUPPORTED_MODELS.to_vec()
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ModelStatus {
-    /// One of: "disabled" | "missing" | "downloading" | "ready"
     pub state: String,
-    /// Absolute path where the model file lives (or will live).
     pub path: String,
-    /// How many MB have been downloaded so far (only meaningful during "downloading").
     pub downloaded_mb: u64,
-    /// Total model size in MB.
     pub total_mb: u64,
 }
 
-/// Return the current model state without triggering a download.
 #[tauri::command]
 pub async fn whisper_model_status(app: AppHandle) -> Result<ModelStatus, String> {
-    let path = model_file(&app)?;
-    let path_str = path.to_string_lossy().to_string();
+    if custom_model_override() {
+        let path = model_file(&app)?;
+        let ready = path.exists();
+        return Ok(ModelStatus {
+            state: if ready { "ready" } else { "missing" }.into(),
+            path: path.to_string_lossy().into(),
+            downloaded_mb: 0,
+            total_mb: 0,
+        });
+    }
+
     let config = crate::config::feature_config(&app);
+    let model = find_model(&config.whisper_model_id)?;
+    let dir = models_dir(&app)?;
+    let path = model_path(&dir, model);
+    let path_str = path.to_string_lossy().into_owned();
 
     if !config.whisper_model_enabled {
         return Ok(ModelStatus {
             state: "disabled".into(),
             path: path_str,
             downloaded_mb: 0,
-            total_mb: MODEL_SIZE_MB,
+            total_mb: model.size_mb,
         });
     }
     if DOWNLOADING.load(Ordering::Relaxed) {
-        let downloaded_mb = DOWNLOADED_BYTES.load(Ordering::Relaxed) / (1024 * 1024);
         return Ok(ModelStatus {
             state: "downloading".into(),
             path: path_str,
-            downloaded_mb,
-            total_mb: MODEL_SIZE_MB,
+            downloaded_mb: downloaded_mb(DOWNLOADED_BYTES.load(Ordering::Relaxed), model),
+            total_mb: model.size_mb,
         });
     }
-    let state = match std::fs::metadata(&path) {
-        Ok(m) if m.len() == MODEL_SIZE || custom_model_override() => "ready",
-        _ => "missing",
-    };
+    let ready = is_complete_on_disk(&path, model);
     Ok(ModelStatus {
-        state: state.into(),
+        state: if ready { "ready" } else { "missing" }.into(),
         path: path_str,
-        downloaded_mb: if state == "ready" { MODEL_SIZE_MB } else { 0 },
-        total_mb: MODEL_SIZE_MB,
+        downloaded_mb: if ready { model.size_mb } else { 0 },
+        total_mb: model.size_mb,
     })
 }
 
-/// Spawn a background download. Idempotent — no-ops if already downloading or
-/// already present. Emits `whisper:model-progress`, `whisper:model-ready`, or
-/// `whisper:model-error` as the download progresses.
 #[tauri::command]
 pub async fn whisper_model_download(app: AppHandle) -> Result<(), String> {
     if DOWNLOADING.load(Ordering::Acquire) {
         return Ok(());
     }
-    // Quick check: if model is already present, just emit ready and return.
-    if let Ok(path) = model_file(&app) {
-        if let Ok(m) = std::fs::metadata(&path) {
-            if m.len() == MODEL_SIZE || custom_model_override() {
+    let path = model_file(&app)?;
+    if let Ok(meta) = std::fs::metadata(&path) {
+        let config = crate::config::feature_config(&app);
+        if let Ok(model) = find_model(&config.whisper_model_id) {
+            if meta.len() == model.size_bytes || custom_model_override() {
                 let _ = app.emit("whisper:model-ready", ());
                 return Ok(());
             }
@@ -130,164 +222,182 @@ pub async fn whisper_model_download(app: AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-/// Ensure the model file exists, downloading it on first use. ~142 MB, so the
-/// first meeting after install pays a one-time download cost.
-///
-/// The default `ggml-base.bin` download is verified against `MODEL_SHA256` /
-/// `MODEL_SIZE`. A custom model supplied via `CLIPS_WHISPER_MODEL` is exempt
-/// (it may legitimately be a different model) — we only require it to exist.
-///
-/// Emits `whisper:model-progress { downloadedMb, totalMb }` every ~16 MB.
-pub async fn ensure_model(app: &AppHandle) -> Result<PathBuf, String> {
+#[tauri::command]
+pub async fn whisper_downloaded_models(app: AppHandle) -> Vec<String> {
+    let Ok(dir) = models_dir(&app) else {
+        return vec![];
+    };
+    SUPPORTED_MODELS
+        .iter()
+        .filter(|m| is_complete_on_disk(&model_path(&dir, m), m))
+        .map(|m| m.id.to_string())
+        .collect()
+}
+
+#[tauri::command]
+pub async fn whisper_model_delete(app: AppHandle, model_id: String) -> Result<(), String> {
+    if custom_model_override() {
+        return Err("Cannot manage models while CLIPS_WHISPER_MODEL is set.".to_string());
+    }
+    if crate::config::feature_config(&app).whisper_model_id == model_id {
+        return Err("Cannot delete the model that is currently selected.".to_string());
+    }
+    let model = find_model(&model_id)?;
+    let path = model_path(&models_dir(&app)?, model);
+    if path.exists() {
+        std::fs::remove_file(&path).map_err(|e| format!("delete model: {e}"))?;
+    }
+    let _ = app.emit("whisper:model-deleted", serde_json::json!({ "modelId": model_id }));
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Download logic (called by whisper_model_download and lib.rs startup prewarm)
+// ---------------------------------------------------------------------------
+
+pub(crate) async fn ensure_model(app: &AppHandle) -> Result<PathBuf, String> {
     let path = model_file(app)?;
     let custom = custom_model_override();
 
-    if custom && !path.exists() {
+    if custom {
+        if path.exists() {
+            eprintln!("[whisper] using custom model at {}", path.display());
+            return Ok(path);
+        }
         return Err(format!(
-            "CLIPS_WHISPER_MODEL is set to '{}' but the file does not exist.",
+            "CLIPS_WHISPER_MODEL points to '{}' but the file does not exist.",
             path.display()
         ));
     }
 
+    let config = crate::config::feature_config(app);
+    let model = find_model(&config.whisper_model_id)?;
+
+    if is_complete_on_disk(&path, model) {
+        eprintln!("[whisper] model found at {}", path.display());
+        return Ok(path);
+    }
     if path.exists() {
-        if custom {
-            eprintln!("[whisper] using custom model at {}", path.display());
-            return Ok(path);
+        eprintln!(
+            "[whisper] cached model has wrong size — re-downloading {}",
+            path.display()
+        );
+    }
+
+    if DOWNLOADING.load(Ordering::SeqCst) {
+        eprintln!("[whisper] waiting for in-progress download…");
+        while DOWNLOADING.load(Ordering::SeqCst) {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         }
-        match std::fs::metadata(&path) {
-            Ok(m) if m.len() == MODEL_SIZE => {
-                eprintln!("[whisper] model found at {}", path.display());
-                return Ok(path);
-            }
-            Ok(m) => {
-                eprintln!(
-                    "[whisper] cached model size {} != expected {} — re-downloading",
-                    m.len(),
-                    MODEL_SIZE
-                );
-            }
-            Err(e) => return Err(format!("stat model: {e}")),
+        if is_complete_on_disk(&path, model) {
+            return Ok(path);
         }
     }
 
-    // If a download is already in progress, wait for it rather than failing —
-    // the caller (meeting start) should succeed once the model lands.
-    if DOWNLOADING.load(Ordering::SeqCst) {
-        eprintln!("[whisper] waiting for in-progress model download…");
-        loop {
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            if !DOWNLOADING.load(Ordering::SeqCst) {
-                break;
-            }
-        }
-        // Re-check: the download that just finished may have placed the model.
-        if path.exists() {
-            if custom {
-                return Ok(path);
-            }
-            if let Ok(m) = std::fs::metadata(&path) {
-                if m.len() == MODEL_SIZE {
-                    return Ok(path);
-                }
-            }
-        }
-    }
-    // Guard against concurrent downloads.
     if DOWNLOADING
         .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
         .is_err()
     {
-        return Err("Whisper model download already in progress — please wait.".to_string());
+        return Err("Download already in progress — please wait.".to_string());
     }
     DOWNLOADED_BYTES.store(0, Ordering::Relaxed);
 
-    let result = do_download(app, &path, custom).await;
+    let result = do_download(app, &path, model).await;
     DOWNLOADING.store(false, Ordering::SeqCst);
     result
 }
 
-async fn do_download(app: &AppHandle, path: &PathBuf, custom: bool) -> Result<PathBuf, String> {
+async fn do_download(app: &AppHandle, path: &Path, model: &WhisperModel) -> Result<PathBuf, String> {
     eprintln!(
-        "[whisper] model not found at {} — downloading {} (~142 MB, one time)",
-        path.display(),
-        MODEL_URL
+        "[whisper] downloading {} (~{} MB)",
+        model.url, model.size_mb
     );
-    let mut resp = reqwest::get(MODEL_URL).await.map_err(|e| {
-        let msg = format!("model download request failed: {e}");
-        eprintln!("[whisper] {msg}");
-        msg
+    let mut response = reqwest::get(model.url).await.map_err(|e| {
+        format!("model download failed: {e}")
     })?;
-    if !resp.status().is_success() {
-        let msg = format!("model download HTTP {}", resp.status());
-        eprintln!("[whisper] {msg}");
-        return Err(msg);
+    if !response.status().is_success() {
+        return Err(format!("model download HTTP {}", response.status()));
     }
 
-    // Stream body to a temp file, hashing as we go. Keeps memory flat
-    // (no 142 MB heap spike) and lets us verify before the rename.
     use sha2::{Digest, Sha256};
     use std::io::Write as _;
 
     let tmp = path.with_extension("bin.tmp");
-    let mut file = std::fs::File::create(&tmp).map_err(|e| format!("create model tmp: {e}"))?;
+    let mut file =
+        std::fs::File::create(&tmp).map_err(|e| format!("create tmp: {e}"))?;
     let mut hasher = Sha256::new();
-    let mut total: u64 = 0;
-    let mut last_progress: u64 = 0;
+    let mut total = 0_u64;
+    let mut last_progress = 0_u64;
 
-    while let Some(chunk) = resp
-        .chunk()
-        .await
-        .map_err(|e| format!("model download body failed: {e}"))?
-    {
-        if !custom {
-            hasher.update(&chunk);
-        }
+    while let Some(chunk) = response.chunk().await.map_err(|e| format!("download body: {e}"))? {
+        hasher.update(&chunk);
         total += chunk.len() as u64;
         DOWNLOADED_BYTES.store(total, Ordering::Relaxed);
 
         if let Err(e) = file.write_all(&chunk) {
             let _ = std::fs::remove_file(&tmp);
-            let msg = format!("write model tmp: {e}");
-            eprintln!("[whisper] {msg}");
-            return Err(msg);
+            return Err(format!("write tmp: {e}"));
         }
 
-        // Emit progress + log every ~16 MB.
         if total - last_progress >= 16 * 1024 * 1024 {
             last_progress = total;
-            let downloaded_mb = total / (1024 * 1024);
-            eprintln!("[whisper] downloading model… {downloaded_mb} / {MODEL_SIZE_MB} MB");
+            let mb = downloaded_mb(total, model);
+            eprintln!("[whisper] {mb} / {} MB", model.size_mb);
             let _ = app.emit(
                 "whisper:model-progress",
-                serde_json::json!({ "downloadedMb": downloaded_mb, "totalMb": MODEL_SIZE_MB }),
+                serde_json::json!({ "downloadedMb": mb, "totalMb": model.size_mb }),
             );
         }
     }
-    file.flush().map_err(|e| format!("flush model tmp: {e}"))?;
+    file.flush().map_err(|e| format!("flush tmp: {e}"))?;
     drop(file);
 
-    if !custom {
-        if total != MODEL_SIZE {
-            let _ = std::fs::remove_file(&tmp);
-            let msg = format!("model size mismatch: got {total} bytes, expected {MODEL_SIZE}");
-            eprintln!("[whisper] {msg}");
-            return Err(msg);
-        }
-        let digest: String = hasher
-            .finalize()
-            .iter()
-            .map(|b| format!("{b:02x}"))
-            .collect();
-        if digest != MODEL_SHA256 {
-            let _ = std::fs::remove_file(&tmp);
-            let msg = format!("model checksum mismatch: got {digest}, expected {MODEL_SHA256}");
-            eprintln!("[whisper] {msg}");
-            return Err(msg);
-        }
-        eprintln!("[whisper] model checksum verified (sha256 {MODEL_SHA256})");
+    if total != model.size_bytes {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(format!(
+            "size mismatch: got {total} bytes, expected {}",
+            model.size_bytes
+        ));
+    }
+    let digest: String = hasher.finalize().iter().map(|b| format!("{b:02x}")).collect();
+    if digest != model.sha256 {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(format!(
+            "checksum mismatch: got {digest}, expected {}",
+            model.sha256
+        ));
     }
 
     std::fs::rename(&tmp, path).map_err(|e| format!("rename model: {e}"))?;
-    eprintln!("[whisper] model saved → {}", path.display());
-    Ok(path.clone())
+    eprintln!("[whisper] saved → {}", path.display());
+    Ok(path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn supported_models_have_unique_ids_and_filenames() {
+        for (i, model) in SUPPORTED_MODELS.iter().enumerate() {
+            assert!(model.size_bytes > 0);
+            assert_eq!(model.sha256.len(), 64, "bad sha256 for {}", model.id);
+            assert!(!model.title.is_empty());
+            assert!(!model.description.is_empty());
+            for other in SUPPORTED_MODELS.iter().skip(i + 1) {
+                assert_ne!(model.id, other.id);
+                assert_ne!(model.filename, other.filename);
+            }
+        }
+    }
+
+    #[test]
+    fn base_model_is_default() {
+        assert!(is_supported_model_id("base"));
+    }
+
+    #[test]
+    fn unknown_model_id_is_rejected() {
+        assert!(find_model("does-not-exist").is_err());
+    }
 }

--- a/templates/clips/desktop/src-tauri/src/whisper_speech.rs
+++ b/templates/clips/desktop/src-tauri/src/whisper_speech.rs
@@ -134,6 +134,7 @@ pub async fn whisper_transcription_reset_timeline() -> Result<(), String> {
 
 #[cfg(target_os = "macos")]
 mod macos {
+    use std::path::PathBuf;
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
     use std::sync::{Arc, Mutex, OnceLock};
     use std::time::{Duration, Instant};
@@ -189,13 +190,20 @@ mod macos {
         // the first call takes effect.
         whisper_rs::install_logging_hooks();
 
-        static CTX: OnceLock<Mutex<Option<Arc<WhisperContext>>>> = OnceLock::new();
+        struct CachedContext {
+            model_path: PathBuf,
+            context: Arc<WhisperContext>,
+        }
+
+        static CTX: OnceLock<Mutex<Option<CachedContext>>> = OnceLock::new();
         let slot = CTX.get_or_init(|| Mutex::new(None));
         let mut guard = slot.lock().map_err(|e| e.to_string())?;
-        if let Some(ctx) = guard.as_ref() {
-            return Ok(ctx.clone());
-        }
         let path = model_file(app)?;
+        if let Some(cached) = guard.as_ref() {
+            if cached.model_path == path {
+                return Ok(cached.context.clone());
+            }
+        }
         let path_str = path
             .to_str()
             .ok_or_else(|| "model path is not valid UTF-8".to_string())?;
@@ -208,9 +216,12 @@ mod macos {
         params.use_gpu(cfg!(target_arch = "aarch64"));
         let ctx = WhisperContext::new_with_params(path_str, params)
             .map_err(|e| format!("whisper model load failed: {e}"))?;
-        let ctx = Arc::new(ctx);
-        *guard = Some(ctx.clone());
-        Ok(ctx)
+        let context = Arc::new(ctx);
+        *guard = Some(CachedContext {
+            model_path: path,
+            context: context.clone(),
+        });
+        Ok(context)
     }
 
     pub fn prewarm(app: &AppHandle) -> Result<(), String> {

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -51,6 +51,7 @@ import { UpdateBanner } from "./components/UpdateBanner";
 import { useMediaDevices } from "./hooks/useMediaDevices";
 import { useMeetingTranscription } from "./hooks/useMeetingTranscription";
 import { stopAllMicMeters } from "./hooks/useMicMeter";
+import { useWhisperSettings } from "./hooks/useWhisperSettings";
 import { startBubbleFramePump } from "./lib/bubble-pump";
 import {
   startBubbleWebrtc,
@@ -4940,17 +4941,20 @@ function Setup({
     featureConfig?.meetingTranscriptionMode ?? "ask";
   const showMeetingWidgetEnabled =
     featureConfig?.showMeetingWidgetEnabled !== false;
-  const whisperModelEnabled = featureConfig?.whisperModelEnabled !== false;
-  type WhisperModelState = "disabled" | "missing" | "downloading" | "ready";
-  interface WhisperModelStatus {
-    state: WhisperModelState;
-    path: string;
-    downloadedMb: number;
-    totalMb: number;
-  }
-  const [whisperStatus, setWhisperStatus] = useState<WhisperModelStatus | null>(
-    null,
+  const whisper = useWhisperSettings(
+    featureConfig,
+    voiceProvider,
+    onVoiceProviderChange,
+    nativeVoiceProvider,
   );
+  const {
+    catalog: whisperModels,
+    status: whisperStatus,
+    enabled: whisperModelEnabled,
+    modelId: whisperModelId,
+    selectedModel: selectedWhisperModel,
+    deletableModels,
+  } = whisper;
   const [screenMemoryStatus, setScreenMemoryStatus] =
     useState<ScreenMemoryStatus | null>(null);
   const screenMemoryStatusRefreshVersionRef = useRef(0);
@@ -5057,24 +5061,6 @@ function Setup({
     }).catch((err) =>
       console.error("[settings] set_feature_config failed", err),
     );
-  }
-
-  function triggerWhisperDownload() {
-    invoke("whisper_model_download").catch(() => {});
-  }
-
-  function setWhisperModelEnabled(enabled: boolean) {
-    if (!featureConfig) return;
-    invoke("set_feature_config", {
-      config: { ...featureConfig, whisperModelEnabled: enabled },
-    }).catch((err) =>
-      console.error("[settings] set_feature_config failed", err),
-    );
-    if (enabled) {
-      triggerWhisperDownload();
-    } else if (voiceProvider === "whisper") {
-      onVoiceProviderChange(nativeVoiceProvider());
-    }
   }
 
   function setLaunchAtLoginEnabled(enabled: boolean) {
@@ -5480,47 +5466,6 @@ function Setup({
     };
   }, [refreshScreenMemoryStatus]);
 
-  // Load model status on mount and keep it current via events.
-  useEffect(() => {
-    let cancelled = false;
-    const refresh = () => {
-      invoke<WhisperModelStatus>("whisper_model_status")
-        .then((s) => {
-          if (!cancelled) setWhisperStatus(s);
-        })
-        .catch(() => {});
-    };
-    refresh();
-    const unlistens: Array<() => void> = [];
-    const track = (p: Promise<() => void>) => {
-      p.then((u) => {
-        if (cancelled) {
-          try {
-            u();
-          } catch {
-            /* ignore */
-          }
-          return;
-        }
-        unlistens.push(u);
-      }).catch(() => {});
-    };
-    track(listen("whisper:model-progress", () => refresh()));
-    track(listen("whisper:model-ready", () => refresh()));
-    track(listen("whisper:model-error", () => refresh()));
-    track(listen("whisper:model-enabled-changed", () => refresh()));
-    return () => {
-      cancelled = true;
-      unlistens.forEach((u) => {
-        try {
-          u();
-        } catch {
-          /* ignore */
-        }
-      });
-    };
-  }, []);
-
   useEffect(() => {
     const base = (serverUrl ?? initial ?? DEFAULT_URL).replace(/\/+$/, "");
     let cancelled = false;
@@ -5606,7 +5551,7 @@ function Setup({
       onVoiceProviderChange(nativeVoiceProvider());
     } else if (mode === "whisper") {
       onVoiceProviderChange("whisper");
-      if (!whisperModelEnabled) setWhisperModelEnabled(true);
+      if (!whisperModelEnabled) whisper.setEnabled(true);
     } else if (mode === "builder") {
       onVoiceProviderChange("builder-gemini");
     } else {
@@ -7192,15 +7137,58 @@ function Setup({
           />
           <Switch
             on={whisperModelEnabled}
-            onChange={setWhisperModelEnabled}
+            onChange={whisper.setEnabled}
             label="Enable Whisper model"
           />
         </div>
+        <SettingLabel
+          label="Model"
+          hint="Larger models can improve transcription accuracy but use more storage and may run more slowly."
+          htmlFor="whisper-model"
+        />
+        <select
+          id="whisper-model"
+          className="setup-select"
+          value={whisperModelId}
+          onChange={(event) => whisper.setModelId(event.target.value)}
+          disabled={
+            whisperModels.length === 0 || whisperStatus?.state === "downloading"
+          }
+        >
+          {whisperModels.map((model) => (
+            <option key={model.id} value={model.id}>
+              {model.title} · {model.sizeMb} MB — {model.description}
+            </option>
+          ))}
+        </select>
+        {selectedWhisperModel ? (
+          <p className="setup-hint">{selectedWhisperModel.description}</p>
+        ) : null}
         <WhisperModelStatusRow
           status={whisperStatus}
           enabled={whisperModelEnabled}
-          onDownload={triggerWhisperDownload}
+          onDownload={whisper.triggerDownload}
         />
+        {deletableModels.length > 0 ? (
+          <div className="whisper-other-models">
+            <p className="setup-hint">Other downloaded models</p>
+            {deletableModels.map((model) => (
+              <div key={model.id} className="whisper-other-model-row">
+                <span className="whisper-other-model-name">
+                  {model.title} &middot; {model.sizeMb} MB
+                </span>
+                <button
+                  type="button"
+                  className="whisper-delete-btn"
+                  onClick={() => whisper.deleteModel(model.id)}
+                >
+                  <IconTrash size={13} />
+                  Delete
+                </button>
+              </div>
+            ))}
+          </div>
+        ) : null}
       </div>
 
       <div className="setup-section-heading">Dictation</div>
@@ -7528,9 +7516,12 @@ function WhisperModelStatusRow({
         <span className="whisper-progress-label">
           Downloading… {status.downloadedMb} / {status.totalMb} MB ({pct}%)
         </span>
-        <div className="whisper-progress-bar">
-          <div className="whisper-progress-fill" style={{ width: `${pct}%` }} />
-        </div>
+        <progress
+          className="whisper-progress-bar"
+          value={pct}
+          max={100}
+          aria-label={`Whisper model download ${pct}% complete`}
+        />
       </div>
     );
   }

--- a/templates/clips/desktop/src/hooks/useWhisperSettings.ts
+++ b/templates/clips/desktop/src/hooks/useWhisperSettings.ts
@@ -29,9 +29,8 @@ export interface WhisperModelStatus {
   totalMb: number;
 }
 
-const WHISPER_EVENTS = [
+const WHISPER_STATUS_EVENTS = [
   "whisper:model-progress",
-  "whisper:model-ready",
   "whisper:model-error",
   "whisper:model-enabled-changed",
   "whisper:model-selection-changed",
@@ -94,9 +93,15 @@ export function useWhisperSettings(
       }).catch(() => {});
     };
 
-    for (const event of WHISPER_EVENTS) {
+    for (const event of WHISPER_STATUS_EVENTS) {
       track(listen(event, () => refreshStatus()));
     }
+    track(
+      listen("whisper:model-ready", () => {
+        refreshStatus();
+        refreshDownloaded();
+      }),
+    );
     track(listen("whisper:model-deleted", () => refreshDownloaded()));
 
     return () => {
@@ -121,14 +126,15 @@ export function useWhisperSettings(
       config: { ...featureConfig, whisperModelEnabled: next },
     })
       .then(() => {
-        if (next) triggerDownload();
+        if (next) {
+          triggerDownload();
+        } else if (voiceProvider === "whisper") {
+          onVoiceProviderChange(nativeVoiceProvider());
+        }
       })
       .catch((err) =>
         console.error("[whisper] set_feature_config failed", err),
       );
-    if (!next && voiceProvider === "whisper") {
-      onVoiceProviderChange(nativeVoiceProvider());
-    }
   }
 
   function setModelId(next: string) {

--- a/templates/clips/desktop/src/hooks/useWhisperSettings.ts
+++ b/templates/clips/desktop/src/hooks/useWhisperSettings.ts
@@ -1,0 +1,166 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { useCallback, useEffect, useState } from "react";
+
+import type { VoiceProvider } from "../lib/voice-dictation";
+import type { FeatureConfig } from "../shared/config";
+
+export interface WhisperModelOption {
+  id: string;
+  title: string;
+  description: string;
+  url: string;
+  filename: string;
+  sha256: string;
+  sizeBytes: number;
+  sizeMb: number;
+}
+
+export type WhisperModelState =
+  | "disabled"
+  | "missing"
+  | "downloading"
+  | "ready";
+
+export interface WhisperModelStatus {
+  state: WhisperModelState;
+  path: string;
+  downloadedMb: number;
+  totalMb: number;
+}
+
+const WHISPER_EVENTS = [
+  "whisper:model-progress",
+  "whisper:model-ready",
+  "whisper:model-error",
+  "whisper:model-enabled-changed",
+  "whisper:model-selection-changed",
+] as const;
+
+export function useWhisperSettings(
+  featureConfig: FeatureConfig | null,
+  voiceProvider: VoiceProvider,
+  onVoiceProviderChange: (provider: VoiceProvider) => void,
+  nativeVoiceProvider: () => VoiceProvider,
+) {
+  const [catalog, setCatalog] = useState<WhisperModelOption[]>([]);
+  const [downloadedModelIds, setDownloadedModelIds] = useState<string[]>([]);
+  const [status, setStatus] = useState<WhisperModelStatus | null>(null);
+
+  const enabled = featureConfig?.whisperModelEnabled !== false;
+  const modelId = featureConfig?.whisperModelId ?? "base";
+  const selectedModel = catalog.find((m) => m.id === modelId) ?? null;
+  const deletableModels = catalog.filter(
+    (m) => m.id !== modelId && downloadedModelIds.includes(m.id),
+  );
+
+  useEffect(() => {
+    invoke<WhisperModelOption[]>("whisper_models")
+      .then(setCatalog)
+      .catch(() => {});
+  }, []);
+
+  const refreshDownloaded = useCallback(() => {
+    invoke<string[]>("whisper_downloaded_models")
+      .then(setDownloadedModelIds)
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const refreshStatus = () => {
+      invoke<WhisperModelStatus>("whisper_model_status")
+        .then((s) => {
+          if (!cancelled) setStatus(s);
+        })
+        .catch(() => {});
+    };
+
+    refreshStatus();
+    refreshDownloaded();
+
+    const unlistens: Array<() => void> = [];
+    const track = (p: Promise<() => void>) => {
+      p.then((u) => {
+        if (cancelled) {
+          try {
+            u();
+          } catch {
+            /* ignore */
+          }
+          return;
+        }
+        unlistens.push(u);
+      }).catch(() => {});
+    };
+
+    for (const event of WHISPER_EVENTS) {
+      track(listen(event, () => refreshStatus()));
+    }
+    track(listen("whisper:model-deleted", () => refreshDownloaded()));
+
+    return () => {
+      cancelled = true;
+      unlistens.forEach((u) => {
+        try {
+          u();
+        } catch {
+          /* ignore */
+        }
+      });
+    };
+  }, [refreshDownloaded]);
+
+  function triggerDownload() {
+    invoke("whisper_model_download").catch(() => {});
+  }
+
+  function setEnabled(next: boolean) {
+    if (!featureConfig) return;
+    invoke("set_feature_config", {
+      config: { ...featureConfig, whisperModelEnabled: next },
+    })
+      .then(() => {
+        if (next) triggerDownload();
+      })
+      .catch((err) =>
+        console.error("[whisper] set_feature_config failed", err),
+      );
+    if (!next && voiceProvider === "whisper") {
+      onVoiceProviderChange(nativeVoiceProvider());
+    }
+  }
+
+  function setModelId(next: string) {
+    if (!featureConfig) return;
+    invoke("set_feature_config", {
+      config: { ...featureConfig, whisperModelId: next },
+    })
+      .then(() => {
+        if (enabled) triggerDownload();
+      })
+      .catch((err) =>
+        console.error("[whisper] set_feature_config failed", err),
+      );
+  }
+
+  function deleteModel(modelIdToDelete: string) {
+    invoke("whisper_model_delete", { modelId: modelIdToDelete })
+      .then(() => refreshDownloaded())
+      .catch(() => {});
+  }
+
+  return {
+    catalog,
+    downloadedModelIds,
+    status,
+    enabled,
+    modelId,
+    selectedModel,
+    deletableModels,
+    triggerDownload,
+    setEnabled,
+    setModelId,
+    deleteModel,
+  };
+}

--- a/templates/clips/desktop/src/shared/config.ts
+++ b/templates/clips/desktop/src/shared/config.ts
@@ -130,6 +130,7 @@ export interface FeatureConfig {
   screenMemory: ScreenMemoryConfig;
   onboardingComplete: boolean;
   whisperModelEnabled: boolean;
+  whisperModelId: string;
 }
 
 export function useFeatureConfig() {

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -5580,23 +5580,39 @@ body[data-clips-route="recording-pill"] #root {
 }
 
 .whisper-progress-bar {
-  height: 4px;
   width: 100%;
-  border-radius: 999px;
-  background: var(--surface-strong);
-  overflow: hidden;
+  height: 4px;
   margin-top: 4px;
+  border: none;
+  border-radius: 999px;
+  appearance: none;
+  overflow: hidden;
+  background: var(--surface-strong);
+  color: #16a34a;
 }
 
-.whisper-progress-fill {
-  height: 100%;
+.whisper-progress-bar::-webkit-progress-bar {
+  border-radius: inherit;
+  background: var(--surface-strong);
+}
+
+.whisper-progress-bar::-webkit-progress-value {
   border-radius: inherit;
   background: #16a34a;
-  transition: width 300ms ease;
+}
+
+.whisper-progress-bar::-moz-progress-bar {
+  border-radius: inherit;
+  background: #16a34a;
 }
 
 @media (prefers-color-scheme: dark) {
-  .whisper-progress-fill {
+  .whisper-progress-bar {
+    color: #4ade80;
+  }
+
+  .whisper-progress-bar::-webkit-progress-value,
+  .whisper-progress-bar::-moz-progress-bar {
     background: #4ade80;
   }
 }
@@ -5622,6 +5638,63 @@ body[data-clips-route="recording-pill"] #root {
 
 .whisper-download-btn:hover {
   background: var(--surface-hover);
+}
+
+.whisper-other-models {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 6px;
+}
+
+.whisper-other-model-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+}
+
+.whisper-other-model-name {
+  font-size: 11px;
+  color: var(--fg-muted);
+}
+
+.whisper-delete-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  height: 22px;
+  padding: 0 8px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--fg-muted);
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 600;
+  transition:
+    background 120ms,
+    color 120ms,
+    border-color 120ms;
+}
+
+.whisper-delete-btn:hover {
+  background: rgba(239, 68, 68, 0.1);
+  border-color: rgba(239, 68, 68, 0.4);
+  color: #ef4444;
+}
+
+@media (prefers-color-scheme: dark) {
+  .whisper-delete-btn:hover {
+    background: rgba(239, 68, 68, 0.15);
+    border-color: rgba(239, 68, 68, 0.5);
+    color: #f87171;
+  }
 }
 
 /* ---- */


### PR DESCRIPTION
https://clips.agent-native.com/share/ht4dJPnBwqmq?ref=clip_share

Users can now choose which local Whisper model to use for offline transcription directly from the Whisper section in Settings.

## What changed

**Four models are now available:**

| Model          | Size    | When to use                                    |
| -------------- | ------- | ---------------------------------------------- |
| Tiny           | 74 MB   | Fastest, works on any Mac, may miss some words |
| Base           | 141 MB  | Good everyday default (unchanged behavior)     |
| Small          | 488 MB  | Better with accents and background noise       |
| Large v3 Turbo | ~1.5 GB | Most accurate, best on newer Macs              |

The dropdown shows the model name, size, and a short description so users can make an informed choice before downloading.

**Model management:** Models are downloaded on demand. Users can delete models they no longer use directly from the settings panel. Only the currently active model cannot be deleted.

**No breaking changes:** Existing users default to Base, the same model that was always used. Their `feature-config.json` is forward-compatible — the new `whisperModelId` field defaults to `"base"` when missing.
