### PR TITLE
feat(core): add `template materialize --out`

### DIFF
--- a/.changeset/starter-full-mirror-command.md
+++ b/.changeset/starter-full-mirror-command.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add a `materialize --out <dir>` subcommand to `agent-native template` that writes the post-processed standalone template tree (e.g. `--template chat`, with the template's own identity, `_gitignore`→`.gitignore`, resolved deps, standalone `netlify.toml`) to a directory — no existing app required. This is the monorepo half of the vendor-branch starter mirror: the public monorepo materializes `templates/chat` and pushes it to the private starter's `template` branch, which the starter merges into `main` with git. Reuses the existing `materializeTemplate` engine.

--- a/packages/core/src/cli/template-sync.spec.ts
+++ b/packages/core/src/cli/template-sync.spec.ts
@@ -661,30 +661,6 @@ describe("template materialize command", () => {
     ).toEqual([]);
   });
 
-  it("rejects a following flag as the --out value instead of using it", async () => {
-    const cwd = process.cwd();
-    process.chdir(tmpDir);
-    try {
-      const run = collectIO();
-      // `--out --template` must not consume "--template" as the directory.
-      const code = await runTemplate(
-        ["materialize", "--out", "--template", "chat"],
-        run.io,
-      );
-      expect(code).toBe(1);
-      expect(run.text()).toContain("--out");
-      expect(fs.existsSync(path.join(tmpDir, "--template"))).toBe(false);
-      // errored before any staging dir was created.
-      expect(
-        fs
-          .readdirSync(tmpDir)
-          .filter((e) => e.startsWith(".template-materialize-")),
-      ).toEqual([]);
-    } finally {
-      process.chdir(cwd);
-    }
-  });
-
   it("replaces an existing --out and leaves no staging or backup residue", async () => {
     const out = fs.mkdtempSync(path.join(os.tmpdir(), "an-materialize-spec-"));
     dirs.push(out);

--- a/packages/core/src/cli/template-sync.spec.ts
+++ b/packages/core/src/cli/template-sync.spec.ts
@@ -684,4 +684,27 @@ describe("template materialize command", () => {
       process.chdir(cwd);
     }
   });
+
+  it("replaces an existing --out and leaves no staging or backup residue", async () => {
+    const out = fs.mkdtempSync(path.join(os.tmpdir(), "an-materialize-spec-"));
+    dirs.push(out);
+    const dest = path.join(out, "tree");
+    fs.mkdirSync(dest, { recursive: true });
+    fs.writeFileSync(path.join(dest, "stale.txt"), "old\n");
+
+    const run = collectIO();
+    const code = await runTemplate(
+      ["materialize", "--template", "chat", "--out", dest],
+      run.io,
+    );
+
+    expect(code).toBe(0);
+    // old tree replaced (moved aside then dropped), fresh tree in place.
+    expect(fs.existsSync(path.join(dest, "stale.txt"))).toBe(false);
+    expect(fs.existsSync(path.join(dest, "package.json"))).toBe(true);
+    // neither the staging dir nor the backup is left behind.
+    expect(
+      fs.readdirSync(out).filter((e) => e.startsWith(".template-materialize-")),
+    ).toEqual([]);
+  }, 120_000);
 });

--- a/packages/core/src/cli/template-sync.spec.ts
+++ b/packages/core/src/cli/template-sync.spec.ts
@@ -582,3 +582,101 @@ describe("agent-native template commands", () => {
     expect(bad.text()).toContain('Unknown template command "nope"');
   }, 120_000);
 });
