### PR TITLE
feat: verify design

### DIFF
--- a/templates/design/.agents/skills/design-generation/SKILL.md
+++ b/templates/design/.agents/skills/design-generation/SKILL.md
@@ -379,7 +379,12 @@ view only when the user asked to focus one specific screen.
 
 ### The save gate rejects malformed markup
 
-Every write runs an integrity check, and a **new** file is held to it strictly.
+Every path that persists model-authored HTML — `generate-design`, `create-file`,
+`present-design-variants`, `edit-design`, `update-file`, canvas edits — runs an
+integrity check, and a **new** file is held to it strictly. Import paths
+(Figma, localhost, templates, duplication) deliberately do not fail closed:
+that markup comes from a real app or an existing design, and rejecting it would
+block bringing work in rather than prevent a bad generation.
 Rejections name the file, line, column, and offending source line — fix exactly
 what it points at instead of re-sending the payload differently. Blocked: an
 attribute quote that is never closed; an unclosed element or a closing tag with

--- a/templates/design/.agents/skills/design-generation/SKILL.md
+++ b/templates/design/.agents/skills/design-generation/SKILL.md
@@ -377,6 +377,24 @@ view only when the user asked to focus one specific screen.
 
 ## HTML Structure Requirements
 
+### The save gate rejects malformed markup
+
+Every write runs an integrity check, and a **new** file is held to it strictly.
+Rejections name the file, line, column, and offending source line — fix exactly
+what it points at instead of re-sending the payload differently. Blocked: an
+attribute quote that is never closed; an unclosed element or a closing tag with
+no opener; content ending mid-tag (a payload cut off in transit); a
+`<style>`/`<script>` missing its opener or closer; duplicated editor-managed
+style blocks; more than one `<html>`/`<body>`.
+
+This exists because the HTML parser never throws — it recovers silently and
+renders a page, just not the one you wrote. An unterminated quote in `<head>`
+swallows every following tag into that attribute, so the Tailwind runtime stops
+applying and the screen renders unstyled with no console error to show it.
+
+Saves may also return non-blocking `warnings` (e.g. utility classes with no
+reachable Tailwind runtime). Fix those before reporting the design as ready.
+
 ### Mandatory Elements
 
 Every `index.html` must include:

