### PR TITLE
Set CRM production URL

### DIFF
--- a/packages/core/src/cli/templates-meta.ts
+++ b/packages/core/src/cli/templates-meta.ts
@@ -237,6 +237,7 @@ export const TEMPLATES: TemplateMeta[] = [
     color: "#2563EB",
     colorRgb: "37 99 235",
     devPort: 8107,
+    prodUrl: "https://crm.agent-native.com",
     hidden: true,
     defaultMode: "dev",
     core: false,

--- a/packages/shared-app-config/templates.ts
+++ b/packages/shared-app-config/templates.ts
@@ -240,6 +240,7 @@ export const TEMPLATES: TemplateMeta[] = [
     color: "#2563EB",
     colorRgb: "37 99 235",
     devPort: 8107,
+    prodUrl: "https://crm.agent-native.com",
     hidden: true,
     defaultMode: "dev",
     core: false,


### PR DESCRIPTION
## Summary
- add the live CRM production URL to both mirrored template registries
- keep CRM hidden and out of the public template catalog

## Verification
- `pnpm exec oxfmt --check packages/shared-app-config/templates.ts packages/core/src/cli/templates-meta.ts`
- `pnpm guard:template-list`
- `pnpm typecheck`
- `crm.agent-native.com` resolves to the Netlify site with an issued TLS certificate

The CRM production deploy for merged commit `661ee71cf2b6c664d0c6f5bd841910f6abc9fd21` is queued in Netlify and will be verified separately.
