### PR TITLE
Improve Analytics dashboard and report performance

### DIFF
--- a/packages/docs/app/components/Header.tsx
+++ b/packages/docs/app/components/Header.tsx
@@ -279,6 +279,9 @@ export default function Header() {
               <DocsLanguagePicker />
             </div>
             <div className="hidden lg:block">
+              <DocsLanguageSuggestion />
+            </div>
+            <div className="hidden lg:block">
               <ThemeToggle />
             </div>
             <button
@@ -301,7 +304,6 @@ export default function Header() {
             >
               {mobileMenuOpen ? <CloseIcon /> : <HamburgerIcon />}
             </button>
-            <DocsLanguageSuggestion />
           </div>
         </nav>
 

--- a/packages/docs/app/components/Header.tsx
+++ b/packages/docs/app/components/Header.tsx
@@ -268,16 +268,20 @@ export default function Header() {
               align="end"
               side="bottom"
             />
-            <SearchTrigger
-              onClick={openModal}
-              label={t("header.searchAria")}
-              placeholder={t("header.searchPlaceholder")}
-            />
-            <div className="flex shrink-0 items-center">
+            <div className="hidden lg:block">
+              <SearchTrigger
+                onClick={openModal}
+                label={t("header.searchAria")}
+                placeholder={t("header.searchPlaceholder")}
+              />
+            </div>
+            <div className="hidden shrink-0 items-center lg:flex">
               <DocsLanguagePicker />
               <DocsLanguageSuggestion />
             </div>
-            <ThemeToggle />
+            <div className="hidden lg:block">
+              <ThemeToggle />
+            </div>
             <button
               onClick={() =>
                 window.dispatchEvent(new Event("agent-panel:toggle"))
@@ -304,6 +308,19 @@ export default function Header() {
         {/* Mobile dropdown menu */}
         {mobileMenuOpen && (
           <div className="lg:hidden border-t border-[var(--docs-border)] bg-[var(--header-bg)] backdrop-blur-lg px-6 py-4 flex flex-col gap-4">
+            <div className="flex items-center gap-2">
+              <SearchTrigger
+                onClick={() => {
+                  closeMobileMenu();
+                  openModal();
+                }}
+                label={t("header.searchAria")}
+                placeholder={t("header.searchPlaceholder")}
+              />
+              <DocsLanguagePicker />
+              <DocsLanguageSuggestion />
+              <ThemeToggle />
+            </div>
             <NavLink
               data-an-prefetch="render"
               to={localizedPath("/docs")}

--- a/packages/docs/app/components/Header.tsx
+++ b/packages/docs/app/components/Header.tsx
@@ -277,7 +277,6 @@ export default function Header() {
             </div>
             <div className="hidden shrink-0 items-center lg:flex">
               <DocsLanguagePicker />
-              <DocsLanguageSuggestion />
             </div>
             <div className="hidden lg:block">
               <ThemeToggle />
@@ -302,6 +301,7 @@ export default function Header() {
             >
               {mobileMenuOpen ? <CloseIcon /> : <HamburgerIcon />}
             </button>
+            <DocsLanguageSuggestion />
           </div>
         </nav>
 
@@ -318,7 +318,6 @@ export default function Header() {
                 placeholder={t("header.searchPlaceholder")}
               />
               <DocsLanguagePicker />
-              <DocsLanguageSuggestion />
               <ThemeToggle />
             </div>
             <NavLink

--- a/scripts/guard-db-tool-scoping.mjs
+++ b/scripts/guard-db-tool-scoping.mjs
@@ -48,6 +48,8 @@ const SKIP_DIRS = new Set([
 // cache pathway. Key format: "<template>:<sql_table_name>".
 const INTENTIONAL_RAW_DB_DENYLIST = {
   "analytics:bigquery_cache": "provider cache, not a user-facing resource",
+  "analytics:first_party_analytics_cache":
+    "internal query cache, accessed through scoped analytics queries",
   "analytics:dashboard_views": "view telemetry, scoped by dashboard/action",
   "brain:brain_ingest_queue": "internal ingestion queue scoped by actions",
   "brain:brain_audience_members":

--- a/templates/analytics/.agents/skills/dashboard-management/SKILL.md
+++ b/templates/analytics/.agents/skills/dashboard-management/SKILL.md
@@ -84,6 +84,21 @@ Do not rely on undeclared time variables. Server validation rejects unbound
 first-party SQL, so declare the filter or choose an explicit non-dashboard
 scope before saving.
 
+**A bound anywhere in the SQL is not the same as every CTE having its own
+bound.** If a panel has multiple top-level CTEs (`WITH a AS (...), b AS
+(...)`) and more than one of them reads `analytics_events`, EVERY one of
+those CTEs needs its own `{{timeRange}}`/`{{<id>Start}}`/`{{<id>End}}`
+reference or literal date bound — not just the final `SELECT` or one sibling
+CTE. A CTE that computes something like "this user's first-ever active day"
+by scanning `analytics_events` with no bound at all will full-table-scan on
+every render even though the panel *looks* time-bound overall (root cause of
+a 2026-07-25 production incident: several dashboards had exactly this shape).
+Server validation checks each top-level CTE independently now, so this fails
+at save time — but write it right the first time: bound every CTE, or use
+`config.timeScope: "cohort-history"` only for a CTE that is genuinely
+defining a cohort (e.g. a first-seen date), never as a way to skip bounding
+an ordinary activity scan.
+
 ## Creating A Dashboard
 
 When the user asks for a dashboard:

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/report-panel-window.spec.ts
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/report-panel-window.spec.ts
@@ -57,7 +57,7 @@ describe("report panel windows", () => {
   it("only enables the report window when both offset and limit are present", () => {
     expect(parseReportPanelWindow(null, "8")).toBeNull();
     expect(parseReportPanelWindow("0", null)).toBeNull();
-    expect(parseReportPanelWindow("8", "8")).toEqual({ offset: 8, limit: 8 });
+    expect(parseReportPanelWindow("8", "8")).toEqual({ offset: 8, limit: 4 });
   });
 
   it("splits eight reportable panels into two concurrency-sized query waves", () => {

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/report-panel-window.spec.ts
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/report-panel-window.spec.ts
@@ -57,7 +57,7 @@ describe("report panel windows", () => {
   it("only enables the report window when both offset and limit are present", () => {
     expect(parseReportPanelWindow(null, "8")).toBeNull();
     expect(parseReportPanelWindow("0", null)).toBeNull();
-    expect(parseReportPanelWindow("8", "8")).toEqual({ offset: 8, limit: 4 });
+    expect(parseReportPanelWindow("8", "8")).toEqual({ offset: 8, limit: 8 });
   });
 
   it("splits eight reportable panels into two concurrency-sized query waves", () => {

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/report-panel-window.ts
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/report-panel-window.ts
@@ -1,8 +1,12 @@
-import { MAX_CONCURRENT_SQL_QUERIES } from "@shared/sql-query-limits";
-
 import type { SqlPanel } from "./types";
 
-export const REPORT_PANEL_CHUNK_SIZE = MAX_CONCURRENT_SQL_QUERIES;
+// Panel count per emailed report screenshot window. This is a capture-layer
+// batching knob (fixed page navigations within a serverless time budget), not
+// a live-browser query concurrency limit — do not couple it to
+// MAX_CONCURRENT_SQL_QUERIES. A smaller value multiplies per-window
+// navigation/auth/render overhead across more sequential page loads and can
+// blow the sweep's total capture budget before later windows even start.
+export const REPORT_PANEL_CHUNK_SIZE = 8;
 
 export function listReportablePanelIds(panels: SqlPanel[]): string[] {
   return panels

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/report-panel-window.ts
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/report-panel-window.ts
@@ -1,12 +1,8 @@
 import type { SqlPanel } from "./types";
 
-// Panel count per emailed report screenshot window. This is a capture-layer
-// batching knob (fixed page navigations within a serverless time budget), not
-// a live-browser query concurrency limit — do not couple it to
-// MAX_CONCURRENT_SQL_QUERIES. A smaller value multiplies per-window
-// navigation/auth/render overhead across more sequential page loads and can
-// blow the sweep's total capture budget before later windows even start.
-export const REPORT_PANEL_CHUNK_SIZE = 8;
+// Keep each report window within the browser-side SQL query concurrency limit
+// so a cold window does not serialize into multiple waves before readiness.
+export const REPORT_PANEL_CHUNK_SIZE = 4;
 
 export function listReportablePanelIds(panels: SqlPanel[]): string[] {
   return panels

--- a/templates/analytics/changelog/2026-07-25-analytics-dashboards-and-scheduled-reports-are-faster-and-mo.md
+++ b/templates/analytics/changelog/2026-07-25-analytics-dashboards-and-scheduled-reports-are-faster-and-mo.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-25
+---
+
+Analytics dashboards and scheduled reports are faster and more reliable with large event histories.

--- a/templates/analytics/server/db/schema.ts
+++ b/templates/analytics/server/db/schema.ts
@@ -194,6 +194,18 @@ export const bigqueryCache = table("bigquery_cache", {
 });
 
 /**
+ * First-party dashboard panel result cache — see
+ * server/lib/first-party-analytics-cache.ts.
+ */
+export const firstPartyAnalyticsCache = table("first_party_analytics_cache", {
+  key: text("key").primaryKey(),
+  sql: text("sql").notNull(),
+  result: text("result").notNull(),
+  createdAt: text("created_at").notNull(),
+  expiresAt: text("expires_at").notNull(),
+});
+
+/**
  * Public write keys for the first-party analytics ingestion endpoint.
  * The key is intentionally public/write-only: it can create events for the
  * owning user/org but grants no read or admin access.

--- a/templates/analytics/server/lib/dashboard-panel-query.ts
+++ b/templates/analytics/server/lib/dashboard-panel-query.ts
@@ -446,10 +446,14 @@ export async function runDashboardPanelQuery(args: {
   }
 
   if (source === "first-party") {
-    return await queryFirstPartyAnalytics(query, {
-      userEmail: ctx.userEmail,
-      orgId: ctx.orgId ?? null,
-    });
+    return await queryFirstPartyAnalytics(
+      query,
+      {
+        userEmail: ctx.userEmail,
+        orgId: ctx.orgId ?? null,
+      },
+      { cache: true },
+    );
   }
 
   if (source === "demo") {

--- a/templates/analytics/server/lib/dashboard-report.spec.ts
+++ b/templates/analytics/server/lib/dashboard-report.spec.ts
@@ -309,12 +309,12 @@ describe("dashboard report email", () => {
   });
 
   it("captures every chunk in one browser, closes each page, and attaches CID images in order", async () => {
-    mocks.getReportDashboard.mockResolvedValue(dashboard(80));
-    const ids = Array.from({ length: 80 }, (_, index) => `panel-${index}`);
+    mocks.getReportDashboard.mockResolvedValue(dashboard(40));
+    const ids = Array.from({ length: 40 }, (_, index) => `panel-${index}`);
     const pages = Array.from({ length: 10 }, (_, index) =>
       createPage({
         screenshot: Buffer.from(`image-${index + 1}`),
-        renderedPanelIds: ids.slice(index * 8, (index + 1) * 8),
+        renderedPanelIds: ids.slice(index * 4, (index + 1) * 4),
       }),
     );
     const { browser } = createBrowser([...pages]);
@@ -330,20 +330,12 @@ describe("dashboard report email", () => {
     expect(browser.newPage).toHaveBeenCalledTimes(10);
     for (const page of pages) expect(page.page.close).toHaveBeenCalledOnce();
     const urls = pages.map((entry) => entry.page.goto.mock.calls[0]?.[0]);
-    expect(urls).toEqual([
-      expect.stringContaining("reportPanelOffset=0"),
-      expect.stringContaining("reportPanelOffset=8"),
-      expect.stringContaining("reportPanelOffset=16"),
-      expect.stringContaining("reportPanelOffset=24"),
-      expect.stringContaining("reportPanelOffset=32"),
-      expect.stringContaining("reportPanelOffset=40"),
-      expect.stringContaining("reportPanelOffset=48"),
-      expect.stringContaining("reportPanelOffset=56"),
-      expect.stringContaining("reportPanelOffset=64"),
-      expect.stringContaining("reportPanelOffset=72"),
-    ]);
+    expect(urls).toHaveLength(10);
+    urls.forEach((url, index) => {
+      expect(url).toContain(`reportPanelOffset=${index * 4}`);
+    });
     expect(
-      urls.every((url) => (url ?? "").includes("reportPanelLimit=8")),
+      urls.every((url) => (url ?? "").includes("reportPanelLimit=4")),
     ).toBe(true);
     const email = mocks.sendEmail.mock.calls[0]?.[0];
     expect(email.timeoutMs).toBe(10_000);
@@ -415,21 +407,21 @@ describe("dashboard report email", () => {
     expect(email.html).not.toContain("limited fallback");
   });
 
-  it("gives sixteen panels two independent eight-query serverless readiness windows", async () => {
+  it("gives eight panels two independent four-query serverless readiness windows", async () => {
     vi.stubEnv("NETLIFY", "true");
     vi.stubEnv("PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH", "");
     mocks.existsSync.mockReturnValue(false);
-    mocks.getReportDashboard.mockResolvedValue(dashboard(16));
+    mocks.getReportDashboard.mockResolvedValue(dashboard(8));
     const first = createPage({
       renderedPanelIds: Array.from(
-        { length: 8 },
+        { length: 4 },
         (_, index) => `panel-${index}`,
       ),
     });
     const second = createPage({
       renderedPanelIds: Array.from(
-        { length: 8 },
-        (_, index) => `panel-${index + 8}`,
+        { length: 4 },
+        (_, index) => `panel-${index + 4}`,
       ),
     });
     const { browser } = createBrowser([first, second]);
@@ -446,7 +438,7 @@ describe("dashboard report email", () => {
         { timeout: DASHBOARD_REPORT_READY_TIMEOUT_MS },
       );
       expect(page.page.goto).toHaveBeenCalledWith(
-        expect.stringContaining("reportPanelLimit=8"),
+        expect.stringContaining("reportPanelLimit=4"),
         expect.any(Object),
       );
     }
@@ -471,18 +463,18 @@ describe("dashboard report email", () => {
   });
 
   it("does not send completed chunks while a retry still requires a complete capture", async () => {
-    mocks.getReportDashboard.mockResolvedValue(dashboard(16));
+    mocks.getReportDashboard.mockResolvedValue(dashboard(8));
     const first = createPage({
       renderedPanelIds: Array.from(
-        { length: 8 },
+        { length: 4 },
         (_, index) => `panel-${index}`,
       ),
     });
     const failed = createPage({
       waitForFails: true,
       renderedPanelIds: Array.from(
-        { length: 8 },
-        (_, index) => `panel-${index + 8}`,
+        { length: 4 },
+        (_, index) => `panel-${index + 4}`,
       ),
     });
     const { browser } = createBrowser([first, failed]);
@@ -503,18 +495,18 @@ describe("dashboard report email", () => {
   });
 
   it("does not let a partial capture satisfy requireScreenshot", async () => {
-    mocks.getReportDashboard.mockResolvedValue(dashboard(16));
+    mocks.getReportDashboard.mockResolvedValue(dashboard(8));
     const first = createPage({
       renderedPanelIds: Array.from(
-        { length: 8 },
+        { length: 4 },
         (_, index) => `panel-${index}`,
       ),
     });
     const failed = createPage({
       waitForFails: true,
       renderedPanelIds: Array.from(
-        { length: 8 },
-        (_, index) => `panel-${index + 8}`,
+        { length: 4 },
+        (_, index) => `panel-${index + 4}`,
       ),
     });
     const { browser } = createBrowser([first, failed]);
@@ -555,7 +547,7 @@ describe("dashboard report email", () => {
   );
 
   it("fails before browser launch when a complete dashboard needs more than ten chunks", async () => {
-    mocks.getReportDashboard.mockResolvedValue(dashboard(81));
+    mocks.getReportDashboard.mockResolvedValue(dashboard(41));
 
     const result = await sendDashboardReportSubscription(subscription(), {
       skipEmailWithoutScreenshot: true,
@@ -595,10 +587,10 @@ describe("dashboard report email", () => {
   });
 
   it("discards every chunk when a later panel window no longer matches the dashboard snapshot", async () => {
-    mocks.getReportDashboard.mockResolvedValue(dashboard(16));
+    mocks.getReportDashboard.mockResolvedValue(dashboard(8));
     const first = createPage({
       renderedPanelIds: Array.from(
-        { length: 8 },
+        { length: 4 },
         (_, index) => `panel-${index}`,
       ),
     });
@@ -613,7 +605,7 @@ describe("dashboard report email", () => {
       screenshotMode: "none",
       emailsSent: true,
       screenshotError: expect.stringContaining(
-        'report chunk panel mismatch; expected=["panel-8","panel-9","panel-10","panel-11","panel-12","panel-13","panel-14","panel-15"] actual=[]',
+        'report chunk panel mismatch; expected=["panel-4","panel-5","panel-6","panel-7"] actual=[]',
       ),
     });
     expect(mocks.sendEmail).toHaveBeenCalledWith(
@@ -644,17 +636,17 @@ describe("dashboard report email", () => {
   });
 
   it("pre-seeds each chunk's signed embed token before navigation", async () => {
-    mocks.getReportDashboard.mockResolvedValue(dashboard(16));
+    mocks.getReportDashboard.mockResolvedValue(dashboard(8));
     const first = createPage({
       renderedPanelIds: Array.from(
-        { length: 8 },
+        { length: 4 },
         (_, index) => `panel-${index}`,
       ),
     });
     const second = createPage({
       renderedPanelIds: Array.from(
-        { length: 8 },
-        (_, index) => `panel-${index + 8}`,
+        { length: 4 },
+        (_, index) => `panel-${index + 4}`,
       ),
     });
     const { browser } = createBrowser([first, second]);
@@ -1004,19 +996,19 @@ describe("dashboard report email", () => {
       vi.stubEnv("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", "1024");
       vi.stubEnv("PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH", "");
       mocks.existsSync.mockReturnValue(false);
-      mocks.getReportDashboard.mockResolvedValue(dashboard(16));
+      mocks.getReportDashboard.mockResolvedValue(dashboard(8));
       const first = createPage({
         screenshot: Buffer.from("first"),
         renderedPanelIds: Array.from(
-          { length: 8 },
+          { length: 4 },
           (_, index) => `panel-${index}`,
         ),
       });
       const second = createPage({
         blockReadyWait: true,
         renderedPanelIds: Array.from(
-          { length: 8 },
-          (_, index) => `panel-${index + 8}`,
+          { length: 4 },
+          (_, index) => `panel-${index + 4}`,
         ),
       });
       const { browser } = createBrowser([first, second]);

--- a/templates/analytics/server/lib/dashboard-report.spec.ts
+++ b/templates/analytics/server/lib/dashboard-report.spec.ts
@@ -309,12 +309,12 @@ describe("dashboard report email", () => {
   });
 
   it("captures every chunk in one browser, closes each page, and attaches CID images in order", async () => {
-    mocks.getReportDashboard.mockResolvedValue(dashboard(39));
-    const ids = Array.from({ length: 39 }, (_, index) => `panel-${index}`);
+    mocks.getReportDashboard.mockResolvedValue(dashboard(80));
+    const ids = Array.from({ length: 80 }, (_, index) => `panel-${index}`);
     const pages = Array.from({ length: 10 }, (_, index) =>
       createPage({
         screenshot: Buffer.from(`image-${index + 1}`),
-        renderedPanelIds: ids.slice(index * 4, (index + 1) * 4),
+        renderedPanelIds: ids.slice(index * 8, (index + 1) * 8),
       }),
     );
     const { browser } = createBrowser([...pages]);
@@ -332,18 +332,18 @@ describe("dashboard report email", () => {
     const urls = pages.map((entry) => entry.page.goto.mock.calls[0]?.[0]);
     expect(urls).toEqual([
       expect.stringContaining("reportPanelOffset=0"),
-      expect.stringContaining("reportPanelOffset=4"),
       expect.stringContaining("reportPanelOffset=8"),
-      expect.stringContaining("reportPanelOffset=12"),
       expect.stringContaining("reportPanelOffset=16"),
-      expect.stringContaining("reportPanelOffset=20"),
       expect.stringContaining("reportPanelOffset=24"),
-      expect.stringContaining("reportPanelOffset=28"),
       expect.stringContaining("reportPanelOffset=32"),
-      expect.stringContaining("reportPanelOffset=36"),
+      expect.stringContaining("reportPanelOffset=40"),
+      expect.stringContaining("reportPanelOffset=48"),
+      expect.stringContaining("reportPanelOffset=56"),
+      expect.stringContaining("reportPanelOffset=64"),
+      expect.stringContaining("reportPanelOffset=72"),
     ]);
     expect(
-      urls.every((url) => (url ?? "").includes("reportPanelLimit=4")),
+      urls.every((url) => (url ?? "").includes("reportPanelLimit=8")),
     ).toBe(true);
     const email = mocks.sendEmail.mock.calls[0]?.[0];
     expect(email.timeoutMs).toBe(10_000);
@@ -415,16 +415,22 @@ describe("dashboard report email", () => {
     expect(email.html).not.toContain("limited fallback");
   });
 
-  it("gives eight panels two independent four-query serverless readiness windows", async () => {
+  it("gives sixteen panels two independent eight-query serverless readiness windows", async () => {
     vi.stubEnv("NETLIFY", "true");
     vi.stubEnv("PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH", "");
     mocks.existsSync.mockReturnValue(false);
-    mocks.getReportDashboard.mockResolvedValue(dashboard(8));
+    mocks.getReportDashboard.mockResolvedValue(dashboard(16));
     const first = createPage({
-      renderedPanelIds: ["panel-0", "panel-1", "panel-2", "panel-3"],
+      renderedPanelIds: Array.from(
+        { length: 8 },
+        (_, index) => `panel-${index}`,
+      ),
     });
     const second = createPage({
-      renderedPanelIds: ["panel-4", "panel-5", "panel-6", "panel-7"],
+      renderedPanelIds: Array.from(
+        { length: 8 },
+        (_, index) => `panel-${index + 8}`,
+      ),
     });
     const { browser } = createBrowser([first, second]);
     mocks.launchPersistentContext.mockResolvedValue(browser);
@@ -440,7 +446,7 @@ describe("dashboard report email", () => {
         { timeout: DASHBOARD_REPORT_READY_TIMEOUT_MS },
       );
       expect(page.page.goto).toHaveBeenCalledWith(
-        expect.stringContaining("reportPanelLimit=4"),
+        expect.stringContaining("reportPanelLimit=8"),
         expect.any(Object),
       );
     }
@@ -465,16 +471,19 @@ describe("dashboard report email", () => {
   });
 
   it("does not send completed chunks while a retry still requires a complete capture", async () => {
-    mocks.getReportDashboard.mockResolvedValue(dashboard(8));
+    mocks.getReportDashboard.mockResolvedValue(dashboard(16));
     const first = createPage({
       renderedPanelIds: Array.from(
-        { length: 4 },
+        { length: 8 },
         (_, index) => `panel-${index}`,
       ),
     });
     const failed = createPage({
       waitForFails: true,
-      renderedPanelIds: ["panel-4", "panel-5", "panel-6", "panel-7"],
+      renderedPanelIds: Array.from(
+        { length: 8 },
+        (_, index) => `panel-${index + 8}`,
+      ),
     });
     const { browser } = createBrowser([first, failed]);
     mocks.launch.mockResolvedValue(browser);
@@ -494,16 +503,19 @@ describe("dashboard report email", () => {
   });
 
   it("does not let a partial capture satisfy requireScreenshot", async () => {
-    mocks.getReportDashboard.mockResolvedValue(dashboard(8));
+    mocks.getReportDashboard.mockResolvedValue(dashboard(16));
     const first = createPage({
       renderedPanelIds: Array.from(
-        { length: 4 },
+        { length: 8 },
         (_, index) => `panel-${index}`,
       ),
     });
     const failed = createPage({
       waitForFails: true,
-      renderedPanelIds: ["panel-4", "panel-5", "panel-6", "panel-7"],
+      renderedPanelIds: Array.from(
+        { length: 8 },
+        (_, index) => `panel-${index + 8}`,
+      ),
     });
     const { browser } = createBrowser([first, failed]);
     mocks.launch.mockResolvedValue(browser);
@@ -543,7 +555,7 @@ describe("dashboard report email", () => {
   );
 
   it("fails before browser launch when a complete dashboard needs more than ten chunks", async () => {
-    mocks.getReportDashboard.mockResolvedValue(dashboard(41));
+    mocks.getReportDashboard.mockResolvedValue(dashboard(81));
 
     const result = await sendDashboardReportSubscription(subscription(), {
       skipEmailWithoutScreenshot: true,
@@ -583,10 +595,10 @@ describe("dashboard report email", () => {
   });
 
   it("discards every chunk when a later panel window no longer matches the dashboard snapshot", async () => {
-    mocks.getReportDashboard.mockResolvedValue(dashboard(8));
+    mocks.getReportDashboard.mockResolvedValue(dashboard(16));
     const first = createPage({
       renderedPanelIds: Array.from(
-        { length: 4 },
+        { length: 8 },
         (_, index) => `panel-${index}`,
       ),
     });
@@ -601,7 +613,7 @@ describe("dashboard report email", () => {
       screenshotMode: "none",
       emailsSent: true,
       screenshotError: expect.stringContaining(
-        'report chunk panel mismatch; expected=["panel-4","panel-5","panel-6","panel-7"] actual=[]',
+        'report chunk panel mismatch; expected=["panel-8","panel-9","panel-10","panel-11","panel-12","panel-13","panel-14","panel-15"] actual=[]',
       ),
     });
     expect(mocks.sendEmail).toHaveBeenCalledWith(
@@ -632,15 +644,18 @@ describe("dashboard report email", () => {
   });
 
   it("pre-seeds each chunk's signed embed token before navigation", async () => {
-    mocks.getReportDashboard.mockResolvedValue(dashboard(8));
+    mocks.getReportDashboard.mockResolvedValue(dashboard(16));
     const first = createPage({
       renderedPanelIds: Array.from(
-        { length: 4 },
+        { length: 8 },
         (_, index) => `panel-${index}`,
       ),
     });
     const second = createPage({
-      renderedPanelIds: ["panel-4", "panel-5", "panel-6", "panel-7"],
+      renderedPanelIds: Array.from(
+        { length: 8 },
+        (_, index) => `panel-${index + 8}`,
+      ),
     });
     const { browser } = createBrowser([first, second]);
     mocks.launch.mockResolvedValue(browser);
@@ -989,17 +1004,20 @@ describe("dashboard report email", () => {
       vi.stubEnv("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", "1024");
       vi.stubEnv("PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH", "");
       mocks.existsSync.mockReturnValue(false);
-      mocks.getReportDashboard.mockResolvedValue(dashboard(8));
+      mocks.getReportDashboard.mockResolvedValue(dashboard(16));
       const first = createPage({
         screenshot: Buffer.from("first"),
         renderedPanelIds: Array.from(
-          { length: 4 },
+          { length: 8 },
           (_, index) => `panel-${index}`,
         ),
       });
       const second = createPage({
         blockReadyWait: true,
-        renderedPanelIds: ["panel-4", "panel-5", "panel-6", "panel-7"],
+        renderedPanelIds: Array.from(
+          { length: 8 },
+          (_, index) => `panel-${index + 8}`,
+        ),
       });
       const { browser } = createBrowser([first, second]);
       browser.close.mockImplementation(async () => {
@@ -1066,7 +1084,7 @@ describe("dashboard report email", () => {
       const capture = sendDashboardReportSubscription(subscription(), {
         skipEmailWithoutScreenshot: true,
       });
-      await vi.advanceTimersByTimeAsync(150_000);
+      await vi.advanceTimersByTimeAsync(210_000);
       const result = await capture;
       resolveLateLaunch(lateBrowser);
       await Promise.resolve();

--- a/templates/analytics/server/lib/dashboard-report.ts
+++ b/templates/analytics/server/lib/dashboard-report.ts
@@ -384,6 +384,14 @@ function boundedStageTimeout(capMs: number, deadlineAt?: number): number {
   return Math.max(1, Math.min(capMs, remainingMs));
 }
 
+function reportDeliveryReserveMs(recipientCount: number): number {
+  return (
+    MAX_CAPTURE_CLEANUP_RESERVE_MS +
+    recipientCount * DASHBOARD_REPORT_EMAIL_TIMEOUT_MS +
+    DASHBOARD_REPORT_EMAIL_OVERHEAD_RESERVE_MS
+  );
+}
+
 async function runWithinCaptureDeadline<T>(
   operation: () => Promise<T>,
   deadlineAt?: number,
@@ -534,8 +542,8 @@ const PREWARM_MAX_BUDGET_MS = 45_000;
  * what was pushing panels past their capture timeout. Best-effort: a panel
  * that fails or times out here is simply computed cold by the capture later,
  * exactly as it always was, so this can never make a report worse than
- * before it existed. Bounded to a fraction of the remaining report deadline
- * so prewarming can't starve the capture itself of time.
+ * before it existed. Bounded to time left after reserving the full chunked
+ * capture attempt and delivery tail, so prewarming cannot starve capture.
  * The per-panel timeout only bounds how long a worker waits before logging;
  * it is also passed to the database/cache layers, and the original query is
  * still awaited before this function returns so it cannot overlap capture.
@@ -544,6 +552,7 @@ async function prewarmFirstPartyPanelCache(
   sub: DashboardReportSubscription,
   snapshot: ReportSnapshot,
   deadlineAt?: number,
+  recipientCount = 0,
 ): Promise<void> {
   const panels = (snapshot.panels ?? []).filter(
     (panel) => panel.source === "first-party" && panel.sql != null,
@@ -553,7 +562,14 @@ async function prewarmFirstPartyPanelCache(
   const remaining = deadlineAt ? deadlineAt - Date.now() : Infinity;
   const budgetMs = Math.max(
     0,
-    Math.min(PREWARM_MAX_BUDGET_MS, remaining * 0.3),
+    Math.min(
+      PREWARM_MAX_BUDGET_MS,
+      deadlineAt
+        ? remaining -
+            SERVERLESS_CHUNKED_ATTEMPT_TIMEOUT_MS -
+            reportDeliveryReserveMs(recipientCount)
+        : PREWARM_MAX_BUDGET_MS,
+    ),
   );
   if (budgetMs <= 0) return;
   const prewarmDeadline = Date.now() + budgetMs;
@@ -1463,7 +1479,12 @@ export async function sendDashboardReportSubscription(
     options.deadlineAt,
   );
   try {
-    await prewarmFirstPartyPanelCache(sub, snapshot, options.deadlineAt);
+    await prewarmFirstPartyPanelCache(
+      sub,
+      snapshot,
+      options.deadlineAt,
+      recipients.length,
+    );
   } catch (err) {
     console.warn(
       "[dashboard-report] panel cache prewarm failed (non-fatal):",
@@ -1475,9 +1496,7 @@ export async function sendDashboardReportSubscription(
         SERVERLESS_CHUNKED_ATTEMPT_TIMEOUT_MS,
         options.deadlineAt -
           Date.now() -
-          MAX_CAPTURE_CLEANUP_RESERVE_MS -
-          recipients.length * DASHBOARD_REPORT_EMAIL_TIMEOUT_MS -
-          DASHBOARD_REPORT_EMAIL_OVERHEAD_RESERVE_MS,
+          reportDeliveryReserveMs(recipients.length),
       )
     : undefined;
   const capture = await captureDashboardPngWithFallback(

--- a/templates/analytics/server/lib/dashboard-report.ts
+++ b/templates/analytics/server/lib/dashboard-report.ts
@@ -15,6 +15,8 @@ import {
   EMBED_TOKEN_QUERY_PARAM,
 } from "@agent-native/core/shared";
 
+import { interpolate } from "../../app/pages/adhoc/sql-dashboard/interpolate";
+import { serializePanelSql } from "../../app/pages/adhoc/sql-dashboard/panel-sql";
 import {
   listReportablePanelIds,
   REPORT_PANEL_CHUNK_SIZE,
@@ -32,6 +34,7 @@ import {
   type DashboardReportCaptureOutcome,
   type DashboardReportSubscription,
 } from "./dashboard-report-subscriptions";
+import { queryFirstPartyAnalytics } from "./first-party-analytics.js";
 
 type ReportSnapshot = {
   dashboardId: string;
@@ -42,6 +45,8 @@ type ReportSnapshot = {
   reportSettingsUrl: string;
   generatedAt: string;
   panelIds: string[];
+  panels: SqlDashboardConfig["panels"];
+  variables?: Record<string, string>;
 };
 
 const DATE_FILTER_TYPES: ReadonlySet<FilterType> = new Set([
@@ -58,7 +63,9 @@ const LOCAL_SCREENSHOT_TIMEOUT_MS = 90_000;
 const SERVERLESS_SCREENSHOT_TIMEOUT_MS = 90_000;
 const SERVERLESS_SECOND_READY_TIMEOUT_MS = 45_000;
 // Cap browser work separately from the sweep-level delivery deadline.
-const SERVERLESS_CHUNKED_ATTEMPT_TIMEOUT_MS = 150_000;
+// Reserve time under Netlify's 300s background-function limit for cleanup and
+// email delivery (see MAX_CAPTURE_CLEANUP_RESERVE_MS / delivery reserves below).
+const SERVERLESS_CHUNKED_ATTEMPT_TIMEOUT_MS = 210_000;
 const BROWSER_CLEANUP_TIMEOUT_MS = 10_000;
 const DASHBOARD_REPORT_EMAIL_TIMEOUT_MS = 10_000;
 const DASHBOARD_REPORT_EMAIL_OVERHEAD_RESERVE_MS = 5_000;
@@ -226,6 +233,8 @@ async function collectReportSnapshot(
     }),
     generatedAt: new Date().toISOString(),
     panelIds: listReportablePanelIds(config.panels),
+    panels: config.panels,
+    variables: config.variables,
   };
 }
 
@@ -448,7 +457,15 @@ async function waitForDashboardReportReady(
         if (root.getAttribute("data-dashboard-report-ready") !== "true") {
           return false;
         }
-        return !root.querySelector("[data-dashboard-report-loading='true']");
+        if (root.querySelector("[data-dashboard-report-loading='true']")) {
+          return false;
+        }
+        // A panel that errored (including its own query-call timeout) clears
+        // its loading marker just like a successful panel, so without this
+        // check the capture would treat a broken panel as "ready" and bake
+        // its raw error text into the delivered screenshot instead of
+        // failing the attempt so the retry sweep can pick it up.
+        return !root.querySelector("[role='alert']");
       })()`,
       undefined,
       { timeout },
@@ -503,6 +520,78 @@ async function waitForDashboardReportReady(
       : `${err?.message ?? String(err)}; dashboard page was not inspectable; capture diagnostics: ${JSON.stringify(captureDiagnostics)}`;
     throw new Error(message);
   }
+}
+
+const PREWARM_CONCURRENCY = 3;
+const PREWARM_PANEL_TIMEOUT_MS = 20_000;
+const PREWARM_MAX_BUDGET_MS = 45_000;
+
+/**
+ * Runs first-party panel queries once, directly, before the browser capture
+ * starts, so the capture's own query-dashboard-panel calls hit a warm cache
+ * instead of several panels racing each other cold for database time inside
+ * a single capture window — that contention, not any one query alone, is
+ * what was pushing panels past their capture timeout. Best-effort: a panel
+ * that fails or times out here is simply computed cold by the capture later,
+ * exactly as it always was, so this can never make a report worse than
+ * before it existed. Bounded to a fraction of the remaining report deadline
+ * so prewarming can't starve the capture itself of time.
+ */
+async function prewarmFirstPartyPanelCache(
+  sub: DashboardReportSubscription,
+  snapshot: ReportSnapshot,
+  deadlineAt?: number,
+): Promise<void> {
+  const panels = (snapshot.panels ?? []).filter(
+    (panel) => panel.source === "first-party" && panel.sql != null,
+  );
+  if (!panels.length) return;
+
+  const remaining = deadlineAt ? deadlineAt - Date.now() : Infinity;
+  const budgetMs = Math.max(
+    0,
+    Math.min(PREWARM_MAX_BUDGET_MS, remaining * 0.3),
+  );
+  if (budgetMs <= 0) return;
+  const prewarmDeadline = Date.now() + budgetMs;
+
+  const vars: Record<string, string> = { ...snapshot.variables };
+  for (const [key, value] of Object.entries(snapshot.filters)) {
+    if (key.startsWith("f_")) vars[key.slice(2)] = value;
+  }
+  const scope = { userEmail: sub.ownerEmail, orgId: sub.orgId ?? null };
+
+  let index = 0;
+  async function worker(): Promise<void> {
+    while (index < panels.length && Date.now() < prewarmDeadline) {
+      const panel = panels[index++];
+      const sql = interpolate(serializePanelSql(panel.sql), vars, {
+        failClosedTimeVariables: true,
+      });
+      if (!sql.trim()) continue;
+      try {
+        await Promise.race([
+          queryFirstPartyAnalytics(sql, scope),
+          new Promise((_, reject) => {
+            const t = setTimeout(
+              () => reject(new Error("prewarm panel timeout")),
+              PREWARM_PANEL_TIMEOUT_MS,
+            );
+            t.unref?.();
+          }),
+        ]);
+      } catch (err) {
+        console.warn(
+          `[dashboard-report] prewarm failed for panel ${panel.id}:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: PREWARM_CONCURRENCY }, () => worker()),
+  );
 }
 
 async function assertDashboardReportPanelWindow(
@@ -1358,6 +1447,14 @@ export async function sendDashboardReportSubscription(
     () => collectReportSnapshot(sub),
     options.deadlineAt,
   );
+  try {
+    await prewarmFirstPartyPanelCache(sub, snapshot, options.deadlineAt);
+  } catch (err) {
+    console.warn(
+      "[dashboard-report] panel cache prewarm failed (non-fatal):",
+      err instanceof Error ? err.message : err,
+    );
+  }
   const captureTimeoutMs = options.deadlineAt
     ? Math.min(
         SERVERLESS_CHUNKED_ATTEMPT_TIMEOUT_MS,

--- a/templates/analytics/server/lib/dashboard-report.ts
+++ b/templates/analytics/server/lib/dashboard-report.ts
@@ -537,8 +537,8 @@ const PREWARM_MAX_BUDGET_MS = 45_000;
  * before it existed. Bounded to a fraction of the remaining report deadline
  * so prewarming can't starve the capture itself of time.
  * The per-panel timeout only bounds how long a worker waits before logging;
- * the original query is still awaited before this function returns so a
- * timed-out database request cannot overlap the capture.
+ * it is also passed to the database/cache layers, and the original query is
+ * still awaited before this function returns so it cannot overlap capture.
  */
 async function prewarmFirstPartyPanelCache(
   sub: DashboardReportSubscription,
@@ -572,7 +572,14 @@ async function prewarmFirstPartyPanelCache(
         failClosedTimeVariables: true,
       });
       if (!sql.trim()) continue;
-      const query = queryFirstPartyAnalytics(sql, scope);
+      const panelTimeoutMs = Math.max(
+        1,
+        Math.min(PREWARM_PANEL_TIMEOUT_MS, prewarmDeadline - Date.now()),
+      );
+      const query = queryFirstPartyAnalytics(sql, scope, {
+        cache: true,
+        timeoutMs: panelTimeoutMs,
+      });
       let timeout: ReturnType<typeof setTimeout> | undefined;
       try {
         await Promise.race([
@@ -580,7 +587,7 @@ async function prewarmFirstPartyPanelCache(
           new Promise<never>((_, reject) => {
             timeout = setTimeout(
               () => reject(new Error("prewarm panel timeout")),
-              PREWARM_PANEL_TIMEOUT_MS,
+              panelTimeoutMs,
             );
             timeout.unref?.();
           }),

--- a/templates/analytics/server/lib/dashboard-report.ts
+++ b/templates/analytics/server/lib/dashboard-report.ts
@@ -536,6 +536,9 @@ const PREWARM_MAX_BUDGET_MS = 45_000;
  * exactly as it always was, so this can never make a report worse than
  * before it existed. Bounded to a fraction of the remaining report deadline
  * so prewarming can't starve the capture itself of time.
+ * The per-panel timeout only bounds how long a worker waits before logging;
+ * the original query is still awaited before this function returns so a
+ * timed-out database request cannot overlap the capture.
  */
 async function prewarmFirstPartyPanelCache(
   sub: DashboardReportSubscription,
@@ -569,15 +572,17 @@ async function prewarmFirstPartyPanelCache(
         failClosedTimeVariables: true,
       });
       if (!sql.trim()) continue;
+      const query = queryFirstPartyAnalytics(sql, scope);
+      let timeout: ReturnType<typeof setTimeout> | undefined;
       try {
         await Promise.race([
-          queryFirstPartyAnalytics(sql, scope),
-          new Promise((_, reject) => {
-            const t = setTimeout(
+          query,
+          new Promise<never>((_, reject) => {
+            timeout = setTimeout(
               () => reject(new Error("prewarm panel timeout")),
               PREWARM_PANEL_TIMEOUT_MS,
             );
-            t.unref?.();
+            timeout.unref?.();
           }),
         ]);
       } catch (err) {
@@ -585,6 +590,9 @@ async function prewarmFirstPartyPanelCache(
           `[dashboard-report] prewarm failed for panel ${panel.id}:`,
           err instanceof Error ? err.message : err,
         );
+      } finally {
+        if (timeout) clearTimeout(timeout);
+        await query.catch(() => undefined);
       }
     }
   }

--- a/templates/analytics/server/lib/dashboard-time-scope.spec.ts
+++ b/templates/analytics/server/lib/dashboard-time-scope.spec.ts
@@ -139,6 +139,18 @@ describe("first-party dashboard time scope", () => {
     ).toBeNull();
   });
 
+  it("parses quoted CTE identifiers when checking their analytics bounds", () => {
+    expect(
+      validateFirstPartyDashboardTimeScope(
+        panel({
+          sql: 'WITH "recent events" AS (SELECT * FROM analytics_events WHERE event_date >= CURRENT_DATE - INTERVAL \'30 days\') SELECT COUNT(*) FROM "recent events"',
+        }),
+        { filters: [] },
+        0,
+      ),
+    ).toBeNull();
+  });
+
   it("ignores parentheses inside quoted CTE text", () => {
     expect(
       validateFirstPartyDashboardTimeScope(

--- a/templates/analytics/server/lib/dashboard-time-scope.spec.ts
+++ b/templates/analytics/server/lib/dashboard-time-scope.spec.ts
@@ -150,4 +150,40 @@ describe("first-party dashboard time scope", () => {
       ),
     ).toMatch(/at least one analytics_events read/);
   });
+
+  it("fails closed when one CTE contains multiple analytics scans", () => {
+    expect(
+      validateFirstPartyDashboardTimeScope(
+        panel({
+          sql: "WITH mixed AS (SELECT * FROM analytics_events WHERE event_date >= CURRENT_DATE - INTERVAL '30 days' UNION ALL SELECT * FROM analytics_events) SELECT COUNT(*) FROM mixed",
+        }),
+        { filters: [] },
+        0,
+      ),
+    ).toMatch(/at least one analytics_events read/);
+  });
+
+  it("parses materialized CTE modifiers", () => {
+    expect(
+      validateFirstPartyDashboardTimeScope(
+        panel({
+          sql: "WITH bounded AS NOT MATERIALIZED (SELECT * FROM analytics_events WHERE event_date >= CURRENT_DATE - INTERVAL '30 days') SELECT COUNT(*) FROM bounded",
+        }),
+        { filters: [] },
+        0,
+      ),
+    ).toBeNull();
+  });
+
+  it("skips comments between CTE declarations", () => {
+    expect(
+      validateFirstPartyDashboardTimeScope(
+        panel({
+          sql: "WITH bounded AS (SELECT * FROM analytics_events WHERE event_date >= CURRENT_DATE - INTERVAL '30 days'), /* another CTE follows */ unbounded AS (SELECT * FROM analytics_events) SELECT COUNT(*) FROM bounded",
+        }),
+        { filters: [] },
+        0,
+      ),
+    ).toMatch(/at least one analytics_events read/);
+  });
 });

--- a/templates/analytics/server/lib/dashboard-time-scope.spec.ts
+++ b/templates/analytics/server/lib/dashboard-time-scope.spec.ts
@@ -102,4 +102,52 @@ describe("first-party dashboard time scope", () => {
       ),
     ).toBeNull();
   });
+
+  it("rejects an unbounded analytics scan in the outer query after a bounded CTE", () => {
+    expect(
+      validateFirstPartyDashboardTimeScope(
+        panel({
+          sql: "WITH bounded AS (SELECT * FROM analytics_events WHERE event_date >= CURRENT_DATE - INTERVAL '30 days') SELECT COUNT(*) FROM analytics_events",
+        }),
+        { filters: [] },
+        0,
+      ),
+    ).toMatch(/at least one analytics_events read/);
+  });
+
+  it("parses recursive CTEs when checking their analytics bounds", () => {
+    expect(
+      validateFirstPartyDashboardTimeScope(
+        panel({
+          sql: "WITH RECURSIVE bounded AS (SELECT * FROM analytics_events WHERE event_date >= CURRENT_DATE - INTERVAL '30 days') SELECT COUNT(*) FROM bounded",
+        }),
+        { filters: [] },
+        0,
+      ),
+    ).toBeNull();
+  });
+
+  it("parses CTE column lists when checking their analytics bounds", () => {
+    expect(
+      validateFirstPartyDashboardTimeScope(
+        panel({
+          sql: "WITH bounded(day) AS (SELECT event_date FROM analytics_events WHERE event_date >= CURRENT_DATE - INTERVAL '30 days') SELECT COUNT(*) FROM bounded",
+        }),
+        { filters: [] },
+        0,
+      ),
+    ).toBeNull();
+  });
+
+  it("ignores parentheses inside quoted CTE text", () => {
+    expect(
+      validateFirstPartyDashboardTimeScope(
+        panel({
+          sql: "WITH unbounded AS (SELECT 'literal ) still in this CTE' AS label FROM analytics_events), recent AS (SELECT * FROM analytics_events WHERE event_date >= CURRENT_DATE - INTERVAL '30 days') SELECT COUNT(*) FROM recent",
+        }),
+        { filters: [] },
+        0,
+      ),
+    ).toMatch(/at least one analytics_events read/);
+  });
 });

--- a/templates/analytics/server/lib/dashboard-time-scope.ts
+++ b/templates/analytics/server/lib/dashboard-time-scope.ts
@@ -65,40 +65,94 @@ function hasExplicitLowerBound(sql: string): boolean {
 }
 
 const ANALYTICS_SCAN_RE = /\b(?:FROM|JOIN)\s+analytics_events\b/i;
-const TOP_LEVEL_CTE_HEAD_RE = /^\s*WITH\s+/i;
-const CTE_NAME_RE = /^\s*([A-Za-z_]\w*)\s+AS\s*\(/i;
+const TOP_LEVEL_CTE_HEAD_RE = /^\s*WITH(?:\s+RECURSIVE)?\s+/i;
+const CTE_NAME_RE = /^\s*([A-Za-z_]\w*)\s*(?:\([^)]*\)\s*)?AS\s*\(/i;
+
+type TopLevelCte = { name: string; bodyStart: number; bodyEnd: number };
+
+type TopLevelCteParse = {
+  ctes: TopLevelCte[];
+  outerQueryStart: number;
+};
+
+function findClosingParenthesis(sql: string, bodyStart: number): number {
+  let depth = 1;
+  let quote: "'" | '"' | "`" | null = null;
+  let lineComment = false;
+  let blockComment = false;
+
+  for (let i = bodyStart; i < sql.length; i += 1) {
+    const char = sql[i];
+    const next = sql[i + 1];
+
+    if (lineComment) {
+      if (char === "\n") lineComment = false;
+      continue;
+    }
+    if (blockComment) {
+      if (char === "*" && next === "/") {
+        blockComment = false;
+        i += 1;
+      }
+      continue;
+    }
+    if (quote) {
+      if (char === quote) {
+        if (next === quote) {
+          i += 1;
+        } else {
+          quote = null;
+        }
+      }
+      continue;
+    }
+    if (char === "-" && next === "-") {
+      lineComment = true;
+      i += 1;
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      blockComment = true;
+      i += 1;
+      continue;
+    }
+    if (char === "'" || char === '"' || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "(") depth += 1;
+    else if (char === ")") {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+
+  return -1;
+}
 
 /** One top-level `name AS (...)` common-table-expression's body span. */
-function topLevelCtes(
-  sql: string,
-): Array<{ name: string; bodyStart: number; bodyEnd: number }> {
+function topLevelCtes(sql: string): TopLevelCteParse | null {
   const head = TOP_LEVEL_CTE_HEAD_RE.exec(sql);
-  if (!head) return [];
-  const ctes: Array<{ name: string; bodyStart: number; bodyEnd: number }> = [];
+  if (!head) return null;
+  const ctes: TopLevelCte[] = [];
   let i = head[0].length;
   while (i < sql.length) {
     const nameMatch = CTE_NAME_RE.exec(sql.slice(i));
-    if (!nameMatch) break;
+    if (!nameMatch) return null;
     const name = nameMatch[1];
     const bodyStart = i + nameMatch[0].length;
-    let depth = 1;
-    let j = bodyStart;
-    while (j < sql.length && depth > 0) {
-      if (sql[j] === "(") depth += 1;
-      else if (sql[j] === ")") depth -= 1;
-      j += 1;
-    }
-    const bodyEnd = j - 1;
+    const bodyEnd = findClosingParenthesis(sql, bodyStart);
+    if (bodyEnd === -1) return null;
     ctes.push({ name, bodyStart, bodyEnd });
-    let k = j;
+    let k = bodyEnd + 1;
     while (k < sql.length && /\s/.test(sql[k])) k += 1;
     if (sql[k] === ",") {
       i = k + 1;
       continue;
     }
-    break;
+    return { ctes, outerQueryStart: k };
   }
-  return ctes;
+  return null;
 }
 
 function hasAnyTimeBound(text: string): boolean {
@@ -125,10 +179,15 @@ function hasAnyTimeBound(text: string): boolean {
  * and over-flagging it would make this check untrustworthy.
  */
 function everyScanIsBounded(sql: string): boolean {
-  const ctes = topLevelCtes(sql);
-  if (ctes.length === 0) return hasAnyTimeBound(sql);
-  return ctes.every(({ bodyStart, bodyEnd }) => {
-    const body = sql.slice(bodyStart, bodyEnd);
+  const parsed = topLevelCtes(sql);
+  if (!parsed) return hasAnyTimeBound(sql);
+  const units = [
+    ...parsed.ctes.map(({ bodyStart, bodyEnd }) =>
+      sql.slice(bodyStart, bodyEnd),
+    ),
+    sql.slice(parsed.outerQueryStart),
+  ];
+  return units.every((body) => {
     if (body.search(ANALYTICS_SCAN_RE) === -1) return true;
     return hasAnyTimeBound(body);
   });

--- a/templates/analytics/server/lib/dashboard-time-scope.ts
+++ b/templates/analytics/server/lib/dashboard-time-scope.ts
@@ -14,7 +14,7 @@ type DashboardFilterLike = {
   default?: unknown;
 };
 
-type DashboardPanelLike = {
+export type DashboardPanelLike = {
   id?: unknown;
   title?: unknown;
   chartType?: unknown;
@@ -62,6 +62,76 @@ function hasExplicitLowerBound(sql: string): boolean {
   return /\b(?:event_date|timestamp|started_at|ended_at|cohort_date|created_at|date)\b[\s\S]{0,100}?(?:>=|>)\s*[\s\S]{0,160}?(?:CURRENT_DATE|CURRENT_TIMESTAMP|NOW\s*\(|INTERVAL\s*['"]|DATE\s*['"]|TIMESTAMP\s*['"]|\b20\d{2}-\d{2}-\d{2}\b)/i.test(
     sql,
   );
+}
+
+const ANALYTICS_SCAN_RE = /\b(?:FROM|JOIN)\s+analytics_events\b/i;
+const TOP_LEVEL_CTE_HEAD_RE = /^\s*WITH\s+/i;
+const CTE_NAME_RE = /^\s*([A-Za-z_]\w*)\s+AS\s*\(/i;
+
+/** One top-level `name AS (...)` common-table-expression's body span. */
+function topLevelCtes(
+  sql: string,
+): Array<{ name: string; bodyStart: number; bodyEnd: number }> {
+  const head = TOP_LEVEL_CTE_HEAD_RE.exec(sql);
+  if (!head) return [];
+  const ctes: Array<{ name: string; bodyStart: number; bodyEnd: number }> = [];
+  let i = head[0].length;
+  while (i < sql.length) {
+    const nameMatch = CTE_NAME_RE.exec(sql.slice(i));
+    if (!nameMatch) break;
+    const name = nameMatch[1];
+    const bodyStart = i + nameMatch[0].length;
+    let depth = 1;
+    let j = bodyStart;
+    while (j < sql.length && depth > 0) {
+      if (sql[j] === "(") depth += 1;
+      else if (sql[j] === ")") depth -= 1;
+      j += 1;
+    }
+    const bodyEnd = j - 1;
+    ctes.push({ name, bodyStart, bodyEnd });
+    let k = j;
+    while (k < sql.length && /\s/.test(sql[k])) k += 1;
+    if (sql[k] === ",") {
+      i = k + 1;
+      continue;
+    }
+    break;
+  }
+  return ctes;
+}
+
+function hasAnyTimeBound(text: string): boolean {
+  // .search() ignores the shared global-flagged regex's lastIndex state,
+  // unlike .test(), which would otherwise give wrong results across calls.
+  return (
+    text.search(TEMPORAL_VARIABLE_RE) !== -1 || hasExplicitLowerBound(text)
+  );
+}
+
+/**
+ * True if every `analytics_events` scan in `sql` has its own time bound.
+ *
+ * `hasExplicitLowerBound`/time-variable checks used to run against the whole
+ * SQL string: a multi-CTE panel with a bound ANYWHERE (e.g. only on the
+ * final SELECT, or only on one of several sibling CTEs) passed validation
+ * even though an earlier, unbounded sibling CTE still did a full-table scan
+ * — the exact shape of several production incidents (2026-07-25 org-wide
+ * audit). This only tightens the check for that specific shape: sibling
+ * top-level CTEs each need their own bound. It deliberately does NOT require
+ * every nested subquery to be independently bounded — a correlated lookup
+ * nested inside an already-bounded outer query (e.g. "has this id EVER
+ * appeared as a referrer") is a legitimate, intentionally all-time pattern,
+ * and over-flagging it would make this check untrustworthy.
+ */
+function everyScanIsBounded(sql: string): boolean {
+  const ctes = topLevelCtes(sql);
+  if (ctes.length === 0) return hasAnyTimeBound(sql);
+  return ctes.every(({ bodyStart, bodyEnd }) => {
+    const body = sql.slice(bodyStart, bodyEnd);
+    if (body.search(ANALYTICS_SCAN_RE) === -1) return true;
+    return hasAnyTimeBound(body);
+  });
 }
 
 function hasIntentionalHistoryDescription(
@@ -164,6 +234,20 @@ export function validateFirstPartyDashboardTimeScope(
 
   if (!scope && !hasDashboardBinding && !hasLowerBound) {
     return `panel[${index}] ${label} reads first-party analytics without a time bound; use {{timeRange}} with a non-empty default filter, or explicitly set config.timeScope to "cohort-history" or "all-time" for intentional history scans`;
+  }
+
+  // A bound anywhere in the SQL text (checked above) is not the same as
+  // every CTE/subquery that reads analytics_events having its own bound — a
+  // multi-CTE panel can look bound overall while an earlier CTE still does a
+  // full-table scan. Skip this for "all-time" and "cohort-history": both are
+  // explicit escape hatches, and a cohort-defining CTE (e.g. "first ever
+  // active date per user") is legitimately unbounded by design.
+  if (
+    scope !== "all-time" &&
+    scope !== "cohort-history" &&
+    !everyScanIsBounded(sql)
+  ) {
+    return `panel[${index}] ${label} has at least one analytics_events read (in a CTE or subquery) without its own time bound — a {{timeRange}} reference or literal bound elsewhere in the SQL does not cover it; add a bound to every analytics_events scan, or set config.timeScope to "all-time" for an intentional full-history scan`;
   }
 
   return null;

--- a/templates/analytics/server/lib/dashboard-time-scope.ts
+++ b/templates/analytics/server/lib/dashboard-time-scope.ts
@@ -67,7 +67,7 @@ function hasExplicitLowerBound(sql: string): boolean {
 const ANALYTICS_SCAN_RE = /\b(?:FROM|JOIN)\s+analytics_events\b/gi;
 const TOP_LEVEL_CTE_HEAD_RE = /^\s*WITH\b/i;
 const CTE_NAME_RE =
-  /^\s*([A-Za-z_]\w*)\s*(?:\([^)]*\)\s*)?AS\s*(?:(?:NOT\s+)?MATERIALIZED\s*)?\(/i;
+  /^\s*((?:[A-Za-z_]\w*|"(?:[^"]|"")*"|`(?:[^`]|``)*`|\[(?:[^\]]|\]\])*\]))\s*(?:\([^)]*\)\s*)?AS\s*(?:(?:NOT\s+)?MATERIALIZED\s*)?\(/i;
 
 type TopLevelCte = { name: string; bodyStart: number; bodyEnd: number };
 

--- a/templates/analytics/server/lib/dashboard-time-scope.ts
+++ b/templates/analytics/server/lib/dashboard-time-scope.ts
@@ -64,9 +64,10 @@ function hasExplicitLowerBound(sql: string): boolean {
   );
 }
 
-const ANALYTICS_SCAN_RE = /\b(?:FROM|JOIN)\s+analytics_events\b/i;
-const TOP_LEVEL_CTE_HEAD_RE = /^\s*WITH(?:\s+RECURSIVE)?\s+/i;
-const CTE_NAME_RE = /^\s*([A-Za-z_]\w*)\s*(?:\([^)]*\)\s*)?AS\s*\(/i;
+const ANALYTICS_SCAN_RE = /\b(?:FROM|JOIN)\s+analytics_events\b/gi;
+const TOP_LEVEL_CTE_HEAD_RE = /^\s*WITH\b/i;
+const CTE_NAME_RE =
+  /^\s*([A-Za-z_]\w*)\s*(?:\([^)]*\)\s*)?AS\s*(?:(?:NOT\s+)?MATERIALIZED\s*)?\(/i;
 
 type TopLevelCte = { name: string; bodyStart: number; bodyEnd: number };
 
@@ -130,12 +131,105 @@ function findClosingParenthesis(sql: string, bodyStart: number): number {
   return -1;
 }
 
+function skipSqlTrivia(sql: string, start: number): number {
+  let i = start;
+  while (i < sql.length) {
+    if (/\s/.test(sql[i])) {
+      i += 1;
+      continue;
+    }
+    if (sql[i] === "-" && sql[i + 1] === "-") {
+      i += 2;
+      while (i < sql.length && sql[i] !== "\n") i += 1;
+      continue;
+    }
+    if (sql[i] === "/" && sql[i + 1] === "*") {
+      const end = sql.indexOf("*/", i + 2);
+      if (end === -1) return sql.length;
+      i = end + 2;
+      continue;
+    }
+    break;
+  }
+  return i;
+}
+
+function splitTopLevelUnionBranches(sql: string): string[] {
+  const branches: string[] = [];
+  let start = 0;
+  let depth = 0;
+  let quote: "'" | '"' | "`" | null = null;
+  let lineComment = false;
+  let blockComment = false;
+
+  for (let i = 0; i < sql.length; i += 1) {
+    const char = sql[i];
+    const next = sql[i + 1];
+
+    if (lineComment) {
+      if (char === "\n") lineComment = false;
+      continue;
+    }
+    if (blockComment) {
+      if (char === "*" && next === "/") {
+        blockComment = false;
+        i += 1;
+      }
+      continue;
+    }
+    if (quote) {
+      if (char === quote) {
+        if (next === quote) i += 1;
+        else quote = null;
+      }
+      continue;
+    }
+    if (char === "-" && next === "-") {
+      lineComment = true;
+      i += 1;
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      blockComment = true;
+      i += 1;
+      continue;
+    }
+    if (char === "'" || char === '"' || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "(") {
+      depth += 1;
+      continue;
+    }
+    if (char === ")") {
+      depth = Math.max(0, depth - 1);
+      continue;
+    }
+    if (depth !== 0) continue;
+
+    const union = /^UNION\b/i.exec(sql.slice(i));
+    if (!union) continue;
+    branches.push(sql.slice(start, i));
+    start = skipSqlTrivia(sql, i + union[0].length);
+    const modifier = /^(?:ALL|DISTINCT)\b/i.exec(sql.slice(start));
+    if (modifier) start = skipSqlTrivia(sql, start + modifier[0].length);
+    i = start - 1;
+  }
+
+  branches.push(sql.slice(start));
+  return branches;
+}
+
 /** One top-level `name AS (...)` common-table-expression's body span. */
 function topLevelCtes(sql: string): TopLevelCteParse | null {
-  const head = TOP_LEVEL_CTE_HEAD_RE.exec(sql);
+  const sqlStart = skipSqlTrivia(sql, 0);
+  const head = TOP_LEVEL_CTE_HEAD_RE.exec(sql.slice(sqlStart));
   if (!head) return null;
   const ctes: TopLevelCte[] = [];
-  let i = head[0].length;
+  let i = skipSqlTrivia(sql, sqlStart + head[0].length);
+  const recursive = /^RECURSIVE\b/i.exec(sql.slice(i));
+  if (recursive) i = skipSqlTrivia(sql, i + recursive[0].length);
   while (i < sql.length) {
     const nameMatch = CTE_NAME_RE.exec(sql.slice(i));
     if (!nameMatch) return null;
@@ -144,8 +238,7 @@ function topLevelCtes(sql: string): TopLevelCteParse | null {
     const bodyEnd = findClosingParenthesis(sql, bodyStart);
     if (bodyEnd === -1) return null;
     ctes.push({ name, bodyStart, bodyEnd });
-    let k = bodyEnd + 1;
-    while (k < sql.length && /\s/.test(sql[k])) k += 1;
+    const k = skipSqlTrivia(sql, bodyEnd + 1);
     if (sql[k] === ",") {
       i = k + 1;
       continue;
@@ -180,17 +273,30 @@ function hasAnyTimeBound(text: string): boolean {
  */
 function everyScanIsBounded(sql: string): boolean {
   const parsed = topLevelCtes(sql);
-  if (!parsed) return hasAnyTimeBound(sql);
+  if (!parsed) {
+    // A WITH query that we cannot parse must fail closed. Falling back to a
+    // whole-query bound lets a bounded sibling hide an unbounded CTE.
+    if (TOP_LEVEL_CTE_HEAD_RE.test(sql.slice(skipSqlTrivia(sql, 0)))) {
+      return false;
+    }
+    return hasAnyTimeBound(sql);
+  }
   const units = [
     ...parsed.ctes.map(({ bodyStart, bodyEnd }) =>
       sql.slice(bodyStart, bodyEnd),
     ),
     sql.slice(parsed.outerQueryStart),
   ];
-  return units.every((body) => {
-    if (body.search(ANALYTICS_SCAN_RE) === -1) return true;
-    return hasAnyTimeBound(body);
-  });
+  return units.every((unit) =>
+    splitTopLevelUnionBranches(unit).every((branch) => {
+      const scans = branch.match(ANALYTICS_SCAN_RE) ?? [];
+      if (scans.length === 0) return true;
+      // A single lower bound cannot prove that every scan in a join or nested
+      // branch is bounded. Fail closed until the SQL has one scan per branch.
+      if (scans.length > 1) return false;
+      return hasAnyTimeBound(branch);
+    }),
+  );
 }
 
 function hasIntentionalHistoryDescription(

--- a/templates/analytics/server/lib/first-party-analytics-cache.ts
+++ b/templates/analytics/server/lib/first-party-analytics-cache.ts
@@ -1,0 +1,147 @@
+import { createHash } from "crypto";
+
+import { getDbExec } from "@agent-native/core/db";
+
+import type { AnalyticsQueryResult } from "./first-party-analytics.js";
+
+/**
+ * First-party dashboard panel query cache.
+ *
+ * `analytics_events` grows unbounded and several panels (rolling-window and
+ * cohort self-joins) are inherently expensive, so a page with many panels or
+ * a daily report screenshot capturing many panels at once repeatedly
+ * recomputes the same rows under concurrent load — that contention, not any
+ * single query alone, is what was pushing panels past their timeout budget.
+ * This mirrors bigquery.ts's L1 (in-process) + L2 (SQL-backed, shared across
+ * serverless invocations) cache, but keyed per scoped+interpolated SQL text
+ * (which already embeds org_id/owner_email via query args) and with a much
+ * shorter TTL since this is the app's own live data, not an immutable
+ * warehouse result.
+ */
+
+interface L1Entry {
+  result: AnalyticsQueryResult;
+  createdAt: number;
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const MAX_L1_ENTRIES = 500;
+
+const l1Cache = new Map<string, L1Entry>();
+// De-dupes identical concurrent cache misses (e.g. the same panel query fired
+// by several viewers, or by the report capture's 4-panel concurrent window)
+// so only one of them actually hits the database.
+const inFlight = new Map<string, Promise<AnalyticsQueryResult>>();
+
+export function firstPartyCacheKey(
+  scopedSql: string,
+  args: Array<string | null>,
+): string {
+  return createHash("sha256")
+    .update(`${scopedSql}\n${JSON.stringify(args)}`)
+    .digest("hex");
+}
+
+function getL1(key: string): AnalyticsQueryResult | null {
+  const entry = l1Cache.get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.createdAt > CACHE_TTL_MS) {
+    l1Cache.delete(key);
+    return null;
+  }
+  return entry.result;
+}
+
+function setL1(key: string, result: AnalyticsQueryResult): void {
+  if (l1Cache.size >= MAX_L1_ENTRIES) {
+    const oldest = l1Cache.keys().next().value;
+    if (oldest) l1Cache.delete(oldest);
+  }
+  l1Cache.set(key, { result, createdAt: Date.now() });
+}
+
+async function getL2(key: string): Promise<AnalyticsQueryResult | null> {
+  try {
+    const db = getDbExec();
+    const nowIso = new Date().toISOString();
+    const { rows } = await db.execute({
+      sql: "SELECT result FROM first_party_analytics_cache WHERE key = ? AND expires_at > ?",
+      args: [key, nowIso],
+    });
+    if (!rows.length) return null;
+    const raw = (rows[0] as { result: string }).result;
+    return JSON.parse(raw) as AnalyticsQueryResult;
+  } catch (err) {
+    console.warn("[first-party-analytics] L2 cache read failed:", err);
+    return null;
+  }
+}
+
+async function setL2(
+  key: string,
+  sql: string,
+  result: AnalyticsQueryResult,
+): Promise<void> {
+  try {
+    const db = getDbExec();
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + CACHE_TTL_MS);
+    const serialized = JSON.stringify(result);
+    // Upsert via delete+insert to stay dialect-agnostic (SQLite/Postgres).
+    await db.execute({
+      sql: "DELETE FROM first_party_analytics_cache WHERE key = ?",
+      args: [key],
+    });
+    await db.execute({
+      sql: "INSERT INTO first_party_analytics_cache (key, sql, result, created_at, expires_at) VALUES (?, ?, ?, ?, ?)",
+      args: [key, sql, serialized, now.toISOString(), expiresAt.toISOString()],
+    });
+    // Opportunistically prune expired rows so the table doesn't grow
+    // unbounded — the keyspace is effectively every distinct panel/filter
+    // combination. Run ~1% of the time to avoid thrashing on every write.
+    if (Math.random() < 0.01) {
+      await db.execute({
+        sql: "DELETE FROM first_party_analytics_cache WHERE expires_at <= ?",
+        args: [now.toISOString()],
+      });
+    }
+  } catch (err) {
+    console.warn("[first-party-analytics] L2 cache write failed:", err);
+  }
+}
+
+/**
+ * Returns a cached result for (key, sql) if fresh, otherwise runs `compute`
+ * exactly once — even under concurrent callers with the same key — and
+ * caches the result.
+ */
+export async function withFirstPartyCache(
+  key: string,
+  sql: string,
+  compute: () => Promise<AnalyticsQueryResult>,
+): Promise<AnalyticsQueryResult> {
+  const l1Hit = getL1(key);
+  if (l1Hit) return l1Hit;
+
+  const existing = inFlight.get(key);
+  if (existing) return existing;
+
+  // Register the in-flight promise synchronously (before any `await`) so two
+  // callers racing on the same key can't both slip past the check above and
+  // both hit L2/compute.
+  const promise = (async () => {
+    const l2Hit = await getL2(key);
+    if (l2Hit) {
+      setL1(key, l2Hit);
+      return l2Hit;
+    }
+    const result = await compute();
+    setL1(key, result);
+    await setL2(key, sql, result);
+    return result;
+  })().finally(() => {
+    inFlight.delete(key);
+  });
+  inFlight.set(key, promise);
+  return promise;
+}

--- a/templates/analytics/server/lib/first-party-analytics-cache.ts
+++ b/templates/analytics/server/lib/first-party-analytics-cache.ts
@@ -33,6 +33,10 @@ const l1Cache = new Map<string, L1Entry>();
 // so only one of them actually hits the database.
 const inFlight = new Map<string, Promise<AnalyticsQueryResult>>();
 
+export interface FirstPartyCacheOptions {
+  timeoutMs?: number;
+}
+
 export function firstPartyCacheKey(
   scopedSql: string,
   args: Array<string | null>,
@@ -60,13 +64,17 @@ function setL1(key: string, result: AnalyticsQueryResult): void {
   l1Cache.set(key, { result, createdAt: Date.now() });
 }
 
-async function getL2(key: string): Promise<AnalyticsQueryResult | null> {
+async function getL2(
+  key: string,
+  timeoutMs?: number,
+): Promise<AnalyticsQueryResult | null> {
   try {
     const db = getDbExec();
     const nowIso = new Date().toISOString();
     const { rows } = await db.execute({
       sql: "SELECT result FROM first_party_analytics_cache WHERE key = ? AND expires_at > ?",
       args: [key, nowIso],
+      timeoutMs,
     });
     if (!rows.length) return null;
     const raw = (rows[0] as { result: string }).result;
@@ -81,6 +89,7 @@ async function setL2(
   key: string,
   sql: string,
   result: AnalyticsQueryResult,
+  timeoutMs?: number,
 ): Promise<void> {
   try {
     const db = getDbExec();
@@ -91,10 +100,12 @@ async function setL2(
     await db.execute({
       sql: "DELETE FROM first_party_analytics_cache WHERE key = ?",
       args: [key],
+      timeoutMs,
     });
     await db.execute({
       sql: "INSERT INTO first_party_analytics_cache (key, sql, result, created_at, expires_at) VALUES (?, ?, ?, ?, ?)",
       args: [key, sql, serialized, now.toISOString(), expiresAt.toISOString()],
+      timeoutMs,
     });
     // Opportunistically prune expired rows so the table doesn't grow
     // unbounded — the keyspace is effectively every distinct panel/filter
@@ -103,6 +114,7 @@ async function setL2(
       await db.execute({
         sql: "DELETE FROM first_party_analytics_cache WHERE expires_at <= ?",
         args: [now.toISOString()],
+        timeoutMs,
       });
     }
   } catch (err) {
@@ -119,6 +131,7 @@ export async function withFirstPartyCache(
   key: string,
   sql: string,
   compute: () => Promise<AnalyticsQueryResult>,
+  options: FirstPartyCacheOptions = {},
 ): Promise<AnalyticsQueryResult> {
   const l1Hit = getL1(key);
   if (l1Hit) return l1Hit;
@@ -130,14 +143,14 @@ export async function withFirstPartyCache(
   // callers racing on the same key can't both slip past the check above and
   // both hit L2/compute.
   const promise = (async () => {
-    const l2Hit = await getL2(key);
+    const l2Hit = await getL2(key, options.timeoutMs);
     if (l2Hit) {
       setL1(key, l2Hit);
       return l2Hit;
     }
     const result = await compute();
     setL1(key, result);
-    await setL2(key, sql, result);
+    await setL2(key, sql, result, options.timeoutMs);
     return result;
   })().finally(() => {
     inFlight.delete(key);

--- a/templates/analytics/server/lib/first-party-analytics-cache.ts
+++ b/templates/analytics/server/lib/first-party-analytics-cache.ts
@@ -33,6 +33,10 @@ const l1Cache = new Map<string, L1Entry>();
 // so only one of them actually hits the database.
 const inFlight = new Map<string, Promise<AnalyticsQueryResult>>();
 
+function inFlightKey(key: string, timeoutMs?: number): string {
+  return `${key}:${timeoutMs ?? "unbounded"}`;
+}
+
 export interface FirstPartyCacheOptions {
   timeoutMs?: number;
 }
@@ -136,7 +140,10 @@ export async function withFirstPartyCache(
   const l1Hit = getL1(key);
   if (l1Hit) return l1Hit;
 
-  const existing = inFlight.get(key);
+  // A report prewarm may have a shorter deadline than a normal panel request;
+  // never let those callers inherit one another's database timeout.
+  const requestKey = inFlightKey(key, options.timeoutMs);
+  const existing = inFlight.get(requestKey);
   if (existing) return existing;
 
   // Register the in-flight promise synchronously (before any `await`) so two
@@ -153,8 +160,8 @@ export async function withFirstPartyCache(
     await setL2(key, sql, result, options.timeoutMs);
     return result;
   })().finally(() => {
-    inFlight.delete(key);
+    inFlight.delete(requestKey);
   });
-  inFlight.set(key, promise);
+  inFlight.set(requestKey, promise);
   return promise;
 }

--- a/templates/analytics/server/lib/first-party-analytics.spec.ts
+++ b/templates/analytics/server/lib/first-party-analytics.spec.ts
@@ -142,7 +142,7 @@ describe("scopedAnalyticsSql", () => {
 });
 
 describe("queryFirstPartyAnalytics", () => {
-  it("gives an idempotent first-party read a 30 second, single-attempt budget", async () => {
+  it("gives an idempotent first-party read a 45 second, single-attempt budget", async () => {
     execute.mockResolvedValue({ rows: [{ count: "1" }], rowsAffected: 0 });
 
     await queryFirstPartyAnalytics(
@@ -152,7 +152,7 @@ describe("queryFirstPartyAnalytics", () => {
 
     expect(execute).toHaveBeenCalledWith(
       expect.objectContaining({
-        timeoutMs: 30_000,
+        timeoutMs: 45_000,
         maxAttempts: 1,
       }),
     );

--- a/templates/analytics/server/lib/first-party-analytics.spec.ts
+++ b/templates/analytics/server/lib/first-party-analytics.spec.ts
@@ -142,7 +142,7 @@ describe("scopedAnalyticsSql", () => {
 });
 
 describe("queryFirstPartyAnalytics", () => {
-  it("gives an idempotent first-party read a 45 second, single-attempt budget", async () => {
+  it("keeps ad-hoc first-party reads uncached", async () => {
     execute.mockResolvedValue({ rows: [{ count: "1" }], rowsAffected: 0 });
 
     await queryFirstPartyAnalytics(
@@ -150,10 +150,36 @@ describe("queryFirstPartyAnalytics", () => {
       { userEmail: "alice@example.com", orgId: null },
     );
 
+    expect(execute).toHaveBeenCalledTimes(1);
     expect(execute).toHaveBeenCalledWith(
       expect.objectContaining({
         timeoutMs: 45_000,
         maxAttempts: 1,
+      }),
+    );
+  });
+
+  it("caches dashboard-panel reads only when explicitly requested", async () => {
+    const random = vi.spyOn(Math, "random").mockReturnValue(1);
+    execute.mockImplementation(async ({ sql }: { sql: string }) =>
+      sql.includes("first_party_analytics_cache")
+        ? { rows: [], rowsAffected: 0 }
+        : { rows: [{ count: "1" }], rowsAffected: 0 },
+    );
+
+    try {
+      const query = "SELECT COUNT(*) AS count FROM analytics_events";
+      const scope = { userEmail: "cached@example.com", orgId: null };
+      await queryFirstPartyAnalytics(query, scope, { cache: true });
+      await queryFirstPartyAnalytics(query, scope, { cache: true });
+    } finally {
+      random.mockRestore();
+    }
+
+    expect(execute).toHaveBeenCalledTimes(4);
+    expect(execute.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        sql: expect.stringContaining("first_party_analytics_cache"),
       }),
     );
   });

--- a/templates/analytics/server/lib/first-party-analytics.ts
+++ b/templates/analytics/server/lib/first-party-analytics.ts
@@ -33,6 +33,13 @@ export interface AnalyticsQueryResult {
   schema: { name: string; type: string }[];
 }
 
+export interface AnalyticsQueryOptions {
+  /** Cache only callers with a stable dashboard-panel lifecycle. */
+  cache?: boolean;
+  /** Bound the database work for callers with a smaller delivery deadline. */
+  timeoutMs?: number;
+}
+
 const MAX_EVENTS_PER_REQUEST = 100;
 const MAX_QUERY_ROWS = 5_000;
 const FIRST_PARTY_QUERY_TABLES = new Set([
@@ -640,23 +647,30 @@ function inferSchema(rows: Record<string, unknown>[]): {
 export async function queryFirstPartyAnalytics(
   sql: string,
   scope: AnalyticsScope,
+  options: AnalyticsQueryOptions = {},
 ): Promise<AnalyticsQueryResult> {
   validateFirstPartyAnalyticsSql(sql);
   const scoped = scopedAnalyticsSql(sql, scope);
   const wrappedSql = `SELECT * FROM (${scoped.sql}) AS first_party_analytics_query LIMIT ${MAX_QUERY_ROWS}`;
+  const timeoutMs = Math.max(
+    1,
+    options.timeoutMs ?? FIRST_PARTY_ANALYTICS_QUERY_TIMEOUT_MS,
+  );
   // The cache key is the fully scoped SQL + args, which already embeds
   // org_id/owner_email (see scopeClause) — a cache hit can only ever return
   // rows the same tenant was already entitled to query.
   const cacheKey = firstPartyCacheKey(wrappedSql, scoped.args);
-  return withFirstPartyCache(cacheKey, wrappedSql, async () => {
+  const compute = async (): Promise<AnalyticsQueryResult> => {
     const exec = getDbExec();
     const result = await exec.execute({
       sql: wrappedSql,
       args: scoped.args,
-      timeoutMs: FIRST_PARTY_ANALYTICS_QUERY_TIMEOUT_MS,
+      timeoutMs,
       maxAttempts: 1,
     });
     const rows = result.rows as Record<string, unknown>[];
     return { rows, schema: inferSchema(rows) };
-  });
+  };
+  if (!options.cache) return compute();
+  return withFirstPartyCache(cacheKey, wrappedSql, compute, { timeoutMs });
 }

--- a/templates/analytics/server/lib/first-party-analytics.ts
+++ b/templates/analytics/server/lib/first-party-analytics.ts
@@ -8,6 +8,10 @@ import {
   ingestAnalyticsExceptionEvents,
   type DerivedExceptionFields,
 } from "./error-capture.js";
+import {
+  firstPartyCacheKey,
+  withFirstPartyCache,
+} from "./first-party-analytics-cache.js";
 
 export interface AnalyticsScope {
   userEmail: string;
@@ -639,13 +643,20 @@ export async function queryFirstPartyAnalytics(
 ): Promise<AnalyticsQueryResult> {
   validateFirstPartyAnalyticsSql(sql);
   const scoped = scopedAnalyticsSql(sql, scope);
-  const exec = getDbExec();
-  const result = await exec.execute({
-    sql: `SELECT * FROM (${scoped.sql}) AS first_party_analytics_query LIMIT ${MAX_QUERY_ROWS}`,
-    args: scoped.args,
-    timeoutMs: FIRST_PARTY_ANALYTICS_QUERY_TIMEOUT_MS,
-    maxAttempts: 1,
+  const wrappedSql = `SELECT * FROM (${scoped.sql}) AS first_party_analytics_query LIMIT ${MAX_QUERY_ROWS}`;
+  // The cache key is the fully scoped SQL + args, which already embeds
+  // org_id/owner_email (see scopeClause) — a cache hit can only ever return
+  // rows the same tenant was already entitled to query.
+  const cacheKey = firstPartyCacheKey(wrappedSql, scoped.args);
+  return withFirstPartyCache(cacheKey, wrappedSql, async () => {
+    const exec = getDbExec();
+    const result = await exec.execute({
+      sql: wrappedSql,
+      args: scoped.args,
+      timeoutMs: FIRST_PARTY_ANALYTICS_QUERY_TIMEOUT_MS,
+      maxAttempts: 1,
+    });
+    const rows = result.rows as Record<string, unknown>[];
+    return { rows, schema: inferSchema(rows) };
   });
-  const rows = result.rows as Record<string, unknown>[];
-  return { rows, schema: inferSchema(rows) };
 }

--- a/templates/analytics/server/lib/first-party-dashboard-repair.spec.ts
+++ b/templates/analytics/server/lib/first-party-dashboard-repair.spec.ts
@@ -50,7 +50,10 @@ vi.mock("../db/index.js", () => ({
 }));
 
 import { LEGACY_NEW_VS_RECURRING_USERS_SQL } from "./canonical-first-party-dashboard-repair";
-import { repairPersistedFirstPartyDashboardQueries } from "./first-party-dashboard-repair";
+import {
+  repairPersistedFirstPartyDashboardQueries,
+  repairUnboundedFirstPartyPanelsAcrossDashboards,
+} from "./first-party-dashboard-repair";
 import {
   FIRST_PARTY_DASHBOARD_ID,
   INTERMEDIATE_RECURRING_USERS_BY_TEMPLATE_SQL,
@@ -59,6 +62,7 @@ import {
   LEGACY_SIGNUPS_OVER_TIME_SQL,
   buildPanel,
 } from "./first-party-metric-catalog";
+import { UNBOUNDED_FIRST_PARTY_PANEL_FIXES } from "./first-party-unbounded-panel-repair";
 
 function requiredFirstPartyPanel(
   id: string,
@@ -439,6 +443,79 @@ describe("repairPersistedFirstPartyDashboardQueries", () => {
       column: "id",
       value: FIRST_PARTY_DASHBOARD_ID,
     });
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("repairUnboundedFirstPartyPanelsAcrossDashboards", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-25T17:00:00.000Z"));
+    dbMocks.getDb.mockReset();
+    dbMocks.recordChange.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("repairs a non-canonical dashboard whose panel SQL matches a known-unbounded pattern", async () => {
+    const [{ legacySql }] = UNBOUNDED_FIRST_PARTY_PANEL_FIXES;
+    const row = {
+      id: "someone-elses-dashboard",
+      kind: "sql",
+      config: JSON.stringify({
+        panels: [
+          {
+            id: "sessions",
+            title: "Sessions",
+            source: "first-party",
+            chartType: "line",
+            width: 2,
+            sql: legacySql,
+          },
+        ],
+      }),
+      title: "Someone Else's Dashboard",
+      updatedAt: "2026-07-24T00:00:00.000Z",
+      ownerEmail: "nicholas@builder.io",
+      orgId: "builder",
+      visibility: "org" as const,
+    };
+    const mocks = createDb(row, [{ id: row.id }]);
+    dbMocks.getDb.mockReturnValue(mocks.db);
+
+    const repairedCount =
+      await repairUnboundedFirstPartyPanelsAcrossDashboards();
+
+    expect(repairedCount).toBe(1);
+    expect(mocks.update).toHaveBeenCalledOnce();
+    expect(mocks.insert).toHaveBeenCalledOnce();
+    expect(dbMocks.recordChange).toHaveBeenCalledWith(
+      expect.objectContaining({ key: row.id, orgId: "builder" }),
+    );
+  });
+
+  it("does not update a dashboard with no unbounded first-party panels", async () => {
+    const row = {
+      id: "already-fine",
+      kind: "sql",
+      config: JSON.stringify({
+        panels: [{ id: "p", source: "first-party", sql: "SELECT 1" }],
+      }),
+      title: "Already Fine",
+      updatedAt: "2026-07-24T00:00:00.000Z",
+      ownerEmail: "nicholas@builder.io",
+      orgId: null,
+      visibility: "private" as const,
+    };
+    const mocks = createDb(row);
+    dbMocks.getDb.mockReturnValue(mocks.db);
+
+    const repairedCount =
+      await repairUnboundedFirstPartyPanelsAcrossDashboards();
+
+    expect(repairedCount).toBe(0);
     expect(mocks.update).not.toHaveBeenCalled();
   });
 });

--- a/templates/analytics/server/lib/first-party-dashboard-repair.ts
+++ b/templates/analytics/server/lib/first-party-dashboard-repair.ts
@@ -6,35 +6,41 @@ import { and, desc, eq } from "drizzle-orm";
 import { getDb, schema } from "../db/index.js";
 import { repairCanonicalFirstPartyDashboardQueries } from "./canonical-first-party-dashboard-repair";
 import { FIRST_PARTY_DASHBOARD_ID } from "./first-party-metric-catalog";
+import { repairUnboundedFirstPartyPanels } from "./first-party-unbounded-panel-repair.js";
 
-export async function repairPersistedFirstPartyDashboardQueries(): Promise<boolean> {
-  // guard:allow-unscoped — startup repair targets one fixed canonical dashboard
-  // and only replaces the exact shipped legacy SQL under an optimistic fence.
+type DashboardRepairRow = {
+  id: string;
+  config: string;
+  kind: string;
+  title: string;
+  updatedAt: string;
+  ownerEmail: string;
+  orgId: string | null;
+  visibility: string;
+};
+
+/**
+ * Apply `repairFn` to one already-fetched dashboard row inside a transaction,
+ * guarded by an optimistic-concurrency fence on (config, updatedAt) so a
+ * concurrent human/agent edit always wins over the repair. Snapshots the
+ * pre-repair config into dashboard_revisions (bounded to the 50 most recent)
+ * before committing, so any repair is one click away from undo.
+ */
+async function applyRepairToDashboardRow(
+  row: DashboardRepairRow,
+  repairFn: (config: Record<string, unknown>) => {
+    config: Record<string, unknown>;
+    changed: boolean;
+  },
+): Promise<boolean> {
   const db = getDb() as any;
-  const [row] = await db
-    .select({
-      id: schema.dashboards.id,
-      config: schema.dashboards.config,
-      kind: schema.dashboards.kind,
-      title: schema.dashboards.title,
-      updatedAt: schema.dashboards.updatedAt,
-      ownerEmail: schema.dashboards.ownerEmail,
-      orgId: schema.dashboards.orgId,
-      visibility: schema.dashboards.visibility,
-    })
-    .from(schema.dashboards)
-    .where(eq(schema.dashboards.id, FIRST_PARTY_DASHBOARD_ID));
-  if (!row || row.kind !== "sql" || typeof row.config !== "string") {
-    return false;
-  }
-
   let config: Record<string, unknown>;
   try {
     config = JSON.parse(row.config) as Record<string, unknown>;
   } catch {
     return false;
   }
-  const repaired = repairCanonicalFirstPartyDashboardQueries(config);
+  const repaired = repairFn(config);
   if (!repaired.changed) return false;
 
   const repairedAt = new Date().toISOString();
@@ -49,7 +55,7 @@ export async function repairPersistedFirstPartyDashboardQueries(): Promise<boole
       })
       .where(
         and(
-          eq(schema.dashboards.id, FIRST_PARTY_DASHBOARD_ID),
+          eq(schema.dashboards.id, row.id),
           eq(schema.dashboards.config, row.config),
           eq(schema.dashboards.updatedAt, row.updatedAt),
         ),
@@ -104,9 +110,84 @@ export async function repairPersistedFirstPartyDashboardQueries(): Promise<boole
     });
   } catch (err) {
     console.warn(
-      "[db] Canonical dashboard repair committed without a live change event:",
+      "[db] Dashboard repair committed without a live change event:",
       err instanceof Error ? err.message : err,
     );
   }
   return true;
+}
+
+export async function repairPersistedFirstPartyDashboardQueries(): Promise<boolean> {
+  // guard:allow-unscoped — startup repair targets one fixed canonical dashboard
+  // and only replaces the exact shipped legacy SQL under an optimistic fence.
+  const db = getDb() as any;
+  const [row] = await db
+    .select({
+      id: schema.dashboards.id,
+      config: schema.dashboards.config,
+      kind: schema.dashboards.kind,
+      title: schema.dashboards.title,
+      updatedAt: schema.dashboards.updatedAt,
+      ownerEmail: schema.dashboards.ownerEmail,
+      orgId: schema.dashboards.orgId,
+      visibility: schema.dashboards.visibility,
+    })
+    .from(schema.dashboards)
+    .where(eq(schema.dashboards.id, FIRST_PARTY_DASHBOARD_ID));
+  if (!row || row.kind !== "sql" || typeof row.config !== "string") {
+    return false;
+  }
+  return applyRepairToDashboardRow(
+    row,
+    repairCanonicalFirstPartyDashboardQueries,
+  );
+}
+
+/**
+ * Scan every SQL dashboard (not just the one canonical dashboard above) for
+ * first-party panels whose SQL exactly matches a known-unbounded pattern —
+ * see first-party-unbounded-panel-repair.ts for how these were found (a
+ * full-org audit, 2026-07-25) and why exact-string matching, not a general
+ * SQL rewrite, is the safe way to fix panels this repair didn't author.
+ * Returns the number of dashboards actually changed.
+ */
+export async function repairUnboundedFirstPartyPanelsAcrossDashboards(): Promise<number> {
+  // guard:allow-unscoped — this is an org-wide startup repair: it may touch
+  // any dashboard's persisted panel SQL, but only ever replaces an exact
+  // known-bad SQL string under the same optimistic (config, updatedAt) fence
+  // used by the canonical repair above, so a concurrent edit always wins.
+  const db = getDb() as any;
+  const rows = await db
+    .select({
+      id: schema.dashboards.id,
+      config: schema.dashboards.config,
+      kind: schema.dashboards.kind,
+      title: schema.dashboards.title,
+      updatedAt: schema.dashboards.updatedAt,
+      ownerEmail: schema.dashboards.ownerEmail,
+      orgId: schema.dashboards.orgId,
+      visibility: schema.dashboards.visibility,
+    })
+    .from(schema.dashboards)
+    .where(eq(schema.dashboards.kind, "sql"));
+
+  let repairedCount = 0;
+  for (const row of rows as DashboardRepairRow[]) {
+    if (typeof row.config !== "string") continue;
+    try {
+      const wasRepaired = await applyRepairToDashboardRow(
+        row,
+        repairUnboundedFirstPartyPanels,
+      );
+      if (wasRepaired) repairedCount += 1;
+    } catch (err) {
+      // One dashboard's malformed config or a lost optimistic-concurrency
+      // race must not block repairing every other dashboard.
+      console.warn(
+        `[db] Unbounded first-party panel repair failed for dashboard "${row.id}" (non-fatal):`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+  return repairedCount;
 }

--- a/templates/analytics/server/lib/first-party-dashboard-repair.ts
+++ b/templates/analytics/server/lib/first-party-dashboard-repair.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 
+import { getDialect } from "@agent-native/core/db";
 import { recordChange } from "@agent-native/core/server";
 import { and, desc, eq } from "drizzle-orm";
 
@@ -157,6 +158,7 @@ export async function repairUnboundedFirstPartyPanelsAcrossDashboards(): Promise
   // known-bad SQL string under the same optimistic (config, updatedAt) fence
   // used by the canonical repair above, so a concurrent edit always wins.
   const db = getDb() as any;
+  const dialect = getDialect();
   const rows = await db
     .select({
       id: schema.dashboards.id,
@@ -175,9 +177,8 @@ export async function repairUnboundedFirstPartyPanelsAcrossDashboards(): Promise
   for (const row of rows as DashboardRepairRow[]) {
     if (typeof row.config !== "string") continue;
     try {
-      const wasRepaired = await applyRepairToDashboardRow(
-        row,
-        repairUnboundedFirstPartyPanels,
+      const wasRepaired = await applyRepairToDashboardRow(row, (config) =>
+        repairUnboundedFirstPartyPanels(config, dialect),
       );
       if (wasRepaired) repairedCount += 1;
     } catch (err) {

--- a/templates/analytics/server/lib/first-party-unbounded-panel-repair.spec.ts
+++ b/templates/analytics/server/lib/first-party-unbounded-panel-repair.spec.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { validateFirstPartyDashboardTimeScope } from "./dashboard-time-scope";
+import {
+  UNBOUNDED_FIRST_PARTY_PANEL_FIXES,
+  repairUnboundedFirstPartyPanels,
+} from "./first-party-unbounded-panel-repair";
+
+describe("repairUnboundedFirstPartyPanels", () => {
+  it("rewrites a matching first-party panel's SQL and leaves everything else untouched", () => {
+    const [{ legacySql, sql: fixedSql }] = UNBOUNDED_FIRST_PARTY_PANEL_FIXES;
+    const config = {
+      name: "Some Dashboard",
+      panels: [
+        { id: "kept", source: "bigquery", sql: "SELECT 1" },
+        {
+          id: "broken",
+          title: "Broken panel",
+          source: "first-party",
+          chartType: "line",
+          width: 2,
+          sql: legacySql,
+        },
+      ],
+    };
+
+    const result = repairUnboundedFirstPartyPanels(config);
+
+    expect(result.changed).toBe(true);
+    const panels = result.config.panels as Record<string, unknown>[];
+    expect(panels[0]).toEqual(config.panels[0]);
+    expect(panels[1]).toMatchObject({ id: "broken", sql: fixedSql });
+  });
+
+  it("is a no-op when no panel SQL matches a known-unbounded pattern", () => {
+    const config = {
+      panels: [{ id: "fine", source: "first-party", sql: "SELECT 1 AS one" }],
+    };
+    const result = repairUnboundedFirstPartyPanels(config);
+    expect(result.changed).toBe(false);
+    expect(result.config).toBe(config);
+  });
+
+  it("ignores non-first-party panels even if their SQL text happens to match", () => {
+    const [{ legacySql }] = UNBOUNDED_FIRST_PARTY_PANEL_FIXES;
+    const config = {
+      panels: [{ id: "p", source: "bigquery", sql: legacySql }],
+    };
+    const result = repairUnboundedFirstPartyPanels(config);
+    expect(result.changed).toBe(false);
+  });
+
+  it("every fixed replacement passes the strengthened per-scan-unit time-scope guard", () => {
+    for (const { sql } of UNBOUNDED_FIRST_PARTY_PANEL_FIXES) {
+      const panel = { source: "first-party", sql, config: {} };
+      const dashboard = {
+        filters: [
+          {
+            id: "timeRange",
+            type: "select",
+            default: "90d",
+          },
+          {
+            id: "date",
+            type: "date-range",
+            default: "90d",
+          },
+          {
+            id: "emailFilter",
+            type: "select",
+            default: "exclude_builder",
+          },
+        ],
+      };
+      expect(
+        validateFirstPartyDashboardTimeScope(panel, dashboard, 0),
+      ).toBeNull();
+    }
+  });
+});

--- a/templates/analytics/server/lib/first-party-unbounded-panel-repair.spec.ts
+++ b/templates/analytics/server/lib/first-party-unbounded-panel-repair.spec.ts
@@ -32,6 +32,20 @@ describe("repairUnboundedFirstPartyPanels", () => {
     expect(panels[1]).toMatchObject({ id: "broken", sql: fixedSql });
   });
 
+  it("uses SQLite date syntax for SQLite dashboard databases", () => {
+    const [{ legacySql }] = UNBOUNDED_FIRST_PARTY_PANEL_FIXES;
+    const result = repairUnboundedFirstPartyPanels(
+      {
+        panels: [{ source: "first-party", sql: legacySql }],
+      },
+      "sqlite",
+    );
+
+    const panels = result.config.panels as Record<string, unknown>[];
+    expect(panels[0]?.sql).toContain("date('now', '-365 days')");
+    expect(panels[0]?.sql).not.toContain("to_char(CURRENT_DATE");
+  });
+
   it("is a no-op when no panel SQL matches a known-unbounded pattern", () => {
     const config = {
       panels: [{ id: "fine", source: "first-party", sql: "SELECT 1 AS one" }],

--- a/templates/analytics/server/lib/first-party-unbounded-panel-repair.ts
+++ b/templates/analytics/server/lib/first-party-unbounded-panel-repair.ts
@@ -1,0 +1,156 @@
+import type { DashboardPanelLike } from "./dashboard-time-scope.js";
+
+/**
+ * Fixes for first-party dashboard panels found, via a full-org audit
+ * (2026-07-25), reading `analytics_events` with no date bound at all in some
+ * or all of their scan units — a full 6.7M-row table scan on every render.
+ * Unlike the id-keyed replacements in first-party-metric-catalog.ts (which
+ * repair one specific dashboard's known panel ids), these are matched purely
+ * by exact SQL text so the same fix applies wherever the identical broken
+ * query was cloned into a different dashboard under a different panel id.
+ * Each entry only changes the added bound (`AND event_date >= ...365 days`,
+ * or the exact same bound already live on the repaired canonical dashboard
+ * for the retention-cohort case) — never the query's selected columns,
+ * grouping, or business logic.
+ */
+export type UnboundedFirstPartyPanelFix = {
+  legacySql: string;
+  sql: string;
+};
+
+export const UNBOUNDED_FIRST_PARTY_PANEL_FIXES: readonly UnboundedFirstPartyPanelFix[] =
+  [
+    {
+      legacySql:
+        "SELECT event_date AS date, COUNT(*) AS count FROM analytics_events WHERE event_name = 'session status' GROUP BY event_date ORDER BY date",
+      sql: "SELECT event_date AS date, COUNT(*) AS count FROM analytics_events WHERE event_name = 'session status' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') GROUP BY event_date ORDER BY date",
+    },
+    {
+      legacySql:
+        "SELECT COALESCE(NULLIF(signed_in, ''), 'unknown') AS signed_in, COUNT(*) AS count FROM analytics_events WHERE event_name = 'session status' GROUP BY COALESCE(NULLIF(signed_in, ''), 'unknown') ORDER BY signed_in",
+      sql: "SELECT COALESCE(NULLIF(signed_in, ''), 'unknown') AS signed_in, COUNT(*) AS count FROM analytics_events WHERE event_name = 'session status' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') GROUP BY COALESCE(NULLIF(signed_in, ''), 'unknown') ORDER BY signed_in",
+    },
+    {
+      legacySql:
+        "SELECT COALESCE(NULLIF(app, ''), 'unknown') AS app, COUNT(*) AS count FROM analytics_events WHERE event_name = 'session status' GROUP BY COALESCE(NULLIF(app, ''), 'unknown') ORDER BY count DESC LIMIT 20",
+      sql: "SELECT COALESCE(NULLIF(app, ''), 'unknown') AS app, COUNT(*) AS count FROM analytics_events WHERE event_name = 'session status' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') GROUP BY COALESCE(NULLIF(app, ''), 'unknown') ORDER BY count DESC LIMIT 20",
+    },
+    {
+      legacySql:
+        "SELECT COUNT(*) AS count FROM analytics_events WHERE event_name = 'skills_cli started'",
+      sql: "SELECT COUNT(*) AS count FROM analytics_events WHERE event_name = 'skills_cli started' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD')",
+    },
+    {
+      legacySql:
+        "SELECT COUNT(DISTINCT anonymous_id) AS count FROM analytics_events WHERE event_name LIKE 'skills_cli %'",
+      sql: "SELECT COUNT(DISTINCT anonymous_id) AS count FROM analytics_events WHERE event_name LIKE 'skills_cli %' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD')",
+    },
+    {
+      legacySql:
+        "SELECT COUNT(DISTINCT session_id) AS count FROM analytics_events WHERE event_name = 'skills_cli install completed'",
+      sql: "SELECT COUNT(DISTINCT session_id) AS count FROM analytics_events WHERE event_name = 'skills_cli install completed' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD')",
+    },
+    {
+      legacySql:
+        "WITH started AS (SELECT COUNT(DISTINCT session_id) AS n FROM analytics_events WHERE event_name = 'skills_cli started'), completed AS (SELECT COUNT(DISTINCT session_id) AS n FROM analytics_events WHERE event_name = 'skills_cli install completed') SELECT CASE WHEN started.n = 0 THEN 0 ELSE ROUND(completed.n * 100.0 / started.n) END AS rate FROM started, completed",
+      sql: "WITH started AS (SELECT COUNT(DISTINCT session_id) AS n FROM analytics_events WHERE event_name = 'skills_cli started' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD')), completed AS (SELECT COUNT(DISTINCT session_id) AS n FROM analytics_events WHERE event_name = 'skills_cli install completed' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD')) SELECT CASE WHEN started.n = 0 THEN 0 ELSE ROUND(completed.n * 100.0 / started.n) END AS rate FROM started, completed",
+    },
+    {
+      legacySql:
+        "WITH steps AS (SELECT 1 AS step_order, 'Started' AS step, COUNT(DISTINCT session_id) AS count FROM analytics_events WHERE event_name = 'skills_cli started' UNION ALL SELECT 2, 'Skills prompted', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli skills prompted' UNION ALL SELECT 3, 'Skills selected', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli skills selected' UNION ALL SELECT 4, 'Clients selected', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli clients selected' UNION ALL SELECT 5, 'Scope selected', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli scope selected' UNION ALL SELECT 6, 'Install completed', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli install completed' UNION ALL SELECT 7, 'Completed', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli completed') SELECT step, count FROM steps ORDER BY step_order",
+      sql: "WITH steps AS (SELECT 1 AS step_order, 'Started' AS step, COUNT(DISTINCT session_id) AS count FROM analytics_events WHERE event_name = 'skills_cli started' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') UNION ALL SELECT 2, 'Skills prompted', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli skills prompted' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') UNION ALL SELECT 3, 'Skills selected', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli skills selected' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') UNION ALL SELECT 4, 'Clients selected', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli clients selected' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') UNION ALL SELECT 5, 'Scope selected', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli scope selected' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') UNION ALL SELECT 6, 'Install completed', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli install completed' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') UNION ALL SELECT 7, 'Completed', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli completed' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD')) SELECT step, count FROM steps ORDER BY step_order",
+    },
+    {
+      legacySql:
+        "SELECT trim(s) AS skill, COUNT(*) AS count FROM analytics_events, LATERAL unnest(string_to_array(properties::jsonb ->> 'selected', ',')) AS s WHERE event_name = 'skills_cli skills selected' AND (properties::jsonb ->> 'selected') <> '' GROUP BY trim(s) ORDER BY count DESC LIMIT 30",
+      sql: "SELECT trim(s) AS skill, COUNT(*) AS count FROM analytics_events, LATERAL unnest(string_to_array(properties::jsonb ->> 'selected', ',')) AS s WHERE event_name = 'skills_cli skills selected' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') AND (properties::jsonb ->> 'selected') <> '' GROUP BY trim(s) ORDER BY count DESC LIMIT 30",
+    },
+    {
+      legacySql:
+        "SELECT substr(timestamp, 1, 10) AS date, COUNT(*) AS count FROM analytics_events WHERE event_name = 'skills_cli started' GROUP BY substr(timestamp, 1, 10) ORDER BY date",
+      sql: "SELECT substr(timestamp, 1, 10) AS date, COUNT(*) AS count FROM analytics_events WHERE event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') AND event_name = 'skills_cli started' GROUP BY substr(timestamp, 1, 10) ORDER BY date",
+    },
+    {
+      legacySql:
+        "SELECT COALESCE(NULLIF(properties::jsonb ->> 'cli', ''), 'unknown') AS cli, COUNT(*) AS count FROM analytics_events WHERE event_name = 'skills_cli started' GROUP BY COALESCE(NULLIF(properties::jsonb ->> 'cli', ''), 'unknown') ORDER BY count DESC",
+      sql: "SELECT COALESCE(NULLIF(properties::jsonb ->> 'cli', ''), 'unknown') AS cli, COUNT(*) AS count FROM analytics_events WHERE event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') AND event_name = 'skills_cli started' GROUP BY COALESCE(NULLIF(properties::jsonb ->> 'cli', ''), 'unknown') ORDER BY count DESC",
+    },
+    {
+      legacySql:
+        "SELECT COALESCE(NULLIF(properties::jsonb ->> 'platform', ''), 'unknown') AS platform, COUNT(*) AS count FROM analytics_events WHERE event_name = 'skills_cli started' GROUP BY COALESCE(NULLIF(properties::jsonb ->> 'platform', ''), 'unknown') ORDER BY count DESC",
+      sql: "SELECT COALESCE(NULLIF(properties::jsonb ->> 'platform', ''), 'unknown') AS platform, COUNT(*) AS count FROM analytics_events WHERE event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') AND event_name = 'skills_cli started' GROUP BY COALESCE(NULLIF(properties::jsonb ->> 'platform', ''), 'unknown') ORDER BY count DESC",
+    },
+    {
+      legacySql:
+        "SELECT COALESCE(NULLIF(properties::jsonb ->> 'scope', ''), 'unknown') AS scope, COUNT(*) AS count FROM analytics_events WHERE event_name = 'skills_cli scope selected' GROUP BY COALESCE(NULLIF(properties::jsonb ->> 'scope', ''), 'unknown') ORDER BY count DESC",
+      sql: "SELECT COALESCE(NULLIF(properties::jsonb ->> 'scope', ''), 'unknown') AS scope, COUNT(*) AS count FROM analytics_events WHERE event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') AND event_name = 'skills_cli scope selected' GROUP BY COALESCE(NULLIF(properties::jsonb ->> 'scope', ''), 'unknown') ORDER BY count DESC",
+    },
+    {
+      legacySql:
+        "SELECT trim(c) AS client, COUNT(*) AS count FROM analytics_events, LATERAL unnest(string_to_array(properties::jsonb ->> 'clients', ',')) AS c WHERE event_name = 'skills_cli clients selected' AND (properties::jsonb ->> 'clients') <> '' GROUP BY trim(c) ORDER BY count DESC LIMIT 30",
+      sql: "SELECT trim(c) AS client, COUNT(*) AS count FROM analytics_events, LATERAL unnest(string_to_array(properties::jsonb ->> 'clients', ',')) AS c WHERE event_name = 'skills_cli clients selected' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') AND (properties::jsonb ->> 'clients') <> '' GROUP BY trim(c) ORDER BY count DESC LIMIT 30",
+    },
+    {
+      legacySql:
+        "WITH steps AS (SELECT 1 AS step_order, 'Started' AS step, COUNT(DISTINCT session_id) AS reached FROM analytics_events WHERE event_name = 'skills_cli started' UNION ALL SELECT 2, 'Skills prompted', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli skills prompted' UNION ALL SELECT 3, 'Skills selected', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli skills selected' UNION ALL SELECT 4, 'Clients selected', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli clients selected' UNION ALL SELECT 5, 'Scope selected', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli scope selected' UNION ALL SELECT 6, 'Install completed', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli install completed' UNION ALL SELECT 7, 'Completed', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli completed'), start_total AS (SELECT COUNT(DISTINCT session_id) AS n FROM analytics_events WHERE event_name = 'skills_cli started') SELECT steps.step, steps.reached, CASE WHEN start_total.n = 0 THEN 0 ELSE ROUND(steps.reached * 100.0 / start_total.n) END AS pct_of_start FROM steps, start_total ORDER BY steps.step_order",
+      sql: "WITH steps AS (SELECT 1 AS step_order, 'Started' AS step, COUNT(DISTINCT session_id) AS reached FROM analytics_events WHERE event_name = 'skills_cli started' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') UNION ALL SELECT 2, 'Skills prompted', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli skills prompted' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') UNION ALL SELECT 3, 'Skills selected', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli skills selected' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') UNION ALL SELECT 4, 'Clients selected', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli clients selected' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') UNION ALL SELECT 5, 'Scope selected', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli scope selected' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') UNION ALL SELECT 6, 'Install completed', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli install completed' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') UNION ALL SELECT 7, 'Completed', COUNT(DISTINCT session_id) FROM analytics_events WHERE event_name = 'skills_cli completed' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD')), start_total AS (SELECT COUNT(DISTINCT session_id) AS n FROM analytics_events WHERE event_name = 'skills_cli started' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD')) SELECT steps.step, steps.reached, CASE WHEN start_total.n = 0 THEN 0 ELSE ROUND(steps.reached * 100.0 / start_total.n) END AS pct_of_start FROM steps, start_total ORDER BY steps.step_order",
+    },
+    {
+      legacySql: "SELECT COUNT(*) AS value FROM analytics_events",
+      sql: "SELECT COUNT(*) AS value FROM analytics_events WHERE event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD')",
+    },
+    {
+      legacySql:
+        "SELECT COUNT(DISTINCT session_id) AS value FROM analytics_events",
+      sql: "SELECT COUNT(DISTINCT session_id) AS value FROM analytics_events WHERE event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD')",
+    },
+    {
+      legacySql:
+        "SELECT event_name AS label, COUNT(*) AS value FROM analytics_events GROUP BY event_name ORDER BY value DESC LIMIT 8",
+      sql: "SELECT event_name AS label, COUNT(*) AS value FROM analytics_events WHERE event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') GROUP BY event_name ORDER BY value DESC LIMIT 8",
+    },
+    {
+      legacySql:
+        "SELECT CASE WHEN signed_in = 'true' THEN 'Signed In' ELSE 'Anonymous' END AS user_type, COUNT(*) AS events FROM analytics_events GROUP BY signed_in",
+      sql: "SELECT CASE WHEN signed_in = 'true' THEN 'Signed In' ELSE 'Anonymous' END AS user_type, COUNT(*) AS events FROM analytics_events WHERE event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') GROUP BY signed_in",
+    },
+    {
+      legacySql:
+        "SELECT timestamp, event_name, app, signed_in FROM analytics_events ORDER BY timestamp DESC LIMIT 50",
+      sql: "SELECT timestamp, event_name, app, signed_in FROM analytics_events WHERE event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD') ORDER BY timestamp DESC LIMIT 50",
+    },
+    {
+      legacySql:
+        "WITH base AS (SELECT NULLIF(user_key, '') AS user_key, event_date AS event_date, user_id FROM analytics_events WHERE event_name = 'session status' AND signed_in = 'true' AND NULLIF(user_key, '') IS NOT NULL AND lower(COALESCE(NULLIF(template, ''), NULLIF(properties::jsonb ->> 'templateId', ''), NULLIF(properties::jsonb ->> 'agent_native_template', ''), NULLIF(properties::jsonb ->> 'agentNativeTemplate', ''), NULLIF(app, ''), NULLIF(properties::jsonb ->> 'agent_native_app', ''), NULLIF(properties::jsonb ->> 'agentNativeApp', ''), 'unknown')) <> 'docs' AND ('{{emailFilter}}' IN ('', 'all') OR ('{{emailFilter}}' = 'exclude_builder' AND lower(coalesce(user_id, '')) NOT LIKE '%@builder.io') OR ('{{emailFilter}}' = 'only_builder' AND lower(coalesce(user_id, '')) LIKE '%@builder.io'))), first_seen AS (SELECT user_key, MIN(event_date) AS cohort_date FROM base GROUP BY user_key), anchor_dates AS (SELECT DISTINCT cohort_date AS date FROM first_seen WHERE cohort_date <= to_char(CURRENT_DATE - INTERVAL '14 days', 'YYYY-MM-DD') AND ('{{timeRange}}' IN ('', 'all') OR ('{{timeRange}}' = '7d' AND cohort_date >= to_char(CURRENT_DATE - INTERVAL '7 days', 'YYYY-MM-DD')) OR ('{{timeRange}}' = '30d' AND cohort_date >= to_char(CURRENT_DATE - INTERVAL '30 days', 'YYYY-MM-DD')) OR ('{{timeRange}}' = '90d' AND cohort_date >= to_char(CURRENT_DATE - INTERVAL '90 days', 'YYYY-MM-DD')) OR ('{{timeRange}}' = '180d' AND cohort_date >= to_char(CURRENT_DATE - INTERVAL '180 days', 'YYYY-MM-DD')) OR ('{{timeRange}}' = '365d' AND cohort_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD')))), cohort_windows AS (SELECT a.date, f.user_key, f.cohort_date FROM anchor_dates a JOIN first_seen f ON f.cohort_date >= to_char(a.date::date - INTERVAL '6 days', 'YYYY-MM-DD') AND f.cohort_date <= a.date), cohort_sizes AS (SELECT date, COUNT(DISTINCT user_key) AS users FROM cohort_windows GROUP BY date), periods AS (SELECT '1-7d return' AS period UNION ALL SELECT '7-14d return' AS period), retained AS (SELECT cw.date, '1-7d return' AS period, COUNT(DISTINCT cw.user_key) AS retained FROM cohort_windows cw JOIN base b ON b.user_key = cw.user_key AND b.event_date > cw.cohort_date AND b.event_date <= to_char(cw.cohort_date::date + INTERVAL '7 days', 'YYYY-MM-DD') GROUP BY cw.date UNION ALL SELECT cw.date, '7-14d return' AS period, COUNT(DISTINCT cw.user_key) AS retained FROM cohort_windows cw JOIN base b ON b.user_key = cw.user_key AND b.event_date >= to_char(cw.cohort_date::date + INTERVAL '7 days', 'YYYY-MM-DD') AND b.event_date <= to_char(cw.cohort_date::date + INTERVAL '14 days', 'YYYY-MM-DD') GROUP BY cw.date) SELECT cs.date, p.period, COALESCE(r.retained, 0) AS retained_users, cs.users AS cohort_users, COALESCE(r.retained::float / NULLIF(cs.users, 0), 0) AS rate FROM cohort_sizes cs CROSS JOIN periods p LEFT JOIN retained r ON r.date = cs.date AND r.period = p.period WHERE cs.users >= 5 ORDER BY cs.date, p.period",
+      sql: "WITH base AS (SELECT NULLIF(user_key, '') AS user_key, event_date AS event_date, user_id FROM analytics_events WHERE event_name = 'session status' AND signed_in = 'true' AND NULLIF(user_key, '') IS NOT NULL AND lower(COALESCE(NULLIF(template, ''), NULLIF(properties::jsonb ->> 'templateId', ''), NULLIF(properties::jsonb ->> 'agent_native_template', ''), NULLIF(properties::jsonb ->> 'agentNativeTemplate', ''), NULLIF(app, ''), NULLIF(properties::jsonb ->> 'agent_native_app', ''), NULLIF(properties::jsonb ->> 'agentNativeApp', ''), 'unknown')) <> 'docs' AND ('{{emailFilter}}' IN ('', 'all') OR ('{{emailFilter}}' = 'exclude_builder' AND lower(coalesce(user_id, '')) NOT LIKE '%@builder.io') OR ('{{emailFilter}}' = 'only_builder' AND lower(coalesce(user_id, '')) LIKE '%@builder.io')) AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD')), first_seen AS (SELECT user_key, MIN(event_date) AS cohort_date FROM base GROUP BY user_key), anchor_dates AS (SELECT DISTINCT cohort_date AS date FROM first_seen WHERE cohort_date <= to_char(CURRENT_DATE - INTERVAL '14 days', 'YYYY-MM-DD') AND (cohort_date <= to_char(CURRENT_DATE, 'YYYY-MM-DD') AND ('{{timeRange}}' IN ('', 'all') OR ('{{timeRange}}' = '7d' AND cohort_date >= to_char(CURRENT_DATE - INTERVAL '7 days', 'YYYY-MM-DD')) OR ('{{timeRange}}' = '30d' AND cohort_date >= to_char(CURRENT_DATE - INTERVAL '30 days', 'YYYY-MM-DD')) OR ('{{timeRange}}' = '90d' AND cohort_date >= to_char(CURRENT_DATE - INTERVAL '90 days', 'YYYY-MM-DD')) OR ('{{timeRange}}' = '180d' AND cohort_date >= to_char(CURRENT_DATE - INTERVAL '180 days', 'YYYY-MM-DD')) OR ('{{timeRange}}' = '365d' AND cohort_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD'))))), cohort_windows AS (SELECT a.date, f.user_key, f.cohort_date FROM anchor_dates a JOIN first_seen f ON f.cohort_date >= to_char(a.date::date - INTERVAL '6 days', 'YYYY-MM-DD') AND f.cohort_date <= a.date), cohort_sizes AS (SELECT date, COUNT(DISTINCT user_key) AS users FROM cohort_windows GROUP BY date), periods AS (SELECT '1-7d return' AS period UNION ALL SELECT '7-14d return' AS period), retained AS (SELECT cw.date, '1-7d return' AS period, COUNT(DISTINCT cw.user_key) AS retained FROM cohort_windows cw JOIN base b ON b.user_key = cw.user_key AND b.event_date > cw.cohort_date AND b.event_date <= to_char(cw.cohort_date::date + INTERVAL '7 days', 'YYYY-MM-DD') GROUP BY cw.date UNION ALL SELECT cw.date, '7-14d return' AS period, COUNT(DISTINCT cw.user_key) AS retained FROM cohort_windows cw JOIN base b ON b.user_key = cw.user_key AND b.event_date >= to_char(cw.cohort_date::date + INTERVAL '7 days', 'YYYY-MM-DD') AND b.event_date <= to_char(cw.cohort_date::date + INTERVAL '14 days', 'YYYY-MM-DD') GROUP BY cw.date) SELECT cs.date, p.period, COALESCE(r.retained, 0) AS retained_users, cs.users AS cohort_users, COALESCE(r.retained::float / NULLIF(cs.users, 0), 0) AS rate FROM cohort_sizes cs CROSS JOIN periods p LEFT JOIN retained r ON r.date = cs.date AND r.period = p.period WHERE cs.users >= 5 ORDER BY cs.date, p.period",
+    },
+    {
+      legacySql:
+        "WITH offsets AS (SELECT (ROW_NUMBER() OVER (ORDER BY event_date) - 1)::int AS n FROM analytics_events LIMIT 800), signup_events AS (SELECT event_date AS date, COALESCE(NULLIF(template, ''), NULLIF(properties::jsonb ->> 'templateId', ''), NULLIF(properties::jsonb ->> 'agent_native_template', ''), NULLIF(properties::jsonb ->> 'agentNativeTemplate', ''), NULLIF(app, ''), NULLIF(properties::jsonb ->> 'agent_native_app', ''), NULLIF(properties::jsonb ->> 'agentNativeApp', ''), 'unknown') AS template FROM analytics_events WHERE event_name = 'signup' AND ('{{timeRange}}' IN ('', 'all') OR ('{{timeRange}}' = '7d' AND event_date >= to_char(CURRENT_DATE - INTERVAL '7 days', 'YYYY-MM-DD')) OR ('{{timeRange}}' = '30d' AND event_date >= to_char(CURRENT_DATE - INTERVAL '30 days', 'YYYY-MM-DD')) OR ('{{timeRange}}' = '90d' AND event_date >= to_char(CURRENT_DATE - INTERVAL '90 days', 'YYYY-MM-DD')) OR ('{{timeRange}}' = '180d' AND event_date >= to_char(CURRENT_DATE - INTERVAL '180 days', 'YYYY-MM-DD')) OR ('{{timeRange}}' = '365d' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD'))) AND ('{{emailFilter}}' IN ('', 'all') OR ('{{emailFilter}}' = 'exclude_builder' AND lower(coalesce(user_id, '')) NOT LIKE '%@builder.io') OR ('{{emailFilter}}' = 'only_builder' AND lower(coalesce(user_id, '')) LIKE '%@builder.io'))), bounds AS (SELECT MIN(date::date) AS start_date, MAX(date::date) AS end_date FROM signup_events), dates AS (SELECT to_char(bounds.start_date + offsets.n, 'YYYY-MM-DD') AS date FROM bounds CROSS JOIN offsets WHERE bounds.start_date IS NOT NULL AND bounds.start_date + offsets.n <= bounds.end_date), templates AS (SELECT DISTINCT template FROM signup_events), daily AS (SELECT date, template, COUNT(*) AS count FROM signup_events GROUP BY date, template) SELECT dates.date, templates.template, COALESCE(daily.count, 0) AS count FROM dates CROSS JOIN templates LEFT JOIN daily ON daily.date = dates.date AND daily.template = templates.template ORDER BY dates.date, templates.template",
+      sql: "WITH signup_events AS (SELECT event_date AS date, COALESCE(NULLIF(template, ''), NULLIF(properties::jsonb ->> 'templateId', ''), NULLIF(properties::jsonb ->> 'agent_native_template', ''), NULLIF(properties::jsonb ->> 'agentNativeTemplate', ''), NULLIF(app, ''), NULLIF(properties::jsonb ->> 'agent_native_app', ''), NULLIF(properties::jsonb ->> 'agentNativeApp', ''), 'unknown') AS template FROM analytics_events WHERE event_name = 'signup' AND ('{{timeRange}}' IN ('', 'all') OR ('{{timeRange}}' = '7d' AND event_date >= to_char(CURRENT_DATE - INTERVAL '7 days', 'YYYY-MM-DD')) OR ('{{timeRange}}' = '30d' AND event_date >= to_char(CURRENT_DATE - INTERVAL '30 days', 'YYYY-MM-DD')) OR ('{{timeRange}}' = '90d' AND event_date >= to_char(CURRENT_DATE - INTERVAL '90 days', 'YYYY-MM-DD')) OR ('{{timeRange}}' = '180d' AND event_date >= to_char(CURRENT_DATE - INTERVAL '180 days', 'YYYY-MM-DD')) OR ('{{timeRange}}' = '365d' AND event_date >= to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD'))) AND ('{{emailFilter}}' IN ('', 'all') OR ('{{emailFilter}}' = 'exclude_builder' AND lower(coalesce(user_id, '')) NOT LIKE '%@builder.io') OR ('{{emailFilter}}' = 'only_builder' AND lower(coalesce(user_id, '')) LIKE '%@builder.io'))), bounds AS (SELECT MIN(date::date) AS start_date, MAX(date::date) AS end_date FROM signup_events), dates AS (SELECT to_char(d, 'YYYY-MM-DD') AS date FROM bounds, generate_series(bounds.start_date, bounds.end_date, INTERVAL '1 day') AS d WHERE bounds.start_date IS NOT NULL), templates AS (SELECT DISTINCT template FROM signup_events), daily AS (SELECT date, template, COUNT(*) AS count FROM signup_events GROUP BY date, template) SELECT dates.date, templates.template, COALESCE(daily.count, 0) AS count FROM dates CROSS JOIN templates LEFT JOIN daily ON daily.date = dates.date AND daily.template = templates.template ORDER BY dates.date, templates.template",
+    },
+  ];
+
+export function repairUnboundedFirstPartyPanels(
+  config: Record<string, unknown>,
+): { config: Record<string, unknown>; changed: boolean } {
+  if (!Array.isArray(config.panels)) return { config, changed: false };
+
+  const fixBySql = new Map(
+    UNBOUNDED_FIRST_PARTY_PANEL_FIXES.map((fix) => [fix.legacySql, fix.sql]),
+  );
+  let changed = false;
+  const panels = config.panels.map((rawPanel) => {
+    if (!rawPanel || typeof rawPanel !== "object") return rawPanel;
+    const panel = rawPanel as DashboardPanelLike & Record<string, unknown>;
+    if (panel.source !== "first-party" || typeof panel.sql !== "string") {
+      return rawPanel;
+    }
+    const fixedSql = fixBySql.get(panel.sql);
+    if (fixedSql === undefined) return rawPanel;
+    changed = true;
+    return { ...panel, sql: fixedSql };
+  });
+  if (!changed) return { config, changed: false };
+  return { config: { ...config, panels }, changed: true };
+}

--- a/templates/analytics/server/lib/first-party-unbounded-panel-repair.ts
+++ b/templates/analytics/server/lib/first-party-unbounded-panel-repair.ts
@@ -1,4 +1,10 @@
+import type { Dialect } from "@agent-native/core/db";
+
 import type { DashboardPanelLike } from "./dashboard-time-scope.js";
+
+const POSTGRES_DATE_BOUND =
+  "to_char(CURRENT_DATE - INTERVAL '365 days', 'YYYY-MM-DD')";
+const SQLITE_DATE_BOUND = "date('now', '-365 days')";
 
 /**
  * Fixes for first-party dashboard panels found, via a full-org audit
@@ -17,6 +23,12 @@ export type UnboundedFirstPartyPanelFix = {
   legacySql: string;
   sql: string;
 };
+
+function dialectBoundedSql(sql: string, dialect: Dialect): string {
+  return dialect === "postgres"
+    ? sql
+    : sql.split(POSTGRES_DATE_BOUND).join(SQLITE_DATE_BOUND);
+}
 
 export const UNBOUNDED_FIRST_PARTY_PANEL_FIXES: readonly UnboundedFirstPartyPanelFix[] =
   [
@@ -133,6 +145,7 @@ export const UNBOUNDED_FIRST_PARTY_PANEL_FIXES: readonly UnboundedFirstPartyPane
 
 export function repairUnboundedFirstPartyPanels(
   config: Record<string, unknown>,
+  dialect: Dialect = "postgres",
 ): { config: Record<string, unknown>; changed: boolean } {
   if (!Array.isArray(config.panels)) return { config, changed: false };
 
@@ -149,7 +162,7 @@ export function repairUnboundedFirstPartyPanels(
     const fixedSql = fixBySql.get(panel.sql);
     if (fixedSql === undefined) return rawPanel;
     changed = true;
-    return { ...panel, sql: fixedSql };
+    return { ...panel, sql: dialectBoundedSql(fixedSql, dialect) };
   });
   if (!changed) return { config, changed: false };
   return { config: { ...config, panels }, changed: true };

--- a/templates/analytics/server/plugins/db.ts
+++ b/templates/analytics/server/plugins/db.ts
@@ -8,7 +8,10 @@ import {
 // startup so the dashboard / analysis share actions know where to dispatch.
 import "../db/index.js";
 import * as schema from "../db/schema.js";
-import { repairPersistedFirstPartyDashboardQueries } from "../lib/first-party-dashboard-repair.js";
+import {
+  repairPersistedFirstPartyDashboardQueries,
+  repairUnboundedFirstPartyPanelsAcrossDashboards,
+} from "../lib/first-party-dashboard-repair.js";
 
 /**
  * Every Drizzle table exported from schema.ts. Filters out type-only and
@@ -1284,6 +1287,29 @@ const runAnalyticsMigrations = runMigrations(
         ALTER TABLE dashboard_report_subscriptions ADD COLUMN IF NOT EXISTS last_capture_error TEXT;
       `,
     },
+    // First-party dashboard panel result cache. Same shape/pattern as
+    // bigquery_cache above, short TTL (set in first-party-analytics-cache.ts)
+    // since this is the app's own live data, not an immutable warehouse
+    // result. See first-party-analytics-cache.ts for why this exists: panel
+    // queries had no cache at all, so every dashboard render and every daily
+    // report screenshot recomputed from scratch and stacked concurrent load
+    // on the same rows, which is what was blowing report/panel timeouts.
+    {
+      version: 124,
+      name: "first-party-analytics-cache-table",
+      sql: `CREATE TABLE IF NOT EXISTS first_party_analytics_cache (
+      key TEXT PRIMARY KEY,
+      sql TEXT NOT NULL,
+      result TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      expires_at TEXT NOT NULL
+    )`,
+    },
+    {
+      version: 125,
+      name: "first-party-analytics-cache-expires-idx",
+      sql: `CREATE INDEX IF NOT EXISTS first_party_analytics_cache_expires_at_idx ON first_party_analytics_cache (expires_at)`,
+    },
   ],
   { table: "analytics_migrations" },
 );
@@ -1309,6 +1335,20 @@ export default async (nitroApp: any): Promise<void> => {
   } catch (err) {
     console.warn(
       "[db] Failed to repair canonical first-party dashboard queries (non-fatal):",
+      err instanceof Error ? err.message : err,
+    );
+  }
+  try {
+    const repairedCount =
+      await repairUnboundedFirstPartyPanelsAcrossDashboards();
+    if (repairedCount > 0) {
+      console.info(
+        `[db] Repaired ${repairedCount} dashboard(s) with unbounded first-party panel SQL.`,
+      );
+    }
+  } catch (err) {
+    console.warn(
+      "[db] Failed to repair unbounded first-party panels across dashboards (non-fatal):",
       err instanceof Error ? err.message : err,
     );
   }

--- a/templates/analytics/shared/dashboard-report-timeouts.ts
+++ b/templates/analytics/shared/dashboard-report-timeouts.ts
@@ -1,3 +1,6 @@
-export const FIRST_PARTY_ANALYTICS_QUERY_TIMEOUT_MS = 30_000;
-export const DASHBOARD_REPORT_ACTION_TIMEOUT_MS = 38_000;
-export const DASHBOARD_REPORT_READY_TIMEOUT_MS = 60_000;
+// These three must stay ordered with headroom (DB timeout < action timeout <
+// page-ready timeout) so the innermost layer's own, more specific error
+// surfaces before an outer layer gives up for an unrelated reason.
+export const FIRST_PARTY_ANALYTICS_QUERY_TIMEOUT_MS = 45_000;
+export const DASHBOARD_REPORT_ACTION_TIMEOUT_MS = 50_000;
+export const DASHBOARD_REPORT_READY_TIMEOUT_MS = 75_000;


### PR DESCRIPTION
## Summary
- cache scoped first-party analytics queries and prewarm report panels
- bound first-party dashboard scans and repair known unbounded persisted panels safely
- increase report capture headroom and expose mobile docs header controls

## Validation
- pnpm --dir templates/analytics test (130 files, 1030 tests)
- pnpm --dir templates/analytics typecheck
- pnpm --filter @agent-native/docs typecheck
- focused Analytics tests (72 passed)