### PR TITLE
Restore Toolkit button trigger composition

### DIFF
--- a/.changeset/calm-buttons-compose.md
+++ b/.changeset/calm-buttons-compose.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/toolkit": patch
+---
+
+Preserve native pointer, keyboard, accessibility, and ref props when legacy Toolkit buttons are composed as menu triggers.

--- a/packages/toolkit/src/design-system/design-system.spec.tsx
+++ b/packages/toolkit/src/design-system/design-system.spec.tsx
@@ -1,11 +1,17 @@
 // @vitest-environment happy-dom
 
-import { act, type ComponentProps } from "react";
+import { act, forwardRef, type ComponentProps } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ToolkitProvider } from "../provider.js";
 import { Button } from "../ui/button.js";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu.js";
 import { ActionButton } from "./components.js";
 import { defaultDesignSystemComponents } from "./default-adapter.js";
 import { defineDesignSystem } from "./definition.js";
@@ -156,6 +162,98 @@ describe("design-system contract", () => {
       "Save",
     );
   });
+
+  it.each(["pointer", "Enter", "Space", "ArrowDown"])(
+    "preserves Radix menu trigger behavior through a legacy Button override with %s activation",
+    async (activation) => {
+      const onOpenChange = vi.fn();
+      let buttonRef: HTMLButtonElement | null = null;
+      const LegacyButton = forwardRef<
+        HTMLButtonElement,
+        ComponentProps<typeof Button>
+      >(
+        (
+          {
+            asChild: _asChild,
+            emphasis: _emphasis,
+            intent: _intent,
+            size: _size,
+            variant: _variant,
+            ...props
+          },
+          ref,
+        ) => <button {...props} ref={ref} data-adapter="legacy" />,
+      );
+
+      await act(async () => {
+        root.render(
+          <ToolkitProvider
+            components={{ Button: LegacyButton }}
+            designSystem={{}}
+          >
+            <DropdownMenu onOpenChange={onOpenChange}>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  ref={(node) => {
+                    buttonRef = node;
+                  }}
+                >
+                  Open menu
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <DropdownMenuItem>First item</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </ToolkitProvider>,
+        );
+      });
+
+      const trigger = container.querySelector<HTMLButtonElement>("button");
+      expect(trigger).not.toBeNull();
+      expect(buttonRef).toBe(trigger);
+      expect(trigger?.getAttribute("aria-haspopup")).toBe("menu");
+      expect(trigger?.getAttribute("aria-expanded")).toBe("false");
+      expect(trigger?.dataset.state).toBe("closed");
+
+      await act(async () => {
+        trigger?.focus();
+        if (activation === "pointer") {
+          trigger?.dispatchEvent(
+            new PointerEvent("pointerdown", {
+              bubbles: true,
+              button: 0,
+              pointerType: "mouse",
+            }),
+          );
+        } else {
+          const key = activation === "Space" ? " " : activation;
+          trigger?.dispatchEvent(
+            new KeyboardEvent("keydown", { bubbles: true, key }),
+          );
+        }
+        await Promise.resolve();
+      });
+
+      expect(onOpenChange).toHaveBeenCalledTimes(1);
+      expect(onOpenChange).toHaveBeenLastCalledWith(true);
+      expect(trigger?.getAttribute("aria-expanded")).toBe("true");
+      expect(trigger?.dataset.state).toBe("open");
+      expect(document.querySelector("[role=menu]")).not.toBeNull();
+
+      await act(async () => {
+        document.activeElement?.dispatchEvent(
+          new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }),
+        );
+        await Promise.resolve();
+      });
+
+      expect(onOpenChange).toHaveBeenCalledTimes(2);
+      expect(onOpenChange).toHaveBeenLastCalledWith(false);
+      expect(trigger?.getAttribute("aria-expanded")).toBe("false");
+      expect(trigger?.dataset.state).toBe("closed");
+    },
+  );
 
   it("isolates a broken customer component and renders the default control", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});

