### PR TITLE
fix(content): stabilize database toolbar state

### DIFF
--- a/.changeset/calm-filters-arrive.md
+++ b/.changeset/calm-filters-arrive.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Expose atomic user-scoped setting mutations for ordered personal preferences.

--- a/packages/core/src/settings/index.ts
+++ b/packages/core/src/settings/index.ts
@@ -22,6 +22,7 @@ export { readSetting, writeSetting, removeSetting } from "./script-helpers.js";
 export {
   getUserSetting,
   putUserSetting,
+  mutateUserSetting,
   deleteUserSetting,
 } from "./user-settings.js";
 

--- a/packages/core/src/settings/user-settings.spec.ts
+++ b/packages/core/src/settings/user-settings.spec.ts
@@ -4,15 +4,18 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mockGetSetting = vi.fn();
 const mockPutSetting = vi.fn();
 const mockDeleteSetting = vi.fn();
+const mockMutateSetting = vi.fn();
 
 vi.mock("./store.js", () => ({
   getSetting: (...args: any[]) => mockGetSetting(...args),
   putSetting: (...args: any[]) => mockPutSetting(...args),
   deleteSetting: (...args: any[]) => mockDeleteSetting(...args),
+  mutateSetting: (...args: any[]) => mockMutateSetting(...args),
 }));
 
 import {
   getUserSetting,
+  mutateUserSetting,
   putUserSetting,
   deleteUserSetting,
 } from "./user-settings.js";
@@ -77,6 +80,29 @@ describe("user-settings", () => {
         { v: 1 },
         { requestSource: "tab-1" },
       );
+    });
+  });
+
+  describe("mutateUserSetting", () => {
+    it("atomically mutates only the prefixed user key", async () => {
+      const updater = vi.fn((current) => ({
+        count: Number(current?.count ?? 0) + 1,
+      }));
+      mockMutateSetting.mockResolvedValue({ count: 2 });
+
+      const result = await mutateUserSetting(
+        "alice@test.com",
+        "counter",
+        updater,
+        { requestSource: "tab-1" },
+      );
+
+      expect(mockMutateSetting).toHaveBeenCalledWith(
+        "u:alice@test.com:counter",
+        updater,
+        { requestSource: "tab-1" },
+      );
+      expect(result).toEqual({ count: 2 });
     });
   });
 

--- a/packages/core/src/settings/user-settings.ts
+++ b/packages/core/src/settings/user-settings.ts
@@ -12,6 +12,7 @@ import {
   getSetting,
   putSetting,
   deleteSetting,
+  mutateSetting,
   type StoreWriteOptions,
 } from "./store.js";
 
@@ -35,6 +36,18 @@ export async function putUserSetting(
   options?: StoreWriteOptions,
 ): Promise<void> {
   return putSetting(userKey(email, key), value, options);
+}
+
+/** Atomically derive and persist one user-scoped setting. */
+export async function mutateUserSetting(
+  email: string,
+  key: string,
+  updater: (
+    current: Record<string, unknown> | null,
+  ) => Record<string, unknown> | Promise<Record<string, unknown>>,
+  options?: StoreWriteOptions,
+): Promise<Record<string, unknown>> {
+  return mutateSetting(userKey(email, key), updater, options);
 }
 
 /** Delete a user-scoped setting. */

--- a/templates/content/actions/_content-database-personal-view.ts
+++ b/templates/content/actions/_content-database-personal-view.ts
@@ -64,6 +64,51 @@ const legacyPersonalViewOverridesSchema = z.object({
   ...personalViewOverridesFields,
 });
 
+const storedPersonalViewStateSchema = z.object({
+  storageVersion: z.literal(1),
+  overrides: personalViewOverridesSchema.nullable(),
+  mutationSequences: z.record(z.string(), z.number().int().nonnegative()),
+});
+
+export function normalizeStoredPersonalDatabaseViewState(
+  stored: Record<string, unknown> | null,
+) {
+  const state = storedPersonalViewStateSchema.safeParse(stored);
+  if (state.success) return state.data;
+  const overrides = personalViewOverridesSchema.safeParse(stored);
+  return {
+    storageVersion: 1 as const,
+    overrides: overrides.success ? overrides.data : null,
+    mutationSequences: {} as Record<string, number>,
+  };
+}
+
+export function orderedPersonalDatabaseViewState(args: {
+  current: Record<string, unknown> | null;
+  mutationSource: string;
+  mutationSequence: number;
+  overrides: z.infer<typeof personalViewOverridesSchema> | null;
+}) {
+  const current = normalizeStoredPersonalDatabaseViewState(args.current);
+  if (
+    args.mutationSequence <=
+    (current.mutationSequences[args.mutationSource] ?? -1)
+  ) {
+    return current;
+  }
+  const recentSources = Object.entries(current.mutationSequences)
+    .filter(([source]) => source !== args.mutationSource)
+    .slice(-15);
+  return {
+    storageVersion: 1 as const,
+    overrides: args.overrides,
+    mutationSequences: Object.fromEntries([
+      ...recentSources,
+      [args.mutationSource, args.mutationSequence],
+    ]),
+  };
+}
+
 export async function assertContentDatabaseViewerAccess(databaseId: string) {
   const db = getDb();
   const [database] = await db
@@ -93,10 +138,14 @@ export async function readPersonalDatabaseViewOverrides(
     userEmail,
     personalDatabaseViewSettingKey(databaseId),
   );
-  const parsed = personalViewOverridesSchema.safeParse(stored);
+  const storedState = storedPersonalViewStateSchema.safeParse(stored);
+  const storedOverrides = storedState.success
+    ? storedState.data.overrides
+    : stored;
+  const parsed = personalViewOverridesSchema.safeParse(storedOverrides);
   if (parsed.success) return parsed.data;
 
-  const legacy = legacyPersonalViewOverridesSchema.safeParse(stored);
+  const legacy = legacyPersonalViewOverridesSchema.safeParse(storedOverrides);
   if (!legacy.success) return null;
   const [database] = await getDb()
     .select({ systemRole: schema.contentDatabases.systemRole })

--- a/templates/content/actions/update-content-database-personal-view.test.ts
+++ b/templates/content/actions/update-content-database-personal-view.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { PERSONAL_DATABASE_VIEW_OVERRIDES_VERSION } from "./_content-database-personal-view";
+import {
+  PERSONAL_DATABASE_VIEW_OVERRIDES_VERSION,
+  normalizeStoredPersonalDatabaseViewState,
+  orderedPersonalDatabaseViewState,
+} from "./_content-database-personal-view";
 import action from "./update-content-database-personal-view";
 
 describe("update content database personal view", () => {
@@ -44,4 +48,75 @@ describe("update content database personal view", () => {
       }).overrides,
     ).toBeNull();
   });
