### PR TITLE
Add an isolated trusted acceptance lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,37 @@ jobs:
       - name: Build all packages
         run: pnpm build
 
+  trusted-acceptance:
+    name: Trusted acceptance substrate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Validate config, provenance, receipts, and workflow boundaries
+        run: pnpm test:trusted-acceptance
+
+      - name: Build the pilot as secretless Netlify artifacts
+        env:
+          AGENT_NATIVE_BUILD_SHA: ${{ github.sha }}
+          NITRO_PRESET: netlify
+        run: |
+          pnpm --filter calendar build
+          pnpm --filter content build
+          test -d templates/calendar/dist
+          test -f templates/calendar/.netlify/functions-internal/server/main.mjs
+          test -d templates/content/dist
+          test -f templates/content/.netlify/functions-internal/server/main.mjs
+
   scaffold-e2e:
     name: Scaffold E2E — create + pnpm install
     runs-on: ubuntu-latest

--- a/.github/workflows/trusted-acceptance.yml
+++ b/.github/workflows/trusted-acceptance.yml
@@ -1,0 +1,447 @@
+name: Trusted acceptance
+
+on:
+  workflow_dispatch:
+    inputs:
+      workspace:
+        description: Declarative acceptance workspace
+        required: true
+        type: string
+        default: calendar-content
+      pull_request:
+        description: Open same-repository pull request number
+        required: false
+        type: string
+      sha:
+        description: Full current pull request head SHA
+        required: false
+        type: string
+      rollback_sha:
+        description: Optional prior known-good full SHA to redeploy
+        required: false
+        type: string
+      rollback_run_id:
+        description: Prior passing trusted-acceptance run containing rollback receipt
+        required: false
+        type: string
+      deploy:
+        description: Deploy after planning and secretless builds
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: trusted-acceptance-${{ inputs.workspace }}
+  cancel-in-progress: false
+
+env:
+  TRUSTED_REPOSITORY: BuilderIO/agent-native
+  CONFIG_FILE: scripts/trusted-acceptance-workspaces.json
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      controller_sha: ${{ github.sha }}
+      config_revision: ${{ steps.plan.outputs.config_revision }}
+      effective_sha: ${{ steps.provenance.outputs.effective_sha }}
+      operation: ${{ steps.provenance.outputs.operation }}
+      pull_request: ${{ steps.provenance.outputs.pull_request }}
+      matrix: ${{ steps.plan.outputs.matrix }}
+      assertions: ${{ steps.plan.outputs.assertions }}
+    steps:
+      - name: Require the trusted default-branch controller
+        env:
+          RUN_REF: ${{ github.ref }}
+        run: |
+          if [[ "$RUN_REF" != "refs/heads/main" ]]; then
+            echo "Dispatch this workflow from main so controller code is trusted." >&2
+            exit 1
+          fi
+
+      - name: Check out trusted controller
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install trusted controller dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Verify candidate or known-good rollback provenance
+        id: provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pull_request }}
+          SELECTED_SHA: ${{ inputs.sha }}
+          ROLLBACK_SHA: ${{ inputs.rollback_sha }}
+          ROLLBACK_RUN_ID: ${{ inputs.rollback_run_id }}
+          WORKSPACE: ${{ inputs.workspace }}
+        run: |
+          if [[ -n "$ROLLBACK_SHA" ]]; then
+            if [[ -n "$PR_NUMBER" || -n "$SELECTED_SHA" ]]; then
+              echo "Rollback runs must not include candidate pull_request or sha inputs." >&2
+              exit 1
+            fi
+            if [[ ! "$ROLLBACK_RUN_ID" =~ ^[0-9]+$ ]]; then
+              echo "rollback_run_id must identify a prior passing run." >&2
+              exit 1
+            fi
+            if [[ ! "$ROLLBACK_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "rollback_sha must be a full lowercase 40-character SHA" >&2
+              exit 1
+            fi
+            resolved_sha="$(gh api "repos/$TRUSTED_REPOSITORY/commits/$ROLLBACK_SHA" --jq .sha)"
+            if [[ "$resolved_sha" != "$ROLLBACK_SHA" ]]; then
+              echo "rollback_sha did not resolve exactly in $TRUSTED_REPOSITORY" >&2
+              exit 1
+            fi
+            effective_sha="$ROLLBACK_SHA"
+            available_templates="$(find templates -mindepth 2 -maxdepth 2 -name package.json -print | sed 's#templates/##;s#/package.json##' | sort | paste -sd, -)"
+            pnpm tsx scripts/trusted-acceptance.ts plan --file "$CONFIG_FILE" --templates "$available_templates" --workspace "$WORKSPACE" --allow-disabled > "$RUNNER_TEMP/rollback-plan.json"
+            expected_assertions="$(node -e 'const p=require(process.env.RUNNER_TEMP + "/rollback-plan.json"); if (!p.ok) process.exit(1); process.stdout.write(JSON.stringify(p.plan.assertions))')"
+            gh api "repos/$TRUSTED_REPOSITORY/actions/runs/$ROLLBACK_RUN_ID" > "$RUNNER_TEMP/prior-run.json"
+            node - <<'NODE'
+            const fs = require("node:fs");
+            const run = JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + "/prior-run.json", "utf8"));
+            if (run.path !== ".github/workflows/trusted-acceptance.yml" || run.event !== "workflow_dispatch" || run.conclusion !== "success" || run.head_branch !== "main") {
+              throw new Error("rollback_run_id must be a successful main dispatch of the trusted acceptance workflow");
+            }
+            NODE
+            artifact_id="$(gh api "repos/$TRUSTED_REPOSITORY/actions/runs/$ROLLBACK_RUN_ID/artifacts" --jq ".artifacts[] | select(.name == \"trusted-acceptance-receipt-$ROLLBACK_RUN_ID\") | .id" | head -n 1)"
+            if [[ -z "$artifact_id" ]]; then
+              echo "No trusted acceptance receipt artifact found for rollback_run_id." >&2
+              exit 1
+            fi
+            gh api "repos/$TRUSTED_REPOSITORY/actions/artifacts/$artifact_id/zip" > "$RUNNER_TEMP/prior-receipt.zip"
+            prior_receipt="$RUNNER_TEMP/prior-receipt.json"
+            unzip -p "$RUNNER_TEMP/prior-receipt.zip" trusted-acceptance-receipt.json > "$prior_receipt"
+            test -s "$prior_receipt"
+            pnpm tsx scripts/trusted-acceptance.ts receipt --file "$prior_receipt" --expected-assertions "$expected_assertions"
+            node - "$prior_receipt" <<'NODE'
+            const fs = require("node:fs");
+            const receipt = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+            const run = JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + "/prior-run.json", "utf8"));
+            const expectedRunUrl = `https://github.com/${process.env.TRUSTED_REPOSITORY}/actions/runs/${process.env.ROLLBACK_RUN_ID}`;
+            if (receipt.result !== "pass" || receipt.runUrl !== expectedRunUrl || receipt.controllerSha !== run.head_sha || receipt.workspace !== process.env.WORKSPACE || receipt.currentKnownGoodSha !== process.env.ROLLBACK_SHA) {
+              throw new Error("Rollback SHA is not the known-good SHA from the selected passing workspace receipt");
+            }
+            NODE
+            operation="rollback"
+            receipt_pr=""
+          else
+            if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ || ! "$SELECTED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "Candidate runs require pull_request and a full lowercase head sha." >&2
+              exit 1
+            fi
+            if [[ -n "$ROLLBACK_RUN_ID" ]]; then
+              echo "rollback_run_id is only valid with rollback_sha." >&2
+              exit 1
+            fi
+            gh api "repos/$TRUSTED_REPOSITORY/pulls/$PR_NUMBER" \
+              --jq '{number, state, headSha: .head.sha, headRepository: .head.repo.full_name, isFork: (.head.repo.fork or (.head.repo.full_name != .base.repo.full_name))}' \
+              > "$RUNNER_TEMP/pull-request.json"
+            pnpm tsx scripts/trusted-acceptance.ts provenance \
+              --file "$RUNNER_TEMP/pull-request.json" \
+              --sha "$SELECTED_SHA" \
+              --repository "$TRUSTED_REPOSITORY"
+            effective_sha="$SELECTED_SHA"
+            operation="candidate"
+            receipt_pr="$PR_NUMBER"
+          fi
+          echo "effective_sha=$effective_sha" >> "$GITHUB_OUTPUT"
+          echo "operation=$operation" >> "$GITHUB_OUTPUT"
+          echo "pull_request=$receipt_pr" >> "$GITHUB_OUTPUT"
+
+      - name: Validate config and produce generic member matrix
+        id: plan
+        env:
+          WORKSPACE: ${{ inputs.workspace }}
+          DEPLOY: ${{ inputs.deploy }}
+        run: |
+          templates="$(find templates -mindepth 2 -maxdepth 2 -name package.json -print | sed 's#templates/##;s#/package.json##' | sort | paste -sd, -)"
+          args=(plan --file "$CONFIG_FILE" --templates "$templates" --workspace "$WORKSPACE")
+          if [[ "$DEPLOY" != "true" ]]; then
+            args+=(--allow-disabled)
+          fi
+          pnpm tsx scripts/trusted-acceptance.ts "${args[@]}" > "$RUNNER_TEMP/plan.json"
+          node - <<'NODE'
+          const fs = require("node:fs");
+          const plan = JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + "/plan.json", "utf8"));
+          if (!plan.ok) throw new Error(JSON.stringify(plan.issues));
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `config_revision=${plan.plan.revision}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `matrix=${JSON.stringify({ include: plan.plan.members })}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `assertions=${JSON.stringify(plan.plan.assertions)}\n`);
+          NODE
+
+      - name: Record dry-run plan
+        env:
+          EFFECTIVE_SHA: ${{ steps.provenance.outputs.effective_sha }}
+          MATRIX: ${{ steps.plan.outputs.matrix }}
+        run: |
+          {
+            echo "## Trusted acceptance plan"
+            echo
+            echo "- Workspace: \`${{ inputs.workspace }}\`"
+            echo "- Exact SHA: \`$EFFECTIVE_SHA\`"
+            echo "- Deploy requested: \`${{ inputs.deploy }}\`"
+            echo "- Generic member matrix: \`$MATRIX\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  build:
+    needs: plan
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    steps:
+      - name: Check out candidate without persistent credentials
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ needs.plan.outputs.effective_sha }}
+          path: candidate
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: candidate/.nvmrc
+          cache: pnpm
+          cache-dependency-path: candidate/pnpm-lock.yaml
+
+      - name: Install candidate dependencies without runtime credentials
+        working-directory: candidate
+        run: pnpm install --frozen-lockfile
+
+      - name: Build candidate without runtime or deployment credentials
+        working-directory: candidate
+        env:
+          AGENT_NATIVE_BUILD_SHA: ${{ needs.plan.outputs.effective_sha }}
+          NITRO_PRESET: netlify
+        run: ${{ matrix.build.command }}
+
+      - name: Package inert build output
+        working-directory: candidate
+        env:
+          ACCEPTANCE_SHA: ${{ needs.plan.outputs.effective_sha }}
+          TEMPLATE: ${{ matrix.template }}
+        run: |
+          test -d "${{ matrix.build.publishDirectory }}"
+          mkdir -p "$RUNNER_TEMP/acceptance-artifact/$TEMPLATE"
+          cp -R "${{ matrix.build.publishDirectory }}" "$RUNNER_TEMP/acceptance-artifact/$TEMPLATE/publish"
+          if [[ -d "templates/$TEMPLATE/.netlify" ]]; then
+            cp -R "templates/$TEMPLATE/.netlify" "$RUNNER_TEMP/acceptance-artifact/$TEMPLATE/.netlify"
+          fi
+          node -e 'require("node:fs").writeFileSync(process.env.RUNNER_TEMP + "/acceptance-artifact/" + process.env.TEMPLATE + "/build-metadata.json", JSON.stringify({sha: process.env.ACCEPTANCE_SHA, template: process.env.TEMPLATE}))'
+
+      - name: Upload inert candidate artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trusted-acceptance-build-${{ matrix.template }}
+          path: ${{ runner.temp }}/acceptance-artifact/${{ matrix.template }}
+          if-no-files-found: error
+          retention-days: 7
+
+  deploy:
+    if: ${{ inputs.deploy }}
+    needs: [plan, build]
+    runs-on: ubuntu-latest
+    environment: trusted-acceptance
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    steps:
+      - name: Check out trusted controller
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install pinned deployment client before credentials enter the job
+        run: npm install --global netlify-cli@27.0.0 --ignore-scripts
+
+      - name: Resolve isolated acceptance site before credentials enter the step
+        id: site
+        env:
+          SITE_ID: ${{ vars[matrix.siteIdVariable] }}
+          TEMPLATE: ${{ matrix.template }}
+        run: |
+          if [[ -z "$SITE_ID" ]]; then
+            echo "The trusted-acceptance environment has no site ID for $TEMPLATE." >&2
+            exit 1
+          fi
+          node - <<'NODE'
+          const fs = require("node:fs");
+          const productionSites = Object.values(JSON.parse(fs.readFileSync("scripts/netlify-sites.json", "utf8")));
+          if (productionSites.includes(process.env.SITE_ID)) {
+            throw new Error("Acceptance deployment resolved to a known production site ID");
+          }
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `site_id=${process.env.SITE_ID}\n`);
+          NODE
+
+      - name: Download inert candidate artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: trusted-acceptance-build-${{ matrix.template }}
+          path: ${{ runner.temp }}/acceptance-artifact/${{ matrix.template }}
+
+      - name: Verify artifact provenance before credentials enter the step
+        env:
+          EXPECTED_SHA: ${{ needs.plan.outputs.effective_sha }}
+          TEMPLATE: ${{ matrix.template }}
+        run: |
+          node - <<'NODE'
+          const fs = require("node:fs");
+          const path = `${process.env.RUNNER_TEMP}/acceptance-artifact/${process.env.TEMPLATE}/build-metadata.json`;
+          const metadata = JSON.parse(fs.readFileSync(path, "utf8"));
+          if (metadata.sha !== process.env.EXPECTED_SHA || metadata.template !== process.env.TEMPLATE) {
+            throw new Error("Candidate artifact provenance mismatch");
+          }
+          NODE
+          mkdir -p "$RUNNER_TEMP/trusted-acceptance-deploy"
+
+      - name: Deploy inert artifact to isolated acceptance site
+        working-directory: ${{ runner.temp }}/trusted-acceptance-deploy
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/acceptance-artifact/${{ matrix.template }}
+          NETLIFY_AUTH_TOKEN: ${{ secrets.ACCEPTANCE_NETLIFY_AUTH_TOKEN }}
+          SITE_ID: ${{ steps.site.outputs.site_id }}
+          TEMPLATE: ${{ matrix.template }}
+        run: |
+          if [[ -z "$NETLIFY_AUTH_TOKEN" ]]; then
+            echo "The trusted-acceptance environment is not provisioned for $TEMPLATE." >&2
+            exit 1
+          fi
+          raw_result="$(mktemp)"
+          trap 'rm -f "$raw_result"' EXIT
+          netlify deploy --prod --no-build --json --auth "$NETLIFY_AUTH_TOKEN" --site "$SITE_ID" --dir "$ARTIFACT_DIR/publish" --functions "$ARTIFACT_DIR/.netlify/functions-internal" > "$raw_result"
+          node - "$raw_result" "$RUNNER_TEMP/deploy-$TEMPLATE.json" <<'NODE'
+          const fs = require("node:fs");
+          const result = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const deployId = result.deploy_id ?? result.id;
+          if (!deployId) throw new Error("Netlify did not return a deploy ID");
+          fs.writeFileSync(process.argv[3], JSON.stringify({template: process.env.TEMPLATE, deployId}));
+          NODE
+
+      - name: Upload redacted deployment result
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trusted-acceptance-deploy-${{ matrix.template }}
+          path: ${{ runner.temp }}/deploy-${{ matrix.template }}.json
+          if-no-files-found: error
+          retention-days: 30
+
+  receipt:
+    if: ${{ always() && needs.plan.result == 'success' }}
+    needs: [plan, build, deploy]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out trusted receipt validator
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install trusted receipt dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Download redacted deployment results
+        if: ${{ inputs.deploy && needs.deploy.result == 'success' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: trusted-acceptance-deploy-*
+          path: ${{ runner.temp }}/deploy-results
+          merge-multiple: true
+
+      - name: Assemble and validate redacted receipt
+        env:
+          ACTOR: ${{ github.actor }}
+          ASSERTIONS: ${{ needs.plan.outputs.assertions }}
+          CONFIG_REVISION: ${{ needs.plan.outputs.config_revision }}
+          CONTROLLER_SHA: ${{ needs.plan.outputs.controller_sha }}
+          DEPLOY_REQUESTED: ${{ inputs.deploy }}
+          DEPLOY_RESULT: ${{ needs.deploy.result }}
+          MATRIX: ${{ needs.plan.outputs.matrix }}
+          OPERATION: ${{ needs.plan.outputs.operation }}
+          PR_NUMBER: ${{ needs.plan.outputs.pull_request }}
+          ROLLBACK_SHA: ${{ inputs.rollback_sha }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SHA: ${{ needs.plan.outputs.effective_sha }}
+          WORKSPACE: ${{ inputs.workspace }}
+        run: |
+          node - <<'NODE'
+          const fs = require("node:fs");
+          const path = require("node:path");
+          const members = JSON.parse(process.env.MATRIX).include.map(member => {
+            const resultPath = path.join(process.env.RUNNER_TEMP, "deploy-results", `deploy-${member.template}.json`);
+            const deployId = fs.existsSync(resultPath)
+              ? JSON.parse(fs.readFileSync(resultPath, "utf8")).deployId
+              : null;
+            return {template: member.template, origin: member.origin, deployId};
+          });
+          const deployed = process.env.DEPLOY_REQUESTED === "true" && process.env.DEPLOY_RESULT === "success";
+          const assertions = JSON.parse(process.env.ASSERTIONS).map(id => ({
+            id,
+            state: "blocked",
+            evidencePointer: deployed ? "workflow://runtime-proof-pending" : "workflow://dry-run-only",
+          }));
+          const receipt = {
+            actor: process.env.ACTOR,
+            runUrl: process.env.RUN_URL,
+            operation: process.env.OPERATION,
+            pullRequest: process.env.PR_NUMBER ? Number(process.env.PR_NUMBER) : null,
+            sha: process.env.SHA,
+            controllerSha: process.env.CONTROLLER_SHA,
+            configRevision: process.env.CONFIG_REVISION,
+            workspace: process.env.WORKSPACE,
+            members,
+            assertions,
+            startedAt: new Date().toISOString(),
+            completedAt: new Date().toISOString(),
+            result: "blocked",
+            rollbackTarget: process.env.ROLLBACK_SHA || null,
+            priorKnownGoodSha: process.env.ROLLBACK_SHA || null,
+            currentKnownGoodSha: null,
+          };
+          fs.writeFileSync(process.env.RUNNER_TEMP + "/trusted-acceptance-receipt.json", JSON.stringify(receipt, null, 2));
+          NODE
+          pnpm tsx scripts/trusted-acceptance.ts receipt --file "$RUNNER_TEMP/trusted-acceptance-receipt.json" --expected-assertions "$ASSERTIONS"
+          {
+            echo "## Trusted acceptance receipt"
+            echo
+            echo "The repository substrate ran for exact SHA \`$SHA\`. Runtime OAuth/A2A assertions remain blocked until the isolated workspace is provisioned and enabled."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload redacted acceptance receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trusted-acceptance-receipt-${{ github.run_id }}
+          path: ${{ runner.temp }}/trusted-acceptance-receipt.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/trusted-acceptance.yml
+++ b/.github/workflows/trusted-acceptance.yml
@@ -88,6 +88,7 @@ jobs:
           SELECTED_SHA: ${{ inputs.sha }}
           ROLLBACK_SHA: ${{ inputs.rollback_sha }}
           ROLLBACK_RUN_ID: ${{ inputs.rollback_run_id }}
+          DEPLOY_REQUESTED: ${{ inputs.deploy }}
           WORKSPACE: ${{ inputs.workspace }}
         run: |
           if [[ -n "$ROLLBACK_SHA" ]]; then
@@ -110,7 +111,11 @@ jobs:
             fi
             effective_sha="$ROLLBACK_SHA"
             available_templates="$(find templates -mindepth 2 -maxdepth 2 -name package.json -print | sed 's#templates/##;s#/package.json##' | sort | paste -sd, -)"
-            pnpm tsx scripts/trusted-acceptance.ts plan --file "$CONFIG_FILE" --templates "$available_templates" --workspace "$WORKSPACE" --allow-disabled > "$RUNNER_TEMP/rollback-plan.json"
+            rollback_plan_args=(plan --file "$CONFIG_FILE" --templates "$available_templates" --workspace "$WORKSPACE")
+            if [[ "$DEPLOY_REQUESTED" != "true" ]]; then
+              rollback_plan_args+=(--allow-disabled)
+            fi
+            pnpm tsx scripts/trusted-acceptance.ts "${rollback_plan_args[@]}" > "$RUNNER_TEMP/rollback-plan.json"
             expected_assertions="$(node -e 'const p=require(process.env.RUNNER_TEMP + "/rollback-plan.json"); if (!p.ok) process.exit(1); process.stdout.write(JSON.stringify(p.plan.assertions))')"
             gh api "repos/$TRUSTED_REPOSITORY/actions/runs/$ROLLBACK_RUN_ID" > "$RUNNER_TEMP/prior-run.json"
             node - <<'NODE'
@@ -252,6 +257,7 @@ jobs:
         with:
           name: trusted-acceptance-build-${{ matrix.template }}
           path: ${{ runner.temp }}/acceptance-artifact/${{ matrix.template }}
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 7
 

--- a/docs/trusted-acceptance-lane.md
+++ b/docs/trusted-acceptance-lane.md
@@ -17,8 +17,9 @@ The `calendar-content` pilot in
 `scripts/trusted-acceptance-workspaces.json` is checked in with `enabled: false`.
 The workflow can validate an open PR, produce the generic app matrix, and build
 the candidate without runtime or deployment credentials. A live deployment
-fails closed until a reviewed change enables the workspace after its isolated
-resources have been provisioned.
+fails closed even if the flag is changed: the bootstrap config deliberately has
+no runtime-authority provisioner. A later reviewed change must implement the
+trusted per-run credential lease and cleanup path before activation.
 
 ## Custody boundaries
 
@@ -56,18 +57,43 @@ Provisioning is an infrastructure-owner operation after the controller is on
 the default branch. Create new non-production resources; do not reuse or copy
 production or ordinary-preview values.
 
-For each app:
+Candidate server code can read every value available to its hosted runtime.
+Therefore a long-lived acceptance database credential, Better Auth secret, or
+A2A secret is not an isolation boundary: a candidate could retain it after the
+run. Static runtime credentials configured directly on the stable acceptance
+sites are forbidden.
+
+Before this workspace can be enabled, a follow-up implementation must add a
+trusted runtime-authority provisioner that:
+
+- creates a fresh, revocable database credential over synthetic data for each
+  run;
+- generates fresh Better Auth and shared-workspace A2A secrets for that run;
+- installs those values on the acceptance sites only after candidate build
+  artifacts are inert and verified;
+- revokes or rotates every leased value in an `always()` cleanup path, including
+  failed and cancelled acceptance runs; and
+- records only lease identifiers, issue/revocation timestamps, and cleanup
+  status in the redacted receipt. A receipt cannot pass until revocation is
+  confirmed.
+
+The candidate may inspect or corrupt its disposable lease while the test is in
+progress. Its authority must become useless when cleanup completes; production,
+ordinary previews, other workspaces, and later acceptance runs remain outside
+the blast radius.
+
+For each app, the infrastructure owner may prepare:
 
 - create a dedicated Netlify site and stable acceptance domain matching the
   configured origin;
-- create a dedicated database containing only synthetic users and fixtures;
-- create a unique Better Auth secret;
+- create an acceptance database service capable of issuing per-run revocable
+  credentials over synthetic users and fixtures;
 - set the exact acceptance origin as `APP_URL` and `BETTER_AUTH_URL`; and
-- configure the app's acceptance-only runtime values directly on that site.
+- leave reusable database, Better Auth, and A2A credentials off the site.
 
-All apps in one workspace share one acceptance-only A2A secret. That secret
-must not be used by production, previews, another workspace, or a provider
-integration.
+All apps in one workspace receive the same per-run A2A secret. It must be
+rotated after the run and must never be used by production, previews, another
+workspace, a provider integration, or a later acceptance run.
 
 Configure the protected GitHub Environment named `trusted-acceptance` with:
 
@@ -81,9 +107,12 @@ The repository contains key names and resource references only. Never put
 secret values, synthetic login credentials, tokens, or raw provider responses
 in the workspace config, workflow, docs, logs, or receipt.
 
-After a redacted inventory proves those resources are isolated, change the
-workspace to `enabled: true` in a reviewed PR. Keep GitHub Environment approval
-rules in place; enabling configuration is not permission to bypass them.
+After a redacted inventory proves those resources are isolated and the trusted
+provision/cleanup implementation has its own security review and tests, replace
+the bootstrap `unconfigured` provisioner and change the workspace to
+`enabled: true` in a reviewed PR. Changing only the flag still fails closed.
+Keep GitHub Environment approval rules in place; enabling configuration is not
+permission to bypass them.
 
 ## Run a dry plan
 
@@ -124,13 +153,15 @@ No workflow branch is required. Add a member or workspace entry containing:
 - a unique template ID that exists under `templates/`;
 - a stable, non-production HTTPS acceptance origin;
 - a unique acceptance-scoped Netlify site-variable name;
-- acceptance-scoped runtime key names;
+- acceptance-scoped runtime key names and an implemented disposable-authority
+  provisioner;
 - the template's build command and relative publish directory;
 - absolute health, protected-resource metadata, and MCP paths; and
 - the assertion IDs that the workspace must prove.
 
-Keep the entry disabled until its dedicated site, database, identity, A2A
-boundary, DNS, and protected-environment custody have been independently
+Keep the entry disabled and its provisioner unconfigured until its dedicated
+site, per-run database credential lease, per-run identity and A2A rotation,
+cleanup path, DNS, and protected-environment custody have been independently
 verified. Run the focused validator and workflow boundary tests before review:
 
 ```sh

--- a/docs/trusted-acceptance-lane.md
+++ b/docs/trusted-acceptance-lane.md
@@ -1,0 +1,144 @@
+# Trusted acceptance lane
+
+The trusted acceptance lane is the repository-owned path for testing an exact
+same-repository pull request SHA against stable, isolated hosted apps. It is for
+framework behavior that a local test or ordinary visual preview cannot prove,
+including remote MCP OAuth, workspace discovery, A2A delegation, and hosted
+async task status.
+
+The lane is intentionally separate from ordinary Netlify deploy previews. It
+does not read, copy, reconcile, or repair preview environment configuration,
+and a successful lane receipt says nothing about preview OAuth or preview
+credential isolation.
+
+## Current bootstrap state
+
+The `calendar-content` pilot in
+`scripts/trusted-acceptance-workspaces.json` is checked in with `enabled: false`.
+The workflow can validate an open PR, produce the generic app matrix, and build
+the candidate without runtime or deployment credentials. A live deployment
+fails closed until a reviewed change enables the workspace after its isolated
+resources have been provisioned.
+
+## Custody boundaries
+
+The manual `.github/workflows/trusted-acceptance.yml` controller must be
+dispatched from `main`. Every trusted job pins controller code to that immutable
+dispatch SHA. Candidate runs verify that the selected full SHA is the current
+head of an open, non-fork pull request in `BuilderIO/agent-native`.
+
+The jobs deliberately have different custody:
+
+1. `plan` checks out trusted default-branch controller code and validates PR
+   provenance plus the declarative workspace.
+2. `build` checks out the selected candidate without persistent GitHub
+   credentials. Candidate dependency and build scripts run without Netlify,
+   database, Better Auth, A2A, provider, OAuth, or runtime secrets, then upload
+   inert build artifacts and SHA metadata.
+3. `deploy` uses the protected `trusted-acceptance` GitHub Environment. It
+   checks out trusted controller code, installs the pinned Netlify client,
+   rejects any resolved site ID present in the production-site inventory,
+   downloads and verifies inert artifacts, then uploads them from an empty
+   trusted directory using explicit paths. Candidate `netlify.toml`, plugins,
+   and hooks never cross into this job. Only then does the upload step receive
+   the scoped Netlify token; it uses `--no-build` and never runs candidate
+   scripts.
+4. `receipt` records a redacted artifact. Until the real OAuth/A2A harness is
+   run, behavioral assertions remain `blocked`; a deployment alone is not a
+   passing acceptance result.
+
+Runs share a non-cancelling concurrency group per workspace, so two candidate
+SHAs cannot interleave across the same apps.
+
+## Provision the first workspace
+
+Provisioning is an infrastructure-owner operation after the controller is on
+the default branch. Create new non-production resources; do not reuse or copy
+production or ordinary-preview values.
+
+For each app:
+
+- create a dedicated Netlify site and stable acceptance domain matching the
+  configured origin;
+- create a dedicated database containing only synthetic users and fixtures;
+- create a unique Better Auth secret;
+- set the exact acceptance origin as `APP_URL` and `BETTER_AUTH_URL`; and
+- configure the app's acceptance-only runtime values directly on that site.
+
+All apps in one workspace share one acceptance-only A2A secret. That secret
+must not be used by production, previews, another workspace, or a provider
+integration.
+
+Configure the protected GitHub Environment named `trusted-acceptance` with:
+
+- secret `ACCEPTANCE_NETLIFY_AUTH_TOKEN`, scoped to deployment of only the
+  dedicated acceptance sites; and
+- non-secret site variables named by each member's `siteIdVariable`, initially
+  `ACCEPTANCE_CALENDAR_NETLIFY_SITE_ID` and
+  `ACCEPTANCE_CONTENT_NETLIFY_SITE_ID`.
+
+The repository contains key names and resource references only. Never put
+secret values, synthetic login credentials, tokens, or raw provider responses
+in the workspace config, workflow, docs, logs, or receipt.
+
+After a redacted inventory proves those resources are isolated, change the
+workspace to `enabled: true` in a reviewed PR. Keep GitHub Environment approval
+rules in place; enabling configuration is not permission to bypass them.
+
+## Run a dry plan
+
+Open **Actions → Trusted acceptance → Run workflow** from `main` and provide:
+
+- `workspace`: `calendar-content`;
+- `pull_request`: the open same-repository PR number;
+- `sha`: its full lowercase 40-character current head SHA; and
+- `deploy`: false.
+
+The run must fail before build for a fork, closed PR, stale or abbreviated SHA,
+unknown workspace, or invalid configuration. A dry run emits a blocked receipt
+and never enters the protected deployment environment.
+
+For a live run after activation, set `deploy` to true. The stable apps must then
+be tested with a real authorization-code plus PKCE client: inspect protected
+resource metadata, connect to Calendar, require Content from `list_apps`, call a
+bounded read-only `ask_app`, and poll the returned ID through `ask_app_status`.
+Run production-to-acceptance, acceptance-to-production, and cross-resource
+token replay negatives before marking the receipt passed.
+
+## Roll back
+
+Use `rollback_sha` together with the `rollback_run_id` of a prior passing,
+redacted acceptance receipt. Leave the candidate `pull_request` and `sha` inputs
+empty. The controller downloads and validates that same-repository receipt,
+requires the prior run to be a successful `main` dispatch of this exact
+workflow, and matches its controller SHA, workspace, and current known-good SHA.
+It then verifies that the commit still resolves exactly in
+`BuilderIO/agent-native`, rebuilds it without credentials, and redeploys it
+through the same isolated path. Rollback never promotes acceptance code or data
+to production.
+
+## Add another hosted template
+
+No workflow branch is required. Add a member or workspace entry containing:
+
+- a unique template ID that exists under `templates/`;
+- a stable, non-production HTTPS acceptance origin;
+- a unique acceptance-scoped Netlify site-variable name;
+- acceptance-scoped runtime key names;
+- the template's build command and relative publish directory;
+- absolute health, protected-resource metadata, and MCP paths; and
+- the assertion IDs that the workspace must prove.
+
+Keep the entry disabled until its dedicated site, database, identity, A2A
+boundary, DNS, and protected-environment custody have been independently
+verified. Run the focused validator and workflow boundary tests before review:
+
+```sh
+pnpm tsx --test scripts/trusted-acceptance.spec.ts scripts/guard-trusted-acceptance-workflow.spec.ts
+pnpm guard:trusted-acceptance
+```
+
+The generic fixture in `scripts/trusted-acceptance.spec.ts` uses the repository's
+real Tasks template to demonstrate that a third template validates and produces
+a plan without changing workflow code. A real secretless Tasks build remains an
+activation-time proof, not something this schema test claims to establish.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:content-db": "pnpm --filter content exec vitest --run actions/bind-content-database-source-field.db.test.ts actions/blocks-seeding.db.test.ts actions/builder-source-review-gates.db.test.ts actions/content-database-lifecycle.db.test.ts actions/database-row-batch-actions.db.test.ts actions/list-content-databases.db.test.ts actions/move-document.db.test.ts actions/resync-content-database-source.db.test.ts actions/stage-builder-source-bulk-update.db.test.ts actions/submit-content-database-form.db.test.ts actions/update-document.db.test.ts --config vitest.config.ts",
     "test:core-integration": "pnpm --filter @agent-native/core exec vitest --run src/agent/engine/translate-ai-sdk.integration.spec.ts src/agent/run-loop-with-resume.integration.spec.ts src/client/extensions/AgentNativeExtensionFrame.e2e.spec.ts src/client/session-replay-iframe.e2e.spec.ts src/scripts/db/migrate-encrypt-credentials.e2e.spec.ts src/scripts/db/scope-isolation.e2e.spec.ts src/server/csrf-plugin-ordering.integration.spec.ts src/server/embedded.integration.spec.ts --maxWorkers=25% --passWithNoTests",
     "test:plan-e2e": "pnpm --filter plan exec vitest --run actions/create-visual-recap.e2e.spec.ts --passWithNoTests",
+    "test:trusted-acceptance": "tsx --test scripts/trusted-acceptance.spec.ts scripts/guard-trusted-acceptance-workflow.spec.ts",
     "test:brain-evals": "pnpm --filter brain eval:ci",
     "test:brain-privacy-evals": "pnpm --filter brain privacy:eval",
     "test:content-parity": "pnpm --filter content test:parity-capabilities",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "guard:db-tool-scoping": "node scripts/guard-db-tool-scoping.mjs",
     "guard:template-list": "node scripts/guard-template-list.mjs",
     "guard:netlify-private-env": "tsx scripts/guard-netlify-private-env.ts",
+    "guard:trusted-acceptance": "tsx scripts/guard-trusted-acceptance-workflow.ts",
     "guard:workspace-skills": "tsx scripts/sync-workspace-core-skills.ts --check",
     "sync:template-standard": "tsx scripts/template-standard/index.ts",
     "guard:template-standard": "tsx scripts/template-standard/index.ts --check",

--- a/scripts/guard-trusted-acceptance-workflow.spec.ts
+++ b/scripts/guard-trusted-acceptance-workflow.spec.ts
@@ -27,6 +27,44 @@ describe("trusted acceptance workflow boundary", () => {
     assert(result.issues.some((issue) => issue.includes("candidate build")));
   });
 
+  it("rejects a secret inherited from the workflow environment", () => {
+    const unsafe = workflow.replace(
+      "  CONFIG_FILE: scripts/trusted-acceptance-workspaces.json",
+      "  CONFIG_FILE: scripts/trusted-acceptance-workspaces.json\n  LEAKED_DATABASE_URL: ${{ secrets.ACCEPTANCE_DATABASE_URL }}",
+    );
+    const result = validateTrustedAcceptanceWorkflow(unsafe);
+    assert.equal(result.ok, false);
+    assert(
+      result.issues.some((issue) =>
+        issue.includes("workflow-level environment"),
+      ),
+    );
+  });
+
+  it("requires the hidden Netlify function bundle in candidate artifacts", () => {
+    const unsafe = workflow.replace(
+      "          include-hidden-files: true\n",
+      "",
+    );
+    const result = validateTrustedAcceptanceWorkflow(unsafe);
+    assert.equal(result.ok, false);
+    assert(result.issues.some((issue) => issue.includes("hidden Netlify")));
+  });
+
+  it("rejects rollback planning that always bypasses activation gates", () => {
+    const unsafe = workflow.replace(
+      '            if [[ "$DEPLOY_REQUESTED" != "true" ]]; then\n              rollback_plan_args+=(--allow-disabled)\n            fi',
+      "            rollback_plan_args+=(--allow-disabled)",
+    );
+    const result = validateTrustedAcceptanceWorkflow(unsafe);
+    assert.equal(result.ok, false);
+    assert(
+      result.issues.some((issue) =>
+        issue.includes("only when no deployment is requested"),
+      ),
+    );
+  });
+
   it("rejects candidate checkouts that persist GitHub credentials", () => {
     const unsafe = workflow.replace(
       "path: candidate\n          persist-credentials: false",

--- a/scripts/guard-trusted-acceptance-workflow.spec.ts
+++ b/scripts/guard-trusted-acceptance-workflow.spec.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+import { validateTrustedAcceptanceWorkflow } from "./guard-trusted-acceptance-workflow.ts";
+
+const workflow = readFileSync(
+  ".github/workflows/trusted-acceptance.yml",
+  "utf8",
+);
+
+describe("trusted acceptance workflow boundary", () => {
+  it("keeps candidate builds separate from protected deployment custody", () => {
+    assert.deepEqual(validateTrustedAcceptanceWorkflow(workflow), {
+      ok: true,
+      issues: [],
+    });
+  });
+
+  it("rejects a secret exposed to candidate build steps", () => {
+    const unsafe = workflow.replace(
+      "\n  deploy:\n",
+      "\n    env:\n      LEAK: ${{ secrets.ACCEPTANCE_NETLIFY_AUTH_TOKEN }}\n\n  deploy:\n",
+    );
+    const result = validateTrustedAcceptanceWorkflow(unsafe);
+    assert.equal(result.ok, false);
+    assert(result.issues.some((issue) => issue.includes("candidate build")));
+  });
+
+  it("rejects candidate checkouts that persist GitHub credentials", () => {
+    const unsafe = workflow.replace(
+      "path: candidate\n          persist-credentials: false",
+      "path: candidate\n          persist-credentials: true",
+    );
+    const result = validateTrustedAcceptanceWorkflow(unsafe);
+    assert.equal(result.ok, false);
+    assert(result.issues.some((issue) => issue.includes("candidate checkout")));
+  });
+
+  it("rejects candidate-controlled workflow triggers", () => {
+    const unsafe = workflow.replace(
+      "on:\n  workflow_dispatch:",
+      "on:\n  pull_request:\n  workflow_dispatch:",
+    );
+    const result = validateTrustedAcceptanceWorkflow(unsafe);
+    assert.equal(result.ok, false);
+    assert(
+      result.issues.some((issue) => issue.includes("candidate-controlled")),
+    );
+  });
+
+  it("rejects candidate Netlify configuration crossing into privileged custody", () => {
+    const unsafe = workflow.replace(
+      '          node -e \'require("node:fs")',
+      '          cp "templates/$TEMPLATE/netlify.toml" "$RUNNER_TEMP/acceptance-artifact/$TEMPLATE/netlify.toml"\n          node -e \'require("node:fs")',
+    );
+    const result = validateTrustedAcceptanceWorkflow(unsafe);
+    assert.equal(result.ok, false);
+    assert(
+      result.issues.some((issue) => issue.includes("Netlify configuration")),
+    );
+  });
+
+  it("rejects moving trusted-controller checkouts", () => {
+    const unsafe = workflow.replace("ref: ${{ github.sha }}", "ref: main");
+    const result = validateTrustedAcceptanceWorkflow(unsafe);
+    assert.equal(result.ok, false);
+    assert(result.issues.some((issue) => issue.includes("controller SHA")));
+  });
+});

--- a/scripts/guard-trusted-acceptance-workflow.ts
+++ b/scripts/guard-trusted-acceptance-workflow.ts
@@ -161,6 +161,13 @@ export function validateTrustedAcceptanceWorkflow(
       "trusted acceptance must not depend on production Netlify custody",
     );
   }
+  if (
+    !source.includes("CONFIG_FILE: scripts/trusted-acceptance-workspaces.json")
+  ) {
+    issues.push(
+      "workflow must use the guarded runtime-authority configuration",
+    );
+  }
 
   return { ok: issues.length === 0, issues };
 }
@@ -171,6 +178,26 @@ function main(): void {
     "utf8",
   );
   const result = validateTrustedAcceptanceWorkflow(workflow);
+  const config = JSON.parse(
+    readFileSync("scripts/trusted-acceptance-workspaces.json", "utf8"),
+  ) as {
+    workspaces?: Array<{
+      runtimeAuthority?: { lifecycle?: string; provisioner?: string };
+    }>;
+  };
+  if (
+    !config.workspaces?.length ||
+    config.workspaces.some(
+      ({ runtimeAuthority }) =>
+        runtimeAuthority?.lifecycle !== "ephemeral-per-run" ||
+        runtimeAuthority.provisioner !== "unconfigured",
+    )
+  ) {
+    result.ok = false;
+    result.issues.push(
+      "bootstrap must fail closed without a trusted ephemeral runtime authority provisioner",
+    );
+  }
   if (!result.ok) {
     for (const issue of result.issues)
       console.error(`[trusted-acceptance] ${issue}`);

--- a/scripts/guard-trusted-acceptance-workflow.ts
+++ b/scripts/guard-trusted-acceptance-workflow.ts
@@ -1,0 +1,183 @@
+import { readFileSync } from "node:fs";
+
+export type WorkflowGuardResult = {
+  ok: boolean;
+  issues: string[];
+};
+
+function section(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex === -1 || endIndex === -1) return "";
+  return source.slice(startIndex, endIndex);
+}
+
+function count(source: string, pattern: RegExp): number {
+  return source.match(pattern)?.length ?? 0;
+}
+
+export function validateTrustedAcceptanceWorkflow(
+  source: string,
+): WorkflowGuardResult {
+  const issues: string[] = [];
+  const build = section(source, "\n  build:\n", "\n  deploy:\n");
+  const deploy = section(source, "\n  deploy:\n", "\n  receipt:\n");
+
+  if (!source.includes("workflow_dispatch:")) {
+    issues.push("workflow must be manually dispatched");
+  }
+  if (/\n  (?:pull_request|push|pull_request_target):/.test(source)) {
+    issues.push("workflow must not run from candidate-controlled events");
+  }
+  if (!source.includes('RUN_REF" != "refs/heads/main"')) {
+    issues.push("workflow must fail closed unless dispatched from main");
+  }
+  if (!source.includes("group: trusted-acceptance-${{ inputs.workspace }}")) {
+    issues.push("workflow must serialize each declarative workspace");
+  }
+  if (!source.includes("cancel-in-progress: false")) {
+    issues.push("workspace serialization must not cancel an active run");
+  }
+
+  if (!build) {
+    issues.push("build job is missing");
+  } else {
+    if (!build.includes("persist-credentials: false")) {
+      issues.push("candidate checkout must not persist GitHub credentials");
+    }
+    if (/\bsecrets\.|\bvars\[|\benvironment:|github\.token/.test(build)) {
+      issues.push(
+        "candidate build must not receive secrets or environment variables",
+      );
+    }
+    if (!build.includes("needs.plan.outputs.effective_sha")) {
+      issues.push("candidate build must use the provenance-verified exact SHA");
+    }
+    if (!build.includes("Upload inert candidate artifact")) {
+      issues.push("candidate output must cross jobs as an inert artifact");
+    }
+  }
+
+  if (!deploy) {
+    issues.push("deploy job is missing");
+  } else {
+    if (!deploy.includes("environment: trusted-acceptance")) {
+      issues.push("deploy job must use the protected acceptance environment");
+    }
+    if (!deploy.includes("Check out trusted controller")) {
+      issues.push("deploy job must use default-branch controller code");
+    }
+    if (!deploy.includes("Verify artifact provenance before credentials")) {
+      issues.push("artifact provenance must be checked before deployment");
+    }
+    if (
+      !deploy.includes("scripts/netlify-sites.json") ||
+      !deploy.includes("known production site ID")
+    ) {
+      issues.push(
+        "resolved acceptance site must be rejected if it is a production site",
+      );
+    }
+    if (!deploy.includes("netlify deploy --prod --no-build")) {
+      issues.push("privileged deployment must never rebuild candidate code");
+    }
+    if (
+      !deploy.includes(
+        '--functions "$ARTIFACT_DIR/.netlify/functions-internal"',
+      )
+    ) {
+      issues.push(
+        "deployment must upload the prebuilt Netlify function bundle",
+      );
+    }
+    if (
+      !deploy.includes(
+        "working-directory: ${{ runner.temp }}/trusted-acceptance-deploy",
+      ) ||
+      deploy.includes(
+        "working-directory: ${{ runner.temp }}/acceptance-artifact",
+      )
+    ) {
+      issues.push(
+        "privileged upload must run from an empty trusted directory, not candidate files",
+      );
+    }
+    const secretIndex = deploy.indexOf("secrets.ACCEPTANCE_NETLIFY_AUTH_TOKEN");
+    const verifyIndex = deploy.indexOf(
+      "Verify artifact provenance before credentials",
+    );
+    if (secretIndex === -1 || secretIndex < verifyIndex) {
+      issues.push(
+        "deployment credential must enter only after artifact verification",
+      );
+    }
+    if (
+      /pnpm\s+(?:run\s+)?(?:build|install)|npm\s+(?:run\s+)?build/.test(
+        deploy.slice(secretIndex),
+      )
+    ) {
+      issues.push(
+        "candidate or dependency scripts must not run after credentials enter",
+      );
+    }
+  }
+
+  if (count(source, /secrets\.ACCEPTANCE_NETLIFY_AUTH_TOKEN/g) !== 1) {
+    issues.push(
+      "acceptance Netlify credential must appear in exactly one step",
+    );
+  }
+  if (count(source, /vars\[matrix\.siteIdVariable\]/g) !== 1) {
+    issues.push("acceptance site variable must appear in exactly one step");
+  }
+  if (count(source, /ref: \$\{\{ github\.sha \}\}/g) !== 3) {
+    issues.push(
+      "plan, deploy, and receipt must pin trusted code to the dispatch controller SHA",
+    );
+  }
+  if (/ref: main/.test(source)) {
+    issues.push("trusted checkouts must not follow a moving default branch");
+  }
+  if (
+    !source.includes("rollback_run_id") ||
+    !source.includes("currentKnownGoodSha") ||
+    !source.includes("trusted-acceptance-receipt-$ROLLBACK_RUN_ID") ||
+    !source.includes('--expected-assertions "$expected_assertions"') ||
+    !source.includes(
+      'run.path !== ".github/workflows/trusted-acceptance.yml"',
+    ) ||
+    !source.includes('run.conclusion !== "success"') ||
+    !source.includes("receipt.controllerSha !== run.head_sha")
+  ) {
+    issues.push("rollback must be bound to a prior passing workspace receipt");
+  }
+  if (/cp .*netlify\.toml/.test(build)) {
+    issues.push(
+      "candidate Netlify configuration must not cross into deployment custody",
+    );
+  }
+  if (/secrets\.NETLIFY_AUTH_TOKEN/.test(source)) {
+    issues.push(
+      "trusted acceptance must not depend on production Netlify custody",
+    );
+  }
+
+  return { ok: issues.length === 0, issues };
+}
+
+function main(): void {
+  const workflow = readFileSync(
+    ".github/workflows/trusted-acceptance.yml",
+    "utf8",
+  );
+  const result = validateTrustedAcceptanceWorkflow(workflow);
+  if (!result.ok) {
+    for (const issue of result.issues)
+      console.error(`[trusted-acceptance] ${issue}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log("Trusted acceptance workflow boundary checks passed.");
+}
+
+if (process.argv[1]?.endsWith("guard-trusted-acceptance-workflow.ts")) main();

--- a/scripts/guard-trusted-acceptance-workflow.ts
+++ b/scripts/guard-trusted-acceptance-workflow.ts
@@ -20,6 +20,7 @@ export function validateTrustedAcceptanceWorkflow(
   source: string,
 ): WorkflowGuardResult {
   const issues: string[] = [];
+  const workflowEnvironment = section(source, "\nenv:\n", "\njobs:\n");
   const build = section(source, "\n  build:\n", "\n  deploy:\n");
   const deploy = section(source, "\n  deploy:\n", "\n  receipt:\n");
 
@@ -38,6 +39,16 @@ export function validateTrustedAcceptanceWorkflow(
   if (!source.includes("cancel-in-progress: false")) {
     issues.push("workspace serialization must not cancel an active run");
   }
+  if (
+    /\bsecrets\.|\bvars\[|github\.token/.test(workflowEnvironment) ||
+    /^\s+(?:[A-Z0-9_]*(?:SECRET|TOKEN|PASSWORD|PRIVATE_KEY|DATABASE_URL)[A-Z0-9_]*):/m.test(
+      workflowEnvironment,
+    )
+  ) {
+    issues.push(
+      "workflow-level environment must not expose inherited credentials to candidate jobs",
+    );
+  }
 
   if (!build) {
     issues.push("build job is missing");
@@ -55,6 +66,9 @@ export function validateTrustedAcceptanceWorkflow(
     }
     if (!build.includes("Upload inert candidate artifact")) {
       issues.push("candidate output must cross jobs as an inert artifact");
+    }
+    if (!build.includes("include-hidden-files: true")) {
+      issues.push("candidate artifact must include the hidden Netlify bundle");
     }
   }
 
@@ -150,6 +164,14 @@ export function validateTrustedAcceptanceWorkflow(
     !source.includes("receipt.controllerSha !== run.head_sha")
   ) {
     issues.push("rollback must be bound to a prior passing workspace receipt");
+  }
+  if (
+    !source.includes("DEPLOY_REQUESTED: ${{ inputs.deploy }}") ||
+    !source.includes('if [[ "$DEPLOY_REQUESTED" != "true" ]]')
+  ) {
+    issues.push(
+      "rollback may allow disabled planning only when no deployment is requested",
+    );
   }
   if (/cp .*netlify\.toml/.test(build)) {
     issues.push(

--- a/scripts/run-guards.ts
+++ b/scripts/run-guards.ts
@@ -12,6 +12,7 @@ const guards = [
   "guard:db-tool-scoping",
   "guard:template-list",
   "guard:netlify-private-env",
+  "guard:trusted-acceptance",
   "guard:workspace-skills",
   "guard:template-standard",
   "guard:public-packages",

--- a/scripts/trusted-acceptance-workspaces.json
+++ b/scripts/trusted-acceptance-workspaces.json
@@ -1,9 +1,13 @@
 {
-  "revision": "1",
+  "revision": "2",
   "workspaces": [
     {
       "id": "calendar-content",
       "enabled": false,
+      "runtimeAuthority": {
+        "lifecycle": "ephemeral-per-run",
+        "provisioner": "unconfigured"
+      },
       "assertions": [
         "A1",
         "A2",

--- a/scripts/trusted-acceptance-workspaces.json
+++ b/scripts/trusted-acceptance-workspaces.json
@@ -1,0 +1,65 @@
+{
+  "revision": "1",
+  "workspaces": [
+    {
+      "id": "calendar-content",
+      "enabled": false,
+      "assertions": [
+        "A1",
+        "A2",
+        "A3",
+        "A4",
+        "A5",
+        "A6",
+        "A7",
+        "A8",
+        "A9",
+        "A10",
+        "A11",
+        "A12",
+        "A13",
+        "A14"
+      ],
+      "members": [
+        {
+          "template": "calendar",
+          "origin": "https://calendar.acceptance.agent-native.com",
+          "siteIdVariable": "ACCEPTANCE_CALENDAR_NETLIFY_SITE_ID",
+          "environment": {
+            "databaseUrl": "ACCEPTANCE_CALENDAR_DATABASE_URL",
+            "betterAuthSecret": "ACCEPTANCE_CALENDAR_BETTER_AUTH_SECRET",
+            "a2aSecret": "ACCEPTANCE_WORKSPACE_A2A_SECRET"
+          },
+          "build": {
+            "command": "pnpm --filter calendar build",
+            "publishDirectory": "templates/calendar/dist"
+          },
+          "paths": {
+            "health": "/_agent-native/health",
+            "oauthMetadata": "/.well-known/oauth-protected-resource",
+            "mcp": "/mcp"
+          }
+        },
+        {
+          "template": "content",
+          "origin": "https://content.acceptance.agent-native.com",
+          "siteIdVariable": "ACCEPTANCE_CONTENT_NETLIFY_SITE_ID",
+          "environment": {
+            "databaseUrl": "ACCEPTANCE_CONTENT_DATABASE_URL",
+            "betterAuthSecret": "ACCEPTANCE_CONTENT_BETTER_AUTH_SECRET",
+            "a2aSecret": "ACCEPTANCE_WORKSPACE_A2A_SECRET"
+          },
+          "build": {
+            "command": "pnpm --filter content build",
+            "publishDirectory": "templates/content/dist"
+          },
+          "paths": {
+            "health": "/_agent-native/health",
+            "oauthMetadata": "/.well-known/oauth-protected-resource",
+            "mcp": "/mcp"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/trusted-acceptance.spec.ts
+++ b/scripts/trusted-acceptance.spec.ts
@@ -1,0 +1,341 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { describe, it } from "node:test";
+
+import {
+  type TrustedAcceptanceConfig,
+  type TrustedAcceptanceReceipt,
+  createTrustedAcceptancePlan,
+  validatePullRequestProvenance,
+  validateTrustedAcceptanceConfig,
+  validateTrustedAcceptanceReceipt,
+} from "./trusted-acceptance.ts";
+
+const sha = "a".repeat(40);
+
+function config(): TrustedAcceptanceConfig {
+  return {
+    revision: "3",
+    workspaces: [
+      {
+        id: "calendar-content-acceptance",
+        enabled: false,
+        assertions: ["A1", "A2", "A3"],
+        members: [
+          {
+            template: "calendar",
+            origin: "https://calendar-acceptance.example.test",
+            siteIdVariable: "ACCEPTANCE_CALENDAR_NETLIFY_SITE_ID",
+            environment: {
+              databaseUrl: "ACCEPTANCE_CALENDAR_DATABASE_URL",
+              betterAuthSecret: "ACCEPTANCE_CALENDAR_BETTER_AUTH_SECRET",
+              a2aSecret: "ACCEPTANCE_A2A_SECRET",
+            },
+            build: {
+              command: "pnpm --filter calendar build",
+              publishDirectory: "templates/calendar/dist",
+            },
+            paths: {
+              health: "/health",
+              oauthMetadata: "/.well-known/oauth-authorization-server",
+              mcp: "/mcp",
+            },
+          },
+          {
+            template: "content",
+            origin: "https://content-acceptance.example.test",
+            siteIdVariable: "ACCEPTANCE_CONTENT_NETLIFY_SITE_ID",
+            environment: {
+              databaseUrl: "ACCEPTANCE_CONTENT_DATABASE_URL",
+              betterAuthSecret: "ACCEPTANCE_CONTENT_BETTER_AUTH_SECRET",
+              a2aSecret: "ACCEPTANCE_A2A_SECRET",
+            },
+            build: {
+              command: "pnpm --filter content build",
+              publishDirectory: "templates/content/dist",
+            },
+            paths: {
+              health: "/health",
+              oauthMetadata: "/.well-known/oauth-authorization-server",
+              mcp: "/mcp",
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("trusted acceptance configuration", () => {
+  it("accepts a generic third-template workspace without a controller branch", () => {
+    assert.equal(existsSync("templates/tasks/package.json"), true);
+    const fixture = config();
+    fixture.workspaces.push({
+      id: "third-template-acceptance",
+      enabled: false,
+      assertions: ["A1"],
+      members: [
+        {
+          ...fixture.workspaces[0]!.members[0]!,
+          template: "tasks",
+          origin: "https://tasks-acceptance.example.test",
+          siteIdVariable: "ACCEPTANCE_TASKS_NETLIFY_SITE_ID",
+          build: {
+            command: "pnpm --filter tasks build",
+            publishDirectory: "templates/tasks/dist",
+          },
+        },
+      ],
+    });
+    const availableTemplates = ["calendar", "content", "tasks"];
+    assert.deepEqual(
+      validateTrustedAcceptanceConfig(fixture, availableTemplates),
+      {
+        ok: true,
+        issues: [],
+      },
+    );
+    const plan = createTrustedAcceptancePlan(
+      fixture,
+      availableTemplates,
+      "third-template-acceptance",
+      true,
+    );
+    assert.equal(plan.ok, true);
+    if (plan.ok) {
+      assert.deepEqual(
+        plan.plan.members.map(({ template }) => template),
+        ["tasks"],
+      );
+    }
+  });
+
+  it("rejects production, preview, duplicate, unknown-template, and unsafe-key configuration", () => {
+    const fixture = config();
+    const member = fixture.workspaces[0]!.members[1]!;
+    member.origin = "https://deploy-preview-123--content.netlify.app";
+    member.siteIdVariable = fixture.workspaces[0]!.members[0]!.siteIdVariable;
+    member.template = "unknown";
+    member.environment.betterAuthSecret = "PRODUCTION_BETTER_AUTH_SECRET";
+    const result = validateTrustedAcceptanceConfig(fixture, [
+      "calendar",
+      "content",
+    ]);
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.deepEqual(
+        result.issues.map(({ path }) => path),
+        [
+          "workspaces[0].members[1].template",
+          "workspaces[0].members[1].origin",
+          "workspaces[0].members[1].siteIdVariable",
+          "workspaces[0].members[1].environment.betterAuthSecret",
+          "workspaces[0].members[1].build.command",
+          "workspaces[0].members[1].build.publishDirectory",
+        ],
+      );
+    }
+  });
+
+  it("rejects production origins and unsafe site variable names", () => {
+    const fixture = config();
+    const member = fixture.workspaces[0]!.members[1]!;
+    member.origin = "https://content-production.example.test";
+    member.siteIdVariable = "PRODUCTION_CONTENT_NETLIFY_SITE_ID";
+    const result = validateTrustedAcceptanceConfig(fixture, [
+      "calendar",
+      "content",
+    ]);
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.deepEqual(
+        result.issues.map(({ path }) => path),
+        [
+          "workspaces[0].members[1].origin",
+          "workspaces[0].members[1].siteIdVariable",
+        ],
+      );
+    }
+  });
+
+  it("permits disabled workspaces only for dry-run planning", () => {
+    const fixture = config();
+    const disabled = createTrustedAcceptancePlan(
+      fixture,
+      ["calendar", "content"],
+      "calendar-content-acceptance",
+      false,
+    );
+    assert.equal(disabled.ok, false);
+
+    const dryRun = createTrustedAcceptancePlan(
+      fixture,
+      ["calendar", "content"],
+      "calendar-content-acceptance",
+      true,
+    );
+    assert.equal(dryRun.ok, true);
+    if (dryRun.ok) {
+      assert.equal(dryRun.plan.enabled, false);
+      assert.deepEqual(
+        dryRun.plan.members.map(({ template }) => template),
+        ["calendar", "content"],
+      );
+    }
+  });
+
+  it("rejects unknown workspaces", () => {
+    const result = createTrustedAcceptancePlan(
+      config(),
+      ["calendar", "content"],
+      "unknown-workspace",
+      true,
+    );
+    assert.deepEqual(result, {
+      ok: false,
+      issues: [{ path: "workspace", message: "is not configured" }],
+    });
+  });
+});
+
+describe("pull request provenance", () => {
+  it("requires a full current same-repository open PR head", () => {
+    assert.deepEqual(
+      validatePullRequestProvenance({
+        selectedSha: sha,
+        expectedRepository: "BuilderIO/agent-native",
+        pullRequest: {
+          number: 42,
+          state: "open",
+          headSha: sha,
+          headRepository: "BuilderIO/agent-native",
+          isFork: false,
+        },
+      }),
+      { ok: true, issues: [] },
+    );
+  });
+
+  it("rejects abbreviated SHA, forks, closed PRs, and stale heads", () => {
+    const result = validatePullRequestProvenance({
+      selectedSha: "abc123",
+      expectedRepository: "BuilderIO/agent-native",
+      pullRequest: {
+        number: 42,
+        state: "closed",
+        headSha: sha,
+        headRepository: "someone/agent-native",
+        isFork: true,
+      },
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.equal(result.issues.length, 4);
+  });
+});
+
+describe("trusted acceptance receipts", () => {
+  it("accepts a complete redacted receipt", () => {
+    const receipt: TrustedAcceptanceReceipt = {
+      actor: "maintainer-123",
+      runUrl: "https://github.com/BuilderIO/agent-native/actions/runs/123",
+      operation: "candidate",
+      pullRequest: 42,
+      sha,
+      controllerSha: "c".repeat(40),
+      configRevision: "3",
+      workspace: "calendar-content-acceptance",
+      members: [
+        {
+          template: "calendar",
+          origin: "https://calendar-acceptance.example.test",
+          deployId: "deploy-calendar-123",
+        },
+      ],
+      assertions: [
+        { id: "A1", state: "pass", evidencePointer: "artifacts://receipt/A1" },
+      ],
+      startedAt: "2026-07-25T12:00:00.000Z",
+      completedAt: "2026-07-25T12:01:00.000Z",
+      result: "pass",
+      rollbackTarget: "b".repeat(40),
+      priorKnownGoodSha: "b".repeat(40),
+      currentKnownGoodSha: sha,
+    };
+    assert.deepEqual(validateTrustedAcceptanceReceipt(receipt), {
+      ok: true,
+      issues: [],
+    });
+  });
+
+  it("rejects sensitive fields and values in receipts", () => {
+    const receipt = {
+      actor: "maintainer-123",
+      runUrl: "https://github.com/BuilderIO/agent-native/actions/runs/123",
+      operation: "candidate",
+      pullRequest: 42,
+      sha,
+      controllerSha: "c".repeat(40),
+      configRevision: "3",
+      workspace: "calendar-content-acceptance",
+      members: [
+        {
+          template: "calendar",
+          origin: "https://calendar-acceptance.example.test",
+          deployId: "deploy-calendar-123",
+        },
+      ],
+      assertions: [{ id: "A1", state: "pass" }],
+      startedAt: "2026-07-25T12:00:00.000Z",
+      completedAt: "2026-07-25T12:01:00.000Z",
+      result: "fail",
+      rollbackTarget: null,
+      priorKnownGoodSha: null,
+      currentKnownGoodSha: null,
+      secretValue: "not allowed",
+    } as unknown as TrustedAcceptanceReceipt;
+    const result = validateTrustedAcceptanceReceipt(receipt);
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.match(result.issues[0]!.message, /sensitive fields/);
+  });
+
+  it("rejects a passing result with blocked assertions", () => {
+    const receipt: TrustedAcceptanceReceipt = {
+      actor: "maintainer-123",
+      runUrl: "https://github.com/BuilderIO/agent-native/actions/runs/123",
+      operation: "candidate",
+      pullRequest: 42,
+      sha,
+      controllerSha: "c".repeat(40),
+      configRevision: "3",
+      workspace: "calendar-content-acceptance",
+      members: [
+        {
+          template: "calendar",
+          origin: "https://calendar-acceptance.example.test",
+          deployId: "deploy-calendar-123",
+        },
+      ],
+      assertions: [{ id: "A1", state: "blocked" }],
+      startedAt: "2026-07-25T12:00:00.000Z",
+      completedAt: "2026-07-25T12:01:00.000Z",
+      result: "pass",
+      rollbackTarget: "b".repeat(40),
+      priorKnownGoodSha: "b".repeat(40),
+      currentKnownGoodSha: sha,
+    };
+    const result = validateTrustedAcceptanceReceipt(receipt, ["A1", "A2"]);
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert(
+        result.issues.some(({ message }) =>
+          message.includes("every assertion"),
+        ),
+      );
+      assert(
+        result.issues.some(({ message }) =>
+          message.includes("configured assertion"),
+        ),
+      );
+    }
+  });
+});

--- a/scripts/trusted-acceptance.spec.ts
+++ b/scripts/trusted-acceptance.spec.ts
@@ -20,6 +20,10 @@ function config(): TrustedAcceptanceConfig {
       {
         id: "calendar-content-acceptance",
         enabled: false,
+        runtimeAuthority: {
+          lifecycle: "ephemeral-per-run",
+          provisioner: "unconfigured",
+        },
         assertions: ["A1", "A2", "A3"],
         members: [
           {
@@ -73,6 +77,10 @@ describe("trusted acceptance configuration", () => {
     fixture.workspaces.push({
       id: "third-template-acceptance",
       enabled: false,
+      runtimeAuthority: {
+        lifecycle: "ephemeral-per-run",
+        provisioner: "unconfigured",
+      },
       assertions: ["A1"],
       members: [
         {
@@ -180,6 +188,46 @@ describe("trusted acceptance configuration", () => {
       assert.deepEqual(
         dryRun.plan.members.map(({ template }) => template),
         ["calendar", "content"],
+      );
+    }
+  });
+
+  it("fails closed if activation is attempted without an ephemeral authority provisioner", () => {
+    const fixture = config();
+    fixture.workspaces[0]!.enabled = true;
+    const result = createTrustedAcceptancePlan(
+      fixture,
+      ["calendar", "content"],
+      "calendar-content-acceptance",
+      false,
+    );
+    assert.deepEqual(result, {
+      ok: false,
+      issues: [
+        {
+          path: "workspace.runtimeAuthority.provisioner",
+          message:
+            "has no trusted ephemeral runtime authority provisioner; live deployment is unavailable",
+        },
+      ],
+    });
+  });
+
+  it("rejects reusable runtime authority configuration", () => {
+    const fixture = config();
+    (
+      fixture.workspaces[0]!.runtimeAuthority as { lifecycle: string }
+    ).lifecycle = "workspace-static";
+    const result = validateTrustedAcceptanceConfig(fixture, [
+      "calendar",
+      "content",
+    ]);
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert(
+        result.issues.some(
+          ({ path }) => path === "workspaces[0].runtimeAuthority.lifecycle",
+        ),
       );
     }
   });

--- a/scripts/trusted-acceptance.ts
+++ b/scripts/trusted-acceptance.ts
@@ -1,0 +1,685 @@
+import { readFileSync } from "node:fs";
+
+/**
+ * Pure validation contracts for the isolated trusted-acceptance lane.
+ *
+ * This module deliberately contains no environment access, network access, or
+ * deployment code. The default-branch controller supplies available templates
+ * and PR metadata, then fails closed on these results before a build starts.
+ */
+
+export type AcceptancePaths = {
+  health: string;
+  oauthMetadata: string;
+  mcp: string;
+};
+
+export type AcceptanceBuild = {
+  command: string;
+  publishDirectory: string;
+};
+
+export type AcceptanceEnvironmentKeys = {
+  databaseUrl: string;
+  betterAuthSecret: string;
+  a2aSecret: string;
+};
+
+export type TrustedAcceptanceMember = {
+  template: string;
+  origin: string;
+  siteIdVariable: string;
+  environment: AcceptanceEnvironmentKeys;
+  build: AcceptanceBuild;
+  paths: AcceptancePaths;
+};
+
+export type TrustedAcceptanceWorkspace = {
+  id: string;
+  enabled: boolean;
+  assertions: string[];
+  members: TrustedAcceptanceMember[];
+};
+
+export type TrustedAcceptanceConfig = {
+  revision: string;
+  workspaces: TrustedAcceptanceWorkspace[];
+};
+
+export type ValidationIssue = {
+  path: string;
+  message: string;
+};
+
+export type ValidationResult =
+  | { ok: true; issues: [] }
+  | { ok: false; issues: ValidationIssue[] };
+
+const forbiddenKeyPattern =
+  /(?:^|_)(?:PROD(?:UCTION)?|NETLIFY|GITHUB|DEPLOY(?:MENT)?|TOKEN|API_KEY|PROVIDER)(?:_|$)/i;
+const shaPattern = /^[0-9a-f]{40}$/;
+const mutablePreviewHostPattern =
+  /(?:^|[-.])(?:deploy-preview-\d+|branch|preview)(?:--|[-.])/i;
+const acceptanceHostPattern = /(?:^|[-.])acceptance(?:[-.]|$)/i;
+
+function isAbsolutePath(value: string): boolean {
+  return value.startsWith("/") && !value.startsWith("//") && !/\s/.test(value);
+}
+
+function isSafeEnvironmentKey(value: string, suffix: string): boolean {
+  return (
+    /^[A-Z][A-Z0-9_]*$/.test(value) &&
+    value.startsWith("ACCEPTANCE_") &&
+    value.endsWith(suffix) &&
+    !forbiddenKeyPattern.test(value)
+  );
+}
+
+function isAcceptanceSiteVariable(value: string): boolean {
+  return (
+    /^[A-Z][A-Z0-9_]*_NETLIFY_SITE_ID$/.test(value) &&
+    value.startsWith("ACCEPTANCE_") &&
+    !/(?:^|_)(?:PROD(?:UCTION)?|DEPLOY(?:MENT)?|TOKEN|API_KEY)(?:_|$)/i.test(
+      value,
+    )
+  );
+}
+
+function isAcceptanceOrigin(origin: string): boolean {
+  try {
+    const url = new URL(origin);
+    return (
+      url.protocol === "https:" &&
+      url.pathname === "/" &&
+      !url.search &&
+      !url.hash &&
+      acceptanceHostPattern.test(url.hostname) &&
+      !mutablePreviewHostPattern.test(url.hostname) &&
+      !/(?:^|[-.])(?:prod|production)(?:[-.]|$)/i.test(url.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Validates config shape plus the isolation constraints that are knowable locally. */
+export function validateTrustedAcceptanceConfig(
+  config: TrustedAcceptanceConfig,
+  availableTemplates: readonly string[],
+): ValidationResult {
+  const issues: ValidationIssue[] = [];
+  const workspaceIds = new Set<string>();
+  const origins = new Set<string>();
+  const siteIdVariables = new Set<string>();
+
+  if (!config.revision.trim()) {
+    issues.push({ path: "revision", message: "must be non-empty" });
+  }
+  if (config.workspaces.length === 0) {
+    issues.push({ path: "workspaces", message: "must contain a workspace" });
+  }
+
+  for (const [workspaceIndex, workspace] of config.workspaces.entries()) {
+    const workspacePath = `workspaces[${workspaceIndex}]`;
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(workspace.id)) {
+      issues.push({
+        path: `${workspacePath}.id`,
+        message: "must be a stable slug",
+      });
+    }
+    if (workspaceIds.has(workspace.id)) {
+      issues.push({
+        path: `${workspacePath}.id`,
+        message: "duplicates a workspace",
+      });
+    }
+    workspaceIds.add(workspace.id);
+    if (workspace.assertions.length === 0) {
+      issues.push({
+        path: `${workspacePath}.assertions`,
+        message: "must contain at least one assertion",
+      });
+    }
+    if (new Set(workspace.assertions).size !== workspace.assertions.length) {
+      issues.push({
+        path: `${workspacePath}.assertions`,
+        message: "must not contain duplicate assertion IDs",
+      });
+    }
+    if (workspace.members.length === 0) {
+      issues.push({
+        path: `${workspacePath}.members`,
+        message: "must contain a member",
+      });
+    }
+
+    const templates = new Set<string>();
+    for (const [memberIndex, member] of workspace.members.entries()) {
+      const memberPath = `${workspacePath}.members[${memberIndex}]`;
+      if (!availableTemplates.includes(member.template)) {
+        issues.push({
+          path: `${memberPath}.template`,
+          message: "is not an available template",
+        });
+      }
+      if (templates.has(member.template)) {
+        issues.push({
+          path: `${memberPath}.template`,
+          message: "duplicates a workspace member",
+        });
+      }
+      templates.add(member.template);
+      if (!isAcceptanceOrigin(member.origin)) {
+        issues.push({
+          path: `${memberPath}.origin`,
+          message: "must be a stable non-production acceptance HTTPS origin",
+        });
+      }
+      if (origins.has(member.origin)) {
+        issues.push({
+          path: `${memberPath}.origin`,
+          message: "duplicates an acceptance origin",
+        });
+      }
+      origins.add(member.origin);
+      if (!isAcceptanceSiteVariable(member.siteIdVariable)) {
+        issues.push({
+          path: `${memberPath}.siteIdVariable`,
+          message: "must be an acceptance-scoped NETLIFY_SITE_ID variable name",
+        });
+      }
+      if (siteIdVariables.has(member.siteIdVariable)) {
+        issues.push({
+          path: `${memberPath}.siteIdVariable`,
+          message: "duplicates an acceptance site variable",
+        });
+      }
+      siteIdVariables.add(member.siteIdVariable);
+
+      const environment = member.environment;
+      if (!isSafeEnvironmentKey(environment.databaseUrl, "_DATABASE_URL")) {
+        issues.push({
+          path: `${memberPath}.environment.databaseUrl`,
+          message: "must be an acceptance-scoped DATABASE_URL key name",
+        });
+      }
+      if (
+        !isSafeEnvironmentKey(
+          environment.betterAuthSecret,
+          "_BETTER_AUTH_SECRET",
+        )
+      ) {
+        issues.push({
+          path: `${memberPath}.environment.betterAuthSecret`,
+          message: "must be an acceptance-scoped BETTER_AUTH_SECRET key name",
+        });
+      }
+      if (!isSafeEnvironmentKey(environment.a2aSecret, "_A2A_SECRET")) {
+        issues.push({
+          path: `${memberPath}.environment.a2aSecret`,
+          message: "must be an acceptance-scoped A2A_SECRET key name",
+        });
+      }
+      if (member.build.command !== `pnpm --filter ${member.template} build`) {
+        issues.push({
+          path: `${memberPath}.build.command`,
+          message: "must use the template's standard pnpm build command",
+        });
+      }
+      if (
+        !member.build.publishDirectory.trim() ||
+        member.build.publishDirectory.startsWith("/") ||
+        member.build.publishDirectory.includes("..") ||
+        !member.build.publishDirectory.startsWith(
+          `templates/${member.template}/`,
+        )
+      ) {
+        issues.push({
+          path: `${memberPath}.build.publishDirectory`,
+          message: "must be a relative publish directory",
+        });
+      }
+      for (const [key, value] of Object.entries(member.paths)) {
+        if (!isAbsolutePath(value)) {
+          issues.push({
+            path: `${memberPath}.paths.${key}`,
+            message: "must be an absolute path",
+          });
+        }
+      }
+    }
+  }
+  return issues.length === 0 ? { ok: true, issues: [] } : { ok: false, issues };
+}
+
+export type TrustedAcceptancePlan = {
+  revision: string;
+  workspace: string;
+  enabled: boolean;
+  assertions: string[];
+  members: TrustedAcceptanceMember[];
+};
+
+export function createTrustedAcceptancePlan(
+  config: TrustedAcceptanceConfig,
+  availableTemplates: readonly string[],
+  workspaceId: string,
+  allowDisabled: boolean,
+):
+  | { ok: true; plan: TrustedAcceptancePlan }
+  | { ok: false; issues: ValidationIssue[] } {
+  const validation = validateTrustedAcceptanceConfig(
+    config,
+    availableTemplates,
+  );
+  if (!validation.ok) return validation;
+
+  const workspace = config.workspaces.find(({ id }) => id === workspaceId);
+  if (!workspace) {
+    return {
+      ok: false,
+      issues: [{ path: "workspace", message: "is not configured" }],
+    };
+  }
+  if (!workspace.enabled && !allowDisabled) {
+    return {
+      ok: false,
+      issues: [
+        {
+          path: "workspace",
+          message: "is disabled; only dry-run planning is permitted",
+        },
+      ],
+    };
+  }
+
+  return {
+    ok: true,
+    plan: {
+      revision: config.revision,
+      workspace: workspace.id,
+      enabled: workspace.enabled,
+      assertions: workspace.assertions,
+      members: workspace.members,
+    },
+  };
+}
+
+export type PullRequestProvenance = {
+  number: number;
+  state: "open" | "closed";
+  headSha: string;
+  headRepository: string;
+  isFork: boolean;
+};
+
+export type PullRequestProvenanceInput = {
+  selectedSha: string;
+  expectedRepository: string;
+  pullRequest: PullRequestProvenance;
+};
+
+/** Checks GitHub-sourced PR facts without making a GitHub request itself. */
+export function validatePullRequestProvenance(
+  input: PullRequestProvenanceInput,
+): ValidationResult {
+  const { selectedSha, expectedRepository, pullRequest } = input;
+  const issues: ValidationIssue[] = [];
+  if (!shaPattern.test(selectedSha)) {
+    issues.push({
+      path: "selectedSha",
+      message: "must be a full lowercase 40-character SHA",
+    });
+  }
+  if (pullRequest.state !== "open") {
+    issues.push({ path: "pullRequest.state", message: "must be open" });
+  }
+  if (pullRequest.isFork || pullRequest.headRepository !== expectedRepository) {
+    issues.push({
+      path: "pullRequest.headRepository",
+      message: "must be the same repository, not a fork",
+    });
+  }
+  if (selectedSha !== pullRequest.headSha) {
+    issues.push({
+      path: "selectedSha",
+      message: "must equal the current pull request head SHA",
+    });
+  }
+  return issues.length === 0 ? { ok: true, issues: [] } : { ok: false, issues };
+}
+
+export type AcceptanceAssertionState = "pass" | "fail" | "blocked";
+
+export type TrustedAcceptanceReceipt = {
+  actor: string;
+  runUrl: string;
+  operation: "candidate" | "rollback";
+  pullRequest: number | null;
+  sha: string;
+  controllerSha: string;
+  configRevision: string;
+  workspace: string;
+  members: Array<{
+    template: string;
+    origin: string;
+    deployId: string | null;
+  }>;
+  assertions: Array<{
+    id: string;
+    state: AcceptanceAssertionState;
+    evidencePointer?: string;
+  }>;
+  startedAt: string;
+  completedAt: string;
+  result: AcceptanceAssertionState;
+  rollbackTarget: string | null;
+  priorKnownGoodSha: string | null;
+  currentKnownGoodSha: string | null;
+};
+
+const sensitiveFieldPattern =
+  /(?:secret|token|password|credential|private.?key|value)/i;
+const credentialLikeValuePattern =
+  /(?:gh[pousr]_|ntl_[A-Za-z0-9]|-----BEGIN|data:)/i;
+
+function containsSensitiveReceiptData(
+  value: unknown,
+  path = "receipt",
+): ValidationIssue[] {
+  if (typeof value === "string") {
+    return credentialLikeValuePattern.test(value)
+      ? [{ path, message: "must not contain secret or credential values" }]
+      : [];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((entry, index) =>
+      containsSensitiveReceiptData(entry, `${path}[${index}]`),
+    );
+  }
+  if (value && typeof value === "object") {
+    return Object.entries(value).flatMap(([key, entry]) => {
+      const fieldPath = `${path}.${key}`;
+      return sensitiveFieldPattern.test(key)
+        ? [{ path: fieldPath, message: "must not include sensitive fields" }]
+        : containsSensitiveReceiptData(entry, fieldPath);
+    });
+  }
+  return [];
+}
+
+/** Validates the redacted receipt shape before it is emitted as an artifact. */
+export function validateTrustedAcceptanceReceipt(
+  receipt: TrustedAcceptanceReceipt,
+  expectedAssertions?: readonly string[],
+): ValidationResult {
+  const issues = containsSensitiveReceiptData(receipt);
+  if (!receipt.actor.trim())
+    issues.push({ path: "actor", message: "must be non-empty" });
+  try {
+    const runUrl = new URL(receipt.runUrl);
+    if (runUrl.protocol !== "https:" || runUrl.hostname !== "github.com") {
+      issues.push({ path: "runUrl", message: "must be a GitHub HTTPS URL" });
+    }
+  } catch {
+    issues.push({ path: "runUrl", message: "must be a GitHub HTTPS URL" });
+  }
+  if (!["candidate", "rollback"].includes(receipt.operation)) {
+    issues.push({
+      path: "operation",
+      message: "must be candidate or rollback",
+    });
+  }
+  if (
+    receipt.operation === "candidate" &&
+    (!Number.isInteger(receipt.pullRequest) || (receipt.pullRequest ?? 0) < 1)
+  ) {
+    issues.push({
+      path: "pullRequest",
+      message: "must be a positive integer for a candidate receipt",
+    });
+  }
+  if (receipt.operation === "rollback" && receipt.pullRequest !== null) {
+    issues.push({
+      path: "pullRequest",
+      message: "must be null for a rollback receipt",
+    });
+  }
+  if (!shaPattern.test(receipt.sha)) {
+    issues.push({
+      path: "sha",
+      message: "must be a full lowercase 40-character SHA",
+    });
+  }
+  if (!shaPattern.test(receipt.controllerSha)) {
+    issues.push({
+      path: "controllerSha",
+      message: "must be a full lowercase 40-character SHA",
+    });
+  }
+  if (!receipt.configRevision.trim())
+    issues.push({ path: "configRevision", message: "must be non-empty" });
+  if (!receipt.workspace.trim())
+    issues.push({ path: "workspace", message: "must be non-empty" });
+  if (receipt.members.length === 0)
+    issues.push({ path: "members", message: "must not be empty" });
+  for (const [index, member] of receipt.members.entries()) {
+    if (
+      !member.template ||
+      !isAcceptanceOrigin(member.origin) ||
+      (member.deployId !== null && !member.deployId)
+    ) {
+      issues.push({
+        path: `members[${index}]`,
+        message: "must include template and stable acceptance origin",
+      });
+    }
+  }
+  if (receipt.assertions.length === 0)
+    issues.push({ path: "assertions", message: "must not be empty" });
+  if (
+    new Set(receipt.assertions.map(({ id }) => id)).size !==
+    receipt.assertions.length
+  ) {
+    issues.push({
+      path: "assertions",
+      message: "must not contain duplicate assertion IDs",
+    });
+  }
+  for (const [index, assertion] of receipt.assertions.entries()) {
+    if (
+      !assertion.id ||
+      !["pass", "fail", "blocked"].includes(assertion.state)
+    ) {
+      issues.push({
+        path: `assertions[${index}]`,
+        message: "must include an ID and valid state",
+      });
+    }
+  }
+  if (
+    expectedAssertions &&
+    JSON.stringify(receipt.assertions.map(({ id }) => id)) !==
+      JSON.stringify(expectedAssertions)
+  ) {
+    issues.push({
+      path: "assertions",
+      message: "must exactly match the configured assertion IDs",
+    });
+  }
+  for (const [key, value] of Object.entries({
+    startedAt: receipt.startedAt,
+    completedAt: receipt.completedAt,
+  })) {
+    if (!/^\d{4}-\d{2}-\d{2}T/.test(value) || Number.isNaN(Date.parse(value)))
+      issues.push({ path: key, message: "must be an ISO timestamp" });
+  }
+  if (!["pass", "fail", "blocked"].includes(receipt.result)) {
+    issues.push({ path: "result", message: "must be pass, fail, or blocked" });
+  }
+  if (!receipt.rollbackTarget && receipt.result === "pass") {
+    issues.push({
+      path: "rollbackTarget",
+      message: "is required for a passing receipt",
+    });
+  } else if (
+    receipt.rollbackTarget &&
+    !shaPattern.test(receipt.rollbackTarget)
+  ) {
+    issues.push({
+      path: "rollbackTarget",
+      message: "must be a full lowercase 40-character SHA or null",
+    });
+  }
+  if (
+    receipt.result === "pass" &&
+    receipt.assertions.some(({ state }) => state !== "pass")
+  ) {
+    issues.push({
+      path: "assertions",
+      message: "every assertion must pass when the receipt result passes",
+    });
+  }
+  for (const key of ["priorKnownGoodSha", "currentKnownGoodSha"] as const) {
+    const value = receipt[key];
+    if (value && !shaPattern.test(value)) {
+      issues.push({
+        path: key,
+        message: "must be a full lowercase 40-character SHA or null",
+      });
+    }
+  }
+  if (
+    receipt.result === "pass" &&
+    receipt.members.some(({ deployId }) => !deployId)
+  ) {
+    issues.push({
+      path: "members",
+      message: "passing receipts require every deployment ID",
+    });
+  }
+  if (
+    receipt.result === "pass" &&
+    receipt.currentKnownGoodSha !== receipt.sha
+  ) {
+    issues.push({
+      path: "currentKnownGoodSha",
+      message: "must equal the deployed SHA for a passing receipt",
+    });
+  }
+  if (
+    receipt.result === "pass" &&
+    receipt.priorKnownGoodSha !== receipt.rollbackTarget
+  ) {
+    issues.push({
+      path: "priorKnownGoodSha",
+      message: "must equal the rollback target for a passing receipt",
+    });
+  }
+  return issues.length === 0 ? { ok: true, issues: [] } : { ok: false, issues };
+}
+
+type CliCommand = "config" | "plan" | "provenance" | "receipt";
+
+function readJsonFile<T>(file: string): T {
+  return JSON.parse(readFileSync(file, "utf8")) as T;
+}
+
+function argumentValue(args: string[], name: string): string | undefined {
+  const index = args.indexOf(name);
+  return index === -1 ? undefined : args[index + 1];
+}
+
+/**
+ * CLI commands intentionally accept JSON files, never inline secrets:
+ *
+ * - config --file <config.json> --templates calendar,content
+ * - plan --file <config.json> --templates calendar,content --workspace <id> [--allow-disabled]
+ * - provenance --file <github-pr.json> --sha <full-sha> --repository BuilderIO/agent-native
+ * - receipt --file <receipt.json>
+ */
+export function runTrustedAcceptanceCli(
+  args: string[],
+): ValidationResult | { ok: true; plan: TrustedAcceptancePlan } {
+  const [command] = args as [CliCommand | undefined];
+  const file = argumentValue(args, "--file");
+  if (!command || !file) {
+    return {
+      ok: false,
+      issues: [{ path: "arguments", message: "requires a command and --file" }],
+    };
+  }
+  if (command === "config") {
+    const templates = (argumentValue(args, "--templates") ?? "")
+      .split(",")
+      .filter(Boolean);
+    return validateTrustedAcceptanceConfig(
+      readJsonFile<TrustedAcceptanceConfig>(file),
+      templates,
+    );
+  }
+  if (command === "plan") {
+    const templates = (argumentValue(args, "--templates") ?? "")
+      .split(",")
+      .filter(Boolean);
+    const workspace = argumentValue(args, "--workspace");
+    if (!workspace) {
+      return {
+        ok: false,
+        issues: [{ path: "arguments", message: "plan requires --workspace" }],
+      };
+    }
+    return createTrustedAcceptancePlan(
+      readJsonFile<TrustedAcceptanceConfig>(file),
+      templates,
+      workspace,
+      args.includes("--allow-disabled"),
+    );
+  }
+  if (command === "provenance") {
+    const selectedSha = argumentValue(args, "--sha");
+    const expectedRepository = argumentValue(args, "--repository");
+    if (!selectedSha || !expectedRepository) {
+      return {
+        ok: false,
+        issues: [
+          {
+            path: "arguments",
+            message: "provenance requires --sha and --repository",
+          },
+        ],
+      };
+    }
+    return validatePullRequestProvenance({
+      selectedSha,
+      expectedRepository,
+      pullRequest: readJsonFile<PullRequestProvenance>(file),
+    });
+  }
+  if (command === "receipt") {
+    const expectedAssertions = argumentValue(args, "--expected-assertions");
+    return validateTrustedAcceptanceReceipt(
+      readJsonFile<TrustedAcceptanceReceipt>(file),
+      expectedAssertions
+        ? (JSON.parse(expectedAssertions) as string[])
+        : undefined,
+    );
+  }
+  return {
+    ok: false,
+    issues: [
+      {
+        path: "command",
+        message: "must be config, plan, provenance, or receipt",
+      },
+    ],
+  };
+}
+
+async function main(): Promise<void> {
+  const result = runTrustedAcceptanceCli(process.argv.slice(2));
+  console.log(JSON.stringify(result));
+  if (!result.ok) process.exitCode = 1;
+}
+
+if (process.argv[1]?.endsWith("trusted-acceptance.ts")) void main();

--- a/scripts/trusted-acceptance.ts
+++ b/scripts/trusted-acceptance.ts
@@ -37,6 +37,10 @@ export type TrustedAcceptanceMember = {
 export type TrustedAcceptanceWorkspace = {
   id: string;
   enabled: boolean;
+  runtimeAuthority: {
+    lifecycle: "ephemeral-per-run";
+    provisioner: "unconfigured";
+  };
   assertions: string[];
   members: TrustedAcceptanceMember[];
 };
@@ -134,6 +138,19 @@ export function validateTrustedAcceptanceConfig(
       });
     }
     workspaceIds.add(workspace.id);
+    if (workspace.runtimeAuthority?.lifecycle !== "ephemeral-per-run") {
+      issues.push({
+        path: `${workspacePath}.runtimeAuthority.lifecycle`,
+        message: "must require disposable per-run runtime authority",
+      });
+    }
+    if (workspace.runtimeAuthority?.provisioner !== "unconfigured") {
+      issues.push({
+        path: `${workspacePath}.runtimeAuthority.provisioner`,
+        message:
+          "must remain unconfigured until a trusted lease provider is implemented",
+      });
+    }
     if (workspace.assertions.length === 0) {
       issues.push({
         path: `${workspacePath}.assertions`,
@@ -256,6 +273,7 @@ export type TrustedAcceptancePlan = {
   revision: string;
   workspace: string;
   enabled: boolean;
+  runtimeAuthority: TrustedAcceptanceWorkspace["runtimeAuthority"];
   assertions: string[];
   members: TrustedAcceptanceMember[];
 };
@@ -292,6 +310,21 @@ export function createTrustedAcceptancePlan(
       ],
     };
   }
+  if (
+    !allowDisabled &&
+    workspace.runtimeAuthority.provisioner === "unconfigured"
+  ) {
+    return {
+      ok: false,
+      issues: [
+        {
+          path: "workspace.runtimeAuthority.provisioner",
+          message:
+            "has no trusted ephemeral runtime authority provisioner; live deployment is unavailable",
+        },
+      ],
+    };
+  }
 
   return {
     ok: true,
@@ -299,6 +332,7 @@ export function createTrustedAcceptancePlan(
       revision: config.revision,
       workspace: workspace.id,
       enabled: workspace.enabled,
+      runtimeAuthority: workspace.runtimeAuthority,
       assertions: workspace.assertions,
       members: workspace.members,
     },


### PR DESCRIPTION
## Problem

Agent Native maintainers have no blessed pre-merge environment where an exact candidate commit can exercise hosted, environment-sensitive framework behavior across participating apps. Local tests and ordinary deploy previews cannot prove real remote MCP OAuth, cross-app discovery, A2A delegation, hosted task status, stable origins, or deployment provenance.

This affects any hosted template that needs those framework capabilities. Calendar and Content exposed the gap and provide the first demanding acceptance story; they are the pilot fixture, not the architecture.

## What this PR delivers

This is the **Framework-wide, inert bootstrap PR** for that acceptance path. It adds:

- a manual, default-branch-controlled `Trusted acceptance` workflow that consumes a declarative workspace rather than branching on app names;
- validation that the selected SHA is the current head of an open, non-fork `BuilderIO/agent-native` PR;
- a generic workspace/member configuration contract for participating hosted templates;
- Calendar and Content as the first disabled workspace, plus a real third-template fixture proving another app can join without workflow changes;
- credential-free candidate builds followed by an immutable trusted deployment controller;
- redacted receipts, rollback provenance, workspace serialization, security guards, tests, and reusable maintainer onboarding documentation; and
- a dedicated CI job that builds the pilot’s real Calendar and Content Netlify artifacts without secrets and verifies their server bundles.

After this PR merges, maintainers can validate exact-SHA plans and builds through the generic repository substrate. No acceptance workspace can deploy until it has separately reviewed isolated infrastructure and disposable runtime authority; the checked-in Calendar/Content pilot remains the first disabled consumer.

## Why deployment remains disabled

The pilot is committed with `enabled: false` and `runtimeAuthority.provisioner: unconfigured`. Both candidate and rollback deployment fail closed even if someone changes only the enabled flag.

Candidate server functions can read any credential available to their hosted runtime. A reusable acceptance database credential, Better Auth secret, or A2A secret would therefore outlive the candidate run and break the isolation boundary. Activation requires a separate reviewed implementation that issues disposable per-run database/Auth/A2A authority, installs it only for the acceptance run, and proves revocation or rotation in an `always()` cleanup path before a receipt can pass.

That lifecycle is part of the reusable workspace contract: future participating templates must use the same disposable-authority boundary rather than receiving app-specific exceptions.

## Security boundaries in this PR

- Candidate install and build jobs receive no Netlify, database, Better Auth, A2A, OAuth, provider, or runtime secrets.
- Workflow-level and build-job inherited credential exposure is guarded against regression.
- Candidate `netlify.toml`, plugins, and hooks do not enter privileged custody.
- The trusted upload uses verified prebuilt output, explicitly includes the hidden Netlify server bundle, runs from an empty controller-owned directory, and passes `--no-build`.
- Trusted controller checkouts are pinned to the immutable dispatch SHA.
- Production Netlify site IDs are rejected.
- Live rollback must pass the same activation and ephemeral-authority gates as a candidate deployment.
- Ordinary preview configuration is neither read nor changed, and this PR makes no claim about preview OAuth or credential isolation.

## Acceptance for this PR

Repository-level bootstrap assertions A1-A4 are complete, including the generic third-template proof. The first operational OAuth/A2A story, isolated infrastructure, token-replay negatives, passing behavioral receipt, and rollback proof (A5-A14) remain intentionally blocked for activation work. Calendar → Content is the first story that will prove the generic lane against real hosted framework behavior; it is not a restriction on future workspace membership.

Verification on `0ad49322e01620fd003569b1785d2d486c4afb4a`:

- 21 focused configuration, provenance, receipt, and workflow-boundary tests pass;
- the registered trusted-acceptance security guard passes;
- independent security review found no remaining concrete blocker;
- CI completed with 49 successful and 43 intentionally skipped checks, including the dedicated secretless pilot builds, security guards, typecheck, lint, build, Fast tests, and scaffold E2E; and
- all review threads are resolved.

## Follow-up required before the first activation

1. Implement and security-review the generic trusted per-run runtime-authority provisioner and guaranteed cleanup path.
2. Provision the first dedicated non-production sites, stable domains, synthetic databases/fixtures, and protected environment custody.
3. Enable the Calendar/Content pilot in a reviewed change.
4. Run the real Calendar → Content OAuth, discovery, `ask_app`, `ask_app_status`, token-isolation, receipt, and rollback story.
5. Onboard later hosted-template workspaces through configuration and resource provisioning, without adding app-specific controller branches.

This PR does not merge, deploy, provision, rotate credentials, or activate any workspace by itself.
