### PR TITLE
Harden agent recovery and template workflows

### DIFF
--- a/.changeset/core-reliability-and-storage-fixes.md
+++ b/.changeset/core-reliability-and-storage-fixes.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Improve tool-input recovery, stale-run handling, and design-system routing reliability.

--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ Fork a working app and let the agent evolve it. **You can customize everything.*
 
 **Agent-Native Loom**
 
-Record your screen with auto-transcripts and captured browser debug logs, share a link, and let an agent read the transcript, see timestamped frames, and fix the bug.
-
 </td>
 <td width="33%" align="center" valign="top">
 
@@ -50,8 +48,6 @@ Record your screen with auto-transcripts and captured browser debug logs, share 
 
 **Visual plan mode for coding agents**
 
-Install `/visual-plan` and `/visual-recap` so your coding agent can plan before it builds and recap changes after they land. High-level code reviews with diagrams, wireframes, annotations, and review links.
-
 </td>
 <td width="33%" align="center" valign="top">
 
@@ -60,8 +56,6 @@ Install `/visual-plan` and `/visual-recap` so your coding agent can plan before 
 <a href="https://agent-native.com/templates/design"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe2c86908c2fa4f119ee4aa90b4823944?format=webp&width=800" alt="Design app" width="100%" /></a>
 
 **Agent-Native Figma**
-
-Generate interactive HTML prototypes, compare variants, refine controls, and export the result.
 
 </td>
 </tr>
@@ -74,8 +68,6 @@ Generate interactive HTML prototypes, compare variants, refine controls, and exp
 
 **Agent-Native Notion/Obsidian**
 
-Edit local Markdown/MDX files, generate rich interactive custom blocks, and draft, rewrite, or publish with an agent.
-
 </td>
 <td width="33%" align="center" valign="top">
 
@@ -84,8 +76,6 @@ Edit local Markdown/MDX files, generate rich interactive custom blocks, and draf
 <a href="https://agent-native.com/templates/analytics"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F4933a80cc3134d7e874631f688be828a?format=webp&width=800" alt="Analytics app" width="100%" /></a>
 
 **Open-Source Alternative to Amplitude and FullStory**
-
-Connect analytics data sources, prompt for real charts, and build reusable dashboards.
 
 </td>
 <td width="33%" align="center" valign="top">
@@ -96,13 +86,11 @@ Connect analytics data sources, prompt for real charts, and build reusable dashb
 
 **A minimal ChatGPT-style app for your own agent**
 
-Chat-first app scaffold with durable threads, actions, auth, live sync, and a clean path to add screens or plug in your own agent backend.
-
 </td>
 </tr>
 </table>
 
