### PR TITLE
Import designed PDF slides as full-bleed images with text overlay

### DIFF
--- a/templates/slides/actions/import-file.ts
+++ b/templates/slides/actions/import-file.ts
@@ -2,6 +2,7 @@ import path from "path";
 
 import { defineAction } from "@agent-native/core";
 import { writeAppState } from "@agent-native/core/application-state";
+import { uploadFile } from "@agent-native/core/file-upload";
 import { startBuilderDesignSystemIndex } from "@agent-native/core/server";
 import {
   getRequestOrgId,
@@ -213,6 +214,25 @@ export default defineAction({
 
     if (detectedFormat === "pdf") {
       const { PDFParse, canvasFactory } = await setupPdfParse();
+      const title = titleFromPath(filename);
+
+      // Designed slide PDFs (photo backgrounds, gradients, custom
+      // typography) bake their visuals into vector/image page content with
+      // no reliable text/shape structure to reconstruct, so importing into a
+      // deck rasterizes each page instead of flattening it to generic bullet
+      // text. Falls through to the text-only path below when the optional
+      // canvas renderer isn't available in this runtime.
+      if (importIntoDeck && canvasFactory) {
+        if (!deckId) throw new Error("deckId is required to import into deck");
+        return importPdfPagesAsFullBleedSlides({
+          fileBuffer,
+          title,
+          deckId,
+          PDFParse,
+          canvasFactory,
+        });
+      }
+
       const { convertSectionsToSlides } =
         await import("../server/handlers/import/html-converter.js");
       const pdf = new PDFParse({
@@ -222,7 +242,6 @@ export default defineAction({
       const result = await pdf.getText().finally(() => pdf.destroy());
       const pages = normalizePdfPages(result);
       const textPages = pages.filter((p) => p.text.trim());
-      const title = titleFromPath(filename);
 
       if (textPages.length === 0) {
         throw new Error(
@@ -277,6 +296,72 @@ export default defineAction({
     throw new Error(`Unsupported format: ${detectedFormat}`);
   },
 });
+
+async function importPdfPagesAsFullBleedSlides(args: {
+  fileBuffer: Buffer;
+  title: string;
+  deckId: string;
+  PDFParse: Awaited<ReturnType<typeof setupPdfParse>>["PDFParse"];
+  canvasFactory: object;
+}) {
+  const { fileBuffer, title, deckId, PDFParse, canvasFactory } = args;
+  const { buildFullBleedImageSlideHtml } =
+    await import("../server/handlers/import/html-converter.js");
+
+  const pdf = new PDFParse({
+    data: new Uint8Array(fileBuffer),
+    CanvasFactory: canvasFactory,
+  });
+  let pages: { num: number; text: string }[];
+  let screenshotPages: { pageNumber: number; data: Uint8Array }[];
+  try {
+    pages = normalizePdfPages(await pdf.getText());
+    const screenshots = await pdf.getScreenshot({
+      desiredWidth: 1600,
+      imageBuffer: true,
+      imageDataUrl: false,
+    });
+    screenshotPages = screenshots.pages;
+  } finally {
+    await pdf.destroy();
+  }
+
+  const ownerEmail = getRequestUserEmail();
+  const slides = await Promise.all(
+    screenshotPages.map(async (page) => {
+      const uploadResult = await uploadFile({
+        data: Buffer.from(page.data),
+        filename: `slide-import-${Date.now()}-p${page.pageNumber}.png`,
+        mimeType: "image/png",
+        ownerEmail: ownerEmail ?? undefined,
+        recordAsset: false,
+      });
+      if (!uploadResult?.url) {
+        throw new Error(
+          "File storage is not configured. Connect Builder.io or another upload provider before importing PDF slides.",
+        );
+      }
+      const pageText = pages.find((p) => p.num === page.pageNumber)?.text ?? "";
+      return {
+        id: newSlideId(),
+        content: buildFullBleedImageSlideHtml(uploadResult.url),
+        layout: "full-image",
+        notes: pageText,
+      };
+    }),
+  );
+
+  await replaceDeckSlides(deckId, title, slides, "import-file:pdf");
+
+  return {
+    format: "pdf",
+    title,
+    pageCount: slides.length,
+    slideCount: slides.length,
+    deckId,
+    imported: true,
+  };
+}
 
 function newSlideId(): string {
   return `slide-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;

--- a/templates/slides/actions/import-file.ts
+++ b/templates/slides/actions/import-file.ts
@@ -16,6 +16,11 @@ import { getDb, schema } from "../server/db/index.js";
 import { notifyClients } from "../server/handlers/decks.js";
 import { upsertBuilderProxyDesignSystem } from "../server/lib/builder-design-system-proxy.js";
 import { setupPdfParse } from "../server/lib/pdf-parse-setup.js";
+import {
+  ASPECT_RATIOS,
+  DEFAULT_ASPECT_RATIO,
+  type AspectRatio,
+} from "../shared/aspect-ratios.js";
 import { readUserUploadedFile } from "./_uploaded-files.js";
 
 const DEFAULT_MAX_SOURCE_CHARS = 60_000;
@@ -297,6 +302,22 @@ export default defineAction({
   },
 });
 
+/** Closest configured deck aspect ratio to a source image's own dimensions. */
+function nearestAspectRatio(width: number, height: number): AspectRatio {
+  const target = width / height;
+  let best: AspectRatio = DEFAULT_ASPECT_RATIO;
+  let bestDiff = Infinity;
+  for (const key of Object.keys(ASPECT_RATIOS) as AspectRatio[]) {
+    const preset = ASPECT_RATIOS[key];
+    const diff = Math.abs(preset.width / preset.height - target);
+    if (diff < bestDiff) {
+      bestDiff = diff;
+      best = key;
+    }
+  }
+  return best;
+}
+
 async function importPdfPagesAsFullBleedSlides(args: {
   fileBuffer: Buffer;
   title: string;
@@ -343,22 +364,32 @@ async function importPdfPagesAsFullBleedSlides(args: {
     await pdf.destroy();
   }
 
+  // Source decks (e.g. Instagram carousel exports) are commonly portrait or
+  // square, not the deck editor's 16:9 default — match the canvas to the
+  // first embedded photo's own proportions instead of stretching/cropping it.
+  const firstImage = pages
+    .map((page) => imagesByPage.get(page.num))
+    .find((image): image is NonNullable<typeof image> => Boolean(image));
+  const aspectRatio = firstImage
+    ? nearestAspectRatio(firstImage.width, firstImage.height)
+    : undefined;
+
   const ownerEmail = getRequestUserEmail();
   const slides = await Promise.all(
     pages.map(async (page) => {
-      const heading = page.text
+      const lines = page.text
         .split(/\r?\n/)
-        .find((line) => line.trim())
-        ?.trim();
+        .map((line) => line.trim())
+        .filter(Boolean);
       const backgroundImage = imagesByPage.get(page.num);
 
       if (!backgroundImage) {
         const [content] = convertSectionsToSlides([
-          { heading: heading ?? `Page ${page.num}`, content: page.text },
+          { heading: lines[0] ?? `Page ${page.num}`, content: page.text },
         ]);
         return {
           id: newSlideId(),
-          content: content ?? `<div class="fmd-slide"></div>`,
+          content: content ?? '<div class="fmd-slide"></div>',
           layout: "content",
           notes: "",
         };
@@ -376,6 +407,10 @@ async function importPdfPagesAsFullBleedSlides(args: {
           "File storage is not configured. Connect Builder.io or another upload provider before importing PDF slides.",
         );
       }
+      // Join every extracted line back into one heading — pdf-parse breaks
+      // wrapped title text across lines, and using only the first line was
+      // silently dropping the rest of the sentence from the overlay.
+      const heading = lines.length > 0 ? lines.join(" ") : undefined;
       return {
         id: newSlideId(),
         content: buildFullBleedImageSlideHtml(uploadResult.url, heading),
@@ -385,13 +420,20 @@ async function importPdfPagesAsFullBleedSlides(args: {
     }),
   );
 
-  await replaceDeckSlides(deckId, title, slides, "import-file:pdf");
+  await replaceDeckSlides(
+    deckId,
+    title,
+    slides,
+    "import-file:pdf",
+    aspectRatio,
+  );
 
   return {
     format: "pdf",
     title,
     pageCount: slides.length,
     slideCount: slides.length,
+    aspectRatio,
     deckId,
     imported: true,
   };
@@ -486,6 +528,7 @@ async function replaceDeckSlides(
     notes?: string;
   }>,
   source: string,
+  aspectRatio?: AspectRatio,
 ) {
   await assertAccess("deck", deckId, "editor");
 
@@ -506,6 +549,7 @@ async function replaceDeckSlides(
     ...previousData,
     title,
     slides,
+    ...(aspectRatio ? { aspectRatio } : {}),
     updatedAt: now,
   };
 

--- a/templates/slides/actions/import-file.ts
+++ b/templates/slides/actions/import-file.ts
@@ -305,7 +305,7 @@ async function importPdfPagesAsFullBleedSlides(args: {
   canvasFactory: object;
 }) {
   const { fileBuffer, title, deckId, PDFParse, canvasFactory } = args;
-  const { buildFullBleedImageSlideHtml } =
+  const { buildFullBleedImageSlideHtml, convertSectionsToSlides } =
     await import("../server/handlers/import/html-converter.js");
 
   const pdf = new PDFParse({
@@ -313,25 +313,60 @@ async function importPdfPagesAsFullBleedSlides(args: {
     CanvasFactory: canvasFactory,
   });
   let pages: { num: number; text: string }[];
-  let screenshotPages: { pageNumber: number; data: Uint8Array }[];
+  let imagesByPage: Map<
+    number,
+    { data: Uint8Array; width: number; height: number }
+  >;
   try {
     pages = normalizePdfPages(await pdf.getText());
-    const screenshots = await pdf.getScreenshot({
-      desiredWidth: 1600,
+    // Reuse the page's own embedded photo rather than rasterizing the whole
+    // page: headless canvas text rendering depends on the PDF's embedded
+    // fonts resolving in this runtime, which is unreliable, so real
+    // extracted text is drawn as HTML below instead of trusting the render.
+    const imageResult = await pdf.getImage({
       imageBuffer: true,
       imageDataUrl: false,
     });
-    screenshotPages = screenshots.pages;
+    imagesByPage = new Map();
+    for (const page of imageResult.pages) {
+      const largest = page.images.reduce<
+        { data: Uint8Array; width: number; height: number } | undefined
+      >((best, image) => {
+        if (!best || image.width * image.height > best.width * best.height) {
+          return { data: image.data, width: image.width, height: image.height };
+        }
+        return best;
+      }, undefined);
+      if (largest) imagesByPage.set(page.pageNumber, largest);
+    }
   } finally {
     await pdf.destroy();
   }
 
   const ownerEmail = getRequestUserEmail();
   const slides = await Promise.all(
-    screenshotPages.map(async (page) => {
+    pages.map(async (page) => {
+      const heading = page.text
+        .split(/\r?\n/)
+        .find((line) => line.trim())
+        ?.trim();
+      const backgroundImage = imagesByPage.get(page.num);
+
+      if (!backgroundImage) {
+        const [content] = convertSectionsToSlides([
+          { heading: heading ?? `Page ${page.num}`, content: page.text },
+        ]);
+        return {
+          id: newSlideId(),
+          content: content ?? `<div class="fmd-slide"></div>`,
+          layout: "content",
+          notes: "",
+        };
+      }
+
       const uploadResult = await uploadFile({
-        data: Buffer.from(page.data),
-        filename: `slide-import-${Date.now()}-p${page.pageNumber}.png`,
+        data: Buffer.from(backgroundImage.data),
+        filename: `slide-import-${Date.now()}-p${page.num}.png`,
         mimeType: "image/png",
         ownerEmail: ownerEmail ?? undefined,
         recordAsset: false,
@@ -341,12 +376,11 @@ async function importPdfPagesAsFullBleedSlides(args: {
           "File storage is not configured. Connect Builder.io or another upload provider before importing PDF slides.",
         );
       }
-      const pageText = pages.find((p) => p.num === page.pageNumber)?.text ?? "";
       return {
         id: newSlideId(),
-        content: buildFullBleedImageSlideHtml(uploadResult.url),
+        content: buildFullBleedImageSlideHtml(uploadResult.url, heading),
         layout: "full-image",
-        notes: pageText,
+        notes: page.text,
       };
     }),
   );

--- a/templates/slides/actions/import-file.ts
+++ b/templates/slides/actions/import-file.ts
@@ -407,13 +407,22 @@ async function importPdfPagesAsFullBleedSlides(args: {
           "File storage is not configured. Connect Builder.io or another upload provider before importing PDF slides.",
         );
       }
-      // Join every extracted line back into one heading — pdf-parse breaks
-      // wrapped title text across lines, and using only the first line was
-      // silently dropping the rest of the sentence from the overlay.
-      const heading = lines.length > 0 ? lines.join(" ") : undefined;
+      // pdf-parse breaks wrapped text across lines with no way to tell a
+      // wrapped title from a heading followed by a body paragraph. Treat a
+      // couple of short lines as one wrapped title (join them so the
+      // sentence isn't cut off); three or more lines as a heading plus body
+      // text, rendered with distinct sizes so they don't collapse into one
+      // flat paragraph.
+      const heading =
+        lines.length > 2 ? lines[0] : lines.join(" ") || undefined;
+      const subtitle = lines.length > 2 ? lines.slice(1).join(" ") : undefined;
       return {
         id: newSlideId(),
-        content: buildFullBleedImageSlideHtml(uploadResult.url, heading),
+        content: buildFullBleedImageSlideHtml(
+          uploadResult.url,
+          heading,
+          subtitle,
+        ),
         layout: "full-image",
         notes: page.text,
       };

--- a/templates/slides/server/handlers/import/html-converter.ts
+++ b/templates/slides/server/handlers/import/html-converter.ts
@@ -9,6 +9,18 @@ function esc(text: string): string {
     .replace(/"/g, "&quot;");
 }
 
+/**
+ * Render a page image as the full-bleed slide background. Designed PDF pages
+ * (photo backgrounds, gradients, custom typography baked into vector/image
+ * content) have no reliable text/shape structure to reconstruct, so a
+ * rasterized page image is the only faithful conversion.
+ */
+export function buildFullBleedImageSlideHtml(imageUrl: string): string {
+  return `<div class="fmd-slide" style="position: relative; width: 100%; height: 100%; overflow: hidden;">
+    <img src="${esc(imageUrl)}" alt="" style="position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover;" />
+</div>`;
+}
+
 /** Wrap text in formatting tags based on run properties. */
 function formatRun(run: ParsedTextRun): string {
   let text = esc(run.content);

--- a/templates/slides/server/handlers/import/html-converter.ts
+++ b/templates/slides/server/handlers/import/html-converter.ts
@@ -11,23 +11,37 @@ function esc(text: string): string {
 
 /**
  * Render a page's embedded photo as the full-bleed slide background with the
- * page's extracted heading text overlaid on a bottom gradient. Designed PDF
- * pages (photo backgrounds, gradients, custom typography) have no reliable
- * shape structure to reconstruct, so the embedded image is reused directly —
- * but the vector/glyph text on the page is not something we can rasterize
+ * page's extracted text overlaid on top. Designed PDF pages (photo
+ * backgrounds, gradients, custom typography) have no reliable shape
+ * structure to reconstruct, so the embedded image is reused directly — but
+ * the vector/glyph text on the page is not something we can rasterize
  * reliably headless, so the extracted text is drawn as real HTML on top
  * instead of relying on the page's own (font-dependent) rendering.
+ *
+ * `pdf-parse`'s plain-text extraction carries no color/font metadata, so the
+ * heading accent color below is a stand-in, not a recovered value — when a
+ * subtitle is present (a content slide, not a title slide) it renders as a
+ * centered card with a divider rule so the two text roles stay visually
+ * distinct instead of collapsing into one flat paragraph.
  */
 export function buildFullBleedImageSlideHtml(
   imageUrl: string,
   headingText?: string,
+  subtitleText?: string,
 ): string {
-  const overlay = headingText
-    ? `\n    <div style="position: absolute; inset: 0; background: linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.15) 45%, rgba(0,0,0,0) 65%);"></div>
+  let overlay = "";
+  if (headingText && subtitleText) {
+    overlay = `\n    <div style="position: absolute; left: 0; right: 0; bottom: 0; background: linear-gradient(to top, rgba(12,10,8,0.95) 0%, rgba(12,10,8,0.88) 55%, rgba(12,10,8,0.4) 82%, rgba(12,10,8,0) 100%); padding: 56px 56px 60px; text-align: center; font-family: 'Poppins', sans-serif;">
+      <div style="width: 72px; height: 3px; background: #d8b26a; margin: 0 auto 20px;"></div>
+      <h2 style="font-size: 30px; font-weight: 800; color: #d8b26a; line-height: 1.25; margin: 0 0 14px;">${esc(headingText)}</h2>
+      <p style="font-size: 19px; font-weight: 500; color: #fff; line-height: 1.5; margin: 0;">${esc(subtitleText)}</p>
+    </div>`;
+  } else if (headingText) {
+    overlay = `\n    <div style="position: absolute; inset: 0; background: linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.15) 45%, rgba(0,0,0,0) 65%);"></div>
     <div style="position: absolute; left: 0; right: 0; bottom: 0; padding: 60px 70px; font-family: 'Poppins', sans-serif;">
       <h2 style="font-size: 40px; font-weight: 900; color: #fff; line-height: 1.15; letter-spacing: -1px; margin: 0;">${esc(headingText)}</h2>
-    </div>`
-    : "";
+    </div>`;
+  }
   return `<div class="fmd-slide" style="position: relative; width: 100%; height: 100%; overflow: hidden;">
     <img src="${esc(imageUrl)}" alt="" style="position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover;" />${overlay}
 </div>`;

--- a/templates/slides/server/handlers/import/html-converter.ts
+++ b/templates/slides/server/handlers/import/html-converter.ts
@@ -10,14 +10,26 @@ function esc(text: string): string {
 }
 
 /**
- * Render a page image as the full-bleed slide background. Designed PDF pages
- * (photo backgrounds, gradients, custom typography baked into vector/image
- * content) have no reliable text/shape structure to reconstruct, so a
- * rasterized page image is the only faithful conversion.
+ * Render a page's embedded photo as the full-bleed slide background with the
+ * page's extracted heading text overlaid on a bottom gradient. Designed PDF
+ * pages (photo backgrounds, gradients, custom typography) have no reliable
+ * shape structure to reconstruct, so the embedded image is reused directly —
+ * but the vector/glyph text on the page is not something we can rasterize
+ * reliably headless, so the extracted text is drawn as real HTML on top
+ * instead of relying on the page's own (font-dependent) rendering.
  */
-export function buildFullBleedImageSlideHtml(imageUrl: string): string {
+export function buildFullBleedImageSlideHtml(
+  imageUrl: string,
+  headingText?: string,
+): string {
+  const overlay = headingText
+    ? `\n    <div style="position: absolute; inset: 0; background: linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.15) 45%, rgba(0,0,0,0) 65%);"></div>
+    <div style="position: absolute; left: 0; right: 0; bottom: 0; padding: 60px 70px; font-family: 'Poppins', sans-serif;">
+      <h2 style="font-size: 40px; font-weight: 900; color: #fff; line-height: 1.15; letter-spacing: -1px; margin: 0;">${esc(headingText)}</h2>
+    </div>`
+    : "";
   return `<div class="fmd-slide" style="position: relative; width: 100%; height: 100%; overflow: hidden;">
-    <img src="${esc(imageUrl)}" alt="" style="position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover;" />
+    <img src="${esc(imageUrl)}" alt="" style="position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover;" />${overlay}
 </div>`;
 }
 


### PR DESCRIPTION
### Summary
Improves PDF import for visually designed slide decks by rendering each page's embedded photo as a full-bleed background with extracted text overlaid, instead of flattening the page into generic bullet text.

### Problem
Importing designed PDF slides (e.g. photo backgrounds, gradients, custom typography) into a deck produced poor results — the visuals baked into the PDF's vector/image content had no reliable text/shape structure to reconstruct, so the import collapsed everything into plain bullet text and lost the original look, sizing, and layout of the source deck.

### Solution
When importing into a deck and a canvas renderer is available, each PDF page's largest embedded image is reused directly as the slide background, sized to match the deck's aspect ratio to the source image's own proportions. The page's extracted text is drawn as real HTML on top of that background (rather than trying to rasterize font-dependent PDF text), distinguishing a short wrapped title from a heading+body case. This full-bleed path falls back to the existing text-only conversion when no canvas renderer is available or a page has no embedded image.

<img width="1829" height="950" alt="image" src="https://github.com/user-attachments/assets/aae47c08-cde8-4ee6-8d9c-48aa10ecdb43" />


### Key Changes
- `import-file.ts`: adds `importPdfPagesAsFullBleedSlides`, which extracts each page's largest embedded image and text, uploads the image, and builds a full-bleed slide per page; picks the deck's aspect ratio via a new `nearestAspectRatio` helper based on the first embedded image's dimensions; `replaceDeckSlides` now accepts an optional `aspectRatio` to persist on the deck.
- `html-converter.ts`: adds `buildFullBleedImageSlideHtml`, which renders the background image with an absolutely-positioned overlay — a bottom card with divider rule and heading/subtitle when both are present, or a bottom gradient with just a heading otherwise.
- Text-only PDF import path is preserved as a fallback for pages/environments without an embedded image or canvas support.


---

<a href="https://builder.io/app/projects/88e92dea5bdd4ad396c8/nova-melody-godbbahq"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://88e92dea5bdd4ad396c8-nova-melody-godbbahq.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2441`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>88e92dea5bdd4ad396c8</projectId>-->
<!--<branchName>nova-melody-godbbahq</branchName>-->