### PR TITLE
Keep Content database preview action menu interactive

### DIFF
--- a/templates/content/app/components/editor/DatabasePreviewSheet.layout.test.ts
+++ b/templates/content/app/components/editor/DatabasePreviewSheet.layout.test.ts
@@ -27,6 +27,9 @@ describe("database preview sheet layout", () => {
         'return !!target.closest("[data-database-preview-portal]")',
       );
       expect(source).toContain('data-database-preview-portal=""');
+      expect(source).toContain(
+        "<DropdownMenu\n                modal={false}\n                open={actionsMenuOpen}",
+      );
     },
   );
 

--- a/templates/content/app/components/editor/database/DatabaseView.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.tsx
@@ -4781,6 +4781,7 @@ function DatabaseItemPreview({
             </Button>
             {canEdit || canManage || removesFavoriteMembership ? (
               <DropdownMenu
+                modal={false}
                 open={actionsMenuOpen}
                 onOpenChange={setActionsMenuOpen}
               >

--- a/templates/content/changelog/2026-07-25-database-preview-actions-open-reliably.md
+++ b/templates/content/changelog/2026-07-25-database-preview-actions-open-reliably.md
@@ -2,4 +2,5 @@
 type: fixed
 date: 2026-07-25
 ---
+
 Database page preview action menus open reliably with pointer and keyboard.

--- a/templates/content/changelog/2026-07-25-database-preview-actions-open-reliably.md
+++ b/templates/content/changelog/2026-07-25-database-preview-actions-open-reliably.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+date: 2026-07-25
+---
+Database page preview action menus open reliably with pointer and keyboard.

--- a/templates/content/e2e/database-preview-menu.spec.ts
+++ b/templates/content/e2e/database-preview-menu.spec.ts
@@ -1,0 +1,184 @@
+import { expect, test, type APIResponse, type Page } from "@playwright/test";
+
+const ACTION_HEADERS = { "X-Agent-Native-Frontend": "1" };
+
+type ActionResult = Record<string, any>;
+
+async function readJson(response: APIResponse): Promise<ActionResult> {
+  try {
+    return (await response.json()) as ActionResult;
+  } catch {
+    return {};
+  }
+}
+
+async function runAction(
+  page: Page,
+  name: string,
+  data: Record<string, unknown>,
+): Promise<ActionResult> {
+  const response = await page.request.post(`/_agent-native/actions/${name}`, {
+    data,
+    headers: ACTION_HEADERS,
+  });
+  const result = await readJson(response);
+  expect(
+    response.ok(),
+    `${name} should succeed (${response.status()}): ${JSON.stringify(result).slice(0, 500)}`,
+  ).toBeTruthy();
+  return result;
+}
+
+async function readAction(
+  page: Page,
+  name: string,
+  params: Record<string, string>,
+): Promise<ActionResult> {
+  const query = new URLSearchParams(params);
+  const response = await page.request.get(
+    `/_agent-native/actions/${name}?${query.toString()}`,
+    { headers: ACTION_HEADERS },
+  );
+  const result = await readJson(response);
+  expect(
+    response.ok(),
+    `${name} should succeed (${response.status()}): ${JSON.stringify(result).slice(0, 500)}`,
+  ).toBeTruthy();
+  return result;
+}
+
+async function createDatabaseFixture(page: Page) {
+  const title = `Preview menu E2E ${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  const created = await runAction(page, "create-content-database", { title });
+  const databaseId = created.database?.id as string | undefined;
+  const databaseDocumentId = created.database?.documentId as string | undefined;
+  expect(
+    databaseId,
+    "create-content-database returns database.id",
+  ).toBeTruthy();
+  expect(
+    databaseDocumentId,
+    "create-content-database returns database.documentId",
+  ).toBeTruthy();
+
+  const row = await runAction(page, "add-database-item", {
+    databaseId,
+    title: "",
+  });
+  const rowDocumentId = row.createdDocumentId as string | undefined;
+  expect(
+    rowDocumentId,
+    "add-database-item returns createdDocumentId",
+  ).toBeTruthy();
+  await runAction(page, "update-document", {
+    id: rowDocumentId,
+    content: "Loaded preview body for the overflow menu acceptance test.",
+  });
+
+  return {
+    databaseId: databaseId as string,
+    databaseDocumentId: databaseDocumentId as string,
+    rowDocumentId: rowDocumentId as string,
+  };
+}
+
+async function cleanupDatabaseFixture(
+  page: Page,
+  fixture: Awaited<ReturnType<typeof createDatabaseFixture>>,
+) {
+  const trashed = await runAction(page, "delete-content-database", {
+    databaseId: fixture.databaseId,
+  });
+  expect(trashed.documentId).toBe(fixture.databaseDocumentId);
+  await runAction(page, "permanently-delete-document", {
+    id: fixture.databaseDocumentId,
+  });
+}
+
+for (const theme of ["light", "dark"] as const) {
+  test(`database half-page preview menu works with pointer and keyboard in ${theme} mode`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.addInitScript((selectedTheme) => {
+      window.localStorage.setItem("theme", selectedTheme);
+    }, theme);
+
+    let fixture: Awaited<ReturnType<typeof createDatabaseFixture>> | null =
+      null;
+    try {
+      fixture = await createDatabaseFixture(page);
+      await page.goto(`/page/${fixture.databaseDocumentId}`, {
+        waitUntil: "domcontentloaded",
+      });
+
+      const openPreview = page.getByRole("button", {
+        name: "Open Untitled preview",
+      });
+      await expect(openPreview).toBeVisible();
+      await openPreview.click();
+
+      const preview = page.getByRole("dialog", { name: "Untitled" });
+      const trigger = page.getByRole("button", {
+        name: "Preview actions for Untitled",
+      });
+      await expect(preview).toBeVisible();
+      await expect(
+        preview.getByText(
+          "Loaded preview body for the overflow menu acceptance test.",
+        ),
+      ).toBeVisible();
+      await expect(trigger).toBeVisible();
+
+      await trigger.click();
+      const menu = page.getByRole("menu");
+      const duplicateRow = page.getByRole("menuitem", {
+        name: "Duplicate row",
+      });
+      await expect(menu).toBeVisible();
+      await expect(duplicateRow).toBeVisible();
+      await expect(preview).toBeVisible();
+
+      await page.keyboard.press("Escape");
+      await expect(menu).toBeHidden();
+      await expect(preview).toBeVisible();
+      await expect(trigger).toBeFocused();
+
+      await trigger.press("Enter");
+      await expect(menu).toBeVisible();
+      await expect(duplicateRow).toBeFocused();
+      await page.keyboard.press("Escape");
+      await expect(trigger).toBeFocused();
+
+      await trigger.press("Space");
+      await expect(menu).toBeVisible();
+      await page.keyboard.press("Escape");
+      await expect(preview).toBeVisible();
+
+      const databaseAfterMenu = await readAction(page, "get-content-database", {
+        documentId: fixture.databaseDocumentId,
+      });
+      expect(databaseAfterMenu.items).toHaveLength(1);
+      expect(databaseAfterMenu.items[0]?.document?.id).toBe(
+        fixture.rowDocumentId,
+      );
+
+      await page.locator("main").click({ position: { x: 24, y: 160 } });
+      await expect(preview).toBeHidden();
+
+      await openPreview.click();
+      await page.getByRole("button", { name: "Open page" }).click();
+      await expect(page).toHaveURL(`/page/${fixture.rowDocumentId}`);
+      const fullPageMenu = page.getByRole("button", {
+        name: "More page actions",
+      });
+      await expect(fullPageMenu).toBeVisible();
+      await fullPageMenu.click();
+      await expect(
+        page.getByRole("menuitem", { name: "Copy page link" }),
+      ).toBeVisible();
+    } finally {
+      if (fixture) await cleanupDatabaseFixture(page, fixture);
+    }
+  });
+}

--- a/templates/content/e2e/playwright.config.ts
+++ b/templates/content/e2e/playwright.config.ts
@@ -14,7 +14,7 @@ import { defineConfig, devices } from "@playwright/test";
  */
 export default defineConfig({
   testDir: ".",
-  testMatch: /(registry-blocks|local-files)\.spec\.ts/,
+  testMatch: /(registry-blocks|local-files|database-preview-menu)\.spec\.ts/,
   fullyParallel: true,
   workers: process.env.CI ? 2 : 3,
   retries: 2,


### PR DESCRIPTION
## Problem

Opening a row from a Content database keeps the database visible while showing the page in a half-page preview. In the reported failure, the horizontal three-dot button beside **Open page** did not show its action menu, even though the vertical menu on the full-page view still worked. That left preview-only actions such as duplicate and delete unreachable from a common database workflow.

This PR owns only that half-page preview interaction. It does not change the separately resolved editor hydration behavior or the separately owned Select/schema issue.

## Approach

The preview uses a non-modal sheet so the database behind it remains interactive. Its nested dropdown still used the component default of modal behavior. This change makes only the preview dropdown non-modal as well, aligning the two interaction layers while leaving the full-page menu unchanged.

The exact historical browser state no longer reproduced after a cache-bypassing refresh, so the modality mismatch is the narrow source-level cause this PR hardens rather than a claimed reconstruction of that stale state. Acceptance is based on the current PR head in the real deployed Content UI.

## What changed

- configure the preview-only action dropdown with `modal={false}`
- assert that interaction contract in the preview layout test
- add light- and dark-theme browser cases for pointer and keyboard opening, focus restoration, outside dismissal, data preservation, and the full-page menu regression
- add a user-facing Content changelog entry

## Safety and operations

This is a system-ready UI fix with no feature flag. It changes no database schema, actions, permissions, authentication, or persisted user data. Rolling it back only removes the preview dropdown setting and would not require data repair, though it could restore the interaction risk.

The automated fixture creates an isolated database and permanently removes it in `finally`. Deployed-preview QA permanently removed its disposable row; the preview environment retains an empty auto-provisioned Personal database and disposable test account because those surfaces provide no safe deletion control. No direct database cleanup was used.

## Verification

Evidence applies to head `5624c4c87f4fd7d4831141edbf89c5ed7ebbc30c`:

- the focused preview layout test passed: 2 tests
- Playwright discovered both new light and dark browser cases; the automated cases were not executed locally because the configured remote compute host was offline
- every required PR check passed, including formatting, typecheck, fast tests, Content DB tests, Content parity, core integration, build, scaffold E2E, security guards, and static template QA
- independent human QA passed the frozen story on the deployed Content preview at 1440×900: pointer, Enter, and Space opened the menu; focus entered the first action; Escape closed only the menu and returned focus; outside click dismissed the preview; light and dark menus were visible and unclipped; the row stayed unchanged; and the existing full-page vertical menu still opened
- Builder review reported no findings, and the PR is approved

Preview: https://deploy-preview-2407--agent-native-content.netlify.app

## Review focus

- Confirm that matching the dropdown to the sheet’s non-modal interaction model is the smallest correct boundary and does not weaken dismissal behavior.
- Confirm that the browser fixture proves opening and closing menus cannot accidentally trigger duplicate or delete actions.
- Confirm the full-page menu remains outside the implementation boundary.