### PR TITLE
fix: google block pop up for google auth in mobile web view

### DIFF
--- a/packages/mobile-app/app.json
+++ b/packages/mobile-app/app.json
@@ -75,7 +75,8 @@
       "./plugins/with-mobile-companion",
       "./plugins/with-ios-app-intents",
       "./plugins/with-ios-companion",
-      "./plugins/with-android-capture-tile"
+      "./plugins/with-android-capture-tile",
+      "./plugins/with-android-oauth-deeplink"
     ],
     "extra": {
       "router": {},

--- a/packages/mobile-app/app/_layout.tsx
+++ b/packages/mobile-app/app/_layout.tsx
@@ -5,12 +5,14 @@ import { KeyboardProvider } from "react-native-keyboard-controller";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 
 import CaptureSyncProvider from "@/components/CaptureSyncProvider";
+import OAuthDeepLinkHandler from "@/components/OAuthDeepLinkHandler";
 
 export default function RootLayout() {
   return (
     <SafeAreaProvider>
       <KeyboardProvider>
         <CaptureSyncProvider>
+          <OAuthDeepLinkHandler />
           <StatusBar style="light" />
           <Stack
             screenOptions={{

--- a/packages/mobile-app/app/app/[id].tsx
+++ b/packages/mobile-app/app/app/[id].tsx
@@ -1,106 +1,17 @@
 import { Feather } from "@expo/vector-icons";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useLocalSearchParams, Stack } from "expo-router";
-import { useState, useRef, useCallback, useEffect, useMemo } from "react";
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  ActivityIndicator,
-  Linking,
-  AppState,
-} from "react-native";
-import type { WebView as WebViewRef } from "react-native-webview";
+import { useRef } from "react";
+import { View, Text, TouchableOpacity } from "react-native";
 
-import { WebView } from "@/components/uniwind-interop";
-import { getSessionToken } from "@/lib/session-token-store";
+import AppWebView, { type AppWebViewHandle } from "@/components/AppWebView";
 import { useApps } from "@/lib/use-apps";
-import {
-  isTrustedWebViewUrl,
-  parseTrustedOrigin,
-} from "@/lib/webview-security";
-
-const OAUTH_STATE_KEY = "agent-native:oauth-state";
-
-// Google blocks OAuth in embedded WebViews. Open Google auth URLs in the
-// system browser (Safari) instead.
-const EXTERNAL_HOSTS = ["accounts.google.com", "oauth2.googleapis.com"];
-
-function rememberOAuthState(url: string) {
-  try {
-    const state = new URL(url).searchParams.get("state");
-    if (state) void AsyncStorage.setItem(OAUTH_STATE_KEY, state);
-  } catch {
-    // Invalid URL — ignore
-  }
-}
 
 export default function AppScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const { apps } = useApps();
-  const webviewRef = useRef<WebViewRef>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
-  const openedExternal = useRef(false);
+  const webviewRef = useRef<AppWebViewHandle>(null);
 
   const app = apps.find((a) => a.id === id);
-  const trustedOrigin = useMemo(
-    () => parseTrustedOrigin(app?.url ?? ""),
-    [app?.url],
-  );
-  const [sessionToken, setSessionToken] = useState<string | null>(null);
-
-  // Load stored session token on mount.
-  useEffect(() => {
-    void getSessionToken().then((token) => setSessionToken(token));
-  }, []);
-
-  // When the app returns to foreground after external OAuth, re-read the token
-  // (it may have been set by oauth-complete) and reload the WebView.
-  // Use a short delay to let oauth-complete store the token in SecureStore
-  // before we read it — the deep link handler and AppState listener race.
-  useEffect(() => {
-    const sub = AppState.addEventListener("change", (state) => {
-      if (state === "active" && openedExternal.current) {
-        openedExternal.current = false;
-        setTimeout(() => {
-          void getSessionToken().then((token) => {
-            setSessionToken(token);
-            webviewRef.current?.reload();
-          });
-        }, 500);
-      }
-    });
-    return () => sub.remove();
-  }, []);
-
-  const handleReload = useCallback(() => {
-    setError(false);
-    setLoading(true);
-    webviewRef.current?.reload();
-  }, []);
-
-  const handleShouldStartLoad = useCallback(
-    (event: { url: string }) => {
-      if (isTrustedWebViewUrl(event.url, trustedOrigin)) return true;
-      try {
-        const parsed = new URL(event.url);
-        if (parsed.protocol === "about:") return true;
-        parsed.searchParams.delete("_session");
-        if (EXTERNAL_HOSTS.includes(parsed.hostname)) {
-          openedExternal.current = true;
-          rememberOAuthState(parsed.toString());
-        }
-        if (parsed.protocol === "http:" || parsed.protocol === "https:") {
-          void Linking.openURL(parsed.toString());
-        }
-      } catch {
-        // Invalid and non-web URLs do not belong in the authenticated WebView.
-      }
-      return false;
-    },
-    [trustedOrigin],
-  );
 
   if (!app) {
     return (
@@ -112,21 +23,6 @@ export default function AppScreen() {
     );
   }
 
-  const baseUrl = app.url;
-
-  // Append the session token as a query param so the server can promote it to
-  // an httpOnly cookie. This bridges the Safari/WKWebView cookie jar gap.
-  const url = (() => {
-    if (!sessionToken) return baseUrl;
-    try {
-      const parsed = new URL(baseUrl);
-      parsed.searchParams.set("_session", sessionToken);
-      return parsed.toString();
-    } catch {
-      return baseUrl;
-    }
-  })();
-
   return (
     <>
       <Stack.Screen
@@ -136,7 +32,7 @@ export default function AppScreen() {
           headerTintColor: "#ffffff",
           headerRight: () => (
             <TouchableOpacity
-              onPress={handleReload}
+              onPress={() => webviewRef.current?.reload()}
               className="p-2 active:opacity-75"
             >
               <Feather name="refresh-cw" size={20} color="#ffffff" />
@@ -144,59 +40,7 @@ export default function AppScreen() {
           ),
         }}
       />
-
-      <View className="flex-1 bg-background-dark">
-        {error ? (
-          <View className="flex-1 justify-center items-center bg-background-dark p-6">
-            <Feather name="alert-circle" size={48} color="#EF4444" />
-            <Text className="text-white text-lg font-semibold mt-4 mb-1.5">
-              Failed to load {app.name}
-            </Text>
-            <Text className="text-gray-medium text-xs mb-5">{baseUrl}</Text>
-            <TouchableOpacity
-              className="flex-row items-center bg-white px-5 py-2.5 rounded-lg gap-2 active:opacity-75"
-              onPress={handleReload}
-            >
-              <Feather name="refresh-cw" size={16} color="#ffffff" />
-              <Text className="text-background-dark text-sm font-semibold">
-                Retry
-              </Text>
-            </TouchableOpacity>
-          </View>
-        ) : (
-          <WebView
-            ref={webviewRef}
-            source={{ uri: url }}
-            className="flex-1 bg-background-dark"
-            onLoadStart={() => setLoading(true)}
-            onLoadEnd={() => setLoading(false)}
-            onError={() => {
-              setLoading(false);
-              setError(true);
-            }}
-            onHttpError={(syntheticEvent) => {
-              const { statusCode } = syntheticEvent.nativeEvent;
-              if (statusCode >= 500) {
-                setError(true);
-              }
-            }}
-            onShouldStartLoadWithRequest={handleShouldStartLoad}
-            javaScriptEnabled
-            domStorageEnabled
-            sharedCookiesEnabled
-            thirdPartyCookiesEnabled
-            startInLoadingState={false}
-            allowsBackForwardNavigationGestures
-            pullToRefreshEnabled
-          />
-        )}
-
-        {loading && !error && (
-          <View className="absolute top-0 right-0 bottom-0 left-0 justify-center items-center bg-background-dark">
-            <ActivityIndicator size="large" color="#ffffff" />
-          </View>
-        )}
-      </View>
+      <AppWebView ref={webviewRef} url={app.url} appName={app.name} />
     </>
   );
 }

--- a/packages/mobile-app/app/oauth-complete.tsx
+++ b/packages/mobile-app/app/oauth-complete.tsx
@@ -1,36 +1,19 @@
-import AsyncStorage from "@react-native-async-storage/async-storage";
-import { router, useLocalSearchParams } from "expo-router";
 import { useEffect } from "react";
 import { View, ActivityIndicator } from "react-native";
 
-import { saveSessionToken } from "@/lib/session-token-store";
-
-const OAUTH_STATE_KEY = "agent-native:oauth-state";
-
 /**
- * Handles the agentnative://oauth-complete?token=xyz deep link after Google OAuth.
- * Stores the session token so the WebView can inject it as a cookie, then
- * redirects back to the main tabs.
+ * Transient screen shown if the agentnative://oauth-complete deep link happens
+ * to route here. The real work — applying the token and navigating back to the
+ * originating app — is owned by OAuthDeepLinkHandler at the app root, so this
+ * screen must not touch the stored token/state/return keys (that would race the
+ * root handler and consume them first).
  */
 export default function OAuthComplete() {
-  const { token, state } = useLocalSearchParams<{
-    token?: string;
-    state?: string;
-  }>();
-
   useEffect(() => {
-    void (async () => {
-      if (token) {
-        const expectedState = await AsyncStorage.getItem(OAUTH_STATE_KEY);
-        await AsyncStorage.removeItem(OAUTH_STATE_KEY);
-        if (expectedState && state === expectedState) {
-          await saveSessionToken(token);
-        }
-      }
-      router.replace("/(tabs)");
-    })();
-  }, [state, token]);
-
+    console.log(
+      "[oauth] oauth-complete ROUTE mounted (expo-router routed here)",
+    );
+  }, []);
   return (
     <View className="flex-1 justify-center items-center bg-background-dark">
       <ActivityIndicator size="large" color="#ffffff" />

--- a/packages/mobile-app/components/AppWebView.tsx
+++ b/packages/mobile-app/components/AppWebView.tsx
@@ -424,15 +424,12 @@ function AppWebView(
   );
 
   // Append the session token as a query param so the server can promote it to
-  // an httpOnly cookie (bridges the Safari/WKWebView cookie jar gap), and force
-  // the sign-in page into redirect mode. Its default popup flow opens Google in
-  // a window this WebView can't intercept; redirect mode navigates the main
-  // frame to the auth-url endpoint, which handleShouldStartLoad hands to Safari.
+  // an httpOnly cookie (bridges the Safari/WKWebView cookie jar gap).
   const webviewUrl = useMemo(() => {
+    if (!sessionToken) return url;
     try {
       const parsed = new URL(url);
-      parsed.searchParams.set("authMode", "redirect");
-      if (sessionToken) parsed.searchParams.set("_session", sessionToken);
+      parsed.searchParams.set("_session", sessionToken);
       return parsed.toString();
     } catch {
       return url;

--- a/packages/mobile-app/components/AppWebView.tsx
+++ b/packages/mobile-app/components/AppWebView.tsx
@@ -24,6 +24,7 @@ import type { WebView as WebViewRef } from "react-native-webview";
 
 import { WebView } from "@/components/uniwind-interop";
 import { clipsSessionOwnerKey } from "@/lib/clips-session";
+import { completeOAuthCallback } from "@/lib/oauth-session";
 import {
   OAUTH_BASE_URL_KEY,
   OAUTH_OWNER_KEY_KEY,
@@ -141,16 +142,6 @@ function isGoogleAuthUrl(url: string): boolean {
   }
 }
 
-// The redirect is agentnative://oauth-complete?token=…&state=…. Custom-scheme
-// URLs don't parse reliably via `new URL` in React Native, so read the token
-// straight off the query string.
-function tokenFromRedirect(url: string): string | null {
-  const queryStart = url.indexOf("?");
-  if (queryStart < 0) return null;
-  const token = new URLSearchParams(url.slice(queryStart + 1)).get("token");
-  return token && token.length > 0 ? token : null;
-}
-
 // Resolve the auth-url endpoint's JSON form (without `redirect=1`) so we get
 // the accounts.google.com URL — including the server-minted `state`. The start
 // URL itself has no `state` yet (the server mints it), so it can't be opened
@@ -247,40 +238,37 @@ function AppWebView(
     return () => sub.remove();
   }, [sessionTokenKey]);
 
-  const applySessionToken = useCallback(
-    (token: string) => {
-      void saveSessionToken(token, sessionTokenKey).then(() => {
-        if (token !== lastTokenRef.current) {
-          lastTokenRef.current = token;
-          setSessionToken(token);
-        }
-      });
-    },
-    [sessionTokenKey],
+  // The OAuth completion context for this WebView — passed to the shared
+  // completeOAuthCallback so the iOS inline path and the Android deep-link
+  // handler validate and persist the session identically.
+  const oauthContext = useMemo(
+    () => ({
+      tokenKey: sessionTokenKey,
+      ownerKeyName: sessionOwnerKey ?? null,
+      baseUrl: trustedOrigin,
+    }),
+    [sessionTokenKey, sessionOwnerKey, trustedOrigin],
   );
 
   // Google refuses OAuth inside embedded WebViews, so run the flow in a system
-  // browser tab. The return-path and token key are persisted first so the
-  // OAuthDeepLinkHandler can finish the sign-in even if Android kills this app
-  // while it's in the browser.
+  // browser tab.
   const openGoogleSession = useCallback(
     async (googleUrl: string) => {
       rememberOAuthState(googleUrl);
-      await AsyncStorage.multiSet([
-        [OAUTH_RETURN_PATH_KEY, pathnameRef.current],
-        [OAUTH_TOKEN_STORE_KEY, sessionTokenKey],
-        // Only Clips passes a sessionOwnerKey; the handler uses it plus the app
-        // origin to set the owner key the Clips session also requires.
-        [OAUTH_OWNER_KEY_KEY, sessionOwnerKey ?? ""],
-        [OAUTH_BASE_URL_KEY, trustedOrigin ?? ""],
-      ]);
       try {
         if (Platform.OS === "android") {
           // openAuthSessionAsync is unreliable on Android — it can hand off to
           // an external browser/app and never redirect back (expo #27500).
-          // Open a Custom Tab in the preferred browser instead and let the
+          // Open a Custom Tab in the preferred browser and let the
           // agentnative://oauth-complete deep link (OAuthDeepLinkHandler) bring
-          // the result back into the app.
+          // the result back — persist the completion context first so it can
+          // finish even if Android kills this app while it's in the browser.
+          await AsyncStorage.multiSet([
+            [OAUTH_RETURN_PATH_KEY, pathnameRef.current],
+            [OAUTH_TOKEN_STORE_KEY, sessionTokenKey],
+            [OAUTH_OWNER_KEY_KEY, sessionOwnerKey ?? ""],
+            [OAUTH_BASE_URL_KEY, trustedOrigin ?? ""],
+          ]);
           const { preferredBrowserPackage } =
             await WebBrowser.getCustomTabsSupportingBrowsersAsync();
           await WebBrowser.openBrowserAsync(googleUrl, {
@@ -289,20 +277,24 @@ function AppWebView(
           });
           return;
         }
+        // iOS: the auth session returns the callback inline. Run it through the
+        // same validated completion, then apply the token to this WebView.
         const result = await WebBrowser.openAuthSessionAsync(
           googleUrl,
           "agentnative://oauth-complete",
         );
         console.log("[oauth] auth session result:", result.type);
         if (result.type !== "success" || !result.url) return;
-        const token = tokenFromRedirect(result.url);
-        console.log("[oauth] inline token extracted:", token ? "yes" : "no");
-        if (token) applySessionToken(token);
+        const token = await completeOAuthCallback(result.url, oauthContext);
+        if (token && token !== lastTokenRef.current) {
+          lastTokenRef.current = token;
+          setSessionToken(token);
+        }
       } catch (e) {
         console.log("[oauth] auth session error:", String(e));
       }
     },
-    [applySessionToken, sessionTokenKey, sessionOwnerKey, trustedOrigin],
+    [oauthContext, sessionTokenKey, sessionOwnerKey, trustedOrigin],
   );
 
   // Some core versions navigate the WebView straight to the auth-url endpoint,
@@ -311,7 +303,14 @@ function AppWebView(
   const startGoogleAuth = useCallback(
     async (startUrl: string) => {
       const authUrl = await resolveGoogleAuthUrl(startUrl);
-      if (authUrl) await openGoogleSession(authUrl);
+      if (authUrl) {
+        await openGoogleSession(authUrl);
+      } else {
+        // We already blocked the in-WebView auth navigation, so a failed
+        // resolve would otherwise leave the page stuck with no browser and no
+        // feedback. Surface the recoverable error/retry screen instead.
+        setError(true);
+      }
     },
     [openGoogleSession],
   );

--- a/packages/mobile-app/components/AppWebView.tsx
+++ b/packages/mobile-app/components/AppWebView.tsx
@@ -1,10 +1,36 @@
+import { Feather } from "@expo/vector-icons";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ActivityIndicator, AppState, Linking, View } from "react-native";
+import { useFocusEffect, usePathname } from "expo-router";
+import * as WebBrowser from "expo-web-browser";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  ActivityIndicator,
+  AppState,
+  Linking,
+  Platform,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
 import type { WebView as WebViewRef } from "react-native-webview";
 
 import { WebView } from "@/components/uniwind-interop";
 import { clipsSessionOwnerKey } from "@/lib/clips-session";
+import {
+  OAUTH_BASE_URL_KEY,
+  OAUTH_OWNER_KEY_KEY,
+  OAUTH_RETURN_PATH_KEY,
+  OAUTH_STATE_KEY,
+  OAUTH_TOKEN_STORE_KEY,
+} from "@/lib/oauth-storage";
 import {
   clearSessionToken,
   getSessionToken,
@@ -21,13 +47,42 @@ interface AppWebViewProps {
   captureSessionToken?: boolean;
   sessionTokenKey?: string;
   sessionOwnerKey?: string;
+  /** Shown in the load-failure message, e.g. "Failed to load Calendar". */
+  appName?: string;
 }
 
-const OAUTH_STATE_KEY = "agent-native:oauth-state";
+export interface AppWebViewHandle {
+  reload: () => void;
+}
 
 // Google blocks OAuth in embedded WebViews. Open Google auth URLs in the
 // system browser (Safari) instead.
 const EXTERNAL_HOSTS = ["accounts.google.com", "oauth2.googleapis.com"];
+
+// The web sign-in page navigates the WebView to this same-origin endpoint,
+// which then 302s to accounts.google.com. Android does not re-fire
+// onShouldStartLoadWithRequest on that server redirect, so Google's block
+// page loads inside the WebView. Intercept the start URL here instead.
+const GOOGLE_AUTH_URL_PATH = "/_agent-native/google/auth-url";
+
+// The remote sign-in page opens Google in a window.open popup. Inside this
+// WebView that popup either loads Google inline (which Google blocks) or spins
+// forever polling a callback that never lands. Neutering window.open on the
+// sign-in page forces the page's built-in redirect fallback, which navigates
+// the main frame to /_agent-native/google/auth-url — a top-level navigation
+// handleShouldStartLoad intercepts and hands to the system browser. Scoped to
+// the sign-in page so the authenticated app's own window.open is untouched.
+const FORCE_REDIRECT_AUTH_SCRIPT = `
+  (function () {
+    try {
+      if (location.pathname.indexOf('/_agent-native/sign-in') !== -1) {
+        window.open = function () { return null; };
+      }
+    } catch (e) {}
+    return true;
+  })();
+  true;
+`;
 const SESSION_BRIDGE_SCRIPT = `
   (function () {
     if (window.__agentNativeSessionBridgeRunning) return true;
@@ -78,17 +133,75 @@ function rememberOAuthState(url: string) {
   }
 }
 
-export default function AppWebView({
-  url,
-  captureSessionToken = false,
-  sessionTokenKey = SESSION_TOKEN_KEY,
-  sessionOwnerKey,
-}: AppWebViewProps) {
+function isGoogleAuthUrl(url: string): boolean {
+  try {
+    return new URL(url).pathname.endsWith(GOOGLE_AUTH_URL_PATH);
+  } catch {
+    return false;
+  }
+}
+
+// The redirect is agentnative://oauth-complete?token=…&state=…. Custom-scheme
+// URLs don't parse reliably via `new URL` in React Native, so read the token
+// straight off the query string.
+function tokenFromRedirect(url: string): string | null {
+  const queryStart = url.indexOf("?");
+  if (queryStart < 0) return null;
+  const token = new URLSearchParams(url.slice(queryStart + 1)).get("token");
+  return token && token.length > 0 ? token : null;
+}
+
+// Resolve the auth-url endpoint's JSON form (without `redirect=1`) so we get
+// the accounts.google.com URL — including the server-minted `state`. The start
+// URL itself has no `state` yet (the server mints it), so it can't be opened
+// directly without breaking the callback's state check.
+async function resolveGoogleAuthUrl(startUrl: string): Promise<string | null> {
+  try {
+    const parsed = new URL(startUrl);
+    parsed.searchParams.delete("redirect");
+    const res = await fetch(parsed.toString(), {
+      headers: { Accept: "application/json" },
+    });
+    const data = (await res.json()) as { url?: unknown };
+    return typeof data.url === "string" && data.url.length > 0
+      ? data.url
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function AppWebView(
+  {
+    url,
+    captureSessionToken = false,
+    sessionTokenKey = SESSION_TOKEN_KEY,
+    sessionOwnerKey,
+    appName,
+  }: AppWebViewProps,
+  ref: React.Ref<AppWebViewHandle>,
+) {
   const webviewRef = useRef<WebViewRef>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
   const [sessionToken, setSessionToken] = useState<string | null>(null);
   const lastTokenRef = useRef<string | null>(null);
   const trustedOrigin = useMemo(() => parseTrustedOrigin(url), [url]);
+
+  // Remember the current route so the oauth-complete fallback can return here
+  // instead of Home if the deep link leaks to the OS (Android resets the stack,
+  // so router.canGoBack() is false and it would otherwise land on Home).
+  const pathname = usePathname();
+  const pathnameRef = useRef(pathname);
+  pathnameRef.current = pathname;
+
+  const reload = useCallback(() => {
+    setError(false);
+    setLoading(true);
+    webviewRef.current?.reload();
+  }, []);
+
+  useImperativeHandle(ref, () => ({ reload }), [reload]);
 
   // Load stored session token on mount.
   useEffect(() => {
@@ -97,6 +210,21 @@ export default function AppWebView({
       setSessionToken(token);
     });
   }, [sessionTokenKey]);
+
+  // Re-read the token every time this screen regains focus. Returning from the
+  // Google sign-in browser (via oauth-complete's replace/back, or the inline
+  // auth session) refocuses this screen; without this, an already-mounted
+  // WebView keeps its stale null token and stays signed out.
+  useFocusEffect(
+    useCallback(() => {
+      void getSessionToken(sessionTokenKey).then((token) => {
+        if (token !== lastTokenRef.current) {
+          lastTokenRef.current = token;
+          setSessionToken(token);
+        }
+      });
+    }, [sessionTokenKey]),
+  );
 
   // When the app returns to foreground, check if the session token was updated
   // (e.g. by the oauth-complete deep link handler storing a new token in
@@ -119,15 +247,96 @@ export default function AppWebView({
     return () => sub.remove();
   }, [sessionTokenKey]);
 
+  const applySessionToken = useCallback(
+    (token: string) => {
+      void saveSessionToken(token, sessionTokenKey).then(() => {
+        if (token !== lastTokenRef.current) {
+          lastTokenRef.current = token;
+          setSessionToken(token);
+        }
+      });
+    },
+    [sessionTokenKey],
+  );
+
+  // Google refuses OAuth inside embedded WebViews, so run the flow in a system
+  // browser tab. The return-path and token key are persisted first so the
+  // OAuthDeepLinkHandler can finish the sign-in even if Android kills this app
+  // while it's in the browser.
+  const openGoogleSession = useCallback(
+    async (googleUrl: string) => {
+      rememberOAuthState(googleUrl);
+      await AsyncStorage.multiSet([
+        [OAUTH_RETURN_PATH_KEY, pathnameRef.current],
+        [OAUTH_TOKEN_STORE_KEY, sessionTokenKey],
+        // Only Clips passes a sessionOwnerKey; the handler uses it plus the app
+        // origin to set the owner key the Clips session also requires.
+        [OAUTH_OWNER_KEY_KEY, sessionOwnerKey ?? ""],
+        [OAUTH_BASE_URL_KEY, trustedOrigin ?? ""],
+      ]);
+      try {
+        if (Platform.OS === "android") {
+          // openAuthSessionAsync is unreliable on Android — it can hand off to
+          // an external browser/app and never redirect back (expo #27500).
+          // Open a Custom Tab in the preferred browser instead and let the
+          // agentnative://oauth-complete deep link (OAuthDeepLinkHandler) bring
+          // the result back into the app.
+          const { preferredBrowserPackage } =
+            await WebBrowser.getCustomTabsSupportingBrowsersAsync();
+          await WebBrowser.openBrowserAsync(googleUrl, {
+            browserPackage: preferredBrowserPackage,
+            showInRecents: true,
+          });
+          return;
+        }
+        const result = await WebBrowser.openAuthSessionAsync(
+          googleUrl,
+          "agentnative://oauth-complete",
+        );
+        console.log("[oauth] auth session result:", result.type);
+        if (result.type !== "success" || !result.url) return;
+        const token = tokenFromRedirect(result.url);
+        console.log("[oauth] inline token extracted:", token ? "yes" : "no");
+        if (token) applySessionToken(token);
+      } catch (e) {
+        console.log("[oauth] auth session error:", String(e));
+      }
+    },
+    [applySessionToken, sessionTokenKey, sessionOwnerKey, trustedOrigin],
+  );
+
+  // Some core versions navigate the WebView straight to the auth-url endpoint,
+  // which has no `state` yet; resolve its JSON form to the accounts.google.com
+  // URL (with state) before opening the browser session.
+  const startGoogleAuth = useCallback(
+    async (startUrl: string) => {
+      const authUrl = await resolveGoogleAuthUrl(startUrl);
+      if (authUrl) await openGoogleSession(authUrl);
+    },
+    [openGoogleSession],
+  );
+
   const handleShouldStartLoad = useCallback(
     (event: { url: string }) => {
+      // Same-origin Google sign-in start URL: open the flow in the system
+      // browser so Google doesn't reject the embedded WebView.
+      if (
+        isTrustedWebViewUrl(event.url, trustedOrigin) &&
+        isGoogleAuthUrl(event.url)
+      ) {
+        void startGoogleAuth(event.url);
+        return false;
+      }
       if (isTrustedWebViewUrl(event.url, trustedOrigin)) return true;
       try {
         const parsed = new URL(event.url);
         if (parsed.protocol === "about:") return true;
         parsed.searchParams.delete("_session");
-        if (EXTERNAL_HOSTS.includes(parsed.hostname)) {
-          rememberOAuthState(parsed.toString());
+        // Direct navigation to Google's consent screen: it already carries the
+        // `state`, so open it in the browser session and apply the token here.
+        if (parsed.hostname === "accounts.google.com") {
+          void openGoogleSession(parsed.toString());
+          return false;
         }
         if (parsed.protocol === "http:" || parsed.protocol === "https:") {
           void Linking.openURL(parsed.toString());
@@ -137,7 +346,7 @@ export default function AppWebView({
       }
       return false;
     },
-    [trustedOrigin],
+    [trustedOrigin, startGoogleAuth, openGoogleSession],
   );
 
   // Handle messages from the web app (e.g. open a URL in the system browser)
@@ -215,17 +424,41 @@ export default function AppWebView({
   );
 
   // Append the session token as a query param so the server can promote it to
-  // an httpOnly cookie. This bridges the Safari/WKWebView cookie jar gap.
+  // an httpOnly cookie (bridges the Safari/WKWebView cookie jar gap), and force
+  // the sign-in page into redirect mode. Its default popup flow opens Google in
+  // a window this WebView can't intercept; redirect mode navigates the main
+  // frame to the auth-url endpoint, which handleShouldStartLoad hands to Safari.
   const webviewUrl = useMemo(() => {
-    if (!sessionToken) return url;
     try {
       const parsed = new URL(url);
-      parsed.searchParams.set("_session", sessionToken);
+      parsed.searchParams.set("authMode", "redirect");
+      if (sessionToken) parsed.searchParams.set("_session", sessionToken);
       return parsed.toString();
     } catch {
       return url;
     }
   }, [sessionToken, url]);
+
+  if (error) {
+    return (
+      <View className="flex-1 justify-center items-center bg-background-pure p-6">
+        <Feather name="alert-circle" size={48} color="#EF4444" />
+        <Text className="text-white text-lg font-semibold mt-4 mb-1.5">
+          Failed to load{appName ? ` ${appName}` : ""}
+        </Text>
+        <Text className="text-gray-medium text-xs mb-5">{url}</Text>
+        <TouchableOpacity
+          className="flex-row items-center bg-white px-5 py-2.5 rounded-lg gap-2 active:opacity-75"
+          onPress={reload}
+        >
+          <Feather name="refresh-cw" size={16} color="#111111" />
+          <Text className="text-background-dark text-sm font-semibold">
+            Retry
+          </Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
 
   return (
     <View className="flex-1 bg-background-pure">
@@ -235,8 +468,16 @@ export default function AppWebView({
         className="flex-1 bg-background-pure"
         onLoadStart={() => setLoading(true)}
         onLoadEnd={handleLoadEnd}
+        onError={() => {
+          setLoading(false);
+          setError(true);
+        }}
+        onHttpError={(event: { nativeEvent: { statusCode: number } }) => {
+          if (event.nativeEvent.statusCode >= 500) setError(true);
+        }}
         onShouldStartLoadWithRequest={handleShouldStartLoad}
         onMessage={handleMessage}
+        injectedJavaScriptBeforeContentLoaded={FORCE_REDIRECT_AUTH_SCRIPT}
         javaScriptEnabled
         domStorageEnabled
         sharedCookiesEnabled
@@ -244,6 +485,13 @@ export default function AppWebView({
         startInLoadingState={false}
         allowsBackForwardNavigationGestures
         pullToRefreshEnabled
+        // Google refuses OAuth in embedded WebViews. The remote sign-in page
+        // defaults to a window.open popup that Android's multi-window support
+        // would load inline (and Google blocks). Disabling it makes window.open
+        // return null, so the page falls back to a top-level redirect to
+        // /_agent-native/google/auth-url — which handleShouldStartLoad hands to
+        // the system browser. Works across every app domain and core version.
+        setSupportMultipleWindows={false}
       />
       {loading && (
         <View className="absolute inset-0 justify-center items-center bg-background-pure">
@@ -253,3 +501,5 @@ export default function AppWebView({
     </View>
   );
 }
+
+export default forwardRef(AppWebView);

--- a/packages/mobile-app/components/AppWebView.tsx
+++ b/packages/mobile-app/components/AppWebView.tsx
@@ -250,6 +250,21 @@ function AppWebView(
     [sessionTokenKey, sessionOwnerKey, trustedOrigin],
   );
 
+  // Persist everything the deep-link handler needs to finish an OAuth callback
+  // (route to return to, token/owner storage keys, app origin) so completion
+  // works even if Android kills this app while it's in the browser. Shared by
+  // every path that hands OAuth off to the system browser via a deep link.
+  const persistOAuthReturnContext = useCallback(
+    () =>
+      AsyncStorage.multiSet([
+        [OAUTH_RETURN_PATH_KEY, pathnameRef.current],
+        [OAUTH_TOKEN_STORE_KEY, sessionTokenKey],
+        [OAUTH_OWNER_KEY_KEY, sessionOwnerKey ?? ""],
+        [OAUTH_BASE_URL_KEY, trustedOrigin ?? ""],
+      ]),
+    [sessionTokenKey, sessionOwnerKey, trustedOrigin],
+  );
+
   // Google refuses OAuth inside embedded WebViews, so run the flow in a system
   // browser tab.
   const openGoogleSession = useCallback(
@@ -261,14 +276,8 @@ function AppWebView(
           // an external browser/app and never redirect back (expo #27500).
           // Open a Custom Tab in the preferred browser and let the
           // agentnative://oauth-complete deep link (OAuthDeepLinkHandler) bring
-          // the result back — persist the completion context first so it can
-          // finish even if Android kills this app while it's in the browser.
-          await AsyncStorage.multiSet([
-            [OAUTH_RETURN_PATH_KEY, pathnameRef.current],
-            [OAUTH_TOKEN_STORE_KEY, sessionTokenKey],
-            [OAUTH_OWNER_KEY_KEY, sessionOwnerKey ?? ""],
-            [OAUTH_BASE_URL_KEY, trustedOrigin ?? ""],
-          ]);
+          // the result back.
+          await persistOAuthReturnContext();
           const { preferredBrowserPackage } =
             await WebBrowser.getCustomTabsSupportingBrowsersAsync();
           await WebBrowser.openBrowserAsync(googleUrl, {
@@ -294,7 +303,7 @@ function AppWebView(
         console.log("[oauth] auth session error:", String(e));
       }
     },
-    [oauthContext, sessionTokenKey, sessionOwnerKey, trustedOrigin],
+    [oauthContext, persistOAuthReturnContext],
   );
 
   // Some core versions navigate the WebView straight to the auth-url endpoint,
@@ -396,17 +405,29 @@ function AppWebView(
         }
         if (msg.type === "openUrl" && typeof msg.url === "string") {
           const parsed = new URL(msg.url);
-          // Only open external hosts in Safari — anything else is ignored
+          // Only open external hosts in Safari — anything else is ignored.
+          // These are Google OAuth hosts, so persist the completion context
+          // (like the intercepted-navigation path) before handing off, or the
+          // deep-link callback can't restore the return route / Clips token key.
           if (EXTERNAL_HOSTS.includes(parsed.hostname)) {
             rememberOAuthState(msg.url);
-            void Linking.openURL(msg.url);
+            void (async () => {
+              await persistOAuthReturnContext();
+              await Linking.openURL(msg.url);
+            })().catch(() => {});
           }
         }
       } catch {
         // Ignore malformed messages
       }
     },
-    [captureSessionToken, sessionOwnerKey, sessionTokenKey, trustedOrigin],
+    [
+      captureSessionToken,
+      sessionOwnerKey,
+      sessionTokenKey,
+      trustedOrigin,
+      persistOAuthReturnContext,
+    ],
   );
 
   const handleLoadEnd = useCallback(

--- a/packages/mobile-app/components/OAuthDeepLinkHandler.tsx
+++ b/packages/mobile-app/components/OAuthDeepLinkHandler.tsx
@@ -1,0 +1,124 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { router } from "expo-router";
+import * as WebBrowser from "expo-web-browser";
+import { useEffect } from "react";
+import { Linking } from "react-native";
+
+import { clipsSessionOwnerKey } from "@/lib/clips-session";
+import {
+  OAUTH_BASE_URL_KEY,
+  OAUTH_OWNER_KEY_KEY,
+  OAUTH_RETURN_PATH_KEY,
+  OAUTH_STATE_KEY,
+  OAUTH_TOKEN_STORE_KEY,
+} from "@/lib/oauth-storage";
+import { saveSessionToken } from "@/lib/session-token-store";
+
+// Clips needs an owner key (email/orgId) alongside the token before its session
+// counts as connected. The token alone can't produce it, so resolve the owner
+// from the app's session endpoint using the freshly-saved token.
+async function setOwnerKeyIfNeeded(
+  token: string,
+  ownerKeyName: string | null,
+  baseUrl: string | null,
+): Promise<void> {
+  if (!ownerKeyName || !baseUrl) return;
+  try {
+    const res = await fetch(
+      `${baseUrl}/_agent-native/auth/session?_session=${encodeURIComponent(token)}`,
+      { headers: { Accept: "application/json" } },
+    );
+    const data = (await res.json()) as { email?: unknown; orgId?: unknown };
+    if (typeof data.email === "string" && data.email.trim()) {
+      await AsyncStorage.setItem(
+        ownerKeyName,
+        clipsSessionOwnerKey(
+          data.email,
+          typeof data.orgId === "string" ? data.orgId : undefined,
+        ),
+      );
+      console.log("[oauth] owner key set for", ownerKeyName);
+    }
+  } catch {
+    // Owner key will still be set by the WebView session bridge on next load.
+  }
+}
+
+// Custom-scheme URLs don't parse reliably via `new URL` in React Native, so
+// read the query string directly.
+function queryParams(url: string): URLSearchParams {
+  const queryStart = url.indexOf("?");
+  return new URLSearchParams(queryStart < 0 ? "" : url.slice(queryStart + 1));
+}
+
+async function handleOAuthUrl(url: string | null): Promise<void> {
+  console.log("[oauth] handleOAuthUrl saw url:", url);
+  if (!url || !url.includes("oauth-complete")) return;
+  const params = queryParams(url);
+  const token = params.get("token");
+  const state = params.get("state");
+  const [expectedState, returnPath, tokenKey, ownerKeyName, baseUrl] =
+    await Promise.all([
+      AsyncStorage.getItem(OAUTH_STATE_KEY),
+      AsyncStorage.getItem(OAUTH_RETURN_PATH_KEY),
+      AsyncStorage.getItem(OAUTH_TOKEN_STORE_KEY),
+      AsyncStorage.getItem(OAUTH_OWNER_KEY_KEY),
+      AsyncStorage.getItem(OAUTH_BASE_URL_KEY),
+    ]);
+  await AsyncStorage.multiRemove([
+    OAUTH_STATE_KEY,
+    OAUTH_RETURN_PATH_KEY,
+    OAUTH_TOKEN_STORE_KEY,
+    OAUTH_OWNER_KEY_KEY,
+    OAUTH_BASE_URL_KEY,
+  ]);
+  const stateMatch = !!expectedState && state === expectedState;
+  console.log(
+    "[oauth] deep link handler. token:",
+    !!token,
+    "stateMatch:",
+    stateMatch,
+    "returnPath:",
+    returnPath,
+    "tokenKey:",
+    tokenKey,
+  );
+  if (token && stateMatch) {
+    await saveSessionToken(token, tokenKey ?? undefined);
+    console.log("[oauth] token saved via deep link handler");
+    await setOwnerKeyIfNeeded(token, ownerKeyName, baseUrl);
+  }
+  // Close the Custom Tab left open by openBrowserAsync (Android) so the app is
+  // visible again. No-op if nothing is open.
+  try {
+    await WebBrowser.dismissBrowser();
+  } catch {
+    // Nothing to dismiss.
+  }
+  if (returnPath) router.replace(returnPath as never);
+}
+
+/**
+ * Owns the agentnative://oauth-complete return, at the app root, so it works
+ * even when the OS killed the app while it was in the Google sign-in browser
+ * and cold-starts it from the deep link. getInitialURL covers that cold start;
+ * the url listener covers a warm return. Running here (not in a route) sidesteps
+ * expo-router's host/path ambiguity for agentnative://oauth-complete, which
+ * otherwise lands the user on Home. The persisted return-path and token key
+ * survive the app kill in AsyncStorage.
+ */
+export default function OAuthDeepLinkHandler() {
+  useEffect(() => {
+    console.log("[oauth] handler mounted");
+    void Linking.getInitialURL().then((url) => {
+      console.log("[oauth] getInitialURL:", url);
+      return handleOAuthUrl(url);
+    });
+    const sub = Linking.addEventListener("url", (event) => {
+      console.log("[oauth] url event:", event.url);
+      void handleOAuthUrl(event.url);
+    });
+    return () => sub.remove();
+  }, []);
+  return null;
+}

--- a/packages/mobile-app/components/OAuthDeepLinkHandler.tsx
+++ b/packages/mobile-app/components/OAuthDeepLinkHandler.tsx
@@ -4,90 +4,38 @@ import * as WebBrowser from "expo-web-browser";
 import { useEffect } from "react";
 import { Linking } from "react-native";
 
-import { clipsSessionOwnerKey } from "@/lib/clips-session";
+import { completeOAuthCallback } from "@/lib/oauth-session";
 import {
   OAUTH_BASE_URL_KEY,
   OAUTH_OWNER_KEY_KEY,
   OAUTH_RETURN_PATH_KEY,
-  OAUTH_STATE_KEY,
   OAUTH_TOKEN_STORE_KEY,
 } from "@/lib/oauth-storage";
-import { saveSessionToken } from "@/lib/session-token-store";
-
-// Clips needs an owner key (email/orgId) alongside the token before its session
-// counts as connected. The token alone can't produce it, so resolve the owner
-// from the app's session endpoint using the freshly-saved token.
-async function setOwnerKeyIfNeeded(
-  token: string,
-  ownerKeyName: string | null,
-  baseUrl: string | null,
-): Promise<void> {
-  if (!ownerKeyName || !baseUrl) return;
-  try {
-    const res = await fetch(
-      `${baseUrl}/_agent-native/auth/session?_session=${encodeURIComponent(token)}`,
-      { headers: { Accept: "application/json" } },
-    );
-    const data = (await res.json()) as { email?: unknown; orgId?: unknown };
-    if (typeof data.email === "string" && data.email.trim()) {
-      await AsyncStorage.setItem(
-        ownerKeyName,
-        clipsSessionOwnerKey(
-          data.email,
-          typeof data.orgId === "string" ? data.orgId : undefined,
-        ),
-      );
-      console.log("[oauth] owner key set for", ownerKeyName);
-    }
-  } catch {
-    // Owner key will still be set by the WebView session bridge on next load.
-  }
-}
-
-// Custom-scheme URLs don't parse reliably via `new URL` in React Native, so
-// read the query string directly.
-function queryParams(url: string): URLSearchParams {
-  const queryStart = url.indexOf("?");
-  return new URLSearchParams(queryStart < 0 ? "" : url.slice(queryStart + 1));
-}
 
 async function handleOAuthUrl(url: string | null): Promise<void> {
   console.log("[oauth] handleOAuthUrl saw url:", url);
   if (!url || !url.includes("oauth-complete")) return;
-  const params = queryParams(url);
-  const token = params.get("token");
-  const state = params.get("state");
-  const [expectedState, returnPath, tokenKey, ownerKeyName, baseUrl] =
-    await Promise.all([
-      AsyncStorage.getItem(OAUTH_STATE_KEY),
-      AsyncStorage.getItem(OAUTH_RETURN_PATH_KEY),
-      AsyncStorage.getItem(OAUTH_TOKEN_STORE_KEY),
-      AsyncStorage.getItem(OAUTH_OWNER_KEY_KEY),
-      AsyncStorage.getItem(OAUTH_BASE_URL_KEY),
-    ]);
+  // completeOAuthCallback consumes OAUTH_STATE_KEY itself; here we read the rest
+  // of the context persisted before the browser opened (they survive an app
+  // kill) so the completion is identical to the iOS inline path.
+  const [returnPath, tokenKey, ownerKeyName, baseUrl] = await Promise.all([
+    AsyncStorage.getItem(OAUTH_RETURN_PATH_KEY),
+    AsyncStorage.getItem(OAUTH_TOKEN_STORE_KEY),
+    AsyncStorage.getItem(OAUTH_OWNER_KEY_KEY),
+    AsyncStorage.getItem(OAUTH_BASE_URL_KEY),
+  ]);
   await AsyncStorage.multiRemove([
-    OAUTH_STATE_KEY,
     OAUTH_RETURN_PATH_KEY,
     OAUTH_TOKEN_STORE_KEY,
     OAUTH_OWNER_KEY_KEY,
     OAUTH_BASE_URL_KEY,
   ]);
-  const stateMatch = !!expectedState && state === expectedState;
-  console.log(
-    "[oauth] deep link handler. token:",
-    !!token,
-    "stateMatch:",
-    stateMatch,
-    "returnPath:",
-    returnPath,
-    "tokenKey:",
+  const token = await completeOAuthCallback(url, {
     tokenKey,
-  );
-  if (token && stateMatch) {
-    await saveSessionToken(token, tokenKey ?? undefined);
-    console.log("[oauth] token saved via deep link handler");
-    await setOwnerKeyIfNeeded(token, ownerKeyName, baseUrl);
-  }
+    ownerKeyName,
+    baseUrl,
+  });
+  console.log("[oauth] deep link handler. token saved:", !!token, returnPath);
   // Close the Custom Tab left open by openBrowserAsync (Android) so the app is
   // visible again. No-op if nothing is open.
   try {

--- a/packages/mobile-app/components/OAuthDeepLinkHandler.tsx
+++ b/packages/mobile-app/components/OAuthDeepLinkHandler.tsx
@@ -24,17 +24,22 @@ async function handleOAuthUrl(url: string | null): Promise<void> {
     AsyncStorage.getItem(OAUTH_OWNER_KEY_KEY),
     AsyncStorage.getItem(OAUTH_BASE_URL_KEY),
   ]);
+  const token = await completeOAuthCallback(url, {
+    tokenKey,
+    ownerKeyName,
+    baseUrl,
+  });
+  // Only consume the persisted context once a matching callback is accepted. A
+  // stale or forged agentnative://oauth-complete fails state validation and
+  // returns null; clearing here would erase the route/Clips context the real
+  // redirect still needs.
+  if (!token) return;
   await AsyncStorage.multiRemove([
     OAUTH_RETURN_PATH_KEY,
     OAUTH_TOKEN_STORE_KEY,
     OAUTH_OWNER_KEY_KEY,
     OAUTH_BASE_URL_KEY,
   ]);
-  const token = await completeOAuthCallback(url, {
-    tokenKey,
-    ownerKeyName,
-    baseUrl,
-  });
   console.log("[oauth] deep link handler. token saved:", !!token, returnPath);
   // Close the Custom Tab left open by openBrowserAsync (Android) so the app is
   // visible again. No-op if nothing is open.

--- a/packages/mobile-app/lib/oauth-session.ts
+++ b/packages/mobile-app/lib/oauth-session.ts
@@ -1,0 +1,82 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+import { clipsSessionOwnerKey } from "./clips-session";
+import { OAUTH_STATE_KEY } from "./oauth-storage";
+import { saveSessionToken } from "./session-token-store";
+
+// Custom-scheme callback URLs (agentnative://oauth-complete?…) don't parse
+// reliably via `new URL` in React Native, so read the query string directly.
+export function redirectParam(url: string, name: string): string | null {
+  const queryStart = url.indexOf("?");
+  if (queryStart < 0) return null;
+  const value = new URLSearchParams(url.slice(queryStart + 1)).get(name);
+  return value && value.length > 0 ? value : null;
+}
+
+// Validate a callback `state` against the one stored before the browser opened,
+// consuming it so it can't be replayed. A custom URL scheme is not
+// origin-authenticated, so without this a mismatched or forged callback could
+// replace the active session. Both the iOS inline path and the deep-link
+// handler must gate token acceptance on this.
+export async function consumeOAuthStateMatches(
+  state: string | null,
+): Promise<boolean> {
+  const expected = await AsyncStorage.getItem(OAUTH_STATE_KEY);
+  await AsyncStorage.removeItem(OAUTH_STATE_KEY);
+  return Boolean(expected) && state === expected;
+}
+
+// Clips needs an owner key (derived from email/orgId) alongside the token
+// before its session counts as connected. The token alone can't produce it, so
+// resolve the owner from the app's session endpoint using the saved token.
+export async function resolveAndStoreOwnerKey(
+  token: string,
+  ownerKeyName: string | null,
+  baseUrl: string | null,
+): Promise<void> {
+  if (!ownerKeyName || !baseUrl) return;
+  try {
+    const res = await fetch(
+      `${baseUrl}/_agent-native/auth/session?_session=${encodeURIComponent(token)}`,
+      { headers: { Accept: "application/json" } },
+    );
+    const data = (await res.json()) as { email?: unknown; orgId?: unknown };
+    if (typeof data.email === "string" && data.email.trim()) {
+      await AsyncStorage.setItem(
+        ownerKeyName,
+        clipsSessionOwnerKey(
+          data.email,
+          typeof data.orgId === "string" ? data.orgId : undefined,
+        ),
+      );
+    }
+  } catch {
+    // Owner key will still be set by the WebView session bridge on next load.
+  }
+}
+
+export interface OAuthCompletionContext {
+  /** Session-token storage key (Clips uses its own; others the default). */
+  tokenKey: string | null;
+  /** Owner-key storage key, set only for Clips. */
+  ownerKeyName: string | null;
+  /** App origin, used to resolve the owner's email/orgId. */
+  baseUrl: string | null;
+}
+
+// The single validated completion for an OAuth callback URL, shared by the iOS
+// inline auth-session path and the Android deep-link handler. Validates the
+// callback state, saves the session token under the given key, and resolves the
+// Clips owner key. Returns the token on success, or null if the callback is
+// invalid (no token or state mismatch).
+export async function completeOAuthCallback(
+  callbackUrl: string,
+  ctx: OAuthCompletionContext,
+): Promise<string | null> {
+  const token = redirectParam(callbackUrl, "token");
+  const state = redirectParam(callbackUrl, "state");
+  if (!token || !(await consumeOAuthStateMatches(state))) return null;
+  await saveSessionToken(token, ctx.tokenKey ?? undefined);
+  await resolveAndStoreOwnerKey(token, ctx.ownerKeyName, ctx.baseUrl);
+  return token;
+}

--- a/packages/mobile-app/lib/oauth-session.ts
+++ b/packages/mobile-app/lib/oauth-session.ts
@@ -22,8 +22,12 @@ export async function consumeOAuthStateMatches(
   state: string | null,
 ): Promise<boolean> {
   const expected = await AsyncStorage.getItem(OAUTH_STATE_KEY);
-  await AsyncStorage.removeItem(OAUTH_STATE_KEY);
-  return Boolean(expected) && state === expected;
+  const matches = Boolean(expected) && state === expected;
+  // Only consume on a match. A stale or forged callback must not clear the
+  // pending state, or the legitimate redirect that follows would fail to
+  // validate and leave the user signed out.
+  if (matches) await AsyncStorage.removeItem(OAUTH_STATE_KEY);
+  return matches;
 }
 
 // Clips needs an owner key (derived from email/orgId) alongside the token

--- a/packages/mobile-app/lib/oauth-storage.ts
+++ b/packages/mobile-app/lib/oauth-storage.ts
@@ -1,0 +1,11 @@
+// Keys shared between AppWebView (which starts Google sign-in) and the
+// oauth-complete deep-link fallback. Kept in one place so the strings can't
+// drift apart and silently break the state check or the return navigation.
+export const OAUTH_STATE_KEY = "agent-native:oauth-state";
+export const OAUTH_RETURN_PATH_KEY = "agent-native:oauth-return-path";
+export const OAUTH_TOKEN_STORE_KEY = "agent-native:oauth-token-key";
+// Set only for apps that also need an owner key (Clips): the AsyncStorage key
+// to write the owner into, and the app origin used to resolve the owner's
+// email/orgId from the session after the token is saved.
+export const OAUTH_OWNER_KEY_KEY = "agent-native:oauth-owner-key";
+export const OAUTH_BASE_URL_KEY = "agent-native:oauth-base-url";

--- a/packages/mobile-app/plugins/with-android-oauth-deeplink.ts
+++ b/packages/mobile-app/plugins/with-android-oauth-deeplink.ts
@@ -1,0 +1,96 @@
+import {
+  AndroidConfig,
+  type ConfigPlugin,
+  createRunOncePlugin,
+  withAndroidManifest,
+  withMainActivity,
+} from "expo/config-plugins";
+
+const OAUTH_SCHEME = "agentnative";
+const OAUTH_HOST = "oauth-complete";
+
+// Declares agentnative://oauth-complete as an explicit deep link on MainActivity
+// so the Google OAuth redirect is reliably delivered to the app.
+const withOAuthIntentFilter: ConfigPlugin = (config) =>
+  withAndroidManifest(config, (cfg) => {
+    const application = AndroidConfig.Manifest.getMainApplicationOrThrow(
+      cfg.modResults,
+    );
+    const mainActivity = application.activity?.find(
+      (activity) => activity.$?.["android:name"] === ".MainActivity",
+    );
+    if (mainActivity) {
+      const filters = mainActivity["intent-filter"] ?? [];
+      const alreadyDeclared = filters.some((filter) =>
+        (filter.data ?? []).some(
+          (data) => data.$?.["android:host"] === OAUTH_HOST,
+        ),
+      );
+      if (!alreadyDeclared) {
+        filters.push({
+          action: [{ $: { "android:name": "android.intent.action.VIEW" } }],
+          category: [
+            { $: { "android:name": "android.intent.category.DEFAULT" } },
+            { $: { "android:name": "android.intent.category.BROWSABLE" } },
+          ],
+          data: [
+            {
+              $: {
+                "android:scheme": OAUTH_SCHEME,
+                "android:host": OAUTH_HOST,
+              },
+            },
+          ],
+        } as unknown as (typeof filters)[number]);
+        mainActivity["intent-filter"] = filters;
+      }
+    }
+    return cfg;
+  });
+
+// MainActivity uses launchMode=singleTask, so a deep link arrives via
+// onNewIntent rather than a fresh onCreate. Without updating the activity's
+// intent, React Native's Linking.getInitialURL() reads the stale launch intent
+// and returns null, so the OAuth redirect URL never reaches JS.
+const withOnNewIntent: ConfigPlugin = (config) =>
+  withMainActivity(config, (cfg) => {
+    if (cfg.modResults.language !== "kt") {
+      throw new Error(
+        "with-android-oauth-deeplink expects a Kotlin MainActivity.",
+      );
+    }
+    let contents = cfg.modResults.contents;
+    if (contents.includes("onNewIntent")) return cfg;
+
+    if (!contents.includes("import android.content.Intent")) {
+      contents = contents.replace(
+        /^(package [^\n]+\n)/m,
+        "$1\nimport android.content.Intent\n",
+      );
+    }
+
+    const method = `
+  override fun onNewIntent(intent: Intent) {
+    super.onNewIntent(intent)
+    setIntent(intent)
+  }
+`;
+    const lastBrace = contents.lastIndexOf("}");
+    contents =
+      contents.slice(0, lastBrace) + method + contents.slice(lastBrace);
+
+    cfg.modResults.contents = contents;
+    return cfg;
+  });
+
+const withAndroidOAuthDeepLink: ConfigPlugin = (config) => {
+  config = withOAuthIntentFilter(config);
+  config = withOnNewIntent(config);
+  return config;
+};
+
+export default createRunOncePlugin(
+  withAndroidOAuthDeepLink,
+  "with-android-oauth-deeplink",
+  "1.0.0",
+);

--- a/packages/mobile-app/plugins/with-android-oauth-deeplink.ts
+++ b/packages/mobile-app/plugins/with-android-oauth-deeplink.ts
@@ -60,7 +60,18 @@ const withOnNewIntent: ConfigPlugin = (config) =>
       );
     }
     let contents = cfg.modResults.contents;
-    if (contents.includes("onNewIntent")) return cfg;
+    // Skip only when an existing override already forwards the intent. If
+    // onNewIntent is present but never calls setIntent, the singleTask launch
+    // intent stays stale and getInitialURL() returns null — fail loud rather
+    // than silently omit the fix, since blindly appending a second override
+    // would not compile.
+    if (contents.includes("setIntent(intent)")) return cfg;
+    if (/\boverride\s+fun\s+onNewIntent\b/.test(contents)) {
+      throw new Error(
+        "with-android-oauth-deeplink: MainActivity already overrides onNewIntent " +
+          "without calling setIntent(intent); update that override to forward the intent.",
+      );
+    }
 
     if (!contents.includes("import android.content.Intent")) {
       contents = contents.replace(


### PR DESCRIPTION
## Fix Google sign-in inside mobile WebViews (Android)

### Summary
Google sign-in did not work from the mobile app's in-WebView apps on Android.
This PR fixes it in two parts: (1) Google blocking OAuth inside the embedded
WebView, and (2) the app cold-starting to the Home screen instead of returning
signed-in after the browser redirect. A follow-up covers the Clips session.

---

### Problem 1 — Google blocks OAuth in the embedded WebView
Google refuses to render its consent screen inside an embedded WebView
(`disallowed_useragent`). The remote sign-in page opens Google via a
`window.open` popup; inside the Android WebView that popup either loaded Google
**inline** (blocked → blank/error page) or **escaped to external Chrome**,
breaking the return flow.

**Solution**
- Neutralize `window.open` on the sign-in page via
  `injectedJavaScriptBeforeContentLoaded` (scoped to `/_agent-native/sign-in`),
  forcing the page's built-in **redirect fallback** — a top-level navigation to
  `/_agent-native/google/auth-url` — instead of a popup. Also set
  `setSupportMultipleWindows={false}`.
- Intercept that navigation in `onShouldStartLoadWithRequest`, resolve the
  endpoint's JSON form to obtain the real `accounts.google.com` URL **with its
  `state`**.
- Open the flow in a **system browser tab** Google allows:
  - **Android:** `WebBrowser.openBrowserAsync(url, { browserPackage:
    preferredBrowserPackage })` — `openAuthSessionAsync` is unreliable on
    Android and can hand off to an external app that never redirects back
    (expo/expo#27500).
  - **iOS:** `WebBrowser.openAuthSessionAsync` (works well, returns inline).

---

### Problem 2 — App reopens to the Home screen after auth (deep link lost)
After signing in, the `agentnative://oauth-complete` redirect **cold-started**
the app (Android kills the backgrounded app while it's in the browser) and
landed on the Home launcher, not signed in. Root cause: `MainActivity` uses
`launchMode="singleTask"`, and the deep-link `VIEW` intent arrived without
updating the activity's intent — so `Linking.getInitialURL()` returned `null`
and the token URL never reached JavaScript.

**Solution**
- **`MainActivity.onNewIntent` → `setIntent(intent)`** so `getInitialURL()`
  returns the deep-link URL on the singleTask return.
- Added an explicit `<data android:scheme="agentnative"
  android:host="oauth-complete"/>` intent-filter so the redirect is
  unambiguously delivered to the app.
- New root-level **`OAuthDeepLinkHandler`** that handles both cold-start
  (`getInitialURL`) and warm (`url` event): it reads the return-path/token-key
  persisted **before** the browser opened (they survive the app being killed),
  validates `state`, saves the token, dismisses the browser tab, and navigates
  back to the **originating screen** — never forcing the user to Home.
- `useFocusEffect` in `AppWebView` re-reads the session token on focus so the
  returned-to WebView reloads signed-in.

---

### Follow-up — Clips did not connect after sign-in
Clips is the only app that also requires an **owner key** (derived from the
user's email); `getClipsSession()` returns null without it, so the tab stayed
signed-out even with a valid token.

**Solution**
- `OAuthDeepLinkHandler` now resolves the owner: after saving the Clips token it
  fetches `…/_agent-native/auth/session?_session=<token>` to get `email`/`orgId`
  and stores the owner key, so Clips flips to connected on return.

---

### Files changed
- `components/AppWebView.tsx` — window.open neutralization, auth-url
  interception, system-browser launch, persisted return context, focus-based
  token re-read, error UI + `forwardRef` reload.
- `components/OAuthDeepLinkHandler.tsx` *(new)* — cold-start/warm deep-link
  return handling + Clips owner-key resolution.
- `app/oauth-complete.tsx` — reduced to a passive fallback screen.
- `app/app/[id].tsx` — consolidated onto the shared `AppWebView` (removed a
  duplicate WebView implementation).
- `lib/oauth-storage.ts` *(new)* — shared storage keys.
- `android/.../MainActivity.kt` — `onNewIntent` + `setIntent`.
- `android/app/src/main/AndroidManifest.xml` — explicit `oauth-complete`
  intent-filter.

### Testing
- Verified on a physical Android device: sign-in from tab apps, the Apps
  section, and Clips all return signed-in on the originating screen.
- `tsc`, `oxfmt`, and the mobile-app test suite (94 tests) pass.

### Notes
- `BAD_AUTHENTICATION` logs from `com.google.android.gms`/Chrome during testing
  are background SSO noise, unrelated to this flow.
- iOS keeps `openAuthSessionAsync`; only Android switches to `openBrowserAsync`
  + the deep-link handler.
