### PR TITLE
Add disposable authority for trusted acceptance

### DIFF
--- a/.github/workflows/trusted-acceptance-reaper.yml
+++ b/.github/workflows/trusted-acceptance-reaper.yml
@@ -1,0 +1,110 @@
+name: Trusted acceptance reaper
+
+on:
+  workflow_dispatch:
+    inputs:
+      workspace:
+        description: Declarative acceptance workspace to reconcile
+        required: true
+        type: string
+        default: calendar-content
+  schedule:
+    - cron: "17 * * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.workspaces.outputs.matrix }}
+    steps:
+      - name: Require the trusted default-branch reaper
+        env:
+          RUN_REF: ${{ github.ref }}
+        run: |
+          if [[ "$RUN_REF" != "refs/heads/main" ]]; then
+            echo "Dispatch the trusted acceptance reaper from main." >&2
+            exit 1
+          fi
+
+      - name: Check out pinned trusted reaper
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Select configured authority workspaces
+        id: workspaces
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REQUESTED_WORKSPACE: ${{ inputs.workspace }}
+        run: |
+          node - <<'NODE'
+          const fs = require("node:fs");
+          const config = JSON.parse(fs.readFileSync("scripts/trusted-acceptance-workspaces.json", "utf8"));
+          const configured = config.workspaces.filter(workspace => workspace.runtimeAuthority?.provisioner?.kind === "trusted-lease-v1");
+          let selected = configured;
+          if (process.env.EVENT_NAME === "workflow_dispatch") {
+            selected = configured.filter(workspace => workspace.id === process.env.REQUESTED_WORKSPACE);
+            if (selected.length !== 1) throw new Error("Requested workspace has no configured trusted lease authority");
+          }
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `matrix=${JSON.stringify({include: selected.map(({id}) => ({workspace: id}))})}\n`);
+          NODE
+
+  reap:
+    needs: plan
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    concurrency:
+      group: trusted-acceptance-${{ matrix.workspace }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    environment: trusted-acceptance
+    steps:
+      - name: Check out pinned trusted reaper
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install trusted controller dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Reconcile expired deterministic acceptance leases
+        env:
+          AUTHORITY_PROFILES_JSON: ${{ vars.ACCEPTANCE_AUTHORITY_PROFILES_JSON }}
+          ACCEPTANCE_NEON_API_KEY: ${{ secrets.ACCEPTANCE_NEON_API_KEY }}
+          ACCEPTANCE_NETLIFY_AUTH_TOKEN: ${{ secrets.ACCEPTANCE_NETLIFY_AUTH_TOKEN }}
+          ACCEPTANCE_OPENROUTER_API_KEY: ${{ secrets.ACCEPTANCE_OPENROUTER_API_KEY }}
+          WORKSPACE: ${{ matrix.workspace }}
+        run: |
+          if [[ -z "$AUTHORITY_PROFILES_JSON" ]]; then
+            echo "No trusted authority profiles are configured; refusing reaper execution." >&2
+            exit 1
+          fi
+          node - <<'NODE'
+          const fs = require("node:fs");
+          const profile = JSON.parse(process.env.AUTHORITY_PROFILES_JSON)[process.env.WORKSPACE];
+          if (!profile || profile.workspace !== process.env.WORKSPACE) throw new Error("No exact trusted authority profile exists for this workspace");
+          fs.writeFileSync(process.env.RUNNER_TEMP + "/trusted-authority-profile.json", JSON.stringify(profile));
+          NODE
+          pnpm tsx scripts/trusted-acceptance/controller.ts reap --profile "$RUNNER_TEMP/trusted-authority-profile.json" --journal "$RUNNER_TEMP/trusted-acceptance-reaper.json"
+
+      - name: Upload current redacted reaper journal
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trusted-acceptance-reaper-journal-${{ matrix.workspace }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/trusted-acceptance-reaper.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/trusted-acceptance.yml
+++ b/.github/workflows/trusted-acceptance.yml
@@ -266,9 +266,6 @@ jobs:
     needs: [plan, build]
     runs-on: ubuntu-latest
     environment: trusted-acceptance
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
     steps:
       - name: Check out trusted controller
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -283,76 +280,122 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Install pinned deployment client before credentials enter the job
-        run: npm install --global netlify-cli@27.0.0 --ignore-scripts
-
-      - name: Resolve isolated acceptance site before credentials enter the step
-        id: site
-        env:
-          SITE_ID: ${{ vars[matrix.siteIdVariable] }}
-          TEMPLATE: ${{ matrix.template }}
         run: |
-          if [[ -z "$SITE_ID" ]]; then
-            echo "The trusted-acceptance environment has no site ID for $TEMPLATE." >&2
-            exit 1
-          fi
-          node - <<'NODE'
-          const fs = require("node:fs");
-          const productionSites = Object.values(JSON.parse(fs.readFileSync("scripts/netlify-sites.json", "utf8")));
-          if (productionSites.includes(process.env.SITE_ID)) {
-            throw new Error("Acceptance deployment resolved to a known production site ID");
-          }
-          fs.appendFileSync(process.env.GITHUB_OUTPUT, `site_id=${process.env.SITE_ID}\n`);
-          NODE
+          pnpm install --frozen-lockfile --ignore-scripts
+          npm install --global netlify-cli@27.0.0 --ignore-scripts
 
-      - name: Download inert candidate artifact
+      - name: Download every inert candidate artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: trusted-acceptance-build-${{ matrix.template }}
-          path: ${{ runner.temp }}/acceptance-artifact/${{ matrix.template }}
+          pattern: trusted-acceptance-build-*
+          path: ${{ runner.temp }}/acceptance-artifacts
 
-      - name: Verify artifact provenance before credentials enter the step
+      - name: Verify every artifact provenance before credentials enter the step
         env:
           EXPECTED_SHA: ${{ needs.plan.outputs.effective_sha }}
-          TEMPLATE: ${{ matrix.template }}
+          MATRIX: ${{ needs.plan.outputs.matrix }}
         run: |
           node - <<'NODE'
           const fs = require("node:fs");
-          const path = `${process.env.RUNNER_TEMP}/acceptance-artifact/${process.env.TEMPLATE}/build-metadata.json`;
-          const metadata = JSON.parse(fs.readFileSync(path, "utf8"));
-          if (metadata.sha !== process.env.EXPECTED_SHA || metadata.template !== process.env.TEMPLATE) {
-            throw new Error("Candidate artifact provenance mismatch");
+          const path = require("node:path");
+          for (const member of JSON.parse(process.env.MATRIX).include) {
+            const artifact = path.join(process.env.RUNNER_TEMP, "acceptance-artifacts", `trusted-acceptance-build-${member.template}`);
+            const metadata = JSON.parse(fs.readFileSync(path.join(artifact, "build-metadata.json"), "utf8"));
+            if (metadata.sha !== process.env.EXPECTED_SHA || metadata.template !== member.template || !fs.statSync(path.join(artifact, "publish")).isDirectory()) {
+              throw new Error(`Candidate artifact provenance mismatch for ${member.template}`);
+            }
           }
           NODE
           mkdir -p "$RUNNER_TEMP/trusted-acceptance-deploy"
 
-      - name: Deploy inert artifact to isolated acceptance site
-        working-directory: ${{ runner.temp }}/trusted-acceptance-deploy
+      # This file is a trusted, redacted resource allowlist, not a credential
+      # container. It is intentionally materialized only after provenance is
+      # verified and only in the protected environment.
+      - name: Materialize trusted authority profile after provenance verification
         env:
-          ARTIFACT_DIR: ${{ runner.temp }}/acceptance-artifact/${{ matrix.template }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.ACCEPTANCE_NETLIFY_AUTH_TOKEN }}
-          SITE_ID: ${{ steps.site.outputs.site_id }}
-          TEMPLATE: ${{ matrix.template }}
+          AUTHORITY_PROFILES_JSON: ${{ vars.ACCEPTANCE_AUTHORITY_PROFILES_JSON }}
+          MATRIX: ${{ needs.plan.outputs.matrix }}
+          WORKSPACE: ${{ inputs.workspace }}
         run: |
-          if [[ -z "$NETLIFY_AUTH_TOKEN" ]]; then
-            echo "The trusted-acceptance environment is not provisioned for $TEMPLATE." >&2
+          if [[ -z "$AUTHORITY_PROFILES_JSON" ]]; then
+            echo "The trusted-acceptance environment has no configured authority profiles." >&2
             exit 1
           fi
-          raw_result="$(mktemp)"
-          trap 'rm -f "$raw_result"' EXIT
-          netlify deploy --prod --no-build --json --auth "$NETLIFY_AUTH_TOKEN" --site "$SITE_ID" --dir "$ARTIFACT_DIR/publish" --functions "$ARTIFACT_DIR/.netlify/functions-internal" > "$raw_result"
-          node - "$raw_result" "$RUNNER_TEMP/deploy-$TEMPLATE.json" <<'NODE'
+          node - <<'NODE'
           const fs = require("node:fs");
-          const result = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
-          const deployId = result.deploy_id ?? result.id;
-          if (!deployId) throw new Error("Netlify did not return a deploy ID");
-          fs.writeFileSync(process.argv[3], JSON.stringify({template: process.env.TEMPLATE, deployId}));
+          const profiles = JSON.parse(process.env.AUTHORITY_PROFILES_JSON);
+          const profile = profiles[process.env.WORKSPACE];
+          if (!profile || profile.workspace !== process.env.WORKSPACE) throw new Error("No exact trusted authority profile exists for this workspace");
+          fs.writeFileSync(process.env.RUNNER_TEMP + "/trusted-authority-profile.json", JSON.stringify(profile));
           NODE
+          pnpm tsx scripts/trusted-acceptance/controller.ts validate-profile --profile "$RUNNER_TEMP/trusted-authority-profile.json"
+          node - <<'NODE'
+          const fs = require("node:fs");
+          const path = require("node:path");
+          const profile = JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + "/trusted-authority-profile.json", "utf8"));
+          const expected = new Set(JSON.parse(process.env.MATRIX).include.map(({template}) => template));
+          const runtime = new Map(profile.runtime.members.map((member) => [member.id, member]));
+          const productionSiteIds = new Set(Object.values(JSON.parse(fs.readFileSync("scripts/netlify-sites.json", "utf8"))));
+          const members = profile.members.map(({id}) => {
+            if (!expected.has(id) || !runtime.has(id)) throw new Error(`Profile member ${id} is not an expected artifact`);
+            if (productionSiteIds.has(runtime.get(id).netlifySiteId)) throw new Error(`Profile member ${id} resolves to a known production site ID`);
+            const artifact = path.join(process.env.RUNNER_TEMP, "acceptance-artifacts", `trusted-acceptance-build-${id}`);
+            if (!fs.existsSync(artifact)) throw new Error(`Missing verified artifact for ${id}`);
+            return {id, siteId: runtime.get(id).netlifySiteId, artifact};
+          });
+          if (members.length !== expected.size) throw new Error("Profile must deploy the entire configured workspace");
+          fs.writeFileSync(process.env.RUNNER_TEMP + "/trusted-deploy-manifest.json", JSON.stringify(members));
+          NODE
+
+      - name: Acquire one whole-workspace disposable lease
+        env:
+          ACCEPTANCE_NEON_API_KEY: ${{ secrets.ACCEPTANCE_NEON_API_KEY }}
+          ACCEPTANCE_NETLIFY_AUTH_TOKEN: ${{ secrets.ACCEPTANCE_NETLIFY_AUTH_TOKEN }}
+          ACCEPTANCE_OPENROUTER_API_KEY: ${{ secrets.ACCEPTANCE_OPENROUTER_API_KEY }}
+        run: |
+          pnpm tsx scripts/trusted-acceptance/controller.ts acquire --profile "$RUNNER_TEMP/trusted-authority-profile.json" --journal "$RUNNER_TEMP/trusted-acceptance-lease.json"
+
+      - name: Deploy every preverified inert artifact
+        working-directory: ${{ runner.temp }}/trusted-acceptance-deploy
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.ACCEPTANCE_NETLIFY_AUTH_TOKEN }}
+        run: |
+          node -e 'const fs=require("node:fs"); for (const member of JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + "/trusted-deploy-manifest.json", "utf8"))) process.stdout.write(`${member.id}\t${member.siteId}\t${member.artifact}\n`)' | while IFS=$'\t' read -r template site_id artifact_dir; do
+            raw_result="$(mktemp)"
+            trap 'rm -f "$raw_result"' EXIT
+            netlify deploy --prod --no-build --json --auth "$NETLIFY_AUTH_TOKEN" --site "$site_id" --dir "$artifact_dir/publish" --functions "$artifact_dir/.netlify/functions-internal" > "$raw_result"
+            node - "$raw_result" "$RUNNER_TEMP/deploy-$template.json" "$template" <<'NODE'
+            const fs = require("node:fs");
+            const result = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+            const deployId = result.deploy_id ?? result.id;
+            if (!deployId) throw new Error("Netlify did not return a deploy ID");
+            fs.writeFileSync(process.argv[3], JSON.stringify({template: process.argv[4], deployId}));
+            NODE
+          done
+
+      - name: Revoke one whole-workspace disposable lease
+        if: ${{ always() }}
+        env:
+          ACCEPTANCE_NEON_API_KEY: ${{ secrets.ACCEPTANCE_NEON_API_KEY }}
+          ACCEPTANCE_NETLIFY_AUTH_TOKEN: ${{ secrets.ACCEPTANCE_NETLIFY_AUTH_TOKEN }}
+          ACCEPTANCE_OPENROUTER_API_KEY: ${{ secrets.ACCEPTANCE_OPENROUTER_API_KEY }}
+        run: pnpm tsx scripts/trusted-acceptance/controller.ts revoke --profile "$RUNNER_TEMP/trusted-authority-profile.json" --journal "$RUNNER_TEMP/trusted-acceptance-lease.json"
+
+      - name: Upload current redacted lease journal and controller receipt
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trusted-acceptance-lease-state-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/trusted-acceptance-lease.json
+          if-no-files-found: warn
+          retention-days: 30
 
       - name: Upload redacted deployment result
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: trusted-acceptance-deploy-${{ matrix.template }}
-          path: ${{ runner.temp }}/deploy-${{ matrix.template }}.json
+          name: trusted-acceptance-deploy-results
+          path: ${{ runner.temp }}/deploy-*.json
           if-no-files-found: error
           retention-days: 30
 

--- a/docs/trusted-acceptance-lane.md
+++ b/docs/trusted-acceptance-lane.md
@@ -11,15 +11,21 @@ does not read, copy, reconcile, or repair preview environment configuration,
 and a successful lane receipt says nothing about preview OAuth or preview
 credential isolation.
 
-## Current bootstrap state
+## Current disabled state
 
 The `calendar-content` pilot in
 `scripts/trusted-acceptance-workspaces.json` is checked in with `enabled: false`.
 The workflow can validate an open PR, produce the generic app matrix, and build
-the candidate without runtime or deployment credentials. A live deployment
-fails closed even if the flag is changed: the bootstrap config deliberately has
-no runtime-authority provisioner. A later reviewed change must implement the
-trusted per-run credential lease and cleanup path before activation.
+the candidate without runtime or deployment credentials. The repository also
+contains the provider-neutral `trusted-lease-v1` controller contract, bounded
+provider adapters, acceptance-only directory fixture, hosted OAuth/A2A harness,
+and independent reaper entrypoint. None of those declarations activates the
+pilot. A live deployment fails closed because the checked-in workspace has an
+`unconfigured` provisioner as well as `enabled: false`.
+
+Activation is a separate reviewed change. It must name an allowlisted protected
+authority profile, prove the dedicated resources exist, and change the flag.
+Changing only the flag still fails closed.
 
 ## Custody boundaries
 
@@ -36,20 +42,99 @@ The jobs deliberately have different custody:
    credentials. Candidate dependency and build scripts run without Netlify,
    database, Better Auth, A2A, provider, OAuth, or runtime secrets, then upload
    inert build artifacts and SHA metadata.
-3. `deploy` uses the protected `trusted-acceptance` GitHub Environment. It
-   checks out trusted controller code, installs the pinned Netlify client,
+3. The privileged controller uses the protected `trusted-acceptance` GitHub
+   Environment. It
+   checks out trusted controller code, installs dependencies and the pinned
+   Netlify client before credentials enter,
    rejects any resolved site ID present in the production-site inventory,
    downloads and verifies inert artifacts, then uploads them from an empty
    trusted directory using explicit paths. Candidate `netlify.toml`, plugins,
-   and hooks never cross into this job. Only then does the upload step receive
-   the scoped Netlify token; it uses `--no-build` and never runs candidate
-   scripts.
+   and hooks never cross into this job. Only then do the fixed trusted
+   acquire/upload/revoke steps receive scoped provider credentials. The upload
+   uses `--no-build`, and no candidate or dependency script runs after that
+   boundary.
 4. `receipt` records a redacted artifact. Until the real OAuth/A2A harness is
    run, behavioral assertions remain `blocked`; a deployment alone is not a
    passing acceptance result.
 
 Runs share a non-cancelling concurrency group per workspace, so two candidate
 SHAs cannot interleave across the same apps.
+
+The controller credentials enter only the trusted default-branch job, after
+candidate artifacts have been downloaded and their embedded SHA metadata has
+been verified. No candidate checkout, package lifecycle command, build hook, or
+candidate configuration runs after that boundary.
+
+## Disposable authority contract
+
+`scripts/trusted-acceptance/runtime-authority.ts` separates two kinds of state:
+
+- transient runtime material, which contains the database URL, freshly
+  generated Better Auth and A2A values, and an optional bounded inference key;
+  and
+- a durable redacted lease record containing only deterministic lease identity,
+  opaque provider handles, timestamps, state transitions, and cleanup results.
+
+The provider contract is generic, while the first protected profile uses:
+
+- one expiring Neon child branch in each member's unique dedicated synthetic
+  seed project (two workspace members may not share a project ID);
+- Netlify environment values managed through the current account environment
+  API, scoped only to functions/runtime on isolated acceptance sites;
+- one expiring OpenRouter child key for each member that declares inference,
+  with a small USD cap and no automatic limit reset; and
+- a trusted tombstone artifact deployed after runtime values are removed.
+
+The OpenRouter management key, Neon API key, and Netlify control token remain in
+the protected controller environment. Candidate code sees only the disposable
+runtime values for its current lease. Provider endpoints and project/site IDs
+come from the trusted profile, not workflow inputs or candidate files.
+
+Before creating any branch or runtime value, the controller queries each
+declared Netlify site, requires its exact site ID to serve the profile's exact
+acceptance origin, and requires every managed runtime key to be absent. It never
+overwrites or later deletes a pre-existing value. A reused or misbound site is a
+hard preflight failure instead of collateral damage.
+
+Acquisition journals before and after every provider mutation. Revocation is
+idempotent and is incomplete until the inference key is absent, database
+branches are absent, runtime configuration is absent, and each isolated site is
+serving its verified trusted tombstone deploy. A passing receipt must include
+those cleanup states and opaque tombstone deploy IDs.
+
+The normal workflow invokes revocation from an `always()` cleanup path. The
+separate `trusted-acceptance-reaper.yml` workflow is main-pinned and can also be
+run on a schedule or manually. It builds a generic matrix from configured
+workspaces and shares each workspace's non-cancelling concurrency group. It
+discovers expired deterministic lease names from Neon branches, bounded
+OpenRouter keys, and one atomic non-secret Netlify lease marker, then calls the
+same idempotent cleanup path. Marker values are identifiers and expiries only;
+runtime credentials remain secret and unreadable. Recovery deletes site runtime
+keys or deploys a tombstone only when that site's marker still names the lease;
+a markerless branch/key recovery cleans only its matching provider handles.
+The marker is re-read immediately before cleanup, so an ownership race fails
+closed without deleting another actor's site state.
+This is required because
+force-cancelling a workflow can interrupt even an `always()` job.
+
+## Acceptance-only app directory
+
+Separately hosted templates do not form a local filesystem workspace. Hosted
+`list_apps` therefore uses the organization-directory HTTP contract. The
+acceptance lane supplies a small trusted fixture implementing only that public
+contract; it does not reuse production Dispatch data or authority.
+
+The fixture validates the disposable A2A bearer and returns only the members
+declared by the trusted workspace profile. Its mode is controller-owned and has
+two allowlisted states: stable membership and withdrawal of one declared
+member. There is no candidate-callable control endpoint and no request field
+that selects arbitrary apps or URLs.
+
+The hosted harness first proves stable discovery, calls `ask_app`, records the
+returned task ID only in redacted form, asks the trusted controller to withdraw
+the target member, and polls `ask_app_status` for that same task. This makes
+directory loss a discriminating test of preserved task routing instead of a
+simulation that skips discovery.
 
 ## Provision the first workspace
 
@@ -63,8 +148,8 @@ A2A secret is not an isolation boundary: a candidate could retain it after the
 run. Static runtime credentials configured directly on the stable acceptance
 sites are forbidden.
 
-Before this workspace can be enabled, a follow-up implementation must add a
-trusted runtime-authority provisioner that:
+Before this workspace can be enabled, the implemented trusted runtime-authority
+provisioner must be connected to dedicated resources and prove that it:
 
 - creates a fresh, revocable database credential over synthetic data for each
   run;
@@ -76,6 +161,12 @@ trusted runtime-authority provisioner that:
 - records only lease identifiers, issue/revocation timestamps, and cleanup
   status in the redacted receipt. A receipt cannot pass until revocation is
   confirmed.
+
+Content also needs a real inference call to complete the delegated task. The
+controller mints a child key with an exact expiry and tiny spend cap, installs
+it together with `AGENT_ENGINE=ai-sdk:openrouter` only for the leased runtime,
+and deletes or disables it before cleanup can pass. A reusable model-provider
+key is forbidden.
 
 The candidate may inspect or corrupt its disposable lease while the test is in
 progress. Its authority must become useless when cleanup completes; production,
@@ -98,10 +189,14 @@ workspace, a provider integration, or a later acceptance run.
 Configure the protected GitHub Environment named `trusted-acceptance` with:
 
 - secret `ACCEPTANCE_NETLIFY_AUTH_TOKEN`, scoped to deployment of only the
-  dedicated acceptance sites; and
-- non-secret site variables named by each member's `siteIdVariable`, initially
-  `ACCEPTANCE_CALENDAR_NETLIFY_SITE_ID` and
-  `ACCEPTANCE_CONTENT_NETLIFY_SITE_ID`.
+  dedicated acceptance sites;
+- secrets `ACCEPTANCE_NEON_API_KEY` and `ACCEPTANCE_OPENROUTER_API_KEY`, each
+  scoped to the dedicated synthetic projects or bounded child-key authority;
+  and
+- non-secret `ACCEPTANCE_AUTHORITY_PROFILES_JSON`, an object keyed by workspace
+  ID. Each profile allowlists exact member origins, Neon project/database/role
+  IDs, Netlify account/site IDs, the tiny inference cap, and the verified
+  tombstone artifact. It contains no provider token or runtime credential.
 
 The repository contains key names and resource references only. Never put
 secret values, synthetic login credentials, tokens, or raw provider responses
@@ -109,8 +204,11 @@ in the workspace config, workflow, docs, logs, or receipt.
 
 After a redacted inventory proves those resources are isolated and the trusted
 provision/cleanup implementation has its own security review and tests, replace
-the bootstrap `unconfigured` provisioner and change the workspace to
-`enabled: true` in a reviewed PR. Changing only the flag still fails closed.
+the `{ "kind": "unconfigured" }` provisioner with a `trusted-lease-v1`
+descriptor, add its exact entry to the protected profile map, then change the
+workspace to `enabled: true` in a separate reviewed PR. The descriptor's
+`profileMapVariable` must be exactly `ACCEPTANCE_AUTHORITY_PROFILES_JSON`;
+changing only the flag still fails closed.
 Keep GitHub Environment approval rules in place; enabling configuration is not
 permission to bypass them.
 
@@ -131,8 +229,10 @@ For a live run after activation, set `deploy` to true. The stable apps must then
 be tested with a real authorization-code plus PKCE client: inspect protected
 resource metadata, connect to Calendar, require Content from `list_apps`, call a
 bounded read-only `ask_app`, and poll the returned ID through `ask_app_status`.
-Run production-to-acceptance, acceptance-to-production, and cross-resource
-token replay negatives before marking the receipt passed.
+After `ask_app`, the trusted directory fixture withdraws the target member;
+`ask_app_status` must still complete that exact task through its preserved
+route. Run production-to-acceptance, acceptance-to-production, and
+cross-resource token replay negatives before marking the receipt passed.
 
 ## Roll back
 
@@ -152,9 +252,10 @@ No workflow branch is required. Add a member or workspace entry containing:
 
 - a unique template ID that exists under `templates/`;
 - a stable, non-production HTTPS acceptance origin;
-- a unique acceptance-scoped Netlify site-variable name;
-- acceptance-scoped runtime key names and an implemented disposable-authority
-  provisioner;
+- exact acceptance-scoped Netlify account and site IDs in the protected
+  non-secret profile map;
+- acceptance-scoped runtime key names, optional inference declaration, and an
+  implemented disposable-authority provisioner;
 - the template's build command and relative publish directory;
 - absolute health, protected-resource metadata, and MCP paths; and
 - the assertion IDs that the workspace must prove.
@@ -166,6 +267,7 @@ verified. Run the focused validator and workflow boundary tests before review:
 
 ```sh
 pnpm tsx --test scripts/trusted-acceptance.spec.ts scripts/guard-trusted-acceptance-workflow.spec.ts
+pnpm tsx --test scripts/trusted-acceptance/*.spec.ts
 pnpm guard:trusted-acceptance
 ```
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test:content-db": "pnpm --filter content exec vitest --run actions/bind-content-database-source-field.db.test.ts actions/blocks-seeding.db.test.ts actions/builder-source-review-gates.db.test.ts actions/content-database-lifecycle.db.test.ts actions/database-row-batch-actions.db.test.ts actions/list-content-databases.db.test.ts actions/move-document.db.test.ts actions/resync-content-database-source.db.test.ts actions/slack-correction-identity.db.test.ts actions/stage-builder-source-bulk-update.db.test.ts actions/submit-content-database-form.db.test.ts actions/update-document.db.test.ts --config vitest.config.ts",
     "test:core-integration": "pnpm --filter @agent-native/core exec vitest --run src/agent/engine/translate-ai-sdk.integration.spec.ts src/agent/run-loop-with-resume.integration.spec.ts src/client/extensions/AgentNativeExtensionFrame.e2e.spec.ts src/client/session-replay-iframe.e2e.spec.ts src/scripts/db/migrate-encrypt-credentials.e2e.spec.ts src/scripts/db/scope-isolation.e2e.spec.ts src/server/csrf-plugin-ordering.integration.spec.ts src/server/embedded.integration.spec.ts --maxWorkers=25% --passWithNoTests",
     "test:plan-e2e": "pnpm --filter plan exec vitest --run actions/create-visual-recap.e2e.spec.ts --passWithNoTests",
