### PR TITLE
Fix(design): 500s file changed since it was read

### DIFF
--- a/templates/design/actions/update-file.spec.ts
+++ b/templates/design/actions/update-file.spec.ts
@@ -204,6 +204,7 @@ vi.mock("../server/db/index.js", () => {
 });
 
 import { hasCollabState, applyText } from "@agent-native/core/collab";
+import { assertAccess } from "@agent-native/core/sharing";
 
 import { sourceContentHash } from "../shared/source-workspace.js";
 import updateFileAction from "./update-file.js";
@@ -603,5 +604,31 @@ describe("update-file: expectedVersionHash / syncCollab regression baseline", ()
     // make.
     const liveText = getOrCreateDoc(FILE_ID).getText("content").toString();
     expect(liveText).toContain("mirror-state-plus-mine-");
+  });
+
+  it("12. delete-race after the access lookup: inner missing-file guard returns 404 (not a bare 500) so the outbox drops it", async () => {
+    // The row exists for the access lookup, then a concurrent delete removes it
+    // before the write-lock reread. assertAccess runs in exactly that window,
+    // so clear the store there to reach the inner missing-file guard.
+    vi.mocked(assertAccess).mockImplementationOnce(async () => {
+      designFilesStore.rows.clear();
+      return { role: "editor", resource: {} } as never;
+    });
+
+    let rejection: unknown = null;
+    try {
+      await updateFileAction.run({
+        id: FILE_ID,
+        content: buildDoc(" delete-race-"),
+        syncCollab: true,
+      } as never);
+    } catch (error) {
+      rejection = error;
+    }
+
+    expect((rejection as Error)?.message).toMatch(/file not found/i);
+    // 404, not a bare 500 — otherwise the save-outbox retries the gone file
+    // forever (the orphan-storm this fix prevents).
+    expect((rejection as { statusCode?: number })?.statusCode).toBe(404);
   });
 });

