### PR TITLE
fix(agent-engine): AI-SDK engines unusable on serverless (require.resolve) + custom OpenAI model IDs dropped

### DIFF
--- a/.changeset/fix-agent-engine-serverless-and-custom-models.md
+++ b/.changeset/fix-agent-engine-serverless-and-custom-models.md
@@ -1,0 +1,8 @@
+---
+"@agent-native/core": patch
+---
+
+Fix AI SDK provider engines being unusable on bundled serverless deploys, and stop rewriting custom model IDs on save/read.
+
+- **Serverless package detection.** `isAgentEnginePackageInstalled` relied on `require.resolve`, which fails on bundled serverless runtimes (Vercel/Netlify via Nitro) where optional provider packages (`ai`, `@ai-sdk/*`) are inlined into the function bundle. Every engine-usability gate then rejected the AI SDK engines and the agent silently fell back to the native Anthropic engine. Package resolution now treats a resolve miss as available only when there is real evidence of a bundled runtime (Vercel/Netlify markers, or a bundle-output module path), and defers to the engine's own dynamic `import()` as the real gate. Generic container/Lambda/Cloud Run deploys that ship a real `node_modules` still surface genuine "package not installed" misses.
+- **Custom model preservation.** `normalizeModelForEngine` replaced any unrecognized model ID with the engine default when the settings actions passed a static registry entry, so a custom OpenAI-compatible gateway model (e.g. an Ollama model) reverted to the OpenAI default on save and read. The set/list/app-default actions now resolve the OpenAI-compatible-endpoint capability (`resolveEnginePreservesCustomModels`) and pass it through, preserving custom IDs verbatim — including version-shaped IDs — while first-party OpenAI still normalizes unknown IDs to a supported model.

--- a/packages/core/src/agent/engine/index.ts
+++ b/packages/core/src/agent/engine/index.ts
@@ -25,6 +25,8 @@ export {
   getConfiguredEngineNameForRequest,
   getStoredModelForEngine,
   normalizeModelForEngine,
+  resolveEnginePreservesCustomModels,
+  type NormalizeModelOptions,
   detectEngineFromEnv,
   detectEngineFromEnvForRequest,
   detectEngineFromUserSecrets,

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -472,6 +472,58 @@ describe("AgentEngine registry", () => {
         "moonshot-v1-8k",
       );
     });
