### PR TITLE
Fix Builder Connect in Fusion previews

### DIFF
--- a/.changeset/quiet-cats-connect.md
+++ b/.changeset/quiet-cats-connect.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Route Builder Connect attempts from Fusion preview hosts through the stable Assets settings flow.

--- a/packages/core/src/server/builder-browser.spec.ts
+++ b/packages/core/src/server/builder-browser.spec.ts
@@ -17,6 +17,7 @@ import {
   getBuilderBrowserConnectUrl,
   getBuilderBrowserConnectUrlForOwner,
   getBuilderBrowserOriginForEvent,
+  getBuilderPreviewConnectFallbackUrl,
   getBuilderBrowserStatusForEvent,
   isBuilderBranchingEnabled,
   resolveBuilderCallbackReturnUrl,
@@ -28,6 +29,34 @@ import {
   verifyBuilderCallbackStateAndGetOwner,
   verifyBuilderConnectTokenAndGetOwner,
 } from "./builder-browser.js";
+
+describe("Builder preview connect fallback", () => {
+  it.each([
+    "https://builderio.xyz",
+    "https://preview.builderio.xyz",
+    "https://preview.builderio.dev",
+    "https://preview.builder.codes",
+    "https://PREVIEW.BUILDER.CODES",
+    "https://preview.builder.codes:443",
+    "https://preview.builder.my",
+  ])("routes Fusion preview origin %s through Assets", (origin) => {
+    expect(getBuilderPreviewConnectFallbackUrl(origin)).toBe(
+      "https://assets.agent-native.com/settings",
+    );
+  });
+
+  it.each([
+    "https://builder.io",
+    "https://agent-workspace.builder.io",
+    "https://assets.agent-native.com",
+    "http://preview.builderio.xyz",
+    "http://localhost:8080",
+    "https://builderio.xyz.attacker.example",
+    "https://preview.builderio.xyz/path",
+  ])("leaves non-Fusion origin %s unchanged", (origin) => {
+    expect(getBuilderPreviewConnectFallbackUrl(origin)).toBeNull();
+  });
+});
 
 function createBuilderBrowserEvent(headers: Record<string, string>): H3Event {
   const requestHeaders = new Headers(headers);
@@ -500,6 +529,26 @@ describe("Builder callback CSRF state", () => {
       expect(getBuilderBrowserStatusForEvent(event).connectUrl).toBe(
         "https://940ebc5a83164aa6a37dde445e494f3a-fluid-crack-ctnhvsyb.builderio.xyz/dispatch/_agent-native/builder/connect",
       );
+      expect(
+        getBuilderPreviewConnectFallbackUrl(
+          getBuilderBrowserOriginForEvent(event),
+        ),
+      ).toBe("https://assets.agent-native.com/settings");
+    });
+
+    it("classifies a direct Fusion preview request for the Assets fallback", () => {
+      process.env.NODE_ENV = "production";
+
+      const event = createBuilderBrowserEvent({
+        "x-forwarded-host": "preview.builder.codes",
+        "x-forwarded-proto": "https",
+      });
+
+      expect(
+        getBuilderPreviewConnectFallbackUrl(
+          getBuilderBrowserOriginForEvent(event),
+        ),
+      ).toBe("https://assets.agent-native.com/settings");
     });
 
     it("returns users to the preview opener after a gateway callback", () => {

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -28,6 +28,15 @@ export const BUILDER_RELAY_TARGET_ORIGINS_ENV =
 export const BUILDER_RELAY_TIMESTAMP_HEADER = "x-agent-native-relay-timestamp";
 export const BUILDER_RELAY_FLOW_HEADER = "x-agent-native-relay-flow";
 export const BUILDER_RELAY_SIGNATURE_HEADER = "x-agent-native-relay-signature";
+export const BUILDER_PREVIEW_CONNECT_FALLBACK_URL =
+  "https://assets.agent-native.com/settings";
+
+const BUILDER_PREVIEW_CONNECT_FALLBACK_DOMAINS = [
+  "builderio.xyz",
+  "builderio.dev",
+  "builder.codes",
+  "builder.my",
+] as const;
 
 const BUILDER_RELAY_PURPOSE = "builder-preview-callback-relay";
 const BUILDER_RELAY_STATE_VERSION = 1;
@@ -61,6 +70,37 @@ export interface BuilderRelayCredentials {
 export interface BuilderRelayRequestBody {
   relayState: string;
   credentials: BuilderRelayCredentials;
+}
+
+/**
+ * Fusion preview hosts cannot currently complete Builder's cli-auth callback.
+ * Send only those connect attempts through the stable Assets deployment until
+ * the standard Builder OAuth flow replaces this compatibility path.
+ */
+export function getBuilderPreviewConnectFallbackUrl(
+  origin: string | null | undefined,
+): string | null {
+  if (!origin) return null;
+  try {
+    const url = new URL(origin);
+    if (
+      url.protocol !== "https:" ||
+      url.username ||
+      url.password ||
+      url.pathname !== "/" ||
+      url.search ||
+      url.hash
+    ) {
+      return null;
+    }
+    const hostname = url.hostname.toLowerCase();
+    const isFusionPreview = BUILDER_PREVIEW_CONNECT_FALLBACK_DOMAINS.some(
+      (domain) => hostname === domain || hostname.endsWith(`.${domain}`),
+    );
+    return isFusionPreview ? BUILDER_PREVIEW_CONNECT_FALLBACK_URL : null;
+  } catch {
+    return null;
+  }
 }
 
 function builderRelaySecret(): string {

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -124,6 +124,7 @@ import {
   getBuilderConnectTrackingParams,
   getBuilderCliAuthCallbackOriginForEvent,
   getBuilderBrowserOriginForEvent,
+  getBuilderPreviewConnectFallbackUrl,
   resolveBuilderCallbackReturnUrl,
   getBuilderBrowserStatusForEvent,
   resolveBuilderBranchProjectId,
@@ -1655,6 +1656,9 @@ export function createCoreRoutesPlugin(
             ...status,
             connectUrl: appendBuilderConnectToken(status.connectUrl, userEmail),
           } as T & { cliAuthUrl?: string };
+          if (getBuilderPreviewConnectFallbackUrl(previewOrigin)) {
+            return statusWithConnectToken;
+          }
           // Direct cli-auth only works when the callback lands on the same
           // deployment that minted the signed state. Builder/Fusion previews
           // often need a gateway callback origin; in that case use the
@@ -2031,6 +2035,13 @@ export function createCoreRoutesPlugin(
             /\/+$/,
             "",
           );
+          const fallbackUrl =
+            getBuilderPreviewConnectFallbackUrl(previewOrigin);
+          if (fallbackUrl) {
+            setResponseStatus(event, 302);
+            setResponseHeader(event, "Location", fallbackUrl);
+            return "";
+          }
           const callbackOrigin = getBuilderCliAuthCallbackOriginForEvent(
             event,
           ).replace(/\/+$/, "");


### PR DESCRIPTION
## Why

[PR #2130](https://github.com/BuilderIO/agent-native/pull/2130) added a callback relay so isolated Netlify previews could connect to Builder and store credentials in the preview database that started the flow.

Builder connection handling lives in shared Core code, so Fusion inherited that relay automatically. Fusion uses different Builder-controlled preview domains, where the relay cannot currently complete Connect or Reconnect. Existing hosted Agent Native connections continue to work.

## What changes

- Recognize only HTTPS origins on `builderio.xyz`, `builderio.dev`, `builder.codes`, and `builder.my`, including their subdomains.
- After the existing owner and signed-link checks pass, redirect Connect or Reconnect from those origins to [Assets Settings](https://assets.agent-native.com/settings) before relay state, pending rows, or cookies are created.
- Suppress the direct `cliAuthUrl` for affected Fusion origins so it cannot bypass the fallback.
- Add a Core patch changeset and focused regression coverage.

## What stays unchanged

- Normal hosted templates, including Clips on `*.agent-native.com`, do not redirect.
- `*.builder.io`, `*.agent-native.com`, localhost, insecure origins, and lookalike domains keep their existing behavior.
- Existing stored credentials, connection status, and authenticated reads are untouched.
- If any template is running inside a Fusion preview domain, its Connect or Reconnect action intentionally uses the Assets fallback.

## Scope

This is a temporary, Agent Native-only mitigation. It does not roll back #2130, change Builder Internal, or replace the longer-term standard Builder OAuth work.

## Verification

- 116 focused Core tests passed
- `@agent-native/core` typecheck passed
- oxfmt and changeset checks passed
- all GitHub Actions and generated deploy previews passed
- independent auth-boundary and Builder review agents found no correctness or security issues
- Steve approved the PR

Exact end-to-end Fusion UI verification remains a post-deploy check because this unmerged commit cannot be loaded on a secure Fusion preview origin.