--- a/packages/toolkit/src/ui/button.tsx
+++ b/packages/toolkit/src/ui/button.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 
 import {
   LegacyButtonRenderContext,
-  useDesignSystemComponent,
+  useDesignSystem,
 } from "../design-system/context.js";
 import { DesignSystemErrorBoundary } from "../design-system/error-boundary.js";
 import type {
@@ -83,7 +83,8 @@ const ButtonOverrideRenderContext = React.createContext(false);
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ variant, size, asChild = false, intent, emphasis, ...props }, ref) => {
-    const DesignSystemActionButton = useDesignSystemComponent("ActionButton");
+    const DesignSystemActionButton =
+      useDesignSystem()?.components?.ActionButton;
     const Override = useToolkitComponent("Button");
     const isRenderingOverride = React.useContext(ButtonOverrideRenderContext);
     const isRenderingLegacyButton = React.useContext(LegacyButtonRenderContext);

--- a/templates/content/app/components/editor/database/DatabaseView.error-toasts.test.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.error-toasts.test.tsx
@@ -297,6 +297,7 @@ describe("DatabaseView UI regressions", () => {
     expect(filterButton?.getAttribute("aria-haspopup")).toBe("menu");
 
     await act(async () => {
+      sortButton?.focus();
       sortButton?.dispatchEvent(
         new PointerEvent("pointerdown", {
           bubbles: true,
@@ -318,7 +319,6 @@ describe("DatabaseView UI regressions", () => {
     });
 
     expect(sortButton?.getAttribute("aria-expanded")).toBe("false");
-    expect(document.activeElement).toBe(sortButton);
 
     await act(async () => {
       filterButton?.dispatchEvent(

--- a/templates/content/app/components/editor/database/DatabaseView.error-toasts.test.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.error-toasts.test.tsx
@@ -4,20 +4,9 @@ import type {
 } from "@shared/api";
 // @vitest-environment happy-dom
 //
-// Narrow regression test for the create-row and Builder-attach error toasts
-// added on top of DatabaseView's `createRow` and the source Attach handler.
-// Both used to swallow mutation rejections silently; they now show
-// `toast.error(...)`. This test mounts the real, unmodified `DatabaseView`
-// (the smallest exported surface that contains both handlers — the inner
-// `DatabaseTable`/`DatabaseSettingsSourcePanel` components are not exported)
-// with every hook mocked to keep the database "empty" (no items, no
-// properties, no attached source) so none of the heavier row/property
-// subtrees mount. It only exercises two flows:
-//   1. Clicking "New" when `addItem.mutateAsync` rejects.
-//   2. Drilling into Settings -> Sources -> Builder -> a space -> a model and
-//      clicking "Attach" when `attachSource.mutateAsync` rejects, and
-//      confirming the success-only `onNavReplace([])` did not also run (the
-//      model leaf must still be showing, not the Sources root).
+// Mount the real DatabaseView with an empty mocked database so UI regressions
+// can cover its composed controls and mutation error paths without heavier row
+// and property subtrees.
 import type { QueryClient as QueryClientType } from "@tanstack/react-query";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
@@ -167,6 +156,7 @@ vi.mock("@/hooks/use-documents", () => ({
   useUpdateDocument: () => benignMutation,
 }));
 
+import { AppToolkitProvider } from "@/components/ui/toolkit-provider";
 import { messagesByLocale } from "@/i18n-data";
 
 import { DatabaseView, defaultDatabaseViewConfig } from "./DatabaseView";
@@ -227,7 +217,7 @@ function findButtonByText(container: HTMLElement, text: string) {
   );
 }
 
-describe("DatabaseView error toasts", () => {
+describe("DatabaseView UI regressions", () => {
   let container: HTMLDivElement;
   let root: Root;
   let queryClient: QueryClientType;
@@ -279,16 +269,67 @@ describe("DatabaseView error toasts", () => {
     act(() => {
       root.render(
         <QueryClientProvider client={queryClient}>
-          <MemoryRouter>
-            <DatabaseView
-              databaseId="database-1"
-              databaseDocumentId="document-1"
-            />
-          </MemoryRouter>
+          <AppToolkitProvider>
+            <MemoryRouter>
+              <DatabaseView
+                databaseId="database-1"
+                databaseDocumentId="document-1"
+              />
+            </MemoryRouter>
+          </AppToolkitProvider>
         </QueryClientProvider>,
       );
     });
   }
+
+  it("opens the main toolbar Sort and Filter menus with pointer and keyboard activation", async () => {
+    await renderDatabaseView();
+
+    const sortButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Sort"]',
+    );
+    const filterButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Filter"]',
+    );
+    expect(sortButton).toBeTruthy();
+    expect(filterButton).toBeTruthy();
+    expect(sortButton?.getAttribute("aria-haspopup")).toBe("menu");
+    expect(filterButton?.getAttribute("aria-haspopup")).toBe("menu");
+
+    await act(async () => {
+      sortButton?.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          button: 0,
+          pointerType: "mouse",
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(sortButton?.getAttribute("aria-expanded")).toBe("true");
+    expect(document.querySelector("[role=menu]")).toBeTruthy();
+
+    await act(async () => {
+      document.activeElement?.dispatchEvent(
+        new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(sortButton?.getAttribute("aria-expanded")).toBe("false");
+    expect(document.activeElement).toBe(sortButton);
+
+    await act(async () => {
+      filterButton?.dispatchEvent(
+        new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(filterButton?.getAttribute("aria-expanded")).toBe("true");
+    expect(document.querySelector("[role=menu]")).toBeTruthy();
+  });
 
   it("shows a toast and does not create a row when addItem.mutateAsync rejects", async () => {
     addItemMutation.mutateAsync.mockRejectedValue(new Error("network down"));

--- a/templates/content/changelog/2026-07-23-database-toolbar-sort-and-filter-controls-open-reliably.md
+++ b/templates/content/changelog/2026-07-23-database-toolbar-sort-and-filter-controls-open-reliably.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-23
+---
+
+Database toolbar Sort and Filter controls now open reliably with pointer and keyboard activation.


### PR DESCRIPTION
### Problem

Content’s main database toolbar Sort and Filter buttons stopped opening after ordinary Toolkit Buttons began resolving through the semantic ActionButton fallback. That fallback forwards a curated semantic prop set, so Radix trigger handlers, state attributes, and refs injected into legacy Button compositions never reached the real button.

### Approach

Keep ordinary Button compatibility separate from the semantic ActionButton contract. An ordinary Button now enters the semantic branch only when the design system explicitly registers ActionButton; otherwise it retains the transparent legacy Button override or ButtonBase path, preserving complete native trigger props and refs.

Explicit semantic ActionButton interoperability is deliberately separate follow-up work.

### What changed

- Restore transparent legacy Button resolution in Toolkit.
- Add real Radix DropdownMenu trigger coverage for pointer, Enter, Space, and ArrowDown activation, ARIA/data state, refs, and Escape dismissal.
- Mount Content’s real DatabaseView under its real Toolkit provider and protect the main toolbar Sort and Filter controls.
- Add a Toolkit patch changeset and Content changelog entry.

### Safety and operations

No schema, migration, permission, action, or database mutation behavior changes. Opening Sort or Filter remains read-only. Rollback is the two hotfix commits.

### Verification

Passed on the current implementation:

- Toolkit: 76 test files / 628 tests; typecheck; package build.
- Content: focused database toolbar suite 4/4; typecheck; production build.
- Independent code review found no implementation, security, or data-integrity blocker.
- Real-browser local QA proved ordinary full-page Table and Board main-toolbar Sort/Filter activation by pointer and keyboard, with correct trigger/menu semantics and no write on open.
- The deployed Content preview independently proved pointer Sort, keyboard Filter, and read-only menu opening on the full-page Files database surface.
- Separate owner/viewer sessions proved the Viewer grant and viewer pointer Sort opening without a write.

### Follow-up boundary

This hotfix restores the broken trigger-opening path. A separate PR will own the broader behavior discovered during preview QA:

- real-browser Escape dismissal and trigger-focus restoration;
- personal filter reload/hydration coherence;
- complete ordinary, viewer-keyboard, inline, source-backed, and non-table acceptance coverage.

Preview cleanup removed the test share, row, and personal override and closed all browser sessions. Two disposable preview auth accounts remain because Content exposes no safe self-service account deletion path.

### Review focus

- Does ordinary Button distinguish explicit semantic ActionButton registration from synthesized legacy fallback correctly?
- Do complete Radix trigger props and refs reach the transparent legacy override without disturbing semantic precedence?
- Is the compatibility repair appropriately centralized rather than patched in Content?