+
+    it("falls back an unrecognized first-party OpenAI model to the default without a gateway", async () => {
+      const { normalizeModelForEngine } = await import("./registry.js");
+      const engine = {
+        name: "ai-sdk:openai",
+        defaultModel: "gpt-5.6-sol",
+        supportedModels: ["gpt-5.5", "gpt-5.6-sol"],
+      } as any;
+
+      // No `preserveCustomModels` flag and no gateway option: an unknown id is
+      // not a valid first-party OpenAI model, so it must normalize to a
+      // supported model rather than being persisted/sent to OpenAI verbatim.
+      expect(normalizeModelForEngine(engine, "gemma4")).toBe("gpt-5.6-sol");
+    });
+
+    it("preserves an unrecognized OpenAI model when the gateway capability is passed", async () => {
+      const { normalizeModelForEngine } = await import("./registry.js");
+      const engine = {
+        name: "ai-sdk:openai",
+        defaultModel: "gpt-5.6-sol",
+        supportedModels: ["gpt-5.5", "gpt-5.6-sol"],
+      } as any;
+
+      // An OpenAI-compatible gateway (Ollama/LiteLLM) serves ids outside the
+      // built-in catalog; the settings actions resolve that capability and pass
+      // it here so the id survives save/read.
+      expect(
+        normalizeModelForEngine(engine, "gemma4", {
+          preserveCustomModels: true,
+        }),
+      ).toBe("gemma4");
+    });
+
+    it("does not version-rewrite a gateway model that shares a catalog family", async () => {
+      const { normalizeModelForEngine } = await import("./registry.js");
+      const engine = {
+        name: "ai-sdk:openai",
+        defaultModel: "gpt-5.6-sol",
+        supportedModels: ["gpt-5.5", "gpt-5.6-sol"],
+      } as any;
+
+      // Without the capability a version-shaped id is upgraded to the newest
+      // same-family match (correct for first-party OpenAI)...
+      expect(normalizeModelForEngine(engine, "gpt-5.4")).toBe("gpt-5.5");
+      // ...but with the gateway capability the exact id is preserved, proving
+      // the version match never fires before preservation.
+      expect(
+        normalizeModelForEngine(engine, "gpt-5.4", {
+          preserveCustomModels: true,
+        }),
+      ).toBe("gpt-5.4");
+    });
   });
 
   it("resolveEngine uses env AGENT_ENGINE when set", async () => {

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -96,6 +96,33 @@ function packageNameFromInstallSpecifier(specifier: string): string | null {
   return versionIndex === -1 ? trimmed : trimmed.slice(0, versionIndex);
 }
 
+/**
+ * True when running inside a bundled serverless function (Vercel/Netlify/Nitro,
+ * AWS Lambda, Cloud Run, …). In those runtimes optional dependencies are inlined
+ * into the function bundle and are NOT resolvable via `require.resolve`, even
+ * though a dynamic `import()` of them works.
+ */
+function isBundledServerlessRuntime(): boolean {
+  const env = process.env;
+  if (
+    env.LAMBDA_TASK_ROOT ||
+    env.AWS_LAMBDA_FUNCTION_NAME ||
+    env.VERCEL ||
+    env.NETLIFY ||
+    env.FUNCTION_TARGET ||
+    env.K_SERVICE
+  ) {
+    return true;
+  }
+  try {
+    return /\/var\/task\/|[\\/](?:_libs|\.vercel|\.netlify)[\\/]/.test(
+      import.meta.url ?? "",
+    );
+  } catch {
+    return false;
+  }
+}
+
 function canResolvePackage(packageName: string): boolean {
   const cached = _packageAvailabilityCache.get(packageName);
   if (cached !== undefined) return cached;
@@ -104,7 +131,15 @@ function canResolvePackage(packageName: string): boolean {
     require.resolve(packageName);
     available = true;
   } catch {
-    available = false;
+    // Bundled serverless runtimes (e.g. Nitro on Vercel/Netlify) inline optional
+    // provider packages into the function bundle, so require.resolve cannot find
+    // them even though the dynamic `import()` the engine actually uses to load
+    // them works. Treat them as available there and let the engine's own import
+    // be the real gate — it already fails with a clear "pnpm add …" message when
+    // the package is genuinely missing. Without this, every engine-usability
+    // gate rejects the AI-SDK engines at runtime and the agent silently falls
+    // back to the native Anthropic engine.
+    available = isBundledServerlessRuntime();
   }
   _packageAvailabilityCache.set(packageName, available);
   return available;
@@ -197,10 +232,23 @@ export function normalizeModelForEngine(
     return candidate;
   }
 
-  return (
-    findLatestSupportedVersionMatch(candidate, engine.supportedModels) ??
-    engine.defaultModel
+  const versionMatch = findLatestSupportedVersionMatch(
+    candidate,
+    engine.supportedModels,
   );
+  if (versionMatch) return versionMatch;
+
+  // The OpenAI engine is commonly pointed at an OpenAI-compatible gateway
+  // (OPENAI_BASE_URL, e.g. Ollama Cloud or LiteLLM) whose model IDs aren't in
+  // the built-in OpenAI catalog. The live engine instance preserves those via
+  // preserveCustomModels, but the sync registry entry passed here (from
+  // set-agent-engine / list-agent-engines) doesn't carry it — so keep an
+  // unrecognized OpenAI model as-is instead of silently replacing it with the
+  // engine default (which would revert e.g. an Ollama model to gpt-5.6-sol on
+  // both save and read).
+  if (engine.name === "ai-sdk:openai") return candidate;
+
+  return engine.defaultModel;
 }
 
 function assertAgentEnginePackageInstalled(entry: AgentEngineEntry): void {

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -97,25 +97,34 @@ function packageNameFromInstallSpecifier(specifier: string): string | null {
 }
 
 /**
- * True when running inside a bundled serverless function (Vercel/Netlify/Nitro,
- * AWS Lambda, Cloud Run, …). In those runtimes optional dependencies are inlined
- * into the function bundle and are NOT resolvable via `require.resolve`, even
- * though a dynamic `import()` of them works.
+ * True only when there is positive evidence this module is executing from a
+ * bundled serverless function where optional dependencies were inlined into the
+ * bundle and are therefore NOT resolvable via `require.resolve` — even though
+ * the dynamic `import()` the engine uses to load them still works.
+ *
+ * Deliberately narrow. The Nitro Vercel/Netlify presets (which agent-native's
+ * own `deploy` command emits) inline optional peers and always set these env
+ * markers, so they are a reliable signal. Other serverless runtimes — a
+ * container on Cloud Run / Google Cloud Functions (`K_SERVICE` /
+ * `FUNCTION_TARGET`), or a plain AWS Lambda — commonly ship a real
+ * `node_modules` where `require.resolve` is authoritative; there a resolve miss
+ * means the package is genuinely absent and must NOT be masked. Those runtimes
+ * are still covered *when the code is actually bundled*, via the module-path
+ * check below, which stays false for a normal `node_modules` layout.
  */
 function isBundledServerlessRuntime(): boolean {
   const env = process.env;
-  if (
-    env.LAMBDA_TASK_ROOT ||
-    env.AWS_LAMBDA_FUNCTION_NAME ||
-    env.VERCEL ||
-    env.NETLIFY ||
-    env.FUNCTION_TARGET ||
-    env.K_SERVICE
-  ) {
-    return true;
-  }
+  // Nitro's Vercel/Netlify presets inline optional peers into the function
+  // bundle; these platforms always set these markers.
+  if (env.VERCEL || env.NETLIFY) return true;
+  // Otherwise require direct evidence that this module is running from inside a
+  // bundle output directory (Vercel's `/var/task`, Nitro's `.output/server`,
+  // inlined `_libs`). This is the real signal that `require.resolve` cannot be
+  // trusted; it stays false for normal `node_modules` layouts (dev, tests, and
+  // container/Lambda/Cloud Run deploys that ship their dependencies), so a
+  // genuine "package not installed" miss still surfaces there.
   try {
-    return /\/var\/task\/|[\\/](?:_libs|\.vercel|\.netlify)[\\/]/.test(
+    return /[\\/](?:_libs|\.vercel|\.netlify|\.output)[\\/]|\/var\/task\//.test(
       import.meta.url ?? "",
     );
   } catch {
@@ -214,17 +223,41 @@ function findLatestSupportedVersionMatch(
   return best?.model;
 }
 
+export interface NormalizeModelOptions {
+  /**
+   * Force unrecognized (custom) model IDs to be kept verbatim, as if
+   * `engine.preserveCustomModels` were set on a live engine instance.
+   *
+   * The settings actions call `normalizeModelForEngine` with a static registry
+   * ENTRY, which never carries the runtime `preserveCustomModels` flag — that
+   * is only set on the engine INSTANCE created with an OpenAI-compatible
+   * `baseUrl`. They resolve the capability with
+   * {@link resolveEnginePreservesCustomModels} and pass it here so a gateway
+   * model (e.g. an Ollama `gemma4`) is not rewritten to the OpenAI default on
+   * save/read. First-party OpenAI (no gateway) leaves this unset, so an unknown
+   * or invalid model still normalizes to a supported one.
+   */
+  preserveCustomModels?: boolean;
+}
+
 export function normalizeModelForEngine(
   engine: Pick<
     AgentEngine,
     "name" | "defaultModel" | "supportedModels" | "preserveCustomModels"
   >,
   model: string | null | undefined,
+  options: NormalizeModelOptions = {},
 ): string {
   const candidate = typeof model === "string" ? model.trim() : "";
   if (!candidate) return engine.defaultModel;
 
-  if (engine.preserveCustomModels) return candidate;
+  // Preserve custom IDs verbatim BEFORE any catalog/version matching, so a
+  // version-shaped gateway model that happens to share a family with a
+  // built-in model (e.g. `gpt-5.4` on an OpenAI-compatible endpoint) is not
+  // rewritten to a catalog entry.
+  if (engine.preserveCustomModels || options.preserveCustomModels) {
+    return candidate;
+  }
 
   if (engine.supportedModels.length === 0) return candidate;
 
@@ -232,23 +265,35 @@ export function normalizeModelForEngine(
     return candidate;
   }
 
-  const versionMatch = findLatestSupportedVersionMatch(
-    candidate,
-    engine.supportedModels,
+  return (
+    findLatestSupportedVersionMatch(candidate, engine.supportedModels) ??
+    engine.defaultModel
   );
-  if (versionMatch) return versionMatch;
+}
 
-  // The OpenAI engine is commonly pointed at an OpenAI-compatible gateway
-  // (OPENAI_BASE_URL, e.g. Ollama Cloud or LiteLLM) whose model IDs aren't in
-  // the built-in OpenAI catalog. The live engine instance preserves those via
-  // preserveCustomModels, but the sync registry entry passed here (from
-  // set-agent-engine / list-agent-engines) doesn't carry it — so keep an
-  // unrecognized OpenAI model as-is instead of silently replacing it with the
-  // engine default (which would revert e.g. an Ollama model to gpt-5.6-sol on
-  // both save and read).
-  if (engine.name === "ai-sdk:openai") return candidate;
-
-  return engine.defaultModel;
+/**
+ * Whether models saved or read for this engine ENTRY should be preserved
+ * verbatim instead of normalized against the built-in catalog.
+ *
+ * `normalizeModelForEngine` honors a live engine's `preserveCustomModels`, but
+ * that flag is only set on an AI SDK engine INSTANCE when the OpenAI provider
+ * is pointed at an OpenAI-compatible gateway (a custom base URL — e.g. Ollama
+ * Cloud or LiteLLM), whose model IDs are not in the built-in OpenAI catalog.
+ * The static registry entry the settings actions pass to
+ * `normalizeModelForEngine` cannot carry that runtime flag, so this async
+ * helper reproduces the same decision — `ai-sdk:openai` AND a resolved base URL
+ * — from the request's stored/deploy config. First-party OpenAI (no gateway)
+ * returns false so an unknown/invalid model still normalizes to a supported one.
+ */
+export async function resolveEnginePreservesCustomModels(
+  entry: Pick<AgentEngineEntry, "name">,
+): Promise<boolean> {
+  if (entry.name !== "ai-sdk:openai") return false;
+  try {
+    return Boolean(await resolveOpenAiBaseUrl());
+  } catch {
+    return false;
+  }
 }
 
 function assertAgentEnginePackageInstalled(entry: AgentEngineEntry): void {

--- a/packages/core/src/scripts/agent-engines/list-agent-engines.ts
+++ b/packages/core/src/scripts/agent-engines/list-agent-engines.ts
@@ -13,6 +13,7 @@ import {
   isAgentEnginePackageInstalled,
   isStoredEngineUsableForRequest,
   normalizeModelForEngine,
+  resolveEnginePreservesCustomModels,
 } from "../../agent/engine/index.js";
 import type { ActionTool } from "../../agent/types.js";
 import { getSetting } from "../../settings/index.js";
@@ -82,11 +83,18 @@ export async function run(args: Record<string, string> = {}): Promise<string> {
         ? current?.model
         : undefined;
   const currentEngineName = currentEntry?.name ?? "anthropic";
+  // Resolve the OpenAI-compatible-endpoint capability so a custom gateway model
+  // is reported as-is instead of being normalized to the engine default — the
+  // read-side counterpart of the same fix in set-/manage-agent-engine.
+  const preserveCustomModels = currentEntry
+    ? await resolveEnginePreservesCustomModels(currentEntry)
+    : false;
   const currentModel =
     currentEntry && !envUnavailable
       ? normalizeModelForEngine(
           currentEntry,
           currentModelCandidate ?? currentEntry.defaultModel,
+          { preserveCustomModels },
         )
       : (currentModelCandidate ?? DEFAULT_MODEL);
   const result = {

--- a/packages/core/src/scripts/agent-engines/manage-agent-engine.ts
+++ b/packages/core/src/scripts/agent-engines/manage-agent-engine.ts
@@ -16,6 +16,7 @@ import {
   getAgentEngineEntry,
   isAgentEnginePackageInstalled,
   normalizeModelForEngine,
+  resolveEnginePreservesCustomModels,
   registerBuiltinEngines,
 } from "../../agent/engine/index.js";
 import type { ActionTool } from "../../agent/types.js";
@@ -113,7 +114,11 @@ async function runSetAppDefault(args: Record<string, string>): Promise<string> {
   if (!isAgentEnginePackageInstalled(entry)) {
     return `Error: Engine "${engine}" requires optional packages that are not installed in this app. Run: pnpm add ${entry.installPackage}`;
   }
-  const normalizedModel = normalizeModelForEngine(entry, model);
+  const preserveCustomModels =
+    await resolveEnginePreservesCustomModels(entry);
+  const normalizedModel = normalizeModelForEngine(entry, model, {
+    preserveCustomModels,
+  });
 
   const ctx = currentContext();
   const canUpdate = await canUpdateAgentAppModelDefaultSettings(

--- a/packages/core/src/scripts/agent-engines/manage-agent-engine.ts
+++ b/packages/core/src/scripts/agent-engines/manage-agent-engine.ts
@@ -114,8 +114,7 @@ async function runSetAppDefault(args: Record<string, string>): Promise<string> {
   if (!isAgentEnginePackageInstalled(entry)) {
     return `Error: Engine "${engine}" requires optional packages that are not installed in this app. Run: pnpm add ${entry.installPackage}`;
   }
-  const preserveCustomModels =
-    await resolveEnginePreservesCustomModels(entry);
+  const preserveCustomModels = await resolveEnginePreservesCustomModels(entry);
   const normalizedModel = normalizeModelForEngine(entry, model, {
     preserveCustomModels,
   });

--- a/packages/core/src/scripts/agent-engines/set-agent-engine.spec.ts
+++ b/packages/core/src/scripts/agent-engines/set-agent-engine.spec.ts
@@ -26,6 +26,7 @@ vi.mock("../../agent/engine/index.js", () => {
     isStoredEngineUsableForRequest: (...args: unknown[]) =>
       isStoredEngineUsableForRequest(...args),
     normalizeModelForEngine: (_entry: unknown, model: string) => model,
+    resolveEnginePreservesCustomModels: () => false,
     registerBuiltinEngines: vi.fn(),
   };
 });

--- a/packages/core/src/scripts/agent-engines/set-agent-engine.ts
+++ b/packages/core/src/scripts/agent-engines/set-agent-engine.ts
@@ -59,8 +59,7 @@ export async function run(args: Record<string, string>): Promise<string> {
   // flag, so resolve the OpenAI-compatible-endpoint capability here and pass it
   // through — otherwise a gateway model (e.g. an Ollama id) is rewritten to the
   // engine default on save.
-  const preserveCustomModels =
-    await resolveEnginePreservesCustomModels(entry);
+  const preserveCustomModels = await resolveEnginePreservesCustomModels(entry);
   const resolvedModel = normalizeModelForEngine(entry, requestedModel, {
     preserveCustomModels,
   });

--- a/packages/core/src/scripts/agent-engines/set-agent-engine.ts
+++ b/packages/core/src/scripts/agent-engines/set-agent-engine.ts
@@ -8,6 +8,7 @@ import {
   isAgentEnginePackageInstalled,
   isStoredEngineUsableForRequest,
   normalizeModelForEngine,
+  resolveEnginePreservesCustomModels,
   registerBuiltinEngines,
 } from "../../agent/engine/index.js";
 import type { ActionTool } from "../../agent/types.js";
@@ -54,7 +55,15 @@ export async function run(args: Record<string, string>): Promise<string> {
   }
 
   const requestedModel = model ?? entry.defaultModel;
-  const resolvedModel = normalizeModelForEngine(entry, requestedModel);
+  // A static registry entry can't carry the runtime `preserveCustomModels`
+  // flag, so resolve the OpenAI-compatible-endpoint capability here and pass it
+  // through — otherwise a gateway model (e.g. an Ollama id) is rewritten to the
+  // engine default on save.
+  const preserveCustomModels =
+    await resolveEnginePreservesCustomModels(entry);
+  const resolvedModel = normalizeModelForEngine(entry, requestedModel, {
+    preserveCustomModels,
+  });
 
   const usable = await isStoredEngineUsableForRequest(
     { engine: engineName },


### PR DESCRIPTION
Fixes #2340.

Two fixes in the agent engine registry, both verified on a live Vercel deploy (Nitro `vercel` preset, multi-app workspace) with an `ai-sdk:openai` engine pointed at an OpenAI-compatible endpoint (Ollama Cloud, `https://ollama.com/v1`).

## 1. AI-SDK provider engines are unusable on bundled/serverless deploys

`isAgentEnginePackageInstalled()` → `canResolvePackage()` uses **`require.resolve`**. On Vercel/Nitro the optional provider packages (`ai`, `@ai-sdk/openai`, …) are **inlined** into the function bundle (`.vercel/output/functions/__server.func/_libs/ai.mjs`, `…/ai-sdk__openai.mjs`) with no `node_modules/ai` to resolve, so `require.resolve("ai")` throws — even though the dynamic `import("ai")` the engine actually uses works fine.

Because `isAgentEnginePackageInstalled` returns `false`, **every** runtime usability gate hard-fails (`isStoredEngineUsable`, `isStoredEngineUsableForRequest`, `isResolvedEngineUsableForRequest`, and the `detectEngineFromEnv*` filters), so `resolveEngine()` skips the configured/stored/detected AI-SDK engine and falls through to the native `anthropic` default. The result: BYO-key AI-SDK providers (OpenAI, Google, Groq, Mistral, Cohere, OpenRouter, Ollama, `ai-sdk:anthropic`) silently don't work on serverless — only `builder` and native `anthropic` (which have no `installPackage`) do. `manage-agent-engine` `test` masks this because it constructs the engine directly, bypassing the gates.

**Fix:** treat a `require.resolve` miss as *available* only when there is real evidence of a bundled runtime, then let the engine's own `import()` be the real gate — it already yields a clear `"pnpm add …"` error when the package is genuinely missing. "Real evidence" is scoped deliberately (per review): the Nitro presets that inline peers (`VERCEL` / `NETLIFY`), or a module path inside a bundle output dir (`/var/task`, `.output`, `.vercel`, `.netlify`, `_libs`). Generic serverless runtimes that ship a real `node_modules` — a Cloud Run / Cloud Functions container (`K_SERVICE` / `FUNCTION_TARGET`), or a plain AWS Lambda — keep the authoritative `require.resolve` gate, so a genuinely-missing peer still surfaces there.

This also resolves the "provider picker snaps back to Claude" symptom in #2340 — that was purely downstream of the same gate rejecting the stored/detected engine, so no separate change is needed.

## 2. Custom OpenAI model IDs are replaced with the default on save/read

`set-agent-engine`, `manage-agent-engine` (app default), and `list-agent-engines` call `normalizeModelForEngine(entry, model)` with the **registry entry**, which does not carry `preserveCustomModels` (that flag lives on the engine *instance*, set as `provider === "openai" && Boolean(baseUrl)`). So a model that isn't in the built-in OpenAI catalog — e.g. an Ollama model like `gemma4` on an OpenAI-compatible endpoint — is normalized to the OpenAI default on **save** (and again on read), so the picker reverts to `gpt-5.6-sol`. The live engine instance preserves it, so runtime and the settings UI disagree.

**Fix (capability-based, per review):**

- `normalizeModelForEngine` takes an explicit `{ preserveCustomModels }` option, honored **before** catalog/version matching (so a version-shaped custom id like `gpt-5.4` on a gateway is not upgraded to a catalog entry).
- `resolveEnginePreservesCustomModels(entry)` reproduces the live engine's rule — `ai-sdk:openai` **and** a resolved OpenAI-compatible base URL — from the request's stored/deploy config, independent of whether the base URL is an env var or a stored secret.
- The three settings actions resolve that capability and pass it through.

First-party OpenAI (no gateway) still normalizes an unknown/invalid id to a supported model, so a bad id can't be persisted or sent to OpenAI. An earlier revision special-cased `ai-sdk:openai` inside `normalizeModelForEngine`; that ran after version matching and applied to first-party OpenAI too, so it was replaced with the capability approach above.

## Tests

Adds `registry.spec.ts` cases for the new option: unknown first-party OpenAI id → default (no option); unknown id preserved with the gateway option; and a version-shaped id upgraded without the option but preserved verbatim with it.

## Verification

- Before: App Default Model showed *"requires optional packages that are not installed in this app"*; the agent fell back to Anthropic; `gemma4` reverted to `gpt-5.6-sol`.
- After: the OpenAI/Ollama engine is usable, the agent responds through `https://ollama.com/v1`, and `gemma4` persists across refreshes in both the LLM section and App Default Model.
