### PR TITLE
Clarify credential resolver organization scope

### DIFF
--- a/.agents/skills/secrets/SKILL.md
+++ b/.agents/skills/secrets/SKILL.md
@@ -177,9 +177,34 @@ workspace repo:
 npx agent-native doctor --only no-env-credentials
 ```
 
-Findings in files that already call `resolveCredential` are usually the
-sanctioned `resolveCredential(key, ctx) ?? process.env.KEY` fallback. The bugs
-are the files with **no** resolver at all.
+## `resolveCredential` sees exactly one organization
+
+`resolveCredential(key, { userEmail, orgId })` checks the user scope, then the
+one `orgId` you pass, then the solo workspace. That is the whole search. It is
+correct for a signed-in request, and wrong for two common cases:
+
+- **The caller has no organization.** A cron, a scheduled job, or any CLI run
+  without a real member identity resolves no `orgId`, so only the user and solo
+  scopes are ever consulted — and a shared key is in neither.
+- **The key was synced under a different organization.** `app_secrets` has no
+  scope visible to every org (`readAppSecret` is strict equality on
+  `(scope, scope_id, key)`), so a key the vault UI advertises as available to
+  every app is unreadable from any org except the one that ran the sync.
+
+Both produce the same misleading "not set" that the split brain above produces,
+which is why swapping `process.env` for `resolveCredential` can look like a fix
+and change nothing. A workspace app should read shared keys through a resolver
+that also sweeps the caller's other memberships and a designated vault org —
+see `resolveConnectorSecret` and `AGENT_VAULT_ORG_ID` in the builder-workspace
+repo for the shape, including the boot-time assertion that the deployment really
+is single-tenant before a non-membership-gated fallback is safe.
+
+**The doctor guard does not catch this second form** — it looks for
+`process.env` reads, and `resolveCredential` is not one. Grep for
+`resolveCredential` yourself and confirm each call sits somewhere a single-org
+lookup is genuinely the right question. Findings that pair it with a
+`?? process.env.KEY` fallback are the sanctioned deploy-level escape hatch; the
+bugs are calls whose value can only live in another org's vault.
 
 ## HTTP routes
 

--- a/.changeset/clarify-credential-scope-guidance.md
+++ b/.changeset/clarify-credential-scope-guidance.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Clarify credential resolver organization scope in generated workspace guidance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,12 @@ instructions, and application state.
   decide identity. Run `npx agent-native doctor --only no-env-credentials` from
   the app directory before finishing a credential change. See the `secrets`
   skill.
+- `resolveCredential` searches exactly one organization, so it cannot read a
+  shared key for a caller with no org (cron, CLI) or one synced under a
+  different org. Swapping `process.env` for it looks like a fix and changes
+  nothing; the doctor guard does not catch this form. For workspace-wide keys
+  use a resolver that also sweeps the caller's memberships and a designated
+  vault org. See the `secrets` skill.
 - Never create an organization, repoint a user's `active-org-id`, or migrate a
   roster/identity list into a new org on your own initiative. Vault credentials
   are per-organization, so a second org orphans every key synced under the first

--- a/packages/core/src/templates/default/.agents/skills/secrets/SKILL.md
+++ b/packages/core/src/templates/default/.agents/skills/secrets/SKILL.md
@@ -177,9 +177,34 @@ workspace repo:
 npx agent-native doctor --only no-env-credentials
 ```
 
-Findings in files that already call `resolveCredential` are usually the
-sanctioned `resolveCredential(key, ctx) ?? process.env.KEY` fallback. The bugs
-are the files with **no** resolver at all.
+## `resolveCredential` sees exactly one organization
+
+`resolveCredential(key, { userEmail, orgId })` checks the user scope, then the
+one `orgId` you pass, then the solo workspace. That is the whole search. It is
+correct for a signed-in request, and wrong for two common cases:
+
+- **The caller has no organization.** A cron, a scheduled job, or any CLI run
+  without a real member identity resolves no `orgId`, so only the user and solo
+  scopes are ever consulted — and a shared key is in neither.
+- **The key was synced under a different organization.** `app_secrets` has no
+  scope visible to every org (`readAppSecret` is strict equality on
+  `(scope, scope_id, key)`), so a key the vault UI advertises as available to
+  every app is unreadable from any org except the one that ran the sync.
+
+Both produce the same misleading "not set" that the split brain above produces,
+which is why swapping `process.env` for `resolveCredential` can look like a fix
+and change nothing. A workspace app should read shared keys through a resolver
+that also sweeps the caller's other memberships and a designated vault org —
+see `resolveConnectorSecret` and `AGENT_VAULT_ORG_ID` in the builder-workspace
+repo for the shape, including the boot-time assertion that the deployment really
+is single-tenant before a non-membership-gated fallback is safe.
+
+**The doctor guard does not catch this second form** — it looks for
+`process.env` reads, and `resolveCredential` is not one. Grep for
+`resolveCredential` yourself and confirm each call sits somewhere a single-org
+lookup is genuinely the right question. Findings that pair it with a
+`?? process.env.KEY` fallback are the sanctioned deploy-level escape hatch; the
+bugs are calls whose value can only live in another org's vault.
 
 ## HTTP routes
 