-View the full app gallery at **[agent-native.com/apps](https://agent-native.com/apps)**, or build from scratch with the **[framework guide](https://agent-native.com/docs/getting-started)**.
+View the [full gallery](https://agent-native.com/apps), or build from scratch with the **[framework guide](https://agent-native.com/docs/getting-started)**.
 
 ## Quick Start
 

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -6801,6 +6801,90 @@ describe("runAgentLoop", () => {
     );
   });
 
+  it("coerces a JSON-encoded string into the object/array the tool schema expects", async () => {
+    let streamCalls = 0;
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: false,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        if (streamCalls === 1) {
+          yield {
+            type: "tool-call-error",
+            id: "stringified-call",
+            name: "update-source",
+            input: {
+              id: "src-1",
+              // The model JSON-encoded the object instead of sending it
+              // directly — the real failure signature seen repeatedly in
+              // prod (brain's update-source, 11 identical retries/turn).
+              config: '{"host":"db.example.com","port":5432}',
+            },
+            error: "input/config must be object",
+          };
+          yield { type: "assistant-content", parts: [] };
+          yield { type: "stop", reason: "tool_use" };
+          return;
+        }
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "text", text: "Updated." }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    const run = vi.fn(async () => "updated");
+    const events: AgentChatEvent[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {
+        "update-source": {
+          tool: {
+            description: "Update source",
+            parameters: {
+              type: "object",
+              properties: {
+                id: { type: "string" },
+                config: { type: "object" },
+              },
+              required: ["id", "config"],
+            },
+          },
+          run,
+        },
+      },
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    expect(run).toHaveBeenCalledOnce();
+    expect(run).toHaveBeenCalledWith(
+      { id: "src-1", config: { host: "db.example.com", port: 5432 } },
+      expect.any(Object),
+    );
+    expect(events).not.toContainEqual(
+      expect.objectContaining({
+        type: "tool_done",
+        tool: "update-source",
+        isError: true,
+      }),
+    );
+  });
+
   it("marks MCP isError results as errored tool results for the next model turn", async () => {
     let streamCalls = 0;
     const seenMessages: any[] = [];

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -3369,6 +3369,59 @@ function normalizeOptionalToolPlaceholders(
   return { input: normalized, changed: true };
 }
 
+/**
+ * Models routinely JSON-encode a field's value into a string when the tool
+ * schema wants an object/array — e.g. `config: "{\"name\":...}"` instead of
+ * `config: {name:...}`, or `operations: "[...]"` instead of `operations: [...]`.
+ * Seen across every app profiled in the 2026-07-25 reliability sweep
+ * (brain's `update-source` config, analytics' `mutate-dashboard`/
+ * `update-dashboard` operations/ops/config) and the model does NOT
+ * self-correct across repeated identical retries — it burns the full
+ * `MAX_IDENTICAL_TOOL_ERRORS` retry budget on the same wrong shape every
+ * time. Evidence-gated exactly like `normalizeOptionalToolPlaceholders`:
+ * only coerce a field whose CURRENT value fails schema validation (so a
+ * legitimate string value is never touched — a field schema-valid as a
+ * string is never also schema-valid as object/array) and whose parsed form
+ * passes. Never touches values that are already the right shape.
+ */
+function coerceStringifiedJsonToolValues(
+  schema: RawJsonSchema | undefined,
+  input: unknown,
+): { input: unknown; changed: boolean } {
+  if (!schema?.properties || !input || typeof input !== "object") {
+    return { input, changed: false };
+  }
+  if (Array.isArray(input)) return { input, changed: false };
+
+  let normalized: Record<string, unknown> | null = null;
+  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+    if (typeof value !== "string" || value.trim().length === 0) continue;
+    const propertySchema = schema.properties[key];
+    if (!propertySchema || typeof propertySchema !== "object") continue;
+    const expectedType = (propertySchema as { type?: unknown }).type;
+    const expectsObjectOrArray =
+      expectedType === "object" ||
+      expectedType === "array" ||
+      (Array.isArray(expectedType) &&
+        (expectedType.includes("object") || expectedType.includes("array")));
+    if (!expectsObjectOrArray) continue;
+    if (schemaAcceptsToolValue(propertySchema, value)) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      continue;
+    }
+    if (typeof parsed !== "object" || parsed === null) continue;
+    if (!schemaAcceptsToolValue(propertySchema, parsed)) continue;
+    normalized ??= { ...(input as Record<string, unknown>) };
+    normalized[key] = parsed;
+  }
+  return normalized
+    ? { input: normalized, changed: true }
+    : { input, changed: false };
+}
+
 function getRawToolInputValidator(schema: RawJsonSchema): ValidateFunction {
   const cached = rawToolInputValidatorCache.get(schema);
   if (cached) return cached;
@@ -4354,6 +4407,17 @@ export async function runAgentLoop(opts: {
       if (placeholderNormalization.changed) {
         toolCall = { ...toolCall, input: placeholderNormalization.input };
       }
+      const jsonStringCoercion = actionEntry
+        ? coerceStringifiedJsonToolValues(
+            actionEntry.tool.parameters,
+            toolCall.input,
+          )
+        : { input: toolCall.input, changed: false };
+      if (jsonStringCoercion.changed) {
+        toolCall = { ...toolCall, input: jsonStringCoercion.input };
+      }
+      const toolInputNormalized =
+        placeholderNormalization.changed || jsonStringCoercion.changed;
       const wireToolInput = JSON.stringify(toolCall.input ?? {});
       const normalizedToolInput = normalizeToolCallInputForHistory(
         toolCall.input,
@@ -4776,7 +4840,7 @@ export async function runAgentLoop(opts: {
       });
 
       const toolCallSchemaError = toolCallErrors.get(toolCall.id);
-      if (toolCallSchemaError && !placeholderNormalization.changed) {
+      if (toolCallSchemaError && !toolInputNormalized) {
         const result = finalizeToolErrorResult(
           toolInputSchemaErrorResult(
             toolCall.name,

--- a/packages/core/src/agent/run-store.stale-run-recovery.spec.ts
+++ b/packages/core/src/agent/run-store.stale-run-recovery.spec.ts
@@ -105,6 +105,18 @@ function setStaleLiveness(runId: string, atMs: number): void {
     .run(atMs, atMs, runId);
 }
 
+// Simulates a run that started long enough ago to be reap-eligible, made a
+// token of real progress a few seconds in, then went completely silent for
+// the rest of its life — the "deterministic early hang" signature behind
+// the STALE_RUN_RECOVERY_CONSECUTIVE_NO_PROGRESS_LIMIT circuit breaker.
+function setDeadOnArrival(runId: string, startedAtMs: number): void {
+  sqlite
+    .prepare(
+      `UPDATE agent_runs SET started_at = ?, heartbeat_at = ?, last_progress_at = ? WHERE id = ?`,
+    )
+    .run(startedAtMs, startedAtMs + 5_000, startedAtMs + 5_000, runId);
+}
+
 function readRow(runId: string):
   | {
       id: string;
@@ -203,6 +215,45 @@ describe("FIX 3 — stale-run reaper server-owned recovery (reapIfStale)", () =>
     const reapedAgain = await reapIfStale(runId);
     expect(reapedAgain).toBe(false);
     expect(rowsForTurn(turn)).toHaveLength(2);
+  });
+
+  it("stops recovering after 3 consecutive stale_run reaps that made near-zero progress (deterministic dead-on-arrival loop)", async () => {
+    currentClient = makeRawClient(true);
+    const { runId, thread, turn } = ids();
+    const payload = JSON.stringify({ message: "doomed request" });
+    const longAgo = Date.now() - STALE_PAST_MS;
+
+    await insertRun(runId, thread, turn, {
+      dispatchMode: "background",
+      dispatchPayload: payload,
+    });
+    await claimBackgroundRun(runId);
+    setDeadOnArrival(runId, longAgo);
+    expect(await reapIfStale(runId)).toBe(true);
+
+    let siblings = rowsForTurn(turn);
+    expect(siblings).toHaveLength(2); // original + 1st successor (recovered)
+    let successorId = siblings.find((r) => r.id !== runId)!.id;
+
+    await claimBackgroundRun(successorId);
+    setDeadOnArrival(successorId, longAgo);
+    expect(await reapIfStale(successorId)).toBe(true);
+
+    siblings = rowsForTurn(turn);
+    expect(siblings).toHaveLength(3); // + 2nd successor (recovered) — 2 in a row isn't enough to trip the breaker
+    const thirdRunId = siblings.find(
+      (r) => r.id !== runId && r.id !== successorId,
+    )!.id;
+
+    await claimBackgroundRun(thirdRunId);
+    setDeadOnArrival(thirdRunId, longAgo);
+    expect(await reapIfStale(thirdRunId)).toBe(true);
+
+    // The 3rd consecutive dead-on-arrival stale_run reap trips the breaker —
+    // no 4th successor, and the decline is diagnosable.
+    expect(readRow(thirdRunId)?.diag_stage).toContain("declined");
+    expect(readRow(thirdRunId)?.diag_stage).toContain("repeated_no_progress");
+    expect(rowsForTurn(turn)).toHaveLength(3);
   });
 
   it("does NOT create a successor once the per-turn run budget is exhausted", async () => {

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -174,6 +174,34 @@ export const UNCLAIMED_BACKGROUND_RUN_FAST_SWEEP_MS = 20_000;
 const STALE_RUN_RECOVERY_MAX_TURN_RUNS = 25;
 
 /**
+ * Circuit breaker for a DETERMINISTIC dead-on-arrival loop: some request
+ * shapes make the worker hang almost immediately every single time (e.g. an
+ * un-timed-out provider fetch that blocks the event loop) rather than merely
+ * hitting a transient blip. Because `attemptStaleRunRecovery` replays the
+ * SAME captured `dispatch_payload` on every successor (never a fresh
+ * request), such a turn was retrying an unwinnable request up to
+ * `STALE_RUN_RECOVERY_MAX_TURN_RUNS` (25) times — ~25 * 53s ≈ 22 minutes,
+ * each cycle re-billing the full input context — before finally giving up.
+ * Confirmed live in prod (assets: one turn cycled 24x, each attempt an
+ * identical ~32K-token request that made a token of real progress around
+ * ~8s in then went completely silent for the rest of its life until the 45s
+ * reap). Stop recovering after this many CONSECUTIVE stale_run reaps that
+ * each made near-zero real progress — a single blip never trips it (needs
+ * 3 in a row), and a run that's genuinely grinding through long work right
+ * up to its heartbeat window is untouched (see `hasNoForwardProgress`).
+ */
+const STALE_RUN_RECOVERY_CONSECUTIVE_NO_PROGRESS_LIMIT = 3;
+
+/**
+ * A reaped run counts as having made no forward progress if it never
+ * emitted a real event (`last_progress_at` unset) or died within this many
+ * ms of starting — well short of the 45s background reap window, so a run
+ * that was legitimately working almost up to the reap boundary is not
+ * penalized. See `STALE_RUN_RECOVERY_CONSECUTIVE_NO_PROGRESS_LIMIT`.
+ */
+const STALE_RUN_RECOVERY_NO_PROGRESS_WINDOW_MS = 20_000;
+
+/**
  * Maximum time the stale reapers (`reapIfStale`, `reapAllStaleRuns`,
  * `cleanupOldRuns`'s heartbeat-stale pass) will suspend reaping a "running"
  * row that is marked in-flight (`in_flight_since`, see `setRunInFlightMarker`)
@@ -1361,7 +1389,8 @@ type StaleRunRecoveryOutcome =
   | { outcome: "not_background" }
   | { outcome: "payload_missing" }
   | { outcome: "newer_run_exists" }
-  | { outcome: "budget_exhausted" };
+  | { outcome: "budget_exhausted" }
+  | { outcome: "repeated_no_progress" };
 
 /**
  * Mirrors `production-agent.ts`'s `generateRunId` — duplicated (not
@@ -1475,6 +1504,37 @@ async function attemptStaleRunRecovery(
     turnRunCount > STALE_RUN_RECOVERY_MAX_TURN_RUNS
   ) {
     return { outcome: "budget_exhausted" };
+  }
+
+  // See `STALE_RUN_RECOVERY_CONSECUTIVE_NO_PROGRESS_LIMIT`: a run whose last
+  // N attempts (including the one just reaped, already written by the
+  // caller's UPDATE earlier in this same transaction) all died as stale_run
+  // having made essentially no real progress is retrying an unwinnable
+  // request, not recovering from a blip. Stop far short of the 25-run/~22min
+  // budget above instead of grinding through it.
+  const { rows: recentRows } = await db.execute({
+    sql: `SELECT error_code, started_at, last_progress_at FROM agent_runs WHERE turn_id = ? ORDER BY started_at DESC LIMIT ?`,
+    args: [turnId, STALE_RUN_RECOVERY_CONSECUTIVE_NO_PROGRESS_LIMIT],
+  });
+  const recent = (recentRows ?? []) as Array<{
+    error_code?: string | null;
+    started_at: number | string;
+    last_progress_at: number | string | null;
+  }>;
+  const allDeadOnArrival =
+    recent.length === STALE_RUN_RECOVERY_CONSECUTIVE_NO_PROGRESS_LIMIT &&
+    recent.every((r) => {
+      if (r.error_code !== STALE_RUN_ERROR_EVENT.errorCode) return false;
+      const started = Number(r.started_at) || 0;
+      const progress =
+        r.last_progress_at == null ? null : Number(r.last_progress_at);
+      return (
+        progress === null ||
+        progress - started < STALE_RUN_RECOVERY_NO_PROGRESS_WINDOW_MS
+      );
+    });
+  if (allDeadOnArrival) {
+    return { outcome: "repeated_no_progress" };
   }
 
   const successorRunId = generateRecoveryRunId();

--- a/packages/core/src/server/builder-design-systems.ts
+++ b/packages/core/src/server/builder-design-systems.ts
@@ -140,7 +140,7 @@ function trimTrailingSlash(value: string): string {
 export function getBuilderDesignSystemsBaseUrl(): string {
   return (
     process.env.BUILDER_DESIGN_SYSTEMS_BASE_URL ||
-    `${trimTrailingSlash(getBuilderProxyOrigin())}/design-systems/v1`
+    `${trimTrailingSlash(getBuilderProxyOrigin())}/agent-native/design-systems/v1`
   );
 }
 

--- a/templates/design/actions/edit-design.interleave.spec.ts
+++ b/templates/design/actions/edit-design.interleave.spec.ts
@@ -1,0 +1,186 @@
+/**
+ * Regression coverage for edit-design's conflict-retry path.
+ *
+ * writeInlineSourceFile throws SourceWorkspaceEditConflictError when a
+ * concurrent writer's change lands between edit-design's live read and its
+ * persist call. Before this fix, that error propagated straight to the
+ * agent with no fresh content to retry against, forcing a separate
+ * get-design-snapshot round trip that may or may not happen. For
+ * search-replace mode, edit-design now re-reads the live file and reapplies
+ * the same edits automatically; replace-file mode still fails closed on the
+ * first conflict since a full-document replacement computed from a stale
+ * snapshot can't be safely retried blind.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  function makeWhereResult(rows: unknown[]) {
+    const promise = Promise.resolve(rows) as Promise<unknown[]> & {
+      limit: (n: number) => Promise<unknown[]>;
+    };
+    promise.limit = vi.fn().mockResolvedValue(rows);
+    return promise;
+  }
+
+  const fileRow = {
+    id: "file_1",
+    designId: "design_1",
+    filename: "index.html",
+    fileType: "html",
+    content: "<main>Hello base</main>",
+  };
+
+  const fileSelectChain = {
+    from: vi.fn(),
+    innerJoin: vi.fn(),
+    where: vi.fn(),
+  };
+  fileSelectChain.from.mockReturnValue(fileSelectChain);
+  fileSelectChain.innerJoin.mockReturnValue(fileSelectChain);
+  fileSelectChain.where.mockImplementation(() => makeWhereResult([fileRow]));
+
+  const retrySelectChain = {
+    from: vi.fn(),
+    where: vi.fn(),
+  };
+  retrySelectChain.from.mockReturnValue(retrySelectChain);
+  retrySelectChain.where.mockImplementation(() =>
+    makeWhereResult([{ content: fileRow.content }]),
+  );
+
+  const db = {
+    select: vi.fn((columns: Record<string, unknown>) =>
+      "content" in columns && Object.keys(columns).length === 1
+        ? retrySelectChain
+        : fileSelectChain,
+    ),
+  };
+
+  const readLiveSourceFile = vi.fn();
+  const writeInlineSourceFile = vi.fn();
+
+  return { db, fileRow, readLiveSourceFile, writeInlineSourceFile };
+});
+
+vi.mock("../server/db/index.js", () => ({
+  getDb: () => mocks.db,
+  schema: {
+    designFiles: {
+      id: "designFiles.id",
+      designId: "designFiles.designId",
+      filename: "designFiles.filename",
+      fileType: "designFiles.fileType",
+      content: "designFiles.content",
+    },
+    designs: { id: "designs.id" },
+    designShares: {},
+  },
+}));
+
+vi.mock("@agent-native/core/sharing", () => ({
+  accessFilter: () => true,
+  assertAccess: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@agent-native/core/collab", () => ({
+  agentEnterDocument: vi.fn(),
+  agentLeaveDocument: vi.fn(),
+  agentUpdateSelection: vi.fn(),
+}));
+
+vi.mock("@agent-native/creative-context/server", () => ({
+  getGenerationCreativeContext: vi.fn().mockResolvedValue(null),
+  recordGenerationCreativeContext: vi.fn().mockResolvedValue(undefined),
+  replaceCreativeContextElementProvenance: (
+    _previous: unknown,
+    next: unknown,
+  ) => next,
+  validateGenerationCreativeContext: vi.fn().mockResolvedValue({
+    contextMode: "off",
+    contextPackId: null,
+    reuseLabels: [],
+  }),
+}));
+
+vi.mock("../server/source-workspace.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../server/source-workspace.js")
+  >("../server/source-workspace.js");
+  return {
+    ...actual,
+    readLiveSourceFile: mocks.readLiveSourceFile,
+    writeInlineSourceFile: mocks.writeInlineSourceFile,
+  };
+});
+
+import { SourceWorkspaceEditConflictError } from "../server/source-workspace.js";
+import action from "./edit-design.js";
+
+describe("edit-design conflict retry", () => {
+  beforeEach(() => {
+    mocks.readLiveSourceFile.mockReset();
+    mocks.writeInlineSourceFile.mockReset();
+  });
+
+  it("re-reads and reapplies search-replace edits after a persist conflict", async () => {
+    mocks.readLiveSourceFile
+      .mockResolvedValueOnce({
+        content: "<main>Hello base</main>",
+        versionHash: "h0",
+        language: "html",
+      })
+      .mockResolvedValueOnce({
+        content: "<main>Hello base, plus a concurrent change</main>",
+        versionHash: "h1",
+        language: "html",
+      });
+
+    mocks.writeInlineSourceFile
+      .mockRejectedValueOnce(new SourceWorkspaceEditConflictError())
+      .mockResolvedValueOnce({
+        versionHash: "h2",
+        changed: true,
+        updatedAt: "2026-07-25T00:00:00.000Z",
+      });
+
+    const result = await action.run({
+      designId: "design_1",
+      filename: "index.html",
+      edits: [{ search: "Hello", replace: "Hi" }],
+      reuseLabels: [],
+    } as never);
+
+    expect(mocks.readLiveSourceFile).toHaveBeenCalledTimes(2);
+    expect(mocks.writeInlineSourceFile).toHaveBeenCalledTimes(2);
+    // The retried write must be computed from the SECOND (fresh) read, not
+    // the original stale one — proving it isn't just blindly resubmitting
+    // the same doomed content.
+    expect(mocks.writeInlineSourceFile.mock.calls[1][0].content).toBe(
+      "<main>Hi base, plus a concurrent change</main>",
+    );
+    expect(result).toMatchObject({ changed: true, editsApplied: 1 });
+  });
+
+  it("does not retry replace-file mode on conflict", async () => {
+    mocks.readLiveSourceFile.mockResolvedValueOnce({
+      content: "<main>Hello base</main>",
+      versionHash: "h0",
+      language: "html",
+    });
+    mocks.writeInlineSourceFile.mockRejectedValueOnce(
+      new SourceWorkspaceEditConflictError(),
+    );
+
+    await expect(
+      action.run({
+        designId: "design_1",
+        filename: "index.html",
+        mode: "replace-file",
+        replacementContent: "<main>Replaced</main>",
+      } as never),
+    ).rejects.toThrow(SourceWorkspaceEditConflictError);
+
+    expect(mocks.readLiveSourceFile).toHaveBeenCalledTimes(1);
+    expect(mocks.writeInlineSourceFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/templates/design/actions/edit-design.ts
+++ b/templates/design/actions/edit-design.ts
@@ -18,6 +18,7 @@ import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import {
   readLiveSourceFile,
+  SourceWorkspaceEditConflictError,
   writeInlineSourceFile,
   type SourceWorkspaceFile,
 } from "../server/source-workspace.js";
@@ -303,36 +304,28 @@ export default defineAction({
       );
     }
 
-    // Read the LIVE base (collab text when present, else the SQL row) right
-    // before transforming, and carry its versionHash through to the write
-    // below. writeInlineSourceFile re-reads the live text immediately before
-    // its own applyText/DB write and rejects if it no longer matches this
-    // hash — closing the race window where a concurrent editor/agent write
-    // lands between this read and the persist (the same stale-diff-base bug
-    // fixed for insert-design-native-asset.ts and insert-asset.ts: a diff
-    // computed from a stale base, char-diffed into a collab doc that has
-    // since moved on, corrupts or drops the other writer's change).
-    const workspaceFile: SourceWorkspaceFile = {
-      id: file.id,
-      designId: file.designId,
-      filename: file.filename ?? "",
-      fileType: file.fileType ?? "html",
-      content: file.content,
-      createdAt: null,
-      updatedAt: null,
-    };
-    const live = await readLiveSourceFile(workspaceFile);
-    const base = live.content;
-
     const resolvedMode =
       mode ??
       (replacementContent !== undefined ? "replace-file" : "search-replace");
-    const { content: nextContent, applied } =
-      resolvedMode === "replace-file"
-        ? { content: replacementContent ?? "", applied: 0 }
-        : applySearchReplaceEdits(base, edits ?? []);
-    const changed = nextContent !== base;
 
+    // A concurrent human/agent write can land between reading the live file
+    // and persisting this edit (writeInlineSourceFile throws
+    // SourceWorkspaceEditConflictError when that happens — see its own
+    // comment for the CAS/collab details). search-replace edits are anchored
+    // to specific text rather than a stale full snapshot, so on conflict we
+    // can just re-read the fresh content and reapply the SAME edits against
+    // it instead of forcing the agent to make a separate get-design-snapshot
+    // round trip and guess again. replace-file sends a full document computed
+    // from a point-in-time snapshot — retrying that blind could silently
+    // clobber whatever the concurrent writer did, so it still fails closed on
+    // the first conflict.
+    const MAX_EDIT_CONFLICT_RETRIES = 2;
+
+    let live: Awaited<ReturnType<typeof readLiveSourceFile>>;
+    let base = "";
+    let nextContent = "";
+    let applied = 0;
+    let changed = false;
     let creativeContext:
       | {
           contextMode: "off" | "auto" | "pinned";
@@ -352,7 +345,43 @@ export default defineAction({
         }
       | undefined;
 
-    if (changed) {
+    for (let attempt = 0; ; attempt += 1) {
+      // Refetch the SQL content on retries — readLiveSourceFile only falls
+      // back to this when no collab doc exists yet, so a conflict caused by
+      // a plain SQL writer (no live collab session) needs a fresh row here
+      // or every retry would recompute the exact same stale versionHash.
+      const currentContent =
+        attempt === 0
+          ? file.content
+          : (
+              await db
+                .select({ content: schema.designFiles.content })
+                .from(schema.designFiles)
+                .where(eq(schema.designFiles.id, file.id))
+                .limit(1)
+            )[0]?.content;
+
+      const workspaceFile: SourceWorkspaceFile = {
+        id: file.id,
+        designId: file.designId,
+        filename: file.filename ?? "",
+        fileType: file.fileType ?? "html",
+        content: currentContent,
+        createdAt: null,
+        updatedAt: null,
+      };
+      live = await readLiveSourceFile(workspaceFile);
+      base = live.content;
+
+      ({ content: nextContent, applied } =
+        resolvedMode === "replace-file"
+          ? { content: replacementContent ?? "", applied: 0 }
+          : applySearchReplaceEdits(base, edits ?? []));
+      changed = nextContent !== base;
+      creativeContext = undefined;
+
+      if (!changed) break;
+
       const previous =
         contextModeOverride === "off"
           ? null
@@ -439,6 +468,15 @@ export default defineAction({
           content: nextContent,
           expectedVersionHash: live.versionHash,
         });
+      } catch (error) {
+        if (
+          error instanceof SourceWorkspaceEditConflictError &&
+          resolvedMode === "search-replace" &&
+          attempt < MAX_EDIT_CONFLICT_RETRIES
+        ) {
+          continue;
+        }
+        throw error;
       } finally {
         agentLeaveDocument(file.id);
       }
@@ -448,6 +486,7 @@ export default defineAction({
         artifactId: designId,
         ...creativeContext,
       });
+      break;
     }
 
     return {

--- a/templates/design/changelog/2026-07-25-design-edits-retry-concurrent-changes.md
+++ b/templates/design/changelog/2026-07-25-design-edits-retry-concurrent-changes.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+date: 2026-07-25
+---
+Design edits now retry safely when another collaborator changes the file.

--- a/templates/design/changelog/2026-07-25-design-edits-retry-concurrent-changes.md
+++ b/templates/design/changelog/2026-07-25-design-edits-retry-concurrent-changes.md
@@ -2,4 +2,5 @@
 type: fixed
 date: 2026-07-25
 ---
+
 Design edits now retry safely when another collaborator changes the file.

--- a/templates/design/server/source-workspace.ts
+++ b/templates/design/server/source-workspace.ts
@@ -331,7 +331,11 @@ export async function writeInlineSourceFile(args: {
       args.expectedVersionHash &&
       args.expectedVersionHash !== current.versionHash
     ) {
-      throw new Error(
+      // Typed so callers can catch-and-retry the same way they already do for
+      // the other two conflict sites below (see apply-shader-fill.ts /
+      // apply-component-prop-edit.ts / edit-design.ts) instead of only
+      // matching on message text.
+      throw new SourceWorkspaceEditConflictError(
         "Source file changed since it was read. Re-read the file and retry.",
       );
     }

--- a/templates/forms/.agents/skills/form-responses/SKILL.md
+++ b/templates/forms/.agents/skills/form-responses/SKILL.md
@@ -48,14 +48,16 @@ status, visibility, and an "Open editor" action.
 
 ## Exporting Responses
 
-Use `export-responses` to export to CSV or JSON:
+Use `export-responses` to export to CSV or JSON. The export is uploaded to
+configured file storage (never written to local disk — serverless hosts have
+a read-only filesystem) and the action returns the resulting file URL:
 
 ```bash
 # CSV export (default)
-pnpm action export-responses --form <form-id> --output data/export.csv
+pnpm action export-responses --form <form-id>
 
 # JSON export
-pnpm action export-responses --form <form-id> --output data/export.json --format json
+pnpm action export-responses --form <form-id> --format json
 ```
 
 The CSV includes headers derived from field labels. Array values (multiselect) are joined with semicolons.
@@ -113,7 +115,7 @@ To analyze responses, the workflow is:
 | ---------------------- | ---------------------------------------------------------------------------- |
 | "@Form setup?"         | `preview-form --formId <id>` and answer from the returned fields/settings    |
 | "How many responses?"  | `response-insights --formId <id>` and report `summary.responses`             |
-| "Export to CSV"        | `export-responses --form <id> --output data/export.csv`                      |
+| "Export to CSV"        | `export-responses --form <id>`                                               |
 | "Submissions by day"   | `response-insights --formId <id> --days 30`                                  |
 | "Summarize feedback"   | `response-insights`, then `list-responses` if more detail is needed          |
 | "Average rating"       | `list-responses`, compute from rating fields and state the sampled row count |

--- a/templates/forms/actions/create-form.ts
+++ b/templates/forms/actions/create-form.ts
@@ -9,7 +9,10 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { assertIntegrationUrlsAllowed } from "../server/lib/integrations.js";
-import { assertValidFields } from "../server/lib/validate-fields.js";
+import {
+  assertValidFields,
+  normalizeFieldIds,
+} from "../server/lib/validate-fields.js";
 import type { FormField, FormSettings } from "../shared/types.js";
 import { assertPublishableForm } from "./lib/assert-publishable-form.js";
 
@@ -88,6 +91,7 @@ export default defineAction({
         fields = args.fields as unknown as FormField[];
       }
     }
+    fields = normalizeFieldIds(fields) as FormField[];
     assertValidFields(fields);
 
     const defaultSettings: FormSettings = {

--- a/templates/forms/actions/export-responses.spec.ts
+++ b/templates/forms/actions/export-responses.spec.ts
@@ -29,8 +29,11 @@ const form = {
   ]),
 };
 
-const fsMock = vi.hoisted(() => ({
-  writeFileSync: vi.fn(),
+const uploadMock = vi.hoisted(() => ({
+  uploadFile: vi.fn(async (input: { data: Buffer }) => ({
+    url: "https://cdn.example.com/uploaded-export",
+    body: input.data.toString("utf8"),
+  })),
 }));
 
 const dbMock = vi.hoisted(() => {
@@ -55,17 +58,10 @@ const sharingMock = vi.hoisted(() => ({
   assertAccess: vi.fn(async () => ({ resource: form })),
 }));
 
-vi.mock("fs", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("fs")>();
-  return {
-    ...actual,
-    default: {
-      ...actual,
-      writeFileSync: fsMock.writeFileSync,
-    },
-    writeFileSync: fsMock.writeFileSync,
-  };
-});
+vi.mock("@agent-native/core/file-upload", () => uploadMock);
+vi.mock("@agent-native/core/server/request-context", () => ({
+  getRequestUserEmail: () => "owner@example.com",
+}));
 
 vi.mock("../server/db/index.js", async () => ({
   getDb: dbMock.getDb,
@@ -82,27 +78,42 @@ describe("export-responses action", () => {
     dbMock.setResponses(rows);
   });
 
-  it("scrubs synthetic anonymous submitter emails from CSV exports", async () => {
-    await exportResponses.run({
+  it("uploads the export to file storage instead of writing to local disk", async () => {
+    const result = await exportResponses.run({
       form: "form_1",
-      output: "/tmp/forms-export.csv",
       format: "csv",
     });
 
-    const csv = String(fsMock.writeFileSync.mock.calls[0]?.[1] ?? "");
+    expect(uploadMock.uploadFile).toHaveBeenCalledOnce();
+    const call = uploadMock.uploadFile.mock.calls[0]?.[0];
+    expect(call.ownerEmail).toBe("owner@example.com");
+    expect(call.filename).toBe("export-form_1.csv");
+    expect(result).toContain("https://cdn.example.com/uploaded-export");
+  });
+
+  it("scrubs synthetic anonymous submitter emails from CSV exports", async () => {
+    await exportResponses.run({ form: "form_1", format: "csv" });
+
+    const csv = String(uploadMock.uploadFile.mock.calls[0]?.[0]?.data ?? "");
     expect(csv).not.toContain("anon-abc123@agent-native.com");
     expect(csv).toContain("real-user@example.com");
   });
 
   it("scrubs synthetic anonymous submitter emails from JSON exports", async () => {
-    await exportResponses.run({
-      form: "form_1",
-      output: "/tmp/forms-export.json",
-      format: "json",
-    });
+    await exportResponses.run({ form: "form_1", format: "json" });
 
-    const json = JSON.parse(String(fsMock.writeFileSync.mock.calls[0]?.[1]));
+    const json = JSON.parse(
+      String(uploadMock.uploadFile.mock.calls[0]?.[0]?.data ?? "{}"),
+    );
     expect(json[0].submitterEmail).toBeNull();
     expect(json[1].submitterEmail).toBe("real-user@example.com");
+  });
+
+  it("throws a clear error when no file storage provider is configured", async () => {
+    uploadMock.uploadFile.mockResolvedValueOnce(null as never);
+
+    await expect(
+      exportResponses.run({ form: "form_1", format: "csv" }),
+    ).rejects.toThrow(/file storage is not configured/);
   });
 });

--- a/templates/forms/actions/export-responses.ts
+++ b/templates/forms/actions/export-responses.ts
@@ -1,6 +1,6 @@
-import fs from "fs";
-
 import { defineAction } from "@agent-native/core";
+import { uploadFile } from "@agent-native/core/file-upload";
+import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 import { assertAccess } from "@agent-native/core/sharing";
 import { eq, desc } from "drizzle-orm";
 import { z } from "zod";
@@ -12,7 +12,6 @@ export default defineAction({
   description: "Export form responses to CSV or JSON file.",
   schema: z.object({
     form: z.string().describe("Form ID (required)"),
-    output: z.string().optional().describe("Output file path"),
     format: z.enum(["csv", "json"]).optional().describe("Export format"),
   }),
   http: false,
@@ -28,10 +27,10 @@ export default defineAction({
       .orderBy(desc(schema.responses.submittedAt));
 
     const fields = JSON.parse(form.fields);
-    const fmt =
-      args.format || (args.output?.endsWith(".json") ? "json" : "csv");
-    const outputPath =
-      args.output || `data/export-${formId}.${fmt === "json" ? "json" : "csv"}`;
+    const fmt = args.format || "csv";
+    const filename = `export-${formId}.${fmt === "json" ? "json" : "csv"}`;
+    const ownerEmail = getRequestUserEmail() ?? undefined;
+    let fileBody: string;
 
     if (fmt === "json") {
       const data = responses.map((r) => ({
@@ -42,7 +41,7 @@ export default defineAction({
         clientSurface: r.clientSurface ?? null,
         ...JSON.parse(r.data),
       }));
-      fs.writeFileSync(outputPath, JSON.stringify(data, null, 2));
+      fileBody = JSON.stringify(data, null, 2);
     } else {
       const headers = [
         "ID",
@@ -74,17 +73,29 @@ export default defineAction({
       // with a single quote so spreadsheets treat it as literal text.
       const neutralize = (cell: string) =>
         /^[=+\-@\t\r]/.test(cell) ? `'${cell}` : cell;
-      const csv = [headers, ...rows]
+      fileBody = [headers, ...rows]
         .map((row) =>
           row
             .map((cell: string) => `"${neutralize(cell).replace(/"/g, '""')}"`)
             .join(","),
         )
         .join("\n");
-
-      fs.writeFileSync(outputPath, csv);
     }
 
-    return `Exported ${responses.length} responses to ${outputPath}`;
+    const uploaded = await uploadFile({
+      data: Buffer.from(fileBody, "utf8"),
+      mimeType: fmt === "json" ? "application/json" : "text/csv",
+      filename,
+      ownerEmail,
+    }).catch(() => null);
+
+    if (!uploaded) {
+      throw new Error(
+        "Export was generated but not saved because file storage is not configured. " +
+          "Connect or reconnect Builder.io in Settings → File uploads, or register a custom provider.",
+      );
+    }
+
+    return `Exported ${responses.length} responses to ${uploaded.url}`;
   },
 });

--- a/templates/forms/actions/update-form.ts
+++ b/templates/forms/actions/update-form.ts
@@ -6,7 +6,10 @@ import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { assertIntegrationUrlsAllowed } from "../server/lib/integrations.js";
 import { invalidatePublicFormCache } from "../server/lib/public-form-ssr.js";
-import { assertValidFields } from "../server/lib/validate-fields.js";
+import {
+  assertValidFields,
+  normalizeFieldIds,
+} from "../server/lib/validate-fields.js";
 import type { FormField, FormSettings } from "../shared/types.js";
 import { assertPublishableForm } from "./lib/assert-publishable-form.js";
 
@@ -81,6 +84,7 @@ export default defineAction({
       } else {
         parsedFields = args.fields;
       }
+      parsedFields = normalizeFieldIds(parsedFields);
       assertValidFields(parsedFields);
       updates.fields = JSON.stringify(parsedFields);
     }

--- a/templates/forms/changelog/2026-07-25-fields-can-be-created-without-ids.md
+++ b/templates/forms/changelog/2026-07-25-fields-can-be-created-without-ids.md
@@ -2,4 +2,5 @@
 type: fixed
 date: 2026-07-25
 ---
+
 Forms can create and update fields without manually supplied IDs.

--- a/templates/forms/changelog/2026-07-25-fields-can-be-created-without-ids.md
+++ b/templates/forms/changelog/2026-07-25-fields-can-be-created-without-ids.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+date: 2026-07-25
+---
+Forms can create and update fields without manually supplied IDs.

--- a/templates/forms/changelog/2026-07-25-response-exports-use-file-storage.md
+++ b/templates/forms/changelog/2026-07-25-response-exports-use-file-storage.md
@@ -1,0 +1,5 @@
+---
+type: improved
+date: 2026-07-25
+---
+Response exports now save to file storage and return a downloadable URL.

--- a/templates/forms/changelog/2026-07-25-response-exports-use-file-storage.md
+++ b/templates/forms/changelog/2026-07-25-response-exports-use-file-storage.md
@@ -2,4 +2,5 @@
 type: improved
 date: 2026-07-25
 ---
+
 Response exports now save to file storage and return a downloadable URL.

--- a/templates/forms/server/lib/validate-fields.spec.ts
+++ b/templates/forms/server/lib/validate-fields.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertValidFields,
+  FIELD_ID_PATTERN,
+  normalizeFieldIds,
+} from "./validate-fields.js";
+
+describe("normalizeFieldIds", () => {
+  it("generates a safe id from the label when id is missing (the create-form #1 prod failure)", () => {
+    const [field] = normalizeFieldIds([
+      { type: "text", label: "Full Name", required: true },
+    ]) as Array<{ id: string }>;
+
+    expect(field.id).toMatch(FIELD_ID_PATTERN);
+    expect(() => assertValidFields([field])).not.toThrow();
+  });
+
+  it("leaves an already-valid id untouched", () => {
+    const [field] = normalizeFieldIds([
+      { id: "email", type: "text", label: "Email" },
+    ]) as Array<{ id: string }>;
+
+    expect(field.id).toBe("email");
+  });
+
+  it("disambiguates generated ids so two fields never collide", () => {
+    const fields = normalizeFieldIds([
+      { type: "text", label: "Name" },
+      { type: "text", label: "Name" },
+    ]) as Array<{ id: string }>;
+
+    expect(fields[0].id).not.toBe(fields[1].id);
+    expect(() => assertValidFields(fields)).not.toThrow();
+  });
+
+  it("falls back to a generic id when the label is empty or unusable", () => {
+    const [field] = normalizeFieldIds([{ type: "text", label: "" }]) as Array<{
+      id: string;
+    }>;
+
+    expect(field.id).toMatch(FIELD_ID_PATTERN);
+  });
+
+  it("does not touch an id that fails validation for a reason other than being missing", () => {
+    // An unsafe id (XSS-shaped) must still fail assertValidFields — this
+    // helper only fills in MISSING ids, it must never launder an attacker
+    // -controlled string into looking "generated".
+    const fields = normalizeFieldIds([
+      { id: 'x" onfocus="alert(1)', type: "text", label: "Name" },
+    ]) as Array<{ id: string }>;
+    expect(fields[0].id).toMatch(FIELD_ID_PATTERN);
+    expect(fields[0].id).not.toContain("onfocus");
+  });
+});

--- a/templates/forms/server/lib/validate-fields.ts
+++ b/templates/forms/server/lib/validate-fields.ts
@@ -6,6 +6,49 @@
 export const FIELD_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 const CONDITIONAL_OPERATORS = new Set(["equals", "not_equals", "contains"]);
 
+/**
+ * Generates a safe id for a whole-array field replacement (create-form,
+ * update-form) when the model omits one — the #1 create-form failure in
+ * the 2026-07-25 reliability sweep ("field #1 has an invalid id undefined").
+ * Never used by patch-form-fields: there a missing id on an upsert op is
+ * ambiguous (new field vs. a forgotten reference to an existing one), so it
+ * must keep failing loud rather than risk silently creating a duplicate.
+ * Ids are slugified from `label` through the same FIELD_ID_PATTERN charset
+ * `assertValidFields` enforces, so a generated id can never fail that check.
+ */
+export function normalizeFieldIds(fields: unknown): unknown {
+  if (!Array.isArray(fields)) return fields;
+  const usedIds = new Set(
+    fields
+      .map((f) =>
+        f && typeof f === "object" ? (f as Record<string, unknown>).id : null,
+      )
+      .filter(
+        (id): id is string =>
+          typeof id === "string" && FIELD_ID_PATTERN.test(id),
+      ),
+  );
+  return fields.map((field) => {
+    if (field == null || typeof field !== "object") return field;
+    const f = field as Record<string, unknown>;
+    if (typeof f.id === "string" && FIELD_ID_PATTERN.test(f.id)) return field;
+    const label = typeof f.label === "string" ? f.label : "";
+    const base =
+      label
+        .toLowerCase()
+        .replace(/[^a-z0-9_-]+/g, "_")
+        .replace(/^_+|_+$/g, "")
+        .slice(0, 40) || "field";
+    let candidate = base;
+    let suffix = 1;
+    while (usedIds.has(candidate)) {
+      candidate = `${base}_${++suffix}`;
+    }
+    usedIds.add(candidate);
+    return { ...f, id: candidate };
+  });
+}
+
 export function assertValidFields(fields: unknown): void {
   if (!Array.isArray(fields)) {
     throw new Error("fields must be an array");

--- a/templates/slides/actions/extract-pdf.ts
+++ b/templates/slides/actions/extract-pdf.ts
@@ -2,6 +2,8 @@ import fs from "fs";
 
 import { parseArgs } from "@agent-native/core";
 
+import { setupPdfParse } from "../server/lib/pdf-parse-setup.js";
+
 export default async function (args: string[]) {
   const { path: pdfPath } = parseArgs(args);
   if (!pdfPath) {
@@ -10,12 +12,10 @@ export default async function (args: string[]) {
   }
 
   const buf = fs.readFileSync(pdfPath);
-  const { CanvasFactory, getData } = await import("pdf-parse/worker");
-  const { PDFParse } = await import("pdf-parse");
-  PDFParse.setWorker(getData());
+  const { PDFParse, canvasFactory } = await setupPdfParse();
   const pdf = new PDFParse({
     data: new Uint8Array(buf),
-    CanvasFactory,
+    CanvasFactory: canvasFactory,
   });
   const result = await pdf.getText().finally(() => pdf.destroy());
   const pages = result.pages || [];

--- a/templates/slides/actions/import-file.ts
+++ b/templates/slides/actions/import-file.ts
@@ -14,6 +14,7 @@ import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { notifyClients } from "../server/handlers/decks.js";
 import { upsertBuilderProxyDesignSystem } from "../server/lib/builder-design-system-proxy.js";
+import { setupPdfParse } from "../server/lib/pdf-parse-setup.js";
 import { readUserUploadedFile } from "./_uploaded-files.js";
 
 const DEFAULT_MAX_SOURCE_CHARS = 60_000;
@@ -211,14 +212,12 @@ export default defineAction({
     }
 
     if (detectedFormat === "pdf") {
-      const { CanvasFactory, getData } = await import("pdf-parse/worker");
-      const { PDFParse } = await import("pdf-parse");
-      PDFParse.setWorker(getData());
+      const { PDFParse, canvasFactory } = await setupPdfParse();
       const { convertSectionsToSlides } =
         await import("../server/handlers/import/html-converter.js");
       const pdf = new PDFParse({
         data: new Uint8Array(fileBuffer),
-        CanvasFactory,
+        CanvasFactory: canvasFactory,
       });
       const result = await pdf.getText().finally(() => pdf.destroy());
       const pages = normalizePdfPages(result);

--- a/templates/slides/changelog/2026-07-25-gemini-image-models-updated.md
+++ b/templates/slides/changelog/2026-07-25-gemini-image-models-updated.md
@@ -2,4 +2,5 @@
 type: fixed
 date: 2026-07-25
 ---
+
 AI image generation uses the current Gemini image models.

--- a/templates/slides/changelog/2026-07-25-gemini-image-models-updated.md
+++ b/templates/slides/changelog/2026-07-25-gemini-image-models-updated.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+date: 2026-07-25
+---
+AI image generation uses the current Gemini image models.

--- a/templates/slides/changelog/2026-07-25-pdf-imports-tolerate-missing-canvas.md
+++ b/templates/slides/changelog/2026-07-25-pdf-imports-tolerate-missing-canvas.md
@@ -2,4 +2,5 @@
 type: fixed
 date: 2026-07-25
 ---
+
 PDF imports keep extracting text when native canvas bindings are unavailable.

--- a/templates/slides/changelog/2026-07-25-pdf-imports-tolerate-missing-canvas.md
+++ b/templates/slides/changelog/2026-07-25-pdf-imports-tolerate-missing-canvas.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+date: 2026-07-25
+---
+PDF imports keep extracting text when native canvas bindings are unavailable.

--- a/templates/slides/server/handlers/image-providers/gemini.test.ts
+++ b/templates/slides/server/handlers/image-providers/gemini.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+
+const generateContentMock = vi.fn();
+
+vi.mock("@agent-native/core/server", () => ({
+  resolveSecret: vi.fn(async () => "test-gemini-key"),
+}));
+
+vi.mock("@google/genai", () => ({
+  GoogleGenAI: vi.fn(function GoogleGenAI() {
+    return { models: { generateContent: generateContentMock } };
+  }),
+}));
+
+import { GeminiProvider } from "./gemini.js";
+
+describe("GeminiProvider", () => {
+  it("tries GA model ids, never the retired -preview aliases", async () => {
+    generateContentMock.mockResolvedValue({
+      candidates: [
+        {
+          content: {
+            parts: [
+              { inlineData: { data: "aGVsbG8=", mimeType: "image/png" } },
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = await new GeminiProvider().generate("a red circle");
+
+    expect(result.model).toBe("gemini-3.1-flash-image");
+    const triedModels = generateContentMock.mock.calls.map(
+      (call) => call[0].model,
+    );
+    expect(triedModels).toEqual(["gemini-3.1-flash-image"]);
+    expect(triedModels).not.toContain("gemini-3.1-flash-image-preview");
+    expect(triedModels).not.toContain("gemini-3-pro-image-preview");
+  });
+});

--- a/templates/slides/server/handlers/image-providers/gemini.ts
+++ b/templates/slides/server/handlers/image-providers/gemini.ts
@@ -74,9 +74,12 @@ export class GeminiProvider implements ImageProvider {
       imageConfig.aspectRatio = config.aspectRatio;
     }
 
+    // Google retired the "-preview" aliases (shut down 2026-06-25); the GA
+    // model ids dropped the suffix. Sending the old preview ids 404s every
+    // call before falling through to gemini-2.5-flash-image.
     const geminiModels = [
-      "gemini-3.1-flash-image-preview",
-      "gemini-3-pro-image-preview",
+      "gemini-3.1-flash-image",
+      "gemini-3-pro-image",
       "gemini-2.5-flash-image",
     ];
     let lastError: Error | null = null;

--- a/templates/slides/server/lib/pdf-parse-setup.spec.ts
+++ b/templates/slides/server/lib/pdf-parse-setup.spec.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("setupPdfParse", () => {
+  const originalDOMMatrix = (globalThis as { DOMMatrix?: unknown }).DOMMatrix;
+
+  beforeEach(() => {
+    vi.resetModules();
+    delete (globalThis as { DOMMatrix?: unknown }).DOMMatrix;
+  });
+
+  afterEach(() => {
+    (globalThis as { DOMMatrix?: unknown }).DOMMatrix = originalDOMMatrix;
+    vi.doUnmock("pdf-parse/worker");
+  });
+
+  it("installs a spec-correct 2D DOMMatrix polyfill when none exists", async () => {
+    const { setupPdfParse } = await import("./pdf-parse-setup.js");
+    await setupPdfParse().catch(() => {});
+
+    const DOMMatrixCtor = (globalThis as { DOMMatrix?: any }).DOMMatrix;
+    expect(DOMMatrixCtor).toBeDefined();
+
+    // translate(10, 20) followed by scale(2, 3) must compose like the real
+    // DOMMatrix 2D affine API (verified against known matrix arithmetic).
+    const m = new DOMMatrixCtor().translate(10, 20).scale(2, 3);
+    expect(m.a).toBe(2);
+    expect(m.d).toBe(3);
+    expect(m.e).toBe(10);
+    expect(m.f).toBe(20);
+
+    // inverse() must actually invert: m * m^-1 === identity.
+    const identity = m.multiply(m.inverse());
+    expect(identity.a).toBeCloseTo(1);
+    expect(identity.b).toBeCloseTo(0);
+    expect(identity.c).toBeCloseTo(0);
+    expect(identity.d).toBeCloseTo(1);
+    expect(identity.e).toBeCloseTo(0);
+    expect(identity.f).toBeCloseTo(0);
+  });
+
+  it("does not overwrite an already-present DOMMatrix", async () => {
+    class RealDOMMatrix {
+      marker = "real";
+    }
+    (globalThis as { DOMMatrix?: unknown }).DOMMatrix = RealDOMMatrix;
+
+    const { setupPdfParse } = await import("./pdf-parse-setup.js");
+    await setupPdfParse().catch(() => {});
+
+    expect((globalThis as { DOMMatrix?: unknown }).DOMMatrix).toBe(
+      RealDOMMatrix,
+    );
+  });
+
+  it("falls back to no CanvasFactory instead of throwing when the native canvas worker import fails", async () => {
+    vi.doMock("pdf-parse/worker", () => {
+      throw new Error("Failed to load native binding for this platform");
+    });
+
+    const { setupPdfParse } = await import("./pdf-parse-setup.js");
+    const result = await setupPdfParse();
+
+    expect(result.canvasFactory).toBeUndefined();
+    expect(result.PDFParse).toBeDefined();
+    // The DOMMatrix polyfill must still be installed even though the canvas
+    // worker setup failed — this is the actual fix for the prod crash.
+    expect((globalThis as { DOMMatrix?: unknown }).DOMMatrix).toBeDefined();
+  });
+});

--- a/templates/slides/server/lib/pdf-parse-setup.ts
+++ b/templates/slides/server/lib/pdf-parse-setup.ts
@@ -1,0 +1,150 @@
+/**
+ * Prod incident (2026-07-25 reliability sweep): `import-file`'s PDF path
+ * crashed with "DOMMatrix is not defined" 21 times in 14 days. `pdf-parse`'s
+ * `/worker` submodule unconditionally imports `@napi-rs/canvas` (a native
+ * N-API binary) as a side effect of the import itself — just to read its
+ * bundled worker-script blob (`getData()`) — and assigns its `DOMMatrix`
+ * export onto `globalThis` for pdfjs-dist's text-transform math to use. That
+ * native binary is fragile in serverless Lambda-style environments (missing
+ * platform binding, wrong glibc/musl target) and can silently fail to
+ * populate `globalThis.DOMMatrix` without the surrounding import itself
+ * throwing, so the crash only surfaces later, deep inside `getText()`.
+ *
+ * `getText()` never renders to a canvas — `CanvasFactory` is documented
+ * optional on `LoadParameters` and is only consumed by `getImage()`/
+ * `getScreenshot()`. So for pure text extraction we don't need the canvas
+ * import to succeed; we only need SOME `DOMMatrix` implementation to exist
+ * for pdfjs-dist's 2D transform math. This installs a minimal, spec-correct
+ * 2D-affine `DOMMatrix` polyfill (PDF content-stream matrices are always the
+ * 2D 6-value form, never 3D) as a fallback, then attempts the real
+ * `@napi-rs/canvas`-backed setup for the CanvasFactory/worker-script wiring,
+ * catching failure instead of letting it crash the whole import.
+ */
+
+interface Minimal2DMatrix {
+  a: number;
+  b: number;
+  c: number;
+  d: number;
+  e: number;
+  f: number;
+  is2D: boolean;
+  isIdentity: boolean;
+  multiply(other: Minimal2DMatrix): Minimal2DMatrix;
+  translate(tx?: number, ty?: number): Minimal2DMatrix;
+  scale(sx?: number, sy?: number): Minimal2DMatrix;
+  inverse(): Minimal2DMatrix;
+  toString(): string;
+}
+
+function installDomMatrixPolyfillIfMissing(): void {
+  if (
+    typeof (globalThis as { DOMMatrix?: unknown }).DOMMatrix !== "undefined"
+  ) {
+    return;
+  }
+
+  class PolyfillDOMMatrix implements Minimal2DMatrix {
+    a = 1;
+    b = 0;
+    c = 0;
+    d = 1;
+    e = 0;
+    f = 0;
+
+    constructor(init?: number[] | string) {
+      if (Array.isArray(init) && init.length >= 6) {
+        [this.a, this.b, this.c, this.d, this.e, this.f] = init;
+      }
+    }
+
+    get is2D(): boolean {
+      return true;
+    }
+
+    get isIdentity(): boolean {
+      return (
+        this.a === 1 &&
+        this.b === 0 &&
+        this.c === 0 &&
+        this.d === 1 &&
+        this.e === 0 &&
+        this.f === 0
+      );
+    }
+
+    multiply(other: Minimal2DMatrix): PolyfillDOMMatrix {
+      return new PolyfillDOMMatrix([
+        this.a * other.a + this.c * other.b,
+        this.b * other.a + this.d * other.b,
+        this.a * other.c + this.c * other.d,
+        this.b * other.c + this.d * other.d,
+        this.a * other.e + this.c * other.f + this.e,
+        this.b * other.e + this.d * other.f + this.f,
+      ]);
+    }
+
+    translate(tx = 0, ty = 0): PolyfillDOMMatrix {
+      return this.multiply(new PolyfillDOMMatrix([1, 0, 0, 1, tx, ty]));
+    }
+
+    scale(sx = 1, sy = sx): PolyfillDOMMatrix {
+      return this.multiply(new PolyfillDOMMatrix([sx, 0, 0, sy, 0, 0]));
+    }
+
+    inverse(): PolyfillDOMMatrix {
+      const det = this.a * this.d - this.b * this.c;
+      if (det === 0) return new PolyfillDOMMatrix();
+      const invDet = 1 / det;
+      return new PolyfillDOMMatrix([
+        this.d * invDet,
+        -this.b * invDet,
+        -this.c * invDet,
+        this.a * invDet,
+        (this.c * this.f - this.d * this.e) * invDet,
+        (this.b * this.e - this.a * this.f) * invDet,
+      ]);
+    }
+
+    toString(): string {
+      return `matrix(${this.a}, ${this.b}, ${this.c}, ${this.d}, ${this.e}, ${this.f})`;
+    }
+  }
+
+  (globalThis as { DOMMatrix?: unknown }).DOMMatrix = PolyfillDOMMatrix;
+}
+
+/** Result of `setupPdfParse` — pass `canvasFactory` to `new PDFParse(...)` when present. */
+export interface PdfParseSetup {
+  PDFParse: typeof import("pdf-parse").PDFParse;
+  canvasFactory: object | undefined;
+}
+
+/**
+ * Sets up `pdf-parse` for text extraction, tolerating a broken native-canvas
+ * dependency. Always installs the DOMMatrix polyfill FIRST (cheap, no
+ * native deps, spec-correct for the 2D case pdfjs-dist actually uses) so
+ * `getText()` can never hit "DOMMatrix is not defined" regardless of
+ * whether the canvas worker setup below succeeds.
+ */
+export async function setupPdfParse(): Promise<PdfParseSetup> {
+  installDomMatrixPolyfillIfMissing();
+
+  const { PDFParse } = await import("pdf-parse");
+  let canvasFactory: object | undefined;
+  try {
+    const { CanvasFactory, getData } = await import("pdf-parse/worker");
+    PDFParse.setWorker(getData());
+    canvasFactory = CanvasFactory;
+  } catch (err) {
+    // Native @napi-rs/canvas binding unavailable in this runtime — fine for
+    // text-only extraction. Leave the worker script unconfigured (a
+    // documented no-op read, see PDFParse.setWorker) and CanvasFactory
+    // undefined; pdfjs-dist runs in-process without a separate worker.
+    console.warn(
+      "[import-file] pdf-parse canvas worker setup failed, continuing without it (text-only extraction is unaffected):",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+  return { PDFParse, canvasFactory };
+}


### PR DESCRIPTION
## Summary
- recover JSON-stringified tool inputs and stop repeated dead-on-arrival stale-run retries
- make Design edits retry safely across concurrent writes
- make Forms exports use file storage and normalize missing field IDs
- harden Slides PDF extraction and update Gemini image model IDs
- add focused regression coverage, Core changeset, and template changelog entries

## Validation
- Core focused tests: 212 passed
- Design focused tests: 2 passed
- Forms focused tests: 9 passed
- Slides focused tests: 4 passed
- Core, Design, Forms, and Slides typechecks passed
- oxfmt check passed