+
+  it("requires mutation ordering fields together", () => {
+    expect(() =>
+      action.schema.parse({
+        databaseId: "database",
+        overrides: null,
+        mutationSource: "tab-1",
+      }),
+    ).toThrow(/mutationSource and mutationSequence/);
+  });
+
+  it("keeps the newest override when requests arrive out of order", () => {
+    const first = orderedPersonalDatabaseViewState({
+      current: null,
+      mutationSource: "tab-1",
+      mutationSequence: 2,
+      overrides: personalOverrides("newest"),
+    });
+    const stale = orderedPersonalDatabaseViewState({
+      current: first,
+      mutationSource: "tab-1",
+      mutationSequence: 1,
+      overrides: personalOverrides("stale"),
+    });
+
+    expect(
+      normalizeStoredPersonalDatabaseViewState(stale).overrides?.views[0]
+        ?.filters[0]?.value,
+    ).toBe("newest");
+  });
+
+  it("keeps an ordered clear as a tombstone against a stale write", () => {
+    const cleared = orderedPersonalDatabaseViewState({
+      current: null,
+      mutationSource: "tab-1",
+      mutationSequence: 2,
+      overrides: null,
+    });
+    const stale = orderedPersonalDatabaseViewState({
+      current: cleared,
+      mutationSource: "tab-1",
+      mutationSequence: 1,
+      overrides: personalOverrides("stale"),
+    });
+
+    expect(
+      normalizeStoredPersonalDatabaseViewState(stale).overrides,
+    ).toBeNull();
+  });
 });
+
+function personalOverrides(value: string) {
+  return {
+    version: PERSONAL_DATABASE_VIEW_OVERRIDES_VERSION,
+    activeViewId: "table",
+    views: [
+      {
+        id: "table",
+        sorts: [],
+        filters: [
+          {
+            key: "name",
+            label: "Name",
+            operator: "contains" as const,
+            value,
+          },
+        ],
+        filterMode: "and" as const,
+      },
+    ],
+  };
+}

--- a/templates/content/actions/update-content-database-personal-view.ts
+++ b/templates/content/actions/update-content-database-personal-view.ts
@@ -1,9 +1,11 @@
 import { defineAction } from "@agent-native/core";
-import { deleteUserSetting, putUserSetting } from "@agent-native/core/settings";
+import { mutateUserSetting } from "@agent-native/core/settings";
 import { z } from "zod";
 
 import {
   assertContentDatabaseViewerAccess,
+  normalizeStoredPersonalDatabaseViewState,
+  orderedPersonalDatabaseViewState,
   personalDatabaseViewSettingKey,
   personalViewOverridesSchema,
 } from "./_content-database-personal-view.js";
