### PR TITLE
Fix calendar sizing and mobile responsiveness

### DIFF
--- a/.changeset/calendar-responsive-cell-size.md
+++ b/.changeset/calendar-responsive-cell-size.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/toolkit": patch
+---
+
+Fix cramped calendar day grid under Tailwind v4 and make the date picker responsive: smaller cell size on mobile, 20% smaller on desktop, and a viewport-bounded popover width.

--- a/packages/toolkit/src/ui/calendar.tsx
+++ b/packages/toolkit/src/ui/calendar.tsx
@@ -27,7 +27,7 @@ function Calendar({
     <DayPicker
       showOutsideDays={showOutsideDays}
       className={cn(
-        "bg-background group/calendar p-3 [--cell-size:2rem] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
+        "bg-background group/calendar p-3 [--cell-size:1.75rem] sm:[--cell-size:2rem] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
         String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
         String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
         className,

--- a/packages/toolkit/src/ui/calendar.tsx
+++ b/packages/toolkit/src/ui/calendar.tsx
@@ -27,7 +27,7 @@ function Calendar({
     <DayPicker
       showOutsideDays={showOutsideDays}
       className={cn(
-        "bg-background group/calendar p-3 [--cell-size:1.75rem] sm:[--cell-size:2rem] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
+        "bg-background group/calendar p-3 [--cell-size:1.75rem] sm:[--cell-size:1.6rem] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
         String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
         String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
         className,

--- a/packages/toolkit/src/ui/calendar.tsx
+++ b/packages/toolkit/src/ui/calendar.tsx
@@ -51,20 +51,20 @@ function Calendar({
         ),
         button_previous: cn(
           buttonVariants({ variant: buttonVariant }),
-          "h-[--cell-size] w-[--cell-size] select-none p-0 aria-disabled:opacity-50",
+          "h-(--cell-size) w-(--cell-size) select-none p-0 aria-disabled:opacity-50",
           defaultClassNames.button_previous,
         ),
         button_next: cn(
           buttonVariants({ variant: buttonVariant }),
-          "h-[--cell-size] w-[--cell-size] select-none p-0 aria-disabled:opacity-50",
+          "h-(--cell-size) w-(--cell-size) select-none p-0 aria-disabled:opacity-50",
           defaultClassNames.button_next,
         ),
         month_caption: cn(
-          "flex h-[--cell-size] w-full items-center justify-center px-[--cell-size]",
+          "flex h-(--cell-size) w-full items-center justify-center px-(--cell-size)",
           defaultClassNames.month_caption,
         ),
         dropdowns: cn(
-          "flex h-[--cell-size] w-full items-center justify-center gap-1.5 text-sm font-medium",
+          "flex h-(--cell-size) w-full items-center justify-center gap-1.5 text-sm font-medium",
           defaultClassNames.dropdowns,
         ),
         dropdown_root: cn(
@@ -90,7 +90,7 @@ function Calendar({
         ),
         week: cn("mt-2 flex w-full", defaultClassNames.week),
         week_number_header: cn(
-          "w-[--cell-size] select-none",
+          "w-(--cell-size) select-none",
           defaultClassNames.week_number_header,
         ),
         week_number: cn(
@@ -160,7 +160,7 @@ function Calendar({
         WeekNumber: ({ children, ...props }) => {
           return (
             <td {...props}>
-              <div className="flex size-[--cell-size] items-center justify-center text-center">
+              <div className="flex size-(--cell-size) items-center justify-center text-center">
                 {children}
               </div>
             </td>
@@ -202,7 +202,7 @@ function CalendarDayButton({
       data-range-end={modifiers.range_end}
       data-range-middle={modifiers.range_middle}
       className={cn(
-        "data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-ring/50 flex aspect-square h-auto w-full min-w-[--cell-size] flex-col gap-1 font-normal leading-none data-[range-end=true]:rounded-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:ring-[3px] [&>span]:text-xs [&>span]:opacity-70",
+        "data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-ring/50 flex aspect-square h-auto w-full min-w-(--cell-size) flex-col gap-1 font-normal leading-none data-[range-end=true]:rounded-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:ring-[3px] [&>span]:text-xs [&>span]:opacity-70",
         defaultClassNames.day,
         className,
       )}

--- a/packages/toolkit/src/ui/date-picker.tsx
+++ b/packages/toolkit/src/ui/date-picker.tsx
@@ -45,7 +45,10 @@ export function DatePicker({
           )}
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-auto p-0" align="start">
+      <PopoverContent
+        className="w-auto max-w-[calc(100vw-2rem)] p-0"
+        align="start"
+      >
         <Calendar
           mode="single"
           selected={validDate}


### PR DESCRIPTION
### Summary
Fixes calendar date cell sizing and makes the date picker popover responsive on mobile screens.

## Before:
<img width="1290" height="1024" alt="image" src="https://github.com/user-attachments/assets/a9262298-c4ef-4ae0-8128-e9b9e7a5819c" />


## After
<img width="1548" height="1090" alt="image" src="https://github.com/user-attachments/assets/b49b4810-6575-4541-8e83-d1a9bb198d11" />


### Problem
The calendar dates in the date picker weren't well styled/formatted, and the calendar was too large on mobile devices, causing it to overflow or look poorly fitted on smaller screens.

### Solution
Updated the `--cell-size` CSS variable to use smaller, responsive values and switched from bracket syntax `[--cell-size]` to the parenthesis syntax `(--cell-size)` for Tailwind arbitrary value references. Also constrained the popover content's max width to fit within the viewport on smaller screens.

### Key Changes
- `calendar.tsx`: Reduced `--cell-size` from `2rem` to `1.75rem` (with `sm:1.6rem` for larger screens), and replaced all `h-[--cell-size]`, `w-[--cell-size]`, `size-[--cell-size]`, `min-w-[--cell-size]`, and `px-[--cell-size]` usages with the `(--cell-size)` syntax for consistency
- `date-picker.tsx`: Added `max-w-[calc(100vw-2rem)]` to the `PopoverContent` to prevent the calendar from overflowing the viewport on mobile


---

<a href="https://builder.io/app/projects/ae8cb7b8045d4c21b2a343e11036d454/scout-boundary-rhsulakr"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ae8cb7b8045d4c21b2a343e11036d454-scout-boundary-rhsulakr.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2307`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ae8cb7b8045d4c21b2a343e11036d454</projectId>-->
<!--<branchName>scout-boundary-rhsulakr</branchName>-->