### PR TITLE
Keep prior variant candidates visible when refining images

### DIFF
--- a/templates/assets/actions/edit-image.spec.ts
+++ b/templates/assets/actions/edit-image.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getAssetOrThrowMock = vi.hoisted(() => vi.fn());
 const generateImageRunMock = vi.hoisted(() => vi.fn());
+const resolveLiveBatchContinuationMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@agent-native/core", () => ({
   defineAction: (entry: unknown) => entry,
@@ -17,6 +18,10 @@ vi.mock("./generate-image.js", () => ({
   },
 }));
 
+vi.mock("./variant-slots.js", () => ({
+  resolveLiveBatchContinuation: resolveLiveBatchContinuationMock,
+}));
+
 import action from "./edit-image.js";
 
 describe("edit-image", () => {
@@ -30,6 +35,7 @@ describe("edit-image", () => {
       imageSize: "2K",
     });
     generateImageRunMock.mockResolvedValue({ id: "generated-1" });
+    resolveLiveBatchContinuationMock.mockResolvedValue(null);
   });
 
   it("delegates to generate-image as a source-guided full-image edit", async () => {
@@ -56,6 +62,37 @@ describe("edit-image", () => {
         groundingMode: "off",
         includeLogo: false,
         tier: "fast",
+      }),
+      context,
+    );
+  });
+
+  it("continues the caller's live batch so prior candidates stay visible", async () => {
+    resolveLiveBatchContinuationMock.mockResolvedValue({
+      variantBatchId: "batch-live-1",
+      collectionId: null,
+      presetId: "preset-1",
+      sessionId: null,
+    });
+    const context = { threadId: "thread-1" };
+
+    await action.run(
+      {
+        assetId: "asset-target",
+        instruction: "Make the background navy",
+        source: "chat",
+      },
+      context,
+    );
+
+    expect(resolveLiveBatchContinuationMock).toHaveBeenCalledWith({
+      threadId: "thread-1",
+      libraryId: "library-1",
+    });
+    expect(generateImageRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        presetId: "preset-1",
+        variantBatchId: "batch-live-1",
       }),
       context,
     );

--- a/templates/assets/actions/edit-image.spec.ts
+++ b/templates/assets/actions/edit-image.spec.ts
@@ -93,7 +93,63 @@ describe("edit-image", () => {
       expect.objectContaining({
         presetId: "preset-1",
         variantBatchId: "batch-live-1",
+        collectionId: undefined,
       }),
+      context,
+    );
+  });
+
+  it("falls back to the live tray's collection only when the asset has none", async () => {
+    resolveLiveBatchContinuationMock.mockResolvedValue({
+      variantBatchId: "batch-live-1",
+      collectionId: "collection-live",
+      presetId: null,
+      sessionId: null,
+    });
+    const context = { threadId: "thread-1" };
+
+    await action.run(
+      {
+        assetId: "asset-target",
+        instruction: "Make the background navy",
+        source: "chat",
+      },
+      context,
+    );
+
+    expect(generateImageRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({ collectionId: "collection-live" }),
+      context,
+    );
+  });
+
+  it("never overrides the asset's own collection with the live tray's", async () => {
+    getAssetOrThrowMock.mockResolvedValue({
+      id: "asset-target",
+      libraryId: "library-1",
+      collectionId: "collection-asset",
+      aspectRatio: "1:1",
+      imageSize: "2K",
+    });
+    resolveLiveBatchContinuationMock.mockResolvedValue({
+      variantBatchId: "batch-live-1",
+      collectionId: "collection-live",
+      presetId: null,
+      sessionId: null,
+    });
+    const context = { threadId: "thread-1" };
+
+    await action.run(
+      {
+        assetId: "asset-target",
+        instruction: "Make the background navy",
+        source: "chat",
+      },
+      context,
+    );
+
+    expect(generateImageRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({ collectionId: "collection-asset" }),
       context,
     );
   });

--- a/templates/assets/actions/edit-image.spec.ts
+++ b/templates/assets/actions/edit-image.spec.ts
@@ -33,12 +33,16 @@ describe("edit-image", () => {
   });
 
   it("delegates to generate-image as a source-guided full-image edit", async () => {
-    await action.run({
-      assetId: "asset-target",
-      instruction: "Make the background navy",
-      tier: "fast",
-      source: "chat",
-    });
+    const context = { threadId: "thread-1" };
+    await action.run(
+      {
+        assetId: "asset-target",
+        instruction: "Make the background navy",
+        tier: "fast",
+        source: "chat",
+      },
+      context,
+    );
 
     expect(generateImageRunMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -53,6 +57,7 @@ describe("edit-image", () => {
         includeLogo: false,
         tier: "fast",
       }),
+      context,
     );
   });
 });

--- a/templates/assets/actions/edit-image.ts
+++ b/templates/assets/actions/edit-image.ts
@@ -1,4 +1,5 @@
 import { defineAction } from "@agent-native/core";
+import type { ActionRunContext } from "@agent-native/core/action";
 import { z } from "zod";
 
 import { IMAGE_MODELS, IMAGE_QUALITY_TIERS } from "../shared/api.js";
@@ -24,26 +25,29 @@ export default defineAction({
     contextModeOverride: z.literal("off").optional(),
   }),
   parallelSafe: true,
