### PR TITLE
Improve workspace navigation, branding, and Loom imports

### DIFF
--- a/.changeset/a2a-audience-origin.md
+++ b/.changeset/a2a-audience-origin.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Sign the A2A identity token's audience as the target's origin. Receivers derive their expected audience from `APP_URL`, which carries no app path, so a path-qualified audience could never match — every direct `actions/invoke` between workspace apps failed with "Invalid or expired A2A token".

--- a/.changeset/a2a-workspace-loopback.md
+++ b/.changeset/a2a-workspace-loopback.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow agent-to-agent calls between apps in a locally running workspace. The gateway serves every app on loopback, so sibling A2A targets are private addresses by construction and `ssrfSafeFetch` rejected them as SSRF — making cross-app delegation fail locally with "refusing to fetch private/internal address". `ssrfSafeFetch` now accepts an `allowedPrivateOrigins` list and the A2A client passes the deployment's own gateway origin (never a request-supplied value).

--- a/.changeset/creative-context-react-query-dep.md
+++ b/.changeset/creative-context-react-query-dep.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/creative-context": patch
+---
+
+Declare `@tanstack/react-query` as a peer/dev dependency so `tsc` can name its types under pnpm's isolated layout. Without it the package fails to build with TS2883 in a generated workspace, which breaks the root `postinstall` and therefore `pnpm install`.

--- a/.changeset/dispatch-navigation-branding.md
+++ b/.changeset/dispatch-navigation-branding.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Keep Dispatch navigation and workspace branding aligned with the first-party app surfaces.

--- a/.changeset/dispatch-workspace-navigation.md
+++ b/.changeset/dispatch-workspace-navigation.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Improve Dispatch workspace navigation and branding.

--- a/.changeset/nitro-dev-retry-guard.md
+++ b/.changeset/nitro-dev-retry-guard.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Bound Nitro dev-server startup recovery so a failed restart stops refreshing forever.

--- a/.changeset/settings-agent-link-position.md
+++ b/.changeset/settings-agent-link-position.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep Manage agent as a dedicated linked destination at the bottom of settings navigation.

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,7 @@
 node_modules
 dist
+# Root README prose is published alongside the docs homepage.
+/README.md
 .netlify
 out
 .video-bakeoff

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## The framework for agentic apps
 
-Agent-Native is an open-source framework for rapidly building robust applications with agents at their core.
+Don't pick between apps or agents. Agent-Native apps are both.
 
 ```ts
 // One action powers every app surface: UI, agent, HTTP, MCP, A2A, and CLI.
@@ -22,16 +22,7 @@ export default defineAction({
 - **[Backend agnostic](https://agent-native.com/docs/database)**: Plug in any Drizzle-supported SQL database and Nitro-compatible host.
 - **[Toolkits](https://agent-native.com/docs/agent-native-toolkit)**: Reusable building blocks for collaboration, sharing, settings, teams, and observability.
 
-## Don't pick between apps or agents.
-
-Agent-native apps are both
-
-|                   | SaaS Tools         | Raw AI Agents           | Internal Tools             | Agent-Native App        |
-| ----------------- | ------------------ | ----------------------- | -------------------------- | ----------------------- |
-| **UI**            | Polished but rigid | None                    | Mixed quality              | Full UI, fork & go      |
-| **AI**            | Bolted on          | Powerful                | Shallowly connected        | Agent-first, integrated |
-| **Customization** | Can't              | Instructions and skills | Full, but high maintenance | Agent modifies the app  |
-| **Ownership**     | Rented             | Somewhat yours          | You own the code           | You own the code        |
+https://github.com/user-attachments/assets/ef51644b-6506-46d8-8083-0af7b7e5b65c
 
 ## Try an Agent-Native app
 
@@ -123,7 +114,7 @@ pnpm install
 pnpm dev
 ```
 
