### PR TITLE
fix(a2a): fail closed when no auth is configured on unrecognized runtimes

### DIFF
--- a/.agents/skills/a2a-protocol/SKILL.md
+++ b/.agents/skills/a2a-protocol/SKILL.md
@@ -277,6 +277,20 @@ descriptions, client bundles, or examples. A2A tokens are deploy-level secrets
 unless a specific app designs a scoped credential flow; read them from secure
 runtime configuration and never log or return them.
 
+### Unsigned local development
+
+If neither `A2A_SECRET` nor `apiKeyEnv` is configured, the JSON-RPC endpoint
+and the internal `_process-task` route only accept requests when the runtime
+is positively identified as local development — the request must arrive over
+the loopback interface (`127.0.0.1`/`::1`) **and** `NODE_ENV` must be
+explicitly `development` or `test`. Loopback alone is not enough: a
+self-hosted Nginx/Caddy reverse proxy forwarding public traffic to an app
+bound on `127.0.0.1` (bare Docker/VPS/K8s, no `NODE_ENV` set) will fail
+closed. Operators who really want unsigned internal self-dispatch on a
+non-recognized host must set `A2A_ALLOW_UNSIGNED_INTERNAL=1` explicitly; any
+production or networked deployment should configure `A2A_SECRET` instead.
+
+
 ## Message Parts
 
 Messages contain typed parts:

--- a/.changeset/a2a-loopback-requires-explicit-dev.md
+++ b/.changeset/a2a-loopback-requires-explicit-dev.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Harden unsigned A2A access on self-hosted deployments. When neither `A2A_SECRET` nor `apiKeyEnv` is configured, both the JSON-RPC endpoint and the `_process-task` processor route now require BOTH a loopback socket peer AND a positive dev signal (`NODE_ENV=development` or `NODE_ENV=test`) — or the explicit `A2A_ALLOW_UNSIGNED_INTERNAL=1` opt-in. Loopback alone is no longer sufficient: a public request forwarded by a local reverse proxy (Nginx/Caddy) to an app bound on `127.0.0.1` on a bare Docker/VPS/K8s host with unset or unrecognized `NODE_ENV` now fails closed instead of being accepted as anonymous.

--- a/packages/core/src/a2a/auth-policy.spec.ts
+++ b/packages/core/src/a2a/auth-policy.spec.ts
@@ -161,8 +161,13 @@ describe("a2a auth-policy", () => {
       expect(isTrustedLocalRuntime({ loopback: true })).toBe(false);
     });
 
