### PR TITLE
Fix false draft conflict banner while typing content

### DIFF
--- a/templates/content/app/components/editor/database/DatabaseView.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.tsx
@@ -4410,6 +4410,8 @@ function DatabaseItemPreview({
       }
       return;
     }
+    const previouslyExpectedVersion =
+      draftVersionsRef.current.get(documentId) ?? null;
     draftVersionsRef.current.set(documentId, draft.version);
     const controller = peekPreviewDocumentSaveController(documentId);
     if (!controller) return;
@@ -4431,8 +4433,19 @@ function DatabaseItemPreview({
           ? draft.deferredReason
           : null,
     } as const;
+    // A poll tick simply confirming a version this client's own debounced
+    // write already advanced the ref to is not an external change — it is
+    // this client's typing racing ahead of its own last round trip. Comparing
+    // that echo against the still-live `pending` would flag a conflict on
+    // almost every keystroke. Only treat the draft as having moved out from
+    // under the user when its version is newer than what this client itself
+    // last recorded.
+    const draftAdvancedExternally =
+      previouslyExpectedVersion !== null &&
+      draft.version > previouslyExpectedVersion;
     if (controllerDirty) {
       if (
+        draftAdvancedExternally &&
         previewDraftNeedsConflict({
           returnedDraft: draft,
           pending: controller.pending,

--- a/templates/content/app/components/editor/database/DatabaseView.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.tsx
@@ -4298,7 +4298,13 @@ function DatabaseItemPreview({
                 );
                 return;
               }
-              resolve(undefined);
+              resolve({
+                outcome: "saved" as const,
+                loadedUpdatedAt: result.updatedAt,
+                loadedContentWasEmpty: isEffectivelyEmptyDocumentContent(
+                  result.content,
+                ),
+              });
             },
             onError: reject,
           },

--- a/templates/content/app/components/editor/database/DatabaseView.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.tsx
@@ -4143,25 +4143,6 @@ function DatabaseItemPreview({
             draftVersionsRef.current.set(documentId, null);
           else if (result.draft) {
             draftVersionsRef.current.set(documentId, result.draft.version);
-            if (
-              previewDraftNeedsConflict({
-                returnedDraft: result.draft,
-                pending: controller.pending,
-              })
-            ) {
-              controller.notifyDraftConflict({
-                lastSaved: snapshot.lastSaved,
-                pending: {
-                  title: result.draft.title,
-                  content: result.draft.content,
-                  loadedUpdatedAt:
-                    result.draft.baseDocumentUpdatedAt ?? undefined,
-                  loadedContentWasEmpty:
-                    result.draft.loadedContentWasEmpty === 1,
-                },
-                deferredReason: "conflict",
-              });
-            }
           } else {
             // Another tab already removed the row. Treat the stale delete as
             // converged instead of retaining a version that can never match.
@@ -4186,24 +4167,6 @@ function DatabaseItemPreview({
           draftVersionsRef.current.set(documentId, result.draft.version);
         } else if (result.draft) {
           draftVersionsRef.current.set(documentId, result.draft.version);
-          if (
-            previewDraftNeedsConflict({
-              returnedDraft: result.draft,
-              pending: controller.pending,
-            })
-          ) {
-            controller.notifyDraftConflict({
-              lastSaved: snapshot.lastSaved,
-              pending: {
-                title: result.draft.title,
-                content: result.draft.content,
-                loadedUpdatedAt:
-                  result.draft.baseDocumentUpdatedAt ?? undefined,
-                loadedContentWasEmpty: result.draft.loadedContentWasEmpty === 1,
-              },
-              deferredReason: "conflict",
-            });
-          }
         } else {
           // A competing tab deleted the version we tried to update. Reset to
           // create mode and enqueue the latest pending payload once; keeping

--- a/templates/content/app/components/editor/previewDocumentSaveController.ts
+++ b/templates/content/app/components/editor/previewDocumentSaveController.ts
@@ -67,6 +67,19 @@ export interface PreviewDocumentSaveDeferred {
   conflictSnapshot?: PreviewDocumentDraftSnapshot;
 }
 
+/**
+ * A successful save can report the server's fresh `updatedAt`/emptiness back
+ * to the controller so its baseline stops looking stale. Without this, a
+ * baseline seeded as empty (a brand-new page) stays flagged empty forever, so
+ * a later poll of content the user just saved themselves gets mistaken for a
+ * non-empty body arriving externally over an empty one.
+ */
+export interface PreviewDocumentSaveSuccess {
+  outcome: "saved";
+  loadedUpdatedAt?: string;
+  loadedContentWasEmpty?: boolean;
+}
+
 export interface PreviewDocumentSaveAdapter {
   save: (
     documentId: string,
@@ -151,6 +164,18 @@ function payloadsEqual(a: PreviewDocumentPayload, b: PreviewDocumentPayload) {
   return a.title === b.title && a.content === b.content;
 }
 
+function asSaveSuccess(result: unknown): PreviewDocumentSaveSuccess | null {
+  if (
+    result &&
+    typeof result === "object" &&
+    "outcome" in result &&
+    (result as { outcome?: unknown }).outcome === "saved"
+  ) {
+    return result as PreviewDocumentSaveSuccess;
+  }
+  return null;
+}
+
 export function createPreviewDocumentSaveController(
   args: PreviewDocumentSaveAdapter & {
     /**
@@ -230,7 +255,21 @@ export function createPreviewDocumentSaveController(
           }
           return;
         }
-        lastSaved = attempted;
+        // Adopt the server's fresh metadata (if the adapter reported it) into
+        // the confirmed baseline. Otherwise `loadedUpdatedAt`/
+        // `loadedContentWasEmpty` would keep carrying whatever was true when
+        // the controller was created/last marked — e.g. "empty" for a
+        // brand-new page — forever, even after real content has been saved.
+        const success = asSaveSuccess(result);
+        lastSaved = {
+          ...attempted,
+          ...(success?.loadedUpdatedAt !== undefined
+            ? { loadedUpdatedAt: success.loadedUpdatedAt }
+            : {}),
+          ...(success?.loadedContentWasEmpty !== undefined
+            ? { loadedContentWasEmpty: success.loadedContentWasEmpty }
+            : {}),
+        };
         hasSavedLocally = true;
         deferredReason = null;
         inFlight = null;


### PR DESCRIPTION
### Summary
Fixes a bug where the "Builder content arrived while you were editing" conflict banner incorrectly appeared while a user was actively typing content or editing a title.

### Problem
The database preview editor polls for draft updates while a user is editing. This polling was mistakenly treating the client's own debounced save round-trips as external changes, triggering a spurious draft conflict notification on nearly every keystroke, even though no one else had touched the content.

### Solution
The poll-handling logic now only raises a conflict when the draft's version has actually advanced beyond what this client itself last recorded, distinguishing a genuine external update from the echo of the client's own save. Additionally, the save controller now adopts the server's fresh `updatedAt`/emptiness metadata after a successful save so its baseline doesn't stay stuck reporting "empty" for a brand-new page after real content has already been saved.

### Key Changes
- Removed the conflict check that fired immediately after issuing a create/update save request, since it could misfire on the client's own in-flight save.
- Added `draftAdvancedExternally` check in `DatabaseView.tsx` that compares the incoming draft version against the previously recorded version, only flagging a conflict when the draft version is genuinely newer.
- Introduced `PreviewDocumentSaveSuccess` type and `asSaveSuccess` helper in `previewDocumentSaveController.ts` to let save adapters report the server's fresh `loadedUpdatedAt`/`loadedContentWasEmpty` values.
- Updated the save controller's `lastSaved` baseline to merge in this fresh metadata after a successful save, preventing stale "empty" baselines from causing false positives later.


---

<a href="https://builder.io/app/projects/ed2c0a2d1a894b3b9ea9/storm-lever-etndazd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ed2c0a2d1a894b3b9ea9-storm-lever-etndazd9.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2303`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ed2c0a2d1a894b3b9ea9</projectId>-->
<!--<branchName>storm-lever-etndazd9</branchName>-->