### PR TITLE
Add a trusted hosted acceptance lane

### DIFF
--- a/.github/workflows/trusted-acceptance.yml
+++ b/.github/workflows/trusted-acceptance.yml
@@ -417,9 +417,10 @@ jobs:
             ? declaredPlan.members.find(({template}) => template === declaredPlan.harness.callerMemberId)
             : declaredPlan.members.find(({template}) => template === declaredPlan.harness.memberId);
           if (!selected) throw new Error("Configured harness member is missing from the trusted plan");
-          const target = declaredPlan.harness.kind === "a2a-directory-withdrawal"
-            ? declaredPlan.members.find(({template}) => template === declaredPlan.harness.targetMemberId)
+          const isolationTarget = declaredPlan.isolation
+            ? declaredPlan.members.find(({template}) => template === declaredPlan.isolation.otherAcceptanceMemberId)
             : undefined;
+          if (declaredPlan.isolation && !isolationTarget) throw new Error("Configured isolation member is missing from the trusted plan");
           const hostedPlan = {
             version: 1,
             workspace: profile.workspace,
@@ -443,7 +444,7 @@ jobs:
                 : {kind: "mcp-read-only-tool", tool: declaredPlan.harness.tool, arguments: declaredPlan.harness.arguments},
               ...(declaredPlan.isolation ? {
                 productionMcpUrl: new URL(selected.paths.mcp, declaredPlan.isolation.productionOrigin).toString(),
-                otherAcceptanceMcpUrl: new URL(target.paths.mcp, target.origin).toString(),
+                otherAcceptanceMcpUrl: new URL(isolationTarget.paths.mcp, isolationTarget.origin).toString(),
               } : {}),
             }],
           };

--- a/.github/workflows/trusted-acceptance.yml
+++ b/.github/workflows/trusted-acceptance.yml
@@ -54,6 +54,7 @@ jobs:
       pull_request: ${{ steps.provenance.outputs.pull_request }}
       matrix: ${{ steps.plan.outputs.matrix }}
       assertions: ${{ steps.plan.outputs.assertions }}
+      plan_json: ${{ steps.plan.outputs.plan_json }}
     steps:
       - name: Require the trusted default-branch controller
         env:
@@ -116,7 +117,7 @@ jobs:
               rollback_plan_args+=(--allow-disabled)
             fi
             pnpm tsx scripts/trusted-acceptance.ts "${rollback_plan_args[@]}" > "$RUNNER_TEMP/rollback-plan.json"
-            expected_assertions="$(node -e 'const p=require(process.env.RUNNER_TEMP + "/rollback-plan.json"); if (!p.ok) process.exit(1); process.stdout.write(JSON.stringify(p.plan.assertions))')"
+            expected_assertions="$(node -e 'const p=require(process.env.RUNNER_TEMP + "/rollback-plan.json"); if (!p.ok) process.exit(1); process.stdout.write(JSON.stringify(p.plan.assertions.filter(id => id !== "A14")))')"
             gh api "repos/$TRUSTED_REPOSITORY/actions/runs/$ROLLBACK_RUN_ID" > "$RUNNER_TEMP/prior-run.json"
             node - <<'NODE'
             const fs = require("node:fs");
@@ -175,6 +176,7 @@ jobs:
         env:
           WORKSPACE: ${{ inputs.workspace }}
           DEPLOY: ${{ inputs.deploy }}
+          OPERATION: ${{ steps.provenance.outputs.operation }}
         run: |
           templates="$(find templates -mindepth 2 -maxdepth 2 -name package.json -print | sed 's#templates/##;s#/package.json##' | sort | paste -sd, -)"
           args=(plan --file "$CONFIG_FILE" --templates "$templates" --workspace "$WORKSPACE")
@@ -188,7 +190,11 @@ jobs:
           if (!plan.ok) throw new Error(JSON.stringify(plan.issues));
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `config_revision=${plan.plan.revision}\n`);
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `matrix=${JSON.stringify({ include: plan.plan.members })}\n`);
-          fs.appendFileSync(process.env.GITHUB_OUTPUT, `assertions=${JSON.stringify(plan.plan.assertions)}\n`);
+          const assertions = process.env.OPERATION === "candidate"
+            ? plan.plan.assertions.filter(id => id !== "A14")
+            : plan.plan.assertions;
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `assertions=${JSON.stringify(assertions)}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `plan_json=${JSON.stringify(plan.plan)}\n`);
           NODE
 
       - name: Record dry-run plan
@@ -282,6 +288,7 @@ jobs:
       - name: Install pinned deployment client before credentials enter the job
         run: |
           pnpm install --frozen-lockfile --ignore-scripts
+          pnpm exec playwright install --with-deps chromium
           npm install --global netlify-cli@27.0.0 --ignore-scripts
 
       - name: Download every inert candidate artifact
@@ -298,10 +305,25 @@ jobs:
           node - <<'NODE'
           const fs = require("node:fs");
           const path = require("node:path");
+          const assertRegularTree = (root) => {
+            const rootStat = fs.lstatSync(root);
+            if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) throw new Error(`Candidate artifact root is not a regular directory: ${root}`);
+            const visit = directory => {
+              for (const entry of fs.readdirSync(directory, {withFileTypes: true})) {
+                const file = path.join(directory, entry.name);
+                const stat = fs.lstatSync(file);
+                if (stat.isSymbolicLink()) throw new Error(`Candidate artifact contains a symlink: ${file}`);
+                if (stat.isDirectory()) visit(file);
+                else if (!stat.isFile()) throw new Error(`Candidate artifact contains a non-regular file: ${file}`);
+              }
+            };
+            visit(root);
+          };
           for (const member of JSON.parse(process.env.MATRIX).include) {
             const artifact = path.join(process.env.RUNNER_TEMP, "acceptance-artifacts", `trusted-acceptance-build-${member.template}`);
             const metadata = JSON.parse(fs.readFileSync(path.join(artifact, "build-metadata.json"), "utf8"));
-            if (metadata.sha !== process.env.EXPECTED_SHA || metadata.template !== member.template || !fs.statSync(path.join(artifact, "publish")).isDirectory()) {
+            assertRegularTree(artifact);
+            if (metadata.sha !== process.env.EXPECTED_SHA || metadata.template !== member.template || !fs.lstatSync(path.join(artifact, "publish")).isDirectory()) {
               throw new Error(`Candidate artifact provenance mismatch for ${member.template}`);
             }
           }
@@ -315,6 +337,7 @@ jobs:
         env:
           AUTHORITY_PROFILES_JSON: ${{ vars.ACCEPTANCE_AUTHORITY_PROFILES_JSON }}
           MATRIX: ${{ needs.plan.outputs.matrix }}
+          PLAN_JSON: ${{ needs.plan.outputs.plan_json }}
           WORKSPACE: ${{ inputs.workspace }}
         run: |
           if [[ -z "$AUTHORITY_PROFILES_JSON" ]]; then
@@ -333,53 +356,126 @@ jobs:
           const fs = require("node:fs");
           const path = require("node:path");
           const profile = JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + "/trusted-authority-profile.json", "utf8"));
+          const declaredPlan = JSON.parse(process.env.PLAN_JSON);
           const expected = new Set(JSON.parse(process.env.MATRIX).include.map(({template}) => template));
           const runtime = new Map(profile.runtime.members.map((member) => [member.id, member]));
           const productionSiteIds = new Set(Object.values(JSON.parse(fs.readFileSync("scripts/netlify-sites.json", "utf8"))));
-          const members = profile.members.map(({id}) => {
+          const root = path.join(process.env.RUNNER_TEMP, "trusted-acceptance-deploy");
+          const members = profile.members.map(({id, artifactDirectory}) => {
             if (!expected.has(id) || !runtime.has(id)) throw new Error(`Profile member ${id} is not an expected artifact`);
             if (productionSiteIds.has(runtime.get(id).netlifySiteId)) throw new Error(`Profile member ${id} resolves to a known production site ID`);
-            const artifact = path.join(process.env.RUNNER_TEMP, "acceptance-artifacts", `trusted-acceptance-build-${id}`);
-            if (!fs.existsSync(artifact)) throw new Error(`Missing verified artifact for ${id}`);
-            return {id, siteId: runtime.get(id).netlifySiteId, artifact};
+            const source = path.join(process.env.RUNNER_TEMP, "acceptance-artifacts", `trusted-acceptance-build-${id}`);
+            const artifact = path.join(root, artifactDirectory);
+            if (!fs.existsSync(source)) throw new Error(`Missing verified artifact for ${id}`);
+            fs.cpSync(source, artifact, {recursive: true, errorOnExist: true, force: false});
+            return {
+              id,
+              siteId: runtime.get(id).netlifySiteId,
+              artifactDirectory,
+              publishDirectory: path.posix.join(artifactDirectory, "publish"),
+              functionsDirectory: path.posix.join(artifactDirectory, ".netlify/functions-internal"),
+            };
           });
           if (members.length !== expected.size) throw new Error("Profile must deploy the entire configured workspace");
-          fs.writeFileSync(process.env.RUNNER_TEMP + "/trusted-deploy-manifest.json", JSON.stringify(members));
+
+          let directoryFixture;
+          if (profile.directoryFixture) {
+            if (productionSiteIds.has(profile.directoryFixture.netlifySiteId)) throw new Error("Directory fixture resolves to a known production site ID");
+            const artifactDirectory = profile.directoryFixture.artifactDirectory;
+            const fixtureRoot = path.join(root, artifactDirectory);
+            const functionsDirectory = path.join(fixtureRoot, "functions");
+            const publishDirectory = path.join(fixtureRoot, "public");
+            fs.mkdirSync(functionsDirectory, {recursive: true});
+            fs.mkdirSync(publishDirectory, {recursive: true});
+            fs.copyFileSync("scripts/trusted-acceptance/directory-fixture.ts", path.join(functionsDirectory, "directory-fixture.ts"));
+            fs.copyFileSync("scripts/trusted-acceptance/directory-netlify-function.ts", path.join(functionsDirectory, "acceptance-directory.ts"));
+            fs.writeFileSync(path.join(publishDirectory, "index.html"), "<!doctype html><title>Trusted acceptance directory</title>\n");
+            const hash = require("node:crypto").createHash("sha256");
+            const visit = (directory, prefix = "") => {
+              for (const entry of fs.readdirSync(directory, {withFileTypes: true}).sort((a, b) => a.name.localeCompare(b.name))) {
+                if (entry.isSymbolicLink()) throw new Error("Trusted directory artifact must not contain symlinks");
+                const relative = path.posix.join(prefix, entry.name);
+                const absolute = path.join(directory, entry.name);
+                if (entry.isDirectory()) visit(absolute, relative);
+                else if (entry.isFile()) hash.update(relative).update("\0").update(fs.readFileSync(absolute)).update("\0");
+                else throw new Error("Trusted directory artifact contains a non-regular file");
+              }
+            };
+            visit(fixtureRoot);
+            const sha256 = hash.digest("hex");
+            if (sha256 !== profile.directoryFixture.artifactSha256) throw new Error("Trusted directory artifact digest does not match the protected profile");
+            directoryFixture = {
+              siteId: profile.directoryFixture.netlifySiteId,
+              artifactDirectory,
+              publishDirectory: path.posix.join(artifactDirectory, "public"),
+              functionsDirectory: path.posix.join(artifactDirectory, "functions"),
+              sha256,
+            };
+          }
+
+          const selected = declaredPlan.harness.kind === "a2a-directory-withdrawal"
+            ? declaredPlan.members.find(({template}) => template === declaredPlan.harness.callerMemberId)
+            : declaredPlan.members.find(({template}) => template === declaredPlan.harness.memberId);
+          if (!selected) throw new Error("Configured harness member is missing from the trusted plan");
+          const target = declaredPlan.harness.kind === "a2a-directory-withdrawal"
+            ? declaredPlan.members.find(({template}) => template === declaredPlan.harness.targetMemberId)
+            : undefined;
+          const hostedPlan = {
+            version: 1,
+            workspace: profile.workspace,
+            profileSha256: require("node:crypto").createHash("sha256").update(fs.readFileSync(process.env.RUNNER_TEMP + "/trusted-authority-profile.json")).digest("hex"),
+            tokenExpiryMs: 300000,
+            members: [{
+              id: selected.template,
+              origin: selected.origin,
+              mcpUrl: new URL(selected.paths.mcp, selected.origin).toString(),
+              wrongAudienceResource: declaredPlan.isolation
+                ? new URL(selected.paths.mcp, declaredPlan.isolation.productionOrigin).toString()
+                : "https://wrong-audience.acceptance.invalid/mcp",
+              harness: declaredPlan.harness.kind === "a2a-directory-withdrawal"
+                ? {
+                    kind: "a2a-directory-withdrawal",
+                    targetApp: declaredPlan.harness.targetMemberId,
+                    message: declaredPlan.harness.message,
+                    expectedResult: declaredPlan.harness.expectedResult,
+                    maxStatusPolls: declaredPlan.harness.maxStatusPolls,
+                  }
+                : {kind: "mcp-read-only-tool", tool: declaredPlan.harness.tool, arguments: declaredPlan.harness.arguments},
+              ...(declaredPlan.isolation ? {
+                productionMcpUrl: new URL(selected.paths.mcp, declaredPlan.isolation.productionOrigin).toString(),
+                otherAcceptanceMcpUrl: new URL(target.paths.mcp, target.origin).toString(),
+              } : {}),
+            }],
+          };
+          fs.writeFileSync(process.env.RUNNER_TEMP + "/trusted-hosted-plan.json", JSON.stringify(hostedPlan));
+          fs.writeFileSync(process.env.RUNNER_TEMP + "/trusted-deploy-manifest.json", JSON.stringify({version: 1, members, ...(directoryFixture ? {directoryFixture} : {})}));
           NODE
 
-      - name: Acquire one whole-workspace disposable lease
+      - name: Run trusted hosted OAuth, harness, deployment, and cleanup
+        working-directory: ${{ runner.temp }}/trusted-acceptance-deploy
         env:
           ACCEPTANCE_NEON_API_KEY: ${{ secrets.ACCEPTANCE_NEON_API_KEY }}
           ACCEPTANCE_NETLIFY_AUTH_TOKEN: ${{ secrets.ACCEPTANCE_NETLIFY_AUTH_TOKEN }}
           ACCEPTANCE_OPENROUTER_API_KEY: ${{ secrets.ACCEPTANCE_OPENROUTER_API_KEY }}
         run: |
-          pnpm tsx scripts/trusted-acceptance/controller.ts acquire --profile "$RUNNER_TEMP/trusted-authority-profile.json" --journal "$RUNNER_TEMP/trusted-acceptance-lease.json"
+          "$GITHUB_WORKSPACE/node_modules/.bin/tsx" "$GITHUB_WORKSPACE/scripts/trusted-acceptance/run-hosted-acceptance.ts" \
+            --plan "$RUNNER_TEMP/trusted-hosted-plan.json" \
+            --profile "$RUNNER_TEMP/trusted-authority-profile.json" \
+            --deploy-manifest "$RUNNER_TEMP/trusted-deploy-manifest.json" \
+            --journal "$RUNNER_TEMP/trusted-acceptance-lease.json" \
+            --receipt "$RUNNER_TEMP/trusted-acceptance-controller-receipt.json" \
+            --deploy-result "$RUNNER_TEMP/trusted-acceptance-deploy-result.json"
 
-      - name: Deploy every preverified inert artifact
-        working-directory: ${{ runner.temp }}/trusted-acceptance-deploy
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.ACCEPTANCE_NETLIFY_AUTH_TOKEN }}
-        run: |
-          node -e 'const fs=require("node:fs"); for (const member of JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + "/trusted-deploy-manifest.json", "utf8"))) process.stdout.write(`${member.id}\t${member.siteId}\t${member.artifact}\n`)' | while IFS=$'\t' read -r template site_id artifact_dir; do
-            raw_result="$(mktemp)"
-            trap 'rm -f "$raw_result"' EXIT
-            netlify deploy --prod --no-build --json --auth "$NETLIFY_AUTH_TOKEN" --site "$site_id" --dir "$artifact_dir/publish" --functions "$artifact_dir/.netlify/functions-internal" > "$raw_result"
-            node - "$raw_result" "$RUNNER_TEMP/deploy-$template.json" "$template" <<'NODE'
-            const fs = require("node:fs");
-            const result = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
-            const deployId = result.deploy_id ?? result.id;
-            if (!deployId) throw new Error("Netlify did not return a deploy ID");
-            fs.writeFileSync(process.argv[3], JSON.stringify({template: process.argv[4], deployId}));
-            NODE
-          done
-
-      - name: Revoke one whole-workspace disposable lease
+      - name: Revoke one whole-workspace disposable lease after interruption
         if: ${{ always() }}
         env:
           ACCEPTANCE_NEON_API_KEY: ${{ secrets.ACCEPTANCE_NEON_API_KEY }}
           ACCEPTANCE_NETLIFY_AUTH_TOKEN: ${{ secrets.ACCEPTANCE_NETLIFY_AUTH_TOKEN }}
           ACCEPTANCE_OPENROUTER_API_KEY: ${{ secrets.ACCEPTANCE_OPENROUTER_API_KEY }}
-        run: pnpm tsx scripts/trusted-acceptance/controller.ts revoke --profile "$RUNNER_TEMP/trusted-authority-profile.json" --journal "$RUNNER_TEMP/trusted-acceptance-lease.json"
+        run: |
+          if [[ -f "$RUNNER_TEMP/trusted-acceptance-lease.json" ]]; then
+            pnpm tsx scripts/trusted-acceptance/controller.ts revoke --profile "$RUNNER_TEMP/trusted-authority-profile.json" --journal "$RUNNER_TEMP/trusted-acceptance-lease.json"
+          fi
 
       - name: Upload current redacted lease journal and controller receipt
         if: ${{ always() }}
@@ -388,15 +484,19 @@ jobs:
           name: trusted-acceptance-lease-state-${{ github.run_id }}
           path: |
             ${{ runner.temp }}/trusted-acceptance-lease.json
+            ${{ runner.temp }}/trusted-acceptance-controller-receipt.json
           if-no-files-found: warn
           retention-days: 30
 
-      - name: Upload redacted deployment result
+      - name: Upload redacted hosted acceptance result
+        if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: trusted-acceptance-deploy-results
-          path: ${{ runner.temp }}/deploy-*.json
-          if-no-files-found: error
+          path: |
+            ${{ runner.temp }}/trusted-acceptance-deploy-result.json
+            ${{ runner.temp }}/trusted-acceptance-controller-receipt.json
+          if-no-files-found: warn
           retention-days: 30
 
   receipt:
@@ -421,7 +521,8 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Download redacted deployment results
-        if: ${{ inputs.deploy && needs.deploy.result == 'success' }}
+        if: ${{ inputs.deploy && needs.deploy.result != 'skipped' }}
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: trusted-acceptance-deploy-*
@@ -438,6 +539,7 @@ jobs:
           DEPLOY_RESULT: ${{ needs.deploy.result }}
           MATRIX: ${{ needs.plan.outputs.matrix }}
           OPERATION: ${{ needs.plan.outputs.operation }}
+          PLAN_JSON: ${{ needs.plan.outputs.plan_json }}
           PR_NUMBER: ${{ needs.plan.outputs.pull_request }}
           ROLLBACK_SHA: ${{ inputs.rollback_sha }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -447,19 +549,92 @@ jobs:
           node - <<'NODE'
           const fs = require("node:fs");
           const path = require("node:path");
+          const plan = JSON.parse(process.env.PLAN_JSON);
+          const deployResultPath = path.join(process.env.RUNNER_TEMP, "deploy-results", "trusted-acceptance-deploy-result.json");
+          const controllerReceiptPath = path.join(process.env.RUNNER_TEMP, "deploy-results", "trusted-acceptance-controller-receipt.json");
+          const deployResult = fs.existsSync(deployResultPath)
+            ? JSON.parse(fs.readFileSync(deployResultPath, "utf8"))
+            : {deployments: []};
+          const controllerReceipt = fs.existsSync(controllerReceiptPath)
+            ? JSON.parse(fs.readFileSync(controllerReceiptPath, "utf8"))
+            : null;
+          const deployIds = new Map(deployResult.deployments.map(({id, deployId}) => [id, deployId]));
           const members = JSON.parse(process.env.MATRIX).include.map(member => {
-            const resultPath = path.join(process.env.RUNNER_TEMP, "deploy-results", `deploy-${member.template}.json`);
-            const deployId = fs.existsSync(resultPath)
-              ? JSON.parse(fs.readFileSync(resultPath, "utf8")).deployId
-              : null;
-            return {template: member.template, origin: member.origin, deployId};
+            return {template: member.template, origin: member.origin, deployId: deployIds.get(member.template) ?? null};
           });
-          const deployed = process.env.DEPLOY_REQUESTED === "true" && process.env.DEPLOY_RESULT === "success";
-          const assertions = JSON.parse(process.env.ASSERTIONS).map(id => ({
-            id,
-            state: "blocked",
-            evidencePointer: deployed ? "workflow://runtime-proof-pending" : "workflow://dry-run-only",
-          }));
+          const controllerPassed = controllerReceipt?.result === "passed";
+          const evidence = new Map((controllerReceipt?.evidence ?? []).map(entry => [entry.assertionId, entry]));
+          const callerId = plan.harness.kind === "a2a-directory-withdrawal" ? plan.harness.callerMemberId : plan.harness.memberId;
+          const has = suffix => evidence.get(`${callerId}:${suffix}`)?.status === "passed";
+          const cleanupPassed = controllerPassed && controllerReceipt.lease?.state === "revoked" &&
+            controllerReceipt.lease.verification?.inferenceDisabled &&
+            controllerReceipt.lease.verification?.runtimeVariablesAbsent &&
+            controllerReceipt.lease.verification?.tombstoneActive &&
+            controllerReceipt.lease.verification?.branchesDeleted;
+          const oauthPassed = has("oauth");
+          const harnessPassed = has("harness");
+          const isolationPassed = [
+            "acceptance-token-rejected-by-production-resource",
+            "acceptance-token-rejected-by-other-acceptance-resource",
+            "foreign-domain-sentinel-rejected-by-acceptance",
+            "production-oauth-metadata-distinct",
+            "oauth-authorization-code-replay-rejected",
+            "oauth-wrong-audience-rejected",
+            "expiry",
+            "post-cleanup",
+          ].every(has);
+          const repositoryProof = new Set(["A1", "A2", "A3", "A4", "A12", "A13"]);
+          const liveProof = id => {
+            if (!controllerPassed) return false;
+            if (["A5", "I5"].includes(id)) return cleanupPassed;
+            if (["A6", "A7", "I6"].includes(id)) return oauthPassed && has("oauth-authorization-code-replay-rejected") && has("oauth-wrong-audience-rejected");
+            if (["A8", "A9", "A10"].includes(id)) return plan.harness.kind === "a2a-directory-withdrawal" && harnessPassed;
+            if (["A11", "I7"].includes(id)) return isolationPassed;
+            if (id === "I1") return has("unauthenticated-oauth-code-rejected");
+            if (["I2", "I3"].includes(id)) return has("session") && has("wrong-password-rejected");
+            if (id === "I4") return has("wrong-password-rejected") && has("second-tenant-data-isolated");
+            if (id === "I8") return plan.harness.kind === "mcp-read-only-tool" && harnessPassed && oauthPassed && cleanupPassed;
+            if (id === "A14") return process.env.OPERATION === "rollback" && controllerPassed && members.every(member => member.deployId);
+            return false;
+          };
+          const assertions = JSON.parse(process.env.ASSERTIONS).map(id => {
+            const passed = repositoryProof.has(id) || liveProof(id);
+            return {
+              id,
+              state: passed ? "pass" : "blocked",
+              evidencePointer: passed
+                ? (repositoryProof.has(id) ? "workflow://trusted-controller" : `controller-receipt://${callerId}`)
+                : (process.env.DEPLOY_REQUESTED === "true" ? "workflow://required-proof-missing" : "workflow://dry-run-only"),
+            };
+          });
+          const allPassed = assertions.every(({state}) => state === "pass");
+          const lease = controllerReceipt?.lease;
+          const scenarios = plan.harness.kind === "a2a-directory-withdrawal"
+            ? {kind: plan.harness.kind, hostedOAuth: oauthPassed ? "pass" : "blocked", stableDiscovery: harnessPassed ? "pass" : "blocked", discoveryWithdrawal: harnessPassed ? "pass" : "blocked", taskRouteContinuity: harnessPassed ? "pass" : "blocked"}
+            : {kind: plan.harness.kind, hostedOAuth: oauthPassed ? "pass" : "blocked", readOnlyTool: harnessPassed ? "pass" : "blocked"};
+          const authorities = (lease?.members ?? []).flatMap(member => member.authSigningAuthority ? [{
+            memberId: member.memberId,
+            provenance: "fresh-per-run",
+            algorithm: "sha256",
+            digest: `sha256:${member.authSigningAuthority.sha256}`,
+            generatedAt: member.authSigningAuthority.generatedAt,
+          }] : []);
+          const acceptanceMetadata = [...evidence.values()].filter(entry => entry.assertionId.endsWith(":oauth") && entry.publicResource && entry.publicIssuer).map(entry => ({role: "acceptance", resource: entry.publicResource, issuer: entry.publicIssuer}));
+          const productionMetadata = [...evidence.values()].filter(entry => entry.assertionId.endsWith(":production-oauth-metadata-distinct") && entry.publicResource && entry.publicIssuer).map(entry => ({role: "production", resource: entry.publicResource, issuer: entry.publicIssuer}));
+          const probeMap = [
+            ["acceptance-token-rejected-by-production-resource", "acceptance-at-production"],
+            ["acceptance-token-rejected-by-other-acceptance-resource", "acceptance-at-other-acceptance"],
+            ["foreign-domain-sentinel-rejected-by-acceptance", "foreign-domain-sentinel-at-acceptance"],
+            ["expiry", "expired-acceptance"],
+            ["oauth-authorization-code-replay-rejected", "replayed-acceptance"],
+            ["oauth-wrong-audience-rejected", "wrong-audience"],
+            ["post-cleanup", "post-cleanup"],
+          ];
+          const probes = probeMap.flatMap(([suffix, kind]) => {
+            const entry = evidence.get(`${callerId}:${suffix}`);
+            return entry?.httpStatus ? [{kind, status: entry.httpStatus, at: entry.timestamp, ...(entry.proofDigest ? {proofDigest: entry.proofDigest} : {})}] : [];
+          });
+          const revokedAt = lease?.journal?.findLast(entry => entry.operation === "revoke-cleanup" && entry.outcome === "ok")?.at ?? null;
           const receipt = {
             actor: process.env.ACTOR,
             runUrl: process.env.RUN_URL,
@@ -473,10 +648,22 @@ jobs:
             assertions,
             startedAt: new Date().toISOString(),
             completedAt: new Date().toISOString(),
-            result: "blocked",
+            result: allPassed ? "pass" : "blocked",
             rollbackTarget: process.env.ROLLBACK_SHA || null,
             priorKnownGoodSha: process.env.ROLLBACK_SHA || null,
-            currentKnownGoodSha: null,
+            currentKnownGoodSha: allPassed ? process.env.SHA : null,
+            ...(lease ? {
+              lease: {id: lease.id, issuedAt: lease.createdAt, expiresAt: lease.expiresAt, revokedAt: lease.state === "revoked" ? revokedAt : null, state: lease.state},
+              cleanup: {
+                inferenceAuthority: lease.verification.inferenceDisabled ? "verified-absent" : "failed",
+                databaseBranches: lease.verification.branchesDeleted ? "verified-absent" : "failed",
+                runtimeConfiguration: lease.verification.runtimeVariablesAbsent ? "verified-absent" : "failed",
+                tombstoneDeployIds: lease.members.flatMap(member => member.tombstoneDeployId ? [member.tombstoneDeployId] : []),
+                verifiedAt: cleanupPassed ? new Date().toISOString() : null,
+              },
+              scenarios,
+              ...(authorities.length || acceptanceMetadata.length || productionMetadata.length || probes.length ? {isolation: {authorities, metadata: [...productionMetadata, ...acceptanceMetadata], probes}} : {}),
+            } : {}),
           };
           fs.writeFileSync(process.env.RUNNER_TEMP + "/trusted-acceptance-receipt.json", JSON.stringify(receipt, null, 2));
           NODE

--- a/.github/workflows/trusted-acceptance.yml
+++ b/.github/workflows/trusted-acceptance.yml
@@ -659,7 +659,10 @@ jobs:
                 inferenceAuthority: lease.verification.inferenceDisabled ? "verified-absent" : "failed",
                 databaseBranches: lease.verification.branchesDeleted ? "verified-absent" : "failed",
                 runtimeConfiguration: lease.verification.runtimeVariablesAbsent ? "verified-absent" : "failed",
-                tombstoneDeployIds: lease.members.flatMap(member => member.tombstoneDeployId ? [member.tombstoneDeployId] : []),
+                tombstoneDeployIds: [
+                  ...lease.members.flatMap(member => member.tombstoneDeployId ? [member.tombstoneDeployId] : []),
+                  ...(lease.directoryFixture?.tombstoneDeployId ? [lease.directoryFixture.tombstoneDeployId] : []),
+                ],
                 verifiedAt: cleanupPassed ? new Date().toISOString() : null,
               },
               scenarios,

--- a/docs/trusted-acceptance-lane.md
+++ b/docs/trusted-acceptance-lane.md
@@ -15,13 +15,23 @@ credential isolation.
 
 The `calendar-content` pilot in
 `scripts/trusted-acceptance-workspaces.json` is checked in with `enabled: false`.
-The workflow can validate an open PR, produce the generic app matrix, and build
-the candidate without runtime or deployment credentials. The repository also
-contains the provider-neutral `trusted-lease-v1` controller contract, bounded
-provider adapters, acceptance-only directory fixture, hosted OAuth/A2A harness,
-and independent reaper entrypoint. None of those declarations activates the
-pilot. A live deployment fails closed because the checked-in workspace has an
-`unconfigured` provisioner as well as `enabled: false`.
+Its reviewed source contract selects the generic `trusted-lease-v1`
+provisioner, fixed Calendar-to-Content withdrawal harness, and an exact
+acceptance-only directory origin. The workflow can validate an open PR, produce
+the generic app matrix, and build the candidate without runtime or deployment
+credentials. The repository also contains the bounded provider adapters,
+hosted OAuth/A2A runner, Playwright adapter, and independent reaper entrypoint.
+None of those declarations activates the pilot. A live deployment fails closed
+while `enabled` remains false, and activation still requires an exact protected
+authority profile backed by resources that do not yet exist as part of this
+source change.
+
+The `tasks-hosted-oauth-proof` workspace is also disabled and intentionally
+unconfigured. It declares the same generic hosted OAuth path plus one harmless
+read-only Tasks tool. That is the source-blind third-template acceptance story;
+it does not claim that a Tasks site or authority profile has already been
+provisioned. I8 belongs to that separate Tasks receipt rather than being marked
+passed inside a Calendar/Content run that did not execute Tasks.
 
 Activation is a separate reviewed change. It must name an allowlisted protected
 authority profile, prove the dedicated resources exist, and change the flag.
@@ -44,18 +54,25 @@ The jobs deliberately have different custody:
    inert build artifacts and SHA metadata.
 3. The privileged controller uses the protected `trusted-acceptance` GitHub
    Environment. It
-   checks out trusted controller code, installs dependencies and the pinned
-   Netlify client before credentials enter,
+   checks out trusted controller code, installs dependencies, Playwright
+   Chromium, and the pinned Netlify client before credentials enter,
    rejects any resolved site ID present in the production-site inventory,
    downloads and verifies inert artifacts, then uploads them from an empty
    trusted directory using explicit paths. Candidate `netlify.toml`, plugins,
-   and hooks never cross into this job. Only then do the fixed trusted
+   and hooks never cross into this job, and recursive inspection rejects
+   symlinks and non-regular artifact entries. Only then do the fixed trusted
    acquire/upload/revoke steps receive scoped provider credentials. The upload
    uses `--no-build`, and no candidate or dependency script runs after that
    boundary.
