### PR TITLE
Fix Content route commits on slow networks

### DIFF
--- a/templates/content/app/components/editor/DocumentEditor.tsx
+++ b/templates/content/app/components/editor/DocumentEditor.tsx
@@ -85,6 +85,7 @@ import { cn } from "@/lib/utils";
 import {
   documentBodyHydrationIsPending,
   isEffectivelyEmptyDocumentContent,
+  newDocumentPageChoiceIsDisabled,
 } from "./body-hydration";
 import { BuilderBodySyncingNotice } from "./BuilderBodySyncingNotice";
 import type { CommentTextAnchor } from "./comment-anchors";
@@ -1779,9 +1780,12 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
                               type="button"
                               variant="outline"
                               className="justify-start gap-2"
-                              disabled={
-                                !editorCanEdit || createDatabase.isPending
-                              }
+                              disabled={newDocumentPageChoiceIsDisabled({
+                                canEdit,
+                                bodyHydrationPending,
+                                databaseCreationPending:
+                                  createDatabase.isPending,
+                              })}
                               onClick={handleChoosePage}
                             >
                               <IconFileText />

--- a/templates/content/app/components/editor/body-hydration.test.ts
+++ b/templates/content/app/components/editor/body-hydration.test.ts
@@ -7,6 +7,7 @@ import {
   databaseItemBodyHydrationIsPending,
   documentBodyHydrationIsPending,
   isEffectivelyEmptyDocumentContent,
+  newDocumentPageChoiceIsDisabled,
   previewBodyHydrationIsPending,
   previewBodyHydrationIsTerminalError,
   previewDraftConflictsWithHydratedBody,
@@ -289,6 +290,40 @@ describe("body hydration editing gates", () => {
     expect(isEffectivelyEmptyDocumentContent("")).toBe(true);
     expect(isEffectivelyEmptyDocumentContent(" <empty-block/> ")).toBe(true);
     expect(isEffectivelyEmptyDocumentContent("Hydrated body")).toBe(false);
+  });
+
+  it("keeps the page choice usable while collaboration connects", () => {
+    expect(
+      newDocumentPageChoiceIsDisabled({
+        canEdit: true,
+        bodyHydrationPending: false,
+        databaseCreationPending: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("disables the page choice for viewers, body hydration, or database conversion", () => {
+    expect(
+      newDocumentPageChoiceIsDisabled({
+        canEdit: false,
+        bodyHydrationPending: false,
+        databaseCreationPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      newDocumentPageChoiceIsDisabled({
+        canEdit: true,
+        bodyHydrationPending: true,
+        databaseCreationPending: false,
+      }),
+    ).toBe(true);
+    expect(
+      newDocumentPageChoiceIsDisabled({
+        canEdit: true,
+        bodyHydrationPending: false,
+        databaseCreationPending: true,
+      }),
+    ).toBe(true);
   });
 
   it("ignores untouched empty preview normalization before it can dirty-save", () => {

--- a/templates/content/app/components/editor/body-hydration.ts
+++ b/templates/content/app/components/editor/body-hydration.ts
@@ -69,6 +69,16 @@ export function documentBodyHydrationIsPending(
   return builderBodyHydrationIsPending(hydration);
 }
 
+export function newDocumentPageChoiceIsDisabled(args: {
+  canEdit: boolean;
+  bodyHydrationPending: boolean;
+  databaseCreationPending: boolean;
+}) {
+  return (
+    !args.canEdit || args.bodyHydrationPending || args.databaseCreationPending
+  );
+}
+
 export function previewBodyHydrationIsPending(args: {
   item: Pick<ContentDatabaseItem, "bodyHydration" | "document">;
   document: Pick<Document, "content" | "databaseMembership"> | null | undefined;

--- a/templates/content/app/root.revalidation.test.ts
+++ b/templates/content/app/root.revalidation.test.ts
@@ -1,0 +1,39 @@
+import type { ShouldRevalidateFunctionArgs } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import { shouldRevalidate } from "./root";
+
+function revalidationArgs(
+  overrides: Partial<ShouldRevalidateFunctionArgs> = {},
+): ShouldRevalidateFunctionArgs {
+  return {
+    currentUrl: new URL("https://content.test/page/previous"),
+    currentParams: { id: "previous" },
+    nextUrl: new URL("https://content.test/page/next"),
+    nextParams: { id: "next" },
+    defaultShouldRevalidate: true,
+    ...overrides,
+  } as ShouldRevalidateFunctionArgs;
+}
+
+describe("root route revalidation", () => {
+  it("does not block ordinary page navigations on bootstrap locale data", () => {
+    expect(shouldRevalidate(revalidationArgs())).toBe(false);
+  });
+
+  it("retains React Router's default revalidation for action submissions", () => {
+    expect(
+      shouldRevalidate(
+        revalidationArgs({ formMethod: "POST", defaultShouldRevalidate: true }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldRevalidate(
+        revalidationArgs({
+          formMethod: "POST",
+          defaultShouldRevalidate: false,
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/templates/content/app/root.tsx
+++ b/templates/content/app/root.tsx
@@ -49,7 +49,11 @@ import {
   useRouteLoaderData,
   useRouteError,
 } from "react-router";
-import type { LinksFunction, LoaderFunctionArgs } from "react-router";
+import type {
+  LinksFunction,
+  LoaderFunctionArgs,
+  ShouldRevalidateFunctionArgs,
+} from "react-router";
 
 // Styled sonner wrapper — passed via AppProviders `toaster` prop to avoid duplicate.
 import { Toaster as Sonner } from "@/components/ui/sonner";
@@ -103,6 +107,13 @@ export async function loader({
     dir: resolved.dir,
     messages,
   };
+}
+
+export function shouldRevalidate({
+  defaultShouldRevalidate,
+  formMethod,
+}: ShouldRevalidateFunctionArgs) {
+  return formMethod ? defaultShouldRevalidate : false;
 }
 
 // Pass args to match content's 3-way theme-cycle UX (no disableTransitionOnChange).

--- a/templates/content/changelog/2026-07-23-new-pages-open-immediately-while-slow-network-work-continues.md
+++ b/templates/content/changelog/2026-07-23-new-pages-open-immediately-while-slow-network-work-continues.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-23
+---
+
+New pages open immediately while slow network work continues


### PR DESCRIPTION
## Problem

With global network throttling, creating a page from Content's sidebar left the browser on the previous `/page` route and replaced the editor with a full skeleton while the root route reloaded locale data. The optimistic page and its Page/Database chooser were therefore hidden even though the new page identity already existed locally.

This is the intentionally separate follow-up to the issue found while validating #2363. It does not modify, absorb, or block that PR.

## Approach

Let ordinary client-side path navigation commit without re-running the bootstrap-only root locale loader, while retaining React Router's default revalidation for form/action submissions. Separately, let authorized users choose Page while collaboration connects; authorization, body hydration, and database conversion still disable that choice, and Database retains its stricter pending gate.

## What changed

- added root-route revalidation policy and focused coverage for navigation versus action submissions
- narrowed the pending Page-choice gate to the states that actually prevent that operation
- added the required Content changelog entry

## Safety and scope

- no schema, database action, credential, Builder, or Notion workflow changes
- current `origin/main` and the #2363 QA head both produce conflict-free merge trees with this branch

## Verification

- 65 focused route, layout, editor, hydration, and sidebar tests passed
- 22 targeted root/sidebar tests passed for direct local-file mode and database-backed workspaces containing imported local files; the creation branches themselves are unchanged by this diff
- local typecheck, production build, and oxfmt passed
- the full GitHub CI matrix is green on head `b6522362d39a54d28db5e3b5ef3decef75dad352`, including Content DB tests, fast tests, build, typecheck, lint/format, Content parity, security guards, and SSR cold-start smoke
- independent real-browser QA used an 8-second global CDP network delay: click → `/page/<id>` route commit measured 65.3 ms with Page enabled and Database disabled
- keyboard activation of disabled Database produced zero conversion requests; after persistence, one Database click produced exactly one conversion without a reload
- back/forward preserved the route and Content shell; normal-speed route commit measured 122.7 ms; reload restored the signed-in shell and `en-US`/`ltr` locale state
- no Builder operations or Notion OAuth/sync/write operations were initiated; only passive Notion status reads were observed

## Review focus

- confirm the root loader is bootstrap-only for ordinary path changes while action submissions retain default revalidation
- confirm the Page gate remains closed for viewers, body hydration, and active database conversion
- confirm the follow-up composes with #2363 without taking ownership of its Database conversion behavior

## Unrelated observations

- the first Content DB CI attempt failed during dependency installation because the runner lacked `pixman-1`; one failed-job rerun installed successfully and the actual Content DB suite passed
- the successful local build continues to emit existing repository doctor warnings; none originate from the files changed here