-    "test:trusted-acceptance": "tsx --test scripts/trusted-acceptance.spec.ts scripts/guard-trusted-acceptance-workflow.spec.ts",
+    "test:trusted-acceptance": "tsx --test scripts/trusted-acceptance.spec.ts scripts/guard-trusted-acceptance-workflow.spec.ts scripts/trusted-acceptance/*.spec.ts",
     "test:brain-evals": "pnpm --filter brain eval:ci",
     "test:brain-privacy-evals": "pnpm --filter brain privacy:eval",
     "test:content-parity": "pnpm --filter content test:parity-capabilities",

--- a/scripts/guard-trusted-acceptance-workflow.spec.ts
+++ b/scripts/guard-trusted-acceptance-workflow.spec.ts
@@ -2,10 +2,18 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { describe, it } from "node:test";
 
-import { validateTrustedAcceptanceWorkflow } from "./guard-trusted-acceptance-workflow.ts";
+import {
+  validateRuntimeAuthorityConfiguration,
+  validateTrustedAcceptanceReaper,
+  validateTrustedAcceptanceWorkflow,
+} from "./guard-trusted-acceptance-workflow.ts";
 
 const workflow = readFileSync(
   ".github/workflows/trusted-acceptance.yml",
+  "utf8",
+);
+const reaper = readFileSync(
+  ".github/workflows/trusted-acceptance-reaper.yml",
   "utf8",
 );
 
@@ -104,5 +112,58 @@ describe("trusted acceptance workflow boundary", () => {
     const result = validateTrustedAcceptanceWorkflow(unsafe);
     assert.equal(result.ok, false);
     assert(result.issues.some((issue) => issue.includes("controller SHA")));
+  });
+});
+
+describe("trusted acceptance reaper boundary", () => {
+  it("uses generic profiles and serializes against each workspace", () => {
+    assert.deepEqual(validateTrustedAcceptanceReaper(reaper), {
+      ok: true,
+      issues: [],
+    });
+  });
+
+  it("rejects a reaper that does not share workspace custody", () => {
+    const unsafe = reaper.replace(
+      "group: trusted-acceptance-${{ matrix.workspace }}",
+      "group: trusted-acceptance-reaper",
+    );
+    const result = validateTrustedAcceptanceReaper(unsafe);
+    assert.equal(result.ok, false);
+    assert(result.issues.some((issue) => issue.includes("serialize")));
+  });
+});
+
+describe("trusted acceptance runtime authority boundary", () => {
+  it("permits a disabled workspace to declare the implemented lease contract", () => {
+    assert.deepEqual(
+      validateRuntimeAuthorityConfiguration([
+        {
+          enabled: false,
+          runtimeAuthority: {
+            lifecycle: "ephemeral-per-run",
+            provisioner: {
+              kind: "trusted-lease-v1",
+              profileMapVariable: "ACCEPTANCE_AUTHORITY_PROFILES_JSON",
+            },
+          },
+        },
+      ]),
+      { ok: true, issues: [] },
+    );
+  });
+
+  it("fails closed if an enabled workspace has no configured provisioner", () => {
+    const result = validateRuntimeAuthorityConfiguration([
+      {
+        enabled: true,
+        runtimeAuthority: {
+          lifecycle: "ephemeral-per-run",
+          provisioner: { kind: "unconfigured" },
+        },
+      },
+    ]);
+    assert.equal(result.ok, false);
+    assert(result.issues.some((issue) => issue.includes("remain disabled")));
   });
 });

--- a/scripts/guard-trusted-acceptance-workflow.ts
+++ b/scripts/guard-trusted-acceptance-workflow.ts
@@ -5,6 +5,52 @@ export type WorkflowGuardResult = {
   issues: string[];
 };
 
