### PR TITLE
Dictation - fix the flow bar not showing

### DIFF
--- a/templates/clips/changelog/2026-07-21-live-dictation-text-now-appears-above-the-desktop-recording-.md
+++ b/templates/clips/changelog/2026-07-21-live-dictation-text-now-appears-above-the-desktop-recording-.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-21
+---
+
+Live dictation text now appears above the desktop recording pill.

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -1506,9 +1506,9 @@ pub async fn show_flow_bar(app: AppHandle) -> Result<(), String> {
 
     let (mx, my, mw, mh) = tray_monitor_physical_rect(&app);
     let scale = overlay_scale_factor(&app);
-    // Keep enough transparent canvas for the transcript preview above the pill.
-    let content_w: u32 = (320.0 * scale).round() as u32;
-    let content_h: u32 = (84.0 * scale).round() as u32;
+    // Wide + tall enough for a 5-line transcript preview above the pill.
+    let content_w: u32 = (640.0 * scale).round() as u32;
+    let content_h: u32 = (160.0 * scale).round() as u32;
     let bottom_margin: i32 = (14.0 * scale).round() as i32;
     let gutter = overlay_shadow_gutter_physical(&app);
     let w: u32 = content_w + gutter * 2;

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -1506,10 +1506,9 @@ pub async fn show_flow_bar(app: AppHandle) -> Result<(), String> {
 
     let (mx, my, mw, mh) = tray_monitor_physical_rect(&app);
     let scale = overlay_scale_factor(&app);
-    // Compact Wispr-style pill window: just enough transparent canvas for
-    // the bottom-centered waveform bar and its shadow gutter.
-    let content_w: u32 = (160.0 * scale).round() as u32;
-    let content_h: u32 = (56.0 * scale).round() as u32;
+    // Keep enough transparent canvas for the transcript preview above the pill.
+    let content_w: u32 = (320.0 * scale).round() as u32;
+    let content_h: u32 = (84.0 * scale).round() as u32;
     let bottom_margin: i32 = (14.0 * scale).round() as i32;
     let gutter = overlay_shadow_gutter_physical(&app);
     let w: u32 = content_w + gutter * 2;

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -1445,6 +1445,9 @@ export function installDesktopVoiceDictation(
         // the tail because Web Speech only marks a segment as `isFinal`
         // after a confidence-threshold pass.
         next.browserTranscript = (finalSoFar + interim).trim();
+        emit("voice:dictation-preview", {
+          text: next.browserTranscript,
+        }).catch(() => {});
       };
       recognition.onerror = (ev) => {
         if (ev.error !== "no-speech" && ev.error !== "aborted") {
@@ -2038,15 +2041,16 @@ export function installDesktopVoiceDictation(
 
   // Native (SFSpeechRecognizer) event subscriptions. These are always
   // installed — the events only fire when the Rust side has an active
-  // session, so subscribing on non-native sessions is harmless. The
-  // flow-bar listens to `voice:partial-transcript` independently so we
-  // don't re-emit it here.
+  // session, so subscribing on non-native sessions is harmless.
   onPartialTranscript(({ text }) => {
     const current = session;
     if (!current || (current.kind !== "native" && current.kind !== "whisper"))
       return;
     if (current.cancelled || current.stopping) return;
     setInterimTranscript(current, text);
+    emit("voice:dictation-preview", {
+      text: current.browserTranscript,
+    }).catch(() => {});
   })
     .then((u) => unlistens.push(u))
     .catch(() => {});
@@ -2065,6 +2069,13 @@ export function installDesktopVoiceDictation(
     if (!current) return;
     if (current.cancelled) return;
     appendFinalTranscript(current, text);
+    const supersededLingeringSession =
+      current === lingeringSession && session !== null && session !== current;
+    if (!supersededLingeringSession) {
+      emit("voice:dictation-preview", {
+        text: current.browserTranscript,
+      }).catch(() => {});
+    }
     if (current === lingeringSession) {
       current.onNativeFinalize?.();
     }

--- a/templates/clips/desktop/src/overlays/flow-bar.tsx
+++ b/templates/clips/desktop/src/overlays/flow-bar.tsx
@@ -2,11 +2,7 @@ import { IconX } from "@tabler/icons-react";
 import { emit, listen } from "@tauri-apps/api/event";
 import { useEffect, useRef, useState } from "react";
 
-import {
-  onAudioLevel,
-  onFinalTranscript,
-  onPartialTranscript,
-} from "../lib/transcription-engine";
+import { onAudioLevel } from "../lib/transcription-engine";
 
 type FlowState = "idle" | "recording" | "processing" | "complete" | "error";
 
@@ -20,7 +16,7 @@ type FlowState = "idle" | "recording" | "processing" | "complete" | "error";
  * Events:
  *   - `voice:state-change` { state: "idle"|"recording"|"processing"|"complete"|"error" }
  *   - `voice:audio-level` { level: number } (0-1) for waveform visualization
- *   - `voice:partial-transcript` / `voice:final-transcript` { text: string }
+ *   - `voice:dictation-preview` { text: string }
  */
 export function FlowBar() {
   // Default to "recording" not "idle" — there's a race between the Rust
@@ -29,8 +25,7 @@ export function FlowBar() {
   // away if the start event was missed.
   const [state, setState] = useState<FlowState>("recording");
   const [transcript, setTranscript] = useState("");
-  const finalTranscriptPartsRef = useRef<string[]>([]);
-  const transcriptRef = useRef<HTMLSpanElement | null>(null);
+  const transcriptRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const levelRef = useRef(0);
   const rafRef = useRef<number | null>(null);
@@ -56,10 +51,7 @@ export function FlowBar() {
     trackListen(
       listen<{ state: FlowState }>("voice:state-change", (ev) => {
         setState(ev.payload.state);
-        if (ev.payload.state === "recording") {
-          finalTranscriptPartsRef.current = [];
-          setTranscript("");
-        }
+        if (ev.payload.state === "recording") setTranscript("");
       }),
     );
 
@@ -70,20 +62,8 @@ export function FlowBar() {
     );
 
     trackListen(
-      onPartialTranscript(({ text }) => {
-        setTranscript(
-          [...finalTranscriptPartsRef.current, text.trim()]
-            .filter(Boolean)
-            .join(" "),
-        );
-      }),
-    );
-
-    trackListen(
-      onFinalTranscript(({ text }) => {
-        const finalText = text.trim();
-        if (finalText) finalTranscriptPartsRef.current.push(finalText);
-        setTranscript(finalTranscriptPartsRef.current.join(" "));
+      listen<{ text: string }>("voice:dictation-preview", (ev) => {
+        setTranscript(ev.payload.text.trim());
       }),
     );
 
@@ -102,7 +82,7 @@ export function FlowBar() {
 
   useEffect(() => {
     const preview = transcriptRef.current;
-    if (preview) preview.scrollLeft = preview.scrollWidth;
+    if (preview) preview.scrollTop = preview.scrollHeight;
   }, [transcript]);
 
   // Waveform canvas rendering loop — only runs during the "recording" state.
@@ -187,8 +167,12 @@ export function FlowBar() {
   return (
     <div className="flow-bar-root">
       {transcript ? (
-        <div className="flow-bar-transcript-preview" aria-live="polite">
-          <span ref={transcriptRef}>{transcript}</span>
+        <div
+          ref={transcriptRef}
+          className="flow-bar-transcript-preview"
+          aria-live="polite"
+        >
+          {transcript}
         </div>
       ) : null}
 

--- a/templates/clips/desktop/src/overlays/flow-bar.tsx
+++ b/templates/clips/desktop/src/overlays/flow-bar.tsx
@@ -2,7 +2,11 @@ import { IconX } from "@tabler/icons-react";
 import { emit, listen } from "@tauri-apps/api/event";
 import { useEffect, useRef, useState } from "react";
 
-import { onAudioLevel } from "../lib/transcription-engine";
+import {
+  onAudioLevel,
+  onFinalTranscript,
+  onPartialTranscript,
+} from "../lib/transcription-engine";
 
 type FlowState = "idle" | "recording" | "processing" | "complete" | "error";
 
@@ -16,6 +20,7 @@ type FlowState = "idle" | "recording" | "processing" | "complete" | "error";
  * Events:
  *   - `voice:state-change` { state: "idle"|"recording"|"processing"|"complete"|"error" }
  *   - `voice:audio-level` { level: number } (0-1) for waveform visualization
+ *   - `voice:partial-transcript` / `voice:final-transcript` { text: string }
  */
 export function FlowBar() {
   // Default to "recording" not "idle" — there's a race between the Rust
@@ -23,6 +28,9 @@ export function FlowBar() {
   // "idle" caused the bar to flash an "EN" language pill that never went
   // away if the start event was missed.
   const [state, setState] = useState<FlowState>("recording");
+  const [transcript, setTranscript] = useState("");
+  const finalTranscriptPartsRef = useRef<string[]>([]);
+  const transcriptRef = useRef<HTMLSpanElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const levelRef = useRef(0);
   const rafRef = useRef<number | null>(null);
@@ -48,12 +56,34 @@ export function FlowBar() {
     trackListen(
       listen<{ state: FlowState }>("voice:state-change", (ev) => {
         setState(ev.payload.state);
+        if (ev.payload.state === "recording") {
+          finalTranscriptPartsRef.current = [];
+          setTranscript("");
+        }
       }),
     );
 
     trackListen(
       onAudioLevel(({ level }) => {
         levelRef.current = Math.max(0, Math.min(1, level));
+      }),
+    );
+
+    trackListen(
+      onPartialTranscript(({ text }) => {
+        setTranscript(
+          [...finalTranscriptPartsRef.current, text.trim()]
+            .filter(Boolean)
+            .join(" "),
+        );
+      }),
+    );
+
+    trackListen(
+      onFinalTranscript(({ text }) => {
+        const finalText = text.trim();
+        if (finalText) finalTranscriptPartsRef.current.push(finalText);
+        setTranscript(finalTranscriptPartsRef.current.join(" "));
       }),
     );
 
@@ -69,6 +99,11 @@ export function FlowBar() {
       unlistens.length = 0;
     };
   }, []);
+
+  useEffect(() => {
+    const preview = transcriptRef.current;
+    if (preview) preview.scrollLeft = preview.scrollWidth;
+  }, [transcript]);
 
   // Waveform canvas rendering loop — only runs during the "recording" state.
   useEffect(() => {
@@ -151,6 +186,12 @@ export function FlowBar() {
 
   return (
     <div className="flow-bar-root">
+      {transcript ? (
+        <div className="flow-bar-transcript-preview" aria-live="polite">
+          <span ref={transcriptRef}>{transcript}</span>
+        </div>
+      ) : null}
+
       {/* Pill is ALWAYS mounted — when state goes idle we fade the
           opacity to 0 (see CSS) instead of removing it from the DOM.
           Inner content keeps its last frame rendered during the fade

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -4905,11 +4905,36 @@ body[data-clips-route="recording-pill"] #root {
   position: fixed;
   inset: var(--overlay-shadow-gutter);
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: flex-end;
+  gap: 6px;
   padding-bottom: 8px;
   background: transparent;
   pointer-events: none;
+}
+
+.flow-bar-transcript-preview {
+  max-width: 280px;
+  padding: 5px 10px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  background: rgba(18, 18, 20, 0.92);
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 16px;
+  text-align: center;
+  white-space: nowrap;
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+}
+
+.flow-bar-transcript-preview span {
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .flow-bar {

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -4915,7 +4915,8 @@ body[data-clips-route="recording-pill"] #root {
 }
 
 .flow-bar-transcript-preview {
-  max-width: 280px;
+  max-width: 560px;
+  max-height: 90px;
   padding: 5px 10px;
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.06);
@@ -4924,17 +4925,11 @@ body[data-clips-route="recording-pill"] #root {
   color: rgba(255, 255, 255, 0.9);
   font-size: 12px;
   font-weight: 500;
-  line-height: 16px;
+  line-height: 18px;
   text-align: center;
-  white-space: nowrap;
+  word-break: break-word;
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
-}
-
-.flow-bar-transcript-preview span {
-  display: block;
-  overflow: hidden;
-  white-space: nowrap;
 }
 
 .flow-bar {


### PR DESCRIPTION
- Shows live transcript text above the Clips desktop dictation pill so users can confirm what is being recognized while they speak.
- Keeps the newest words visible during longer dictations instead of cutting off the latest text.