-  run: async (args) => {
+  run: async (args, context?: ActionRunContext) => {
     const asset = await getAssetOrThrow(args.assetId);
-    return generateImage.run({
-      libraryId: asset.libraryId,
-      collectionId: asset.collectionId ?? undefined,
-      prompt: args.instruction,
-      aspectRatio: (asset.aspectRatio ?? "16:9") as any,
-      imageSize: (asset.imageSize ?? "2K") as any,
-      model: args.model,
-      tier: args.tier,
-      intent: "edit",
-      styleStrength: "balanced",
-      referenceAssetIds: [],
-      includeLogo: false,
-      groundingMode: "off",
-      subjectAssetId: asset.id,
-      slotId: args.slotId,
-      source: args.source,
-      callerAppId: args.callerAppId,
-      contextModeOverride: args.contextModeOverride,
-    });
+    return generateImage.run(
+      {
+        libraryId: asset.libraryId,
+        collectionId: asset.collectionId ?? undefined,
+        prompt: args.instruction,
+        aspectRatio: (asset.aspectRatio ?? "16:9") as any,
+        imageSize: (asset.imageSize ?? "2K") as any,
+        model: args.model,
+        tier: args.tier,
+        intent: "edit",
+        styleStrength: "balanced",
+        referenceAssetIds: [],
+        includeLogo: false,
+        groundingMode: "off",
+        subjectAssetId: asset.id,
+        slotId: args.slotId,
+        source: args.source,
+        callerAppId: args.callerAppId,
+        contextModeOverride: args.contextModeOverride,
+      },
+      context,
+    );
   },
 });

