### PR TITLE
Clips audio clipping when using external USB microphones in fullscreen

### DIFF
--- a/templates/clips/desktop/src-tauri/src/native_screen/custom_capture.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen/custom_capture.rs
@@ -2465,8 +2465,15 @@ impl LiveAudioMixer {
     }
 
     /// Emit mixed sample buffers covering `out_pos..safe_end` in
-    /// `MIX_CHUNK_FRAMES` chunks: sum system + mic per frame, clamp, wrap as
-    /// LPCM `CMSampleBuffer`s with contiguous PTS.
+    /// `MIX_CHUNK_FRAMES` chunks: average system + mic per frame, clamp, wrap
+    /// as LPCM `CMSampleBuffer`s with contiguous PTS.
+    ///
+    /// Each source is weighted at 0.5 before summing so that two full-scale
+    /// signals (which occurs when a USB audio interface with software monitoring
+    /// routes the mic back through system audio) can never exceed ±1.0 and
+    /// hard-clip. The standard SCK pipeline applies the same 0.5×L + 0.5×R
+    /// pan-downmix for the same reason; loudnorm restores the target loudness
+    /// in post-processing.
     fn drain_ready(
         &mut self,
         flush: bool,
@@ -2488,8 +2495,8 @@ impl LiveAudioMixer {
                 let frame = a + f as i64;
                 let (sl, sr) = self.system.sample_at(frame);
                 let (ml, mr) = self.mic.sample_at(frame);
-                interleaved[f * 2] = (sl + ml).clamp(-1.0, 1.0);
-                interleaved[f * 2 + 1] = (sr + mr).clamp(-1.0, 1.0);
+                interleaved[f * 2] = (sl * 0.5 + ml * 0.5).clamp(-1.0, 1.0);
+                interleaved[f * 2 + 1] = (sr * 0.5 + mr * 0.5).clamp(-1.0, 1.0);
             }
             emitted.push(self.build_sample_buffer(&interleaved, a)?);
             a = b;


### PR DESCRIPTION
Users with external USB audio interfaces (like the Native Instruments Komplete Audio 2) were getting audio that sounded extremely loud, distorted, and impossible to understand in fullscreen recordings.

## What was happening

When you use an external USB audio interface with software monitoring turned on, macOS routes the microphone signal through the system audio stream. This means Clips was picking up the microphone twice — once from the mic input, and once from the system audio — and adding them together. That doubled signal went way over the maximum audio level and got hard-clipped, causing the distorted sound.

This didn't happen with the built-in Mac microphone because macOS excludes it from the system audio stream automatically.

## What changed

Instead of adding the two audio sources together at full volume, each source is now mixed at half volume before combining. This matches how the standard (non-fullscreen) recording path already handles mixing, and the loudness normalization step that runs after recording brings the final level back up to the right target. Two full-scale signals can no longer exceed the ceiling.
