### PR TITLE
Pin scaffolded toolkit dependency to core's published range

### DIFF
--- a/.changeset/pin-create-toolkit-version.md
+++ b/.changeset/pin-create-toolkit-version.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Pin scaffolded standalone apps' `@agent-native/core` and `@agent-native/toolkit` dependencies to the exact release pair this CLI was built and tested with, instead of the independently-moving npm `latest` dist-tag for each. Prevents `agent-native create` from installing a core/toolkit pair that were never released together, which could produce duplicate toolkit installs and "does not provide an export" errors at runtime.

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -31,6 +31,7 @@ import {
   _getCoreDependencyVersion,
   _getDispatchDependencyVersion,
   _getToolkitDependencyVersion,
+  _getCorePackageVersion,
   _getGitHubTemplateRef,
   _getGitHubTemplateRefCandidates,
   _githubTarballUrl,
@@ -976,14 +977,50 @@ describe("workspace add-app scaffold", { timeout: 60000 }, () => {
 });
 
 describe("template/core version compatibility", () => {
-  it("uses the npm latest dist-tag for the generated core dependency", () => {
+  it("pins the generated core dependency to the exact running CLI version", () => {
     // Pin the default behaviour even when the headless install e2e has set
     // AGENT_NATIVE_CREATE_USE_LOCAL_CORE in the ambient environment.
     const previous = process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
     delete process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
     try {
-      expect(_getCoreDependencyVersion()).toBe("latest");
+      expect(_getCoreDependencyVersion()).toBe(_getCorePackageVersion());
     } finally {
+      if (previous === undefined) {
+        delete process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
+      } else {
+        process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE = previous;
+      }
+    }
+  });
+
+  it("keeps core and toolkit paired even when a stale CLI scaffolds after a newer core/toolkit pair has published", () => {
+    // Simulate an old/cached CLI binary (bundled with core 0.114.2, which
+    // itself depended on toolkit ^0.8.0) running `create` after core 0.117.2
+    // (toolkit ^0.9.1) is already the npm `latest`. Pinning core to `latest`
+    // here would install 0.117.2 while the toolkit range stays ^0.8.0 from
+    // the stale CLI's own manifest — the exact duplicate/mismatched-toolkit
+    // pairing this pinning strategy exists to prevent. Pinning core to the
+    // exact version bundled with the running CLI keeps the pair consistent
+    // regardless of what `latest` has moved on to.
+    const previous = process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
+    delete process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
+    const originalReadFileSync = fs.readFileSync;
+    const readFileSyncSpy = vi
+      .spyOn(fs, "readFileSync")
+      .mockImplementation((filePath: any, options: any) => {
+        if (String(filePath).endsWith(path.join("core", "package.json"))) {
+          return JSON.stringify({
+            version: "0.114.2",
+            dependencies: { "@agent-native/toolkit": "^0.8.0" },
+          });
+        }
+        return originalReadFileSync(filePath, options);
+      });
+    try {
+      expect(_getCoreDependencyVersion()).toBe("0.114.2");
+      expect(_getToolkitDependencyVersion()).toBe("^0.8.0");
+    } finally {
+      readFileSyncSpy.mockRestore();
       if (previous === undefined) {
         delete process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
       } else {

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -1009,12 +1009,14 @@ describe("template/core version compatibility", () => {
     }
   });
 
-  it("pins the generated toolkit/dispatch dependency to core's own published range", () => {
+  it("pins the generated toolkit dependency to the core published range", () => {
     // Once changesets publishes core, its package.json has the `workspace:`
     // protocol rewritten to a real semver range. Scaffolded apps must use
-    // that exact range instead of `latest`, since toolkit/dispatch are
-    // versioned and published independently and their `latest` dist-tag can
-    // briefly lag or outrun the core release this CLI shipped with.
+    // that exact range instead of `latest`, since toolkit is versioned and
+    // published independently and its `latest` dist-tag can briefly lag or
+    // outrun the core release this CLI shipped with. Dispatch is not listed
+    // as a dependency of core, so it has no published range to read and
+    // stays pinned to `latest`.
     const previous = process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
     delete process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
     const originalReadFileSync = fs.readFileSync;
@@ -1025,7 +1027,6 @@ describe("template/core version compatibility", () => {
           return JSON.stringify({
             dependencies: {
               "@agent-native/toolkit": "^0.9.1",
-              "@agent-native/dispatch": "^1.2.3",
             },
           });
         }
@@ -1033,7 +1034,7 @@ describe("template/core version compatibility", () => {
       });
     try {
       expect(_getToolkitDependencyVersion()).toBe("^0.9.1");
-      expect(_getDispatchDependencyVersion()).toBe("^1.2.3");
+      expect(_getDispatchDependencyVersion()).toBe("latest");
     } finally {
       readFileSyncSpy.mockRestore();
       if (previous === undefined) {

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "url";
  *   - postinstall scripts missing for required packages
  *   - dist/catalog.json not embedded in the built package
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 import { addAppToWorkspace, createApp } from "./create.js";
 import {
@@ -992,12 +992,50 @@ describe("template/core version compatibility", () => {
     }
   });
 
-  it("pins the generated toolkit dependency to latest by default", () => {
+  it("pins the generated toolkit dependency to latest when unpublished", () => {
+    // In monorepo source, core's own package.json still has the raw
+    // `workspace:^` protocol for toolkit/dispatch, so there is no published
+    // range to trust yet — falling back to `latest` is correct here.
     const previous = process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
     delete process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
     try {
       expect(_getToolkitDependencyVersion()).toBe("latest");
     } finally {
+      if (previous === undefined) {
+        delete process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
+      } else {
+        process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE = previous;
+      }
+    }
+  });
+
+  it("pins the generated toolkit/dispatch dependency to core's own published range", () => {
+    // Once changesets publishes core, its package.json has the `workspace:`
+    // protocol rewritten to a real semver range. Scaffolded apps must use
+    // that exact range instead of `latest`, since toolkit/dispatch are
+    // versioned and published independently and their `latest` dist-tag can
+    // briefly lag or outrun the core release this CLI shipped with.
+    const previous = process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
+    delete process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
+    const originalReadFileSync = fs.readFileSync;
+    const readFileSyncSpy = vi
+      .spyOn(fs, "readFileSync")
+      .mockImplementation((filePath: any, options: any) => {
+        if (String(filePath).endsWith(path.join("core", "package.json"))) {
+          return JSON.stringify({
+            dependencies: {
+              "@agent-native/toolkit": "^0.9.1",
+              "@agent-native/dispatch": "^1.2.3",
+            },
+          });
+        }
+        return originalReadFileSync(filePath, options);
+      });
+    try {
+      expect(_getToolkitDependencyVersion()).toBe("^0.9.1");
+      expect(_getDispatchDependencyVersion()).toBe("^1.2.3");
+    } finally {
+      readFileSyncSpy.mockRestore();
       if (previous === undefined) {
         delete process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE;
       } else {

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -1766,7 +1766,7 @@ function getDispatchDependencyVersion(): string {
     if (localDispatch) return pathToFileURL(localDispatch).href;
   }
 
-  return "latest";
+  return getOwnPackageDependencyVersion("@agent-native/dispatch");
 }
 
 function getToolkitDependencyVersion(): string {
@@ -1774,6 +1774,30 @@ function getToolkitDependencyVersion(): string {
     const localToolkit = findLocalPackage("toolkit");
     if (localToolkit) return localPackageTarball(localToolkit);
   }
+
+  return getOwnPackageDependencyVersion("@agent-native/toolkit");
+}
+
+/**
+ * Sibling framework packages (toolkit, dispatch) are versioned and published
+ * independently of core, so their npm `latest` dist-tags can briefly point to
+ * incompatible releases relative to the core version currently running this
+ * CLI. The published core `package.json` already carries the exact
+ * compatible range changesets resolved at release time — read it from there
+ * instead of trusting `latest`, which is only safe for pinning `core` itself.
+ */
+function getOwnPackageDependencyVersion(depName: string): string {
+  try {
+    const ownPkgPath = path.join(__dirname, "../../package.json");
+    const ownPkg = JSON.parse(fs.readFileSync(ownPkgPath, "utf-8"));
+    const range = ownPkg.dependencies?.[depName];
+    const isPublishedRange =
+      typeof range === "string" &&
+      range.length > 0 &&
+      !range.startsWith("workspace:") &&
+      range !== "catalog:";
+    if (isPublishedRange) return range;
+  } catch {}
 
   return "latest";
 }

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -1384,6 +1384,7 @@ export {
   getCoreDependencyVersion as _getCoreDependencyVersion,
   getDispatchDependencyVersion as _getDispatchDependencyVersion,
   getToolkitDependencyVersion as _getToolkitDependencyVersion,
+  getCorePackageVersion as _getCorePackageVersion,
   getGitHubTemplateRef as _getGitHubTemplateRef,
   getGitHubTemplateRefCandidates as _getGitHubTemplateRefCandidates,
   githubTarballUrl as _githubTarballUrl,
@@ -1753,11 +1754,18 @@ function getCoreDependencyVersion(): string {
     if (localCore) return localPackageTarball(localCore);
   }
 
-  // Generated apps must install before the current package version is
-  // published. The dist-tag resolves to the newest released core today and to
-  // this package version once the release goes live. Local file deps are
-  // intentionally opt-in so scaffolded repos remain portable by default.
-  return "latest";
+  // Pin to the exact core version running this CLI rather than the npm
+  // `latest` dist-tag. `latest` can drift forward after `create` runs (a
+  // stale/cached CLI invocation, or simply time passing before `npm
+  // install`), installing a newer core release whose internal toolkit
+  // dependency no longer matches the toolkit range this CLI just wrote into
+  // the scaffold via getOwnPackageDependencyVersion() — reintroducing the
+  // exact duplicate/mismatched-toolkit class of bug this pinning exists to
+  // prevent. This code only runs from an already-published CLI (npx must
+  // have fetched this exact version from the registry to execute it), so the
+  // pinned version is always installable. Local file deps stay opt-in so
+  // scaffolded repos remain portable by default.
+  return getCorePackageVersion() ?? "latest";
 }
 
 function getDispatchDependencyVersion(): string {

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -1761,10 +1761,14 @@ function getCoreDependencyVersion(): string {
   // dependency no longer matches the toolkit range this CLI just wrote into
   // the scaffold via getOwnPackageDependencyVersion() — reintroducing the
   // exact duplicate/mismatched-toolkit class of bug this pinning exists to
-  // prevent. This code only runs from an already-published CLI (npx must
-  // have fetched this exact version from the registry to execute it), so the
-  // pinned version is always installable. Local file deps stay opt-in so
-  // scaffolded repos remain portable by default.
+  // prevent. For the common case — `npx @agent-native/core@<version> create`
+  // against the public registry — this exact version is guaranteed
+  // installable, since npx just fetched it. Private/offline mirrors with a
+  // retention window narrower than "every historical version" are a known
+  // gap; `getCorePackageVersion()` returning undefined (e.g. malformed own
+  // package.json) falls back to `latest` rather than failing scaffolding
+  // outright. Local file deps stay opt-in so scaffolded repos remain
+  // portable by default.
   return getCorePackageVersion() ?? "latest";
 }
 

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -1766,7 +1766,10 @@ function getDispatchDependencyVersion(): string {
     if (localDispatch) return pathToFileURL(localDispatch).href;
   }
 
-  return getOwnPackageDependencyVersion("@agent-native/dispatch");
+  // Unlike toolkit, core's own package.json does not declare
+  // @agent-native/dispatch as a dependency, so there is no published
+  // compatible range to read here — "latest" is the best available signal.
+  return "latest";
 }
 
 function getToolkitDependencyVersion(): string {
@@ -1779,12 +1782,12 @@ function getToolkitDependencyVersion(): string {
 }
 
 /**
- * Sibling framework packages (toolkit, dispatch) are versioned and published
- * independently of core, so their npm `latest` dist-tags can briefly point to
- * incompatible releases relative to the core version currently running this
- * CLI. The published core `package.json` already carries the exact
- * compatible range changesets resolved at release time — read it from there
- * instead of trusting `latest`, which is only safe for pinning `core` itself.
+ * Toolkit is versioned and published independently of core, so its npm
+ * `latest` dist-tag can briefly point to an incompatible release relative to
+ * the core version currently running this CLI. The published core
+ * `package.json` already carries the exact compatible range changesets
+ * resolved at release time — read it from there instead of trusting
+ * `latest`, which is only safe for pinning `core` itself.
  */
 function getOwnPackageDependencyVersion(depName: string): string {
   try {

--- a/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import { _getCoreDependencyVersion } from "./create.js";
 import {
   applyStarterToolchainSync,
   applyWorkspaceFileSync,
@@ -35,7 +36,7 @@ describe("sync-builder-starter-manifest", () => {
       };
 
       expect(packageJson.name).toBe("builder-agent-native-starter");
-      expect(deps["@agent-native/core"]).toBe("latest");
+      expect(deps["@agent-native/core"]).toBe(_getCoreDependencyVersion());
       expect(deps.postgres).toBe("^3.4.9");
       expect(
         Object.values(deps).some((value) => value.startsWith("workspace:")),


### PR DESCRIPTION
### Summary
Fixes scaffolded apps pinning `@agent-native/toolkit` to `latest` even when core's own published `package.json` already specifies a compatible semver range.

### Problem
Toolkit is versioned and published independently from core. Because scaffolded apps always pinned `@agent-native/toolkit` to the `latest` dist-tag, a new app could end up with an incompatible toolkit version if `latest` briefly lagged or outran the core release the CLI shipped with.

### Solution
When generating a new app, read the compatible toolkit version from core's own published `package.json` (resolved by changesets at release time) instead of always falling back to `latest`. Falling back to `latest` is still correct when running from the monorepo source, where core's `package.json` still has the raw `workspace:` protocol.

### Key Changes
- Added `getOwnPackageDependencyVersion` in `create.ts`, which reads a dependency's version from core's own `package.json` and returns it only if it's a real published range (not `workspace:` or `catalog:`).
- Updated `getToolkitDependencyVersion` to use `getOwnPackageDependencyVersion("@agent-native/toolkit")` instead of unconditionally returning `latest`.
- Documented why `getDispatchDependencyVersion` still returns `latest`, since dispatch isn't declared as a dependency of core.
- Added a test verifying that when core's `package.json` declares a published toolkit range, the scaffolded app uses that exact range while dispatch stays pinned to `latest`.
- Renamed the existing "pins to latest" test to clarify it covers the unpublished/workspace case.


---

<a href="https://builder.io/app/projects/8a4a0eb9ae3d486cace5/loud-repository-uhrhatlr"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://8a4a0eb9ae3d486cace5-loud-repository-uhrhatlr.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2334`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8a4a0eb9ae3d486cace5</projectId>-->
<!--<branchName>loud-repository-uhrhatlr</branchName>-->