@@ -11,20 +13,51 @@ import {
 export default defineAction({
   description:
     "Update or clear the current user's personal saved filter, sort, and active view overrides for a content database.",
-  schema: z.object({
-    databaseId: z.string().describe("Database ID"),
-    overrides: personalViewOverridesSchema.nullable(),
-  }),
-  run: async ({ databaseId, overrides }, ctx) => {
+  schema: z
+    .object({
+      databaseId: z.string().describe("Database ID"),
+      overrides: personalViewOverridesSchema.nullable(),
+      mutationSource: z.string().min(1).max(200).optional(),
+      mutationSequence: z.number().int().nonnegative().optional(),
+    })
+    .refine(
+      ({ mutationSource, mutationSequence }) =>
+        (mutationSource == null) === (mutationSequence == null),
+      {
+        message:
+          "mutationSource and mutationSequence must be provided together.",
+      },
+    ),
+  run: async (
+    { databaseId, overrides, mutationSource, mutationSequence },
+    ctx,
+  ) => {
     if (!ctx?.userEmail) throw new Error("Not authenticated.");
     await assertContentDatabaseViewerAccess(databaseId);
 
     const key = personalDatabaseViewSettingKey(databaseId);
-    if (overrides) {
-      await putUserSetting(ctx.userEmail, key, overrides);
-    } else {
-      await deleteUserSetting(ctx.userEmail, key);
+    if (mutationSource != null && mutationSequence != null) {
+      const stored = await mutateUserSetting(
+        ctx.userEmail,
+        key,
+        (current) =>
+          orderedPersonalDatabaseViewState({
+            current,
+            mutationSource,
+            mutationSequence,
+            overrides,
+          }),
+        { requestSource: mutationSource },
+      );
+      return {
+        databaseId,
+        overrides: normalizeStoredPersonalDatabaseViewState(stored).overrides,
+      };
     }
+    await mutateUserSetting(ctx.userEmail, key, (current) => ({
+      ...normalizeStoredPersonalDatabaseViewState(current),
+      overrides,
+    }));
 
     return { databaseId, overrides };
   },

--- a/templates/content/app/components/editor/database/DatabaseView.error-toasts.test.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.error-toasts.test.tsx
@@ -531,7 +531,23 @@ describe("DatabaseView UI regressions", () => {
 
     expect(personalViewMutation.mutate).toHaveBeenCalledTimes(1);
     expect(personalViewMutation.mutate).toHaveBeenCalledWith(
-      expect.objectContaining({ databaseId: "database-1" }),
+      expect.objectContaining({
+        databaseId: "database-1",
+        overrides: expect.objectContaining({
+          activeViewId: databaseViewConfig.activeViewId,
+          views: expect.arrayContaining([
+            expect.objectContaining({
+              id: databaseViewConfig.activeViewId,
+              filters: [
+                expect.objectContaining({
+                  key: "name",
+                  value: "Personal only",
+                }),
+              ],
+            }),
+          ]),
+        }),
+      }),
       expect.any(Object),
     );
     expect(keepaliveActionMock).not.toHaveBeenCalled();

--- a/templates/content/app/components/editor/database/DatabaseView.error-toasts.test.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.error-toasts.test.tsx
@@ -1,7 +1,9 @@
 import type {
   BuilderCmsModelSummary,
+  ContentDatabasePersonalViewResponse,
   ContentDatabaseResponse,
 } from "@shared/api";
+import { CONTENT_DATABASE_PERSONAL_VIEW_OVERRIDES_VERSION } from "@shared/api";
 // @vitest-environment happy-dom
 //
 // Mount the real DatabaseView with an empty mocked database so UI regressions
@@ -16,6 +18,30 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const toastErrorMock = vi.hoisted(() => vi.fn());
 const toastSuccessMock = vi.hoisted(() => vi.fn());
 const contentDatabaseQueryMock = vi.hoisted(() => vi.fn());
+const keepaliveActionMock = vi.hoisted(() => vi.fn());
+const personalViewQuery = vi.hoisted<{
+  data: ContentDatabasePersonalViewResponse | undefined;
+  isLoading: boolean;
+}>(() => ({ data: undefined, isLoading: false }));
+const personalViewMutation = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  mutateAsync: vi.fn().mockResolvedValue(undefined),
+  isPending: false,
+}));
+const updateViewMutation = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  mutateAsync: vi.fn().mockResolvedValue(undefined),
+  isPending: false,
+}));
+
+vi.mock("@agent-native/core/client/hooks", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@agent-native/core/client/hooks")>();
+  return {
+    ...actual,
+    tryCallActionKeepalive: keepaliveActionMock,
+  };
+});
 
 vi.mock("sonner", async (importOriginal) => {
   const actual = await importOriginal<typeof import("sonner")>();
@@ -135,9 +161,9 @@ vi.mock("@/hooks/use-content-database", () => ({
   useExecuteBuilderSourceExecution: () => benignMutation,
   useCancelPreparedBuilderSourceUpdate: () => benignMutation,
   useSetContentDatabaseSourceWriteMode: () => benignMutation,
-  useContentDatabasePersonalView: () => ({ data: undefined, isLoading: false }),
-  useUpdateContentDatabasePersonalView: () => benignMutation,
-  useUpdateContentDatabaseView: () => benignMutation,
+  useContentDatabasePersonalView: () => personalViewQuery,
+  useUpdateContentDatabasePersonalView: () => personalViewMutation,
+  useUpdateContentDatabaseView: () => updateViewMutation,
   useDeleteDatabaseItems: () => benignMutation,
   useDuplicateDatabaseItems: () => benignMutation,
   useMoveDatabaseItem: () => benignMutation,
@@ -229,6 +255,19 @@ describe("DatabaseView UI regressions", () => {
     toastErrorMock.mockReset();
     toastSuccessMock.mockReset();
     contentDatabaseQueryMock.mockReset();
+    keepaliveActionMock.mockReset();
+    keepaliveActionMock.mockReturnValue({
+      accepted: true,
+      bodyBytes: 1,
+      completion: Promise.resolve({
+        databaseId: "database-1",
+        overrides: null,
+      }),
+    });
+    personalViewQuery.data = undefined;
+    personalViewQuery.isLoading = false;
+    personalViewMutation.mutate.mockReset();
+    updateViewMutation.mutate.mockReset();
     addItemMutation.mutateAsync.mockReset();
     attachSourceMutation.mutateAsync.mockReset();
     databasePagination.totalItems = 0;
@@ -257,6 +296,7 @@ describe("DatabaseView UI regressions", () => {
 
   afterEach(() => {
     act(() => root.unmount());
+    vi.useRealTimers();
     container.remove();
     vi.unstubAllGlobals();
     (
@@ -310,15 +350,20 @@ describe("DatabaseView UI regressions", () => {
 
     expect(sortButton?.getAttribute("aria-expanded")).toBe("true");
     expect(document.querySelector("[role=menu]")).toBeTruthy();
+    const sortPickerInput =
+      document.querySelector<HTMLInputElement>("[role=menu] input");
+    expect(sortPickerInput).toBeTruthy();
 
     await act(async () => {
-      document.activeElement?.dispatchEvent(
+      sortPickerInput?.focus();
+      sortPickerInput?.dispatchEvent(
         new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }),
       );
       await Promise.resolve();
     });
 
     expect(sortButton?.getAttribute("aria-expanded")).toBe("false");
+    expect(document.activeElement).toBe(sortButton);
 
     await act(async () => {
       filterButton?.dispatchEvent(
@@ -329,6 +374,138 @@ describe("DatabaseView UI regressions", () => {
 
     expect(filterButton?.getAttribute("aria-expanded")).toBe("true");
     expect(document.querySelector("[role=menu]")).toBeTruthy();
+
+    const filterPickerInput =
+      document.querySelector<HTMLInputElement>("[role=menu] input");
+    expect(filterPickerInput).toBeTruthy();
+    await act(async () => {
+      filterPickerInput?.focus();
+      filterPickerInput?.dispatchEvent(
+        new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(filterButton?.getAttribute("aria-expanded")).toBe("false");
+    expect(document.activeElement).toBe(filterButton);
+  });
+
+  it("does not expose shared database state before personal overrides hydrate", async () => {
+    personalViewQuery.isLoading = true;
+    await renderDatabaseView();
+
+    expect(container.querySelector('button[aria-label="Filter"]')).toBeNull();
+
+    personalViewQuery.data = {
+      databaseId: "database-1",
+      overrides: {
+        version: CONTENT_DATABASE_PERSONAL_VIEW_OVERRIDES_VERSION,
+        activeViewId: databaseViewConfig.activeViewId,
+        views: databaseViewConfig.views.map((view) => ({
+          id: view.id,
+          sorts: [],
+          filters:
+            view.id === databaseViewConfig.activeViewId
+              ? [
+                  {
+                    key: "name",
+                    label: "Name",
+                    operator: "contains" as const,
+                    value: "Personal only",
+                  },
+                ]
+              : [],
+          filterMode: "and" as const,
+        })),
+      },
+    };
+    personalViewQuery.isLoading = false;
+    await renderDatabaseView();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(
+      container.querySelector('button[aria-label="1 active filters"]'),
+    ).toBeTruthy();
+    expect(personalViewMutation.mutate).not.toHaveBeenCalled();
+    expect(updateViewMutation.mutate).not.toHaveBeenCalled();
+  });
+
+  it("opens both toolbar menus with Enter, Space, and ArrowDown", async () => {
+    await renderDatabaseView();
+
+    for (const label of ["Sort", "Filter"]) {
+      for (const key of ["Enter", " ", "ArrowDown"]) {
+        const button = container.querySelector<HTMLButtonElement>(
+          `button[aria-label="${label}"]`,
+        );
+        expect(button).toBeTruthy();
+
+        await act(async () => {
+          button?.focus();
+          button?.dispatchEvent(
+            new KeyboardEvent("keydown", { bubbles: true, key }),
+          );
+          await Promise.resolve();
+        });
+
+        expect(button?.getAttribute("aria-expanded")).toBe("true");
+        const pickerInput =
+          document.querySelector<HTMLInputElement>("[role=menu] input");
+        expect(pickerInput).toBeTruthy();
+        await act(async () => {
+          pickerInput?.focus();
+          pickerInput?.dispatchEvent(
+            new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }),
+          );
+          await Promise.resolve();
+        });
+
+        expect(button?.getAttribute("aria-expanded")).toBe("false");
+        expect(document.activeElement).toBe(button);
+      }
+    }
+  });
+
+  it("persists one personal override and protects a pending reload with keepalive", async () => {
+    vi.useFakeTimers();
+    await renderDatabaseView();
+    const filterButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Filter"]',
+    );
+
+    await act(async () => {
+      filterButton?.dispatchEvent(
+        new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }),
+      );
+      await Promise.resolve();
+    });
+    const nameItem = [
+      ...document.querySelectorAll<HTMLElement>("[role=menuitem]"),
+    ].find((item) => item.textContent?.trim() === "Name");
+    expect(nameItem).toBeTruthy();
+
+    await act(async () => {
+      nameItem?.click();
+      await Promise.resolve();
+    });
+    window.dispatchEvent(new Event("pagehide"));
+
+    expect(keepaliveActionMock).toHaveBeenCalledTimes(1);
+    expect(keepaliveActionMock).toHaveBeenCalledWith(
+      "update-content-database-personal-view",
+      expect.objectContaining({ databaseId: "database-1" }),
+    );
+    expect(personalViewMutation.mutate).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    expect(personalViewMutation.mutate).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 
   it("shows a toast and does not create a row when addItem.mutateAsync rejects", async () => {

--- a/templates/content/app/components/editor/database/DatabaseView.error-toasts.test.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.error-toasts.test.tsx
@@ -491,6 +491,19 @@ describe("DatabaseView UI regressions", () => {
       nameItem?.click();
       await Promise.resolve();
     });
+    const filterValueInput = container.querySelector<HTMLInputElement>(
+      'input[placeholder="Text"]',
+    );
+    expect(filterValueInput).toBeTruthy();
+    await act(async () => {
+      if (!filterValueInput) return;
+      Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )?.set?.call(filterValueInput, "Personal only");
+      filterValueInput.dispatchEvent(new Event("input", { bubbles: true }));
+      await Promise.resolve();
+    });
 
     personalViewQuery.data = {
       databaseId: "database-1",

--- a/templates/content/app/components/editor/database/DatabaseView.error-toasts.test.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.error-toasts.test.tsx
@@ -468,7 +468,40 @@ describe("DatabaseView UI regressions", () => {
     }
   });
 
-  it("persists one personal override and protects a pending reload with keepalive", async () => {
+  it("persists exactly one personal override after filter selection", async () => {
+    vi.useFakeTimers();
+    await renderDatabaseView();
+    const filterButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Filter"]',
+    );
+
+    await act(async () => {
+      filterButton?.dispatchEvent(
+        new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }),
+      );
+      await Promise.resolve();
+    });
+    const nameItem = [
+      ...document.querySelectorAll<HTMLElement>("[role=menuitem]"),
+    ].find((item) => item.textContent?.trim() === "Name");
+    expect(nameItem).toBeTruthy();
+
+    await act(async () => {
+      nameItem?.click();
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    expect(personalViewMutation.mutate).toHaveBeenCalledTimes(1);
+    expect(personalViewMutation.mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ databaseId: "database-1" }),
+      expect.any(Object),
+    );
+    expect(keepaliveActionMock).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("protects a pending personal override during reload with one keepalive", async () => {
     vi.useFakeTimers();
     await renderDatabaseView();
     const filterButton = container.querySelector<HTMLButtonElement>(

--- a/templates/content/app/components/editor/database/DatabaseView.error-toasts.test.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.error-toasts.test.tsx
@@ -493,7 +493,7 @@ describe("DatabaseView UI regressions", () => {
     });
     await renderDatabaseView();
     const filterValueInput = container.querySelector<HTMLInputElement>(
-      'input[placeholder="Text"]',
+      'input[placeholder="Value"]',
     );
     expect(filterValueInput).toBeTruthy();
     await act(async () => {

--- a/templates/content/app/components/editor/database/DatabaseView.error-toasts.test.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.error-toasts.test.tsx
@@ -266,6 +266,7 @@ describe("DatabaseView UI regressions", () => {
     });
     personalViewQuery.data = undefined;
     personalViewQuery.isLoading = false;
+    personalViewMutation.isPending = false;
     personalViewMutation.mutate.mockReset();
     updateViewMutation.mutate.mockReset();
     addItemMutation.mutateAsync.mockReset();
@@ -561,6 +562,43 @@ describe("DatabaseView UI regressions", () => {
     });
 
     expect(personalViewMutation.mutate).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("serializes a newer personal override behind an active save", async () => {
+    vi.useFakeTimers();
+    personalViewMutation.isPending = true;
+    await renderDatabaseView();
+    const filterButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Filter"]',
+    );
+
+    await act(async () => {
+      filterButton?.dispatchEvent(
+        new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }),
+      );
+      await Promise.resolve();
+    });
+    const nameItem = [
+      ...document.querySelectorAll<HTMLElement>("[role=menuitem]"),
+    ].find((item) => item.textContent?.trim() === "Name");
+    expect(nameItem).toBeTruthy();
+
+    await act(async () => {
+      nameItem?.click();
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+    expect(personalViewMutation.mutate).not.toHaveBeenCalled();
+
+    personalViewMutation.isPending = false;
+    await renderDatabaseView();
+    await act(async () => {
+      vi.advanceTimersByTime(50);
+      await Promise.resolve();
+    });
+
+    expect(personalViewMutation.mutate).toHaveBeenCalledTimes(1);
     vi.useRealTimers();
   });
 

--- a/templates/content/app/components/editor/database/DatabaseView.error-toasts.test.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.error-toasts.test.tsx
@@ -492,7 +492,7 @@ describe("DatabaseView UI regressions", () => {
       await Promise.resolve();
     });
     await renderDatabaseView();
-    const filterValueInput = container.querySelector<HTMLInputElement>(
+    const filterValueInput = document.querySelector<HTMLInputElement>(
       'input[placeholder="Value"]',
     );
     expect(filterValueInput).toBeTruthy();

--- a/templates/content/app/components/editor/database/DatabaseView.error-toasts.test.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.error-toasts.test.tsx
@@ -491,6 +491,7 @@ describe("DatabaseView UI regressions", () => {
       nameItem?.click();
       await Promise.resolve();
     });
+    await renderDatabaseView();
     const filterValueInput = container.querySelector<HTMLInputElement>(
       'input[placeholder="Text"]',
     );

--- a/templates/content/app/components/editor/database/DatabaseView.error-toasts.test.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.error-toasts.test.tsx
@@ -488,6 +488,29 @@ describe("DatabaseView UI regressions", () => {
 
     await act(async () => {
       nameItem?.click();
+      await Promise.resolve();
+    });
+
+    personalViewQuery.data = {
+      databaseId: "database-1",
+      overrides: {
+        version: CONTENT_DATABASE_PERSONAL_VIEW_OVERRIDES_VERSION,
+        activeViewId: databaseViewConfig.activeViewId,
+        views: databaseViewConfig.views.map((view) => ({
+          id: view.id,
+          sorts: [],
+          filters: [],
+          filterMode: "and" as const,
+        })),
+      },
+    };
+    await renderDatabaseView();
+
+    expect(
+      container.querySelector('button[aria-label="1 active filters"]'),
+    ).toBeTruthy();
+
+    await act(async () => {
       vi.advanceTimersByTime(300);
       await Promise.resolve();
     });

--- a/templates/content/app/components/editor/database/DatabaseView.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.tsx
@@ -1652,7 +1652,7 @@ function DatabaseTable({
     });
   }
 
-  const flushPendingPersonalViewSave = useCallback(() => {
+  const flushPendingPersonalViewSave: () => void = useCallback(() => {
     if (unmountingRef.current) return;
     if (personalViewSaveTimerRef.current) {
       clearTimeout(personalViewSaveTimerRef.current);

--- a/templates/content/app/components/editor/database/DatabaseView.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.tsx
@@ -895,6 +895,7 @@ function DatabaseTable({
     databaseId: string;
     overrides: PersonalDatabaseViewOverrides;
   } | null>(null);
+  const unmountingRef = useRef(false);
   const updatePersonalViewRef = useRef(updatePersonalView);
   updatePersonalViewRef.current = updatePersonalView;
   const autoContinueBuilderSourceRef = useRef<Set<string>>(new Set());
@@ -1652,9 +1653,16 @@ function DatabaseTable({
   }
 
   const flushPendingPersonalViewSave = useCallback(() => {
+    if (unmountingRef.current) return;
     if (personalViewSaveTimerRef.current) {
       clearTimeout(personalViewSaveTimerRef.current);
       personalViewSaveTimerRef.current = null;
+    }
+    if (updatePersonalViewRef.current.isPending) {
+      personalViewSaveTimerRef.current = setTimeout(() => {
+        flushPendingPersonalViewSave();
+      }, 50);
+      return;
     }
     const pending = pendingPersonalViewSaveRef.current;
     if (!pending) return;
@@ -2229,7 +2237,8 @@ function DatabaseTable({
     window.addEventListener("pagehide", handlePageHide);
     return () => {
       window.removeEventListener("pagehide", handlePageHide);
-      flushPendingPersonalViewSave();
+      sendPendingPersonalViewSaveKeepalive();
+      unmountingRef.current = true;
     };
   }, [flushPendingPersonalViewSave, sendPendingPersonalViewSaveKeepalive]);
 

--- a/templates/content/app/components/editor/database/DatabaseView.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.tsx
@@ -3,6 +3,7 @@ import { agentNativePath } from "@agent-native/core/client/api-path";
 import {
   getBrowserTabId,
   setClientAppState,
+  tryCallActionKeepalive,
   useSession,
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
@@ -23,6 +24,7 @@ import {
   type ProcessBuilderBodyHydrationResponse,
   type SourceJoinSuggestion,
   type ContentDatabasePersonalViewOverrides,
+  type ContentDatabasePersonalViewResponse,
   type ContentDatabaseView,
   type ContentDatabaseViewConfig,
   type ContentDatabaseColumnCalculation,
@@ -103,6 +105,7 @@ import {
   useRef,
   useState,
   type DragEvent as ReactDragEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
@@ -680,12 +683,19 @@ export function DatabaseView({
   isActive,
 }: DatabaseViewProps) {
   const { data: document } = useDocument(databaseDocumentId);
+  const personalView = useContentDatabasePersonalView(databaseId);
 
-  if (!document?.database || document.database.id !== databaseId) return null;
+  if (
+    !document?.database ||
+    document.database.id !== databaseId ||
+    personalView.isLoading
+  )
+    return null;
 
   return (
     <DatabaseTable
       document={document}
+      personalView={personalView.data}
       databaseDocumentId={databaseDocumentId}
       databaseId={databaseId}
       hostDocumentId={hostDocumentId}
@@ -698,6 +708,7 @@ export function DatabaseView({
 
 function DatabaseTable({
   document,
+  personalView,
   databaseId: expectedDatabaseId,
   databaseDocumentId,
   hostDocumentId,
@@ -706,6 +717,7 @@ function DatabaseTable({
   isActive,
 }: {
   document: Document;
+  personalView: ContentDatabasePersonalViewResponse | undefined;
   databaseId: string;
   databaseDocumentId: string;
   hostDocumentId: string;
@@ -763,7 +775,6 @@ function DatabaseTable({
   const newDatabaseRowLabel = isWorkspaceCatalog
     ? t("sidebar.addWorkspace")
     : dbText("newPage");
-  const personalView = useContentDatabasePersonalView(databaseId);
   const updatePersonalView = useUpdateContentDatabasePersonalView(databaseId);
   const source = data?.source ?? null;
   const sources = useMemo(
@@ -821,12 +832,23 @@ function DatabaseTable({
     useState<Record<string, string> | null>(null);
   const [settingsPanel, setSettingsPanel] =
     useState<DatabaseSettingsPanel>("main");
-  const [viewConfig, setViewConfig] = useState<ContentDatabaseViewConfig>(
-    defaultDatabaseViewConfig(),
+  const initialSavedViewConfig = normalizeClientDatabaseViewConfig(
+    document.database?.viewConfig,
   );
+  const initialViewConfig = applyPersonalDatabaseViewOverrides(
+    initialSavedViewConfig,
+    normalizePersonalDatabaseViewOverrides(personalView?.overrides),
+  );
+  const [viewConfig, setViewConfig] =
+    useState<ContentDatabaseViewConfig>(initialViewConfig);
   const [savedViewConfig, setSavedViewConfig] =
-    useState<ContentDatabaseViewConfig>(defaultDatabaseViewConfig());
-  const [personalQueryDirty, setPersonalQueryDirty] = useState(false);
+    useState<ContentDatabaseViewConfig>(initialSavedViewConfig);
+  const [personalQueryDirty, setPersonalQueryDirty] = useState(() =>
+    databaseViewHasPersonalQueryChanges(
+      initialViewConfig,
+      initialSavedViewConfig,
+    ),
+  );
   const [dateViewMonth, setDateViewMonth] = useState(() =>
     startOfMonth(new Date()),
   );
@@ -862,11 +884,19 @@ function DatabaseTable({
     () => databaseDateViewRange(activeView.type, dateViewMonth),
     [activeView.type, dateViewMonth],
   );
-  const hydratedViewRef = useRef("");
+  const hydratedViewRef = useRef(
+    databaseViewStateKey(expectedDatabaseId, initialViewConfig),
+  );
   const saveViewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const personalViewSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  const pendingPersonalViewSaveRef = useRef<{
+    databaseId: string;
+    overrides: PersonalDatabaseViewOverrides;
+  } | null>(null);
+  const updatePersonalViewRef = useRef(updatePersonalView);
+  updatePersonalViewRef.current = updatePersonalView;
   const autoContinueBuilderSourceRef = useRef<Set<string>>(new Set());
   const builderContinuationWatchdogRef = useRef<Map<string, number>>(new Map());
   const refreshSourceInFlightRef = useRef<string | null>(null);
@@ -1579,6 +1609,7 @@ function DatabaseTable({
         clearTimeout(personalViewSaveTimerRef.current);
         personalViewSaveTimerRef.current = null;
       }
+      pendingPersonalViewSaveRef.current = null;
       updatePersonalView.mutate({ databaseId, overrides: null });
       setSavedViewConfig(nextViewConfig);
       setViewConfig(nextViewConfig);
@@ -1601,6 +1632,7 @@ function DatabaseTable({
       clearTimeout(personalViewSaveTimerRef.current);
       personalViewSaveTimerRef.current = null;
     }
+    pendingPersonalViewSaveRef.current = null;
     setViewConfig((current) => {
       const nextViewConfig = databaseViewConfigWithSavedQueryState(
         current,
@@ -1619,6 +1651,49 @@ function DatabaseTable({
     });
   }
 
+  const flushPendingPersonalViewSave = useCallback(() => {
+    if (personalViewSaveTimerRef.current) {
+      clearTimeout(personalViewSaveTimerRef.current);
+      personalViewSaveTimerRef.current = null;
+    }
+    const pending = pendingPersonalViewSaveRef.current;
+    if (!pending) return;
+    pendingPersonalViewSaveRef.current = null;
+    updatePersonalViewRef.current.mutate(pending, {
+      onError: (err) => {
+        toast.error(dbText("failedToSaveView"), {
+          description:
+            err instanceof Error ? err.message : dbText("somethingWentWrong"),
+        });
+      },
+    });
+  }, []);
+
+  const sendPendingPersonalViewSaveKeepalive = useCallback(() => {
+    const pending = pendingPersonalViewSaveRef.current;
+    if (!pending) return;
+    const attempt = tryCallActionKeepalive(
+      "update-content-database-personal-view",
+      pending,
+    );
+    if (!attempt.accepted) {
+      flushPendingPersonalViewSave();
+      return;
+    }
+    if (personalViewSaveTimerRef.current) {
+      clearTimeout(personalViewSaveTimerRef.current);
+      personalViewSaveTimerRef.current = null;
+    }
+    pendingPersonalViewSaveRef.current = null;
+    void attempt.completion.catch(() => {
+      if (pendingPersonalViewSaveRef.current) return;
+      pendingPersonalViewSaveRef.current = pending;
+      personalViewSaveTimerRef.current = setTimeout(() => {
+        flushPendingPersonalViewSave();
+      }, 300);
+    });
+  }, [flushPendingPersonalViewSave]);
+
   function schedulePersonalDatabaseViewOverrideWrite(
     databaseId: string,
     viewConfig: ContentDatabaseViewConfig,
@@ -1627,21 +1702,9 @@ function DatabaseTable({
       clearTimeout(personalViewSaveTimerRef.current);
     }
     const overrides = personalDatabaseViewOverridesFromConfig(viewConfig);
+    pendingPersonalViewSaveRef.current = { databaseId, overrides };
     personalViewSaveTimerRef.current = setTimeout(() => {
-      personalViewSaveTimerRef.current = null;
-      updatePersonalView.mutate(
-        { databaseId, overrides },
-        {
-          onError: (err) => {
-            toast.error(dbText("failedToSaveView"), {
-              description:
-                err instanceof Error
-                  ? err.message
-                  : dbText("somethingWentWrong"),
-            });
-          },
-        },
-      );
+      flushPendingPersonalViewSave();
     }, 300);
   }
 
@@ -2131,13 +2194,12 @@ function DatabaseTable({
   ]);
   useEffect(() => {
     if (!data?.database.id) return;
-    if (personalView.isLoading) return;
     const nextSavedViewConfig = normalizeClientDatabaseViewConfig(
       data.database.viewConfig,
     );
     const nextViewConfig = applyPersonalDatabaseViewOverrides(
       nextSavedViewConfig,
-      normalizePersonalDatabaseViewOverrides(personalView.data?.overrides),
+      normalizePersonalDatabaseViewOverrides(personalView?.overrides),
     );
     const nextKey = databaseViewStateKey(data.database.id, nextViewConfig);
     if (hydratedViewRef.current === nextKey) return;
@@ -2151,20 +2213,18 @@ function DatabaseTable({
         ? current
         : nextViewConfig,
     );
-  }, [
-    data?.database.id,
-    data?.database.viewConfig,
-    personalView.data?.overrides,
-    personalView.isLoading,
-  ]);
+  }, [data?.database.id, data?.database.viewConfig, personalView?.overrides]);
 
   useEffect(() => {
-    return () => {
-      if (personalViewSaveTimerRef.current) {
-        clearTimeout(personalViewSaveTimerRef.current);
-      }
+    const handlePageHide = () => {
+      sendPendingPersonalViewSaveKeepalive();
     };
-  }, []);
+    window.addEventListener("pagehide", handlePageHide);
+    return () => {
+      window.removeEventListener("pagehide", handlePageHide);
+      flushPendingPersonalViewSave();
+    };
+  }, [flushPendingPersonalViewSave, sendPendingPersonalViewSaveKeepalive]);
 
   useEffect(() => {
     if (!databaseId) return;
@@ -2192,7 +2252,7 @@ function DatabaseTable({
                 ? applyPersonalDatabaseViewOverrides(
                     nextViewConfig,
                     normalizePersonalDatabaseViewOverrides(
-                      personalView.data?.overrides,
+                      personalView?.overrides,
                     ),
                   )
                 : nextViewConfig,
@@ -2210,7 +2270,7 @@ function DatabaseTable({
     canEdit,
     databaseId,
     personalQueryDirty,
-    personalView.data?.overrides,
+    personalView?.overrides,
     savedViewConfig,
     updateView,
     viewConfig,
@@ -10865,7 +10925,7 @@ function DatabasePropertyPickerSearch({
         <Input
           value={value}
           onChange={(event) => onChange(event.target.value)}
-          onKeyDown={(event) => event.stopPropagation()}
+          onKeyDown={stopDatabasePickerKeydownPropagation}
           placeholder={placeholder}
           aria-label={placeholder}
           className="h-6 border-0 bg-transparent px-0 text-xs shadow-none focus-visible:ring-0"
@@ -10873,6 +10933,13 @@ function DatabasePropertyPickerSearch({
       </div>
     </div>
   );
+}
+
+function stopDatabasePickerKeydownPropagation(
+  event: ReactKeyboardEvent<HTMLElement>,
+) {
+  if (event.key === "Escape" || event.key === "Tab") return;
+  event.stopPropagation();
 }
 
 function DatabasePropertyPickerItem({
@@ -16964,7 +17031,7 @@ function SortMenu({
         className={cn("w-[340px]", sorts.length === 0 && "w-64 p-0")}
       >
         {sorts.length === 0 ? (
-          <div onKeyDown={(event) => event.stopPropagation()}>
+          <div onKeyDown={stopDatabasePickerKeydownPropagation}>
             <DatabasePropertyPickerMenuItems
               properties={properties}
               includeName
@@ -17139,7 +17206,7 @@ function FilterMenu({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-64">
-        <div onKeyDown={(event) => event.stopPropagation()}>
+        <div onKeyDown={stopDatabasePickerKeydownPropagation}>
           <DatabasePropertyPickerMenuItems
             properties={properties}
             includeName

--- a/templates/content/app/components/editor/database/DatabaseView.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.tsx
@@ -42,6 +42,7 @@ import {
   type DocumentPropertyOption,
   type DocumentPropertyType,
   type DocumentPropertyValue,
+  type UpdateContentDatabasePersonalViewRequest,
 } from "@shared/api";
 import { contentDatabaseFormQuestions } from "@shared/database-form";
 import {
@@ -358,6 +359,8 @@ export const PERSONAL_DATABASE_VIEW_OVERRIDES_VERSION =
   CONTENT_DATABASE_PERSONAL_VIEW_OVERRIDES_VERSION;
 export const BUILDER_SOURCE_CONTINUATION_STALL_MS = 5_000;
 export const BUILDER_SOURCE_CONTINUATION_MAX_BACKOFF_MS = 30_000;
+
+let personalViewMutationSequence = Date.now() * 1_000;
 
 export type PersonalDatabaseViewOverrides =
   ContentDatabasePersonalViewOverrides;
@@ -891,10 +894,8 @@ function DatabaseTable({
   const personalViewSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
-  const pendingPersonalViewSaveRef = useRef<{
-    databaseId: string;
-    overrides: PersonalDatabaseViewOverrides;
-  } | null>(null);
+  const pendingPersonalViewSaveRef =
+    useRef<UpdateContentDatabasePersonalViewRequest | null>(null);
   const unmountingRef = useRef(false);
   const updatePersonalViewRef = useRef(updatePersonalView);
   updatePersonalViewRef.current = updatePersonalView;
@@ -1611,7 +1612,9 @@ function DatabaseTable({
         personalViewSaveTimerRef.current = null;
       }
       pendingPersonalViewSaveRef.current = null;
-      updatePersonalView.mutate({ databaseId, overrides: null });
+      updatePersonalView.mutate(
+        personalDatabaseViewMutationRequest(databaseId, null),
+      );
       setSavedViewConfig(nextViewConfig);
       setViewConfig(nextViewConfig);
       setPersonalQueryDirty(false);
@@ -1639,10 +1642,9 @@ function DatabaseTable({
         current,
         savedViewConfig,
       );
-      updatePersonalView.mutate({
-        databaseId,
-        overrides: null,
-      });
+      updatePersonalView.mutate(
+        personalDatabaseViewMutationRequest(databaseId, null),
+      );
       setPersonalQueryDirty(false);
       hydratedViewRef.current = databaseViewStateKey(
         databaseId,
@@ -1710,7 +1712,10 @@ function DatabaseTable({
       clearTimeout(personalViewSaveTimerRef.current);
     }
     const overrides = personalDatabaseViewOverridesFromConfig(viewConfig);
-    pendingPersonalViewSaveRef.current = { databaseId, overrides };
+    pendingPersonalViewSaveRef.current = personalDatabaseViewMutationRequest(
+      databaseId,
+      overrides,
+    );
     personalViewSaveTimerRef.current = setTimeout(() => {
       flushPendingPersonalViewSave();
     }, 300);
@@ -13571,6 +13576,19 @@ function personalDatabaseViewOverridesFromConfig(
       filters: view.filters,
       filterMode: view.filterMode ?? "and",
     })),
+  };
+}
+
+function personalDatabaseViewMutationRequest(
+  databaseId: string,
+  overrides: PersonalDatabaseViewOverrides | null,
+): UpdateContentDatabasePersonalViewRequest {
+  personalViewMutationSequence += 1;
+  return {
+    databaseId,
+    overrides,
+    mutationSource: getBrowserTabId(),
+    mutationSequence: personalViewMutationSequence,
   };
 }
 

--- a/templates/content/app/components/editor/database/DatabaseView.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.tsx
@@ -2194,6 +2194,8 @@ function DatabaseTable({
   ]);
   useEffect(() => {
     if (!data?.database.id) return;
+    if (pendingPersonalViewSaveRef.current || updatePersonalView.isPending)
+      return;
     const nextSavedViewConfig = normalizeClientDatabaseViewConfig(
       data.database.viewConfig,
     );
@@ -2213,7 +2215,12 @@ function DatabaseTable({
         ? current
         : nextViewConfig,
     );
-  }, [data?.database.id, data?.database.viewConfig, personalView?.overrides]);
+  }, [
+    data?.database.id,
+    data?.database.viewConfig,
+    personalView?.overrides,
+    updatePersonalView.isPending,
+  ]);
 
   useEffect(() => {
     const handlePageHide = () => {

--- a/templates/content/app/hooks/use-content-database.ts
+++ b/templates/content/app/hooks/use-content-database.ts
@@ -51,6 +51,7 @@ import type {
 } from "@shared/api";
 import type { Query, QueryClient } from "@tanstack/react-query";
 import { useQueryClient } from "@tanstack/react-query";
+import { useRef } from "react";
 
 export function contentDatabaseQueryKey(documentId: string) {
   return ["action", "get-content-database", { documentId }] as const;
@@ -815,20 +816,49 @@ export function useUpdateContentDatabasePersonalView(
   _databaseId: string | null,
 ) {
   const queryClient = useQueryClient();
+  const latestMutationRef = useRef<{
+    variables: UpdateContentDatabasePersonalViewRequest;
+    previous: ContentDatabasePersonalViewResponse | undefined;
+  } | null>(null);
   return useActionMutation<
     ContentDatabasePersonalViewResponse,
     UpdateContentDatabasePersonalViewRequest
   >("update-content-database-personal-view", {
     skipActionQueryInvalidation: true,
-    onSuccess: (data) => {
+    onMutate: (variables) => {
+      const queryKey = [
+        "action",
+        "get-content-database-personal-view",
+        { databaseId: variables.databaseId },
+      ] as const;
+      latestMutationRef.current = {
+        variables,
+        previous:
+          queryClient.getQueryData<ContentDatabasePersonalViewResponse>(
+            queryKey,
+          ),
+      };
+      queryClient.setQueryData(queryKey, {
+        databaseId: variables.databaseId,
+        overrides: variables.overrides,
+      });
+    },
+    onError: (_error, variables) => {
+      const latest = latestMutationRef.current;
+      if (latest?.variables !== variables) return;
       queryClient.setQueryData(
         [
           "action",
           "get-content-database-personal-view",
-          { databaseId: data.databaseId },
+          { databaseId: variables.databaseId },
         ],
-        data,
+        latest.previous,
       );
+    },
+    onSettled: (_data, _error, variables) => {
+      if (latestMutationRef.current?.variables === variables) {
+        latestMutationRef.current = null;
+      }
     },
   });
 }

--- a/templates/content/app/hooks/use-content-database.ts
+++ b/templates/content/app/hooks/use-content-database.ts
@@ -812,17 +812,21 @@ export function useContentDatabasePersonalView(databaseId: string | null) {
 }
 
 export function useUpdateContentDatabasePersonalView(
-  databaseId: string | null,
+  _databaseId: string | null,
 ) {
   const queryClient = useQueryClient();
   return useActionMutation<
     ContentDatabasePersonalViewResponse,
     UpdateContentDatabasePersonalViewRequest
   >("update-content-database-personal-view", {
+    skipActionQueryInvalidation: true,
     onSuccess: (data) => {
-      if (!databaseId) return;
       queryClient.setQueryData(
-        ["action", "get-content-database-personal-view", { databaseId }],
+        [
+          "action",
+          "get-content-database-personal-view",
+          { databaseId: data.databaseId },
+        ],
         data,
       );
     },

--- a/templates/content/app/hooks/use-content-database.ts
+++ b/templates/content/app/hooks/use-content-database.ts
@@ -818,7 +818,6 @@ export function useUpdateContentDatabasePersonalView(
   const queryClient = useQueryClient();
   const latestMutationRef = useRef<{
     variables: UpdateContentDatabasePersonalViewRequest;
-    previous: ContentDatabasePersonalViewResponse | undefined;
   } | null>(null);
   return useActionMutation<
     ContentDatabasePersonalViewResponse,
@@ -833,10 +832,6 @@ export function useUpdateContentDatabasePersonalView(
       ] as const;
       latestMutationRef.current = {
         variables,
-        previous:
-          queryClient.getQueryData<ContentDatabasePersonalViewResponse>(
-            queryKey,
-          ),
       };
       queryClient.setQueryData(queryKey, {
         databaseId: variables.databaseId,
@@ -846,14 +841,15 @@ export function useUpdateContentDatabasePersonalView(
     onError: (_error, variables) => {
       const latest = latestMutationRef.current;
       if (latest?.variables !== variables) return;
-      queryClient.setQueryData(
-        [
+      return queryClient.invalidateQueries({
+        queryKey: [
           "action",
           "get-content-database-personal-view",
           { databaseId: variables.databaseId },
         ],
-        latest.previous,
-      );
+        exact: true,
+        refetchType: "all",
+      });
     },
     onSettled: (_data, _error, variables) => {
       if (latestMutationRef.current?.variables === variables) {

--- a/templates/content/app/hooks/use-content-database.ts
+++ b/templates/content/app/hooks/use-content-database.ts
@@ -51,7 +51,6 @@ import type {
 } from "@shared/api";
 import type { Query, QueryClient } from "@tanstack/react-query";
 import { useQueryClient } from "@tanstack/react-query";
-import { useRef } from "react";
 
 export function contentDatabaseQueryKey(documentId: string) {
   return ["action", "get-content-database", { documentId }] as const;
@@ -816,9 +815,6 @@ export function useUpdateContentDatabasePersonalView(
   _databaseId: string | null,
 ) {
   const queryClient = useQueryClient();
-  const latestMutationRef = useRef<{
-    variables: UpdateContentDatabasePersonalViewRequest;
-  } | null>(null);
   return useActionMutation<
     ContentDatabasePersonalViewResponse,
     UpdateContentDatabasePersonalViewRequest
@@ -830,17 +826,12 @@ export function useUpdateContentDatabasePersonalView(
         "get-content-database-personal-view",
         { databaseId: variables.databaseId },
       ] as const;
-      latestMutationRef.current = {
-        variables,
-      };
       queryClient.setQueryData(queryKey, {
         databaseId: variables.databaseId,
         overrides: variables.overrides,
       });
     },
     onError: (_error, variables) => {
-      const latest = latestMutationRef.current;
-      if (latest?.variables !== variables) return;
       return queryClient.invalidateQueries({
         queryKey: [
           "action",
@@ -850,11 +841,6 @@ export function useUpdateContentDatabasePersonalView(
         exact: true,
         refetchType: "all",
       });
-    },
-    onSettled: (_data, _error, variables) => {
-      if (latestMutationRef.current?.variables === variables) {
-        latestMutationRef.current = null;
-      }
     },
   });
 }

--- a/templates/content/app/hooks/use-content-database.ts
+++ b/templates/content/app/hooks/use-content-database.ts
@@ -831,6 +831,17 @@ export function useUpdateContentDatabasePersonalView(
         overrides: variables.overrides,
       });
     },
+    onSuccess: (data) => {
+      return queryClient.invalidateQueries({
+        queryKey: [
+          "action",
+          "get-content-database-personal-view",
+          { databaseId: data.databaseId },
+        ],
+        exact: true,
+        refetchType: "all",
+      });
+    },
     onError: (_error, variables) => {
       return queryClient.invalidateQueries({
         queryKey: [

--- a/templates/content/changelog/2026-07-23-database-toolbar-menus-dismiss-and-personal-filters-reload-reliably.md
+++ b/templates/content/changelog/2026-07-23-database-toolbar-menus-dismiss-and-personal-filters-reload-reliably.md
@@ -2,4 +2,5 @@
 type: fixed
 date: 2026-07-23
 ---
+
 Database Sort and Filter menus now dismiss cleanly with Escape, restore keyboard focus, and reload personal filters without flashing shared defaults.

--- a/templates/content/changelog/2026-07-23-database-toolbar-menus-dismiss-and-personal-filters-reload-reliably.md
+++ b/templates/content/changelog/2026-07-23-database-toolbar-menus-dismiss-and-personal-filters-reload-reliably.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+date: 2026-07-23
+---
+Database Sort and Filter menus now dismiss cleanly with Escape, restore keyboard focus, and reload personal filters without flashing shared defaults.

--- a/templates/content/shared/api.ts
+++ b/templates/content/shared/api.ts
@@ -344,7 +344,7 @@ export interface ContentDatabaseViewConfig {
 export const CONTENT_DATABASE_PERSONAL_VIEW_OVERRIDES_VERSION = 2;
 
 export interface ContentDatabasePersonalViewOverrides {
-  version: number;
+  version: typeof CONTENT_DATABASE_PERSONAL_VIEW_OVERRIDES_VERSION;
   activeViewId?: string;
   views: Array<{
     id: string;

--- a/templates/content/shared/api.ts
+++ b/templates/content/shared/api.ts
@@ -362,6 +362,8 @@ export interface ContentDatabasePersonalViewResponse {
 export interface UpdateContentDatabasePersonalViewRequest {
   databaseId: string;
   overrides: ContentDatabasePersonalViewOverrides | null;
+  mutationSource?: string;
+  mutationSequence?: number;
 }
 
 export interface ContentDatabaseMembership {


### PR DESCRIPTION
## Outcome

Content database Sort and Filter menus now let Radix receive Escape and restore trigger focus. Personal filter/sort overrides hydrate before the toolbar becomes interactive, update their exact user-scoped cache entry, and survive ordinary, overlapping, reload, and out-of-order terminal saves.

## Scope

- Content template main database toolbar only; column-header menus remain distinct.
- Personal-view settings remain current-user scoped through `update-content-database-personal-view`.
- Shared database configuration and source-backed data paths are unchanged.
- No Toolkit or semantic ActionButton adapter changes; that fleet-wide work remains separate.

## Implementation

- Main picker wrappers allow Escape and Tab to reach Radix while retaining local key isolation for other picker keys.
- The toolbar is gated on initial personal-view hydration, and a pending local payload cannot be overwritten by a stale personal query response.
- The exact personal query cache is optimistic, then authoritatively refetched on both mutation success and error without broad action-query invalidation.
- User-setting writes use the existing compare-and-swap path through a backward-compatible stored envelope. Per-browser monotonic sequences reject stale same-source normal or keepalive writes, including stale writes after a clear tombstone. Shared/source rows are never touched.
- `@agent-native/core` has a patch changeset for the reusable user-setting mutation helper.

## Automated verification

Final SHA: `2f1af50ab6e9981e012a2c44d726439a6c81b759`

- CI run `30049704196`: fully green, including lint/format, typecheck, Content DB, full fast tests, build, scaffold E2E, Content parity, Core integration, security guards, SSR smoke, Plan E2E, Brain eval/privacy, and static QA.
- Mounted coverage proves pointer and Enter/Space/ArrowDown activation; Escape dismissal and trigger-focus restoration; initial hydration gating and no hydration write; stale-query protection; exactly one latest personal payload after field-plus-value selection; reload keepalive without duplicate; and serialization behind an active save.
- Action/settings coverage proves ordered same-source writes, stale-arrival rejection, clear tombstones, and exact user-key compare-and-swap behavior.
- Independent technical review found no remaining actionable issue.

## Real-browser acceptance still required before ready

A branch-matching Content deploy-preview exists for this SHA and reports `ready`, but independent Chrome QA reaches `ERR_BLOCKED_BY_CLIENT`; the in-app browser is unavailable. Framework preflight also reports `teenylilframework` offline with SSH timeout. No fixture was created and no application/user data was written.

The frozen matrix is therefore unproven, not passed: ordinary full-page owner/editor, viewer keyboard/no-write, inline database, source-backed database, and Board mode. For each applicable surface, capture pointer plus Enter/Space/ArrowDown, ARIA/open state, Escape/focus, zero write on open, exactly one personal override on selection, reload persistence, unchanged shared/source state, and clean console/network evidence. Setup and cleanup must use safe actions.

Exact unblock: an accessible browser session for the same deploy-preview or a reachable Framework runtime built from this SHA, plus safe disposable action-backed fixtures and owner/editor/viewer access.

## Risk

System-ready, no feature flag. Keep draft until the real-browser matrix is green. No merge requested.