### PR TITLE
Improve PPTX import rendering: real images and better layouts

### DIFF
--- a/.changeset/pptx-import-image-geometry.md
+++ b/.changeset/pptx-import-image-geometry.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Extract picture shape size and slide dimensions when parsing PPTX files, so importers can tell a full-bleed cover photo from a small inset image and preserve each image's real aspect ratio.

--- a/packages/core/src/a2a/client.spec.ts
+++ b/packages/core/src/a2a/client.spec.ts
@@ -644,7 +644,7 @@ describe("A2AClient", () => {
     );
 
     const result = callAgent("https://slides.agent.test", "make a deck", {
-      timeoutMs: 3,
+      timeoutMs: 200,
       pollIntervalMs: 1,
     });
     const assertion = expect(result).resolves.toContain(

--- a/packages/core/src/ingestion/pptx.ts
+++ b/packages/core/src/ingestion/pptx.ts
@@ -10,6 +10,10 @@ export interface ParsedPptxImage {
   data: Uint8Array;
   mimeType: string;
   name: string;
+  /** Width / height of the picture shape on the slide, from its own placed size (not the source file's pixel dimensions). */
+  aspectRatio?: number;
+  /** True when the picture shape covers at least ~85% of the slide's width and height — a full-bleed background photo rather than an inset card image. */
+  fullBleed?: boolean;
 }
 
 export interface ParsedPptxSlide {
@@ -46,11 +50,13 @@ export async function parsePptxPresentation(
   if (!presentationXml)
     throw new Error("Invalid PPTX: missing ppt/presentation.xml");
   const presentation = parseXml(presentationXml);
+  const presentationRoot = record(record(presentation)?.["p:presentation"]);
   const slideIds = asArray(
-    record(record(record(presentation)?.["p:presentation"])?.["p:sldIdLst"])?.[
-      "p:sldId"
-    ],
+    record(presentationRoot?.["p:sldIdLst"])?.["p:sldId"],
   ).map((entry) => stringValue(record(entry)?.["@_r:id"]) ?? "");
+  const sldSz = record(presentationRoot?.["p:sldSz"]);
+  const slideWidthEmu = Number(sldSz?.["@_cx"]) || undefined;
+  const slideHeightEmu = Number(sldSz?.["@_cy"]) || undefined;
   const relationshipsXml = await zip
     .file("ppt/_rels/presentation.xml.rels")
     ?.async("string");
@@ -95,9 +101,20 @@ export async function parsePptxPresentation(
       .file(relationshipPath)
       ?.async("string");
     if (slideRelationshipsXml) {
-      for (const relationship of parseRelationships(
+      const slideRelationships = parseRelationships(
         parseXml(slideRelationshipsXml),
-      ).values()) {
+      );
+      // Walk the slide's own picture shapes (in document order) rather than
+      // every image relationship, so each image carries the placed size the
+      // author gave it on the slide — that size is what tells a full-bleed
+      // cover photo apart from a small inset card photo, which a flat
+      // relationship scan has no way to know.
+      const pictureShapes: PictureShape[] = [];
+      collectPictureShapes(slide, pictureShapes);
+      for (const shape of pictureShapes) {
+        if (!shape.embedId) continue;
+        const relationship = slideRelationships.get(shape.embedId);
+        if (!relationship) continue;
         if (
           !relationship.type.includes("/image") &&
           !/\.(png|jpe?g|gif|svg|webp|bmp|tiff?|emf|wmf)$/i.test(
@@ -114,10 +131,24 @@ export async function parsePptxPresentation(
         const image = zip.file(imagePath);
         if (!image) continue;
         const name = imagePath.split("/").at(-1) ?? "image";
+        const aspectRatio =
+          shape.widthEmu && shape.heightEmu
+            ? shape.widthEmu / shape.heightEmu
+            : undefined;
+        const fullBleed = Boolean(
+          shape.widthEmu &&
+          shape.heightEmu &&
+          slideWidthEmu &&
+          slideHeightEmu &&
+          shape.widthEmu / slideWidthEmu >= 0.85 &&
+          shape.heightEmu / slideHeightEmu >= 0.85,
+        );
         images.push({
           data: new Uint8Array(await image.async("nodebuffer")),
           mimeType: imageMimeType(name),
           name,
+          aspectRatio,
+          fullBleed,
         });
       }
     }
@@ -202,6 +233,41 @@ function collectTextRuns(
     if (key.startsWith("@_") || key === "a:r" || key === "a:t") continue;
     for (const item of asArray(child)) collectTextRuns(item, runs, inherited);
   }
+}
+
+interface PictureShape {
+  embedId?: string;
+  widthEmu?: number;
+  heightEmu?: number;
+}
+
+/** Recursively find every `p:pic` node in a slide, in document order, and read its embed relationship id plus its placed size on the slide canvas. */
+function collectPictureShapes(value: unknown, out: PictureShape[]): void {
+  const node = record(value);
+  if (!node) return;
+  for (const [key, child] of Object.entries(node)) {
+    if (key.startsWith("@_")) continue;
+    if (key === "p:pic") {
+      for (const picNode of asArray(child))
+        out.push(extractPictureShape(picNode));
+      continue;
+    }
+    for (const item of asArray(child)) collectPictureShapes(item, out);
+  }
+}
+
+function extractPictureShape(value: unknown): PictureShape {
+  const pic = record(value);
+  const blip = record(record(pic?.["p:blipFill"])?.["a:blip"]);
+  const embedId = stringValue(blip?.["@_r:embed"]);
+  const ext = record(record(record(pic?.["p:spPr"])?.["a:xfrm"])?.["a:ext"]);
+  const cx = Number(ext?.["@_cx"]);
+  const cy = Number(ext?.["@_cy"]);
+  return {
+    embedId,
+    widthEmu: Number.isFinite(cx) && cx > 0 ? cx : undefined,
+    heightEmu: Number.isFinite(cy) && cy > 0 ? cy : undefined,
+  };
 }
 
 function runProperties(

--- a/packages/core/src/ingestion/pptx.ts
+++ b/packages/core/src/ingestion/pptx.ts
@@ -111,6 +111,7 @@ export async function parsePptxPresentation(
       // relationship scan has no way to know.
       const pictureShapes: PictureShape[] = [];
       collectPictureShapes(slide, pictureShapes);
+      reorderByDocumentPosition(pictureShapes, xml);
       addBackgroundFillShape(
         slide,
         pictureShapes,
@@ -333,19 +334,29 @@ function groupChildScale(
   return { x: parentScaleX * groupScaleX, y: parentScaleY * groupScaleY };
 }
 
+/**
+ * `a:xfrm/a:ext` always stores the shape's *unrotated* design-time width and
+ * height — `a:xfrm/@rot` (in 60,000ths of a degree) rotates it around its
+ * own center afterward. For a 90/270-degree turn, the shape's effective
+ * on-slide footprint has its width and height swapped relative to that
+ * declared size, so a rotated full-bleed photo can otherwise get treated as
+ * a small inset, or a portrait image get an inverted aspect ratio.
+ */
 function extFromSpPr(shapeNode: Record<string, unknown> | null): {
   cx?: number;
   cy?: number;
 } {
-  const ext = record(
-    record(record(shapeNode?.["p:spPr"])?.["a:xfrm"])?.["a:ext"],
-  );
+  const xfrm = record(record(shapeNode?.["p:spPr"])?.["a:xfrm"]);
+  const ext = record(xfrm?.["a:ext"]);
   const cx = Number(ext?.["@_cx"]);
   const cy = Number(ext?.["@_cy"]);
-  return {
-    cx: Number.isFinite(cx) && cx > 0 ? cx : undefined,
-    cy: Number.isFinite(cy) && cy > 0 ? cy : undefined,
-  };
+  if (!Number.isFinite(cx) || cx <= 0 || !Number.isFinite(cy) || cy <= 0) {
+    return { cx: undefined, cy: undefined };
+  }
+  const rot = Number(xfrm?.["@_rot"]);
+  const quarterTurns = Number.isFinite(rot) ? Math.round(rot / 60000 / 90) : 0;
+  const isOddQuarterTurn = ((quarterTurns % 2) + 2) % 2 === 1;
+  return isOddQuarterTurn ? { cx: cy, cy: cx } : { cx, cy };
 }
 
 function scaledShape(
@@ -359,6 +370,27 @@ function scaledShape(
     widthEmu: size.cx !== undefined ? size.cx * scaleX : undefined,
     heightEmu: size.cy !== undefined ? size.cy * scaleY : undefined,
   };
+}
+
+/**
+ * fast-xml-parser groups sibling elements by tag name, so a slide whose
+ * picture-bearing shapes alternate types on the page (e.g. `p:sp`, `p:pic`,
+ * `p:sp`) comes out of `collectPictureShapes` re-sorted by tag rather than
+ * by the order they actually appear — every `p:sp` gets visited before any
+ * `p:pic`, even if a `p:pic` came first in the file. Re-derive the true
+ * order from the raw XML text instead: `<a:blip r:embed="...">` occurrences
+ * appear in exactly document order regardless of nesting, so they can be
+ * used to restore the author's original front-to-back ordering (which
+ * matters because downstream rendering treats the first image as primary).
+ */
+function reorderByDocumentPosition(shapes: PictureShape[], xml: string): void {
+  const order: string[] = [];
+  const blipPattern = /<a:blip\b[^>]*\br:embed="([^"]+)"/g;
+  let match: RegExpExecArray | null;
+  while ((match = blipPattern.exec(xml))) order.push(match[1]);
+  const indexOf = (embedId: string | undefined) =>
+    embedId ? order.indexOf(embedId) : -1;
+  shapes.sort((a, b) => indexOf(a.embedId) - indexOf(b.embedId));
 }
 
 /** Read the embed relationship id of a slide's background picture fill (`p:cSld/p:bg/p:bgPr/a:blipFill/a:blip`), if any. */

--- a/packages/core/src/ingestion/pptx.ts
+++ b/packages/core/src/ingestion/pptx.ts
@@ -247,32 +247,117 @@ interface PictureShape {
   heightEmu?: number;
 }
 
-/** Recursively find every `p:pic` node in a slide, in document order, and read its embed relationship id plus its placed size on the slide canvas. */
-function collectPictureShapes(value: unknown, out: PictureShape[]): void {
+/**
+ * Recursively find every embedded picture in a slide, in document order:
+ * plain `p:pic` shapes, and `p:sp` autoshapes whose fill is a picture
+ * (common for "photo cutout" shapes and full-bleed decorative rectangles).
+ * A group shape (`p:grpSp`) defines its own local coordinate space for its
+ * children (`chOff`/`chExt`) that can be scaled arbitrarily relative to the
+ * group's own placed size on the slide, so each level of nesting multiplies
+ * a running scale factor into the child sizes below it — without that, a
+ * picture inside a resized group would report its unscaled design-time
+ * size instead of how large it actually appears on the slide.
+ */
+function collectPictureShapes(
+  value: unknown,
+  out: PictureShape[],
+  scaleX = 1,
+  scaleY = 1,
+): void {
   const node = record(value);
   if (!node) return;
   for (const [key, child] of Object.entries(node)) {
     if (key.startsWith("@_")) continue;
     if (key === "p:pic") {
-      for (const picNode of asArray(child))
-        out.push(extractPictureShape(picNode));
+      for (const picNode of asArray(child)) {
+        const pic = record(picNode);
+        const blip = record(record(pic?.["p:blipFill"])?.["a:blip"]);
+        out.push(
+          scaledShape(
+            stringValue(blip?.["@_r:embed"]),
+            extFromSpPr(pic),
+            scaleX,
+            scaleY,
+          ),
+        );
+      }
       continue;
     }
-    for (const item of asArray(child)) collectPictureShapes(item, out);
+    if (key === "p:sp") {
+      for (const spNode of asArray(child)) {
+        const sp = record(spNode);
+        const blip = record(
+          record(record(sp?.["p:spPr"])?.["a:blipFill"])?.["a:blip"],
+        );
+        const embedId = stringValue(blip?.["@_r:embed"]);
+        if (embedId) {
+          out.push(scaledShape(embedId, extFromSpPr(sp), scaleX, scaleY));
+        }
+      }
+      continue;
+    }
+    if (key === "p:grpSp") {
+      for (const groupNode of asArray(child)) {
+        const scale = groupChildScale(record(groupNode), scaleX, scaleY);
+        collectPictureShapes(groupNode, out, scale.x, scale.y);
+      }
+      continue;
+    }
+    for (const item of asArray(child)) {
+      collectPictureShapes(item, out, scaleX, scaleY);
+    }
   }
 }
 
-function extractPictureShape(value: unknown): PictureShape {
-  const pic = record(value);
-  const blip = record(record(pic?.["p:blipFill"])?.["a:blip"]);
-  const embedId = stringValue(blip?.["@_r:embed"]);
-  const ext = record(record(record(pic?.["p:spPr"])?.["a:xfrm"])?.["a:ext"]);
+/** A group's `chExt` is the coordinate space its children are authored in; `ext` is how large the group actually renders — the ratio between them is the extra scale nested children need on top of their own declared size. */
+function groupChildScale(
+  groupNode: Record<string, unknown> | null,
+  parentScaleX: number,
+  parentScaleY: number,
+): { x: number; y: number } {
+  const xfrm = record(record(groupNode?.["p:grpSpPr"])?.["a:xfrm"]);
+  const ext = record(xfrm?.["a:ext"]);
+  const chExt = record(xfrm?.["a:chExt"]);
+  const extCx = Number(ext?.["@_cx"]);
+  const extCy = Number(ext?.["@_cy"]);
+  const chExtCx = Number(chExt?.["@_cx"]);
+  const chExtCy = Number(chExt?.["@_cy"]);
+  const groupScaleX =
+    Number.isFinite(extCx) && Number.isFinite(chExtCx) && chExtCx > 0
+      ? extCx / chExtCx
+      : 1;
+  const groupScaleY =
+    Number.isFinite(extCy) && Number.isFinite(chExtCy) && chExtCy > 0
+      ? extCy / chExtCy
+      : 1;
+  return { x: parentScaleX * groupScaleX, y: parentScaleY * groupScaleY };
+}
+
+function extFromSpPr(shapeNode: Record<string, unknown> | null): {
+  cx?: number;
+  cy?: number;
+} {
+  const ext = record(
+    record(record(shapeNode?.["p:spPr"])?.["a:xfrm"])?.["a:ext"],
+  );
   const cx = Number(ext?.["@_cx"]);
   const cy = Number(ext?.["@_cy"]);
   return {
+    cx: Number.isFinite(cx) && cx > 0 ? cx : undefined,
+    cy: Number.isFinite(cy) && cy > 0 ? cy : undefined,
+  };
+}
+
+function scaledShape(
+  embedId: string | undefined,
+  size: { cx?: number; cy?: number },
+  scaleX: number,
+  scaleY: number,
+): PictureShape {
+  return {
     embedId,
-    widthEmu: Number.isFinite(cx) && cx > 0 ? cx : undefined,
-    heightEmu: Number.isFinite(cy) && cy > 0 ? cy : undefined,
+    widthEmu: size.cx !== undefined ? size.cx * scaleX : undefined,
+    heightEmu: size.cy !== undefined ? size.cy * scaleY : undefined,
   };
 }
 
@@ -284,7 +369,14 @@ function extractBackgroundFillEmbedId(slide: unknown): string | undefined {
   return stringValue(blip?.["@_r:embed"]);
 }
 
-/** Add the slide's background picture fill, if any, as a synthetic full-slide-sized shape so it's treated like any other embedded photo. */
+/**
+ * Add the slide's background picture fill, if any, as a synthetic
+ * full-slide-sized shape. It's unshifted to the front rather than appended:
+ * downstream rendering only ever uses the first image in the list, and a
+ * background fill is the slide's base layer — the primary visual — so a
+ * smaller foreground picture (a logo, an icon) must not bump it out of that
+ * slot.
+ */
 function addBackgroundFillShape(
   slide: unknown,
   pictureShapes: PictureShape[],
@@ -293,7 +385,7 @@ function addBackgroundFillShape(
 ): void {
   const embedId = extractBackgroundFillEmbedId(slide);
   if (!embedId) return;
-  pictureShapes.push({
+  pictureShapes.unshift({
     embedId,
     widthEmu: slideWidthEmu,
     heightEmu: slideHeightEmu,

--- a/packages/core/src/ingestion/pptx.ts
+++ b/packages/core/src/ingestion/pptx.ts
@@ -111,6 +111,12 @@ export async function parsePptxPresentation(
       // relationship scan has no way to know.
       const pictureShapes: PictureShape[] = [];
       collectPictureShapes(slide, pictureShapes);
+      addBackgroundFillShape(
+        slide,
+        pictureShapes,
+        slideWidthEmu,
+        slideHeightEmu,
+      );
       for (const shape of pictureShapes) {
         if (!shape.embedId) continue;
         const relationship = slideRelationships.get(shape.embedId);
@@ -268,6 +274,30 @@ function extractPictureShape(value: unknown): PictureShape {
     widthEmu: Number.isFinite(cx) && cx > 0 ? cx : undefined,
     heightEmu: Number.isFinite(cy) && cy > 0 ? cy : undefined,
   };
+}
+
+/** Read the embed relationship id of a slide's background picture fill (`p:cSld/p:bg/p:bgPr/a:blipFill/a:blip`), if any. */
+function extractBackgroundFillEmbedId(slide: unknown): string | undefined {
+  const cSld = record(record(slide)?.["p:cSld"]);
+  const bgPr = record(record(cSld?.["p:bg"])?.["p:bgPr"]);
+  const blip = record(record(bgPr?.["a:blipFill"])?.["a:blip"]);
+  return stringValue(blip?.["@_r:embed"]);
+}
+
+/** Add the slide's background picture fill, if any, as a synthetic full-slide-sized shape so it's treated like any other embedded photo. */
+function addBackgroundFillShape(
+  slide: unknown,
+  pictureShapes: PictureShape[],
+  slideWidthEmu: number | undefined,
+  slideHeightEmu: number | undefined,
+): void {
+  const embedId = extractBackgroundFillEmbedId(slide);
+  if (!embedId) return;
+  pictureShapes.push({
+    embedId,
+    widthEmu: slideWidthEmu,
+    heightEmu: slideHeightEmu,
+  });
 }
 
 function runProperties(

--- a/packages/core/src/ingestion/pptx.ts
+++ b/packages/core/src/ingestion/pptx.ts
@@ -310,7 +310,21 @@ function collectPictureShapes(
   }
 }
 
-/** A group's `chExt` is the coordinate space its children are authored in; `ext` is how large the group actually renders — the ratio between them is the extra scale nested children need on top of their own declared size. */
+/** Whether an `a:xfrm` `rot` value (60,000ths of a degree) is an odd multiple of 90° — a 90/270 turn that swaps effective width and height. */
+function isOddQuarterTurn(rot: number): boolean {
+  if (!Number.isFinite(rot)) return false;
+  const quarterTurns = Math.round(rot / 60000 / 90);
+  return ((quarterTurns % 2) + 2) % 2 === 1;
+}
+
+/**
+ * A group's `chExt` is the coordinate space its children are authored in;
+ * `ext` is how large the group actually renders — the ratio between them is
+ * the extra scale nested children need on top of their own declared size.
+ * When the group itself is rotated a 90/270-degree turn, that ratio applies
+ * to the perpendicular axis on the slide, so the X/Y scale factors need
+ * swapping the same way a rotated picture's own width/height do.
+ */
 function groupChildScale(
   groupNode: Record<string, unknown> | null,
   parentScaleX: number,
@@ -323,14 +337,17 @@ function groupChildScale(
   const extCy = Number(ext?.["@_cy"]);
   const chExtCx = Number(chExt?.["@_cx"]);
   const chExtCy = Number(chExt?.["@_cy"]);
-  const groupScaleX =
+  let groupScaleX =
     Number.isFinite(extCx) && Number.isFinite(chExtCx) && chExtCx > 0
       ? extCx / chExtCx
       : 1;
-  const groupScaleY =
+  let groupScaleY =
     Number.isFinite(extCy) && Number.isFinite(chExtCy) && chExtCy > 0
       ? extCy / chExtCy
       : 1;
+  if (isOddQuarterTurn(Number(xfrm?.["@_rot"]))) {
+    [groupScaleX, groupScaleY] = [groupScaleY, groupScaleX];
+  }
   return { x: parentScaleX * groupScaleX, y: parentScaleY * groupScaleY };
 }
 
@@ -353,10 +370,9 @@ function extFromSpPr(shapeNode: Record<string, unknown> | null): {
   if (!Number.isFinite(cx) || cx <= 0 || !Number.isFinite(cy) || cy <= 0) {
     return { cx: undefined, cy: undefined };
   }
-  const rot = Number(xfrm?.["@_rot"]);
-  const quarterTurns = Number.isFinite(rot) ? Math.round(rot / 60000 / 90) : 0;
-  const isOddQuarterTurn = ((quarterTurns % 2) + 2) % 2 === 1;
-  return isOddQuarterTurn ? { cx: cy, cy: cx } : { cx, cy };
+  return isOddQuarterTurn(Number(xfrm?.["@_rot"]))
+    ? { cx: cy, cy: cx }
+    : { cx, cy };
 }
 
 function scaledShape(
@@ -385,17 +401,35 @@ function scaledShape(
  */
 function reorderByDocumentPosition(shapes: PictureShape[], xml: string): void {
   const order: string[] = [];
-  const blipPattern = /<a:blip\b[^>]*\br:embed="([^"]+)"/g;
+  const blipPattern = /<a:blip\b[^>]*\br:embed=(?:"([^"]+)"|'([^']+)')/g;
   let match: RegExpExecArray | null;
-  while ((match = blipPattern.exec(xml))) order.push(match[1]);
-  const indexOf = (embedId: string | undefined) =>
-    embedId ? order.indexOf(embedId) : -1;
-  shapes.sort((a, b) => indexOf(a.embedId) - indexOf(b.embedId));
+  while ((match = blipPattern.exec(xml))) order.push(match[1] ?? match[2]);
+
+  // The same relationship id can legitimately be reused across multiple
+  // placements (e.g. a repeated icon), so looking up a single fixed index
+  // per id would assign every reused shape the position of its first XML
+  // occurrence. Instead give each id a queue of its occurrence positions
+  // and consume one per shape, in the order shapes were collected.
+  const occurrences = new Map<string, number[]>();
+  order.forEach((embedId, index) => {
+    const queue = occurrences.get(embedId);
+    if (queue) queue.push(index);
+    else occurrences.set(embedId, [index]);
+  });
+  const positions = shapes.map((shape) => {
+    const queue = shape.embedId ? occurrences.get(shape.embedId) : undefined;
+    return queue && queue.length > 0 ? queue.shift()! : -1;
+  });
+  const sortedIndices = shapes.map((_, i) => i);
+  sortedIndices.sort((a, b) => positions[a] - positions[b]);
+  const sorted = sortedIndices.map((i) => shapes[i]);
+  shapes.splice(0, shapes.length, ...sorted);
 }
 
 /** Read the embed relationship id of a slide's background picture fill (`p:cSld/p:bg/p:bgPr/a:blipFill/a:blip`), if any. */
 function extractBackgroundFillEmbedId(slide: unknown): string | undefined {
-  const cSld = record(record(slide)?.["p:cSld"]);
+  const root = record(slide);
+  const cSld = record(record(root?.["p:sld"])?.["p:cSld"] ?? root?.["p:cSld"]);
   const bgPr = record(record(cSld?.["p:bg"])?.["p:bgPr"]);
   const blip = record(record(bgPr?.["a:blipFill"])?.["a:blip"]);
   return stringValue(blip?.["@_r:embed"]);

--- a/templates/slides/actions/import-file.ts
+++ b/templates/slides/actions/import-file.ts
@@ -460,9 +460,8 @@ async function buildPptxSlide(
   layout: string;
   notes?: string;
 }> {
-  const { convertToSlideHtml } = await import(
-    "../server/handlers/import/html-converter.js"
-  );
+  const { convertToSlideHtml } =
+    await import("../server/handlers/import/html-converter.js");
   const image = slide.images[0];
   const imageUrl = image
     ? (

--- a/templates/slides/actions/import-file.ts
+++ b/templates/slides/actions/import-file.ts
@@ -492,21 +492,24 @@ async function buildPptxSlide(
       ? image
       : undefined;
   const imageUrl = uploadable
-    ? (
-        await uploadFile({
-          data: Buffer.from(uploadable.data),
-          filename:
-            "pptx-import-" +
-            Date.now() +
-            "-s" +
-            slideIndex +
-            "-" +
-            uploadable.name,
-          mimeType: uploadable.mimeType,
-          ownerEmail,
-          recordAsset: false,
-        })
-      )?.url
+    ? await uploadFile({
+        data: Buffer.from(uploadable.data),
+        filename:
+          "pptx-import-" +
+          Date.now() +
+          "-s" +
+          slideIndex +
+          "-" +
+          uploadable.name,
+        mimeType: uploadable.mimeType,
+        ownerEmail,
+        recordAsset: false,
+      })
+        .then((result) => result?.url)
+        // A single slide's upload failing (network/API/rate-limit)
+        // shouldn't abort the whole deck replacement — fall back to a
+        // placeholder like an unsupported format would.
+        .catch(() => undefined)
     : undefined;
   return {
     slide: {

--- a/templates/slides/actions/import-file.ts
+++ b/templates/slides/actions/import-file.ts
@@ -146,7 +146,10 @@ export default defineAction({
           ),
         );
         const slides = pptxResults.map((r) => r.slide);
-        const imagesSkipped = pptxResults.filter((r) => r.imageSkipped).length;
+        const imagesSkipped = pptxResults.reduce(
+          (total, r) => total + r.imageSkippedCount,
+          0,
+        );
         await replaceDeckSlides(deckId, title, slides, "import-file:pptx");
         return {
           format: "pptx",
@@ -479,7 +482,7 @@ async function buildPptxSlide(
   themeFont: string | undefined,
 ): Promise<{
   slide: { id: string; content: string; layout: string; notes?: string };
-  imageSkipped: boolean;
+  imageSkippedCount: number;
 }> {
   const { convertToSlideHtml } =
     await import("../server/handlers/import/html-converter.js");
@@ -512,7 +515,10 @@ async function buildPptxSlide(
       layout: slide.layoutHint ?? "content",
       notes: slide.notes,
     },
-    imageSkipped: Boolean(image && !imageUrl),
+    // Only the first image on a slide is ever uploaded, so every other
+    // image on that slide is unconditionally dropped too — not just the
+    // first one when it's unsupported.
+    imageSkippedCount: Math.max(0, slide.images.length - (imageUrl ? 1 : 0)),
   };
 }
 

--- a/templates/slides/actions/import-file.ts
+++ b/templates/slides/actions/import-file.ts
@@ -10,6 +10,7 @@ import {
 } from "@agent-native/core/server/request-context";
 import { assertAccess } from "@agent-native/core/sharing";
 import { eq } from "drizzle-orm";
+import pLimit from "p-limit";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
@@ -132,11 +133,16 @@ export default defineAction({
 
       if (importIntoDeck) {
         if (!deckId) throw new Error("deckId is required to import into deck");
+        await assertAccess("deck", deckId, "editor");
         const pptxOwnerEmail = getRequestUserEmail();
+        if (!pptxOwnerEmail) throw new Error("no authenticated user");
         const pptxThemeFont = presentation.theme?.fonts?.[0];
+        const uploadLimit = pLimit(4);
         const slides = await Promise.all(
           presentation.slides.map((slide, i) =>
-            buildPptxSlide(slide, i, pptxOwnerEmail, pptxThemeFont),
+            uploadLimit(() =>
+              buildPptxSlide(slide, i, pptxOwnerEmail, pptxThemeFont),
+            ),
           ),
         );
         await replaceDeckSlides(deckId, title, slides, "import-file:pptx");
@@ -454,7 +460,7 @@ function newSlideId(): string {
 async function buildPptxSlide(
   slide: import("../server/handlers/import/pptx-parser.js").ParsedSlide,
   slideIndex: number,
-  ownerEmail: string | undefined,
+  ownerEmail: string,
   themeFont: string | undefined,
 ): Promise<{
   id: string;
@@ -472,7 +478,7 @@ async function buildPptxSlide(
           filename:
             "pptx-import-" + Date.now() + "-s" + slideIndex + "-" + image.name,
           mimeType: image.mimeType,
-          ownerEmail: ownerEmail ?? undefined,
+          ownerEmail,
           recordAsset: false,
         })
       )?.url

--- a/templates/slides/actions/import-file.ts
+++ b/templates/slides/actions/import-file.ts
@@ -138,13 +138,15 @@ export default defineAction({
         if (!pptxOwnerEmail) throw new Error("no authenticated user");
         const pptxThemeFont = presentation.theme?.fonts?.[0];
         const uploadLimit = pLimit(4);
-        const slides = await Promise.all(
+        const pptxResults = await Promise.all(
           presentation.slides.map((slide, i) =>
             uploadLimit(() =>
               buildPptxSlide(slide, i, pptxOwnerEmail, pptxThemeFont),
             ),
           ),
         );
+        const slides = pptxResults.map((r) => r.slide);
+        const imagesSkipped = pptxResults.filter((r) => r.imageSkipped).length;
         await replaceDeckSlides(deckId, title, slides, "import-file:pptx");
         return {
           format: "pptx",
@@ -153,6 +155,7 @@ export default defineAction({
           theme: presentation.theme,
           deckId,
           imported: true,
+          ...(imagesSkipped > 0 ? { imagesSkipped } : {}),
         };
       }
 
@@ -457,37 +460,59 @@ function newSlideId(): string {
   return `slide-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
 }
 
+// EMF/WMF (Windows metafiles) and TIFF are valid PPTX embed formats but
+// browsers can't render them in an <img> tag — uploading and linking one
+// would just produce a broken image icon.
+const PPTX_BROWSER_RENDERABLE_IMAGE_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/svg+xml",
+  "image/bmp",
+]);
+
 async function buildPptxSlide(
   slide: import("../server/handlers/import/pptx-parser.js").ParsedSlide,
   slideIndex: number,
   ownerEmail: string,
   themeFont: string | undefined,
 ): Promise<{
-  id: string;
-  content: string;
-  layout: string;
-  notes?: string;
+  slide: { id: string; content: string; layout: string; notes?: string };
+  imageSkipped: boolean;
 }> {
   const { convertToSlideHtml } =
     await import("../server/handlers/import/html-converter.js");
   const image = slide.images[0];
-  const imageUrl = image
+  const uploadable =
+    image && PPTX_BROWSER_RENDERABLE_IMAGE_MIME_TYPES.has(image.mimeType)
+      ? image
+      : undefined;
+  const imageUrl = uploadable
     ? (
         await uploadFile({
-          data: Buffer.from(image.data),
+          data: Buffer.from(uploadable.data),
           filename:
-            "pptx-import-" + Date.now() + "-s" + slideIndex + "-" + image.name,
-          mimeType: image.mimeType,
+            "pptx-import-" +
+            Date.now() +
+            "-s" +
+            slideIndex +
+            "-" +
+            uploadable.name,
+          mimeType: uploadable.mimeType,
           ownerEmail,
           recordAsset: false,
         })
       )?.url
     : undefined;
   return {
-    id: newSlideId(),
-    content: convertToSlideHtml(slide, imageUrl, themeFont),
-    layout: slide.layoutHint ?? "content",
-    notes: slide.notes,
+    slide: {
+      id: newSlideId(),
+      content: convertToSlideHtml(slide, imageUrl, themeFont),
+      layout: slide.layoutHint ?? "content",
+      notes: slide.notes,
+    },
+    imageSkipped: Boolean(image && !imageUrl),
   };
 }
 

--- a/templates/slides/actions/import-file.ts
+++ b/templates/slides/actions/import-file.ts
@@ -133,9 +133,10 @@ export default defineAction({
       if (importIntoDeck) {
         if (!deckId) throw new Error("deckId is required to import into deck");
         const pptxOwnerEmail = getRequestUserEmail();
+        const pptxThemeFont = presentation.theme?.fonts?.[0];
         const slides = await Promise.all(
           presentation.slides.map((slide, i) =>
-            buildPptxSlide(slide, i, pptxOwnerEmail),
+            buildPptxSlide(slide, i, pptxOwnerEmail, pptxThemeFont),
           ),
         );
         await replaceDeckSlides(deckId, title, slides, "import-file:pptx");
@@ -454,6 +455,7 @@ async function buildPptxSlide(
   slide: import("../server/handlers/import/pptx-parser.js").ParsedSlide,
   slideIndex: number,
   ownerEmail: string | undefined,
+  themeFont: string | undefined,
 ): Promise<{
   id: string;
   content: string;
@@ -477,7 +479,7 @@ async function buildPptxSlide(
     : undefined;
   return {
     id: newSlideId(),
-    content: convertToSlideHtml(slide, imageUrl),
+    content: convertToSlideHtml(slide, imageUrl, themeFont),
     layout: slide.layoutHint ?? "content",
     notes: slide.notes,
   };

--- a/templates/slides/actions/import-file.ts
+++ b/templates/slides/actions/import-file.ts
@@ -127,19 +127,17 @@ export default defineAction({
     if (detectedFormat === "pptx") {
       const { parsePptx } =
         await import("../server/handlers/import/pptx-parser.js");
-      const { convertToSlideHtml } =
-        await import("../server/handlers/import/html-converter.js");
       const presentation = await parsePptx(fileBuffer);
       const title = presentation.title || titleFromPath(filename);
 
       if (importIntoDeck) {
         if (!deckId) throw new Error("deckId is required to import into deck");
-        const slides = presentation.slides.map((slide) => ({
-          id: newSlideId(),
-          content: convertToSlideHtml(slide),
-          layout: slide.layoutHint ?? "content",
-          notes: slide.notes,
-        }));
+        const pptxOwnerEmail = getRequestUserEmail();
+        const slides = await Promise.all(
+          presentation.slides.map((slide, i) =>
+            buildPptxSlide(slide, i, pptxOwnerEmail),
+          ),
+        );
         await replaceDeckSlides(deckId, title, slides, "import-file:pptx");
         return {
           format: "pptx",
@@ -450,6 +448,40 @@ async function importPdfPagesAsFullBleedSlides(args: {
 
 function newSlideId(): string {
   return `slide-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+async function buildPptxSlide(
+  slide: import("../server/handlers/import/pptx-parser.js").ParsedSlide,
+  slideIndex: number,
+  ownerEmail: string | undefined,
+): Promise<{
+  id: string;
+  content: string;
+  layout: string;
+  notes?: string;
+}> {
+  const { convertToSlideHtml } = await import(
+    "../server/handlers/import/html-converter.js"
+  );
+  const image = slide.images[0];
+  const imageUrl = image
+    ? (
+        await uploadFile({
+          data: Buffer.from(image.data),
+          filename:
+            "pptx-import-" + Date.now() + "-s" + slideIndex + "-" + image.name,
+          mimeType: image.mimeType,
+          ownerEmail: ownerEmail ?? undefined,
+          recordAsset: false,
+        })
+      )?.url
+    : undefined;
+  return {
+    id: newSlideId(),
+    content: convertToSlideHtml(slide, imageUrl),
+    layout: slide.layoutHint ?? "content",
+    notes: slide.notes,
+  };
 }
 
 function titleFromPath(filePath: string): string {

--- a/templates/slides/actions/import-pptx.ts
+++ b/templates/slides/actions/import-pptx.ts
@@ -1,5 +1,6 @@
 import { defineAction } from "@agent-native/core";
 import { writeAppState } from "@agent-native/core/application-state";
+import { uploadFile } from "@agent-native/core/file-upload";
 import {
   getRequestUserEmail,
   getRequestOrgId,
@@ -11,9 +12,31 @@ import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { notifyClients } from "../server/handlers/decks.js";
 import { convertToSlideHtml } from "../server/handlers/import/html-converter.js";
-import { parsePptx } from "../server/handlers/import/pptx-parser.js";
+import {
+  parsePptx,
+  type ParsedSlide,
+} from "../server/handlers/import/pptx-parser.js";
 import { getDeckUrl } from "./_app-url.js";
 import { readUserUploadedFile } from "./_uploaded-files.js";
+
+async function uploadFirstSlideImage(
+  slide: ParsedSlide,
+  slideIndex: number,
+  ownerEmail: string | undefined,
+): Promise<string | undefined> {
+  const image = slide.images[0];
+  if (!image) return undefined;
+  const filename =
+    "pptx-import-" + Date.now() + "-s" + slideIndex + "-" + image.name;
+  const result = await uploadFile({
+    data: Buffer.from(image.data),
+    filename,
+    mimeType: image.mimeType,
+    ownerEmail: ownerEmail ?? undefined,
+    recordAsset: false,
+  });
+  return result?.url;
+}
 
 export default defineAction({
   description:
@@ -43,17 +66,27 @@ export default defineAction({
     const presentation = await parsePptx(fileBuffer);
 
     const deckTitle = title || presentation.title || "Imported Presentation";
+    const ownerEmail = getRequestUserEmail();
 
-    // Convert each parsed slide to our HTML format
-    const slides = presentation.slides.map((parsedSlide, i) => {
-      const html = convertToSlideHtml(parsedSlide);
-      return {
-        id: `slide-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
-        content: html,
-        layout: parsedSlide.layoutHint ?? "content",
-        notes: parsedSlide.notes,
-      };
-    });
+    // Convert each parsed slide to our HTML format, uploading the first
+    // embedded image (if any) so it renders as a real image instead of a
+    // text placeholder.
+    const slides = await Promise.all(
+      presentation.slides.map(async (parsedSlide, i) => {
+        const imageUrl = await uploadFirstSlideImage(
+          parsedSlide,
+          i,
+          ownerEmail,
+        );
+        const html = convertToSlideHtml(parsedSlide, imageUrl);
+        return {
+          id: `slide-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+          content: html,
+          layout: parsedSlide.layoutHint ?? "content",
+          notes: parsedSlide.notes,
+        };
+      }),
+    );
 
     const db = getDb();
     const now = new Date().toISOString();
@@ -100,9 +133,8 @@ export default defineAction({
       title: deckTitle,
       data: JSON.stringify(data),
       ownerEmail: (() => {
-        const e = getRequestUserEmail();
-        if (!e) throw new Error("no authenticated user");
-        return e;
+        if (!ownerEmail) throw new Error("no authenticated user");
+        return ownerEmail;
       })(),
       orgId: getRequestOrgId(),
       createdAt: now,

--- a/templates/slides/actions/import-pptx.ts
+++ b/templates/slides/actions/import-pptx.ts
@@ -67,6 +67,7 @@ export default defineAction({
 
     const deckTitle = title || presentation.title || "Imported Presentation";
     const ownerEmail = getRequestUserEmail();
+    const themeFont = presentation.theme?.fonts?.[0];
 
     // Convert each parsed slide to our HTML format, uploading the first
     // embedded image (if any) so it renders as a real image instead of a
@@ -78,7 +79,7 @@ export default defineAction({
           i,
           ownerEmail,
         );
-        const html = convertToSlideHtml(parsedSlide, imageUrl);
+        const html = convertToSlideHtml(parsedSlide, imageUrl, themeFont);
         return {
           id: `slide-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
           content: html,

--- a/templates/slides/actions/import-pptx.ts
+++ b/templates/slides/actions/import-pptx.ts
@@ -20,13 +20,27 @@ import {
 import { getDeckUrl } from "./_app-url.js";
 import { readUserUploadedFile } from "./_uploaded-files.js";
 
+// EMF/WMF (Windows metafiles) and TIFF are valid PPTX embed formats but
+// browsers can't render them in an <img> tag — uploading and linking one
+// would just produce a broken image icon.
+const BROWSER_RENDERABLE_IMAGE_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/svg+xml",
+  "image/bmp",
+]);
+
 async function uploadFirstSlideImage(
   slide: ParsedSlide,
   slideIndex: number,
   ownerEmail: string,
 ): Promise<string | undefined> {
   const image = slide.images[0];
-  if (!image) return undefined;
+  if (!image || !BROWSER_RENDERABLE_IMAGE_MIME_TYPES.has(image.mimeType)) {
+    return undefined;
+  }
   const filename =
     "pptx-import-" + Date.now() + "-s" + slideIndex + "-" + image.name;
   const result = await uploadFile({
@@ -81,9 +95,13 @@ export default defineAction({
     // Convert each parsed slide to our HTML format, uploading the first
     // embedded image (if any) so it renders as a real image instead of a
     // text placeholder. Concurrency is capped so a large deck doesn't fire
-    // one outbound upload per slide at once.
+    // one outbound upload per slide at once. An image can end up unused
+    // (unsupported format, or upload storage not configured) without
+    // failing the whole import — the slide's text still imports fine — but
+    // that shouldn't be a silent, invisible degradation, so it's counted
+    // and returned to the caller.
     const uploadLimit = pLimit(4);
-    const slides = await Promise.all(
+    const results = await Promise.all(
       presentation.slides.map((parsedSlide, i) =>
         uploadLimit(async () => {
           const imageUrl = await uploadFirstSlideImage(
@@ -93,14 +111,19 @@ export default defineAction({
           );
           const html = convertToSlideHtml(parsedSlide, imageUrl, themeFont);
           return {
-            id: `slide-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
-            content: html,
-            layout: parsedSlide.layoutHint ?? "content",
-            notes: parsedSlide.notes,
+            slide: {
+              id: `slide-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+              content: html,
+              layout: parsedSlide.layoutHint ?? "content",
+              notes: parsedSlide.notes,
+            },
+            imageSkipped: Boolean(parsedSlide.images[0] && !imageUrl),
           };
         }),
       ),
     );
+    const slides = results.map((r) => r.slide);
+    const imagesSkipped = results.filter((r) => r.imageSkipped).length;
 
     const db = getDb();
     const now = new Date().toISOString();
@@ -134,6 +157,7 @@ export default defineAction({
         theme: presentation.theme,
         imported: true,
         url: getDeckUrl(deckId),
+        ...(imagesSkipped > 0 ? { imagesSkipped } : {}),
       };
     }
 
@@ -160,6 +184,7 @@ export default defineAction({
       theme: presentation.theme,
       imported: true,
       url: getDeckUrl(id),
+      ...(imagesSkipped > 0 ? { imagesSkipped } : {}),
     };
   },
 });

--- a/templates/slides/actions/import-pptx.ts
+++ b/templates/slides/actions/import-pptx.ts
@@ -43,14 +43,21 @@ async function uploadFirstSlideImage(
   }
   const filename =
     "pptx-import-" + Date.now() + "-s" + slideIndex + "-" + image.name;
-  const result = await uploadFile({
-    data: Buffer.from(image.data),
-    filename,
-    mimeType: image.mimeType,
-    ownerEmail,
-    recordAsset: false,
-  });
-  return result?.url;
+  try {
+    const result = await uploadFile({
+      data: Buffer.from(image.data),
+      filename,
+      mimeType: image.mimeType,
+      ownerEmail,
+      recordAsset: false,
+    });
+    return result?.url;
+  } catch {
+    // A single slide's upload failing (network/API/rate-limit) shouldn't
+    // abort the whole deck import — that slide's text still imports fine,
+    // it just falls back to a placeholder like an unsupported format would.
+    return undefined;
+  }
 }
 
 export default defineAction({

--- a/templates/slides/actions/import-pptx.ts
+++ b/templates/slides/actions/import-pptx.ts
@@ -7,6 +7,7 @@ import {
 } from "@agent-native/core/server/request-context";
 import { assertAccess } from "@agent-native/core/sharing";
 import { eq } from "drizzle-orm";
+import pLimit from "p-limit";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
@@ -22,7 +23,7 @@ import { readUserUploadedFile } from "./_uploaded-files.js";
 async function uploadFirstSlideImage(
   slide: ParsedSlide,
   slideIndex: number,
-  ownerEmail: string | undefined,
+  ownerEmail: string,
 ): Promise<string | undefined> {
   const image = slide.images[0];
   if (!image) return undefined;
@@ -32,7 +33,7 @@ async function uploadFirstSlideImage(
     data: Buffer.from(image.data),
     filename,
     mimeType: image.mimeType,
-    ownerEmail: ownerEmail ?? undefined,
+    ownerEmail,
     recordAsset: false,
   });
   return result?.url;
@@ -67,34 +68,44 @@ export default defineAction({
 
     const deckTitle = title || presentation.title || "Imported Presentation";
     const ownerEmail = getRequestUserEmail();
+    if (!ownerEmail) throw new Error("no authenticated user");
     const themeFont = presentation.theme?.fonts?.[0];
+
+    // Check edit access before uploading any embedded images — uploads are
+    // a side effect with real storage cost, so an unauthorized caller must
+    // be rejected before that side effect happens, not after.
+    if (deckId) {
+      await assertAccess("deck", deckId, "editor");
+    }
 
     // Convert each parsed slide to our HTML format, uploading the first
     // embedded image (if any) so it renders as a real image instead of a
-    // text placeholder.
+    // text placeholder. Concurrency is capped so a large deck doesn't fire
+    // one outbound upload per slide at once.
+    const uploadLimit = pLimit(4);
     const slides = await Promise.all(
-      presentation.slides.map(async (parsedSlide, i) => {
-        const imageUrl = await uploadFirstSlideImage(
-          parsedSlide,
-          i,
-          ownerEmail,
-        );
-        const html = convertToSlideHtml(parsedSlide, imageUrl, themeFont);
-        return {
-          id: `slide-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
-          content: html,
-          layout: parsedSlide.layoutHint ?? "content",
-          notes: parsedSlide.notes,
-        };
-      }),
+      presentation.slides.map((parsedSlide, i) =>
+        uploadLimit(async () => {
+          const imageUrl = await uploadFirstSlideImage(
+            parsedSlide,
+            i,
+            ownerEmail,
+          );
+          const html = convertToSlideHtml(parsedSlide, imageUrl, themeFont);
+          return {
+            id: `slide-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+            content: html,
+            layout: parsedSlide.layoutHint ?? "content",
+            notes: parsedSlide.notes,
+          };
+        }),
+      ),
     );
 
     const db = getDb();
     const now = new Date().toISOString();
 
     if (deckId) {
-      await assertAccess("deck", deckId, "editor");
-
       const existing = await db
         .select()
         .from(schema.decks)
@@ -133,10 +144,7 @@ export default defineAction({
       id,
       title: deckTitle,
       data: JSON.stringify(data),
-      ownerEmail: (() => {
-        if (!ownerEmail) throw new Error("no authenticated user");
-        return ownerEmail;
-      })(),
+      ownerEmail,
       orgId: getRequestOrgId(),
       createdAt: now,
       updatedAt: now,

--- a/templates/slides/actions/import-pptx.ts
+++ b/templates/slides/actions/import-pptx.ts
@@ -117,13 +117,22 @@ export default defineAction({
               layout: parsedSlide.layoutHint ?? "content",
               notes: parsedSlide.notes,
             },
-            imageSkipped: Boolean(parsedSlide.images[0] && !imageUrl),
+            // Only the first image on a slide is ever uploaded, so every
+            // other image on that slide is unconditionally dropped too —
+            // not just the first one when it's unsupported.
+            imageSkippedCount: Math.max(
+              0,
+              parsedSlide.images.length - (imageUrl ? 1 : 0),
+            ),
           };
         }),
       ),
     );
     const slides = results.map((r) => r.slide);
-    const imagesSkipped = results.filter((r) => r.imageSkipped).length;
+    const imagesSkipped = results.reduce(
+      (total, r) => total + r.imageSkippedCount,
+      0,
+    );
 
     const db = getDb();
     const now = new Date().toISOString();

--- a/templates/slides/server/handlers/import/html-converter.ts
+++ b/templates/slides/server/handlers/import/html-converter.ts
@@ -177,14 +177,24 @@ ${bulletItems}
 </div>`;
 }
 
-/** Render the slide's embedded image, or a text placeholder if it couldn't be uploaded. */
+/**
+ * Render the slide's embedded image, or a text placeholder if it couldn't
+ * be uploaded. `objectFit` defaults to `contain` — the stacked-image layout
+ * sizes its box to the shape's own placed aspect ratio specifically so the
+ * source photo isn't cropped, but the embedded file's actual pixel ratio
+ * can still differ slightly from that placed ratio, and `cover` would crop
+ * to fill the box in that case, defeating the point. `cover` is only
+ * correct for a full-bleed background image, which intentionally fills its
+ * box edge-to-edge.
+ */
 function imageOrPlaceholder(
   imageUrl: string | undefined,
   imageName: string,
   style: string,
+  objectFit: "cover" | "contain" = "contain",
 ): string {
   if (imageUrl) {
-    return `<img src="${esc(imageUrl)}" alt="" style="${style} object-fit: cover;" />`;
+    return `<img src="${esc(imageUrl)}" alt="" style="${style} object-fit: ${objectFit};" />`;
   }
   return `<div class="fmd-img-placeholder" style="${style}">Imported image: ${esc(imageName)}</div>`;
 }

--- a/templates/slides/server/handlers/import/html-converter.ts
+++ b/templates/slides/server/handlers/import/html-converter.ts
@@ -190,13 +190,53 @@ function imageOrPlaceholder(
 }
 
 /**
- * Photo-led layout: image first, heading/caption below — this matches how
- * PPTX/Keynote decks with a hero image per slide are actually laid out.
- * Putting the heading above the image (the old order) pushed the image
- * further down the slide and made overflow far more likely for slides with
- * any real amount of body text.
+ * A PPTX slide's picture and heading always go through one of two real
+ * designs, decided by how big the photo was placed on the original slide —
+ * not by a single fixed template:
+ *  - a near-full-slide photo (a cover/section photo) had its title overlaid
+ *    on top of it in the original, so it's rendered full-bleed with the
+ *    text overlaid over a legibility scrim;
+ *  - a smaller inset photo (a card-style illustration) had its caption
+ *    stacked below it, so it's rendered that way, sized to the image's own
+ *    aspect ratio instead of a fixed box that would crop or stretch it.
  */
 function buildImageSlide(
+  paragraphs: ParsedTextRun[][],
+  slide: ParsedSlide,
+  imageUrl: string | undefined,
+  fontFamily: string,
+): string {
+  if (imageUrl && slide.images[0]?.fullBleed) {
+    return buildOverlayImageSlide(paragraphs, imageUrl, fontFamily);
+  }
+  return buildStackedImageSlide(paragraphs, slide, imageUrl, fontFamily);
+}
+
+/** Full-bleed photo with the heading/caption overlaid at the bottom behind a gradient scrim. */
+function buildOverlayImageSlide(
+  paragraphs: ParsedTextRun[][],
+  imageUrl: string,
+  fontFamily: string,
+): string {
+  const headingPara = paragraphs[0] ?? [];
+  const headingHtml = headingPara.map(formatRun).join(" ") || "Slide";
+
+  const captionParas = paragraphs.slice(1);
+  const captionHtml = captionParas
+    .map((para) => para.map(formatRun).join(" "))
+    .join(" ");
+
+  return `<div class="fmd-slide" style="position: relative; width: 100%; height: 100%; overflow: hidden;">
+    <img src="${esc(imageUrl)}" alt="" style="position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover;" />
+    <div style="position: absolute; inset: 0; background: linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.35) 55%, rgba(0,0,0,0) 80%);"></div>
+    <div style="position: absolute; left: 0; right: 0; bottom: 0; padding: 56px 70px; font-family: ${fontFamily};">
+      <h2 style="font-size: 40px; font-weight: 900; color: #fff; line-height: 1.15; letter-spacing: -1px; margin: 0 0 ${captionHtml ? "12px" : "0"} 0;">${headingHtml}</h2>${captionHtml ? `\n      <p style="font-size: 18px; color: rgba(255,255,255,0.75); line-height: 1.5; margin: 0;">${captionHtml}</p>` : ""}
+    </div>
+</div>`;
+}
+
+/** Photo card on top (sized to its own aspect ratio), heading/caption below. */
+function buildStackedImageSlide(
   paragraphs: ParsedTextRun[][],
   slide: ParsedSlide,
   imageUrl: string | undefined,
@@ -211,10 +251,15 @@ function buildImageSlide(
     .join(" ");
 
   const imageName = slide.images[0]?.name ?? "image";
+  // Size the box to the image's own placed aspect ratio instead of a fixed
+  // height, so portrait and landscape source photos both render undistorted
+  // — a fixed height forced `object-fit: cover` to crop whichever
+  // orientation didn't match the assumed box.
+  const aspectRatio = slide.images[0]?.aspectRatio ?? 16 / 9;
   const imageHtml = imageOrPlaceholder(
     imageUrl,
     imageName,
-    "width: 100%; height: 260px; border-radius: 12px; margin-bottom: 24px;",
+    `width: 100%; aspect-ratio: ${aspectRatio}; max-height: 320px; border-radius: 12px; margin-bottom: 24px;`,
   );
 
   return `<div class="fmd-slide" style="padding: 64px 90px; display: flex; flex-direction: column; justify-content: flex-start; font-family: ${fontFamily};">

--- a/templates/slides/server/handlers/import/html-converter.ts
+++ b/templates/slides/server/handlers/import/html-converter.ts
@@ -50,9 +50,20 @@ export function buildFullBleedImageSlideHtml(
 /** Wrap text in formatting tags based on run properties. */
 function formatRun(run: ParsedTextRun): string {
   let text = esc(run.content);
+  if (run.color)
+    text = `<span style="color: ${esc(run.color)};">${text}</span>`;
   if (run.bold) text = `<strong>${text}</strong>`;
   if (run.italic) text = `<em>${text}</em>`;
   return text;
+}
+
+const DEFAULT_IMPORT_FONT = "'Poppins', sans-serif";
+
+/** Turn an extracted PPTX theme font name into a safe CSS font-family value, falling back to the default when absent. */
+function cssFontFamily(themeFont: string | undefined): string {
+  if (!themeFont) return DEFAULT_IMPORT_FONT;
+  const safeName = themeFont.replace(/["']/g, "").trim();
+  return safeName ? `'${safeName}', sans-serif` : DEFAULT_IMPORT_FONT;
 }
 
 /**
@@ -90,30 +101,36 @@ function groupIntoParagraphs(texts: ParsedTextRun[]): ParsedTextRun[][] {
  * for the slide's first embedded image (already uploaded by the caller) —
  * pass undefined when the slide has no image or the upload failed, and the
  * builders fall back to a text placeholder instead of a broken `<img>`.
+ * `themeFont` is the presentation's extracted theme font, if any, so
+ * imported slides keep the source deck's typeface instead of always
+ * rendering in Poppins.
  */
 export function convertToSlideHtml(
   slide: ParsedSlide,
   imageUrl?: string,
+  themeFont?: string,
 ): string {
   const paragraphs = groupIntoParagraphs(slide.texts);
+  const fontFamily = cssFontFamily(themeFont);
 
   // An embedded image always wins the layout choice — a forced title slide
   // has no room to show it, which is how imports used to silently drop
   // photos from otherwise short/title-shaped slides.
   if (slide.images.length > 0) {
-    return buildImageSlide(paragraphs, slide, imageUrl);
+    return buildImageSlide(paragraphs, slide, imageUrl, fontFamily);
   }
 
   if (slide.layoutHint === "title" || paragraphs.length <= 2) {
-    return buildTitleSlide(paragraphs, slide);
+    return buildTitleSlide(paragraphs, slide, fontFamily);
   }
 
-  return buildContentSlide(paragraphs, slide);
+  return buildContentSlide(paragraphs, slide, fontFamily);
 }
 
 function buildTitleSlide(
   paragraphs: ParsedTextRun[][],
   slide: ParsedSlide,
+  fontFamily: string,
 ): string {
   const titlePara = paragraphs[0] ?? [];
   const subtitlePara = paragraphs[1] ?? [];
@@ -121,7 +138,7 @@ function buildTitleSlide(
   const titleText = titlePara.map(formatRun).join(" ") || "Untitled Slide";
   const subtitleText = subtitlePara.map(formatRun).join(" ");
 
-  return `<div class="fmd-slide" style="padding: 80px 110px; display: flex; flex-direction: column; justify-content: center; align-items: flex-start; font-family: 'Poppins', sans-serif;">
+  return `<div class="fmd-slide" style="padding: 80px 110px; display: flex; flex-direction: column; justify-content: center; align-items: flex-start; font-family: ${fontFamily};">
     <h1 style="font-size: 64px; font-weight: 900; color: #fff; line-height: 1.1; letter-spacing: -2px; margin: 0 0 24px 0;">${titleText}</h1>${subtitleText ? `\n    <p style="font-size: 22px; color: rgba(255,255,255,0.55); margin: 0;">${subtitleText}</p>` : ""}
 </div>`;
 }
@@ -129,6 +146,7 @@ function buildTitleSlide(
 function buildContentSlide(
   paragraphs: ParsedTextRun[][],
   slide: ParsedSlide,
+  fontFamily: string,
 ): string {
   // First paragraph is the heading, rest are bullet points
   const headingPara = paragraphs[0] ?? [];
@@ -153,7 +171,7 @@ ${bulletItems}
     </div>`;
   }
 
-  return `<div class="fmd-slide" style="padding: 80px 110px; display: flex; flex-direction: column; justify-content: flex-start; font-family: 'Poppins', sans-serif;">
+  return `<div class="fmd-slide" style="padding: 80px 110px; display: flex; flex-direction: column; justify-content: flex-start; font-family: ${fontFamily};">
     <div style="font-size: 14px; font-weight: 700; letter-spacing: 3px; text-transform: uppercase; color: #00E5FF; margin-bottom: 16px;">IMPORTED</div>
     <h2 style="font-size: 40px; font-weight: 900; color: #fff; line-height: 1.15; letter-spacing: -1px; margin: 0 0 48px 0;">${headingText}</h2>${bulletsHtml}
 </div>`;
@@ -171,10 +189,18 @@ function imageOrPlaceholder(
   return `<div class="fmd-img-placeholder" style="${style}">Imported image: ${esc(imageName)}</div>`;
 }
 
+/**
+ * Photo-led layout: image first, heading/caption below — this matches how
+ * PPTX/Keynote decks with a hero image per slide are actually laid out.
+ * Putting the heading above the image (the old order) pushed the image
+ * further down the slide and made overflow far more likely for slides with
+ * any real amount of body text.
+ */
 function buildImageSlide(
   paragraphs: ParsedTextRun[][],
   slide: ParsedSlide,
-  imageUrl?: string,
+  imageUrl: string | undefined,
+  fontFamily: string,
 ): string {
   const headingPara = paragraphs[0] ?? [];
   const headingText = headingPara.map(formatRun).join(" ") || "Slide";
@@ -188,13 +214,12 @@ function buildImageSlide(
   const imageHtml = imageOrPlaceholder(
     imageUrl,
     imageName,
-    "width: 100%; height: 300px; border-radius: 12px;",
+    "width: 100%; height: 260px; border-radius: 12px; margin-bottom: 24px;",
   );
 
-  return `<div class="fmd-slide" style="padding: 80px 110px; display: flex; flex-direction: column; justify-content: flex-start; font-family: 'Poppins', sans-serif;">
-    <div style="font-size: 14px; font-weight: 700; letter-spacing: 3px; text-transform: uppercase; color: #00E5FF; margin-bottom: 16px;">IMPORTED</div>
-    <h2 style="font-size: 40px; font-weight: 900; color: #fff; line-height: 1.15; letter-spacing: -1px; margin: 0 0 32px 0;">${headingText}</h2>
-    ${imageHtml}${captionText ? `\n    <p style="font-size: 18px; color: rgba(255,255,255,0.55); margin: 24px 0 0 0;">${captionText}</p>` : ""}
+  return `<div class="fmd-slide" style="padding: 64px 90px; display: flex; flex-direction: column; justify-content: flex-start; font-family: ${fontFamily};">
+    ${imageHtml}
+    <h2 style="font-size: 32px; font-weight: 900; color: #fff; line-height: 1.2; letter-spacing: -0.5px; margin: 0 0 12px 0;">${headingText}</h2>${captionText ? `\n    <p style="font-size: 16px; color: rgba(255,255,255,0.7); line-height: 1.5; margin: 0;">${captionText}</p>` : ""}
 </div>`;
 }
 

--- a/templates/slides/server/handlers/import/html-converter.ts
+++ b/templates/slides/server/handlers/import/html-converter.ts
@@ -256,10 +256,14 @@ function buildStackedImageSlide(
   // — a fixed height forced `object-fit: cover` to crop whichever
   // orientation didn't match the assumed box.
   const aspectRatio = slide.images[0]?.aspectRatio ?? 16 / 9;
+  // `max-width` (not `width: 100%`) so the aspect-ratio box is never forced
+  // wider than the height cap allows — pinning width to 100% while also
+  // capping height made `object-fit: cover` crop the image to fit, which
+  // defeated the point of sizing the box to its real aspect ratio.
   const imageHtml = imageOrPlaceholder(
     imageUrl,
     imageName,
-    `width: 100%; aspect-ratio: ${aspectRatio}; max-height: 320px; border-radius: 12px; margin-bottom: 24px;`,
+    `display: block; max-width: 100%; max-height: 320px; aspect-ratio: ${aspectRatio}; border-radius: 12px; margin: 0 auto 24px;`,
   );
 
   return `<div class="fmd-slide" style="padding: 64px 90px; display: flex; flex-direction: column; justify-content: flex-start; font-family: ${fontFamily};">

--- a/templates/slides/server/handlers/import/html-converter.ts
+++ b/templates/slides/server/handlers/import/html-converter.ts
@@ -85,17 +85,27 @@ function groupIntoParagraphs(texts: ParsedTextRun[]): ParsedTextRun[][] {
   return paragraphs;
 }
 
-/** Determine slide layout and generate HTML. */
-export function convertToSlideHtml(slide: ParsedSlide): string {
+/**
+ * Determine slide layout and generate HTML. `imageUrl` is the hosted URL
+ * for the slide's first embedded image (already uploaded by the caller) —
+ * pass undefined when the slide has no image or the upload failed, and the
+ * builders fall back to a text placeholder instead of a broken `<img>`.
+ */
+export function convertToSlideHtml(
+  slide: ParsedSlide,
+  imageUrl?: string,
+): string {
   const paragraphs = groupIntoParagraphs(slide.texts);
 
-  // Determine layout
-  if (slide.layoutHint === "title" || paragraphs.length <= 2) {
-    return buildTitleSlide(paragraphs, slide);
+  // An embedded image always wins the layout choice — a forced title slide
+  // has no room to show it, which is how imports used to silently drop
+  // photos from otherwise short/title-shaped slides.
+  if (slide.images.length > 0) {
+    return buildImageSlide(paragraphs, slide, imageUrl);
   }
 
-  if (slide.images.length > 0) {
-    return buildImageSlide(paragraphs, slide);
+  if (slide.layoutHint === "title" || paragraphs.length <= 2) {
+    return buildTitleSlide(paragraphs, slide);
   }
 
   return buildContentSlide(paragraphs, slide);
@@ -111,13 +121,8 @@ function buildTitleSlide(
   const titleText = titlePara.map(formatRun).join(" ") || "Untitled Slide";
   const subtitleText = subtitlePara.map(formatRun).join(" ");
 
-  let imageHtml = "";
-  if (slide.images.length > 0) {
-    imageHtml = `\n    <div class="fmd-img-placeholder" style="width: 100%; height: 200px; border-radius: 12px; margin-top: 32px;">Imported image: ${esc(slide.images[0].name)}</div>`;
-  }
-
   return `<div class="fmd-slide" style="padding: 80px 110px; display: flex; flex-direction: column; justify-content: center; align-items: flex-start; font-family: 'Poppins', sans-serif;">
-    <h1 style="font-size: 64px; font-weight: 900; color: #fff; line-height: 1.1; letter-spacing: -2px; margin: 0 0 24px 0;">${titleText}</h1>${subtitleText ? `\n    <p style="font-size: 22px; color: rgba(255,255,255,0.55); margin: 0;">${subtitleText}</p>` : ""}${imageHtml}
+    <h1 style="font-size: 64px; font-weight: 900; color: #fff; line-height: 1.1; letter-spacing: -2px; margin: 0 0 24px 0;">${titleText}</h1>${subtitleText ? `\n    <p style="font-size: 22px; color: rgba(255,255,255,0.55); margin: 0;">${subtitleText}</p>` : ""}
 </div>`;
 }
 
@@ -148,20 +153,28 @@ ${bulletItems}
     </div>`;
   }
 
-  let imageHtml = "";
-  if (slide.images.length > 0) {
-    imageHtml = `\n    <div class="fmd-img-placeholder" style="width: 100%; height: 300px; border-radius: 12px; margin-top: 24px;">Imported image: ${esc(slide.images[0].name)}</div>`;
-  }
-
   return `<div class="fmd-slide" style="padding: 80px 110px; display: flex; flex-direction: column; justify-content: flex-start; font-family: 'Poppins', sans-serif;">
     <div style="font-size: 14px; font-weight: 700; letter-spacing: 3px; text-transform: uppercase; color: #00E5FF; margin-bottom: 16px;">IMPORTED</div>
-    <h2 style="font-size: 40px; font-weight: 900; color: #fff; line-height: 1.15; letter-spacing: -1px; margin: 0 0 48px 0;">${headingText}</h2>${bulletsHtml}${imageHtml}
+    <h2 style="font-size: 40px; font-weight: 900; color: #fff; line-height: 1.15; letter-spacing: -1px; margin: 0 0 48px 0;">${headingText}</h2>${bulletsHtml}
 </div>`;
+}
+
+/** Render the slide's embedded image, or a text placeholder if it couldn't be uploaded. */
+function imageOrPlaceholder(
+  imageUrl: string | undefined,
+  imageName: string,
+  style: string,
+): string {
+  if (imageUrl) {
+    return `<img src="${esc(imageUrl)}" alt="" style="${style} object-fit: cover;" />`;
+  }
+  return `<div class="fmd-img-placeholder" style="${style}">Imported image: ${esc(imageName)}</div>`;
 }
 
 function buildImageSlide(
   paragraphs: ParsedTextRun[][],
   slide: ParsedSlide,
+  imageUrl?: string,
 ): string {
   const headingPara = paragraphs[0] ?? [];
   const headingText = headingPara.map(formatRun).join(" ") || "Slide";
@@ -172,11 +185,16 @@ function buildImageSlide(
     .join(" ");
 
   const imageName = slide.images[0]?.name ?? "image";
+  const imageHtml = imageOrPlaceholder(
+    imageUrl,
+    imageName,
+    "width: 100%; height: 300px; border-radius: 12px;",
+  );
 
   return `<div class="fmd-slide" style="padding: 80px 110px; display: flex; flex-direction: column; justify-content: flex-start; font-family: 'Poppins', sans-serif;">
     <div style="font-size: 14px; font-weight: 700; letter-spacing: 3px; text-transform: uppercase; color: #00E5FF; margin-bottom: 16px;">IMPORTED</div>
     <h2 style="font-size: 40px; font-weight: 900; color: #fff; line-height: 1.15; letter-spacing: -1px; margin: 0 0 32px 0;">${headingText}</h2>
-    <div class="fmd-img-placeholder" style="width: 100%; height: 300px; border-radius: 12px;">Imported image: ${esc(imageName)}</div>${captionText ? `\n    <p style="font-size: 18px; color: rgba(255,255,255,0.55); margin: 24px 0 0 0;">${captionText}</p>` : ""}
+    ${imageHtml}${captionText ? `\n    <p style="font-size: 18px; color: rgba(255,255,255,0.55); margin: 24px 0 0 0;">${captionText}</p>` : ""}
 </div>`;
 }
 


### PR DESCRIPTION
### Summary
Improves PPTX slide import so embedded images are actually uploaded and rendered, and slide layouts better reflect the original presentation's structure (image size, aspect ratio, and theme font).

### Problem
Importing `.pptx` files produced poor results: images were replaced with text placeholders instead of being shown, layout order/hierarchy didn't match the source deck (e.g. text/image ordering), photos were forced into a fixed 16:9 box regardless of their real orientation, and imported slides always used a hardcoded font rather than the source theme's font.

### Solution
The PPTX parser now captures each picture shape's placed size on the slide (not just the raw image relationship), which is used to compute an aspect ratio and detect "full-bleed" background photos vs. smaller inset images. Import actions upload the slide's first embedded image and pass its hosted URL (plus the extracted theme font) into the HTML converter, which now picks between an overlay layout (for full-bleed photos) and a stacked layout (for inset photos sized to their own aspect ratio) instead of always using a placeholder box.

### Key Changes
- `packages/core/src/ingestion/pptx.ts`: walk slide's `p:pic` shapes in document order to read each image's placed width/height (EMU), compute `aspectRatio` and `fullBleed` (≥85% of slide width/height) per image, and expose them on `ParsedPptxImage`.
- `templates/slides/actions/import-file.ts` and `import-pptx.ts`: upload the first embedded image per slide via `uploadFile` and pass the resulting URL, plus the presentation's extracted theme font, into `convertToSlideHtml`.
- `templates/slides/server/handlers/import/html-converter.ts`:
  - `convertToSlideHtml` now accepts `imageUrl` and `themeFont`, and always renders an image slide when the slide has images (previously a short/title-shaped slide with an image could drop the image entirely).
  - Added `cssFontFamily` helper to build a CSS font stack from the theme font, falling back to a default when absent.
  - Added `imageOrPlaceholder` helper to render a real `<img>` when a URL is available, falling back to the text placeholder otherwise.
  - Split image slide rendering into `buildOverlayImageSlide` (full-bleed photo with heading/caption overlaid on a gradient scrim) and `buildStackedImageSlide` (photo sized to its own aspect ratio with heading/caption below), chosen based on the image's `fullBleed` flag.
  - Title and content slide builders now accept and use `fontFamily` instead of a hardcoded font.


---

<a href="https://builder.io/app/projects/88e92dea5bdd4ad396c8/stellar-network-pffjkzug"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://88e92dea5bdd4ad396c8-stellar-network-pffjkzug.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2444`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>88e92dea5bdd4ad396c8</projectId>-->
<!--<branchName>stellar-network-pffjkzug</branchName>-->