-Prefer flags? `create my-app --template mail`, `--headless`, or `--standalone` skip the prompt.
+Prefer flags? `create my-app --template chat`, `--headless`, or `--standalone` skip the prompt.
 
 See the full [getting started docs](https://agent-native.com/docs).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Agent-Native
-
 ## The framework for agentic apps
 
 Don't pick between apps or agents. Agent-Native apps are both.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Agent-Native
 
-<!-- Agent-Native apps are both UI and agent surfaces. -->
-
 ## The framework for agentic apps
 
 Don't pick between apps or agents. Agent-Native apps are both.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Agent-Native
+
 ## The framework for agentic apps
 
 Don't pick between apps or agents. Agent-Native apps are both.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Agent-Native
 
+<!-- Agent-Native apps are both UI and agent surfaces. -->
+
 ## The framework for agentic apps
 
 Don't pick between apps or agents. Agent-Native apps are both.

--- a/packages/core/src/a2a/client.ts
+++ b/packages/core/src/a2a/client.ts
@@ -927,7 +927,16 @@ async function buildA2AApiKeyAttempts(
 
 function normalizeA2AAudience(url: string): string {
   const explicit = splitExplicitA2AEndpoint(url.replace(/\/$/, ""));
-  return (explicit?.baseUrl ?? url).replace(/\/$/, "");
+  const base = (explicit?.baseUrl ?? url).replace(/\/$/, "");
+  // Receivers derive their expected audience from APP_URL, which carries no
+  // app path. In a workspace every app is mounted under one gateway origin, so
+  // signing the path-qualified URL yields an audience the receiver can never
+  // match. The origin is the identifier both sides agree on.
+  try {
+    return new URL(base).origin;
+  } catch {
+    return base;
+  }
 }
 
 function isA2AAuthRejection(err: unknown): boolean {

--- a/packages/core/src/a2a/client.ts
+++ b/packages/core/src/a2a/client.ts
@@ -1,6 +1,45 @@
 import * as jose from "jose";
 
 import { ssrfSafeFetch } from "../extensions/url-safety.js";
+
+/**
+ * A workspace serves every app from one gateway on loopback, so sibling A2A
+ * targets are private addresses by construction and the SSRF guard cannot tell
+ * them apart from an attack. Trust only origins this deployment configured for
+ * itself — never a value that arrived on a request.
+ */
+function workspacePrivateOrigins(): string[] {
+  const origins = [
+    process.env.WORKSPACE_GATEWAY_URL,
+    process.env.APP_URL,
+    process.env.BETTER_AUTH_URL,
+  ].filter((value): value is string => !!value);
+
+  // The gateway also hands each child the sibling manifest, and siblings are
+  // reached on their own loopback ports rather than through the gateway.
+  const raw = process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON;
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      const apps = Array.isArray(parsed?.apps)
+        ? parsed.apps
+        : Array.isArray(parsed)
+          ? parsed
+          : [];
+      for (const app of apps) {
+        const url = app?.url ?? app?.origin ?? app?.baseUrl;
+        if (typeof url === "string" && url) origins.push(url);
+        const port = app?.port;
+        if (typeof port === "number" && Number.isFinite(port)) {
+          origins.push(`http://127.0.0.1:${port}`);
+        }
+      }
+    } catch {
+      // A malformed manifest must not disable the SSRF guard.
+    }
+  }
+  return origins;
+}
 import { sanitizeA2ACorrelationMetadata } from "./correlation.js";
 import type {
   A2AApprovedAction,
@@ -138,7 +177,7 @@ export class A2AClient {
         const res = await ssrfSafeFetch(
           endpoint,
           { method: "OPTIONS" },
-          { maxRedirects: 3 },
+          { maxRedirects: 3, allowedPrivateOrigins: workspacePrivateOrigins() },
         );
         if (res.status !== 404 && res.status !== 405) {
           this.endpointCandidates = [endpoint];
@@ -237,7 +276,7 @@ export class A2AClient {
     const res = await ssrfSafeFetch(
       `${this.baseUrl}/.well-known/agent-card.json`,
       {},
-      { maxRedirects: 3 },
+      { maxRedirects: 3, allowedPrivateOrigins: workspacePrivateOrigins() },
     );
     if (!res.ok) {
       throw new Error(`Failed to fetch agent card (${res.status})`);
@@ -548,7 +587,7 @@ export class A2AClient {
           body: JSON.stringify(body),
           signal: controller?.signal,
         },
-        { maxRedirects: 3 },
+        { maxRedirects: 3, allowedPrivateOrigins: workspacePrivateOrigins() },
       );
     } finally {
       if (timer) clearTimeout(timer);

--- a/packages/core/src/a2a/client.ts
+++ b/packages/core/src/a2a/client.ts
@@ -13,7 +13,12 @@ function workspacePrivateOrigins(): string[] {
     process.env.WORKSPACE_GATEWAY_URL,
     process.env.APP_URL,
     process.env.BETTER_AUTH_URL,
-  ].filter((value): value is string => !!value);
+    // Escape hatch for contexts that never receive the gateway manifest (the
+    // action CLI, one-off scripts). Comma-separated origins.
+    ...(process.env.AGENT_NATIVE_A2A_ALLOWED_ORIGINS ?? "").split(","),
+  ]
+    .map((value) => value?.trim())
+    .filter((value): value is string => !!value);
 
   // The gateway also hands each child the sibling manifest, and siblings are
   // reached on their own loopback ports rather than through the gateway.

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -3002,17 +3002,9 @@ export function useAgentSettingsTabs(): SettingsTabItem[] {
     const workspace = searchTab("workspace");
     return [
       {
-        ...agent,
-        icon: IconHierarchy2,
-        group: "agent",
-        href: "/agent#settings",
-        searchEntries: undefined,
-        content: <Navigate to="/agent#settings" replace />,
-      },
-      {
         ...connections,
         icon: IconPlugConnected,
-        group: "agent",
+        group: "workspace",
         content: <ConnectionsSettingsContent settingsPanelProps={baseProps} />,
       },
       {
@@ -3046,6 +3038,14 @@ export function useAgentSettingsTabs(): SettingsTabItem[] {
         group: "workspace",
         keywords: "extensions widgets mini apps tools sandboxed apps",
         content: <ExtensionsSettingsContent />,
+      },
+      {
+        ...agent,
+        icon: IconHierarchy2,
+        group: "manage-agent",
+        href: "/agent#settings",
+        searchEntries: undefined,
+        content: <Navigate to="/agent#settings" replace />,
       },
     ];
   }, [baseProps]);

--- a/packages/core/src/client/settings/SettingsTabsPage.spec.tsx
+++ b/packages/core/src/client/settings/SettingsTabsPage.spec.tsx
@@ -2,6 +2,7 @@
 
 import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SettingsTabsPage } from "./SettingsTabsPage.js";
@@ -196,7 +197,7 @@ describe("SettingsTabsPage", () => {
     expect(tabLabels).toEqual(["General", "Agent", "Team", "What's new"]);
   });
 
-  it("visually separates app, agent, workspace, and update tabs", () => {
+  it("visually separates app, agent, and workspace tabs", () => {
     act(() => {
       root.render(
         <SettingsTabsPage
@@ -232,6 +233,50 @@ describe("SettingsTabsPage", () => {
     ).not.toBeNull();
     expect(
       container.querySelector('[data-settings-tab-group="updates"]'),
+    ).toBeNull();
+  });
+
+  it("keeps linked settings navigation last with an external-link marker", () => {
+    act(() => {
+      root.render(
+        <MemoryRouter initialEntries={["/settings"]}>
+          <SettingsTabsPage
+            general={<div>General content</div>}
+            team={<div>Team members</div>}
+            whatsNew={<div>Recent updates</div>}
+            extraTabs={[
+              {
+                id: "connections",
+                label: "Connections",
+                group: "workspace",
+                content: <div>Connection settings</div>,
+              },
+              {
+                id: "agent",
+                label: "Manage agent",
+                group: "manage-agent",
+                href: "/agent#settings",
+                content: <div>Agent settings</div>,
+              },
+            ]}
+          />
+        </MemoryRouter>,
+      );
+    });
+
+    expect(
+      Array.from(container.querySelectorAll('[role="tab"]'), (tab) =>
+        tab.textContent?.trim(),
+      ),
+    ).toEqual(["General", "Connections", "Team", "What's new", "Manage agent"]);
+
+    const manageAgentLink = container.querySelector<HTMLAnchorElement>(
+      'a[href="/agent#settings"]',
+    );
+    expect(manageAgentLink).not.toBeNull();
+    expect(manageAgentLink?.querySelector("svg")).not.toBeNull();
+    expect(
+      manageAgentLink?.closest('[data-settings-tab-group="manage-agent"]'),
     ).not.toBeNull();
   });
 

--- a/packages/core/src/client/settings/SettingsTabsPage.tsx
+++ b/packages/core/src/client/settings/SettingsTabsPage.tsx
@@ -1,5 +1,6 @@
 import { Tabs, useDesignSystem } from "@agent-native/toolkit/design-system";
 import {
+  IconArrowUpRight,
   IconHistory,
   IconSearch,
   IconSettings,
@@ -216,6 +217,8 @@ export function SettingsTabsPage({
     const hasOrganizationTab = extraTabs.some(
       (tab) => tab.id === "organization",
     );
+    const inlineTabs = extraTabs.filter((tab) => !tab.href);
+    const linkedTabs = extraTabs.filter((tab) => tab.href);
     const next: SettingsTabItem[] = [
       {
         id: "general",
@@ -234,7 +237,7 @@ export function SettingsTabsPage({
         keywords: "profile photo avatar identity signed in email name",
       });
     }
-    next.push(...extraTabs);
+    next.push(...inlineTabs);
     if (team && !hasOrganizationTab) {
       next.push({
         id: "team",
@@ -249,10 +252,11 @@ export function SettingsTabsPage({
         id: "whats-new",
         label: whatsNewLabel,
         icon: IconHistory,
-        group: "updates",
+        group: next.at(-1)?.group ?? "app",
         content: whatsNew,
       });
     }
+    next.push(...linkedTabs);
     return next;
   }, [
     account,
@@ -615,6 +619,12 @@ export function SettingsTabsPage({
                           />
                         ) : null}
                         <span className="truncate">{tab.label}</span>
+                        {tab.href ? (
+                          <IconArrowUpRight
+                            aria-hidden="true"
+                            className="size-3.5 shrink-0 text-muted-foreground/80"
+                          />
+                        ) : null}
                       </>
                     );
                     if (tab.href) {

--- a/packages/core/src/extensions/ssrf-fetch.spec.ts
+++ b/packages/core/src/extensions/ssrf-fetch.spec.ts
@@ -29,6 +29,25 @@ describe("ssrfSafeFetch", () => {
     await expect(ssrfSafeFetch(PUBLIC)).rejects.toThrow(/SSRF blocked/i);
   });
 
+  it("allows a configured private origin for workspace calls", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("ok", { status: 200 }));
+    const privateOrigin = "http://127.0.0.1:19100";
+
+    const response = await ssrfSafeFetch(
+      `${privateOrigin}/.well-known/agent-card.json`,
+      {},
+      { allowedPrivateOrigins: [privateOrigin] },
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${privateOrigin}/.well-known/agent-card.json`,
+      expect.objectContaining({ redirect: "manual" }),
+    );
+  });
+
   it("returns the response for an allowed external URL", async () => {
     const ok = new Response("hello", { status: 200 });
     vi.spyOn(globalThis, "fetch").mockResolvedValue(ok);

--- a/packages/core/src/extensions/url-safety.ts
+++ b/packages/core/src/extensions/url-safety.ts
@@ -163,7 +163,32 @@ export async function isBlockedExtensionUrlWithDns(
  * runtimes); the caller should fall back to the regular `fetch` path —
  * `isBlockedExtensionUrlWithDns` will still have caught most rebinding cases.
  */
-export async function createSsrfSafeDispatcher(): Promise<unknown | null> {
+function normalizeLookupHostname(hostname: string): string {
+  return hostname.toLowerCase().replace(/^\[|\]$/g, "");
+}
+
+function normalizeAllowedPrivateOriginKeys(
+  origins: readonly string[],
+): Set<string> {
+  const keys = new Set<string>();
+  for (const origin of origins) {
+    try {
+      const parsed = new URL(origin);
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        continue;
+      }
+      const port = parsed.port || (parsed.protocol === "https:" ? "443" : "80");
+      keys.add(`${normalizeLookupHostname(parsed.hostname)}:${port}`);
+    } catch {
+      // Ignore malformed deployment configuration and retain the private-IP guard.
+    }
+  }
+  return keys;
+}
+
+export async function createSsrfSafeDispatcher(
+  allowedPrivateOrigins: readonly string[] = [],
+): Promise<unknown | null> {
   // Keep the optional undici import opaque to Vite/Rolldown. A static
   // `import("undici")` makes browser builds try to resolve and bundle undici
   // even though this dispatcher is only useful in Node server runtimes.
@@ -182,6 +207,9 @@ export async function createSsrfSafeDispatcher(): Promise<unknown | null> {
 
   const { Agent } = undici;
   const { lookup } = dnsModule;
+  const allowedPrivateOriginKeys = normalizeAllowedPrivateOriginKeys(
+    allowedPrivateOrigins,
+  );
   if (!Agent || !lookup) return null;
 
   return new Agent({
@@ -209,7 +237,10 @@ export async function createSsrfSafeDispatcher(): Promise<unknown | null> {
               ? addresses
               : [{ address: addresses, family: 4 }];
             for (const record of list) {
-              if (isPrivateHost(record.address)) {
+              const allowedOrigin = allowedPrivateOriginKeys.has(
+                `${normalizeLookupHostname(hostname)}:${String(options?.port ?? "")}`,
+              );
+              if (isPrivateHost(record.address) && !allowedOrigin) {
                 const e = new Error(
                   `Connect blocked: ${hostname} resolved to private address ${record.address}`,
                 ) as NodeJS.ErrnoException;
@@ -275,7 +306,9 @@ export async function ssrfSafeFetch(
   } = {},
 ): Promise<Response> {
   const maxRedirects = options.maxRedirects ?? 3;
-  const dispatcher = (await createSsrfSafeDispatcher()) ?? undefined;
+  const dispatcher =
+    (await createSsrfSafeDispatcher(options.allowedPrivateOrigins)) ??
+    undefined;
   const allowedPrivateOrigins = new Set(
     (options.allowedPrivateOrigins ?? [])
       .map((origin) => {

--- a/packages/core/src/extensions/url-safety.ts
+++ b/packages/core/src/extensions/url-safety.ts
@@ -264,10 +264,37 @@ export async function ssrfSafeFetch(
     maxRedirects?: number;
     httpsOnly?: boolean;
     assertUrlAllowed?: (url: string) => void | Promise<void>;
+    /**
+     * Exact origins that may resolve to a private address. A workspace runs
+     * every app on loopback behind one gateway, so sibling A2A calls are
+     * private by construction; without this they are indistinguishable from an
+     * SSRF attempt and get blocked. Only ever pass origins the deployment
+     * itself configured (never a request-supplied value).
+     */
+    allowedPrivateOrigins?: readonly string[];
   } = {},
 ): Promise<Response> {
   const maxRedirects = options.maxRedirects ?? 3;
   const dispatcher = (await createSsrfSafeDispatcher()) ?? undefined;
+  const allowedPrivateOrigins = new Set(
+    (options.allowedPrivateOrigins ?? [])
+      .map((origin) => {
+        try {
+          return new URL(origin).origin;
+        } catch {
+          return "";
+        }
+      })
+      .filter(Boolean),
+  );
+  const isAllowedPrivateOrigin = (candidate: string): boolean => {
+    if (allowedPrivateOrigins.size === 0) return false;
+    try {
+      return allowedPrivateOrigins.has(new URL(candidate).origin);
+    } catch {
+      return false;
+    }
+  };
 
   let currentUrl = url;
   for (let hop = 0; hop <= maxRedirects; hop++) {
@@ -277,7 +304,10 @@ export async function ssrfSafeFetch(
         `SSRF blocked: refusing to fetch non-HTTPS address (${currentUrl})`,
       );
     }
-    if (await isBlockedExtensionUrlWithDns(currentUrl)) {
+    if (
+      !isAllowedPrivateOrigin(currentUrl) &&
+      (await isBlockedExtensionUrlWithDns(currentUrl))
+    ) {
       throw new Error(
         `SSRF blocked: refusing to fetch private/internal address (${currentUrl})`,
       );

--- a/packages/core/src/templates/chat/app/components/layout/Sidebar.tsx
+++ b/packages/core/src/templates/chat/app/components/layout/Sidebar.tsx
@@ -14,7 +14,6 @@ import {
   type ChatHistoryItem,
 } from "@agent-native/toolkit/chat-history";
 import {
-  IconHierarchy2,
   IconLayoutSidebarLeftCollapse,
   IconLayoutSidebarLeftExpand,
   IconMessageCircle,
@@ -43,12 +42,6 @@ const navItems = [
 ];
 
 const bottomNavItems = [
-  {
-    icon: IconHierarchy2,
-    labelKey: "settings.agentTitle",
-    href: "/agent",
-    view: "agent",
-  },
   {
     icon: IconSettings,
     labelKey: "navigation.settings",

--- a/packages/core/src/templates/default/app/root.tsx
+++ b/packages/core/src/templates/default/app/root.tsx
@@ -327,7 +327,7 @@ export function ErrorBoundary() {
           {copy.goHome}
         </Link>
         <ErrorReportActions
-          appName="Agent Native"
+          appName="{{APP_TITLE}}"
           title={title}
           details={details}
           status={status}

--- a/packages/core/src/templates/default/public/manifest.json
+++ b/packages/core/src/templates/default/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Agent Native App",
-  "short_name": "App",
+  "name": "{{APP_TITLE}}",
+  "short_name": "{{APP_TITLE}}",
   "description": "Agent-native application",
   "start_url": "/",
   "display": "standalone",

--- a/packages/core/src/vite/client.spec.ts
+++ b/packages/core/src/vite/client.spec.ts
@@ -125,7 +125,11 @@ describe("Nitro dev startup recovery", () => {
     expect(next).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(503);
     expect(res.setHeader).toHaveBeenCalledWith("retry-after", "1");
-    expect(res.end).toHaveBeenCalledWith(expect.stringContaining("refresh"));
+    const html = res.end.mock.calls[0]?.[0] as string;
+    expect(html).toContain("__agent_native_nitro_startup_retry");
+    expect(html).toContain("Retrying in one second");
+    expect(html).toContain("Refresh when it is ready");
+    expect(html).not.toContain('http-equiv="refresh"');
   });
 
   it("preserves genuine Nitro errors and non-document requests", () => {

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -2414,6 +2414,10 @@ type NitroModuleGraph = {
 
 const NITRO_STARTUP_SETTLE_MS = 1_000;
 const NITRO_STARTUP_TIMEOUT_MS = 30_000;
+const NITRO_STARTUP_RETRY_KEY = "__agent_native_nitro_startup_retry";
+const NITRO_STARTUP_RETRY_MAX = 5;
+const NITRO_STARTUP_RETRY_DELAY_MS = 1_000;
+const NITRO_STARTUP_RETRY_RESET_MS = 15_000;
 
 function nitroModuleGraphSignature(environment: unknown): string | null {
   const graph = (environment as { moduleGraph?: NitroModuleGraph } | undefined)
@@ -2456,9 +2460,66 @@ function sendNitroStartingResponse(
     res.end();
     return;
   }
-  res.end(
-    '<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="refresh" content="0.25"><title>Starting…</title></head><body></body></html>',
-  );
+  res.end(`<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Dev server restarting…</title>
+    <style>
+      body { margin: 0; min-height: 100vh; display: grid; place-items: center; font: 16px/1.5 system-ui, sans-serif; color: #171717; background: #fafafa; }
+      main { width: min(560px, calc(100vw - 48px)); }
+      h1 { margin: 0 0 8px; font-size: 1.25rem; }
+      p { margin: 0; color: #737373; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Dev server is restarting…</h1>
+      <p id="agent-native-nitro-retry-status">Checking again shortly.</p>
+    </main>
+    <script>
+      (() => {
+        const key = ${JSON.stringify(NITRO_STARTUP_RETRY_KEY)};
+        const maxRetries = ${NITRO_STARTUP_RETRY_MAX};
+        const resetAfterMs = ${NITRO_STARTUP_RETRY_RESET_MS};
+        const retryDelayMs = ${NITRO_STARTUP_RETRY_DELAY_MS};
+        const status = document.getElementById("agent-native-nitro-retry-status");
+        const now = Date.now();
+        let count = 0;
+        let lastAttemptAt = 0;
+
+        try {
+          const stored = JSON.parse(sessionStorage.getItem(key) || "null");
+          if (stored && typeof stored === "object") {
+            count = Number.isFinite(stored.count) ? stored.count : 0;
+            lastAttemptAt = Number.isFinite(stored.at) ? stored.at : 0;
+          }
+        } catch (error) {
+          // A blocked session store is handled below by showing a manual retry.
+        }
+
+        if (now - lastAttemptAt > resetAfterMs) count = 0;
+        if (count >= maxRetries) {
+          if (status) status.textContent = "The server is still unavailable. Refresh when it is ready.";
+          return;
+        }
+
+        const nextState = JSON.stringify({ count: count + 1, at: now });
+        try {
+          sessionStorage.setItem(key, nextState);
+          if (sessionStorage.getItem(key) !== nextState) throw new Error("unavailable");
+        } catch (error) {
+          if (status) status.textContent = "Refresh manually when the server is ready.";
+          return;
+        }
+
+        if (status) status.textContent = "Retrying in one second…";
+        setTimeout(() => window.location.reload(), retryDelayMs);
+      })();
+    </script>
+  </body>
+</html>`);
 }
 
 function nitroStartupGate(

--- a/packages/creative-context/package.json
+++ b/packages/creative-context/package.json
@@ -59,6 +59,7 @@
     "@agent-native/core": "workspace:*",
     "@agent-native/toolkit": "workspace:*",
     "@tabler/icons-react": "catalog:",
+    "@tanstack/react-query": "^5.101.4",
     "@types/node": "^26.1.1",
     "@types/react": "catalog:",
     "drizzle-orm": "^0.45.2",
@@ -71,6 +72,7 @@
     "@agent-native/core": ">=0.8.0",
     "@agent-native/toolkit": ">=0.1.0",
     "@tabler/icons-react": ">=3.41.1",
+    "@tanstack/react-query": ">=5.101.4",
     "drizzle-orm": ">=0.45",
     "react": ">=19.2.7",
     "react-dom": ">=19.2.7"

--- a/packages/dispatch/src/components/layout/Layout.spec.tsx
+++ b/packages/dispatch/src/components/layout/Layout.spec.tsx
@@ -170,6 +170,39 @@ describe("Dispatch NavContent", () => {
     expect(lists[0].querySelector("a")?.className).toContain("h-8 w-8");
   });
 
+  it("keeps Dispatch branding and anchors Settings above the organization picker", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/overview"]}>
+          <TooltipProvider>
+            <NavContent />
+          </TooltipProvider>
+        </MemoryRouter>,
+      );
+    });
+
+    expect(container.textContent).toContain("Dispatch");
+    expect(container.textContent).not.toContain("Agent-Native");
+
+    const settingsLink = container.querySelector('a[href="/settings"]');
+    const organization = [...container.querySelectorAll("div")].find(
+      (element) => element.textContent?.trim() === "Organization",
+    );
+    const footerActions = container.querySelector(
+      "[data-sidebar-footer-actions]",
+    );
+
+    expect(settingsLink).not.toBeNull();
+    expect(organization).toBeDefined();
+    expect(footerActions).not.toBeNull();
+    expect(settingsLink!.compareDocumentPosition(organization!)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(organization!.compareDocumentPosition(footerActions!)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+
   it("uses the shared chat history rail and retains thread actions", async () => {
     await act(async () => {
       root.render(

--- a/packages/dispatch/src/components/layout/Layout.tsx
+++ b/packages/dispatch/src/components/layout/Layout.tsx
@@ -8,7 +8,6 @@ import {
   type ChatThreadSummary,
 } from "@agent-native/core/client/agent-chat";
 import { appBasePath, appPath } from "@agent-native/core/client/api-path";
-import { useActionQuery } from "@agent-native/core/client/hooks";
 import { LanguagePicker, useT } from "@agent-native/core/client/i18n";
 import { openCommandMenu } from "@agent-native/core/client/navigation";
 import { InvitationBanner, OrgSwitcher } from "@agent-native/core/client/org";
@@ -243,12 +242,6 @@ function pageOwnsToolbar(pathname: string): boolean {
   return false;
 }
 
-interface WorkspaceInfo {
-  name: string | null;
-  displayName: string | null;
-  appCount: number;
-}
-
 function sectionFor(item: DispatchNavItem): DispatchNavSection {
   return item.section ?? "operations";
 }
@@ -478,13 +471,6 @@ export function NavContent({
   const t = useT();
   const location = useLocation();
   const navigate = useNavigate();
-  const { data: workspace } = useActionQuery(
-    "get-workspace-info",
-    {},
-    { staleTime: 60_000 },
-  );
-  const ws = workspace as WorkspaceInfo | undefined;
-  const workspaceLabel = ws?.displayName ?? ws?.name ?? null;
   const extensionNavItems = extensions?.navItems ?? EMPTY_NAV_ITEMS;
   const primaryNavItems = [
     ...PRIMARY_NAV_ITEMS,
@@ -681,7 +667,7 @@ export function NavContent({
               />
               <div className="min-w-0 flex-1">
                 <div className="truncate text-lg font-bold tracking-tight text-foreground">
-                  {workspaceLabel ?? "Dispatch"}
+                  Dispatch
                 </div>
               </div>
             </>
@@ -745,16 +731,13 @@ export function NavContent({
               {BOTTOM_NAV_ITEMS.map(renderNavItem)}
             </ul>
           </nav>
-        </div>
-
-        <div className="mt-auto shrink-0">
           <div
             className={cn(
               "py-2",
               collapsed ? "flex justify-center px-1" : "px-3",
             )}
           >
-            <OrgSwitcher compact={collapsed} />
+            <OrgSwitcher compact={collapsed} reserveSpace />
           </div>
         </div>
         <SidebarFooterActions

--- a/packages/dispatch/src/routes/pages/_index.tsx
+++ b/packages/dispatch/src/routes/pages/_index.tsx
@@ -4,7 +4,7 @@ import { redirect, type LoaderFunctionArgs } from "react-router";
 import { Spinner } from "../../components/ui/spinner";
 
 const SEO_TITLE =
-  "Agent-Native Dispatch - Open Source workspace control plane for AI agents";
+  "Dispatch - Open Source workspace control plane for AI agents";
 const SEO_DESCRIPTION =
   "Open Source workspace control plane for AI agents to manage apps, secrets, approvals, messages, jobs, and cross-app delegation.";
 

--- a/packages/dispatch/src/routes/pages/overview.tsx
+++ b/packages/dispatch/src/routes/pages/overview.tsx
@@ -1,7 +1,7 @@
 import { DispatchControlPlane } from "../../components/dispatch-control-plane";
 
 const SEO_TITLE =
-  "Agent-Native Dispatch - Open Source workspace control plane for AI agents";
+  "Dispatch - Open Source workspace control plane for AI agents";
 const SEO_DESCRIPTION =
   "Open Source workspace control plane for AI agents to manage apps, secrets, approvals, messages, jobs, and cross-app delegation.";
 

--- a/packages/dispatch/src/server/plugins/auth.ts
+++ b/packages/dispatch/src/server/plugins/auth.ts
@@ -3,7 +3,7 @@ import { createAuthPlugin } from "@agent-native/core/server";
 import { getDispatchConfig } from "../index.js";
 
 const DEFAULT_MARKETING = {
-  appName: "Agent-Native Dispatch",
+  appName: "Dispatch",
   tagline:
     "Your AI agent manages secrets, orchestrates other agents, and routes messages across your workspace.",
   features: [

--- a/packages/docs/app/components/Header.tsx
+++ b/packages/docs/app/components/Header.tsx
@@ -190,14 +190,18 @@ export default function Header() {
             <img
               src="/agent-native-logo-light.svg"
               alt="Agent-Native"
-              className="hidden h-[1.155rem] w-auto min-[380px]:block dark:hidden"
+              width={1023}
+              height={120}
+              className="hidden aspect-[1023/120] h-[1.155rem] w-auto min-[380px]:block dark:hidden"
               loading="lazy"
               decoding="async"
             />
             <img
               src="/agent-native-logo-dark.svg"
               alt="Agent-Native"
-              className="hidden h-[1.155rem] w-auto min-[380px]:dark:block"
+              width={1023}
+              height={120}
+              className="hidden aspect-[1023/120] h-[1.155rem] w-auto min-[380px]:dark:block"
               loading="lazy"
               decoding="async"
             />

--- a/packages/docs/app/global.css
+++ b/packages/docs/app/global.css
@@ -1043,7 +1043,14 @@ html.dark .shiki span {
   display: none;
 }
 
-/* Comparison table */
+/* Comparison media */
+.homepage-comparison-video {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+}
+
 .approaches-table-wrapper {
   margin: 0 auto;
   max-width: 900px;

--- a/packages/docs/app/global.css
+++ b/packages/docs/app/global.css
@@ -977,7 +977,6 @@ html.dark .shiki span {
 .hero-section {
   text-align: center;
   padding: 80px 24px 64px;
-  border-bottom: 1px solid var(--docs-border);
 }
 
 .hero-section h1 {
@@ -1049,6 +1048,8 @@ html.dark .shiki span {
   width: 100%;
   aspect-ratio: 16 / 9;
   object-fit: cover;
+  border-radius: 4px;
+  mix-blend-mode: screen;
 }
 
 .approaches-table-wrapper {

--- a/packages/docs/app/i18n/ar-SA.ts
+++ b/packages/docs/app/i18n/ar-SA.ts
@@ -81,10 +81,9 @@ const arSA = {
   },
   home: {
     hero: {
-      badge: "framework مفتوح المصدر",
       titleLine1: "framework من أجل",
       titleAccent: "agentic apps",
-      body: "Agent-Native هو framework مفتوح المصدر لبناء تطبيقات قوية بسرعة مع agents في جوهرها.",
+      body: "لا تختر بين التطبيقات والوكلاء. تطبيقات Agent-Native تجمع بينهما.",
       primaryCta: "جرّب تطبيقًا",
       secondaryCta: "اقرأ الوثائق",
     },
@@ -97,7 +96,7 @@ const arSA = {
     },
     actionSurface: {
       eyebrow: "مصمم بعمق للوكلاء، وليس ذكاء اصطناعياً ملحقاً",
-      title: "إجراء واحد يفتح سطح التطبيق كله",
+      title: "إجراء واحد يمنحك السطح بأكمله",
       body: "عرّف العملية مرة واحدة. يحولها Agent-Native إلى إجراء UI، وأداة agent، ونقطة HTTP، وسطح MCP/A2A، وأمر CLI، وفحص صلاحيات، وسجل تدقيق.",
       buildAction: "أنشئ إجراء",
       benefits: {

--- a/packages/docs/app/i18n/de-DE.ts
+++ b/packages/docs/app/i18n/de-DE.ts
@@ -82,10 +82,9 @@ const deDE = {
   },
   home: {
     hero: {
-      badge: "Open-Source-Framework",
       titleLine1: "Das Framework für",
       titleAccent: "agentic Apps",
-      body: "Agent-Native ist ein Open-Source-Framework zum schnellen Aufbau robuster Anwendungen mit Agents im Kern.",
+      body: "Entscheide dich nicht zwischen Apps und Agents. Agent-Native-Apps sind beides.",
       primaryCta: "App ausprobieren",
       secondaryCta: "Docs lesen",
     },
@@ -99,7 +98,7 @@ const deDE = {
     },
     actionSurface: {
       eyebrow: "Wirklich agentisch, nicht nur KI daneben",
-      title: "Eine Aktion öffnet die ganze App-Oberfläche",
+      title: "Eine Aktion gibt dir die gesamte Oberfläche",
       body: "Definiere eine Operation einmal. Agent-Native macht daraus UI-Aktion, Agent-Tool, HTTP-Endpunkt, MCP/A2A-Oberfläche, CLI-Befehl, Berechtigungsprüfung und Audit-Trail.",
       buildAction: "Eine Aktion erstellen",
       benefits: {

--- a/packages/docs/app/i18n/en-US.ts
+++ b/packages/docs/app/i18n/en-US.ts
@@ -110,7 +110,7 @@ const enUS = {
     },
     actionSurface: {
       eyebrow: "Deeply agentic, not AI-adjacent",
-      title: "One action gives you the whole app surface",
+      title: "One action gives you the whole surface",
       body: "Define an operation once. Agent-Native turns it into the UI action, agent tool, HTTP endpoint, MCP/A2A surface, CLI command, scoped permission check, and audit trail.",
       buildAction: "Build an action",
       benefits: {

--- a/packages/docs/app/i18n/en-US.ts
+++ b/packages/docs/app/i18n/en-US.ts
@@ -93,10 +93,9 @@ const enUS = {
   },
   home: {
     hero: {
-      badge: "Open source framework",
       titleLine1: "The framework for",
       titleAccent: "agentic apps",
-      body: "Agent-Native is an open-source framework for rapidly building robust applications with agents at their core.",
+      body: "Don't pick between apps or agents. Agent-Native apps are both.",
       primaryCta: "Try an app",
       secondaryCta: "Read the docs",
     },

--- a/packages/docs/app/i18n/es-ES.ts
+++ b/packages/docs/app/i18n/es-ES.ts
@@ -82,10 +82,9 @@ const esES = {
   },
   home: {
     hero: {
-      badge: "Framework open source",
       titleLine1: "El framework para",
       titleAccent: "apps agentic",
-      body: "Agent-Native es un framework de código abierto para construir rápidamente aplicaciones robustas con agents en su núcleo.",
+      body: "No elijas entre apps o agentes. Las apps Agent-Native son ambas cosas.",
       primaryCta: "Probar una app",
       secondaryCta: "Leer la documentación",
     },
@@ -99,7 +98,7 @@ const esES = {
     },
     actionSurface: {
       eyebrow: "Profundamente agentic, no solo IA pegada",
-      title: "Una acción te da toda la superficie de la app",
+      title: "Una acción te da toda la superficie",
       body: "Define una operación una vez. Agent-Native la convierte en acción de UI, herramienta del agent, endpoint HTTP, superficie MCP/A2A, comando CLI, permiso acotado y registro de auditoría.",
       buildAction: "Crear una acción",
       benefits: {

--- a/packages/docs/app/i18n/fr-FR.ts
+++ b/packages/docs/app/i18n/fr-FR.ts
@@ -82,10 +82,9 @@ const frFR = {
   },
   home: {
     hero: {
-      badge: "Framework open source",
       titleLine1: "Le framework pour",
       titleAccent: "apps agentic",
-      body: "Agent-Native est un framework open source pour créer rapidement des applications robustes avec des agents au cœur.",
+      body: "Ne choisissez pas entre les apps et les agents. Les apps Agent-Native sont les deux.",
       primaryCta: "Commencer à construire",
       secondaryCta: "Voir la documentation",
     },
@@ -99,7 +98,7 @@ const frFR = {
     },
     actionSurface: {
       eyebrow: "Profondément agentique, pas une IA ajoutée à côté",
-      title: "Une action expose toute la surface de l’app",
+      title: "Une action vous donne toute la surface",
       body: "Définissez une opération une fois. Agent-Native en fait l’action UI, l’outil agent, le endpoint HTTP, la surface MCP/A2A, la commande CLI, le contrôle de permission et la piste d’audit.",
       buildAction: "Créer une action",
       benefits: {

--- a/packages/docs/app/i18n/hi-IN.ts
+++ b/packages/docs/app/i18n/hi-IN.ts
@@ -81,10 +81,9 @@ const hiIN = {
   },
   home: {
     hero: {
-      badge: "ओपन सोर्स framework",
       titleLine1: "agentic apps के लिए",
       titleAccent: "framework",
-      body: "Agent-Native एक ओपन-सोर्स framework है, जो agents को कोर में रखकर मज़बूत applications तेज़ी से बनाने के लिए है।",
+      body: "ऐप्स या एजेंट्स में से किसी एक को न चुनें। Agent-Native apps दोनों हैं।",
       primaryCta: "एक app आज़माएँ",
       secondaryCta: "दस्तावेज़ पढ़ें",
     },
@@ -98,7 +97,7 @@ const hiIN = {
     },
     actionSurface: {
       eyebrow: "ऊपर से चिपकाई AI नहीं, सच में agentic",
-      title: "एक action पूरी app surface खोल देता है",
+      title: "एक action पूरी surface देता है",
       body: "एक operation एक बार define करें। Agent-Native उसे UI action, agent tool, HTTP endpoint, MCP/A2A surface, CLI command, scoped permission check और audit trail में बदल देता है।",
       buildAction: "एक action बनाएं",
       benefits: {

--- a/packages/docs/app/i18n/ja-JP.ts
+++ b/packages/docs/app/i18n/ja-JP.ts
@@ -82,10 +82,9 @@ const jaJP = {
   },
   home: {
     hero: {
-      badge: "オープンソース framework",
       titleLine1: "agentic apps のための",
       titleAccent: "framework",
-      body: "Agent-Native は、agent を中心に堅牢なアプリケーションを迅速に構築するためのオープンソース framework です。",
+      body: "アプリとエージェントのどちらかを選ぶ必要はありません。Agent-Native アプリはその両方です。",
       primaryCta: "app を試す",
       secondaryCta: "ドキュメントを読む",
     },
@@ -99,7 +98,7 @@ const jaJP = {
     },
     actionSurface: {
       eyebrow: "後付けAIではなく、深くエージェント指向",
-      title: "ひとつのアクションでアプリ全体の面を開く",
+      title: "ひとつのアクションで全体のサーフェスを使える",
       body: "操作を一度だけ定義します。Agent-Native はそれを UI アクション、agent ツール、HTTP エンドポイント、MCP/A2A 面、CLI コマンド、権限チェック、監査証跡にします。",
       buildAction: "アクションを作る",
       benefits: {

--- a/packages/docs/app/i18n/ko-KR.ts
+++ b/packages/docs/app/i18n/ko-KR.ts
@@ -82,10 +82,9 @@ const koKR = {
   },
   home: {
     hero: {
-      badge: "오픈소스 framework",
       titleLine1: "agentic apps 를 위한",
       titleAccent: "framework",
-      body: "Agent-Native 는 agent 를 핵심으로 견고한 애플리케이션을 빠르게 구축하기 위한 오픈소스 framework 입니다.",
+      body: "앱과 에이전트 중 하나를 고를 필요가 없습니다. Agent-Native 앱은 둘 다입니다.",
       primaryCta: "app 사용해 보기",
       secondaryCta: "문서 읽기",
     },
@@ -99,7 +98,7 @@ const koKR = {
     },
     actionSurface: {
       eyebrow: "겉에 붙인 AI가 아니라 깊이 agentic",
-      title: "하나의 action이 앱 전체 표면을 엽니다",
+      title: "하나의 action이 전체 표면을 엽니다",
       body: "작업을 한 번만 정의하세요. Agent-Native는 이를 UI action, agent 도구, HTTP endpoint, MCP/A2A 표면, CLI 명령, 권한 검사, 감사 기록으로 바꿉니다.",
       buildAction: "Action 만들기",
       benefits: {

--- a/packages/docs/app/i18n/pt-BR.ts
+++ b/packages/docs/app/i18n/pt-BR.ts
@@ -82,10 +82,9 @@ const ptBR = {
   },
   home: {
     hero: {
-      badge: "Framework open source",
       titleLine1: "O framework para",
       titleAccent: "apps agentic",
-      body: "Agent-Native é um framework open source para construir rapidamente aplicações robustas com agents no núcleo.",
+      body: "Não escolha entre apps e agents. As apps Agent-Native são as duas coisas.",
       primaryCta: "Testar uma app",
       secondaryCta: "Ler a documentação",
     },
@@ -98,7 +97,7 @@ const ptBR = {
     },
     actionSurface: {
       eyebrow: "Profundamente agentic, não IA colada por fora",
-      title: "Uma action abre toda a superfície da app",
+      title: "Uma action abre toda a superfície",
       body: "Defina uma operação uma vez. O Agent-Native transforma isso em ação de UI, ferramenta do agent, endpoint HTTP, superfície MCP/A2A, comando CLI, verificação de permissão e trilha de auditoria.",
       buildAction: "Criar uma action",
       benefits: {

--- a/packages/docs/app/i18n/zh-CN.ts
+++ b/packages/docs/app/i18n/zh-CN.ts
@@ -81,10 +81,9 @@ const zhCN = {
   },
   home: {
     hero: {
-      badge: "开源框架",
       titleLine1: "面向",
       titleAccent: "agentic apps 的框架",
-      body: "Agent-Native 是一个开源 framework，用于以 agent 为核心快速构建健壮的应用程序。",
+      body: "无需在应用和 agent 之间做选择。Agent-Native 应用两者兼具。",
       primaryCta: "试用一个 app",
       secondaryCta: "阅读文档",
     },
@@ -96,7 +95,7 @@ const zhCN = {
     },
     actionSurface: {
       eyebrow: "真正面向代理，而不是外挂式 AI",
-      title: "一个 action 覆盖整套应用能力面",
+      title: "一个 action 覆盖完整能力面",
       body: "只定义一次操作。Agent-Native 会把它变成 UI action、agent 工具、HTTP 端点、MCP/A2A 能力面、CLI 命令、权限检查和审计记录。",
       buildAction: "构建一个 action",
       benefits: {

--- a/packages/docs/app/i18n/zh-TW.ts
+++ b/packages/docs/app/i18n/zh-TW.ts
@@ -79,10 +79,9 @@ const messages = {
   },
   home: {
     hero: {
-      badge: "開放原始碼框架",
       titleLine1: "面向",
       titleAccent: "agentic apps 的框架",
-      body: "Agent-Native 是一個開源 framework，用於以 agent 為核心快速建構穩健的應用程式。",
+      body: "不用在 app 與 agent 之間做選擇。Agent-Native app 兩者兼具。",
       primaryCta: "試用一個 app",
       secondaryCta: "閱讀檔案",
     },
@@ -94,7 +93,7 @@ const messages = {
     },
     actionSurface: {
       eyebrow: "真正為代理而生，不是外掛式 AI",
-      title: "一個 action 打開整個應用能力面",
+      title: "一個 action 打開完整能力面",
       body: "只定義一次操作。Agent-Native 會把它變成 UI action、agent 工具、HTTP 端點、MCP/A2A 能力面、CLI 指令、權限檢查和稽核紀錄。",
       buildAction: "建立一個 action",
       benefits: {

--- a/packages/docs/app/routes/_index.tsx
+++ b/packages/docs/app/routes/_index.tsx
@@ -498,23 +498,10 @@ function ActionSurfaceSection({
 }
 
 function ComparisonSection() {
-  const t = useT();
-
   return (
-    <section className="relative z-10 border-t border-[var(--docs-border)] px-6 py-20">
+    <section className="relative z-10 px-6 pb-20">
       <div className="mx-auto max-w-[1200px]">
-        <div className="mb-6 text-center">
-          <h2 className="mb-3 text-3xl font-bold tracking-tight md:text-4xl">
-            {t("home.comparison.titleLine1")}
-          </h2>
-          <p className="mx-auto max-w-2xl text-base leading-relaxed text-[var(--fg-secondary)]">
-            <span className="font-semibold text-[var(--docs-accent)]">
-              {t("home.comparison.titleAccent")}
-            </span>
-          </p>
-        </div>
-
-        <div className="mx-auto max-w-[900px] overflow-hidden rounded-xl border border-[var(--docs-border)] bg-black">
+        <div className="mx-auto max-w-[900px]">
           <video
             className="homepage-comparison-video"
             src="https://cdn.builder.io/o/assets%2Fc5b47d20f6a943e485717e5895739988%2Fc88d506c160142ae9b8618616ceedcea%2Fcompressed?apiKey=c5b47d20f6a943e485717e5895739988&token=c88d506c160142ae9b8618616ceedcea&alt=media&optimized=true"
@@ -623,7 +610,7 @@ export default defineAction({
 
           {/* Hero */}
           <section
-            className="hero-section relative z-10 mx-auto flex min-h-[85vh] max-w-[1200px] items-center justify-center px-6"
+            className="hero-section relative z-10 mx-auto flex min-h-[80vh] max-w-[1200px] items-center justify-center px-6"
             style={{ clipPath: "inset(-100vh -100vw 0 -100vw)" }}
           >
             <div
@@ -635,11 +622,6 @@ export default defineAction({
               }}
             />
             <div className="relative z-10 hero-content">
-              <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] bg-[var(--bg-secondary)] px-4 py-1.5 text-sm text-[var(--fg-secondary)]">
-                <span className="inline-block h-2 w-2 rounded-full bg-[var(--docs-accent)]" />
-                {t("home.hero.badge")}
-              </div>
-
               <h1 className="mx-auto max-w-3xl">
                 {t("home.hero.titleLine1")} <br className="hidden md:inline" />
                 <span className="hero-gradient-text">

--- a/packages/docs/app/routes/_index.tsx
+++ b/packages/docs/app/routes/_index.tsx
@@ -465,7 +465,7 @@ function ActionSurfaceSection({
   return (
     <section className="border-t border-[var(--docs-border)] bg-black px-6 py-20 text-white md:py-24">
       <div className="mx-auto grid max-w-[1200px] gap-10 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] lg:items-center">
-        <div className="min-w-0">
+        <div className="min-w-0 max-w-[400px]">
           <h2 className="m-0 max-w-xl text-3xl font-bold leading-tight tracking-tight md:text-4xl">
             {t("home.actionSurface.title")}
           </h2>
@@ -501,9 +501,9 @@ function ComparisonSection() {
   const t = useT();
 
   return (
-    <section className="border-t border-[var(--docs-border)] px-6 py-20">
+    <section className="relative z-10 border-t border-[var(--docs-border)] px-6 py-20">
       <div className="mx-auto max-w-[1200px]">
-        <div className="mb-12 text-center">
+        <div className="mb-6 text-center">
           <h2 className="mb-3 text-3xl font-bold tracking-tight md:text-4xl">
             {t("home.comparison.titleLine1")}
           </h2>
@@ -514,100 +514,16 @@ function ComparisonSection() {
           </p>
         </div>
 
-        <div className="approaches-table-outer">
-          <div className="approaches-table-wrapper">
-            <div className="approaches-table-scroll">
-              <table className="approaches-table">
-                <thead>
-                  <tr className="border-b border-[var(--docs-border)] bg-[var(--bg-secondary)]">
-                    <th className="approaches-th approaches-col-dim"></th>
-                    <th className="approaches-th approaches-col-muted">
-                      {t("home.comparison.columns.saas")}
-                    </th>
-                    <th className="approaches-th approaches-col-muted">
-                      {t("home.comparison.columns.agents")}
-                    </th>
-                    <th className="approaches-th approaches-col-muted">
-                      {t("home.comparison.columns.internal")}
-                    </th>
-                    <th className="approaches-th">
-                      {t("home.comparison.columns.native")}
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr className="border-b border-[var(--docs-border)]">
-                    <td className="approaches-td approaches-td--dim">
-                      {t("home.comparison.rows.ui")}
-                    </td>
-                    <td className="approaches-td approaches-td--good">
-                      {t("home.comparison.cells.polishedButRigid")}
-                    </td>
-                    <td className="approaches-td approaches-td--bad">
-                      {t("home.comparison.cells.none")}
-                    </td>
-                    <td className="approaches-td approaches-td--warn">
-                      {t("home.comparison.cells.mixedQuality")}
-                    </td>
-                    <td className="approaches-td approaches-td--good">
-                      {t("home.comparison.cells.fullUi")}
-                    </td>
-                  </tr>
-                  <tr className="border-b border-[var(--docs-border)]">
-                    <td className="approaches-td approaches-td--dim">
-                      {t("home.comparison.rows.ai")}
-                    </td>
-                    <td className="approaches-td approaches-td--bad">
-                      {t("home.comparison.cells.boltedOn")}
-                    </td>
-                    <td className="approaches-td approaches-td--good">
-                      {t("home.comparison.cells.powerful")}
-                    </td>
-                    <td className="approaches-td approaches-td--warn">
-                      {t("home.comparison.cells.shallowlyConnected")}
-                    </td>
-                    <td className="approaches-td approaches-td--good">
-                      {t("home.comparison.cells.agentFirst")}
-                    </td>
-                  </tr>
-                  <tr className="border-b border-[var(--docs-border)]">
-                    <td className="approaches-td approaches-td--dim">
-                      {t("home.comparison.rows.customization")}
-                    </td>
-                    <td className="approaches-td approaches-td--bad">
-                      {t("home.comparison.cells.cant")}
-                    </td>
-                    <td className="approaches-td approaches-td--warn">
-                      {t("home.comparison.cells.instructionsAndSkills")}
-                    </td>
-                    <td className="approaches-td approaches-td--warn">
-                      {t("home.comparison.cells.fullHighMaintenance")}
-                    </td>
-                    <td className="approaches-td approaches-td--good">
-                      {t("home.comparison.cells.agentModifies")}
-                    </td>
-                  </tr>
-                  <tr>
-                    <td className="approaches-td approaches-td--dim">
-                      {t("home.comparison.rows.ownership")}
-                    </td>
-                    <td className="approaches-td approaches-td--bad">
-                      {t("home.comparison.cells.rented")}
-                    </td>
-                    <td className="approaches-td approaches-td--warn">
-                      {t("home.comparison.cells.somewhatYours")}
-                    </td>
-                    <td className="approaches-td approaches-td--good">
-                      {t("home.comparison.cells.youOwnCode")}
-                    </td>
-                    <td className="approaches-td approaches-td--good">
-                      {t("home.comparison.cells.youOwnCode")}
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
+        <div className="mx-auto max-w-[900px] overflow-hidden rounded-xl border border-[var(--docs-border)] bg-black">
+          <video
+            className="homepage-comparison-video"
+            src="https://cdn.builder.io/o/assets%2Fc5b47d20f6a943e485717e5895739988%2Fc88d506c160142ae9b8618616ceedcea%2Fcompressed?apiKey=c5b47d20f6a943e485717e5895739988&token=c88d506c160142ae9b8618616ceedcea&alt=media&optimized=true"
+            autoPlay
+            controls
+            muted
+            playsInline
+            preload="metadata"
+          />
         </div>
       </div>
     </section>
@@ -700,94 +616,89 @@ export default defineAction({
   return (
     <>
       <main className="docs-home-page">
-        {/* Hero */}
-        <section
-          className="hero-section relative mx-auto flex min-h-[85vh] max-w-[1200px] items-center justify-center px-6"
-          style={{ clipPath: "inset(-100vh -100vw 0 -100vw)" }}
-        >
-          <div
-            className="pointer-events-none absolute bottom-0"
-            style={{
-              left: "50%",
-              transform: "translateX(-50%)",
-              width: "100vw",
-              top: "-65px",
-            }}
-          >
+        <div className="relative isolate">
+          <div className="pointer-events-none absolute inset-0 z-0">
             <Seascape className="opacity-30 dark:opacity-70" />
           </div>
-          <div
-            className="pointer-events-none absolute inset-0 z-[5]"
-            style={{
-              background:
-                "radial-gradient(ellipse at center, var(--bg) 0%, transparent 70%)",
-              opacity: 0.5,
-            }}
-          />
-          <div className="relative z-10 hero-content">
-            <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] bg-[var(--bg-secondary)] px-4 py-1.5 text-sm text-[var(--fg-secondary)]">
-              <span className="inline-block h-2 w-2 rounded-full bg-[var(--docs-accent)]" />
-              {t("home.hero.badge")}
-            </div>
 
-            <h1 className="mx-auto max-w-3xl">
-              {t("home.hero.titleLine1")} <br className="hidden md:inline" />
-              <span className="hero-gradient-text">
-                {t("home.hero.titleAccent")}
-              </span>
-            </h1>
+          {/* Hero */}
+          <section
+            className="hero-section relative z-10 mx-auto flex min-h-[85vh] max-w-[1200px] items-center justify-center px-6"
+            style={{ clipPath: "inset(-100vh -100vw 0 -100vw)" }}
+          >
+            <div
+              className="pointer-events-none absolute inset-0 z-[5]"
+              style={{
+                background:
+                  "radial-gradient(ellipse at center, var(--bg) 0%, transparent 70%)",
+                opacity: 0.5,
+              }}
+            />
+            <div className="relative z-10 hero-content">
+              <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] bg-[var(--bg-secondary)] px-4 py-1.5 text-sm text-[var(--fg-secondary)]">
+                <span className="inline-block h-2 w-2 rounded-full bg-[var(--docs-accent)]" />
+                {t("home.hero.badge")}
+              </div>
 
-            <p className="mx-auto mb-10 max-w-xl text-lg leading-relaxed text-[var(--fg-secondary)]">
-              {t("home.hero.body")}
-            </p>
+              <h1 className="mx-auto max-w-3xl">
+                {t("home.hero.titleLine1")} <br className="hidden md:inline" />
+                <span className="hero-gradient-text">
+                  {t("home.hero.titleAccent")}
+                </span>
+              </h1>
 
-            <div className="flex flex-wrap items-center justify-center gap-4">
-              <Link
-                data-an-prefetch="render"
-                to={localizedPath("/apps")}
-                className="primary-button"
-                onClick={() =>
-                  trackEvent("click cta", {
-                    label: "try_app",
-                    location: "hero",
-                  })
-                }
-              >
-                {t("home.hero.primaryCta")}
-                <svg
-                  width="16"
-                  height="16"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+              <p className="mx-auto mb-10 max-w-xl text-lg leading-relaxed text-[var(--fg-secondary)]">
+                {t("home.hero.body")}
+              </p>
+
+              <div className="flex flex-wrap items-center justify-center gap-4">
+                <Link
+                  data-an-prefetch="render"
+                  to={localizedPath("/apps")}
+                  className="primary-button"
+                  onClick={() =>
+                    trackEvent("click cta", {
+                      label: "try_app",
+                      location: "hero",
+                    })
+                  }
                 >
-                  <line x1="5" y1="12" x2="19" y2="12" />
-                  <polyline points="12 5 19 12 12 19" />
-                </svg>
-              </Link>
-              <Link
-                data-an-prefetch="render"
-                to={localizedPath("/docs")}
-                className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
-                onClick={() =>
-                  trackEvent("click cta", {
-                    label: "read_the_docs",
-                    location: "hero",
-                  })
-                }
-              >
-                {t("home.hero.secondaryCta")}
-              </Link>
+                  {t("home.hero.primaryCta")}
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <line x1="5" y1="12" x2="19" y2="12" />
+                    <polyline points="12 5 19 12 12 19" />
+                  </svg>
+                </Link>
+                <Link
+                  data-an-prefetch="render"
+                  to={localizedPath("/docs")}
+                  className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
+                  onClick={() =>
+                    trackEvent("click cta", {
+                      label: "read_the_docs",
+                      location: "hero",
+                    })
+                  }
+                >
+                  {t("home.hero.secondaryCta")}
+                </Link>
+              </div>
+
+              <TerminalCommand command={chatCommand} />
             </div>
+          </section>
 
-            <TerminalCommand command={chatCommand} />
-          </div>
-        </section>
-
-        <ComparisonSection />
+          <ComparisonSection />
+        </div>
 
         <AppsSection localizedPath={localizedPath} />
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1112,6 +1112,9 @@ importers:
       '@tabler/icons-react':
         specifier: 'catalog:'
         version: 3.44.0(react@19.2.7)
+      '@tanstack/react-query':
+        specifier: 5.101.2
+        version: 5.101.2(react@19.2.7)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1

--- a/scripts/qa-standalone-chat-dev-smoke.ts
+++ b/scripts/qa-standalone-chat-dev-smoke.ts
@@ -654,6 +654,14 @@ function isBenignHttpError(status: number, url: string): boolean {
   if (status === 404 && url.includes("/_agent-native/agent-chat/threads/")) {
     return true;
   }
+  // Chat can request checkpoints for a client-created thread before its first
+  // message persists that thread on the server.
+  if (
+    status === 404 &&
+    url.includes("/_agent-native/agent-chat/checkpoints?")
+  ) {
+    return true;
+  }
   // Nitro can briefly remount framework routes while Vite optimizes the first
   // browser dependency graph; waitForDevStable verifies this route is ready.
   if (status === 404 && url.includes("/_agent-native/speculation-rules.json")) {

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -19,14 +19,12 @@ import {
   IconLock,
   IconLink,
   IconMessageCircle,
-  IconHierarchy2,
   IconUsersGroup,
   IconEye,
   IconEyeOff,
   IconPlayerPlay,
   IconLayoutSidebarLeftCollapse,
   IconLayoutSidebarLeftExpand,
-  IconArrowUpRight,
 } from "@tabler/icons-react";
 import {
   useQuery,
@@ -183,12 +181,6 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 
 const bottomItems = [
-  {
-    icon: IconHierarchy2,
-    labelKey: "settings.agentTitle",
-    href: "/agent",
-    showExternalLinkIcon: true,
-  },
   { icon: IconSettings, labelKey: "navigation.settings", href: "/settings" },
 ];
 
@@ -2099,12 +2091,6 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
       active: location.pathname.startsWith("/data-dictionary"),
     },
     {
-      icon: IconHierarchy2,
-      label: t("settings.agentTitle"),
-      href: "/agent",
-      active: location.pathname === "/agent",
-    },
-    {
       icon: IconSettings,
       label: t("navigation.settings"),
       href: "/settings",
@@ -2572,15 +2558,7 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
                       )}
                     >
                       <Icon className="h-4 w-4" />
-                      <span className="flex min-w-0 items-center gap-1">
-                        <span className="truncate">{t(item.labelKey)}</span>
-                        {item.showExternalLinkIcon && (
-                          <IconArrowUpRight
-                            aria-hidden="true"
-                            className="h-3.5 w-3.5 shrink-0 text-muted-foreground/70"
-                          />
-                        )}
-                      </span>
+                      <span className="truncate">{t(item.labelKey)}</span>
                     </Link>
                   );
                 })}

--- a/templates/analytics/app/routes/_index.tsx
+++ b/templates/analytics/app/routes/_index.tsx
@@ -1,7 +1,7 @@
 import { redirect, type LoaderFunctionArgs } from "react-router";
 
 const SEO_TITLE =
-  "Agent-Native Analytics - Open Source Alternative to Amplitude & FullStory";
+  "Analytics - Open Source Alternative to Amplitude & FullStory";
 const SEO_DESCRIPTION =
   "Open Source analytics app and alternative to Amplitude and FullStory where AI agents connect to warehouses, product analytics, and CRM data to answer questions and build dashboards.";
 

--- a/templates/analytics/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
+++ b/templates/analytics/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+App branding now uses the product name without the Agent-Native prefix.

--- a/templates/analytics/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
+++ b/templates/analytics/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+Settings navigation now keeps Manage agent as a dedicated linked destination at the bottom.

--- a/templates/analytics/package.json
+++ b/templates/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytics",
-  "displayName": "Agent-Native Analytics",
+  "displayName": "Analytics",
   "private": true,
   "type": "module",
   "scripts": {

--- a/templates/analytics/public/manifest.json
+++ b/templates/analytics/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Agent Native Analytics",
+  "name": "Analytics",
   "short_name": "Analytics",
   "description": "Analytics dashboard",
   "start_url": ".",

--- a/templates/analytics/server/plugins/auth.ts
+++ b/templates/analytics/server/plugins/auth.ts
@@ -13,7 +13,7 @@ export default createAuthPlugin({
     "/_agent-native/actions/get-public-status-page",
   ],
   marketing: {
-    appName: "Agent-Native Analytics",
+    appName: "Analytics",
     tagline:
       "Your AI agent queries your data sources, builds dashboards, and answers business questions alongside you.",
     features: [

--- a/templates/assets/app/components/layout/Sidebar.tsx
+++ b/templates/assets/app/components/layout/Sidebar.tsx
@@ -17,7 +17,6 @@ import {
   type ChatHistoryItem,
 } from "@agent-native/toolkit/chat-history";
 import {
-  IconHierarchy2,
   IconClipboardList,
   IconLayoutSidebarLeftCollapse,
   IconLayoutSidebarLeftExpand,
@@ -45,7 +44,6 @@ const baseNavItems = [
 ];
 
 const bottomNavItems = [
-  { icon: IconHierarchy2, labelKey: "settings.agentTitle", href: "/agent" },
   { icon: IconSettings, labelKey: "navigation.settings", href: "/settings" },
 ];
 

--- a/templates/assets/app/routes/_index.tsx
+++ b/templates/assets/app/routes/_index.tsx
@@ -35,7 +35,7 @@ const CHAT_STARTERS = [
 ] as const;
 
 const SEO_TITLE =
-  "Agent-Native Assets - Open Source AI asset library for brand-safe images and video";
+  "Assets - Open Source AI asset library for brand-safe images and video";
 const SEO_DESCRIPTION =
   "Open Source asset manager for AI teams to organize brand libraries, search creative work, and generate on-brand images and videos.";
 

--- a/templates/assets/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
+++ b/templates/assets/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+App branding now uses the product name without the Agent-Native prefix.

--- a/templates/assets/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
+++ b/templates/assets/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+Settings navigation now keeps Manage agent as a dedicated linked destination at the bottom.

--- a/templates/assets/server/plugins/auth.ts
+++ b/templates/assets/server/plugins/auth.ts
@@ -2,7 +2,7 @@ import { createAuthPlugin } from "@agent-native/core/server";
 
 export default createAuthPlugin({
   marketing: {
-    appName: "Agent-Native Assets",
+    appName: "Assets",
     tagline:
       "Your AI agent creates, refines, and organizes on-brand assets alongside you.",
     features: [

--- a/templates/brain/app/lib/brain.ts
+++ b/templates/brain/app/lib/brain.ts
@@ -1,6 +1,5 @@
 import type { Icon } from "@tabler/icons-react";
 import {
-  IconHierarchy2,
   IconBook2,
   IconChecks,
   IconDatabase,
@@ -1006,12 +1005,6 @@ export const navItems: Array<{
     label: "Settings",
     href: "/settings",
     icon: IconSettings,
-  },
-  {
-    view: "agent",
-    label: "Manage agent",
-    href: "/agent",
-    icon: IconHierarchy2,
   },
 ];
 

--- a/templates/brain/app/routes/_index.tsx
+++ b/templates/brain/app/routes/_index.tsx
@@ -9,8 +9,7 @@ import { useEffect } from "react";
 import { shouldEnableBrainProviderStatusChecks } from "@/lib/brain-chat-readiness";
 import { TAB_ID } from "@/lib/tab-id";
 
-const SEO_TITLE =
-  "Agent-Native Brain - Open Source company knowledge base for AI agents";
+const SEO_TITLE = "Brain - Open Source company knowledge base for AI agents";
 const SEO_DESCRIPTION =
   "Open Source company knowledge base that turns Slack, meetings, transcripts, docs, and decisions into cited answers for AI agents.";
 

--- a/templates/brain/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
+++ b/templates/brain/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+App branding now uses the product name without the Agent-Native prefix.

--- a/templates/brain/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
+++ b/templates/brain/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+Settings navigation now keeps Manage agent as a dedicated linked destination at the bottom.

--- a/templates/brain/package.json
+++ b/templates/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brain",
-  "displayName": "Agent-Native Brain",
+  "displayName": "Brain",
   "private": true,
   "type": "module",
   "scripts": {

--- a/templates/brain/public/manifest.json
+++ b/templates/brain/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Agent-Native Brain",
+  "name": "Brain",
   "short_name": "Brain",
   "start_url": "/",
   "display": "standalone",

--- a/templates/brain/server/plugins/auth.ts
+++ b/templates/brain/server/plugins/auth.ts
@@ -2,7 +2,7 @@ import { createAuthPlugin } from "@agent-native/core/server";
 
 export default createAuthPlugin({
   marketing: {
-    appName: "Agent-Native Brain",
+    appName: "Brain",
     tagline:
       "A company knowledge layer where raw conversations become reviewed, searchable institutional knowledge.",
     features: [

--- a/templates/calendar/app/components/layout/Sidebar.tsx
+++ b/templates/calendar/app/components/layout/Sidebar.tsx
@@ -6,7 +6,6 @@ import { OrgSwitcher } from "@agent-native/core/client/org";
 import { FeedbackButton } from "@agent-native/core/client/ui";
 import { SidebarFooterActions } from "@agent-native/toolkit/app-shell";
 import {
-  IconHierarchy2,
   IconCalendar,
   IconSettings,
   IconLink,
@@ -101,11 +100,6 @@ const navItems = [
 ];
 
 const bottomNavItems = [
-  {
-    path: "/agent",
-    labelKey: "settings.agentTitle",
-    icon: IconHierarchy2,
-  },
   { path: "/settings", labelKey: "navigation.settings", icon: IconSettings },
 ];
 

--- a/templates/calendar/app/routes/_app._index.tsx
+++ b/templates/calendar/app/routes/_app._index.tsx
@@ -1,7 +1,7 @@
 import CalendarView from "@/pages/CalendarView";
 
 const SEO_TITLE =
-  "Agent-Native Calendar - Open Source AI scheduling and Google Calendar automation";
+  "Calendar - Open Source AI scheduling and Google Calendar automation";
 const SEO_DESCRIPTION =
   "Open Source AI calendar app for Google Calendar scheduling, booking links, meeting coordination, and agent-managed event updates.";
 

--- a/templates/calendar/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
+++ b/templates/calendar/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+App branding now uses the product name without the Agent-Native prefix.

--- a/templates/calendar/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
+++ b/templates/calendar/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+Settings navigation now keeps Manage agent as a dedicated linked destination at the bottom.

--- a/templates/calendar/package.json
+++ b/templates/calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calendar",
-  "displayName": "Agent-Native Calendar",
+  "displayName": "Calendar",
   "private": true,
   "type": "module",
   "scripts": {

--- a/templates/calendar/public/manifest.json
+++ b/templates/calendar/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Agent Native Calendar",
+  "name": "Calendar",
   "short_name": "Calendar",
   "description": "Google Calendar integration",
   "start_url": ".",

--- a/templates/calendar/server/plugins/auth.ts
+++ b/templates/calendar/server/plugins/auth.ts
@@ -8,7 +8,7 @@ export default createAuthPlugin({
   googleOnly: true,
   mountGoogleOAuthRoutes: false,
   marketing: {
-    appName: "Agent-Native Calendar",
+    appName: "Calendar",
     tagline:
       "Your AI agent schedules, reschedules, and manages your calendar so you never have to.",
     features: [

--- a/templates/chat/app/components/layout/Sidebar.tsx
+++ b/templates/chat/app/components/layout/Sidebar.tsx
@@ -14,7 +14,6 @@ import {
   type ChatHistoryItem,
 } from "@agent-native/toolkit/chat-history";
 import {
-  IconHierarchy2,
   IconLayoutSidebarLeftCollapse,
   IconLayoutSidebarLeftExpand,
   IconMessageCircle,
@@ -43,12 +42,6 @@ const navItems = [
 ];
 
 const bottomNavItems = [
-  {
-    icon: IconHierarchy2,
-    labelKey: "settings.agentTitle",
-    href: "/agent",
-    view: "agent",
-  },
   {
     icon: IconSettings,
     labelKey: "navigation.settings",

--- a/templates/chat/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
+++ b/templates/chat/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+Settings navigation now keeps Manage agent as a dedicated linked destination at the bottom.

--- a/templates/clips/actions/import-loom-recording.ts
+++ b/templates/clips/actions/import-loom-recording.ts
@@ -18,6 +18,7 @@ import {
   stringifySpaceIds,
 } from "../server/lib/recordings.js";
 import { hasRequestVideoStorage } from "../server/lib/video-storage.js";
+import { failLoomImport } from "./lib/loom-import-job.js";
 
 const LoomOembedSchema = z
   .object({
@@ -157,15 +158,17 @@ export default defineAction({
       const existingSourceUrl = normalizeLoomShareUrl(
         existingRecording.sourceWindowTitle ?? "",
       );
-      const isWaitingStorageRetry =
-        existingRecording.status === "uploading" &&
+      const isRetryableLoomImport =
         !existingRecording.videoUrl &&
-        existingRecording.failureReason ===
-          LOOM_STORAGE_SETUP_REQUIRED_REASON &&
-        existingSourceUrl === shareUrl;
-      if (!isWaitingStorageRetry) {
+        existingSourceUrl === shareUrl &&
+        (existingRecording.status === "processing" ||
+          existingRecording.status === "failed" ||
+          (existingRecording.status === "uploading" &&
+            existingRecording.failureReason ===
+              LOOM_STORAGE_SETUP_REQUIRED_REASON));
+      if (!isRetryableLoomImport) {
         throw new Error(
-          "Only a waiting-storage Loom import can be retried in place.",
+          "Only an incomplete Loom import can be retried in place.",
         );
       }
     }
@@ -334,15 +337,19 @@ export default defineAction({
     await writeAppState("refresh-signal", { ts: Date.now() });
     await writeAppState("navigate", { view: "recording", recordingId: id });
 
-    await dispatchPostFinalizeJob({
-      recordingId: id,
-      kind: "loom-import",
-    }).catch((err: unknown) => {
-      console.error("[clips] Loom import job dispatch failed", {
+    try {
+      await dispatchPostFinalizeJob({
         recordingId: id,
-        error: err instanceof Error ? err.message : String(err),
+        kind: "loom-import",
+        requireAccepted: true,
       });
-    });
+    } catch (err) {
+      const failureReason = `Could not start the Loom import: ${
+        err instanceof Error ? err.message : String(err)
+      }`;
+      await failLoomImport(id, failureReason);
+      throw new Error(failureReason);
+    }
 
     return {
       recordingId: id,

--- a/templates/clips/actions/import-loom-recording.ts
+++ b/templates/clips/actions/import-loom-recording.ts
@@ -1,14 +1,13 @@
 import { defineAction } from "@agent-native/core";
 import { writeAppState } from "@agent-native/core/application-state";
 import { ssrfSafeFetch } from "@agent-native/core/extensions/url-safety";
-import { uploadFile } from "@agent-native/core/file-upload";
 import { buildDeepLink } from "@agent-native/core/server";
 import { extractLoomVideoId, normalizeLoomShareUrl } from "@shared/loom.js";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
-import { queueBuilderMediaCompression } from "../server/lib/builder-media-compression.js";
+import { dispatchPostFinalizeJob } from "../server/lib/post-finalize-dispatch.js";
 import {
   getCurrentOwnerEmail,
   getOrganizationDefaultVisibility,
@@ -19,11 +18,6 @@ import {
   stringifySpaceIds,
 } from "../server/lib/recordings.js";
 import { hasRequestVideoStorage } from "../server/lib/video-storage.js";
-import {
-  fetchLoomTranscript,
-  loomTranscriptUnavailableMessage,
-} from "./lib/loom-transcript.js";
-import { downloadLoomVideo } from "./lib/loom-video.js";
 
 const LoomOembedSchema = z
   .object({
@@ -132,7 +126,7 @@ async function fetchLoomOembed(shareUrl: string) {
 
 export default defineAction({
   description:
-    "Import a public Loom share URL into Clips as a playable recording. Downloads Loom's public MP4, reuploads it to the configured Clips storage provider, and imports Loom's public transcript when available. If storage is not connected, creates a waiting recording that can be retried after storage setup.",
+    "Import a public Loom share URL into Clips as a playable recording. Creates the recording immediately and downloads Loom's public MP4, reuploads it to the configured Clips storage provider, and imports Loom's public transcript in the background (Loom's CDN plus a reupload can take longer than a single request should block on). If storage is not connected, creates a waiting recording that can be retried after storage setup.",
   schema: ImportLoomRecordingSchema,
   run: async (args) => {
     const shareUrl = normalizeLoomShareUrl(args.url);
@@ -293,35 +287,22 @@ export default defineAction({
       );
     }
 
-    const media = await downloadLoomVideo({ loomId, shareUrl });
-    const upload = await uploadFile({
-      data: media.bytes,
-      filename: `${id}.mp4`,
-      mimeType: media.mimeType,
-      ownerEmail,
-      stableUrl: true,
-      recordAsset: false,
-    });
-
-    const recordingValues = buildRecordingValues(media.sizeBytes);
-    if (upload === null) {
-      return await saveWaitingForStorage(media.sizeBytes);
-    }
-
-    if (!upload?.url) {
-      throw new Error(
-        "File upload returned no URL. Check your storage provider configuration.",
-      );
-    }
-
-    const videoUrl = upload.url;
+    // Storage is connected: create the row now and hand the slow Loom
+    // download + reupload + transcript off to a durable background job.
+    // Loom's CDN plus a reupload can outlast the platform's request timeout;
+    // doing it inline previously crashed the function mid-download instead of
+    // returning a clean error (see post-finalize-worker.post.ts's "loom-import"
+    // kind / runLoomImportJob).
+    const recordingValues = buildRecordingValues(
+      existingRecording?.videoSizeBytes ?? 0,
+    );
     if (existingRecording) {
       await db
         .update(schema.recordings)
         .set({
           ...recordingValues,
-          videoUrl,
-          status: "ready",
+          status: "processing",
+          videoUrl: null,
           failureReason: null,
         })
         .where(eq(schema.recordings.id, id));
@@ -329,87 +310,50 @@ export default defineAction({
       await db.insert(schema.recordings).values({
         id,
         ...recordingValues,
-        videoUrl,
-        status: "ready",
+        videoUrl: null,
+        status: "processing",
         failureReason: null,
         ownerEmail,
         createdAt: now,
       });
     }
 
-    void queueBuilderMediaCompression({
+    await writeAppState(`recording-upload-${id}`, {
       recordingId: id,
-      ownerEmail,
-      videoUrl,
-      mimeType: media.mimeType,
-      providerId: upload.provider,
-      assetDbId: upload.id,
-      sourceSizeBytes: media.sizeBytes,
-    }).catch((err) => {
-      console.warn("[clips] Loom media compression queue failed", {
+      status: "processing",
+      progress: 100,
+      provider: "loom",
+      sourceUrl: shareUrl,
+      durationMs,
+      width,
+      height,
+      hasAudio: true,
+      hasCamera: false,
+      updatedAt: now,
+    });
+    await writeAppState("refresh-signal", { ts: Date.now() });
+    await writeAppState("navigate", { view: "recording", recordingId: id });
+
+    await dispatchPostFinalizeJob({
+      recordingId: id,
+      kind: "loom-import",
+    }).catch((err: unknown) => {
+      console.error("[clips] Loom import job dispatch failed", {
         recordingId: id,
         error: err instanceof Error ? err.message : String(err),
       });
     });
 
-    let transcript: Awaited<ReturnType<typeof fetchLoomTranscript>> = null;
-    try {
-      transcript = await fetchLoomTranscript({ shareUrl, durationMs });
-    } catch (err) {
-      console.warn(
-        `[clips] Loom transcript import skipped for ${loomId}:`,
-        (err as Error)?.message ?? String(err),
-      );
-    }
-
-    const transcriptValues = {
-      ownerEmail,
-      language: transcript?.language ?? "en",
-      segmentsJson: transcript ? JSON.stringify(transcript.segments) : "[]",
-      fullText: transcript?.fullText ?? "",
-      status: transcript ? ("ready" as const) : ("failed" as const),
-      failureReason: transcript ? null : loomTranscriptUnavailableMessage(),
-      updatedAt: now,
-    };
-    const [existingTranscript] = await db
-      .select({ recordingId: schema.recordingTranscripts.recordingId })
-      .from(schema.recordingTranscripts)
-      .where(eq(schema.recordingTranscripts.recordingId, id));
-    if (existingTranscript) {
-      await db
-        .update(schema.recordingTranscripts)
-        .set(transcriptValues)
-        .where(eq(schema.recordingTranscripts.recordingId, id));
-    } else {
-      await db.insert(schema.recordingTranscripts).values({
-        recordingId: id,
-        ...transcriptValues,
-        createdAt: now,
-      });
-    }
-
-    await writeAppState("refresh-signal", { ts: Date.now() });
-    await writeAppState("navigate", { view: "recording", recordingId: id });
-
     return {
       recordingId: id,
       title,
-      status: "ready" as const,
+      status: "processing" as const,
       provider: "loom" as const,
       sourceUrl: shareUrl,
-      videoUrl,
-      embedUrl: videoUrl,
       thumbnailUrl: oembed.thumbnail_url ?? null,
       durationMs,
-      transcriptStatus: transcript
-        ? ("ready" as const)
-        : ("unavailable" as const),
       importMode: "reuploaded" as const,
-      storageProvider: upload.provider,
-      videoSizeBytes: media.sizeBytes,
-      note: transcript
-        ? "Imported as a Clips-hosted MP4 with Loom's public transcript."
-        : "Imported as a Clips-hosted MP4. Loom did not expose an importable transcript; use request-transcript to transcribe the uploaded media.",
+      note: "Downloading and importing this Loom recording in the background.",
     };
   },
   link: ({ result }) => {

--- a/templates/clips/actions/import-loom-recording.ts
+++ b/templates/clips/actions/import-loom-recording.ts
@@ -238,6 +238,8 @@ export default defineAction({
             status: "uploading",
             videoUrl: null,
             failureReason: LOOM_STORAGE_SETUP_REQUIRED_REASON,
+            loomImportClaimId: null,
+            loomImportClaimedAt: null,
           })
           .where(eq(schema.recordings.id, id));
       } else {
@@ -307,6 +309,8 @@ export default defineAction({
           status: "processing",
           videoUrl: null,
           failureReason: null,
+          loomImportClaimId: null,
+          loomImportClaimedAt: null,
         })
         .where(eq(schema.recordings.id, id));
     } else {

--- a/templates/clips/actions/lib/loom-import-job.test.ts
+++ b/templates/clips/actions/lib/loom-import-job.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSelectRows = vi.hoisted(() => ({
+  queue: [] as Array<Array<Record<string, unknown>>>,
+}));
+const mockUpdateWhere = vi.hoisted(() => vi.fn(async () => undefined));
+const mockUpdateSet = vi.hoisted(() =>
+  vi.fn(() => ({ where: mockUpdateWhere })),
+);
+const mockInsertValues = vi.hoisted(() => vi.fn(async () => undefined));
+const mockDb = vi.hoisted(() => ({
+  select: vi.fn(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn(async () => mockSelectRows.queue.shift() ?? []),
+    })),
+  })),
+  update: vi.fn(() => ({ set: mockUpdateSet })),
+  insert: vi.fn(() => ({ values: mockInsertValues })),
+}));
+const mockWriteAppState = vi.hoisted(() => vi.fn(async () => undefined));
+const mockUploadFile = vi.hoisted(() => vi.fn());
+const mockDownloadLoomVideo = vi.hoisted(() => vi.fn());
+const mockFetchLoomTranscript = vi.hoisted(() => vi.fn());
+const mockQueueBuilderMediaCompression = vi.hoisted(() =>
+  vi.fn(async () => undefined),
+);
+
+vi.mock("@agent-native/core/application-state", () => ({
+  writeAppState: mockWriteAppState,
+}));
+vi.mock("@agent-native/core/file-upload", () => ({
+  uploadFile: mockUploadFile,
+}));
+vi.mock("../../server/db/index.js", () => ({
+  getDb: () => mockDb,
+  schema: {
+    recordings: { id: "id", ownerEmail: "ownerEmail" },
+    recordingTranscripts: { recordingId: "recordingId" },
+  },
+}));
+vi.mock("../../server/lib/builder-media-compression.js", () => ({
+  queueBuilderMediaCompression: mockQueueBuilderMediaCompression,
+}));
+vi.mock("./loom-transcript.js", () => ({
+  fetchLoomTranscript: mockFetchLoomTranscript,
+  loomTranscriptUnavailableMessage: () => "Loom transcript unavailable",
+}));
+vi.mock("./loom-video.js", () => ({
+  downloadLoomVideo: mockDownloadLoomVideo,
+}));
+
+import { runLoomImportJob } from "./loom-import-job";
+
+describe("runLoomImportJob", () => {
+  beforeEach(() => {
+    mockSelectRows.queue = [];
+    mockUpdateWhere.mockClear();
+    mockUpdateSet.mockClear();
+    mockInsertValues.mockClear();
+    mockWriteAppState.mockClear();
+    mockUploadFile.mockReset();
+    mockDownloadLoomVideo.mockReset();
+    mockFetchLoomTranscript.mockReset();
+    mockQueueBuilderMediaCompression.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("downloads, reuploads, and marks the recording ready", async () => {
+    mockSelectRows.queue.push([
+      {
+        id: "rec_1",
+        durationMs: 5_000,
+        sourceWindowTitle: "https://www.loom.com/share/abcDEF_123456",
+      },
+    ]);
+    mockDownloadLoomVideo.mockResolvedValue({
+      bytes: new Uint8Array([1, 2, 3]),
+      mimeType: "video/mp4",
+      sizeBytes: 3,
+      sourceUrl: "https://cdn.loom.com/sessions/transcoded/x.mp4",
+    });
+    mockUploadFile.mockResolvedValue({
+      url: "https://cdn.example.com/rec_1.mp4",
+      provider: "builder",
+      id: "asset_1",
+    });
+    mockFetchLoomTranscript.mockResolvedValue(null);
+    mockSelectRows.queue.push([]); // no existing transcript row
+
+    const result = await runLoomImportJob({
+      recordingId: "rec_1",
+      ownerEmail: "owner@example.com",
+    });
+
+    expect(result).toEqual({ status: "ready" });
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "ready",
+        videoUrl: "https://cdn.example.com/rec_1.mp4",
+        failureReason: null,
+      }),
+    );
+    expect(mockQueueBuilderMediaCompression).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recordingId: "rec_1",
+        videoUrl: "https://cdn.example.com/rec_1.mp4",
+      }),
+    );
+  });
+
+  it("marks the recording failed instead of throwing when the download fails", async () => {
+    mockSelectRows.queue.push([
+      {
+        id: "rec_2",
+        durationMs: 0,
+        sourceWindowTitle: "https://www.loom.com/share/abcDEF_123456",
+      },
+    ]);
+    mockDownloadLoomVideo.mockRejectedValue(
+      new Error("Loom video download failed (404 Not Found)."),
+    );
+
+    const result = await runLoomImportJob({
+      recordingId: "rec_2",
+      ownerEmail: "owner@example.com",
+    });
+
+    expect(result).toEqual({
+      status: "failed",
+      failureReason: "Loom video download failed (404 Not Found).",
+    });
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "failed",
+        failureReason: "Loom video download failed (404 Not Found).",
+      }),
+    );
+    expect(mockUploadFile).not.toHaveBeenCalled();
+  });
+});

--- a/templates/clips/actions/lib/loom-import-job.test.ts
+++ b/templates/clips/actions/lib/loom-import-job.test.ts
@@ -140,4 +140,75 @@ describe("runLoomImportJob", () => {
     );
     expect(mockUploadFile).not.toHaveBeenCalled();
   });
+
+  it("marks the recording failed instead of throwing when upload fails", async () => {
+    mockSelectRows.queue.push([
+      {
+        id: "rec_3",
+        durationMs: 0,
+        sourceWindowTitle: "https://www.loom.com/share/abcDEF_123456",
+      },
+    ]);
+    mockDownloadLoomVideo.mockResolvedValue({
+      bytes: new Uint8Array([1]),
+      mimeType: "video/mp4",
+      sizeBytes: 1,
+    });
+    mockUploadFile.mockRejectedValue(new Error("storage unavailable"));
+
+    const result = await runLoomImportJob({
+      recordingId: "rec_3",
+      ownerEmail: "owner@example.com",
+    });
+
+    expect(result).toEqual({
+      status: "failed",
+      failureReason: "storage unavailable",
+    });
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "failed",
+        failureReason: "storage unavailable",
+      }),
+    );
+  });
+
+  it("marks the recording failed when transcript persistence fails", async () => {
+    mockSelectRows.queue.push([
+      {
+        id: "rec_4",
+        durationMs: 0,
+        sourceWindowTitle: "https://www.loom.com/share/abcDEF_123456",
+      },
+    ]);
+    mockDownloadLoomVideo.mockResolvedValue({
+      bytes: new Uint8Array([1]),
+      mimeType: "video/mp4",
+      sizeBytes: 1,
+    });
+    mockUploadFile.mockResolvedValue({
+      url: "https://cdn.example.com/rec_4.mp4",
+      provider: "builder",
+      id: "asset_4",
+    });
+    mockFetchLoomTranscript.mockResolvedValue(null);
+    mockSelectRows.queue.push([]);
+    mockInsertValues.mockRejectedValueOnce(new Error("database unavailable"));
+
+    const result = await runLoomImportJob({
+      recordingId: "rec_4",
+      ownerEmail: "owner@example.com",
+    });
+
+    expect(result).toEqual({
+      status: "failed",
+      failureReason: "database unavailable",
+    });
+    expect(mockUpdateSet).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        status: "failed",
+        failureReason: "database unavailable",
+      }),
+    );
+  });
 });

--- a/templates/clips/actions/lib/loom-import-job.test.ts
+++ b/templates/clips/actions/lib/loom-import-job.test.ts
@@ -3,7 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mockSelectRows = vi.hoisted(() => ({
   queue: [] as Array<Array<Record<string, unknown>>>,
 }));
-const mockUpdateWhere = vi.hoisted(() => vi.fn(async () => undefined));
+const mockReturning = vi.hoisted(() =>
+  vi.fn(async () => [{ id: "updated-recording" }]),
+);
+const mockUpdateWhere = vi.hoisted(() =>
+  vi.fn(() => ({ returning: mockReturning })),
+);
 const mockUpdateSet = vi.hoisted(() =>
   vi.fn(() => ({ where: mockUpdateWhere })),
 );
@@ -34,7 +39,11 @@ vi.mock("@agent-native/core/file-upload", () => ({
 vi.mock("../../server/db/index.js", () => ({
   getDb: () => mockDb,
   schema: {
-    recordings: { id: "id", ownerEmail: "ownerEmail" },
+    recordings: {
+      id: "id",
+      ownerEmail: "ownerEmail",
+      loomImportClaimId: "loomImportClaimId",
+    },
     recordingTranscripts: { recordingId: "recordingId" },
   },
 }));
@@ -55,6 +64,7 @@ describe("runLoomImportJob", () => {
   beforeEach(() => {
     mockSelectRows.queue = [];
     mockUpdateWhere.mockClear();
+    mockReturning.mockClear();
     mockUpdateSet.mockClear();
     mockInsertValues.mockClear();
     mockWriteAppState.mockClear();
@@ -74,6 +84,7 @@ describe("runLoomImportJob", () => {
         id: "rec_1",
         durationMs: 5_000,
         sourceWindowTitle: "https://www.loom.com/share/abcDEF_123456",
+        loomImportClaimId: "claim_1",
       },
     ]);
     mockDownloadLoomVideo.mockResolvedValue({
@@ -93,6 +104,7 @@ describe("runLoomImportJob", () => {
     const result = await runLoomImportJob({
       recordingId: "rec_1",
       ownerEmail: "owner@example.com",
+      claimId: "claim_1",
     });
 
     expect(result).toEqual({ status: "ready" });
@@ -117,6 +129,7 @@ describe("runLoomImportJob", () => {
         id: "rec_2",
         durationMs: 0,
         sourceWindowTitle: "https://www.loom.com/share/abcDEF_123456",
+        loomImportClaimId: "claim_2",
       },
     ]);
     mockDownloadLoomVideo.mockRejectedValue(
@@ -126,6 +139,7 @@ describe("runLoomImportJob", () => {
     const result = await runLoomImportJob({
       recordingId: "rec_2",
       ownerEmail: "owner@example.com",
+      claimId: "claim_2",
     });
 
     expect(result).toEqual({
@@ -147,6 +161,7 @@ describe("runLoomImportJob", () => {
         id: "rec_3",
         durationMs: 0,
         sourceWindowTitle: "https://www.loom.com/share/abcDEF_123456",
+        loomImportClaimId: "claim_3",
       },
     ]);
     mockDownloadLoomVideo.mockResolvedValue({
@@ -159,6 +174,7 @@ describe("runLoomImportJob", () => {
     const result = await runLoomImportJob({
       recordingId: "rec_3",
       ownerEmail: "owner@example.com",
+      claimId: "claim_3",
     });
 
     expect(result).toEqual({
@@ -173,12 +189,13 @@ describe("runLoomImportJob", () => {
     );
   });
 
-  it("marks the recording failed when transcript persistence fails", async () => {
+  it("keeps playable media ready when transcript persistence fails", async () => {
     mockSelectRows.queue.push([
       {
         id: "rec_4",
         durationMs: 0,
         sourceWindowTitle: "https://www.loom.com/share/abcDEF_123456",
+        loomImportClaimId: "claim_4",
       },
     ]);
     mockDownloadLoomVideo.mockResolvedValue({
@@ -198,16 +215,14 @@ describe("runLoomImportJob", () => {
     const result = await runLoomImportJob({
       recordingId: "rec_4",
       ownerEmail: "owner@example.com",
+      claimId: "claim_4",
     });
 
-    expect(result).toEqual({
-      status: "failed",
-      failureReason: "database unavailable",
-    });
-    expect(mockUpdateSet).toHaveBeenLastCalledWith(
+    expect(result).toEqual({ status: "ready" });
+    expect(mockUpdateSet).toHaveBeenCalledWith(
       expect.objectContaining({
-        status: "failed",
-        failureReason: "database unavailable",
+        status: "ready",
+        videoUrl: "https://cdn.example.com/rec_4.mp4",
       }),
     );
   });

--- a/templates/clips/actions/lib/loom-import-job.ts
+++ b/templates/clips/actions/lib/loom-import-job.ts
@@ -1,0 +1,174 @@
+import { writeAppState } from "@agent-native/core/application-state";
+import { uploadFile } from "@agent-native/core/file-upload";
+import { eq } from "drizzle-orm";
+
+import { getDb, schema } from "../../server/db/index.js";
+import { queueBuilderMediaCompression } from "../../server/lib/builder-media-compression.js";
+import {
+  extractLoomVideoId,
+  normalizeLoomShareUrl,
+} from "../../shared/loom.js";
+import {
+  fetchLoomTranscript,
+  loomTranscriptUnavailableMessage,
+} from "./loom-transcript.js";
+import { downloadLoomVideo } from "./loom-video.js";
+
+export type LoomImportJobResult = {
+  status: "ready" | "failed";
+  failureReason?: string;
+};
+
+async function failLoomImport(
+  recordingId: string,
+  failureReason: string,
+): Promise<LoomImportJobResult> {
+  const now = new Date().toISOString();
+  await getDb()
+    .update(schema.recordings)
+    .set({ status: "failed", failureReason, updatedAt: now })
+    .where(eq(schema.recordings.id, recordingId));
+  await writeAppState(`recording-upload-${recordingId}`, {
+    recordingId,
+    status: "failed",
+    failureReason,
+    updatedAt: now,
+  });
+  await writeAppState("refresh-signal", { ts: Date.now() });
+  return { status: "failed", failureReason };
+}
+
+/**
+ * Downloads a Loom video and re-uploads it to Clips storage, off the request
+ * that created the "processing" row. Loom's CDN plus a reupload can outlast a
+ * synchronous serverless function's execution ceiling; running it here keeps
+ * import-loom-recording's own request fast regardless of Loom video length.
+ */
+export async function runLoomImportJob({
+  recordingId,
+  ownerEmail,
+}: {
+  recordingId: string;
+  ownerEmail: string;
+}): Promise<LoomImportJobResult> {
+  const db = getDb();
+  const [recording] = await db
+    .select({
+      id: schema.recordings.id,
+      durationMs: schema.recordings.durationMs,
+      sourceWindowTitle: schema.recordings.sourceWindowTitle,
+    })
+    .from(schema.recordings)
+    .where(eq(schema.recordings.id, recordingId));
+
+  const shareUrl = normalizeLoomShareUrl(recording?.sourceWindowTitle ?? "");
+  const loomId = shareUrl ? extractLoomVideoId(shareUrl) : null;
+  if (!recording || !shareUrl || !loomId) {
+    return failLoomImport(
+      recordingId,
+      "This Loom recording is missing its source URL.",
+    );
+  }
+
+  let media: Awaited<ReturnType<typeof downloadLoomVideo>>;
+  try {
+    media = await downloadLoomVideo({ loomId, shareUrl });
+  } catch (err) {
+    return failLoomImport(
+      recordingId,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  const upload = await uploadFile({
+    data: media.bytes,
+    filename: `${recordingId}.mp4`,
+    mimeType: media.mimeType,
+    ownerEmail,
+    stableUrl: true,
+    recordAsset: false,
+  });
+  if (!upload?.url) {
+    return failLoomImport(
+      recordingId,
+      "File upload returned no URL. Check your storage provider configuration.",
+    );
+  }
+
+  const now = new Date().toISOString();
+  await db
+    .update(schema.recordings)
+    .set({
+      videoUrl: upload.url,
+      videoSizeBytes: media.sizeBytes,
+      status: "ready",
+      failureReason: null,
+      updatedAt: now,
+    })
+    .where(eq(schema.recordings.id, recordingId));
+
+  void queueBuilderMediaCompression({
+    recordingId,
+    ownerEmail,
+    videoUrl: upload.url,
+    mimeType: media.mimeType,
+    providerId: upload.provider,
+    assetDbId: upload.id,
+    sourceSizeBytes: media.sizeBytes,
+  }).catch((err) => {
+    console.warn("[clips] Loom media compression queue failed", {
+      recordingId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
+
+  let transcript: Awaited<ReturnType<typeof fetchLoomTranscript>> = null;
+  try {
+    transcript = await fetchLoomTranscript({
+      shareUrl,
+      durationMs: recording.durationMs,
+    });
+  } catch (err) {
+    console.warn(
+      `[clips] Loom transcript import skipped for ${loomId}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  const transcriptValues = {
+    ownerEmail,
+    language: transcript?.language ?? "en",
+    segmentsJson: transcript ? JSON.stringify(transcript.segments) : "[]",
+    fullText: transcript?.fullText ?? "",
+    status: transcript ? ("ready" as const) : ("failed" as const),
+    failureReason: transcript ? null : loomTranscriptUnavailableMessage(),
+    updatedAt: now,
+  };
+  const [existingTranscript] = await db
+    .select({ recordingId: schema.recordingTranscripts.recordingId })
+    .from(schema.recordingTranscripts)
+    .where(eq(schema.recordingTranscripts.recordingId, recordingId));
+  if (existingTranscript) {
+    await db
+      .update(schema.recordingTranscripts)
+      .set(transcriptValues)
+      .where(eq(schema.recordingTranscripts.recordingId, recordingId));
+  } else {
+    await db.insert(schema.recordingTranscripts).values({
+      recordingId,
+      ...transcriptValues,
+      createdAt: now,
+    });
+  }
+
+  await writeAppState(`recording-upload-${recordingId}`, {
+    recordingId,
+    status: "ready",
+    progress: 100,
+    videoUrl: upload.url,
+    updatedAt: now,
+  });
+  await writeAppState("refresh-signal", { ts: Date.now() });
+
+  return { status: "ready" };
+}

--- a/templates/clips/actions/lib/loom-import-job.ts
+++ b/templates/clips/actions/lib/loom-import-job.ts
@@ -19,7 +19,7 @@ export type LoomImportJobResult = {
   failureReason?: string;
 };
 
-async function failLoomImport(
+export async function failLoomImport(
   recordingId: string,
   failureReason: string,
 ): Promise<LoomImportJobResult> {
@@ -80,95 +80,102 @@ export async function runLoomImportJob({
     );
   }
 
-  const upload = await uploadFile({
-    data: media.bytes,
-    filename: `${recordingId}.mp4`,
-    mimeType: media.mimeType,
-    ownerEmail,
-    stableUrl: true,
-    recordAsset: false,
-  });
-  if (!upload?.url) {
+  try {
+    const upload = await uploadFile({
+      data: media.bytes,
+      filename: `${recordingId}.mp4`,
+      mimeType: media.mimeType,
+      ownerEmail,
+      stableUrl: true,
+      recordAsset: false,
+    });
+    if (!upload?.url) {
+      return failLoomImport(
+        recordingId,
+        "File upload returned no URL. Check your storage provider configuration.",
+      );
+    }
+
+    const now = new Date().toISOString();
+    await db
+      .update(schema.recordings)
+      .set({
+        videoUrl: upload.url,
+        videoSizeBytes: media.sizeBytes,
+        status: "ready",
+        failureReason: null,
+        updatedAt: now,
+      })
+      .where(eq(schema.recordings.id, recordingId));
+
+    void queueBuilderMediaCompression({
+      recordingId,
+      ownerEmail,
+      videoUrl: upload.url,
+      mimeType: media.mimeType,
+      providerId: upload.provider,
+      assetDbId: upload.id,
+      sourceSizeBytes: media.sizeBytes,
+    }).catch((err) => {
+      console.warn("[clips] Loom media compression queue failed", {
+        recordingId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+
+    let transcript: Awaited<ReturnType<typeof fetchLoomTranscript>> = null;
+    try {
+      transcript = await fetchLoomTranscript({
+        shareUrl,
+        durationMs: recording.durationMs,
+      });
+    } catch (err) {
+      console.warn(
+        `[clips] Loom transcript import skipped for ${loomId}:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+
+    const transcriptValues = {
+      ownerEmail,
+      language: transcript?.language ?? "en",
+      segmentsJson: transcript ? JSON.stringify(transcript.segments) : "[]",
+      fullText: transcript?.fullText ?? "",
+      status: transcript ? ("ready" as const) : ("failed" as const),
+      failureReason: transcript ? null : loomTranscriptUnavailableMessage(),
+      updatedAt: now,
+    };
+    const [existingTranscript] = await db
+      .select({ recordingId: schema.recordingTranscripts.recordingId })
+      .from(schema.recordingTranscripts)
+      .where(eq(schema.recordingTranscripts.recordingId, recordingId));
+    if (existingTranscript) {
+      await db
+        .update(schema.recordingTranscripts)
+        .set(transcriptValues)
+        .where(eq(schema.recordingTranscripts.recordingId, recordingId));
+    } else {
+      await db.insert(schema.recordingTranscripts).values({
+        recordingId,
+        ...transcriptValues,
+        createdAt: now,
+      });
+    }
+
+    await writeAppState(`recording-upload-${recordingId}`, {
+      recordingId,
+      status: "ready",
+      progress: 100,
+      videoUrl: upload.url,
+      updatedAt: now,
+    });
+    await writeAppState("refresh-signal", { ts: Date.now() });
+
+    return { status: "ready" };
+  } catch (err) {
     return failLoomImport(
       recordingId,
-      "File upload returned no URL. Check your storage provider configuration.",
-    );
-  }
-
-  const now = new Date().toISOString();
-  await db
-    .update(schema.recordings)
-    .set({
-      videoUrl: upload.url,
-      videoSizeBytes: media.sizeBytes,
-      status: "ready",
-      failureReason: null,
-      updatedAt: now,
-    })
-    .where(eq(schema.recordings.id, recordingId));
-
-  void queueBuilderMediaCompression({
-    recordingId,
-    ownerEmail,
-    videoUrl: upload.url,
-    mimeType: media.mimeType,
-    providerId: upload.provider,
-    assetDbId: upload.id,
-    sourceSizeBytes: media.sizeBytes,
-  }).catch((err) => {
-    console.warn("[clips] Loom media compression queue failed", {
-      recordingId,
-      error: err instanceof Error ? err.message : String(err),
-    });
-  });
-
-  let transcript: Awaited<ReturnType<typeof fetchLoomTranscript>> = null;
-  try {
-    transcript = await fetchLoomTranscript({
-      shareUrl,
-      durationMs: recording.durationMs,
-    });
-  } catch (err) {
-    console.warn(
-      `[clips] Loom transcript import skipped for ${loomId}:`,
       err instanceof Error ? err.message : String(err),
     );
   }
-
-  const transcriptValues = {
-    ownerEmail,
-    language: transcript?.language ?? "en",
-    segmentsJson: transcript ? JSON.stringify(transcript.segments) : "[]",
-    fullText: transcript?.fullText ?? "",
-    status: transcript ? ("ready" as const) : ("failed" as const),
-    failureReason: transcript ? null : loomTranscriptUnavailableMessage(),
-    updatedAt: now,
-  };
-  const [existingTranscript] = await db
-    .select({ recordingId: schema.recordingTranscripts.recordingId })
-    .from(schema.recordingTranscripts)
-    .where(eq(schema.recordingTranscripts.recordingId, recordingId));
-  if (existingTranscript) {
-    await db
-      .update(schema.recordingTranscripts)
-      .set(transcriptValues)
-      .where(eq(schema.recordingTranscripts.recordingId, recordingId));
-  } else {
-    await db.insert(schema.recordingTranscripts).values({
-      recordingId,
-      ...transcriptValues,
-      createdAt: now,
-    });
-  }
-
-  await writeAppState(`recording-upload-${recordingId}`, {
-    recordingId,
-    status: "ready",
-    progress: 100,
-    videoUrl: upload.url,
-    updatedAt: now,
-  });
-  await writeAppState("refresh-signal", { ts: Date.now() });
-
-  return { status: "ready" };
 }

--- a/templates/clips/actions/lib/loom-import-job.ts
+++ b/templates/clips/actions/lib/loom-import-job.ts
@@ -1,6 +1,6 @@
 import { writeAppState } from "@agent-native/core/application-state";
 import { uploadFile } from "@agent-native/core/file-upload";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import { getDb, schema } from "../../server/db/index.js";
 import { queueBuilderMediaCompression } from "../../server/lib/builder-media-compression.js";
@@ -22,19 +22,43 @@ export type LoomImportJobResult = {
 export async function failLoomImport(
   recordingId: string,
   failureReason: string,
+  claimId?: string,
 ): Promise<LoomImportJobResult> {
   const now = new Date().toISOString();
-  await getDb()
+  const [updated] = await getDb()
     .update(schema.recordings)
-    .set({ status: "failed", failureReason, updatedAt: now })
-    .where(eq(schema.recordings.id, recordingId));
-  await writeAppState(`recording-upload-${recordingId}`, {
-    recordingId,
-    status: "failed",
-    failureReason,
-    updatedAt: now,
-  });
-  await writeAppState("refresh-signal", { ts: Date.now() });
+    .set({
+      status: "failed",
+      failureReason,
+      loomImportClaimId: null,
+      loomImportClaimedAt: null,
+      updatedAt: now,
+    })
+    .where(
+      claimId
+        ? and(
+            eq(schema.recordings.id, recordingId),
+            eq(schema.recordings.loomImportClaimId, claimId),
+          )
+        : eq(schema.recordings.id, recordingId),
+    )
+    .returning({ id: schema.recordings.id });
+  if (!updated) return { status: "failed", failureReason };
+
+  try {
+    await writeAppState(`recording-upload-${recordingId}`, {
+      recordingId,
+      status: "failed",
+      failureReason,
+      updatedAt: now,
+    });
+    await writeAppState("refresh-signal", { ts: Date.now() });
+  } catch (err) {
+    console.warn("[clips] Loom failure state update failed", {
+      recordingId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
   return { status: "failed", failureReason };
 }
 
@@ -47,9 +71,11 @@ export async function failLoomImport(
 export async function runLoomImportJob({
   recordingId,
   ownerEmail,
+  claimId,
 }: {
   recordingId: string;
   ownerEmail: string;
+  claimId: string;
 }): Promise<LoomImportJobResult> {
   const db = getDb();
   const [recording] = await db
@@ -57,16 +83,23 @@ export async function runLoomImportJob({
       id: schema.recordings.id,
       durationMs: schema.recordings.durationMs,
       sourceWindowTitle: schema.recordings.sourceWindowTitle,
+      loomImportClaimId: schema.recordings.loomImportClaimId,
     })
     .from(schema.recordings)
     .where(eq(schema.recordings.id, recordingId));
 
   const shareUrl = normalizeLoomShareUrl(recording?.sourceWindowTitle ?? "");
   const loomId = shareUrl ? extractLoomVideoId(shareUrl) : null;
-  if (!recording || !shareUrl || !loomId) {
+  if (
+    !recording ||
+    recording.loomImportClaimId !== claimId ||
+    !shareUrl ||
+    !loomId
+  ) {
     return failLoomImport(
       recordingId,
       "This Loom recording is missing its source URL.",
+      claimId,
     );
   }
 
@@ -77,6 +110,7 @@ export async function runLoomImportJob({
     return failLoomImport(
       recordingId,
       err instanceof Error ? err.message : String(err),
+      claimId,
     );
   }
 
@@ -93,11 +127,12 @@ export async function runLoomImportJob({
       return failLoomImport(
         recordingId,
         "File upload returned no URL. Check your storage provider configuration.",
+        claimId,
       );
     }
 
     const now = new Date().toISOString();
-    await db
+    const [mediaReady] = await db
       .update(schema.recordings)
       .set({
         videoUrl: upload.url,
@@ -106,7 +141,19 @@ export async function runLoomImportJob({
         failureReason: null,
         updatedAt: now,
       })
-      .where(eq(schema.recordings.id, recordingId));
+      .where(
+        and(
+          eq(schema.recordings.id, recordingId),
+          eq(schema.recordings.loomImportClaimId, claimId),
+        ),
+      )
+      .returning({ id: schema.recordings.id });
+    if (!mediaReady) {
+      return {
+        status: "failed",
+        failureReason: "The Loom import lease was lost before media was saved.",
+      };
+    }
 
     void queueBuilderMediaCompression({
       recordingId,
@@ -123,59 +170,91 @@ export async function runLoomImportJob({
       });
     });
 
-    let transcript: Awaited<ReturnType<typeof fetchLoomTranscript>> = null;
     try {
-      transcript = await fetchLoomTranscript({
-        shareUrl,
-        durationMs: recording.durationMs,
-      });
-    } catch (err) {
-      console.warn(
-        `[clips] Loom transcript import skipped for ${loomId}:`,
-        err instanceof Error ? err.message : String(err),
-      );
-    }
+      let transcript: Awaited<ReturnType<typeof fetchLoomTranscript>> = null;
+      try {
+        transcript = await fetchLoomTranscript({
+          shareUrl,
+          durationMs: recording.durationMs,
+        });
+      } catch (err) {
+        console.warn(
+          `[clips] Loom transcript import skipped for ${loomId}:`,
+          err instanceof Error ? err.message : String(err),
+        );
+      }
 
-    const transcriptValues = {
-      ownerEmail,
-      language: transcript?.language ?? "en",
-      segmentsJson: transcript ? JSON.stringify(transcript.segments) : "[]",
-      fullText: transcript?.fullText ?? "",
-      status: transcript ? ("ready" as const) : ("failed" as const),
-      failureReason: transcript ? null : loomTranscriptUnavailableMessage(),
-      updatedAt: now,
-    };
-    const [existingTranscript] = await db
-      .select({ recordingId: schema.recordingTranscripts.recordingId })
-      .from(schema.recordingTranscripts)
-      .where(eq(schema.recordingTranscripts.recordingId, recordingId));
-    if (existingTranscript) {
-      await db
-        .update(schema.recordingTranscripts)
-        .set(transcriptValues)
+      const transcriptValues = {
+        ownerEmail,
+        language: transcript?.language ?? "en",
+        segmentsJson: transcript ? JSON.stringify(transcript.segments) : "[]",
+        fullText: transcript?.fullText ?? "",
+        status: transcript ? ("ready" as const) : ("failed" as const),
+        failureReason: transcript ? null : loomTranscriptUnavailableMessage(),
+        updatedAt: now,
+      };
+      const [existingTranscript] = await db
+        .select({ recordingId: schema.recordingTranscripts.recordingId })
+        .from(schema.recordingTranscripts)
         .where(eq(schema.recordingTranscripts.recordingId, recordingId));
-    } else {
-      await db.insert(schema.recordingTranscripts).values({
+      if (existingTranscript) {
+        await db
+          .update(schema.recordingTranscripts)
+          .set(transcriptValues)
+          .where(eq(schema.recordingTranscripts.recordingId, recordingId));
+      } else {
+        await db.insert(schema.recordingTranscripts).values({
+          recordingId,
+          ...transcriptValues,
+          createdAt: now,
+        });
+      }
+    } catch (err) {
+      console.warn("[clips] Loom transcript persistence skipped", {
         recordingId,
-        ...transcriptValues,
-        createdAt: now,
+        error: err instanceof Error ? err.message : String(err),
       });
     }
 
-    await writeAppState(`recording-upload-${recordingId}`, {
-      recordingId,
-      status: "ready",
-      progress: 100,
-      videoUrl: upload.url,
-      updatedAt: now,
-    });
-    await writeAppState("refresh-signal", { ts: Date.now() });
+    try {
+      await writeAppState(`recording-upload-${recordingId}`, {
+        recordingId,
+        status: "ready",
+        progress: 100,
+        videoUrl: upload.url,
+        updatedAt: now,
+      });
+      await writeAppState("refresh-signal", { ts: Date.now() });
+    } catch (err) {
+      console.warn("[clips] Loom ready state update skipped", {
+        recordingId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    try {
+      await db
+        .update(schema.recordings)
+        .set({ loomImportClaimId: null, loomImportClaimedAt: null })
+        .where(
+          and(
+            eq(schema.recordings.id, recordingId),
+            eq(schema.recordings.loomImportClaimId, claimId),
+          ),
+        );
+    } catch (err) {
+      console.warn("[clips] Loom import lease release failed", {
+        recordingId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
 
     return { status: "ready" };
   } catch (err) {
     return failLoomImport(
       recordingId,
       err instanceof Error ? err.message : String(err),
+      claimId,
     );
   }
 }

--- a/templates/clips/app/components/library/library-layout.tsx
+++ b/templates/clips/app/components/library/library-layout.tsx
@@ -30,7 +30,6 @@ import {
   IconLayoutSidebarLeftExpand,
   IconPlus,
   IconShare,
-  IconHierarchy2,
   IconSettings,
   IconSearch,
 } from "@tabler/icons-react";
@@ -304,12 +303,6 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
     icon: React.ComponentType<{ className?: string }>;
     match: (path: string) => boolean;
   }[] = [
-    {
-      to: "/agent",
-      label: t("settings.agentTitle"),
-      icon: IconHierarchy2,
-      match: (p) => p.startsWith("/agent"),
-    },
     {
       to: "/settings",
       label: t("navigation.settings"),

--- a/templates/clips/app/routes/_app.library._index.tsx
+++ b/templates/clips/app/routes/_app.library._index.tsx
@@ -6,7 +6,7 @@ import { LibraryGrid } from "@/components/library/library-grid";
 import { usePageHeaderLayout } from "@/components/library/page-header";
 import { Button } from "@/components/ui/button";
 
-const SEO_TITLE = "Agent-Native Clips - Open Source screen recorder";
+const SEO_TITLE = "Clips - Open Source screen recorder";
 const SEO_DESCRIPTION =
   "Open Source screen recorder and meeting-notes app with AI transcripts, summaries, search, dictation, and agent-readable share links.";
 

--- a/templates/clips/app/routes/_index.tsx
+++ b/templates/clips/app/routes/_index.tsx
@@ -1,7 +1,7 @@
 import { DefaultSpinner } from "@agent-native/core/client/ui";
 import { redirect, type LoaderFunctionArgs } from "react-router";
 
-const SEO_TITLE = "Agent-Native Clips - Open Source screen recorder";
+const SEO_TITLE = "Clips - Open Source screen recorder";
 const SEO_DESCRIPTION =
   "Open Source screen recorder and meeting-notes app with AI transcripts, summaries, search, dictation, and agent-readable share links.";
 

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -596,6 +596,12 @@ export default function RecordingPage() {
         });
         return;
       }
+      if (retryingLoomImport && result?.status === "processing") {
+        // Download + reupload now run as a background job; this request only
+        // confirms the retry was accepted, not that the clip is ready yet.
+        toast.info(t("recordingPage.importingLoom"));
+        return;
+      }
       toast.success(
         retryingLoomImport
           ? t("recordingPage.loomImportResumed")

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -1850,6 +1850,11 @@ export default function RecordRoute() {
             description: t("recordRoute.connectStorageToRetryLoom"),
             duration: 12_000,
           });
+        } else if (result?.status === "processing") {
+          // The video download + reupload run as a background job (see
+          // import-loom-recording.ts) so this request stays fast regardless of
+          // Loom video length; the recording page polls until it is ready.
+          toast.info(t("recordingPage.importingLoom"));
         } else {
           showSavedToast(
             t("recordRoute.loomImported"),

--- a/templates/clips/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
+++ b/templates/clips/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+App branding now uses the product name without the Agent-Native prefix.

--- a/templates/clips/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
+++ b/templates/clips/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+Settings navigation now keeps Manage agent as a dedicated linked destination at the bottom.

--- a/templates/clips/server/db/schema.ts
+++ b/templates/clips/server/db/schema.ts
@@ -166,6 +166,8 @@ export const recordings = table("recordings", {
     .default("uploading"),
   uploadProgress: integer("upload_progress").notNull().default(0),
   failureReason: text("failure_reason"),
+  loomImportClaimId: text("loom_import_claim_id"),
+  loomImportClaimedAt: text("loom_import_claimed_at"),
 
   // Non-destructive edits: JSON `{ trims: [{startMs,endMs,excluded}], blurs: [...], speed: [...] }`
   editsJson: text("edits_json").notNull().default("{}"),

--- a/templates/clips/server/lib/post-finalize-dispatch.ts
+++ b/templates/clips/server/lib/post-finalize-dispatch.ts
@@ -11,7 +11,8 @@ export type PostFinalizeJobKind =
   | "media-ready"
   | "seekable"
   | "transcript"
-  | "brain-export";
+  | "brain-export"
+  | "loom-import";
 
 export const POST_FINALIZE_JOB_TOKEN_KIND = "clips-post-finalize-job";
 

--- a/templates/clips/server/plugins/auth.ts
+++ b/templates/clips/server/plugins/auth.ts
@@ -7,7 +7,7 @@ export default createAuthPlugin({
   // callback can handle both normal sign-in and the Calendar connect flow.
   mountGoogleOAuthRoutes: false,
   marketing: {
-    appName: "Agent-Native Clips",
+    appName: "Clips",
     tagline:
       "Your AI agent transcribes, summarizes, and searches everything you record alongside you.",
     features: [

--- a/templates/clips/server/plugins/db.ts
+++ b/templates/clips/server/plugins/db.ts
@@ -873,6 +873,14 @@ const migrations = runMigrations(
         `CREATE INDEX IF NOT EXISTS recording_agent_views_recording_idx ON recording_agent_views (recording_id, last_seen_at)`,
       ].join("; "),
     },
+    {
+      version: 52,
+      name: "recording-loom-import-claim-lease",
+      sql: [
+        `ALTER TABLE recordings ADD COLUMN IF NOT EXISTS loom_import_claim_id TEXT`,
+        `ALTER TABLE recordings ADD COLUMN IF NOT EXISTS loom_import_claimed_at TEXT`,
+      ].join("; "),
+    },
   ],
   { table: "clips_migrations" },
 );

--- a/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.test.ts
+++ b/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.test.ts
@@ -5,6 +5,10 @@ const mockSetResponseStatus = vi.hoisted(() => vi.fn());
 const mockDispatchPostFinalizeJob = vi.hoisted(() => vi.fn());
 const mockRunWithRequestContext = vi.hoisted(() => vi.fn());
 const mockVerifyScopedAgentAccessToken = vi.hoisted(() => vi.fn());
+const mockRunLoomImportJob = vi.hoisted(() => vi.fn());
+const mockUpdateReturning = vi.hoisted(() =>
+  vi.fn(async () => [{ id: "rec-1" }]),
+);
 const mockDb = vi.hoisted(() => ({
   select: vi.fn(() => {
     const builder = {
@@ -21,6 +25,11 @@ const mockDb = vi.hoisted(() => ({
     };
     return builder;
   }),
+  update: vi.fn(() => ({
+    set: vi.fn(() => ({
+      where: vi.fn(() => ({ returning: mockUpdateReturning })),
+    })),
+  })),
 }));
 
 vi.mock("h3", () => ({
@@ -29,7 +38,13 @@ vi.mock("h3", () => ({
   setResponseStatus: (...args: unknown[]) => mockSetResponseStatus(...args),
 }));
 
-vi.mock("drizzle-orm", () => ({ eq: vi.fn(() => "eq") }));
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn(() => "and"),
+  eq: vi.fn(() => "eq"),
+  isNull: vi.fn(() => "isNull"),
+  lt: vi.fn(() => "lt"),
+  or: vi.fn(() => "or"),
+}));
 
 vi.mock("@agent-native/core/server", () => ({
   runWithRequestContext: (...args: unknown[]) =>
@@ -58,8 +73,14 @@ vi.mock("../../../db/index.js", () => ({
       ownerEmail: "recordings.ownerEmail",
       orgId: "recordings.orgId",
       status: "recordings.status",
+      loomImportClaimId: "recordings.loomImportClaimId",
+      loomImportClaimedAt: "recordings.loomImportClaimedAt",
     },
   },
+}));
+
+vi.mock("../../../../actions/lib/loom-import-job.js", () => ({
+  runLoomImportJob: (...args: unknown[]) => mockRunLoomImportJob(...args),
 }));
 
 vi.mock("../../../lib/post-finalize-dispatch.js", () => ({
@@ -113,5 +134,43 @@ describe("post-finalize worker", () => {
       regenerate: undefined,
       requireAccepted: true,
     });
+  });
+
+  it("claims a Loom import before running its side effects", async () => {
+    mockReadBody.mockResolvedValue({
+      recordingId: "rec-1",
+      kind: "loom-import",
+      token: "valid-token",
+    });
+    mockRunLoomImportJob.mockResolvedValue({ status: "ready" });
+
+    await expect(handler({} as any)).resolves.toMatchObject({
+      ok: true,
+      kind: "loom-import",
+      result: { status: "ready" },
+    });
+    expect(mockDb.update).toHaveBeenCalled();
+    expect(mockRunLoomImportJob).toHaveBeenCalledWith({
+      recordingId: "rec-1",
+      ownerEmail: "owner@example.test",
+      claimId: expect.any(String),
+    });
+  });
+
+  it("skips a Loom import when its atomic claim is already held", async () => {
+    mockReadBody.mockResolvedValue({
+      recordingId: "rec-1",
+      kind: "loom-import",
+      token: "valid-token",
+    });
+    mockUpdateReturning.mockResolvedValueOnce([]);
+
+    await expect(handler({} as any)).resolves.toMatchObject({
+      ok: true,
+      kind: "loom-import",
+      skipped: true,
+      reason: "loom-import-already-running",
+    });
+    expect(mockRunLoomImportJob).not.toHaveBeenCalled();
   });
 });

--- a/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.ts
+++ b/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.ts
@@ -1,8 +1,10 @@
+import { randomUUID } from "node:crypto";
+
 import {
   runWithRequestContext,
   verifyScopedAgentAccessToken,
 } from "@agent-native/core/server";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull, lt, or } from "drizzle-orm";
 import {
   defineEventHandler,
   readBody,
@@ -37,6 +39,8 @@ const bodySchema = z.object({
   retryAttempt: z.number().int().min(1).max(10).optional(),
   regenerate: z.boolean().optional(),
 });
+
+const LOOM_IMPORT_LEASE_MS = 30 * 60 * 1000;
 
 export default defineEventHandler(async (event: H3Event) => {
   const parsed = bodySchema.safeParse(await readBody(event).catch(() => null));
@@ -121,9 +125,42 @@ export default defineEventHandler(async (event: H3Event) => {
       }
 
       if (kind === "loom-import") {
+        const claimId = randomUUID();
+        const claimStartedAt = new Date().toISOString();
+        const claimExpiredBefore = new Date(
+          Date.now() - LOOM_IMPORT_LEASE_MS,
+        ).toISOString();
+        const [claimed] = await getDb()
+          .update(schema.recordings)
+          .set({
+            loomImportClaimId: claimId,
+            loomImportClaimedAt: claimStartedAt,
+          })
+          .where(
+            and(
+              eq(schema.recordings.id, recordingId),
+              eq(schema.recordings.status, "processing"),
+              or(
+                isNull(schema.recordings.loomImportClaimId),
+                isNull(schema.recordings.loomImportClaimedAt),
+                lt(schema.recordings.loomImportClaimedAt, claimExpiredBefore),
+              ),
+            ),
+          )
+          .returning({ id: schema.recordings.id });
+        if (!claimed) {
+          return {
+            ok: true,
+            recordingId,
+            kind,
+            skipped: true,
+            reason: "loom-import-already-running",
+          };
+        }
         const result = await runLoomImportJob({
           recordingId,
           ownerEmail: recording.ownerEmail,
+          claimId,
         });
         return { ok: true, kind, result };
       }

--- a/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.ts
+++ b/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.ts
@@ -14,6 +14,7 @@ import { z } from "zod";
 import exportToBrain from "../../../../actions/export-to-brain.js";
 import finalizeRecording from "../../../../actions/finalize-recording.js";
 import { ensureRecordingSeekable } from "../../../../actions/lib/ensure-seekable-video.js";
+import { runLoomImportJob } from "../../../../actions/lib/loom-import-job.js";
 import requestTranscript from "../../../../actions/request-transcript.js";
 import { getDb, schema } from "../../../db/index.js";
 import {
@@ -24,7 +25,13 @@ import {
 
 const bodySchema = z.object({
   recordingId: z.string().min(1).max(200),
-  kind: z.enum(["media-ready", "seekable", "transcript", "brain-export"]),
+  kind: z.enum([
+    "media-ready",
+    "seekable",
+    "transcript",
+    "brain-export",
+    "loom-import",
+  ]),
   token: z.string().min(1),
   delayMs: z.number().int().min(0).max(30_000).optional(),
   retryAttempt: z.number().int().min(1).max(10).optional(),
@@ -63,7 +70,8 @@ export default defineEventHandler(async (event: H3Event) => {
     setResponseStatus(event, 404);
     return { ok: false, error: "Recording not found" };
   }
-  const requiredStatus = kind === "media-ready" ? "processing" : "ready";
+  const requiredStatus =
+    kind === "media-ready" || kind === "loom-import" ? "processing" : "ready";
   if (recording.status !== requiredStatus) {
     return {
       ok: true,
@@ -108,6 +116,14 @@ export default defineEventHandler(async (event: H3Event) => {
         const result = await finalizeRecording.run({
           id: recordingId,
           mediaVerificationRetryAttempt: retryAttempt ?? 1,
+        });
+        return { ok: true, kind, result };
+      }
+
+      if (kind === "loom-import") {
+        const result = await runLoomImportJob({
+          recordingId,
+          ownerEmail: recording.ownerEmail,
         });
         return { ok: true, kind, result };
       }

--- a/templates/content/app/components/sidebar/DocumentSidebar.tsx
+++ b/templates/content/app/components/sidebar/DocumentSidebar.tsx
@@ -34,7 +34,6 @@ import type {
 } from "@shared/api";
 import { CONTENT_DATABASE_PERSONAL_VIEW_OVERRIDES_VERSION } from "@shared/api";
 import {
-  IconHierarchy2,
   IconFolder,
   IconFolderOpen,
   IconPlus,
@@ -637,7 +636,6 @@ export function DocumentSidebar({
   }, [setStoredCollapsedSections]);
   const [removeLocalFilesDialogOpen, setRemoveLocalFilesDialogOpen] =
     useState(false);
-  const agentActive = location.pathname.startsWith("/agent");
   const settingsActive = location.pathname.startsWith("/settings");
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -1326,23 +1324,6 @@ export function DocumentSidebar({
     />
   );
 
-  const renderAgentNavButton = () => (
-    <Link
-      to="/agent"
-      className={cn(
-        "flex h-8 w-full items-center gap-2 rounded-md px-2 text-sm",
-        agentActive
-          ? "bg-accent text-accent-foreground"
-          : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-      )}
-    >
-      <IconHierarchy2 size={15} className="shrink-0" />
-      <span className="min-w-0 flex-1 truncate text-start">
-        {t("settings.agentTitle")}
-      </span>
-    </Link>
-  );
-
   const toggleSection = (id: SidebarSectionId) => {
     setStoredCollapsedSections((current) => {
       const normalized = normalizeCollapsedSections(current);
@@ -1884,22 +1865,6 @@ export function DocumentSidebar({
         <Tooltip>
           <TooltipTrigger asChild>
             <Link
-              to="/agent"
-              className={cn(
-                "w-10 h-10 flex items-center justify-center rounded-lg hover:bg-accent",
-                agentActive
-                  ? "bg-accent text-accent-foreground"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              <IconHierarchy2 size={16} />
-            </Link>
-          </TooltipTrigger>
-          <TooltipContent>{t("settings.agentTitle")}</TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Link
               to="/settings"
               className={cn(
                 "w-10 h-10 flex items-center justify-center rounded-lg hover:bg-accent",
@@ -2091,10 +2056,7 @@ export function DocumentSidebar({
       </ScrollArea>
 
       <div className="shrink-0 px-3 py-2">
-        <div className="space-y-1">
-          {renderAgentNavButton()}
-          {renderSettingsNavButton()}
-        </div>
+        <div className="space-y-1">{renderSettingsNavButton()}</div>
       </div>
 
       <div className="shrink-0">

--- a/templates/content/app/routes/_app._index.tsx
+++ b/templates/content/app/routes/_app._index.tsx
@@ -7,8 +7,7 @@ import { QueryErrorState } from "@/components/QueryErrorState";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useDocuments } from "@/hooks/use-documents";
 
-const SEO_TITLE =
-  "Agent-Native Content - Open Source, agent-friendly Obsidian alternative";
+const SEO_TITLE = "Content - Open Source, agent-friendly Obsidian alternative";
 const SEO_DESCRIPTION =
   "Open Source MDX editor for local docs, knowledge bases, and content systems, with custom blocks and agent-assisted editing.";
 

--- a/templates/content/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
+++ b/templates/content/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+App branding now uses the product name without the Agent-Native prefix.

--- a/templates/content/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
+++ b/templates/content/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+Settings navigation now keeps Manage agent as a dedicated linked destination at the bottom.

--- a/templates/content/package.json
+++ b/templates/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "content",
-  "displayName": "Agent-Native Content",
+  "displayName": "Content",
   "private": true,
   "type": "module",
   "scripts": {

--- a/templates/content/public/manifest.json
+++ b/templates/content/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Agent Native Content",
+  "name": "Content",
   "short_name": "Content",
   "description": "Open-source Obsidian for MDX",
   "start_url": ".",

--- a/templates/content/server/plugins/auth.ts
+++ b/templates/content/server/plugins/auth.ts
@@ -2,7 +2,7 @@ import { createAuthPlugin } from "@agent-native/core/server";
 
 export default createAuthPlugin({
   marketing: {
-    appName: "Agent-Native Content",
+    appName: "Content",
     tagline:
       "Open-source Obsidian for MDX: your AI agent edits local docs, creates custom blocks, and organizes everything alongside you.",
     features: [

--- a/templates/design/app/components/layout/Sidebar.tsx
+++ b/templates/design/app/components/layout/Sidebar.tsx
@@ -9,7 +9,6 @@ import {
   IconPencil,
   IconTemplate,
   IconPalette,
-  IconHierarchy2,
   IconSettings,
   IconLayoutSidebarLeftCollapse,
   IconLayoutSidebarLeftExpand,
@@ -37,7 +36,6 @@ const navItems = [
 ];
 
 const bottomNavItems = [
-  { icon: IconHierarchy2, labelKey: "settings.agentTitle", href: "/agent" },
   { icon: IconSettings, labelKey: "navigation.settings", href: "/settings" },
 ];
 

--- a/templates/design/app/routes/_index.tsx
+++ b/templates/design/app/routes/_index.tsx
@@ -1,7 +1,7 @@
 export { default } from "../pages/Index";
 
 const SEO_TITLE =
-  "Agent-Native Design - Open Source AI design tool for agent-built prototypes";
+  "Design - Open Source AI design tool for agent-built prototypes";
 const SEO_DESCRIPTION =
   "Open Source AI design tool for creating, remixing, and sharing responsive prototypes, design systems, and coding handoffs.";
 

--- a/templates/design/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
+++ b/templates/design/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+App branding now uses the product name without the Agent-Native prefix.

--- a/templates/design/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
+++ b/templates/design/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+Settings navigation now keeps Manage agent as a dedicated linked destination at the bottom.

--- a/templates/design/server/plugins/auth.ts
+++ b/templates/design/server/plugins/auth.ts
@@ -7,7 +7,7 @@ export default createAuthPlugin({
   // still go through authenticated actions.
   workspaceAppPublicPaths: ["/visual-edit", "/design", "/present"],
   marketing: {
-    appName: "Agent-Native Design",
+    appName: "Design",
     tagline:
       "Design and prototype by describing what you want. The AI agent turns your ideas into interactive, fully responsive designs in seconds.",
     features: [

--- a/templates/dispatch/app/dispatch-extensions.tsx
+++ b/templates/dispatch/app/dispatch-extensions.tsx
@@ -1,5 +1,4 @@
 import type { DispatchExtensionConfig } from "@agent-native/dispatch/components";
-import { IconHierarchy2 } from "@tabler/icons-react";
 
 /**
  * Local Dispatch extensions for this generated workspace.
@@ -26,14 +25,6 @@ import { IconHierarchy2 } from "@tabler/icons-react";
  *   } satisfies DispatchExtensionConfig;
  */
 export const dispatchExtensions = {
-  navItems: [
-    {
-      id: "agent",
-      to: "/agent",
-      label: "Manage agent",
-      icon: IconHierarchy2,
-      section: "operations",
-    },
-  ],
+  navItems: [],
   queryKeys: [],
 } satisfies DispatchExtensionConfig;

--- a/templates/dispatch/app/routes/overview.tsx
+++ b/templates/dispatch/app/routes/overview.tsx
@@ -6,7 +6,7 @@ import {
 import type { LoaderFunctionArgs } from "react-router";
 
 const SEO_TITLE =
-  "Agent-Native Dispatch - Open Source workspace control plane for AI agents";
+  "Dispatch - Open Source workspace control plane for AI agents";
 const SEO_DESCRIPTION =
   "Open Source workspace control plane for AI agents to manage apps, secrets, approvals, messages, jobs, and cross-app delegation.";
 

--- a/templates/dispatch/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
+++ b/templates/dispatch/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+App branding now uses the product name without the Agent-Native prefix.

--- a/templates/dispatch/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
+++ b/templates/dispatch/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+Settings navigation now keeps Manage agent as a dedicated linked destination at the bottom.

--- a/templates/dispatch/package.json
+++ b/templates/dispatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dispatch",
-  "displayName": "Agent-Native Dispatch",
+  "displayName": "Dispatch",
   "private": true,
   "type": "module",
   "scripts": {

--- a/templates/dispatch/public/manifest.json
+++ b/templates/dispatch/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Agent-Native Dispatch",
+  "name": "Dispatch",
   "short_name": "Dispatch",
   "description": "Workspace control plane for secrets, integrations, agents, and app creation.",
   "start_url": ".",

--- a/templates/forms/app/components/layout/Sidebar.tsx
+++ b/templates/forms/app/components/layout/Sidebar.tsx
@@ -17,7 +17,6 @@ import {
   IconMenu2,
   IconX,
   IconMessageCircle,
-  IconHierarchy2,
   IconSettings,
   IconForms,
   IconLayoutSidebarLeftCollapse,
@@ -320,26 +319,6 @@ export function Sidebar() {
             <Tooltip>
               <TooltipTrigger asChild>
                 <Link
-                  to="/agent"
-                  aria-label={t("settings.agentTitle")}
-                  className={cn(
-                    "forms-sidebar-nav-item flex size-10 items-center justify-center rounded-lg active:scale-[0.96] transition-[background-color,box-shadow,color,transform]",
-                    location.pathname.startsWith("/agent")
-                      ? "bg-accent text-accent-foreground"
-                      : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-                  )}
-                >
-                  <IconHierarchy2 className="h-4 w-4" />
-                </Link>
-              </TooltipTrigger>
-              <TooltipContent side="right">
-                {t("settings.agentTitle")}
-              </TooltipContent>
-            </Tooltip>
-
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Link
                   to="/settings"
                   aria-label={t("navigation.settings")}
                   className={cn(
@@ -465,20 +444,6 @@ export function Sidebar() {
 
       {/* Pinned nav + footer */}
       <div className="shrink-0 px-3 py-1.5">
-        <Link
-          to="/agent"
-          onClick={() => isMobile && setMobileOpen(false)}
-          className={cn(
-            "forms-sidebar-nav-item flex min-h-[44px] w-full items-center gap-2.5 rounded-lg px-3 py-2 text-sm active:scale-[0.96] transition-[background-color,box-shadow,color,transform]",
-            location.pathname.startsWith("/agent")
-              ? "bg-accent text-accent-foreground"
-              : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-          )}
-        >
-          <IconHierarchy2 size={14} className="shrink-0" />
-          <span>{t("settings.agentTitle")}</span>
-        </Link>
-
         <Link
           to="/settings"
           onClick={() => isMobile && setMobileOpen(false)}

--- a/templates/forms/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
+++ b/templates/forms/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+App branding now uses the product name without the Agent-Native prefix.

--- a/templates/forms/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
+++ b/templates/forms/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+Settings navigation now keeps Manage agent as a dedicated linked destination at the bottom.

--- a/templates/forms/package.json
+++ b/templates/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forms",
-  "displayName": "Agent-Native Forms",
+  "displayName": "Forms",
   "private": true,
   "type": "module",
   "scripts": {

--- a/templates/forms/public/manifest.json
+++ b/templates/forms/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Agent Native Forms",
+  "name": "Forms",
   "short_name": "Forms",
   "description": "Form builder",
   "start_url": ".",

--- a/templates/forms/server/plugins/auth.ts
+++ b/templates/forms/server/plugins/auth.ts
@@ -2,7 +2,7 @@ import { createAuthPlugin } from "@agent-native/core/server";
 
 export default createAuthPlugin({
   marketing: {
-    appName: "Agent-Native Forms",
+    appName: "Forms",
     tagline:
       "Your AI agent builds, publishes, and analyzes forms alongside you.",
     features: [

--- a/templates/macros/app/components/layout/AppLayout.tsx
+++ b/templates/macros/app/components/layout/AppLayout.tsx
@@ -13,7 +13,6 @@ import {
   IconFlame,
   IconLoader2,
   IconChartBar,
-  IconHierarchy2,
   IconSettings,
   IconLayoutSidebarLeftCollapse,
   IconLayoutSidebarLeftExpand,
@@ -46,7 +45,6 @@ const navItems = [
 ];
 
 const bottomNavItems = [
-  { icon: IconHierarchy2, labelKey: "settings.agentTitle", href: "/agent" },
   { icon: IconSettings, labelKey: "navigation.settings", href: "/settings" },
 ];
 

--- a/templates/macros/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
+++ b/templates/macros/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+App branding now uses the product name without the Agent-Native prefix.

--- a/templates/macros/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
+++ b/templates/macros/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+Settings navigation now keeps Manage agent as a dedicated linked destination at the bottom.

--- a/templates/macros/package.json
+++ b/templates/macros/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macros",
-  "displayName": "Agent-Native Macros",
+  "displayName": "Macros",
   "private": true,
   "type": "module",
   "scripts": {

--- a/templates/macros/server/plugins/auth.ts
+++ b/templates/macros/server/plugins/auth.ts
@@ -38,9 +38,9 @@ function getSupabase() {
 const LOGIN_HTML = `<!DOCTYPE html>
 <html lang="en"><head>
 <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
-<title>Agent-Native Macros — Sign in</title>
+<title>Macros — Sign in</title>
 <meta name="description" content="Log meals, exercises, and weight by typing or voice while the agent estimates calories and macros for you."/>
-<meta property="og:title" content="Agent-Native Macros"/>
+<meta property="og:title" content="Macros"/>
 <meta property="og:description" content="Log meals, exercises, and weight by typing or voice while the agent estimates calories and macros for you."/>
 <style>
 *{margin:0;padding:0;box-sizing:border-box}

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -14,7 +14,6 @@ import { normalizeMailLabel } from "@shared/gmail-labels";
 import type { Label } from "@shared/types";
 import {
   IconMenu2,
-  IconHierarchy2,
   IconSettings,
   IconSearch,
   IconCheck,
@@ -1778,25 +1777,6 @@ function AppLayoutInner({ children }: AppLayoutProps) {
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <Link
-                            to="/agent"
-                            onClick={closeSidebar}
-                            aria-label={t("settings.openAgentSettings")}
-                            className={cn(
-                              "flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground",
-                              location.pathname === "/agent" &&
-                                "bg-accent/60 text-foreground",
-                            )}
-                          >
-                            <IconHierarchy2 className="h-4 w-4" />
-                          </Link>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          {t("settings.openAgentSettings")}
-                        </TooltipContent>
-                      </Tooltip>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Link
                             to="/settings"
                             onClick={closeSidebar}
                             aria-label={t("mail.toolbar.settings")}
@@ -2196,25 +2176,6 @@ function StandardLayout({ children }: AppLayoutProps) {
             <div className="flex items-center justify-end gap-1 px-2 py-2">
               <DevDatabaseLink />
               <div className="flex shrink-0 items-center gap-0.5">
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Link
-                      to="/agent"
-                      onClick={() => setSidebarOpen(false)}
-                      aria-label={t("settings.openAgentSettings")}
-                      className={cn(
-                        "flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground",
-                        location.pathname === "/agent" &&
-                          "bg-accent/60 text-foreground",
-                      )}
-                    >
-                      <IconHierarchy2 className="h-4 w-4" />
-                    </Link>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    {t("settings.openAgentSettings")}
-                  </TooltipContent>
-                </Tooltip>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Link

--- a/templates/mail/app/routes/$view.$threadId.tsx
+++ b/templates/mail/app/routes/$view.$threadId.tsx
@@ -1,7 +1,7 @@
 import { InboxPage } from "@/pages/InboxPage";
 
 const SEO_TITLE =
-  "Agent-Native Mail - Open Source AI email client and Superhuman alternative";
+  "Mail - Open Source AI email client and Superhuman alternative";
 const SEO_DESCRIPTION =
   "Open Source AI email client for Gmail triage, drafting, organization, follow-ups, and inbox workflows built around shared actions.";
 

--- a/templates/mail/app/routes/$view.tsx
+++ b/templates/mail/app/routes/$view.tsx
@@ -1,7 +1,7 @@
 import { InboxPage } from "@/pages/InboxPage";
 
 const SEO_TITLE =
-  "Agent-Native Mail - Open Source AI email client and Superhuman alternative";
+  "Mail - Open Source AI email client and Superhuman alternative";
 const SEO_DESCRIPTION =
   "Open Source AI email client for Gmail triage, drafting, organization, follow-ups, and inbox workflows built around shared actions.";
 

--- a/templates/mail/app/routes/_index.tsx
+++ b/templates/mail/app/routes/_index.tsx
@@ -3,7 +3,7 @@ import { redirect } from "react-router";
 import { Spinner } from "@/components/ui/spinner";
 
 const SEO_TITLE =
-  "Agent-Native Mail - Open Source AI email client and Superhuman alternative";
+  "Mail - Open Source AI email client and Superhuman alternative";
 const SEO_DESCRIPTION =
   "Open Source AI email client for Gmail triage, drafting, organization, follow-ups, and inbox workflows built around shared actions.";
 

--- a/templates/mail/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
+++ b/templates/mail/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+App branding now uses the product name without the Agent-Native prefix.

--- a/templates/mail/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
+++ b/templates/mail/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+Settings navigation now keeps Manage agent as a dedicated linked destination at the bottom.

--- a/templates/mail/package.json
+++ b/templates/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail",
-  "displayName": "Agent-Native Mail",
+  "displayName": "Mail",
   "private": true,
   "type": "module",
   "scripts": {

--- a/templates/mail/public/manifest.json
+++ b/templates/mail/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Agent Native Mail",
+  "name": "Mail",
   "short_name": "Mail",
   "description": "Email client",
   "start_url": ".",

--- a/templates/mail/server/plugins/auth.ts
+++ b/templates/mail/server/plugins/auth.ts
@@ -26,7 +26,7 @@ export default createAuthPlugin({
     "https://www.googleapis.com/auth/calendar.events",
   ],
   marketing: {
-    appName: "Agent-Native Mail",
+    appName: "Mail",
     tagline: "Your AI agent reads, drafts, and organizes email alongside you.",
     features: [
       "Replies that match your tone and style",

--- a/templates/plan/agent-native.app-skill.json
+++ b/templates/plan/agent-native.app-skill.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "plans",
-  "displayName": "Agent-Native Plan",
+  "displayName": "Plan",
   "description": "Generate and review coding-agent plans as structured visual documents with diagrams, wireframes, prototypes, annotations, share links, feedback, and HTML export.",
   "hosted": {
     "url": "https://plan.agent-native.com",

--- a/templates/plan/app/components/layout/Sidebar.tsx
+++ b/templates/plan/app/components/layout/Sidebar.tsx
@@ -20,7 +20,6 @@ import {
   type ChatHistoryItem,
 } from "@agent-native/toolkit/chat-history";
 import {
-  IconHierarchy2,
   IconClipboardCheck,
   IconEdit,
   IconLayoutSidebarLeftCollapse,
@@ -57,19 +56,16 @@ const PLAN_CHAT_STORAGE_KEY = "plans";
 
 const PLAN_BRANDING_CODE_CONTEXT = [
   "The user is using the Plan app branding customization popover.",
-  "Make source-code changes for Agent-Native Plan branding in templates/plan.",
+  "Make source-code changes for Plan branding in templates/plan.",
   "Inspect the current brand surfaces first: app/lib/app-config.ts, app/components/layout/Sidebar.tsx, app/root.tsx metadata/icons, public brand assets, and app/global.css theme tokens.",
   "Keep runtime plan data, stored plans, recaps, comments, and generated plan content unchanged unless the user explicitly asks for those data changes.",
   "Use existing Plan styling, shadcn primitives, Tabler icons, and repo patterns. Keep changes tightly scoped.",
 ].join("\n");
 
 function buildBrandingCustomizationMessage(request: string) {
-  return [
-    "Customize the Agent-Native Plan app branding.",
-    "",
-    "Request:",
-    request,
-  ].join("\n");
+  return ["Customize the Plan app branding.", "", "Request:", request].join(
+    "\n",
+  );
 }
 
 const navItems = [
@@ -78,7 +74,6 @@ const navItems = [
 ];
 
 const bottomNavItems = [
-  { icon: IconHierarchy2, labelKey: "settings.agentTitle", href: "/agent" },
   { icon: IconSettings, labelKey: "navigation.settings", href: "/settings" },
 ];
 

--- a/templates/plan/app/lib/app-config.ts
+++ b/templates/plan/app/lib/app-config.ts
@@ -8,4 +8,4 @@ export const APP_NAME =
   rawAppName === APP_NAME_PLACEHOLDER ? "plan" : rawAppName;
 
 export const APP_TITLE =
-  rawAppTitle === APP_TITLE_PLACEHOLDER ? "Agent-Native Plan" : rawAppTitle;
+  rawAppTitle === APP_TITLE_PLACEHOLDER ? "Plan" : rawAppTitle;

--- a/templates/plan/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
+++ b/templates/plan/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+App branding now uses the product name without the Agent-Native prefix.

--- a/templates/plan/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
+++ b/templates/plan/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+Settings navigation now keeps Manage agent as a dedicated linked destination at the bottom.

--- a/templates/plan/package.json
+++ b/templates/plan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plan",
-  "displayName": "Agent-Native Plan",
+  "displayName": "Plan",
   "private": true,
   "description": "Generate and review coding-agent plans with diagrams, wireframes, annotations, prototypes, and feedback.",
   "type": "module",

--- a/templates/plan/public/manifest.json
+++ b/templates/plan/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Agent-Native Plan",
+  "name": "Plan",
   "short_name": "Plan",
   "description": "Generate and review coding-agent plans with diagrams, wireframes, prototypes, annotations, sharing, and feedback.",
   "start_url": ".",

--- a/templates/plan/server/plugins/auth.ts
+++ b/templates/plan/server/plugins/auth.ts
@@ -59,7 +59,7 @@ export default createAuthPlugin({
     ...PUBLIC_AGENT_CHAT_PATHS,
   ],
   marketing: {
-    appName: "Agent-Native Plan",
+    appName: "Plan",
     tagline:
       "Turn coding-agent plans into visual, annotatable HTML before code changes happen.",
     features: [

--- a/templates/slides/app/components/layout/Sidebar.test.tsx
+++ b/templates/slides/app/components/layout/Sidebar.test.tsx
@@ -107,7 +107,6 @@ describe("<Sidebar collapsed>", () => {
     expect(screen.getByLabelText("Decks")).toBeDefined();
     expect(screen.getByLabelText("Design Systems")).toBeDefined();
     expect(screen.getByLabelText("Settings")).toBeDefined();
-    expect(screen.getByLabelText("Manage agent")).toBeDefined();
   });
 });
 
@@ -123,7 +122,6 @@ describe("<Sidebar expanded>", () => {
     expect(screen.getByText("Decks")).toBeDefined();
     expect(screen.getByText("Design Systems")).toBeDefined();
     expect(screen.getByText("Settings")).toBeDefined();
-    expect(screen.getByText("Manage agent")).toBeDefined();
 
     const collapseBtn = screen.getByLabelText("Collapse sidebar");
     collapseBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
@@ -169,7 +167,6 @@ describe("<Sidebar> accessibility", () => {
     expect(screen.getByLabelText("Decks")).toBeDefined();
     expect(screen.getByLabelText("Design Systems")).toBeDefined();
     expect(screen.getByLabelText("Settings")).toBeDefined();
-    expect(screen.getByLabelText("Manage agent")).toBeDefined();
   });
 
   it("labels the Collapse button in the expanded layout", () => {

--- a/templates/slides/app/components/layout/Sidebar.tsx
+++ b/templates/slides/app/components/layout/Sidebar.tsx
@@ -7,7 +7,6 @@ import { FeedbackButton } from "@agent-native/core/client/ui";
 import { SidebarFooterActions } from "@agent-native/toolkit/app-shell";
 import {
   IconStack2,
-  IconHierarchy2,
   IconPalette,
   IconSettings,
   IconLayoutSidebarLeftCollapse,
@@ -33,7 +32,6 @@ const navItems = [
 ];
 
 const bottomNavItems = [
-  { icon: IconHierarchy2, labelKey: "settings.agentTitle", href: "/agent" },
   { icon: IconSettings, labelKey: "navigation.settings", href: "/settings" },
 ];
 

--- a/templates/slides/app/routes/_index.tsx
+++ b/templates/slides/app/routes/_index.tsx
@@ -1,7 +1,7 @@
 import Index from "@/pages/Index";
 
 const SEO_TITLE =
-  "Agent-Native Slides - Open Source AI presentation builder and Google Slides alternative";
+  "Slides - Open Source AI presentation builder and Google Slides alternative";
 const SEO_DESCRIPTION =
   "Open Source AI presentation builder for generating, editing, refining, and exporting React decks as Google Slides-ready presentations.";
 

--- a/templates/slides/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
+++ b/templates/slides/changelog/2026-07-25-app-branding-now-uses-the-product-name-without-the-agent-nat.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+App branding now uses the product name without the Agent-Native prefix.

--- a/templates/slides/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
+++ b/templates/slides/changelog/2026-07-25-settings-navigation-now-keeps-manage-agent-as-a-dedicated-li.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+Settings navigation now keeps Manage agent as a dedicated linked destination at the bottom.

--- a/templates/slides/package.json
+++ b/templates/slides/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slides",
-  "displayName": "Agent-Native Slides",
+  "displayName": "Slides",
   "private": true,
   "type": "module",
   "scripts": {

--- a/templates/slides/public/manifest.json
+++ b/templates/slides/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Agent Native Slides",
+  "name": "Slides",
   "short_name": "Slides",
   "description": "AI slide deck creator",
   "start_url": ".",

--- a/templates/slides/server/plugins/auth.ts
+++ b/templates/slides/server/plugins/auth.ts
@@ -2,7 +2,7 @@ import { createAuthPlugin } from "@agent-native/core/server";
 
 export default createAuthPlugin({
   marketing: {
-    appName: "Agent-Native Slides",
+    appName: "Slides",
     tagline:
       "Your AI agent builds, edits, and refines presentations alongside you.",
     features: [


### PR DESCRIPTION
## Summary
- allow configured local workspace origins for sibling A2A calls while retaining SSRF protections
- refine settings and Dispatch navigation, remove redundant agent links, and apply product branding across first-party templates
- move Loom video and transcript import work to a background job with coverage

## Validation
- focused Core, Dispatch, and Clips tests pass
- all repository guards pass
- full test:fast passes
- full prep typecheck is blocked by the pre-existing mobile-app expo-document-picker dependency failure