--- a/packages/core/src/templates/headless/.agents/skills/secrets/SKILL.md
+++ b/packages/core/src/templates/headless/.agents/skills/secrets/SKILL.md
@@ -177,9 +177,34 @@ workspace repo:
 npx agent-native doctor --only no-env-credentials
 ```
 
-Findings in files that already call `resolveCredential` are usually the
-sanctioned `resolveCredential(key, ctx) ?? process.env.KEY` fallback. The bugs
-are the files with **no** resolver at all.
+## `resolveCredential` sees exactly one organization
+
+`resolveCredential(key, { userEmail, orgId })` checks the user scope, then the
+one `orgId` you pass, then the solo workspace. That is the whole search. It is
+correct for a signed-in request, and wrong for two common cases:
+
+- **The caller has no organization.** A cron, a scheduled job, or any CLI run
+  without a real member identity resolves no `orgId`, so only the user and solo
+  scopes are ever consulted — and a shared key is in neither.
+- **The key was synced under a different organization.** `app_secrets` has no
+  scope visible to every org (`readAppSecret` is strict equality on
+  `(scope, scope_id, key)`), so a key the vault UI advertises as available to
+  every app is unreadable from any org except the one that ran the sync.
+
+Both produce the same misleading "not set" that the split brain above produces,
+which is why swapping `process.env` for `resolveCredential` can look like a fix
+and change nothing. A workspace app should read shared keys through a resolver
+that also sweeps the caller's other memberships and a designated vault org —
+see `resolveConnectorSecret` and `AGENT_VAULT_ORG_ID` in the builder-workspace
+repo for the shape, including the boot-time assertion that the deployment really
+is single-tenant before a non-membership-gated fallback is safe.
+
+**The doctor guard does not catch this second form** — it looks for
+`process.env` reads, and `resolveCredential` is not one. Grep for
+`resolveCredential` yourself and confirm each call sits somewhere a single-org
+lookup is genuinely the right question. Findings that pair it with a
+`?? process.env.KEY` fallback are the sanctioned deploy-level escape hatch; the
+bugs are calls whose value can only live in another org's vault.
 
 ## HTTP routes
 

--- a/packages/core/src/templates/workspace-core/.agents/skills/secrets/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/secrets/SKILL.md
@@ -177,9 +177,34 @@ workspace repo:
 npx agent-native doctor --only no-env-credentials
 ```
 
-Findings in files that already call `resolveCredential` are usually the
-sanctioned `resolveCredential(key, ctx) ?? process.env.KEY` fallback. The bugs
-are the files with **no** resolver at all.
+## `resolveCredential` sees exactly one organization
+
+`resolveCredential(key, { userEmail, orgId })` checks the user scope, then the
+one `orgId` you pass, then the solo workspace. That is the whole search. It is
+correct for a signed-in request, and wrong for two common cases:
+
+- **The caller has no organization.** A cron, a scheduled job, or any CLI run
+  without a real member identity resolves no `orgId`, so only the user and solo
+  scopes are ever consulted — and a shared key is in neither.
+- **The key was synced under a different organization.** `app_secrets` has no
+  scope visible to every org (`readAppSecret` is strict equality on
+  `(scope, scope_id, key)`), so a key the vault UI advertises as available to
+  every app is unreadable from any org except the one that ran the sync.
+
+Both produce the same misleading "not set" that the split brain above produces,
+which is why swapping `process.env` for `resolveCredential` can look like a fix
+and change nothing. A workspace app should read shared keys through a resolver
+that also sweeps the caller's other memberships and a designated vault org —
+see `resolveConnectorSecret` and `AGENT_VAULT_ORG_ID` in the builder-workspace
+repo for the shape, including the boot-time assertion that the deployment really
+is single-tenant before a non-membership-gated fallback is safe.
+
+**The doctor guard does not catch this second form** — it looks for
+`process.env` reads, and `resolveCredential` is not one. Grep for
+`resolveCredential` yourself and confirm each call sits somewhere a single-org
+lookup is genuinely the right question. Findings that pair it with a
+`?? process.env.KEY` fallback are the sanctioned deploy-level escape hatch; the
+bugs are calls whose value can only live in another org's vault.
 
 ## HTTP routes
 


### PR DESCRIPTION
Document the one-organization behavior of resolveCredential and the workspace-wide resolver guidance.

Also sync the generated workspace skill templates so the canonical skill and template copies stay aligned.

Validation:
- pnpm guard:workspace-skills
- git diff --check