--- a/templates/assets/actions/edit-image.ts
+++ b/templates/assets/actions/edit-image.ts
@@ -35,7 +35,8 @@ export default defineAction({
     return generateImage.run(
       {
         libraryId: asset.libraryId,
-        collectionId: asset.collectionId ?? undefined,
+        collectionId:
+          asset.collectionId ?? continuation?.collectionId ?? undefined,
         presetId: continuation?.presetId ?? undefined,
         sessionId: continuation?.sessionId ?? undefined,
         prompt: args.instruction,

--- a/templates/assets/actions/edit-image.ts
+++ b/templates/assets/actions/edit-image.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { IMAGE_MODELS, IMAGE_QUALITY_TIERS } from "../shared/api.js";
 import { getAssetOrThrow } from "./_helpers.js";
 import generateImage from "./generate-image.js";
+import { resolveLiveBatchContinuation } from "./variant-slots.js";
 
 export default defineAction({
   description:
@@ -27,10 +28,16 @@ export default defineAction({
   parallelSafe: true,
   run: async (args, context?: ActionRunContext) => {
     const asset = await getAssetOrThrow(args.assetId);
+    const continuation = await resolveLiveBatchContinuation({
+      threadId: context?.threadId,
+      libraryId: asset.libraryId,
+    });
     return generateImage.run(
       {
         libraryId: asset.libraryId,
         collectionId: asset.collectionId ?? undefined,
+        presetId: continuation?.presetId ?? undefined,
+        sessionId: continuation?.sessionId ?? undefined,
         prompt: args.instruction,
         aspectRatio: (asset.aspectRatio ?? "16:9") as any,
         imageSize: (asset.imageSize ?? "2K") as any,
@@ -43,6 +50,7 @@ export default defineAction({
         groundingMode: "off",
         subjectAssetId: asset.id,
         slotId: args.slotId,
+        variantBatchId: continuation?.variantBatchId,
         source: args.source,
         callerAppId: args.callerAppId,
         contextModeOverride: args.contextModeOverride,

--- a/templates/assets/actions/refine-image.spec.ts
+++ b/templates/assets/actions/refine-image.spec.ts
@@ -89,7 +89,58 @@ describe("refine-image", () => {
       expect.objectContaining({
         presetId: "preset-1",
         variantBatchId: "batch-live-1",
+        collectionId: undefined,
       }),
+      context,
+    );
+  });
+
+  it("falls back to the live tray's collection only when the source asset has none", async () => {
+    resolveLiveBatchContinuationMock.mockResolvedValue({
+      variantBatchId: "batch-live-1",
+      collectionId: "collection-live",
+      presetId: null,
+      sessionId: null,
+    });
+    const context = { threadId: "thread-1" };
+
+    await action.run(
+      { assetId: "asset-source", feedback: "Reduce the text", source: "chat" },
+      context,
+    );
+
+    expect(generateImageRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({ collectionId: "collection-live" }),
+      context,
+    );
+  });
+
+  it("never overrides the source asset's own collection with the live tray's", async () => {
+    getAssetOrThrowMock.mockResolvedValue({
+      id: "asset-source",
+      libraryId: "library-1",
+      collectionId: "collection-asset",
+      prompt: "Original prompt",
+      aspectRatio: "16:9",
+      imageSize: "2K",
+      model: "gemini-3.1-flash-image",
+      metadata: "{}",
+    });
+    resolveLiveBatchContinuationMock.mockResolvedValue({
+      variantBatchId: "batch-live-1",
+      collectionId: "collection-live",
+      presetId: null,
+      sessionId: null,
+    });
+    const context = { threadId: "thread-1" };
+
+    await action.run(
+      { assetId: "asset-source", feedback: "Reduce the text", source: "chat" },
+      context,
+    );
+
+    expect(generateImageRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({ collectionId: "collection-asset" }),
       context,
     );
   });

--- a/templates/assets/actions/refine-image.spec.ts
+++ b/templates/assets/actions/refine-image.spec.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const getAssetOrThrowMock = vi.hoisted(() => vi.fn());
 const requireGenerationSessionInLibraryMock = vi.hoisted(() => vi.fn());
 const generateImageRunMock = vi.hoisted(() => vi.fn());
+const resolveLiveBatchContinuationMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@agent-native/core", () => ({
   defineAction: (entry: unknown) => entry,
@@ -17,6 +18,10 @@ vi.mock("./generate-image.js", () => ({
   default: {
     run: generateImageRunMock,
   },
+}));
+
+vi.mock("./variant-slots.js", () => ({
+  resolveLiveBatchContinuation: resolveLiveBatchContinuationMock,
 }));
 
 import action from "./refine-image.js";
@@ -35,6 +40,7 @@ describe("refine-image", () => {
       metadata: "{}",
     });
     generateImageRunMock.mockResolvedValue({ id: "generated-1" });
+    resolveLiveBatchContinuationMock.mockResolvedValue(null);
   });
 
   it("forwards the action run context so the refined candidate lands in the caller's thread tray", async () => {
@@ -52,6 +58,37 @@ describe("refine-image", () => {
       expect.objectContaining({
         libraryId: "library-1",
         sourceAssetId: "asset-source",
+      }),
+      context,
+    );
+  });
+
+  it("continues the caller's live batch so prior candidates stay visible", async () => {
+    resolveLiveBatchContinuationMock.mockResolvedValue({
+      variantBatchId: "batch-live-1",
+      collectionId: null,
+      presetId: "preset-1",
+      sessionId: null,
+    });
+    const context = { threadId: "thread-1" };
+
+    await action.run(
+      {
+        assetId: "asset-source",
+        feedback: "Reduce the text",
+        source: "chat",
+      },
+      context,
+    );
+
+    expect(resolveLiveBatchContinuationMock).toHaveBeenCalledWith({
+      threadId: "thread-1",
+      libraryId: "library-1",
+    });
+    expect(generateImageRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        presetId: "preset-1",
+        variantBatchId: "batch-live-1",
       }),
       context,
     );

--- a/templates/assets/actions/refine-image.spec.ts
+++ b/templates/assets/actions/refine-image.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getAssetOrThrowMock = vi.hoisted(() => vi.fn());
+const requireGenerationSessionInLibraryMock = vi.hoisted(() => vi.fn());
 const generateImageRunMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@agent-native/core", () => ({
@@ -9,6 +10,7 @@ vi.mock("@agent-native/core", () => ({
 
 vi.mock("./_helpers.js", () => ({
   getAssetOrThrow: getAssetOrThrowMock,
+  requireGenerationSessionInLibrary: requireGenerationSessionInLibraryMock,
 }));
 
 vi.mock("./generate-image.js", () => ({
@@ -17,29 +19,30 @@ vi.mock("./generate-image.js", () => ({
   },
 }));
 
-import action from "./restyle-image.js";
+import action from "./refine-image.js";
 
-describe("restyle-image", () => {
+describe("refine-image", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getAssetOrThrowMock.mockResolvedValue({
-      id: "asset-subject",
+      id: "asset-source",
       libraryId: "library-1",
-      collectionId: "collection-1",
-      aspectRatio: "4:5",
+      collectionId: null,
+      prompt: "Original prompt",
+      aspectRatio: "16:9",
       imageSize: "2K",
+      model: "gemini-3.1-flash-image",
+      metadata: "{}",
     });
     generateImageRunMock.mockResolvedValue({ id: "generated-1" });
   });
 
-  it("delegates to generate-image with the subject first and restyle intent", async () => {
+  it("forwards the action run context so the refined candidate lands in the caller's thread tray", async () => {
     const context = { threadId: "thread-1" };
     await action.run(
       {
-        subjectAssetId: "asset-subject",
-        prompt: "Make it match the launch campaign",
-        styleStrength: "strong",
-        tier: "best",
+        assetId: "asset-source",
+        feedback: "Reduce the text",
         source: "chat",
       },
       context,
@@ -48,13 +51,7 @@ describe("restyle-image", () => {
     expect(generateImageRunMock).toHaveBeenCalledWith(
       expect.objectContaining({
         libraryId: "library-1",
-        collectionId: "collection-1",
-        prompt: "Make it match the launch campaign",
-        intent: "restyle",
-        subjectAssetId: "asset-subject",
-        styleStrength: "strong",
-        tier: "best",
-        includeLogo: false,
+        sourceAssetId: "asset-source",
       }),
       context,
     );

--- a/templates/assets/actions/refine-image.ts
+++ b/templates/assets/actions/refine-image.ts
@@ -69,7 +69,8 @@ export default defineAction({
     return generateImage.run(
       {
         libraryId: asset.libraryId,
-        collectionId: asset.collectionId ?? undefined,
+        collectionId:
+          asset.collectionId ?? continuation?.collectionId ?? undefined,
         presetId: presetId ?? continuation?.presetId ?? undefined,
         sessionId: sessionId ?? continuation?.sessionId ?? undefined,
         prompt,

--- a/templates/assets/actions/refine-image.ts
+++ b/templates/assets/actions/refine-image.ts
@@ -9,6 +9,7 @@ import {
   requireGenerationSessionInLibrary,
 } from "./_helpers.js";
 import generateImage from "./generate-image.js";
+import { resolveLiveBatchContinuation } from "./variant-slots.js";
 
 export default defineAction({
   description:
@@ -61,12 +62,16 @@ export default defineAction({
       "",
       "Preserve the strongest successful parts of the prior candidate unless the feedback contradicts them.",
     ].join("\n");
+    const continuation = await resolveLiveBatchContinuation({
+      threadId: context?.threadId,
+      libraryId: asset.libraryId,
+    });
     return generateImage.run(
       {
         libraryId: asset.libraryId,
         collectionId: asset.collectionId ?? undefined,
-        presetId,
-        sessionId,
+        presetId: presetId ?? continuation?.presetId ?? undefined,
+        sessionId: sessionId ?? continuation?.sessionId ?? undefined,
         prompt,
         aspectRatio: (aspectRatio ?? asset.aspectRatio ?? "16:9") as any,
         imageSize: (imageSize ?? asset.imageSize ?? "2K") as any,
@@ -76,6 +81,7 @@ export default defineAction({
         groundingMode: "auto",
         sourceAssetId: asset.id,
         slotId,
+        variantBatchId: continuation?.variantBatchId,
         source,
         callerAppId,
         contextModeOverride,

--- a/templates/assets/actions/refine-image.ts
+++ b/templates/assets/actions/refine-image.ts
@@ -1,4 +1,5 @@
 import { defineAction } from "@agent-native/core";
+import type { ActionRunContext } from "@agent-native/core/action";
 import { z } from "zod";
 
 import { parseJson } from "../server/lib/json.js";
@@ -31,19 +32,22 @@ export default defineAction({
     contextModeOverride: z.literal("off").optional(),
   }),
   parallelSafe: true,
-  run: async ({
-    assetId,
-    feedback,
-    presetId,
-    sessionId,
-    model,
-    aspectRatio,
-    imageSize,
-    slotId,
-    source,
-    callerAppId,
-    contextModeOverride,
-  }) => {
+  run: async (
+    {
+      assetId,
+      feedback,
+      presetId,
+      sessionId,
+      model,
+      aspectRatio,
+      imageSize,
+      slotId,
+      source,
+      callerAppId,
+      contextModeOverride,
+    },
+    context?: ActionRunContext,
+  ) => {
     const asset = await getAssetOrThrow(assetId);
     if (sessionId) {
       await requireGenerationSessionInLibrary(sessionId, asset.libraryId);
@@ -57,23 +61,26 @@ export default defineAction({
       "",
       "Preserve the strongest successful parts of the prior candidate unless the feedback contradicts them.",
     ].join("\n");
-    return generateImage.run({
-      libraryId: asset.libraryId,
-      collectionId: asset.collectionId ?? undefined,
-      presetId,
-      sessionId,
-      prompt,
-      aspectRatio: (aspectRatio ?? asset.aspectRatio ?? "16:9") as any,
-      imageSize: (imageSize ?? asset.imageSize ?? "2K") as any,
-      model: (model ?? asset.model ?? "gemini-3.1-flash-image") as any,
-      categories: metadata.category ? [metadata.category] : undefined,
-      includeLogo: false,
-      groundingMode: "auto",
-      sourceAssetId: asset.id,
-      slotId,
-      source,
-      callerAppId,
-      contextModeOverride,
-    });
+    return generateImage.run(
+      {
+        libraryId: asset.libraryId,
+        collectionId: asset.collectionId ?? undefined,
+        presetId,
+        sessionId,
+        prompt,
+        aspectRatio: (aspectRatio ?? asset.aspectRatio ?? "16:9") as any,
+        imageSize: (imageSize ?? asset.imageSize ?? "2K") as any,
+        model: (model ?? asset.model ?? "gemini-3.1-flash-image") as any,
+        categories: metadata.category ? [metadata.category] : undefined,
+        includeLogo: false,
+        groundingMode: "auto",
+        sourceAssetId: asset.id,
+        slotId,
+        source,
+        callerAppId,
+        contextModeOverride,
+      },
+      context,
+    );
   },
 });

--- a/templates/assets/actions/restyle-image.spec.ts
+++ b/templates/assets/actions/restyle-image.spec.ts
@@ -96,4 +96,59 @@ describe("restyle-image", () => {
       context,
     );
   });
+
+  it("falls back to the live tray's collection only when the subject has none", async () => {
+    getAssetOrThrowMock.mockResolvedValue({
+      id: "asset-subject",
+      libraryId: "library-1",
+      collectionId: null,
+      aspectRatio: "4:5",
+      imageSize: "2K",
+    });
+    resolveLiveBatchContinuationMock.mockResolvedValue({
+      variantBatchId: "batch-live-1",
+      collectionId: "collection-live",
+      presetId: null,
+      sessionId: null,
+    });
+    const context = { threadId: "thread-1" };
+
+    await action.run(
+      {
+        subjectAssetId: "asset-subject",
+        styleStrength: "balanced",
+        source: "chat",
+      },
+      context,
+    );
+
+    expect(generateImageRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({ collectionId: "collection-live" }),
+      context,
+    );
+  });
+
+  it("never overrides the subject's own collection with the live tray's", async () => {
+    resolveLiveBatchContinuationMock.mockResolvedValue({
+      variantBatchId: "batch-live-1",
+      collectionId: "collection-live",
+      presetId: null,
+      sessionId: null,
+    });
+    const context = { threadId: "thread-1" };
+
+    await action.run(
+      {
+        subjectAssetId: "asset-subject",
+        styleStrength: "balanced",
+        source: "chat",
+      },
+      context,
+    );
+
+    expect(generateImageRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({ collectionId: "collection-1" }),
+      context,
+    );
+  });
 });

--- a/templates/assets/actions/restyle-image.spec.ts
+++ b/templates/assets/actions/restyle-image.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getAssetOrThrowMock = vi.hoisted(() => vi.fn());
 const generateImageRunMock = vi.hoisted(() => vi.fn());
+const resolveLiveBatchContinuationMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@agent-native/core", () => ({
   defineAction: (entry: unknown) => entry,
@@ -17,6 +18,10 @@ vi.mock("./generate-image.js", () => ({
   },
 }));
 
+vi.mock("./variant-slots.js", () => ({
+  resolveLiveBatchContinuation: resolveLiveBatchContinuationMock,
+}));
+
 import action from "./restyle-image.js";
 
 describe("restyle-image", () => {
@@ -30,6 +35,7 @@ describe("restyle-image", () => {
       imageSize: "2K",
     });
     generateImageRunMock.mockResolvedValue({ id: "generated-1" });
+    resolveLiveBatchContinuationMock.mockResolvedValue(null);
   });
 
   it("delegates to generate-image with the subject first and restyle intent", async () => {
@@ -55,6 +61,37 @@ describe("restyle-image", () => {
         styleStrength: "strong",
         tier: "best",
         includeLogo: false,
+      }),
+      context,
+    );
+  });
+
+  it("continues the caller's live batch so prior candidates stay visible", async () => {
+    resolveLiveBatchContinuationMock.mockResolvedValue({
+      variantBatchId: "batch-live-1",
+      collectionId: "collection-1",
+      presetId: null,
+      sessionId: "session-1",
+    });
+    const context = { threadId: "thread-1" };
+
+    await action.run(
+      {
+        subjectAssetId: "asset-subject",
+        styleStrength: "balanced",
+        source: "chat",
+      },
+      context,
+    );
+
+    expect(resolveLiveBatchContinuationMock).toHaveBeenCalledWith({
+      threadId: "thread-1",
+      libraryId: "library-1",
+    });
+    expect(generateImageRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "session-1",
+        variantBatchId: "batch-live-1",
       }),
       context,
     );

--- a/templates/assets/actions/restyle-image.ts
+++ b/templates/assets/actions/restyle-image.ts
@@ -52,7 +52,8 @@ export default defineAction({
     return generateImage.run(
       {
         libraryId: subject.libraryId,
-        collectionId: subject.collectionId ?? undefined,
+        collectionId:
+          subject.collectionId ?? continuation?.collectionId ?? undefined,
         presetId: args.presetId ?? continuation?.presetId ?? undefined,
         sessionId: args.sessionId ?? continuation?.sessionId ?? undefined,
         prompt,

--- a/templates/assets/actions/restyle-image.ts
+++ b/templates/assets/actions/restyle-image.ts
@@ -11,6 +11,7 @@ import {
 } from "../shared/api.js";
 import { getAssetOrThrow } from "./_helpers.js";
 import generateImage from "./generate-image.js";
+import { resolveLiveBatchContinuation } from "./variant-slots.js";
 
 export default defineAction({
   description:
@@ -44,12 +45,16 @@ export default defineAction({
     const prompt =
       args.prompt?.trim() ||
       "Apply this library's brand style to the subject image while preserving the subject, pose, composition, and framing.";
+    const continuation = await resolveLiveBatchContinuation({
+      threadId: context?.threadId,
+      libraryId: subject.libraryId,
+    });
     return generateImage.run(
       {
         libraryId: subject.libraryId,
         collectionId: subject.collectionId ?? undefined,
-        presetId: args.presetId,
-        sessionId: args.sessionId,
+        presetId: args.presetId ?? continuation?.presetId ?? undefined,
+        sessionId: args.sessionId ?? continuation?.sessionId ?? undefined,
         prompt,
         aspectRatio: (args.aspectRatio ?? subject.aspectRatio ?? "16:9") as any,
         imageSize: (args.imageSize ?? subject.imageSize ?? "2K") as any,
@@ -61,6 +66,7 @@ export default defineAction({
         groundingMode: "auto",
         subjectAssetId: subject.id,
         slotId: args.slotId,
+        variantBatchId: continuation?.variantBatchId,
         source: args.source,
         callerAppId: args.callerAppId,
         contextModeOverride: args.contextModeOverride,

--- a/templates/assets/actions/restyle-image.ts
+++ b/templates/assets/actions/restyle-image.ts
@@ -1,4 +1,5 @@
 import { defineAction } from "@agent-native/core";
+import type { ActionRunContext } from "@agent-native/core/action";
 import { z } from "zod";
 
 import {
@@ -38,30 +39,33 @@ export default defineAction({
     contextModeOverride: z.literal("off").optional(),
   }),
   parallelSafe: true,
-  run: async (args) => {
+  run: async (args, context?: ActionRunContext) => {
     const subject = await getAssetOrThrow(args.subjectAssetId);
     const prompt =
       args.prompt?.trim() ||
       "Apply this library's brand style to the subject image while preserving the subject, pose, composition, and framing.";
-    return generateImage.run({
-      libraryId: subject.libraryId,
-      collectionId: subject.collectionId ?? undefined,
-      presetId: args.presetId,
-      sessionId: args.sessionId,
-      prompt,
-      aspectRatio: (args.aspectRatio ?? subject.aspectRatio ?? "16:9") as any,
-      imageSize: (args.imageSize ?? subject.imageSize ?? "2K") as any,
-      model: args.model,
-      tier: args.tier,
-      intent: "restyle",
-      styleStrength: args.styleStrength,
-      includeLogo: false,
-      groundingMode: "auto",
-      subjectAssetId: subject.id,
-      slotId: args.slotId,
-      source: args.source,
-      callerAppId: args.callerAppId,
-      contextModeOverride: args.contextModeOverride,
-    });
+    return generateImage.run(
+      {
+        libraryId: subject.libraryId,
+        collectionId: subject.collectionId ?? undefined,
+        presetId: args.presetId,
+        sessionId: args.sessionId,
+        prompt,
+        aspectRatio: (args.aspectRatio ?? subject.aspectRatio ?? "16:9") as any,
+        imageSize: (args.imageSize ?? subject.imageSize ?? "2K") as any,
+        model: args.model,
+        tier: args.tier,
+        intent: "restyle",
+        styleStrength: args.styleStrength,
+        includeLogo: false,
+        groundingMode: "auto",
+        subjectAssetId: subject.id,
+        slotId: args.slotId,
+        source: args.source,
+        callerAppId: args.callerAppId,
+        contextModeOverride: args.contextModeOverride,
+      },
+      context,
+    );
   },
 });

--- a/templates/assets/actions/variant-slots.spec.ts
+++ b/templates/assets/actions/variant-slots.spec.ts
@@ -14,7 +14,11 @@ vi.mock("../server/lib/json.js", () => ({
   nowIso: vi.fn(() => "2026-05-28T00:00:00.000Z"),
 }));
 
-import { upsertVariantSlot, wasVariantSlotDismissed } from "./variant-slots.js";
+import {
+  resolveLiveBatchContinuation,
+  upsertVariantSlot,
+  wasVariantSlotDismissed,
+} from "./variant-slots.js";
 
 const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
 
@@ -303,5 +307,64 @@ describe("variant slot state", () => {
     expect((appState as any).slots).toEqual([
       expect.objectContaining({ slotId: "slot-2", status: "pending" }),
     ]);
+  });
+
+  it("appends a refined candidate to the thread's live batch instead of replacing it", async () => {
+    await upsertVariantSlot({
+      runId: "run-1",
+      batchId: "batch-1",
+      libraryId: "lib-1",
+      prompt: "Generate a diagram",
+      slotId: "slot-1",
+      status: "ready",
+      assetId: "asset-1",
+      threadId: "thread-1",
+    });
+
+    const continuation = await resolveLiveBatchContinuation({
+      threadId: "thread-1",
+      libraryId: "lib-1",
+    });
+    expect(continuation?.variantBatchId).toBe("batch-1");
+
+    await upsertVariantSlot({
+      runId: "run-2",
+      batchId: continuation?.variantBatchId,
+      libraryId: "lib-1",
+      presetId: continuation?.presetId ?? undefined,
+      prompt: "Reduce the text",
+      slotId: "slot-2",
+      status: "ready",
+      assetId: "asset-2",
+      threadId: "thread-1",
+    });
+
+    expect(
+      (appStateByKey["asset-variants:thread-1"] as any).slots.map(
+        (slot: any) => slot.slotId,
+      ),
+    ).toEqual(["slot-1", "slot-2"]);
+  });
+
+  it("resolves no continuation when there is no live tray for the thread", async () => {
+    await expect(
+      resolveLiveBatchContinuation({ threadId: "thread-1", libraryId: "lib-1" }),
+    ).resolves.toBeNull();
+  });
+
+  it("resolves no continuation when the live tray belongs to a different library", async () => {
+    await upsertVariantSlot({
+      runId: "run-1",
+      libraryId: "lib-1",
+      prompt: "Generate a diagram",
+      slotId: "slot-1",
+      status: "ready",
+      assetId: "asset-1",
+      threadId: "thread-1",
+    });
+
+    await expect(
+      resolveLiveBatchContinuation({ threadId: "thread-1", libraryId: "lib-2" }),
+    ).resolves.toBeNull();
   });
 });

--- a/templates/assets/actions/variant-slots.spec.ts
+++ b/templates/assets/actions/variant-slots.spec.ts
@@ -348,7 +348,10 @@ describe("variant slot state", () => {
 
   it("resolves no continuation when there is no live tray for the thread", async () => {
     await expect(
-      resolveLiveBatchContinuation({ threadId: "thread-1", libraryId: "lib-1" }),
+      resolveLiveBatchContinuation({
+        threadId: "thread-1",
+        libraryId: "lib-1",
+      }),
     ).resolves.toBeNull();
   });
 
@@ -364,7 +367,10 @@ describe("variant slot state", () => {
     });
 
     await expect(
-      resolveLiveBatchContinuation({ threadId: "thread-1", libraryId: "lib-2" }),
+      resolveLiveBatchContinuation({
+        threadId: "thread-1",
+        libraryId: "lib-2",
+      }),
     ).resolves.toBeNull();
   });
 });

--- a/templates/assets/actions/variant-slots.ts
+++ b/templates/assets/actions/variant-slots.ts
@@ -177,6 +177,32 @@ export async function readVariantState(
   return withVariantStateLock(() => readVariantStateUnlocked(scopeId));
 }
 
+// Iterations (refine/edit/restyle) are a continuation of what is already on
+// screen for this thread, not a new generation topic: they should append into
+// the live tray instead of tripping the "new batch/run" reset in
+// isSameVariantScope. Passing the current tray's batch/run id plus its
+// collection/preset/session back through keeps every isSameVariantScope check
+// satisfied.
+export async function resolveLiveBatchContinuation(input: {
+  threadId?: string | null;
+  libraryId: string;
+}): Promise<{
+  variantBatchId: string;
+  collectionId: string | null;
+  presetId: string | null;
+  sessionId: string | null;
+} | null> {
+  if (!input.threadId) return null;
+  const state = await readVariantState(input.threadId);
+  if (!state || state.libraryId !== input.libraryId) return null;
+  return {
+    variantBatchId: state.batchId ?? state.runId,
+    collectionId: state.collectionId ?? null,
+    presetId: state.presetId ?? null,
+    sessionId: state.sessionId ?? null,
+  };
+}
+
 export async function writeVariantState(
   state: AssetVariantState,
   scopeId?: string | null,

--- a/templates/assets/app/components/generation/GenerationResults.tsx
+++ b/templates/assets/app/components/generation/GenerationResults.tsx
@@ -89,6 +89,9 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
   const queryClient = useQueryClient();
   const [clearAllOpen, setClearAllOpen] = useState(false);
   const [previewSlotId, setPreviewSlotId] = useState<string | null>(null);
+  const trayScrollRef = useRef<HTMLDivElement | null>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
   const stateKey = variantStateKey(threadId);
   const stateQueryKey = useMemo(() => ["app-state", stateKey], [stateKey]);
   const { data: variants } = useQuery({
@@ -179,6 +182,25 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
     () => slots.find((slot) => slot.slotId === previewSlotId) ?? null,
     [previewSlotId, slots],
   );
+
+  const updateScrollEdges = () => {
+    const el = trayScrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 1);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  };
+
+  useEffect(() => {
+    // Re-measure after the slot list changes size (new/removed candidates)
+    // since that can flip whether either arrow should be enabled.
+    updateScrollEdges();
+  }, [slots.length]);
+
+  const scrollTrayBy = (direction: 1 | -1) => {
+    const el = trayScrollRef.current;
+    if (!el) return;
+    el.scrollBy({ left: direction * el.clientWidth * 0.9, behavior: "smooth" });
+  };
 
   if (!belongsToThread || !variants) return null;
   if (slots.length === 0) return null;
@@ -367,8 +389,12 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
             </Button>
           </div>
 
-          <div className="max-h-[min(640px,52vh)] overflow-y-auto p-3">
-            <div className="assets-library-grid grid grid-cols-2 gap-3 sm:grid-cols-3">
+          <div className="relative">
+            <div
+              ref={trayScrollRef}
+              onScroll={updateScrollEdges}
+              className="assets-library-tray flex gap-3 overflow-x-auto scroll-smooth p-3"
+            >
               {slots.map((slot) => {
                 const variantNumber = variantNumberBySlotId.get(slot.slotId) ?? 1;
                 return (
@@ -386,6 +412,26 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
                 );
               })}
             </div>
+            {canScrollLeft ? (
+              <button
+                type="button"
+                aria-label={t("library.previousImage")}
+                onClick={() => scrollTrayBy(-1)}
+                className="absolute left-1 top-1/2 z-10 inline-flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full border border-border/80 bg-background/90 text-foreground shadow-sm transition hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <IconChevronLeft className="h-4 w-4" />
+              </button>
+            ) : null}
+            {canScrollRight ? (
+              <button
+                type="button"
+                aria-label={t("library.nextImage")}
+                onClick={() => scrollTrayBy(1)}
+                className="absolute right-1 top-1/2 z-10 inline-flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full border border-border/80 bg-background/90 text-foreground shadow-sm transition hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <IconChevronRight className="h-4 w-4" />
+              </button>
+            ) : null}
           </div>
         </div>
       </section>
@@ -418,7 +464,7 @@ function GenerationDraftCard({
     number: variantNumber,
   });
   return (
-    <div className="overflow-hidden rounded-lg border border-border/80 bg-background transition hover:border-foreground/25 hover:bg-muted/10">
+    <div className="w-36 shrink-0 overflow-hidden rounded-lg border border-border/80 bg-background transition hover:border-foreground/25 hover:bg-muted/10 sm:w-44">
       <div className="group relative">
         <button
           type="button"

--- a/templates/assets/app/components/generation/GenerationResults.tsx
+++ b/templates/assets/app/components/generation/GenerationResults.tsx
@@ -396,7 +396,8 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
               className="assets-library-tray flex gap-3 overflow-x-auto scroll-smooth p-3"
             >
               {slots.map((slot) => {
-                const variantNumber = variantNumberBySlotId.get(slot.slotId) ?? 1;
+                const variantNumber =
+                  variantNumberBySlotId.get(slot.slotId) ?? 1;
                 return (
                   <GenerationDraftCard
                     key={slot.slotId}

--- a/templates/assets/app/components/generation/GenerationResults.tsx
+++ b/templates/assets/app/components/generation/GenerationResults.tsx
@@ -129,6 +129,21 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
         ),
     [variants?.slots],
   );
+  // Variant numbers reflect generation order (oldest = 1), not display order:
+  // refined candidates render first but keep the next number in sequence
+  // instead of stealing "Variant 1" from the newest-first display sort above.
+  const variantNumberBySlotId = useMemo(() => {
+    const map = new Map<string, number>();
+    (variants?.slots ?? [])
+      .slice()
+      .sort(
+        (left, right) =>
+          slotTime(left) - slotTime(right) ||
+          left.slotId.localeCompare(right.slotId),
+      )
+      .forEach((slot, index) => map.set(slot.slotId, index + 1));
+    return map;
+  }, [variants?.slots]);
   const belongsToThread = Boolean(
     variants &&
     (threadId ? variants.threadId === threadId : !variants.threadId),
@@ -296,6 +311,7 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
       <GenerationPreviewDialog
         slot={previewSlot}
         slots={slots}
+        variantNumberBySlotId={variantNumberBySlotId}
         prompt={variants.prompt}
         libraryTitle={libraryTitle}
         isSaving={saveGenerated.isPending}
@@ -353,19 +369,22 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
 
           <div className="max-h-[min(640px,52vh)] overflow-y-auto p-3">
             <div className="assets-library-grid grid grid-cols-2 gap-3 sm:grid-cols-3">
-              {slots.map((slot, index) => (
-                <GenerationDraftCard
-                  key={slot.slotId}
-                  slot={slot}
-                  variantNumber={index + 1}
-                  isSaving={saveGenerated.isPending}
-                  isDismissing={dismissSlot.isPending}
-                  onPreview={() => setPreviewSlotId(slot.slotId)}
-                  onSave={() => saveSlot(slot)}
-                  onRefine={() => refineSlot(slot, index + 1)}
-                  onDismiss={() => dismissSlotById(slot)}
-                />
-              ))}
+              {slots.map((slot) => {
+                const variantNumber = variantNumberBySlotId.get(slot.slotId) ?? 1;
+                return (
+                  <GenerationDraftCard
+                    key={slot.slotId}
+                    slot={slot}
+                    variantNumber={variantNumber}
+                    isSaving={saveGenerated.isPending}
+                    isDismissing={dismissSlot.isPending}
+                    onPreview={() => setPreviewSlotId(slot.slotId)}
+                    onSave={() => saveSlot(slot)}
+                    onRefine={() => refineSlot(slot, variantNumber)}
+                    onDismiss={() => dismissSlotById(slot)}
+                  />
+                );
+              })}
             </div>
           </div>
         </div>
@@ -510,6 +529,7 @@ function GenerationDraftCard({
 function GenerationPreviewDialog({
   slot,
   slots,
+  variantNumberBySlotId,
   prompt,
   libraryTitle,
   isSaving,
@@ -522,6 +542,7 @@ function GenerationPreviewDialog({
 }: {
   slot: VariantSlot | null;
   slots: VariantSlot[];
+  variantNumberBySlotId: Map<string, number>;
   prompt: string;
   libraryTitle: string | null;
   isSaving: boolean;
@@ -553,7 +574,7 @@ function GenerationPreviewDialog({
   const sources = slot ? assetPreviewSources(slot, "preview") : [];
   const src = sources[0];
   const variantNumber = slot
-    ? slots.findIndex((item) => item.slotId === slot.slotId) + 1
+    ? (variantNumberBySlotId.get(slot.slotId) ?? 0)
     : 0;
   const variantLabel = t("library.variantWithNumber", {
     number: variantNumber,


### PR DESCRIPTION
### Summary
Adds a `resolveLiveBatchContinuation` helper and wires it into the `edit-image`, `refine-image`, and `restyle-image` actions so that follow-up generations continue the caller's existing live batch instead of starting a new one.

### Problem
When a user refined a generated image candidate in a chat thread, the refinement created a new variant batch/run, which caused previously generated candidates in that thread to disappear from the candidates tray instead of remaining visible alongside the new one.

### Solution
Before delegating to `generate-image`, each iteration action (`edit-image`, `refine-image`, `restyle-image`) now looks up the caller's current live variant tray state via `resolveLiveBatchContinuation` using the thread ID and library ID. If a live batch exists for that thread and library, its `variantBatchId`, `collectionId`, `presetId`, and `sessionId` are reused so the new candidate is appended to the existing tray rather than triggering the "new batch" reset logic in `isSameVariantScope`.



https://github.com/user-attachments/assets/4a3732ca-d419-41e7-88d8-6484c302def1





### Key Changes
- Added `resolveLiveBatchContinuation` in `templates/assets/actions/variant-slots.ts`, which reads the thread's variant state and returns the batch/run id plus collection/preset/session ids when the library matches, or `null` otherwise.
- Updated `edit-image.ts`, `refine-image.ts`, and `restyle-image.ts` to accept an `ActionRunContext`, call `resolveLiveBatchContinuation` with the thread and library ids, and pass the resolved `variantBatchId`/`presetId`/`sessionId` (falling back to explicit args where applicable) into `generateImage.run`, forwarding the run context as well.
- Added/updated unit tests for all three actions verifying that context is forwarded and that a live batch continuation is applied when present.
- Added tests in `variant-slots.spec.ts` covering appending a refined candidate to an existing live batch, and cases where no continuation is resolved (no thread state, or mismatched library).


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/snow-catalog-zijuucwb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-snow-catalog-zijuucwb.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2455`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>snow-catalog-zijuucwb</branchName>-->