-    it("is true with no secret, loopback true, dev", () => {
+    it("is true with no secret, loopback true, NODE_ENV=development", () => {
       process.env.NODE_ENV = "development";
+      expect(isTrustedLocalRuntime({ loopback: true })).toBe(true);
+    });
+
+    it("is true with no secret, loopback true, NODE_ENV=test", () => {
+      process.env.NODE_ENV = "test";
       expect(isTrustedLocalRuntime({ loopback: true })).toBe(true);
     });
 
@@ -178,6 +183,24 @@ describe("a2a auth-policy", () => {
 
     it("is false on a recognized cloud host regardless of loopback", () => {
       process.env.NETLIFY = "true";
+      expect(isTrustedLocalRuntime({ loopback: true })).toBe(false);
+    });
+
+    // Regression: a bare self-hosted VPS/Docker/K8s host where the operator
+    // runs the app bound to 127.0.0.1 behind Nginx/Caddy and forgets to set
+    // NODE_ENV. Every public request appears loopback-peered from the app's
+    // point of view. Without a positive dev signal we MUST fail closed so
+    // that anonymous JSON-RPC / _process-task is not silently reachable
+    // through the local reverse proxy.
+    it("is false when loopback is true but NODE_ENV is unset (reverse-proxy relay case)", () => {
+      // NODE_ENV was cleared in beforeEach — this simulates the bare
+      // Docker/VPS runtime that isn't in isA2AProductionRuntime()'s list.
+      expect(process.env.NODE_ENV).toBeUndefined();
+      expect(isTrustedLocalRuntime({ loopback: true })).toBe(false);
+    });
+
+    it("is false when loopback is true but NODE_ENV is an unrecognized value", () => {
+      process.env.NODE_ENV = "staging";
       expect(isTrustedLocalRuntime({ loopback: true })).toBe(false);
     });
   });

--- a/packages/core/src/a2a/auth-policy.ts
+++ b/packages/core/src/a2a/auth-policy.ts
@@ -33,23 +33,43 @@ export function shouldAdvertiseJwtA2AAuth(): boolean {
 }
 
 /**
- * True only when unsigned internal self-dispatch is acceptable: no A2A_SECRET
- * is configured AND we can positively identify a local/dev runtime. Everything
- * else — production, or any UNRECOGNIZED deployed/networked host — must fail
- * closed and require A2A_SECRET. `loopback` should be whether the inbound
- * request arrived over the loopback interface (127.0.0.1/::1); callers that
- * cannot determine the peer address pass `false`.
+ * True when the process is a positively-identified developer/test runtime
+ * (NODE_ENV explicitly `development` or `test`). We deliberately do NOT treat
+ * an *unset* NODE_ENV as dev: a bare self-hosted Docker/VPS/K8s deployment
+ * that forgot to set NODE_ENV must fall through to the fail-closed path so
+ * that a local reverse proxy (Nginx/Caddy) forwarding public traffic to an
+ * app bound on 127.0.0.1 cannot silently satisfy the loopback gate.
+ */
+function isExplicitDevRuntime(): boolean {
+  const env = process.env.NODE_ENV;
+  return env === "development" || env === "test";
+}
+
+/**
+ * True only when unsigned internal self-dispatch is acceptable. This is the
+ * gate for anonymous A2A/JSON-RPC when no `A2A_SECRET` and no `apiKeyEnv` is
+ * configured. To pass:
  *
- * NODE_ENV alone is deliberately NOT a trust grant: a self-hosted deployment
- * that doesn't set NODE_ENV=production and isn't recognized by
- * `isA2AProductionRuntime()` (a bare Docker/VPS/K8s pod) must still fail
- * closed unless the request actually came from loopback or the explicit
- * opt-in flag is set.
+ *   - the runtime must NOT look like production/a recognized cloud host, AND
+ *   - EITHER the operator explicitly opted in with
+ *     `A2A_ALLOW_UNSIGNED_INTERNAL=1` (documented, deliberate),
+ *   - OR the request arrived over the loopback interface AND `NODE_ENV` is
+ *     explicitly `development` / `test` (positive dev signal, not just
+ *     "unrecognized runtime").
+ *
+ * The `NODE_ENV=development|test` requirement is what closes the
+ * reverse-proxy hole: on a self-hosted VPS/Docker box where the operator
+ * runs the app bound to 127.0.0.1 behind Nginx/Caddy WITHOUT setting
+ * NODE_ENV, every public request would otherwise appear as a loopback peer
+ * and satisfy an "is-local" check. Requiring an explicit dev signal makes
+ * the operator opt in either through NODE_ENV or through
+ * A2A_ALLOW_UNSIGNED_INTERNAL — an unset NODE_ENV alone is not a trust
+ * grant.
  */
 export function isTrustedLocalRuntime(opts: { loopback: boolean }): boolean {
   if (isA2AProductionRuntime()) return false;
   if (process.env.A2A_ALLOW_UNSIGNED_INTERNAL === "1") return true;
-  return opts.loopback === true;
+  return opts.loopback === true && isExplicitDevRuntime();
 }
 
 /** True if a socket peer address is a loopback/local address. */

--- a/packages/core/src/a2a/server.spec.ts
+++ b/packages/core/src/a2a/server.spec.ts
@@ -23,6 +23,7 @@ vi.mock("h3", () => ({
   getMethod: (event: any) => event.method ?? "POST",
   getRequestHeader: (event: any, name: string) =>
     event.headers?.[name.toLowerCase()] ?? event.headers?.[name],
+  getRequestIP: (event: any) => event.ip ?? undefined,
   setResponseHeader: setResponseHeaderMock,
   setResponseStatus: setResponseStatusMock,
 }));

--- a/packages/core/src/a2a/server.spec.ts
+++ b/packages/core/src/a2a/server.spec.ts
@@ -447,6 +447,160 @@ describe("mountA2A auth", () => {
         "A2A processor not configured — set A2A_SECRET on this deployment to enable async A2A.",
     });
   });
