### PR TITLE
more figma parity based on rules

### DIFF
--- a/templates/design/.generated/bridge/editor-chrome.generated.ts
+++ b/templates/design/.generated/bridge/editor-chrome.generated.ts
@@ -23,6 +23,13 @@ export const editorChromeBridgeScript: string = `"use strict";
         return false;
       }
     })();
+    var selectedLayerDragPriorityEnabled = (function() {
+      try {
+        return !!__SELECTED_LAYER_DRAG_PRIORITY__;
+      } catch (_e) {
+        return false;
+      }
+    })();
     var scaleToolEnabled = false;
     function dndLog(phase, data) {
       if (!window.__DND_DEBUG) return;
@@ -1596,6 +1603,7 @@ export const editorChromeBridgeScript: string = `"use strict";
       clearComponentTag();
     }
     var selectedEl = null;
+    var selectionChromeHidden = false;
     var hoveredEl = null;
     var highlightOverlayStyle = "default";
     var activeNodeHtmlPreview = null;
@@ -2773,7 +2781,11 @@ export const editorChromeBridgeScript: string = `"use strict";
           hideSelectionOverlay();
         }
       } else if (selectedEl) {
-        positionOverlay(selectionOverlay, selectedEl);
+        if (selectionChromeHidden) {
+          hideSelectionOverlay();
+        } else {
+          positionOverlay(selectionOverlay, selectedEl);
+        }
       } else {
         hideParentAutoLayoutOverlay();
       }
@@ -3507,29 +3519,27 @@ export const editorChromeBridgeScript: string = `"use strict";
       document.addEventListener(events.move, onMove, true);
       document.addEventListener(events.up, onUp, true);
     }
