### PR TITLE
Show the org logo in share emails

### DIFF
--- a/.changeset/email-org-brand-logo.md
+++ b/.changeset/email-org-brand-logo.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": minor
+---
+
+Add an optional `brandLogoUrl` to `renderEmail` and a `getShareEmailLogoUrl` resolver on `registerShareableResource`, so share-notification emails show the sharing org's logo (absolute `https://`) when available and fall back to the embedded Agent Native logo otherwise.

--- a/packages/core/src/server/email-template.spec.ts
+++ b/packages/core/src/server/email-template.spec.ts
@@ -15,6 +15,29 @@ describe("renderEmail", () => {
     expect(html).toContain(">Clips</span>");
   });
 
+  it("uses an org logo when a valid https URL is provided", () => {
+    const { html } = renderEmail({
+      brandName: "Clips",
+      brandLogoUrl: "https://cdn.example.com/org-logo.png",
+      heading: "You've been given access",
+      paragraphs: ["Open your recording below."],
+    });
+
+    expect(html).toContain('src="https://cdn.example.com/org-logo.png"');
+    expect(html).not.toContain('src="cid:agent-native-logo"');
+  });
+
+  it("falls back to the embedded logo for non-https or relative logo URLs", () => {
+    const { html } = renderEmail({
+      brandName: "Clips",
+      brandLogoUrl: "/api/media/org-logo.png",
+      heading: "You've been given access",
+      paragraphs: ["Open your recording below."],
+    });
+
+    expect(html).toContain('src="cid:agent-native-logo"');
+  });
+
   it("renders CTA buttons without visible fallback URLs", () => {
     const { html } = renderEmail({
       heading: "Your meeting is booked",

--- a/packages/core/src/server/email-template.ts
+++ b/packages/core/src/server/email-template.ts
@@ -41,6 +41,12 @@ export interface RenderEmailArgs {
   /** Optional app name shown beside the framework logo. */
   brandName?: string;
   /**
+   * Optional absolute `https://` logo URL shown in the brand header. When a
+   * valid URL is provided it replaces the default embedded Agent Native logo;
+   * anything else (missing, relative, non-https) falls back to that logo.
+   */
+  brandLogoUrl?: string;
+  /**
    * Optional brand hex color for the CTA button and inline links. Defaults to
    * a monochrome near-white button with dark text.
    */
@@ -74,10 +80,27 @@ function sanitizeHexColor(input: string | undefined): string | undefined {
   return /^#[0-9a-fA-F]{6}$/.test(input) ? input : undefined;
 }
 
+/**
+ * Only accept an absolute `https://` URL for the brand logo. Email clients drop
+ * relative and mixed-content images, and an unvalidated string in `src` is an
+ * injection surface — so anything else falls back to the embedded logo.
+ */
+function sanitizeLogoUrl(input: string | undefined): string | undefined {
+  if (!input) return undefined;
+  try {
+    return new URL(input).protocol === "https:" ? input : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function renderEmail(args: RenderEmailArgs): RenderedEmail {
   const preheader = args.preheader || "";
   const brand = sanitizeHexColor(args.brandColor);
   const brandName = args.brandName?.trim() || getAppName() || "Agent Native";
+  const logoSrc =
+    sanitizeLogoUrl(args.brandLogoUrl) ??
+    `cid:${AGENT_NATIVE_EMAIL_LOGO_CONTENT_ID}`;
 
   // Monochrome default: near-white button with dark text. Brand override:
   // colored button with white text.
@@ -115,7 +138,7 @@ export function renderEmail(args: RenderEmailArgs): RenderedEmail {
                 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="margin:0 0 28px 0; padding:0 0 24px 0; border-bottom:1px solid #27272a;">
                   <tr>
                     <td align="center">
-                      <img src="cid:${AGENT_NATIVE_EMAIL_LOGO_CONTENT_ID}" alt="${escapeAttr(brandName)}" width="28" height="28" style="display:inline-block; vertical-align:middle; width:28px; height:28px; margin:0 8px 0 0; border:0;" />
+                      <img src="${escapeAttr(logoSrc)}" alt="${escapeAttr(brandName)}" width="28" height="28" style="display:inline-block; vertical-align:middle; width:28px; height:28px; margin:0 8px 0 0; border:0;" />
                       <span style="font-size:18px; line-height:28px; font-weight:600; color:#fafafa; vertical-align:middle;">${escapeHtml(brandName)}</span>
                     </td>
                   </tr>

--- a/packages/core/src/sharing/actions/share-resource.ts
+++ b/packages/core/src/sharing/actions/share-resource.ts
@@ -297,9 +297,22 @@ export default defineAction({
         );
         const appName =
           process.env.APP_NAME || process.env.VITE_APP_NAME || "Agent Native";
+        let brandLogoUrl: string | undefined;
+        if (reg.getShareEmailLogoUrl) {
+          try {
+            brandLogoUrl =
+              (await reg.getShareEmailLogoUrl(resource)) ?? undefined;
+          } catch (err) {
+            console.error(
+              "[share-resource] brand logo resolver failed; using default logo:",
+              err,
+            );
+          }
+        }
         const subject = `${actor} shared "${resourceTitle}" with you on ${appName}`;
         const { html, text } = renderEmail({
           brandName: appName,
+          brandLogoUrl,
           preheader: subject,
           heading: "You've been given access",
           paragraphs: [

--- a/packages/core/src/sharing/registry.ts
+++ b/packages/core/src/sharing/registry.ts
@@ -37,6 +37,15 @@ export interface ShareableResourceRegistration {
    */
   getResourcePath?: (resource: any) => string | undefined;
   /**
+   * Optional resolver for the share-notification email's brand logo. Return an
+   * absolute `https://` URL to override the default embedded Agent Native logo
+   * (e.g. the sharing org's own logo), or undefined to fall back. Receives the
+   * resource row being shared so the template can scope the logo to its org.
+   */
+  getShareEmailLogoUrl?: (
+    resource: any,
+  ) => string | undefined | Promise<string | undefined>;
+  /**
    * Drizzle DB accessor from the template's server/db/index.ts. Required —
    * the framework-level share actions and access helpers call this to reach
    * the right DB instance (schema is template-specific).

--- a/templates/clips/changelog/2026-07-27-organization-brand-logos-now-upload-to-configured-file-stora.md
+++ b/templates/clips/changelog/2026-07-27-organization-brand-logos-now-upload-to-configured-file-stora.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-27
+---
+
+Organization brand logos now upload to configured file storage so they persist and render in share emails

--- a/templates/clips/server/db/index.ts
+++ b/templates/clips/server/db/index.ts
@@ -1,10 +1,31 @@
 import { createGetDb, getDbExec } from "@agent-native/core/db";
+import { getAppProductionUrl } from "@agent-native/core/server";
 import { registerShareableResource } from "@agent-native/core/sharing";
+import { eq } from "drizzle-orm";
 
 import * as schema from "./schema.js";
 
 export const getDb = createGetDb(schema);
 export { schema, getDbExec };
+
+/**
+ * Resolve the sharing org's brand logo as an absolute URL for share emails.
+ * Returns undefined so `renderEmail` falls back to the Agent Native logo when
+ * the org has no logo set.
+ */
+async function orgBrandLogoUrl(
+  organizationId: string | undefined,
+): Promise<string | undefined> {
+  if (!organizationId) return undefined;
+  const [row] = await getDb()
+    .select({ brandLogoUrl: schema.organizationSettings.brandLogoUrl })
+    .from(schema.organizationSettings)
+    .where(eq(schema.organizationSettings.organizationId, organizationId))
+    .limit(1);
+  const logo = row?.brandLogoUrl?.trim();
+  if (!logo) return undefined;
+  return logo.startsWith("/") ? `${getAppProductionUrl()}${logo}` : logo;
+}
 
 registerShareableResource({
   type: "recording",
@@ -13,6 +34,8 @@ registerShareableResource({
   displayName: "Recording",
   titleColumn: "title",
   getResourcePath: (recording) => `/r/${recording.id}`,
+  getShareEmailLogoUrl: (recording) =>
+    orgBrandLogoUrl(recording.organizationId),
   getDb,
   ownerAccessIgnoresOrg: true,
 });

--- a/templates/clips/server/routes/api/media/index.post.ts
+++ b/templates/clips/server/routes/api/media/index.post.ts
@@ -7,12 +7,12 @@
  *   Body: raw file bytes (Content-Type header determines the MIME type)
  *   Response: { url, filename, mimeType, size }
  *
- * Max size: 5 MB (logos). Storage: ./data/uploads.
+ * Max size: 5 MB (logos). Storage: the configured file-upload provider
+ * (Builder.io / S3 / …) via `uploadFile`. Fails closed with setup guidance
+ * when no provider is configured — bytes never touch SQL or local disk.
  */
 
-import fs from "node:fs";
-import path from "node:path";
-
+import { uploadFile } from "@agent-native/core/file-upload";
 import { getSession, runWithRequestContext } from "@agent-native/core/server";
 import {
   defineEventHandler,
@@ -23,18 +23,10 @@ import {
   type H3Event,
 } from "h3";
 
-const UPLOADS_DIR = path.resolve("data/uploads");
 const MAX_BYTES = 5 * 1024 * 1024;
 
-// Ensure the uploads dir exists at startup (best effort — edge runtimes have
-// no filesystem, so we silently fall through and fail at write time).
-try {
-  if (!fs.existsSync(UPLOADS_DIR)) {
-    fs.mkdirSync(UPLOADS_DIR, { recursive: true });
-  }
-} catch {
-  // no-op
-}
+const STORAGE_SETUP_REQUIRED_REASON =
+  "File storage is not connected yet. Connect Builder.io or configure S3-compatible storage in Settings → File uploads, then retry.";
 
 function randId(): string {
   const chars =
@@ -75,13 +67,6 @@ function hasExpectedImageSignature(bytes: Uint8Array, mimeType: string) {
     );
   }
   return false;
-}
-
-function appPath(path: string): string {
-  if (!path.startsWith("/")) return path;
-  const raw = process.env.VITE_APP_BASE_PATH || process.env.APP_BASE_PATH || "";
-  const base = raw.trim().replace(/^\/+/, "").replace(/\/+$/, "");
-  return base ? `/${base}${path}` : path;
 }
 
 export default defineEventHandler(async (event: H3Event) => {
@@ -132,20 +117,23 @@ export default defineEventHandler(async (event: H3Event) => {
       const originalName =
         typeof query.filename === "string" ? query.filename : "upload";
 
-      const id = `${randId()}${ext}`;
-      const filePath = path.join(UPLOADS_DIR, id);
+      const filename = `logo-${randId()}${ext}`;
+      const uploaded = await uploadFile({
+        data: bytes,
+        mimeType,
+        filename,
+        ownerEmail: session.email,
+        recordAsset: false,
+      });
 
-      try {
-        fs.writeFileSync(filePath, bytes);
-      } catch (err) {
-        console.error("[clips media] write failed:", err);
-        setResponseStatus(event, 500);
-        return { error: "Upload failed" };
+      if (!uploaded?.url) {
+        setResponseStatus(event, 409);
+        return { error: STORAGE_SETUP_REQUIRED_REASON };
       }
 
       return {
-        url: appPath(`/api/media/${id}`),
-        filename: id,
+        url: uploaded.url,
+        filename,
         originalName,
         mimeType,
         size: bytes.byteLength,


### PR DESCRIPTION
We added an option to override the logo used in notification emails. Instead of always showing the default Agent Native logo, an app can now supply its own logo per shared item.

We use this in Clips: when someone shares a recording, the notification email now shows the organization's own logo at the top. If the org hasn't set a logo, the email falls back to the default Agent Native logo, just like before.

## Changes

- **Logo override option for notification emails.** Emails can now be given a custom logo to show instead of the default one.
- **Share emails use the org logo.** The share notification email now displays the sharing organization's brand logo when one is set.
- **Logos are stored properly.** Uploaded org logos now go to the app's configured file storage instead of the local disk, so they stay available and actually show up in emails on deployed apps.
- **Safe fallback.** Any email without a valid org logo keeps using the Agent Native logo.

## How to use it

Go to **Settings → Organization**, upload a logo, and click **Save**. New share emails from that org will use it.

## Notes

If no file storage is connected, logo uploads will ask you to set one up rather than saving to a place that won't last.

<img width="1526" height="641" alt="image" src="https://github.com/user-attachments/assets/e46591f6-4dd2-46f2-bfff-dcb17c728986" />

