### PR TITLE
Explicitly disable bundling for Netlify keep-warm function

### DIFF
--- a/.changeset/explicit-keep-warm-packaging.md
+++ b/.changeset/explicit-keep-warm-packaging.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Explicitly disable dependency bundling and include all self-contained files for generated Netlify keep-warm functions.
+Explicitly disable dependency bundling for generated self-contained Netlify keep-warm functions.

--- a/.changeset/explicit-keep-warm-packaging.md
+++ b/.changeset/explicit-keep-warm-packaging.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Explicitly disable dependency bundling and include all self-contained files for generated Netlify keep-warm functions.

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -1585,7 +1585,7 @@ describe("durable-background Netlify function emit (single-template, flag-gated)
     expect(entry).toContain('const HEALTH_PATH = "/_agent-native/health"');
     expect(entry).toContain('schedule: "* * * * *"');
     expect(entry).toContain('nodeBundler: "none"');
-    expect(entry).toContain('includedFiles: ["**"]');
+    expect(entry).not.toContain("includedFiles");
     expect(entry).toContain("await fetch(url");
     expect(entry).toContain("agent-native-netlify-keep-warm");
     expect(entry).not.toMatch(/^\s*path:/m);

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -1584,6 +1584,8 @@ describe("durable-background Netlify function emit (single-template, flag-gated)
     const entry = fs.readFileSync(entryPath, "utf8");
     expect(entry).toContain('const HEALTH_PATH = "/_agent-native/health"');
     expect(entry).toContain('schedule: "* * * * *"');
+    expect(entry).toContain('nodeBundler: "none"');
+    expect(entry).toContain('includedFiles: ["**"]');
     expect(entry).toContain("await fetch(url");
     expect(entry).toContain("agent-native-netlify-keep-warm");
     expect(entry).not.toMatch(/^\s*path:/m);

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -2447,6 +2447,8 @@ export const config = {
   name: "agent-native server keep warm",
   generator: "agent-native build",
   schedule: "* * * * *",
+  nodeBundler: "none",
+  includedFiles: ["**"],
 };
 `;
 

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -2448,7 +2448,6 @@ export const config = {
   generator: "agent-native build",
   schedule: "* * * * *",
   nodeBundler: "none",
-  includedFiles: ["**"],
 };
 `;
 


### PR DESCRIPTION
### Summary
Makes the packaging config for the generated Netlify keep-warm function explicit by adding `nodeBundler: "none"`  alongside the existing schedule.

### Problem
The generated keep-warm function config only set `schedule: "* * * * *"`, leaving Netlify's bundling behavior implicit. Since this function is self-contained and needs no dependency tracing, relying on defaults doesn't clearly communicate this intent and is inconsistent with how the background/integration-recovery emitters declare their config.

### Solution
Update `emitSingleTemplateNetlifyKeepWarmFunction` in `packages/core/src/deploy/build.ts` to explicitly declare a no-op bundler.

### Key Changes
- Added `nodeBundler: "none"` to the emitted `config` object in `emitSingleTemplateNetlifyKeepWarmFunction`, keeping the existing `schedule: "* * * * *"`.
- Updated `packages/core/src/deploy/build.spec.ts` to assert the keep-warm entry contains the new packaging field in addition to the schedule, while retaining the existing test that the function is only emitted when Nitro's server bundle exists.
- Added a changeset documenting the patch for `@agent-native/core`.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/velour-volt-gvqiuh0s"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-velour-volt-gvqiuh0s.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2386`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>velour-volt-gvqiuh0s</branchName>-->