--- a/templates/design/actions/create-file.ts
+++ b/templates/design/actions/create-file.ts
@@ -6,6 +6,10 @@ import { nanoid } from "nanoid";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import {
+  assertDesignHtmlCreateIntegrity,
+  describeDesignHtmlIntegrityIssue,
+} from "../shared/html-integrity.js";
 import { annotateScreenHtmlForPersist } from "../shared/screen-annotation.js";
 
 export default defineAction({
@@ -63,6 +67,14 @@ export default defineAction({
     // the first time someone opens it.
     const annotatedContent = annotateScreenHtmlForPersist(content, fileType);
 
+    // Reject malformed HTML before the row exists — creation went through raw
+    // inserts, so it was the one write path with no integrity gate.
+    const advisory = assertDesignHtmlCreateIntegrity({
+      content: annotatedContent,
+      fileType: fileType ?? "html",
+      filename,
+    });
+
     await db.insert(schema.designFiles).values({
       id,
       designId,
@@ -94,6 +106,9 @@ export default defineAction({
       fileType: resolvedFileType,
       renderable,
       urlPath: renderable ? `/design/${designId}` : null,
+      ...(advisory.length > 0
+        ? { warnings: advisory.map(describeDesignHtmlIntegrityIssue) }
+        : {}),
     };
   },
 });

--- a/templates/design/actions/generate-design.ts
+++ b/templates/design/actions/generate-design.ts
@@ -778,7 +778,15 @@ const generateDesignAction = defineAction({
     // writeInlineSourceFile, which still allows repairing a malformed screen.
     const integrityWarnings: Array<{ filename: string; message: string }> = [];
     for (const file of annotatedFiles) {
-      if (existingByName.has(file.filename)) continue;
+      const existing = existingByName.get(file.filename);
+      // A file changing type into HTML is new HTML, not an edit: the edit
+      // transition inside writeInlineSourceFile validates against the row's
+      // CURRENT type, so a css→html candidate would skip the HTML checks and
+      // then be stored as HTML by the update below.
+      const becomesHtml =
+        (file.fileType ?? "html") === "html" &&
+        (existing?.fileType ?? "html") !== "html";
+      if (existing && !becomesHtml) continue;
       const advisory = assertDesignHtmlCreateIntegrity({
         content: file.content,
         fileType: file.fileType ?? "html",

--- a/templates/design/actions/generate-design.ts
+++ b/templates/design/actions/generate-design.ts
@@ -48,6 +48,7 @@ import {
 import {
   assertDesignHtmlCreateIntegrity,
   describeDesignHtmlIntegrityIssue,
+  inspectDesignHtmlDocumentIntegrity,
 } from "../shared/html-integrity.js";
 import { assertLockedLayersPreserved } from "../shared/locked-layers.js";
 import { widthToPrefix } from "../shared/responsive-classes.js";
@@ -778,20 +779,25 @@ const generateDesignAction = defineAction({
     // writeInlineSourceFile, which still allows repairing a malformed screen.
     const integrityWarnings: Array<{ filename: string; message: string }> = [];
     for (const file of annotatedFiles) {
+      if ((file.fileType ?? "html") !== "html") continue;
       const existing = existingByName.get(file.filename);
-      // A file changing type into HTML is new HTML, not an edit: the edit
-      // transition inside writeInlineSourceFile validates against the row's
-      // CURRENT type, so a css→html candidate would skip the HTML checks and
-      // then be stored as HTML by the update below.
+      // A row changing type into HTML is new HTML, not an edit: the edit
+      // transition validates against the row's CURRENT type, so a css→html
+      // candidate would skip the HTML checks and still be stored as HTML below.
       const becomesHtml =
-        (file.fileType ?? "html") === "html" &&
-        (existing?.fileType ?? "html") !== "html";
-      if (existing && !becomesHtml) continue;
-      const advisory = assertDesignHtmlCreateIntegrity({
-        content: file.content,
-        fileType: file.fileType ?? "html",
-        filename: file.filename,
-      });
+        existing !== undefined && (existing.fileType ?? "html") !== "html";
+      // Blocking applies to new files and type transitions. An existing HTML row
+      // takes the lenient edit transition instead, so a legacy-malformed screen
+      // stays repairable — but its advisories are still reported, or the same
+      // content would warn as a new file and save silently as a regeneration.
+      const advisory =
+        !existing || becomesHtml
+          ? assertDesignHtmlCreateIntegrity({
+              content: file.content,
+              fileType: "html",
+              filename: file.filename,
+            })
+          : (inspectDesignHtmlDocumentIntegrity(file.content).advisory ?? []);
       for (const entry of advisory) {
         integrityWarnings.push({
           filename: file.filename,

--- a/templates/design/actions/generate-design.ts
+++ b/templates/design/actions/generate-design.ts
@@ -45,6 +45,10 @@ import {
   type DesignGenerationSession,
   updateGenerationSessionWithSavedFiles,
 } from "../shared/generation-session.js";
+import {
+  assertDesignHtmlCreateIntegrity,
+  describeDesignHtmlIntegrityIssue,
+} from "../shared/html-integrity.js";
 import { assertLockedLayersPreserved } from "../shared/locked-layers.js";
 import { widthToPrefix } from "../shared/responsive-classes.js";
 import { annotateScreenHtmlForPersist } from "../shared/screen-annotation.js";
@@ -769,6 +773,25 @@ const generateDesignAction = defineAction({
       content: annotateScreenHtmlForPersist(file.content, file.fileType),
     }));
 
+    // Gate every NEW file up front so a rejected file cannot orphan the ones
+    // written before it. Existing files take the edit transition inside
+    // writeInlineSourceFile, which still allows repairing a malformed screen.
+    const integrityWarnings: Array<{ filename: string; message: string }> = [];
+    for (const file of annotatedFiles) {
+      if (existingByName.has(file.filename)) continue;
+      const advisory = assertDesignHtmlCreateIntegrity({
+        content: file.content,
+        fileType: file.fileType ?? "html",
+        filename: file.filename,
+      });
+      for (const entry of advisory) {
+        integrityWarnings.push({
+          filename: file.filename,
+          message: describeDesignHtmlIntegrityIssue(entry),
+        });
+      }
+    }
+
     for (const file of annotatedFiles) {
       const existing = existingByName.get(file.filename);
       if (existing) {
@@ -1198,6 +1221,9 @@ const generateDesignAction = defineAction({
       savedFiles,
       placedFrames,
       fileCount: savedFiles.length,
+      // Non-blocking: a well-formed screen with no Tailwind runtime renders
+      // unstyled, which reads as a layout bug rather than a missing runtime.
+      ...(integrityWarnings.length > 0 ? { warnings: integrityWarnings } : {}),
       ...creativeContextProvenance,
     };
   },

--- a/templates/design/actions/present-design-variants.spec.ts
+++ b/templates/design/actions/present-design-variants.spec.ts
@@ -149,6 +149,7 @@ vi.mock("../server/lib/design-data-mutation.js", () => ({
   mutateDesignData: mocks.mutateDesignData,
 }));
 
+import { DESIGN_HTML_INTEGRITY_ERROR_CODE } from "../shared/html-integrity.js";
 import action from "./present-design-variants.js";
 
 describe("present-design-variants", () => {
@@ -790,6 +791,46 @@ describe("present-design-variants", () => {
 
     expect(result.cleanedUpPreviousVariantScreens).toBe(0);
     expect(result.deletedSupersededSetIds).toEqual([]);
+  });
+
+  it("rejects malformed variant HTML before deleting anything", async () => {
+    // Ordering, not just validation: supersession and deletion are irreversible,
+    // so a gate that ran after them would destroy the caller's existing sets and
+    // create nothing to replace them.
+    mocks.designData = {
+      screenMetadata: {
+        "old-file-a": { title: "Old A", variantSetId: "old-set" },
+        "old-file-b": { title: "Old B", variantSetId: "old-set" },
+      },
+      designVariantSets: {
+        "old-set": {
+          id: "old-set",
+          prompt: "Old prompt",
+          createdAt: "2026-07-01T00:00:00.000Z",
+          screenCount: 2,
+          screens: [
+            { id: "old-file-a", variantId: "a", label: "Old A" },
+            { id: "old-file-b", variantId: "b", label: "Old B" },
+          ],
+        },
+      },
+    };
+
+    await expect(
+      action.run({
+        designId: "design_123",
+        prompt: "Try again",
+        deleteSupersededSetIds: ["old-set"],
+        variants: [
+          { id: "a", label: "A", content: '<div class="p-6">fine</div>' },
+          { id: "b", label: "B", content: '<div class="p-6>never closed' },
+        ],
+      }),
+    ).rejects.toThrow(DESIGN_HTML_INTEGRITY_ERROR_CODE);
+
+    expect(mocks.deleteChain.where).not.toHaveBeenCalled();
+    expect(mocks.insertChain.values).not.toHaveBeenCalled();
+    expect(mocks.updateChain.set).not.toHaveBeenCalled();
   });
 
   it("deletes a superseded set's screens only when the agent explicitly opts in via deleteSupersededSetIds", async () => {

--- a/templates/design/actions/present-design-variants.ts
+++ b/templates/design/actions/present-design-variants.ts
@@ -19,6 +19,7 @@ import {
   type CanvasFramePlacement,
 } from "../shared/canvas-frames.js";
 import { isUniqueConstraintViolation } from "../shared/db-conflict.js";
+import { assertDesignHtmlWellFormed } from "../shared/html-integrity.js";
 import { widthToPrefix } from "../shared/responsive-classes.js";
 import { annotateScreenHtmlForPersist } from "../shared/screen-annotation.js";
 
@@ -848,6 +849,20 @@ export default defineAction({
     const usedFilenames = new Set(existingFiles.map((file) => file.filename));
     const variantSetId = nanoid();
     const screens: VariantScreen[] = [];
+
+    // Model-authored screens created by raw insert, so they need the same
+    // well-formedness gate — but not generate-design's document-shape rules: a
+    // variant is allowed to be a sketch with `<html>`/`<body>` implied.
+    // Validated up front so a rejected variant cannot leave earlier ones on the
+    // board.
+    for (const variant of variants) {
+      const candidate = variant.content?.trim();
+      if (!candidate) continue;
+      assertDesignHtmlWellFormed({
+        content: annotateScreenHtmlForPersist(candidate, "html"),
+        filename: `variant-${slugify(variant.label.trim(), "option")}.html`,
+      });
+    }
 
     for (let index = 0; index < variants.length; index += 1) {
       const variant = variants[index]!;

--- a/templates/design/actions/present-design-variants.ts
+++ b/templates/design/actions/present-design-variants.ts
@@ -827,6 +827,21 @@ export default defineAction({
   run: async ({ designId, prompt, variants, deleteSupersededSetIds }) => {
     await assertAccess("design", designId, "editor");
 
+    // Before any mutation. These are model-authored screens created by raw
+    // insert, so they need the same well-formedness gate as generate-design —
+    // though not its document-shape rules, since a variant may be a sketch with
+    // `<html>`/`<body>` implied. Ordering is the load-bearing part: the
+    // supersession and deletion below are irreversible, so throwing after them
+    // would destroy existing variant sets and create nothing to replace them.
+    for (const variant of variants) {
+      const candidate = variant.content?.trim();
+      if (!candidate) continue;
+      assertDesignHtmlWellFormed({
+        content: annotateScreenHtmlForPersist(candidate, "html"),
+        filename: `variant-${slugify(variant.label.trim(), "option")}.html`,
+      });
+    }
+
     // Non-destructive bookkeeping: flag earlier still-complete variant sets
     // as superseded. Files are NEVER deleted automatically — a user's pick
     // exists only as a chat instruction until the agent's delete-file turn
@@ -849,20 +864,6 @@ export default defineAction({
     const usedFilenames = new Set(existingFiles.map((file) => file.filename));
     const variantSetId = nanoid();
     const screens: VariantScreen[] = [];
-
-    // Model-authored screens created by raw insert, so they need the same
-    // well-formedness gate — but not generate-design's document-shape rules: a
-    // variant is allowed to be a sketch with `<html>`/`<body>` implied.
-    // Validated up front so a rejected variant cannot leave earlier ones on the
-    // board.
-    for (const variant of variants) {
-      const candidate = variant.content?.trim();
-      if (!candidate) continue;
-      assertDesignHtmlWellFormed({
-        content: annotateScreenHtmlForPersist(candidate, "html"),
-        filename: `variant-${slugify(variant.label.trim(), "option")}.html`,
-      });
-    }
 
     for (let index = 0; index < variants.length; index += 1) {
       const variant = variants[index]!;

--- a/templates/design/app/pages/design-editor/save-failure.ts
+++ b/templates/design/app/pages/design-editor/save-failure.ts
@@ -1,4 +1,7 @@
-import { isDesignHtmlIntegrityError } from "@shared/html-integrity";
+import {
+  DESIGN_HTML_INTEGRITY_SUMMARY,
+  isDesignHtmlIntegrityError,
+} from "@shared/html-integrity";
 
 export type DesignSaveFailureKind =
   | "offline"
@@ -14,6 +17,9 @@ function errorField(error: unknown, field: string): unknown {
 }
 
 export function designSaveErrorMessage(error: unknown): string | null {
+  // Integrity errors carry located, agent-facing guidance in `message`. Toasts
+  // get the summary instead; the two audiences need different text.
+  if (isDesignHtmlIntegrityError(error)) return DESIGN_HTML_INTEGRITY_SUMMARY;
   const message = errorField(error, "message");
   if (typeof message !== "string" || !message.trim()) return null;
   return message.replace(/^DESIGN_HTML_INTEGRITY:\s*/, "");

--- a/templates/design/changelog/2026-07-28-generated-designs-with-malformed-html-are-now-rejected-at-sa.md
+++ b/templates/design/changelog/2026-07-28-generated-designs-with-malformed-html-are-now-rejected-at-sa.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-28
+---
+
+Generated designs with malformed HTML are now rejected at save with the exact line and character to fix, instead of persisting and rendering broken.

--- a/templates/design/server/source-workspace.ts
+++ b/templates/design/server/source-workspace.ts
@@ -361,6 +361,7 @@ export async function writeInlineSourceFile(args: {
       previousContent: current.content,
       nextContent: args.content,
       fileType: currentFile.fileType ?? args.file.fileType ?? "html",
+      filename: currentFile.filename ?? args.file.filename,
     });
 
     if (await hasCollabState(args.file.id)) {

--- a/templates/design/shared/html-integrity.test.ts
+++ b/templates/design/shared/html-integrity.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   assertDesignHtmlCreateIntegrity,
   assertDesignHtmlEditIntegrity,
+  assertDesignHtmlWellFormed,
   DESIGN_HTML_INTEGRITY_ERROR_CODE,
   inspectDesignHtmlDocumentIntegrity,
 } from "./html-integrity";
@@ -395,6 +396,33 @@ describe("Design HTML structural integrity", () => {
     ).toEqual({ valid: true });
   });
 
+  it.each([
+    ["li with an inline descendant", "<ul><li><span>one<li>two</ul>"],
+    ["tr with an inline descendant", "<table><tr><td><b>a<tr><td>b</table>"],
+    ["dt/dd with an inline descendant", "<dl><dt><em>k<dd>v</dl>"],
+  ])("closes intervening elements on an implied close: %s", (_label, body) => {
+    // The browser closes the descendant along with the list item, so popping
+    // only the stack top reported the still-open <span> as unclosed.
+    expect(
+      inspectDesignHtmlDocumentIntegrity(
+        SCREEN.replace(
+          '<div class="rounded-xl p-6"><h1 class="text-3xl">Hi</h1></div>',
+          `<div class="p-6">${body}</div>`,
+        ),
+      ),
+    ).toEqual({ valid: true });
+  });
+
+  it("still reports a missing runtime when the only script tag is commented out", () => {
+    const commentedOut = SCREEN.replace(
+      '<script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>',
+      '<!-- <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script> -->',
+    );
+    expect(
+      inspectDesignHtmlDocumentIntegrity(commentedOut).advisory?.[0],
+    ).toMatchObject({ issue: "runtime-missing" });
+  });
+
   it("stays linear across many raw-text blocks", () => {
     // Slicing the remaining document per raw-text opener was quadratic
     // allocation on the synchronous save path.
@@ -443,6 +471,39 @@ describe("Design HTML structural integrity", () => {
     const result = inspectDesignHtmlDocumentIntegrity(nested);
     expect(result.valid).toBe(false);
     expect(result.detail!.length).toBeLessThanOrEqual(3);
+  });
+});
+
+describe("assertDesignHtmlWellFormed", () => {
+  it("accepts a sketch with an implied document skeleton", () => {
+    // Variants may omit <html>/<body>; document-shape rules are not its job.
+    expect(() =>
+      assertDesignHtmlWellFormed({
+        content:
+          "<!doctype html><style>.app{max-width:390px}</style><div class='app'>One</div>",
+      }),
+    ).not.toThrow();
+  });
+
+  it.each([
+    ["script", "<script>const x = 1"],
+    ["style", "<div><style>.a{}"],
+    ["title", "<title>Hi"],
+    ["textarea", "<div><textarea>Hi"],
+  ])("rejects an unclosed raw-text <%s> in a fragment", (_label, content) => {
+    // Fragments never reach the document-only raw-text balance check, so this
+    // has to be caught during the structural scan or it passes entirely.
+    expect(() => assertDesignHtmlWellFormed({ content })).toThrow(
+      DESIGN_HTML_INTEGRITY_ERROR_CODE,
+    );
+  });
+
+  it("rejects an unterminated attribute in a fragment", () => {
+    expect(() =>
+      assertDesignHtmlWellFormed({
+        content: '<section class="grid gap-4><div>Hi</div></section>',
+      }),
+    ).toThrow(DESIGN_HTML_INTEGRITY_ERROR_CODE);
   });
 });
 

--- a/templates/design/shared/html-integrity.test.ts
+++ b/templates/design/shared/html-integrity.test.ts
@@ -317,6 +317,67 @@ describe("Design HTML structural integrity", () => {
     });
   });
 
+  it("treats a literal closing tag in a script string as the break it is", () => {
+    // Not a false positive: per the HTML spec, `</script>` inside a JS string
+    // DOES end the element — which is why `"<\\/script>"` escaping exists. The
+    // browser ends the script early, leaves `";` as text, and orphans the real
+    // closer. Rejecting is the gate working, not over-reach.
+    expect(
+      inspectDesignHtmlDocumentIntegrity(
+        SCREEN.replace(
+          '<div class="rounded-xl p-6"><h1 class="text-3xl">Hi</h1></div>',
+          '<script>const s = "</script>";</script>',
+        ),
+      ).valid,
+    ).toBe(false);
+  });
+
+  it.each([
+    [
+      "title",
+      "<!doctype html><html><head><title>Hi</head><body>x</body></html>",
+    ],
+    [
+      "textarea",
+      "<!doctype html><html><head></head><body><textarea>Hi<div>x</div></body></html>",
+    ],
+  ])("rejects an unclosed raw-text %s", (_label, html) => {
+    expect(inspectDesignHtmlDocumentIntegrity(html).valid).toBe(false);
+  });
+
+  it.each([
+    [
+      "title",
+      "<!doctype html><html><head><title>How to write <body></title></head><body>x</body></html>",
+    ],
+    [
+      "textarea",
+      "<!doctype html><html><head></head><body><textarea>paste <body> here</textarea></body></html>",
+    ],
+  ])(
+    "does not read root tags inside a %s body as document markup",
+    (_l, html) => {
+      expect(inspectDesignHtmlDocumentIntegrity(html)).toEqual({ valid: true });
+    },
+  );
+
+  it("stays linear on large valid documents", () => {
+    // Locating per close tag made this quadratic: a 117KB valid screen cost
+    // ~700ms synchronously on every save.
+    const build = (count: number) =>
+      `<!doctype html><html><head><meta charset="UTF-8"></head><body>${"<div>x</div>".repeat(count)}</body></html>`;
+    const time = (html: string) => {
+      const start = performance.now();
+      expect(inspectDesignHtmlDocumentIntegrity(html).valid).toBe(true);
+      return performance.now() - start;
+    };
+    time(build(1000));
+    const small = time(build(2000));
+    const large = time(build(8000));
+    // 4x the input must not cost anything like 16x the time.
+    expect(large).toBeLessThan(Math.max(small, 1) * 10);
+  });
+
   it("reports a missing Tailwind runtime as advisory, not a rejection", () => {
     const result = inspectDesignHtmlDocumentIntegrity(
       SCREEN.replace(/<script[^>]*><\/script>/, ""),

--- a/templates/design/shared/html-integrity.test.ts
+++ b/templates/design/shared/html-integrity.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  assertDesignHtmlCreateIntegrity,
   assertDesignHtmlEditIntegrity,
   DESIGN_HTML_INTEGRITY_ERROR_CODE,
   inspectDesignHtmlDocumentIntegrity,
@@ -31,10 +32,13 @@ describe("Design HTML integrity", () => {
       'data-agent-native-breakpoints">',
     );
 
-    expect(inspectDesignHtmlDocumentIntegrity(corrupted)).toEqual({
-      valid: false,
-      issue: "raw-text-balance",
-    });
+    // The structural pass reaches this before the raw-text count does, and
+    // reports the stray `</style>` with its line instead of the unlocated
+    // "raw text is unbalanced somewhere" verdict. Same rejection, narrower cause.
+    const result = inspectDesignHtmlDocumentIntegrity(corrupted);
+    expect(result.valid).toBe(false);
+    expect(result.issue).toBe("close-tag-orphaned");
+    expect(result.detail?.[0]).toMatchObject({ tag: "style", line: 4 });
     expect(() =>
       assertDesignHtmlEditIntegrity({
         previousContent: DOCUMENT,
@@ -165,5 +169,231 @@ describe("Design HTML integrity", () => {
         }),
       ).not.toThrow();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Structural pass
+//
+// Every case below persisted silently before this pass existed: the counting
+// checks are blind to nesting, so an unclosed element or a stray closing tag
+// left all root-tag counts intact. The browser's HTML parser recovers from all
+// of them without an error, which is why nothing downstream ever reported them.
+// ---------------------------------------------------------------------------
+
+const SCREEN = `<!doctype html>
+<html lang="en"><head><meta charset="UTF-8">
+<script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+<style>:root { --color-accent: #0EA5E9; }</style>
+</head><body class="bg-white"><div class="rounded-xl p-6"><h1 class="text-3xl">Hi</h1></div></body></html>`;
+
+describe("Design HTML structural integrity", () => {
+  it("accepts a well-formed generated screen", () => {
+    expect(inspectDesignHtmlDocumentIntegrity(SCREEN)).toEqual({ valid: true });
+  });
+
+  it("names the unterminated attribute rather than the root tags it swallows", () => {
+    const corrupted = SCREEN.replace(
+      'src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"',
+      'src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4',
+    );
+    const result = inspectDesignHtmlDocumentIntegrity(corrupted);
+    expect(result.valid).toBe(false);
+    // The counting pass would have reported `document-root` here — accurate as a
+    // symptom, useless as a fix, because <html> is present and correct.
+    expect(result.issue).toBe("attribute-unterminated");
+    expect(result.detail?.[0]).toMatchObject({
+      tag: "script",
+      attribute: "src",
+    });
+    expect(result.detail?.[0]?.line).toBe(3);
+  });
+
+  it("detects an unterminated attribute even when a later quote re-syncs the tokenizer", () => {
+    const corrupted = SCREEN.replace('class="bg-white"', 'class="bg-white');
+    expect(inspectDesignHtmlDocumentIntegrity(corrupted).issue).toBe(
+      "attribute-unterminated",
+    );
+  });
+
+  it("detects an unclosed element and names what closed it instead", () => {
+    const result = inspectDesignHtmlDocumentIntegrity(
+      SCREEN.replace("</div></body>", "</body>"),
+    );
+    expect(result.issue).toBe("element-unclosed");
+    expect(result.detail?.[0]).toMatchObject({
+      tag: "div",
+      closedBy: { tag: "body" },
+    });
+  });
+
+  it("detects a closing tag with no opener", () => {
+    const result = inspectDesignHtmlDocumentIntegrity(
+      SCREEN.replace("<h1", "</section><h1"),
+    );
+    expect(result.issue).toBe("close-tag-orphaned");
+    expect(result.detail?.[0]?.tag).toBe("section");
+  });
+
+  it("detects crossed nesting", () => {
+    const result = inspectDesignHtmlDocumentIntegrity(
+      SCREEN.replace(
+        '<h1 class="text-3xl">Hi</h1></div>',
+        '<h1 class="text-3xl">Hi</div></h1>',
+      ),
+    );
+    expect(result.issue).toBe("element-unclosed");
+    expect(result.detail?.[0]?.tag).toBe("h1");
+  });
+
+  it("detects a payload cut off mid-attribute", () => {
+    const truncated = SCREEN.slice(0, SCREEN.indexOf('class="rounded-xl') + 12);
+    expect(inspectDesignHtmlDocumentIntegrity(truncated).valid).toBe(false);
+  });
+
+  it("distinguishes a cut-off tag from an unterminated quote", () => {
+    // Every quote here is closed; the TAG is what got cut off. Deciding this by
+    // "is there a quote anywhere after this point" told the author to close a
+    // quote that was already closed.
+    const result = inspectDesignHtmlDocumentIntegrity(
+      '<!doctype html><html><head></head><body><div class="a" data-y',
+    );
+    expect(result.issue).toBe("content-truncated");
+    expect(
+      inspectDesignHtmlDocumentIntegrity(
+        '<!doctype html><html><head></head><body><div class="a',
+      ).issue,
+    ).toBe("attribute-unterminated");
+  });
+
+  it("reads a spaced closing tag as a close, not a second open", () => {
+    expect(
+      inspectDesignHtmlDocumentIntegrity(
+        "<!doctype html><html><head></head><body><div>x< /div></body></html>",
+      ),
+    ).toEqual({ valid: true });
+  });
+
+  it("detects an unterminated comment", () => {
+    expect(
+      inspectDesignHtmlDocumentIntegrity(SCREEN.replace("<h1", "<!-- note <h1"))
+        .issue,
+    ).toBe("content-truncated");
+  });
+
+  it("checks fragments too — an unterminated quote is not a document-only defect", () => {
+    expect(
+      inspectDesignHtmlDocumentIntegrity(
+        `<section class="grid gap-4><div class="card">Hi</div></section>`,
+      ).issue,
+    ).toBe("attribute-unterminated");
+  });
+
+  it.each([
+    [
+      "omitted </td> and </tr>",
+      "<table><tbody><tr><td>a<td>b<tr><td>c</tbody></table>",
+    ],
+    ["omitted </li> and </p>", "<ul><li>a<li>b</ul><p>one<p>two"],
+    [
+      "void and self-closing elements",
+      '<img src="x.png"><br><svg viewBox="0 0 4 4"><circle cx="2" cy="2" r="1"/></svg>',
+    ],
+    [
+      "closing tags inside script text",
+      "<script>const s = '</div></body>'</script><div>ok</div>",
+    ],
+    [
+      "closing tags inside a style body",
+      "<style>/* </div> */ .a{color:red}</style><div>ok</div>",
+    ],
+  ])("does not flag legal authoring: %s", (_label, body) => {
+    const document = SCREEN.replace(
+      '<div class="rounded-xl p-6"><h1 class="text-3xl">Hi</h1></div>',
+      body,
+    );
+    expect(inspectDesignHtmlDocumentIntegrity(document)).toEqual({
+      valid: true,
+    });
+  });
+
+  it("reports a missing Tailwind runtime as advisory, not a rejection", () => {
+    const result = inspectDesignHtmlDocumentIntegrity(
+      SCREEN.replace(/<script[^>]*><\/script>/, ""),
+    );
+    expect(result.valid).toBe(true);
+    expect(result.advisory?.[0]?.issue).toBe("runtime-missing");
+  });
+
+  it("caps cascading reports so one defect cannot flood a tool result", () => {
+    const nested = `<!doctype html><html><head></head><body>${"<div><section><article>".repeat(
+      6,
+    )}</body></html>`;
+    const result = inspectDesignHtmlDocumentIntegrity(nested);
+    expect(result.valid).toBe(false);
+    expect(result.detail!.length).toBeLessThanOrEqual(3);
+  });
+});
+
+describe("assertDesignHtmlCreateIntegrity", () => {
+  it("throws a located, explanatory error naming the file", () => {
+    const corrupted = SCREEN.replace('class="bg-white"', 'class="bg-white');
+    let message = "";
+    try {
+      assertDesignHtmlCreateIntegrity({
+        content: corrupted,
+        fileType: "html",
+        filename: "index.html",
+      });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toContain(DESIGN_HTML_INTEGRITY_ERROR_CODE);
+    expect(message).toContain("index.html");
+    expect(message).toContain("never closed");
+    // The excerpt is what makes the error actionable without a re-read.
+    expect(message).toContain("class=");
+  });
+
+  it("returns advisory findings instead of throwing when the document is well-formed", () => {
+    expect(
+      assertDesignHtmlCreateIntegrity({
+        content: SCREEN,
+        fileType: "html",
+        filename: "index.html",
+      }),
+    ).toEqual([]);
+  });
+
+  it("leaves non-HTML file types alone", () => {
+    for (const fileType of ["css", "jsx", "asset"]) {
+      expect(
+        assertDesignHtmlCreateIntegrity({
+          content: "export default function Broken() { return <div>; }",
+          fileType,
+          filename: "Card.jsx",
+        }),
+      ).toEqual([]);
+    }
+  });
+
+  it("does not grant creation the legacy-repair leniency edits get", () => {
+    const corrupted = SCREEN.replace("</div></body>", "</body>");
+    // An edit from malformed to malformed is tolerated so legacy screens stay
+    // repairable; a brand-new file has no such history to protect.
+    expect(() =>
+      assertDesignHtmlEditIntegrity({
+        previousContent: corrupted,
+        nextContent: corrupted.replace("Hi", "Hello"),
+        fileType: "html",
+      }),
+    ).toThrow();
+    expect(() =>
+      assertDesignHtmlCreateIntegrity({
+        content: corrupted,
+        fileType: "html",
+        filename: "index.html",
+      }),
+    ).toThrow(DESIGN_HTML_INTEGRITY_ERROR_CODE);
   });
 });

--- a/templates/design/shared/html-integrity.test.ts
+++ b/templates/design/shared/html-integrity.test.ts
@@ -361,6 +361,56 @@ describe("Design HTML structural integrity", () => {
     },
   );
 
+  it.each([
+    [
+      "an invalid end-tag prefix",
+      '<script>const s = "</script=template>";</script>',
+    ],
+    ["a longer tag name", '<script>const s = "</scriptfoo>";</script>'],
+  ])("does not treat %s as the raw-text closer", (_label, body) => {
+    // A raw-text end tag closes the element only when the name is followed by
+    // whitespace, `/`, or `>`. Matching a word boundary instead orphaned the
+    // real closer, rejecting a document the browser parses fine.
+    expect(
+      inspectDesignHtmlDocumentIntegrity(
+        SCREEN.replace(
+          '<div class="rounded-xl p-6"><h1 class="text-3xl">Hi</h1></div>',
+          `${body}<div class="p-6">ok</div>`,
+        ),
+      ),
+    ).toEqual({ valid: true });
+  });
+
+  it.each([
+    ["rtc", "<ruby>漢<rtc><rt>kan</ruby>"],
+    ["rb", "<ruby><rb>漢<rt>kan</ruby>"],
+  ])("accepts ruby markup with an omitted optional </%s>", (_label, body) => {
+    expect(
+      inspectDesignHtmlDocumentIntegrity(
+        SCREEN.replace(
+          '<div class="rounded-xl p-6"><h1 class="text-3xl">Hi</h1></div>',
+          `<div class="p-6">${body}</div>`,
+        ),
+      ),
+    ).toEqual({ valid: true });
+  });
+
+  it("stays linear across many raw-text blocks", () => {
+    // Slicing the remaining document per raw-text opener was quadratic
+    // allocation on the synchronous save path.
+    const build = (count: number) =>
+      `<!doctype html><html><head><meta charset="UTF-8"></head><body>${"<style>.a{color:red}</style><script>var a=1</script>".repeat(count)}</body></html>`;
+    const time = (html: string) => {
+      const start = performance.now();
+      expect(inspectDesignHtmlDocumentIntegrity(html).valid).toBe(true);
+      return performance.now() - start;
+    };
+    time(build(400));
+    const small = time(build(800));
+    const large = time(build(3200));
+    expect(large).toBeLessThan(Math.max(small, 1) * 10);
+  });
+
   it("stays linear on large valid documents", () => {
     // Locating per close tag made this quadratic: a 117KB valid screen cost
     // ~700ms synchronously on every save.

--- a/templates/design/shared/html-integrity.ts
+++ b/templates/design/shared/html-integrity.ts
@@ -333,7 +333,7 @@ function scanRawTextTags(value: string): RawTextScan {
     if (active) {
       // HTML raw-text elements terminate at the first matching end-tag token,
       // even when that text happens to look like a JavaScript/CSS string.
-      const closer = new RegExp(`<\\s*\\/\\s*${active}\\b[^>]*>`, "gi");
+      const closer = new RegExp(`<\\s*\\/\\s*${active}(?=[\\s/>])[^>]*>`, "gi");
       closer.lastIndex = cursor;
       const match = closer.exec(value);
       if (!match) break;
@@ -426,8 +426,10 @@ const OPTIONAL_CLOSE_TAGS = new Set([
   "optgroup",
   "option",
   "p",
+  "rb",
   "rp",
   "rt",
+  "rtc",
   "tbody",
   "td",
   "tfoot",
@@ -510,6 +512,15 @@ interface TagScan {
   quoteOpen: boolean;
   /** The attribute that quote belonged to, when one was named. */
   unterminatedAttribute?: string;
+}
+
+/**
+ * A raw-text end tag only closes the element when the name is followed by
+ * whitespace, `/`, or `>`. Matching on a word boundary instead treats script
+ * text like `"</script=template>"` as the closer, which orphans the real one.
+ */
+function rawTextCloser(tag: string): RegExp {
+  return new RegExp(`<\\s*/\\s*${tag}(?=[\\s/>])`, "gi");
 }
 
 /** Consume one markup token starting at `start` (the `<`), honoring quotes. */
@@ -665,15 +676,15 @@ function collectStructuralIssues(
       // Resume AT the closing tag so the close branch pops this element,
       // rather than duplicating that logic here. An unterminated body is left
       // to the raw-text-balance check, which names that cause correctly.
-      const closer = new RegExp(`<\\s*/\\s*${tag}\\b`, "i");
-      const rest = value.slice(scan.end);
-      const found = closer.exec(rest);
+      const closer = rawTextCloser(tag);
+      closer.lastIndex = scan.end;
+      const found = closer.exec(value);
       if (!found) {
         cursor = value.length;
         continue;
       }
       stack.push({ tag, start: open });
-      cursor = scan.end + found.index;
+      cursor = found.index;
       continue;
     }
 

--- a/templates/design/shared/html-integrity.ts
+++ b/templates/design/shared/html-integrity.ts
@@ -69,7 +69,7 @@ const DOCUMENT_SHAPE_MESSAGES: Partial<
   "document-boundary":
     "the document's <html>/<body> tags are out of order, or content sits outside <html>",
   "raw-text-balance":
-    "a <style> or <script> element is missing its opening or closing tag",
+    "a <style>, <script>, <textarea>, or <title> element is missing its opening or closing tag",
   "managed-marker-orphaned":
     "an editor-managed <style>/<script> marker is no longer attached to its element — it was likely split by a partial edit",
   "managed-marker-duplicated":
@@ -149,6 +149,15 @@ export class DesignHtmlIntegrityError extends Error {
     this.detail = options.detail;
   }
 }
+
+/**
+ * Bodies are text, not markup — mis-tokenizing these turns a `'</div>'` string
+ * inside Alpine JavaScript into a phantom structural error. Both passes must
+ * agree on this set: when only one treated `<title>`/`<textarea>` as raw text,
+ * literal `<body>` text inside a title reached the root-tag count as real markup.
+ */
+const RAW_TEXT_TAGS = new Set(["script", "style", "textarea", "title"]);
+type RawTextTag = "script" | "style" | "textarea" | "title";
 
 const MANAGED_RAW_TEXT_MARKERS = [
   { marker: "data-agent-native-breakpoints", tag: "style" },
@@ -315,7 +324,7 @@ function scanRawTextTags(value: string): RawTextScan {
   // seen, ignore every tag-like token except that element's own closer. This
   // mirrors browser tokenization closely enough to avoid rejecting code-heavy
   // Alpine documents while still detecting an orphaned closer/missing opener.
-  let active: "style" | "script" | null = null;
+  let active: RawTextTag | null = null;
   let bodyStart = -1;
   let severity = 0;
   const bodyRanges: RawTextScan["bodyRanges"] = [];
@@ -361,10 +370,10 @@ function scanRawTextTags(value: string): RawTextScan {
       }
     }
     const token = value.slice(nextOpen, tokenEnd);
-    const match = token.match(/^<\s*(\/?)\s*(style|script)\b/i);
-    if (match) {
+    const match = token.match(/^<\s*(\/?)\s*([a-zA-Z][a-zA-Z0-9:-]*)\b/i);
+    if (match && RAW_TEXT_TAGS.has(match[2]!.toLowerCase())) {
       const closing = match[1] === "/";
-      const tag = match[2]!.toLowerCase() as "style" | "script";
+      const tag = match[2]!.toLowerCase() as RawTextTag;
       if (closing) severity += 1;
       else {
         active = tag;
@@ -400,12 +409,6 @@ const VOID_TAGS = new Set([
   "track",
   "wbr",
 ]);
-
-/**
- * Bodies are text, not markup — mis-tokenizing these turns a `'</div>'` string
- * inside Alpine JavaScript into a phantom structural error.
- */
-const RAW_TEXT_TAGS = new Set(["script", "style", "textarea", "title"]);
 
 /**
  * Closing tag optional per HTML5, so omitting one is legal authoring.
@@ -457,28 +460,45 @@ const MAX_EXCERPT_CHARS = 120;
 const USES_TAILWIND_UTILITIES =
   /\bclass\s*=\s*["'][^"']*(?:\b(?:flex|grid|hidden|absolute|relative|sticky)\b|\b(?:p|m|px|py|mx|my|pt|pb|pl|pr|gap|w|h|text|bg|border|rounded|shadow|items|justify|font|leading|tracking|space-x|space-y|min-h|max-w|opacity|ring|z)-[a-z0-9[\]./-]+)/i;
 
-function locate(
-  value: string,
-  index: number,
-): { line: number; column: number; excerpt: string } {
-  let line = 1;
-  let lineStart = 0;
-  for (let cursor = 0; cursor < index && cursor < value.length; cursor += 1) {
-    if (value[cursor] === "\n") {
-      line += 1;
-      lineStart = cursor + 1;
+type Locator = (index: number) => {
+  line: number;
+  column: number;
+  excerpt: string;
+};
+
+/**
+ * Scanning to the offset per call made validation quadratic on VALID documents,
+ * not just malformed ones — a 117KB screen cost ~700ms on every save. Index the
+ * line starts once, lazily, and binary search.
+ */
+function createLocator(value: string): Locator {
+  let starts: number[] | null = null;
+  return (index) => {
+    if (!starts) {
+      starts = [0];
+      for (let cursor = 0; cursor < value.length; cursor += 1) {
+        if (value[cursor] === "\n") starts.push(cursor + 1);
+      }
     }
-  }
-  let lineEnd = value.indexOf("\n", lineStart);
-  if (lineEnd === -1) lineEnd = value.length;
-  const raw = value.slice(lineStart, lineEnd).trim();
-  return {
-    line,
-    column: index - lineStart + 1,
-    excerpt:
-      raw.length > MAX_EXCERPT_CHARS
-        ? `${raw.slice(0, MAX_EXCERPT_CHARS)}…`
-        : raw,
+    let low = 0;
+    let high = starts.length - 1;
+    while (low < high) {
+      const mid = (low + high + 1) >> 1;
+      if (starts[mid]! <= index) low = mid;
+      else high = mid - 1;
+    }
+    const lineStart = starts[low]!;
+    let lineEnd = value.indexOf("\n", lineStart);
+    if (lineEnd === -1) lineEnd = value.length;
+    const raw = value.slice(lineStart, lineEnd).trim();
+    return {
+      line: low + 1,
+      column: index - lineStart + 1,
+      excerpt:
+        raw.length > MAX_EXCERPT_CHARS
+          ? `${raw.slice(0, MAX_EXCERPT_CHARS)}…`
+          : raw,
+    };
   };
 }
 
@@ -559,6 +579,7 @@ function collectStructuralIssues(
 ): DesignHtmlIntegrityIssueDetail[] {
   const issues: DesignHtmlIntegrityIssueDetail[] = [];
   const stack: Array<{ tag: string; start: number }> = [];
+  const locate = createLocator(value);
   let cursor = 0;
 
   while (cursor < value.length) {
@@ -568,10 +589,7 @@ function collectStructuralIssues(
     if (value.startsWith("<!--", open)) {
       const commentEnd = value.indexOf("-->", open + 4);
       if (commentEnd === -1) {
-        issues.push({
-          issue: "content-truncated",
-          ...locate(value, open),
-        });
+        issues.push({ issue: "content-truncated", ...locate(open) });
         return issues;
       }
       cursor = commentEnd + 3;
@@ -594,7 +612,7 @@ function collectStructuralIssues(
     const scan = scanTag(value, open);
     if (!scan.terminated) {
       // Anything after an unclosed tag would be invented structure. Stop here.
-      const located = locate(value, open);
+      const located = locate(open);
       issues.push(
         scan.quoteOpen
           ? {
@@ -618,20 +636,19 @@ function collectStructuralIssues(
       }
       if (matched === -1) {
         if (!OPTIONAL_CLOSE_TAGS.has(tag) && !VOID_TAGS.has(tag)) {
-          issues.push({
-            issue: "close-tag-orphaned",
-            ...locate(value, open),
-            tag,
-          });
+          issues.push({ issue: "close-tag-orphaned", ...locate(open), tag });
         }
       } else {
-        const closeLine = locate(value, open).line;
+        // Located lazily: computing this for every balanced close tag is what
+        // made a valid document quadratic.
+        let closeLine: number | null = null;
         for (let index = stack.length - 1; index > matched; index -= 1) {
           const abandoned = stack[index]!;
           if (OPTIONAL_CLOSE_TAGS.has(abandoned.tag)) continue;
+          closeLine ??= locate(open).line;
           issues.push({
             issue: "element-unclosed",
-            ...locate(value, abandoned.start),
+            ...locate(abandoned.start),
             tag: abandoned.tag,
             closedBy: { tag, line: closeLine },
           });
@@ -678,7 +695,7 @@ function collectStructuralIssues(
     if (OPTIONAL_CLOSE_TAGS.has(abandoned.tag)) continue;
     issues.push({
       issue: "element-unclosed",
-      ...locate(value, abandoned.start),
+      ...locate(abandoned.start),
       tag: abandoned.tag,
     });
   }
@@ -720,7 +737,7 @@ function collectAdvisoryIssues(
   return [
     {
       issue: "runtime-missing",
-      ...locate(value, headIndex === -1 ? 0 : headIndex),
+      ...createLocator(value)(headIndex === -1 ? 0 : headIndex),
     },
   ];
 }
@@ -772,6 +789,13 @@ export function inspectDesignHtmlDocumentIntegrity(
   }
 
   if (!isDocumentHtml(value, rawText.bodyRanges)) return { valid: true };
+
+  // Before the root counts: an unbalanced raw-text element swallows the tags
+  // those counts look for, so checking order decides whether the report names
+  // the cause or its effect.
+  if (rawText.severity > 0) {
+    return { valid: false, issue: "raw-text-balance" };
+  }
 
   const html = tagCount(value, "html", rawText.bodyRanges);
   if (html.open !== 1 || html.close !== 1) {
@@ -826,10 +850,6 @@ export function inspectDesignHtmlDocumentIntegrity(
   );
   if (prefix.trim() || suffix.trim()) {
     return { valid: false, issue: "document-boundary" };
-  }
-
-  if (rawText.severity > 0) {
-    return { valid: false, issue: "raw-text-balance" };
   }
 
   for (const { marker, tag } of MANAGED_RAW_TEXT_MARKERS) {
@@ -894,6 +914,26 @@ export function assertDesignHtmlEditIntegrity(args: {
  * Returns advisory issues for the caller to surface; throws on anything
  * blocking.
  */
+/**
+ * Well-formedness only — no document-shape rules. For markup that is not
+ * required to be a complete screen, such as a variant sketch, where `<html>` and
+ * `<body>` are legitimately implied. Unbalanced tags are defects at any level of
+ * completeness; a missing skeleton is not.
+ */
+export function assertDesignHtmlWellFormed(args: {
+  content: string;
+  filename?: string;
+}): void {
+  if (!args.content.trim()) return;
+  const structural = collectStructuralIssues(args.content);
+  if (structural.length > 0) {
+    throw new DesignHtmlIntegrityError(structural[0]!.issue, {
+      filename: args.filename,
+      detail: structural,
+    });
+  }
+}
+
 export function assertDesignHtmlCreateIntegrity(args: {
   content: string;
   fileType: string;

--- a/templates/design/shared/html-integrity.ts
+++ b/templates/design/shared/html-integrity.ts
@@ -4,6 +4,14 @@
  */
 export const DESIGN_HTML_INTEGRITY_ERROR_CODE = "DESIGN_HTML_INTEGRITY";
 
+/**
+ * Human-facing summary for the editor toast. `message` carries the located,
+ * agent-facing detail instead — a person dragging on the canvas did not author
+ * the markup, so a line and column are noise to them.
+ */
+export const DESIGN_HTML_INTEGRITY_SUMMARY =
+  "The edit was not applied because it would make the design HTML invalid.";
+
 export type DesignHtmlIntegrityIssue =
   | "document-boundary"
   | "document-root"

--- a/templates/design/shared/html-integrity.ts
+++ b/templates/design/shared/html-integrity.ts
@@ -11,24 +11,134 @@ export type DesignHtmlIntegrityIssue =
   | "document-head"
   | "raw-text-balance"
   | "managed-marker-orphaned"
-  | "managed-marker-duplicated";
+  | "managed-marker-duplicated"
+  | "attribute-unterminated"
+  | "element-unclosed"
+  | "close-tag-orphaned"
+  | "content-truncated"
+  | "runtime-missing";
+
+/**
+ * Reporting the symptom instead of the cause sends the fix to the wrong line:
+ * an unterminated quote in `<head>` swallows the root tags, which reads as a
+ * missing `<html>` unless the quote itself is named.
+ */
+export interface DesignHtmlIntegrityIssueDetail {
+  issue: DesignHtmlIntegrityIssue;
+  /** 1-based. */
+  line: number;
+  /** 1-based. */
+  column: number;
+  /** The offending source line, bounded for readability. */
+  excerpt: string;
+  tag?: string;
+  attribute?: string;
+  /** The tag that arrived where this element's close belonged, if any. */
+  closedBy?: { tag: string; line: number };
+}
 
 export interface DesignHtmlIntegrityResult {
   valid: boolean;
   issue?: DesignHtmlIntegrityIssue;
+  /** Present only when invalid; first entry corresponds to `issue`. */
+  detail?: DesignHtmlIntegrityIssueDetail[];
+  /** Present only when non-empty. Never blocks a write. */
+  advisory?: DesignHtmlIntegrityIssueDetail[];
+}
+
+/** Cap cascades: one unclosed tag can leave a dozen ancestors unbalanced. */
+const MAX_REPORTED_ISSUES = 3;
+
+const DOCUMENT_SHAPE_MESSAGES: Partial<
+  Record<DesignHtmlIntegrityIssue, string>
+> = {
+  "document-root":
+    "the document must have exactly one <html> element with a matching </html>",
+  "document-body":
+    "the document must have exactly one <body> element with a matching </body>",
+  "document-head":
+    "the document must have at most one <head> element, with a matching </head> if present",
+  "document-boundary":
+    "the document's <html>/<body> tags are out of order, or content sits outside <html>",
+  "raw-text-balance":
+    "a <style> or <script> element is missing its opening or closing tag",
+  "managed-marker-orphaned":
+    "an editor-managed <style>/<script> marker is no longer attached to its element — it was likely split by a partial edit",
+  "managed-marker-duplicated":
+    "an editor-managed <style>/<script> block appears more than once; there must be exactly one of each",
+};
+
+export function describeDesignHtmlIntegrityIssue(
+  detail: DesignHtmlIntegrityIssueDetail,
+): string {
+  const at = `line ${detail.line} col ${detail.column}`;
+  switch (detail.issue) {
+    case "attribute-unterminated":
+      return (
+        `the ${detail.attribute ? `\`${detail.attribute}\`` : "attribute"} value on ` +
+        `<${detail.tag ?? "element"}> at ${at} is never closed. The HTML parser absorbs ` +
+        `everything after it into that attribute — including any markup, <style>, or ` +
+        `<script> that follows — so the rest of the document silently stops applying. ` +
+        `Close the quote.`
+      );
+    case "element-unclosed":
+      return detail.closedBy
+        ? `<${detail.tag}> opened at ${at} is never closed; the next closing tag is ` +
+            `</${detail.closedBy.tag}> on line ${detail.closedBy.line}, which belongs to an ` +
+            `ancestor. Everything between them gets nested inside <${detail.tag}>. ` +
+            `Add the missing </${detail.tag}>.`
+        : `<${detail.tag}> opened at ${at} is never closed before the document ends. ` +
+            `Add the missing </${detail.tag}>.`;
+    case "close-tag-orphaned":
+      return (
+        `</${detail.tag}> at ${at} closes an element that was never opened. ` +
+        `Remove the stray closing tag, or add the matching <${detail.tag}>.`
+      );
+    case "content-truncated":
+      return (
+        `the content ends mid-markup at ${at} — the final tag or comment is never ` +
+        `terminated. This is the signature of a payload that was cut off in transit; ` +
+        `re-send this file complete.`
+      );
+    case "runtime-missing":
+      return (
+        `no Tailwind runtime is reachable from this document (expected a ` +
+        `<script src="…@tailwindcss/browser@4"> or a <style type="text/tailwindcss">). ` +
+        `Utility classes will not apply and the design renders unstyled.`
+      );
+    default:
+      return `the document structure is invalid (${detail.issue}) at ${at}.`;
+  }
 }
 
 export class DesignHtmlIntegrityError extends Error {
   readonly code = DESIGN_HTML_INTEGRITY_ERROR_CODE;
   readonly status = 422;
   readonly issue: DesignHtmlIntegrityIssue;
+  readonly detail?: DesignHtmlIntegrityIssueDetail[];
 
-  constructor(issue: DesignHtmlIntegrityIssue) {
-    super(
-      `${DESIGN_HTML_INTEGRITY_ERROR_CODE}: The edit was not applied because it would make the design HTML invalid.`,
-    );
+  constructor(
+    issue: DesignHtmlIntegrityIssue,
+    options: {
+      filename?: string;
+      detail?: DesignHtmlIntegrityIssueDetail[];
+    } = {},
+  ) {
+    const where = options.filename ? `${options.filename}: ` : "";
+    const explained = options.detail?.length
+      ? options.detail
+          .map(
+            (entry) =>
+              `${describeDesignHtmlIntegrityIssue(entry)}\n\n  ${entry.line} | ${entry.excerpt}`,
+          )
+          .join("\n\n")
+      : // Whole-document properties have no single offending character, but must
+        // still name which property failed.
+        `${DOCUMENT_SHAPE_MESSAGES[issue] ?? "the design HTML is invalid"}. The write was not applied.`;
+    super(`${DESIGN_HTML_INTEGRITY_ERROR_CODE}: ${where}${explained}`);
     this.name = "DesignHtmlIntegrityError";
     this.issue = issue;
+    this.detail = options.detail;
   }
 }
 
@@ -259,6 +369,354 @@ function scanRawTextTags(value: string): RawTextScan {
   return { severity: severity + (active ? 1 : 0), bodyRanges };
 }
 
+// ---------------------------------------------------------------------------
+// Structural pass. Counting tokens is blind to order, so an unclosed <div> or
+// a stray </section> leaves every root count above intact — those need a stack
+// walk, and they are the defects browsers recover from most invisibly.
+// ---------------------------------------------------------------------------
+
+/** Closing tag is forbidden, so these never reach the stack. */
+const VOID_TAGS = new Set([
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr",
+]);
+
+/**
+ * Bodies are text, not markup — mis-tokenizing these turns a `'</div>'` string
+ * inside Alpine JavaScript into a phantom structural error.
+ */
+const RAW_TEXT_TAGS = new Set(["script", "style", "textarea", "title"]);
+
+/**
+ * Closing tag optional per HTML5, so omitting one is legal authoring.
+ * `html`/`head`/`body` belong here because the counting pass already owns them.
+ */
+const OPTIONAL_CLOSE_TAGS = new Set([
+  "body",
+  "caption",
+  "colgroup",
+  "dd",
+  "dt",
+  "head",
+  "html",
+  "li",
+  "optgroup",
+  "option",
+  "p",
+  "rp",
+  "rt",
+  "tbody",
+  "td",
+  "tfoot",
+  "th",
+  "thead",
+  "tr",
+]);
+
+/** Opening one of these implicitly closes the listed open sibling. */
+const IMPLICIT_SIBLING_CLOSE = new Map<string, Set<string>>([
+  ["li", new Set(["li"])],
+  ["p", new Set(["p"])],
+  ["td", new Set(["td", "th"])],
+  ["th", new Set(["td", "th"])],
+  ["tr", new Set(["tr", "td", "th"])],
+  ["dt", new Set(["dt", "dd"])],
+  ["dd", new Set(["dt", "dd"])],
+  ["option", new Set(["option"])],
+  ["optgroup", new Set(["optgroup", "option"])],
+  ["tbody", new Set(["thead", "tbody", "tr", "td", "th"])],
+  ["tfoot", new Set(["thead", "tbody", "tr", "td", "th"])],
+]);
+
+const MAX_EXCERPT_CHARS = 120;
+
+/**
+ * Deliberately conservative: a miss costs one unreported advisory, a false hit
+ * costs trust in every advisory after it.
+ */
+const USES_TAILWIND_UTILITIES =
+  /\bclass\s*=\s*["'][^"']*(?:\b(?:flex|grid|hidden|absolute|relative|sticky)\b|\b(?:p|m|px|py|mx|my|pt|pb|pl|pr|gap|w|h|text|bg|border|rounded|shadow|items|justify|font|leading|tracking|space-x|space-y|min-h|max-w|opacity|ring|z)-[a-z0-9[\]./-]+)/i;
+
+function locate(
+  value: string,
+  index: number,
+): { line: number; column: number; excerpt: string } {
+  let line = 1;
+  let lineStart = 0;
+  for (let cursor = 0; cursor < index && cursor < value.length; cursor += 1) {
+    if (value[cursor] === "\n") {
+      line += 1;
+      lineStart = cursor + 1;
+    }
+  }
+  let lineEnd = value.indexOf("\n", lineStart);
+  if (lineEnd === -1) lineEnd = value.length;
+  const raw = value.slice(lineStart, lineEnd).trim();
+  return {
+    line,
+    column: index - lineStart + 1,
+    excerpt:
+      raw.length > MAX_EXCERPT_CHARS
+        ? `${raw.slice(0, MAX_EXCERPT_CHARS)}…`
+        : raw,
+  };
+}
+
+interface TagScan {
+  end: number;
+  /** False when EOF arrived before the tag's `>`. */
+  terminated: boolean;
+  /** Whether EOF arrived inside a quoted value — the truncation cause. */
+  quoteOpen: boolean;
+  /** The attribute that quote belonged to, when one was named. */
+  unterminatedAttribute?: string;
+}
+
+/** Consume one markup token starting at `start` (the `<`), honoring quotes. */
+function scanTag(value: string, start: number): TagScan {
+  let quote: '"' | "'" | null = null;
+  let pendingAttribute: string | undefined;
+  let quotedAttribute: string | undefined;
+  let word = "";
+  for (let cursor = start; cursor < value.length; cursor += 1) {
+    const character = value[cursor]!;
+    if (quote) {
+      if (character === quote) {
+        quote = null;
+        quotedAttribute = undefined;
+      }
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      quotedAttribute = pendingAttribute;
+      continue;
+    }
+    if (character === ">") {
+      return { end: cursor + 1, terminated: true, quoteOpen: false };
+    }
+    if (character === "=") {
+      if (word) pendingAttribute = word;
+      word = "";
+      continue;
+    }
+    if (character === "<" || character === "/" || /\s/.test(character)) {
+      word = "";
+      continue;
+    }
+    word += character;
+  }
+  return {
+    end: value.length,
+    terminated: false,
+    quoteOpen: quote !== null,
+    unterminatedAttribute: quotedAttribute,
+  };
+}
+
+/**
+ * One parse for both facts. Deriving `isClose` separately let `< /div>` be read
+ * as a close tag by one check and an open tag by the other.
+ */
+function tagAt(
+  value: string,
+  index: number,
+): { tag: string; isClose: boolean } | null {
+  const match = /^<(\s*\/)?\s*([a-zA-Z][a-zA-Z0-9:-]*)/.exec(
+    value.slice(index, index + 64),
+  );
+  return match
+    ? { tag: match[2]!.toLowerCase(), isClose: match[1] !== undefined }
+    : null;
+}
+
+/**
+ * Runs on fragments as well as documents — an unterminated quote is as
+ * destructive in a `<template>` snippet as in a full page.
+ */
+function collectStructuralIssues(
+  value: string,
+): DesignHtmlIntegrityIssueDetail[] {
+  const issues: DesignHtmlIntegrityIssueDetail[] = [];
+  const stack: Array<{ tag: string; start: number }> = [];
+  let cursor = 0;
+
+  while (cursor < value.length) {
+    const open = value.indexOf("<", cursor);
+    if (open === -1) break;
+
+    if (value.startsWith("<!--", open)) {
+      const commentEnd = value.indexOf("-->", open + 4);
+      if (commentEnd === -1) {
+        issues.push({
+          issue: "content-truncated",
+          ...locate(value, open),
+        });
+        return issues;
+      }
+      cursor = commentEnd + 3;
+      continue;
+    }
+
+    if (value.startsWith("<!", open)) {
+      cursor = Math.max(scanTag(value, open).end, open + 1);
+      continue;
+    }
+
+    const parsed = tagAt(value, open);
+    if (!parsed) {
+      // A bare `<` in text content. Not markup, not a defect.
+      cursor = open + 1;
+      continue;
+    }
+    const { tag, isClose } = parsed;
+
+    const scan = scanTag(value, open);
+    if (!scan.terminated) {
+      // Anything after an unclosed tag would be invented structure. Stop here.
+      const located = locate(value, open);
+      issues.push(
+        scan.quoteOpen
+          ? {
+              issue: "attribute-unterminated",
+              ...located,
+              tag,
+              attribute: scan.unterminatedAttribute,
+            }
+          : { issue: "content-truncated", ...located, tag },
+      );
+      return issues;
+    }
+
+    if (isClose) {
+      let matched = -1;
+      for (let index = stack.length - 1; index >= 0; index -= 1) {
+        if (stack[index]!.tag === tag) {
+          matched = index;
+          break;
+        }
+      }
+      if (matched === -1) {
+        if (!OPTIONAL_CLOSE_TAGS.has(tag) && !VOID_TAGS.has(tag)) {
+          issues.push({
+            issue: "close-tag-orphaned",
+            ...locate(value, open),
+            tag,
+          });
+        }
+      } else {
+        const closeLine = locate(value, open).line;
+        for (let index = stack.length - 1; index > matched; index -= 1) {
+          const abandoned = stack[index]!;
+          if (OPTIONAL_CLOSE_TAGS.has(abandoned.tag)) continue;
+          issues.push({
+            issue: "element-unclosed",
+            ...locate(value, abandoned.start),
+            tag: abandoned.tag,
+            closedBy: { tag, line: closeLine },
+          });
+        }
+        stack.length = matched;
+      }
+      cursor = scan.end;
+      continue;
+    }
+
+    const selfClosing = /\/\s*>$/.test(value.slice(open, scan.end));
+
+    if (RAW_TEXT_TAGS.has(tag) && !selfClosing) {
+      // Resume AT the closing tag so the close branch pops this element,
+      // rather than duplicating that logic here. An unterminated body is left
+      // to the raw-text-balance check, which names that cause correctly.
+      const closer = new RegExp(`<\\s*/\\s*${tag}\\b`, "i");
+      const rest = value.slice(scan.end);
+      const found = closer.exec(rest);
+      if (!found) {
+        cursor = value.length;
+        continue;
+      }
+      stack.push({ tag, start: open });
+      cursor = scan.end + found.index;
+      continue;
+    }
+
+    if (VOID_TAGS.has(tag) || selfClosing) {
+      cursor = scan.end;
+      continue;
+    }
+
+    const top = stack[stack.length - 1];
+    if (top && IMPLICIT_SIBLING_CLOSE.get(tag)?.has(top.tag)) stack.pop();
+    stack.push({ tag, start: open });
+    cursor = scan.end;
+  }
+
+  // Stack order is document order, so stopping at the cap keeps the earliest
+  // (outermost) unclosed elements without locating every one of them.
+  for (const abandoned of stack) {
+    if (issues.length >= MAX_REPORTED_ISSUES) break;
+    if (OPTIONAL_CLOSE_TAGS.has(abandoned.tag)) continue;
+    issues.push({
+      issue: "element-unclosed",
+      ...locate(value, abandoned.start),
+      tag: abandoned.tag,
+    });
+  }
+
+  return issues
+    .sort((left, right) =>
+      left.line === right.line
+        ? left.column - right.column
+        : left.line - right.line,
+    )
+    .slice(0, MAX_REPORTED_ISSUES);
+}
+
+/**
+ * Reported, never enforced: legitimate fragments and token-only screens carry no
+ * runtime of their own, so blocking here would reject valid work.
+ */
+function collectAdvisoryIssues(
+  value: string,
+  rawTextBodyRanges: RawTextScan["bodyRanges"],
+): DesignHtmlIntegrityIssueDetail[] {
+  if (!isDocumentHtml(value, rawTextBodyRanges)) return [];
+  // Only documents that actually depend on utility classes can be broken by a
+  // missing runtime. A screen styled entirely through its own CSS needs no
+  // Tailwind, and flagging it would train authors to ignore this warning.
+  if (!USES_TAILWIND_UTILITIES.test(value)) return [];
+  const hasTailwindRuntime =
+    /<script\b[^>]*\bsrc\s*=\s*(?:"[^"]*tailwind[^"]*"|'[^']*tailwind[^']*')/i.test(
+      value,
+    ) ||
+    /<style\b[^>]*\btype\s*=\s*(?:"text\/tailwindcss"|'text\/tailwindcss')/i.test(
+      value,
+    ) ||
+    /<link\b[^>]*\bhref\s*=\s*(?:"[^"]*tailwind[^"]*"|'[^']*tailwind[^']*')/i.test(
+      value,
+    );
+  if (hasTailwindRuntime) return [];
+  const headIndex = value.search(/<head\b/i);
+  return [
+    {
+      issue: "runtime-missing",
+      ...locate(value, headIndex === -1 ? 0 : headIndex),
+    },
+  ];
+}
+
 function markerCounts(
   value: string,
   marker: string,
@@ -292,6 +750,19 @@ export function inspectDesignHtmlDocumentIntegrity(
   value: string,
 ): DesignHtmlIntegrityResult {
   const rawText = scanRawTextTags(value);
+
+  // Structure first, counting second. An unterminated quote swallows the root
+  // tags, so the counting pass would report `document-root` — sending the fix to
+  // a `<html>` tag that is present and correct instead of to the quote.
+  const structural = collectStructuralIssues(value);
+  if (structural.length > 0) {
+    return {
+      valid: false,
+      issue: structural[0]!.issue,
+      detail: structural,
+    };
+  }
+
   if (!isDocumentHtml(value, rawText.bodyRanges)) return { valid: true };
 
   const html = tagCount(value, "html", rawText.bodyRanges);
@@ -363,7 +834,8 @@ export function inspectDesignHtmlDocumentIntegrity(
     }
   }
 
-  return { valid: true };
+  const advisory = collectAdvisoryIssues(value, rawText.bodyRanges);
+  return advisory.length > 0 ? { valid: true, advisory } : { valid: true };
 }
 
 /**
@@ -376,18 +848,59 @@ export function assertDesignHtmlEditIntegrity(args: {
   previousContent: string;
   nextContent: string;
   fileType: string;
+  filename?: string;
 }): void {
   if (args.fileType.toLowerCase() !== "html") return;
   const previousIsDocument = isDocumentHtml(args.previousContent);
   const nextIsDocument = isDocumentHtml(args.nextContent);
-  if (!previousIsDocument && !nextIsDocument) return;
+  // Fragments still get the structural pass; only the document-shape checks
+  // below need a document to apply to.
+  if (!previousIsDocument && !nextIsDocument) {
+    const structural = collectStructuralIssues(args.nextContent);
+    if (structural.length > 0) {
+      throw new DesignHtmlIntegrityError(structural[0]!.issue, {
+        filename: args.filename,
+        detail: structural,
+      });
+    }
+    return;
+  }
   if (previousIsDocument && !nextIsDocument) {
-    throw new DesignHtmlIntegrityError("document-root");
+    throw new DesignHtmlIntegrityError("document-root", {
+      filename: args.filename,
+    });
   }
   const result = inspectDesignHtmlDocumentIntegrity(args.nextContent);
   if (!result.valid) {
-    throw new DesignHtmlIntegrityError(result.issue ?? "document-root");
+    throw new DesignHtmlIntegrityError(result.issue ?? "document-root", {
+      filename: args.filename,
+      detail: result.detail,
+    });
   }
+}
+
+/**
+ * Creation counterpart to the edit transition above. Every creation path must
+ * run this, or a design's first save is the one write with no gate at all.
+ *
+ * Returns advisory issues for the caller to surface; throws on anything
+ * blocking.
+ */
+export function assertDesignHtmlCreateIntegrity(args: {
+  content: string;
+  fileType: string;
+  filename?: string;
+}): DesignHtmlIntegrityIssueDetail[] {
+  if ((args.fileType || "html").toLowerCase() !== "html") return [];
+  if (!args.content.trim()) return [];
+  const result = inspectDesignHtmlDocumentIntegrity(args.content);
+  if (!result.valid) {
+    throw new DesignHtmlIntegrityError(result.issue ?? "document-root", {
+      filename: args.filename,
+      detail: result.detail,
+    });
+  }
+  return result.advisory ?? [];
 }
 
 export function isDesignHtmlIntegrityError(error: unknown): boolean {

--- a/templates/design/shared/html-integrity.ts
+++ b/templates/design/shared/html-integrity.ts
@@ -680,8 +680,15 @@ function collectStructuralIssues(
       closer.lastIndex = scan.end;
       const found = closer.exec(value);
       if (!found) {
-        cursor = value.length;
-        continue;
+        // Report here rather than deferring to the document-only raw-text
+        // balance check: fragments never reach that check, so an unclosed
+        // <script> would pass the well-formedness gate entirely.
+        issues.push({
+          issue: "raw-text-balance",
+          ...locate(open),
+          tag,
+        });
+        return issues;
       }
       stack.push({ tag, start: open });
       cursor = found.index;
@@ -693,8 +700,17 @@ function collectStructuralIssues(
       continue;
     }
 
-    const top = stack[stack.length - 1];
-    if (top && IMPLICIT_SIBLING_CLOSE.get(tag)?.has(top.tag)) stack.pop();
+    // An implied close discards the target AND everything opened inside it —
+    // the browser closes those too, so popping only the stack top reports a
+    // still-open inline descendant (`<li><span>one<li>`) as unclosed.
+    const impliedClose = IMPLICIT_SIBLING_CLOSE.get(tag);
+    if (impliedClose) {
+      for (let index = stack.length - 1; index >= 0; index -= 1) {
+        if (!impliedClose.has(stack[index]!.tag)) continue;
+        stack.length = index;
+        break;
+      }
+    }
     stack.push({ tag, start: open });
     cursor = scan.end;
   }
@@ -733,15 +749,17 @@ function collectAdvisoryIssues(
   // missing runtime. A screen styled entirely through its own CSS needs no
   // Tailwind, and flagging it would train authors to ignore this warning.
   if (!USES_TAILWIND_UTILITIES.test(value)) return [];
+  // Comments are not markup: a commented-out runtime tag is not a runtime.
+  const value_ = value.replace(/<!--[\s\S]*?-->/g, "");
   const hasTailwindRuntime =
     /<script\b[^>]*\bsrc\s*=\s*(?:"[^"]*tailwind[^"]*"|'[^']*tailwind[^']*')/i.test(
-      value,
+      value_,
     ) ||
     /<style\b[^>]*\btype\s*=\s*(?:"text\/tailwindcss"|'text\/tailwindcss')/i.test(
-      value,
+      value_,
     ) ||
     /<link\b[^>]*\bhref\s*=\s*(?:"[^"]*tailwind[^"]*"|'[^']*tailwind[^']*')/i.test(
-      value,
+      value_,
     );
   if (hasTailwindRuntime) return [];
   const headIndex = value.search(/<head\b/i);


### PR DESCRIPTION
Generated designs with malformed HTML — a missing quote, an unclosed tag, a payload cut off mid-attribute — would slip through silently. The browser's parser never throws; it just recovers and renders something different from what you wrote, so nothing downstream ever flagged it.
The old integrity guard only counted root tags, which meant it was blind to nesting issues. Worse, creation paths skipped the check entirely: both generate-design's new-file branch and create-file would raw-insert content, making a design's first save completely ungated.
This change adds a stack-machine tokenizer to shared/html-integrity.ts that catches unterminated attributes, unclosed elements, orphaned closing tags, and truncated content. Errors now include the file, line, column, and offending source line so you know exactly what to fix.
It also gates both creation paths, validating the entire batch before the first insert so a rejection can't leave earlier files orphaned. Finally, it warns (without blocking) when a document uses Tailwind utility classes but has no reachable runtime.