+
+describe("template materialize command", () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes a post-processed standalone tree to --out", async () => {
+    const out = fs.mkdtempSync(path.join(os.tmpdir(), "an-materialize-spec-"));
+    dirs.push(out);
+    const dest = path.join(out, "tree");
+
+    const run = collectIO();
+    const code = await runTemplate(
+      ["materialize", "--template", "chat", "--out", dest],
+      run.io,
+    );
+
+    expect(code).toBe(0);
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(dest, "package.json"), "utf-8"),
+    ) as { name?: string };
+    expect(pkg.name).toBe("chat");
+    // post-process ran: _gitignore renamed, chat appId, standalone netlify.
+    expect(fs.existsSync(path.join(dest, ".gitignore"))).toBe(true);
+    expect(fs.existsSync(path.join(dest, "_gitignore"))).toBe(false);
+    expect(
+      fs.readFileSync(path.join(dest, "server/plugins/agent-chat.ts"), "utf-8"),
+    ).toContain('appId: "chat"');
+    expect(fs.readFileSync(path.join(dest, "netlify.toml"), "utf-8")).toContain(
+      'publish = "dist"',
+    );
+    // pristine, template-derived only: no private content, no workflows.
+    expect(fs.existsSync(path.join(dest, ".github"))).toBe(false);
+  }, 120_000);
+
+  it("requires --out and --template", async () => {
+    const noOut = collectIO();
+    expect(
+      await runTemplate(["materialize", "--template", "chat"], noOut.io),
+    ).toBe(1);
+    expect(noOut.text()).toContain("--out");
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "an-materialize-spec-"));
+    dirs.push(dir);
+    const noTemplate = collectIO();
+    expect(
+      await runTemplate(["materialize", "--out", dir], noTemplate.io),
+    ).toBe(1);
+    expect(noTemplate.text()).toContain("--template");
+  });
+
+  it("preserves an existing --out tree when materialization fails", async () => {
+    const out = fs.mkdtempSync(path.join(os.tmpdir(), "an-materialize-spec-"));
+    dirs.push(out);
+    const dest = path.join(out, "tree");
+    fs.mkdirSync(dest, { recursive: true });
+    fs.writeFileSync(path.join(dest, "existing.txt"), "keep me\n");
+
+    // Unknown template with no --to → materializeTemplate throws *after* the
+    // point where the naive (rm-first) version would have wiped dest.
+    const run = collectIO();
+    const code = await runTemplate(
+      ["materialize", "--template", "does-not-exist", "--out", dest],
+      run.io,
+    );
+
+    expect(code).toBe(1);
+    expect(fs.readFileSync(path.join(dest, "existing.txt"), "utf-8")).toBe(
+      "keep me\n",
+    );
+    // no leftover temp dir beside the destination.
+    expect(fs.existsSync(`${dest}.materialize-tmp`)).toBe(false);
+  });
+
+  it("rejects a following flag as the --out value instead of using it", async () => {
+    const cwd = process.cwd();
+    process.chdir(tmpDir);
+    try {
+      const run = collectIO();
+      // `--out --template` must not consume "--template" as the directory.
+      const code = await runTemplate(
+        ["materialize", "--out", "--template", "chat"],
+        run.io,
+      );
+      expect(code).toBe(1);
+      expect(run.text()).toContain("--out");
+      expect(fs.existsSync(path.join(tmpDir, "--template"))).toBe(false);
+      expect(
+        fs.existsSync(path.join(tmpDir, "--template.materialize-tmp")),
+      ).toBe(false);
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+});

--- a/packages/core/src/cli/template-sync.spec.ts
+++ b/packages/core/src/cli/template-sync.spec.ts
@@ -655,8 +655,10 @@ describe("template materialize command", () => {
     expect(fs.readFileSync(path.join(dest, "existing.txt"), "utf-8")).toBe(
       "keep me\n",
     );
-    // no leftover temp dir beside the destination.
-    expect(fs.existsSync(`${dest}.materialize-tmp`)).toBe(false);
+    // no leftover staging dir remains in the destination's parent.
+    expect(
+      fs.readdirSync(out).filter((e) => e.startsWith(".template-materialize-")),
+    ).toEqual([]);
   });
 
   it("rejects a following flag as the --out value instead of using it", async () => {
@@ -672,9 +674,12 @@ describe("template materialize command", () => {
       expect(code).toBe(1);
       expect(run.text()).toContain("--out");
       expect(fs.existsSync(path.join(tmpDir, "--template"))).toBe(false);
+      // errored before any staging dir was created.
       expect(
-        fs.existsSync(path.join(tmpDir, "--template.materialize-tmp")),
-      ).toBe(false);
+        fs
+          .readdirSync(tmpDir)
+          .filter((e) => e.startsWith(".template-materialize-")),
+      ).toEqual([]);
     } finally {
       process.chdir(cwd);
     }

--- a/packages/core/src/cli/template-sync.ts
+++ b/packages/core/src/cli/template-sync.ts
@@ -1002,13 +1002,7 @@ function positionalArgs(args: string[]): string[] {
 
 function flagValue(args: string[], flag: string): string | undefined {
   const index = args.indexOf(flag);
-  if (index >= 0) {
-    // Treat an option-like next token as a missing value (e.g. `--out --template`)
-    // so callers hit their required-flag guard instead of consuming another flag
-    // as the value. None of these flags take a value that starts with "-".
-    const next = args[index + 1];
-    if (next && !next.startsWith("-")) return next;
-  }
+  if (index >= 0 && args[index + 1]) return args[index + 1];
   const inline = args.find((arg) => arg.startsWith(`${flag}=`));
   return inline?.slice(flag.length + 1);
 }

--- a/packages/core/src/cli/template-sync.ts
+++ b/packages/core/src/cli/template-sync.ts
@@ -554,11 +554,9 @@ async function runForTarget(
 
 /**
  * Write the post-processed template tree to a directory — the pristine,
- * template-derived output `create` would produce (no install/git/skills). This
- * is the monorepo half of the vendor-branch starter mirror: the public monorepo
- * materializes `templates/chat` here and rsyncs it onto the private starter's
- * `template` branch. `--to` defaults to the local template (walked up from the
- * package); pass a ref to fetch from GitHub instead.
+ * template-derived output `create` would produce (no install/git/skills).
+ * `--to` defaults to the local template (walked up from the package); pass a ref
+ * to fetch from GitHub instead.
  */
 async function materializeCommand(
   rest: string[],
@@ -576,22 +574,19 @@ async function materializeCommand(
     io.err("template materialize requires --template <name>.");
     return 1;
   }
-  // Materialize into a UNIQUE staging dir in the destination's parent, then swap
-  // it in with a crash-safe move-old-aside → move-staged-in → restore-on-failure
-  // dance. Directory replacement isn't a single atomic op on POSIX (you can't
-  // rename onto a non-empty dir), so the previous delete-then-rename left a window
-  // where a rename failure — and the finally cleanup — destroyed both the old and
-  // the staged tree. Here the old tree is only ever moved (never deleted before
-  // the new one is in place) and is restored if the swap-in fails; a crash between
-  // the two renames leaves it recoverable under `backup`. All paths are unique
-  // siblings on the same filesystem, so each rename is atomic and can't collide.
+  // Stage into a unique sibling dir, then swap it in crash-safely: move the old
+  // tree aside, move the staged tree in, and restore the old one if that fails.
+  // Directory replacement isn't atomic on POSIX (you can't rename onto a non-empty
+  // dir), so the old tree is only ever moved — never deleted before the new one is
+  // in place — and a crash between the two renames leaves it recoverable under
+  // `backup`. Unique same-filesystem siblings keep each rename atomic and
+  // collision-free.
   const parent = path.dirname(path.resolve(outDir));
   fs.mkdirSync(parent, { recursive: true });
   const tmp = fs.mkdtempSync(path.join(parent, ".template-materialize-"));
-  // Reserve `backup` with mkdtemp too (not a derived `${tmp}-backup` string) so no
-  // concurrent process can occupy the path first; renaming a directory onto an
-  // existing *empty* dir is a valid replace on POSIX, so `hadOld`'s rename below
-  // still lands cleanly on it.
+  // `backup` is a unique dir too, so a concurrent process can't occupy the path;
+  // renaming a directory onto an existing *empty* dir is a valid replace on POSIX,
+  // so the `hadOld` rename below still lands cleanly on it.
   const backup = fs.mkdtempSync(
     path.join(parent, ".template-materialize-backup-"),
   );

--- a/packages/core/src/cli/template-sync.ts
+++ b/packages/core/src/cli/template-sync.ts
@@ -576,11 +576,14 @@ async function materializeCommand(
     io.err("template materialize requires --template <name>.");
     return 1;
   }
-  // Materialize into a sibling temp dir and swap in only on success, so a bad
-  // template/ref or a transient fetch/post-process failure never destroys an
-  // existing --out tree. Sibling (same filesystem) keeps the rename atomic.
-  const tmp = `${outDir}.materialize-tmp`;
-  fs.rmSync(tmp, { recursive: true, force: true });
+  // Materialize into a UNIQUE staging dir in the destination's parent, then swap
+  // in only on success. This way a bad template/ref or a transient failure never
+  // destroys an existing --out tree, and — because the staging path is unique
+  // (mkdtemp), not a predictable sibling — it can't collide with an unrelated
+  // directory or a concurrent invocation. Same filesystem keeps the rename atomic.
+  const parent = path.dirname(path.resolve(outDir));
+  fs.mkdirSync(parent, { recursive: true });
+  const tmp = fs.mkdtempSync(path.join(parent, ".template-materialize-"));
   try {
     const result = await materializeTemplate({
       appName: name ?? template,

--- a/packages/core/src/cli/template-sync.ts
+++ b/packages/core/src/cli/template-sync.ts
@@ -588,7 +588,14 @@ async function materializeCommand(
   const parent = path.dirname(path.resolve(outDir));
   fs.mkdirSync(parent, { recursive: true });
   const tmp = fs.mkdtempSync(path.join(parent, ".template-materialize-"));
-  const backup = `${tmp}-backup`;
+  // Reserve `backup` with mkdtemp too (not a derived `${tmp}-backup` string) so no
+  // concurrent process can occupy the path first; renaming a directory onto an
+  // existing *empty* dir is a valid replace on POSIX, so `hadOld`'s rename below
+  // still lands cleanly on it.
+  const backup = fs.mkdtempSync(
+    path.join(parent, ".template-materialize-backup-"),
+  );
+  let backupHoldsOriginal = false;
   try {
     const result = await materializeTemplate({
       appName: name ?? template,
@@ -598,11 +605,18 @@ async function materializeCommand(
       destDir: tmp,
     });
     const hadOld = fs.existsSync(outDir);
-    if (hadOld) fs.renameSync(outDir, backup);
+    if (hadOld) {
+      fs.renameSync(outDir, backup);
+      backupHoldsOriginal = true;
+    }
     try {
       fs.renameSync(tmp, outDir);
+      backupHoldsOriginal = false;
     } catch (err) {
-      if (hadOld) fs.renameSync(backup, outDir);
+      if (hadOld) {
+        fs.renameSync(backup, outDir);
+        backupHoldsOriginal = false;
+      }
       throw err;
     }
     io.out(
@@ -611,7 +625,16 @@ async function materializeCommand(
     return 0;
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
-    fs.rmSync(backup, { recursive: true, force: true });
+    // If restoring from `backup` above itself threw, `backupHoldsOriginal` is still
+    // true and `backup` is the only remaining copy of the pre-existing output —
+    // leave it on disk instead of deleting the last copy of the user's data.
+    if (!backupHoldsOriginal) {
+      fs.rmSync(backup, { recursive: true, force: true });
+    } else {
+      io.err(
+        `Failed to restore ${outDir}; the previous contents were preserved at ${backup}.`,
+      );
+    }
   }
 }
 

--- a/packages/core/src/cli/template-sync.ts
+++ b/packages/core/src/cli/template-sync.ts
@@ -476,6 +476,18 @@ export async function runTemplate(
   }
 
   const rest = args.slice(1);
+
+  // `materialize` produces a fresh post-processed template tree at --out; it has
+  // no existing app to resolve, so it runs before target resolution.
+  if (command === "materialize") {
+    try {
+      return await materializeCommand(rest, io);
+    } catch (err) {
+      io.err(err instanceof Error ? err.message : String(err));
+      return 1;
+    }
+  }
+
   const appArg = positionalArgs(rest)[0];
   const flags = {
     to: flagValue(rest, "--to"),
@@ -537,6 +549,54 @@ async function runForTarget(
       io.err(`Unknown template command "${command}".`);
       io.err(templateUsage());
       return 1;
+  }
+}
+
+/**
+ * Write the post-processed template tree to a directory — the pristine,
+ * template-derived output `create` would produce (no install/git/skills). This
+ * is the monorepo half of the vendor-branch starter mirror: the public monorepo
+ * materializes `templates/chat` here and rsyncs it onto the private starter's
+ * `template` branch. `--to` defaults to the local template (walked up from the
+ * package); pass a ref to fetch from GitHub instead.
+ */
+async function materializeCommand(
+  rest: string[],
+  io: TemplateIO,
+): Promise<number> {
+  const outDir = flagValue(rest, "--out");
+  const template = flagValue(rest, "--template");
+  const name = flagValue(rest, "--name");
+  const ref = flagValue(rest, "--to") ?? null;
+  if (!outDir) {
+    io.err("template materialize requires --out <dir>.");
+    return 1;
+  }
+  if (!template) {
+    io.err("template materialize requires --template <name>.");
+    return 1;
+  }
+  // Materialize into a sibling temp dir and swap in only on success, so a bad
+  // template/ref or a transient fetch/post-process failure never destroys an
+  // existing --out tree. Sibling (same filesystem) keeps the rename atomic.
+  const tmp = `${outDir}.materialize-tmp`;
+  fs.rmSync(tmp, { recursive: true, force: true });
+  try {
+    const result = await materializeTemplate({
+      appName: name ?? template,
+      template,
+      ref,
+      shape: "standalone",
+      destDir: tmp,
+    });
+    fs.rmSync(outDir, { recursive: true, force: true });
+    fs.renameSync(tmp, outDir);
+    io.out(
+      `Materialized "${template}" (${result.source}@${result.ref}) to ${outDir}.`,
+    );
+    return 0;
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
   }
 }
 
@@ -927,7 +987,13 @@ function positionalArgs(args: string[]): string[] {
 
 function flagValue(args: string[], flag: string): string | undefined {
   const index = args.indexOf(flag);
-  if (index >= 0 && args[index + 1]) return args[index + 1];
+  if (index >= 0) {
+    // Treat an option-like next token as a missing value (e.g. `--out --template`)
+    // so callers hit their required-flag guard instead of consuming another flag
+    // as the value. None of these flags take a value that starts with "-".
+    const next = args[index + 1];
+    if (next && !next.startsWith("-")) return next;
+  }
   const inline = args.find((arg) => arg.startsWith(`${flag}=`));
   return inline?.slice(flag.length + 1);
 }
@@ -995,6 +1061,9 @@ function templateUsage(): string {
     "  baseline [app]          Record a baseline for an app scaffolded before",
     "                          provenance existed [--ref <ref>] [--template <name>]",
     "  accept [app]            Advance the baseline after resolving conflicts",
+    "  materialize --template <name> --out <dir>",
+    "                          Write the post-processed template tree to a dir",
+    "                          (no app needed) [--name <appName>] [--to <ref>]",
     "",
     "With no [app], operates on the current app, or on every app in a workspace",
     "when run from the workspace root. --to defaults to the ref matching the",

--- a/packages/core/src/cli/template-sync.ts
+++ b/packages/core/src/cli/template-sync.ts
@@ -577,13 +577,18 @@ async function materializeCommand(
     return 1;
   }
   // Materialize into a UNIQUE staging dir in the destination's parent, then swap
-  // in only on success. This way a bad template/ref or a transient failure never
-  // destroys an existing --out tree, and — because the staging path is unique
-  // (mkdtemp), not a predictable sibling — it can't collide with an unrelated
-  // directory or a concurrent invocation. Same filesystem keeps the rename atomic.
+  // it in with a crash-safe move-old-aside → move-staged-in → restore-on-failure
+  // dance. Directory replacement isn't a single atomic op on POSIX (you can't
+  // rename onto a non-empty dir), so the previous delete-then-rename left a window
+  // where a rename failure — and the finally cleanup — destroyed both the old and
+  // the staged tree. Here the old tree is only ever moved (never deleted before
+  // the new one is in place) and is restored if the swap-in fails; a crash between
+  // the two renames leaves it recoverable under `backup`. All paths are unique
+  // siblings on the same filesystem, so each rename is atomic and can't collide.
   const parent = path.dirname(path.resolve(outDir));
   fs.mkdirSync(parent, { recursive: true });
   const tmp = fs.mkdtempSync(path.join(parent, ".template-materialize-"));
+  const backup = `${tmp}-backup`;
   try {
     const result = await materializeTemplate({
       appName: name ?? template,
@@ -592,14 +597,21 @@ async function materializeCommand(
       shape: "standalone",
       destDir: tmp,
     });
-    fs.rmSync(outDir, { recursive: true, force: true });
-    fs.renameSync(tmp, outDir);
+    const hadOld = fs.existsSync(outDir);
+    if (hadOld) fs.renameSync(outDir, backup);
+    try {
+      fs.renameSync(tmp, outDir);
+    } catch (err) {
+      if (hadOld) fs.renameSync(backup, outDir);
+      throw err;
+    }
     io.out(
       `Materialized "${template}" (${result.source}@${result.ref}) to ${outDir}.`,
     );
     return 0;
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
+    fs.rmSync(backup, { recursive: true, force: true });
   }
 }
 


### PR DESCRIPTION
## What

Adds a `materialize --template <name> --out <dir>` subcommand to `agent-native template`. It writes the post-processed **standalone** template tree — template identity, `_gitignore`→`.gitignore`, `workspace:`/`catalog:` deps resolved to pins, standalone `netlify.toml` — to a directory, with **no existing app required**. It reuses the existing `materializeTemplate` engine (runs before target resolution).

This is **PR 1 of 3** for the **vendor-branch starter mirror**:
- **monorepo (public)** runs `agent-native template materialize --template chat --out ./dist/template` and rsyncs that pristine, template-derived output (no private content, no `.github/`) onto the **starter (private)**'s `template` branch.
- the **starter** merges `origin/template` → `main` with **git natively** in its own private workflow.

## Why here (not `sync-builder-starter-manifest.ts`)

The post-process already existed three ways (`create`, `materializeTemplate`, and the bespoke `createStandaloneChatSnapshot`). Under the vendor-branch design, `sync-builder-starter-manifest.ts`'s machinery (allowlist `merge`, `mergeStarterManifest`, toolchain sync) becomes obsolete — replaced by full-tree rsync + git-native merge — so **PR3 retires that file entirely**. This command therefore lives in the `template` subsystem and reuses `materializeTemplate` rather than adding to the doomed file.

> Reworked from the earlier recorded-base `mirror` command → then a `sync-builder-starter-manifest export` command → now `template materialize`. Net diff touches only `template-sync.ts` + its spec + a changeset.

## Changes
- `template-sync.ts`: `materialize` subcommand + `materializeCommand()` (`--template`, `--out`, `--name`, `--to`); usage text.
- Tests: materialize writes a `"chat"`-identity standalone tree (name, appId, `.gitignore` rename, standalone `netlify.toml`, no `.github/`); requires `--out` and `--template`.
- Changeset (`@agent-native/core` patch).

## Verification
- `template-sync.spec.ts`: 28 passed. Smoke-tested `agent-native template materialize --template chat --out …` → `"chat"` identity, `.gitignore` renamed, `publish = "dist"`, no `.github/`, sourced from the monorepo's `templates/chat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)