### PR TITLE
Restore trusted acceptance workflow execution

### DIFF
--- a/.github/workflows/trusted-acceptance.yml
+++ b/.github/workflows/trusted-acceptance.yml
@@ -119,13 +119,13 @@ jobs:
             pnpm tsx scripts/trusted-acceptance.ts "${rollback_plan_args[@]}" > "$RUNNER_TEMP/rollback-plan.json"
             expected_assertions="$(node -e 'const p=require(process.env.RUNNER_TEMP + "/rollback-plan.json"); if (!p.ok) process.exit(1); process.stdout.write(JSON.stringify(p.plan.assertions.filter(id => id !== "A14")))')"
             gh api "repos/$TRUSTED_REPOSITORY/actions/runs/$ROLLBACK_RUN_ID" > "$RUNNER_TEMP/prior-run.json"
-            node - <<'NODE'
-            const fs = require("node:fs");
-            const run = JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + "/prior-run.json", "utf8"));
-            if (run.path !== ".github/workflows/trusted-acceptance.yml" || run.event !== "workflow_dispatch" || run.conclusion !== "success" || run.head_branch !== "main") {
-              throw new Error("rollback_run_id must be a successful main dispatch of the trusted acceptance workflow");
-            }
-            NODE
+            node -e '
+              const fs = require("node:fs");
+              const run = JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + "/prior-run.json", "utf8"));
+              if (run.path !== ".github/workflows/trusted-acceptance.yml" || run.event !== "workflow_dispatch" || run.conclusion !== "success" || run.head_branch !== "main") {
+                throw new Error("rollback_run_id must be a successful main dispatch of the trusted acceptance workflow");
+              }
+            '
             artifact_id="$(gh api "repos/$TRUSTED_REPOSITORY/actions/runs/$ROLLBACK_RUN_ID/artifacts" --jq ".artifacts[] | select(.name == \"trusted-acceptance-receipt-$ROLLBACK_RUN_ID\") | .id" | head -n 1)"
             if [[ -z "$artifact_id" ]]; then
               echo "No trusted acceptance receipt artifact found for rollback_run_id." >&2
@@ -136,15 +136,15 @@ jobs:
             unzip -p "$RUNNER_TEMP/prior-receipt.zip" trusted-acceptance-receipt.json > "$prior_receipt"
             test -s "$prior_receipt"
             pnpm tsx scripts/trusted-acceptance.ts receipt --file "$prior_receipt" --expected-assertions "$expected_assertions"
-            node - "$prior_receipt" <<'NODE'
-            const fs = require("node:fs");
-            const receipt = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
-            const run = JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + "/prior-run.json", "utf8"));
-            const expectedRunUrl = `https://github.com/${process.env.TRUSTED_REPOSITORY}/actions/runs/${process.env.ROLLBACK_RUN_ID}`;
-            if (receipt.result !== "pass" || receipt.runUrl !== expectedRunUrl || receipt.controllerSha !== run.head_sha || receipt.workspace !== process.env.WORKSPACE || receipt.currentKnownGoodSha !== process.env.ROLLBACK_SHA) {
-              throw new Error("Rollback SHA is not the known-good SHA from the selected passing workspace receipt");
-            }
-            NODE
+            node -e '
+              const fs = require("node:fs");
+              const receipt = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+              const run = JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + "/prior-run.json", "utf8"));
+              const expectedRunUrl = `https://github.com/${process.env.TRUSTED_REPOSITORY}/actions/runs/${process.env.ROLLBACK_RUN_ID}`;
+              if (receipt.result !== "pass" || receipt.runUrl !== expectedRunUrl || receipt.controllerSha !== run.head_sha || receipt.workspace !== process.env.WORKSPACE || receipt.currentKnownGoodSha !== process.env.ROLLBACK_SHA) {
+                throw new Error("Rollback SHA is not the known-good SHA from the selected passing workspace receipt");
+              }
+            ' "$prior_receipt"
             operation="rollback"
             receipt_pr=""
           else

--- a/scripts/guard-trusted-acceptance-workflow.spec.ts
+++ b/scripts/guard-trusted-acceptance-workflow.spec.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { describe, it } from "node:test";
 
@@ -17,12 +18,47 @@ const reaper = readFileSync(
   "utf8",
 );
 