--- a/templates/design/actions/update-file.spec.ts
+++ b/templates/design/actions/update-file.spec.ts
@@ -268,14 +268,21 @@ describe("update-file: expectedVersionHash / syncCollab regression baseline", ()
     await applyText(FILE_ID, buildDoc(" live-edit-"), "content", "agent");
     const staleHash = sourceContentHash(buildDoc()); // pre-live-edit hash
 
-    await expect(
-      updateFileAction.run({
+    let rejection: unknown = null;
+    try {
+      await updateFileAction.run({
         id: FILE_ID,
         content: buildDoc(" caller-stale-"),
         syncCollab: true,
         expectedVersionHash: staleHash,
-      } as never),
-    ).rejects.toThrow(/changed since it was read/);
+      } as never);
+    } catch (error) {
+      rejection = error;
+    }
+    expect((rejection as Error)?.message).toMatch(/changed since it was read/);
+    // Typed 409, not a bare 500: the framework returns it verbatim (no Sentry
+    // capture, no error log) and the client rebases instead of a retry storm.
+    expect((rejection as { statusCode?: number })?.statusCode).toBe(409);
 
     // Not skipped: no skippedStaleMirror flag could have been produced since
     // the call threw. The SQL row must remain untouched by the rejected call.

--- a/templates/design/actions/update-file.ts
+++ b/templates/design/actions/update-file.ts
@@ -5,7 +5,7 @@ import {
   applyText,
   seedFromText,
 } from "@agent-native/core/collab";
-import { isPostgres } from "@agent-native/core/db";
+import { getDbExec, isPostgres } from "@agent-native/core/db";
 import { accessFilter, assertAccess } from "@agent-native/core/sharing";
 import { and, eq, isNull, sql } from "drizzle-orm";
 import { z } from "zod";
@@ -15,6 +15,18 @@ import { withSourceFileWriteLock } from "../server/source-workspace.js";
 import { assertDesignHtmlEditIntegrity } from "../shared/html-integrity.js";
 import { assertLockedLayersPreserved } from "../shared/locked-layers.js";
 import { sourceContentHash } from "../shared/source-workspace.js";
+
+// TEMPORARY diagnostic — remove once we've read a few real conflicts in prod.
+// Conflicts are now benign 409s the framework no longer error-logs; this keeps
+// them visible in Netlify, and `content-conflict`'s cacheIsStale field tells us
+// whether they're the multi-instance stale-cache phantom (→ worth the core
+// reload fix) or a genuine concurrent writer (→ 409-rebase is already correct).
+function logSaveConflictDebug(
+  event: string,
+  detail: Record<string, unknown>,
+): void {
+  console.warn(`[update-file:debug] ${event}`, detail);
+}
 
 function rowsAffected(result: unknown): number | undefined {
   const candidate = result as {
@@ -169,15 +181,13 @@ export default defineAction({
       .limit(1);
 
     if (!file) {
-      // Terminal (not transient): the row is gone or out of access scope, so a
-      // retry can never succeed. Mark it 404 so the client save-outbox drops the
-      // entry instead of retrying forever (which turns one orphaned/deleted
-      // screen into an update-file 500 storm — see design-save-outbox
-      // isTerminalSaveError).
+      // Terminal: the row is gone/out of scope, so retry can't succeed. Tag 404
+      // via statusCode (NOT status — the action route only reads statusCode) so
+      // the save-outbox drops it instead of looping an update-file 500 storm.
       const notFound = new Error(`File not found: ${id}`) as Error & {
-        status?: number;
+        statusCode?: number;
       };
-      notFound.status = 404;
+      notFound.statusCode = 404;
       throw notFound;
     }
 
@@ -390,9 +400,47 @@ export default defineAction({
                 skippedStaleMirror = true;
               }
             } else {
-              throw new Error(
+              const liveContentHash = sourceContentHash(liveContent);
+              // Diagnostic probe (never affects the outcome): `getText` read this
+              // instance's Y.Doc cache, never re-hydrated from the DB. Compare it
+              // to the freshly persisted text_snapshot so the log distinguishes a
+              // multi-instance stale cache (cacheIsStale) from a genuine writer.
+              let freshDbLiveHash: string | null = null;
+              try {
+                const { rows } = await getDbExec().execute({
+                  sql: "SELECT text_snapshot FROM _collab_docs WHERE doc_id = ?",
+                  args: [id],
+                });
+                if (rows.length > 0) {
+                  freshDbLiveHash = sourceContentHash(
+                    String(rows[0]?.text_snapshot ?? ""),
+                  );
+                }
+              } catch {
+                // diagnostic only
+              }
+              logSaveConflictDebug("content-conflict", {
+                id,
+                caller: context?.caller,
+                syncCollab,
+                operationRevision: operationRevision ?? null,
+                expectedVersionHash,
+                sentContentHash: sourceContentHash(content),
+                liveContentHash,
+                persistedMirrorHash: persistedContentHash,
+                cacheIsStale:
+                  freshDbLiveHash !== null &&
+                  freshDbLiveHash !== liveContentHash,
+                freshDbMatchesExpected: freshDbLiveHash === expectedVersionHash,
+              });
+              // 409 (statusCode), not a bare 500: an expected optimistic-
+              // concurrency outcome the framework returns verbatim and the client
+              // rebases from, instead of a Sentry-captured fault + retry storm.
+              const conflict = new Error(
                 "File changed since it was read. Re-read the file and retry.",
-              );
+              ) as Error & { statusCode?: number };
+              conflict.statusCode = 409;
+              throw conflict;
             }
           }
         }
@@ -461,7 +509,9 @@ export default defineAction({
             // guarded UPDATE alone can still race. Serialize design-file renames in
             // this rare path without using SQLite's fragile async savepoint wrapper.
             await (
-              tx as unknown as { execute: (query: unknown) => Promise<unknown> }
+              tx as unknown as {
+                execute: (query: unknown) => Promise<unknown>;
+              }
             ).execute(sql`LOCK TABLE design_files IN SHARE ROW EXCLUSIVE MODE`);
             const [collision] = await tx
               .select({ id: schema.designFiles.id })
@@ -622,9 +672,18 @@ export default defineAction({
         }
         return;
       }
-      throw new Error(
+      logSaveConflictDebug("retry-exhausted", {
+        id,
+        caller: context?.caller,
+        operationSource: operationSource ?? null,
+        operationRevision: operationRevision ?? null,
+        expectedVersionHash,
+      });
+      const exhausted = new Error(
         "File changed repeatedly while it was being saved. Re-read the file and retry.",
-      );
+      ) as Error & { statusCode?: number };
+      exhausted.statusCode = 409;
+      throw exhausted;
     });
 
     // Update the parent design's updatedAt timestamp. This still runs even

--- a/templates/design/actions/update-file.ts
+++ b/templates/design/actions/update-file.ts
@@ -28,6 +28,18 @@ function logSaveConflictDebug(
   console.warn(`[update-file:debug] ${event}`, detail);
 }
 
+// 404 via statusCode (NOT status — the action route only reads statusCode) so
+// the client save-outbox treats a gone file as terminal and drops it, instead
+// of looping a masked 500. Used at every missing-file guard, including the
+// post-lock rereads a concurrent delete can hit.
+function fileNotFound(id: string): Error & { statusCode?: number } {
+  const err = new Error(`File not found: ${id}`) as Error & {
+    statusCode?: number;
+  };
+  err.statusCode = 404;
+  return err;
+}
+
 function rowsAffected(result: unknown): number | undefined {
   const candidate = result as {
     rowsAffected?: unknown;
@@ -181,14 +193,8 @@ export default defineAction({
       .limit(1);
 
     if (!file) {
-      // Terminal: the row is gone/out of scope, so retry can't succeed. Tag 404
-      // via statusCode (NOT status — the action route only reads statusCode) so
-      // the save-outbox drops it instead of looping an update-file 500 storm.
-      const notFound = new Error(`File not found: ${id}`) as Error & {
-        statusCode?: number;
-      };
-      notFound.statusCode = 404;
-      throw notFound;
+      // The row is gone or out of access scope — retry can't succeed.
+      throw fileNotFound(id);
     }
 
     await assertAccess("design", file.designId, "editor");
@@ -242,7 +248,9 @@ export default defineAction({
           .where(eq(schema.designFiles.id, id))
           .limit(1);
         if (!persistedFile) {
-          throw new Error(`File not found: ${id}`);
+          // Delete-race: the row passed the access check but is gone now.
+          // Same 404 as the outer guard, not a bare 500 the outbox retries.
+          throw fileNotFound(id);
         }
 
         const persistedContentHash = sourceContentHash(persistedFile.content);
@@ -595,7 +603,7 @@ export default defineAction({
             .from(schema.designFiles)
             .where(eq(schema.designFiles.id, id))
             .limit(1);
-          if (!confirmed) throw new Error(`File not found: ${id}`);
+          if (!confirmed) throw fileNotFound(id);
           const confirmedHash = sourceContentHash(confirmed.content);
           const exactOperationPersisted =
             confirmed.contentOperationSource === operationSource &&

--- a/templates/design/app/lib/design-save-outbox.test.ts
+++ b/templates/design/app/lib/design-save-outbox.test.ts
@@ -289,7 +289,7 @@ describe("design save outbox", () => {
       storage,
     });
 
-    expect(result).toEqual({ saved: [], failed: [], dropped: [] });
+    expect(result).toEqual({ saved: [], failed: [], dropped: [], rebased: [] });
     expect(invokeAction).not.toHaveBeenCalled();
     expect(await storage.list("design-1", "user-1")).toHaveLength(1);
   });
@@ -311,6 +311,29 @@ describe("design save outbox", () => {
     // A permanent failure is dropped (never retried), unlike a 409 conflict
     // which stays queued — otherwise an orphaned screen loops 500s forever.
     expect(result.dropped).toHaveLength(1);
+    expect(result.failed).toEqual([]);
+    expect(await storage.list("design-1", "user-1")).toEqual([]);
+  });
+
+  it("rebases (not drops) a server version conflict so it is never shown as a deleted file", async () => {
+    const storage = new MemoryOutboxStorage();
+    await journalDesignSaveOutboxEntry(fileEntry(1), storage);
+    const conflict = Object.assign(
+      new Error("File changed since it was read. Re-read the file and retry."),
+      { status: 409 },
+    );
+
+    const result = await drainDesignSaveOutbox({
+      designId: "design-1",
+      actorScope: "user-1",
+      invokeAction: vi.fn().mockRejectedValue(conflict),
+      storage,
+    });
+
+    // Superseded base: removed from the queue, but into `rebased` — the editor
+    // refetches; it must NOT land in `dropped` (which warns "changes discarded").
+    expect(result.rebased).toHaveLength(1);
+    expect(result.dropped).toEqual([]);
     expect(result.failed).toEqual([]);
     expect(await storage.list("design-1", "user-1")).toEqual([]);
   });

--- a/templates/design/app/lib/design-save-outbox.ts
+++ b/templates/design/app/lib/design-save-outbox.ts
@@ -37,6 +37,14 @@ export interface DrainDesignSaveOutboxResult {
    * transient/conflict errors that SHOULD be retried.
    */
   dropped: Array<{ entry: DesignSaveOutboxEntry; error: unknown }>;
+  /**
+   * Entries dropped because the server moved past their base version (a 409
+   * conflict). Distinct from `dropped`: the file still exists and nothing was
+   * lost to deletion, so the editor should rebase from the server rather than
+   * warn "changes discarded". Kept separate so a normal concurrent edit is
+   * never presented as a deleted file.
+   */
+  rebased: Array<{ entry: DesignSaveOutboxEntry; error: unknown }>;
 }
 
 /**
@@ -342,6 +350,7 @@ async function drainEntries(
     saved: [],
     failed: [],
     dropped: [],
+    rebased: [],
   };
   for (const entry of await storage.list(designId, actorScope)) {
     try {
@@ -394,13 +403,14 @@ async function drainEntries(
         }
       } else if (isConflictSaveError(error)) {
         // Base version superseded — retry is futile and replaying the stale
-        // snapshot would clobber newer content. Drop and rebase (the conflict
-        // analogue of the 404 orphan drop).
+        // snapshot would clobber newer content. Drop into `rebased` (NOT
+        // `dropped`) so the editor rebases from the server instead of warning
+        // that the file was discarded/deleted.
         await storage.deleteIfRevision(entry);
-        result.dropped.push({ entry, error });
+        result.rebased.push({ entry, error });
         if (typeof console !== "undefined") {
           console.warn(
-            `[design-save-outbox] dropped superseded save for ${entry.actionName} ${entry.resourceId} (server content moved on)`,
+            `[design-save-outbox] rebased superseded save for ${entry.actionName} ${entry.resourceId} (server content moved on)`,
           );
         }
       } else {

--- a/templates/design/app/lib/design-save-outbox.ts
+++ b/templates/design/app/lib/design-save-outbox.ts
@@ -58,6 +58,24 @@ export function isTerminalSaveError(error: unknown): boolean {
   );
 }
 
+/**
+ * The server's update-file version conflict ("File changed since it was read…").
+ * Its frozen expectedVersionHash can never match on retry, so drop-and-rebase
+ * rather than loop forever. Matched by MESSAGE, not bare status 409, on purpose:
+ * the client-side "no known base version" / "changed elsewhere" 409 synthetics
+ * are intentionally retained by drainEntries, and the client-build-mismatch 409
+ * is a reload-then-retry.
+ */
+export function isConflictSaveError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as { code?: unknown; message?: unknown };
+  if (candidate.code === "client_build_mismatch") return false;
+  return (
+    typeof candidate.message === "string" &&
+    /changed since it was read|re-read the file/i.test(candidate.message)
+  );
+}
+
 const DATABASE_NAME = "agent-native-design-save-outbox";
 const DATABASE_VERSION = 2;
 const ENTRY_STORE = "entries";
@@ -372,6 +390,17 @@ async function drainEntries(
         if (typeof console !== "undefined") {
           console.warn(
             `[design-save-outbox] dropped unrecoverable save for ${entry.actionName} ${entry.resourceId} (file no longer exists)`,
+          );
+        }
+      } else if (isConflictSaveError(error)) {
+        // Base version superseded — retry is futile and replaying the stale
+        // snapshot would clobber newer content. Drop and rebase (the conflict
+        // analogue of the 404 orphan drop).
+        await storage.deleteIfRevision(entry);
+        result.dropped.push({ entry, error });
+        if (typeof console !== "undefined") {
+          console.warn(
+            `[design-save-outbox] dropped superseded save for ${entry.actionName} ${entry.resourceId} (server content moved on)`,
           );
         }
       } else {

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -4041,7 +4041,9 @@ function DesignEditor() {
         designId: id,
         actorScope: designSaveActorScope,
       });
-      if (result.saved.length > 0) {
+      if (result.saved.length > 0 || result.rebased.length > 0) {
+        // rebased = a 409 the server moved past; refetch so the editor rebases
+        // onto current content. No toast: the file wasn't lost, unlike dropped.
         queryClient.invalidateQueries({
           queryKey: ["action", "get-design"],
         });

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -4265,7 +4265,12 @@ function DesignEditor() {
             );
             if (failureKind === "offline") {
               warnChangesWillRetry();
-            } else if (failureKind !== "intentional-abort") {
+            } else if (
+              failureKind !== "intentional-abort" &&
+              failureKind !== "conflict"
+            ) {
+              // Conflicts already rebased above (acked-hash reset + get-design
+              // invalidation); a red toast for a routine rebase is just noise.
               toast.error(
                 designSaveErrorMessage(error) ?? t("common.genericError"),
                 { id: `design-save-error:${pending.id}` },


### PR DESCRIPTION
update-file threw its optimistic-concurrency conflict ("File changed since it was read") as a bare Error, which the framework mapped to a 500: Sentry-captured, error-logged, message masked, and — because the client save-outbox never recognized it — retried with the same stale hash forever, a 500 storm that made the editor feel unusable.
    
- Throw the conflict (and the repeated-save variant) with statusCode 409, and the missing-file guard with statusCode 404, so the framework returns them verbatim without a Sentry capture or error log.
- Teach the save-outbox to drop a superseded (409) entry and rebase, instead of retrying a dead base version forever.
- Stop surfacing a red error toast for a routine conflict rebase.
    
A temporary diagnostic logs each conflict cacheIsStale/freshDbMatchesExpected so we can confirm in prod whether these are multi-instance stale-cache phantoms (warranting a follow-up collab getDoc reload) or genuine concurrent writers.