### PR TITLE
Fix recordings failing during upload

### DIFF
--- a/templates/clips/changelog/2026-07-23-fixed-recordings-failing-to-save-with-a-cancelled-or-cleanup.md
+++ b/templates/clips/changelog/2026-07-23-fixed-recordings-failing-to-save-with-a-cancelled-or-cleanup.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-23
+---
+
+Fixed recordings failing to save with a "cancelled" or "cleanup window" error during upload

--- a/templates/clips/server/plugins/db.ts
+++ b/templates/clips/server/plugins/db.ts
@@ -1333,8 +1333,16 @@ async function sweepOrphanedResumableSessions(): Promise<void> {
     if (!key.startsWith(prefix)) continue;
     const recordingId = key.slice(prefix.length);
     if (!recordingId) continue;
+    // `application_state.updated_at` is epoch-ms (a JS number on SQLite, a
+    // BIGINT string on Postgres), but the staleness cutoffs below are ISO-8601.
+    // Normalize to ISO before comparing — a raw epoch-ms value ("1753…") always
+    // sorts lexically below any "2…" ISO date, which would flag every live
+    // upload as stale and force-fail it.
+    const sessionUpdatedAtMs = Number(row.updated_at);
     const sessionUpdatedAt =
-      typeof row.updated_at === "string" ? row.updated_at : "";
+      Number.isFinite(sessionUpdatedAtMs) && sessionUpdatedAtMs > 0
+        ? new Date(sessionUpdatedAtMs).toISOString()
+        : "";
 
     let shouldSweep = false;
     try {


### PR DESCRIPTION
Recordings sometimes failed to save while uploading. Users saw one of two errors:

- "Recording was cancelled before it finished saving."
- "Upload did not finish before the resumable upload cleanup window."

This change fixes both. Recordings now upload and save reliably.

## Why it happened

A background cleanup task runs when the server starts. Its job is to clear out old, abandoned uploads. A recent change added a change against another timestamp that is in different format.

The state update_at uses unit timestamp, while the recordings and check values use iso string, which is causing all checks to fail and recordings to be marked as failed.