-4. `receipt` records a redacted artifact. Until the real OAuth/A2A harness is
-   run, behavioral assertions remain `blocked`; a deployment alone is not a
-   passing acceptance result.
+4. The trusted hosted runner creates the disposable lease, deploys only the
+   verified artifacts, signs into each app with a lease-bound synthetic QA
+   identity, and performs real authorization-code plus S256 PKCE. It then runs
+   the workspace's declared harness and negative isolation probes. The runner
+   keeps passwords, authorization codes, verifiers, client secrets, access
+   tokens, and provider credentials in process memory only.
+5. `receipt` records status, origins, public OAuth metadata, timestamps, and
+   SHA-256 proof digests only. Any missing live probe remains `blocked`; a
+   deployment alone is not a passing acceptance result.
 
 Runs share a non-cancelling concurrency group per workspace, so two candidate
 SHAs cannot interleave across the same apps.
@@ -70,8 +87,9 @@ candidate configuration runs after that boundary.
 `scripts/trusted-acceptance/runtime-authority.ts` separates two kinds of state:
 
 - transient runtime material, which contains the database URL, freshly
-  generated Better Auth and A2A values, and an optional bounded inference key;
-  and
+  generated Better Auth and A2A values, the hosted-QA verification flag, a
+  five-minute acceptance access-token lifetime, and an optional bounded
+  inference key; and
 - a durable redacted lease record containing only deterministic lease identity,
   opaque provider handles, timestamps, state transitions, and cleanup results.
 
@@ -84,6 +102,10 @@ The provider contract is generic, while the first protected profile uses:
 - one expiring OpenRouter child key for each member that declares inference,
   with a small USD cap and no automatic limit reset; and
 - a trusted tombstone artifact deployed after runtime values are removed.
+
+Every leased Netlify value is scoped to the production deploy context of its
+dedicated acceptance site. Branch, preview, and development contexts never
+receive the disposable database, authentication, A2A, or inference values.
 
 The OpenRouter management key, Neon API key, and Netlify control token remain in
 the protected controller environment. Candidate code sees only the disposable
@@ -124,17 +146,31 @@ Separately hosted templates do not form a local filesystem workspace. Hosted
 acceptance lane supplies a small trusted fixture implementing only that public
 contract; it does not reuse production Dispatch data or authority.
 
-The fixture validates the disposable A2A bearer and returns only the members
-declared by the trusted workspace profile. Its mode is controller-owned and has
-two allowlisted states: stable membership and withdrawal of one declared
-member. There is no candidate-callable control endpoint and no request field
-that selects arbitrary apps or URLs.
+The fixture is a separate, database-free Netlify runtime. It validates the
+disposable A2A bearer and returns only the members declared by the trusted
+workspace profile. Its mode is controller-owned and has two allowlisted states:
+stable membership and withdrawal of one declared member. There is no
+candidate-callable control endpoint and no request field that selects arbitrary
+apps or URLs. Changing that allowlisted state is not sufficient by itself: the
+controller redeploys the same digest-pinned trusted fixture artifact so the
+running function observes the new state before status polling continues.
+Each leased member receives the fixture's exact origin through
+`AGENT_NATIVE_ORG_DIRECTORY_URL`. A freshly registered QA account may not have
+an organization row yet, so the fixture accepts its signed email domain as the
+organization scope only when the JWT omits `org_domain` and that domain exactly
+matches the protected fixture profile.
 
 The hosted harness first proves stable discovery, calls `ask_app`, records the
 returned task ID only in redacted form, asks the trusted controller to withdraw
-the target member, and polls `ask_app_status` for that same task. This makes
-directory loss a discriminating test of preserved task routing instead of a
-simulation that skips discovery.
+the target member, and redeploys both the trusted fixture and the caller from
+their already verified artifacts. Redeploying the caller clears its bounded
+directory cache; `list_apps` must then prove the target is absent before the
+harness polls `ask_app_status` for that same task. The configured poll budget is
+preserved exactly, with a bounded delay between attempts, and the completed
+result must contain a controller-rendered, lease-unique marker carried in the
+task prompt. The marker is not stored in an app database and its digest, not its
+value, enters evidence. This makes directory loss a discriminating test of
+preserved task routing without adding an undeclared seed-data dependency.
 
 ## Provision the first workspace
 
@@ -173,6 +209,44 @@ progress. Its authority must become useless when cleanup completes; production,
 ordinary previews, other workspaces, and later acceptance runs remain outside
 the blast radius.
 
+## Hosted QA identity and OAuth
+
+The hosted-QA identity uses the framework's normal email/password session path,
+not `AUTH_DISABLED`, direct session seeding, a provider account, or a production
+identity. The controller creates a synthetic `+qa` email and a random 256-bit
+password for one lease, registers it at the exact acceptance origin, verifies a
+wrong password fails in an isolated browser context, and closes the credential
+over an in-memory callback. `AUTH_SKIP_EMAIL_VERIFICATION=1` is installed only
+after exact lease-marker ownership is proven and is removed by normal cleanup
+and the independent reaper.
+
+After sign-in, the browser approves the app's real MCP OAuth authorization
+surface. The runner uses dynamic client registration, an exact loopback
+callback, exact state matching, and RFC 7636 S256 PKCE before exchanging the
+code for a five-minute access token. The browser and protocol adapters reject
+cross-origin authorization, consent, registration, and token endpoints.
+
+The runner also creates a second synthetic user in a separate browser context.
+The first user writes a lease-bound display-name marker through the shared
+`update-user-profile` action; the second reads through `get-user-profile` and
+must not receive that marker, while the first must still receive it. This is the
+generic tenant-data isolation probe used by I4 and does not depend on a
+template-specific schema.
+
+The isolation story does not require a valid production token. An acceptance
+token must fail at the production resource and a different acceptance resource,
+and a controller-created foreign-domain sentinel must fail at the acceptance
+resource. The receipt also requires public issuer/resource metadata to remain
+distinct and records expiry, replay, wrong-audience, and post-cleanup failures.
+If the running framework does not expose a safe way to perform one of those
+probes, that assertion stays blocked rather than being inferred. Only response
+status and proof digests are durable.
+
+The controller imposes a hard hosted-harness deadline shorter than the lease,
+and every HTTP phase has a bounded timeout. The loopback callback listener also
+closes itself on timeout. Any stall enters the same verified revoke path; the
+independent reaper remains the recovery layer for runner or host termination.
+
 For each app, the infrastructure owner may prepare:
 
 - create a dedicated Netlify site and stable acceptance domain matching the
@@ -195,20 +269,22 @@ Configure the protected GitHub Environment named `trusted-acceptance` with:
   and
 - non-secret `ACCEPTANCE_AUTHORITY_PROFILES_JSON`, an object keyed by workspace
   ID. Each profile allowlists exact member origins, Neon project/database/role
-  IDs, Netlify account/site IDs, the tiny inference cap, and the verified
-  tombstone artifact. It contains no provider token or runtime credential.
+  IDs, Netlify account/site IDs, the tiny inference cap, the verified tombstone
+  artifact, and the directory fixture's exact account, site, origin, member map,
+  withdrawal target, trusted artifact path, artifact SHA-256, and the exact
+  synthetic hosted-QA domain `agent-native.acceptance.invalid`. It contains no
+  provider token or runtime credential.
 
 The repository contains key names and resource references only. Never put
 secret values, synthetic login credentials, tokens, or raw provider responses
 in the workspace config, workflow, docs, logs, or receipt.
 
 After a redacted inventory proves those resources are isolated and the trusted
-provision/cleanup implementation has its own security review and tests, replace
-the `{ "kind": "unconfigured" }` provisioner with a `trusted-lease-v1`
-descriptor, add its exact entry to the protected profile map, then change the
-workspace to `enabled: true` in a separate reviewed PR. The descriptor's
-`profileMapVariable` must be exactly `ACCEPTANCE_AUTHORITY_PROFILES_JSON`;
-changing only the flag still fails closed.
+provision/cleanup implementation has its own security review and tests, add the
+workspace's exact entry to the protected profile map, then change the workspace
+to `enabled: true` in a separate reviewed activation PR. The checked-in
+descriptor's `profileMapVariable` must remain exactly
+`ACCEPTANCE_AUTHORITY_PROFILES_JSON`; changing only the flag still fails closed.
 Keep GitHub Environment approval rules in place; enabling configuration is not
 permission to bypass them.
 
@@ -229,10 +305,12 @@ For a live run after activation, set `deploy` to true. The stable apps must then
 be tested with a real authorization-code plus PKCE client: inspect protected
 resource metadata, connect to Calendar, require Content from `list_apps`, call a
 bounded read-only `ask_app`, and poll the returned ID through `ask_app_status`.
-After `ask_app`, the trusted directory fixture withdraws the target member;
-`ask_app_status` must still complete that exact task through its preserved
-route. Run production-to-acceptance, acceptance-to-production, and
-cross-resource token replay negatives before marking the receipt passed.
+After `ask_app`, the trusted directory fixture withdraws the target member and
+both fixture and caller are redeployed from their same verified artifacts;
+`list_apps` must no longer name the target, while `ask_app_status` must still
+complete that exact task through its preserved route and return the expected
+synthetic result. The declared isolation probes must all return their required
+fail-closed status before the receipt can pass.
 
 ## Roll back
 
@@ -243,8 +321,13 @@ requires the prior run to be a successful `main` dispatch of this exact
 workflow, and matches its controller SHA, workspace, and current known-good SHA.
 It then verifies that the commit still resolves exactly in
 `BuilderIO/agent-native`, rebuilds it without credentials, and redeploys it
-through the same isolated path. Rollback never promotes acceptance code or data
-to production.
+through the same isolated path. A14 passes only when the rollback operation's
+own hosted controller receipt passes and every workspace member records a
+deployment ID; selecting a rollback operation is not evidence by itself.
+Candidate receipts intentionally omit rollback-only A14, allowing a fully
+passing candidate to establish the known-good SHA that a later rollback run
+must cite. Rollback receipts include A14 and re-run the other configured proofs.
+Rollback never promotes acceptance code or data to production.
 
 ## Add another hosted template
 
