### PR TITLE
Restore exact-PR builds in trusted acceptance

### DIFF
--- a/.github/workflows/trusted-acceptance.yml
+++ b/.github/workflows/trusted-acceptance.yml
@@ -226,6 +226,8 @@ jobs:
           persist-credentials: false
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          package_json_file: candidate/package.json
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/package.json
+++ b/package.json
@@ -124,7 +124,8 @@
     "prettier": "^3.6.2",
     "tsx": "^4.20.3",
     "typescript-7": "catalog:",
-    "wrangler": "^4.80.0"
+    "wrangler": "^4.80.0",
+    "yaml": "2.9.0"
   },
   "engines": {
     "node": ">=22.22.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,6 +221,9 @@ importers:
       wrangler:
         specifier: ^4.80.0
         version: 4.81.0
+      yaml:
+        specifier: 2.9.0
+        version: 2.9.0
 
   examples/chat-antd:
     dependencies:

--- a/scripts/guard-trusted-acceptance-workflow.spec.ts
+++ b/scripts/guard-trusted-acceptance-workflow.spec.ts
@@ -129,6 +129,39 @@ describe("trusted acceptance workflow boundary", () => {
     assert(result.issues.some((issue) => issue.includes("candidate checkout")));
   });
 
+  it("requires pnpm metadata to follow the nested candidate checkout", () => {
+    const unsafe = workflow.replace(
+      "        with:\n          package_json_file: candidate/package.json\n",
+      "",
+    );
+    const result = validateTrustedAcceptanceWorkflow(unsafe);
+    assert.equal(result.ok, false);
+    assert(
+      result.issues.some((issue) =>
+        issue.includes("package-manager metadata from the nested checkout"),
+      ),
+    );
+  });
+
+  it("requires nested candidate metadata on the pnpm setup step", () => {
+    const unsafe = workflow
+      .replace(
+        "        with:\n          package_json_file: candidate/package.json\n\n      - uses: actions/setup-node@",
+        "\n      - uses: actions/setup-node@",
+      )
+      .replace(
+        "        with:\n          node-version-file: candidate/.nvmrc",
+        "        with:\n          package_json_file: candidate/package.json\n          node-version-file: candidate/.nvmrc",
+      );
+    const result = validateTrustedAcceptanceWorkflow(unsafe);
+    assert.equal(result.ok, false);
+    assert(
+      result.issues.some((issue) =>
+        issue.includes("package-manager metadata from the nested checkout"),
+      ),
+    );
+  });
+
   it("rejects candidate-controlled workflow triggers", () => {
     const unsafe = workflow.replace(
       "on:\n  workflow_dispatch:",

--- a/scripts/guard-trusted-acceptance-workflow.spec.ts
+++ b/scripts/guard-trusted-acceptance-workflow.spec.ts
@@ -162,6 +162,48 @@ describe("trusted acceptance workflow boundary", () => {
     );
   });
 
+  it("rejects duplicate pnpm setup steps", () => {
+    const unsafe = workflow.replace(
+      "          package_json_file: candidate/package.json\n\n      - uses: actions/setup-node@",
+      "          package_json_file: candidate/package.json\n\n      - uses: pnpm/action-setup@duplicate\n\n      - uses: actions/setup-node@",
+    );
+    const result = validateTrustedAcceptanceWorkflow(unsafe);
+    assert.equal(result.ok, false);
+    assert(
+      result.issues.some((issue) =>
+        issue.includes("exactly one pnpm setup step"),
+      ),
+    );
+  });
+
+  it("ignores pnpm setup lookalikes inside run blocks", () => {
+    const unsafe = workflow
+      .replace(
+        "        with:\n          package_json_file: candidate/package.json\n",
+        "",
+      )
+      .replace(
+        "      - name: Install candidate dependencies without runtime credentials",
+        "      - name: Lookalike is not an action step\n        run: |\n          uses: pnpm/action-setup@lookalike\n          with:\n            package_json_file: candidate/package.json\n\n      - name: Install candidate dependencies without runtime credentials",
+      );
+    const result = validateTrustedAcceptanceWorkflow(unsafe);
+    assert.equal(result.ok, false);
+    assert(
+      result.issues.some((issue) =>
+        issue.includes("package-manager metadata from the nested checkout"),
+      ),
+    );
+  });
+
+  it("accepts equivalent quoted candidate metadata", () => {
+    const equivalent = workflow.replace(
+      "        with:\n          package_json_file: candidate/package.json",
+      '        # Candidate metadata remains bound to pnpm setup.\n\n        with:\n          package_json_file: "candidate/package.json" # repository-root-relative',
+    );
+    const result = validateTrustedAcceptanceWorkflow(equivalent);
+    assert.equal(result.ok, true, result.issues.join("\n"));
+  });
+
   it("rejects candidate-controlled workflow triggers", () => {
     const unsafe = workflow.replace(
       "on:\n  workflow_dispatch:",

--- a/scripts/guard-trusted-acceptance-workflow.spec.ts
+++ b/scripts/guard-trusted-acceptance-workflow.spec.ts
@@ -204,6 +204,26 @@ describe("trusted acceptance workflow boundary", () => {
     assert.equal(result.ok, true, result.issues.join("\n"));
   });
 
+  it("accepts equivalent workflow step indentation", () => {
+    const stepsStart = workflow.indexOf(
+      "\n    steps:\n",
+      workflow.indexOf("\n  build:\n"),
+    );
+    const deployStart = workflow.indexOf("\n  deploy:\n", stepsStart);
+    const reindentedSteps = workflow
+      .slice(stepsStart, deployStart)
+      .split("\n")
+      .map((line) => {
+        const indent = line.search(/\S/);
+        if (indent < 6) return line;
+        return `${" ".repeat(indent - 4)}${line}`;
+      })
+      .join("\n");
+    const equivalent = `${workflow.slice(0, stepsStart)}${reindentedSteps}${workflow.slice(deployStart)}`;
+    const result = validateTrustedAcceptanceWorkflow(equivalent);
+    assert.equal(result.ok, true, result.issues.join("\n"));
+  });
+
   it("rejects candidate-controlled workflow triggers", () => {
     const unsafe = workflow.replace(
       "on:\n  workflow_dispatch:",

--- a/scripts/guard-trusted-acceptance-workflow.spec.ts
+++ b/scripts/guard-trusted-acceptance-workflow.spec.ts
@@ -3,6 +3,8 @@ import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { describe, it } from "node:test";
 
+import { parse, stringify } from "yaml";
+
 import {
   validateRuntimeAuthorityConfiguration,
   validateTrustedAcceptanceReaper,
@@ -210,16 +212,24 @@ describe("trusted acceptance workflow boundary", () => {
       workflow.indexOf("\n  build:\n"),
     );
     const deployStart = workflow.indexOf("\n  deploy:\n", stepsStart);
-    const reindentedSteps = workflow
-      .slice(stepsStart, deployStart)
+    const parsed = parse(workflow) as {
+      jobs: { build: { steps: unknown[] } };
+    };
+    const reindentedSteps = stringify(parsed.jobs.build.steps, { indent: 4 })
+      .trimEnd()
       .split("\n")
-      .map((line) => {
-        const indent = line.search(/\S/);
-        if (indent < 6) return line;
-        return `${" ".repeat(indent - 4)}${line}`;
-      })
+      .map((line) => `        ${line}`)
       .join("\n");
-    const equivalent = `${workflow.slice(0, stepsStart)}${reindentedSteps}${workflow.slice(deployStart)}`;
+    const equivalent = `${workflow.slice(0, stepsStart)}\n    steps:\n${reindentedSteps}${workflow.slice(deployStart)}`;
+    const result = validateTrustedAcceptanceWorkflow(equivalent);
+    assert.equal(result.ok, true, result.issues.join("\n"));
+  });
+
+  it("accepts flow-style pnpm setup inputs", () => {
+    const equivalent = workflow.replace(
+      "        with:\n          package_json_file: candidate/package.json",
+      "        with: { package_json_file: candidate/package.json }",
+    );
     const result = validateTrustedAcceptanceWorkflow(equivalent);
     assert.equal(result.ok, true, result.issues.join("\n"));
   });

--- a/scripts/guard-trusted-acceptance-workflow.ts
+++ b/scripts/guard-trusted-acceptance-workflow.ts
@@ -1,5 +1,7 @@
 import { readFileSync } from "node:fs";
 
+import { parse } from "yaml";
+
 export type WorkflowGuardResult = {
   ok: boolean;
   issues: string[];
@@ -67,85 +69,26 @@ type GuardedWorkflowStep = {
   with: Record<string, string>;
 };
 
-function parseYamlScalar(source: string): string {
-  const value = source.trim();
-  const doubleQuoted = value.match(/^("(?:\\.|[^"\\])*")(?:\s+#.*)?$/);
-  if (doubleQuoted) {
-    try {
-      return JSON.parse(doubleQuoted[1]!) as string;
-    } catch {
-      return value;
-    }
-  }
-  const singleQuoted = value.match(/^'((?:''|[^'])*)'(?:\s+#.*)?$/);
-  if (singleQuoted) {
-    return singleQuoted[1]!.replaceAll("''", "'");
-  }
-  return value.replace(/\s+#.*$/, "").trim();
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function parseWorkflowSteps(job: string): GuardedWorkflowStep[] {
-  const lines = job.split("\n");
-  const stepsIndex = lines.findIndex((line) =>
-    /^\s+steps:\s*(?:#.*)?$/.test(line),
-  );
-  if (stepsIndex === -1) return [];
+function parseWorkflowSteps(source: string): GuardedWorkflowStep[] {
+  const workflow: unknown = parse(source);
+  if (!isRecord(workflow) || !isRecord(workflow.jobs)) return [];
+  const build = workflow.jobs.build;
+  if (!isRecord(build) || !Array.isArray(build.steps)) return [];
 
-  const stepsIndent = lines[stepsIndex]!.search(/\S/);
-  const firstItem = lines.slice(stepsIndex + 1).find((line) => {
-    const indent = line.search(/\S/);
-    return indent > stepsIndent && line.trim().startsWith("-");
-  });
-  if (!firstItem) return [];
-  const itemIndent = firstItem.search(/\S/);
-  const steps: GuardedWorkflowStep[] = [];
-  let current: GuardedWorkflowStep | undefined;
-  let propertyIndent: number | undefined;
-  let inputIndent: number | undefined;
-  let readingInputs = false;
-
-  for (const line of lines.slice(stepsIndex + 1)) {
-    if (!line.trim() || line.trimStart().startsWith("#")) continue;
-    const indent = line.search(/\S/);
-    const trimmed = line.trim();
-    if (indent <= stepsIndent) break;
-
-    if (indent === itemIndent && trimmed.startsWith("-")) {
-      current = { with: {} };
-      steps.push(current);
-      propertyIndent = undefined;
-      inputIndent = undefined;
-      readingInputs = false;
-      const inlineUses = trimmed.match(/^-\s+uses:\s*(.+)$/);
-      if (inlineUses) current.uses = parseYamlScalar(inlineUses[1]!);
-      continue;
-    }
-    if (!current) continue;
-
-    if (propertyIndent === undefined && indent > itemIndent) {
-      propertyIndent = indent;
-    }
-    if (indent === propertyIndent) {
-      readingInputs = trimmed === "with:";
-      inputIndent = undefined;
-      const uses = trimmed.match(/^uses:\s*(.+)$/);
-      if (uses) current.uses = parseYamlScalar(uses[1]!);
-      continue;
-    }
-    if (
-      readingInputs &&
-      propertyIndent !== undefined &&
-      indent > propertyIndent
-    ) {
-      inputIndent ??= indent;
-    }
-    if (readingInputs && indent === inputIndent) {
-      const input = trimmed.match(/^([^:#]+):\s*(.+)$/);
-      if (input) current.with[input[1]!.trim()] = parseYamlScalar(input[2]!);
-    }
-  }
-
-  return steps;
+  return build.steps.filter(isRecord).map((step) => ({
+    uses: typeof step.uses === "string" ? step.uses : undefined,
+    with: isRecord(step.with)
+      ? Object.fromEntries(
+          Object.entries(step.with).filter(
+            (entry): entry is [string, string] => typeof entry[1] === "string",
+          ),
+        )
+      : {},
+  }));
 }
 
 export function validateTrustedAcceptanceWorkflow(
@@ -155,6 +98,12 @@ export function validateTrustedAcceptanceWorkflow(
   const workflowEnvironment = section(source, "\nenv:\n", "\njobs:\n");
   const build = section(source, "\n  build:\n", "\n  deploy:\n");
   const deploy = section(source, "\n  deploy:\n", "\n  receipt:\n");
+  let workflowSteps: GuardedWorkflowStep[] = [];
+  try {
+    workflowSteps = parseWorkflowSteps(source);
+  } catch {
+    issues.push("workflow must be valid YAML");
+  }
 
   if (!source.includes("workflow_dispatch:")) {
     issues.push("workflow must be manually dispatched");
@@ -196,7 +145,7 @@ export function validateTrustedAcceptanceWorkflow(
     if (!build.includes("needs.plan.outputs.effective_sha")) {
       issues.push("candidate build must use the provenance-verified exact SHA");
     }
-    const pnpmSetupSteps = parseWorkflowSteps(build).filter((step) =>
+    const pnpmSetupSteps = workflowSteps.filter((step) =>
       step.uses?.startsWith("pnpm/action-setup@"),
     );
     if (pnpmSetupSteps.length !== 1) {

--- a/scripts/guard-trusted-acceptance-workflow.ts
+++ b/scripts/guard-trusted-acceptance-workflow.ts
@@ -92,11 +92,16 @@ function parseWorkflowSteps(job: string): GuardedWorkflowStep[] {
   if (stepsIndex === -1) return [];
 
   const stepsIndent = lines[stepsIndex]!.search(/\S/);
-  const itemIndent = stepsIndent + 2;
-  const propertyIndent = itemIndent + 2;
-  const inputIndent = propertyIndent + 2;
+  const firstItem = lines.slice(stepsIndex + 1).find((line) => {
+    const indent = line.search(/\S/);
+    return indent > stepsIndent && line.trim().startsWith("-");
+  });
+  if (!firstItem) return [];
+  const itemIndent = firstItem.search(/\S/);
   const steps: GuardedWorkflowStep[] = [];
   let current: GuardedWorkflowStep | undefined;
+  let propertyIndent: number | undefined;
+  let inputIndent: number | undefined;
   let readingInputs = false;
 
   for (const line of lines.slice(stepsIndex + 1)) {
@@ -108,6 +113,8 @@ function parseWorkflowSteps(job: string): GuardedWorkflowStep[] {
     if (indent === itemIndent && trimmed.startsWith("-")) {
       current = { with: {} };
       steps.push(current);
+      propertyIndent = undefined;
+      inputIndent = undefined;
       readingInputs = false;
       const inlineUses = trimmed.match(/^-\s+uses:\s*(.+)$/);
       if (inlineUses) current.uses = parseYamlScalar(inlineUses[1]!);
@@ -115,11 +122,22 @@ function parseWorkflowSteps(job: string): GuardedWorkflowStep[] {
     }
     if (!current) continue;
 
+    if (propertyIndent === undefined && indent > itemIndent) {
+      propertyIndent = indent;
+    }
     if (indent === propertyIndent) {
       readingInputs = trimmed === "with:";
+      inputIndent = undefined;
       const uses = trimmed.match(/^uses:\s*(.+)$/);
       if (uses) current.uses = parseYamlScalar(uses[1]!);
       continue;
+    }
+    if (
+      readingInputs &&
+      propertyIndent !== undefined &&
+      indent > propertyIndent
+    ) {
+      inputIndent ??= indent;
     }
     if (readingInputs && indent === inputIndent) {
       const input = trimmed.match(/^([^:#]+):\s*(.+)$/);

--- a/scripts/guard-trusted-acceptance-workflow.ts
+++ b/scripts/guard-trusted-acceptance-workflow.ts
@@ -62,6 +62,74 @@ function count(source: string, pattern: RegExp): number {
   return source.match(pattern)?.length ?? 0;
 }
 
+type GuardedWorkflowStep = {
+  uses?: string;
+  with: Record<string, string>;
+};
+
+function parseYamlScalar(source: string): string {
+  const value = source.trim();
+  const doubleQuoted = value.match(/^("(?:\\.|[^"\\])*")(?:\s+#.*)?$/);
+  if (doubleQuoted) {
+    try {
+      return JSON.parse(doubleQuoted[1]!) as string;
+    } catch {
+      return value;
+    }
+  }
+  const singleQuoted = value.match(/^'((?:''|[^'])*)'(?:\s+#.*)?$/);
+  if (singleQuoted) {
+    return singleQuoted[1]!.replaceAll("''", "'");
+  }
+  return value.replace(/\s+#.*$/, "").trim();
+}
+
+function parseWorkflowSteps(job: string): GuardedWorkflowStep[] {
+  const lines = job.split("\n");
+  const stepsIndex = lines.findIndex((line) =>
+    /^\s+steps:\s*(?:#.*)?$/.test(line),
+  );
+  if (stepsIndex === -1) return [];
+
+  const stepsIndent = lines[stepsIndex]!.search(/\S/);
+  const itemIndent = stepsIndent + 2;
+  const propertyIndent = itemIndent + 2;
+  const inputIndent = propertyIndent + 2;
+  const steps: GuardedWorkflowStep[] = [];
+  let current: GuardedWorkflowStep | undefined;
+  let readingInputs = false;
+
+  for (const line of lines.slice(stepsIndex + 1)) {
+    if (!line.trim() || line.trimStart().startsWith("#")) continue;
+    const indent = line.search(/\S/);
+    const trimmed = line.trim();
+    if (indent <= stepsIndent) break;
+
+    if (indent === itemIndent && trimmed.startsWith("-")) {
+      current = { with: {} };
+      steps.push(current);
+      readingInputs = false;
+      const inlineUses = trimmed.match(/^-\s+uses:\s*(.+)$/);
+      if (inlineUses) current.uses = parseYamlScalar(inlineUses[1]!);
+      continue;
+    }
+    if (!current) continue;
+
+    if (indent === propertyIndent) {
+      readingInputs = trimmed === "with:";
+      const uses = trimmed.match(/^uses:\s*(.+)$/);
+      if (uses) current.uses = parseYamlScalar(uses[1]!);
+      continue;
+    }
+    if (readingInputs && indent === inputIndent) {
+      const input = trimmed.match(/^([^:#]+):\s*(.+)$/);
+      if (input) current.with[input[1]!.trim()] = parseYamlScalar(input[2]!);
+    }
+  }
+
+  return steps;
+}
+
 export function validateTrustedAcceptanceWorkflow(
   source: string,
 ): WorkflowGuardResult {
@@ -110,10 +178,13 @@ export function validateTrustedAcceptanceWorkflow(
     if (!build.includes("needs.plan.outputs.effective_sha")) {
       issues.push("candidate build must use the provenance-verified exact SHA");
     }
-    if (
-      !/uses:\s+pnpm\/action-setup@[^\n]+\n\s+with:\n\s+package_json_file:\s+candidate\/package\.json(?:\s|$)/.test(
-        build,
-      )
+    const pnpmSetupSteps = parseWorkflowSteps(build).filter((step) =>
+      step.uses?.startsWith("pnpm/action-setup@"),
+    );
+    if (pnpmSetupSteps.length !== 1) {
+      issues.push("candidate build must contain exactly one pnpm setup step");
+    } else if (
+      pnpmSetupSteps[0]!.with.package_json_file !== "candidate/package.json"
     ) {
       issues.push(
         "candidate pnpm setup must read package-manager metadata from the nested checkout",

--- a/scripts/guard-trusted-acceptance-workflow.ts
+++ b/scripts/guard-trusted-acceptance-workflow.ts
@@ -110,6 +110,15 @@ export function validateTrustedAcceptanceWorkflow(
     if (!build.includes("needs.plan.outputs.effective_sha")) {
       issues.push("candidate build must use the provenance-verified exact SHA");
     }
+    if (
+      !/uses:\s+pnpm\/action-setup@[^\n]+\n\s+with:\n\s+package_json_file:\s+candidate\/package\.json(?:\s|$)/.test(
+        build,
+      )
+    ) {
+      issues.push(
+        "candidate pnpm setup must read package-manager metadata from the nested checkout",
+      );
+    }
     if (!build.includes("Upload inert candidate artifact")) {
       issues.push("candidate output must cross jobs as an inert artifact");
     }


### PR DESCRIPTION
## Problem

Trusted acceptance is the framework maintainer workflow for testing an exact pull-request commit in isolated hosted apps before candidate code receives any protected deployment or provider credentials. It is reusable across participating Agent Native templates; Calendar and Content are only the first cross-app pilot.

The first credential-free run reached the candidate-build boundary, then both app builds stopped before dependency installation. The repository was checked out under `candidate/`, but `pnpm/action-setup` looked for package-manager metadata in the empty controller workspace root. As a result, the lane could validate a PR and plan its app matrix, but it could not produce artifacts for any app.

Failed dry run: https://github.com/BuilderIO/agent-native/actions/runs/30365284170

## Approach

Keep the candidate build credential-free and teach pnpm setup where the exact PR checkout lives. Guard that contract by parsing the workflow as YAML and inspecting the real `jobs.build.steps` structure, rather than matching text that could be fooled by comments, formatting, or shell snippets.

## What changed

- point the pinned `pnpm/action-setup` action at `candidate/package.json`
- add `yaml@2.9.0` as a direct development dependency for structural workflow validation
- require exactly one pnpm setup step in the build job with the nested metadata path
- cover missing metadata, wrong-step placement, duplicate setup steps, run-block lookalikes, flow-style mappings, quoted and commented YAML, indentation changes, and malformed YAML

## Safety and operations

- candidate builds still receive no credentials
- this PR does not enable deployment or change a GitHub Environment
- this PR creates no provider resources, databases, sites, fixtures, or test data
- rollback is a normal revert of this workflow and guard change

## Verification

- trusted-acceptance workflow guard passed
- focused trusted-acceptance suite passed: 113 tests
- adversarial duplicate-step, wrong-step, run-block-lookalike, and malformed-YAML cases are rejected
- equivalent block and flow mappings, quoted and commented YAML, and wider indentation are accepted
- final-head repository CI passed: https://github.com/BuilderIO/agent-native/actions/runs/30369929675
- final-head standalone Chat smoke passed: https://github.com/BuilderIO/agent-native/actions/runs/30369928659
- all PR checks passed: 69 passing, 0 pending, 0 failing
- `git diff --check` passed
- independent technical review and repository review found no remaining actionable issues

## Review focus

Please verify that:

1. pnpm reads metadata from the exact nested candidate checkout
2. the guard validates the parsed build-step structure without accepting lookalikes or duplicate setup steps
3. the YAML parser dependency and lockfile change are appropriately scoped

## Follow-up

After merge, rerun the main-owned credential-free workflow against the refreshed route-continuity candidate. Protected live OAuth and cross-app acceptance remain separately gated on a configured `trusted-acceptance` environment and isolated provider resources.
