### PR TITLE
fix(core): align the streaming grapheme cache window to a cluster boundary

### DIFF
--- a/.changeset/streaming-grapheme-boundary.md
+++ b/.changeset/streaming-grapheme-boundary.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep emoji and other multi-code-point grapheme clusters intact while streaming text. The incremental segmentation cache re-segmented from a fixed character offset, so a cluster straddling that offset was cut in half and characters were silently dropped from the smoothed output. The re-segmentation window now starts on a grapheme boundary.

--- a/packages/core/src/shared/streaming-text-smoothing.spec.ts
+++ b/packages/core/src/shared/streaming-text-smoothing.spec.ts
@@ -141,6 +141,42 @@ describe("streaming text smoothing helpers", () => {
       expect(incrementalFinal.length).toBe(fullFinal.length);
     });
 
+    it("keeps a surrogate pair intact when the overlap boundary lands inside it", () => {
+      // The overlap window starts SEGMENTER_OVERLAP characters back from the
+      // end of the cached text. Streaming one character at a time walks that
+      // boundary through the emoji, so it lands mid-cluster on some step.
+      const text = `${"x".repeat(20)}\u{1F600}${"y".repeat(20)}`;
+
+      resetSegmenterCache();
+      let incremental: string[] = [];
+      for (let end = 1; end <= text.length; end++) {
+        incremental = splitStreamingTextGraphemes(text.slice(0, end));
+      }
+
+      resetSegmenterCache();
+      const full = splitStreamingTextGraphemes(text);
+
+      expect(incremental.join("")).toBe(text);
+      expect(incremental).toEqual(full);
+    });
+
+    it("keeps a ZWJ sequence intact when the overlap boundary lands inside it", () => {
+      const family = "\u{1F468}‍\u{1F469}‍\u{1F467}‍\u{1F466}";
+      const text = `${"a".repeat(20)}${family}${"b".repeat(20)}`;
+
+      resetSegmenterCache();
+      let incremental: string[] = [];
+      for (let end = 1; end <= text.length; end++) {
+        incremental = splitStreamingTextGraphemes(text.slice(0, end));
+      }
+
+      resetSegmenterCache();
+      const full = splitStreamingTextGraphemes(text);
+
+      expect(incremental.join("")).toBe(text);
+      expect(incremental).toEqual(full);
+    });
+
     it("falls back to full segmentation when text is not an append of cached text", () => {
       splitStreamingTextGraphemes("Some text");
       // Different text entirely (not an append)

--- a/packages/core/src/shared/streaming-text-smoothing.ts
+++ b/packages/core/src/shared/streaming-text-smoothing.ts
@@ -70,25 +70,26 @@ export function splitStreamingTextGraphemes(text: string): string[] {
   // Incremental path: new text extends the cached text
   if (_segCache && text.startsWith(_segCache.text)) {
     const prevLen = _segCache.text.length;
-    // Re-segment from (prevLen - OVERLAP) to include the overlap so any
-    // grapheme that was split across the boundary is correctly re-assembled.
-    const overlapStart = Math.max(0, prevLen - SEGMENTER_OVERLAP);
+    const cached = _segCache.graphemes;
+    // Walk back over cached graphemes until at least OVERLAP characters have
+    // been released, so the re-segmented suffix starts on a known grapheme
+    // boundary. Slicing at a fixed character offset instead would cut a
+    // cluster (surrogate pair, ZWJ sequence) in half, and segmenting that
+    // partial cluster in isolation yields a different grapheme count than the
+    // cache holds for the same region — which silently drops characters.
+    let stableCount = cached.length;
+    let releasedChars = 0;
+    while (stableCount > 0 && releasedChars < SEGMENTER_OVERLAP) {
+      stableCount--;
+      releasedChars += cached[stableCount]!.length;
+    }
+    const overlapStart = prevLen - releasedChars;
     const suffix = text.slice(overlapStart);
     const newGraphemes = Array.from(
       segmenter.segment(suffix),
       (entry) => entry.segment,
     );
-    // Drop graphemes that correspond to the overlap region from the cache so
-    // we don't double-count them.
-    const overlapGraphemes = Array.from(
-      segmenter.segment(text.slice(overlapStart, prevLen)),
-      (entry) => entry.segment,
-    );
-    const stableGraphemes = _segCache.graphemes.slice(
-      0,
-      _segCache.graphemes.length - overlapGraphemes.length,
-    );
-    const merged = stableGraphemes.concat(newGraphemes);
+    const merged = cached.slice(0, stableCount).concat(newGraphemes);
     _segCache = { text, graphemes: merged };
     return merged;
   }


### PR DESCRIPTION
## The bug

`packages/core/src/shared/streaming-text-smoothing.ts:75-90` re-segmented from a fixed character offset:

```ts
const overlapStart = Math.max(0, prevLen - SEGMENTER_OVERLAP);
```

then dropped a matching number of cached graphemes by segmenting `text.slice(overlapStart, prevLen)` **in isolation**.

That offset is not guaranteed to be a grapheme boundary. When it lands inside a cluster — surrogate pair, ZWJ sequence, flag, skin-tone modifier — segmenting the partial cluster on its own produces a different grapheme count than the cache holds for the same region. `stableGraphemes` is then sliced at the wrong index and **characters are silently dropped**.

Streaming appends a character at a time, so the 16-character window walks through every emoji in a message and lands mid-cluster essentially always.

## Impact

- `packages/core/src/cli/code-agent-output-smoother.ts:112` writes `graphemes.slice(visibleCount, nextCount).join("")` straight to the TTY. Nothing rewrites it, so **CLI corruption is permanent**.
- `packages/core/src/client/chat/markdown-renderer.tsx:379-489` shows a lone surrogate (`�`) and loses characters mid-stream; the final frame returns `targetText` verbatim, so there the damage is transient.

I'd rather state that plainly than oversell it: in the React path it's a visual glitch during streaming, in the CLI path it's real data loss in the output.

## Why existing tests missed it

Every incremental case in the spec primes the cache with a base string shorter than 16 characters, so `Math.max(0, prevLen - 16)` collapsed to `0` and the code took the full re-segmentation path every time. The bug only exists past the 16-character mark.

## The fix

Walk backwards over the cached grapheme array until at least `SEGMENTER_OVERLAP` characters have been released, and re-segment from *that* boundary.

Correct by construction: `cached.slice(0, stableCount)` covers exactly `prevLen - releasedChars` characters and the suffix starts at the same offset, so the merged array always rejoins to `text`. It also removes the second `segmenter.segment()` call per frame.

## How to test

```
pnpm --filter @builder.io/agent-native-core exec vitest run src/shared/streaming-text-smoothing.spec.ts
```
→ 18 passed.

Two tests added (surrogate pair, ZWJ family emoji), each streaming character-by-character and asserting both `join("") === text` and equality with full segmentation.

Regression proof — source reverted, tests kept:

```
× keeps a surrogate pair intact when the overlap boundary lands inside it
  Expected: "xxxxxxxxxxxxxxxxxxxx😀yyyyyyyyyyyyyyyyyyyy"
  Received: "xxxxxxxxxxxxxxxxxxxx�yyyyyyyyyyyyyyyyyyyy"

× keeps a ZWJ sequence intact when the overlap boundary lands inside it
  Expected: "aaaaaaaaaaaaaaaaaaaa👨‍👩‍👧‍👦bbbbbbbbbbbbbbbbbbbb"
  Received: "aaaaaaaaaaaaaaaaaaa‍�bbbbbbbbbbbbbbbbbbbb"   ← 19 a's; a real character was dropped

Tests  2 failed | 16 passed (18)
```

A randomized fuzz over the same invariant (mixed ASCII / CJK / emoji / flags / skin tones, deterministic seed, 3000 trials): **2668 failures before the fix, 0 after.**

A changeset is included per `AGENTS.md:178`.

## Reviewer notes

- **`SEGMENTER_OVERLAP = 16` is still a heuristic.** This makes the window grapheme-aligned and *at least* 16 characters, which removes the dropped-character failure mode. A cluster longer than 16 characters that both starts before the new boundary and extends past `prevLen` could still segment differently than a full pass — that is the pre-existing design and I did not widen scope to change it.
- **Test style**: the char-by-char loop slices mid-surrogate at intermediate steps, which a real token stream would not do. That is deliberate — it is what forces the boundary through the cluster — but if you prefer code-point-wise stepping, the fuzz covers both.
- **`cached[stableCount]!`** uses a non-null assertion to match the surrounding style in this file; `stableCount > 0` guards it.
- **Not verified against a browser engine.** `Intl.Segmenter` behaviour on lone surrogates is engine-defined. The fix does not depend on it (partial clusters are never segmented any more), but the *pre-fix* failure output above could differ across engines.

## Unrelated lead

While reading `templates/` I noticed `templates/calendar/server/lib/ical-fetcher.ts:53-59` un-escapes ICS in the wrong order — `\\n`→newline runs before `\\\\`→`\`, so a Windows path in a `SUMMARY:` field injects a real newline into the event title. I have not verified it and am not fixing it here; flagging in case it is useful.