@@ -271,7 +354,8 @@ pnpm tsx --test scripts/trusted-acceptance/*.spec.ts
 pnpm guard:trusted-acceptance
 ```
 
-The generic fixture in `scripts/trusted-acceptance.spec.ts` uses the repository's
-real Tasks template to demonstrate that a third template validates and produces
-a plan without changing workflow code. A real secretless Tasks build remains an
-activation-time proof, not something this schema test claims to establish.
+The disabled `tasks-hosted-oauth-proof` workspace uses the repository's real
+Tasks template to demonstrate that the same runner can select a generic
+`mcp-read-only-tool` harness without a template branch or template auth change.
+A real hosted Tasks run remains a later activation-time proof, not something
+this source contract claims to establish.

--- a/scripts/guard-trusted-acceptance-workflow.spec.ts
+++ b/scripts/guard-trusted-acceptance-workflow.spec.ts
@@ -139,6 +139,20 @@ describe("trusted acceptance workflow boundary", () => {
     );
   });
 
+  it("requires isolation targets to resolve independently of A2A harnesses", () => {
+    const unsafe = workflow.replace(
+      "declaredPlan.isolation.otherAcceptanceMemberId",
+      "declaredPlan.harness.targetMemberId",
+    );
+    const result = validateTrustedAcceptanceWorkflow(unsafe);
+    assert.equal(result.ok, false);
+    assert(
+      result.issues.some((issue) =>
+        issue.includes("independently of harness kind"),
+      ),
+    );
+  });
+
   it("requires Playwright installation before protected credentials enter", () => {
     const unsafe = workflow.replace(
       "          pnpm exec playwright install --with-deps chromium\n",

--- a/scripts/guard-trusted-acceptance-workflow.spec.ts
+++ b/scripts/guard-trusted-acceptance-workflow.spec.ts
@@ -59,6 +59,16 @@ describe("trusted acceptance workflow boundary", () => {
     assert(result.issues.some((issue) => issue.includes("hidden Netlify")));
   });
 
+  it("requires candidate artifacts to reject symlinks before credentials", () => {
+    const unsafe = workflow.replace(
+      "                if (stat.isSymbolicLink()) throw new Error(`Candidate artifact contains a symlink: ${file}`);\n",
+      "",
+    );
+    const result = validateTrustedAcceptanceWorkflow(unsafe);
+    assert.equal(result.ok, false);
+    assert(result.issues.some((issue) => issue.includes("symlinks")));
+  });
+
   it("rejects rollback planning that always bypasses activation gates", () => {
     const unsafe = workflow.replace(
       '            if [[ "$DEPLOY_REQUESTED" != "true" ]]; then\n              rollback_plan_args+=(--allow-disabled)\n            fi',
@@ -112,6 +122,31 @@ describe("trusted acceptance workflow boundary", () => {
     const result = validateTrustedAcceptanceWorkflow(unsafe);
     assert.equal(result.ok, false);
     assert(result.issues.some((issue) => issue.includes("controller SHA")));
+  });
+
+  it("requires the generic hosted runner and trusted directory digest", () => {
+    const unsafe = workflow
+      .replace("run-hosted-acceptance.ts", "controller.ts")
+      .replace("artifactSha256", "uncheckedDigest");
+    const result = validateTrustedAcceptanceWorkflow(unsafe);
+    assert.equal(result.ok, false);
+    assert(
+      result.issues.some(
+        (issue) =>
+          issue.includes("hosted runner") ||
+          issue.includes("directory artifact"),
+      ),
+    );
+  });
+
+  it("requires Playwright installation before protected credentials enter", () => {
+    const unsafe = workflow.replace(
+      "          pnpm exec playwright install --with-deps chromium\n",
+      "",
+    );
+    const result = validateTrustedAcceptanceWorkflow(unsafe);
+    assert.equal(result.ok, false);
+    assert(result.issues.some((issue) => issue.includes("Playwright")));
   });
 });
 

--- a/scripts/guard-trusted-acceptance-workflow.ts
+++ b/scripts/guard-trusted-acceptance-workflow.ts
@@ -133,6 +133,13 @@ export function validateTrustedAcceptanceWorkflow(
       issues.push("artifact provenance must be checked before deployment");
     }
     if (
+      !deploy.includes("lstatSync") ||
+      !deploy.includes("Candidate artifact contains a symlink")
+    )
+      issues.push(
+        "candidate artifacts must reject symlinks and non-regular files before privileged custody",
+      );
+    if (
       !deploy.includes('readFileSync("scripts/netlify-sites.json"') ||
       !deploy.includes("known production site ID")
     ) {
@@ -140,18 +147,25 @@ export function validateTrustedAcceptanceWorkflow(
         "resolved acceptance site must be rejected if it is a production site",
       );
     }
-    if (!deploy.includes("netlify deploy --prod --no-build")) {
-      issues.push("privileged deployment must never rebuild candidate code");
-    }
     if (
+      !deploy.includes("run-hosted-acceptance.ts") ||
       !deploy.includes(
-        '--functions "$artifact_dir/.netlify/functions-internal"',
+        '--deploy-manifest "$RUNNER_TEMP/trusted-deploy-manifest.json"',
       )
-    ) {
+    )
       issues.push(
-        "deployment must upload the prebuilt Netlify function bundle",
+        "protected deployment must use the generic trusted hosted runner",
       );
-    }
+    if (!deploy.includes("playwright install --with-deps chromium"))
+      issues.push("Playwright must be installed before credentials enter");
+    if (
+      !deploy.includes("directory-fixture.ts") ||
+      !deploy.includes("artifactSha256") ||
+      !deploy.includes('hash.update(relative).update("\\0")')
+    )
+      issues.push(
+        "trusted directory artifact must be staged and digest-bound before credentials enter",
+      );
     if (
       !deploy.includes(
         "working-directory: ${{ runner.temp }}/trusted-acceptance-deploy",
@@ -168,8 +182,12 @@ export function validateTrustedAcceptanceWorkflow(
       issues.push("privileged authority must operate on one whole workspace");
     }
     if (
-      !deploy.includes("Acquire one whole-workspace disposable lease") ||
-      !deploy.includes("Revoke one whole-workspace disposable lease") ||
+      !deploy.includes(
+        "Run trusted hosted OAuth, harness, deployment, and cleanup",
+      ) ||
+      !deploy.includes(
+        "Revoke one whole-workspace disposable lease after interruption",
+      ) ||
       !deploy.includes("if: ${{ always() }}")
     ) {
       issues.push("whole-workspace cleanup must run unconditionally");
@@ -200,9 +218,9 @@ export function validateTrustedAcceptanceWorkflow(
     }
   }
 
-  if (count(source, /secrets\.ACCEPTANCE_NETLIFY_AUTH_TOKEN/g) !== 3) {
+  if (count(source, /secrets\.ACCEPTANCE_NETLIFY_AUTH_TOKEN/g) !== 2) {
     issues.push(
-      "acceptance Netlify credential must appear only in acquire, deploy, and revoke steps",
+      "acceptance Netlify credential must appear only in hosted-runner and interruption-cleanup steps",
     );
   }
   if (

--- a/scripts/guard-trusted-acceptance-workflow.ts
+++ b/scripts/guard-trusted-acceptance-workflow.ts
@@ -167,6 +167,15 @@ export function validateTrustedAcceptanceWorkflow(
         "trusted directory artifact must be staged and digest-bound before credentials enter",
       );
     if (
+      !deploy.includes("declaredPlan.isolation.otherAcceptanceMemberId") ||
+      !deploy.includes(
+        "Configured isolation member is missing from the trusted plan",
+      )
+    )
+      issues.push(
+        "hosted isolation must resolve its member independently of harness kind",
+      );
+    if (
       !deploy.includes(
         "working-directory: ${{ runner.temp }}/trusted-acceptance-deploy",
       ) ||

--- a/scripts/trusted-acceptance-workspaces.json
+++ b/scripts/trusted-acceptance-workspaces.json
@@ -1,5 +1,5 @@
 {
-  "revision": "3",
+  "revision": "6",
   "workspaces": [
     {
       "id": "calendar-content",
@@ -7,8 +7,26 @@
       "runtimeAuthority": {
         "lifecycle": "ephemeral-per-run",
         "provisioner": {
-          "kind": "unconfigured"
+          "kind": "trusted-lease-v1",
+          "profileMapVariable": "ACCEPTANCE_AUTHORITY_PROFILES_JSON"
         }
+      },
+      "directoryFixture": {
+        "origin": "https://directory.acceptance.agent-native.com",
+        "siteIdVariable": "ACCEPTANCE_DIRECTORY_NETLIFY_SITE_ID",
+        "withdrawnMemberId": "content"
+      },
+      "harness": {
+        "kind": "a2a-directory-withdrawal",
+        "callerMemberId": "calendar",
+        "targetMemberId": "content",
+        "message": "Return only this exact lease-bound marker: {{TRUSTED_ACCEPTANCE_LEASE_MARKER}}",
+        "expectedResult": "{{TRUSTED_ACCEPTANCE_LEASE_MARKER}}",
+        "maxStatusPolls": 20
+      },
+      "isolation": {
+        "productionOrigin": "https://calendar.agent-native.com",
+        "otherAcceptanceMemberId": "content"
       },
       "assertions": [
         "A1",
@@ -24,7 +42,14 @@
         "A11",
         "A12",
         "A13",
-        "A14"
+        "A14",
+        "I1",
+        "I2",
+        "I3",
+        "I4",
+        "I5",
+        "I6",
+        "I7"
       ],
       "members": [
         {
@@ -62,6 +87,46 @@
           "build": {
             "command": "pnpm --filter content build",
             "publishDirectory": "templates/content/dist"
+          },
+          "paths": {
+            "health": "/_agent-native/health",
+            "oauthMetadata": "/.well-known/oauth-protected-resource",
+            "mcp": "/mcp"
+          }
+        }
+      ]
+    },
+    {
+      "id": "tasks-hosted-oauth-proof",
+      "enabled": false,
+      "runtimeAuthority": {
+        "lifecycle": "ephemeral-per-run",
+        "provisioner": {
+          "kind": "unconfigured"
+        }
+      },
+      "harness": {
+        "kind": "mcp-read-only-tool",
+        "memberId": "tasks",
+        "tool": "list-tasks",
+        "arguments": {
+          "limit": 1
+        }
+      },
+      "assertions": ["I1", "I2", "I3", "I5", "I6", "I8"],
+      "members": [
+        {
+          "template": "tasks",
+          "origin": "https://tasks.acceptance.agent-native.com",
+          "siteIdVariable": "ACCEPTANCE_TASKS_NETLIFY_SITE_ID",
+          "environment": {
+            "databaseUrl": "ACCEPTANCE_TASKS_DATABASE_URL",
+            "betterAuthSecret": "ACCEPTANCE_TASKS_BETTER_AUTH_SECRET",
+            "a2aSecret": "ACCEPTANCE_TASKS_A2A_SECRET"
+          },
+          "build": {
+            "command": "pnpm --filter tasks build",
+            "publishDirectory": "templates/tasks/dist"
           },
           "paths": {
             "health": "/_agent-native/health",

--- a/scripts/trusted-acceptance.spec.ts
+++ b/scripts/trusted-acceptance.spec.ts
@@ -338,6 +338,30 @@ describe("trusted acceptance configuration", () => {
     }
   });
 
+  it("rejects an A2A harness that delegates to its caller", () => {
+    const fixture = config();
+    const harness = fixture.workspaces[0]!.harness;
+    assert.equal(harness.kind, "a2a-directory-withdrawal");
+    if (harness.kind === "a2a-directory-withdrawal") {
+      harness.targetMemberId = harness.callerMemberId;
+      fixture.workspaces[0]!.directoryFixture!.withdrawnMemberId =
+        harness.callerMemberId;
+    }
+    const result = validateTrustedAcceptanceConfig(fixture, [
+      "calendar",
+      "content",
+    ]);
+    assert.equal(result.ok, false);
+    if (!result.ok)
+      assert(
+        result.issues.some(
+          ({ path, message }) =>
+            path.endsWith("targetMemberId") &&
+            message.includes("cross-app delegation"),
+        ),
+      );
+  });
+
   it("rejects reusable runtime authority configuration", () => {
     const fixture = config();
     (

--- a/scripts/trusted-acceptance.spec.ts
+++ b/scripts/trusted-acceptance.spec.ts
@@ -468,7 +468,10 @@ describe("trusted acceptance receipts", () => {
         inferenceAuthority: "verified-absent",
         databaseBranches: "verified-absent",
         runtimeConfiguration: "verified-absent",
-        tombstoneDeployIds: ["tombstone-calendar-123"],
+        tombstoneDeployIds: [
+          "tombstone-calendar-123",
+          "tombstone-directory-123",
+        ],
         verifiedAt: "2026-07-25T12:01:00.000Z",
       },
       scenarios: {
@@ -527,6 +530,13 @@ describe("trusted acceptance receipts", () => {
       ok: true,
       issues: [],
     });
+    receipt.cleanup!.tombstoneDeployIds.pop();
+    const missingDirectoryTombstone = validateTrustedAcceptanceReceipt(receipt);
+    assert.equal(missingDirectoryTombstone.ok, false);
+    if (!missingDirectoryTombstone.ok)
+      assert(
+        missingDirectoryTombstone.issues.some(({ path }) => path === "cleanup"),
+      );
   });
 
   it("rejects sensitive fields and values in receipts", () => {

--- a/scripts/trusted-acceptance.spec.ts
+++ b/scripts/trusted-acceptance.spec.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { describe, it } from "node:test";
 
 import {
@@ -23,6 +23,23 @@ function config(): TrustedAcceptanceConfig {
         runtimeAuthority: {
           lifecycle: "ephemeral-per-run",
           provisioner: { kind: "unconfigured" },
+        },
+        directoryFixture: {
+          origin: "https://directory-acceptance.example.test",
+          siteIdVariable: "ACCEPTANCE_DIRECTORY_NETLIFY_SITE_ID",
+          withdrawnMemberId: "content",
+        },
+        harness: {
+          kind: "a2a-directory-withdrawal",
+          callerMemberId: "calendar",
+          targetMemberId: "content",
+          message: "Return the title of the seeded fixture document.",
+          expectedResult: "TRUSTED_ACCEPTANCE_FIXTURE",
+          maxStatusPolls: 12,
+        },
+        isolation: {
+          productionOrigin: "https://calendar.example.test",
+          otherAcceptanceMemberId: "content",
         },
         assertions: ["A1", "A2", "A3"],
         members: [
@@ -71,6 +88,39 @@ function config(): TrustedAcceptanceConfig {
 }
 
 describe("trusted acceptance configuration", () => {
+  it("keeps the declared pilot and Tasks proof disabled while exposing reviewed harness contracts", () => {
+    const declared = JSON.parse(
+      readFileSync("scripts/trusted-acceptance-workspaces.json", "utf8"),
+    ) as TrustedAcceptanceConfig;
+    assert.deepEqual(
+      validateTrustedAcceptanceConfig(declared, [
+        "calendar",
+        "content",
+        "tasks",
+      ]),
+      { ok: true, issues: [] },
+    );
+    assert.equal(declared.revision, "6");
+    assert.equal(
+      declared.workspaces.every(({ enabled }) => !enabled),
+      true,
+    );
+    assert.equal(
+      declared.workspaces[0]?.runtimeAuthority.provisioner.kind,
+      "trusted-lease-v1",
+    );
+    assert.deepEqual(declared.workspaces[0]?.harness, {
+      kind: "a2a-directory-withdrawal",
+      callerMemberId: "calendar",
+      targetMemberId: "content",
+      message:
+        "Return only this exact lease-bound marker: {{TRUSTED_ACCEPTANCE_LEASE_MARKER}}",
+      expectedResult: "{{TRUSTED_ACCEPTANCE_LEASE_MARKER}}",
+      maxStatusPolls: 20,
+    });
+    assert.equal(declared.workspaces[1]?.harness.kind, "mcp-read-only-tool");
+  });
+
   it("accepts a generic third-template workspace without a controller branch", () => {
     assert.equal(existsSync("templates/tasks/package.json"), true);
     const fixture = config();
@@ -80,6 +130,12 @@ describe("trusted acceptance configuration", () => {
       runtimeAuthority: {
         lifecycle: "ephemeral-per-run",
         provisioner: { kind: "unconfigured" },
+      },
+      harness: {
+        kind: "mcp-read-only-tool",
+        memberId: "tasks",
+        tool: "list-tasks",
+        arguments: { limit: 1 },
       },
       assertions: ["A1"],
       members: [
@@ -115,6 +171,12 @@ describe("trusted acceptance configuration", () => {
         plan.plan.members.map(({ template }) => template),
         ["tasks"],
       );
+      assert.deepEqual(plan.plan.harness, {
+        kind: "mcp-read-only-tool",
+        memberId: "tasks",
+        tool: "list-tasks",
+        arguments: { limit: 1 },
+      });
     }
   });
 
@@ -131,17 +193,14 @@ describe("trusted acceptance configuration", () => {
     ]);
     assert.equal(result.ok, false);
     if (!result.ok) {
-      assert.deepEqual(
-        result.issues.map(({ path }) => path),
-        [
-          "workspaces[0].members[1].template",
-          "workspaces[0].members[1].origin",
-          "workspaces[0].members[1].siteIdVariable",
-          "workspaces[0].members[1].environment.betterAuthSecret",
-          "workspaces[0].members[1].build.command",
-          "workspaces[0].members[1].build.publishDirectory",
-        ],
-      );
+      assert.deepEqual(result.issues.map(({ path }) => path).slice(0, 6), [
+        "workspaces[0].members[1].template",
+        "workspaces[0].members[1].origin",
+        "workspaces[0].members[1].siteIdVariable",
+        "workspaces[0].members[1].environment.betterAuthSecret",
+        "workspaces[0].members[1].build.command",
+        "workspaces[0].members[1].build.publishDirectory",
+      ]);
     }
   });
 
@@ -258,6 +317,27 @@ describe("trusted acceptance configuration", () => {
     }
   });
 
+  it("rejects harness members that are not declared or selected for withdrawal", () => {
+    const fixture = config();
+    const harness = fixture.workspaces[0]!.harness;
+    assert.equal(harness.kind, "a2a-directory-withdrawal");
+    if (harness.kind === "a2a-directory-withdrawal") {
+      harness.callerMemberId = "mail";
+      harness.targetMemberId = "calendar";
+      harness.maxStatusPolls = 0;
+    }
+    const result = validateTrustedAcceptanceConfig(fixture, [
+      "calendar",
+      "content",
+    ]);
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert(result.issues.some(({ path }) => path.endsWith("callerMemberId")));
+      assert(result.issues.some(({ path }) => path.endsWith("targetMemberId")));
+      assert(result.issues.some(({ path }) => path.endsWith("maxStatusPolls")));
+    }
+  });
+
   it("rejects reusable runtime authority configuration", () => {
     const fixture = config();
     (
@@ -350,8 +430,8 @@ describe("trusted acceptance receipts", () => {
       startedAt: "2026-07-25T12:00:00.000Z",
       completedAt: "2026-07-25T12:01:00.000Z",
       result: "pass",
-      rollbackTarget: "b".repeat(40),
-      priorKnownGoodSha: "b".repeat(40),
+      rollbackTarget: null,
+      priorKnownGoodSha: null,
       currentKnownGoodSha: sha,
       lease: {
         id: "lease-123",
@@ -368,9 +448,55 @@ describe("trusted acceptance receipts", () => {
         verifiedAt: "2026-07-25T12:01:00.000Z",
       },
       scenarios: {
+        kind: "a2a-directory-withdrawal",
+        hostedOAuth: "pass",
         stableDiscovery: "pass",
         discoveryWithdrawal: "pass",
         taskRouteContinuity: "pass",
+      },
+      isolation: {
+        authorities: [
+          {
+            memberId: "calendar",
+            provenance: "fresh-per-run",
+            algorithm: "sha256",
+            digest: `sha256:${"d".repeat(64)}`,
+            generatedAt: "2026-07-25T11:59:00.000Z",
+          },
+        ],
+        metadata: [
+          {
+            role: "production",
+            resource: "https://calendar.agent-native.com/mcp",
+            issuer: "https://calendar.agent-native.com",
+          },
+          {
+            role: "acceptance",
+            resource: "https://calendar-acceptance.example.test/mcp",
+            issuer: "https://calendar-acceptance.example.test",
+          },
+        ],
+        probes: [
+          "acceptance-at-production",
+          "acceptance-at-other-acceptance",
+          "foreign-domain-sentinel-at-acceptance",
+          "expired-acceptance",
+          "replayed-acceptance",
+          "wrong-audience",
+          "post-cleanup",
+        ].map((kind) => ({
+          kind: kind as
+            | "acceptance-at-production"
+            | "acceptance-at-other-acceptance"
+            | "foreign-domain-sentinel-at-acceptance"
+            | "expired-acceptance"
+            | "replayed-acceptance"
+            | "wrong-audience"
+            | "post-cleanup",
+          status: 401 as const,
+          at: "2026-07-25T12:00:00.000Z",
+          proofDigest: `sha256:${"e".repeat(64)}`,
+        })),
       },
     };
     assert.deepEqual(validateTrustedAcceptanceReceipt(receipt), {
@@ -408,6 +534,62 @@ describe("trusted acceptance receipts", () => {
     const result = validateTrustedAcceptanceReceipt(receipt);
     assert.equal(result.ok, false);
     if (!result.ok) assert.match(result.issues[0]!.message, /sensitive fields/);
+  });
+
+  it("rejects passing isolation evidence that omits a required foreign-domain probe", () => {
+    const receipt = {
+      actor: "maintainer-123",
+      runUrl: "https://github.com/BuilderIO/agent-native/actions/runs/123",
+      operation: "candidate",
+      pullRequest: 42,
+      sha,
+      controllerSha: "c".repeat(40),
+      configRevision: "4",
+      workspace: "tasks-hosted-oauth-proof",
+      members: [
+        {
+          template: "tasks",
+          origin: "https://tasks-acceptance.example.test",
+          deployId: "deploy-tasks-123",
+        },
+      ],
+      assertions: [{ id: "I7", state: "pass" }],
+      startedAt: "2026-07-25T12:00:00.000Z",
+      completedAt: "2026-07-25T12:01:00.000Z",
+      result: "pass",
+      rollbackTarget: "b".repeat(40),
+      priorKnownGoodSha: "b".repeat(40),
+      currentKnownGoodSha: sha,
+      lease: {
+        id: "lease-123",
+        issuedAt: "2026-07-25T11:59:00.000Z",
+        expiresAt: "2026-07-25T12:30:00.000Z",
+        revokedAt: "2026-07-25T12:01:00.000Z",
+        state: "revoked",
+      },
+      cleanup: {
+        inferenceAuthority: "verified-absent",
+        databaseBranches: "verified-absent",
+        runtimeConfiguration: "verified-absent",
+        tombstoneDeployIds: ["tombstone-tasks-123"],
+        verifiedAt: "2026-07-25T12:01:00.000Z",
+      },
+      scenarios: {
+        kind: "mcp-read-only-tool",
+        hostedOAuth: "pass",
+        readOnlyTool: "pass",
+      },
+      isolation: {
+        authorities: [],
+        metadata: [],
+        probes: [],
+      },
+    } as TrustedAcceptanceReceipt;
+    const result = validateTrustedAcceptanceReceipt(receipt, ["I7"]);
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert(result.issues.some(({ path }) => path === "isolation"));
+    }
   });
 
   it("rejects a passing result with blocked assertions", () => {

--- a/scripts/trusted-acceptance.ts
+++ b/scripts/trusted-acceptance.ts
@@ -392,6 +392,14 @@ export function validateTrustedAcceptanceConfig(
         });
       }
       if (
+        workspace.harness.callerMemberId === workspace.harness.targetMemberId
+      ) {
+        issues.push({
+          path: `${harnessPath}.targetMemberId`,
+          message: "must differ from the caller to prove cross-app delegation",
+        });
+      }
+      if (
         !templates.has(workspace.harness.targetMemberId) ||
         workspace.harness.targetMemberId !==
           workspace.directoryFixture?.withdrawnMemberId

--- a/scripts/trusted-acceptance.ts
+++ b/scripts/trusted-acceptance.ts
@@ -1025,6 +1025,9 @@ export function validateTrustedAcceptanceReceipt(
     }
   }
   if (receipt.result === "pass") {
+    const expectedTombstoneCount =
+      receipt.members.length +
+      (receipt.scenarios?.kind === "a2a-directory-withdrawal" ? 1 : 0);
     if (
       receipt.lease?.state !== "revoked" ||
       !receipt.lease.revokedAt ||
@@ -1032,12 +1035,12 @@ export function validateTrustedAcceptanceReceipt(
       receipt.cleanup.databaseBranches !== "verified-absent" ||
       receipt.cleanup.runtimeConfiguration !== "verified-absent" ||
       !receipt.cleanup.verifiedAt ||
-      receipt.cleanup.tombstoneDeployIds.length !== receipt.members.length
+      receipt.cleanup.tombstoneDeployIds.length !== expectedTombstoneCount
     ) {
       issues.push({
         path: "cleanup",
         message:
-          "passing receipts require verified lease revocation, database and runtime cleanup, and one trusted tombstone deploy per member",
+          "passing receipts require verified lease revocation, database and runtime cleanup, and one trusted tombstone deploy per member and directory fixture",
       });
     }
     const scenarios = receipt.scenarios;

--- a/scripts/trusted-acceptance.ts
+++ b/scripts/trusted-acceptance.ts
@@ -38,6 +38,27 @@ export type AcceptanceDirectoryFixture = {
   withdrawnMemberId: string;
 };
 
+export type AcceptanceHarness =
+  | {
+      kind: "a2a-directory-withdrawal";
+      callerMemberId: string;
+      targetMemberId: string;
+      message: string;
+      expectedResult: string;
+      maxStatusPolls: number;
+    }
+  | {
+      kind: "mcp-read-only-tool";
+      memberId: string;
+      tool: string;
+      arguments: Record<string, unknown>;
+    };
+
+export type AcceptanceIsolation = {
+  productionOrigin: string;
+  otherAcceptanceMemberId: string;
+};
+
 export type TrustedAcceptanceMember = {
   template: string;
   origin: string;
@@ -59,6 +80,8 @@ export type TrustedAcceptanceWorkspace = {
     provisioner: RuntimeAuthorityProvisioner;
   };
   directoryFixture?: AcceptanceDirectoryFixture;
+  harness: AcceptanceHarness;
+  isolation?: AcceptanceIsolation;
   assertions: string[];
   members: TrustedAcceptanceMember[];
 };
@@ -343,6 +366,123 @@ export function validateTrustedAcceptanceConfig(
       origins.add(workspace.directoryFixture.origin);
       siteIdVariables.add(workspace.directoryFixture.siteIdVariable);
     }
+
+    const harnessPath = `${workspacePath}.harness`;
+    if (
+      !workspace.harness ||
+      typeof (workspace.harness as { kind?: unknown }).kind !== "string"
+    ) {
+      issues.push({
+        path: harnessPath,
+        message: "must declare a generic acceptance harness",
+      });
+      continue;
+    }
+    if (workspace.harness.kind === "a2a-directory-withdrawal") {
+      if (!workspace.directoryFixture) {
+        issues.push({
+          path: `${harnessPath}.kind`,
+          message: "requires a trusted directory fixture",
+        });
+      }
+      if (!templates.has(workspace.harness.callerMemberId)) {
+        issues.push({
+          path: `${harnessPath}.callerMemberId`,
+          message: "must identify a declared workspace member",
+        });
+      }
+      if (
+        !templates.has(workspace.harness.targetMemberId) ||
+        workspace.harness.targetMemberId !==
+          workspace.directoryFixture?.withdrawnMemberId
+      ) {
+        issues.push({
+          path: `${harnessPath}.targetMemberId`,
+          message: "must identify the directory member selected for withdrawal",
+        });
+      }
+      if (!workspace.isolation) {
+        issues.push({
+          path: `${workspacePath}.isolation`,
+          message: "is required for the route-continuity trust boundary",
+        });
+      }
+      if (
+        !workspace.harness.message.trim() ||
+        workspace.harness.message.length > 500
+      ) {
+        issues.push({
+          path: `${harnessPath}.message`,
+          message: "must be a bounded non-empty fixture message",
+        });
+      }
+      if (
+        !Number.isInteger(workspace.harness.maxStatusPolls) ||
+        workspace.harness.maxStatusPolls < 1 ||
+        workspace.harness.maxStatusPolls > 60
+      ) {
+        issues.push({
+          path: `${harnessPath}.maxStatusPolls`,
+          message: "must be an integer from 1 through 60",
+        });
+      }
+      if (
+        !workspace.harness.expectedResult?.trim() ||
+        workspace.harness.expectedResult.length > 200
+      ) {
+        issues.push({
+          path: `${harnessPath}.expectedResult`,
+          message: "must name a bounded deterministic synthetic result",
+        });
+      }
+    } else if (workspace.harness.kind === "mcp-read-only-tool") {
+      if (!templates.has(workspace.harness.memberId)) {
+        issues.push({
+          path: `${harnessPath}.memberId`,
+          message: "must identify a declared workspace member",
+        });
+      }
+      if (!/^[a-z0-9][a-z0-9_-]*$/.test(workspace.harness.tool)) {
+        issues.push({
+          path: `${harnessPath}.tool`,
+          message: "must be a stable tool name",
+        });
+      }
+    } else {
+      issues.push({
+        path: `${harnessPath}.kind`,
+        message: "must name a supported generic harness",
+      });
+    }
+    if (workspace.isolation) {
+      try {
+        const production = new URL(workspace.isolation.productionOrigin);
+        if (
+          production.protocol !== "https:" ||
+          production.origin !== workspace.isolation.productionOrigin ||
+          acceptanceHostPattern.test(production.hostname)
+        ) {
+          throw new Error("unsafe production origin");
+        }
+      } catch {
+        issues.push({
+          path: `${workspacePath}.isolation.productionOrigin`,
+          message: "must be an exact non-acceptance HTTPS origin",
+        });
+      }
+      if (
+        !templates.has(workspace.isolation.otherAcceptanceMemberId) ||
+        workspace.isolation.otherAcceptanceMemberId ===
+          (workspace.harness.kind === "a2a-directory-withdrawal"
+            ? workspace.harness.callerMemberId
+            : workspace.harness.memberId)
+      ) {
+        issues.push({
+          path: `${workspacePath}.isolation.otherAcceptanceMemberId`,
+          message: "must identify a different declared acceptance member",
+        });
+      }
+    }
   }
   return issues.length === 0 ? { ok: true, issues: [] } : { ok: false, issues };
 }
@@ -352,6 +492,9 @@ export type TrustedAcceptancePlan = {
   workspace: string;
   enabled: boolean;
   runtimeAuthority: TrustedAcceptanceWorkspace["runtimeAuthority"];
+  directoryFixture?: AcceptanceDirectoryFixture;
+  harness: AcceptanceHarness;
+  isolation?: AcceptanceIsolation;
   assertions: string[];
   members: TrustedAcceptanceMember[];
 };
@@ -411,6 +554,11 @@ export function createTrustedAcceptancePlan(
       workspace: workspace.id,
       enabled: workspace.enabled,
       runtimeAuthority: workspace.runtimeAuthority,
+      ...(workspace.directoryFixture
+        ? { directoryFixture: workspace.directoryFixture }
+        : {}),
+      harness: workspace.harness,
+      ...(workspace.isolation ? { isolation: workspace.isolation } : {}),
       assertions: workspace.assertions,
       members: workspace.members,
     },
@@ -502,10 +650,45 @@ export type TrustedAcceptanceReceipt = {
     tombstoneDeployIds: string[];
     verifiedAt: string | null;
   };
-  scenarios?: {
-    stableDiscovery: AcceptanceAssertionState;
-    discoveryWithdrawal: AcceptanceAssertionState;
-    taskRouteContinuity: AcceptanceAssertionState;
+  scenarios?:
+    | {
+        kind: "a2a-directory-withdrawal";
+        hostedOAuth: AcceptanceAssertionState;
+        stableDiscovery: AcceptanceAssertionState;
+        discoveryWithdrawal: AcceptanceAssertionState;
+        taskRouteContinuity: AcceptanceAssertionState;
+      }
+    | {
+        kind: "mcp-read-only-tool";
+        hostedOAuth: AcceptanceAssertionState;
+        readOnlyTool: AcceptanceAssertionState;
+      };
+  isolation?: {
+    authorities: Array<{
+      memberId: string;
+      provenance: "fresh-per-run";
+      algorithm: "sha256";
+      digest: string;
+      generatedAt: string;
+    }>;
+    metadata: Array<{
+      role: "production" | "acceptance";
+      resource: string;
+      issuer: string;
+    }>;
+    probes: Array<{
+      kind:
+        | "acceptance-at-production"
+        | "acceptance-at-other-acceptance"
+        | "foreign-domain-sentinel-at-acceptance"
+        | "expired-acceptance"
+        | "replayed-acceptance"
+        | "wrong-audience"
+        | "post-cleanup";
+      status: number;
+      at: string;
+      proofDigest?: string;
+    }>;
   };
 };
 
@@ -648,7 +831,11 @@ export function validateTrustedAcceptanceReceipt(
   if (!["pass", "fail", "blocked"].includes(receipt.result)) {
     issues.push({ path: "result", message: "must be pass, fail, or blocked" });
   }
-  if (!receipt.rollbackTarget && receipt.result === "pass") {
+  if (
+    receipt.operation === "rollback" &&
+    !receipt.rollbackTarget &&
+    receipt.result === "pass"
+  ) {
     issues.push({
       path: "rollbackTarget",
       message: "is required for a passing receipt",
@@ -660,6 +847,15 @@ export function validateTrustedAcceptanceReceipt(
     issues.push({
       path: "rollbackTarget",
       message: "must be a full lowercase 40-character SHA or null",
+    });
+  }
+  if (
+    receipt.operation === "candidate" &&
+    (receipt.rollbackTarget !== null || receipt.priorKnownGoodSha !== null)
+  ) {
+    issues.push({
+      path: "rollbackTarget",
+      message: "candidate receipts must not claim rollback provenance",
     });
   }
   if (
@@ -699,6 +895,7 @@ export function validateTrustedAcceptanceReceipt(
     });
   }
   if (
+    receipt.operation === "rollback" &&
     receipt.result === "pass" &&
     receipt.priorKnownGoodSha !== receipt.rollbackTarget
   ) {
@@ -760,14 +957,64 @@ export function validateTrustedAcceptanceReceipt(
   }
   if (
     receipt.scenarios &&
-    Object.values(receipt.scenarios).some(
-      (state) => !["pass", "fail", "blocked"].includes(state),
+    Object.entries(receipt.scenarios).some(
+      ([key, state]) =>
+        key !== "kind" && !["pass", "fail", "blocked"].includes(String(state)),
     )
   ) {
     issues.push({
       path: "scenarios",
       message: "must contain valid assertion states",
     });
+  }
+  if (receipt.isolation) {
+    for (const [index, authority] of receipt.isolation.authorities.entries()) {
+      if (
+        !/^[a-z0-9][a-z0-9-]*$/.test(authority.memberId) ||
+        authority.provenance !== "fresh-per-run" ||
+        authority.algorithm !== "sha256" ||
+        !/^sha256:[a-f0-9]{64}$/.test(authority.digest) ||
+        Number.isNaN(Date.parse(authority.generatedAt))
+      ) {
+        issues.push({
+          path: `isolation.authorities[${index}]`,
+          message: "must contain redacted fresh per-run signing provenance",
+        });
+      }
+    }
+    for (const [index, metadata] of receipt.isolation.metadata.entries()) {
+      try {
+        const resource = new URL(metadata.resource);
+        const issuer = new URL(metadata.issuer);
+        if (
+          resource.protocol !== "https:" ||
+          issuer.protocol !== "https:" ||
+          !["production", "acceptance"].includes(metadata.role)
+        ) {
+          throw new Error("unsafe metadata");
+        }
+      } catch {
+        issues.push({
+          path: `isolation.metadata[${index}]`,
+          message: "must name public HTTPS resource and issuer metadata",
+        });
+      }
+    }
+    for (const [index, probe] of receipt.isolation.probes.entries()) {
+      if (
+        probe.status < 400 ||
+        probe.status > 499 ||
+        Number.isNaN(Date.parse(probe.at)) ||
+        (probe.proofDigest !== undefined &&
+          !/^sha256:[a-f0-9]{64}$/.test(probe.proofDigest))
+      ) {
+        issues.push({
+          path: `isolation.probes[${index}]`,
+          message:
+            "must contain only a fail-closed HTTP status, timestamp, and optional redacted digest",
+        });
+      }
+    }
   }
   if (receipt.result === "pass") {
     if (
@@ -785,15 +1032,72 @@ export function validateTrustedAcceptanceReceipt(
           "passing receipts require verified lease revocation, database and runtime cleanup, and one trusted tombstone deploy per member",
       });
     }
-    if (
-      receipt.scenarios?.stableDiscovery !== "pass" ||
-      receipt.scenarios.discoveryWithdrawal !== "pass" ||
-      receipt.scenarios.taskRouteContinuity !== "pass"
-    ) {
+    const scenarios = receipt.scenarios;
+    const scenariosPassed =
+      scenarios?.hostedOAuth === "pass" &&
+      (scenarios.kind === "a2a-directory-withdrawal"
+        ? scenarios.stableDiscovery === "pass" &&
+          scenarios.discoveryWithdrawal === "pass" &&
+          scenarios.taskRouteContinuity === "pass"
+        : scenarios.kind === "mcp-read-only-tool" &&
+          scenarios.readOnlyTool === "pass");
+    if (!scenariosPassed) {
       issues.push({
         path: "scenarios",
         message:
-          "passing receipts require stable and withdrawn-directory route-continuity evidence",
+          "passing receipts require hosted OAuth and every configured generic harness scenario",
+      });
+    }
+    const isolationRequired = expectedAssertions
+      ? expectedAssertions.includes("A11") || expectedAssertions.includes("I7")
+      : true;
+    const requiredProbeKinds = new Set<
+      NonNullable<
+        TrustedAcceptanceReceipt["isolation"]
+      >["probes"][number]["kind"]
+    >([
+      "acceptance-at-production",
+      "acceptance-at-other-acceptance",
+      "foreign-domain-sentinel-at-acceptance",
+      "expired-acceptance",
+      "replayed-acceptance",
+      "wrong-audience",
+      "post-cleanup",
+    ]);
+    const isolation = receipt.isolation;
+    const productionMetadata = isolation?.metadata.filter(
+      ({ role }) => role === "production",
+    );
+    const acceptanceMetadata = isolation?.metadata.filter(
+      ({ role }) => role === "acceptance",
+    );
+    if (
+      isolationRequired &&
+      (!isolation?.authorities.length ||
+        !productionMetadata?.length ||
+        !acceptanceMetadata?.length ||
+        productionMetadata.some((production) =>
+          acceptanceMetadata.some(
+            (acceptance) =>
+              production.resource === acceptance.resource ||
+              production.issuer === acceptance.issuer,
+          ),
+        ) ||
+        isolation.probes.some(({ kind, status }) =>
+          kind === "acceptance-at-production" ||
+          kind === "acceptance-at-other-acceptance" ||
+          kind === "foreign-domain-sentinel-at-acceptance"
+            ? status !== 401
+            : status < 400 || status > 499,
+        ) ||
+        ![...requiredProbeKinds].every((kind) =>
+          isolation.probes.some((probe) => probe.kind === kind),
+        ))
+    ) {
+      issues.push({
+        path: "isolation",
+        message:
+          "passing receipts require fresh signing provenance, distinct public production and acceptance metadata, and every controller-owned 401 isolation probe",
       });
     }
   }

--- a/scripts/trusted-acceptance/controller.spec.ts
+++ b/scripts/trusted-acceptance/controller.spec.ts
@@ -285,6 +285,35 @@ describe("trusted acceptance controller", () => {
     assert.equal(receipt.lease?.members[0]?.tombstoneDeployId, "tombstone");
   });
 
+  it("cannot pass cleanup without a directory fixture tombstone receipt", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "trusted-acceptance-directory-"));
+    const trusted = profile();
+    trusted.directoryFixture = directoryFixture();
+    const injected = providers();
+    injected.netlify.deployTombstoneAndVerify = async (siteId) =>
+      siteId === "directory-site"
+        ? { deployId: "" }
+        : { deployId: "member-tombstone" };
+    await assert.rejects(
+      executeTrustedAcceptance(trusted, {
+        providers: injected,
+        journalFile: join(dir, "lease.json"),
+        receiptFile: join(dir, "receipt.json"),
+        ttlMs: 60_000,
+        expectedAssertionIds: ["stable", "withdrawn"],
+        async deployArtifact() {},
+        async deployDirectoryArtifact() {},
+        async runStableHarness() {
+          return [{ assertionId: "stable", status: "passed" }];
+        },
+        async runWithdrawalHarness() {
+          return [{ assertionId: "withdrawn", status: "passed" }];
+        },
+      }),
+      /cleanup verification failed/,
+    );
+  });
+
   it("cannot pass a controller receipt with missing harness evidence", async () => {
     const dir = await mkdtemp(join(tmpdir(), "trusted-acceptance-empty-"));
     const receipt = await executeTrustedAcceptance(profile(), {

--- a/scripts/trusted-acceptance/controller.spec.ts
+++ b/scripts/trusted-acceptance/controller.spec.ts
@@ -10,6 +10,8 @@ import {
   assertRedacted,
   executeTrustedAcceptance,
   reapTrustedAcceptanceLeases,
+  settleBeforeCleanup,
+  updateTrustedAcceptanceDirectoryScenario,
   validateTrustedAuthorityProfile,
   type TrustedAuthorityProfile,
 } from "./controller.ts";
@@ -96,6 +98,26 @@ function providers() {
   };
 }
 
+function directoryFixture() {
+  return {
+    origin: "https://directory.acceptance.example.test",
+    netlifyAccountId: "directory-account",
+    netlifySiteId: "directory-site",
+    orgDomain: "agent-native.acceptance.invalid",
+    members: [
+      {
+        id: "calendar",
+        name: "Calendar",
+        url: "https://calendar.acceptance.example.test",
+        a2aUrl: "https://calendar.acceptance.example.test",
+      },
+    ],
+    withdrawnMemberId: "calendar",
+    artifactDirectory: "trusted-directory",
+    artifactSha256: "b".repeat(64),
+  };
+}
+
 describe("trusted acceptance controller", () => {
   it("keeps the protected controller and independent reaper main-pinned and fail-closed", () => {
     const workflow = readFileSync(
@@ -112,8 +134,15 @@ describe("trusted acceptance controller", () => {
       workflow,
       /Verify every artifact provenance before credentials/,
     );
-    assert.match(workflow, /Acquire one whole-workspace disposable lease/);
-    assert.match(workflow, /Revoke one whole-workspace disposable lease/);
+    assert.match(
+      workflow,
+      /Run trusted hosted OAuth, harness, deployment, and cleanup/,
+    );
+    assert.match(workflow, /run-hosted-acceptance\.ts/);
+    assert.match(
+      workflow,
+      /Revoke one whole-workspace disposable lease after interruption/,
+    );
     assert.match(workflow, /if: \$\{\{ always\(\) \}\}/);
     assert.match(workflow, /persist-credentials: false/);
     assert.match(reaper, /schedule:/);
@@ -168,6 +197,65 @@ describe("trusted acceptance controller", () => {
       validateTrustedAuthorityProfile(credentialValue).join("\n"),
       /credential-shaped/,
     );
+    const fixture = profile();
+    fixture.directoryFixture = directoryFixture();
+    assert.deepEqual(validateTrustedAuthorityProfile(fixture), []);
+    fixture.directoryFixture.netlifySiteId = "site";
+    assert.match(
+      validateTrustedAuthorityProfile(fixture).join("\n"),
+      /duplicates an app Netlify site/,
+    );
+    const arbitraryTarget = profile();
+    arbitraryTarget.directoryFixture = directoryFixture();
+    arbitraryTarget.directoryFixture.members[0]!.url =
+      "https://attacker.acceptance.example.test";
+    assert.match(
+      validateTrustedAuthorityProfile(arbitraryTarget).join("\n"),
+      /exactly match a declared app origin/,
+    );
+  });
+
+  it("exposes an in-process controller seam that changes only the fixed directory scenario", async () => {
+    const trusted = profile();
+    trusted.directoryFixture = directoryFixture();
+    const lease = {
+      id: "a".repeat(24),
+      createdAt: "2026-07-26T00:00:00.000Z",
+      expiresAt: "2026-07-26T01:00:00.000Z",
+      state: "active" as const,
+      members: [
+        { memberId: "calendar", netlifySiteId: "site", runtimeOwned: true },
+      ],
+      directoryFixture: {
+        netlifySiteId: "directory-site",
+        runtimeOwned: true,
+        scenario: "stable" as const,
+      },
+      journal: [],
+      verification: {
+        inferenceDisabled: false,
+        runtimeVariablesAbsent: false,
+        tombstoneActive: false,
+        branchesDeleted: false,
+      },
+    };
+    const writes: Array<Record<string, string>> = [];
+    const injected = providers();
+    injected.netlify.setRuntime = async (_account, site, values) => {
+      assert.equal(site, "directory-site");
+      writes.push(values);
+    };
+    const result = await updateTrustedAcceptanceDirectoryScenario(
+      trusted,
+      lease,
+      injected,
+      () => new Date("2026-07-26T00:00:00.000Z"),
+      { async save() {} },
+    );
+    assert.equal(result.directoryFixture?.scenario, "withdraw-member");
+    assert.deepEqual(writes, [
+      { AGENT_NATIVE_ACCEPTANCE_DIRECTORY_SCENARIO: "withdraw-member" },
+    ]);
   });
 
   it("persists only redacted journals and receipts after every authority mutation", async () => {
@@ -214,6 +302,75 @@ describe("trusted acceptance controller", () => {
       },
     });
     assert.equal(receipt.result, "failed");
+  });
+
+  it("revokes the lease when the hosted harness exceeds its deadline", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "trusted-acceptance-timeout-"));
+    const receiptFile = join(dir, "receipt.json");
+    await assert.rejects(
+      executeTrustedAcceptance(profile(), {
+        providers: providers(),
+        journalFile: join(dir, "lease.json"),
+        receiptFile,
+        ttlMs: 60_000,
+        harnessTimeoutMs: 5,
+        expectedAssertionIds: ["required"],
+        async deployArtifact() {},
+        async runStableHarness(_lease, signal) {
+          return new Promise((_, reject) =>
+            signal.addEventListener("abort", () => reject(signal.reason), {
+              once: true,
+            }),
+          );
+        },
+        async runWithdrawalHarness() {
+          return [];
+        },
+      }),
+      /timed out/,
+    );
+    const receipt = JSON.parse(await readFile(receiptFile, "utf8")) as {
+      result: string;
+      lease?: { state?: string };
+    };
+    assert.equal(receipt.result, "failed");
+    assert.equal(receipt.lease?.state, "revoked");
+  });
+
+  it("settles an accepted late deploy before placing the cleanup tombstone", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "trusted-acceptance-barrier-"));
+    const events: string[] = [];
+    const runtimeProviders = providers();
+    runtimeProviders.netlify.deployTombstoneAndVerify = async () => {
+      events.push("tombstone");
+      return { deployId: "tombstone" };
+    };
+    await assert.rejects(
+      executeTrustedAcceptance(profile(), {
+        providers: runtimeProviders,
+        journalFile: join(dir, "lease.json"),
+        receiptFile: join(dir, "receipt.json"),
+        ttlMs: 60_000,
+        harnessTimeoutMs: 5,
+        expectedAssertionIds: ["required"],
+        async deployArtifact() {},
+        async runStableHarness() {
+          return [];
+        },
+        async runWithdrawalHarness(_lease, signal) {
+          const lateDeploy = new Promise<void>((resolve) =>
+            setTimeout(() => {
+              events.push("late-deploy-settled");
+              resolve();
+            }, 20),
+          );
+          await settleBeforeCleanup([lateDeploy], signal);
+          return [];
+        },
+      }),
+      /timed out/,
+    );
+    assert.deepEqual(events, ["late-deploy-settled", "tombstone"]);
   });
 
   it("reaps only deterministic acceptance leases through an injected discovery seam", async () => {

--- a/scripts/trusted-acceptance/controller.spec.ts
+++ b/scripts/trusted-acceptance/controller.spec.ts
@@ -366,6 +366,42 @@ describe("trusted acceptance controller", () => {
     assert.equal(receipt.lease?.state, "revoked");
   });
 
+  it("writes a failed receipt when the post-cleanup probe exceeds its deadline", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "trusted-post-cleanup-timeout-"));
+    const receiptFile = join(dir, "receipt.json");
+    await assert.rejects(
+      executeTrustedAcceptance(profile(), {
+        providers: providers(),
+        journalFile: join(dir, "lease.json"),
+        receiptFile,
+        ttlMs: 60_000,
+        postCleanupTimeoutMs: 5,
+        expectedAssertionIds: ["stable", "withdrawn", "post-cleanup"],
+        async deployArtifact() {},
+        async runStableHarness() {
+          return [{ assertionId: "stable", status: "passed" }];
+        },
+        async runWithdrawalHarness() {
+          return [{ assertionId: "withdrawn", status: "passed" }];
+        },
+        async runPostCleanupHarness(_lease, signal) {
+          return new Promise((_, reject) =>
+            signal.addEventListener("abort", () => reject(signal.reason), {
+              once: true,
+            }),
+          );
+        },
+      }),
+      /timed out/,
+    );
+    const receipt = JSON.parse(await readFile(receiptFile, "utf8")) as {
+      result: string;
+      lease?: { state?: string };
+    };
+    assert.equal(receipt.result, "failed");
+    assert.equal(receipt.lease?.state, "revoked");
+  });
+
   it("settles an accepted late deploy before placing the cleanup tombstone", async () => {
     const dir = await mkdtemp(join(tmpdir(), "trusted-acceptance-barrier-"));
     const events: string[] = [];

--- a/scripts/trusted-acceptance/controller.ts
+++ b/scripts/trusted-acceptance/controller.ts
@@ -84,11 +84,13 @@ export type ControllerExecution = {
    */
   runPostCleanupHarness?: (
     lease: RuntimeLease,
+    signal: AbortSignal,
   ) => Promise<RedactedAcceptanceReceipt["evidence"]>;
   journalFile: string;
   receiptFile: string;
   ttlMs: number;
   harnessTimeoutMs?: number;
+  postCleanupTimeoutMs?: number;
   expectedAssertionIds: readonly string[];
   now?: () => Date;
 };
