### PR TITLE
Fix CLI spawn tsx ENOENT by scoping source fallback to monorepo

### DIFF
--- a/.changeset/fix-cli-tsx-source-fallback.md
+++ b/.changeset/fix-cli-tsx-source-fallback.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix `npx @agent-native/core create` failing with `spawn tsx ENOENT`. The CLI launcher's tsx source fallback is now scoped to monorepo source checkouts, so installed packages always run the shipped `dist` build even when tarball extraction leaves `.ts` files newer than their compiled `.js`.

--- a/packages/core/bin/agent-native.js
+++ b/packages/core/bin/agent-native.js
@@ -5,6 +5,8 @@ import { existsSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+import { shouldUseSourceFallback } from "./launcher.js";
+
 const binDir = dirname(fileURLToPath(import.meta.url));
 const distEntry = join(binDir, "../dist/cli/index.js");
 const sourceEntry = join(binDir, "../src/cli/index.ts");
@@ -22,23 +24,33 @@ const freshnessChecks = [
 // (not a runtime dependency). Only consider the fallback in a source checkout.
 const isSourceCheckout = existsSync(join(binDir, "../tsconfig.cli.json"));
 
-function shouldUseSourceFallback() {
-  if (!isSourceCheckout) return false;
-  if (!existsSync(sourceEntry)) return false;
-  if (!existsSync(distEntry)) return true;
+function statMtimeMs(path) {
   try {
-    return freshnessChecks.some(
-      ([source, dist]) =>
-        existsSync(source) &&
-        existsSync(dist) &&
-        statSync(source).mtimeMs > statSync(dist).mtimeMs,
-    );
+    return statSync(path).mtimeMs;
   } catch {
-    return false;
+    return 0;
   }
 }
 
-if (!shouldUseSourceFallback() && existsSync(distEntry)) {
+const freshness = freshnessChecks.map(([source, dist]) => {
+  const sourceExists = existsSync(source);
+  const distExists = existsSync(dist);
+  return {
+    sourceExists,
+    distExists,
+    sourceMtimeMs: sourceExists ? statMtimeMs(source) : 0,
+    distMtimeMs: distExists ? statMtimeMs(dist) : 0,
+  };
+});
+
+const useSourceFallback = shouldUseSourceFallback({
+  isSourceCheckout,
+  sourceEntryExists: existsSync(sourceEntry),
+  distEntryExists: existsSync(distEntry),
+  freshness,
+});
+
+if (!useSourceFallback && existsSync(distEntry)) {
   await import(pathToFileURL(distEntry).href);
 } else {
   if (!existsSync(sourceEntry)) {

--- a/packages/core/bin/agent-native.js
+++ b/packages/core/bin/agent-native.js
@@ -16,7 +16,14 @@ const freshnessChecks = [
   ],
 ];
 
+// The tsx source fallback and mtime freshness check are for local monorepo
+// development only. Published installs ship both src and dist, and tarball
+// extraction can leave .ts files newer than .js, which must not trigger tsx
+// (not a runtime dependency). Only consider the fallback in a source checkout.
+const isSourceCheckout = existsSync(join(binDir, "../tsconfig.cli.json"));
+
 function shouldUseSourceFallback() {
+  if (!isSourceCheckout) return false;
   if (!existsSync(sourceEntry)) return false;
   if (!existsSync(distEntry)) return true;
   try {

--- a/packages/core/bin/agent-native.js
+++ b/packages/core/bin/agent-native.js
@@ -50,16 +50,18 @@ const useSourceFallback = shouldUseSourceFallback({
   freshness,
 });
 
-if (!useSourceFallback && existsSync(distEntry)) {
-  await import(pathToFileURL(distEntry).href);
-} else {
-  if (!existsSync(sourceEntry)) {
+if (!useSourceFallback) {
+  // Installed packages (and up-to-date checkouts) always run the shipped build.
+  // tsx is not a runtime dependency, so it must never be invoked here.
+  if (!existsSync(distEntry)) {
     console.error(
       "agent-native CLI build output is missing. Run `pnpm --filter @agent-native/core build` and try again.",
     );
     process.exit(1);
   }
 
+  await import(pathToFileURL(distEntry).href);
+} else {
   const child = spawn("tsx", [sourceEntry, ...process.argv.slice(2)], {
     stdio: "inherit",
     env: process.env,

--- a/packages/core/bin/launcher.js
+++ b/packages/core/bin/launcher.js
@@ -1,0 +1,34 @@
+// Pure decision logic for the agent-native CLI launcher shim, kept dependency
+// free so it can be unit tested without touching the filesystem.
+//
+// The tsx source fallback and mtime freshness check exist for local monorepo
+// development only. Published installs ship both src and dist, and tarball
+// extraction can leave .ts files newer than .js — that must never route to tsx
+// (not a runtime dependency), or `npx @agent-native/core ...` fails with
+// `spawn tsx ENOENT`. The `isSourceCheckout` gate is what keeps installed
+// packages on the shipped dist build.
+
+/**
+ * @param {object} input
+ * @param {boolean} input.isSourceCheckout Whether we run from a monorepo checkout.
+ * @param {boolean} input.sourceEntryExists Whether the .ts CLI entry exists.
+ * @param {boolean} input.distEntryExists Whether the compiled .js CLI entry exists.
+ * @param {Array<{sourceExists: boolean, distExists: boolean, sourceMtimeMs: number, distMtimeMs: number}>} [input.freshness]
+ * @returns {boolean}
+ */
+export function shouldUseSourceFallback({
+  isSourceCheckout,
+  sourceEntryExists,
+  distEntryExists,
+  freshness = [],
+}) {
+  if (!isSourceCheckout) return false;
+  if (!sourceEntryExists) return false;
+  if (!distEntryExists) return true;
+  return freshness.some(
+    (pair) =>
+      pair.sourceExists &&
+      pair.distExists &&
+      pair.sourceMtimeMs > pair.distMtimeMs,
+  );
+}

--- a/packages/core/src/cli/launcher.spec.ts
+++ b/packages/core/src/cli/launcher.spec.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error - plain JS shim helper without type declarations
+import { shouldUseSourceFallback } from "../../bin/launcher.js";
+
+const fresh = (over: Partial<Record<string, unknown>> = {}) => ({
+  sourceExists: true,
+  distExists: true,
+  sourceMtimeMs: 1,
+  distMtimeMs: 2,
+  ...over,
+});
+
+describe("shouldUseSourceFallback", () => {
+  it("never falls back to source in an installed package (regression guard)", () => {
+    // Installed tarballs ship both src and dist, and extraction can leave .ts
+    // newer than .js. Without the isSourceCheckout gate this returned true and
+    // spawned tsx -> `spawn tsx ENOENT`.
+    expect(
+      shouldUseSourceFallback({
+        isSourceCheckout: false,
+        sourceEntryExists: true,
+        distEntryExists: true,
+        freshness: [fresh({ sourceMtimeMs: 999, distMtimeMs: 1 })],
+      }),
+    ).toBe(false);
+  });
+
+  it("stays on dist even when dist is missing, if not a source checkout", () => {
+    expect(
+      shouldUseSourceFallback({
+        isSourceCheckout: false,
+        sourceEntryExists: true,
+        distEntryExists: false,
+        freshness: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to source when dist is missing in a source checkout", () => {
+    expect(
+      shouldUseSourceFallback({
+        isSourceCheckout: true,
+        sourceEntryExists: true,
+        distEntryExists: false,
+        freshness: [],
+      }),
+    ).toBe(true);
+  });
+
+  it("does not fall back when there is no source entry", () => {
+    expect(
+      shouldUseSourceFallback({
+        isSourceCheckout: true,
+        sourceEntryExists: false,
+        distEntryExists: false,
+        freshness: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back when a source file is newer than its dist output", () => {
+    expect(
+      shouldUseSourceFallback({
+        isSourceCheckout: true,
+        sourceEntryExists: true,
+        distEntryExists: true,
+        freshness: [fresh({ sourceMtimeMs: 10, distMtimeMs: 5 })],
+      }),
+    ).toBe(true);
+  });
+
+  it("uses dist when it is at least as fresh as source", () => {
+    expect(
+      shouldUseSourceFallback({
+        isSourceCheckout: true,
+        sourceEntryExists: true,
+        distEntryExists: true,
+        freshness: [fresh({ sourceMtimeMs: 5, distMtimeMs: 10 })],
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores freshness pairs where a side is missing", () => {
+    expect(
+      shouldUseSourceFallback({
+        isSourceCheckout: true,
+        sourceEntryExists: true,
+        distEntryExists: true,
+        freshness: [
+          fresh({ distExists: false, sourceMtimeMs: 999, distMtimeMs: 0 }),
+        ],
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
### Summary
Fixes `npx @agent-native/core create` failing with `spawn tsx ENOENT` by scoping the CLI launcher's source fallback so it only triggers in monorepo source checkouts.

### Problem
When installed via `npx @agent-native/core create`, the CLI launcher's mtime freshness check compared source `.ts` files against compiled `.js` files to decide whether to fall back to running source via `tsx`. Tarball extraction during npm install can leave `.ts` files with newer mtimes than their compiled `.js` counterparts, causing the launcher to incorrectly attempt to spawn `tsx` — a dependency that isn't installed in published packages — resulting in `spawn tsx ENOENT` and a broken CLI.

### Solution
The launcher now only considers the source fallback when running from an actual monorepo source checkout (detected via presence of `tsconfig.cli.json`). Installed packages always run the shipped `dist` build regardless of file mtimes. The fallback decision logic was extracted into a testable pure function (`shouldUseSourceFallback`) in a new `launcher.js` module.

### Key Changes
- Added `packages/core/bin/launcher.js` exporting `shouldUseSourceFallback`, which takes `isSourceCheckout`, `sourceEntryExists`, `distEntryExists`, and precomputed `freshness` data instead of touching the filesystem directly.
- Updated `packages/core/bin/agent-native.js` to detect `isSourceCheckout` via `existsSync(join(binDir, "../tsconfig.cli.json"))` and to only trigger the freshness-based fallback when in a source checkout.
- Added `packages/core/src/cli/launcher.spec.ts` with unit tests covering installed-package regression, missing dist, missing source entry, and freshness comparison edge cases.
- Added a changeset documenting the patch fix.


---

<a href="https://builder.io/app/projects/8a4a0eb9ae3d486cace5/dark-particle-mjix8cma"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://8a4a0eb9ae3d486cace5-dark-particle-mjix8cma.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2302`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8a4a0eb9ae3d486cace5</projectId>-->
<!--<branchName>dark-particle-mjix8cma</branchName>-->