-    function openContextMenuAtEvent(e) {
-      stopNativeInteraction(e);
-      blurActiveTextEditor();
+    function collectLayerHitCandidates(clientX, clientY) {
       var shieldPointerEvents = shieldOverlay.style.pointerEvents;
       var selectionPointerEvents = selectionOverlay.style.pointerEvents;
       var highlightPointerEvents = highlightOverlay.style.pointerEvents;
       shieldOverlay.style.pointerEvents = "none";
       selectionOverlay.style.pointerEvents = "none";
       highlightOverlay.style.pointerEvents = "none";
-      var pointTargets = document.elementsFromPoint ? document.elementsFromPoint(e.clientX, e.clientY) : [document.elementFromPoint(e.clientX, e.clientY)];
+      var pointTargets = document.elementsFromPoint ? document.elementsFromPoint(clientX, clientY) : [document.elementFromPoint(clientX, clientY)];
       shieldOverlay.style.pointerEvents = shieldPointerEvents;
       selectionOverlay.style.pointerEvents = selectionPointerEvents;
       highlightOverlay.style.pointerEvents = highlightPointerEvents;
-      var candidateElements = [];
+      var elements = [];
       var layerCandidates = [];
       pointTargets.forEach(function(pointTarget) {
         if (!pointTarget || pointTarget.nodeType !== 1) return;
         if (isOverlayElement(pointTarget)) return;
         var candidate = selectionTargetForHit(pointTarget);
-        if (!candidate || isDocumentRootElement(candidate) || isOverlayElement(candidate) || isLayerInteractionBlocked(candidate) || isTemplateCloneElement(candidate) || candidateElements.indexOf(candidate) !== -1) {
+        if (!candidate || isDocumentRootElement(candidate) || isOverlayElement(candidate) || isLayerInteractionBlocked(candidate) || isTemplateCloneElement(candidate) || elements.indexOf(candidate) !== -1) {
           return;
         }
-        candidateElements.push(candidate);
+        elements.push(candidate);
         var candidateInfo = getElementInfo(candidate);
         var explicitLabel = candidate.getAttribute && candidate.getAttribute("data-agent-native-layer-name") || "";
         var textLabel = (candidate.textContent || "").trim().replace(/\\s+/g, " ");
@@ -3541,6 +3551,30 @@ export const editorChromeBridgeScript: string = `"use strict";
           info: candidateInfo
         });
       });
+      return { elements, layerCandidates };
+    }
+    function stackCycleTarget(clientX, clientY, currentEl) {
+      if (!currentEl) return null;
+      var stack = collectLayerHitCandidates(clientX, clientY);
+      var currentIdx = stack.elements.indexOf(currentEl);
+      if (currentIdx === -1) return null;
+      var keys = stack.layerCandidates.map(function(candidate) {
+        return candidate.key;
+      });
+      var nextKey = nextStackCandidate(
+        keys,
+        stack.layerCandidates[currentIdx].key
+      );
+      if (nextKey === null) return null;
+      var nextEl = stack.elements[keys.indexOf(nextKey)];
+      return nextEl && !isLayerInteractionBlocked(nextEl) ? nextEl : null;
+    }
+    function openContextMenuAtEvent(e) {
+      stopNativeInteraction(e);
+      blurActiveTextEditor();
+      var collected = collectLayerHitCandidates(e.clientX, e.clientY);
+      var candidateElements = collected.elements;
+      var layerCandidates = collected.layerCandidates;
       var target = candidateElements[0] || null;
       var info = null;
       if (target) {
@@ -6238,7 +6272,8 @@ export const editorChromeBridgeScript: string = `"use strict";
             height: dragElStartHeight
           },
           snapCandidateRects,
-          SNAP_THRESHOLD_PX
+          // Convert the screen-space base to content px (1/zoom).
+          SNAP_THRESHOLD_PX * chromeLineScale()
         ) : { dx: 0, dy: 0, guideV: null, guideH: null };
         nextLeft += snapResult.dx;
         nextTop += snapResult.dy;
@@ -6726,6 +6761,29 @@ export const editorChromeBridgeScript: string = `"use strict";
       }
       pendingShieldDrag = null;
     }
+    function dragTargetForPointerDown(args) {
+      var selectedEl2 = args.selectedEl;
+      var hitEl = args.hitEl;
+      var hitRaw = args.hitRaw || hitEl;
+      var selectedAlive = !!args.selectedAlive;
+      if (selectedEl2 && selectedAlive && selectedEl2.contains && selectedEl2.contains(hitRaw)) {
+        return selectedEl2;
+      }
+      if (args.preferSelected && selectedEl2 && selectedAlive) {
+        var r = args.selectedRect;
+        var p = args.point;
+        if (r && p && r.width > 0 && r.height > 0 && p.x >= r.left && p.x <= r.right && p.y >= r.top && p.y <= r.bottom) {
+          return selectedEl2;
+        }
+      }
+      return hitEl;
+    }
+    function nextStackCandidate(candidateKeys, currentKey) {
+      if (!candidateKeys || candidateKeys.length === 0) return null;
+      var idx = candidateKeys.indexOf(currentKey);
+      if (idx === -1) return null;
+      return candidateKeys[(idx + 1) % candidateKeys.length];
+    }
     function beginPotentialShieldDrag(e) {
       stopNativeInteraction(e);
       if (e.button !== 0) return;
@@ -6737,7 +6795,17 @@ export const editorChromeBridgeScript: string = `"use strict";
         beginMarqueeSelection(e);
         return;
       }
-      var dragTarget = selectedEl && document.documentElement.contains(selectedEl) && selectedEl.contains(hit) ? selectedEl : hitTarget;
+      var selectedAlive = !!selectedEl && document.documentElement.contains(selectedEl);
+      var selectedRect = selectedAlive && selectedEl.getBoundingClientRect ? selectedEl.getBoundingClientRect() : null;
+      var dragTarget = dragTargetForPointerDown({
+        selectedEl,
+        selectedAlive,
+        selectedRect,
+        hitEl: hitTarget,
+        hitRaw: hit,
+        point: { x: e.clientX, y: e.clientY },
+        preferSelected: selectedLayerDragPriorityEnabled
+      });
       var clickTarget = hitTarget;
       if (!dragTarget || dragTarget === document.body || dragTarget === document.documentElement || isLayerInteractionBlocked(dragTarget)) {
         return;
@@ -6793,7 +6861,12 @@ export const editorChromeBridgeScript: string = `"use strict";
           postCrossScreenDrag("cancel");
         }
         if (ev) stopNativeInteraction(ev);
-        selectTarget(clickTarget || dragTarget, ev);
+        var cycledEl = !readOnly && (e.metaKey || e.ctrlKey) && !e.shiftKey ? stackCycleTarget(e.clientX, e.clientY, selectedEl) : null;
+        if (cycledEl) {
+          selectTarget(cycledEl);
+        } else {
+          selectTarget(clickTarget || dragTarget, ev);
+        }
         suppressNextShieldClickBriefly();
       }
       clearPendingShieldDrag();
@@ -7876,6 +7949,17 @@ export const editorChromeBridgeScript: string = `"use strict";
         );
         return;
       }
+      if (e.data.type === "set-selection-chrome-hidden") {
+        selectionChromeHidden = !!e.data.hidden;
+        if (selectionChromeHidden) {
+          hideSelectionOverlay();
+        } else if (selectedEl) {
+          positionOverlay(selectionOverlay, selectedEl);
+          updateParentAutoLayoutOverlay(selectedEl);
+          refreshOverlays();
+        }
+        return;
+      }
       if (e.data.type === "select-element") {
         var candidates = [];
         if (Array.isArray(e.data.selectorCandidates)) {
@@ -7908,7 +7992,11 @@ export const editorChromeBridgeScript: string = `"use strict";
           hoveredSpacingHandleKey = "";
         }
         selectedEl = target;
-        positionOverlay(selectionOverlay, target);
+        if (selectionChromeHidden) {
+          hideSelectionOverlay();
+        } else {
+          positionOverlay(selectionOverlay, target);
+        }
         if (hoveredEl === selectedEl) highlightOverlay.style.display = "none";
         if (selectionChangedByHost) {
           postElementSelect(target);

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -315,6 +315,15 @@ ${editorChromeBridgeScript}
  */
 const LIVE_REFLOW_ENABLED = true;
 
+/**
+ * Rollout gate: when on, a pointerdown inside the current selection's box keeps
+ * the selected element as the drag target even when an overlapping
+ * non-descendant sibling wins the hit test. Baked into the bridge as
+ * `__SELECTED_LAYER_DRAG_PRIORITY__`; flip to `false` for descendant-only
+ * behavior.
+ */
+const SELECTED_LAYER_DRAG_PRIORITY_ENABLED = true;
+
 interface DesignCanvasProps {
   content: string;
   contentKey?: string;
@@ -948,6 +957,10 @@ function buildEditorChromeBridgeScript(args: {
       .replace(
         "__LIVE_REFLOW_ENABLED__",
         LIVE_REFLOW_ENABLED ? "true" : "false",
+      )
+      .replace(
+        "__SELECTED_LAYER_DRAG_PRIORITY__",
+        SELECTED_LAYER_DRAG_PRIORITY_ENABLED ? "true" : "false",
       )
   );
 }
@@ -2130,6 +2143,10 @@ export function DesignCanvas({
           .replace(
             "__LIVE_REFLOW_ENABLED__",
             LIVE_REFLOW_ENABLED ? "true" : "false",
+          )
+          .replace(
+            "__SELECTED_LAYER_DRAG_PRIORITY__",
+            SELECTED_LAYER_DRAG_PRIORITY_ENABLED ? "true" : "false",
           );
     // ALWAYS injected (like the other always-on bridges above) so
     // MultiScreenCanvas's cross-screen drag hit-testing

--- a/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
+++ b/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
@@ -35,6 +35,7 @@ declare var __DESIGN_CANVAS_CONTENT_OFFSET_X__: number;
 declare var __DESIGN_CANVAS_CONTENT_OFFSET_Y__: number;
 declare var __RUNTIME_LAYER_SNAPSHOT_ENABLED__: boolean;
 declare var __LIVE_REFLOW_ENABLED__: boolean;
+declare var __SELECTED_LAYER_DRAG_PRIORITY__: boolean;
 
 (function () {
   // Idempotency guard: replace-document-content / srcdoc rebuilds can end up
@@ -74,6 +75,16 @@ declare var __LIVE_REFLOW_ENABLED__: boolean;
   var liveReflowEnabled = (function () {
     try {
       return !!__LIVE_REFLOW_ENABLED__;
+    } catch (_e) {
+      return false;
+    }
+  })();
+  // Selected-layer drag priority: when on, a pointerdown inside the selection
+  // box keeps the selected element as the drag target even when an overlapping
+  // non-descendant sibling wins the hit test.
+  var selectedLayerDragPriorityEnabled = (function () {
+    try {
+      return !!__SELECTED_LAYER_DRAG_PRIORITY__;
     } catch (_e) {
       return false;
     }
@@ -2248,6 +2259,9 @@ declare var __LIVE_REFLOW_ENABLED__: boolean;
   }
 
   var selectedEl: Element | null = null;
+  // When true, selection chrome stays hidden through async reflows so a
+  // keyboard-nudge burst does not flicker; selection itself is unchanged.
+  var selectionChromeHidden = false;
   var hoveredEl: Element | null = null;
   var highlightOverlayStyle: "default" | "soft" = "default";
   type NodeHtmlPreviewSession = {
@@ -4080,7 +4094,11 @@ declare var __LIVE_REFLOW_ENABLED__: boolean;
         hideSelectionOverlay();
       }
     } else if (selectedEl) {
-      positionOverlay(selectionOverlay, selectedEl);
+      if (selectionChromeHidden) {
+        hideSelectionOverlay();
+      } else {
+        positionOverlay(selectionOverlay, selectedEl);
+      }
     } else {
       hideParentAutoLayoutOverlay();
     }
@@ -5103,9 +5121,17 @@ declare var __LIVE_REFLOW_ENABLED__: boolean;
     document.addEventListener(events.up, onUp, true);
   }
 
-  function openContextMenuAtEvent(e) {
-    stopNativeInteraction(e);
-    blurActiveTextEditor();
+  // Returns the full z-stack of selectable layers under a point (topmost
+  // first), each element index-aligned with a { key, label, info } descriptor.
+  // Overlays are briefly made pointer-transparent so elementsFromPoint sees
+  // through the editor chrome.
+  function collectLayerHitCandidates(
+    clientX: number,
+    clientY: number,
+  ): {
+    elements: Element[];
+    layerCandidates: Array<{ key: string; label: string; info: unknown }>;
+  } {
     var shieldPointerEvents = shieldOverlay.style.pointerEvents;
     var selectionPointerEvents = selectionOverlay.style.pointerEvents;
     var highlightPointerEvents = highlightOverlay.style.pointerEvents;
@@ -5113,13 +5139,13 @@ declare var __LIVE_REFLOW_ENABLED__: boolean;
     selectionOverlay.style.pointerEvents = "none";
     highlightOverlay.style.pointerEvents = "none";
     var pointTargets = document.elementsFromPoint
-      ? document.elementsFromPoint(e.clientX, e.clientY)
-      : [document.elementFromPoint(e.clientX, e.clientY)];
+      ? document.elementsFromPoint(clientX, clientY)
+      : [document.elementFromPoint(clientX, clientY)];
     shieldOverlay.style.pointerEvents = shieldPointerEvents;
     selectionOverlay.style.pointerEvents = selectionPointerEvents;
     highlightOverlay.style.pointerEvents = highlightPointerEvents;
 
-    var candidateElements: Element[] = [];
+    var elements: Element[] = [];
     var layerCandidates: Array<{
       key: string;
       label: string;
@@ -5135,11 +5161,11 @@ declare var __LIVE_REFLOW_ENABLED__: boolean;
         isOverlayElement(candidate) ||
         isLayerInteractionBlocked(candidate) ||
         isTemplateCloneElement(candidate) ||
-        candidateElements.indexOf(candidate) !== -1
+        elements.indexOf(candidate) !== -1
       ) {
         return;
       }
-      candidateElements.push(candidate);
+      elements.push(candidate);
       var candidateInfo = getElementInfo(candidate);
       var explicitLabel =
         (candidate.getAttribute &&
@@ -5162,6 +5188,39 @@ declare var __LIVE_REFLOW_ENABLED__: boolean;
         info: candidateInfo,
       });
     });
+    return { elements: elements, layerCandidates: layerCandidates };
+  }
+
+  // Given a point and the current selection, return the next layer BELOW it in
+  // the hit stack (wrapping at the bottom), or null when the selection is not
+  // in the stack or the next layer is blocked. Backs Cmd/Ctrl+click deep-select.
+  function stackCycleTarget(
+    clientX: number,
+    clientY: number,
+    currentEl: Element | null,
+  ): Element | null {
+    if (!currentEl) return null;
+    var stack = collectLayerHitCandidates(clientX, clientY);
+    var currentIdx = stack.elements.indexOf(currentEl);
+    if (currentIdx === -1) return null;
+    var keys = stack.layerCandidates.map(function (candidate) {
+      return candidate.key;
+    });
+    var nextKey = nextStackCandidate(
+      keys,
+      stack.layerCandidates[currentIdx].key,
+    );
+    if (nextKey === null) return null;
+    var nextEl = stack.elements[keys.indexOf(nextKey)];
+    return nextEl && !isLayerInteractionBlocked(nextEl) ? nextEl : null;
+  }
+
+  function openContextMenuAtEvent(e) {
+    stopNativeInteraction(e);
+    blurActiveTextEditor();
+    var collected = collectLayerHitCandidates(e.clientX, e.clientY);
+    var candidateElements = collected.elements;
+    var layerCandidates = collected.layerCandidates;
 
     var target = candidateElements[0] || null;
     var info = null;
@@ -8227,10 +8286,9 @@ declare var __LIVE_REFLOW_ENABLED__: boolean;
   // Minimal, dependency-free port of the overview canvas's edge/center snap
   // routine (shared/canvas-math.ts computeMoveSnap) for in-iframe element
   // dragging. The bridge's pointer coordinates and getBoundingClientRect()
-  // values are already in the same iframe-local, zoom-normalized coordinate
-  // space (the host CSS-scales the whole iframe, not individual elements),
-  // so — unlike the overview canvas, which divides a screen-px threshold by
-  // its own camera zoom — no extra scale correction is needed here.
+  // values are iframe-local content px, so SNAP_THRESHOLD_PX is a screen-space
+  // base converted to content px at snap time via chromeLineScale (1/zoom) to
+  // keep the snap tolerance constant on screen at any zoom.
   var SNAP_THRESHOLD_PX = 6;
   var SNAP_CANDIDATE_CAP = 200;
 
@@ -9321,7 +9379,8 @@ declare var __LIVE_REFLOW_ENABLED__: boolean;
                 height: dragElStartHeight,
               },
               snapCandidateRects,
-              SNAP_THRESHOLD_PX,
+              // Convert the screen-space base to content px (1/zoom).
+              SNAP_THRESHOLD_PX * chromeLineScale(),
             )
           : { dx: 0, dy: 0, guideV: null, guideH: null };
       nextLeft += snapResult.dx;
@@ -9970,6 +10029,53 @@ declare var __LIVE_REFLOW_ENABLED__: boolean;
     pendingShieldDrag = null;
   }
 
+  // Decides the drag target for a pointerdown. Descendant hits keep the
+  // selected element; with preferSelected on, a point inside the selection box
+  // also keeps it over an overlapping non-descendant sibling. Falls through to
+  // hitEl when the selection is detached or zero-area. Pure and self-contained
+  // so the snap test can brace-extract and evaluate it in isolation.
+  function dragTargetForPointerDown(args) {
+    var selectedEl = args.selectedEl;
+    var hitEl = args.hitEl;
+    var hitRaw = args.hitRaw || hitEl;
+    var selectedAlive = !!args.selectedAlive;
+    if (
+      selectedEl &&
+      selectedAlive &&
+      selectedEl.contains &&
+      selectedEl.contains(hitRaw)
+    ) {
+      return selectedEl;
+    }
+    if (args.preferSelected && selectedEl && selectedAlive) {
+      var r = args.selectedRect;
+      var p = args.point;
+      if (
+        r &&
+        p &&
+        r.width > 0 &&
+        r.height > 0 &&
+        p.x >= r.left &&
+        p.x <= r.right &&
+        p.y >= r.top &&
+        p.y <= r.bottom
+      ) {
+        return selectedEl;
+      }
+    }
+    return hitEl;
+  }
+
+  // Given the hit-stack candidate keys (topmost first) and the current
+  // selection key, returns the next key below it, wrapping to the top. Returns
+  // null when the selection is not in the stack. Pure, for the snap test.
+  function nextStackCandidate(candidateKeys, currentKey) {
+    if (!candidateKeys || candidateKeys.length === 0) return null;
+    var idx = candidateKeys.indexOf(currentKey);
+    if (idx === -1) return null;
+    return candidateKeys[(idx + 1) % candidateKeys.length];
+  }
+
   function beginPotentialShieldDrag(e) {
     stopNativeInteraction(e);
     if (e.button !== 0) return;
@@ -9988,12 +10094,21 @@ declare var __LIVE_REFLOW_ENABLED__: boolean;
       beginMarqueeSelection(e);
       return;
     }
-    var dragTarget =
-      selectedEl &&
-      document.documentElement.contains(selectedEl) &&
-      selectedEl.contains(hit)
-        ? selectedEl
-        : hitTarget;
+    var selectedAlive =
+      !!selectedEl && document.documentElement.contains(selectedEl);
+    var selectedRect =
+      selectedAlive && selectedEl.getBoundingClientRect
+        ? selectedEl.getBoundingClientRect()
+        : null;
+    var dragTarget = dragTargetForPointerDown({
+      selectedEl: selectedEl,
+      selectedAlive: selectedAlive,
+      selectedRect: selectedRect,
+      hitEl: hitTarget,
+      hitRaw: hit,
+      point: { x: e.clientX, y: e.clientY },
+      preferSelected: selectedLayerDragPriorityEnabled,
+    });
     var clickTarget = hitTarget;
     if (
       !dragTarget ||
@@ -10073,7 +10188,21 @@ declare var __LIVE_REFLOW_ENABLED__: boolean;
         postCrossScreenDrag("cancel");
       }
       if (ev) stopNativeInteraction(ev);
-      selectTarget(clickTarget || dragTarget, ev);
+      // Cmd/Ctrl+click (no Shift) deep-selects the next layer below the current
+      // selection in the z-stack under the pointer, wrapping at the bottom.
+      // Runs here (not in selectElementAtEvent) because a shield click resolves
+      // selection in this onUp and then suppresses the click handler. Selected
+      // plain (no ev) so it replaces the selection rather than adding to it;
+      // Shift-click stays additive via the normal path below.
+      var cycledEl =
+        !readOnly && (e.metaKey || e.ctrlKey) && !e.shiftKey
+          ? stackCycleTarget(e.clientX, e.clientY, selectedEl)
+          : null;
+      if (cycledEl) {
+        selectTarget(cycledEl);
+      } else {
+        selectTarget(clickTarget || dragTarget, ev);
+      }
       suppressNextShieldClickBriefly();
     }
     clearPendingShieldDrag();
@@ -11599,6 +11728,17 @@ declare var __LIVE_REFLOW_ENABLED__: boolean;
       );
       return;
     }
+    if (e.data.type === "set-selection-chrome-hidden") {
+      selectionChromeHidden = !!e.data.hidden;
+      if (selectionChromeHidden) {
+        hideSelectionOverlay();
+      } else if (selectedEl) {
+        positionOverlay(selectionOverlay, selectedEl);
+        updateParentAutoLayoutOverlay(selectedEl);
+        refreshOverlays();
+      }
+      return;
+    }
     if (e.data.type === "select-element") {
       var candidates: string[] = [];
       if (Array.isArray(e.data.selectorCandidates)) {
@@ -11650,7 +11790,14 @@ declare var __LIVE_REFLOW_ENABLED__: boolean;
         hoveredSpacingHandleKey = "";
       }
       selectedEl = target;
-      positionOverlay(selectionOverlay, target);
+      // Respect a nudge-burst chrome-hide: the host re-sends select-element on
+      // every poll tick, and repeated nudges don't resend hidden:true (its ref
+      // stays set), so a replay must not re-show the overlay on its own.
+      if (selectionChromeHidden) {
+        hideSelectionOverlay();
+      } else {
+        positionOverlay(selectionOverlay, target);
+      }
       if (hoveredEl === selectedEl) highlightOverlay.style.display = "none";
       // A host-driven selection (e.g. picking a layer in the Layers panel)
       // only ever moved the overlay above — it never sent the rich

--- a/templates/design/app/components/design/editor-chrome-bridge.snap.test.ts
+++ b/templates/design/app/components/design/editor-chrome-bridge.snap.test.ts
@@ -114,6 +114,204 @@ function loadSnapMath(): {
 
 const { rectBounds, computeMoveSnapOffset } = loadSnapMath();
 
+// Both functions read only their arguments, so a single brace-extracted
+// declaration evaluates in isolation.
+function loadPureBridgeFn<T>(name: string): T {
+  const editorChromeBridgeScript = loadEditorChromeBridgeScript();
+  const src = extractFunction(editorChromeBridgeScript, name);
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  const factory = new Function(`${src}\nreturn ${name};`);
+  return factory() as T;
+}
+
+interface DragTargetArgs {
+  selectedEl: unknown;
+  selectedAlive: boolean;
+  selectedRect: {
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+    width: number;
+    height: number;
+  } | null;
+  hitEl: unknown;
+  hitRaw?: unknown;
+  point: { x: number; y: number } | null;
+  preferSelected: boolean;
+}
+const dragTargetForPointerDown = loadPureBridgeFn<
+  (args: DragTargetArgs) => unknown
+>("dragTargetForPointerDown");
+const nextStackCandidate =
+  loadPureBridgeFn<(keys: string[], current: string | null) => string | null>(
+    "nextStackCandidate",
+  );
+
+describe("editor-chrome bridge — dragTargetForPointerDown", () => {
+  const selRect = {
+    left: 10,
+    top: 10,
+    right: 110,
+    bottom: 60,
+    width: 100,
+    height: 50,
+  };
+
+  it("keeps the selected element when the hit is its descendant (legacy rule, flag off)", () => {
+    const hitRaw = { tag: "child" };
+    const selectedEl = { tag: "sel", contains: (x: unknown) => x === hitRaw };
+    const hitEl = { tag: "hitTarget" };
+    expect(
+      dragTargetForPointerDown({
+        selectedEl,
+        selectedAlive: true,
+        selectedRect: null,
+        hitEl,
+        hitRaw,
+        point: { x: 0, y: 0 },
+        preferSelected: false,
+      }),
+    ).toBe(selectedEl);
+  });
+
+  it("keeps the selected element when the point is inside its box over an overlapping sibling (flag on)", () => {
+    const hitRaw = { tag: "sibling-on-top" };
+    const selectedEl = { tag: "sel", contains: () => false };
+    const hitEl = hitRaw;
+    expect(
+      dragTargetForPointerDown({
+        selectedEl,
+        selectedAlive: true,
+        selectedRect: selRect,
+        hitEl,
+        hitRaw,
+        point: { x: 50, y: 30 },
+        preferSelected: true,
+      }),
+    ).toBe(selectedEl);
+  });
+
+  it("selects the overlapping top sibling when the flag is off (legacy hit wins)", () => {
+    const hitRaw = { tag: "sibling-on-top" };
+    const selectedEl = { tag: "sel", contains: () => false };
+    const hitEl = hitRaw;
+    expect(
+      dragTargetForPointerDown({
+        selectedEl,
+        selectedAlive: true,
+        selectedRect: selRect,
+        hitEl,
+        hitRaw,
+        point: { x: 50, y: 30 },
+        preferSelected: false,
+      }),
+    ).toBe(hitEl);
+  });
+
+  it("falls through to the hit when the point is outside the selected box", () => {
+    const hitRaw = { tag: "elsewhere" };
+    const selectedEl = { tag: "sel", contains: () => false };
+    const hitEl = hitRaw;
+    expect(
+      dragTargetForPointerDown({
+        selectedEl,
+        selectedAlive: true,
+        selectedRect: selRect,
+        hitEl,
+        hitRaw,
+        point: { x: 500, y: 500 },
+        preferSelected: true,
+      }),
+    ).toBe(hitEl);
+  });
+
+  it("falls through to the hit when the selected element is detached (selectedAlive false)", () => {
+    const hitRaw = { tag: "hit" };
+    const selectedEl = { tag: "sel", contains: () => true };
+    const hitEl = hitRaw;
+    expect(
+      dragTargetForPointerDown({
+        selectedEl,
+        selectedAlive: false,
+        selectedRect: selRect,
+        hitEl,
+        hitRaw,
+        point: { x: 50, y: 30 },
+        preferSelected: true,
+      }),
+    ).toBe(hitEl);
+  });
+
+  it("keeps the selected element even when the top hit is a (locked) layer — locking is the caller's concern", () => {
+    const lockedTop = { tag: "locked-top" };
+    const selectedEl = { tag: "sel", contains: () => false };
+    expect(
+      dragTargetForPointerDown({
+        selectedEl,
+        selectedAlive: true,
+        selectedRect: selRect,
+        hitEl: lockedTop,
+        hitRaw: lockedTop,
+        point: { x: 50, y: 30 },
+        preferSelected: true,
+      }),
+    ).toBe(selectedEl);
+  });
+
+  it("falls through when the selected box is zero-area (hidden element)", () => {
+    const hitRaw = { tag: "hit" };
+    const selectedEl = { tag: "sel", contains: () => false };
+    const hitEl = hitRaw;
+    expect(
+      dragTargetForPointerDown({
+        selectedEl,
+        selectedAlive: true,
+        selectedRect: {
+          left: 10,
+          top: 10,
+          right: 10,
+          bottom: 10,
+          width: 0,
+          height: 0,
+        },
+        hitEl,
+        hitRaw,
+        point: { x: 10, y: 10 },
+        preferSelected: true,
+      }),
+    ).toBe(hitEl);
+  });
+});
+
+describe("editor-chrome bridge — nextStackCandidate", () => {
+  const stack = ["a:0", "b:1", "c:2", "d:3"];
+
+  it("returns the next candidate below the current one", () => {
+    expect(nextStackCandidate(stack, "b:1")).toBe("c:2");
+  });
+
+  it("wraps from the bottom back to the top", () => {
+    expect(nextStackCandidate(stack, "d:3")).toBe("a:0");
+  });
+
+  it("moves from the top hit to the one just below it", () => {
+    expect(nextStackCandidate(stack, "a:0")).toBe("b:1");
+  });
+
+  it("returns null when the current selection is not in the stack", () => {
+    expect(nextStackCandidate(stack, "z:9")).toBeNull();
+  });
+
+  it("returns null for an empty stack", () => {
+    expect(nextStackCandidate([], "a:0")).toBeNull();
+  });
+
+  it("wraps to itself for a single-candidate stack", () => {
+    expect(nextStackCandidate(["only:0"], "only:0")).toBe("only:0");
+  });
+});
+
 function loadSelectionTargetForHit(documentRoot: {
   body: Element;
   documentElement: Element;

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -19408,6 +19408,60 @@ function DesignEditor() {
     ],
   );
 
+  // Hide the in-iframe selection outline during keyboard nudges so it doesn't
+  // chase the element, restoring it once the burst settles. The re-armed
+  // settle timer is the authoritative restore (~800ms, matching the nudge
+  // coalesce window); an arrow keyup restores sooner when the host has focus.
+  const selectionChromeHiddenRef = useRef(false);
+  const selectionChromeSettleTimerRef = useRef<number | undefined>(undefined);
+  const restoreSelectionChrome = useCallback(() => {
+    if (selectionChromeSettleTimerRef.current !== undefined) {
+      window.clearTimeout(selectionChromeSettleTimerRef.current);
+      selectionChromeSettleTimerRef.current = undefined;
+    }
+    if (!selectionChromeHiddenRef.current) return;
+    selectionChromeHiddenRef.current = false;
+    canvasIframeRef.current?.contentWindow?.postMessage(
+      { type: "set-selection-chrome-hidden", hidden: false },
+      "*",
+    );
+  }, [canvasIframeRef]);
+  const hideSelectionChromeForNudge = useCallback(() => {
+    if (!selectionChromeHiddenRef.current) {
+      selectionChromeHiddenRef.current = true;
+      canvasIframeRef.current?.contentWindow?.postMessage(
+        { type: "set-selection-chrome-hidden", hidden: true },
+        "*",
+      );
+    }
+    if (selectionChromeSettleTimerRef.current !== undefined) {
+      window.clearTimeout(selectionChromeSettleTimerRef.current);
+    }
+    selectionChromeSettleTimerRef.current = window.setTimeout(() => {
+      selectionChromeSettleTimerRef.current = undefined;
+      restoreSelectionChrome();
+    }, 800);
+  }, [canvasIframeRef, restoreSelectionChrome]);
+  useEffect(() => {
+    const onKeyUp = (event: KeyboardEvent) => {
+      if (
+        event.key === "ArrowUp" ||
+        event.key === "ArrowDown" ||
+        event.key === "ArrowLeft" ||
+        event.key === "ArrowRight"
+      ) {
+        restoreSelectionChrome();
+      }
+    };
+    window.addEventListener("keyup", onKeyUp);
+    return () => {
+      window.removeEventListener("keyup", onKeyUp);
+      if (selectionChromeSettleTimerRef.current !== undefined) {
+        window.clearTimeout(selectionChromeSettleTimerRef.current);
+      }
+    };
+  }, [restoreSelectionChrome]);
+
   const handleNudgeSelection = useCallback(
     (direction: "up" | "right" | "down" | "left", largeStep: boolean) => {
       if (!canEditDesign) return;
@@ -19460,6 +19514,7 @@ function DesignEditor() {
       }
 
       if (!selectedElement?.selector) return;
+      hideSelectionChromeForNudge();
       const left = parseFloat(selectedElement.computedStyles.left || "0") || 0;
       const top = parseFloat(selectedElement.computedStyles.top || "0") || 0;
       commitVisualStyles(selectedElement.selector, {
@@ -19477,6 +19532,7 @@ function DesignEditor() {
       canEditDesign,
       commitVisualStyles,
       handleGeometryCommit,
+      hideSelectionChromeForNudge,
       overviewScreens,
       overviewSelectedScreenIds,
       selectedElement,


### PR DESCRIPTION
- Selected object stays the drag target even when another layer overlaps on top of it — plain click still selects the top layer
- Cmd/Ctrl+click deep-selects the next layer below the current one in the stack (wraps around)
- Selection outline hides while you nudge with arrow keys, and comes back when you stop
- In-canvas snap tolerance stays a constant on-screen distance at any zoom (previously felt tighter when zoomed out)