@@ -541,11 +543,19 @@ export async function executeTrustedAcceptance(
   } finally {
     if (lease) {
       await authority.revoke(lease);
-      if (execution.runPostCleanupHarness)
-        evidence = [
-          ...evidence,
-          ...(await execution.runPostCleanupHarness(lease)),
-        ];
+      if (execution.runPostCleanupHarness) {
+        try {
+          evidence = [
+            ...evidence,
+            ...(await withDeadline(
+              (signal) => execution.runPostCleanupHarness!(lease!, signal),
+              execution.postCleanupTimeoutMs ?? 60_000,
+            )),
+          ];
+        } catch (error) {
+          failure ??= error;
+        }
+      }
     }
     const clean =
       lease?.state === "revoked" &&

--- a/scripts/trusted-acceptance/controller.ts
+++ b/scripts/trusted-acceptance/controller.ts
@@ -552,7 +552,9 @@ export async function executeTrustedAcceptance(
       lease.verification.tombstoneActive &&
       lease.members.every(
         (member) => !member.runtimeOwned || Boolean(member.tombstoneDeployId),
-      );
+      ) &&
+      (!lease.directoryFixture?.runtimeOwned ||
+        Boolean(lease.directoryFixture.tombstoneDeployId));
     const receipt = receiptFor(
       profile,
       lease,
@@ -673,7 +675,9 @@ function assertRevoked(lease: RuntimeLease): void {
     !lease.verification.tombstoneActive ||
     !lease.members.every(
       (member) => !member.runtimeOwned || Boolean(member.tombstoneDeployId),
-    )
+    ) ||
+    (lease.directoryFixture?.runtimeOwned &&
+      !lease.directoryFixture.tombstoneDeployId)
   ) {
     throw new Error(
       "cleanup verification failed: lease was not revoked with tombstone IDs",

--- a/scripts/trusted-acceptance/controller.ts
+++ b/scripts/trusted-acceptance/controller.ts
@@ -34,6 +34,23 @@ export type TrustedAuthorityProfile = {
     artifactDirectory: string;
     withdrawnDirectoryMember?: boolean;
   }>;
+  /** Optional trusted infrastructure, never a candidate app member. */
+  directoryFixture?: {
+    origin: string;
+    netlifyAccountId: string;
+    netlifySiteId: string;
+    orgDomain: string;
+    members: Array<{
+      id: string;
+      name: string;
+      url: string;
+      a2aUrl: string;
+      capabilities?: string[];
+    }>;
+    withdrawnMemberId: string;
+    artifactDirectory: string;
+    artifactSha256: string;
+  };
 };
 
 export type RedactedAcceptanceReceipt = {
@@ -49,11 +66,29 @@ export type ControllerExecution = {
   deployArtifact: (
     member: TrustedAuthorityProfile["members"][number],
   ) => Promise<void>;
-  runStableHarness: () => Promise<RedactedAcceptanceReceipt["evidence"]>;
-  runWithdrawalHarness: () => Promise<RedactedAcceptanceReceipt["evidence"]>;
+  deployDirectoryArtifact?: (
+    fixture: NonNullable<TrustedAuthorityProfile["directoryFixture"]>,
+  ) => Promise<void>;
+  /** The lease is redacted and is the exact controller-owned lease for this run. */
+  runStableHarness: (
+    lease: RuntimeLease,
+    signal: AbortSignal,
+  ) => Promise<RedactedAcceptanceReceipt["evidence"]>;
+  runWithdrawalHarness: (
+    lease: RuntimeLease,
+    signal: AbortSignal,
+  ) => Promise<RedactedAcceptanceReceipt["evidence"]>;
+  /**
+   * Runs only after revoke completed. Transient browser/token state remains in
+   * the caller closure; this controller never receives or persists it.
+   */
+  runPostCleanupHarness?: (
+    lease: RuntimeLease,
+  ) => Promise<RedactedAcceptanceReceipt["evidence"]>;
   journalFile: string;
   receiptFile: string;
   ttlMs: number;
+  harnessTimeoutMs?: number;
   expectedAssertionIds: readonly string[];
   now?: () => Date;
 };
@@ -106,7 +141,15 @@ function assertExactKeys(
 function assertProfileShape(profile: TrustedAuthorityProfile): void {
   assertExactKeys(
     profile,
-    ["version", "workspace", "enabled", "leasePrefix", "runtime", "members"],
+    [
+      "version",
+      "workspace",
+      "enabled",
+      "leasePrefix",
+      "runtime",
+      "members",
+      "directoryFixture",
+    ],
     "profile",
   );
   assertExactKeys(
@@ -140,6 +183,28 @@ function assertProfileShape(profile: TrustedAuthorityProfile): void {
       ["id", "origin", "artifactDirectory", "withdrawnDirectoryMember"],
       `profile.members[${index}]`,
     );
+  if (profile.directoryFixture) {
+    assertExactKeys(
+      profile.directoryFixture,
+      [
+        "origin",
+        "netlifyAccountId",
+        "netlifySiteId",
+        "orgDomain",
+        "members",
+        "withdrawnMemberId",
+        "artifactDirectory",
+        "artifactSha256",
+      ],
+      "profile.directoryFixture",
+    );
+    for (const [index, member] of profile.directoryFixture.members.entries())
+      assertExactKeys(
+        member,
+        ["id", "name", "url", "a2aUrl", "capabilities"],
+        `profile.directoryFixture.members[${index}]`,
+      );
+  }
 }
 
 function stableAcceptanceUrl(value: string): boolean {
@@ -235,6 +300,58 @@ export function validateTrustedAuthorityProfile(
       issues.push(`runtime member ${member.id} has a duplicate Neon project`);
     neonProjectIds.add(member.neonProjectId);
   }
+  const fixture = profile.directoryFixture;
+  if (fixture) {
+    if (!stableAcceptanceUrl(fixture.origin))
+      issues.push("directory fixture has an unsafe acceptance origin");
+    if (!fixture.netlifyAccountId || !fixture.netlifySiteId)
+      issues.push("directory fixture has incomplete Netlify identity");
+    if (/(?:^|[-_])(?:prod|production)(?:[-_]|$)/i.test(fixture.netlifySiteId))
+      issues.push("directory fixture must not name a production Netlify site");
+    if (siteIds.has(fixture.netlifySiteId))
+      issues.push("directory fixture duplicates an app Netlify site");
+    if (origins.has(fixture.origin))
+      issues.push("directory fixture duplicates an app acceptance origin");
+    if (fixture.orgDomain !== "agent-native.acceptance.invalid")
+      issues.push(
+        "directory fixture orgDomain must match the synthetic hosted-QA email domain",
+      );
+    if (
+      !fixture.artifactDirectory ||
+      fixture.artifactDirectory.startsWith("/") ||
+      fixture.artifactDirectory.split("/").includes("..")
+    )
+      issues.push("directory fixture has an unsafe artifact directory");
+    if (!/^[a-f0-9]{64}$/i.test(fixture.artifactSha256))
+      issues.push("directory fixture must pin a trusted artifact sha256");
+    const fixtureIds = new Set<string>();
+    for (const member of fixture.members) {
+      if (!/^[a-z0-9][a-z0-9-]*$/.test(member.id) || fixtureIds.has(member.id))
+        issues.push(
+          `directory fixture member ${member.id || "<empty>"} is unsafe or duplicated`,
+        );
+      fixtureIds.add(member.id);
+      const declared = profile.members.find(({ id }) => id === member.id);
+      if (
+        !declared ||
+        member.url !== declared.origin ||
+        member.a2aUrl !== declared.origin
+      )
+        issues.push(
+          `directory fixture member ${member.id} must exactly match a declared app origin`,
+        );
+      if (!member.name.trim())
+        issues.push(`directory fixture member ${member.id} has no name`);
+    }
+    if (!fixtureIds.has(fixture.withdrawnMemberId))
+      issues.push(
+        "directory fixture withdrawal target must be a fixed declared member",
+      );
+    if (profile.members.some(({ id }) => !fixtureIds.has(id)))
+      issues.push(
+        "directory fixture must map every declared app member exactly once",
+      );
+  }
   if (
     !Number.isFinite(profile.runtime.maxInferenceUsd) ||
     profile.runtime.maxInferenceUsd <= 0 ||
@@ -261,6 +378,18 @@ export function validateTrustedAuthorityProfile(
 function runtimeConfig(profile: TrustedAuthorityProfile): TrustedRuntimeConfig {
   return {
     ...profile.runtime,
+    ...(profile.directoryFixture
+      ? {
+          directoryFixture: {
+            origin: profile.directoryFixture.origin,
+            netlifyAccountId: profile.directoryFixture.netlifyAccountId,
+            netlifySiteId: profile.directoryFixture.netlifySiteId,
+            orgDomain: profile.directoryFixture.orgDomain,
+            members: profile.directoryFixture.members,
+            withdrawnMemberId: profile.directoryFixture.withdrawnMemberId,
+          },
+        }
+      : {}),
     tombstone: {
       sha256: profile.runtime.tombstone.sha256,
       zip: new Uint8Array(
@@ -330,6 +459,45 @@ function hasCompleteEvidence(
   );
 }
 
+async function withDeadline<T>(
+  work: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0)
+    throw new Error("trusted harness timeout must be positive");
+  const controller = new AbortController();
+  let timedOut = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    timer = setTimeout(() => {
+      timedOut = true;
+      controller.abort(new Error("trusted hosted harness timed out"));
+    }, timeoutMs);
+    const result = await work(controller.signal);
+    if (timedOut) throw new Error("trusted hosted harness timed out");
+    return result;
+  } catch (error) {
+    if (timedOut) throw new Error("trusted hosted harness timed out");
+    throw error;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * Provider writes that may already have been accepted must settle before the
+ * cleanup tombstone is placed. Abort is observed only after that barrier.
+ */
+export async function settleBeforeCleanup(
+  operations: readonly Promise<unknown>[],
+  signal: AbortSignal,
+): Promise<void> {
+  const results = await Promise.allSettled(operations);
+  signal.throwIfAborted();
+  const rejected = results.find((result) => result.status === "rejected");
+  if (rejected?.status === "rejected") throw rejected.reason;
+}
+
 /** Runs only after a trusted workflow has verified inert artifact provenance. */
 export async function executeTrustedAcceptance(
   profile: TrustedAuthorityProfile,
@@ -338,6 +506,10 @@ export async function executeTrustedAcceptance(
   const issues = validateTrustedAuthorityProfile(profile);
   if (issues.length)
     throw new Error(`trusted authority profile rejected: ${issues.join("; ")}`);
+  if (profile.directoryFixture && !execution.deployDirectoryArtifact)
+    throw new Error(
+      "directory fixture requires a controller-owned artifact deployer",
+    );
   const journalStore = new JsonLeaseJournalStore(execution.journalFile);
   const authority = new DisposableRuntimeAuthority(
     runtimeConfig(profile),
@@ -353,16 +525,28 @@ export async function executeTrustedAcceptance(
     const acquired = await authority.acquire(execution.ttlMs);
     lease = acquired.lease;
     // Secrets remain in the acquire return value only; no controller output receives it.
+    if (profile.directoryFixture && execution.deployDirectoryArtifact)
+      await execution.deployDirectoryArtifact(profile.directoryFixture);
     for (const member of profile.members)
       await execution.deployArtifact(member);
-    evidence = [
-      ...(await execution.runStableHarness()),
-      ...(await execution.runWithdrawalHarness()),
-    ];
+    evidence = await withDeadline(
+      async (signal) => [
+        ...(await execution.runStableHarness(lease, signal)),
+        ...(await execution.runWithdrawalHarness(lease, signal)),
+      ],
+      execution.harnessTimeoutMs ?? 10 * 60_000,
+    );
   } catch (error) {
     failure = error;
   } finally {
-    if (lease) await authority.revoke(lease);
+    if (lease) {
+      await authority.revoke(lease);
+      if (execution.runPostCleanupHarness)
+        evidence = [
+          ...evidence,
+          ...(await execution.runPostCleanupHarness(lease)),
+        ];
+    }
     const clean =
       lease?.state === "revoked" &&
       lease.verification.tombstoneActive &&
@@ -390,6 +574,26 @@ export async function executeTrustedAcceptance(
   if (!completedReceipt)
     throw new Error("trusted acceptance did not produce a controller receipt");
   return completedReceipt;
+}
+
+/** In-process trusted-runner seam; it accepts only an opaque redacted lease. */
+export async function updateTrustedAcceptanceDirectoryScenario(
+  profile: TrustedAuthorityProfile,
+  lease: RuntimeLease,
+  providers: RuntimeProviders,
+  now?: () => Date,
+  journalStore: LeaseJournalStore,
+): Promise<RuntimeLease> {
+  const issues = validateTrustedAuthorityProfile(profile);
+  if (issues.length)
+    throw new Error(`trusted authority profile rejected: ${issues.join("; ")}`);
+  assertRedacted(lease);
+  return new DisposableRuntimeAuthority(
+    runtimeConfig(profile),
+    providers,
+    now,
+    journalStore,
+  ).updateDirectoryScenario(lease, "withdraw-member");
 }
 
 /** Discovery is injected so providers can be reconciled without candidate code or stored credentials. */
@@ -434,16 +638,22 @@ function requiredAmbientCredentials(): Record<string, string> {
   ) as Record<string, string>;
 }
 
-function ambientProviders(): RuntimeProviders {
+/** Management credentials are read only from the protected process environment. */
+export function createAmbientRuntimeProviders(): RuntimeProviders {
   const credentials = requiredAmbientCredentials();
+  const boundedFetch: typeof fetch = (input, init) =>
+    fetch(input, {
+      ...init,
+      signal: init?.signal ?? AbortSignal.timeout(30_000),
+    });
   return {
-    neon: new NeonBranches(fetch, credentials.ACCEPTANCE_NEON_API_KEY),
+    neon: new NeonBranches(boundedFetch, credentials.ACCEPTANCE_NEON_API_KEY),
     netlify: new NetlifyRuntime(
-      fetch,
+      boundedFetch,
       credentials.ACCEPTANCE_NETLIFY_AUTH_TOKEN,
     ),
     openrouter: new OpenRouterKeys(
-      fetch,
+      boundedFetch,
       credentials.ACCEPTANCE_OPENROUTER_API_KEY,
     ),
   };
@@ -494,7 +704,7 @@ async function main(): Promise<void> {
   const profileFile = option("--profile");
   if (!command || !profileFile)
     throw new Error(
-      "usage: controller <validate-profile|acquire|revoke|reap> --profile <file> --journal <file>",
+      "usage: controller <validate-profile|acquire|withdraw-directory-member|revoke|reap> --profile <file> --journal <file>",
     );
   const profile = await profileFromFile(profileFile);
   if (command === "validate-profile") {
@@ -505,7 +715,11 @@ async function main(): Promise<void> {
     if (issues.length) process.exitCode = 1;
     return;
   }
-  if (!new Set(["acquire", "revoke", "reap"]).has(command))
+  if (
+    !new Set(["acquire", "withdraw-directory-member", "revoke", "reap"]).has(
+      command,
+    )
+  )
     throw new Error(`unknown controller command: ${command}`);
   const issues = validateTrustedAuthorityProfile(profile, {
     requireEnabled: command === "acquire",
@@ -515,7 +729,7 @@ async function main(): Promise<void> {
   const journalFile = option("--journal");
   if (!journalFile)
     throw new Error("live controller commands require --journal");
-  const providers = ambientProviders();
+  const providers = createAmbientRuntimeProviders();
   const authority = new DisposableRuntimeAuthority(
     runtimeConfig(profile),
     providers,
@@ -536,6 +750,16 @@ async function main(): Promise<void> {
     assertRevoked(revoked);
     process.stdout.write(
       `${JSON.stringify({ ok: true, leaseId: revoked.id, state: revoked.state })}\n`,
+    );
+    return;
+  }
+  if (command === "withdraw-directory-member") {
+    const updated = await authority.updateDirectoryScenario(
+      await leaseFromFile(journalFile),
+      "withdraw-member",
+    );
+    process.stdout.write(
+      `${JSON.stringify({ ok: true, leaseId: updated.id, directoryScenario: updated.directoryFixture?.scenario })}\n`,
     );
     return;
   }

--- a/scripts/trusted-acceptance/directory-fixture.spec.ts
+++ b/scripts/trusted-acceptance/directory-fixture.spec.ts
@@ -67,6 +67,23 @@ describe("trusted acceptance directory fixture", () => {
     });
   });
 
+  it("accepts a signed hosted-QA email domain when no org row exists yet", async () => {
+    const response = await handleDirectoryFixtureRequest(
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token(
+            { org_domain: undefined },
+            "trusted-acceptance+fixture@acceptance.example.test",
+          )}`,
+        },
+      },
+      config,
+      "stable",
+    );
+    assert.equal(response.status, 200);
+  });
+
   it("withdraws only the configured declared member", async () => {
     const response = await handleDirectoryFixtureRequest(
       { method: "GET", headers: { authorization: `Bearer ${token()}` } },

--- a/scripts/trusted-acceptance/directory-fixture.ts
+++ b/scripts/trusted-acceptance/directory-fixture.ts
@@ -16,7 +16,7 @@ export type DirectoryFixtureConfig = {
   a2aSecret: string;
   fixtureOrigin: string;
   members: readonly DirectoryMember[];
-  withdrawnMemberId?: string;
+  withdrawnMemberId: string;
 };
 
 export type DirectoryRequest = {
@@ -87,7 +87,6 @@ export function validateDirectoryFixtureConfig(
     }
   }
   if (
-    config.withdrawnMemberId &&
     !config.members.some((member) => member.id === config.withdrawnMemberId)
   ) {
     issues.push("withdrawnMemberId must name a declared member");
@@ -133,10 +132,17 @@ async function isTrustedCaller(
     if (typeof payload.nbf === "number" && now < payload.nbf) return false;
     const scope =
       typeof payload.scope === "string" ? payload.scope.split(/\s+/) : [];
+    const subject = typeof payload.sub === "string" ? payload.sub.trim() : "";
+    const subjectDomain = subject.includes("@")
+      ? subject.slice(subject.lastIndexOf("@") + 1).toLowerCase()
+      : undefined;
+    const callerDomain =
+      typeof payload.org_domain === "string"
+        ? payload.org_domain.toLowerCase()
+        : subjectDomain;
     return (
-      typeof payload.sub === "string" &&
-      payload.sub.trim().length > 0 &&
-      payload.org_domain === config.orgDomain &&
+      subject.length > 0 &&
+      callerDomain === config.orgDomain.toLowerCase() &&
       !scope.includes("identity") &&
       !scope.includes("mcp-connect")
     );

--- a/scripts/trusted-acceptance/hosted-oauth-a2a-harness.spec.ts
+++ b/scripts/trusted-acceptance/hosted-oauth-a2a-harness.spec.ts
@@ -287,6 +287,16 @@ describe("hosted OAuth and A2A acceptance harness", () => {
     }
   });
 
+  it("awaits loopback listener shutdown after a callback timeout", async () => {
+    const listener = await startLoopbackCallbackListener({ timeoutMs: 5 });
+    await assert.rejects(
+      listener.waitForCallback(),
+      /loopback callback listener timed out/,
+    );
+    await listener.close();
+    await assert.rejects(fetch(listener.redirectUri));
+  });
+
   it("polls the same ask_app task after trusted directory withdrawal and returns redacted evidence", async () => {
     const calls: Array<{ name: string; taskId?: string }> = [];
     let withdrawn = false;

--- a/scripts/trusted-acceptance/hosted-oauth-a2a-harness.spec.ts
+++ b/scripts/trusted-acceptance/hosted-oauth-a2a-harness.spec.ts
@@ -3,13 +3,22 @@ import { describe, it } from "node:test";
 
 import {
   HostedMcpClient,
+  authorizationCodeFromCallback,
+  bootstrapHostedQaSession,
   buildAuthorizationUrl,
+  createForeignDomainSentinel,
+  createSyntheticQaIdentity,
   createS256Pkce,
   discoverOAuth,
+  discoverPublicOAuthIdentity,
   exchangeAuthorizationCode,
   expectUnauthorized,
+  expectRejected4xx,
   registerDynamicClient,
+  runCryptographicIsolationProbes,
+  runHostedOAuthCodeFlow,
   runWithdrawalScenario,
+  startLoopbackCallbackListener,
 } from "./hosted-oauth-a2a-harness.ts";
 
 const origin = "https://caller-acceptance.example.test";
@@ -21,6 +30,62 @@ const metadata = {
 };
 
 describe("hosted OAuth and A2A acceptance harness", () => {
+  it("keeps a lease-bound 256-bit synthetic password out of evidence while using only same-origin QA routes", async () => {
+    const identity = createSyntheticQaIdentity("trusted-acceptance-lease-123");
+    const calls: Array<{
+      path: string;
+      email: string;
+      passwordLength: number;
+    }> = [];
+    const evidence = await bootstrapHostedQaSession({
+      appOrigin: origin,
+      identity,
+      browser: {
+        origin,
+        async postJson(path, body) {
+          calls.push({
+            path,
+            email: body.email,
+            passwordLength: body.password.length,
+          });
+          return { status: 200 };
+        },
+        async getJson() {
+          return { email: identity.email };
+        },
+      },
+    });
+    assert.match(identity.email, /\+qa-/);
+    assert.equal(identity.passwordEntropyBits, 256);
+    let password = "";
+    await identity.withPassword((value) => {
+      password = value;
+    });
+    assert.equal(JSON.stringify(identity).includes(password), false);
+    assert.deepEqual(
+      calls.map(({ path }) => path),
+      ["/_agent-native/auth/register", "/_agent-native/auth/login"],
+    );
+    assert.ok(calls.every(({ passwordLength }) => passwordLength >= 43));
+    assert.equal(JSON.stringify(evidence).includes(identity.email), false);
+    await assert.rejects(
+      bootstrapHostedQaSession({
+        appOrigin: origin,
+        identity,
+        browser: {
+          origin: "https://other-acceptance.example.test",
+          async postJson() {
+            return { status: 200 };
+          },
+          async getJson() {
+            return { email: identity.email };
+          },
+        },
+      }),
+      /origin does not match/,
+    );
+  });
+
   it("constructs RFC 7636 S256 authorization URLs with an exact loopback callback", () => {
     const pkce = createS256Pkce("a".repeat(43));
     assert.equal(pkce.challenge, "ZtNPunH49FD35FWYhT5Tv8I7vRKQJ8uxMaL0_9eHjNA");
@@ -84,6 +149,32 @@ describe("hosted OAuth and A2A acceptance harness", () => {
     );
   });
 
+  it("records only public HTTPS resource and issuer identity for production comparison", async () => {
+    const identity = await discoverPublicOAuthIdentity(
+      async () =>
+        Response.json({
+          authorization_servers: ["https://identity.example.test"],
+          resource: "https://calendar.example.test/mcp",
+        }),
+      "https://calendar.example.test",
+    );
+    assert.deepEqual(identity, {
+      resource: "https://calendar.example.test/mcp",
+      issuer: "https://identity.example.test",
+    });
+    await assert.rejects(
+      discoverPublicOAuthIdentity(
+        async () =>
+          Response.json({
+            authorization_servers: ["http://identity.example.test"],
+            resource: "https://calendar.example.test/mcp",
+          }),
+        "https://calendar.example.test",
+      ),
+      /must use HTTPS/,
+    );
+  });
+
   it("uses advertised registration and code exchange without serializing credentials", async () => {
     const requests: Array<{ url: string; body: string }> = [];
     const fetchFn = async (
@@ -116,6 +207,86 @@ describe("hosted OAuth and A2A acceptance harness", () => {
     assert.match(requests[1]!.body, /code_verifier/);
   });
 
+  it("orchestrates consent through an injected browser with exact callback state and redacted OAuth evidence", async () => {
+    let authorizationUrl = "";
+    let resolveCallback: ((value: string) => void) | undefined;
+    const callback = {
+      redirectUri: "http://127.0.0.1:4319/oauth/callback",
+      async waitForCallback() {
+        return new Promise<string>((resolve) => {
+          resolveCallback = resolve;
+        });
+      },
+      async close() {},
+    };
+    const flow = await runHostedOAuthCodeFlow({
+      appOrigin: origin,
+      callback,
+      state: "state-that-is-long-enough-for-a-test",
+      now: () => "2026-07-27T00:00:00.000Z",
+      browser: {
+        origin,
+        async postJson() {
+          return { status: 200 };
+        },
+        async getJson() {
+          return {};
+        },
+        async authorize(url) {
+          authorizationUrl = url;
+          const state = new URL(url).searchParams.get("state");
+          resolveCallback?.(
+            `http://127.0.0.1:4319/oauth/callback?code=private-code&state=${state}`,
+          );
+        },
+      },
+      fetchFn: async (url) => {
+        if (url.endsWith("oauth-protected-resource"))
+          return Response.json({
+            authorization_servers: [origin],
+            resource: metadata.resource,
+          });
+        if (url.endsWith("oauth-authorization-server")) {
+          const { resource: _, ...authorizationMetadata } = metadata;
+          return Response.json(authorizationMetadata);
+        }
+        if (url.endsWith("/oauth/register"))
+          return Response.json({ client_id: "fake-client" });
+        return Response.json({ access_token: "private-access-token" });
+      },
+    });
+    assert.equal(flow.accessToken, "private-access-token");
+    assert.equal(
+      new URL(authorizationUrl).searchParams.get("state"),
+      "state-that-is-long-enough-for-a-test",
+    );
+    assert.equal(JSON.stringify(flow.evidence).includes("private"), false);
+    assert.throws(() =>
+      authorizationCodeFromCallback({
+        callbackUrl: "http://127.0.0.1:4319/oauth/callback?code=x&state=wrong",
+        redirectUri: callback.redirectUri,
+        state: "expected",
+      }),
+    );
+  });
+
+  it("receives the runner callback on an injectable loopback listener", async () => {
+    const listener = await startLoopbackCallbackListener();
+    try {
+      const received = listener.waitForCallback();
+      const response = await fetch(
+        `${listener.redirectUri}?code=private-code&state=state`,
+      );
+      assert.equal(response.status, 204);
+      assert.equal(
+        await received,
+        `${listener.redirectUri}?code=private-code&state=state`,
+      );
+    } finally {
+      await listener.close();
+    }
+  });
+
   it("polls the same ask_app task after trusted directory withdrawal and returns redacted evidence", async () => {
     const calls: Array<{ name: string; taskId?: string }> = [];
     let withdrawn = false;
@@ -138,10 +309,13 @@ describe("hosted OAuth and A2A acceptance harness", () => {
                 calls.filter(({ name }) => name === "ask_app_status").length > 1
                   ? "completed"
                   : "working",
+              output: withdrawn ? "TRUSTED_ACCEPTANCE_FIXTURE" : undefined,
             },
           });
         }
-        return Response.json({ result: { apps: [{ id: "content" }] } });
+        return Response.json({
+          result: { apps: withdrawn ? [] : [{ id: "content" }] },
+        });
       },
       `${origin}/mcp`,
       "private-access-token",
@@ -150,12 +324,13 @@ describe("hosted OAuth and A2A acceptance harness", () => {
       client,
       targetApp: "content",
       message: "safe fixture message",
+      expectedResult: "TRUSTED_ACCEPTANCE_FIXTURE",
       controller: { withdrawDirectoryMember: () => void (withdrawn = true) },
       now: () => "2026-07-26T00:00:00.000Z",
     });
     assert.deepEqual(
       calls.map(({ name }) => name),
-      ["list_apps", "ask_app", "ask_app_status", "ask_app_status"],
+      ["list_apps", "ask_app", "list_apps", "ask_app_status", "ask_app_status"],
     );
     assert.deepEqual(
       calls
@@ -170,6 +345,8 @@ describe("hosted OAuth and A2A acceptance harness", () => {
         timestamp: "2026-07-26T00:00:00.000Z",
         origins: [origin],
         taskIdHash: "sha256:3fed51006e68a9d8",
+        resultHash:
+          "sha256:6f9c5744a4a80b08971deaaf2b43411c82272bc633a63327c68767e87e2706db",
       },
     ]);
     assert.equal(JSON.stringify(evidence).includes("private"), false);
@@ -193,6 +370,7 @@ describe("hosted OAuth and A2A acceptance harness", () => {
         client,
         targetApp: "content",
         message: "safe fixture message",
+        expectedResult: "TRUSTED_ACCEPTANCE_FIXTURE",
         controller: { withdrawDirectoryMember: () => undefined },
       }),
       /did not include the target app/,
@@ -213,5 +391,54 @@ describe("hosted OAuth and A2A acceptance harness", () => {
       { status: 401 },
     );
     assert.equal(bodyRead, false);
+  });
+
+  it("accepts a post-cleanup 404 as fail-closed without reading its body", async () => {
+    let bodyRead = false;
+    const response = new Response("tombstone", { status: 404 });
+    response.text = async () => {
+      bodyRead = true;
+      return "tombstone";
+    };
+    assert.deepEqual(
+      await expectRejected4xx(async () => response, `${origin}/mcp`),
+      { status: 404 },
+    );
+    assert.equal(bodyRead, false);
+  });
+
+  it("records controller-owned isolation negatives without calling a foreign sentinel a production token", async () => {
+    const productionMcp = "https://caller-production.example.test/mcp";
+    const otherAcceptanceMcp = "https://other-acceptance.example.test/mcp";
+    const sentinel = createForeignDomainSentinel({
+      productionResource: productionMcp,
+      acceptanceResource: `${origin}/mcp`,
+      signingKey: new Uint8Array(32).fill(7),
+      now: () => 1_000,
+    });
+    const calls: Array<{ url: string; authorization: string }> = [];
+    const evidence = await runCryptographicIsolationProbes({
+      fetchFn: async (url, init) => {
+        calls.push({
+          url,
+          authorization: String(
+            (init?.headers as Record<string, string>).Authorization,
+          ),
+        });
+        return new Response("private rejection", { status: 401 });
+      },
+      acceptanceToken: "private-acceptance-token",
+      productionMcpUrl: productionMcp,
+      otherAcceptanceMcpUrl: otherAcceptanceMcp,
+      acceptanceMcpUrl: `${origin}/mcp`,
+      foreignDomainSentinel: sentinel,
+      now: () => "2026-07-27T00:00:00.000Z",
+    });
+    assert.equal(calls.length, 3);
+    assert.ok(calls[2]!.authorization.endsWith(sentinel.token));
+    const receipt = JSON.stringify(evidence);
+    assert.equal(receipt.includes("private-acceptance-token"), false);
+    assert.equal(receipt.includes(sentinel.token), false);
+    assert.match(receipt, /not-a-valid-production-token/);
   });
 });

--- a/scripts/trusted-acceptance/hosted-oauth-a2a-harness.ts
+++ b/scripts/trusted-acceptance/hosted-oauth-a2a-harness.ts
@@ -1,4 +1,5 @@
-import { createHash, randomBytes } from "node:crypto";
+import { createHash, createHmac, randomBytes } from "node:crypto";
+import { createServer } from "node:http";
 
 export type InjectedFetch = (
   input: string,
@@ -20,6 +21,58 @@ export type HostedHarnessEvidence = {
   timestamp: string;
   origins: string[];
   taskIdHash?: string;
+  resultHash?: string;
+  proofDigest?: string;
+  provenance?: string;
+  httpStatus?: number;
+  publicResource?: string;
+  publicIssuer?: string;
+};
+
+/**
+ * Minimal browser seam. Implementations retain the browser's HTTP-only cookie;
+ * callers never handle it directly. `postJson` is deliberately same-origin
+ * relative-path only, so credentials cannot be sent to another host.
+ */
+export type HostedQaBrowserAdapter = {
+  origin: string;
+  postJson: (
+    path: "/_agent-native/auth/register" | "/_agent-native/auth/login",
+    body: { email: string; password: string; callbackURL?: string },
+  ) => Promise<{ status: number }>;
+  getJson: (path: "/_agent-native/auth/session") => Promise<unknown>;
+  /** Opens the authorization URL in the already authenticated browser and approves consent. */
+  authorize?: (authorizationUrl: string) => Promise<void>;
+  /** Uses that same authenticated browser to prove a resource is rejected. */
+  authorizeExpectRejected?: (
+    authorizationUrl: string,
+  ) => Promise<{ status: number }>;
+};
+
+export type SyntheticQaIdentity = {
+  email: string;
+  passwordEntropyBits: 256;
+  /** The password stays in this closure and is never included in JSON output. */
+  withPassword: <T>(use: (password: string) => Promise<T> | T) => Promise<T>;
+};
+
+export type LoopbackCallback = {
+  redirectUri: string;
+  waitForCallback: () => Promise<string>;
+  close: () => Promise<void>;
+};
+
+export type OAuthCodeFlowResult = {
+  /** Transient runtime value: callers must not serialize it. */
+  accessToken: string;
+  evidence: HostedHarnessEvidence[];
+};
+
+export type ForeignDomainSentinel = {
+  /** Transient controller-owned value, never evidence or a production token. */
+  token: string;
+  proofDigest: string;
+  signingAuthorityHash: string;
 };
 
 function stableAcceptanceOrigin(value: string): string {
@@ -78,6 +131,119 @@ function hashTaskId(taskId: string): string {
   return `sha256:${createHash("sha256").update(taskId).digest("hex").slice(0, 16)}`;
 }
 
+function redactedHash(value: string): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function exactOrigin(value: string): string {
+  const url = new URL(value);
+  if (url.origin !== value || url.protocol !== "https:")
+    throw new Error("expected an exact HTTPS origin");
+  return url.origin;
+}
+
+function cleanHttpsResource(value: string): string {
+  const url = new URL(value);
+  if (
+    url.protocol !== "https:" ||
+    url.search ||
+    url.hash ||
+    url.username ||
+    url.password
+  )
+    throw new Error("expected a clean HTTPS resource URL");
+  return url.toString();
+}
+
+function leaseHash(leaseId: string): string {
+  if (!/^[a-z0-9][a-z0-9-]{2,127}$/i.test(leaseId))
+    throw new Error("lease ID must be a stable safe identifier");
+  return createHash("sha256").update(leaseId).digest("hex").slice(0, 20);
+}
+
+/**
+ * Creates a lease-bound disposable account without making its password a
+ * serializable field. The adapter receives it only while issuing same-origin
+ * requests from the trusted runner's browser context.
+ */
+export function createSyntheticQaIdentity(
+  leaseId: string,
+  domain = "acceptance.invalid",
+): SyntheticQaIdentity {
+  const suffix = leaseHash(leaseId);
+  if (!/^[a-z0-9.-]+$/i.test(domain) || !domain.includes("."))
+    throw new Error("synthetic QA email domain is invalid");
+  const password = randomBytes(32).toString("base64url");
+  return {
+    email: `trusted-acceptance+qa-${suffix}@${domain.toLowerCase()}`,
+    passwordEntropyBits: 256,
+    withPassword: async (use) => use(password),
+  };
+}
+
+function assertSameAcceptanceBrowser(
+  browser: HostedQaBrowserAdapter,
+  appOrigin: string,
+): string {
+  const origin = stableAcceptanceOrigin(appOrigin);
+  if (exactOrigin(browser.origin) !== origin)
+    throw new Error(
+      "hosted QA browser origin does not match acceptance origin",
+    );
+  return origin;
+}
+
+function sessionEmail(session: unknown): string | undefined {
+  if (!session || typeof session !== "object") return undefined;
+  const value = session as { email?: unknown; user?: { email?: unknown } };
+  return typeof value.email === "string"
+    ? value.email
+    : typeof value.user?.email === "string"
+      ? value.user.email
+      : undefined;
+}
+
+/** Establish and verify a real browser session through the existing hosted-QA routes. */
+export async function bootstrapHostedQaSession(input: {
+  browser: HostedQaBrowserAdapter;
+  appOrigin: string;
+  identity: SyntheticQaIdentity;
+}): Promise<HostedHarnessEvidence> {
+  const origin = assertSameAcceptanceBrowser(input.browser, input.appOrigin);
+  await input.identity.withPassword(async (password) => {
+    const registered = await input.browser.postJson(
+      "/_agent-native/auth/register",
+      { email: input.identity.email, password, callbackURL: "/" },
+    );
+    if (registered.status !== 200 && registered.status !== 409)
+      throw new Error(
+        `same-origin registration failed with HTTP ${registered.status}`,
+      );
+    const loggedIn = await input.browser.postJson("/_agent-native/auth/login", {
+      email: input.identity.email,
+      password,
+    });
+    if (loggedIn.status !== 200)
+      throw new Error(`same-origin login failed with HTTP ${loggedIn.status}`);
+  });
+  if (
+    sessionEmail(await input.browser.getJson("/_agent-native/auth/session")) !==
+    input.identity.email
+  ) {
+    throw new Error(
+      "same-origin session did not report the exact synthetic email",
+    );
+  }
+  return {
+    assertionId: "hosted-qa-synthetic-session",
+    status: "passed",
+    timestamp: new Date().toISOString(),
+    origins: [origin],
+    provenance:
+      "lease-bound-synthetic-email; password-retained-in-runner-memory",
+  };
+}
+
 function requestJson(
   init: RequestInit,
   body?: Record<string, unknown>,
@@ -97,6 +263,15 @@ async function requireOk(response: Response): Promise<Response> {
   if (!response.ok)
     throw new Error(`unexpected HTTP status ${response.status}`);
   return response;
+}
+
+async function require4xx(
+  response: Response,
+  assertion: string,
+): Promise<number> {
+  if (response.status < 400 || response.status >= 500)
+    throw new Error(`${assertion} expected 4xx, received ${response.status}`);
+  return response.status;
 }
 
 export function createS256Pkce(verifier?: string): PkcePair {
@@ -119,6 +294,8 @@ export async function discoverOAuth(
   const protectedResourceResponse = await requireOk(
     await fetchFn(`${origin}/.well-known/oauth-protected-resource`, {
       headers: { Accept: "application/json" },
+      redirect: "manual",
+      signal: AbortSignal.timeout(10_000),
     }),
   );
   const protectedResource = (await protectedResourceResponse.json()) as {
@@ -144,7 +321,11 @@ export async function discoverOAuth(
   const response = await requireOk(
     await fetchFn(
       `${authorizationOrigin}/.well-known/oauth-authorization-server`,
-      { headers: { Accept: "application/json" } },
+      {
+        headers: { Accept: "application/json" },
+        redirect: "manual",
+        signal: AbortSignal.timeout(10_000),
+      },
     ),
   );
   const metadata = (await response.json()) as Omit<OAuthMetadata, "resource">;
@@ -153,6 +334,45 @@ export async function discoverOAuth(
   if (metadata.registration_endpoint)
     trustedUrl(metadata.registration_endpoint, authorizationOrigin);
   return { ...metadata, resource };
+}
+
+/** Read only public OAuth identity metadata for a distinct HTTPS resource. */
+export async function discoverPublicOAuthIdentity(
+  fetchFn: InjectedFetch,
+  appOrigin: string,
+): Promise<{ resource: string; issuer: string }> {
+  const origin = new URL(appOrigin);
+  if (
+    origin.protocol !== "https:" ||
+    origin.origin !== appOrigin ||
+    origin.username ||
+    origin.password
+  ) {
+    throw new Error("public OAuth identity requires an exact HTTPS origin");
+  }
+  const response = await requireOk(
+    await fetchFn(`${origin.origin}/.well-known/oauth-protected-resource`, {
+      headers: { Accept: "application/json" },
+      redirect: "manual",
+      signal: AbortSignal.timeout(10_000),
+    }),
+  );
+  const metadata = (await response.json()) as {
+    authorization_servers?: unknown;
+    resource?: unknown;
+  };
+  const issuer = Array.isArray(metadata.authorization_servers)
+    ? metadata.authorization_servers.find(
+        (value): value is string => typeof value === "string",
+      )
+    : undefined;
+  if (typeof metadata.resource !== "string" || !issuer)
+    throw new Error("public OAuth identity metadata is incomplete");
+  const resourceUrl = new URL(metadata.resource);
+  const issuerUrl = new URL(issuer);
+  if (resourceUrl.protocol !== "https:" || issuerUrl.protocol !== "https:")
+    throw new Error("public OAuth identity metadata must use HTTPS");
+  return { resource: resourceUrl.toString(), issuer: issuerUrl.origin };
 }
 
 export function buildAuthorizationUrl(input: {
@@ -195,7 +415,11 @@ export async function registerDynamicClient(input: {
     await input.fetchFn(
       endpoint.toString(),
       requestJson(
-        { method: "POST" },
+        {
+          method: "POST",
+          redirect: "manual",
+          signal: AbortSignal.timeout(10_000),
+        },
         {
           client_name: "agent-native-trusted-acceptance",
           redirect_uris: [redirectUri],
@@ -238,6 +462,8 @@ export async function exchangeAuthorizationCode(input: {
   const response = await requireOk(
     await input.fetchFn(endpoint.toString(), {
       method: "POST",
+      redirect: "manual",
+      signal: AbortSignal.timeout(10_000),
       headers: {
         Accept: "application/json",
         "Content-Type": "application/x-www-form-urlencoded",
@@ -250,6 +476,305 @@ export async function exchangeAuthorizationCode(input: {
     throw new Error("token response omitted access_token");
   }
   return { accessToken: result.access_token };
+}
+
+/**
+ * Injected callback implementations make browser tests deterministic. This
+ * local listener is the production-shaped runner option and binds loopback
+ * only; it never logs query strings or authorization codes.
+ */
+export async function startLoopbackCallbackListener(
+  options: {
+    host?: "127.0.0.1" | "::1";
+    port?: number;
+    path?: string;
+    timeoutMs?: number;
+  } = {},
+): Promise<LoopbackCallback> {
+  const host = options.host ?? "127.0.0.1";
+  const path = options.path ?? "/oauth/callback";
+  const timeoutMs = options.timeoutMs ?? 60_000;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0 || timeoutMs > 120_000)
+    throw new Error("loopback callback timeout must be 1-120000ms");
+  if (!path.startsWith("/") || path.includes("?"))
+    throw new Error("loopback callback path must be an absolute clean path");
+  let resolveCallback: ((value: string) => void) | undefined;
+  let rejectCallback: ((reason: Error) => void) | undefined;
+  const received = new Promise<string>((resolve, reject) => {
+    resolveCallback = resolve;
+    rejectCallback = reject;
+  });
+  let callbackOrigin = "";
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const server = createServer((request, response) => {
+    const requestUrl = new URL(request.url ?? "/", `http://${host}`);
+    if (request.method !== "GET" || requestUrl.pathname !== path) {
+      response.statusCode = 404;
+      response.end();
+      return;
+    }
+    response.statusCode = 204;
+    response.end();
+    if (timeout) clearTimeout(timeout);
+    resolveCallback?.(`${callbackOrigin}${request.url}`);
+  });
+  const bound = await new Promise<{ port: number }>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(options.port ?? 0, host, () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("loopback callback listener did not bind a TCP port"));
+        return;
+      }
+      resolve({ port: address.port });
+    });
+  });
+  callbackOrigin = `http://${host === "::1" ? `[${host}]` : host}:${bound.port}`;
+  let closed = false;
+  timeout = setTimeout(() => {
+    closed = true;
+    rejectCallback?.(new Error("loopback callback listener timed out"));
+    server.close();
+  }, timeoutMs);
+  return {
+    redirectUri: `${callbackOrigin}${path}`,
+    waitForCallback: () => received,
+    close: async () => {
+      if (closed) return;
+      closed = true;
+      if (timeout) clearTimeout(timeout);
+      rejectCallback?.(
+        new Error("loopback callback listener closed before callback"),
+      );
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    },
+  };
+}
+
+export function authorizationCodeFromCallback(input: {
+  callbackUrl: string;
+  redirectUri: string;
+  state: string;
+}): string {
+  const callback = new URL(input.callbackUrl);
+  const redirect = new URL(validateRedirectUri(input.redirectUri));
+  if (
+    callback.protocol !== redirect.protocol ||
+    callback.hostname !== redirect.hostname ||
+    callback.port !== redirect.port ||
+    callback.pathname !== redirect.pathname ||
+    callback.searchParams.get("state") !== input.state
+  ) {
+    throw new Error(
+      "OAuth callback did not match the exact redirect URI and state",
+    );
+  }
+  const code = callback.searchParams.get("code");
+  if (!code || callback.searchParams.has("error"))
+    throw new Error("OAuth callback did not include an authorization code");
+  return code;
+}
+
+/** Complete discovery, dynamic registration, consent, exact callback validation, and S256 exchange. */
+export async function runHostedOAuthCodeFlow(input: {
+  fetchFn: InjectedFetch;
+  appOrigin: string;
+  browser: HostedQaBrowserAdapter;
+  callback: LoopbackCallback;
+  state?: string;
+  pkce?: PkcePair;
+  nonAllowlistedResource?: string;
+  now?: () => string;
+}): Promise<OAuthCodeFlowResult> {
+  const origin = assertSameAcceptanceBrowser(input.browser, input.appOrigin);
+  if (!input.browser.authorize)
+    throw new Error(
+      "hosted QA browser adapter must provide OAuth consent orchestration",
+    );
+  const metadata = await discoverOAuth(input.fetchFn, origin);
+  const registration = await registerDynamicClient({
+    fetchFn: input.fetchFn,
+    metadata,
+    appOrigin: origin,
+    redirectUri: input.callback.redirectUri,
+  });
+  const state = input.state ?? randomBytes(32).toString("base64url");
+  if (state.length < 32) throw new Error("OAuth state must be high entropy");
+  const pkce = input.pkce ?? createS256Pkce();
+  const authorizationUrl = buildAuthorizationUrl({
+    metadata,
+    appOrigin: origin,
+    clientId: registration.clientId,
+    redirectUri: input.callback.redirectUri,
+    state,
+    pkce,
+  });
+  const callbackPromise = input.callback.waitForCallback();
+  const [, callbackUrl] = await Promise.all([
+    input.browser.authorize(authorizationUrl),
+    callbackPromise,
+  ]);
+  const code = authorizationCodeFromCallback({
+    callbackUrl,
+    redirectUri: input.callback.redirectUri,
+    state,
+  });
+  const token = await exchangeAuthorizationCode({
+    fetchFn: input.fetchFn,
+    metadata,
+    appOrigin: origin,
+    clientId: registration.clientId,
+    redirectUri: input.callback.redirectUri,
+    code,
+    verifier: pkce.verifier,
+  });
+  const negativeEvidence = input.nonAllowlistedResource
+    ? await runRequiredOAuthNegativeProbes({
+        fetchFn: input.fetchFn,
+        browser: input.browser,
+        metadata,
+        appOrigin: origin,
+        clientId: registration.clientId,
+        redirectUri: input.callback.redirectUri,
+        code,
+        verifier: pkce.verifier,
+        authorizationUrl,
+        nonAllowlistedResource: input.nonAllowlistedResource,
+        now: input.now,
+      })
+    : [];
+  return {
+    accessToken: token.accessToken,
+    evidence: [
+      {
+        assertionId: "hosted-oauth-dynamic-registration-s256-pkce",
+        status: "passed",
+        timestamp: (input.now ?? (() => new Date().toISOString()))(),
+        origins: [origin],
+        proofDigest: redactedHash(token.accessToken),
+        publicResource: metadata.resource,
+        publicIssuer: new URL(metadata.authorization_endpoint).origin,
+        provenance:
+          "real-oauth-code-flow; exact-state; loopback-callback; token-redacted",
+      },
+      ...negativeEvidence,
+    ],
+  };
+}
+
+/**
+ * Real negative OAuth probes. Inputs stay transient: evidence records only the
+ * fact that the authority rejected a replay and non-allowlisted audience.
+ */
+export async function runRequiredOAuthNegativeProbes(input: {
+  fetchFn: InjectedFetch;
+  browser: HostedQaBrowserAdapter;
+  metadata: OAuthMetadata;
+  appOrigin: string;
+  clientId: string;
+  redirectUri: string;
+  code: string;
+  verifier: string;
+  authorizationUrl: string;
+  nonAllowlistedResource: string;
+  now?: () => string;
+}): Promise<HostedHarnessEvidence[]> {
+  const origin = assertSameAcceptanceBrowser(input.browser, input.appOrigin);
+  const endpoint = trustedUrl(input.metadata.token_endpoint, origin);
+  const unauthenticated = new URL(input.authorizationUrl);
+  unauthenticated.searchParams.set("prompt", "none");
+  const unauthenticatedResponse = await input.fetchFn(
+    unauthenticated.toString(),
+    { redirect: "manual", signal: AbortSignal.timeout(10_000) },
+  );
+  const unauthenticatedLocation =
+    unauthenticatedResponse.headers.get("location");
+  const unauthenticatedRedirect = unauthenticatedLocation
+    ? new URL(unauthenticatedLocation, unauthenticated.toString())
+    : undefined;
+  if (
+    !unauthenticatedRedirect ||
+    ![302, 303].includes(unauthenticatedResponse.status) ||
+    unauthenticatedRedirect.searchParams.get("error") !== "login_required" ||
+    unauthenticatedRedirect.searchParams.has("code")
+  ) {
+    throw new Error("unauthenticated OAuth authorization did not fail closed");
+  }
+  const replay = new URLSearchParams({
+    grant_type: "authorization_code",
+    client_id: input.clientId,
+    redirect_uri: validateRedirectUri(input.redirectUri),
+    code: input.code,
+    code_verifier: input.verifier,
+    resource: trustedUrl(input.metadata.resource, origin).toString(),
+  });
+  const replayStatus = await require4xx(
+    await input.fetchFn(endpoint.toString(), {
+      method: "POST",
+      redirect: "manual",
+      signal: AbortSignal.timeout(10_000),
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: replay.toString(),
+    }),
+    "authorization-code replay",
+  );
+  if (!input.browser.authorizeExpectRejected)
+    throw new Error(
+      "browser adapter cannot prove wrong-audience authorization rejection",
+    );
+  const forbidden = cleanHttpsResource(input.nonAllowlistedResource);
+  const authorization = trustedUrl(
+    input.metadata.authorization_endpoint,
+    origin,
+  );
+  authorization.search = new URLSearchParams({
+    response_type: "code",
+    client_id: input.clientId,
+    redirect_uri: validateRedirectUri(input.redirectUri),
+    state: randomBytes(32).toString("base64url"),
+    code_challenge: createS256Pkce().challenge,
+    code_challenge_method: "S256",
+    resource: forbidden,
+    scope: "mcp:read",
+  }).toString();
+  const rejected = await input.browser.authorizeExpectRejected(
+    authorization.toString(),
+  );
+  if (rejected.status < 400 || rejected.status >= 500)
+    throw new Error(
+      `wrong-audience authorization expected 4xx, received ${rejected.status}`,
+    );
+  const timestamp = (input.now ?? (() => new Date().toISOString()))();
+  return [
+    {
+      assertionId: "unauthenticated-oauth-code-rejected",
+      status: "passed",
+      timestamp,
+      origins: [origin],
+      httpStatus: unauthenticatedResponse.status,
+      provenance: "prompt-none; login-required; no-code; status-only",
+    },
+    {
+      assertionId: "oauth-authorization-code-replay-rejected",
+      status: "passed",
+      timestamp,
+      origins: [origin],
+      httpStatus: replayStatus,
+      provenance: "same-code-second-exchange; status-only",
+    },
+    {
+      assertionId: "oauth-wrong-audience-rejected",
+      status: "passed",
+      timestamp,
+      origins: [origin, new URL(forbidden).origin],
+      httpStatus: rejected.status,
+      provenance:
+        "authenticated-authorization-request; non-allowlisted-resource; status-only",
+    },
+  ];
 }
 
 export class HostedMcpClient {
@@ -290,6 +815,8 @@ export class HostedMcpClient {
           {
             method: "POST",
             headers: { Authorization: `Bearer ${this.accessToken}` },
+            redirect: "manual",
+            signal: AbortSignal.timeout(10_000),
           },
           {
             jsonrpc: "2.0",
@@ -347,11 +874,23 @@ function hasApp(value: unknown, appId: string): boolean {
   );
 }
 
+function containsExpectedResult(value: unknown, expected: string): boolean {
+  if (typeof value === "string") return value.includes(expected);
+  if (Array.isArray(value))
+    return value.some((entry) => containsExpectedResult(entry, expected));
+  if (value && typeof value === "object")
+    return Object.values(value).some((entry) =>
+      containsExpectedResult(entry, expected),
+    );
+  return false;
+}
+
 /** A trusted controller callback changes fixture state; it is never an HTTP input. */
 export async function runWithdrawalScenario(input: {
   client: HostedMcpClient;
   targetApp: string;
   message: string;
+  expectedResult: string;
   controller: { withdrawDirectoryMember: () => Promise<void> | void };
   now?: () => string;
   maxStatusPolls?: number;
@@ -367,6 +906,8 @@ export async function runWithdrawalScenario(input: {
     await input.client.askApp(input.targetApp, input.message),
   );
   await input.controller.withdrawDirectoryMember();
+  if (hasApp(await input.client.listApps(), input.targetApp))
+    throw new Error("directory withdrawal did not remove the target app");
   const maxStatusPolls = input.maxStatusPolls ?? 3;
   let status: unknown;
   for (let attempt = 0; attempt < maxStatusPolls; attempt++) {
@@ -376,6 +917,10 @@ export async function runWithdrawalScenario(input: {
   }
   if (!isComplete(status))
     throw new Error("same task did not complete after withdrawal");
+  if (!containsExpectedResult(status, input.expectedResult))
+    throw new Error(
+      "completed task did not contain the expected synthetic result",
+    );
   return [
     {
       assertionId: "directory-withdrawal-same-task-status",
@@ -383,6 +928,7 @@ export async function runWithdrawalScenario(input: {
       timestamp,
       origins: [input.client.origin],
       taskIdHash: hashTaskId(taskId),
+      resultHash: redactedHash(input.expectedResult),
     },
   ];
 }
@@ -393,8 +939,150 @@ export async function expectUnauthorized(
   url: string,
   init?: RequestInit,
 ): Promise<{ status: 401 }> {
-  const response = await fetchFn(url, init);
+  const response = await fetchFn(url, {
+    ...init,
+    redirect: "manual",
+    signal: init?.signal ?? AbortSignal.timeout(10_000),
+  });
   if (response.status !== 401)
     throw new Error(`expected 401, received ${response.status}`);
   return { status: 401 };
+}
+
+/** Assert a fail-closed 4xx after runtime teardown without reading its body. */
+export async function expectRejected4xx(
+  fetchFn: InjectedFetch,
+  url: string,
+  init?: RequestInit,
+): Promise<{ status: number }> {
+  const response = await fetchFn(url, {
+    ...init,
+    redirect: "manual",
+    signal: init?.signal ?? AbortSignal.timeout(10_000),
+  });
+  if (response.status < 400 || response.status >= 500)
+    throw new Error(`expected fail-closed 4xx, received ${response.status}`);
+  return { status: response.status };
+}
+
+function base64UrlJson(value: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+/**
+ * Create a disposable controller-owned wrong-domain JWT. It is expressly not
+ * a production token: its independently generated signing key never leaves
+ * runner memory and no production credential is requested or represented.
+ */
+export function createForeignDomainSentinel(input: {
+  productionResource: string;
+  acceptanceResource: string;
+  signingKey?: Uint8Array;
+  now?: () => number;
+}): ForeignDomainSentinel {
+  const production = cleanHttpsResource(input.productionResource);
+  const acceptance = trustedMcpUrl(input.acceptanceResource);
+  if (new URL(production).origin === new URL(acceptance).origin)
+    throw new Error(
+      "foreign-domain sentinel must not name the acceptance resource",
+    );
+  const key = input.signingKey ?? randomBytes(32);
+  if (key.byteLength < 32)
+    throw new Error(
+      "foreign-domain sentinel requires at least 256 bits of signing entropy",
+    );
+  const now = Math.floor((input.now ?? (() => Date.now()))() / 1000);
+  const header = base64UrlJson({ alg: "HS256", typ: "JWT" });
+  const payload = base64UrlJson({
+    iss: production,
+    aud: production,
+    iat: now,
+    exp: now + 60,
+    jti: randomBytes(16).toString("base64url"),
+  });
+  const signingInput = `${header}.${payload}`;
+  const token = `${signingInput}.${createHmac("sha256", key)
+    .update(signingInput)
+    .digest("base64url")}`;
+  return {
+    token,
+    proofDigest: redactedHash(token),
+    signingAuthorityHash: redactedHash(Buffer.from(key).toString("base64url")),
+  };
+}
+
+/**
+ * Exercise only controller-owned negative trust probes. Evidence contains
+ * status and provenance, never token bodies; this does not claim possession
+ * of a valid production token.
+ */
+export async function runCryptographicIsolationProbes(input: {
+  fetchFn: InjectedFetch;
+  acceptanceToken: string;
+  productionMcpUrl: string;
+  otherAcceptanceMcpUrl: string;
+  acceptanceMcpUrl: string;
+  foreignDomainSentinel: ForeignDomainSentinel;
+  now?: () => string;
+}): Promise<HostedHarnessEvidence[]> {
+  const acceptance = trustedMcpUrl(input.acceptanceMcpUrl);
+  const otherAcceptance = trustedMcpUrl(input.otherAcceptanceMcpUrl);
+  const production = new URL(input.productionMcpUrl);
+  if (
+    production.protocol !== "https:" ||
+    production.origin === new URL(acceptance).origin
+  )
+    throw new Error("production MCP probe must be a distinct HTTPS origin");
+  if (new URL(otherAcceptance).origin === new URL(acceptance).origin)
+    throw new Error("other acceptance MCP probe must use a distinct resource");
+  const bearer = (token: string): RequestInit => ({
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  await expectUnauthorized(
+    input.fetchFn,
+    production.toString(),
+    bearer(input.acceptanceToken),
+  );
+  await expectUnauthorized(
+    input.fetchFn,
+    otherAcceptance,
+    bearer(input.acceptanceToken),
+  );
+  await expectUnauthorized(
+    input.fetchFn,
+    acceptance,
+    bearer(input.foreignDomainSentinel.token),
+  );
+  const timestamp = (input.now ?? (() => new Date().toISOString()))();
+  return [
+    {
+      assertionId: "acceptance-token-rejected-by-production-resource",
+      status: "passed",
+      timestamp,
+      origins: [new URL(acceptance).origin, production.origin],
+      httpStatus: 401,
+      proofDigest: redactedHash(input.acceptanceToken),
+      provenance: "acceptance-token; production-rejection-status-only",
+    },
+    {
+      assertionId: "acceptance-token-rejected-by-other-acceptance-resource",
+      status: "passed",
+      timestamp,
+      origins: [new URL(acceptance).origin, new URL(otherAcceptance).origin],
+      httpStatus: 401,
+      proofDigest: redactedHash(input.acceptanceToken),
+      provenance: "acceptance-token; distinct-resource-rejection-status-only",
+    },
+    {
+      assertionId: "foreign-domain-sentinel-rejected-by-acceptance",
+      status: "passed",
+      timestamp,
+      origins: [new URL(acceptance).origin, production.origin],
+      httpStatus: 401,
+      proofDigest: input.foreignDomainSentinel.proofDigest,
+      provenance:
+        "independently-signed-foreign-domain-sentinel; not-a-valid-production-token; signing-authority-hash=" +
+        input.foreignDomainSentinel.signingAuthorityHash,
+    },
+  ];
 }

--- a/scripts/trusted-acceptance/hosted-oauth-a2a-harness.ts
+++ b/scripts/trusted-acceptance/hosted-oauth-a2a-harness.ts
@@ -532,24 +532,34 @@ export async function startLoopbackCallbackListener(
   });
   callbackOrigin = `http://${host === "::1" ? `[${host}]` : host}:${bound.port}`;
   let closed = false;
+  let closePromise: Promise<void> | undefined;
+  const closeServer = () => {
+    closePromise ??= new Promise<void>((resolve, reject) => {
+      if (!server.listening) {
+        resolve();
+        return;
+      }
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+    return closePromise;
+  };
   timeout = setTimeout(() => {
     closed = true;
     rejectCallback?.(new Error("loopback callback listener timed out"));
-    server.close();
+    void closeServer().catch(() => undefined);
   }, timeoutMs);
   return {
     redirectUri: `${callbackOrigin}${path}`,
     waitForCallback: () => received,
     close: async () => {
-      if (closed) return;
-      closed = true;
-      if (timeout) clearTimeout(timeout);
-      rejectCallback?.(
-        new Error("loopback callback listener closed before callback"),
-      );
-      await new Promise<void>((resolve, reject) =>
-        server.close((error) => (error ? reject(error) : resolve())),
-      );
+      if (!closed) {
+        closed = true;
+        if (timeout) clearTimeout(timeout);
+        rejectCallback?.(
+          new Error("loopback callback listener closed before callback"),
+        );
+      }
+      await closeServer();
     },
   };
 }

--- a/scripts/trusted-acceptance/playwright-hosted-qa.spec.ts
+++ b/scripts/trusted-acceptance/playwright-hosted-qa.spec.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createPlaywrightHostedQaBrowser } from "./playwright-hosted-qa.ts";
+
+describe("Playwright hosted-QA adapter", () => {
+  it("keeps auth requests and consent on the exact acceptance origin", async () => {
+    const calls: string[] = [];
+    const adapter = createPlaywrightHostedQaBrowser(
+      {
+        request: {
+          async post(url) {
+            calls.push(`post:${url}`);
+            return { status: () => 200, async json() {} };
+          },
+          async get(url) {
+            calls.push(`get:${url}`);
+            return {
+              status: () => 200,
+              async json() {
+                return { user: { email: "qa@example.test" } };
+              },
+            };
+          },
+        },
+        async goto(url) {
+          calls.push(`goto:${String(url)}`);
+          return null;
+        },
+        locator(selector) {
+          calls.push(`locator:${selector}`);
+          return {
+            async click() {
+              calls.push("click");
+            },
+          } as never;
+        },
+      },
+      "https://calendar.acceptance.example.test",
+    );
+
+    assert.deepEqual(
+      await adapter.postJson("/_agent-native/auth/login", {
+        email: "qa@example.test",
+        password: "in-memory-only",
+      }),
+      { status: 200 },
+    );
+    assert.deepEqual(await adapter.getJson("/_agent-native/auth/session"), {
+      user: { email: "qa@example.test" },
+    });
+    await adapter.authorize?.(
+      "https://calendar.acceptance.example.test/mcp/oauth/authorize?state=x",
+    );
+    assert.deepEqual(calls, [
+      "post:https://calendar.acceptance.example.test/_agent-native/auth/login",
+      "get:https://calendar.acceptance.example.test/_agent-native/auth/session",
+      "goto:https://calendar.acceptance.example.test/mcp/oauth/authorize?state=x",
+      'locator:button[name="decision"][value="approve"]',
+      "click",
+    ]);
+  });
+
+  it("rejects ordinary preview, production, and cross-origin consent URLs", async () => {
+    assert.throws(() =>
+      createPlaywrightHostedQaBrowser(
+        {} as never,
+        "https://calendar.agent-native.com",
+      ),
+    );
+    const adapter = createPlaywrightHostedQaBrowser(
+      {
+        request: {} as never,
+        async goto() {
+          return null;
+        },
+        locator() {
+          return {} as never;
+        },
+      },
+      "https://calendar.acceptance.example.test",
+    );
+    await assert.rejects(
+      adapter.authorize?.("https://calendar.agent-native.com/oauth/authorize"),
+      /left the exact acceptance origin/,
+    );
+  });
+});

--- a/scripts/trusted-acceptance/playwright-hosted-qa.ts
+++ b/scripts/trusted-acceptance/playwright-hosted-qa.ts
@@ -1,0 +1,96 @@
+import type { Browser, BrowserContext, Page } from "@playwright/test";
+
+import type { HostedQaBrowserAdapter } from "./hosted-oauth-a2a-harness.ts";
+
+type JsonResponse = {
+  status(): number;
+  json(): Promise<unknown>;
+};
+
+export type PlaywrightQaPage = Pick<Page, "goto" | "locator"> & {
+  request: {
+    post(url: string, options: { data: unknown }): Promise<JsonResponse>;
+    get(url: string): Promise<JsonResponse>;
+  };
+};
+
+function exactAcceptanceOrigin(value: string): string {
+  const url = new URL(value);
+  if (
+    url.protocol !== "https:" ||
+    url.origin !== value ||
+    !/(?:^|[-.])acceptance(?:[-.]|$)/i.test(url.hostname) ||
+    /(?:^|[-.])(?:prod|production)(?:[-.]|$)/i.test(url.hostname)
+  ) {
+    throw new Error("Playwright QA requires an exact acceptance HTTPS origin");
+  }
+  return url.origin;
+}
+
+/**
+ * Adapts one Playwright browser context to the generic hosted-QA seam. The
+ * context owns the HTTP-only session cookie; this adapter never reads it.
+ */
+export function createPlaywrightHostedQaBrowser(
+  page: PlaywrightQaPage,
+  appOrigin: string,
+): HostedQaBrowserAdapter {
+  const origin = exactAcceptanceOrigin(appOrigin);
+  return {
+    origin,
+    async postJson(path, body) {
+      const response = await page.request.post(
+        new URL(path, origin).toString(),
+        {
+          data: body,
+        },
+      );
+      return { status: response.status() };
+    },
+    async getJson(path) {
+      const response = await page.request.get(new URL(path, origin).toString());
+      if (response.status() !== 200) {
+        throw new Error(
+          `hosted QA session check failed with HTTP ${response.status()}`,
+        );
+      }
+      return response.json();
+    },
+    async authorize(authorizationUrl) {
+      const endpoint = new URL(authorizationUrl);
+      if (endpoint.origin !== origin) {
+        throw new Error("OAuth authorization left the exact acceptance origin");
+      }
+      await page.goto(endpoint.toString(), { waitUntil: "domcontentloaded" });
+      await page.locator('button[name="decision"][value="approve"]').click();
+    },
+    async authorizeExpectRejected(authorizationUrl) {
+      const endpoint = new URL(authorizationUrl);
+      if (endpoint.origin !== origin)
+        throw new Error("OAuth authorization left the exact acceptance origin");
+      const response = await page.goto(endpoint.toString(), {
+        waitUntil: "domcontentloaded",
+      });
+      if (!response)
+        throw new Error("wrong-audience authorization returned no response");
+      return { status: response.status() };
+    },
+  };
+}
+
+export async function createIsolatedQaPage(
+  browser: Browser,
+  appOrigin: string,
+): Promise<{
+  context: BrowserContext;
+  page: Page;
+  adapter: HostedQaBrowserAdapter;
+}> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  return {
+    context,
+    page,
+    adapter: createPlaywrightHostedQaBrowser(page, appOrigin),
+  };
+}

--- a/scripts/trusted-acceptance/run-hosted-acceptance.spec.ts
+++ b/scripts/trusted-acceptance/run-hosted-acceptance.spec.ts
@@ -1,0 +1,491 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+import {
+  parseHostedAcceptanceCliArgs,
+  runHostedAcceptance,
+} from "./run-hosted-acceptance.ts";
+
+const origin = "https://calendar.acceptance.example.test";
+const tombstone = Buffer.from("AQ==", "base64");
+
+function providers() {
+  return {
+    neon: {
+      async createBranch() {
+        return "trusted-acceptance-branch";
+      },
+      async getConnectionUri() {
+        return "postgresql://secret@example.test/db";
+      },
+      async deleteAndVerify() {
+        return true;
+      },
+      async listByPrefixAndExpiry() {
+        return [];
+      },
+    },
+    openrouter: {
+      async create() {
+        return { plaintext: "sk-secret", hash: "opaque-hash" };
+      },
+      async disableByHash() {
+        return true;
+      },
+      async listByPrefixAndExpiry() {
+        return [];
+      },
+    },
+    netlify: {
+      async assertSiteReady() {},
+      async ownsLease() {
+        return true;
+      },
+      async setRuntime() {},
+      async removeRuntime() {
+        return true;
+      },
+      async deployTombstoneAndVerify() {
+        return { deployId: "tombstone" };
+      },
+      async readLeaseMarker() {
+        return undefined;
+      },
+    },
+  };
+}
+
+describe("trusted in-process hosted acceptance runner", () => {
+  it("accepts only the six non-secret CLI file flags", () => {
+    const parsed = parseHostedAcceptanceCliArgs([
+      "--plan",
+      "plan.json",
+      "--profile",
+      "profile.json",
+      "--deploy-manifest",
+      "manifest.json",
+      "--journal",
+      "journal.json",
+      "--receipt",
+      "receipt.json",
+      "--deploy-result",
+      "deploy.json",
+    ]);
+    assert.equal(parsed.planFile, "plan.json");
+    assert.throws(
+      () => parseHostedAcceptanceCliArgs(["--plan", "plan.json"]),
+      /usage/,
+    );
+    assert.throws(
+      () =>
+        parseHostedAcceptanceCliArgs([
+          ...Object.entries(parsed).flatMap(([key, value]) => [
+            `--${key}`,
+            value,
+          ]),
+        ]),
+      /usage/,
+    );
+  });
+
+  it("rejects a tampered staged directory artifact before browser or provider use", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "hosted-acceptance-digest-"));
+    const artifact = join(dir, "directory-artifact");
+    await mkdir(artifact);
+    await writeFile(join(artifact, "acceptance-directory.ts"), "tampered");
+    const profile = {
+      version: 1,
+      workspace: "calendar-content",
+      enabled: true,
+      leasePrefix: "trusted-acceptance-",
+      runtime: {
+        maxInferenceUsd: 0.01,
+        tombstone: {
+          sha256: createHash("sha256").update(tombstone).digest("hex"),
+          zipBase64: tombstone.toString("base64"),
+        },
+        members: [
+          {
+            id: "calendar",
+            origin,
+            neonProjectId: "project",
+            neonDatabaseName: "main",
+            neonRoleName: "owner",
+            netlifyAccountId: "account",
+            netlifySiteId: "site",
+            needsInference: false,
+          },
+        ],
+      },
+      members: [{ id: "calendar", origin, artifactDirectory: "calendar" }],
+      directoryFixture: {
+        origin: "https://directory.acceptance.example.test",
+        netlifyAccountId: "directory-account",
+        netlifySiteId: "directory-site",
+        orgDomain: "agent-native.acceptance.invalid",
+        members: [
+          { id: "calendar", name: "Calendar", url: origin, a2aUrl: origin },
+        ],
+        withdrawnMemberId: "calendar",
+        artifactDirectory: "directory",
+        artifactSha256: "a".repeat(64),
+      },
+    };
+    const profileText = JSON.stringify(profile);
+    const plan = {
+      version: 1,
+      workspace: "calendar-content",
+      profileSha256: createHash("sha256").update(profileText).digest("hex"),
+      tokenExpiryMs: 300000,
+      members: [
+        {
+          id: "calendar",
+          origin,
+          mcpUrl: `${origin}/mcp`,
+          wrongAudienceResource: "https://foreign.example.test/mcp",
+          harness: { kind: "mcp-read-only-tool", tool: "list_apps" },
+        },
+      ],
+    };
+    const files = {
+      planFile: join(dir, "plan.json"),
+      profileFile: join(dir, "profile.json"),
+      deployManifestFile: join(dir, "manifest.json"),
+      journalFile: join(dir, "journal.json"),
+      receiptFile: join(dir, "receipt.json"),
+      deployResultFile: join(dir, "deploy.json"),
+    };
+    await Promise.all([
+      writeFile(files.planFile, JSON.stringify(plan)),
+      writeFile(files.profileFile, profileText),
+      writeFile(
+        files.deployManifestFile,
+        JSON.stringify({
+          version: 1,
+          members: [
+            {
+              id: "calendar",
+              siteId: "site",
+              artifactDirectory: "calendar",
+              publishDirectory: "calendar/publish",
+            },
+          ],
+          directoryFixture: {
+            siteId: "directory-site",
+            artifact,
+            sha256: "a".repeat(64),
+          },
+        }),
+      ),
+    ]);
+    await assert.rejects(
+      runHostedAcceptance(files, {
+        providers: providers(),
+        fetchFn: async () => Response.json({}),
+        browserFactory: {
+          async create() {
+            throw new Error("browser must not launch");
+          },
+        },
+        createLoopbackCallback: async () => {
+          throw new Error("callback must not launch");
+        },
+      }),
+      /sha256 contract failed/,
+    );
+  });
+
+  it("uses injected deploy, browser, OAuth, expiry, and cleanup seams without serializing secrets", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "hosted-acceptance-"));
+    const profile = {
+      version: 1,
+      workspace: "calendar-content",
+      enabled: true,
+      leasePrefix: "trusted-acceptance-",
+      runtime: {
+        maxInferenceUsd: 0.01,
+        tombstone: {
+          sha256: createHash("sha256").update(tombstone).digest("hex"),
+          zipBase64: tombstone.toString("base64"),
+        },
+        members: [
+          {
+            id: "calendar",
+            origin,
+            neonProjectId: "project",
+            neonDatabaseName: "main",
+            neonRoleName: "owner",
+            netlifyAccountId: "account",
+            netlifySiteId: "site",
+            needsInference: false,
+          },
+          {
+            id: "content",
+            origin: "https://content.acceptance.example.test",
+            neonProjectId: "content-project",
+            neonDatabaseName: "main",
+            neonRoleName: "owner",
+            netlifyAccountId: "account",
+            netlifySiteId: "content-site",
+            needsInference: false,
+          },
+        ],
+      },
+      members: [
+        { id: "calendar", origin, artifactDirectory: "calendar" },
+        {
+          id: "content",
+          origin: "https://content.acceptance.example.test",
+          artifactDirectory: "content",
+        },
+      ],
+    };
+    const profileText = JSON.stringify(profile);
+    const plan = {
+      version: 1,
+      workspace: "calendar-content",
+      profileSha256: createHash("sha256").update(profileText).digest("hex"),
+      tokenExpiryMs: 300000,
+      members: [
+        {
+          id: "calendar",
+          origin,
+          mcpUrl: `${origin}/mcp`,
+          wrongAudienceResource: "https://foreign.example.test/mcp",
+          harness: { kind: "mcp-read-only-tool", tool: "list_apps" },
+        },
+      ],
+    };
+    const manifest = {
+      version: 1,
+      members: [
+        {
+          id: "calendar",
+          siteId: "site",
+          artifactDirectory: "calendar",
+          publishDirectory: "calendar/publish",
+        },
+        {
+          id: "content",
+          siteId: "content-site",
+          artifactDirectory: "content",
+          publishDirectory: "content/publish",
+        },
+      ],
+    };
+    const files = {
+      planFile: join(dir, "plan.json"),
+      profileFile: join(dir, "profile.json"),
+      deployManifestFile: join(dir, "manifest.json"),
+      journalFile: join(dir, "journal.json"),
+      receiptFile: join(dir, "receipt.json"),
+      deployResultFile: join(dir, "deploy.json"),
+    };
+    await Promise.all([
+      writeFile(files.planFile, JSON.stringify(plan)),
+      writeFile(files.profileFile, profileText),
+      writeFile(files.deployManifestFile, JSON.stringify(manifest)),
+    ]);
+    let callbackResolve: ((url: string) => void) | undefined;
+    let expired = false;
+    let tokenExchanges = 0;
+    let profileMarker = "";
+    const deployed: string[] = [];
+    const receipt = await runHostedAcceptance(files, {
+      providers: providers(),
+      async deploy(input) {
+        deployed.push(input.siteId);
+        return { deployId: "deploy" };
+      },
+      browserFactory: {
+        async create(browserOrigin) {
+          let signedInEmail = "";
+          return {
+            close: async () => {},
+            adapter: {
+              origin: browserOrigin,
+              async postJson(_path, body) {
+                if (!body.password.endsWith("-wrong"))
+                  signedInEmail = body.email;
+                return { status: body.password.endsWith("-wrong") ? 401 : 200 };
+              },
+              async getJson() {
+                return { email: signedInEmail };
+              },
+              async authorize(url) {
+                callbackResolve?.(
+                  `http://127.0.0.1:4319/oauth/callback?code=private-code&state=${new URL(url).searchParams.get("state")}`,
+                );
+              },
+              async authorizeExpectRejected() {
+                return { status: 400 };
+              },
+            },
+          };
+        },
+      },
+      async createLoopbackCallback() {
+        return {
+          redirectUri: "http://127.0.0.1:4319/oauth/callback",
+          waitForCallback: async () =>
+            new Promise<string>((resolve) => {
+              callbackResolve = resolve;
+            }),
+          close: async () => {},
+        };
+      },
+      async sleep(ms) {
+        expired = true;
+        assert(ms > 0 && ms <= 301000);
+      },
+      async fetchFn(url, init) {
+        if (url.endsWith("oauth-protected-resource"))
+          return Response.json({
+            authorization_servers: [origin],
+            resource: `${origin}/mcp`,
+          });
+        if (url.endsWith("oauth-authorization-server"))
+          return Response.json({
+            authorization_endpoint: `${origin}/oauth/authorize`,
+            token_endpoint: `${origin}/oauth/token`,
+            registration_endpoint: `${origin}/oauth/register`,
+          });
+        if (url.endsWith("oauth/register"))
+          return Response.json({ client_id: "client" });
+        if (url.includes("/oauth/authorize?") && init?.redirect === "manual") {
+          const authorization = new URL(url);
+          const callback = new URL(
+            authorization.searchParams.get("redirect_uri")!,
+          );
+          callback.searchParams.set("error", "login_required");
+          callback.searchParams.set(
+            "state",
+            authorization.searchParams.get("state")!,
+          );
+          return new Response(null, {
+            status: 302,
+            headers: { Location: callback.toString() },
+          });
+        }
+        if (url.endsWith("oauth/token")) {
+          tokenExchanges += 1;
+          if (tokenExchanges === 1)
+            return Response.json({ access_token: "private-access-token" });
+          if (tokenExchanges === 3)
+            return Response.json({ access_token: "second-private-token" });
+          return new Response(null, { status: 400 });
+        }
+        if (expired) return new Response(null, { status: 401 });
+        if (init?.body) {
+          const request = JSON.parse(String(init.body)) as {
+            params?: { name?: string; arguments?: { name?: string } };
+          };
+          if (request.params?.name === "update-user-profile") {
+            profileMarker = request.params.arguments?.name ?? "";
+            return Response.json({
+              result: { name: profileMarker },
+            });
+          }
+          if (request.params?.name === "get-user-profile") {
+            const secondTenant =
+              new Headers(init.headers).get("authorization") ===
+              "Bearer second-private-token";
+            return Response.json({
+              result: {
+                name: secondTenant ? "Second tenant" : profileMarker,
+              },
+            });
+          }
+        }
+        return Response.json({ result: { apps: [] } });
+      },
+    });
+    assert.equal(receipt.result, "passed");
+    assert.deepEqual(deployed.sort(), ["content-site", "site"]);
+    const output = `${await readFile(files.receiptFile, "utf8")}${await readFile(files.deployResultFile, "utf8")}`;
+    assert(!output.includes("private-access-token"));
+    assert(!output.includes("postgresql://secret"));
+    assert.match(output, /deploy/);
+
+    let browserClosed = 0;
+    let factoryClosed = false;
+    let callbackClosed = false;
+    await assert.rejects(
+      runHostedAcceptance(files, {
+        providers: providers(),
+        harnessTimeoutMs: 5,
+        async deploy() {
+          return { deployId: "deploy-timeout" };
+        },
+        browserFactory: {
+          async create(browserOrigin) {
+            let email = "";
+            return {
+              async close() {
+                browserClosed += 1;
+              },
+              adapter: {
+                origin: browserOrigin,
+                async postJson(_path, body) {
+                  if (!body.password.endsWith("-wrong")) email = body.email;
+                  return {
+                    status: body.password.endsWith("-wrong") ? 401 : 200,
+                  };
+                },
+                async getJson() {
+                  return { email };
+                },
+                async authorize() {
+                  return new Promise<void>(() => undefined);
+                },
+                async authorizeExpectRejected() {
+                  return { status: 400 };
+                },
+              },
+            };
+          },
+          async close() {
+            factoryClosed = true;
+          },
+        },
+        async createLoopbackCallback() {
+          return {
+            redirectUri: "http://127.0.0.1:4319/oauth/callback",
+            waitForCallback: async () => new Promise<string>(() => undefined),
+            async close() {
+              callbackClosed = true;
+            },
+          };
+        },
+        async fetchFn(url) {
+          if (url.endsWith("oauth-protected-resource"))
+            return Response.json({
+              authorization_servers: [origin],
+              resource: `${origin}/mcp`,
+            });
+          if (url.endsWith("oauth-authorization-server"))
+            return Response.json({
+              authorization_endpoint: `${origin}/oauth/authorize`,
+              token_endpoint: `${origin}/oauth/token`,
+              registration_endpoint: `${origin}/oauth/register`,
+            });
+          if (url.endsWith("oauth/register"))
+            return Response.json({ client_id: "client" });
+          throw new Error(`unexpected timeout-test request: ${url}`);
+        },
+      }),
+      /timed out/,
+    );
+    const timeoutReceipt = JSON.parse(
+      await readFile(files.receiptFile, "utf8"),
+    ) as { lease?: { state?: string } };
+    assert.equal(timeoutReceipt.lease?.state, "revoked");
+    assert.equal(factoryClosed, true);
+    assert.equal(callbackClosed, true);
+    assert(browserClosed >= 2);
+  });
+});

--- a/scripts/trusted-acceptance/run-hosted-acceptance.spec.ts
+++ b/scripts/trusted-acceptance/run-hosted-acceptance.spec.ts
@@ -7,6 +7,7 @@ import { describe, it } from "node:test";
 
 import {
   defaultHarnessTimeoutMs,
+  defaultLeaseTtlMs,
   parseHostedAcceptanceCliArgs,
   runHostedAcceptance,
 } from "./run-hosted-acceptance.ts";
@@ -66,6 +67,11 @@ describe("trusted in-process hosted acceptance runner", () => {
     assert(
       defaultHarnessTimeoutMs > 60 * 5_000 + 300_000,
       "default deadline must leave setup and network margin",
+    );
+    assert.equal(defaultLeaseTtlMs, 30 * 60_000);
+    assert(
+      defaultLeaseTtlMs - defaultHarnessTimeoutMs >= 15 * 60_000,
+      "lease must retain a bounded cleanup reserve after harness timeout",
     );
   });
 

--- a/scripts/trusted-acceptance/run-hosted-acceptance.spec.ts
+++ b/scripts/trusted-acceptance/run-hosted-acceptance.spec.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { describe, it } from "node:test";
 
 import {
+  defaultHarnessTimeoutMs,
   parseHostedAcceptanceCliArgs,
   runHostedAcceptance,
 } from "./run-hosted-acceptance.ts";
@@ -60,6 +61,14 @@ function providers() {
 }
 
 describe("trusted in-process hosted acceptance runner", () => {
+  it("reserves explicit margin beyond the maximum poll and token-expiry windows", () => {
+    assert.equal(defaultHarnessTimeoutMs, 12 * 60_000);
+    assert(
+      defaultHarnessTimeoutMs > 60 * 5_000 + 300_000,
+      "default deadline must leave setup and network margin",
+    );
+  });
+
   it("accepts only the six non-secret CLI file flags", () => {
     const parsed = parseHostedAcceptanceCliArgs([
       "--plan",

--- a/scripts/trusted-acceptance/run-hosted-acceptance.ts
+++ b/scripts/trusted-acceptance/run-hosted-acceptance.ts
@@ -137,6 +137,8 @@ function sha256(value: string | Uint8Array): string {
 }
 
 const leaseMarkerTemplate = "{{TRUSTED_ACCEPTANCE_LEASE_MARKER}}";
+const statusPollIntervalMs = 5_000;
+export const defaultHarnessTimeoutMs = 12 * 60_000;
 
 function leaseMarker(leaseId: string): string {
   return `TRUSTED_ACCEPTANCE_FIXTURE_${sha256(leaseId).slice(0, 16)}`;
@@ -594,12 +596,13 @@ export async function runHostedAcceptance(
     ),
     ...(profile.directoryFixture ? ["directory:withdrawal-redeployed"] : []),
   ];
+  const harnessTimeoutMs = deps.harnessTimeoutMs ?? defaultHarnessTimeoutMs;
   const controller: ControllerExecution = {
     providers: deps.providers,
     journalFile: files.journalFile,
     receiptFile: files.receiptFile,
     ttlMs: 15 * 60_000,
-    harnessTimeoutMs: deps.harnessTimeoutMs ?? 10 * 60_000,
+    harnessTimeoutMs,
     expectedAssertionIds: expected,
     now: deps.now,
     async deployArtifact(member) {
@@ -806,7 +809,7 @@ export async function runHostedAcceptance(
                     deps.sleep ??
                     ((ms) =>
                       new Promise<void>((resolve) => setTimeout(resolve, ms)))
-                  )(5_000),
+                  )(statusPollIntervalMs),
                 controller: {
                   async withdrawDirectoryMember() {
                     signal.throwIfAborted();

--- a/scripts/trusted-acceptance/run-hosted-acceptance.ts
+++ b/scripts/trusted-acceptance/run-hosted-acceptance.ts
@@ -139,6 +139,7 @@ function sha256(value: string | Uint8Array): string {
 const leaseMarkerTemplate = "{{TRUSTED_ACCEPTANCE_LEASE_MARKER}}";
 const statusPollIntervalMs = 5_000;
 export const defaultHarnessTimeoutMs = 12 * 60_000;
+export const defaultLeaseTtlMs = 30 * 60_000;
 
 function leaseMarker(leaseId: string): string {
   return `TRUSTED_ACCEPTANCE_FIXTURE_${sha256(leaseId).slice(0, 16)}`;
@@ -601,7 +602,7 @@ export async function runHostedAcceptance(
     providers: deps.providers,
     journalFile: files.journalFile,
     receiptFile: files.receiptFile,
-    ttlMs: 15 * 60_000,
+    ttlMs: defaultLeaseTtlMs,
     harnessTimeoutMs,
     expectedAssertionIds: expected,
     now: deps.now,

--- a/scripts/trusted-acceptance/run-hosted-acceptance.ts
+++ b/scripts/trusted-acceptance/run-hosted-acceptance.ts
@@ -929,12 +929,13 @@ export async function runHostedAcceptance(
       }
       return results;
     },
-    async runPostCleanupHarness() {
+    async runPostCleanupHarness(_lease, signal) {
       const results: HostedHarnessEvidence[] = [];
+      const fetchFn = abortableFetch(deps.fetchFn, signal);
       try {
         for (const current of active) {
           const rejected = await expectRejected4xx(
-            deps.fetchFn,
+            fetchFn,
             current.member.mcpUrl,
             {
               headers: { Authorization: `Bearer ${current.token}` },

--- a/scripts/trusted-acceptance/run-hosted-acceptance.ts
+++ b/scripts/trusted-acceptance/run-hosted-acceptance.ts
@@ -1,0 +1,1052 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFile, readdir, stat } from "node:fs/promises";
+import { join, relative, resolve } from "node:path";
+import { promisify } from "node:util";
+
+import {
+  JsonLeaseJournalStore,
+  assertRedacted,
+  createAmbientRuntimeProviders,
+  executeTrustedAcceptance,
+  settleBeforeCleanup,
+  updateTrustedAcceptanceDirectoryScenario,
+  validateTrustedAuthorityProfile,
+  type ControllerExecution,
+  type RedactedAcceptanceReceipt,
+  type TrustedAuthorityProfile,
+} from "./controller.ts";
+import {
+  HostedMcpClient,
+  bootstrapHostedQaSession,
+  createForeignDomainSentinel,
+  createSyntheticQaIdentity,
+  discoverPublicOAuthIdentity,
+  expectUnauthorized,
+  expectRejected4xx,
+  runCryptographicIsolationProbes,
+  runHostedOAuthCodeFlow,
+  runWithdrawalScenario,
+  startLoopbackCallbackListener,
+  type HostedHarnessEvidence,
+  type HostedQaBrowserAdapter,
+  type InjectedFetch,
+  type LoopbackCallback,
+} from "./hosted-oauth-a2a-harness.ts";
+import { createIsolatedQaPage } from "./playwright-hosted-qa.ts";
+import type { RuntimeProviders } from "./runtime-authority.ts";
+
+const execFile = promisify(execFileCallback);
+
+type Harness =
+  | {
+      kind: "a2a-directory-withdrawal";
+      targetApp: string;
+      message: string;
+      expectedResult: string;
+      maxStatusPolls: number;
+    }
+  | {
+      kind: "mcp-read-only-tool";
+      tool: string;
+      arguments?: Record<string, unknown>;
+    };
+
+export type TrustedHostedAcceptancePlan = {
+  version: 1;
+  workspace: string;
+  profileSha256: string;
+  tokenExpiryMs: 300000;
+  members: Array<{
+    id: string;
+    origin: string;
+    mcpUrl: string;
+    wrongAudienceResource: string;
+    harness: Harness;
+    productionMcpUrl?: string;
+    otherAcceptanceMcpUrl?: string;
+  }>;
+};
+
+export type TrustedDeployManifest = {
+  version?: 1;
+  members: Array<{
+    id: string;
+    siteId: string;
+    /** `artifact` is the existing workflow manifest form after provenance verification. */
+    artifact?: string;
+    artifactDirectory?: string;
+    publishDirectory?: string;
+    functionsDirectory?: string;
+  }>;
+  directoryFixture?: {
+    siteId: string;
+    artifact?: string;
+    artifactDirectory?: string;
+    publishDirectory?: string;
+    functionsDirectory?: string;
+    sha256: string;
+  };
+};
+
+export type HostedQaBrowser = {
+  adapter: HostedQaBrowserAdapter;
+  close: () => Promise<void>;
+};
+
+export type HostedQaBrowserFactory = {
+  create: (
+    origin: string,
+    options?: { isolated?: boolean },
+  ) => Promise<HostedQaBrowser>;
+  close?: () => Promise<void>;
+};
+
+export type TrustedHostedAcceptanceDependencies = {
+  providers: RuntimeProviders;
+  fetchFn: InjectedFetch;
+  browserFactory: HostedQaBrowserFactory;
+  createLoopbackCallback: () => Promise<LoopbackCallback>;
+  deploy?: (input: {
+    siteId: string;
+    publishDirectory: string;
+    functionsDirectory?: string;
+    signal?: AbortSignal;
+  }) => Promise<{ deployId: string }>;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => Date;
+  harnessTimeoutMs?: number;
+};
+
+export type HostedAcceptanceFiles = {
+  planFile: string;
+  profileFile: string;
+  deployManifestFile: string;
+  journalFile: string;
+  receiptFile: string;
+  deployResultFile: string;
+};
+
+type DeployResult = {
+  version: 1;
+  deployments: Array<{ id: string; deployId: string }>;
+};
+
+function sha256(value: string | Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+const leaseMarkerTemplate = "{{TRUSTED_ACCEPTANCE_LEASE_MARKER}}";
+
+function leaseMarker(leaseId: string): string {
+  return `TRUSTED_ACCEPTANCE_FIXTURE_${sha256(leaseId).slice(0, 16)}`;
+}
+
+function renderLeaseMarker(value: string, leaseId: string): string {
+  if (!value.includes(leaseMarkerTemplate))
+    throw new Error("A2A harness text must include the lease marker template");
+  return value.replaceAll(leaseMarkerTemplate, leaseMarker(leaseId));
+}
+
+function exactHttps(value: string): string {
+  const url = new URL(value);
+  if (url.protocol !== "https:" || url.origin !== value)
+    throw new Error("expected exact HTTPS origin");
+  return url.origin;
+}
+
+function safePath(value: string): string {
+  if (!value || value.startsWith("/") || value.split("/").includes(".."))
+    throw new Error("deploy manifest contains an unsafe artifact path");
+  return value;
+}
+
+function deploymentPaths(entry: {
+  artifact?: string;
+  artifactDirectory?: string;
+  publishDirectory?: string;
+  functionsDirectory?: string;
+}): {
+  artifactDirectory: string;
+  publishDirectory: string;
+  functionsDirectory?: string;
+} {
+  const artifactDirectory = entry.artifact ?? entry.artifactDirectory;
+  if (!artifactDirectory)
+    throw new Error("deploy manifest omitted artifact directory");
+  const publishDirectory =
+    entry.publishDirectory ?? join(artifactDirectory, "publish");
+  const functionsDirectory =
+    entry.functionsDirectory ??
+    join(artifactDirectory, ".netlify/functions-internal");
+  return { artifactDirectory, publishDirectory, functionsDirectory };
+}
+
+async function directoryArtifactDigest(directory: string): Promise<string> {
+  const root = resolve(directory);
+  const hash = createHash("sha256");
+  const visit = async (current: string): Promise<void> => {
+    const entries = await readdir(current, { withFileTypes: true });
+    for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+      const file = join(current, entry.name);
+      if (entry.isDirectory()) await visit(file);
+      else if (entry.isFile()) {
+        const normalized = relative(root, file).replaceAll("\\", "/");
+        hash.update(`${normalized}\0`);
+        hash.update(await readFile(file));
+        hash.update("\0");
+      } else
+        throw new Error(
+          "trusted directory artifact must contain only regular files",
+        );
+    }
+  };
+  if (!(await stat(root)).isDirectory())
+    throw new Error("trusted directory artifact is not a directory");
+  await visit(root);
+  return hash.digest("hex");
+}
+
+function assertPlan(plan: TrustedHostedAcceptancePlan): void {
+  if (plan.version !== 1 || !plan.workspace || plan.tokenExpiryMs !== 300000)
+    throw new Error(
+      "trusted hosted plan must be version 1 with exact 5m token expiry",
+    );
+  if (!/^[a-f0-9]{64}$/i.test(plan.profileSha256) || !plan.members.length)
+    throw new Error("trusted hosted plan is incomplete");
+  const ids = new Set<string>();
+  for (const member of plan.members) {
+    if (!member.id || ids.has(member.id))
+      throw new Error("trusted hosted plan has duplicate members");
+    ids.add(member.id);
+    exactHttps(member.origin);
+    if (new URL(member.mcpUrl).origin !== member.origin)
+      throw new Error("plan MCP URL must remain at member origin");
+    if (
+      !member.wrongAudienceResource ||
+      new URL(member.wrongAudienceResource).origin === member.origin
+    )
+      throw new Error(
+        "plan must name a distinct non-allowlisted OAuth resource",
+      );
+    if (
+      member.harness.kind === "a2a-directory-withdrawal" &&
+      (!member.harness.targetApp ||
+        !member.harness.message ||
+        !member.harness.expectedResult ||
+        !member.harness.message.includes(leaseMarkerTemplate) ||
+        member.harness.expectedResult !== leaseMarkerTemplate ||
+        !Number.isInteger(member.harness.maxStatusPolls) ||
+        member.harness.maxStatusPolls < 1 ||
+        member.harness.maxStatusPolls > 60)
+    )
+      throw new Error("directory withdrawal harness is incomplete");
+    if (
+      member.harness.kind === "mcp-read-only-tool" &&
+      (!member.harness.tool ||
+        /(?:write|delete|create|update|send)/i.test(member.harness.tool))
+    )
+      throw new Error("MCP harness must name a read-only tool");
+  }
+}
+
+function validateFiles(input: {
+  plan: TrustedHostedAcceptancePlan;
+  profile: TrustedAuthorityProfile;
+  manifest: TrustedDeployManifest;
+  profileText: string;
+}): void {
+  assertPlan(input.plan);
+  const issues = validateTrustedAuthorityProfile(input.profile);
+  if (issues.length)
+    throw new Error(`trusted authority profile rejected: ${issues.join("; ")}`);
+  if (sha256(input.profileText) !== input.plan.profileSha256.toLowerCase())
+    throw new Error("plan profile digest does not match exact profile file");
+  if (input.plan.workspace !== input.profile.workspace)
+    throw new Error("plan workspace does not match profile workspace");
+  const configured = new Map(
+    input.profile.members.map((member) => [member.id, member]),
+  );
+  if (configured.size !== input.manifest.members.length)
+    throw new Error(
+      "profile and deploy manifest must name the exact same members",
+    );
+  for (const member of input.plan.members) {
+    const profileMember = configured.get(member.id);
+    const runtimeMember = input.profile.runtime.members.find(
+      ({ id }) => id === member.id,
+    );
+    const deploy = input.manifest.members.find(({ id }) => id === member.id);
+    if (
+      !profileMember ||
+      !runtimeMember ||
+      !deploy ||
+      member.origin !== profileMember.origin ||
+      member.origin !== runtimeMember.origin
+    )
+      throw new Error(
+        `member ${member.id} does not exactly match profile configuration`,
+      );
+    const paths = deploymentPaths(deploy);
+    if (
+      deploy.siteId !== runtimeMember.netlifySiteId ||
+      (!deploy.artifact &&
+        deploy.artifactDirectory !== profileMember.artifactDirectory)
+    )
+      throw new Error(
+        `deploy manifest member ${member.id} does not match trusted profile`,
+      );
+    if (!deploy.artifact) {
+      safePath(paths.artifactDirectory);
+      safePath(paths.publishDirectory);
+      if (paths.functionsDirectory) safePath(paths.functionsDirectory);
+    }
+  }
+  const fixture = input.profile.directoryFixture;
+  if (fixture) {
+    const deploy = input.manifest.directoryFixture;
+    if (
+      !deploy ||
+      deploy.siteId !== fixture.netlifySiteId ||
+      (!deploy.artifact &&
+        deploy.artifactDirectory !== fixture.artifactDirectory) ||
+      deploy.sha256 !== fixture.artifactSha256
+    )
+      throw new Error(
+        "directory deploy manifest does not match trusted artifact contract",
+      );
+    const paths = deploymentPaths(deploy);
+    if (!deploy.artifact) {
+      safePath(paths.artifactDirectory);
+      safePath(paths.publishDirectory);
+      if (paths.functionsDirectory) safePath(paths.functionsDirectory);
+    }
+  } else if (input.manifest.directoryFixture)
+    throw new Error("deploy manifest names an undeclared directory fixture");
+}
+
+async function loadFiles(files: HostedAcceptanceFiles): Promise<{
+  plan: TrustedHostedAcceptancePlan;
+  profile: TrustedAuthorityProfile;
+  manifest: TrustedDeployManifest;
+}> {
+  const [planText, profileText, manifestText] = await Promise.all([
+    readFile(files.planFile, "utf8"),
+    readFile(files.profileFile, "utf8"),
+    readFile(files.deployManifestFile, "utf8"),
+  ]);
+  const plan = JSON.parse(planText) as TrustedHostedAcceptancePlan;
+  const profile = JSON.parse(profileText) as TrustedAuthorityProfile;
+  const manifest = JSON.parse(manifestText) as TrustedDeployManifest;
+  validateFiles({ plan, profile, manifest, profileText });
+  if (profile.directoryFixture && manifest.directoryFixture) {
+    const artifactDirectory =
+      manifest.directoryFixture.artifact ??
+      manifest.directoryFixture.artifactDirectory;
+    if (!artifactDirectory)
+      throw new Error("directory deploy manifest omitted artifact directory");
+    const digest = await directoryArtifactDigest(artifactDirectory);
+    if (digest !== profile.directoryFixture.artifactSha256)
+      throw new Error("trusted directory artifact sha256 contract failed");
+  }
+  return { plan, profile, manifest };
+}
+
+/** Uses child environment only: the management token is never an argv value or deploy result field. */
+export async function deployWithNetlifyCli(input: {
+  siteId: string;
+  publishDirectory: string;
+  functionsDirectory?: string;
+  token: string;
+  signal?: AbortSignal;
+}): Promise<{ deployId: string }> {
+  const args = [
+    "deploy",
+    "--prod",
+    "--no-build",
+    "--json",
+    "--site",
+    input.siteId,
+    "--dir",
+    input.publishDirectory,
+  ];
+  if (input.functionsDirectory)
+    args.push("--functions", input.functionsDirectory);
+  const result = await execFile("netlify", args, {
+    env: { ...process.env, NETLIFY_AUTH_TOKEN: input.token },
+    timeout: 120_000,
+    signal: input.signal,
+  });
+  const parsed = JSON.parse(result.stdout) as {
+    deploy_id?: unknown;
+    id?: unknown;
+  };
+  const deployId = parsed.deploy_id ?? parsed.id;
+  if (typeof deployId !== "string" || !deployId)
+    throw new Error("Netlify deploy did not return an ID");
+  return { deployId };
+}
+
+function evidence(
+  assertionId: string,
+  status: "passed" | "failed",
+  origin: string,
+): HostedHarnessEvidence {
+  return {
+    assertionId,
+    status,
+    timestamp: new Date().toISOString(),
+    origins: [origin],
+  };
+}
+
+function abortableFetch(
+  fetchFn: InjectedFetch,
+  signal: AbortSignal,
+): InjectedFetch {
+  return (url, init) =>
+    fetchFn(url, {
+      ...init,
+      signal: init?.signal ? AbortSignal.any([init.signal, signal]) : signal,
+    });
+}
+
+function abortReason(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new Error("trusted hosted harness aborted");
+}
+
+async function awaitWithAbort<T>(
+  work: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  if (signal.aborted) throw abortReason(signal);
+  return new Promise<T>((resolvePromise, rejectPromise) => {
+    const onAbort = () => rejectPromise(abortReason(signal));
+    signal.addEventListener("abort", onAbort, { once: true });
+    work.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolvePromise(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        rejectPromise(error);
+      },
+    );
+  });
+}
+
+function abortableBrowserAdapter(
+  browser: HostedQaBrowserAdapter,
+  signal: AbortSignal,
+): HostedQaBrowserAdapter {
+  return {
+    origin: browser.origin,
+    postJson: (path, body) =>
+      awaitWithAbort(browser.postJson(path, body), signal),
+    getJson: (path) => awaitWithAbort(browser.getJson(path), signal),
+    ...(browser.authorize
+      ? {
+          authorize: (url: string) =>
+            awaitWithAbort(browser.authorize!(url), signal),
+        }
+      : {}),
+    ...(browser.authorizeExpectRejected
+      ? {
+          authorizeExpectRejected: (url: string) =>
+            awaitWithAbort(browser.authorizeExpectRejected!(url), signal),
+        }
+      : {}),
+  };
+}
+
+function abortableCallback(
+  callback: LoopbackCallback,
+  signal: AbortSignal,
+): LoopbackCallback {
+  return {
+    redirectUri: callback.redirectUri,
+    waitForCallback: () => awaitWithAbort(callback.waitForCallback(), signal),
+    close: callback.close,
+  };
+}
+
+async function closeWithTimeout(close: () => Promise<void>): Promise<void> {
+  await awaitWithAbort(close(), AbortSignal.timeout(10_000)).catch(
+    () => undefined,
+  );
+}
+
+async function createBrowserWithAbort(
+  factory: HostedQaBrowserFactory,
+  origin: string,
+  signal: AbortSignal,
+  options?: { isolated?: boolean },
+): Promise<HostedQaBrowser> {
+  const creation = factory.create(origin, options);
+  try {
+    return await awaitWithAbort(creation, signal);
+  } catch (error) {
+    if (signal.aborted)
+      void creation.then(
+        (browser) => closeWithTimeout(browser.close),
+        () => undefined,
+      );
+    throw error;
+  }
+}
+
+async function createCallbackWithAbort(
+  create: () => Promise<LoopbackCallback>,
+  signal: AbortSignal,
+): Promise<LoopbackCallback> {
+  const creation = create();
+  try {
+    return await awaitWithAbort(creation, signal);
+  } catch (error) {
+    if (signal.aborted)
+      void creation.then(
+        (callback) => closeWithTimeout(callback.close),
+        () => undefined,
+      );
+    throw error;
+  }
+}
+
+/**
+ * Runs entirely in process once callers have supplied verified files and injected
+ * provider/browser seams. It never executes candidate-authored commands.
+ */
+export async function runHostedAcceptance(
+  files: HostedAcceptanceFiles,
+  deps: TrustedHostedAcceptanceDependencies,
+): Promise<RedactedAcceptanceReceipt> {
+  const { plan, profile, manifest } = await loadFiles(files);
+  const deploy =
+    deps.deploy ??
+    ((input) => {
+      const token = process.env.ACCEPTANCE_NETLIFY_AUTH_TOKEN;
+      if (!token) throw new Error("protected Netlify token is unavailable");
+      return deployWithNetlifyCli({ ...input, token });
+    });
+  const deployments: DeployResult["deployments"] = [];
+  const deployMember = async (
+    id: string,
+    signal?: AbortSignal,
+  ): Promise<void> => {
+    const member = manifest.members.find((entry) => entry.id === id);
+    if (!member) throw new Error(`missing deploy manifest entry for ${id}`);
+    const paths = deploymentPaths(member);
+    const result = await deploy({
+      siteId: member.siteId,
+      publishDirectory: paths.publishDirectory,
+      ...(paths.functionsDirectory
+        ? { functionsDirectory: paths.functionsDirectory }
+        : {}),
+      ...(signal ? { signal } : {}),
+    });
+    deployments.push({ id, deployId: result.deployId });
+  };
+  const deployDirectory = async (signal?: AbortSignal): Promise<void> => {
+    const fixture = manifest.directoryFixture;
+    if (!fixture) throw new Error("missing trusted directory deploy manifest");
+    const paths = deploymentPaths(fixture);
+    const result = await deploy({
+      siteId: fixture.siteId,
+      publishDirectory: paths.publishDirectory,
+      ...(paths.functionsDirectory
+        ? { functionsDirectory: paths.functionsDirectory }
+        : {}),
+      ...(signal ? { signal } : {}),
+    });
+    deployments.push({ id: "directory-fixture", deployId: result.deployId });
+  };
+  const active: Array<{
+    member: TrustedHostedAcceptancePlan["members"][number];
+    browser: HostedQaBrowser;
+    token: string;
+    tokenIssuedAt: number;
+  }> = [];
+  const expected = [
+    ...plan.members.flatMap(({ id }) => [
+      `${id}:wrong-password-rejected`,
+      `${id}:session`,
+      `${id}:second-tenant-data-isolated`,
+      `${id}:oauth`,
+      `${id}:unauthenticated-oauth-code-rejected`,
+      `${id}:oauth-authorization-code-replay-rejected`,
+      `${id}:oauth-wrong-audience-rejected`,
+      `${id}:harness`,
+      `${id}:expiry`,
+      `${id}:post-cleanup`,
+    ]),
+    ...plan.members.flatMap(({ id, productionMcpUrl, otherAcceptanceMcpUrl }) =>
+      productionMcpUrl && otherAcceptanceMcpUrl
+        ? [
+            `${id}:acceptance-token-rejected-by-production-resource`,
+            `${id}:acceptance-token-rejected-by-other-acceptance-resource`,
+            `${id}:foreign-domain-sentinel-rejected-by-acceptance`,
+            `${id}:production-oauth-metadata-distinct`,
+          ]
+        : [],
+    ),
+    ...(profile.directoryFixture ? ["directory:withdrawal-redeployed"] : []),
+  ];
+  const controller: ControllerExecution = {
+    providers: deps.providers,
+    journalFile: files.journalFile,
+    receiptFile: files.receiptFile,
+    ttlMs: 15 * 60_000,
+    harnessTimeoutMs: deps.harnessTimeoutMs ?? 10 * 60_000,
+    expectedAssertionIds: expected,
+    now: deps.now,
+    async deployArtifact(member) {
+      await deployMember(member.id);
+    },
+    ...(profile.directoryFixture
+      ? {
+          async deployDirectoryArtifact() {
+            await deployDirectory();
+          },
+        }
+      : {}),
+    async runStableHarness(lease, signal) {
+      const results: HostedHarnessEvidence[] = [];
+      const fetchFn = abortableFetch(deps.fetchFn, signal);
+      for (const member of plan.members) {
+        const isolated = await createBrowserWithAbort(
+          deps.browserFactory,
+          member.origin,
+          signal,
+          { isolated: true },
+        );
+        const isolatedAdapter = abortableBrowserAdapter(
+          isolated.adapter,
+          signal,
+        );
+        const identity = createSyntheticQaIdentity(
+          lease.id,
+          profile.directoryFixture?.orgDomain,
+        );
+        try {
+          const wrong = await identity.withPassword((password) =>
+            isolatedAdapter.postJson("/_agent-native/auth/login", {
+              email: identity.email,
+              password: `${password}-wrong`,
+            }),
+          );
+          if (wrong.status !== 401)
+            throw new Error("wrong-password probe did not fail closed");
+          results.push(
+            evidence(
+              `${member.id}:wrong-password-rejected`,
+              "passed",
+              member.origin,
+            ),
+          );
+        } finally {
+          await closeWithTimeout(isolated.close);
+        }
+        const browser = await createBrowserWithAbort(
+          deps.browserFactory,
+          member.origin,
+          signal,
+        );
+        const browserAdapter = abortableBrowserAdapter(browser.adapter, signal);
+        let retained = false;
+        try {
+          const session = await bootstrapHostedQaSession({
+            browser: browserAdapter,
+            appOrigin: member.origin,
+            identity,
+          });
+          results.push({ ...session, assertionId: `${member.id}:session` });
+          const rawCallback = await createCallbackWithAbort(
+            deps.createLoopbackCallback,
+            signal,
+          );
+          const callback = abortableCallback(rawCallback, signal);
+          let flow;
+          try {
+            flow = await runHostedOAuthCodeFlow({
+              fetchFn,
+              appOrigin: member.origin,
+              browser: browserAdapter,
+              callback,
+              nonAllowlistedResource: member.wrongAudienceResource,
+            });
+          } finally {
+            await closeWithTimeout(rawCallback.close);
+          }
+          results.push(
+            ...flow.evidence.map((entry) => ({
+              ...entry,
+              assertionId:
+                entry.assertionId ===
+                "hosted-oauth-dynamic-registration-s256-pkce"
+                  ? `${member.id}:oauth`
+                  : `${member.id}:${entry.assertionId}`,
+            })),
+          );
+          const primaryClient = new HostedMcpClient(
+            fetchFn,
+            member.mcpUrl,
+            flow.accessToken,
+          );
+          const isolationMarker = `Lease ${sha256(lease.id).slice(0, 16)}`;
+          await primaryClient.callTool("update-user-profile", {
+            name: isolationMarker,
+          });
+          const secondIdentity = createSyntheticQaIdentity(
+            `${lease.id}-second-tenant`,
+            profile.directoryFixture?.orgDomain,
+          );
+          const secondBrowser = await createBrowserWithAbort(
+            deps.browserFactory,
+            member.origin,
+            signal,
+            { isolated: true },
+          );
+          try {
+            const secondAdapter = abortableBrowserAdapter(
+              secondBrowser.adapter,
+              signal,
+            );
+            await bootstrapHostedQaSession({
+              browser: secondAdapter,
+              appOrigin: member.origin,
+              identity: secondIdentity,
+            });
+            const rawSecondCallback = await createCallbackWithAbort(
+              deps.createLoopbackCallback,
+              signal,
+            );
+            let secondFlow;
+            try {
+              secondFlow = await runHostedOAuthCodeFlow({
+                fetchFn,
+                appOrigin: member.origin,
+                browser: secondAdapter,
+                callback: abortableCallback(rawSecondCallback, signal),
+              });
+            } finally {
+              await closeWithTimeout(rawSecondCallback.close);
+            }
+            const secondProfile = await new HostedMcpClient(
+              fetchFn,
+              member.mcpUrl,
+              secondFlow.accessToken,
+            ).callTool("get-user-profile", {});
+            const primaryProfile = await primaryClient.callTool(
+              "get-user-profile",
+              {},
+            );
+            if (
+              JSON.stringify(secondProfile).includes(isolationMarker) ||
+              !JSON.stringify(primaryProfile).includes(isolationMarker)
+            )
+              throw new Error(
+                "second synthetic tenant could read the harness tenant profile",
+              );
+            results.push(
+              evidence(
+                `${member.id}:second-tenant-data-isolated`,
+                "passed",
+                member.origin,
+              ),
+            );
+          } finally {
+            await closeWithTimeout(secondBrowser.close);
+          }
+          active.push({
+            member,
+            browser,
+            token: flow.accessToken,
+            tokenIssuedAt: (deps.now?.() ?? new Date()).getTime(),
+          });
+          retained = true;
+        } finally {
+          if (!retained) await closeWithTimeout(browser.close);
+        }
+      }
+      return results;
+    },
+    async runWithdrawalHarness(lease, signal) {
+      const results: HostedHarnessEvidence[] = [];
+      const fetchFn = abortableFetch(deps.fetchFn, signal);
+      for (const current of active) {
+        const client = new HostedMcpClient(
+          fetchFn,
+          current.member.mcpUrl,
+          current.token,
+        );
+        if (current.member.harness.kind === "a2a-directory-withdrawal") {
+          if (!profile.directoryFixture)
+            throw new Error(
+              "directory harness requires the trusted directory fixture",
+            );
+          results.push(
+            ...(
+              await runWithdrawalScenario({
+                client,
+                targetApp: current.member.harness.targetApp,
+                message: renderLeaseMarker(
+                  current.member.harness.message,
+                  lease.id,
+                ),
+                expectedResult: renderLeaseMarker(
+                  current.member.harness.expectedResult,
+                  lease.id,
+                ),
+                maxStatusPolls: current.member.harness.maxStatusPolls,
+                wait: () =>
+                  (
+                    deps.sleep ??
+                    ((ms) =>
+                      new Promise<void>((resolve) => setTimeout(resolve, ms)))
+                  )(5_000),
+                controller: {
+                  async withdrawDirectoryMember() {
+                    signal.throwIfAborted();
+                    await updateTrustedAcceptanceDirectoryScenario(
+                      profile,
+                      lease,
+                      deps.providers,
+                      deps.now,
+                      new JsonLeaseJournalStore(files.journalFile),
+                    );
+                    // This is a cleanup barrier, not an abort race. Once a
+                    // provider has accepted a deploy, killing the local CLI
+                    // cannot prove that deploy will not become active later.
+                    // Settle both bounded CLI operations before allowing the
+                    // controller to place and verify its final tombstones.
+                    await settleBeforeCleanup(
+                      [deployDirectory(), deployMember(current.member.id)],
+                      signal,
+                    );
+                  },
+                },
+              })
+            ).map((entry) => ({
+              ...entry,
+              assertionId: `${current.member.id}:harness`,
+            })),
+          );
+          results.push(
+            evidence(
+              "directory:withdrawal-redeployed",
+              "passed",
+              profile.directoryFixture.origin,
+            ),
+          );
+        } else {
+          await client.callTool(
+            current.member.harness.tool,
+            current.member.harness.arguments ?? {},
+          );
+          results.push(
+            evidence(
+              `${current.member.id}:harness`,
+              "passed",
+              current.member.origin,
+            ),
+          );
+        }
+        if (
+          current.member.productionMcpUrl &&
+          current.member.otherAcceptanceMcpUrl
+        ) {
+          const productionIdentity = await discoverPublicOAuthIdentity(
+            fetchFn,
+            new URL(current.member.productionMcpUrl).origin,
+          );
+          const acceptanceIdentity = await discoverPublicOAuthIdentity(
+            fetchFn,
+            current.member.origin,
+          );
+          if (
+            productionIdentity.resource === acceptanceIdentity.resource ||
+            productionIdentity.issuer === acceptanceIdentity.issuer
+          ) {
+            throw new Error(
+              "production and acceptance OAuth identities must remain distinct",
+            );
+          }
+          results.push({
+            ...evidence(
+              `${current.member.id}:production-oauth-metadata-distinct`,
+              "passed",
+              current.member.origin,
+            ),
+            publicResource: productionIdentity.resource,
+            publicIssuer: productionIdentity.issuer,
+          });
+          results.push(
+            ...(
+              await runCryptographicIsolationProbes({
+                fetchFn,
+                acceptanceToken: current.token,
+                acceptanceMcpUrl: current.member.mcpUrl,
+                productionMcpUrl: current.member.productionMcpUrl,
+                otherAcceptanceMcpUrl: current.member.otherAcceptanceMcpUrl,
+                foreignDomainSentinel: createForeignDomainSentinel({
+                  productionResource: current.member.productionMcpUrl,
+                  acceptanceResource: current.member.mcpUrl,
+                }),
+              })
+            ).map((entry) => ({
+              ...entry,
+              assertionId: `${current.member.id}:${entry.assertionId}`,
+            })),
+          );
+        }
+        const elapsed =
+          (deps.now?.() ?? new Date()).getTime() - current.tokenIssuedAt;
+        await awaitWithAbort(
+          (
+            deps.sleep ??
+            ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)))
+          )(Math.max(0, plan.tokenExpiryMs - elapsed + 1_000)),
+          signal,
+        );
+        await expectUnauthorized(fetchFn, current.member.mcpUrl, {
+          headers: { Authorization: `Bearer ${current.token}` },
+        });
+        results.push({
+          ...evidence(
+            `${current.member.id}:expiry`,
+            "passed",
+            current.member.origin,
+          ),
+          httpStatus: 401,
+        });
+      }
+      return results;
+    },
+    async runPostCleanupHarness() {
+      const results: HostedHarnessEvidence[] = [];
+      try {
+        for (const current of active) {
+          const rejected = await expectRejected4xx(
+            deps.fetchFn,
+            current.member.mcpUrl,
+            {
+              headers: { Authorization: `Bearer ${current.token}` },
+            },
+          );
+          results.push({
+            ...evidence(
+              `${current.member.id}:post-cleanup`,
+              "passed",
+              current.member.origin,
+            ),
+            httpStatus: rejected.status,
+          });
+        }
+        return results;
+      } finally {
+        await Promise.all(
+          active.map(({ browser }) => closeWithTimeout(browser.close)),
+        );
+      }
+    },
+  };
+  try {
+    const receipt = await executeTrustedAcceptance(profile, controller);
+    assertRedacted(receipt);
+    return receipt;
+  } finally {
+    try {
+      assertRedacted(deployments);
+      await import("node:fs/promises").then(({ writeFile }) =>
+        writeFile(
+          files.deployResultFile,
+          `${JSON.stringify({ version: 1, deployments }, null, 2)}\n`,
+          "utf8",
+        ),
+      );
+    } finally {
+      await Promise.all(
+        active.map(({ browser }) => browser.close().catch(() => undefined)),
+      );
+      await deps.browserFactory.close?.();
+    }
+  }
+}
+
+export function parseHostedAcceptanceCliArgs(
+  args: readonly string[],
+): HostedAcceptanceFiles {
+  const flags = new Map<string, string>();
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!flag || !value || !flag.startsWith("--") || flags.has(flag))
+      throw new Error(
+        "usage: run-hosted-acceptance --plan <file> --profile <file> --deploy-manifest <file> --journal <file> --receipt <file> --deploy-result <file>",
+      );
+    flags.set(flag, value);
+  }
+  const expected = [
+    "--plan",
+    "--profile",
+    "--deploy-manifest",
+    "--journal",
+    "--receipt",
+    "--deploy-result",
+  ] as const;
+  if (
+    flags.size !== expected.length ||
+    expected.some((flag) => !flags.has(flag))
+  )
+    throw new Error(
+      "usage: run-hosted-acceptance --plan <file> --profile <file> --deploy-manifest <file> --journal <file> --receipt <file> --deploy-result <file>",
+    );
+  return {
+    planFile: flags.get("--plan")!,
+    profileFile: flags.get("--profile")!,
+    deployManifestFile: flags.get("--deploy-manifest")!,
+    journalFile: flags.get("--journal")!,
+    receiptFile: flags.get("--receipt")!,
+    deployResultFile: flags.get("--deploy-result")!,
+  };
+}
+
+/** The CLI has no secret flags: protected management values are process-only. */
+async function main(): Promise<void> {
+  const files = parseHostedAcceptanceCliArgs(process.argv.slice(2));
+  // Launch before reading protected provider credentials; browser setup can fail without any runtime authority.
+  const playwright = await import("@playwright/test");
+  const browser = await playwright.chromium.launch({ headless: true });
+  const browserFactory: HostedQaBrowserFactory = {
+    async create(origin) {
+      const page = await createIsolatedQaPage(browser, origin);
+      return { adapter: page.adapter, close: () => page.context.close() };
+    },
+    close: () => browser.close(),
+  };
+  try {
+    const receipt = await runHostedAcceptance(files, {
+      providers: createAmbientRuntimeProviders(),
+      fetchFn: fetch,
+      browserFactory,
+      createLoopbackCallback: () => startLoopbackCallbackListener(),
+    });
+    process.stdout.write(
+      `${JSON.stringify({ result: receipt.result, workspace: receipt.workspace })}\n`,
+    );
+  } finally {
+    await browser.close().catch(() => undefined);
+  }
+}
+
+if (process.argv[1]?.endsWith("run-hosted-acceptance.ts")) {
+  main().catch((error) => {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/scripts/trusted-acceptance/runtime-authority.spec.ts
+++ b/scripts/trusted-acceptance/runtime-authority.spec.ts
@@ -323,6 +323,51 @@ describe("disposable runtime authority", () => {
     );
   });
 
+  it("persists a failed directory ownership verification for retryable cleanup", async () => {
+    const log: string[] = [];
+    const fake = providers(log);
+    const authority = new DisposableRuntimeAuthority(
+      config({
+        directoryFixture: {
+          origin: "https://directory.acceptance.example.test",
+          netlifyAccountId: "directory-account",
+          netlifySiteId: "directory-site",
+          orgDomain: "acceptance.example.test",
+          withdrawnMemberId: "content",
+          members: [
+            {
+              id: "content",
+              name: "Content",
+              url: "https://content.acceptance.example.test",
+              a2aUrl: "https://content.acceptance.example.test",
+            },
+          ],
+        },
+      }),
+      fake,
+      fixedNow,
+    );
+    const { lease } = await authority.acquire(60_000);
+    fake.netlify.ownsLease = async (_accountId, siteId) => {
+      if (siteId === "directory-site")
+        throw new Error("transient directory ownership read failure");
+      return true;
+    };
+    await authority.revoke(lease);
+    assert.equal(lease.state, "revoking");
+    assert.equal(
+      lease.journal.some(
+        ({ operation, outcome, handle }) =>
+          operation === "verify-directory-lease-owner" &&
+          outcome === "failed" &&
+          handle === "directory-site",
+      ),
+      true,
+    );
+    assert.equal(log.includes("netlify:remove:directory-site"), false);
+    assert.equal(log.includes("netlify:tombstone:directory-site"), false);
+  });
+
   it("journals partial acquire and compensates through the same revoke path", async () => {
     const log: string[] = [];
     const authority = new DisposableRuntimeAuthority(

--- a/scripts/trusted-acceptance/runtime-authority.spec.ts
+++ b/scripts/trusted-acceptance/runtime-authority.spec.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { describe, it } from "node:test";
 
 import {
@@ -133,6 +134,192 @@ describe("disposable runtime authority", () => {
     assert.deepEqual(
       log.slice(0, 4).map((entry) => entry.split(":")[0]),
       ["neon", "neon", "openrouter", "netlify"],
+    );
+  });
+
+  it("installs the acceptance-only email bypass only after lease ownership and records redacted signing provenance", async () => {
+    const log: string[] = [];
+    const fake = providers(log);
+    fake.netlify.assertSiteReady = async (_accountId, _siteId, _origin, keys) =>
+      log.push(`ready:${keys.join(",")}`);
+    fake.netlify.setRuntime = async (_accountId, _siteId, values) =>
+      log.push(`set:${Object.keys(values).sort().join(",")}`);
+    fake.netlify.ownsLease = async () => {
+      log.push("owns-lease");
+      return true;
+    };
+    let removedKeys: readonly string[] = [];
+    fake.netlify.removeRuntime = async (_accountId, _siteId, keys) => {
+      removedKeys = keys;
+      return true;
+    };
+
+    const authority = new DisposableRuntimeAuthority(config(), fake, fixedNow);
+    const issued = await authority.acquire(60_000);
+    const secret = issued.secrets.memberSecrets.content!.betterAuthSecret;
+    const provenance = issued.lease.members[0]?.authSigningAuthority;
+
+    assert.equal(log[0]?.includes("AUTH_SKIP_EMAIL_VERIFICATION"), true);
+    assert.equal(
+      log.indexOf("set:AGENT_NATIVE_ACCEPTANCE_LEASE_MARKER") <
+        log.indexOf("owns-lease"),
+      true,
+    );
+    assert.equal(
+      log.lastIndexOf("owns-lease") <
+        log.indexOf(
+          "set:A2A_SECRET,AGENT_ENGINE,AUTH_SKIP_EMAIL_VERIFICATION,BETTER_AUTH_SECRET,DATABASE_URL,MCP_OAUTH_ACCESS_TOKEN_TTL,OPENROUTER_API_KEY",
+        ),
+      true,
+    );
+    assert.deepEqual(provenance, {
+      algorithm: "sha256",
+      generatedAt: fixedNow().toISOString(),
+      sha256: createHash("sha256").update(secret).digest("hex"),
+      scope: "per-run",
+    });
+    assert.equal(JSON.stringify(issued.lease).includes(secret), false);
+
+    await authority.revoke(issued.lease);
+    assert.equal(removedKeys.includes("AUTH_SKIP_EMAIL_VERIFICATION"), true);
+    assert.equal(removedKeys.includes("MCP_OAUTH_ACCESS_TOKEN_TTL"), true);
+  });
+
+  it("keeps a directory fixture controller-owned and only permits its fixed withdrawal transition", async () => {
+    const log: string[] = [];
+    const fake = providers(log);
+    let ownsLease = true;
+    const runtimeWrites: Array<Record<string, string>> = [];
+    const memberWrites: Array<Record<string, string>> = [];
+    fake.netlify.setRuntime = async (_accountId, siteId, values) => {
+      if (siteId === "directory-site") runtimeWrites.push(values);
+      else memberWrites.push(values);
+    };
+    fake.netlify.ownsLease = async () => ownsLease;
+    let removedKeys: readonly string[] = [];
+    fake.netlify.removeRuntime = async (_accountId, siteId, keys) => {
+      if (siteId === "directory-site") removedKeys = keys;
+      return true;
+    };
+    const authority = new DisposableRuntimeAuthority(
+      config({
+        directoryFixture: {
+          origin: "https://directory.acceptance.example.test",
+          netlifyAccountId: "directory-account",
+          netlifySiteId: "directory-site",
+          orgDomain: "acceptance.example.test",
+          withdrawnMemberId: "content",
+          members: [
+            {
+              id: "content",
+              name: "Content",
+              url: "https://content.acceptance.example.test",
+              a2aUrl: "https://content.acceptance.example.test",
+            },
+          ],
+        },
+      }),
+      fake,
+      fixedNow,
+    );
+    const issued = await authority.acquire(60_000);
+    assert.deepEqual(issued.lease.directoryFixture, {
+      netlifySiteId: "directory-site",
+      runtimeOwned: true,
+      runtimeWriteAttempted: true,
+      scenario: "stable",
+    });
+    assert.deepEqual(Object.keys(runtimeWrites[0]!).sort(), [
+      "AGENT_NATIVE_ACCEPTANCE_LEASE_MARKER",
+    ]);
+    assert.deepEqual(Object.keys(runtimeWrites[1]!).sort(), [
+      "A2A_SECRET",
+      "AGENT_NATIVE_ACCEPTANCE_DIRECTORY_JSON",
+      "AGENT_NATIVE_ACCEPTANCE_DIRECTORY_SCENARIO",
+    ]);
+    assert.equal(
+      memberWrites.some(
+        (values) =>
+          values.AGENT_NATIVE_ORG_DIRECTORY_URL ===
+          "https://directory.acceptance.example.test",
+      ),
+      true,
+    );
+    assert.equal(JSON.stringify(issued.lease).includes("A2A_SECRET"), false);
+
+    ownsLease = false;
+    await assert.rejects(
+      () => authority.updateDirectoryScenario(issued.lease, "withdraw-member"),
+      /not owned/,
+    );
+    ownsLease = true;
+    await authority.updateDirectoryScenario(issued.lease, "withdraw-member");
+    assert.equal(issued.lease.directoryFixture?.scenario, "withdraw-member");
+    await assert.rejects(
+      () => authority.updateDirectoryScenario(issued.lease, "withdraw-member"),
+      /not allowlisted/,
+    );
+    await authority.revoke(issued.lease);
+    assert.deepEqual(removedKeys, [
+      "AGENT_NATIVE_ACCEPTANCE_LEASE_MARKER",
+      "A2A_SECRET",
+      "AGENT_NATIVE_ACCEPTANCE_DIRECTORY_JSON",
+      "AGENT_NATIVE_ACCEPTANCE_DIRECTORY_SCENARIO",
+    ]);
+    assert.equal(
+      issued.lease.directoryFixture?.tombstoneDeployId,
+      "deploy-directory-site",
+    );
+  });
+
+  it("reconstructs an expired controller-owned directory fixture for reaper cleanup", async () => {
+    const log: string[] = [];
+    const fake = providers(log);
+    fake.netlify.readLeaseMarker = async (_accountId, siteId) =>
+      siteId === "directory-site"
+        ? {
+            leaseId: "a".repeat(24),
+            expiresAt: "2026-07-26T11:00:00.000Z",
+          }
+        : undefined;
+    let removedKeys: readonly string[] = [];
+    fake.netlify.removeRuntime = async (_accountId, siteId, keys) => {
+      if (siteId === "directory-site") removedKeys = keys;
+      return true;
+    };
+    const configured = config({
+      directoryFixture: {
+        origin: "https://directory.acceptance.example.test",
+        netlifyAccountId: "directory-account",
+        netlifySiteId: "directory-site",
+        orgDomain: "acceptance.example.test",
+        withdrawnMemberId: "content",
+        members: [
+          {
+            id: "content",
+            name: "Content",
+            url: "https://content.acceptance.example.test",
+            a2aUrl: "https://content.acceptance.example.test",
+          },
+        ],
+      },
+    });
+    const authority = new DisposableRuntimeAuthority(
+      configured,
+      fake,
+      fixedNow,
+    );
+    const [discovered] = await discoverExpiredLeases(
+      configured,
+      fake,
+      fixedNow(),
+    );
+    assert.equal(discovered?.directoryFixture?.runtimeOwned, true);
+    const [reaped] = await authority.reapExpired([discovered!]);
+    assert.equal(reaped?.state, "revoked");
+    assert.equal(
+      removedKeys.includes("AGENT_NATIVE_ACCEPTANCE_DIRECTORY_JSON"),
+      true,
     );
   });
 
@@ -306,11 +493,13 @@ describe("disposable runtime authority", () => {
 
   it("reaps deterministic expired records and leaves late revoked work alone", async () => {
     const log: string[] = [];
-    const authority = new DisposableRuntimeAuthority(
-      config(),
-      providers(log),
-      fixedNow,
-    );
+    const fake = providers(log);
+    let removedKeys: readonly string[] = [];
+    fake.netlify.removeRuntime = async (_accountId, _siteId, keys) => {
+      removedKeys = keys;
+      return true;
+    };
+    const authority = new DisposableRuntimeAuthority(config(), fake, fixedNow);
     const lease: RuntimeLease = {
       id: "expired-lease",
       createdAt: "2026-07-26T10:00:00.000Z",
@@ -345,6 +534,7 @@ describe("disposable runtime authority", () => {
       log.filter((entry) => entry.startsWith("neon:delete")).length,
       1,
     );
+    assert.equal(removedKeys.includes("AUTH_SKIP_EMAIL_VERIFICATION"), true);
   });
 
   it("reconstructs an expired multi-member lease from declared provider inventory and reaps it", async () => {
@@ -999,7 +1189,7 @@ describe("disposable runtime authority", () => {
           JSON.stringify({
             values: [
               {
-                context: "all",
+                context: "production",
                 value: JSON.stringify({
                   leaseId: "a".repeat(24),
                   expiresAt: "2026-07-26T13:00:00.000Z",
@@ -1031,7 +1221,7 @@ describe("disposable runtime authority", () => {
               leaseId: "a".repeat(24),
               expiresAt: "2026-07-26T13:00:00.000Z",
             }),
-            context: "all",
+            context: "production",
           },
         ],
         is_secret: false,

--- a/scripts/trusted-acceptance/runtime-authority.spec.ts
+++ b/scripts/trusted-acceptance/runtime-authority.spec.ts
@@ -1322,6 +1322,35 @@ describe("disposable runtime authority", () => {
     });
   });
 
+  it("settles every parallel runtime deletion before reporting a failure", async () => {
+    let releaseDelayed: (() => void) | undefined;
+    const delayed = new Promise<void>((resolve) => {
+      releaseDelayed = resolve;
+    });
+    const netlify = new NetlifyRuntime(async (input, init) => {
+      if (init?.method !== "DELETE") return new Response(null, { status: 404 });
+      if (input.includes("FIRST_KEY"))
+        throw new Error("injected deletion failure");
+      await delayed;
+      return new Response(null, { status: 204 });
+    }, "injected-management-token");
+    const removal = netlify.removeRuntime("account", "site", [
+      "FIRST_KEY",
+      "DELAYED_KEY",
+    ]);
+    let settled = false;
+    void removal
+      .finally(() => {
+        settled = true;
+      })
+      .catch(() => undefined);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(settled, false);
+    releaseDelayed?.();
+    await assert.rejects(removal, /injected deletion failure/);
+    assert.equal(settled, true);
+  });
+
   it("binds the declared acceptance origin to the exact Netlify site before mutation", async () => {
     const netlify = new NetlifyRuntime(async (input) => {
       if (input.endsWith("/sites/site"))

--- a/scripts/trusted-acceptance/runtime-authority.spec.ts
+++ b/scripts/trusted-acceptance/runtime-authority.spec.ts
@@ -1295,6 +1295,33 @@ describe("disposable runtime authority", () => {
     );
   });
 
+  it("updates an existing acceptance runtime variable through the per-key endpoint", async () => {
+    const requests: Array<{ input: string; init?: RequestInit }> = [];
+    const netlify = new NetlifyRuntime(async (input, init) => {
+      requests.push({ input, init });
+      return init?.method === "PUT"
+        ? new Response(null, { status: 200 })
+        : Response.json({ values: [{ context: "production" }] });
+    }, "injected-management-token");
+    await netlify.setRuntime(
+      "account",
+      "site",
+      { AGENT_NATIVE_ACCEPTANCE_DIRECTORY_SCENARIO: "withdraw-member" },
+      true,
+    );
+    assert.equal(requests[1]?.init?.method, "PUT");
+    assert.equal(
+      requests[1]?.input,
+      "https://api.netlify.com/api/v1/accounts/account/env/AGENT_NATIVE_ACCEPTANCE_DIRECTORY_SCENARIO?site_id=site",
+    );
+    assert.deepEqual(JSON.parse(String(requests[1]?.init?.body)), {
+      key: "AGENT_NATIVE_ACCEPTANCE_DIRECTORY_SCENARIO",
+      scopes: ["functions", "runtime"],
+      values: [{ value: "withdraw-member", context: "production" }],
+      is_secret: true,
+    });
+  });
+
   it("binds the declared acceptance origin to the exact Netlify site before mutation", async () => {
     const netlify = new NetlifyRuntime(async (input) => {
       if (input.endsWith("/sites/site"))

--- a/scripts/trusted-acceptance/runtime-authority.ts
+++ b/scripts/trusted-acceptance/runtime-authority.ts
@@ -561,7 +561,7 @@ export class NetlifyRuntime {
     siteId: string,
     keys: readonly string[],
   ): Promise<boolean> {
-    const removals = await Promise.all(
+    const removals = await Promise.allSettled(
       keys.map((key) =>
         this.fetch(this.envUrl(accountId, siteId, key), {
           method: "DELETE",
@@ -569,12 +569,19 @@ export class NetlifyRuntime {
         }),
       ),
     );
-    const failedRemoval = removals.find(
-      (response) => !response.ok && response.status !== 404,
+    const rejectedRemoval = removals.find(
+      (result) => result.status === "rejected",
     );
-    if (failedRemoval)
+    if (rejectedRemoval?.status === "rejected") throw rejectedRemoval.reason;
+    const failedRemoval = removals.find(
+      (result) =>
+        result.status === "fulfilled" &&
+        !result.value.ok &&
+        result.value.status !== 404,
+    );
+    if (failedRemoval?.status === "fulfilled")
       throw new Error(
-        `Netlify runtime variable removal failed: ${failedRemoval.status}`,
+        `Netlify runtime variable removal failed: ${failedRemoval.value.status}`,
       );
     const verification = await Promise.all(
       keys.map((key) =>

--- a/scripts/trusted-acceptance/runtime-authority.ts
+++ b/scripts/trusted-acceptance/runtime-authority.ts
@@ -1328,13 +1328,17 @@ export class DisposableRuntimeAuthority {
       const fixture = this.config.directoryFixture;
       const durableFixture = lease.directoryFixture;
       if (durableFixture.runtimeOwned || durableFixture.runtimeWriteAttempted) {
-        const stillOwned = await this.providers.netlify.ownsLease(
-          fixture.netlifyAccountId,
-          fixture.netlifySiteId,
-          lease.id,
-          lease.expiresAt,
-        );
-        if (!stillOwned) {
+        let stillOwned = false;
+        let ownershipVerified = true;
+        try {
+          stillOwned = await this.providers.netlify.ownsLease(
+            fixture.netlifyAccountId,
+            fixture.netlifySiteId,
+            lease.id,
+            lease.expiresAt,
+          );
+        } catch {
+          ownershipVerified = false;
           runtimeVariablesAbsent = false;
           tombstoneActive = false;
           await this.record(
@@ -1344,6 +1348,18 @@ export class DisposableRuntimeAuthority {
             "failed",
             fixture.netlifySiteId,
           );
+        }
+        if (!stillOwned) {
+          runtimeVariablesAbsent = false;
+          tombstoneActive = false;
+          if (ownershipVerified)
+            await this.record(
+              lease,
+              "verification",
+              "verify-directory-lease-owner",
+              "failed",
+              fixture.netlifySiteId,
+            );
         } else {
           const absent = await this.cleanup(
             lease,

--- a/scripts/trusted-acceptance/runtime-authority.ts
+++ b/scripts/trusted-acceptance/runtime-authority.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 
 /**
  * Provider-neutral, disposable runtime authority for the disabled acceptance
@@ -24,8 +24,25 @@ export type RuntimeMember = {
   needsInference: boolean;
 };
 
+/** A controller-owned directory is intentionally not a candidate runtime member. */
+export type DirectoryFixtureRuntime = {
+  origin: string;
+  netlifyAccountId: string;
+  netlifySiteId: string;
+  orgDomain: string;
+  members: readonly {
+    id: string;
+    name: string;
+    url: string;
+    a2aUrl: string;
+    capabilities?: readonly string[];
+  }[];
+  withdrawnMemberId: string;
+};
+
 export type TrustedRuntimeConfig = {
   members: readonly RuntimeMember[];
+  directoryFixture?: DirectoryFixtureRuntime;
   maxInferenceUsd: number;
   tombstone: TombstoneArtifact;
 };
@@ -54,9 +71,22 @@ export type RuntimeLease = {
     netlifySiteId: string;
     runtimeWriteAttempted?: boolean;
     runtimeOwned?: boolean;
+    authSigningAuthority?: {
+      algorithm: "sha256";
+      generatedAt: string;
+      sha256: string;
+      scope: "per-run";
+    };
     inferenceKeyHash?: string;
     tombstoneDeployId?: string;
   }>;
+  directoryFixture?: {
+    netlifySiteId: string;
+    runtimeWriteAttempted?: boolean;
+    runtimeOwned?: boolean;
+    scenario: "stable" | "withdraw-member";
+    tombstoneDeployId?: string;
+  };
   journal: LeaseJournal[];
   verification: {
     inferenceDisabled: boolean;
@@ -138,6 +168,21 @@ function checkedConfig(config: TrustedRuntimeConfig): void {
     members.add(member.id);
     neonProjects.add(member.neonProjectId);
     netlifySites.add(member.netlifySiteId);
+  }
+  const fixture = config.directoryFixture;
+  if (!fixture) return;
+  if (
+    !fixture.netlifyAccountId ||
+    !fixture.netlifySiteId ||
+    !fixture.orgDomain ||
+    !isExactHttpsOrigin(fixture.origin) ||
+    netlifySites.has(fixture.netlifySiteId) ||
+    fixture.members.length === 0 ||
+    !fixture.members.some(({ id }) => id === fixture.withdrawnMemberId)
+  ) {
+    throw new Error(
+      "trusted directory fixture config is incomplete or overlaps an app runtime",
+    );
   }
 }
 
@@ -447,6 +492,7 @@ export class NetlifyRuntime {
     accountId: string,
     siteId: string,
     values: Record<string, string>,
+    allowExisting = false,
   ): Promise<void> {
     const entries = Object.entries(values);
     for (const [key] of entries) {
@@ -458,7 +504,7 @@ export class NetlifyRuntime {
         throw new Error(
           `Netlify runtime variable lookup failed: ${existing.status}`,
         );
-      if (existing.ok)
+      if (existing.ok && !allowExisting)
         throw new Error(
           `Netlify runtime variable ${key} already exists; refusing to overwrite acceptance-site state`,
         );
@@ -473,7 +519,7 @@ export class NetlifyRuntime {
         entries.map(([key, value]) => ({
           key,
           scopes: ["functions", "runtime"],
-          values: [{ value, context: "all" }],
+          values: [{ value, context: "production" }],
           is_secret: key !== "AGENT_NATIVE_ACCEPTANCE_LEASE_MARKER",
         })),
       ),
@@ -520,7 +566,9 @@ export class NetlifyRuntime {
       if (response.status === 404) return undefined;
       const body = await json(response);
       const values = body.values as Array<Record<string, unknown>> | undefined;
-      const value = values?.find((entry) => entry.context === "all")?.value;
+      const value = values?.find(
+        (entry) => entry.context === "production",
+      )?.value;
       if (typeof value !== "string")
         throw new Error("Netlify returned a malformed acceptance lease marker");
       return value;
@@ -658,6 +706,7 @@ export async function discoverExpiredLeases(
 
   const branchesByLease = new Map<string, DiscoveredBranch[]>();
   const markersByLease = new Map<string, DiscoveredMarker[]>();
+  const directoryMarkersByLease = new Map<string, { expiresAt: string }>();
   for (const member of config.members) {
     const branches = await providers.neon.listByPrefixAndExpiry(
       member.neonProjectId,
@@ -692,6 +741,26 @@ export async function discoverExpiredLeases(
       markersByLease.set(marker.leaseId, leaseMarkers);
     }
   }
+  if (config.directoryFixture) {
+    const fixture = config.directoryFixture;
+    const marker = await providers.netlify.readLeaseMarker(
+      fixture.netlifyAccountId,
+      fixture.netlifySiteId,
+    );
+    if (marker) {
+      if (!leaseIdPattern.test(marker.leaseId))
+        throw new Error(
+          "Netlify returned an invalid trusted directory fixture lease id",
+        );
+      if (directoryMarkersByLease.has(marker.leaseId))
+        throw new Error(
+          "Netlify returned duplicate trusted directory fixture lease markers",
+        );
+      directoryMarkersByLease.set(marker.leaseId, {
+        expiresAt: marker.expiresAt,
+      });
+    }
+  }
 
   const keysByLease = new Map<string, DiscoveredKey[]>();
   for (const key of await providers.openrouter.listByPrefixAndExpiry()) {
@@ -719,6 +788,7 @@ export async function discoverExpiredLeases(
   const leaseIds = new Set([
     ...branchesByLease.keys(),
     ...markersByLease.keys(),
+    ...directoryMarkersByLease.keys(),
     ...keysByLease.keys(),
   ]);
   const activeMarkerLeases = new Set(
@@ -730,15 +800,23 @@ export async function discoverExpiredLeases(
       )
       .map(([leaseId]) => leaseId),
   );
+  for (const [leaseId, marker] of directoryMarkersByLease) {
+    if (parsedExpiry(marker.expiresAt, "Netlify") > nowMs)
+      activeMarkerLeases.add(leaseId);
+  }
 
   return [...leaseIds].flatMap((id) => {
     const branches = branchesByLease.get(id) ?? [];
     const markers = markersByLease.get(id) ?? [];
     const keys = keysByLease.get(id) ?? [];
+    const directoryMarker = directoryMarkersByLease.get(id);
     const expiries = [
       ...branches.map((branch) => parsedExpiry(branch.expiresAt, "Neon")),
       ...markers.map((marker) => parsedExpiry(marker.expiresAt, "Netlify")),
       ...keys.map((key) => parsedExpiry(key.expiresAt, "OpenRouter")),
+      ...(directoryMarker
+        ? [parsedExpiry(directoryMarker.expiresAt, "Netlify")]
+        : []),
     ];
     if (!expiries.length || expiries.every((expiry) => expiry > nowMs))
       return [];
@@ -781,6 +859,15 @@ export async function discoverExpiredLeases(
             ...(key ? { inferenceKeyHash: key.hash } : {}),
           };
         }),
+        ...(directoryMarker && config.directoryFixture
+          ? {
+              directoryFixture: {
+                netlifySiteId: config.directoryFixture.netlifySiteId,
+                runtimeOwned: true,
+                scenario: "stable" as const,
+              },
+            }
+          : {}),
         journal: [],
         verification: {
           inferenceDisabled: false,
@@ -796,10 +883,19 @@ export async function discoverExpiredLeases(
 const runtimeKeys = [
   "DATABASE_URL",
   "BETTER_AUTH_SECRET",
+  "AUTH_SKIP_EMAIL_VERIFICATION",
+  "MCP_OAUTH_ACCESS_TOKEN_TTL",
   "A2A_SECRET",
+  "AGENT_NATIVE_ORG_DIRECTORY_URL",
   "OPENROUTER_API_KEY",
   "AGENT_ENGINE",
   "AGENT_NATIVE_ACCEPTANCE_LEASE_MARKER",
+] as const;
+const directoryRuntimeKeys = [
+  "AGENT_NATIVE_ACCEPTANCE_LEASE_MARKER",
+  "A2A_SECRET",
+  "AGENT_NATIVE_ACCEPTANCE_DIRECTORY_JSON",
+  "AGENT_NATIVE_ACCEPTANCE_DIRECTORY_SCENARIO",
 ] as const;
 export class DisposableRuntimeAuthority {
   constructor(
@@ -825,6 +921,15 @@ export class DisposableRuntimeAuthority {
         netlifySiteId: member.netlifySiteId,
         runtimeOwned: false,
       })),
+      ...(this.config.directoryFixture
+        ? {
+            directoryFixture: {
+              netlifySiteId: this.config.directoryFixture.netlifySiteId,
+              scenario: "stable" as const,
+              runtimeOwned: false,
+            },
+          }
+        : {}),
       journal: [],
       verification: {
         inferenceDisabled: false,
@@ -843,6 +948,15 @@ export class DisposableRuntimeAuthority {
           member.origin,
           runtimeKeys,
         );
+      if (this.config.directoryFixture) {
+        const fixture = this.config.directoryFixture;
+        await this.providers.netlify.assertSiteReady(
+          fixture.netlifyAccountId,
+          fixture.netlifySiteId,
+          fixture.origin,
+          directoryRuntimeKeys,
+        );
+      }
       const a2aSecret = randomBytes(32).toString("base64url");
       for (const [index, member] of this.config.members.entries()) {
         const durableMember = lease.members[index]!;
@@ -883,6 +997,15 @@ export class DisposableRuntimeAuthority {
           betterAuthSecret: randomBytes(32).toString("base64url"),
           a2aSecret,
         } as TransientLeaseSecrets["memberSecrets"][string];
+        durableMember.authSigningAuthority = {
+          algorithm: "sha256",
+          generatedAt: this.now().toISOString(),
+          sha256: createHash("sha256")
+            .update(memberSecrets.betterAuthSecret)
+            .digest("hex"),
+          scope: "per-run",
+        };
+        await this.journalStore.save(lease);
         if (member.needsInference) {
           await this.record(
             lease,
@@ -917,7 +1040,12 @@ export class DisposableRuntimeAuthority {
             key.hash,
           );
         }
-        await this.record(lease, "before", "set-netlify-runtime", "pending");
+        await this.record(
+          lease,
+          "before",
+          "set-netlify-lease-marker",
+          "pending",
+        );
         durableMember.runtimeWriteAttempted = true;
         await this.journalStore.save(lease);
         try {
@@ -929,15 +1057,6 @@ export class DisposableRuntimeAuthority {
                 leaseId: lease.id,
                 expiresAt: lease.expiresAt,
               }),
-              DATABASE_URL: memberSecrets.databaseUrl,
-              BETTER_AUTH_SECRET: memberSecrets.betterAuthSecret,
-              A2A_SECRET: a2aSecret,
-              ...(memberSecrets.inferenceKey
-                ? {
-                    OPENROUTER_API_KEY: memberSecrets.inferenceKey,
-                    AGENT_ENGINE: "ai-sdk:openrouter",
-                  }
-                : {}),
             },
           );
           if (
@@ -957,6 +1076,59 @@ export class DisposableRuntimeAuthority {
           await this.record(
             lease,
             "after",
+            "set-netlify-lease-marker",
+            "failed",
+            member.netlifySiteId,
+          );
+          throw error;
+        }
+        await this.record(
+          lease,
+          "after",
+          "set-netlify-lease-marker",
+          "ok",
+          member.netlifySiteId,
+        );
+        await this.record(lease, "before", "set-netlify-runtime", "pending");
+        try {
+          if (
+            !(await this.providers.netlify.ownsLease(
+              member.netlifyAccountId,
+              member.netlifySiteId,
+              lease.id,
+              lease.expiresAt,
+            ))
+          )
+            throw new Error(
+              "Netlify lease ownership changed before acceptance runtime install",
+            );
+          await this.providers.netlify.setRuntime(
+            member.netlifyAccountId,
+            member.netlifySiteId,
+            {
+              DATABASE_URL: memberSecrets.databaseUrl,
+              BETTER_AUTH_SECRET: memberSecrets.betterAuthSecret,
+              AUTH_SKIP_EMAIL_VERIFICATION: "1",
+              MCP_OAUTH_ACCESS_TOKEN_TTL: "5m",
+              A2A_SECRET: a2aSecret,
+              ...(this.config.directoryFixture
+                ? {
+                    AGENT_NATIVE_ORG_DIRECTORY_URL:
+                      this.config.directoryFixture.origin,
+                  }
+                : {}),
+              ...(memberSecrets.inferenceKey
+                ? {
+                    OPENROUTER_API_KEY: memberSecrets.inferenceKey,
+                    AGENT_ENGINE: "ai-sdk:openrouter",
+                  }
+                : {}),
+            },
+          );
+        } catch (error) {
+          await this.record(
+            lease,
+            "after",
             "set-netlify-runtime",
             "failed",
             member.netlifySiteId,
@@ -971,6 +1143,80 @@ export class DisposableRuntimeAuthority {
           member.netlifySiteId,
         );
         secrets.memberSecrets[member.id] = memberSecrets;
+      }
+      if (this.config.directoryFixture && lease.directoryFixture) {
+        const fixture = this.config.directoryFixture;
+        const durableFixture = lease.directoryFixture;
+        await this.record(
+          lease,
+          "before",
+          "set-directory-lease-marker",
+          "pending",
+        );
+        durableFixture.runtimeWriteAttempted = true;
+        await this.journalStore.save(lease);
+        await this.providers.netlify.setRuntime(
+          fixture.netlifyAccountId,
+          fixture.netlifySiteId,
+          {
+            AGENT_NATIVE_ACCEPTANCE_LEASE_MARKER: JSON.stringify({
+              leaseId: lease.id,
+              expiresAt: lease.expiresAt,
+            }),
+          },
+        );
+        if (
+          !(await this.providers.netlify.ownsLease(
+            fixture.netlifyAccountId,
+            fixture.netlifySiteId,
+            lease.id,
+            lease.expiresAt,
+          ))
+        )
+          throw new Error(
+            "Netlify did not retain the exact directory fixture lease marker",
+          );
+        durableFixture.runtimeOwned = true;
+        await this.record(
+          lease,
+          "after",
+          "set-directory-lease-marker",
+          "ok",
+          fixture.netlifySiteId,
+        );
+        await this.record(lease, "before", "set-directory-runtime", "pending");
+        if (
+          !(await this.providers.netlify.ownsLease(
+            fixture.netlifyAccountId,
+            fixture.netlifySiteId,
+            lease.id,
+            lease.expiresAt,
+          ))
+        )
+          throw new Error(
+            "Netlify directory fixture lease ownership changed before runtime install",
+          );
+        await this.providers.netlify.setRuntime(
+          fixture.netlifyAccountId,
+          fixture.netlifySiteId,
+          {
+            A2A_SECRET: a2aSecret,
+            AGENT_NATIVE_ACCEPTANCE_DIRECTORY_JSON: JSON.stringify({
+              orgDomain: fixture.orgDomain,
+              fixtureOrigin: fixture.origin,
+              members: fixture.members,
+              withdrawnMemberId: fixture.withdrawnMemberId,
+            }),
+            AGENT_NATIVE_ACCEPTANCE_DIRECTORY_SCENARIO: "stable",
+          },
+        );
+        await this.record(
+          lease,
+          "after",
+          "set-directory-runtime",
+          "ok",
+          fixture.netlifySiteId,
+        );
       }
       await this.setState(lease, "active");
       return { lease, secrets };
@@ -1078,6 +1324,57 @@ export class DisposableRuntimeAuthority {
         branchesDeleted &&= deleted;
       }
     }
+    if (this.config.directoryFixture && lease.directoryFixture) {
+      const fixture = this.config.directoryFixture;
+      const durableFixture = lease.directoryFixture;
+      if (durableFixture.runtimeOwned || durableFixture.runtimeWriteAttempted) {
+        const stillOwned = await this.providers.netlify.ownsLease(
+          fixture.netlifyAccountId,
+          fixture.netlifySiteId,
+          lease.id,
+          lease.expiresAt,
+        );
+        if (!stillOwned) {
+          runtimeVariablesAbsent = false;
+          tombstoneActive = false;
+          await this.record(
+            lease,
+            "verification",
+            "verify-directory-lease-owner",
+            "failed",
+            fixture.netlifySiteId,
+          );
+        } else {
+          const absent = await this.cleanup(
+            lease,
+            "remove-directory-runtime",
+            fixture.netlifySiteId,
+            () =>
+              this.providers.netlify.removeRuntime(
+                fixture.netlifyAccountId,
+                fixture.netlifySiteId,
+                directoryRuntimeKeys,
+              ),
+          );
+          runtimeVariablesAbsent &&= absent;
+          const tombstoned = await this.cleanup(
+            lease,
+            "deploy-directory-tombstone",
+            fixture.netlifySiteId,
+            async () => {
+              const receipt =
+                await this.providers.netlify.deployTombstoneAndVerify(
+                  fixture.netlifySiteId,
+                  this.config.tombstone,
+                );
+              if (receipt) durableFixture.tombstoneDeployId = receipt.deployId;
+              return Boolean(receipt);
+            },
+          );
+          tombstoneActive &&= tombstoned;
+        }
+      }
+    }
     lease.verification = {
       inferenceDisabled,
       runtimeVariablesAbsent,
@@ -1164,5 +1461,59 @@ export class DisposableRuntimeAuthority {
       );
     }
     return reaped;
+  }
+
+  async updateDirectoryScenario(
+    lease: RuntimeLease,
+    scenario: "withdraw-member",
+  ): Promise<RuntimeLease> {
+    const fixture = this.config.directoryFixture;
+    const durableFixture = lease.directoryFixture;
+    if (!fixture || !durableFixture)
+      throw new Error(
+        "trusted acceptance lease has no controller-owned directory fixture",
+      );
+    if (
+      lease.state !== "active" ||
+      durableFixture.scenario !== "stable" ||
+      scenario !== "withdraw-member"
+    )
+      throw new Error(
+        "directory fixture scenario transition is not allowlisted",
+      );
+    if (
+      !durableFixture.runtimeOwned ||
+      !(await this.providers.netlify.ownsLease(
+        fixture.netlifyAccountId,
+        fixture.netlifySiteId,
+        lease.id,
+        lease.expiresAt,
+      ))
+    )
+      throw new Error(
+        "Netlify directory fixture is not owned by the exact acceptance lease",
+      );
+    await this.record(
+      lease,
+      "before",
+      "set-directory-withdraw-member",
+      "pending",
+      fixture.netlifySiteId,
+    );
+    await this.providers.netlify.setRuntime(
+      fixture.netlifyAccountId,
+      fixture.netlifySiteId,
+      { AGENT_NATIVE_ACCEPTANCE_DIRECTORY_SCENARIO: scenario },
+      true,
+    );
+    durableFixture.scenario = scenario;
+    await this.record(
+      lease,
+      "after",
+      "set-directory-withdraw-member",
+      "ok",
+      fixture.netlifySiteId,
+    );
+    return lease;
   }
 }

--- a/scripts/trusted-acceptance/runtime-authority.ts
+++ b/scripts/trusted-acceptance/runtime-authority.ts
@@ -561,24 +561,29 @@ export class NetlifyRuntime {
     siteId: string,
     keys: readonly string[],
   ): Promise<boolean> {
-    for (const key of keys) {
-      const response = await this.fetch(this.envUrl(accountId, siteId, key), {
-        method: "DELETE",
-        headers: { authorization: `Bearer ${this.token}` },
-      });
-      if (!response.ok && response.status !== 404)
-        throw new Error(
-          `Netlify runtime variable removal failed: ${response.status}`,
-        );
-    }
-    for (const key of keys) {
-      const verification = await this.fetch(
-        this.envUrl(accountId, siteId, key),
-        { headers: { authorization: `Bearer ${this.token}` } },
+    const removals = await Promise.all(
+      keys.map((key) =>
+        this.fetch(this.envUrl(accountId, siteId, key), {
+          method: "DELETE",
+          headers: { authorization: `Bearer ${this.token}` },
+        }),
+      ),
+    );
+    const failedRemoval = removals.find(
+      (response) => !response.ok && response.status !== 404,
+    );
+    if (failedRemoval)
+      throw new Error(
+        `Netlify runtime variable removal failed: ${failedRemoval.status}`,
       );
-      if (verification.status !== 404) return false;
-    }
-    return true;
+    const verification = await Promise.all(
+      keys.map((key) =>
+        this.fetch(this.envUrl(accountId, siteId, key), {
+          headers: { authorization: `Bearer ${this.token}` },
+        }),
+      ),
+    );
+    return verification.every((response) => response.status === 404);
   }
 
   async readLeaseMarker(

--- a/scripts/trusted-acceptance/runtime-authority.ts
+++ b/scripts/trusted-acceptance/runtime-authority.ts
@@ -504,10 +504,36 @@ export class NetlifyRuntime {
         throw new Error(
           `Netlify runtime variable lookup failed: ${existing.status}`,
         );
+      if (!existing.ok && allowExisting)
+        throw new Error(
+          `Netlify runtime variable ${key} does not exist; refusing acceptance-site update`,
+        );
       if (existing.ok && !allowExisting)
         throw new Error(
           `Netlify runtime variable ${key} already exists; refusing to overwrite acceptance-site state`,
         );
+    }
+    if (allowExisting) {
+      for (const [key, value] of entries) {
+        const response = await this.fetch(this.envUrl(accountId, siteId, key), {
+          method: "PUT",
+          headers: {
+            authorization: `Bearer ${this.token}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            key,
+            scopes: ["functions", "runtime"],
+            values: [{ value, context: "production" }],
+            is_secret: key !== "AGENT_NATIVE_ACCEPTANCE_LEASE_MARKER",
+          }),
+        });
+        if (!response.ok)
+          throw new Error(
+            `Netlify runtime variable update failed: ${response.status}`,
+          );
+      }
+      return;
     }
     const response = await this.fetch(this.envUrl(accountId, siteId), {
       method: "POST",


### PR DESCRIPTION
## Problem

Framework maintainers can verify cross-app behavior with unit and integration tests, but there is no reusable hosted lane that proves the whole trust chain: an exact pull-request artifact, a real synthetic browser session, MCP OAuth, cross-app delegation, task-status recovery after directory withdrawal, and cleanup of every temporary credential. Ad hoc preview testing either borrows durable authority or stops short of the failure mode we need to catch.

## Approach

Add a default-branch-controlled acceptance runner that deploys inert, digest-verified candidate artifacts into lease-owned non-production runtimes. The runner creates short-lived synthetic identities and credentials, completes the framework's real OAuth authorization-code flow with S256 PKCE, exercises a configured read-only or A2A scenario, records only redacted evidence, and revokes the lease before a receipt can pass.

The lane is generic and configuration-driven. Calendar and Content are the first declared A2A pilot, while unchanged Tasks configuration demonstrates the reusable hosted-OAuth shape. Both workspaces remain disabled in this PR; managed resources, protected credentials, activation, and live receipts are deliberately separate operational work.

## What changed

- Added a Playwright hosted-QA adapter and an in-process trusted runner with exact plan/profile/artifact validation, loopback OAuth callbacks, two-user data-isolation proof, token negative probes, bounded execution, and redacted receipts.
- Extended disposable runtime authority to own per-run database, Better Auth, A2A, inference, directory, and acceptance-only auth configuration, including verified tombstone cleanup and reaping.
- Added a digest-pinned organization-directory fixture and a controlled stable-to-withdrawn transition. The A2A harness submits a lease-unique marker, withdraws Content, refreshes the caller's directory state, and must resolve the same task ID afterward.
- Made candidate and rollback receipt semantics executable: candidates can establish a known-good SHA without claiming rollback-only A14; rollback runs must cite that prior passing receipt and prove their own controller/deployment evidence.
- Hardened the workflow boundary so candidate builds never receive protected values, staged artifacts reject links and non-regular files, privileged deployment uses only trusted code, and started provider deploys settle before cleanup tombstones are placed.

## Safety and operations

- `calendar-content` and `tasks-hosted-oauth-proof` remain `enabled: false`.
- No production credential or valid production token enters the lane. Production and acceptance are compared through public metadata plus independently controlled fail-closed probes.
- Candidate runtimes receive only lease-scoped values. Cleanup removes runtime configuration, disables inference, deletes database branches, and verifies tombstone deployments; an independent reaper shares the same ownership contract.
- This PR does not provision infrastructure, set protected variables or secrets, deploy, enable the lane, or claim live hosted acceptance.

## Verification

- 105 focused tests pass across configuration, workflow guards, controller/reaper custody, runtime authority, directory behavior, OAuth/A2A harnesses, Playwright adapter, and the hosted runner. The suite includes hung-browser teardown, awaitable loopback-listener timeout cleanup, bounded abortable post-cleanup probes, correct per-key Netlify scenario updates, required directory tombstone proof and receipt cardinality, a 12-minute harness inside a 30-minute lease cleanup budget, settled parallel runtime-deletion waves, a late-deploy ordering test that proves cleanup tombstones are last, cross-app self-delegation rejection, harness-independent isolation resolution, and durable directory-ownership failure recording.
- Workflow YAML parses, the trusted-workflow boundary guard passes, `oxfmt` is clean, and `git diff --check` passes.
- Independent integration review found the identity domain, lease marker, two-user I4 proof, token budget, and candidate/rollback receipt flow coherent.
- Independent security review found no remaining material custody issue after abort-aware browser teardown and the deploy-settlement cleanup barrier.
- Independent real-surface preflight verified that this is an open same-repository PR at the exact remote head, that the live `main` workflow exposes separate candidate, rollback, workspace, and deploy inputs, and that the pilot remains fail-closed while disabled. The tester could not visually inspect the dispatch form in a signed-in browser and did not create a dry-run Actions run; live hosted QA remains intentionally unavailable until separately authorized Land work.
- Full repository CI is green on the exact PR head. One unrelated Calendar ICS fixture test failed initially, then passed on the single failed-job retry; all 56 reported checks now pass and 43 are intentionally skipped.

## Review focus

- Does the candidate-build / trusted-controller split keep management authority out of candidate custody?
- Can any timeout, cancellation, or late provider write escape verified revocation and tombstoning?
- Do the synthetic identity, OAuth, audience, and two-user isolation probes prove the stated boundaries without borrowing production authority?
- Are candidate versus rollback receipts strict enough to establish and later restore only a genuinely proven known-good SHA?
- Is the configuration generic enough for another unchanged hosted template without adding workflow branches?

## Follow-ups

- Under separate Land authority, provision the dedicated acceptance sites, databases, domains, provider limits, and protected environment; then enable and run the Calendar/Content pilot.
- Run and retain the first live candidate and rollback receipts, followed by the unchanged Tasks reuse proof. Until those exist, the lane is code-ready only and must not be described as shipped.