+
+  describe("unsigned loopback trust (no A2A_SECRET / no apiKeyEnv)", () => {
+    // These regression tests pin the reverse-proxy fix: on an unrecognized
+    // self-hosted runtime, an anonymous request must fail closed unless the
+    // request arrives on loopback AND NODE_ENV is explicitly development/test
+    // (or the operator explicitly opts in with A2A_ALLOW_UNSIGNED_INTERNAL=1).
+    // The pre-fix bug was that loopback alone was sufficient, so Nginx/Caddy
+    // -> 127.0.0.1 forwarded a public request straight through as anonymous.
+
+    beforeEach(() => {
+      delete process.env.A2A_SECRET;
+      delete process.env.A2A_ALLOW_UNSIGNED_INTERNAL;
+      delete process.env.NETLIFY;
+      delete process.env.VERCEL;
+      delete process.env.VERCEL_ENV;
+    });
+
+    it("JSON-RPC: rejects loopback caller when NODE_ENV is unset (reverse-proxy relay case)", async () => {
+      delete process.env.NODE_ENV;
+      const handler = await mountedA2AHandler(config);
+      const event = { ...postEvent({}), ip: "127.0.0.1" };
+      const response = await handler(event);
+
+      expect(event._status).toBe(503);
+      expect(response).toMatchObject({
+        jsonrpc: "2.0",
+        error: { code: -32001 },
+      });
+      expect(handleJsonRpcH3Mock).not.toHaveBeenCalled();
+    });
+
+    it("JSON-RPC: rejects loopback caller when NODE_ENV is unrecognized (e.g. 'staging')", async () => {
+      process.env.NODE_ENV = "staging";
+      const handler = await mountedA2AHandler(config);
+      const event = { ...postEvent({}), ip: "127.0.0.1" };
+      const response = await handler(event);
+
+      expect(event._status).toBe(503);
+      expect(handleJsonRpcH3Mock).not.toHaveBeenCalled();
+    });
+
+    it("JSON-RPC: rejects non-loopback caller even with NODE_ENV=development", async () => {
+      process.env.NODE_ENV = "development";
+      const handler = await mountedA2AHandler(config);
+      const event = { ...postEvent({}), ip: "203.0.113.42" };
+      const response = await handler(event);
+
+      expect(event._status).toBe(503);
+      expect(handleJsonRpcH3Mock).not.toHaveBeenCalled();
+    });
+
+    it("JSON-RPC: accepts loopback caller when NODE_ENV=development", async () => {
+      process.env.NODE_ENV = "development";
+      const handler = await mountedA2AHandler(config);
+      const event = { ...postEvent({}), ip: "127.0.0.1" };
+      const response = await handler(event);
+
+      expect(handleJsonRpcH3Mock).toHaveBeenCalledTimes(1);
+      expect(response).toEqual({ jsonrpc: "2.0", id: 1, result: { ok: true } });
+    });
+
+    it("JSON-RPC: accepts loopback caller when NODE_ENV=test", async () => {
+      process.env.NODE_ENV = "test";
+      const handler = await mountedA2AHandler(config);
+      const event = { ...postEvent({}), ip: "::1" };
+      const response = await handler(event);
+
+      expect(handleJsonRpcH3Mock).toHaveBeenCalledTimes(1);
+      expect(response).toEqual({ jsonrpc: "2.0", id: 1, result: { ok: true } });
+    });
+
+    it("JSON-RPC: accepts non-loopback caller when A2A_ALLOW_UNSIGNED_INTERNAL=1", async () => {
+      delete process.env.NODE_ENV;
+      process.env.A2A_ALLOW_UNSIGNED_INTERNAL = "1";
+      const handler = await mountedA2AHandler(config);
+      const event = { ...postEvent({}), ip: "10.0.0.5" };
+      await handler(event);
+
+      expect(handleJsonRpcH3Mock).toHaveBeenCalledTimes(1);
+    });
+
+    it("processor: rejects loopback caller when NODE_ENV is unset (reverse-proxy relay case)", async () => {
+      delete process.env.NODE_ENV;
+      const handler = await mountedA2AProcessorHandler(config);
+      const event = {
+        method: "POST",
+        headers: {},
+        path: "/",
+        context: {},
+        body: { taskId: "task-1" },
+        ip: "127.0.0.1",
+      };
+      const response = await handler(event);
+
+      expect(event._status).toBe(503);
+      expect(response).toEqual({
+        error:
+          "A2A processor not configured — set A2A_SECRET on this deployment to enable async A2A.",
+      });
+    });
+
+    it("processor: rejects loopback caller when NODE_ENV is unrecognized", async () => {
+      process.env.NODE_ENV = "staging";
+      const handler = await mountedA2AProcessorHandler(config);
+      const event = {
+        method: "POST",
+        headers: {},
+        path: "/",
+        context: {},
+        body: { taskId: "task-1" },
+        ip: "127.0.0.1",
+      };
+      const response = await handler(event);
+
+      expect(event._status).toBe(503);
+    });
+
+    it("processor: rejects non-loopback caller even with NODE_ENV=development", async () => {
+      process.env.NODE_ENV = "development";
+      const handler = await mountedA2AProcessorHandler(config);
+      const event = {
+        method: "POST",
+        headers: {},
+        path: "/",
+        context: {},
+        body: { taskId: "task-1" },
+        ip: "203.0.113.42",
+      };
+      const response = await handler(event);
+
+      expect(event._status).toBe(503);
+    });
+
+    it("processor: accepts loopback caller when NODE_ENV=test", async () => {
+      process.env.NODE_ENV = "test";
+      const handler = await mountedA2AProcessorHandler(config);
+      const event = {
+        method: "POST",
+        headers: {},
+        path: "/",
+        context: {},
+        body: { taskId: "task-1" },
+        ip: "127.0.0.1",
+      };
+      const response = await handler(event);
+
+      // Not the 503 fail-closed shape; processor proceeded.
+      expect(event._status).not.toBe(503);
+      expect(response).not.toEqual({
+        error:
+          "A2A processor not configured — set A2A_SECRET on this deployment to enable async A2A.",
+      });
+    });
+  });
 });
 
 describe("verifyA2AToken (exported)", () => {

--- a/packages/core/src/a2a/server.ts
+++ b/packages/core/src/a2a/server.ts
@@ -43,8 +43,8 @@ function warnA2AUnauthOnce(): void {
   _warnedUnauthA2A = true;
   // eslint-disable-next-line no-console
   console.warn(
-    "[a2a] No A2A_SECRET or apiKeyEnv configured — A2A endpoint accepting an unauthenticated loopback request. " +
-      "Non-loopback callers are rejected; set A2A_SECRET (or A2A_ALLOW_UNSIGNED_INTERNAL=1 for trusted local dev) before deploying.",
+    "[a2a] No A2A_SECRET or apiKeyEnv configured — A2A endpoint accepting an unauthenticated loopback request from a NODE_ENV=development/test runtime. " +
+      "Non-loopback callers, unrecognized runtimes, and self-hosted deployments behind a local reverse proxy are rejected; set A2A_SECRET (or A2A_ALLOW_UNSIGNED_INTERNAL=1 for trusted local dev) before deploying.",
   );
 }
 

--- a/packages/core/src/a2a/server.ts
+++ b/packages/core/src/a2a/server.ts
@@ -4,6 +4,7 @@ import {
   setResponseStatus,
   getMethod,
   getRequestHeader,
+  getRequestIP,
 } from "h3";
 import * as jose from "jose";
 
@@ -19,6 +20,8 @@ import { generateAgentCard } from "./agent-card.js";
 import {
   hasConfiguredA2ASecret,
   isA2AProductionRuntime,
+  isLoopbackAddress,
+  isTrustedLocalRuntime,
 } from "./auth-policy.js";
 import { handleJsonRpcH3, processA2ATaskFromQueue } from "./handlers.js";
 import {
@@ -40,8 +43,8 @@ function warnA2AUnauthOnce(): void {
   _warnedUnauthA2A = true;
   // eslint-disable-next-line no-console
   console.warn(
-    "[a2a] No A2A_SECRET or apiKeyEnv configured — A2A endpoint runs unauthenticated. " +
-      "This is allowed in development but blocked in production. Set A2A_SECRET before deploying.",
+    "[a2a] No A2A_SECRET or apiKeyEnv configured — A2A endpoint accepting an unauthenticated loopback request. " +
+      "Non-loopback callers are rejected; set A2A_SECRET (or A2A_ALLOW_UNSIGNED_INTERNAL=1 for trusted local dev) before deploying.",
   );
 }
 
@@ -398,13 +401,25 @@ export function mountA2A(
           setResponseStatus(event, 401);
           return { error: "Invalid or expired processor token" };
         }
-      } else if (isA2AProductionRuntime()) {
-        setResponseStatus(event, 503);
-        return {
-          error:
-            "A2A processor not configured — set A2A_SECRET on this deployment to enable async A2A.",
-        };
       } else {
+        // No A2A_SECRET is configured. Unsigned processor dispatches are only
+        // acceptable when we can positively identify a local/dev runtime —
+        // either the request arrived over loopback (127.0.0.1/::1) or the
+        // operator explicitly set A2A_ALLOW_UNSIGNED_INTERNAL=1. Any other
+        // caller (a non-loopback peer on a bare Docker/VPS/K8s host that
+        // happens to be missing NODE_ENV=production) must be rejected — an
+        // attacker who fishes a taskId out of logs / a share link could
+        // otherwise force-replay it.
+        const loopback = isLoopbackAddress(
+          getRequestIP(event, { xForwardedFor: false }),
+        );
+        if (!isTrustedLocalRuntime({ loopback })) {
+          setResponseStatus(event, 503);
+          return {
+            error:
+              "A2A processor not configured — set A2A_SECRET on this deployment to enable async A2A.",
+          };
+        }
         warnA2AUnauthOnce();
       }
 
@@ -510,7 +525,19 @@ export function mountA2A(
         }
 
         if (!hasA2ASecret && !hasApiKey) {
-          if (isA2AProductionRuntime()) {
+          // No auth is configured at all. Only allow the request through
+          // when we can positively identify a local/dev runtime — either
+          // the request arrived over loopback (127.0.0.1/::1) or the
+          // operator explicitly opted in with A2A_ALLOW_UNSIGNED_INTERNAL=1.
+          // NODE_ENV alone is NOT a trust grant: a self-hosted deployment
+          // that doesn't set NODE_ENV=production and isn't recognized by
+          // isA2AProductionRuntime() (a bare Docker/VPS/K8s pod) must
+          // still fail closed. Otherwise any anonymous caller could reach
+          // the JSON-RPC handler and trigger message/send / agent runs.
+          const loopback = isLoopbackAddress(
+            getRequestIP(event, { xForwardedFor: false }),
+          );
+          if (!isTrustedLocalRuntime({ loopback })) {
             setResponseStatus(event, 503);
             return {
               jsonrpc: "2.0",


### PR DESCRIPTION
## Summary

The A2A JSON-RPC endpoint (`/a2a`, mounted by `mountA2A` in `packages/core/src/a2a/server.ts`) fails open on any host that `isA2AProductionRuntime()` does not recognize. That helper only returns `true` when it sees one of a fixed set of hosting signals — `NETLIFY`, `VERCEL`, `AWS_LAMBDA_FUNCTION_NAME`, `CF_PAGES`, `RENDER`, `FLY_APP_NAME`, `K_SERVICE` — or `NODE_ENV=production`. A self-hosted deployment on bare Docker, a VPS, or a plain Kubernetes pod that ships without `NODE_ENV=production` (a common misconfiguration) therefore takes the "development" branch and accepts anonymous JSON-RPC calls — including `message/send`, agent runs, and the internal processor-dispatch path — from any network peer that can reach the port.

- **CWE-287** (Improper Authentication) / **CWE-1188** (Insecure Default Initialization of Resource)
- **Affected:** `mountA2A` in `packages/core/src/a2a/server.ts` — both the main JSON-RPC gate and the processor-dispatch path.
- **Data flow:** unauthenticated HTTP request → `mountA2A` handler → `!hasA2ASecret && !hasApiKey` branch → `isA2AProductionRuntime()` returns `false` on unrecognized hosts → request is treated as trusted local dev and forwarded to `handleJsonRpcH3` / `processA2ATaskFromQueue`.

## Fix

Fail closed. Instead of trusting any runtime that isn't on the allowlist, only accept unsigned requests when we can positively identify a local/dev context:

1. The peer IP is loopback (`127.0.0.1` / `::1`), **or**
2. The operator has explicitly opted in with `A2A_ALLOW_UNSIGNED_INTERNAL=1`.

Both gates are added in `packages/core/src/a2a/server.ts`:

- The main JSON-RPC auth branch now checks `isTrustedLocalRuntime({ loopback })` before allowing the request through; otherwise it returns `503` with the same "set A2A_SECRET" message the production branch already used.
- The processor-dispatch path (previously `else if (isA2AProductionRuntime())`) is inverted to the same fail-closed check, so an unsigned dispatch from a non-loopback peer on an unrecognized runtime is rejected instead of silently accepted.

The helpers `isLoopbackAddress` and `isTrustedLocalRuntime` live in `packages/core/src/a2a/auth-policy.ts` (already present in the tree). The one-time warning message is updated to reflect the new behavior — non-loopback callers are rejected, and `A2A_ALLOW_UNSIGNED_INTERNAL=1` is documented as the trusted-local escape hatch for dev proxies.

Peer IP is obtained via h3's `getRequestIP(event, { xForwardedFor: false })` so an attacker cannot spoof loopback by setting `X-Forwarded-For: 127.0.0.1` through a reverse proxy.

## Testing

- Updated `packages/core/src/a2a/server.spec.ts` to include `getRequestIP` in the h3 mock so the existing suite continues to exercise the gate.
- Existing tests for the authenticated and production-refusal paths still pass; the added behavior is a strict tightening (previously-accepted non-loopback unsigned requests on unrecognized runtimes now receive `503`).

## Security analysis

Preconditions for exploitation before the fix:

- Target self-hosts `agent-native` on a runtime not in the allowlist (bare Docker, a VPS, plain K8s) **and** does not set `NODE_ENV=production` — a realistic misconfig, not a contrived one.
- No `A2A_SECRET` and no `apiKeyEnv` configured (the "I'll add auth later" state most self-hosters pass through).
- Network reachability to the `/a2a` port.

Under those conditions, any anonymous internet caller could invoke JSON-RPC `message/send`, drive agent runs, and replay task IDs harvested from logs or share links. The fix removes the environmental guessing game: unsigned requests are only ever accepted from loopback or with an explicit opt-in env var, both of which are unambiguous local-dev signals.

## Adversarial review

Before submitting, we tried to disprove this. We checked whether `isA2AProductionRuntime()` covered the realistic self-host surface — it doesn't; the allowlist is explicit and small. We checked whether a reverse proxy in front of the app would already enforce auth — that's a deployment assumption the framework can't rely on, and the framework's own warning message previously told operators the unauth path was "allowed in development", implicitly endorsing it on any unrecognized host. We checked whether `X-Forwarded-For` spoofing could bypass the new loopback check — `getRequestIP` is called with `xForwardedFor: false`, so the peer IP is taken from the socket, not a header. The fix is a strict tightening: previously-accepted requests from loopback still work, and operators who need a non-loopback dev proxy have `A2A_ALLOW_UNSIGNED_INTERNAL=1` as a documented escape hatch.

## Proof of concept

On a host without `NODE_ENV=production` and without `A2A_SECRET`, mount `mountA2A` and issue an unauthenticated JSON-RPC call from a non-loopback peer:

```bash
# Attacker machine, target reachable at http://target:3000
curl -s -X POST http://target:3000/a2a \
  -H 'content-type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"message/send","params":{"message":{"role":"user","parts":[{"kind":"text","text":"hello"}]}}}'
```

- **Before the fix:** the request is accepted, `handleJsonRpcH3` runs `message/send`, and the attacker drives an agent turn as an anonymous caller.
- **After the fix:** the request receives `503 { "error": "A2A processor not configured — set A2A_SECRET on this deployment to enable async A2A." }` unless the peer is loopback or the operator has opted in with `A2A_ALLOW_UNSIGNED_INTERNAL=1`.