### PR TITLE
Fix missing share URL for dashboards and analyses

### DIFF
--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -1,5 +1,5 @@
 import { generateTabId } from "@agent-native/core/client/agent-chat";
-import { agentNativePath } from "@agent-native/core/client/api-path";
+import { agentNativePath, appPath } from "@agent-native/core/client/api-path";
 import {
   useCollaborativeDoc,
   emailToColor,
@@ -1384,6 +1384,11 @@ export default function SqlDashboardPage() {
     [saveView],
   );
 
+  const dashboardShareUrl = useMemo(() => {
+    if (!dashboardId || typeof window === "undefined") return undefined;
+    return window.location.origin + appPath("/dashboards/" + dashboardId);
+  }, [dashboardId]);
+
   useSetPageTitle(
     reportScreenshot ? null : dashboard ? (
       <div className="flex min-w-0 items-center gap-2">
@@ -1436,6 +1441,7 @@ export default function SqlDashboardPage() {
             resourceId={dashboardId}
             resourceTitle={dashboard.name}
             variant="compact"
+            shareUrl={dashboardShareUrl}
             shareTabs={{
               tabs: [
                 {

--- a/templates/analytics/app/pages/analyses/AnalysisDetail.tsx
+++ b/templates/analytics/app/pages/analyses/AnalysisDetail.tsx
@@ -1,4 +1,5 @@
 import { useSendToAgentChat } from "@agent-native/core/client/agent-chat";
+import { appPath } from "@agent-native/core/client/api-path";
 import {
   callAction,
   useActionMutation,
@@ -18,7 +19,7 @@ import {
   IconWorld,
 } from "@tabler/icons-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router";
 import { Link, useNavigate } from "react-router";
 
@@ -168,6 +169,11 @@ export default function AnalysisDetail() {
     navigate("/analyses");
   };
 
+  const analysisShareUrl = useMemo(() => {
+    if (!analysis?.id || typeof window === "undefined") return undefined;
+    return window.location.origin + appPath("/analyses/" + analysis.id);
+  }, [analysis?.id]);
+
   useSetPageTitle(
     analysis ? (
       <h1 className="text-lg font-semibold tracking-tight truncate">
@@ -184,6 +190,7 @@ export default function AnalysisDetail() {
           resourceId={analysis.id}
           resourceTitle={analysis.name}
           variant="compact"
+          shareUrl={analysisShareUrl}
         />
         <Button
           variant="outline"

--- a/templates/analytics/changelog/2026-07-22-fixed-dashboards-and-analyses-missing-a-copyable-share-link.md
+++ b/templates/analytics/changelog/2026-07-22-fixed-dashboards-and-analyses-missing-a-copyable-share-link.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-22
+---
+
+Fixed dashboards and analyses missing a copyable share link


### PR DESCRIPTION
### Summary
Fixes the share dialog for dashboards and analyses so it generates a proper, copyable share link instead of an incorrect URL.

### Problem
The share functionality on dashboard and analysis pages was showing an incorrect URL (e.g. `localhost`) instead of a valid, shareable link based on the app's actual origin and path.

### Solution
Compute a correct share URL on the client using `window.location.origin` combined with the app's resolved path, and pass it explicitly to the share component instead of relying on default/inferred behavior.

<img width="1900" height="1578" alt="image" src="https://github.com/user-attachments/assets/a33fad46-ad3d-49b3-b824-191fc7af7b64" />


### Key Changes
- Added `dashboardShareUrl` in `sql-dashboard/index.tsx`, built from `window.location.origin` and `appPath("/dashboards/" + dashboardId)`, memoized on `dashboardId`.
- Added `analysisShareUrl` in `AnalysisDetail.tsx`, built from `window.location.origin` and `appPath("/analyses/" + analysis.id)`, memoized on `analysis?.id`.
- Passed the new `shareUrl` prop to the share component in both pages.
- Imported `appPath` from `@agent-native/core/client/api-path` in both files.
- Added a changelog entry documenting the fix.


---

<a href="https://builder.io/app/projects/ae8cb7b8045d4c21b2a343e11036d454/cotton-vault-73tvo9h8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ae8cb7b8045d4c21b2a343e11036d454-cotton-vault-73tvo9h8.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2338`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ae8cb7b8045d4c21b2a343e11036d454</projectId>-->
<!--<branchName>cotton-vault-73tvo9h8</branchName>-->