+function extractStepRunScript(source: string, stepName: string): string {
+  const stepMarker = `      - name: ${stepName}\n`;
+  const stepStart = source.indexOf(stepMarker);
+  assert.notEqual(stepStart, -1, `Missing workflow step: ${stepName}`);
+
+  const runMarker = "        run: |\n";
+  const runStart = source.indexOf(runMarker, stepStart);
+  assert.notEqual(
+    runStart,
+    -1,
+    `Missing run block for workflow step: ${stepName}`,
+  );
+
+  const scriptStart = runStart + runMarker.length;
+  const nextStep = source.indexOf("\n      - name:", scriptStart);
+  const scriptEnd = nextStep === -1 ? source.length : nextStep;
+  return source
+    .slice(scriptStart, scriptEnd)
+    .split("\n")
+    .map((line) => (line.startsWith("          ") ? line.slice(10) : line))
+    .join("\n");
+}
+
 describe("trusted acceptance workflow boundary", () => {
   it("keeps candidate builds separate from protected deployment custody", () => {
     assert.deepEqual(validateTrustedAcceptanceWorkflow(workflow), {
       ok: true,
       issues: [],
     });
+  });
+
+  it("keeps the rendered candidate and rollback provenance shell parseable", () => {
+    const script = extractStepRunScript(
+      workflow,
+      "Verify candidate or known-good rollback provenance",
+    );
+    const result = spawnSync("bash", ["-n"], {
+      input: script,
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 0, result.stderr);
   });
 
   it("rejects a secret exposed to candidate build steps", () => {


### PR DESCRIPTION
## Why this matters

Agent Native needs a safe way to prove that independently deployed apps can keep working together without lending pull-request code production credentials. The trusted acceptance workflow is that safety lane: a controller owned by `main` builds an exact pull-request commit without credentials, then—only inside a protected environment—can give disposable Calendar and Content deployments short-lived authority and verify the complete OAuth and cross-app task flow.

The first real credential-free dry run never reached candidate validation or builds. Bash rejected the controller's provenance step because two rollback-only JavaScript heredocs remained indented after GitHub rendered the YAML `run` block. Since Bash parses the whole step before choosing its candidate or rollback branch, the malformed rollback branch also blocked ordinary candidate runs.

Until this is repaired, maintainers cannot even perform the safe dry-run prerequisite for the hosted Calendar-to-Content proof, let alone test that an in-flight Content task remains reachable after Content disappears from app discovery.

## Approach

Remove the indentation-sensitive shell construct without changing the security model:

- replace only the two nested rollback heredocs with `node -e` invocations;
- preserve the existing rollback-run and receipt provenance predicates; and
- add a regression that extracts the provenance script with the same YAML block de-indentation GitHub applies, then verifies the rendered shell with `bash -n`.

The candidate build, protected deployment, credential, and cleanup boundaries are otherwise untouched.

## Safety and operations

- The Calendar/Content and Tasks acceptance workspaces remain disabled.
- This PR adds no credentials, infrastructure, acceptance data, or deployment authority.
- Candidate pull-request code still cannot control the trusted workflow or access protected-environment credentials.
- The failed pre-repair run entered no protected environment and deployed nothing: https://github.com/BuilderIO/agent-native/actions/runs/30280794089
- This repair does **not** claim the hosted OAuth/A2A acceptance story has passed. After merge, the same main-owned dry run must succeed before isolated provider resources or pilot activation are considered.

## Verification

- `pnpm guard:trusted-acceptance` passed, demonstrating that the controller/candidate custody boundary remains intact.
- `pnpm test:trusted-acceptance` passed 106/106 tests, including the rendered-shell syntax regression and the disabled-pilot assertions.
- Repository CI passed all 68 executed checks, with 30 intentional skips and no failures or pending checks.
- Independent exact-head review and Builder's high-risk review found no defects; both confirmed the rollback predicates and `process.argv` behavior are preserved.
- Formatting and `git diff --check` passed.

Browser QA is not applicable because this PR changes only a GitHub Actions controller step and its automated regression, not an app interface.

## Review focus

- Does the replacement preserve both rollback provenance checks exactly?
- Does the regression faithfully model GitHub's YAML block de-indentation and catch the observed parser failure?
- Do the disabled pilots and separation between untrusted candidate builds and protected deployment custody remain unchanged?

## What remains after merge

1. Repeat the credential-free `main` dispatch against the exact open route-continuity candidate.
2. Separately provision and review isolated Netlify, Neon, OpenRouter, and GitHub Environment custody.
3. Enable only the reviewed acceptance pilot and run the real OAuth, directory-withdrawal, same-task status, cleanup, rollback, and third-template proof.

Those steps remain part of the original live-acceptance goal; this PR repairs the controller prerequisite rather than declaring that goal complete.