+export type GuardedRuntimeWorkspace = {
+  enabled?: boolean;
+  runtimeAuthority?: {
+    lifecycle?: string;
+    provisioner?: { kind?: string; profileMapVariable?: string };
+  };
+};
+
+export function validateRuntimeAuthorityConfiguration(
+  workspaces: readonly GuardedRuntimeWorkspace[] | undefined,
+): WorkflowGuardResult {
+  const issues: string[] = [];
+  if (!workspaces?.length) {
+    issues.push("trusted acceptance must declare at least one workspace");
+    return { ok: false, issues };
+  }
+  for (const [index, workspace] of workspaces.entries()) {
+    const authority = workspace.runtimeAuthority;
+    if (authority?.lifecycle !== "ephemeral-per-run") {
+      issues.push(
+        `workspace ${index} must require ephemeral per-run authority`,
+      );
+    }
+    const kind = authority?.provisioner?.kind;
+    if (kind !== "unconfigured" && kind !== "trusted-lease-v1") {
+      issues.push(
+        `workspace ${index} must use an approved authority provisioner`,
+      );
+    }
+    if (workspace.enabled && kind === "unconfigured") {
+      issues.push(
+        `workspace ${index} must remain disabled without a configured authority provisioner`,
+      );
+    }
+    if (
+      kind === "trusted-lease-v1" &&
+      authority?.provisioner?.profileMapVariable !==
+        "ACCEPTANCE_AUTHORITY_PROFILES_JSON"
+    )
+      issues.push(
+        `workspace ${index} must use the generic protected profile map`,
+      );
+  }
+  return { ok: issues.length === 0, issues };
+}
+
 function section(source: string, start: string, end: string): string {
   const startIndex = source.indexOf(start);
   const endIndex = source.indexOf(end, startIndex + start.length);
@@ -81,11 +127,13 @@ export function validateTrustedAcceptanceWorkflow(
     if (!deploy.includes("Check out trusted controller")) {
       issues.push("deploy job must use default-branch controller code");
     }
-    if (!deploy.includes("Verify artifact provenance before credentials")) {
+    if (
+      !deploy.includes("Verify every artifact provenance before credentials")
+    ) {
       issues.push("artifact provenance must be checked before deployment");
     }
     if (
-      !deploy.includes("scripts/netlify-sites.json") ||
+      !deploy.includes('readFileSync("scripts/netlify-sites.json"') ||
       !deploy.includes("known production site ID")
     ) {
       issues.push(
@@ -97,7 +145,7 @@ export function validateTrustedAcceptanceWorkflow(
     }
     if (
       !deploy.includes(
-        '--functions "$ARTIFACT_DIR/.netlify/functions-internal"',
+        '--functions "$artifact_dir/.netlify/functions-internal"',
       )
     ) {
       issues.push(
@@ -116,9 +164,25 @@ export function validateTrustedAcceptanceWorkflow(
         "privileged upload must run from an empty trusted directory, not candidate files",
       );
     }
-    const secretIndex = deploy.indexOf("secrets.ACCEPTANCE_NETLIFY_AUTH_TOKEN");
+    if (deploy.includes("strategy:") || deploy.includes("matrix.")) {
+      issues.push("privileged authority must operate on one whole workspace");
+    }
+    if (
+      !deploy.includes("Acquire one whole-workspace disposable lease") ||
+      !deploy.includes("Revoke one whole-workspace disposable lease") ||
+      !deploy.includes("if: ${{ always() }}")
+    ) {
+      issues.push("whole-workspace cleanup must run unconditionally");
+    }
+    if (
+      !deploy.includes("vars.ACCEPTANCE_AUTHORITY_PROFILES_JSON") ||
+      deploy.includes("ACCEPTANCE_CALENDAR_CONTENT_AUTHORITY_PROFILE")
+    ) {
+      issues.push("authority profiles must use the generic protected mapping");
+    }
+    const secretIndex = deploy.indexOf("secrets.ACCEPTANCE_NEON_API_KEY");
     const verifyIndex = deploy.indexOf(
-      "Verify artifact provenance before credentials",
+      "Verify every artifact provenance before credentials",
     );
     if (secretIndex === -1 || secretIndex < verifyIndex) {
       issues.push(
@@ -126,7 +190,7 @@ export function validateTrustedAcceptanceWorkflow(
       );
     }
     if (
-      /pnpm\s+(?:run\s+)?(?:build|install)|npm\s+(?:run\s+)?build/.test(
+      /working-directory:\s+candidate|pnpm\s+(?:run\s+)?(?:build|install)|npm\s+(?:run\s+)?build/.test(
         deploy.slice(secretIndex),
       )
     ) {
@@ -136,13 +200,18 @@ export function validateTrustedAcceptanceWorkflow(
     }
   }
 
-  if (count(source, /secrets\.ACCEPTANCE_NETLIFY_AUTH_TOKEN/g) !== 1) {
+  if (count(source, /secrets\.ACCEPTANCE_NETLIFY_AUTH_TOKEN/g) !== 3) {
     issues.push(
-      "acceptance Netlify credential must appear in exactly one step",
+      "acceptance Netlify credential must appear only in acquire, deploy, and revoke steps",
     );
   }
-  if (count(source, /vars\[matrix\.siteIdVariable\]/g) !== 1) {
-    issues.push("acceptance site variable must appear in exactly one step");
+  if (
+    count(source, /secrets\.ACCEPTANCE_NEON_API_KEY/g) !== 2 ||
+    count(source, /secrets\.ACCEPTANCE_OPENROUTER_API_KEY/g) !== 2
+  ) {
+    issues.push(
+      "provider authority credentials must appear only in acquire and revoke",
+    );
   }
   if (count(source, /ref: \$\{\{ github\.sha \}\}/g) !== 3) {
     issues.push(
@@ -194,31 +263,64 @@ export function validateTrustedAcceptanceWorkflow(
   return { ok: issues.length === 0, issues };
 }
 
+export function validateTrustedAcceptanceReaper(
+  source: string,
+): WorkflowGuardResult {
+  const issues: string[] = [];
+  if (!source.includes("workflow_dispatch:") || !source.includes("schedule:"))
+    issues.push("reaper must support manual and scheduled recovery");
+  if (/pull_request:|path:\s+candidate/.test(source))
+    issues.push("reaper must never execute candidate-controlled code");
+  if (!source.includes('RUN_REF" != "refs/heads/main"'))
+    issues.push("reaper must fail closed unless dispatched from main");
+  if (!source.includes("ref: ${{ github.sha }}"))
+    issues.push("reaper must pin trusted code to the dispatch SHA");
+  if (!source.includes("environment: trusted-acceptance"))
+    issues.push("reaper must use the protected acceptance environment");
+  if (
+    !source.includes("matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}") ||
+    !source.includes("group: trusted-acceptance-${{ matrix.workspace }}") ||
+    !source.includes("cancel-in-progress: false")
+  )
+    issues.push("reaper must serialize against each acceptance workspace");
+  if (
+    !source.includes("vars.ACCEPTANCE_AUTHORITY_PROFILES_JSON") ||
+    source.includes("ACCEPTANCE_CALENDAR_CONTENT_AUTHORITY_PROFILE")
+  )
+    issues.push("reaper must use the generic protected profile mapping");
+  if (!source.includes("controller.ts reap"))
+    issues.push("reaper must invoke the trusted runtime-authority controller");
+  return { ok: issues.length === 0, issues };
+}
+
 function main(): void {
   const workflow = readFileSync(
     ".github/workflows/trusted-acceptance.yml",
     "utf8",
   );
   const result = validateTrustedAcceptanceWorkflow(workflow);
+  const reaper = validateTrustedAcceptanceReaper(
+    readFileSync(".github/workflows/trusted-acceptance-reaper.yml", "utf8"),
+  );
+  if (!reaper.ok) {
+    result.ok = false;
+    result.issues.push(...reaper.issues);
+  }
   const config = JSON.parse(
     readFileSync("scripts/trusted-acceptance-workspaces.json", "utf8"),
   ) as {
     workspaces?: Array<{
-      runtimeAuthority?: { lifecycle?: string; provisioner?: string };
+      enabled?: boolean;
+      runtimeAuthority?: {
+        lifecycle?: string;
+        provisioner?: { kind?: string; profileMapVariable?: string };
+      };
     }>;
   };
-  if (
-    !config.workspaces?.length ||
-    config.workspaces.some(
-      ({ runtimeAuthority }) =>
-        runtimeAuthority?.lifecycle !== "ephemeral-per-run" ||
-        runtimeAuthority.provisioner !== "unconfigured",
-    )
-  ) {
+  const authority = validateRuntimeAuthorityConfiguration(config.workspaces);
+  if (!authority.ok) {
     result.ok = false;
-    result.issues.push(
-      "bootstrap must fail closed without a trusted ephemeral runtime authority provisioner",
-    );
+    result.issues.push(...authority.issues);
   }
   if (!result.ok) {
     for (const issue of result.issues)

--- a/scripts/trusted-acceptance-workspaces.json
+++ b/scripts/trusted-acceptance-workspaces.json
@@ -1,12 +1,14 @@
 {
-  "revision": "2",
+  "revision": "3",
   "workspaces": [
     {
       "id": "calendar-content",
       "enabled": false,
       "runtimeAuthority": {
         "lifecycle": "ephemeral-per-run",
-        "provisioner": "unconfigured"
+        "provisioner": {
+          "kind": "unconfigured"
+        }
       },
       "assertions": [
         "A1",
@@ -52,6 +54,10 @@
             "databaseUrl": "ACCEPTANCE_CONTENT_DATABASE_URL",
             "betterAuthSecret": "ACCEPTANCE_CONTENT_BETTER_AUTH_SECRET",
             "a2aSecret": "ACCEPTANCE_WORKSPACE_A2A_SECRET"
+          },
+          "inference": {
+            "provider": "openrouter",
+            "engine": "ai-sdk:openrouter"
           },
           "build": {
             "command": "pnpm --filter content build",

--- a/scripts/trusted-acceptance.spec.ts
+++ b/scripts/trusted-acceptance.spec.ts
@@ -22,7 +22,7 @@ function config(): TrustedAcceptanceConfig {
         enabled: false,
         runtimeAuthority: {
           lifecycle: "ephemeral-per-run",
-          provisioner: "unconfigured",
+          provisioner: { kind: "unconfigured" },
         },
         assertions: ["A1", "A2", "A3"],
         members: [
@@ -79,7 +79,7 @@ describe("trusted acceptance configuration", () => {
       enabled: false,
       runtimeAuthority: {
         lifecycle: "ephemeral-per-run",
-        provisioner: "unconfigured",
+        provisioner: { kind: "unconfigured" },
       },
       assertions: ["A1"],
       members: [
@@ -213,6 +213,51 @@ describe("trusted acceptance configuration", () => {
     });
   });
 
+  it("accepts a typed trusted lease provisioner while the workspace remains disabled", () => {
+    const fixture = config();
+    fixture.workspaces[0]!.runtimeAuthority.provisioner = {
+      kind: "trusted-lease-v1",
+      profileMapVariable: "ACCEPTANCE_AUTHORITY_PROFILES_JSON",
+    };
+    const result = createTrustedAcceptancePlan(
+      fixture,
+      ["calendar", "content"],
+      "calendar-content-acceptance",
+      true,
+    );
+    assert.equal(result.ok, true);
+  });
+
+  it("rejects unsafe authority profiles and directory fixture targets", () => {
+    const fixture = config();
+    fixture.workspaces[0]!.runtimeAuthority.provisioner = {
+      kind: "trusted-lease-v1",
+      profileMapVariable: "PRODUCTION_AUTHORITY_PROFILE" as never,
+    };
+    fixture.workspaces[0]!.directoryFixture = {
+      origin: "https://directory-production.example.test",
+      siteIdVariable: "PRODUCTION_DIRECTORY_NETLIFY_SITE_ID",
+      withdrawnMemberId: "missing",
+    };
+    const result = validateTrustedAcceptanceConfig(fixture, [
+      "calendar",
+      "content",
+    ]);
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert(
+        result.issues.some(({ path }) =>
+          path.endsWith("runtimeAuthority.provisioner.profileMapVariable"),
+        ),
+      );
+      assert(
+        result.issues.some(({ path }) =>
+          path.endsWith("directoryFixture.withdrawnMemberId"),
+        ),
+      );
+    }
+  });
+
   it("rejects reusable runtime authority configuration", () => {
     const fixture = config();
     (
@@ -308,6 +353,25 @@ describe("trusted acceptance receipts", () => {
       rollbackTarget: "b".repeat(40),
       priorKnownGoodSha: "b".repeat(40),
       currentKnownGoodSha: sha,
+      lease: {
+        id: "lease-123",
+        issuedAt: "2026-07-25T11:59:00.000Z",
+        expiresAt: "2026-07-25T12:30:00.000Z",
+        revokedAt: "2026-07-25T12:01:00.000Z",
+        state: "revoked",
+      },
+      cleanup: {
+        inferenceAuthority: "verified-absent",
+        databaseBranches: "verified-absent",
+        runtimeConfiguration: "verified-absent",
+        tombstoneDeployIds: ["tombstone-calendar-123"],
+        verifiedAt: "2026-07-25T12:01:00.000Z",
+      },
+      scenarios: {
+        stableDiscovery: "pass",
+        discoveryWithdrawal: "pass",
+        taskRouteContinuity: "pass",
+      },
     };
     assert.deepEqual(validateTrustedAcceptanceReceipt(receipt), {
       ok: true,
@@ -384,6 +448,39 @@ describe("trusted acceptance receipts", () => {
           message.includes("configured assertion"),
         ),
       );
+    }
+  });
+
+  it("rejects a passing result until cleanup and fault scenarios are verified", () => {
+    const receipt: TrustedAcceptanceReceipt = {
+      actor: "maintainer-123",
+      runUrl: "https://github.com/BuilderIO/agent-native/actions/runs/123",
+      operation: "candidate",
+      pullRequest: 42,
+      sha,
+      controllerSha: "c".repeat(40),
+      configRevision: "3",
+      workspace: "calendar-content-acceptance",
+      members: [
+        {
+          template: "calendar",
+          origin: "https://calendar-acceptance.example.test",
+          deployId: "deploy-calendar-123",
+        },
+      ],
+      assertions: [{ id: "A1", state: "pass" }],
+      startedAt: "2026-07-25T12:00:00.000Z",
+      completedAt: "2026-07-25T12:01:00.000Z",
+      result: "pass",
+      rollbackTarget: "b".repeat(40),
+      priorKnownGoodSha: "b".repeat(40),
+      currentKnownGoodSha: sha,
+    };
+    const result = validateTrustedAcceptanceReceipt(receipt);
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert(result.issues.some(({ path }) => path === "cleanup"));
+      assert(result.issues.some(({ path }) => path === "scenarios"));
     }
   });
 });

--- a/scripts/trusted-acceptance.ts
+++ b/scripts/trusted-acceptance.ts
@@ -25,11 +25,28 @@ export type AcceptanceEnvironmentKeys = {
   a2aSecret: string;
 };
 
+export type RuntimeAuthorityProvisioner =
+  | { kind: "unconfigured" }
+  | {
+      kind: "trusted-lease-v1";
+      profileMapVariable: "ACCEPTANCE_AUTHORITY_PROFILES_JSON";
+    };
+
+export type AcceptanceDirectoryFixture = {
+  origin: string;
+  siteIdVariable: string;
+  withdrawnMemberId: string;
+};
+
 export type TrustedAcceptanceMember = {
   template: string;
   origin: string;
   siteIdVariable: string;
   environment: AcceptanceEnvironmentKeys;
+  inference?: {
+    provider: "openrouter";
+    engine: "ai-sdk:openrouter";
+  };
   build: AcceptanceBuild;
   paths: AcceptancePaths;
 };
@@ -39,8 +56,9 @@ export type TrustedAcceptanceWorkspace = {
   enabled: boolean;
   runtimeAuthority: {
     lifecycle: "ephemeral-per-run";
-    provisioner: "unconfigured";
+    provisioner: RuntimeAuthorityProvisioner;
   };
+  directoryFixture?: AcceptanceDirectoryFixture;
   assertions: string[];
   members: TrustedAcceptanceMember[];
 };
@@ -144,11 +162,23 @@ export function validateTrustedAcceptanceConfig(
         message: "must require disposable per-run runtime authority",
       });
     }
-    if (workspace.runtimeAuthority?.provisioner !== "unconfigured") {
+    const provisioner = workspace.runtimeAuthority?.provisioner;
+    if (
+      !provisioner ||
+      (provisioner.kind !== "unconfigured" &&
+        provisioner.kind !== "trusted-lease-v1")
+    ) {
       issues.push({
         path: `${workspacePath}.runtimeAuthority.provisioner`,
-        message:
-          "must remain unconfigured until a trusted lease provider is implemented",
+        message: "must name a supported trusted lease provisioner",
+      });
+    } else if (
+      provisioner.kind === "trusted-lease-v1" &&
+      provisioner.profileMapVariable !== "ACCEPTANCE_AUTHORITY_PROFILES_JSON"
+    ) {
+      issues.push({
+        path: `${workspacePath}.runtimeAuthority.provisioner.profileMapVariable`,
+        message: "must use the protected generic authority profile map",
       });
     }
     if (workspace.assertions.length === 0) {
@@ -237,6 +267,16 @@ export function validateTrustedAcceptanceConfig(
           message: "must be an acceptance-scoped A2A_SECRET key name",
         });
       }
+      if (
+        member.inference &&
+        (member.inference.provider !== "openrouter" ||
+          member.inference.engine !== "ai-sdk:openrouter")
+      ) {
+        issues.push({
+          path: `${memberPath}.inference`,
+          message: "must use the bounded OpenRouter acceptance engine",
+        });
+      }
       if (member.build.command !== `pnpm --filter ${member.template} build`) {
         issues.push({
           path: `${memberPath}.build.command`,
@@ -264,6 +304,44 @@ export function validateTrustedAcceptanceConfig(
           });
         }
       }
+    }
+
+    if (workspace.directoryFixture) {
+      const fixturePath = `${workspacePath}.directoryFixture`;
+      if (!isAcceptanceOrigin(workspace.directoryFixture.origin)) {
+        issues.push({
+          path: `${fixturePath}.origin`,
+          message: "must be a stable non-production acceptance HTTPS origin",
+        });
+      }
+      if (
+        !isAcceptanceSiteVariable(workspace.directoryFixture.siteIdVariable)
+      ) {
+        issues.push({
+          path: `${fixturePath}.siteIdVariable`,
+          message: "must be an acceptance-scoped NETLIFY_SITE_ID variable name",
+        });
+      }
+      if (!templates.has(workspace.directoryFixture.withdrawnMemberId)) {
+        issues.push({
+          path: `${fixturePath}.withdrawnMemberId`,
+          message: "must identify a declared workspace member",
+        });
+      }
+      if (origins.has(workspace.directoryFixture.origin)) {
+        issues.push({
+          path: `${fixturePath}.origin`,
+          message: "must not duplicate a workspace member origin",
+        });
+      }
+      if (siteIdVariables.has(workspace.directoryFixture.siteIdVariable)) {
+        issues.push({
+          path: `${fixturePath}.siteIdVariable`,
+          message: "must not duplicate a workspace member site variable",
+        });
+      }
+      origins.add(workspace.directoryFixture.origin);
+      siteIdVariables.add(workspace.directoryFixture.siteIdVariable);
     }
   }
   return issues.length === 0 ? { ok: true, issues: [] } : { ok: false, issues };
@@ -312,7 +390,7 @@ export function createTrustedAcceptancePlan(
   }
   if (
     !allowDisabled &&
-    workspace.runtimeAuthority.provisioner === "unconfigured"
+    workspace.runtimeAuthority.provisioner.kind === "unconfigured"
   ) {
     return {
       ok: false,
@@ -410,6 +488,25 @@ export type TrustedAcceptanceReceipt = {
   rollbackTarget: string | null;
   priorKnownGoodSha: string | null;
   currentKnownGoodSha: string | null;
+  lease?: {
+    id: string;
+    issuedAt: string;
+    expiresAt: string;
+    revokedAt: string | null;
+    state: "active" | "revoking" | "revoked" | "failed";
+  };
+  cleanup?: {
+    inferenceAuthority: "verified-absent" | "pending" | "failed";
+    databaseBranches: "verified-absent" | "pending" | "failed";
+    runtimeConfiguration: "verified-absent" | "pending" | "failed";
+    tombstoneDeployIds: string[];
+    verifiedAt: string | null;
+  };
+  scenarios?: {
+    stableDiscovery: AcceptanceAssertionState;
+    discoveryWithdrawal: AcceptanceAssertionState;
+    taskRouteContinuity: AcceptanceAssertionState;
+  };
 };
 
 const sensitiveFieldPattern =
@@ -609,6 +706,96 @@ export function validateTrustedAcceptanceReceipt(
       path: "priorKnownGoodSha",
       message: "must equal the rollback target for a passing receipt",
     });
+  }
+  if (receipt.lease) {
+    if (!receipt.lease.id.trim()) {
+      issues.push({ path: "lease.id", message: "must be non-empty" });
+    }
+    for (const key of ["issuedAt", "expiresAt"] as const) {
+      if (Number.isNaN(Date.parse(receipt.lease[key]))) {
+        issues.push({
+          path: `lease.${key}`,
+          message: "must be an ISO timestamp",
+        });
+      }
+    }
+    if (
+      receipt.lease.revokedAt !== null &&
+      Number.isNaN(Date.parse(receipt.lease.revokedAt))
+    ) {
+      issues.push({
+        path: "lease.revokedAt",
+        message: "must be an ISO timestamp or null",
+      });
+    }
+    if (
+      Date.parse(receipt.lease.expiresAt) <= Date.parse(receipt.lease.issuedAt)
+    ) {
+      issues.push({
+        path: "lease.expiresAt",
+        message: "must be later than the issue timestamp",
+      });
+    }
+  }
+  if (receipt.cleanup) {
+    if (
+      receipt.cleanup.verifiedAt !== null &&
+      Number.isNaN(Date.parse(receipt.cleanup.verifiedAt))
+    ) {
+      issues.push({
+        path: "cleanup.verifiedAt",
+        message: "must be an ISO timestamp or null",
+      });
+    }
+    if (
+      receipt.cleanup.tombstoneDeployIds.some((id) => !id.trim()) ||
+      new Set(receipt.cleanup.tombstoneDeployIds).size !==
+        receipt.cleanup.tombstoneDeployIds.length
+    ) {
+      issues.push({
+        path: "cleanup.tombstoneDeployIds",
+        message: "must contain unique non-empty opaque deployment IDs",
+      });
+    }
+  }
+  if (
+    receipt.scenarios &&
+    Object.values(receipt.scenarios).some(
+      (state) => !["pass", "fail", "blocked"].includes(state),
+    )
+  ) {
+    issues.push({
+      path: "scenarios",
+      message: "must contain valid assertion states",
+    });
+  }
+  if (receipt.result === "pass") {
+    if (
+      receipt.lease?.state !== "revoked" ||
+      !receipt.lease.revokedAt ||
+      receipt.cleanup?.inferenceAuthority !== "verified-absent" ||
+      receipt.cleanup.databaseBranches !== "verified-absent" ||
+      receipt.cleanup.runtimeConfiguration !== "verified-absent" ||
+      !receipt.cleanup.verifiedAt ||
+      receipt.cleanup.tombstoneDeployIds.length !== receipt.members.length
+    ) {
+      issues.push({
+        path: "cleanup",
+        message:
+          "passing receipts require verified lease revocation, database and runtime cleanup, and one trusted tombstone deploy per member",
+      });
+    }
+    if (
+      receipt.scenarios?.stableDiscovery !== "pass" ||
+      receipt.scenarios.discoveryWithdrawal !== "pass" ||
+      receipt.scenarios.taskRouteContinuity !== "pass"
+    ) {
+      issues.push({
+        path: "scenarios",
+        message:
+          "passing receipts require stable and withdrawn-directory route-continuity evidence",
+      });
+    }
   }
   return issues.length === 0 ? { ok: true, issues: [] } : { ok: false, issues };
 }

--- a/scripts/trusted-acceptance/controller.spec.ts
+++ b/scripts/trusted-acceptance/controller.spec.ts
@@ -1,0 +1,248 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+import {
+  assertRedacted,
+  executeTrustedAcceptance,
+  reapTrustedAcceptanceLeases,
+  validateTrustedAuthorityProfile,
+  type TrustedAuthorityProfile,
+} from "./controller.ts";
+
+const tombstoneZip = Buffer.from("AQ==", "base64");
+const tombstone = {
+  sha256: createHash("sha256").update(tombstoneZip).digest("hex"),
+  zipBase64: tombstoneZip.toString("base64"),
+};
+function profile(): TrustedAuthorityProfile {
+  return {
+    version: 1,
+    workspace: "calendar-content",
+    enabled: true,
+    leasePrefix: "trusted-acceptance-",
+    runtime: {
+      maxInferenceUsd: 0.01,
+      tombstone: { ...tombstone },
+      members: [
+        {
+          id: "calendar",
+          origin: "https://calendar.acceptance.example.test",
+          neonProjectId: "project",
+          neonDatabaseName: "main",
+          neonRoleName: "owner",
+          netlifyAccountId: "account",
+          netlifySiteId: "site",
+          needsInference: false,
+        },
+      ],
+    },
+    members: [
+      {
+        id: "calendar",
+        origin: "https://calendar.acceptance.example.test",
+        artifactDirectory: "calendar",
+      },
+    ],
+  };
+}
+function providers() {
+  return {
+    neon: {
+      async createBranch() {
+        return "trusted-acceptance-branch";
+      },
+      async getConnectionUri() {
+        return "postgresql://secret@example.test/db";
+      },
+      async deleteAndVerify() {
+        return true;
+      },
+      async listByPrefixAndExpiry() {
+        return [];
+      },
+    },
+    openrouter: {
+      async create() {
+        return { plaintext: "sk-secret", hash: "opaque-hash" };
+      },
+      async disableByHash() {
+        return true;
+      },
+      async listByPrefixAndExpiry() {
+        return [];
+      },
+    },
+    netlify: {
+      async assertSiteReady() {},
+      async ownsLease() {
+        return true;
+      },
+      async setRuntime() {},
+      async removeRuntime() {
+        return true;
+      },
+      async deployTombstoneAndVerify() {
+        return { deployId: "tombstone" };
+      },
+      async readLeaseMarker() {
+        return undefined;
+      },
+    },
+  };
+}
+
+describe("trusted acceptance controller", () => {
+  it("keeps the protected controller and independent reaper main-pinned and fail-closed", () => {
+    const workflow = readFileSync(
+      ".github/workflows/trusted-acceptance.yml",
+      "utf8",
+    );
+    const reaper = readFileSync(
+      ".github/workflows/trusted-acceptance-reaper.yml",
+      "utf8",
+    );
+    assert.match(workflow, /RUN_REF" != "refs\/heads\/main"/);
+    assert.match(workflow, /environment: trusted-acceptance/);
+    assert.match(
+      workflow,
+      /Verify every artifact provenance before credentials/,
+    );
+    assert.match(workflow, /Acquire one whole-workspace disposable lease/);
+    assert.match(workflow, /Revoke one whole-workspace disposable lease/);
+    assert.match(workflow, /if: \$\{\{ always\(\) \}\}/);
+    assert.match(workflow, /persist-credentials: false/);
+    assert.match(reaper, /schedule:/);
+    assert.match(reaper, /workflow_dispatch:/);
+    assert.match(reaper, /cancel-in-progress: false/);
+    assert.match(reaper, /controller\.ts reap/);
+    assert.doesNotMatch(reaper, /pull_request|path: candidate/);
+  });
+
+  it("rejects profiles that could carry credentials or non-allowlisted resources", () => {
+    const unsafe = profile() as TrustedAuthorityProfile & { apiToken?: string };
+    unsafe.apiToken = "not-allowed";
+    assert.match(
+      validateTrustedAuthorityProfile(unsafe).join("\n"),
+      /apiToken/,
+    );
+    const productionOrigin = profile();
+    productionOrigin.members[0]!.origin =
+      "https://calendar.production.example.test";
+    assert.match(
+      validateTrustedAuthorityProfile(productionOrigin).join("\n"),
+      /unsafe acceptance origin/,
+    );
+    const mismatched = profile();
+    mismatched.runtime.tombstone.sha256 = "a".repeat(64);
+    assert.match(
+      validateTrustedAuthorityProfile(mismatched).join("\n"),
+      /does not match/,
+    );
+    assert.throws(
+      () =>
+        assertRedacted({ handle: "postgresql://user:pass@example.test/db" }),
+      /secret material/,
+    );
+    const mismatchedOrigin = profile();
+    mismatchedOrigin.runtime.members[0]!.origin =
+      "https://other.acceptance.example.test";
+    assert.match(
+      validateTrustedAuthorityProfile(mismatchedOrigin).join("\n"),
+      /origin must match/,
+    );
+    const unknown = profile() as TrustedAuthorityProfile & { note?: string };
+    unknown.note = "surprise";
+    assert.match(
+      validateTrustedAuthorityProfile(unknown).join("\n"),
+      /not allowed/,
+    );
+    const credentialValue = profile();
+    credentialValue.runtime.members[0]!.neonProjectId =
+      "sk-credential-looking-value";
+    assert.match(
+      validateTrustedAuthorityProfile(credentialValue).join("\n"),
+      /credential-shaped/,
+    );
+  });
+
+  it("persists only redacted journals and receipts after every authority mutation", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "trusted-acceptance-"));
+    const journalFile = join(dir, "lease.json");
+    const receiptFile = join(dir, "receipt.json");
+    const receipt = await executeTrustedAcceptance(profile(), {
+      providers: providers(),
+      journalFile,
+      receiptFile,
+      ttlMs: 60_000,
+      expectedAssertionIds: ["stable", "withdrawn"],
+      async deployArtifact() {},
+      async runStableHarness() {
+        return [{ assertionId: "stable", status: "passed" }];
+      },
+      async runWithdrawalHarness() {
+        return [{ assertionId: "withdrawn", status: "passed" }];
+      },
+      now: () => new Date("2026-07-26T00:00:00.000Z"),
+    });
+    assert.equal(receipt.result, "passed");
+    const output = `${await readFile(journalFile, "utf8")}${await readFile(receiptFile, "utf8")}`;
+    assert(!output.includes("postgresql://secret"));
+    assert(!output.includes("sk-secret"));
+    assert.equal(receipt.lease?.state, "revoked");
+    assert.equal(receipt.lease?.members[0]?.tombstoneDeployId, "tombstone");
+  });
+
+  it("cannot pass a controller receipt with missing harness evidence", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "trusted-acceptance-empty-"));
+    const receipt = await executeTrustedAcceptance(profile(), {
+      providers: providers(),
+      journalFile: join(dir, "lease.json"),
+      receiptFile: join(dir, "receipt.json"),
+      ttlMs: 60_000,
+      expectedAssertionIds: ["required"],
+      async deployArtifact() {},
+      async runStableHarness() {
+        return [];
+      },
+      async runWithdrawalHarness() {
+        return [];
+      },
+    });
+    assert.equal(receipt.result, "failed");
+  });
+
+  it("reaps only deterministic acceptance leases through an injected discovery seam", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "trusted-acceptance-"));
+    const expired = {
+      id: "trusted-acceptance-expired",
+      createdAt: "2026-07-25T00:00:00.000Z",
+      expiresAt: "2026-07-25T00:01:00.000Z",
+      state: "active" as const,
+      members: [
+        { memberId: "calendar", netlifySiteId: "site", neonBranchId: "branch" },
+      ],
+      journal: [],
+      verification: {
+        inferenceDisabled: false,
+        runtimeVariablesAbsent: false,
+        tombstoneActive: false,
+        branchesDeleted: false,
+      },
+    };
+    const result = await reapTrustedAcceptanceLeases(profile(), {
+      providers: providers(),
+      journalFile: join(dir, "reaper.json"),
+      discoverLeases: async (prefix) => {
+        assert.equal(prefix, "trusted-acceptance-");
+        return [expired];
+      },
+      now: () => new Date("2026-07-26T00:00:00.000Z"),
+    });
+    assert.equal(result[0]?.state, "revoked");
+  });
+});

--- a/scripts/trusted-acceptance/controller.ts
+++ b/scripts/trusted-acceptance/controller.ts
@@ -1,0 +1,573 @@
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import {
+  DisposableRuntimeAuthority,
+  NeonBranches,
+  NetlifyRuntime,
+  OpenRouterKeys,
+  type LeaseJournalStore,
+  type RuntimeLease,
+  type RuntimeProviders,
+  type TrustedRuntimeConfig,
+} from "./runtime-authority.ts";
+import * as runtimeAuthority from "./runtime-authority.ts";
+
+/**
+ * This is the only orchestration layer allowed to turn an authority profile
+ * into a live disposable lease. Profiles and journals are intentionally JSON;
+ * provider credentials are ambient execution inputs and never profile fields.
+ */
+export type TrustedAuthorityProfile = {
+  version: 1;
+  workspace: string;
+  enabled: boolean;
+  leasePrefix: "trusted-acceptance-";
+  runtime: Omit<TrustedRuntimeConfig, "tombstone"> & {
+    /** Base64 is an inert, prebuilt tombstone ZIP; it is not credential material. */
+    tombstone: { sha256: string; zipBase64: string };
+  };
+  members: Array<{
+    id: string;
+    origin: string;
+    artifactDirectory: string;
+    withdrawnDirectoryMember?: boolean;
+  }>;
+};
+
+export type RedactedAcceptanceReceipt = {
+  version: 1;
+  workspace: string;
+  result: "passed" | "failed" | "blocked";
+  lease?: RuntimeLease;
+  evidence: Array<{ assertionId: string; status: "passed" | "failed" }>;
+};
+
+export type ControllerExecution = {
+  providers: RuntimeProviders;
+  deployArtifact: (
+    member: TrustedAuthorityProfile["members"][number],
+  ) => Promise<void>;
+  runStableHarness: () => Promise<RedactedAcceptanceReceipt["evidence"]>;
+  runWithdrawalHarness: () => Promise<RedactedAcceptanceReceipt["evidence"]>;
+  journalFile: string;
+  receiptFile: string;
+  ttlMs: number;
+  expectedAssertionIds: readonly string[];
+  now?: () => Date;
+};
+
+export type ReaperExecution = {
+  providers: RuntimeProviders;
+  discoverLeases: (prefix: "trusted-acceptance-") => Promise<RuntimeLease[]>;
+  journalFile: string;
+  now?: () => Date;
+};
+
+const secretField =
+  /(?:token|secret|password|databaseurl|api[_-]?key|credential|private)/i;
+const secretValue =
+  /(?:postgres(?:ql)?:\/\/[^\s]+|sk-[A-Za-z0-9_-]{8,}|Bearer\s+\S+|gh[pous]_[A-Za-z0-9_-]+)/i;
+const acceptanceOrigin = /(?:^|[-.])acceptance(?:[-.]|$)/i;
+
+function assertNoSecrets(value: unknown, path = "profile"): void {
+  if (typeof value === "string" && secretValue.test(value))
+    throw new Error(`${path} contains credential-shaped material`);
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) =>
+      assertNoSecrets(entry, `${path}[${index}]`),
+    );
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  for (const [key, entry] of Object.entries(value)) {
+    if (secretField.test(key)) {
+      throw new Error(
+        `${path}.${key} is not permitted in a trusted authority profile`,
+      );
+    }
+    assertNoSecrets(entry, `${path}.${key}`);
+  }
+}
+
+function assertExactKeys(
+  value: unknown,
+  allowed: readonly string[],
+  path: string,
+): asserts value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    throw new Error(`${path} must be an object`);
+  for (const key of Object.keys(value))
+    if (!allowed.includes(key))
+      throw new Error(`${path}.${key} is not allowed`);
+}
+
+function assertProfileShape(profile: TrustedAuthorityProfile): void {
+  assertExactKeys(
+    profile,
+    ["version", "workspace", "enabled", "leasePrefix", "runtime", "members"],
+    "profile",
+  );
+  assertExactKeys(
+    profile.runtime,
+    ["maxInferenceUsd", "tombstone", "members"],
+    "profile.runtime",
+  );
+  assertExactKeys(
+    profile.runtime.tombstone,
+    ["sha256", "zipBase64"],
+    "profile.runtime.tombstone",
+  );
+  for (const [index, member] of profile.runtime.members.entries())
+    assertExactKeys(
+      member,
+      [
+        "id",
+        "origin",
+        "neonProjectId",
+        "neonDatabaseName",
+        "neonRoleName",
+        "netlifyAccountId",
+        "netlifySiteId",
+        "needsInference",
+      ],
+      `profile.runtime.members[${index}]`,
+    );
+  for (const [index, member] of profile.members.entries())
+    assertExactKeys(
+      member,
+      ["id", "origin", "artifactDirectory", "withdrawnDirectoryMember"],
+      `profile.members[${index}]`,
+    );
+}
+
+function stableAcceptanceUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "https:" &&
+      url.pathname === "/" &&
+      !url.search &&
+      !url.hash &&
+      acceptanceOrigin.test(url.hostname) &&
+      !/(?:^|[-.])(?:prod|production)(?:[-.]|$)/i.test(url.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Pure validation used by dry workflow commands; it neither reads env nor calls a provider. */
+export function validateTrustedAuthorityProfile(
+  profile: TrustedAuthorityProfile,
+  options: { requireEnabled?: boolean } = {},
+): string[] {
+  const issues: string[] = [];
+  try {
+    assertProfileShape(profile);
+    assertNoSecrets(profile);
+  } catch (error) {
+    issues.push(
+      error instanceof Error
+        ? error.message
+        : "profile contains secret material",
+    );
+    return issues;
+  }
+  if (profile.version !== 1) issues.push("profile.version must be 1");
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(profile.workspace))
+    issues.push("profile.workspace must be a stable slug");
+  if (profile.leasePrefix !== "trusted-acceptance-")
+    issues.push(
+      "profile.leasePrefix must use the deterministic acceptance prefix",
+    );
+  if ((options.requireEnabled ?? true) && !profile.enabled)
+    issues.push("profile is disabled; live execution is unavailable");
+  if (!profile.members.length) issues.push("profile.members must be non-empty");
+  const ids = new Set<string>();
+  const origins = new Set<string>();
+  const siteIds = new Set<string>();
+  const neonProjectIds = new Set<string>();
+  for (const member of profile.members) {
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(member.id) || ids.has(member.id))
+      issues.push(`member ${member.id || "<empty>"} is unsafe or duplicated`);
+    ids.add(member.id);
+    if (!stableAcceptanceUrl(member.origin))
+      issues.push(`member ${member.id} has an unsafe acceptance origin`);
+    if (origins.has(member.origin))
+      issues.push(`member ${member.id} has a duplicate acceptance origin`);
+    origins.add(member.origin);
+    if (
+      !member.artifactDirectory ||
+      member.artifactDirectory.startsWith("/") ||
+      member.artifactDirectory.split("/").includes("..")
+    )
+      issues.push(`member ${member.id} has an unsafe artifact directory`);
+  }
+  const runtimeMembers = new Set(profile.runtime.members.map(({ id }) => id));
+  if (
+    runtimeMembers.size !== profile.members.length ||
+    profile.members.some(({ id }) => !runtimeMembers.has(id))
+  )
+    issues.push("profile members must exactly match runtime allowlist members");
+  const declaredOrigins = new Map(
+    profile.members.map((member) => [member.id, member.origin]),
+  );
+  for (const member of profile.runtime.members) {
+    if (
+      !member.neonProjectId ||
+      !member.neonDatabaseName ||
+      !member.neonRoleName ||
+      !member.netlifyAccountId ||
+      !member.netlifySiteId ||
+      typeof member.needsInference !== "boolean"
+    )
+      issues.push(`runtime member ${member.id} has incomplete provider config`);
+    if (member.origin !== declaredOrigins.get(member.id))
+      issues.push(
+        `runtime member ${member.id} origin must match its declared app origin`,
+      );
+    if (siteIds.has(member.netlifySiteId))
+      issues.push(`runtime member ${member.id} has a duplicate Netlify site`);
+    siteIds.add(member.netlifySiteId);
+    if (neonProjectIds.has(member.neonProjectId))
+      issues.push(`runtime member ${member.id} has a duplicate Neon project`);
+    neonProjectIds.add(member.neonProjectId);
+  }
+  if (
+    !Number.isFinite(profile.runtime.maxInferenceUsd) ||
+    profile.runtime.maxInferenceUsd <= 0 ||
+    profile.runtime.maxInferenceUsd > 1
+  )
+    issues.push("profile inference cap must be positive and at most 1 USD");
+  if (!/^[a-f0-9]{64}$/i.test(profile.runtime.tombstone.sha256))
+    issues.push("profile tombstone must have a sha256 digest");
+  try {
+    const zip = Buffer.from(profile.runtime.tombstone.zipBase64, "base64");
+    if (!zip.byteLength)
+      issues.push("profile tombstone must contain a prebuilt ZIP");
+    else if (
+      createHash("sha256").update(zip).digest("hex") !==
+      profile.runtime.tombstone.sha256.toLowerCase()
+    )
+      issues.push("profile tombstone sha256 does not match its ZIP");
+  } catch {
+    issues.push("profile tombstone ZIP must be base64");
+  }
+  return issues;
+}
+
+function runtimeConfig(profile: TrustedAuthorityProfile): TrustedRuntimeConfig {
+  return {
+    ...profile.runtime,
+    tombstone: {
+      sha256: profile.runtime.tombstone.sha256,
+      zip: new Uint8Array(
+        Buffer.from(profile.runtime.tombstone.zipBase64, "base64"),
+      ),
+    },
+  };
+}
+
+export function assertRedacted(value: unknown): void {
+  const credentialValue =
+    /(?:postgres(?:ql)?:\/\/|sk-[A-Za-z0-9_-]{8,}|Bearer\s+\S+|gh[pous]_[A-Za-z0-9_-]+)/i;
+  const visit = (entry: unknown): void => {
+    if (typeof entry === "string" && credentialValue.test(entry))
+      throw new Error("redacted acceptance output contains secret material");
+    if (Array.isArray(entry)) entry.forEach(visit);
+    else if (entry && typeof entry === "object")
+      Object.values(entry).forEach(visit);
+  };
+  visit(value);
+}
+
+export class JsonLeaseJournalStore implements LeaseJournalStore {
+  constructor(private readonly file: string) {}
+
+  async save(lease: RuntimeLease): Promise<void> {
+    assertRedacted(lease);
+    await writeFile(this.file, `${JSON.stringify(lease, null, 2)}\n`, "utf8");
+  }
+}
+
+async function writeReceipt(
+  file: string,
+  receipt: RedactedAcceptanceReceipt,
+): Promise<void> {
+  assertRedacted(receipt);
+  await writeFile(file, `${JSON.stringify(receipt, null, 2)}\n`, "utf8");
+}
+
+function receiptFor(
+  profile: TrustedAuthorityProfile,
+  lease: RuntimeLease | undefined,
+  result: RedactedAcceptanceReceipt["result"],
+  evidence: RedactedAcceptanceReceipt["evidence"],
+): RedactedAcceptanceReceipt {
+  return {
+    version: 1,
+    workspace: profile.workspace,
+    result,
+    ...(lease ? { lease } : {}),
+    evidence,
+  };
+}
+
+function hasCompleteEvidence(
+  evidence: RedactedAcceptanceReceipt["evidence"],
+  expectedAssertionIds: readonly string[],
+): boolean {
+  if (!expectedAssertionIds.length) return false;
+  const expected = new Set(expectedAssertionIds);
+  const actual = new Set(evidence.map(({ assertionId }) => assertionId));
+  return (
+    actual.size === evidence.length &&
+    actual.size === expected.size &&
+    [...expected].every((id) => actual.has(id)) &&
+    evidence.every(({ status }) => status === "passed")
+  );
+}
+
+/** Runs only after a trusted workflow has verified inert artifact provenance. */
+export async function executeTrustedAcceptance(
+  profile: TrustedAuthorityProfile,
+  execution: ControllerExecution,
+): Promise<RedactedAcceptanceReceipt> {
+  const issues = validateTrustedAuthorityProfile(profile);
+  if (issues.length)
+    throw new Error(`trusted authority profile rejected: ${issues.join("; ")}`);
+  const journalStore = new JsonLeaseJournalStore(execution.journalFile);
+  const authority = new DisposableRuntimeAuthority(
+    runtimeConfig(profile),
+    execution.providers,
+    execution.now,
+    journalStore,
+  );
+  let lease: RuntimeLease | undefined;
+  let evidence: RedactedAcceptanceReceipt["evidence"] = [];
+  let failure: unknown;
+  let completedReceipt: RedactedAcceptanceReceipt | undefined;
+  try {
+    const acquired = await authority.acquire(execution.ttlMs);
+    lease = acquired.lease;
+    // Secrets remain in the acquire return value only; no controller output receives it.
+    for (const member of profile.members)
+      await execution.deployArtifact(member);
+    evidence = [
+      ...(await execution.runStableHarness()),
+      ...(await execution.runWithdrawalHarness()),
+    ];
+  } catch (error) {
+    failure = error;
+  } finally {
+    if (lease) await authority.revoke(lease);
+    const clean =
+      lease?.state === "revoked" &&
+      lease.verification.tombstoneActive &&
+      lease.members.every(
+        (member) => !member.runtimeOwned || Boolean(member.tombstoneDeployId),
+      );
+    const receipt = receiptFor(
+      profile,
+      lease,
+      !failure &&
+        clean &&
+        hasCompleteEvidence(evidence, execution.expectedAssertionIds)
+        ? "passed"
+        : "failed",
+      evidence,
+    );
+    completedReceipt = receipt;
+    await writeReceipt(execution.receiptFile, receipt);
+    if (!clean)
+      throw new Error(
+        "cleanup verification failed: lease was not revoked with tombstone IDs",
+      );
+  }
+  if (failure) throw failure;
+  if (!completedReceipt)
+    throw new Error("trusted acceptance did not produce a controller receipt");
+  return completedReceipt;
+}
+
+/** Discovery is injected so providers can be reconciled without candidate code or stored credentials. */
+export async function reapTrustedAcceptanceLeases(
+  profile: TrustedAuthorityProfile,
+  execution: ReaperExecution,
+): Promise<RuntimeLease[]> {
+  const issues = validateTrustedAuthorityProfile(profile, {
+    requireEnabled: false,
+  });
+  if (issues.length)
+    throw new Error(`trusted authority profile rejected: ${issues.join("; ")}`);
+  const authority = new DisposableRuntimeAuthority(
+    runtimeConfig(profile),
+    execution.providers,
+    execution.now,
+    new JsonLeaseJournalStore(execution.journalFile),
+  );
+  const leases = await execution.discoverLeases("trusted-acceptance-");
+  return authority.reapExpired(leases);
+}
+
+async function profileFromFile(file: string): Promise<TrustedAuthorityProfile> {
+  return JSON.parse(
+    await readFile(resolve(file), "utf8"),
+  ) as TrustedAuthorityProfile;
+}
+
+function requiredAmbientCredentials(): Record<string, string> {
+  const keys = [
+    "ACCEPTANCE_NEON_API_KEY",
+    "ACCEPTANCE_NETLIFY_AUTH_TOKEN",
+    "ACCEPTANCE_OPENROUTER_API_KEY",
+  ] as const;
+  const missing = keys.filter((key) => !process.env[key]);
+  if (missing.length)
+    throw new Error(
+      `live controller credentials are unavailable: ${missing.join(", ")}`,
+    );
+  return Object.fromEntries(
+    keys.map((key) => [key, process.env[key]!]),
+  ) as Record<string, string>;
+}
+
+function ambientProviders(): RuntimeProviders {
+  const credentials = requiredAmbientCredentials();
+  return {
+    neon: new NeonBranches(fetch, credentials.ACCEPTANCE_NEON_API_KEY),
+    netlify: new NetlifyRuntime(
+      fetch,
+      credentials.ACCEPTANCE_NETLIFY_AUTH_TOKEN,
+    ),
+    openrouter: new OpenRouterKeys(
+      fetch,
+      credentials.ACCEPTANCE_OPENROUTER_API_KEY,
+    ),
+  };
+}
+
+async function leaseFromFile(file: string): Promise<RuntimeLease> {
+  const lease = JSON.parse(
+    await readFile(resolve(file), "utf8"),
+  ) as RuntimeLease;
+  assertRedacted(lease);
+  return lease;
+}
+
+function assertRevoked(lease: RuntimeLease): void {
+  if (
+    lease.state !== "revoked" ||
+    !lease.verification.tombstoneActive ||
+    !lease.members.every(
+      (member) => !member.runtimeOwned || Boolean(member.tombstoneDeployId),
+    )
+  ) {
+    throw new Error(
+      "cleanup verification failed: lease was not revoked with tombstone IDs",
+    );
+  }
+}
+
+type RuntimeDiscovery = (
+  config: TrustedRuntimeConfig,
+  providers: Pick<RuntimeProviders, "neon" | "openrouter">,
+  now: Date,
+) => Promise<RuntimeLease[]>;
+
+function discoverExpiredLeases(): RuntimeDiscovery {
+  const candidate = (
+    runtimeAuthority as unknown as {
+      discoverExpiredLeases?: RuntimeDiscovery;
+    }
+  ).discoverExpiredLeases;
+  if (!candidate) throw new Error("trusted runtime discovery is not available");
+  return candidate;
+}
+
+async function main(): Promise<void> {
+  const [command, ...args] = process.argv.slice(2);
+  const option = (name: string): string | undefined =>
+    args[args.indexOf(name) + 1];
+  const profileFile = option("--profile");
+  if (!command || !profileFile)
+    throw new Error(
+      "usage: controller <validate-profile|acquire|revoke|reap> --profile <file> --journal <file>",
+    );
+  const profile = await profileFromFile(profileFile);
+  if (command === "validate-profile") {
+    const issues = validateTrustedAuthorityProfile(profile);
+    process.stdout.write(
+      `${JSON.stringify({ ok: issues.length === 0, issues })}\n`,
+    );
+    if (issues.length) process.exitCode = 1;
+    return;
+  }
+  if (!new Set(["acquire", "revoke", "reap"]).has(command))
+    throw new Error(`unknown controller command: ${command}`);
+  const issues = validateTrustedAuthorityProfile(profile, {
+    requireEnabled: command === "acquire",
+  });
+  if (issues.length)
+    throw new Error(`trusted authority profile rejected: ${issues.join("; ")}`);
+  const journalFile = option("--journal");
+  if (!journalFile)
+    throw new Error("live controller commands require --journal");
+  const providers = ambientProviders();
+  const authority = new DisposableRuntimeAuthority(
+    runtimeConfig(profile),
+    providers,
+    undefined,
+    new JsonLeaseJournalStore(journalFile),
+  );
+  if (command === "acquire") {
+    const result = await authority.acquire(
+      Number(option("--ttl-ms") ?? 3600000),
+    );
+    process.stdout.write(
+      `${JSON.stringify({ ok: true, leaseId: result.lease.id })}\n`,
+    );
+    return;
+  }
+  if (command === "revoke") {
+    const revoked = await authority.revoke(await leaseFromFile(journalFile));
+    assertRevoked(revoked);
+    process.stdout.write(
+      `${JSON.stringify({ ok: true, leaseId: revoked.id, state: revoked.state })}\n`,
+    );
+    return;
+  }
+  if (command === "reap") {
+    const discovered = await discoverExpiredLeases()(
+      runtimeConfig(profile),
+      providers,
+      new Date(),
+    );
+    const reaped = await authority.reapExpired(discovered);
+    for (const lease of reaped) {
+      if (new Date(lease.expiresAt).getTime() <= Date.now())
+        assertRevoked(lease);
+    }
+    await writeFile(
+      journalFile,
+      `${JSON.stringify(reaped, null, 2)}\n`,
+      "utf8",
+    );
+    process.stdout.write(
+      `${JSON.stringify({ ok: true, discovered: discovered.length, reaped: reaped.filter(({ state }) => state === "revoked").map(({ id }) => id) })}\n`,
+    );
+    return;
+  }
+  throw new Error(`unreachable controller command: ${command}`);
+}
+
+if (process.argv[1]?.endsWith("controller.ts")) {
+  main().catch((error) => {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/scripts/trusted-acceptance/directory-fixture.spec.ts
+++ b/scripts/trusted-acceptance/directory-fixture.spec.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { describe, it } from "node:test";
+
+import {
+  type DirectoryFixtureConfig,
+  handleDirectoryFixtureRequest,
+  validateDirectoryFixtureConfig,
+} from "./directory-fixture.ts";
+
+const config: DirectoryFixtureConfig = {
+  orgDomain: "acceptance.example.test",
+  a2aSecret: "fake-disposable-a2a-secret",
+  fixtureOrigin: "https://directory-acceptance.example.test",
+  withdrawnMemberId: "content",
+  members: [
+    {
+      id: "calendar",
+      name: "Calendar",
+      url: "https://calendar-acceptance.example.test",
+      a2aUrl: "https://calendar-acceptance.example.test",
+    },
+    {
+      id: "content",
+      name: "Content",
+      url: "https://content-acceptance.example.test",
+      a2aUrl: "https://content-acceptance.example.test",
+    },
+  ],
+};
+
+function base64url(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function token(
+  claims: Record<string, unknown> = {},
+  callerId = "acceptance-caller",
+  signingSecret = config.a2aSecret,
+): string {
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64url({ alg: "HS256" });
+  const payload = base64url({
+    org_domain: config.orgDomain,
+    sub: callerId,
+    iat: now,
+    exp: now + 300,
+    ...claims,
+  });
+  const signature = createHmac("sha256", signingSecret)
+    .update(`${header}.${payload}`)
+    .digest("base64url");
+  return `${header}.${payload}.${signature}`;
+}
+
+describe("trusted acceptance directory fixture", () => {
+  it("returns the public org/apps shape for a trusted stable caller", async () => {
+    const response = await handleDirectoryFixtureRequest(
+      { method: "GET", headers: { Authorization: `Bearer ${token()}` } },
+      config,
+      "stable",
+    );
+    assert.equal(response.status, 200);
+    assert.deepEqual(response.body, {
+      org: "acceptance.example.test",
+      apps: config.members,
+    });
+  });
+
+  it("withdraws only the configured declared member", async () => {
+    const response = await handleDirectoryFixtureRequest(
+      { method: "GET", headers: { authorization: `Bearer ${token()}` } },
+      config,
+      "withdraw-member",
+    );
+    assert.deepEqual(
+      response.body?.apps.map(({ id }) => id),
+      ["calendar"],
+    );
+  });
+
+  it("fails closed for missing caller, wrong org, expired, and forged JWTs", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const expired = token({ exp: now - 1 });
+    const forged = token({}, "acceptance-caller", "another-fake-secret");
+    const notYetValid = token({ nbf: now + 300, exp: now + 600 });
+    const tokens = [
+      undefined,
+      token({}, ""),
+      token({ org_domain: "other-org" }),
+      token({ scope: "identity" }),
+      token({ scope: "mcp-connect" }),
+      expired,
+      notYetValid,
+      forged,
+    ];
+    for (const bearer of tokens) {
+      const response = await handleDirectoryFixtureRequest(
+        {
+          method: "GET",
+          headers: bearer ? { Authorization: `Bearer ${bearer}` } : {},
+        },
+        config,
+        "stable",
+      );
+      assert.equal(response.status, 401);
+      assert.equal(response.body, undefined);
+    }
+  });
+
+  it("rejects unsafe hosts and a withdrawal target outside the declared allowlist", () => {
+    const unsafe: DirectoryFixtureConfig = {
+      ...config,
+      withdrawnMemberId: "missing",
+      members: [
+        {
+          ...config.members[0]!,
+          url: "https://calendar-production.example.test",
+        },
+      ],
+    };
+    assert.deepEqual(validateDirectoryFixtureConfig(unsafe), [
+      "member calendar has an unsafe url",
+      "withdrawnMemberId must name a declared member",
+    ]);
+  });
+});

--- a/scripts/trusted-acceptance/directory-fixture.ts
+++ b/scripts/trusted-acceptance/directory-fixture.ts
@@ -1,0 +1,182 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export type DirectoryScenario = "stable" | "withdraw-member";
+
+export type DirectoryMember = {
+  id: string;
+  name: string;
+  url: string;
+  a2aUrl: string;
+  capabilities?: string[];
+};
+
+/** Trusted runtime configuration; no request field selects a member or mode. */
+export type DirectoryFixtureConfig = {
+  orgDomain: string;
+  a2aSecret: string;
+  fixtureOrigin: string;
+  members: readonly DirectoryMember[];
+  withdrawnMemberId?: string;
+};
+
+export type DirectoryRequest = {
+  method: string;
+  headers?: Headers | Record<string, string | undefined>;
+};
+
+export type DirectoryResponse = {
+  status: number;
+  headers: Record<string, string>;
+  body?: { org: string; apps: DirectoryMember[] };
+};
+
+function header(
+  headers: DirectoryRequest["headers"],
+  name: string,
+): string | undefined {
+  if (!headers) return undefined;
+  if (headers instanceof Headers) return headers.get(name) ?? undefined;
+  const match = Object.entries(headers).find(
+    ([key]) => key.toLowerCase() === name.toLowerCase(),
+  );
+  return match?.[1];
+}
+
+function isAcceptanceOrigin(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "https:" &&
+      url.pathname === "/" &&
+      !url.search &&
+      !url.hash &&
+      /(?:^|[-.])acceptance(?:[-.]|$)/i.test(url.hostname) &&
+      !/(?:^|[-.])(?:prod|production)(?:[-.]|$)/i.test(url.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Validate only the small, allowlisted fixture configuration. */
+export function validateDirectoryFixtureConfig(
+  config: DirectoryFixtureConfig,
+): string[] {
+  const issues: string[] = [];
+  if (!config.orgDomain.trim()) issues.push("orgDomain must be non-empty");
+  if (!config.a2aSecret.trim()) issues.push("a2aSecret must be non-empty");
+  if (!isAcceptanceOrigin(config.fixtureOrigin)) {
+    issues.push(
+      "fixtureOrigin must be a stable non-production acceptance HTTPS origin",
+    );
+  }
+  if (config.members.length === 0) issues.push("members must be non-empty");
+  const ids = new Set<string>();
+  for (const member of config.members) {
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(member.id)) {
+      issues.push(`member ${member.id || "<empty>"} has an unsafe id`);
+    }
+    if (ids.has(member.id)) issues.push(`member ${member.id} is duplicated`);
+    ids.add(member.id);
+    if (!member.name.trim()) issues.push(`member ${member.id} has no name`);
+    if (!isAcceptanceOrigin(member.url)) {
+      issues.push(`member ${member.id} has an unsafe url`);
+    }
+    if (!isAcceptanceOrigin(member.a2aUrl)) {
+      issues.push(`member ${member.id} has an unsafe a2aUrl`);
+    }
+  }
+  if (
+    config.withdrawnMemberId &&
+    !config.members.some((member) => member.id === config.withdrawnMemberId)
+  ) {
+    issues.push("withdrawnMemberId must name a declared member");
+  }
+  return issues;
+}
+
+function unauthorized(): DirectoryResponse {
+  return { status: 401, headers: { "Cache-Control": "no-store" } };
+}
+
+async function isTrustedCaller(
+  authorization: string | undefined,
+  config: DirectoryFixtureConfig,
+): Promise<boolean> {
+  const token = authorization?.match(/^Bearer ([^\s]+)$/i)?.[1];
+  if (!token) return false;
+  try {
+    const [encodedHeader, encodedPayload, encodedSignature, extra] =
+      token.split(".");
+    if (!encodedHeader || !encodedPayload || !encodedSignature || extra) {
+      return false;
+    }
+    const header = JSON.parse(
+      Buffer.from(encodedHeader, "base64url").toString("utf8"),
+    ) as { alg?: unknown };
+    const payload = JSON.parse(
+      Buffer.from(encodedPayload, "base64url").toString("utf8"),
+    ) as Record<string, unknown>;
+    if (header.alg !== "HS256") return false;
+    const actual = Buffer.from(encodedSignature, "base64url");
+    const expected = createHmac("sha256", config.a2aSecret)
+      .update(`${encodedHeader}.${encodedPayload}`)
+      .digest();
+    if (
+      actual.length !== expected.length ||
+      !timingSafeEqual(actual, expected)
+    ) {
+      return false;
+    }
+    const now = Math.floor(Date.now() / 1000);
+    if (typeof payload.exp !== "number" || now >= payload.exp) return false;
+    if (typeof payload.nbf === "number" && now < payload.nbf) return false;
+    const scope =
+      typeof payload.scope === "string" ? payload.scope.split(/\s+/) : [];
+    return (
+      typeof payload.sub === "string" &&
+      payload.sub.trim().length > 0 &&
+      payload.org_domain === config.orgDomain &&
+      !scope.includes("identity") &&
+      !scope.includes("mcp-connect")
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Pure handler for the disposable directory fixture. This deliberately does
+ * not mount a route or inspect process configuration; a trusted host supplies
+ * a validated config and fixed runtime scenario.
+ */
+export async function handleDirectoryFixtureRequest(
+  request: DirectoryRequest,
+  config: DirectoryFixtureConfig,
+  scenario: DirectoryScenario,
+): Promise<DirectoryResponse> {
+  if (request.method !== "GET") return { status: 405, headers: {} };
+  if (scenario !== "stable" && scenario !== "withdraw-member") {
+    return { status: 400, headers: {} };
+  }
+  if (validateDirectoryFixtureConfig(config).length > 0) return unauthorized();
+  if (
+    !(await isTrustedCaller(header(request.headers, "authorization"), config))
+  ) {
+    return unauthorized();
+  }
+  const apps =
+    scenario === "withdraw-member" && config.withdrawnMemberId
+      ? config.members.filter(
+          (member) => member.id !== config.withdrawnMemberId,
+        )
+      : [...config.members];
+  return {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    },
+    body: { org: config.orgDomain, apps },
+  };
+}

--- a/scripts/trusted-acceptance/directory-netlify-function.spec.ts
+++ b/scripts/trusted-acceptance/directory-netlify-function.spec.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { describe, it } from "node:test";
+
+import { handleNetlifyDirectoryRequest } from "./directory-netlify-function.ts";
+
+const secret = "fake-disposable-a2a-secret";
+const directory = {
+  orgDomain: "acceptance.example.test",
+  fixtureOrigin: "https://directory-acceptance.example.test",
+  withdrawnMemberId: "content",
+  members: [
+    {
+      id: "calendar",
+      name: "Calendar",
+      url: "https://calendar-acceptance.example.test",
+      a2aUrl: "https://calendar-acceptance.example.test",
+    },
+    {
+      id: "content",
+      name: "Content",
+      url: "https://content-acceptance.example.test",
+      a2aUrl: "https://content-acceptance.example.test",
+    },
+  ],
+};
+
+function token(): string {
+  const now = Math.floor(Date.now() / 1000);
+  const header = Buffer.from(JSON.stringify({ alg: "HS256" })).toString(
+    "base64url",
+  );
+  const payload = Buffer.from(
+    JSON.stringify({
+      sub: "acceptance-caller",
+      org_domain: directory.orgDomain,
+      exp: now + 300,
+    }),
+  ).toString("base64url");
+  const signature = createHmac("sha256", secret)
+    .update(`${header}.${payload}`)
+    .digest("base64url");
+  return `${header}.${payload}.${signature}`;
+}
+
+describe("acceptance directory Netlify function", () => {
+  it("mounts the public contract from trusted runtime configuration", async () => {
+    const response = await handleNetlifyDirectoryRequest(
+      new Request(`${directory.fixtureOrigin}/_agent-native/org/apps`, {
+        headers: { Authorization: `Bearer ${token()}` },
+      }),
+      {
+        A2A_SECRET: secret,
+        AGENT_NATIVE_ACCEPTANCE_DIRECTORY_JSON: JSON.stringify(directory),
+        AGENT_NATIVE_ACCEPTANCE_DIRECTORY_SCENARIO: "withdraw-member",
+      },
+    );
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as { apps: Array<{ id: string }> };
+    assert.deepEqual(
+      body.apps.map(({ id }) => id),
+      ["calendar"],
+    );
+  });
+
+  it("fails closed without trusted config or for a non-allowlisted mode", async () => {
+    const request = new Request(
+      `${directory.fixtureOrigin}/_agent-native/org/apps`,
+    );
+    assert.equal(
+      (await handleNetlifyDirectoryRequest(request, {})).status,
+      503,
+    );
+    assert.equal(
+      (
+        await handleNetlifyDirectoryRequest(request, {
+          A2A_SECRET: secret,
+          AGENT_NATIVE_ACCEPTANCE_DIRECTORY_JSON: JSON.stringify(directory),
+          AGENT_NATIVE_ACCEPTANCE_DIRECTORY_SCENARIO: "arbitrary-target",
+        })
+      ).status,
+      503,
+    );
+  });
+});

--- a/scripts/trusted-acceptance/directory-netlify-function.ts
+++ b/scripts/trusted-acceptance/directory-netlify-function.ts
@@ -1,0 +1,53 @@
+import {
+  type DirectoryFixtureConfig,
+  type DirectoryScenario,
+  handleDirectoryFixtureRequest,
+} from "./directory-fixture.ts";
+
+type FixtureEnvironment = Record<string, string | undefined>;
+
+function fixtureFromEnvironment(env: FixtureEnvironment): {
+  config: DirectoryFixtureConfig;
+  scenario: DirectoryScenario;
+} {
+  const raw = env.AGENT_NATIVE_ACCEPTANCE_DIRECTORY_JSON;
+  const a2aSecret = env.A2A_SECRET;
+  const scenario = env.AGENT_NATIVE_ACCEPTANCE_DIRECTORY_SCENARIO;
+  if (!raw || !a2aSecret) {
+    throw new Error("acceptance directory runtime is not configured");
+  }
+  if (scenario !== "stable" && scenario !== "withdraw-member") {
+    throw new Error("acceptance directory scenario is not allowlisted");
+  }
+  const parsed = JSON.parse(raw) as Omit<DirectoryFixtureConfig, "a2aSecret">;
+  return { config: { ...parsed, a2aSecret }, scenario };
+}
+
+export async function handleNetlifyDirectoryRequest(
+  request: Request,
+  env: FixtureEnvironment,
+): Promise<Response> {
+  try {
+    const fixture = fixtureFromEnvironment(env);
+    const result = await handleDirectoryFixtureRequest(
+      { method: request.method, headers: request.headers },
+      fixture.config,
+      fixture.scenario,
+    );
+    return new Response(result.body ? JSON.stringify(result.body) : null, {
+      status: result.status,
+      headers: result.headers,
+    });
+  } catch {
+    return new Response(null, {
+      status: 503,
+      headers: { "Cache-Control": "no-store" },
+    });
+  }
+}
+
+export default async function acceptanceDirectory(request: Request) {
+  return handleNetlifyDirectoryRequest(request, process.env);
+}
+
+export const config = { path: "/_agent-native/org/apps" };

--- a/scripts/trusted-acceptance/hosted-oauth-a2a-harness.spec.ts
+++ b/scripts/trusted-acceptance/hosted-oauth-a2a-harness.spec.ts
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  HostedMcpClient,
+  buildAuthorizationUrl,
+  createS256Pkce,
+  discoverOAuth,
+  exchangeAuthorizationCode,
+  expectUnauthorized,
+  registerDynamicClient,
+  runWithdrawalScenario,
+} from "./hosted-oauth-a2a-harness.ts";
+
+const origin = "https://caller-acceptance.example.test";
+const metadata = {
+  authorization_endpoint: `${origin}/oauth/authorize`,
+  token_endpoint: `${origin}/oauth/token`,
+  registration_endpoint: `${origin}/oauth/register`,
+  resource: `${origin}/mcp`,
+};
+
+describe("hosted OAuth and A2A acceptance harness", () => {
+  it("constructs RFC 7636 S256 authorization URLs with an exact loopback callback", () => {
+    const pkce = createS256Pkce("a".repeat(43));
+    assert.equal(pkce.challenge, "ZtNPunH49FD35FWYhT5Tv8I7vRKQJ8uxMaL0_9eHjNA");
+    const url = new URL(
+      buildAuthorizationUrl({
+        metadata,
+        appOrigin: origin,
+        clientId: "fake-client",
+        redirectUri: "http://127.0.0.1:4319/oauth/callback",
+        state: "opaque-state",
+        pkce,
+      }),
+    );
+    assert.equal(url.origin, origin);
+    assert.equal(url.searchParams.get("code_challenge_method"), "S256");
+    assert.equal(url.searchParams.get("code_challenge"), pkce.challenge);
+    assert.equal(url.searchParams.get("resource"), metadata.resource);
+    assert.equal(url.searchParams.get("scope"), "mcp:read mcp:write mcp:apps");
+    assert.equal(
+      url.searchParams.get("redirect_uri"),
+      "http://127.0.0.1:4319/oauth/callback",
+    );
+    assert.throws(() =>
+      buildAuthorizationUrl({
+        metadata,
+        appOrigin: origin,
+        clientId: "fake-client",
+        redirectUri: "http://evil.example.test/callback",
+        state: "opaque-state",
+        pkce,
+      }),
+    );
+  });
+
+  it("discovers OAuth through injected fetch and rejects a non-local endpoint", async () => {
+    const discovered = await discoverOAuth(async (url) => {
+      if (url.endsWith("oauth-protected-resource")) {
+        return Response.json({
+          authorization_servers: [origin],
+          resource: metadata.resource,
+        });
+      }
+      const { resource: _, ...authorizationMetadata } = metadata;
+      return Response.json(authorizationMetadata);
+    }, origin);
+    assert.deepEqual(discovered, metadata);
+    await assert.rejects(
+      discoverOAuth(
+        async (url) =>
+          url.endsWith("oauth-protected-resource")
+            ? Response.json({
+                authorization_servers: [origin],
+                resource: metadata.resource,
+              })
+            : Response.json({
+                ...metadata,
+                token_endpoint: "https://production.example.test/token",
+              }),
+        origin,
+      ),
+    );
+  });
+
+  it("uses advertised registration and code exchange without serializing credentials", async () => {
+    const requests: Array<{ url: string; body: string }> = [];
+    const fetchFn = async (
+      url: string,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      requests.push({ url, body: String(init?.body ?? "") });
+      if (url.endsWith("/oauth/register"))
+        return Response.json({ client_id: "fake-client" });
+      return Response.json({ access_token: "private-access-token" });
+    };
+    const registration = await registerDynamicClient({
+      fetchFn,
+      metadata,
+      appOrigin: origin,
+      redirectUri: "http://127.0.0.1:4319/oauth/callback",
+    });
+    const token = await exchangeAuthorizationCode({
+      fetchFn,
+      metadata,
+      appOrigin: origin,
+      clientId: registration.clientId,
+      redirectUri: "http://127.0.0.1:4319/oauth/callback",
+      code: "fake-code",
+      verifier: "a".repeat(43),
+    });
+    assert.equal(registration.clientId, "fake-client");
+    assert.equal(token.accessToken, "private-access-token");
+    assert.match(requests[0]!.body, /redirect_uris/);
+    assert.match(requests[1]!.body, /code_verifier/);
+  });
+
+  it("polls the same ask_app task after trusted directory withdrawal and returns redacted evidence", async () => {
+    const calls: Array<{ name: string; taskId?: string }> = [];
+    let withdrawn = false;
+    const client = new HostedMcpClient(
+      async (_url, init) => {
+        const body = JSON.parse(String(init?.body)) as {
+          params: { name: string; arguments: { taskId?: string } };
+        };
+        calls.push({
+          name: body.params.name,
+          taskId: body.params.arguments.taskId,
+        });
+        if (body.params.name === "ask_app")
+          return Response.json({ result: { taskId: "private-task-id" } });
+        if (body.params.name === "ask_app_status") {
+          return Response.json({
+            result: {
+              status:
+                withdrawn &&
+                calls.filter(({ name }) => name === "ask_app_status").length > 1
+                  ? "completed"
+                  : "working",
+            },
+          });
+        }
+        return Response.json({ result: { apps: [{ id: "content" }] } });
+      },
+      `${origin}/mcp`,
+      "private-access-token",
+    );
+    const evidence = await runWithdrawalScenario({
+      client,
+      targetApp: "content",
+      message: "safe fixture message",
+      controller: { withdrawDirectoryMember: () => void (withdrawn = true) },
+      now: () => "2026-07-26T00:00:00.000Z",
+    });
+    assert.deepEqual(
+      calls.map(({ name }) => name),
+      ["list_apps", "ask_app", "ask_app_status", "ask_app_status"],
+    );
+    assert.deepEqual(
+      calls
+        .filter(({ name }) => name === "ask_app_status")
+        .map(({ taskId }) => taskId),
+      ["private-task-id", "private-task-id"],
+    );
+    assert.deepEqual(evidence, [
+      {
+        assertionId: "directory-withdrawal-same-task-status",
+        status: "passed",
+        timestamp: "2026-07-26T00:00:00.000Z",
+        origins: [origin],
+        taskIdHash: "sha256:3fed51006e68a9d8",
+      },
+    ]);
+    assert.equal(JSON.stringify(evidence).includes("private"), false);
+  });
+
+  it("requires stable discovery to name the target before ask_app", async () => {
+    const calls: string[] = [];
+    const client = new HostedMcpClient(
+      async (_url, init) => {
+        const body = JSON.parse(String(init?.body)) as {
+          params: { name: string };
+        };
+        calls.push(body.params.name);
+        return Response.json({ result: { apps: [{ id: "other-app" }] } });
+      },
+      `${origin}/mcp`,
+      "private-access-token",
+    );
+    await assert.rejects(
+      runWithdrawalScenario({
+        client,
+        targetApp: "content",
+        message: "safe fixture message",
+        controller: { withdrawDirectoryMember: () => undefined },
+      }),
+      /did not include the target app/,
+    );
+    assert.deepEqual(calls, ["list_apps"]);
+  });
+
+  it("records negative trust probes as 401 without reading response bodies", async () => {
+    let bodyRead = false;
+    const response = new Response("sensitive error", { status: 401 });
+    const originalText = response.text.bind(response);
+    response.text = async () => {
+      bodyRead = true;
+      return originalText();
+    };
+    assert.deepEqual(
+      await expectUnauthorized(async () => response, `${origin}/mcp`),
+      { status: 401 },
+    );
+    assert.equal(bodyRead, false);
+  });
+});

--- a/scripts/trusted-acceptance/hosted-oauth-a2a-harness.ts
+++ b/scripts/trusted-acceptance/hosted-oauth-a2a-harness.ts
@@ -1,0 +1,400 @@
+import { createHash, randomBytes } from "node:crypto";
+
+export type InjectedFetch = (
+  input: string,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export type OAuthMetadata = {
+  authorization_endpoint: string;
+  token_endpoint: string;
+  registration_endpoint?: string;
+  resource: string;
+};
+
+export type PkcePair = { verifier: string; challenge: string; method: "S256" };
+
+export type HostedHarnessEvidence = {
+  assertionId: string;
+  status: "passed" | "failed";
+  timestamp: string;
+  origins: string[];
+  taskIdHash?: string;
+};
+
+function stableAcceptanceOrigin(value: string): string {
+  const url = new URL(value);
+  if (
+    url.protocol !== "https:" ||
+    url.pathname !== "/" ||
+    url.search ||
+    url.hash ||
+    !/(?:^|[-.])acceptance(?:[-.]|$)/i.test(url.hostname) ||
+    /(?:^|[-.])(?:prod|production)(?:[-.]|$)/i.test(url.hostname)
+  ) {
+    throw new Error("expected a stable non-production acceptance origin");
+  }
+  return url.origin;
+}
+
+function trustedUrl(value: string, origin: string): URL {
+  const url = new URL(value);
+  if (url.protocol !== "https:" || url.origin !== origin) {
+    throw new Error(
+      "OAuth endpoint must remain on the configured acceptance origin",
+    );
+  }
+  return url;
+}
+
+function trustedMcpUrl(value: string): string {
+  const url = new URL(value);
+  stableAcceptanceOrigin(url.origin);
+  if (!url.pathname || url.search || url.hash || url.username || url.password) {
+    throw new Error(
+      "MCP endpoint must be a clean URL on the acceptance origin",
+    );
+  }
+  return url.toString();
+}
+
+function validateRedirectUri(value: string): string {
+  const url = new URL(value);
+  const loopback = ["127.0.0.1", "::1", "localhost"].includes(url.hostname);
+  if (
+    url.hash ||
+    url.username ||
+    url.password ||
+    (url.protocol !== "https:" && !(url.protocol === "http:" && loopback))
+  ) {
+    throw new Error(
+      "redirect URI must use HTTPS or an exact loopback HTTP URI",
+    );
+  }
+  return url.toString();
+}
+
+function hashTaskId(taskId: string): string {
+  return `sha256:${createHash("sha256").update(taskId).digest("hex").slice(0, 16)}`;
+}
+
+function requestJson(
+  init: RequestInit,
+  body?: Record<string, unknown>,
+): RequestInit {
+  return {
+    ...init,
+    headers: {
+      Accept: "application/json",
+      ...(body ? { "Content-Type": "application/json" } : {}),
+      ...(init.headers ?? {}),
+    },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  };
+}
+
+async function requireOk(response: Response): Promise<Response> {
+  if (!response.ok)
+    throw new Error(`unexpected HTTP status ${response.status}`);
+  return response;
+}
+
+export function createS256Pkce(verifier?: string): PkcePair {
+  const value = verifier ?? randomBytes(48).toString("base64url");
+  if (!/^[A-Za-z0-9._~-]{43,128}$/.test(value)) {
+    throw new Error("PKCE verifier must be 43-128 RFC 7636 characters");
+  }
+  return {
+    verifier: value,
+    challenge: createHash("sha256").update(value).digest("base64url"),
+    method: "S256",
+  };
+}
+
+export async function discoverOAuth(
+  fetchFn: InjectedFetch,
+  appOrigin: string,
+): Promise<OAuthMetadata> {
+  const origin = stableAcceptanceOrigin(appOrigin);
+  const protectedResourceResponse = await requireOk(
+    await fetchFn(`${origin}/.well-known/oauth-protected-resource`, {
+      headers: { Accept: "application/json" },
+    }),
+  );
+  const protectedResource = (await protectedResourceResponse.json()) as {
+    authorization_servers?: unknown;
+    resource?: unknown;
+  };
+  const authorizationServer = Array.isArray(
+    protectedResource.authorization_servers,
+  )
+    ? protectedResource.authorization_servers.find(
+        (value): value is string => typeof value === "string",
+      )
+    : undefined;
+  if (!authorizationServer) {
+    throw new Error(
+      "protected resource metadata omitted authorization_servers",
+    );
+  }
+  if (typeof protectedResource.resource !== "string")
+    throw new Error("protected resource metadata omitted resource");
+  const resource = trustedUrl(protectedResource.resource, origin).toString();
+  const authorizationOrigin = trustedUrl(authorizationServer, origin).origin;
+  const response = await requireOk(
+    await fetchFn(
+      `${authorizationOrigin}/.well-known/oauth-authorization-server`,
+      { headers: { Accept: "application/json" } },
+    ),
+  );
+  const metadata = (await response.json()) as Omit<OAuthMetadata, "resource">;
+  trustedUrl(metadata.authorization_endpoint, authorizationOrigin);
+  trustedUrl(metadata.token_endpoint, authorizationOrigin);
+  if (metadata.registration_endpoint)
+    trustedUrl(metadata.registration_endpoint, authorizationOrigin);
+  return { ...metadata, resource };
+}
+
+export function buildAuthorizationUrl(input: {
+  metadata: OAuthMetadata;
+  appOrigin: string;
+  clientId: string;
+  redirectUri: string;
+  state: string;
+  pkce: PkcePair;
+}): string {
+  const origin = stableAcceptanceOrigin(input.appOrigin);
+  const endpoint = trustedUrl(input.metadata.authorization_endpoint, origin);
+  const redirectUri = validateRedirectUri(input.redirectUri);
+  endpoint.search = new URLSearchParams({
+    response_type: "code",
+    client_id: input.clientId,
+    redirect_uri: redirectUri,
+    state: input.state,
+    code_challenge: input.pkce.challenge,
+    code_challenge_method: "S256",
+    resource: trustedUrl(input.metadata.resource, origin).toString(),
+    scope: "mcp:read mcp:write mcp:apps",
+  }).toString();
+  return endpoint.toString();
+}
+
+export async function registerDynamicClient(input: {
+  fetchFn: InjectedFetch;
+  metadata: OAuthMetadata;
+  appOrigin: string;
+  redirectUri: string;
+}): Promise<{ clientId: string }> {
+  const origin = stableAcceptanceOrigin(input.appOrigin);
+  if (!input.metadata.registration_endpoint) {
+    throw new Error("OAuth server does not advertise dynamic registration");
+  }
+  const endpoint = trustedUrl(input.metadata.registration_endpoint, origin);
+  const redirectUri = validateRedirectUri(input.redirectUri);
+  const response = await requireOk(
+    await input.fetchFn(
+      endpoint.toString(),
+      requestJson(
+        { method: "POST" },
+        {
+          client_name: "agent-native-trusted-acceptance",
+          redirect_uris: [redirectUri],
+        },
+      ),
+    ),
+  );
+  const result = (await response.json()) as { client_id?: unknown };
+  if (typeof result.client_id !== "string" || !result.client_id) {
+    throw new Error("dynamic registration response omitted client_id");
+  }
+  return { clientId: result.client_id };
+}
+
+export async function exchangeAuthorizationCode(input: {
+  fetchFn: InjectedFetch;
+  metadata: OAuthMetadata;
+  appOrigin: string;
+  clientId: string;
+  redirectUri: string;
+  code: string;
+  verifier: string;
+}): Promise<{ accessToken: string }> {
+  const endpoint = trustedUrl(
+    input.metadata.token_endpoint,
+    stableAcceptanceOrigin(input.appOrigin),
+  );
+  const redirectUri = validateRedirectUri(input.redirectUri);
+  const form = new URLSearchParams({
+    grant_type: "authorization_code",
+    client_id: input.clientId,
+    redirect_uri: redirectUri,
+    code: input.code,
+    code_verifier: input.verifier,
+    resource: trustedUrl(
+      input.metadata.resource,
+      stableAcceptanceOrigin(input.appOrigin),
+    ).toString(),
+  });
+  const response = await requireOk(
+    await input.fetchFn(endpoint.toString(), {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: form.toString(),
+    }),
+  );
+  const result = (await response.json()) as { access_token?: unknown };
+  if (typeof result.access_token !== "string" || !result.access_token) {
+    throw new Error("token response omitted access_token");
+  }
+  return { accessToken: result.access_token };
+}
+
+export class HostedMcpClient {
+  private readonly mcpUrl: string;
+
+  constructor(
+    private readonly fetchFn: InjectedFetch,
+    mcpUrl: string,
+    private readonly accessToken: string,
+  ) {
+    this.mcpUrl = trustedMcpUrl(mcpUrl);
+  }
+
+  get origin(): string {
+    return new URL(this.mcpUrl).origin;
+  }
+
+  async listApps(): Promise<unknown> {
+    return this.callTool("list_apps", {});
+  }
+
+  async askApp(app: string, message: string): Promise<unknown> {
+    return this.callTool("ask_app", { app, message });
+  }
+
+  async askAppStatus(app: string, taskId: string): Promise<unknown> {
+    return this.callTool("ask_app_status", { app, taskId });
+  }
+
+  async callTool(
+    name: string,
+    arguments_: Record<string, unknown>,
+  ): Promise<unknown> {
+    const response = await requireOk(
+      await this.fetchFn(
+        this.mcpUrl,
+        requestJson(
+          {
+            method: "POST",
+            headers: { Authorization: `Bearer ${this.accessToken}` },
+          },
+          {
+            jsonrpc: "2.0",
+            id: "trusted-acceptance",
+            method: "tools/call",
+            params: { name, arguments: arguments_ },
+          },
+        ),
+      ),
+    );
+    const body = (await response.json()) as {
+      error?: unknown;
+      result?: unknown;
+    };
+    if (body.error || !("result" in body))
+      throw new Error("MCP JSON-RPC call failed");
+    return body.result;
+  }
+}
+
+function taskIdFrom(value: unknown): string {
+  const result = value as {
+    taskId?: unknown;
+    structuredContent?: { taskId?: unknown };
+  };
+  const taskId = result?.taskId ?? result?.structuredContent?.taskId;
+  if (typeof taskId !== "string" || !taskId)
+    throw new Error("ask_app did not return a task ID");
+  return taskId;
+}
+
+function isComplete(value: unknown): boolean {
+  const result = value as {
+    status?: unknown;
+    structuredContent?: { status?: unknown };
+  };
+  const status = result?.status ?? result?.structuredContent?.status;
+  return status === "completed" || status === "complete";
+}
+
+function hasApp(value: unknown, appId: string): boolean {
+  const result = value as {
+    apps?: unknown;
+    structuredContent?: { apps?: unknown };
+  };
+  const apps = result?.apps ?? result?.structuredContent?.apps;
+  return (
+    Array.isArray(apps) &&
+    apps.some(
+      (app) =>
+        typeof app === "object" &&
+        app !== null &&
+        (app as { id?: unknown }).id === appId,
+    )
+  );
+}
+
+/** A trusted controller callback changes fixture state; it is never an HTTP input. */
+export async function runWithdrawalScenario(input: {
+  client: HostedMcpClient;
+  targetApp: string;
+  message: string;
+  controller: { withdrawDirectoryMember: () => Promise<void> | void };
+  now?: () => string;
+  maxStatusPolls?: number;
+  wait?: () => Promise<void> | void;
+}): Promise<HostedHarnessEvidence[]> {
+  const timestamp = (input.now ?? (() => new Date().toISOString()))();
+  if (!hasApp(await input.client.listApps(), input.targetApp)) {
+    throw new Error(
+      "stable directory discovery did not include the target app",
+    );
+  }
+  const taskId = taskIdFrom(
+    await input.client.askApp(input.targetApp, input.message),
+  );
+  await input.controller.withdrawDirectoryMember();
+  const maxStatusPolls = input.maxStatusPolls ?? 3;
+  let status: unknown;
+  for (let attempt = 0; attempt < maxStatusPolls; attempt++) {
+    status = await input.client.askAppStatus(input.targetApp, taskId);
+    if (isComplete(status)) break;
+    if (attempt < maxStatusPolls - 1) await input.wait?.();
+  }
+  if (!isComplete(status))
+    throw new Error("same task did not complete after withdrawal");
+  return [
+    {
+      assertionId: "directory-withdrawal-same-task-status",
+      status: "passed",
+      timestamp,
+      origins: [input.client.origin],
+      taskIdHash: hashTaskId(taskId),
+    },
+  ];
+}
+
+/** Assert a failed trust probe without reading or retaining its response body. */
+export async function expectUnauthorized(
+  fetchFn: InjectedFetch,
+  url: string,
+  init?: RequestInit,
+): Promise<{ status: 401 }> {
+  const response = await fetchFn(url, init);
+  if (response.status !== 401)
+    throw new Error(`expected 401, received ${response.status}`);
+  return { status: 401 };
+}

--- a/scripts/trusted-acceptance/runtime-authority.spec.ts
+++ b/scripts/trusted-acceptance/runtime-authority.spec.ts
@@ -83,8 +83,10 @@ function providers(
       },
     },
     openrouter: {
-      async create(expiresAt, maxUsd) {
-        log.push(`openrouter:create:${expiresAt}:${maxUsd}`);
+      async create(leaseId, memberId, expiresAt, maxUsd) {
+        log.push(
+          `openrouter:create:${leaseId}:${memberId}:${expiresAt}:${maxUsd}`,
+        );
         return {
           plaintext: "injected-transient-inference-value",
           hash: "opaque-key-hash",
@@ -138,7 +140,11 @@ describe("disposable runtime authority", () => {
     const log: string[] = [];
     const authority = new DisposableRuntimeAuthority(
       config(),
-      providers(log, { failSet: true }),
+      (() => {
+        const fake = providers(log, { failSet: true });
+        fake.netlify.ownsLease = async () => false;
+        return fake;
+      })(),
       fixedNow,
     );
     await assert.rejects(authority.acquire(60_000), /injected set failure/);
@@ -149,6 +155,67 @@ describe("disposable runtime authority", () => {
     );
     assert.equal(
       log.some((entry) => entry.startsWith("netlify:remove")),
+      false,
+    );
+  });
+
+  it("compensates an ambiguous Netlify write when its exact marker committed", async () => {
+    const log: string[] = [];
+    const fake = providers(log);
+    fake.netlify.setRuntime = async (_accountId, siteId) => {
+      log.push(`netlify:set:${siteId}:committed`);
+      throw new Error("response lost after commit");
+    };
+    fake.netlify.ownsLease = async () => true;
+    const authority = new DisposableRuntimeAuthority(config(), fake, fixedNow);
+    await assert.rejects(
+      authority.acquire(60_000),
+      /response lost after commit/,
+    );
+    assert.equal(log.includes("netlify:remove:declared-netlify-site"), true);
+    assert.equal(log.includes("netlify:tombstone:declared-netlify-site"), true);
+  });
+
+  it("continues independent cleanup when one Netlify ownership read fails", async () => {
+    const log: string[] = [];
+    const twoMembers = config({
+      members: [
+        config().members[0]!,
+        {
+          ...config().members[0]!,
+          id: "calendar",
+          neonProjectId: "declared-neon-project-2",
+          netlifySiteId: "declared-netlify-site-2",
+          needsInference: false,
+        },
+      ],
+    });
+    const fake = providers(log);
+    const authority = new DisposableRuntimeAuthority(
+      twoMembers,
+      fake,
+      fixedNow,
+    );
+    const { lease } = await authority.acquire(60_000);
+    fake.netlify.ownsLease = async (_accountId, siteId) => {
+      if (siteId === "declared-netlify-site")
+        throw new Error("transient ownership read failure");
+      return true;
+    };
+    await authority.revoke(lease);
+    assert.equal(lease.state, "revoking");
+    assert.equal(
+      log.includes("neon:delete:declared-neon-project:branch-handle"),
+      true,
+    );
+    assert.equal(
+      log.includes("neon:delete:declared-neon-project-2:branch-handle"),
+      true,
+    );
+    assert.equal(log.includes("netlify:remove:declared-netlify-site-2"), true);
+    assert.equal(log.includes("netlify:remove:declared-netlify-site"), false);
+    assert.equal(
+      log.includes("netlify:tombstone:declared-netlify-site"),
       false,
     );
   });
@@ -308,6 +375,7 @@ describe("disposable runtime authority", () => {
     fake.openrouter.listByPrefixAndExpiry = async () => [
       {
         leaseId: "a".repeat(24),
+        memberId: "content",
         hash: "opaque-key-hash",
         expiresAt: "2026-07-26T11:00:30.000Z",
       },
@@ -347,6 +415,61 @@ describe("disposable runtime authority", () => {
     );
   });
 
+  it("reconstructs inference keys by declared member identity", async () => {
+    const log: string[] = [];
+    const twoInferenceMembers = config({
+      members: [
+        config().members[0]!,
+        {
+          ...config().members[0]!,
+          id: "calendar",
+          neonProjectId: "declared-neon-project-2",
+          netlifySiteId: "declared-netlify-site-2",
+        },
+      ],
+    });
+    const fake = providers(log);
+    fake.openrouter.listByPrefixAndExpiry = async () => [
+      {
+        leaseId: "8".repeat(24),
+        memberId: "calendar",
+        hash: "a-sorts-first-but-belongs-to-calendar",
+        expiresAt: "2026-07-26T11:00:00.000Z",
+      },
+      {
+        leaseId: "8".repeat(24),
+        memberId: "content",
+        hash: "z-sorts-last-but-belongs-to-content",
+        expiresAt: "2026-07-26T11:00:00.000Z",
+      },
+    ];
+    const [lease] = await discoverExpiredLeases(
+      twoInferenceMembers,
+      fake,
+      fixedNow(),
+    );
+    assert.equal(
+      lease?.members[0]?.inferenceKeyHash,
+      "z-sorts-last-but-belongs-to-content",
+    );
+    assert.equal(
+      lease?.members[1]?.inferenceKeyHash,
+      "a-sorts-first-but-belongs-to-calendar",
+    );
+    await new DisposableRuntimeAuthority(
+      twoInferenceMembers,
+      fake,
+      fixedNow,
+    ).reapExpired([lease!]);
+    assert.deepEqual(
+      log.filter((entry) => entry.startsWith("openrouter:disable:")).sort(),
+      [
+        "openrouter:disable:a-sorts-first-but-belongs-to-calendar",
+        "openrouter:disable:z-sorts-last-but-belongs-to-content",
+      ],
+    );
+  });
+
   it("excludes active provider resources from discovery", async () => {
     const fake = providers([]);
     fake.neon.listByPrefixAndExpiry = async () => [
@@ -359,6 +482,7 @@ describe("disposable runtime authority", () => {
     fake.openrouter.listByPrefixAndExpiry = async () => [
       {
         leaseId: "b".repeat(24),
+        memberId: "content",
         hash: "active-key",
         expiresAt: "2026-07-26T13:00:00.000Z",
       },
@@ -394,6 +518,7 @@ describe("disposable runtime authority", () => {
     undeclaredInference.openrouter.listByPrefixAndExpiry = async () => [
       {
         leaseId: "f".repeat(24),
+        memberId: "content",
         hash: "unexpected-key",
         expiresAt: "2026-07-26T11:00:00.000Z",
       },
@@ -406,7 +531,7 @@ describe("disposable runtime authority", () => {
         undeclaredInference,
         fixedNow(),
       ),
-      /undeclared inference handles/,
+      /invalid trusted acceptance lease member/,
     );
   });
 
@@ -425,6 +550,7 @@ describe("disposable runtime authority", () => {
     missingMember.openrouter.listByPrefixAndExpiry = async () => [
       {
         leaseId: "1".repeat(24),
+        memberId: "content",
         hash: "opaque-key-hash",
         expiresAt: "2026-07-26T11:00:00.000Z",
       },
@@ -455,6 +581,7 @@ describe("disposable runtime authority", () => {
     orphanKey.openrouter.listByPrefixAndExpiry = async () => [
       {
         leaseId: "d".repeat(24),
+        memberId: "content",
         hash: "orphan-key",
         expiresAt: "2026-07-26T11:00:00.000Z",
       },
@@ -554,6 +681,7 @@ describe("disposable runtime authority", () => {
         fake.openrouter.listByPrefixAndExpiry = async () => [
           {
             leaseId: "e".repeat(24),
+            memberId: "content",
             hash: "expired-key",
             expiresAt: "2026-07-26T11:02:00.000Z",
           },
@@ -655,6 +783,46 @@ describe("disposable runtime authority", () => {
     );
   });
 
+  it("reads every bounded Neon cursor page and rejects cursor cycles", async () => {
+    const requests: string[] = [];
+    const neon = new NeonBranches(async (input) => {
+      requests.push(input);
+      if (input.includes("cursor=page-2"))
+        return Response.json({
+          branches: [
+            {
+              id: "page-two-branch",
+              name: `trusted-acceptance-${"7".repeat(24)}`,
+              expires_at: "2026-07-26T11:00:00.000Z",
+            },
+          ],
+          pagination: {},
+        });
+      return Response.json({ branches: [], pagination: { next: "page-2" } });
+    }, "injected-management-token");
+    assert.deepEqual(
+      await neon.listByPrefixAndExpiry("declared-neon-project"),
+      [
+        {
+          leaseId: "7".repeat(24),
+          branchId: "page-two-branch",
+          expiresAt: "2026-07-26T11:00:00.000Z",
+        },
+      ],
+    );
+    assert.equal(requests.length, 2);
+    assert.match(requests[1]!, /cursor=page-2/);
+
+    const cycling = new NeonBranches(
+      async () => Response.json({ branches: [], pagination: { next: "same" } }),
+      "injected-management-token",
+    );
+    await assert.rejects(
+      cycling.listByPrefixAndExpiry("declared-neon-project"),
+      /repeated pagination cursor/,
+    );
+  });
+
   it("persists redacted events in order using the injected clock", async () => {
     const saved: RuntimeLease[] = [];
     const authority = new DisposableRuntimeAuthority(
@@ -725,10 +893,10 @@ describe("disposable runtime authority", () => {
       );
     };
     const keys = new OpenRouterKeys(fetch, "injected-management-token");
-    await keys.create("lease-id", "2026-07-26T13:00:00.000Z", 0.01);
+    await keys.create("lease-id", "content", "2026-07-26T13:00:00.000Z", 0.01);
     await keys.disableByHash("opaque-key-hash");
     assert.deepEqual(JSON.parse(String(requests[0]?.init?.body)), {
-      name: "trusted-acceptance-lease-id",
+      name: "trusted-acceptance-lease-id-content",
       limit: 0.01,
       limit_reset: null,
       expires_at: "2026-07-26T13:00:00.000Z",

--- a/scripts/trusted-acceptance/runtime-authority.spec.ts
+++ b/scripts/trusted-acceptance/runtime-authority.spec.ts
@@ -823,6 +823,56 @@ describe("disposable runtime authority", () => {
     );
   });
 
+  it("reads every bounded OpenRouter offset page", async () => {
+    const requests: string[] = [];
+    const keys = new OpenRouterKeys(async (input) => {
+      requests.push(input);
+      const offset = new URL(input).searchParams.get("offset");
+      if (offset === "100")
+        return Response.json({
+          data: [
+            {
+              name: `trusted-acceptance-${"6".repeat(24)}-content`,
+              hash: "page-two-key",
+              expires_at: "2026-07-26T11:00:00.000Z",
+            },
+          ],
+        });
+      return Response.json({
+        data: Array.from({ length: 100 }, (_, index) => ({
+          name: `unrelated-key-${index}`,
+        })),
+      });
+    }, "injected-management-token");
+    assert.deepEqual(await keys.listByPrefixAndExpiry(), [
+      {
+        leaseId: "6".repeat(24),
+        memberId: "content",
+        hash: "page-two-key",
+        expiresAt: "2026-07-26T11:00:00.000Z",
+      },
+    ]);
+    assert.equal(requests.length, 2);
+    assert.equal(new URL(requests[0]!).searchParams.get("offset"), "0");
+    assert.equal(new URL(requests[1]!).searchParams.get("offset"), "100");
+    assert.equal(
+      new URL(requests[0]!).searchParams.get("include_disabled"),
+      "true",
+    );
+
+    let boundedRequests = 0;
+    const bounded = new OpenRouterKeys(async () => {
+      boundedRequests += 1;
+      return Response.json({
+        data: Array.from({ length: 100 }, (_, index) => ({
+          name: `unrelated-key-${index}`,
+        })),
+      });
+    }, "injected-management-token");
+    await assert.rejects(bounded.listByPrefixAndExpiry(), /bounded page limit/);
+    assert.equal(boundedRequests, 100);
+  });
+
   it("persists redacted events in order using the injected clock", async () => {
     const saved: RuntimeLease[] = [];
     const authority = new DisposableRuntimeAuthority(

--- a/scripts/trusted-acceptance/runtime-authority.spec.ts
+++ b/scripts/trusted-acceptance/runtime-authority.spec.ts
@@ -1,0 +1,870 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  discoverExpiredLeases,
+  DisposableRuntimeAuthority,
+  NeonBranches,
+  NetlifyRuntime,
+  OpenRouterKeys,
+  type RuntimeLease,
+  type RuntimeProviders,
+  type TrustedRuntimeConfig,
+} from "./runtime-authority.ts";
+
+const sha256 = "a".repeat(64);
+const fixedNow = () => new Date("2026-07-26T12:00:00.000Z");
+
+function config(
+  overrides: Partial<TrustedRuntimeConfig> = {},
+): TrustedRuntimeConfig {
+  return {
+    maxInferenceUsd: 0.01,
+    tombstone: { sha256, zip: new Uint8Array([1, 2, 3]) },
+    members: [
+      {
+        id: "content",
+        origin: "https://content.acceptance.example.test",
+        neonProjectId: "declared-neon-project",
+        neonDatabaseName: "declared-database",
+        neonRoleName: "declared-role",
+        netlifyAccountId: "declared-netlify-account",
+        netlifySiteId: "declared-netlify-site",
+        needsInference: true,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function providers(
+  log: string[],
+  options: { failSet?: boolean; verified?: boolean } = {},
+): RuntimeProviders {
+  return {
+    neon: {
+      async createBranch(projectId) {
+        log.push(`neon:create:${projectId}`);
+        return "branch-handle";
+      },
+      async getConnectionUri(projectId) {
+        log.push(`neon:connection:${projectId}`);
+        return "postgres://transient-value";
+      },
+      async deleteAndVerify(projectId, branchId) {
+        log.push(`neon:delete:${projectId}:${branchId}`);
+        return options.verified ?? true;
+      },
+      async listByPrefixAndExpiry() {
+        return [];
+      },
+    },
+    netlify: {
+      async assertSiteReady() {},
+      async ownsLease() {
+        return true;
+      },
+      async setRuntime(_accountId, siteId) {
+        log.push(`netlify:set:${siteId}`);
+        if (options.failSet) throw new Error("injected set failure");
+      },
+      async removeRuntime(_accountId, siteId) {
+        log.push(`netlify:remove:${siteId}`);
+        return options.verified ?? true;
+      },
+      async deployTombstoneAndVerify(siteId) {
+        log.push(`netlify:tombstone:${siteId}`);
+        return (options.verified ?? true)
+          ? { deployId: `deploy-${siteId}` }
+          : undefined;
+      },
+      async readLeaseMarker() {
+        return undefined;
+      },
+    },
+    openrouter: {
+      async create(expiresAt, maxUsd) {
+        log.push(`openrouter:create:${expiresAt}:${maxUsd}`);
+        return {
+          plaintext: "injected-transient-inference-value",
+          hash: "opaque-key-hash",
+        };
+      },
+      async disableByHash(hash) {
+        log.push(`openrouter:disable:${hash}`);
+        return options.verified ?? true;
+      },
+      async listByPrefixAndExpiry() {
+        return [];
+      },
+    },
+  };
+}
+
+describe("disposable runtime authority", () => {
+  it("issues transient per-app credentials while retaining only redacted lease handles", async () => {
+    const log: string[] = [];
+    const authority = new DisposableRuntimeAuthority(
+      config(),
+      providers(log),
+      fixedNow,
+    );
+    const issued = await authority.acquire(60_000);
+
+    assert.equal(issued.lease.state, "active");
+    assert.equal(issued.lease.members[0]?.neonBranchId, "branch-handle");
+    assert.equal(issued.lease.members[0]?.inferenceKeyHash, "opaque-key-hash");
+    assert.equal(issued.lease.members[0]?.tombstoneDeployId, undefined);
+    assert.equal(issued.secrets.memberSecrets.content?.a2aSecret.length, 43);
+    const serialized = JSON.stringify(issued.lease);
+    assert.equal(serialized.includes("postgres://transient-value"), false);
+    assert.equal(
+      serialized.includes("injected-transient-inference-value"),
+      false,
+    );
+    assert.equal(
+      serialized.includes(
+        issued.secrets.memberSecrets.content!.betterAuthSecret,
+      ),
+      false,
+    );
+    assert.deepEqual(
+      log.slice(0, 4).map((entry) => entry.split(":")[0]),
+      ["neon", "neon", "openrouter", "netlify"],
+    );
+  });
+
+  it("journals partial acquire and compensates through the same revoke path", async () => {
+    const log: string[] = [];
+    const authority = new DisposableRuntimeAuthority(
+      config(),
+      providers(log, { failSet: true }),
+      fixedNow,
+    );
+    await assert.rejects(authority.acquire(60_000), /injected set failure/);
+    assert.equal(log.includes("openrouter:disable:opaque-key-hash"), true);
+    assert.equal(
+      log.includes("neon:delete:declared-neon-project:branch-handle"),
+      true,
+    );
+    assert.equal(
+      log.some((entry) => entry.startsWith("netlify:remove")),
+      false,
+    );
+  });
+
+  it("never deletes site state when a competing marker wins the ownership race", async () => {
+    const log: string[] = [];
+    const fake = providers(log);
+    fake.netlify.setRuntime = async () => {
+      throw new Error("competing marker");
+    };
+    fake.netlify.ownsLease = async () => false;
+    const authority = new DisposableRuntimeAuthority(config(), fake, fixedNow);
+    await assert.rejects(authority.acquire(60_000), /competing marker/);
+    assert.equal(
+      log.some((entry) => entry.startsWith("netlify:remove")),
+      false,
+    );
+    assert.equal(
+      log.some((entry) => entry.startsWith("netlify:tombstone")),
+      false,
+    );
+
+    const owned = providers(log);
+    const ownedAuthority = new DisposableRuntimeAuthority(
+      config(),
+      owned,
+      fixedNow,
+    );
+    const { lease } = await ownedAuthority.acquire(60_000);
+    owned.netlify.ownsLease = async () => false;
+    const beforeRevoke = log.length;
+    await ownedAuthority.revoke(lease);
+    assert.equal(lease.state, "revoking");
+    assert.equal(
+      log
+        .slice(beforeRevoke)
+        .some((entry) => entry.startsWith("netlify:remove")),
+      false,
+    );
+  });
+
+  it("compensates a persisted Neon branch when connection URI lookup fails", async () => {
+    const log: string[] = [];
+    const fake = providers(log);
+    fake.neon.getConnectionUri = async () => {
+      log.push("neon:connection:failed");
+      throw new Error("injected connection failure");
+    };
+    const authority = new DisposableRuntimeAuthority(config(), fake, fixedNow);
+    await assert.rejects(
+      authority.acquire(60_000),
+      /injected connection failure/,
+    );
+    assert.equal(
+      log.includes("neon:delete:declared-neon-project:branch-handle"),
+      true,
+    );
+  });
+
+  it("makes revoke idempotent and reaches revoked only after every cleanup verification", async () => {
+    const log: string[] = [];
+    const authority = new DisposableRuntimeAuthority(
+      config(),
+      providers(log),
+      fixedNow,
+    );
+    const { lease } = await authority.acquire(60_000);
+    await authority.revoke(lease);
+    assert.equal(lease.state, "revoked");
+    assert.equal(
+      lease.members[0]?.tombstoneDeployId,
+      "deploy-declared-netlify-site",
+    );
+    const callCount = log.length;
+    await authority.revoke(lease);
+    assert.equal(log.length, callCount);
+
+    const gated = new DisposableRuntimeAuthority(
+      config(),
+      providers([], { verified: false }),
+      fixedNow,
+    );
+    const blockedLease = await gated.acquire(60_000);
+    await gated.revoke(blockedLease.lease);
+    assert.equal(blockedLease.lease.state, "revoking");
+    assert.equal(blockedLease.lease.verification.tombstoneActive, false);
+  });
+
+  it("reaps deterministic expired records and leaves late revoked work alone", async () => {
+    const log: string[] = [];
+    const authority = new DisposableRuntimeAuthority(
+      config(),
+      providers(log),
+      fixedNow,
+    );
+    const lease: RuntimeLease = {
+      id: "expired-lease",
+      createdAt: "2026-07-26T10:00:00.000Z",
+      expiresAt: "2026-07-26T11:00:00.000Z",
+      state: "active",
+      members: [
+        {
+          memberId: "content",
+          netlifySiteId: "declared-netlify-site",
+          runtimeOwned: true,
+          neonBranchId: "branch-handle",
+          inferenceKeyHash: "opaque-key-hash",
+        },
+      ],
+      journal: [],
+      verification: {
+        inferenceDisabled: false,
+        runtimeVariablesAbsent: false,
+        tombstoneActive: false,
+        branchesDeleted: false,
+      },
+    };
+    const alreadyRevoked = {
+      ...lease,
+      id: "already-revoked",
+      state: "revoked" as const,
+    };
+    const result = await authority.reapExpired([lease, alreadyRevoked]);
+    assert.equal(result[0]?.state, "revoked");
+    assert.equal(result[1], alreadyRevoked);
+    assert.equal(
+      log.filter((entry) => entry.startsWith("neon:delete")).length,
+      1,
+    );
+  });
+
+  it("reconstructs an expired multi-member lease from declared provider inventory and reaps it", async () => {
+    const log: string[] = [];
+    const twoMembers = config({
+      members: [
+        config().members[0]!,
+        {
+          id: "calendar",
+          origin: "https://calendar.acceptance.example.test",
+          neonProjectId: "declared-neon-project-2",
+          neonDatabaseName: "declared-database-2",
+          neonRoleName: "declared-role-2",
+          netlifyAccountId: "declared-netlify-account",
+          netlifySiteId: "declared-netlify-site-2",
+          needsInference: false,
+        },
+      ],
+    });
+    const fake = providers(log);
+    fake.neon.listByPrefixAndExpiry = async (projectId) => [
+      {
+        leaseId: "a".repeat(24),
+        branchId: `branch-${projectId}`,
+        expiresAt: "2026-07-26T11:00:00.000Z",
+      },
+    ];
+    fake.openrouter.listByPrefixAndExpiry = async () => [
+      {
+        leaseId: "a".repeat(24),
+        hash: "opaque-key-hash",
+        expiresAt: "2026-07-26T11:00:30.000Z",
+      },
+    ];
+    const discovered = await discoverExpiredLeases(
+      twoMembers,
+      fake,
+      fixedNow(),
+    );
+    assert.deepEqual(discovered[0]?.members, [
+      {
+        memberId: "content",
+        netlifySiteId: "declared-netlify-site",
+        runtimeOwned: false,
+        neonBranchId: "branch-declared-neon-project",
+        inferenceKeyHash: "opaque-key-hash",
+      },
+      {
+        memberId: "calendar",
+        netlifySiteId: "declared-netlify-site-2",
+        runtimeOwned: false,
+        neonBranchId: "branch-declared-neon-project-2",
+      },
+    ]);
+    const authority = new DisposableRuntimeAuthority(
+      twoMembers,
+      fake,
+      fixedNow,
+    );
+    const reaped = await authority.reapExpired(discovered);
+    assert.equal(reaped[0]?.state, "revoked");
+    assert.equal(
+      log.includes(
+        "neon:delete:declared-neon-project:branch-declared-neon-project",
+      ),
+      true,
+    );
+  });
+
+  it("excludes active provider resources from discovery", async () => {
+    const fake = providers([]);
+    fake.neon.listByPrefixAndExpiry = async () => [
+      {
+        leaseId: "b".repeat(24),
+        branchId: "active-branch",
+        expiresAt: "2026-07-26T13:00:00.000Z",
+      },
+    ];
+    fake.openrouter.listByPrefixAndExpiry = async () => [
+      {
+        leaseId: "b".repeat(24),
+        hash: "active-key",
+        expiresAt: "2026-07-26T13:00:00.000Z",
+      },
+    ];
+    assert.deepEqual(
+      await discoverExpiredLeases(config(), fake, fixedNow()),
+      [],
+    );
+  });
+
+  it("fails closed for malformed handles and undeclared inference", async () => {
+    const malformed = providers([]);
+    malformed.neon.listByPrefixAndExpiry = async () => [
+      {
+        leaseId: "not-a-controller-lease",
+        branchId: "branch",
+        expiresAt: "2026-07-26T11:00:00.000Z",
+      },
+    ];
+    await assert.rejects(
+      discoverExpiredLeases(config(), malformed, fixedNow()),
+      /invalid trusted acceptance lease id/,
+    );
+
+    const undeclaredInference = providers([]);
+    undeclaredInference.neon.listByPrefixAndExpiry = async () => [
+      {
+        leaseId: "f".repeat(24),
+        branchId: "branch",
+        expiresAt: "2026-07-26T11:00:00.000Z",
+      },
+    ];
+    undeclaredInference.openrouter.listByPrefixAndExpiry = async () => [
+      {
+        leaseId: "f".repeat(24),
+        hash: "unexpected-key",
+        expiresAt: "2026-07-26T11:00:00.000Z",
+      },
+    ];
+    await assert.rejects(
+      discoverExpiredLeases(
+        config({
+          members: [{ ...config().members[0]!, needsInference: false }],
+        }),
+        undeclaredInference,
+        fixedNow(),
+      ),
+      /undeclared inference handles/,
+    );
+  });
+
+  it("reconstructs partial expired leases so stranded resources remain reapable", async () => {
+    const missingMember = providers([]);
+    missingMember.neon.listByPrefixAndExpiry = async (projectId) =>
+      projectId === "declared-neon-project"
+        ? [
+            {
+              leaseId: "1".repeat(24),
+              branchId: "content-branch",
+              expiresAt: "2026-07-26T11:00:00.000Z",
+            },
+          ]
+        : [];
+    missingMember.openrouter.listByPrefixAndExpiry = async () => [
+      {
+        leaseId: "1".repeat(24),
+        hash: "opaque-key-hash",
+        expiresAt: "2026-07-26T11:00:00.000Z",
+      },
+    ];
+    const discovered = await discoverExpiredLeases(
+      config({
+        members: [
+          config().members[0]!,
+          {
+            id: "calendar",
+            origin: "https://calendar.acceptance.example.test",
+            neonProjectId: "declared-neon-project-2",
+            neonDatabaseName: "declared-database-2",
+            neonRoleName: "declared-role-2",
+            netlifyAccountId: "declared-netlify-account",
+            netlifySiteId: "declared-netlify-site-2",
+            needsInference: false,
+          },
+        ],
+      }),
+      missingMember,
+      fixedNow(),
+    );
+    assert.equal(discovered[0]?.members[0]?.neonBranchId, "content-branch");
+    assert.equal(discovered[0]?.members[1]?.neonBranchId, undefined);
+
+    const orphanKey = providers([]);
+    orphanKey.openrouter.listByPrefixAndExpiry = async () => [
+      {
+        leaseId: "d".repeat(24),
+        hash: "orphan-key",
+        expiresAt: "2026-07-26T11:00:00.000Z",
+      },
+    ];
+    assert.equal(
+      (await discoverExpiredLeases(config(), orphanKey, fixedNow()))[0]
+        ?.members[0]?.inferenceKeyHash,
+      "orphan-key",
+    );
+  });
+
+  it("never deletes site state for a markerless branch-only recovery", async () => {
+    const log: string[] = [];
+    const fake = providers(log);
+    fake.neon.listByPrefixAndExpiry = async () => [
+      {
+        leaseId: "9".repeat(24),
+        branchId: "branch-only",
+        expiresAt: "2026-07-26T11:00:00.000Z",
+      },
+    ];
+    const discovered = await discoverExpiredLeases(config(), fake, fixedNow());
+    assert.equal(discovered[0]?.members[0]?.runtimeOwned, false);
+    const authority = new DisposableRuntimeAuthority(config(), fake, fixedNow);
+    await authority.reapExpired(discovered);
+    assert.equal(
+      log.some((entry) => entry.startsWith("netlify:")),
+      false,
+    );
+    assert.equal(
+      log.includes("neon:delete:declared-neon-project:branch-only"),
+      true,
+    );
+  });
+
+  it("discovers a stranded lease from Netlify markers and protects a newer active owner", async () => {
+    const markerOnly = providers([]);
+    markerOnly.netlify.readLeaseMarker = async () => ({
+      leaseId: "2".repeat(24),
+      expiresAt: "2026-07-26T11:00:00.000Z",
+    });
+    const discovered = await discoverExpiredLeases(
+      config(),
+      markerOnly,
+      fixedNow(),
+    );
+    assert.equal(discovered[0]?.id, "2".repeat(24));
+    assert.equal(discovered[0]?.members[0]?.neonBranchId, undefined);
+
+    const conflicting = providers([]);
+    conflicting.neon.listByPrefixAndExpiry = async () => [
+      {
+        leaseId: "3".repeat(24),
+        branchId: "expired-branch",
+        expiresAt: "2026-07-26T11:00:00.000Z",
+      },
+    ];
+    conflicting.netlify.readLeaseMarker = async () => ({
+      leaseId: "4".repeat(24),
+      expiresAt: "2026-07-26T13:00:00.000Z",
+    });
+    await assert.rejects(
+      discoverExpiredLeases(config(), conflicting, fixedNow()),
+      /active lease owns the workspace/,
+    );
+  });
+
+  for (const [name, prepare, message] of [
+    [
+      "duplicate branches",
+      (fake: RuntimeProviders) => {
+        fake.neon.listByPrefixAndExpiry = async () => [
+          {
+            leaseId: "c".repeat(24),
+            branchId: "one",
+            expiresAt: "2026-07-26T11:00:00.000Z",
+          },
+          {
+            leaseId: "c".repeat(24),
+            branchId: "two",
+            expiresAt: "2026-07-26T11:00:00.000Z",
+          },
+        ];
+      },
+      /duplicate branches/,
+    ],
+    [
+      "inconsistent expiries",
+      (fake: RuntimeProviders) => {
+        fake.neon.listByPrefixAndExpiry = async () => [
+          {
+            leaseId: "e".repeat(24),
+            branchId: "expired-branch",
+            expiresAt: "2026-07-26T11:00:00.000Z",
+          },
+        ];
+        fake.openrouter.listByPrefixAndExpiry = async () => [
+          {
+            leaseId: "e".repeat(24),
+            hash: "expired-key",
+            expiresAt: "2026-07-26T11:02:00.000Z",
+          },
+        ];
+      },
+      /inconsistent provider expiries/,
+    ],
+  ] as const) {
+    it(`fails closed for ${name}`, async () => {
+      const fake = providers([]);
+      prepare(fake);
+      await assert.rejects(
+        discoverExpiredLeases(config(), fake, fixedNow()),
+        message,
+      );
+    });
+  }
+
+  it("rejects non-allowlisted candidate configuration before any provider work", () => {
+    assert.throws(
+      () =>
+        new DisposableRuntimeAuthority(
+          config({ maxInferenceUsd: 2 }),
+          providers([]),
+          fixedNow,
+        ),
+      /tiny USD cap/,
+    );
+    assert.throws(
+      () =>
+        new DisposableRuntimeAuthority(
+          config({
+            members: [
+              {
+                id: "content",
+                origin: "https://content.acceptance.example.test",
+                neonProjectId: "",
+                neonDatabaseName: "declared-database",
+                neonRoleName: "declared-role",
+                netlifyAccountId: "declared-netlify-account",
+                netlifySiteId: "declared-netlify-site",
+                needsInference: false,
+              },
+            ],
+          }),
+          providers([]),
+          fixedNow,
+        ),
+      /invalid or duplicate/,
+    );
+    assert.throws(
+      () =>
+        new DisposableRuntimeAuthority(
+          config({
+            members: [
+              config().members[0]!,
+              {
+                ...config().members[0]!,
+                id: "calendar",
+                netlifySiteId: "another-site",
+              },
+            ],
+          }),
+          providers([]),
+          fixedNow,
+        ),
+      /invalid or duplicate/,
+    );
+  });
+
+  it("uses the fixed Neon endpoint and only declared project ids", async () => {
+    const requests: string[] = [];
+    const fetch = async (input: string) => {
+      requests.push(input);
+      return new Response(
+        JSON.stringify(
+          input.includes("connection_uri")
+            ? { uri: "postgres://transient-value" }
+            : { branch: { id: "branch-handle" } },
+        ),
+        { status: 200 },
+      );
+    };
+    const neon = new NeonBranches(fetch, "injected-management-token");
+    const branchId = await neon.createBranch(
+      "declared-neon-project",
+      "lease",
+      "2026-07-26T13:00:00.000Z",
+    );
+    await neon.getConnectionUri(
+      "declared-neon-project",
+      "declared-database",
+      "declared-role",
+      branchId,
+    );
+    assert.equal(
+      requests[0],
+      "https://console.neon.tech/api/v2/projects/declared-neon-project/branches",
+    );
+  });
+
+  it("persists redacted events in order using the injected clock", async () => {
+    const saved: RuntimeLease[] = [];
+    const authority = new DisposableRuntimeAuthority(
+      config(),
+      providers([]),
+      fixedNow,
+      {
+        async save(lease) {
+          saved.push(JSON.parse(JSON.stringify(lease)));
+        },
+      },
+    );
+    await authority.acquire(60_000);
+    assert.equal(saved[0]?.state, "acquiring");
+    assert.equal(saved[1]?.journal[0]?.phase, "before");
+    assert.equal(saved[1]?.journal[0]?.at, "2026-07-26T12:00:00.000Z");
+    assert.equal(
+      JSON.stringify(saved).includes("postgres://transient-value"),
+      false,
+    );
+  });
+
+  it("records distinct opaque tombstone deploy receipts per member", async () => {
+    const twoMembers = config({
+      members: [
+        config().members[0]!,
+        {
+          id: "calendar",
+          origin: "https://calendar.acceptance.example.test",
+          neonProjectId: "declared-neon-project-2",
+          neonDatabaseName: "declared-database",
+          neonRoleName: "declared-role",
+          netlifyAccountId: "declared-netlify-account",
+          netlifySiteId: "declared-netlify-site-2",
+          needsInference: false,
+        },
+      ],
+    });
+    const authority = new DisposableRuntimeAuthority(
+      twoMembers,
+      providers([]),
+      fixedNow,
+    );
+    const { lease } = await authority.acquire(60_000);
+    await authority.revoke(lease);
+    assert.deepEqual(
+      lease.members.map((member) => member.tombstoneDeployId),
+      ["deploy-declared-netlify-site", "deploy-declared-netlify-site-2"],
+    );
+  });
+
+  it("uses documented OpenRouter and Netlify request shapes", async () => {
+    const requests: Array<{ input: string; init?: RequestInit }> = [];
+    const fetch = async (input: string, init?: RequestInit) => {
+      requests.push({ input, init });
+      if (init?.method === "POST")
+        return new Response(
+          JSON.stringify({
+            key: "injected-transient-inference-value",
+            data: { hash: "opaque-key-hash" },
+          }),
+          { status: 200 },
+        );
+      if (init?.method === "PATCH") return new Response("", { status: 200 });
+      return new Response(
+        JSON.stringify({ data: { hash: "opaque-key-hash", disabled: true } }),
+        { status: 200 },
+      );
+    };
+    const keys = new OpenRouterKeys(fetch, "injected-management-token");
+    await keys.create("lease-id", "2026-07-26T13:00:00.000Z", 0.01);
+    await keys.disableByHash("opaque-key-hash");
+    assert.deepEqual(JSON.parse(String(requests[0]?.init?.body)), {
+      name: "trusted-acceptance-lease-id",
+      limit: 0.01,
+      limit_reset: null,
+      expires_at: "2026-07-26T13:00:00.000Z",
+    });
+    assert.equal(requests[1]?.init?.method, "PATCH");
+
+    const netlifyRequests: Array<{ input: string; init?: RequestInit }> = [];
+    const netlify = new NetlifyRuntime(async (input, init) => {
+      netlifyRequests.push({ input, init });
+      if (init?.method === "POST")
+        return new Response(JSON.stringify({ id: "opaque-deploy-id" }), {
+          status: 200,
+        });
+      if (input.includes("/deploys/"))
+        return new Response(JSON.stringify({ state: "ready" }), {
+          status: 200,
+        });
+      return new Response(
+        JSON.stringify({ published_deploy: { id: "opaque-deploy-id" } }),
+        { status: 200 },
+      );
+    }, "injected-management-token");
+    const receipt = await netlify.deployTombstoneAndVerify(
+      "declared-netlify-site",
+      config().tombstone,
+    );
+    assert.deepEqual(receipt, { deployId: "opaque-deploy-id" });
+    assert.equal(
+      netlifyRequests[0]?.init?.headers &&
+        new Headers(netlifyRequests[0].init.headers).get("content-type"),
+      "application/zip",
+    );
+  });
+
+  it("uses account-scoped Netlify environment APIs and readable lease markers", async () => {
+    const requests: Array<{ input: string; init?: RequestInit }> = [];
+    let markerPresent = false;
+    const netlify = new NetlifyRuntime(async (input, init) => {
+      requests.push({ input, init });
+      if (init?.method === "POST") {
+        markerPresent = true;
+        return new Response("[]", { status: 201 });
+      }
+      if (init?.method === "DELETE") {
+        markerPresent = false;
+        return new Response(null, { status: 204 });
+      }
+      if (markerPresent)
+        return new Response(
+          JSON.stringify({
+            values: [
+              {
+                context: "all",
+                value: JSON.stringify({
+                  leaseId: "a".repeat(24),
+                  expiresAt: "2026-07-26T13:00:00.000Z",
+                }),
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      return new Response("", { status: 404 });
+    }, "injected-management-token");
+    await netlify.setRuntime("account", "site", {
+      AGENT_NATIVE_ACCEPTANCE_LEASE_MARKER: JSON.stringify({
+        leaseId: "a".repeat(24),
+        expiresAt: "2026-07-26T13:00:00.000Z",
+      }),
+    });
+    assert.equal(
+      requests[0]?.input,
+      `https://api.netlify.com/api/v1/accounts/account/env/AGENT_NATIVE_ACCEPTANCE_LEASE_MARKER?site_id=site`,
+    );
+    assert.deepEqual(JSON.parse(String(requests[1]?.init?.body)), [
+      {
+        key: "AGENT_NATIVE_ACCEPTANCE_LEASE_MARKER",
+        scopes: ["functions", "runtime"],
+        values: [
+          {
+            value: JSON.stringify({
+              leaseId: "a".repeat(24),
+              expiresAt: "2026-07-26T13:00:00.000Z",
+            }),
+            context: "all",
+          },
+        ],
+        is_secret: false,
+      },
+    ]);
+    assert.deepEqual(await netlify.readLeaseMarker("account", "site"), {
+      leaseId: "a".repeat(24),
+      expiresAt: "2026-07-26T13:00:00.000Z",
+    });
+    await netlify.removeRuntime("account", "site", [
+      "AGENT_NATIVE_ACCEPTANCE_LEASE_MARKER",
+    ]);
+    assert.equal(requests.at(-1)?.init?.method, undefined);
+  });
+
+  it("refuses to overwrite pre-existing acceptance runtime variables", async () => {
+    const netlify = new NetlifyRuntime(
+      async () => Response.json({ values: [{ context: "all" }] }),
+      "injected-management-token",
+    );
+    await assert.rejects(
+      netlify.setRuntime("account", "site", {
+        DATABASE_URL: "postgres://disposable",
+      }),
+      /refusing to overwrite/,
+    );
+  });
+
+  it("binds the declared acceptance origin to the exact Netlify site before mutation", async () => {
+    const netlify = new NetlifyRuntime(async (input) => {
+      if (input.endsWith("/sites/site"))
+        return Response.json({
+          id: "site",
+          ssl_url: "https://content.acceptance.example.test",
+        });
+      return new Response(null, { status: 404 });
+    }, "injected-management-token");
+    await netlify.assertSiteReady(
+      "account",
+      "site",
+      "https://content.acceptance.example.test",
+      ["DATABASE_URL"],
+    );
+    await assert.rejects(
+      netlify.assertSiteReady(
+        "account",
+        "site",
+        "https://other.acceptance.example.test",
+        ["DATABASE_URL"],
+      ),
+      /does not match/,
+    );
+  });
+});

--- a/scripts/trusted-acceptance/runtime-authority.ts
+++ b/scripts/trusted-acceptance/runtime-authority.ts
@@ -1,0 +1,1103 @@
+import { randomBytes } from "node:crypto";
+
+/**
+ * Provider-neutral, disposable runtime authority for the disabled acceptance
+ * pilot. This module has no ambient environment access and never calls a
+ * provider until its injected FetchLike is invoked by acquire or revoke.
+ */
+
+export type FetchLike = (
+  input: string,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export type TombstoneArtifact = { sha256: string; zip: Uint8Array };
+
+export type RuntimeMember = {
+  id: string;
+  origin: string;
+  neonProjectId: string;
+  neonDatabaseName: string;
+  neonRoleName: string;
+  netlifyAccountId: string;
+  netlifySiteId: string;
+  needsInference: boolean;
+};
+
+export type TrustedRuntimeConfig = {
+  members: readonly RuntimeMember[];
+  maxInferenceUsd: number;
+  tombstone: TombstoneArtifact;
+};
+
+export type LeaseJournal = {
+  at: string;
+  phase: "before" | "after" | "compensated" | "verification";
+  operation: string;
+  handle?: string;
+  outcome: "pending" | "ok" | "failed";
+};
+
+/** Production callers persist this redacted record after every state/event. */
+export type LeaseJournalStore = { save(lease: RuntimeLease): Promise<void> };
+const unitNoopJournalStore: LeaseJournalStore = { async save() {} };
+
+/** Durable, safe-to-log record. Secret values must never be added here. */
+export type RuntimeLease = {
+  id: string;
+  createdAt: string;
+  expiresAt: string;
+  state: "acquiring" | "active" | "revoking" | "revoked" | "failed";
+  members: Array<{
+    memberId: string;
+    neonBranchId?: string;
+    netlifySiteId: string;
+    runtimeOwned?: boolean;
+    inferenceKeyHash?: string;
+    tombstoneDeployId?: string;
+  }>;
+  journal: LeaseJournal[];
+  verification: {
+    inferenceDisabled: boolean;
+    runtimeVariablesAbsent: boolean;
+    tombstoneActive: boolean;
+    branchesDeleted: boolean;
+  };
+};
+
+/** Returned only to the trusted invoker; never persist or JSON serialize it. */
+export type TransientLeaseSecrets = {
+  memberSecrets: Record<
+    string,
+    {
+      databaseUrl: string;
+      betterAuthSecret: string;
+      a2aSecret: string;
+      inferenceKey?: string;
+    }
+  >;
+};
+
+export type AcquireResult = {
+  lease: RuntimeLease;
+  secrets: TransientLeaseSecrets;
+};
+
+const NEON_API = "https://console.neon.tech/api/v2";
+const NETLIFY_API = "https://api.netlify.com/api/v1";
+const OPENROUTER_API = "https://openrouter.ai/api/v1";
+
+function isExactHttpsOrigin(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" && url.origin === value;
+  } catch {
+    return false;
+  }
+}
+
+function checkedConfig(config: TrustedRuntimeConfig): void {
+  if (
+    !Number.isFinite(config.maxInferenceUsd) ||
+    config.maxInferenceUsd <= 0 ||
+    config.maxInferenceUsd > 1
+  ) {
+    throw new Error(
+      "maxInferenceUsd must be a positive tiny USD cap (at most 1)",
+    );
+  }
+  if (
+    !config.tombstone.zip.byteLength ||
+    !/^[a-f0-9]{64}$/i.test(config.tombstone.sha256)
+  ) {
+    throw new Error(
+      "trusted tombstone must have a prebuilt ZIP and sha256 digest",
+    );
+  }
+  const members = new Set<string>();
+  const neonProjects = new Set<string>();
+  const netlifySites = new Set<string>();
+  for (const member of config.members) {
+    if (
+      !/^[a-z0-9][a-z0-9-]*$/.test(member.id) ||
+      !member.neonProjectId ||
+      !member.neonDatabaseName ||
+      !member.neonRoleName ||
+      !member.netlifyAccountId ||
+      !member.netlifySiteId ||
+      !isExactHttpsOrigin(member.origin) ||
+      members.has(member.id) ||
+      neonProjects.has(member.neonProjectId) ||
+      netlifySites.has(member.netlifySiteId)
+    ) {
+      throw new Error(
+        "trusted runtime config contains an invalid or duplicate declared member",
+      );
+    }
+    members.add(member.id);
+    neonProjects.add(member.neonProjectId);
+    netlifySites.add(member.netlifySiteId);
+  }
+}
+
+async function json(response: Response): Promise<Record<string, unknown>> {
+  if (!response.ok)
+    throw new Error(`provider request failed: ${response.status}`);
+  return (await response.json()) as Record<string, unknown>;
+}
+
+export class NeonBranches {
+  constructor(
+    private readonly fetch: FetchLike,
+    private readonly token: string,
+  ) {}
+
+  async createBranch(
+    projectId: string,
+    leaseId: string,
+    expiresAt: string,
+  ): Promise<string> {
+    const body = await json(
+      await this.fetch(
+        `${NEON_API}/projects/${encodeURIComponent(projectId)}/branches`,
+        {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${this.token}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            branch: {
+              name: `trusted-acceptance-${leaseId}`,
+              expires_at: expiresAt,
+            },
+          }),
+        },
+      ),
+    );
+    const branch = body.branch as Record<string, unknown> | undefined;
+    if (typeof branch?.id !== "string")
+      throw new Error("Neon did not return a disposable branch handle");
+    return branch.id;
+  }
+
+  async getConnectionUri(
+    projectId: string,
+    databaseName: string,
+    roleName: string,
+    branchId: string,
+  ): Promise<string> {
+    const query = new URLSearchParams({
+      branch_id: branchId,
+      database_name: databaseName,
+      role_name: roleName,
+      pooled: "true",
+    });
+    const connection = await json(
+      await this.fetch(
+        `${NEON_API}/projects/${encodeURIComponent(projectId)}/connection_uri?${query}`,
+        { headers: { authorization: `Bearer ${this.token}` } },
+      ),
+    );
+    if (typeof connection.uri !== "string")
+      throw new Error("Neon did not return a disposable branch connection URI");
+    return connection.uri;
+  }
+
+  async deleteAndVerify(projectId: string, branchId: string): Promise<boolean> {
+    const deleted = await this.fetch(
+      `${NEON_API}/projects/${encodeURIComponent(projectId)}/branches/${encodeURIComponent(branchId)}`,
+      { method: "DELETE", headers: { authorization: `Bearer ${this.token}` } },
+    );
+    if (!deleted.ok && deleted.status !== 404)
+      throw new Error(`Neon branch delete failed: ${deleted.status}`);
+    const verification = await this.fetch(
+      `${NEON_API}/projects/${encodeURIComponent(projectId)}/branches/${encodeURIComponent(branchId)}`,
+      { headers: { authorization: `Bearer ${this.token}` } },
+    );
+    return verification.status === 404;
+  }
+
+  async listByPrefixAndExpiry(
+    projectId: string,
+  ): Promise<Array<{ leaseId: string; branchId: string; expiresAt: string }>> {
+    const body = await json(
+      await this.fetch(
+        `${NEON_API}/projects/${encodeURIComponent(projectId)}/branches`,
+        { headers: { authorization: `Bearer ${this.token}` } },
+      ),
+    );
+    return ((body.branches ?? []) as Array<Record<string, unknown>>).flatMap(
+      (branch) => {
+        if (typeof branch.name !== "string") return [];
+        if (!branch.name.startsWith("trusted-acceptance-")) return [];
+        const match = /^trusted-acceptance-([a-f0-9]{24})$/.exec(branch.name);
+        if (
+          !match ||
+          typeof branch.id !== "string" ||
+          typeof branch.expires_at !== "string"
+        ) {
+          throw new Error(
+            "Neon returned a malformed trusted acceptance branch",
+          );
+        }
+        return [
+          {
+            leaseId: match[1]!,
+            branchId: branch.id,
+            expiresAt: branch.expires_at,
+          },
+        ];
+      },
+    );
+  }
+}
+
+export class OpenRouterKeys {
+  constructor(
+    private readonly fetch: FetchLike,
+    private readonly token: string,
+  ) {}
+
+  async create(
+    leaseId: string,
+    expiresAt: string,
+    maxUsd: number,
+  ): Promise<{ plaintext: string; hash: string }> {
+    if (!expiresAt || !Number.isFinite(maxUsd) || maxUsd <= 0 || maxUsd > 1)
+      throw new Error(
+        "OpenRouter keys require expiry and a positive tiny USD cap",
+      );
+    const body = await json(
+      await this.fetch(`${OPENROUTER_API}/keys`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${this.token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          name: `trusted-acceptance-${leaseId}`,
+          limit: maxUsd,
+          limit_reset: null,
+          expires_at: expiresAt,
+        }),
+      }),
+    );
+    const data = body.data as Record<string, unknown> | undefined;
+    if (typeof body.key !== "string" || typeof data?.hash !== "string")
+      throw new Error(
+        "OpenRouter did not return transient key material and an opaque hash",
+      );
+    return { plaintext: body.key, hash: data.hash };
+  }
+
+  async disableByHash(hash: string): Promise<boolean> {
+    const disabled = await this.fetch(
+      `${OPENROUTER_API}/keys/${encodeURIComponent(hash)}`,
+      {
+        method: "PATCH",
+        headers: {
+          authorization: `Bearer ${this.token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ disabled: true }),
+      },
+    );
+    if (!disabled.ok && disabled.status !== 404) return false;
+    const verification = await this.fetch(
+      `${OPENROUTER_API}/keys/${encodeURIComponent(hash)}`,
+      { headers: { authorization: `Bearer ${this.token}` } },
+    );
+    if (verification.status === 404) return true;
+    const body = await json(verification);
+    const data = body.data as Record<string, unknown> | undefined;
+    return data?.hash === hash && data.disabled === true;
+  }
+
+  async listByPrefixAndExpiry(): Promise<
+    Array<{ leaseId: string; hash: string; expiresAt: string }>
+  > {
+    const body = await json(
+      await this.fetch(`${OPENROUTER_API}/keys`, {
+        headers: { authorization: `Bearer ${this.token}` },
+      }),
+    );
+    return ((body.data ?? []) as Array<Record<string, unknown>>).flatMap(
+      (item) => {
+        if (typeof item.name !== "string") return [];
+        if (!item.name.startsWith("trusted-acceptance-")) return [];
+        const match = /^trusted-acceptance-([a-f0-9]{24})$/.exec(item.name);
+        if (
+          !match ||
+          typeof item.hash !== "string" ||
+          typeof item.expires_at !== "string"
+        ) {
+          throw new Error(
+            "OpenRouter returned a malformed trusted acceptance key",
+          );
+        }
+        return [
+          {
+            leaseId: match[1]!,
+            hash: item.hash,
+            expiresAt: item.expires_at,
+          },
+        ];
+      },
+    );
+  }
+}
+
+export class NetlifyRuntime {
+  constructor(
+    private readonly fetch: FetchLike,
+    private readonly token: string,
+  ) {}
+
+  async assertSiteReady(
+    accountId: string,
+    siteId: string,
+    origin: string,
+    keys: readonly string[],
+  ): Promise<void> {
+    const site = await json(
+      await this.fetch(`${NETLIFY_API}/sites/${encodeURIComponent(siteId)}`, {
+        headers: { authorization: `Bearer ${this.token}` },
+      }),
+    );
+    const origins = new Set(
+      [site.ssl_url, site.url, site.custom_domain]
+        .concat(Array.isArray(site.domain_aliases) ? site.domain_aliases : [])
+        .filter((value): value is string => typeof value === "string")
+        .map((value) => {
+          try {
+            return new URL(value.includes("://") ? value : `https://${value}`)
+              .origin;
+          } catch {
+            return "";
+          }
+        }),
+    );
+    if (site.id !== siteId || !origins.has(origin))
+      throw new Error(
+        "Netlify site identity does not match the declared acceptance origin",
+      );
+    for (const key of keys) {
+      const response = await this.fetch(this.envUrl(accountId, siteId, key), {
+        headers: { authorization: `Bearer ${this.token}` },
+      });
+      if (response.ok)
+        throw new Error(
+          `Netlify runtime variable ${key} already exists; refusing to overwrite acceptance-site state`,
+        );
+      if (response.status !== 404)
+        throw new Error(
+          `Netlify runtime variable lookup failed: ${response.status}`,
+        );
+    }
+  }
+
+  async setRuntime(
+    accountId: string,
+    siteId: string,
+    values: Record<string, string>,
+  ): Promise<void> {
+    const entries = Object.entries(values);
+    for (const [key] of entries) {
+      const itemUrl = this.envUrl(accountId, siteId, key);
+      const existing = await this.fetch(itemUrl, {
+        headers: { authorization: `Bearer ${this.token}` },
+      });
+      if (!existing.ok && existing.status !== 404)
+        throw new Error(
+          `Netlify runtime variable lookup failed: ${existing.status}`,
+        );
+      if (existing.ok)
+        throw new Error(
+          `Netlify runtime variable ${key} already exists; refusing to overwrite acceptance-site state`,
+        );
+    }
+    const response = await this.fetch(this.envUrl(accountId, siteId), {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${this.token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(
+        entries.map(([key, value]) => ({
+          key,
+          scopes: ["functions", "runtime"],
+          values: [{ value, context: "all" }],
+          is_secret: key !== "AGENT_NATIVE_ACCEPTANCE_LEASE_MARKER",
+        })),
+      ),
+    });
+    if (!response.ok)
+      throw new Error(
+        `Netlify runtime variable update failed: ${response.status}`,
+      );
+  }
+
+  async removeRuntime(
+    accountId: string,
+    siteId: string,
+    keys: readonly string[],
+  ): Promise<boolean> {
+    for (const key of keys) {
+      const response = await this.fetch(this.envUrl(accountId, siteId, key), {
+        method: "DELETE",
+        headers: { authorization: `Bearer ${this.token}` },
+      });
+      if (!response.ok && response.status !== 404)
+        throw new Error(
+          `Netlify runtime variable removal failed: ${response.status}`,
+        );
+    }
+    for (const key of keys) {
+      const verification = await this.fetch(
+        this.envUrl(accountId, siteId, key),
+        { headers: { authorization: `Bearer ${this.token}` } },
+      );
+      if (verification.status !== 404) return false;
+    }
+    return true;
+  }
+
+  async readLeaseMarker(
+    accountId: string,
+    siteId: string,
+  ): Promise<{ leaseId: string; expiresAt: string } | undefined> {
+    const read = async (key: string): Promise<string | undefined> => {
+      const response = await this.fetch(this.envUrl(accountId, siteId, key), {
+        headers: { authorization: `Bearer ${this.token}` },
+      });
+      if (response.status === 404) return undefined;
+      const body = await json(response);
+      const values = body.values as Array<Record<string, unknown>> | undefined;
+      const value = values?.find((entry) => entry.context === "all")?.value;
+      if (typeof value !== "string")
+        throw new Error("Netlify returned a malformed acceptance lease marker");
+      return value;
+    };
+    const serialized = await read("AGENT_NATIVE_ACCEPTANCE_LEASE_MARKER");
+    if (!serialized) return undefined;
+    let marker: unknown;
+    try {
+      marker = JSON.parse(serialized);
+    } catch {
+      throw new Error("Netlify returned a malformed acceptance lease marker");
+    }
+    if (
+      !marker ||
+      typeof marker !== "object" ||
+      typeof (marker as Record<string, unknown>).leaseId !== "string" ||
+      typeof (marker as Record<string, unknown>).expiresAt !== "string"
+    )
+      throw new Error("Netlify returned a malformed acceptance lease marker");
+    return marker as { leaseId: string; expiresAt: string };
+  }
+
+  async ownsLease(
+    accountId: string,
+    siteId: string,
+    leaseId: string,
+    expiresAt: string,
+  ): Promise<boolean> {
+    const marker = await this.readLeaseMarker(accountId, siteId);
+    return marker?.leaseId === leaseId && marker.expiresAt === expiresAt;
+  }
+
+  private envUrl(accountId: string, siteId: string, key?: string): string {
+    const suffix = key ? `/${encodeURIComponent(key)}` : "";
+    return `${NETLIFY_API}/accounts/${encodeURIComponent(accountId)}/env${suffix}?site_id=${encodeURIComponent(siteId)}`;
+  }
+
+  async deployTombstoneAndVerify(
+    siteId: string,
+    artifact: TombstoneArtifact,
+  ): Promise<{ deployId: string } | undefined> {
+    const deploy = await json(
+      await this.fetch(
+        `${NETLIFY_API}/sites/${encodeURIComponent(siteId)}/deploys`,
+        {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${this.token}`,
+            "content-type": "application/zip",
+          },
+          body: artifact.zip,
+        },
+      ),
+    );
+    const deployId = deploy.id;
+    if (typeof deployId !== "string")
+      throw new Error("Netlify did not return a tombstone deploy handle");
+    const deployed = await json(
+      await this.fetch(
+        `${NETLIFY_API}/deploys/${encodeURIComponent(deployId)}`,
+        { headers: { authorization: `Bearer ${this.token}` } },
+      ),
+    );
+    if (deployed.state !== "ready") return undefined;
+    const active = await json(
+      await this.fetch(`${NETLIFY_API}/sites/${encodeURIComponent(siteId)}`, {
+        headers: { authorization: `Bearer ${this.token}` },
+      }),
+    );
+    const published = active.published_deploy as
+      | Record<string, unknown>
+      | undefined;
+    return published?.id === deployId ? { deployId } : undefined;
+  }
+}
+
+export type RuntimeProviders = {
+  neon: Pick<
+    NeonBranches,
+    | "createBranch"
+    | "getConnectionUri"
+    | "deleteAndVerify"
+    | "listByPrefixAndExpiry"
+  >;
+  netlify: Pick<
+    NetlifyRuntime,
+    | "setRuntime"
+    | "assertSiteReady"
+    | "removeRuntime"
+    | "readLeaseMarker"
+    | "ownsLease"
+    | "deployTombstoneAndVerify"
+  >;
+  openrouter: Pick<
+    OpenRouterKeys,
+    "create" | "disableByHash" | "listByPrefixAndExpiry"
+  >;
+};
+type Clock = () => Date;
+const leaseIdPattern = /^[a-f0-9]{24}$/;
+const expiryToleranceMs = 60_000;
+
+type DiscoveredBranch = {
+  memberId: string;
+  branchId: string;
+  expiresAt: string;
+};
+type DiscoveredKey = { hash: string; expiresAt: string };
+type DiscoveredMarker = { memberId: string; expiresAt: string };
+
+function parsedExpiry(expiresAt: string, source: string): number {
+  const timestamp = new Date(expiresAt).getTime();
+  if (!Number.isFinite(timestamp))
+    throw new Error(`${source} returned an invalid trusted acceptance expiry`);
+  return timestamp;
+}
+
+/**
+ * Reconstruct only expired leases from provider inventories. The config, not
+ * Netlify variables or provider metadata, defines the allowed runtime members.
+ */
+export async function discoverExpiredLeases(
+  config: TrustedRuntimeConfig,
+  providers: Pick<RuntimeProviders, "neon" | "netlify" | "openrouter">,
+  now: Date,
+): Promise<RuntimeLease[]> {
+  checkedConfig(config);
+  const nowMs = now.getTime();
+  if (!Number.isFinite(nowMs))
+    throw new Error("discovery requires a valid clock");
+
+  const branchesByLease = new Map<string, DiscoveredBranch[]>();
+  const markersByLease = new Map<string, DiscoveredMarker[]>();
+  for (const member of config.members) {
+    const branches = await providers.neon.listByPrefixAndExpiry(
+      member.neonProjectId,
+    );
+    for (const branch of branches) {
+      if (!leaseIdPattern.test(branch.leaseId) || !branch.branchId)
+        throw new Error("Neon returned an invalid trusted acceptance lease id");
+      const leaseBranches = branchesByLease.get(branch.leaseId) ?? [];
+      if (
+        leaseBranches.some(
+          (entry) =>
+            entry.memberId === member.id || entry.branchId === branch.branchId,
+        )
+      )
+        throw new Error(
+          "Neon returned duplicate branches for one lease member",
+        );
+      leaseBranches.push({ memberId: member.id, ...branch });
+      branchesByLease.set(branch.leaseId, leaseBranches);
+    }
+    const marker = await providers.netlify.readLeaseMarker(
+      member.netlifyAccountId,
+      member.netlifySiteId,
+    );
+    if (marker) {
+      if (!leaseIdPattern.test(marker.leaseId))
+        throw new Error(
+          "Netlify returned an invalid trusted acceptance lease id",
+        );
+      const leaseMarkers = markersByLease.get(marker.leaseId) ?? [];
+      leaseMarkers.push({ memberId: member.id, expiresAt: marker.expiresAt });
+      markersByLease.set(marker.leaseId, leaseMarkers);
+    }
+  }
+
+  const keysByLease = new Map<string, DiscoveredKey[]>();
+  for (const key of await providers.openrouter.listByPrefixAndExpiry()) {
+    if (!leaseIdPattern.test(key.leaseId) || !key.hash)
+      throw new Error(
+        "OpenRouter returned an invalid trusted acceptance lease id",
+      );
+    const keys = keysByLease.get(key.leaseId) ?? [];
+    if (keys.some((entry) => entry.hash === key.hash))
+      throw new Error("OpenRouter returned a duplicate trusted acceptance key");
+    keys.push({ hash: key.hash, expiresAt: key.expiresAt });
+    keysByLease.set(key.leaseId, keys);
+  }
+
+  const inferenceMembers = config.members.filter(
+    (member) => member.needsInference,
+  );
+  const leaseIds = new Set([
+    ...branchesByLease.keys(),
+    ...markersByLease.keys(),
+    ...keysByLease.keys(),
+  ]);
+  const activeMarkerLeases = new Set(
+    [...markersByLease.entries()]
+      .filter(([, markers]) =>
+        markers.some(
+          (marker) => parsedExpiry(marker.expiresAt, "Netlify") > nowMs,
+        ),
+      )
+      .map(([leaseId]) => leaseId),
+  );
+
+  return [...leaseIds].flatMap((id) => {
+    const branches = branchesByLease.get(id) ?? [];
+    const markers = markersByLease.get(id) ?? [];
+    const keys = (keysByLease.get(id) ?? []).toSorted((left, right) =>
+      left.hash.localeCompare(right.hash),
+    );
+    const expiries = [
+      ...branches.map((branch) => parsedExpiry(branch.expiresAt, "Neon")),
+      ...markers.map((marker) => parsedExpiry(marker.expiresAt, "Netlify")),
+      ...keys.map((key) => parsedExpiry(key.expiresAt, "OpenRouter")),
+    ];
+    if (!expiries.length || expiries.every((expiry) => expiry > nowMs))
+      return [];
+    if (expiries.some((expiry) => expiry > nowMs))
+      throw new Error(
+        "trusted acceptance lease has inconsistent provider expiries",
+      );
+    if (activeMarkerLeases.size && !activeMarkerLeases.has(id))
+      throw new Error(
+        "an active lease owns the workspace while expired resources remain",
+      );
+    const branchesByMember = new Map(
+      branches.map((branch) => [branch.memberId, branch]),
+    );
+    const markerMembers = new Set(markers.map(({ memberId }) => memberId));
+    const canonicalExpiry = expiries[0]!;
+    if (
+      expiries.some(
+        (expiry) => Math.abs(expiry - canonicalExpiry) > expiryToleranceMs,
+      )
+    )
+      throw new Error(
+        "trusted acceptance lease has inconsistent provider expiries",
+      );
+    if (keys.length > inferenceMembers.length) {
+      throw new Error(
+        "trusted acceptance lease has undeclared inference handles",
+      );
+    }
+    return [
+      {
+        id,
+        createdAt: new Date(canonicalExpiry).toISOString(),
+        expiresAt: new Date(canonicalExpiry).toISOString(),
+        state: "active" as const,
+        members: config.members.map((member) => {
+          const branch = branchesByMember.get(member.id);
+          const inferenceIndex = inferenceMembers.findIndex(
+            (candidate) => candidate.id === member.id,
+          );
+          return {
+            memberId: member.id,
+            netlifySiteId: member.netlifySiteId,
+            runtimeOwned: markerMembers.has(member.id),
+            ...(branch ? { neonBranchId: branch.branchId } : {}),
+            ...(inferenceIndex >= 0 && keys[inferenceIndex]
+              ? { inferenceKeyHash: keys[inferenceIndex].hash }
+              : {}),
+          };
+        }),
+        journal: [],
+        verification: {
+          inferenceDisabled: false,
+          runtimeVariablesAbsent: false,
+          tombstoneActive: false,
+          branchesDeleted: false,
+        },
+      },
+    ];
+  });
+}
+
+const runtimeKeys = [
+  "DATABASE_URL",
+  "BETTER_AUTH_SECRET",
+  "A2A_SECRET",
+  "OPENROUTER_API_KEY",
+  "AGENT_ENGINE",
+  "AGENT_NATIVE_ACCEPTANCE_LEASE_MARKER",
+] as const;
+export class DisposableRuntimeAuthority {
+  constructor(
+    private readonly config: TrustedRuntimeConfig,
+    private readonly providers: RuntimeProviders,
+    private readonly now: Clock = () => new Date(),
+    private readonly journalStore: LeaseJournalStore = unitNoopJournalStore,
+  ) {
+    checkedConfig(config);
+  }
+
+  async acquire(ttlMs: number): Promise<AcquireResult> {
+    if (!Number.isFinite(ttlMs) || ttlMs <= 0)
+      throw new Error("lease ttl must be positive");
+    const createdAt = this.now();
+    const lease: RuntimeLease = {
+      id: randomBytes(12).toString("hex"),
+      createdAt: createdAt.toISOString(),
+      expiresAt: new Date(createdAt.getTime() + ttlMs).toISOString(),
+      state: "acquiring",
+      members: this.config.members.map((member) => ({
+        memberId: member.id,
+        netlifySiteId: member.netlifySiteId,
+        runtimeOwned: false,
+      })),
+      journal: [],
+      verification: {
+        inferenceDisabled: false,
+        runtimeVariablesAbsent: false,
+        tombstoneActive: false,
+        branchesDeleted: false,
+      },
+    };
+    const secrets: TransientLeaseSecrets = { memberSecrets: {} };
+    await this.journalStore.save(lease);
+    try {
+      for (const member of this.config.members)
+        await this.providers.netlify.assertSiteReady(
+          member.netlifyAccountId,
+          member.netlifySiteId,
+          member.origin,
+          runtimeKeys,
+        );
+      const a2aSecret = randomBytes(32).toString("base64url");
+      for (const [index, member] of this.config.members.entries()) {
+        const durableMember = lease.members[index]!;
+        await this.record(lease, "before", "create-neon-branch", "pending");
+        let branchId: string;
+        try {
+          branchId = await this.providers.neon.createBranch(
+            member.neonProjectId,
+            lease.id,
+            lease.expiresAt,
+          );
+        } catch (error) {
+          await this.record(lease, "after", "create-neon-branch", "failed");
+          throw error;
+        }
+        durableMember.neonBranchId = branchId;
+        await this.record(lease, "after", "create-neon-branch", "ok", branchId);
+        let databaseUrl: string;
+        try {
+          databaseUrl = await this.providers.neon.getConnectionUri(
+            member.neonProjectId,
+            member.neonDatabaseName,
+            member.neonRoleName,
+            branchId,
+          );
+        } catch (error) {
+          await this.record(
+            lease,
+            "after",
+            "get-neon-connection-uri",
+            "failed",
+            branchId,
+          );
+          throw error;
+        }
+        const memberSecrets = {
+          databaseUrl,
+          betterAuthSecret: randomBytes(32).toString("base64url"),
+          a2aSecret,
+        } as TransientLeaseSecrets["memberSecrets"][string];
+        if (member.needsInference) {
+          await this.record(
+            lease,
+            "before",
+            "create-openrouter-key",
+            "pending",
+          );
+          let key: { plaintext: string; hash: string };
+          try {
+            key = await this.providers.openrouter.create(
+              lease.id,
+              lease.expiresAt,
+              this.config.maxInferenceUsd,
+            );
+          } catch (error) {
+            await this.record(
+              lease,
+              "after",
+              "create-openrouter-key",
+              "failed",
+            );
+            throw error;
+          }
+          durableMember.inferenceKeyHash = key.hash;
+          memberSecrets.inferenceKey = key.plaintext;
+          await this.record(
+            lease,
+            "after",
+            "create-openrouter-key",
+            "ok",
+            key.hash,
+          );
+        }
+        await this.record(lease, "before", "set-netlify-runtime", "pending");
+        try {
+          await this.providers.netlify.setRuntime(
+            member.netlifyAccountId,
+            member.netlifySiteId,
+            {
+              AGENT_NATIVE_ACCEPTANCE_LEASE_MARKER: JSON.stringify({
+                leaseId: lease.id,
+                expiresAt: lease.expiresAt,
+              }),
+              DATABASE_URL: memberSecrets.databaseUrl,
+              BETTER_AUTH_SECRET: memberSecrets.betterAuthSecret,
+              A2A_SECRET: a2aSecret,
+              ...(memberSecrets.inferenceKey
+                ? {
+                    OPENROUTER_API_KEY: memberSecrets.inferenceKey,
+                    AGENT_ENGINE: "ai-sdk:openrouter",
+                  }
+                : {}),
+            },
+          );
+          if (
+            !(await this.providers.netlify.ownsLease(
+              member.netlifyAccountId,
+              member.netlifySiteId,
+              lease.id,
+              lease.expiresAt,
+            ))
+          )
+            throw new Error(
+              "Netlify did not retain the exact acceptance lease marker",
+            );
+          durableMember.runtimeOwned = true;
+          await this.journalStore.save(lease);
+        } catch (error) {
+          await this.record(
+            lease,
+            "after",
+            "set-netlify-runtime",
+            "failed",
+            member.netlifySiteId,
+          );
+          throw error;
+        }
+        await this.record(
+          lease,
+          "after",
+          "set-netlify-runtime",
+          "ok",
+          member.netlifySiteId,
+        );
+        secrets.memberSecrets[member.id] = memberSecrets;
+      }
+      await this.setState(lease, "active");
+      return { lease, secrets };
+    } catch (error) {
+      await this.setState(lease, "failed");
+      await this.revoke(lease);
+      throw error;
+    }
+  }
+
+  async revoke(lease: RuntimeLease): Promise<RuntimeLease> {
+    if (lease.state === "revoked") return lease;
+    await this.setState(lease, "revoking");
+    let inferenceDisabled = true,
+      runtimeVariablesAbsent = true,
+      tombstoneActive = true,
+      branchesDeleted = true;
+    for (const [index, member] of this.config.members.entries()) {
+      const durableMember = lease.members[index]!;
+      if (durableMember.inferenceKeyHash) {
+        const disabled = await this.cleanup(
+          lease,
+          "disable-openrouter-key",
+          durableMember.inferenceKeyHash,
+          () =>
+            this.providers.openrouter.disableByHash(
+              durableMember.inferenceKeyHash!,
+            ),
+        );
+        inferenceDisabled &&= disabled;
+      }
+      if (durableMember.runtimeOwned) {
+        const stillOwned = await this.providers.netlify.ownsLease(
+          member.netlifyAccountId,
+          member.netlifySiteId,
+          lease.id,
+          lease.expiresAt,
+        );
+        if (!stillOwned) {
+          runtimeVariablesAbsent = false;
+          tombstoneActive = false;
+          await this.record(
+            lease,
+            "verification",
+            "verify-netlify-lease-owner",
+            "failed",
+            member.netlifySiteId,
+          );
+        } else {
+          const absent = await this.cleanup(
+            lease,
+            "remove-netlify-runtime",
+            member.netlifySiteId,
+            () =>
+              this.providers.netlify.removeRuntime(
+                member.netlifyAccountId,
+                member.netlifySiteId,
+                runtimeKeys,
+              ),
+          );
+          runtimeVariablesAbsent &&= absent;
+          const tombstoned = await this.cleanup(
+            lease,
+            "deploy-netlify-tombstone",
+            member.netlifySiteId,
+            async () => {
+              const receipt =
+                await this.providers.netlify.deployTombstoneAndVerify(
+                  member.netlifySiteId,
+                  this.config.tombstone,
+                );
+              if (receipt) durableMember.tombstoneDeployId = receipt.deployId;
+              return Boolean(receipt);
+            },
+          );
+          tombstoneActive &&= tombstoned;
+        }
+      }
+      if (durableMember.neonBranchId) {
+        const deleted = await this.cleanup(
+          lease,
+          "delete-neon-branch",
+          durableMember.neonBranchId,
+          () =>
+            this.providers.neon.deleteAndVerify(
+              member.neonProjectId,
+              durableMember.neonBranchId!,
+            ),
+        );
+        branchesDeleted &&= deleted;
+      }
+    }
+    lease.verification = {
+      inferenceDisabled,
+      runtimeVariablesAbsent,
+      tombstoneActive,
+      branchesDeleted,
+    };
+    await this.record(
+      lease,
+      "verification",
+      "revoke-cleanup",
+      inferenceDisabled &&
+        runtimeVariablesAbsent &&
+        tombstoneActive &&
+        branchesDeleted
+        ? "ok"
+        : "failed",
+    );
+    if (
+      inferenceDisabled &&
+      runtimeVariablesAbsent &&
+      tombstoneActive &&
+      branchesDeleted
+    )
+      await this.setState(lease, "revoked");
+    return lease;
+  }
+
+  private async cleanup(
+    lease: RuntimeLease,
+    operation: string,
+    handle: string,
+    action: () => Promise<boolean>,
+  ): Promise<boolean> {
+    await this.record(lease, "before", operation, "pending", handle);
+    try {
+      const verified = await action();
+      await this.record(
+        lease,
+        "after",
+        operation,
+        verified ? "ok" : "failed",
+        handle,
+      );
+      return verified;
+    } catch {
+      await this.record(lease, "after", operation, "failed", handle);
+      return false;
+    }
+  }
+
+  private async record(
+    lease: RuntimeLease,
+    phase: LeaseJournal["phase"],
+    operation: string,
+    outcome: LeaseJournal["outcome"],
+    handle?: string,
+  ): Promise<void> {
+    lease.journal.push({
+      at: this.now().toISOString(),
+      phase,
+      operation,
+      outcome,
+      handle,
+    });
+    await this.journalStore.save(lease);
+  }
+
+  private async setState(
+    lease: RuntimeLease,
+    state: RuntimeLease["state"],
+  ): Promise<void> {
+    lease.state = state;
+    await this.journalStore.save(lease);
+  }
+
+  async reapExpired(leases: readonly RuntimeLease[]): Promise<RuntimeLease[]> {
+    const now = this.now().getTime();
+    const reaped: RuntimeLease[] = [];
+    for (const lease of leases) {
+      reaped.push(
+        lease.state === "revoked" || new Date(lease.expiresAt).getTime() > now
+          ? lease
+          : await this.revoke(lease),
+      );
+    }
+    return reaped;
+  }
+}

--- a/scripts/trusted-acceptance/runtime-authority.ts
+++ b/scripts/trusted-acceptance/runtime-authority.ts
@@ -52,6 +52,7 @@ export type RuntimeLease = {
     memberId: string;
     neonBranchId?: string;
     netlifySiteId: string;
+    runtimeWriteAttempted?: boolean;
     runtimeOwned?: boolean;
     inferenceKeyHash?: string;
     tombstoneDeployId?: string;
@@ -221,35 +222,55 @@ export class NeonBranches {
   async listByPrefixAndExpiry(
     projectId: string,
   ): Promise<Array<{ leaseId: string; branchId: string; expiresAt: string }>> {
-    const body = await json(
-      await this.fetch(
-        `${NEON_API}/projects/${encodeURIComponent(projectId)}/branches`,
-        { headers: { authorization: `Bearer ${this.token}` } },
-      ),
-    );
-    return ((body.branches ?? []) as Array<Record<string, unknown>>).flatMap(
-      (branch) => {
-        if (typeof branch.name !== "string") return [];
-        if (!branch.name.startsWith("trusted-acceptance-")) return [];
-        const match = /^trusted-acceptance-([a-f0-9]{24})$/.exec(branch.name);
-        if (
-          !match ||
-          typeof branch.id !== "string" ||
-          typeof branch.expires_at !== "string"
-        ) {
-          throw new Error(
-            "Neon returned a malformed trusted acceptance branch",
-          );
-        }
-        return [
-          {
-            leaseId: match[1]!,
-            branchId: branch.id,
-            expiresAt: branch.expires_at,
-          },
-        ];
-      },
-    );
+    const branches: Array<Record<string, unknown>> = [];
+    const seenCursors = new Set<string>();
+    let cursor: string | undefined;
+    let pageCount = 0;
+    do {
+      pageCount += 1;
+      if (pageCount > 100)
+        throw new Error(
+          "Neon branch inventory exceeded the bounded page limit",
+        );
+      const query = new URLSearchParams({ limit: "100" });
+      if (cursor) query.set("cursor", cursor);
+      const body = await json(
+        await this.fetch(
+          `${NEON_API}/projects/${encodeURIComponent(projectId)}/branches?${query}`,
+          { headers: { authorization: `Bearer ${this.token}` } },
+        ),
+      );
+      if (!Array.isArray(body.branches))
+        throw new Error("Neon returned a malformed branch inventory");
+      branches.push(...(body.branches as Array<Record<string, unknown>>));
+      const pagination = body.pagination as Record<string, unknown> | undefined;
+      const next = pagination?.next;
+      if (next !== undefined && typeof next !== "string")
+        throw new Error("Neon returned a malformed pagination cursor");
+      if (next && seenCursors.has(next))
+        throw new Error("Neon returned a repeated pagination cursor");
+      if (next) seenCursors.add(next);
+      cursor = next || undefined;
+    } while (cursor);
+    return branches.flatMap((branch) => {
+      if (typeof branch.name !== "string") return [];
+      if (!branch.name.startsWith("trusted-acceptance-")) return [];
+      const match = /^trusted-acceptance-([a-f0-9]{24})$/.exec(branch.name);
+      if (
+        !match ||
+        typeof branch.id !== "string" ||
+        typeof branch.expires_at !== "string"
+      ) {
+        throw new Error("Neon returned a malformed trusted acceptance branch");
+      }
+      return [
+        {
+          leaseId: match[1]!,
+          branchId: branch.id,
+          expiresAt: branch.expires_at,
+        },
+      ];
+    });
   }
 }
 
@@ -261,6 +282,7 @@ export class OpenRouterKeys {
 
   async create(
     leaseId: string,
+    memberId: string,
     expiresAt: string,
     maxUsd: number,
   ): Promise<{ plaintext: string; hash: string }> {
@@ -276,7 +298,7 @@ export class OpenRouterKeys {
           "content-type": "application/json",
         },
         body: JSON.stringify({
-          name: `trusted-acceptance-${leaseId}`,
+          name: `trusted-acceptance-${leaseId}-${memberId}`,
           limit: maxUsd,
           limit_reset: null,
           expires_at: expiresAt,
@@ -315,7 +337,12 @@ export class OpenRouterKeys {
   }
 
   async listByPrefixAndExpiry(): Promise<
-    Array<{ leaseId: string; hash: string; expiresAt: string }>
+    Array<{
+      leaseId: string;
+      memberId: string;
+      hash: string;
+      expiresAt: string;
+    }>
   > {
     const body = await json(
       await this.fetch(`${OPENROUTER_API}/keys`, {
@@ -326,7 +353,10 @@ export class OpenRouterKeys {
       (item) => {
         if (typeof item.name !== "string") return [];
         if (!item.name.startsWith("trusted-acceptance-")) return [];
-        const match = /^trusted-acceptance-([a-f0-9]{24})$/.exec(item.name);
+        const match =
+          /^trusted-acceptance-([a-f0-9]{24})-([a-z0-9][a-z0-9-]*)$/.exec(
+            item.name,
+          );
         if (
           !match ||
           typeof item.hash !== "string" ||
@@ -339,6 +369,7 @@ export class OpenRouterKeys {
         return [
           {
             leaseId: match[1]!,
+            memberId: match[2]!,
             hash: item.hash,
             expiresAt: item.expires_at,
           },
@@ -582,7 +613,11 @@ type DiscoveredBranch = {
   branchId: string;
   expiresAt: string;
 };
-type DiscoveredKey = { hash: string; expiresAt: string };
+type DiscoveredKey = {
+  memberId: string;
+  hash: string;
+  expiresAt: string;
+};
 type DiscoveredMarker = { memberId: string; expiresAt: string };
 
 function parsedExpiry(expiresAt: string, source: string): number {
@@ -645,20 +680,27 @@ export async function discoverExpiredLeases(
 
   const keysByLease = new Map<string, DiscoveredKey[]>();
   for (const key of await providers.openrouter.listByPrefixAndExpiry()) {
-    if (!leaseIdPattern.test(key.leaseId) || !key.hash)
+    if (
+      !leaseIdPattern.test(key.leaseId) ||
+      !key.hash ||
+      !config.members.some(
+        (member) => member.id === key.memberId && member.needsInference,
+      )
+    )
       throw new Error(
-        "OpenRouter returned an invalid trusted acceptance lease id",
+        "OpenRouter returned an invalid trusted acceptance lease member",
       );
     const keys = keysByLease.get(key.leaseId) ?? [];
-    if (keys.some((entry) => entry.hash === key.hash))
+    if (
+      keys.some(
+        (entry) => entry.hash === key.hash || entry.memberId === key.memberId,
+      )
+    )
       throw new Error("OpenRouter returned a duplicate trusted acceptance key");
-    keys.push({ hash: key.hash, expiresAt: key.expiresAt });
+    keys.push(key);
     keysByLease.set(key.leaseId, keys);
   }
 
-  const inferenceMembers = config.members.filter(
-    (member) => member.needsInference,
-  );
   const leaseIds = new Set([
     ...branchesByLease.keys(),
     ...markersByLease.keys(),
@@ -677,9 +719,7 @@ export async function discoverExpiredLeases(
   return [...leaseIds].flatMap((id) => {
     const branches = branchesByLease.get(id) ?? [];
     const markers = markersByLease.get(id) ?? [];
-    const keys = (keysByLease.get(id) ?? []).toSorted((left, right) =>
-      left.hash.localeCompare(right.hash),
-    );
+    const keys = keysByLease.get(id) ?? [];
     const expiries = [
       ...branches.map((branch) => parsedExpiry(branch.expiresAt, "Neon")),
       ...markers.map((marker) => parsedExpiry(marker.expiresAt, "Netlify")),
@@ -708,11 +748,7 @@ export async function discoverExpiredLeases(
       throw new Error(
         "trusted acceptance lease has inconsistent provider expiries",
       );
-    if (keys.length > inferenceMembers.length) {
-      throw new Error(
-        "trusted acceptance lease has undeclared inference handles",
-      );
-    }
+    const keysByMember = new Map(keys.map((key) => [key.memberId, key]));
     return [
       {
         id,
@@ -721,17 +757,13 @@ export async function discoverExpiredLeases(
         state: "active" as const,
         members: config.members.map((member) => {
           const branch = branchesByMember.get(member.id);
-          const inferenceIndex = inferenceMembers.findIndex(
-            (candidate) => candidate.id === member.id,
-          );
+          const key = keysByMember.get(member.id);
           return {
             memberId: member.id,
             netlifySiteId: member.netlifySiteId,
             runtimeOwned: markerMembers.has(member.id),
             ...(branch ? { neonBranchId: branch.branchId } : {}),
-            ...(inferenceIndex >= 0 && keys[inferenceIndex]
-              ? { inferenceKeyHash: keys[inferenceIndex].hash }
-              : {}),
+            ...(key ? { inferenceKeyHash: key.hash } : {}),
           };
         }),
         journal: [],
@@ -847,6 +879,7 @@ export class DisposableRuntimeAuthority {
           try {
             key = await this.providers.openrouter.create(
               lease.id,
+              member.id,
               lease.expiresAt,
               this.config.maxInferenceUsd,
             );
@@ -870,6 +903,8 @@ export class DisposableRuntimeAuthority {
           );
         }
         await this.record(lease, "before", "set-netlify-runtime", "pending");
+        durableMember.runtimeWriteAttempted = true;
+        await this.journalStore.save(lease);
         try {
           await this.providers.netlify.setRuntime(
             member.netlifyAccountId,
@@ -952,14 +987,18 @@ export class DisposableRuntimeAuthority {
         );
         inferenceDisabled &&= disabled;
       }
-      if (durableMember.runtimeOwned) {
-        const stillOwned = await this.providers.netlify.ownsLease(
-          member.netlifyAccountId,
-          member.netlifySiteId,
-          lease.id,
-          lease.expiresAt,
-        );
-        if (!stillOwned) {
+      if (durableMember.runtimeOwned || durableMember.runtimeWriteAttempted) {
+        let stillOwned = false;
+        let ownershipVerified = true;
+        try {
+          stillOwned = await this.providers.netlify.ownsLease(
+            member.netlifyAccountId,
+            member.netlifySiteId,
+            lease.id,
+            lease.expiresAt,
+          );
+        } catch {
+          ownershipVerified = false;
           runtimeVariablesAbsent = false;
           tombstoneActive = false;
           await this.record(
@@ -969,7 +1008,8 @@ export class DisposableRuntimeAuthority {
             "failed",
             member.netlifySiteId,
           );
-        } else {
+        }
+        if (stillOwned) {
           const absent = await this.cleanup(
             lease,
             "remove-netlify-runtime",
@@ -997,6 +1037,16 @@ export class DisposableRuntimeAuthority {
             },
           );
           tombstoneActive &&= tombstoned;
+        } else if (ownershipVerified) {
+          runtimeVariablesAbsent = false;
+          tombstoneActive = false;
+          await this.record(
+            lease,
+            "verification",
+            "verify-netlify-lease-owner",
+            "failed",
+            member.netlifySiteId,
+          );
         }
       }
       if (durableMember.neonBranchId) {

--- a/scripts/trusted-acceptance/runtime-authority.ts
+++ b/scripts/trusted-acceptance/runtime-authority.ts
@@ -344,38 +344,53 @@ export class OpenRouterKeys {
       expiresAt: string;
     }>
   > {
-    const body = await json(
-      await this.fetch(`${OPENROUTER_API}/keys`, {
-        headers: { authorization: `Bearer ${this.token}` },
-      }),
-    );
-    return ((body.data ?? []) as Array<Record<string, unknown>>).flatMap(
-      (item) => {
-        if (typeof item.name !== "string") return [];
-        if (!item.name.startsWith("trusted-acceptance-")) return [];
-        const match =
-          /^trusted-acceptance-([a-f0-9]{24})-([a-z0-9][a-z0-9-]*)$/.exec(
-            item.name,
-          );
-        if (
-          !match ||
-          typeof item.hash !== "string" ||
-          typeof item.expires_at !== "string"
-        ) {
-          throw new Error(
-            "OpenRouter returned a malformed trusted acceptance key",
-          );
-        }
-        return [
-          {
-            leaseId: match[1]!,
-            memberId: match[2]!,
-            hash: item.hash,
-            expiresAt: item.expires_at,
-          },
-        ];
-      },
-    );
+    const pageSize = 100;
+    const items: Array<Record<string, unknown>> = [];
+    for (let page = 0; page < 100; page += 1) {
+      const query = new URLSearchParams({
+        include_disabled: "true",
+        offset: String(page * pageSize),
+      });
+      const body = await json(
+        await this.fetch(`${OPENROUTER_API}/keys?${query}`, {
+          headers: { authorization: `Bearer ${this.token}` },
+        }),
+      );
+      if (!Array.isArray(body.data))
+        throw new Error("OpenRouter returned a malformed key inventory");
+      const pageItems = body.data as Array<Record<string, unknown>>;
+      items.push(...pageItems);
+      if (pageItems.length < pageSize) break;
+      if (page === 99)
+        throw new Error(
+          "OpenRouter key inventory exceeded the bounded page limit",
+        );
+    }
+    return items.flatMap((item) => {
+      if (typeof item.name !== "string") return [];
+      if (!item.name.startsWith("trusted-acceptance-")) return [];
+      const match =
+        /^trusted-acceptance-([a-f0-9]{24})-([a-z0-9][a-z0-9-]*)$/.exec(
+          item.name,
+        );
+      if (
+        !match ||
+        typeof item.hash !== "string" ||
+        typeof item.expires_at !== "string"
+      ) {
+        throw new Error(
+          "OpenRouter returned a malformed trusted acceptance key",
+        );
+      }
+      return [
+        {
+          leaseId: match[1]!,
+          memberId: match[2]!,
+          hash: item.hash,
+          expiresAt: item.expires_at,
+        },
+      ];
+    });
   }
 }
 


### PR DESCRIPTION
## Problem

The trusted acceptance lane can verify and build an exact pull-request SHA, but it does not yet have a safe framework-owned way to give hosted candidate apps temporary database, identity, cross-app, and inference authority. Without that boundary, end-to-end OAuth and app-to-app task routing either depend on reusable credentials or cannot be tested at all, and a cancelled run can strand privileged resources.

This is a framework-wide problem. Calendar and Content are the first disabled pilot, not special cases in the controller.

## Approach

Add a generic, default-branch-owned disposable authority and recovery substrate while keeping every workspace disabled until its isolated resources are reviewed separately. Candidate code builds without credentials and crosses into the protected job only as a provenance-checked inert artifact; trusted code acquires one whole-workspace lease, uploads without rebuilding, and always attempts verified revocation.

The change deliberately does not provision infrastructure, add credentials, enable the pilot, deploy an app, or claim that hosted OAuth/A2A acceptance passes.

## What changed

- Added typed workspace authority, profile, provenance, receipt, and fail-closed activation contracts.
- Added Neon, Netlify, and OpenRouter lease adapters with transient secrets, redacted journals, exact site/origin binding, pristine-site checks, bounded inference keys, verified cleanup, and trusted tombstone deploys.
- Added an independent scheduled/manual reaper that discovers deterministic expired leases, shares per-workspace serialization, verifies Netlify marker ownership before site mutation, and safely handles partial acquisitions.
- Added an acceptance-only organization directory fixture plus a hosted OAuth PKCE/MCP harness for stable discovery, ask_app, directory withdrawal, and same-task ask_app_status continuity.
- Updated workflow custody guards and contributor documentation. The Calendar/Content pilot remains `enabled: false` with an unconfigured provisioner.

## Safety and operations

No secret values or provider resources are added by this PR. Protected provider credentials enter only trusted main-pinned steps after artifact verification; candidate dependency/build code never runs in that custody. The controller rejects production sites, non-pristine managed variables, mismatched origins, shared Neon projects, loose profile fields, and credential-shaped profile values. Cleanup re-reads the exact atomic lease marker before deleting site state and fails closed if ownership changed; the reaper serializes leases and never mutates Netlify for markerless provider-only recovery.

Activation and real hosted acceptance are a separate reviewed change. Reverting this PR removes the dormant substrate; it cannot undo a future activated run, whose provider cleanup and tombstone receipt remain the operational rollback evidence.

## Verification

- `pnpm test:trusted-acceptance` — 72 focused tests passed across config/provenance/receipt validation, workflow custody, OAuth PKCE, directory withdrawal, authority compensation, ownership races, and reaper recovery.
- `pnpm guard:trusted-acceptance` — passed the static workflow and disabled-authority boundary checks.
- `git diff --check` — passed.
- Independent security review found no remaining P1/P2 blocker after the recovery fixes and a final re-review.
- Repository-wide remote typecheck was not run locally: Framework preflight failed because Tailscale was stopped. CI remains the authoritative broad check.
- Live hosted OAuth/A2A acceptance is blocked by design until the isolated workspace is provisioned and enabled in the next phase.

## Review focus

- Does candidate code remain fully outside protected credential custody?
- Are Netlify marker ownership and partial-acquisition recovery conservative enough under cancellation and races?
- Do the profile and provider allowlists prevent production or cross-workspace authority from entering a lease?
- Can any blocked or incomplete harness/cleanup result be mistaken for a passing receipt?

## Follow-ups

A separate activation PR must provision and inventory dedicated resources, add the protected non-secret profile map and scoped credentials, wire the directory fixture and hosted harness, enable the first workspace, and produce the real OAuth/A2A acceptance receipt. That phase is required to complete the original routing investigation, but it is intentionally outside this dormant substrate PR.


