### PR TITLE
Improve agent connections and slide presentation workflows

### DIFF
--- a/.agents/skills/a2a-protocol/SKILL.md
+++ b/.agents/skills/a2a-protocol/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: a2a-protocol
 description: >-
-  How agents call other agents via the A2A (agent-to-agent) JSON-RPC protocol.
-  Use when enabling inter-agent communication, exposing agent skills to other
-  agents, or calling external agents from scripts.
+  How agent-native apps discover, authenticate with, and call each other over
+  A2A. Use when connecting one app to another, debugging a remote agent that
+  won't authenticate, exposing skills to peers, or calling agents from scripts.
 scope: dev
 metadata:
   internal: true
@@ -13,109 +13,154 @@ metadata:
 
 ## Rule
 
-Agents can call other agents using the A2A protocol. This is a JSON-RPC-based protocol for agent discovery and communication. Use it when work should go to a different agent entirely — not the local agent chat.
+Agents call other agents over A2A, a JSON-RPC protocol for discovery and
+delegation. Use it when work belongs to a different agent entirely — not the
+local agent chat.
 
-## Why
+Connecting app A to app B is two independent things, and both must be true:
 
-Agent-native apps don't exist in isolation. A mail agent might need analytics data. A calendar agent might need to search issues. A2A lets agents discover each other, send messages, and receive structured results — all over HTTP with bearer token auth.
+1. **B is registered on A** as a `remote-agents/<id>.json` resource.
+2. **A and B share a secret**, so A's signed JWT verifies on B.
 
-## How to Enable A2A (Server Side)
+Neither is a code change, and neither is symmetric. Registering B on A does not
+let B call A.
 
-Add `mountA2A()` to a server plugin:
+## A2A is already mounted
 
-```ts
-// server/plugins/a2a.ts
-import { mountA2A } from "@agent-native/core/a2a";
+`createAgentChatPlugin` calls `mountA2A` for every app, so a generated app
+already serves:
 
-export default defineNitroPlugin((nitro) => {
-  const app = nitro.h3App;
+- `GET /.well-known/agent-card.json` — public discovery, never authenticated
+- `POST /_agent-native/a2a` — JSON-RPC, authenticated
 
-  mountA2A(app, {
-    name: "Analytics Agent",
-    description: "Queries analytics data across providers",
-    version: "1.0.0",
-    skills: [
-      {
-        id: "query-data",
-        name: "Query Data",
-        description: "Run analytics queries across connected data sources",
-        tags: ["analytics", "data"],
-        examples: ["What were last week's signups?", "Show conversion rates"],
-      },
-    ],
-    apiKeyEnv: "A2A_API_KEY", // env var holding the bearer token
-    streaming: true,          // enable message/stream method
-  });
-});
-```
+Do not add a `mountA2A` server plugin to enable A2A; it is on. Hand-mounting is
+only for a bespoke card or a custom handler (see **Custom mount** below).
 
-This mounts the agent-native A2A endpoints:
+The client falls back to `POST /a2a` for external peers that only expose that
+path. New agent-native apps should call `/_agent-native/a2a`.
 
-- `GET /.well-known/agent-card.json` — public agent discovery (no auth required)
-- `POST /_agent-native/a2a` — primary JSON-RPC endpoint (bearer token auth required)
+## Registering a remote agent
 
-The client may fall back to `POST /a2a` for external or legacy peers that only
-expose that simple path. New agent-native apps should document and call the
-`/_agent-native/a2a` endpoint.
-
-## The Config Object
-
-```ts
-interface A2AConfig {
-  name: string;           // agent display name
-  description: string;    // what this agent does
-  version?: string;       // semver version (default: "1.0.0")
-  skills: AgentSkill[];   // capabilities this agent exposes
-  handler?: A2AHandler;   // custom message handler
-  apiKeyEnv?: string;     // env var name for bearer token auth
-  streaming?: boolean;    // enable streaming responses
-}
-
-interface AgentSkill {
-  id: string;             // unique skill identifier
-  name: string;           // human-readable name
-  description: string;    // what this skill does
-  tags?: string[];        // categorization tags
-  examples?: string[];    // example prompts
-}
-```
-
-## Agent Card
-
-The agent card is auto-generated at `GET /.well-known/agent-card.json`. Other agents fetch this to discover what skills are available:
+A remote agent is **a row in the resources table, not a file on disk**. Path
+`remote-agents/<id>.json`, owner `SHARED_OWNER`, content:
 
 ```json
 {
-  "name": "Analytics Agent",
+  "id": "analytics",
+  "name": "Analytics",
   "description": "Queries analytics data across providers",
   "url": "https://analytics.example.com",
-  "version": "1.0.0",
-  "protocolVersion": "0.3",
-  "capabilities": { "streaming": true },
-  "skills": [
-    {
-      "id": "query-data",
-      "name": "Query Data",
-      "description": "Run analytics queries across connected data sources"
-    }
-  ]
+  "color": "#6B7280"
 }
 ```
 
-## Calling Another Agent
+`url` is the only required field. `parseRemoteAgentManifest` accepts **only**
+these five keys — there is no `apiKey`, `env`, `skills`, or `token` field, and
+anything else is silently dropped.
+
+Four ways to create it, all writing the same row:
+
+| Surface | Where |
+| --- | --- |
+| Settings → Manage agent → Connected Agents (A2A) | any app with the settings panel |
+| Agent page → Connections | apps mounting `AgentTabsPage` |
+| Dispatch → Agents → Add external agent | workspace dispatch |
+| The agent itself | `resources` tool, `action: "write"`, `--scope shared` |
+
+The last one matters for template apps with no Code tab: "connect me to
+https://analytics.example.com" is a complete instruction. `remote-agents/` is
+whitelisted as a durable control path, so the write is workspace-scoped, and it
+takes effect on the next `discoverAgents()` call with no restart.
+
+First-party templates are seeded automatically and overlaid on top of manifests,
+so `Mail`, `Calendar`, and friends appear without registration. In dev they
+resolve to `http://localhost:<devPort>`; a manifest pointing at localhost is
+ignored in production.
+
+`call-agent` also accepts a raw URL, which skips registration entirely — useful
+for one-off calls, useless for @-mentions.
+
+### Checking a peer
+
+`GET /_agent-native/agents/probe?url=<base>` reads the peer's card and makes one
+authenticated no-op call, returning `reachable` and `authorized` as independent
+fields. Omit `url` to probe every registered peer. Reachable-but-unauthorized is
+the failure worth looking for: local dev runs the receiver unauthenticated, so a
+mismatched secret only surfaces after deploy. The Connected Agents settings
+section calls this on add and on open.
+
+## Authentication
+
+A2A authenticates with a **short-lived JWT the caller signs**, not a stored
+bearer key. `Authorization: Bearer <jwt>`; claims carry the caller's email and
+org domain; HS256; 15-minute default TTL. There is no per-peer API key
+anywhere in the system, which is why the manifest has no field for one.
+
+Two secrets can sign it:
+
+| Secret | Scope | How it is set |
+| --- | --- | --- |
+| `A2A_SECRET` | whole deployment | env var, **never auto-generated** |
+| org `a2a_secret` | one organization | auto-generated on org creation; Team page UI |
+
+The org secret is the managed path: **Team page → A2A secret** (owner only)
+reveals, copies, regenerates, and pushes it to every discovered peer. Rotation
+is tolerated — the caller tries both secrets in order and sticks to whichever
+worked.
+
+`A2A_SECRET` is the deploy-level path. `workspace-deploy` refuses a production
+workspace deploy without it and prints the generator command. Peers that must
+trust each other need the *same* value on both sides.
+
+With no secret configured at all:
+
+| Runtime | Result |
+| --- | --- |
+| local dev | open, one-time console warning |
+| production | `503` — "A2A authentication not configured" |
+| production, secret set, bad/absent token | `401` |
+
+"Production" is detected broadly (NODE_ENV, Netlify, Lambda, Vercel, Render,
+Fly, Cloud Run, …) and unrecognized deployed hosts fail closed unless the
+request is genuine loopback or `A2A_ALLOW_UNSIGNED_INTERNAL=1`.
+
+`A2AConfig.apiKeyEnv` still exists for static bearer auth against non-agent-native
+peers, but the framework's own mount never sets it. Do not reach for it when
+debugging a connection between two agent-native apps — the answer there is
+always the shared secret.
+
+Never hardcode either secret in source, docs, prompts, app state, action
+descriptions, client bundles, or examples. Read them from runtime config; never
+log or return them.
+
+## Advertising what this agent can do
+
+Card `skills` are derived from actions marked `publicAgent`. An app that marks
+none publishes `"skills": []` and peers cannot see what it offers, even though
+delegation still works. Mark the actions a peer should be able to see and
+invoke directly; leave the rest internal.
+
+## Calling another agent
 
 ### Simple: `callAgent()` (text in, text out)
 
 ```ts
-import { callAgent } from "@agent-native/core/a2a";
+import { callAgent, resolveA2ACallerAuth } from "@agent-native/core/a2a";
 
+const auth = await resolveA2ACallerAuth();
 const answer = await callAgent(
   "https://analytics.example.com",
   "What were last week's signups?",
-  { apiKey: process.env.ANALYTICS_A2A_KEY },
+  auth,
 );
 // answer is a plain string
 ```
+
+`callAgent` signs nothing on its own — with no `userEmail`/`orgSecret` in opts
+it calls **unauthenticated**, which silently works in local dev and 401s in
+production. `resolveA2ACallerAuth()` pulls the authenticated email, org domain,
+and org secret out of request context; pass them explicitly only from CLI or
+cron, where there is no request.
 
 ### Fast bounded read: `invokeAgentAction()`
 
@@ -168,12 +213,13 @@ action arguments or results.
 ### Advanced: `A2AClient` (full control)
 
 ```ts
-import { A2AClient } from "@agent-native/core/a2a";
+import { A2AClient, resolveA2ACallerAuth } from "@agent-native/core/a2a";
 
-const client = new A2AClient(
-  "https://analytics.example.com",
-  process.env.ANALYTICS_A2A_KEY,
-);
+// The second argument is the bearer token itself, not a signing secret.
+const { apiKey, apiKeyFallbacks } = await resolveA2ACallerAuth();
+const client = new A2AClient("https://analytics.example.com", apiKey, {
+  fallbackApiKeys: apiKeyFallbacks,
+});
 
 // Discover agent capabilities
 const card = await client.getAgentCard();
@@ -264,19 +310,6 @@ submitted → working → completed
 - **canceled** — task was canceled via `tasks/cancel`
 - **input-required** — agent needs more information from the caller
 
-## Security
-
-A2A uses bearer token auth. The server reads the token from the environment variable specified by `apiKeyEnv`:
-
-- Set `A2A_API_KEY=<A2A_API_KEY_VALUE>` in the server's deployment environment
-- Callers pass it as `Authorization: Bearer <A2A_API_KEY_VALUE>`
-- The agent card endpoint (`/.well-known/agent-card.json`) is public — no auth needed for discovery
-
-Never hardcode the bearer token in source, docs, prompts, app state, action
-descriptions, client bundles, or examples. A2A tokens are deploy-level secrets
-unless a specific app designs a scoped credential flow; read them from secure
-runtime configuration and never log or return them.
-
 ## Message Parts
 
 Messages contain typed parts:
@@ -287,33 +320,37 @@ Messages contain typed parts:
 | `file`    | `{ type: "file", file: { ... } }`   | Files (bytes or URI)       |
 | `data`    | `{ type: "data", data: { ... } }`   | Structured JSON data       |
 
-## Example: Cross-Agent Workflow
+## Custom mount
 
-A mail agent calls an analytics agent to include data in an email draft:
+Only when the default card is wrong for the app — a curated skill list, a
+non-agent handler, or static bearer auth against an external peer:
 
 ```ts
-// actions/draft-with-analytics.ts
-import { callAgent } from "@agent-native/core/a2a";
-import { writeAppState } from "@agent-native/core/application-state";
+// server/plugins/a2a.ts
+import { mountA2A } from "@agent-native/core/a2a";
 
-export default async function (args: string[]) {
-  // Ask the analytics agent for data
-  const stats = await callAgent(
-    process.env.ANALYTICS_AGENT_URL!,
-    "Summarize last week's key metrics in 3 bullet points",
-    { apiKey: process.env.ANALYTICS_A2A_KEY },
-  );
-
-  // Create a draft with the analytics data
-  await writeAppState("compose-analytics-report", {
-    id: "analytics-report",
-    to: "team@example.com",
-    subject: "Weekly Analytics Summary",
-    body: `Hi team,\n\nHere are last week's numbers:\n\n${stats}\n\nBest`,
-    mode: "compose",
+export default defineNitroPlugin((nitro) => {
+  mountA2A(nitro, {
+    appId: "analytics",
+    name: "Analytics Agent",
+    description: "Queries analytics data across providers",
+    skills: [
+      {
+        id: "query-data",
+        name: "Query Data",
+        description: "Run analytics queries across connected data sources",
+        tags: ["analytics", "data"],
+        examples: ["What were last week's signups?", "Show conversion rates"],
+      },
+    ],
+    streaming: true,
   });
-}
+});
 ```
+
+Config also carries `handler`, `publicSkillsOnly`, `durableBackgroundRuns`,
+`executeReadOnlyAction`, `executeApproval`, and `apiKeyEnv`. See `A2AConfig` in
+`@agent-native/core/a2a` for the full shape.
 
 ## All Types
 
@@ -345,5 +382,8 @@ import type {
 ## Related Skills
 
 - **delegate-to-agent** — For work the local agent handles. Use A2A when the work goes to a different agent.
-- **actions** — A2A calls typically happen inside actions
-- **storing-data** — Results from A2A calls are stored in SQL like any other data
+- **authentication** — Org creation, membership, and where the org secret lives.
+- **actions** — A2A calls typically happen inside actions; `publicAgent` marks what peers can see.
+- **storing-data** — Results from A2A calls are stored in SQL like any other data.
+</content>
+</invoke>

--- a/.changeset/a2a-connect-flow-dedupe.md
+++ b/.changeset/a2a-connect-flow-dedupe.md
@@ -1,0 +1,33 @@
+---
+"@agent-native/core": minor
+"@agent-native/dispatch": patch
+---
+
+Make connecting one agent-native app to another a guided flow instead of three
+blank text fields.
+
+- New `GET /_agent-native/agents/probe` reads a peer's agent card and makes one
+  authenticated no-op call, reporting `reachable` and `authorized` as
+  independent fields. A peer that answers but rejects the caller's token is the
+  failure local dev hides — the receiver runs unauthenticated on localhost, so a
+  mismatched secret previously surfaced only after deploy.
+- Settings → Manage agent → Connected Agents is URL-first: paste a peer URL,
+  press Check, and the name and description come from its card. Unreachable
+  never blocks the save. Rows carry a liveness dot from one batched probe.
+- The section now shows shared-secret state and a Sync to apps action inline,
+  reusing the existing org hooks. A caller who cannot see the secret is told so
+  rather than being shown "not set".
+- After an add, the UI states that registration is one-directional and deep
+  links to the peer's own settings with the values prefilled.
+- The Connected Agents list collapses a remote agent that still has its
+  pre-migration `agents/*.json` row alongside the canonical
+  `remote-agents/*.json` one, instead of listing it twice with the same URL.
+- `list-connected-agents` keys custom manifests by the normalized agent id, so
+  an agent registered as `images`/`asset` no longer appears once as a discovered
+  agent and again as a custom one.
+- Export `resolveA2ACallerAuth` from `@agent-native/core/a2a` so app code can
+  authenticate outbound A2A calls without reimplementing org-secret lookup.
+- The `a2a-protocol` skill documents the real setup path — A2A is auto-mounted,
+  peers are `remote-agents/*.json` resources, and auth is a JWT signed with
+  `A2A_SECRET` or the per-org secret — replacing the `mountA2A` + per-peer
+  `apiKeyEnv` flow the framework no longer wires up.

--- a/.changeset/dispatch-pending-apps.md
+++ b/.changeset/dispatch-pending-apps.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Hide pending workspace apps by default and expose app ownership metadata from each card's overflow menu.

--- a/.changeset/mcp-tool-brand-logos.md
+++ b/.changeset/mcp-tool-brand-logos.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Show the provider's brand logo on agent tool rows for catalog-backed MCP tools, instead of a generic code icon.

--- a/.changeset/model-picker-connect-feedback.md
+++ b/.changeset/model-picker-connect-feedback.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/toolkit": patch
+---
+
+Show only the connect actions in the composer model picker when no LLM provider is configured, instead of a list of unpickable "needs API key" models, and surface Builder connect failures instead of leaving the "Connect Builder.io" button looking dead when the popup is blocked.

--- a/.changeset/secrets-new-key-searchable.md
+++ b/.changeset/secrets-new-key-searchable.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Settings → Connections: the "New" key menu is now a searchable, scrolling combobox instead of a cropped dropdown, so every registered key is reachable.

--- a/.changeset/static-asset-nosniff.md
+++ b/.changeset/static-asset-nosniff.md
@@ -1,0 +1,10 @@
+---
+"@agent-native/core": patch
+---
+
+Send `X-Content-Type-Options: nosniff` on CDN-served static assets.
+
+`/assets/**`, `/favicon.*`, `/manifest.json`, `/icon-*.svg`, and
+`/library-presets/**` are served straight off the CDN, so the security-headers
+h3 middleware never runs for them and they shipped without the `nosniff` header
+that every function-served response already carries.

--- a/.changeset/stop-aborts-whole-turn.md
+++ b/.changeset/stop-aborts-whole-turn.md
@@ -1,0 +1,17 @@
+---
+"@agent-native/core": patch
+---
+
+Make the chat Stop button actually stop the turn.
+
+A turn runs as a chain of runs: every `loop_limit` / `auto_continue` boundary
+and every background handoff starts a successor under a new run id but the same
+turn id. Stop only aborted the run id the client happened to hold, so the
+successor claimed itself and the agent kept looping — the turn-abort marker that
+`isTurnAborted` consults was only ever written on the pre-run path, which is
+dead as soon as a run id exists.
+
+`POST /runs/:id/abort` now escalates user-intent reasons (`user`, `abort`,
+`user_stuck_cancel`, `user_stuck_retry`) to a turn-wide abort. Watchdog reasons
+(`no_progress`, `auto_stuck_retry`) keep single-run semantics so they cannot
+kill a server-side continuation chain that is still making progress.

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -254,7 +254,7 @@
         "PORT=3220",
         "AUTH_MODE=local",
         "APP_URL=http://localhost:3220",
-        "OPENAI_API_KEY=sk-not-a-real-key-local-ui-check",
+        "OPENAI_API_KEY=local-test-placeholder",
         "pnpm",
         "--dir",
         "templates/slides",

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -230,6 +230,41 @@
       "port": 3106
     },
     {
+      "name": "slides-modelpicker",
+      "runtimeExecutable": "env",
+      "runtimeArgs": [
+        "DATABASE_URL=file:/private/tmp/claude-501/-Users-steve-Projects-builder-agent-native-framework/4b6b0d66-427e-468c-afd6-aaf1ec21468d/scratchpad/slides-modelpicker.sqlite",
+        "PORT=3219",
+        "AUTH_MODE=local",
+        "APP_URL=http://localhost:3219",
+        "pnpm",
+        "--dir",
+        "templates/slides",
+        "dev",
+        "--port",
+        "3219"
+      ],
+      "port": 3219
+    },
+    {
+      "name": "slides-modelpicker-keyed",
+      "runtimeExecutable": "env",
+      "runtimeArgs": [
+        "DATABASE_URL=file:/private/tmp/claude-501/-Users-steve-Projects-builder-agent-native-framework/4b6b0d66-427e-468c-afd6-aaf1ec21468d/scratchpad/slides-modelpicker.sqlite",
+        "PORT=3220",
+        "AUTH_MODE=local",
+        "APP_URL=http://localhost:3220",
+        "OPENAI_API_KEY=sk-not-a-real-key-local-ui-check",
+        "pnpm",
+        "--dir",
+        "templates/slides",
+        "dev",
+        "--port",
+        "3220"
+      ],
+      "port": 3220
+    },
+    {
       "name": "slides-feelcheck",
       "runtimeExecutable": "env",
       "runtimeArgs": [
@@ -422,6 +457,42 @@
         "3209"
       ],
       "port": 3209
+    },
+    {
+      "name": "slides-keysearch",
+      "runtimeExecutable": "env",
+      "runtimeArgs": [
+        "DATABASE_URL=file:/private/tmp/claude-501/-Users-steve-Projects-builder-agent-native-framework/84928637-4902-4916-9d06-9174ec3dd630/scratchpad/slides-keysearch.sqlite",
+        "PORT=3224",
+        "AUTH_MODE=local",
+        "AUTH_DISABLED=true",
+        "APP_URL=http://localhost:3224",
+        "pnpm",
+        "--dir",
+        "templates/slides",
+        "dev",
+        "--port",
+        "3224"
+      ],
+      "port": 3224
+    },
+    {
+      "name": "slides-presenter",
+      "runtimeExecutable": "env",
+      "runtimeArgs": [
+        "DATABASE_URL=file:/private/tmp/claude-501/-Users-steve-Projects-builder-agent-native-framework/61efc022-a794-4587-bb1a-516bdb01dfdc/scratchpad/slides-presenter.sqlite",
+        "PORT=3221",
+        "AUTH_MODE=local",
+        "AUTH_DISABLED=true",
+        "APP_URL=http://localhost:3221",
+        "pnpm",
+        "--dir",
+        "templates/slides",
+        "dev",
+        "--port",
+        "3221"
+      ],
+      "port": 3221
     }
   ]
 }

--- a/packages/core/src/a2a/index.ts
+++ b/packages/core/src/a2a/index.ts
@@ -21,6 +21,8 @@ export {
 
 // Client
 export { A2AClient, callAction, callAgent, signA2AToken } from "./client.js";
+export { resolveA2ACallerAuth } from "./caller-auth.js";
+export type { A2ACallerAuth } from "./caller-auth.js";
 export {
   AgentInvocationError,
   buildAgentInvocationPrompt,

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -141,6 +141,7 @@ import {
   getRun,
   abortRun,
   abortRunDurably,
+  abortTurnDurably,
   tryClaimRunSlot,
   isHostedRuntime,
   resolveRunSoftTimeoutMs,
@@ -9020,5 +9021,6 @@ export {
   getRun,
   abortRun,
   abortRunDurably,
+  abortTurnDurably,
   subscribeToRun,
 };

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -15,6 +15,8 @@ import {
   getRunEventsSince,
   getRunById,
   getRunByThread,
+  getRunTurnRef,
+  markTurnAborted,
   cleanupOldRuns,
   updateRunHeartbeat,
   bumpRunProgress,
@@ -2093,6 +2095,41 @@ export async function abortRunDurably(
     );
   }
   return abortedInMemory;
+}
+
+/**
+ * Stop the whole turn `runId` belongs to, not just that run.
+ *
+ * A turn is executed as a chain of runs: every `loop_limit` / `auto_continue`
+ * boundary and every background handoff starts a successor run with a NEW run
+ * id under the same turn id. Aborting one run therefore only ends the current
+ * chunk — the successor claims itself and the turn keeps going, which is what
+ * users see as "Stop didn't stop it". The durable turn-abort marker is the only
+ * thing the successor-claim path (`isTurnAborted`) consults.
+ */
+export async function abortTurnDurably(
+  runId: string,
+  reason: string = "user",
+): Promise<void> {
+  const memRun = activeRuns.get(runId);
+  // In-memory first: a foreground run's SQL insert is async, so the row may not
+  // exist yet when Stop lands moments after send.
+  const ref = memRun
+    ? { threadId: memRun.threadId, turnId: memRun.turnId }
+    : await getRunTurnRef(runId).catch(() => null);
+  if (!ref) return;
+  try {
+    await markTurnAborted(ref.threadId, ref.turnId, reason);
+  } catch (error) {
+    // The current run is already stopped; a failed marker write must not turn
+    // Stop into a 500. Successors will keep running — capture it so that is
+    // visible rather than silent.
+    captureError(error, {
+      route: "/_agent-native/agent-chat/runs/:id/abort",
+      tags: { source: "agent-run-manager", phase: "abort-turn" },
+      extra: { runId, reason, ...ref },
+    });
+  }
 }
 
 // Re-export so callers can avoid importing from run-store directly.

--- a/packages/core/src/agent/run-store.stale-run-recovery.spec.ts
+++ b/packages/core/src/agent/run-store.stale-run-recovery.spec.ts
@@ -171,6 +171,22 @@ describe("FIX 3 — stale-run reaper server-owned recovery (reapIfStale)", () =>
     expect(readRow(runId)?.status).toBe("aborted");
   });
 
+  it("escalates Stop on one chunk to every run of the same turn", async () => {
+    currentClient = makeRawClient(true);
+    const { runId, thread, turn } = ids();
+    await insertRun(runId, thread, turn, { dispatchMode: "background" });
+    const successor = `${runId}-chunk2`;
+    await insertRun(successor, thread, turn, { dispatchMode: "background" });
+
+    const { abortTurnDurably } = await import("./run-manager.js");
+    await abortTurnDurably(runId);
+
+    // Without the turn marker the successor claims itself and the turn keeps
+    // looping — the "Stop didn't stop it" report.
+    expect(await isTurnAborted(thread, turn)).toBe(true);
+    expect(readRow(successor)?.status).toBe("aborted");
+  });
+
   it("creates exactly one unclaimed recovery successor for a dead claimed background worker, and does not stack a second on a re-reap", async () => {
     currentClient = makeRawClient(true);
     const { runId, thread, turn } = ids();

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -2053,6 +2053,24 @@ export async function markTurnAborted(
   );
 }
 
+/**
+ * Turn identity for a run, or null when the row is unknown. `turn_id` is null
+ * for rows written before the column existed; those runs are their own turn.
+ */
+export async function getRunTurnRef(
+  runId: string,
+): Promise<{ threadId: string; turnId: string } | null> {
+  await ensureRunTables();
+  const { rows } = await getDbExec().execute({
+    sql: `SELECT thread_id, turn_id FROM agent_runs WHERE id = ?`,
+    args: [runId],
+  });
+  const row = rows[0] as { thread_id?: unknown; turn_id?: unknown } | undefined;
+  const threadId = row?.thread_id ? String(row.thread_id) : "";
+  if (!threadId) return null;
+  return { threadId, turnId: row?.turn_id ? String(row.turn_id) : runId };
+}
+
 export async function isTurnAborted(
   threadId: string,
   turnId: string,

--- a/packages/core/src/client/chat/tool-call-display.spec.tsx
+++ b/packages/core/src/client/chat/tool-call-display.spec.tsx
@@ -112,6 +112,39 @@ describe("ToolCallDisplay native renderers", () => {
     vi.unstubAllGlobals();
   });
 
+  it("renders the provider logo for catalog-backed MCP tools", async () => {
+    await act(async () => {
+      root.render(
+        <ToolCallDisplay
+          toolName="mcp__slack__search"
+          args={{}}
+          result="ok"
+          isRunning={false}
+        />,
+      );
+    });
+
+    const logo = container.querySelector("img");
+    expect(logo?.getAttribute("src")).toMatch(/^data:image\//);
+    expect(logo?.getAttribute("title")).toBe("Slack");
+  });
+
+  it("falls back to a generic icon for MCP tools with no catalog match", async () => {
+    await act(async () => {
+      root.render(
+        <ToolCallDisplay
+          toolName="mcp__acme-internal__lookup"
+          args={{}}
+          result="ok"
+          isRunning={false}
+        />,
+      );
+    });
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
   it("renders explicit data widgets natively", async () => {
     await act(async () => {
       root.render(

--- a/packages/core/src/client/chat/tool-call-display.tsx
+++ b/packages/core/src/client/chat/tool-call-display.tsx
@@ -41,6 +41,7 @@ import {
 import { ConnectBuilderCard } from "../ConnectBuilderCard.js";
 import { useT } from "../i18n.js";
 import { McpAppRenderer } from "../mcp-apps/McpAppRenderer.js";
+import { findMcpIntegrationForToolName } from "../resources/mcp-integration-catalog.js";
 import type { AgentCallProgress, ContentPart } from "../sse-event-processor.js";
 import {
   BashCell,
@@ -279,7 +280,31 @@ type ToolIconComponent = React.ComponentType<{
   size?: number | string;
 }>;
 
+const brandIcons = new Map<string, ToolIconComponent>();
+
+function brandToolIcon(logoUrl: string, name: string): ToolIconComponent {
+  const cached = brandIcons.get(logoUrl);
+  if (cached) return cached;
+  const Icon: ToolIconComponent = ({ className, size }) => (
+    <img
+      src={logoUrl}
+      alt=""
+      aria-hidden
+      width={size}
+      height={size}
+      title={name}
+      className={cn("rounded-[3px] object-contain", className)}
+    />
+  );
+  brandIcons.set(logoUrl, Icon);
+  return Icon;
+}
+
 function resolveToolIcon(toolName: string): ToolIconComponent {
+  const integration = findMcpIntegrationForToolName(toolName);
+  if (integration) {
+    return brandToolIcon(integration.logoUrl, integration.name);
+  }
   const name = toolName.toLowerCase();
   if (name.includes("slack")) return IconBrandSlack;
   if (

--- a/packages/core/src/client/resources/mcp-integration-catalog.spec.ts
+++ b/packages/core/src/client/resources/mcp-integration-catalog.spec.ts
@@ -5,6 +5,7 @@ import {
   createMcpIntegrationFormDefaults,
   DEFAULT_MCP_INTEGRATIONS,
   findMcpIntegrationForText,
+  findMcpIntegrationForToolName,
   filterMcpIntegrations,
   getMcpIntegrationApiFallback,
   getDefaultMcpIntegrations,
@@ -193,6 +194,27 @@ describe("MCP integration catalog", () => {
       availability: "ready",
       docsUrl: "https://docs.granola.ai/help-center/sharing/integrations/mcp",
     });
+  });
+
+  it("matches MCP tool names to their preset for brand icons", () => {
+    expect(findMcpIntegrationForToolName("mcp__slack__search")?.id).toBe(
+      "slack",
+    );
+    expect(
+      findMcpIntegrationForToolName("mcp__user_deadbeef00_zapier__send")?.id,
+    ).toBe("zapier");
+    expect(
+      findMcpIntegrationForToolName("mcp__atlassian__jira_issue")?.id,
+    ).toBe("atlassian");
+    expect(findMcpIntegrationForToolName("mcp__dropbox__upload")).toBeNull();
+    expect(findMcpIntegrationForToolName("mcp__chrome-devtools__click")).toBe(
+      null,
+    );
+    // The tool half of the name must never drive the icon.
+    expect(
+      findMcpIntegrationForToolName("mcp__zapier__send_slack_message")?.id,
+    ).toBe("zapier");
+    expect(findMcpIntegrationForToolName("run-code")).toBeNull();
   });
 
   it("matches resource links to their MCP preset", () => {

--- a/packages/core/src/client/resources/mcp-integration-catalog.ts
+++ b/packages/core/src/client/resources/mcp-integration-catalog.ts
@@ -803,6 +803,29 @@ export function findMcpIntegrationForText(
   return null;
 }
 
+/**
+ * Matches the server segment of an `mcp__<server>__<tool>` name, not prose, so
+ * ambiguous brand words ("box", "monday", "linear") are safe here in a way they
+ * are not in `findMcpIntegrationForText`.
+ */
+export function findMcpIntegrationForToolName(
+  toolName: string,
+  integrations: readonly DefaultMcpIntegration[] = DEFAULT_MCP_INTEGRATIONS,
+): DefaultMcpIntegration | null {
+  const server = /^mcp__(.+?)__/.exec(toolName.toLowerCase())?.[1];
+  if (!server) return null;
+  return (
+    integrations.find((integration) =>
+      [
+        integration.id,
+        integration.provider,
+        ...(integration.brandAliases ?? []),
+        ...(integration.aliases ?? []),
+      ].some((alias) => textContainsTerm(server, alias)),
+    ) ?? null
+  );
+}
+
 export function isMcpConnectionFailureText(text: string): boolean {
   return /\b(?:can(?:not|'t|’t)|could(?: not|n't|n’t)|unable|failed|don't have access|don’t have access|not connected|not able)\b[\s\S]{0,80}\b(?:read|access|open|see|fetch|connect)\b/i.test(
     text,

--- a/packages/core/src/client/settings/AgentsSection.spec.tsx
+++ b/packages/core/src/client/settings/AgentsSection.spec.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TooltipProvider } from "../components/ui/tooltip.js";
+import { AgentsSection } from "./AgentsSection.js";
+
+vi.mock("../api-path.js", () => ({
+  agentNativePath: (path: string) => path,
+  appBasePath: () => "",
+}));
+
+function renderSection(root: Root) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return act(async () => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <AgentsSection />
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
+  });
+}
+
+// A migrated remote agent keeps its legacy `agents/` row alongside the
+// canonical `remote-agents/` one, so the list has to collapse them.
+const resources = [
+  { id: "legacy-mail", path: "agents/mail.json" },
+  { id: "canonical-mail", path: "remote-agents/mail.json" },
+  { id: "canonical-analytics", path: "remote-agents/analytics.json" },
+  { id: "skill-row", path: "skills/writing/SKILL.md" },
+];
+
+const contentById: Record<string, string> = {
+  "legacy-mail": JSON.stringify({
+    id: "mail",
+    name: "Mail",
+    url: "http://localhost:8088",
+  }),
+  "canonical-mail": JSON.stringify({
+    id: "mail",
+    name: "Mail",
+    url: "http://localhost:8088",
+  }),
+  "canonical-analytics": JSON.stringify({
+    id: "analytics",
+    name: "Analytics",
+    url: "http://localhost:8085",
+  }),
+};
+
+describe("AgentsSection", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        const detail = url.match(/\/resources\/([^?]+)$/);
+        if (detail) return Response.json({ content: contentById[detail[1]] });
+        return Response.json({ resources });
+      }),
+    );
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    document.body.innerHTML = "";
+    vi.unstubAllGlobals();
+  });
+
+  it("lists a migrated agent once instead of twice", async () => {
+    await renderSection(root);
+
+    const names = Array.from(container.querySelectorAll("span")).map((span) =>
+      span.textContent?.trim(),
+    );
+    expect(names.filter((name) => name === "Mail")).toHaveLength(1);
+    expect(names.filter((name) => name === "Analytics")).toHaveLength(1);
+  });
+
+  it("never claims the shared secret is unset when the caller can't see it", async () => {
+    // A member (not owner/admin) gets `a2aSecretSet` omitted entirely by the
+    // server — the client must read that as "can't see it," never coerce the
+    // absence into a false "not set" claim it has no basis for.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes("/_agent-native/org/me")) {
+          return Response.json({
+            email: "member@acme.com",
+            orgId: "org-1",
+            orgName: "Acme",
+            role: "member",
+            orgs: [],
+            pendingInvitations: [],
+            domainMatches: [],
+            allowedDomain: "acme.com",
+            // a2aSecretSet intentionally omitted (member, not owner/admin).
+          });
+        }
+        if (url.includes("/_agent-native/agents/probe")) {
+          return Response.json({ results: [] });
+        }
+        const detail = url.match(/\/resources\/([^?]+)$/);
+        if (detail) return Response.json({ content: contentById[detail[1]] });
+        return Response.json({ resources });
+      }),
+    );
+
+    await renderSection(root);
+
+    const text = container.textContent ?? "";
+    expect(text.toLowerCase()).not.toContain("not set");
+    expect(text.toLowerCase()).toContain("workspace owner");
+  });
+});

--- a/packages/core/src/client/settings/AgentsSection.tsx
+++ b/packages/core/src/client/settings/AgentsSection.tsx
@@ -1,17 +1,35 @@
-import { IconPlus, IconPencil, IconTrash, IconX } from "@tabler/icons-react";
+import { ButtonBase as ToolkitButtonBase } from "@agent-native/toolkit/ui/button";
+import {
+  IconPlus,
+  IconPencil,
+  IconTrash,
+  IconX,
+  IconCheck,
+  IconLoader2,
+  IconAlertTriangle,
+  IconExternalLink,
+  IconRefresh,
+} from "@tabler/icons-react";
 import { useState, useEffect, useRef, useCallback } from "react";
 
 import {
+  buildOpenRoutePath,
+  buildSettingsRoute,
+  STANDARD_SETTINGS_TABS,
+} from "../../navigation/index.js";
+import {
   getRemoteAgentIdFromPath,
   isRemoteAgentPath,
+  REMOTE_AGENT_RESOURCE_PREFIX,
   remoteAgentResourcePath,
 } from "../../resources/metadata.js";
-import { agentNativePath } from "../api-path.js";
+import { agentNativePath, appBasePath } from "../api-path.js";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "../components/ui/tooltip.js";
+import { useOrg, useSyncA2ASecret } from "../org/hooks.js";
 
 interface AgentInfo {
   id: string;
@@ -19,6 +37,61 @@ interface AgentInfo {
   name: string;
   url: string;
   description?: string;
+}
+
+/** Wire shape of `GET /_agent-native/agents/probe` (single or batched result). */
+interface AgentProbeResult {
+  url: string;
+  reachable: boolean;
+  name?: string;
+  description?: string;
+  securitySchemes?: string[];
+  /** Absent (not false) whenever the auth check never ran or never resolved. */
+  authorized?: boolean;
+  authError?: string;
+  publicSkills?: number;
+  error?: string;
+}
+
+function describeSkills(publicSkills: number | undefined): string | null {
+  if (publicSkills === undefined) return null;
+  // An empty public skill list only means the card advertises no anonymous-
+  // safe actions — the peer still has authenticated reads/writes. Saying so
+  // plainly avoids reading as "this agent can't do anything."
+  if (publicSkills === 0) return "reads require auth";
+  return `${publicSkills} public skill${publicSkills === 1 ? "" : "s"}`;
+}
+
+/** One-line status for the row dot tooltip. */
+function describeProbeTooltip(result: AgentProbeResult): string {
+  if (!result.reachable) {
+    return `Unreachable${result.error ? `: ${result.error}` : ""}`;
+  }
+  if (result.authorized === false) {
+    return "Reachable, but the peer rejected our token — calls will 401 in production";
+  }
+  if (result.authorized === undefined) {
+    return "Reachable; couldn't verify our token";
+  }
+  return "Reachable and authorized";
+}
+
+/** Multi-clause status line for the Add popover's Check result. */
+function describeCheckResult(result: AgentProbeResult): string {
+  if (!result.reachable) {
+    return result.error ?? "Not reachable";
+  }
+  const scheme = result.securitySchemes?.length
+    ? result.securitySchemes.join(", ")
+    : "no auth scheme advertised";
+  const authText =
+    result.authorized === false
+      ? "the peer rejected our token — calls will 401 in production"
+      : result.authorized === undefined
+        ? `couldn't verify our token${result.authError ? ` (${result.authError})` : ""}`
+        : "our token works";
+  const skills = describeSkills(result.publicSkills);
+  return [`Live · ${scheme}`, authText, skills].filter(Boolean).join(" · ");
 }
 
 function AgentEditPopover({
@@ -125,21 +198,68 @@ function AgentEditPopover({
   );
 }
 
+type CheckState =
+  | { status: "idle" }
+  | { status: "checking" }
+  | { status: "done"; result: AgentProbeResult }
+  | { status: "error"; message: string };
+
+interface AddedAgentInfo {
+  name: string;
+  url: string;
+  description: string;
+}
+
+/** Builds an absolute deep link into a peer's own Settings > Agents Add
+ * popover, prefilled with THIS app's own name/url/description, via the
+ * existing `/_agent-native/open` route's `f_*` filter-forwarding (the only
+ * non-reserved params the open route echoes onto the redirect URL instead of
+ * only stashing them server-side for `navigate` polling). No new endpoint. */
+function buildPeerRegisterBackLink(peerUrl: string): string {
+  const selfUrl = `${window.location.origin}${appBasePath()}`;
+  const selfName = document.title.trim() || window.location.hostname;
+  const openPath = buildOpenRoutePath({
+    view: "settings",
+    to: buildSettingsRoute(STANDARD_SETTINGS_TABS.agent),
+    params: {
+      f_agentName: selfName,
+      f_agentUrl: selfUrl,
+    },
+  });
+  return `${peerUrl.replace(/\/+$/, "")}${openPath}`;
+}
+
 function AgentAddPopover({
+  initialName = "",
+  initialUrl = "",
+  initialDescription = "",
+  secretSet,
+  syncSecret,
   onAdd,
   onClose,
 }: {
-  onAdd: (name: string, url: string, description: string) => void;
+  initialName?: string;
+  initialUrl?: string;
+  initialDescription?: string;
+  secretSet: boolean | undefined;
+  syncSecret: ReturnType<typeof useSyncA2ASecret>;
+  onAdd: (name: string, url: string, description: string) => Promise<boolean>;
   onClose: () => void;
 }) {
-  const [name, setName] = useState("");
-  const [url, setUrl] = useState("");
-  const [description, setDescription] = useState("");
+  const [name, setName] = useState(initialName);
+  const [url, setUrl] = useState(initialUrl);
+  const [description, setDescription] = useState(initialDescription);
+  const [check, setCheck] = useState<CheckState>({ status: "idle" });
+  const [added, setAdded] = useState<AddedAgentInfo | null>(null);
   const nameRef = useRef<HTMLInputElement>(null);
+  const urlRef = useRef<HTMLInputElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const t = setTimeout(() => nameRef.current?.focus(), 50);
+    const t = setTimeout(
+      () => (urlRef.current?.value ? nameRef : urlRef).current?.focus(),
+      50,
+    );
     return () => clearTimeout(t);
   }, []);
 
@@ -156,17 +276,182 @@ function AgentAddPopover({
     return () => document.removeEventListener("mousedown", handleClick);
   }, [onClose]);
 
-  const handleAdd = () => {
-    if (!name.trim() || !url.trim()) return;
-    onAdd(name.trim(), url.trim(), description.trim());
+  const handleCheck = useCallback(async () => {
+    const trimmedUrl = url.trim();
+    if (!trimmedUrl) return;
+    setCheck({ status: "checking" });
+    try {
+      const res = await fetch(
+        agentNativePath(
+          `/_agent-native/agents/probe?url=${encodeURIComponent(trimmedUrl)}`,
+        ),
+      );
+      const body = await res.json().catch(() => null);
+      if (!res.ok) {
+        setCheck({
+          status: "error",
+          message: body?.error ?? `Check failed (${res.status})`,
+        });
+        return;
+      }
+      const result = body as AgentProbeResult;
+      setCheck({ status: "done", result });
+      if (result.reachable) {
+        if (!name.trim() && result.name) setName(result.name);
+        if (!description.trim() && result.description) {
+          setDescription(result.description);
+        }
+      }
+    } catch (err: any) {
+      setCheck({ status: "error", message: err?.message ?? "Check failed" });
+    }
+  }, [url, name, description]);
+
+  const handleAdd = async () => {
+    const trimmedName = name.trim();
+    const trimmedUrl = url.trim();
+    if (!trimmedName || !trimmedUrl) return;
+    const trimmedDescription = description.trim();
+    const ok = await onAdd(trimmedName, trimmedUrl, trimmedDescription);
+    if (ok) {
+      setAdded({
+        name: trimmedName,
+        url: trimmedUrl,
+        description: trimmedDescription,
+      });
+    }
   };
+
+  if (added) {
+    return (
+      <div
+        ref={popoverRef}
+        className="absolute end-0 top-full z-50 mt-1 w-72 rounded-lg border border-border bg-popover p-2.5 shadow-lg"
+      >
+        <div className="flex flex-col gap-1.5">
+          <p className="text-[10px] leading-relaxed text-muted-foreground">
+            Added {added.name} on your side only — registration is one-way, so
+            it won&apos;t know about this app until it&apos;s added there too.
+          </p>
+          <a
+            href={buildPeerRegisterBackLink(added.url)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex cursor-pointer items-center justify-center gap-1 rounded bg-accent px-2 py-1 text-[10px] font-medium text-foreground no-underline hover:bg-accent/80"
+          >
+            <IconExternalLink size={10} />
+            Open {added.name}&apos;s settings
+          </a>
+          <button
+            onClick={onClose}
+            className="cursor-pointer rounded px-2 py-0.5 text-[10px] text-muted-foreground hover:text-foreground"
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const result = check.status === "done" ? check.result : null;
+  const unreachable = result ? !result.reachable : false;
+  const unauthorized = result ? result.authorized === false : false;
 
   return (
     <div
       ref={popoverRef}
-      className="absolute end-0 top-full z-50 mt-1 w-64 rounded-lg border border-border bg-popover p-2.5 shadow-lg"
+      className="absolute end-0 top-full z-50 mt-1 w-72 rounded-lg border border-border bg-popover p-2.5 shadow-lg"
     >
       <div className="flex flex-col gap-1.5">
+        <div className="flex gap-1">
+          <input
+            ref={urlRef}
+            value={url}
+            onChange={(e) => {
+              setUrl(e.target.value);
+              setCheck({ status: "idle" });
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleCheck();
+              if (e.key === "Escape") onClose();
+            }}
+            className="w-full flex-1 rounded border border-border bg-background px-2 py-1 text-[11px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+            placeholder="URL (e.g. http://localhost:8085)"
+          />
+          <ToolkitButtonBase
+            type="button"
+            variant="outline"
+            onClick={handleCheck}
+            disabled={!url.trim() || check.status === "checking"}
+            className="inline-flex shrink-0 cursor-pointer items-center gap-1 rounded border border-border px-2 py-1 text-[10px] text-muted-foreground hover:bg-accent/40 hover:text-foreground disabled:opacity-40"
+          >
+            {check.status === "checking" ? (
+              <IconLoader2 size={10} className="animate-spin" />
+            ) : (
+              "Check"
+            )}
+          </ToolkitButtonBase>
+        </div>
+
+        {check.status === "error" && (
+          <p className="flex items-start gap-1 text-[10px] text-red-500">
+            <IconAlertTriangle size={11} className="mt-px shrink-0" />
+            {check.message}
+          </p>
+        )}
+        {result && (
+          <div
+            className={`flex items-start gap-1 text-[10px] ${
+              unreachable || unauthorized
+                ? "text-amber-600 dark:text-amber-400"
+                : "text-green-600 dark:text-green-500"
+            }`}
+          >
+            {unreachable || unauthorized ? (
+              <IconAlertTriangle size={11} className="mt-px shrink-0" />
+            ) : (
+              <IconCheck size={11} className="mt-px shrink-0" />
+            )}
+            <span className="leading-relaxed">
+              {describeCheckResult(result)}
+              {unreachable &&
+                " — the app may just not be running yet; you can still add it."}
+            </span>
+          </div>
+        )}
+        {unauthorized &&
+          (secretSet === true ? (
+            <button
+              onClick={() => syncSecret.mutate(undefined)}
+              disabled={syncSecret.isPending}
+              className="inline-flex cursor-pointer items-center gap-1 self-start rounded border border-border px-1.5 py-0.5 text-[10px] text-muted-foreground hover:text-foreground disabled:opacity-40"
+            >
+              {syncSecret.isPending ? (
+                <IconLoader2 size={10} className="animate-spin" />
+              ) : (
+                <IconRefresh size={10} />
+              )}
+              Sync secret to apps
+            </button>
+          ) : (
+            <p className="text-[10px] text-muted-foreground">
+              {secretSet === false ? (
+                <>
+                  No shared secret set yet —{" "}
+                  <a
+                    href={buildSettingsRoute(STANDARD_SETTINGS_TABS.team)}
+                    className="underline underline-offset-2 hover:text-foreground"
+                  >
+                    set one on the Team page
+                  </a>{" "}
+                  first.
+                </>
+              ) : (
+                "Ask your workspace owner to sync the shared secret."
+              )}
+            </p>
+          ))}
+
         <input
           ref={nameRef}
           value={name}
@@ -177,16 +462,6 @@ function AgentAddPopover({
           }}
           className="w-full rounded border border-border bg-background px-2 py-1 text-[11px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
           placeholder="Name"
-        />
-        <input
-          value={url}
-          onChange={(e) => setUrl(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") handleAdd();
-            if (e.key === "Escape") onClose();
-          }}
-          className="w-full rounded border border-border bg-background px-2 py-1 text-[11px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
-          placeholder="URL (e.g. http://localhost:8085)"
         />
         <input
           value={description}
@@ -201,16 +476,16 @@ function AgentAddPopover({
         <div className="flex justify-end gap-1 pt-0.5">
           <button
             onClick={onClose}
-            className="rounded px-2 py-0.5 text-[10px] text-muted-foreground hover:text-foreground"
+            className="cursor-pointer rounded px-2 py-0.5 text-[10px] text-muted-foreground hover:text-foreground"
           >
             Cancel
           </button>
           <button
             onClick={handleAdd}
             disabled={!name.trim() || !url.trim()}
-            className="rounded bg-accent px-2 py-0.5 text-[10px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40"
+            className="cursor-pointer rounded bg-accent px-2 py-0.5 text-[10px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40"
           >
-            Add
+            {unreachable ? "Add anyway" : "Add"}
           </button>
         </div>
       </div>
@@ -218,11 +493,174 @@ function AgentAddPopover({
   );
 }
 
+function A2ASecretStatusRow({
+  org,
+  syncSecret,
+}: {
+  org: { a2aSecretSet?: boolean; allowedDomain: string | null } | undefined;
+  syncSecret: ReturnType<typeof useSyncA2ASecret>;
+}) {
+  if (!org) return null;
+  const secretSet = org.a2aSecretSet;
+
+  if (secretSet === undefined) {
+    // Not an owner/admin — the server omits `a2aSecretSet` entirely for this
+    // role rather than reporting `false`, so this must read as "can't see
+    // it," never as "not set" (a claim we have no basis for).
+    return (
+      <div className="mb-2 rounded-md border border-border/60 bg-accent/20 px-2 py-1.5 text-[10px] text-muted-foreground">
+        Shared secret is managed by your workspace owner.
+      </div>
+    );
+  }
+
+  if (!secretSet) {
+    return (
+      <div className="mb-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1.5 text-[10px] text-amber-600 dark:text-amber-400">
+        No shared secret set — connected apps will reject calls in production.{" "}
+        <a
+          href={buildSettingsRoute(STANDARD_SETTINGS_TABS.team)}
+          className="underline underline-offset-2 hover:text-amber-500"
+        >
+          Set one on the Team page
+        </a>
+      </div>
+    );
+  }
+
+  const noDomain = syncSecret.error?.message?.toLowerCase().includes("domain");
+  const failures = syncSecret.data?.results.filter((r) => !r.ok) ?? [];
+
+  return (
+    <div className="mb-2 flex flex-col gap-1 rounded-md border border-border/60 bg-accent/20 px-2 py-1.5 text-[10px]">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-muted-foreground">
+          Shared secret set
+          {org.allowedDomain ? ` for ${org.allowedDomain}` : ""}
+        </span>
+        <button
+          onClick={() => syncSecret.mutate(undefined)}
+          disabled={syncSecret.isPending}
+          className="inline-flex shrink-0 cursor-pointer items-center gap-1 rounded border border-border px-1.5 py-0.5 text-[10px] text-muted-foreground hover:text-foreground disabled:opacity-40"
+        >
+          {syncSecret.isPending ? (
+            <IconLoader2 size={10} className="animate-spin" />
+          ) : (
+            <IconRefresh size={10} />
+          )}
+          Sync to apps
+        </button>
+      </div>
+      {syncSecret.data && !syncSecret.isPending && (
+        <div className="text-muted-foreground">
+          Synced to {syncSecret.data.succeeded}/{syncSecret.data.total} app
+          {syncSecret.data.total === 1 ? "" : "s"}
+          {syncSecret.data.failed > 0
+            ? ` (${syncSecret.data.failed} failed)`
+            : ""}
+          .
+          {failures.length > 0 && (
+            <ul className="mt-0.5 list-disc ps-3 text-red-500">
+              {failures.map((r) => (
+                <li key={r.id}>
+                  {r.name}: {r.error ?? `HTTP ${r.status ?? "?"}`}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+      {syncSecret.error && (
+        <p className="text-red-500">
+          {syncSecret.error.message}
+          {noDomain && (
+            <>
+              {" "}
+              <a
+                href={buildSettingsRoute(STANDARD_SETTINGS_TABS.team)}
+                className="underline underline-offset-2"
+              >
+                Set the domain
+              </a>
+            </>
+          )}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/** Query params `/_agent-native/open` forwards onto the redirect target. */
+const PREFILL_PARAMS = [
+  "f_agentName",
+  "f_agentUrl",
+  "f_agentDescription",
+] as const;
+
 export function AgentsSection() {
   const [agents, setAgents] = useState<AgentInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [editingAgent, setEditingAgent] = useState<string | null>(null);
   const [showAdd, setShowAdd] = useState(false);
+  const [prefill, setPrefill] = useState<{
+    name: string;
+    url: string;
+    description: string;
+  } | null>(null);
+  const [probeById, setProbeById] = useState<Map<
+    string,
+    AgentProbeResult
+  > | null>(null);
+
+  const { data: org } = useOrg();
+  const syncSecret = useSyncA2ASecret();
+
+  // Landing from a peer's "register back" deep link (see
+  // buildPeerRegisterBackLink): the open route only echoes `f_*` params onto
+  // the redirect URL, so read those here and open the Add popover prefilled.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    const url = params.get("f_agentUrl");
+    if (!url) return;
+    setPrefill({
+      name: params.get("f_agentName") ?? "",
+      url,
+      description: params.get("f_agentDescription") ?? "",
+    });
+    setShowAdd(true);
+    for (const key of PREFILL_PARAMS) params.delete(key);
+    const query = params.toString();
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}${query ? `?${query}` : ""}${window.location.hash}`,
+    );
+  }, []);
+
+  // One batched probe for the whole list — cheap liveness dots, not one
+  // request per row. A row absent from the results (never returned) stays
+  // dot-less rather than defaulting to a color that isn't backed by data.
+  useEffect(() => {
+    let cancelled = false;
+    fetch(agentNativePath("/_agent-native/agents/probe"))
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (cancelled || !data) return;
+        const results = Array.isArray(data.results)
+          ? (data.results as Array<AgentProbeResult & { id: string }>)
+          : [];
+        const map = new Map<string, AgentProbeResult>();
+        for (const result of results) map.set(result.id.toLowerCase(), result);
+        setProbeById(map);
+      })
+      .catch(() => {
+        if (!cancelled) setProbeById(new Map());
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const fetchAgents = useCallback(async () => {
     try {
@@ -231,11 +669,24 @@ export function AgentsSection() {
       );
       if (!res.ok) return;
       const data = await res.json();
-      const agentResources = (data.resources ?? []).filter(
-        (r: { path: string }) => isRemoteAgentPath(r.path),
-      );
+      // Migrating a remote agent to the canonical `remote-agents/` prefix
+      // leaves the legacy `agents/` row in place (resources/store.ts), so
+      // every migrated agent has two resources pointing at one URL. Collapse
+      // them the way discoverAgents does, canonical winning.
+      const byAgentId = new Map<string, { id: string; path: string }>();
+      for (const resource of (data.resources ?? []) as Array<{
+        id: string;
+        path: string;
+      }>) {
+        if (!isRemoteAgentPath(resource.path)) continue;
+        const agentId = getRemoteAgentIdFromPath(resource.path);
+        const existing = byAgentId.get(agentId);
+        if (existing?.path.startsWith(REMOTE_AGENT_RESOURCE_PREFIX)) continue;
+        byAgentId.set(agentId, resource);
+      }
+      const agentResources = [...byAgentId.values()];
       const parsed = await Promise.all(
-        agentResources.map(async (r: { id: string; path: string }) => {
+        agentResources.map(async (r): Promise<AgentInfo | null> => {
           try {
             const detail = await fetch(
               agentNativePath(`/_agent-native/resources/${r.id}`),
@@ -255,7 +706,7 @@ export function AgentsSection() {
           }
         }),
       );
-      setAgents(parsed.filter(Boolean));
+      setAgents(parsed.filter((agent): agent is AgentInfo => agent !== null));
     } finally {
       setLoading(false);
     }
@@ -265,7 +716,11 @@ export function AgentsSection() {
     fetchAgents();
   }, [fetchAgents]);
 
-  const handleAdd = async (name: string, url: string, description: string) => {
+  const handleAdd = async (
+    name: string,
+    url: string,
+    description: string,
+  ): Promise<boolean> => {
     const id = name.toLowerCase().replace(/[^a-z0-9-]/g, "-");
     const agentJson = JSON.stringify(
       {
@@ -289,11 +744,14 @@ export function AgentsSection() {
           shared: true,
         }),
       });
-      if (res.ok) {
-        setShowAdd(false);
-        fetchAgents();
-      }
-    } catch {}
+      // Deliberately don't close the popover here — a successful add shows a
+      // follow-up state (registration is one-way; the peer doesn't know
+      // about us yet) that the user dismisses explicitly.
+      if (res.ok) fetchAgents();
+      return res.ok;
+    } catch {
+      return false;
+    }
   };
 
   const handleSave = async (agent: AgentInfo) => {
@@ -365,12 +823,22 @@ export function AgentsSection() {
           </Tooltip>
           {showAdd && (
             <AgentAddPopover
+              initialName={prefill?.name}
+              initialUrl={prefill?.url}
+              initialDescription={prefill?.description}
+              secretSet={org?.a2aSecretSet}
+              syncSecret={syncSecret}
               onAdd={handleAdd}
-              onClose={() => setShowAdd(false)}
+              onClose={() => {
+                setShowAdd(false);
+                setPrefill(null);
+              }}
             />
           )}
         </div>
       </div>
+
+      <A2ASecretStatusRow org={org} syncSecret={syncSecret} />
 
       {/* Agent list */}
       {loading ? (
@@ -388,42 +856,68 @@ export function AgentsSection() {
         </button>
       ) : (
         <div className="flex flex-col gap-0.5">
-          {agents.map((agent) => (
-            <div key={agent.id} className="group relative">
-              <div className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 hover:bg-accent/30">
-                <span className="text-[11px] font-medium text-foreground truncate shrink-0">
-                  {agent.name}
-                </span>
-                <span className="flex-1 text-[10px] text-muted-foreground/60 truncate text-end">
-                  {agent.url}
-                </span>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      onClick={() => {
-                        setEditingAgent(
-                          editingAgent === agent.id ? null : agent.id,
-                        );
-                        setShowAdd(false);
-                      }}
-                      className="shrink-0 rounded p-0.5 text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-foreground hover:bg-accent/50"
-                    >
-                      <IconPencil size={11} />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent>Edit agent</TooltipContent>
-                </Tooltip>
+          {agents.map((agent) => {
+            const probe = probeById?.get(
+              getRemoteAgentIdFromPath(agent.path).toLowerCase(),
+            );
+            const dotState: "ok" | "warn" | null = !probe
+              ? null
+              : probe.reachable && probe.authorized !== false
+                ? "ok"
+                : "warn";
+            return (
+              <div key={agent.id} className="group relative">
+                <div className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 hover:bg-accent/30">
+                  {dotState ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span
+                          className={`h-1.5 w-1.5 shrink-0 rounded-full ${
+                            dotState === "ok" ? "bg-green-500" : "bg-amber-500"
+                          }`}
+                        />
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {probe && describeProbeTooltip(probe)}
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : (
+                    <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-transparent" />
+                  )}
+                  <span className="text-[11px] font-medium text-foreground truncate shrink-0">
+                    {agent.name}
+                  </span>
+                  <span className="flex-1 text-[10px] text-muted-foreground/60 truncate text-end">
+                    {agent.url}
+                  </span>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        onClick={() => {
+                          setEditingAgent(
+                            editingAgent === agent.id ? null : agent.id,
+                          );
+                          setShowAdd(false);
+                        }}
+                        className="shrink-0 rounded p-0.5 text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-foreground hover:bg-accent/50"
+                      >
+                        <IconPencil size={11} />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>Edit agent</TooltipContent>
+                  </Tooltip>
+                </div>
+                {editingAgent === agent.id && (
+                  <AgentEditPopover
+                    agent={agent}
+                    onSave={handleSave}
+                    onDelete={handleDelete}
+                    onClose={() => setEditingAgent(null)}
+                  />
+                )}
               </div>
-              {editingAgent === agent.id && (
-                <AgentEditPopover
-                  agent={agent}
-                  onSave={handleSave}
-                  onDelete={handleDelete}
-                  onClose={() => setEditingAgent(null)}
-                />
-              )}
-            </div>
-          ))}
+            );
+          })}
           <button
             onClick={() => {
               setShowAdd(true);

--- a/packages/core/src/client/settings/SecretsSection.spec.tsx
+++ b/packages/core/src/client/settings/SecretsSection.spec.tsx
@@ -66,17 +66,7 @@ async function click(element: Element | undefined) {
 }
 
 async function openNewMenu() {
-  const trigger = findButton("New");
-  expect(trigger).toBeTruthy();
-  await act(async () => {
-    trigger!.dispatchEvent(
-      new PointerEvent("pointerdown", {
-        bubbles: true,
-        cancelable: true,
-        button: 0,
-      }),
-    );
-  });
+  await click(findButton("New"));
 }
 
 describe("SecretsSection", () => {
@@ -155,7 +145,7 @@ describe("SecretsSection", () => {
 
     await openNewMenu();
     const braveItem = Array.from(
-      document.querySelectorAll('[role="menuitem"]'),
+      document.querySelectorAll('[role="option"]'),
     ).find((item) => item.textContent?.includes("Brave Search API Key"));
     await click(braveItem);
 
@@ -167,7 +157,7 @@ describe("SecretsSection", () => {
 
     await openNewMenu();
     const customItem = Array.from(
-      document.querySelectorAll('[role="menuitem"]'),
+      document.querySelectorAll('[role="option"]'),
     ).find((item) => item.textContent?.trim() === "Custom");
     await click(customItem);
 
@@ -177,6 +167,38 @@ describe("SecretsSection", () => {
     expect(container.querySelector('[aria-label="Key name"]')).toBeTruthy();
     expect(container.querySelector('[aria-label="Secret value"]')).toBeTruthy();
     expect(container.querySelector('[aria-label="Scope"]')).toBeTruthy();
+  });
+
+  it("filters the key list as you search", async () => {
+    await act(async () => {
+      renderSecretsSection(root);
+    });
+
+    await openNewMenu();
+    const search = document.querySelector<HTMLInputElement>(
+      'input[placeholder="Search keys..."]',
+    );
+    expect(search).toBeTruthy();
+
+    await act(async () => {
+      // React's value tracker ignores a plain assignment; go through the
+      // prototype setter so onChange actually fires.
+      Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )!.set!.call(search, "tavily");
+      search!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const optionText = Array.from(
+      document.querySelectorAll('[role="option"]'),
+    ).map((item) => item.textContent ?? "");
+    expect(optionText.some((text) => text.includes("Tavily API Key"))).toBe(
+      true,
+    );
+    expect(
+      optionText.some((text) => text.includes("Brave Search API Key")),
+    ).toBe(false);
   });
 
   it("reveals and focuses an unset key requested by a deep link", async () => {

--- a/packages/core/src/client/settings/SecretsSection.tsx
+++ b/packages/core/src/client/settings/SecretsSection.tsx
@@ -10,6 +10,15 @@ import {
   ButtonBase as ToolkitButtonBase,
 } from "@agent-native/toolkit/ui/button";
 import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@agent-native/toolkit/ui/command";
+import {
   IconCheck,
   IconChevronRight,
   IconExternalLink,
@@ -23,13 +32,10 @@ import React, { useEffect, useMemo, useState, useCallback } from "react";
 
 import { agentNativePath } from "../api-path.js";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "../components/ui/dropdown-menu.js";
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "../components/ui/popover.js";
 import {
   Tooltip,
   TooltipContent,
@@ -207,11 +213,13 @@ function KeysHeader({
   onSecret?: (key: string) => void;
   onCustomKey: () => void;
 }) {
+  const [open, setOpen] = useState(false);
+
   return (
     <div className="flex items-center justify-between gap-3">
       <p className="text-[11px] font-medium text-foreground">Keys</p>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
           <ToolkitButtonBase
             type="button"
             variant="outline"
@@ -220,34 +228,61 @@ function KeysHeader({
             <IconPlus size={11} />
             New
           </ToolkitButtonBase>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-60">
-          {availableSecrets.length > 0 && (
-            <>
-              <DropdownMenuLabel>Choose a key</DropdownMenuLabel>
-              {availableSecrets.map((secret) => (
-                <DropdownMenuItem
-                  key={secret.key}
-                  onSelect={() => onSecret?.(secret.key)}
-                  className="flex items-center justify-between gap-3"
+        </PopoverTrigger>
+        <PopoverContent align="end" className="w-60 p-0">
+          <Command
+            // cmdk's default scorer matches loose subsequences, so "logo"
+            // also surfaces every "G-o-o-g-l-e ... " key.
+            filter={(value, search) =>
+              value.toLowerCase().includes(search.toLowerCase()) ? 1 : 0
+            }
+          >
+            {availableSecrets.length > 0 && (
+              <CommandInput placeholder="Search keys..." />
+            )}
+            <CommandList>
+              <CommandEmpty>No keys found.</CommandEmpty>
+              {availableSecrets.length > 0 && (
+                <>
+                  <CommandGroup heading="Choose a key">
+                    {availableSecrets.map((secret) => (
+                      <CommandItem
+                        key={secret.key}
+                        value={`${secret.label} ${secret.key}`}
+                        onSelect={() => {
+                          setOpen(false);
+                          onSecret?.(secret.key);
+                        }}
+                        className="flex items-center justify-between gap-3"
+                      >
+                        <span className="truncate">{secret.label}</span>
+                        {secret.required && (
+                          <span className="shrink-0 text-[9px] font-semibold uppercase tracking-wide text-amber-600 dark:text-amber-400">
+                            Required
+                          </span>
+                        )}
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                  <CommandSeparator />
+                </>
+              )}
+              <CommandGroup>
+                <CommandItem
+                  value="custom key"
+                  onSelect={() => {
+                    setOpen(false);
+                    onCustomKey();
+                  }}
                 >
-                  <span className="truncate">{secret.label}</span>
-                  {secret.required && (
-                    <span className="text-[9px] font-semibold uppercase tracking-wide text-amber-600 dark:text-amber-400">
-                      Required
-                    </span>
-                  )}
-                </DropdownMenuItem>
-              ))}
-              <DropdownMenuSeparator />
-            </>
-          )}
-          <DropdownMenuItem onSelect={onCustomKey}>
-            <IconPlus size={14} />
-            Custom
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+                  <IconPlus size={14} />
+                  Custom
+                </CommandItem>
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
     </div>
   );
 }

--- a/packages/core/src/localization/default-messages.ts
+++ b/packages/core/src/localization/default-messages.ts
@@ -206,6 +206,7 @@ const messages = {
       otherAppsDescription: "Open other apps available to you.",
       availableCount: "{{count}} available",
       activeCount: "{{count}} active",
+      pendingCount: "{{count}} pending",
       hiddenCount: "{{count}} hidden",
       createApp: "Create app",
       templates: "Templates",
@@ -215,6 +216,16 @@ const messages = {
       show: "Show",
       hiddenApps: "Hidden apps",
       hiddenAppCount: "{{count}} hidden apps",
+      pendingApps: "Pending apps",
+      pendingAppsDescription:
+        "{{count}} pending apps are hidden by default. Show them only when you need to inspect work in progress.",
+      showPendingApps: "Show pending apps",
+      hidePendingApps: "Hide pending apps",
+      noActiveWorkspaceApps: "No active workspace apps yet",
+      noActiveWorkspaceAppsDescription:
+        "Pending apps are hidden by default. Expand Pending apps below to inspect them.",
+      appMetadataOwner: "Owner",
+      appMetadataTeams: "Teams",
       workspaceAppFallback: "Workspace App",
       workspaceAppDescription:
         "Open a deployed app or check the status of an app being created.",

--- a/packages/core/src/server/agent-capabilities.ts
+++ b/packages/core/src/server/agent-capabilities.ts
@@ -1,5 +1,5 @@
 import { A2AClient } from "../a2a/client.js";
-import type { AgentSkill } from "../a2a/types.js";
+import type { AgentCard, AgentSkill } from "../a2a/types.js";
 import { type DiscoveredAgent } from "./agent-discovery.js";
 
 /** Matches the `<available-apps>` prompt block so both surfaces agree. */
@@ -16,6 +16,12 @@ export interface PeerCapabilities {
   skills: AgentSkill[] | null;
   cardDescription?: string;
   error?: string;
+  /**
+   * The full card from this same fetch, for callers that need more than
+   * skills/description (e.g. the peer-probe route's name/securitySchemes).
+   * Kept optional so existing consumers of this shape are unaffected.
+   */
+  card?: AgentCard;
 }
 
 function truncate(value: string, max: number): string {
@@ -35,6 +41,7 @@ export async function loadCapabilities(
       skills: Array.isArray(card.skills) ? card.skills : [],
       cardDescription:
         typeof card.description === "string" ? card.description : undefined,
+      card,
     };
   } catch (error) {
     return {

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -74,6 +74,7 @@ import {
   toolCallCacheKey,
   getActiveRunForThreadAsync,
   abortRunDurably,
+  abortTurnDurably,
   subscribeToRun,
   type ActionEntry,
 } from "../agent/production-agent.js";
@@ -440,6 +441,19 @@ const generateTitleRateLimit = new Map<string, number[]>();
 /** Only sweep drained rate-limit entries once the map grows past this size,
  * so the common small-map case stays O(1). */
 const RATE_LIMIT_SWEEP_THRESHOLD = 1000;
+
+/**
+ * Abort reasons that mean a human asked to stop, so `/runs/:id/abort` escalates
+ * to a turn-wide abort. Watchdog reasons (`no_progress`, `auto_stuck_retry`)
+ * stay single-run: they end a chunk the client believes is dead and must not
+ * kill a server-side continuation chain that is still making progress.
+ */
+export const USER_STOP_ABORT_REASONS = new Set([
+  "user",
+  "abort",
+  "user_stuck_cancel",
+  "user_stuck_retry",
+]);
 
 /**
  * Pick the URL allowlist to enforce for a `${keys.NAME}` reference used by
@@ -4572,6 +4586,9 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
             // the cross-isolate abort + terminal event to be durable. Returning
             // early lets Retry collide with the still-running row.
             await abortRunDurably(runId, reason);
+            if (USER_STOP_ABORT_REASONS.has(reason)) {
+              await abortTurnDurably(runId, reason);
+            }
             return { ok: true };
           }
 

--- a/packages/core/src/server/agent-discovery.ts
+++ b/packages/core/src/server/agent-discovery.ts
@@ -79,7 +79,7 @@ const HIDDEN_FIRST_PARTY_AGENT_IDS = new Set([
   "workbench",
 ]);
 
-function normalizeAgentId(id: string): string {
+export function normalizeAgentId(id: string): string {
   const normalized = id.trim().toLowerCase();
   if (
     normalized === "image" ||

--- a/packages/core/src/server/agent-peer-probe.spec.ts
+++ b/packages/core/src/server/agent-peer-probe.spec.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import type { PeerCapabilities } from "./agent-capabilities.js";
+import type { DiscoveredAgent } from "./agent-discovery.js";
+import { probePeerAgent, type PeerProbeDeps } from "./agent-peer-probe.js";
+
+const agent: DiscoveredAgent = {
+  id: "peer",
+  name: "Peer",
+  description: "",
+  url: "https://peer.example.com",
+  color: "#000",
+};
+
+function makeDeps(overrides: Partial<PeerProbeDeps> = {}): PeerProbeDeps {
+  return {
+    loadCapabilities: async () =>
+      ({
+        agent,
+        skills: [],
+        card: {
+          name: "Peer",
+          description: "A peer app",
+          url: "https://peer.example.com",
+          version: "1",
+          protocolVersion: "0.3",
+          capabilities: {},
+          skills: [],
+        },
+      }) as PeerCapabilities,
+    resolveCallerAuth: async () => ({ metadata: {} }),
+    createClient: () => ({
+      getTask: async () => {
+        throw new Error("A2A error (-32001): Task not found");
+      },
+    }),
+    ...overrides,
+  };
+}
+
+describe("probePeerAgent", () => {
+  // Reachability and auth are independent questions. An unreachable peer
+  // can't tell us anything about whether our calls would authenticate, so
+  // `authorized` must stay ABSENT — not coerced to `false` — or the settings
+  // UI reports a peer as "auth rejected" when it never even answered.
+  it("leaves authorized undefined when the peer is unreachable", async () => {
+    const deps = makeDeps({
+      loadCapabilities: async () => ({
+        agent,
+        skills: null,
+        error: "Failed to fetch agent card (503)",
+      }),
+      createClient: () => ({
+        getTask: async () => {
+          throw new Error("should never be called for an unreachable peer");
+        },
+      }),
+    });
+
+    const result = await probePeerAgent(agent, deps);
+
+    expect(result.reachable).toBe(false);
+    expect(result.error).toBe("Failed to fetch agent card (503)");
+    expect(result.authorized).toBeUndefined();
+    expect("authorized" in result).toBe(false);
+  });
+
+  it("reports reachable:true, authorized:false on a 401 from the no-op call", async () => {
+    const deps = makeDeps({
+      createClient: () => ({
+        getTask: async () => {
+          throw new Error(
+            'A2A request failed (401): {"jsonrpc":"2.0","error":{"code":-32001,"message":"Invalid or expired A2A token"}}',
+          );
+        },
+      }),
+    });
+
+    const result = await probePeerAgent(agent, deps);
+
+    expect(result.reachable).toBe(true);
+    expect(result.authorized).toBe(false);
+    expect(result.authError).toBe("401");
+  });
+
+  it("reports authorized:true when the no-op call comes back as task-not-found", async () => {
+    const result = await probePeerAgent(agent, makeDeps());
+
+    expect(result.reachable).toBe(true);
+    expect(result.authorized).toBe(true);
+    expect(result.authError).toBeUndefined();
+  });
+
+  // A timeout on the auth-only call proves nothing about auth — the card
+  // fetch already proved reachability. Collapsing a timeout into
+  // `authorized: false` would tell a correctly-configured caller that its
+  // credentials are rejected, when the real cause is an unrelated network hiccup.
+  it("never reports a timeout on the no-op call as authorized:false", async () => {
+    const deps = makeDeps({
+      createClient: () => ({
+        getTask: async () => {
+          const err = new Error("This operation was aborted");
+          err.name = "AbortError";
+          throw err;
+        },
+      }),
+    });
+
+    const result = await probePeerAgent(agent, deps);
+
+    expect(result.reachable).toBe(true);
+    expect(result.authorized).toBeUndefined();
+    expect("authorized" in result).toBe(false);
+    expect(result.authError).toBe("This operation was aborted");
+  });
+});

--- a/packages/core/src/server/agent-peer-probe.ts
+++ b/packages/core/src/server/agent-peer-probe.ts
@@ -1,0 +1,133 @@
+import crypto from "node:crypto";
+
+import { resolveA2ACallerAuth } from "../a2a/caller-auth.js";
+import { A2AClient } from "../a2a/client.js";
+import {
+  loadCapabilities,
+  type PeerCapabilities,
+} from "./agent-capabilities.js";
+import type { DiscoveredAgent } from "./agent-discovery.js";
+
+const AUTH_PROBE_TIMEOUT_MS = 6_000;
+/** Matches CARD_CONCURRENCY in agent-capabilities.ts — bounds simultaneous
+ * outbound probes the same way card loading already does. */
+const PROBE_CONCURRENCY = 8;
+
+export interface PeerProbeResult {
+  url: string;
+  reachable: boolean;
+  name?: string;
+  description?: string;
+  securitySchemes?: string[];
+  /** Absent (not false) whenever the auth check never ran or never resolved. */
+  authorized?: boolean;
+  authError?: string;
+  publicSkills?: number;
+  error?: string;
+}
+
+export interface PeerProbeDeps {
+  loadCapabilities: (agent: DiscoveredAgent) => Promise<PeerCapabilities>;
+  resolveCallerAuth: typeof resolveA2ACallerAuth;
+  createClient: (
+    baseUrl: string,
+    apiKey?: string,
+    options?: { requestTimeoutMs?: number; fallbackApiKeys?: string[] },
+  ) => Pick<A2AClient, "getTask">;
+}
+
+const defaultPeerProbeDeps: PeerProbeDeps = {
+  loadCapabilities,
+  resolveCallerAuth: resolveA2ACallerAuth,
+  createClient: (baseUrl, apiKey, options) =>
+    new A2AClient(baseUrl, apiKey, options),
+};
+
+/**
+ * Probe one peer: does its agent card load (reachability), and separately,
+ * will OUR calls to it authenticate. These two questions must never collapse
+ * into one boolean — an unreachable peer can't tell us anything about auth,
+ * so `authorized` stays absent rather than `false` in that case, and a
+ * transport failure on the auth-only call (timeout, DNS, 5xx) must never be
+ * reported as an auth rejection either.
+ */
+export async function probePeerAgent(
+  agent: DiscoveredAgent,
+  deps: PeerProbeDeps = defaultPeerProbeDeps,
+): Promise<PeerProbeResult> {
+  const capabilities = await deps.loadCapabilities(agent);
+  if (capabilities.skills === null || !capabilities.card) {
+    // Unreachable (includes malformed/SSRF-blocked URLs, which the caller
+    // reclassifies into a 400 by checking for the "SSRF blocked:" prefix).
+    // `authorized` is intentionally omitted — reachability and auth are
+    // independent questions, and we have no evidence either way here.
+    return {
+      url: agent.url,
+      reachable: false,
+      error: capabilities.error ?? "unreachable",
+    };
+  }
+
+  const card = capabilities.card;
+  const result: PeerProbeResult = {
+    url: agent.url,
+    reachable: true,
+    name: card.name,
+    description: capabilities.cardDescription,
+    securitySchemes: card.securitySchemes
+      ? Object.keys(card.securitySchemes)
+      : undefined,
+    publicSkills: capabilities.skills.length,
+  };
+
+  const auth = await deps.resolveCallerAuth();
+  const client = deps.createClient(agent.url, auth.apiKey, {
+    requestTimeoutMs: AUTH_PROBE_TIMEOUT_MS,
+    fallbackApiKeys: auth.apiKeyFallbacks,
+  });
+
+  try {
+    // An id that cannot exist. A "task not found" JSON-RPC error proves the
+    // peer authenticated us and ran our request; a 401 proves it rejected us;
+    // anything else is a transport failure this call can't resolve either way.
+    await client.getTask(`probe-${crypto.randomUUID()}`, {
+      requestTimeoutMs: AUTH_PROBE_TIMEOUT_MS,
+    });
+    result.authorized = true;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/A2A request failed \(401\)/.test(message)) {
+      result.authorized = false;
+      result.authError = "401";
+    } else if (/A2A error \(-?\d+\): task not found/i.test(message)) {
+      result.authorized = true;
+    } else {
+      // Timeout, DNS failure, non-401 HTTP status, etc. The card fetch above
+      // already proved reachability, so this must not be reported as
+      // `reachable: false`, and an unresolved auth outcome must not be
+      // reported as `authorized: false` either — leave it absent.
+      result.authError = message;
+    }
+  }
+
+  return result;
+}
+
+export async function probeAllPeerAgents(
+  agents: DiscoveredAgent[],
+  deps: PeerProbeDeps = defaultPeerProbeDeps,
+): Promise<Array<PeerProbeResult & { id: string }>> {
+  const results: Array<PeerProbeResult & { id: string }> = [];
+  for (let i = 0; i < agents.length; i += PROBE_CONCURRENCY) {
+    const batch = agents.slice(i, i + PROBE_CONCURRENCY);
+    results.push(
+      ...(await Promise.all(
+        batch.map(async (agent) => ({
+          id: agent.id,
+          ...(await probePeerAgent(agent, deps)),
+        })),
+      )),
+    );
+  }
+  return results;
+}

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -1569,6 +1569,73 @@ export function createCoreRoutesPlugin(
       // middleware any plugin's route can possibly land behind, regardless of
       // plugin init ordering.
 
+      // Peer reachability + auth probe for the settings UI. Deliberately
+      // separate from `${P}/agents` (discovery) — this route makes live
+      // network calls to the peer, so it is session-gated and answers one
+      // peer (`?url=`) or every registered peer (no query) via `discoverAgents`.
+      //
+      // MUST be mounted BEFORE `${P}/agents` below: h3's `.use()` matches by
+      // path prefix, and that handler always returns a value (never calls
+      // `next()`), so it would swallow `/agents/probe` requests before they
+      // ever reached this route if registered second (same hazard as the A2A
+      // `_process-task` route vs. its `/a2a` catch-all — see a2a/server.ts).
+      getH3App(nitroApp).use(
+        `${P}/agents/probe`,
+        defineEventHandler(async (event) => {
+          if (getMethod(event) !== "GET") {
+            setResponseStatus(event, 405);
+            return { error: "Method not allowed" };
+          }
+          const session = await getSession(event).catch(() => null);
+          if (!session?.email) {
+            setResponseStatus(event, 401);
+            return { error: "Authentication required" };
+          }
+
+          return runWithRequestContext(
+            { userEmail: session.email, orgId: session.orgId ?? undefined },
+            async () => {
+              const { probePeerAgent, probeAllPeerAgents } =
+                await import("./agent-peer-probe.js");
+              const query = getRequestURL(event).searchParams;
+              const urlParam = query.get("url");
+
+              if (urlParam === null) {
+                const selfAppId = query.get("selfAppId") ?? undefined;
+                const { discoverAgents } = await import("./agent-discovery.js");
+                const agents = await discoverAgents(selfAppId);
+                const results = await probeAllPeerAgents(agents);
+                return { results };
+              }
+
+              if (!urlParam.trim()) {
+                setResponseStatus(event, 400);
+                return { error: "url is required" };
+              }
+
+              const result = await probePeerAgent({
+                id: "probe",
+                name: urlParam,
+                description: "",
+                url: urlParam,
+                color: "",
+              });
+
+              // Reachability and auth are independent, but a malformed/SSRF-blocked
+              // URL is a caller input error, not a peer that failed to answer — the
+              // one case where the probe's "unreachable" result is reclassified into
+              // a 400 instead of a 200 with `reachable: false`.
+              if (result.error?.startsWith("SSRF blocked:")) {
+                setResponseStatus(event, 400);
+                return { url: urlParam, error: result.error };
+              }
+
+              return result;
+            },
+          );
+        }),
+      );
+
       // Agent discovery primitive — shared by headless CLI/A2A surfaces and
       // UI shells that need to show connected peer apps without depending on
       // the chat route namespace.

--- a/packages/core/src/shared/mcp-embed-headers.spec.ts
+++ b/packages/core/src/shared/mcp-embed-headers.spec.ts
@@ -6,10 +6,18 @@ import {
   isLocalMcpEmbedOrigin,
   isMcpEmbedCorsOrigin,
   MCP_EMBED_CORS_ALLOW_HEADERS,
+  mcpEmbedStaticAssetRouteRules,
   shouldAllowMcpEmbedCredentials,
 } from "./mcp-embed-headers.js";
 
 describe("MCP embed headers", () => {
+  it("sets nosniff on CDN-served static assets", () => {
+    // The h3 security-headers middleware never runs for these paths.
+    for (const rule of Object.values(mcpEmbedStaticAssetRouteRules())) {
+      expect(rule.headers["X-Content-Type-Options"]).toBe("nosniff");
+    }
+  });
+
   it("allows frontend action-client headers from embedded apps", () => {
     expect(MCP_EMBED_CORS_ALLOW_HEADERS).toContain("X-Agent-Native-Frontend");
     expect(MCP_EMBED_CORS_ALLOW_HEADERS).toContain(

--- a/packages/core/src/shared/mcp-embed-headers.ts
+++ b/packages/core/src/shared/mcp-embed-headers.ts
@@ -134,9 +134,13 @@ export function shouldAllowMcpEmbedCredentials(
   );
 }
 
+// These paths are served straight off the CDN, so the security-headers h3
+// middleware never runs for them — anything it sets that must also hold for
+// static assets has to be repeated here.
 export const MCP_EMBED_STATIC_ASSET_HEADERS = {
   "Access-Control-Allow-Origin": "*",
   "Cross-Origin-Resource-Policy": "cross-origin",
+  "X-Content-Type-Options": "nosniff",
 } as const;
 
 const STATIC_ASSET_PATTERNS = [

--- a/packages/core/src/templates/workspace-core/.agents/skills/a2a-protocol/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/a2a-protocol/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: a2a-protocol
 description: >-
-  How agents call other agents via the A2A (agent-to-agent) JSON-RPC protocol.
-  Use when enabling inter-agent communication, exposing agent skills to other
-  agents, or calling external agents from scripts.
+  How agent-native apps discover, authenticate with, and call each other over
+  A2A. Use when connecting one app to another, debugging a remote agent that
+  won't authenticate, exposing skills to peers, or calling agents from scripts.
 scope: dev
 metadata:
   internal: true
@@ -13,109 +13,154 @@ metadata:
 
 ## Rule
 
-Agents can call other agents using the A2A protocol. This is a JSON-RPC-based protocol for agent discovery and communication. Use it when work should go to a different agent entirely — not the local agent chat.
+Agents call other agents over A2A, a JSON-RPC protocol for discovery and
+delegation. Use it when work belongs to a different agent entirely — not the
+local agent chat.
 
-## Why
+Connecting app A to app B is two independent things, and both must be true:
 
-Agent-native apps don't exist in isolation. A mail agent might need analytics data. A calendar agent might need to search issues. A2A lets agents discover each other, send messages, and receive structured results — all over HTTP with bearer token auth.
+1. **B is registered on A** as a `remote-agents/<id>.json` resource.
+2. **A and B share a secret**, so A's signed JWT verifies on B.
 
-## How to Enable A2A (Server Side)
+Neither is a code change, and neither is symmetric. Registering B on A does not
+let B call A.
 
-Add `mountA2A()` to a server plugin:
+## A2A is already mounted
 
-```ts
-// server/plugins/a2a.ts
-import { mountA2A } from "@agent-native/core/a2a";
+`createAgentChatPlugin` calls `mountA2A` for every app, so a generated app
+already serves:
 
-export default defineNitroPlugin((nitro) => {
-  const app = nitro.h3App;
+- `GET /.well-known/agent-card.json` — public discovery, never authenticated
+- `POST /_agent-native/a2a` — JSON-RPC, authenticated
 
-  mountA2A(app, {
-    name: "Analytics Agent",
-    description: "Queries analytics data across providers",
-    version: "1.0.0",
-    skills: [
-      {
-        id: "query-data",
-        name: "Query Data",
-        description: "Run analytics queries across connected data sources",
-        tags: ["analytics", "data"],
-        examples: ["What were last week's signups?", "Show conversion rates"],
-      },
-    ],
-    apiKeyEnv: "A2A_API_KEY", // env var holding the bearer token
-    streaming: true,          // enable message/stream method
-  });
-});
-```
+Do not add a `mountA2A` server plugin to enable A2A; it is on. Hand-mounting is
+only for a bespoke card or a custom handler (see **Custom mount** below).
 
-This mounts the agent-native A2A endpoints:
+The client falls back to `POST /a2a` for external peers that only expose that
+path. New agent-native apps should call `/_agent-native/a2a`.
 
-- `GET /.well-known/agent-card.json` — public agent discovery (no auth required)
-- `POST /_agent-native/a2a` — primary JSON-RPC endpoint (bearer token auth required)
+## Registering a remote agent
 
-The client may fall back to `POST /a2a` for external or legacy peers that only
-expose that simple path. New agent-native apps should document and call the
-`/_agent-native/a2a` endpoint.
-
-## The Config Object
-
-```ts
-interface A2AConfig {
-  name: string;           // agent display name
-  description: string;    // what this agent does
-  version?: string;       // semver version (default: "1.0.0")
-  skills: AgentSkill[];   // capabilities this agent exposes
-  handler?: A2AHandler;   // custom message handler
-  apiKeyEnv?: string;     // env var name for bearer token auth
-  streaming?: boolean;    // enable streaming responses
-}
-
-interface AgentSkill {
-  id: string;             // unique skill identifier
-  name: string;           // human-readable name
-  description: string;    // what this skill does
-  tags?: string[];        // categorization tags
-  examples?: string[];    // example prompts
-}
-```
-
-## Agent Card
-
-The agent card is auto-generated at `GET /.well-known/agent-card.json`. Other agents fetch this to discover what skills are available:
+A remote agent is **a row in the resources table, not a file on disk**. Path
+`remote-agents/<id>.json`, owner `SHARED_OWNER`, content:
 
 ```json
 {
-  "name": "Analytics Agent",
+  "id": "analytics",
+  "name": "Analytics",
   "description": "Queries analytics data across providers",
   "url": "https://analytics.example.com",
-  "version": "1.0.0",
-  "protocolVersion": "0.3",
-  "capabilities": { "streaming": true },
-  "skills": [
-    {
-      "id": "query-data",
-      "name": "Query Data",
-      "description": "Run analytics queries across connected data sources"
-    }
-  ]
+  "color": "#6B7280"
 }
 ```
 
-## Calling Another Agent
+`url` is the only required field. `parseRemoteAgentManifest` accepts **only**
+these five keys — there is no `apiKey`, `env`, `skills`, or `token` field, and
+anything else is silently dropped.
+
+Four ways to create it, all writing the same row:
+
+| Surface | Where |
+| --- | --- |
+| Settings → Manage agent → Connected Agents (A2A) | any app with the settings panel |
+| Agent page → Connections | apps mounting `AgentTabsPage` |
+| Dispatch → Agents → Add external agent | workspace dispatch |
+| The agent itself | `resources` tool, `action: "write"`, `--scope shared` |
+
+The last one matters for template apps with no Code tab: "connect me to
+https://analytics.example.com" is a complete instruction. `remote-agents/` is
+whitelisted as a durable control path, so the write is workspace-scoped, and it
+takes effect on the next `discoverAgents()` call with no restart.
+
+First-party templates are seeded automatically and overlaid on top of manifests,
+so `Mail`, `Calendar`, and friends appear without registration. In dev they
+resolve to `http://localhost:<devPort>`; a manifest pointing at localhost is
+ignored in production.
+
+`call-agent` also accepts a raw URL, which skips registration entirely — useful
+for one-off calls, useless for @-mentions.
+
+### Checking a peer
+
+`GET /_agent-native/agents/probe?url=<base>` reads the peer's card and makes one
+authenticated no-op call, returning `reachable` and `authorized` as independent
+fields. Omit `url` to probe every registered peer. Reachable-but-unauthorized is
+the failure worth looking for: local dev runs the receiver unauthenticated, so a
+mismatched secret only surfaces after deploy. The Connected Agents settings
+section calls this on add and on open.
+
+## Authentication
+
+A2A authenticates with a **short-lived JWT the caller signs**, not a stored
+bearer key. `Authorization: Bearer <jwt>`; claims carry the caller's email and
+org domain; HS256; 15-minute default TTL. There is no per-peer API key
+anywhere in the system, which is why the manifest has no field for one.
+
+Two secrets can sign it:
+
+| Secret | Scope | How it is set |
+| --- | --- | --- |
+| `A2A_SECRET` | whole deployment | env var, **never auto-generated** |
+| org `a2a_secret` | one organization | auto-generated on org creation; Team page UI |
+
+The org secret is the managed path: **Team page → A2A secret** (owner only)
+reveals, copies, regenerates, and pushes it to every discovered peer. Rotation
+is tolerated — the caller tries both secrets in order and sticks to whichever
+worked.
+
+`A2A_SECRET` is the deploy-level path. `workspace-deploy` refuses a production
+workspace deploy without it and prints the generator command. Peers that must
+trust each other need the *same* value on both sides.
+
+With no secret configured at all:
+
+| Runtime | Result |
+| --- | --- |
+| local dev | open, one-time console warning |
+| production | `503` — "A2A authentication not configured" |
+| production, secret set, bad/absent token | `401` |
+
+"Production" is detected broadly (NODE_ENV, Netlify, Lambda, Vercel, Render,
+Fly, Cloud Run, …) and unrecognized deployed hosts fail closed unless the
+request is genuine loopback or `A2A_ALLOW_UNSIGNED_INTERNAL=1`.
+
+`A2AConfig.apiKeyEnv` still exists for static bearer auth against non-agent-native
+peers, but the framework's own mount never sets it. Do not reach for it when
+debugging a connection between two agent-native apps — the answer there is
+always the shared secret.
+
+Never hardcode either secret in source, docs, prompts, app state, action
+descriptions, client bundles, or examples. Read them from runtime config; never
+log or return them.
+
+## Advertising what this agent can do
+
+Card `skills` are derived from actions marked `publicAgent`. An app that marks
+none publishes `"skills": []` and peers cannot see what it offers, even though
+delegation still works. Mark the actions a peer should be able to see and
+invoke directly; leave the rest internal.
+
+## Calling another agent
 
 ### Simple: `callAgent()` (text in, text out)
 
 ```ts
-import { callAgent } from "@agent-native/core/a2a";
+import { callAgent, resolveA2ACallerAuth } from "@agent-native/core/a2a";
 
+const auth = await resolveA2ACallerAuth();
 const answer = await callAgent(
   "https://analytics.example.com",
   "What were last week's signups?",
-  { apiKey: process.env.ANALYTICS_A2A_KEY },
+  auth,
 );
 // answer is a plain string
 ```
+
+`callAgent` signs nothing on its own — with no `userEmail`/`orgSecret` in opts
+it calls **unauthenticated**, which silently works in local dev and 401s in
+production. `resolveA2ACallerAuth()` pulls the authenticated email, org domain,
+and org secret out of request context; pass them explicitly only from CLI or
+cron, where there is no request.
 
 ### Fast bounded read: `invokeAgentAction()`
 
@@ -168,12 +213,13 @@ action arguments or results.
 ### Advanced: `A2AClient` (full control)
 
 ```ts
-import { A2AClient } from "@agent-native/core/a2a";
+import { A2AClient, resolveA2ACallerAuth } from "@agent-native/core/a2a";
 
-const client = new A2AClient(
-  "https://analytics.example.com",
-  process.env.ANALYTICS_A2A_KEY,
-);
+// The second argument is the bearer token itself, not a signing secret.
+const { apiKey, apiKeyFallbacks } = await resolveA2ACallerAuth();
+const client = new A2AClient("https://analytics.example.com", apiKey, {
+  fallbackApiKeys: apiKeyFallbacks,
+});
 
 // Discover agent capabilities
 const card = await client.getAgentCard();
@@ -264,19 +310,6 @@ submitted → working → completed
 - **canceled** — task was canceled via `tasks/cancel`
 - **input-required** — agent needs more information from the caller
 
-## Security
-
-A2A uses bearer token auth. The server reads the token from the environment variable specified by `apiKeyEnv`:
-
-- Set `A2A_API_KEY=<A2A_API_KEY_VALUE>` in the server's deployment environment
-- Callers pass it as `Authorization: Bearer <A2A_API_KEY_VALUE>`
-- The agent card endpoint (`/.well-known/agent-card.json`) is public — no auth needed for discovery
-
-Never hardcode the bearer token in source, docs, prompts, app state, action
-descriptions, client bundles, or examples. A2A tokens are deploy-level secrets
-unless a specific app designs a scoped credential flow; read them from secure
-runtime configuration and never log or return them.
-
 ## Message Parts
 
 Messages contain typed parts:
@@ -287,33 +320,37 @@ Messages contain typed parts:
 | `file`    | `{ type: "file", file: { ... } }`   | Files (bytes or URI)       |
 | `data`    | `{ type: "data", data: { ... } }`   | Structured JSON data       |
 
-## Example: Cross-Agent Workflow
+## Custom mount
 
-A mail agent calls an analytics agent to include data in an email draft:
+Only when the default card is wrong for the app — a curated skill list, a
+non-agent handler, or static bearer auth against an external peer:
 
 ```ts
-// actions/draft-with-analytics.ts
-import { callAgent } from "@agent-native/core/a2a";
-import { writeAppState } from "@agent-native/core/application-state";
+// server/plugins/a2a.ts
+import { mountA2A } from "@agent-native/core/a2a";
 
-export default async function (args: string[]) {
-  // Ask the analytics agent for data
-  const stats = await callAgent(
-    process.env.ANALYTICS_AGENT_URL!,
-    "Summarize last week's key metrics in 3 bullet points",
-    { apiKey: process.env.ANALYTICS_A2A_KEY },
-  );
-
-  // Create a draft with the analytics data
-  await writeAppState("compose-analytics-report", {
-    id: "analytics-report",
-    to: "team@example.com",
-    subject: "Weekly Analytics Summary",
-    body: `Hi team,\n\nHere are last week's numbers:\n\n${stats}\n\nBest`,
-    mode: "compose",
+export default defineNitroPlugin((nitro) => {
+  mountA2A(nitro, {
+    appId: "analytics",
+    name: "Analytics Agent",
+    description: "Queries analytics data across providers",
+    skills: [
+      {
+        id: "query-data",
+        name: "Query Data",
+        description: "Run analytics queries across connected data sources",
+        tags: ["analytics", "data"],
+        examples: ["What were last week's signups?", "Show conversion rates"],
+      },
+    ],
+    streaming: true,
   });
-}
+});
 ```
+
+Config also carries `handler`, `publicSkillsOnly`, `durableBackgroundRuns`,
+`executeReadOnlyAction`, `executeApproval`, and `apiKeyEnv`. See `A2AConfig` in
+`@agent-native/core/a2a` for the full shape.
 
 ## All Types
 
@@ -345,5 +382,8 @@ import type {
 ## Related Skills
 
 - **delegate-to-agent** — For work the local agent handles. Use A2A when the work goes to a different agent.
-- **actions** — A2A calls typically happen inside actions
-- **storing-data** — Results from A2A calls are stored in SQL like any other data
+- **authentication** — Org creation, membership, and where the org secret lives.
+- **actions** — A2A calls typically happen inside actions; `publicAgent` marks what peers can see.
+- **storing-data** — Results from A2A calls are stored in SQL like any other data.
+</content>
+</invoke>

--- a/packages/dispatch/src/actions/list-connected-agents.ts
+++ b/packages/dispatch/src/actions/list-connected-agents.ts
@@ -12,6 +12,7 @@ import { getRequestUserEmail } from "@agent-native/core/server";
 import {
   discoverAgents,
   getBuiltinAgents,
+  normalizeAgentId,
   shouldIncludeRemoteAgentManifest,
 } from "@agent-native/core/server/agent-discovery";
 import { z } from "zod";
@@ -58,8 +59,12 @@ export default defineAction({
       const manifest = parseRemoteAgentManifest(full.content, resource.path);
       if (!manifest) continue;
       if (!shouldIncludeRemoteAgentManifest(manifest, "dispatch")) continue;
-      if (builtinIds.has(manifest.id)) continue;
-      customById.set(manifest.id, {
+      // discoverAgents keys agents by the normalized id (image/images/asset
+      // all collapse to assets). Keying this map by the raw manifest id makes
+      // the id lookups below miss, so the same agent lands in the list twice.
+      const manifestId = normalizeAgentId(manifest.id);
+      if (builtinIds.has(manifestId)) continue;
+      customById.set(manifestId, {
         resourceId: resource.id,
         path: resource.path,
         scope: resource.owner === SHARED_OWNER ? "shared" : "personal",

--- a/packages/dispatch/src/components/dispatch-control-plane.tsx
+++ b/packages/dispatch/src/components/dispatch-control-plane.tsx
@@ -6,8 +6,13 @@ import { PromptComposer } from "@agent-native/core/client/composer";
 import { useActionQuery } from "@agent-native/core/client/hooks";
 import { isInBuilderFrame } from "@agent-native/core/client/host";
 import { useT } from "@agent-native/core/client/i18n";
-import { IconArrowUpRight } from "@tabler/icons-react";
+import {
+  IconArrowUpRight,
+  IconChevronDown,
+  IconClockHour4,
+} from "@tabler/icons-react";
 import type { ReactNode } from "react";
+import { useState } from "react";
 import { Link, useNavigate } from "react-router";
 
 import { submitOverviewPrompt } from "../lib/overview-chat";
@@ -16,6 +21,11 @@ import { ActionQueryError } from "./action-query-error";
 import { CreateAppPopover } from "./create-app-popover";
 import { useSetPageTitle } from "./layout/HeaderActions";
 import { Button } from "./ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "./ui/collapsible";
 import { Skeleton } from "./ui/skeleton";
 import { WorkspaceAppCard } from "./workspace-app-card";
 
@@ -135,8 +145,13 @@ function AppsPanel({
   apps: WorkspaceAppSummary[];
   isLoading: boolean;
 }) {
+  const t = useT();
+  const [showPending, setShowPending] = useState(false);
   const visibleApps = apps.filter((app) => !app.isDispatch && !app.archived);
-  const showSkeletons = isLoading && visibleApps.length === 0;
+  const activeApps = visibleApps.filter((app) => app.status !== "pending");
+  const pendingApps = visibleApps.filter((app) => app.status === "pending");
+  const showSkeletons =
+    isLoading && activeApps.length === 0 && pendingApps.length === 0;
 
   return (
     <section className="flex flex-col gap-3">
@@ -161,15 +176,66 @@ function AppsPanel({
             </div>
           ))}
         </div>
-      ) : visibleApps.length > 0 ? (
+      ) : activeApps.length > 0 ? (
         <div className="grid gap-3 md:grid-cols-2">
-          {visibleApps.map((app) => (
+          {activeApps.map((app) => (
             <WorkspaceAppCard key={app.id} app={app} className="min-h-32" />
           ))}
         </div>
       ) : (
         <CreateAppPopover />
       )}
+      {pendingApps.length > 0 ? (
+        <Collapsible open={showPending} onOpenChange={setShowPending}>
+          <div className="space-y-3 border-t pt-3">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="flex min-w-0 items-center gap-2">
+                <IconClockHour4
+                  size={15}
+                  className="shrink-0 text-muted-foreground"
+                />
+                <div className="min-w-0">
+                  <h3 className="text-xs font-semibold text-foreground">
+                    {t("dispatch.pages.pendingApps")}
+                  </h3>
+                  <p className="text-xs text-muted-foreground">
+                    {t("dispatch.pages.pendingAppsDescription", {
+                      count: pendingApps.length,
+                    })}
+                  </p>
+                </div>
+              </div>
+              <CollapsibleTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 gap-1.5 px-2 text-xs"
+                >
+                  {showPending
+                    ? t("dispatch.pages.hidePendingApps")
+                    : t("dispatch.pages.showPendingApps")}
+                  <IconChevronDown
+                    size={13}
+                    className={showPending ? "rotate-180" : undefined}
+                  />
+                </Button>
+              </CollapsibleTrigger>
+            </div>
+            <CollapsibleContent>
+              <div className="grid gap-3 md:grid-cols-2">
+                {pendingApps.map((app) => (
+                  <WorkspaceAppCard
+                    key={app.id}
+                    app={app}
+                    className="min-h-32"
+                  />
+                ))}
+              </div>
+            </CollapsibleContent>
+          </div>
+        </Collapsible>
+      ) : null}
     </section>
   );
 }

--- a/packages/dispatch/src/components/workspace-app-card.spec.tsx
+++ b/packages/dispatch/src/components/workspace-app-card.spec.tsx
@@ -17,6 +17,13 @@ vi.mock("@agent-native/core/client/hooks", () => ({
   }),
 }));
 
+vi.mock("@agent-native/core/client/i18n", () => ({
+  useFormatters: () => ({
+    formatDate: (value: string) => value,
+  }),
+  useT: () => (key: string) => key,
+}));
+
 describe("WorkspaceAppCard", () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -139,5 +146,41 @@ describe("WorkspaceAppCard", () => {
     );
     expect(appLink?.getAttribute("target")).toBe("_blank");
     expect(appLink?.getAttribute("rel")).toBe("noreferrer");
+  });
+
+  it("shows ownership metadata in the more menu", async () => {
+    await act(async () => {
+      root.render(
+        <TooltipProvider>
+          <WorkspaceAppCard
+            app={{
+              id: "analytics",
+              name: "Analytics",
+              path: "/analytics",
+              createdAt: "2026-07-28T12:00:00.000Z",
+              createdBy: "creator@example.com",
+              owner: "owner@example.com",
+              teams: ["Growth", "Operations"],
+              status: "ready",
+            }}
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    const moreButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="More actions for Analytics"]',
+    );
+    expect(moreButton).not.toBeNull();
+
+    await act(async () => {
+      moreButton?.dispatchEvent(
+        new MouseEvent("pointerdown", { bubbles: true, button: 0 }),
+      );
+    });
+
+    expect(document.body.textContent).toContain("creator@example.com");
+    expect(document.body.textContent).toContain("owner@example.com");
+    expect(document.body.textContent).toContain("Growth, Operations");
   });
 });

--- a/packages/dispatch/src/components/workspace-app-card.tsx
+++ b/packages/dispatch/src/components/workspace-app-card.tsx
@@ -2,7 +2,9 @@ import {
   useActionMutation,
   useActionQuery,
 } from "@agent-native/core/client/hooks";
+import { useFormatters, useT } from "@agent-native/core/client/i18n";
 import {
+  IconCalendar,
   IconChevronDown,
   IconChevronRight,
   IconClockHour4,
@@ -13,6 +15,8 @@ import {
   IconFileText,
   IconWorld,
   IconTrash,
+  IconUser,
+  IconUsersGroup,
 } from "@tabler/icons-react";
 import { useEffect, useState, type FormEvent } from "react";
 import { toast } from "sonner";
@@ -40,6 +44,8 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
 import { Input } from "./ui/input";
@@ -58,6 +64,8 @@ export function WorkspaceAppCard({
   app: WorkspaceAppSummary;
   className?: string;
 }) {
+  const t = useT();
+  const { formatDate } = useFormatters();
   const href = workspaceAppHref(app);
   const openInNewTab = isPendingBuilderHref(app);
   const isPending = app.status === "pending";
@@ -215,7 +223,7 @@ export function WorkspaceAppCard({
                 </TooltipTrigger>
                 <TooltipContent>More actions</TooltipContent>
               </Tooltip>
-              <DropdownMenuContent align="end" className="w-44">
+              <DropdownMenuContent align="end" className="w-72">
                 <DropdownMenuItem
                   onSelect={(event) => {
                     event.preventDefault();
@@ -244,6 +252,20 @@ export function WorkspaceAppCard({
                     Hide from list
                   </DropdownMenuItem>
                 )}
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel className="font-normal">
+                  <WorkspaceAppMetadata
+                    app={app}
+                    formatDate={formatDate}
+                    labels={{
+                      created: t("agents.dashboardMetadataCreated"),
+                      createdBy: t("agents.dashboardMetadataCreatedBy"),
+                      owner: t("dispatch.pages.appMetadataOwner"),
+                      teams: t("dispatch.pages.appMetadataTeams"),
+                      notTracked: t("agents.notTracked"),
+                    }}
+                  />
+                </DropdownMenuLabel>
               </DropdownMenuContent>
             </DropdownMenu>
           </div>
@@ -289,6 +311,80 @@ export function WorkspaceAppCard({
           </form>
         </DialogContent>
       </Dialog>
+    </div>
+  );
+}
+
+function WorkspaceAppMetadata({
+  app,
+  formatDate,
+  labels,
+}: {
+  app: WorkspaceAppSummary;
+  formatDate: ReturnType<typeof useFormatters>["formatDate"];
+  labels: {
+    created: string;
+    createdBy: string;
+    owner: string;
+    teams: string;
+    notTracked: string;
+  };
+}) {
+  function formatMetadataDate(value: string | null | undefined): string {
+    if (!value) return labels.notTracked;
+    try {
+      return formatDate(value, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      });
+    } catch {
+      return value;
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5 text-xs text-muted-foreground">
+      <WorkspaceAppMetadataRow
+        icon={IconCalendar}
+        label={labels.created}
+        value={formatMetadataDate(app.createdAt)}
+      />
+      <WorkspaceAppMetadataRow
+        icon={IconUser}
+        label={labels.createdBy}
+        value={app.createdBy || labels.notTracked}
+      />
+      <WorkspaceAppMetadataRow
+        icon={IconUser}
+        label={labels.owner}
+        value={app.owner || labels.notTracked}
+      />
+      <WorkspaceAppMetadataRow
+        icon={IconUsersGroup}
+        label={labels.teams}
+        value={app.teams?.join(", ") || labels.notTracked}
+      />
+    </div>
+  );
+}
+
+function WorkspaceAppMetadataRow({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: typeof IconCalendar;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="flex items-start gap-1.5">
+      <Icon className="mt-0.5 h-3 w-3 shrink-0" />
+      <span className="shrink-0">{label}</span>
+      <span className="min-w-0 truncate text-foreground/80">{value}</span>
     </div>
   );
 }

--- a/packages/dispatch/src/lib/workspace-apps.ts
+++ b/packages/dispatch/src/lib/workspace-apps.ts
@@ -15,6 +15,9 @@ export interface WorkspaceAppSummary {
   builderUrl?: string | null;
   branchName?: string | null;
   createdAt?: string | null;
+  createdBy?: string | null;
+  owner?: string | null;
+  teams?: string[];
   agentCardUrl?: string | null;
   agentCardReachable?: boolean;
   a2aEndpointUrl?: string | null;

--- a/packages/dispatch/src/routes/pages/apps.tsx
+++ b/packages/dispatch/src/routes/pages/apps.tsx
@@ -5,6 +5,7 @@ import {
   IconApps,
   IconArrowUpRight,
   IconChevronDown,
+  IconClockHour4,
   IconEyeOff,
   IconPlus,
   IconStack2,
@@ -46,6 +47,7 @@ interface WorkspaceInfo {
 
 export default function AppsRoute() {
   const t = useT();
+  const [showPending, setShowPending] = useState(false);
   const [showHidden, setShowHidden] = useState(false);
   const appsQuery = useActionQuery("list-workspace-apps", {
     includeAgentCards: false,
@@ -68,6 +70,8 @@ export default function AppsRoute() {
     (app) => !app.isDispatch,
   );
   const visibleApps = allApps.filter((app) => !app.archived);
+  const activeApps = visibleApps.filter((app) => app.status !== "pending");
+  const pendingApps = visibleApps.filter((app) => app.status === "pending");
   const archivedApps = allApps.filter((app) => app.archived);
   const otherApps = filterOtherApps(
     (connectedAppsQuery.data || []) as ConnectedAppSummary[],
@@ -118,8 +122,13 @@ export default function AppsRoute() {
                 </h2>
                 <p className="mt-0.5 text-xs text-muted-foreground">
                   {t("dispatch.pages.activeCount", {
-                    count: visibleApps.length,
+                    count: activeApps.length,
                   })}
+                  {pendingApps.length > 0
+                    ? ` · ${t("dispatch.pages.pendingCount", {
+                        count: pendingApps.length,
+                      })}`
+                    : ""}
                   {archivedApps.length > 0
                     ? ` · ${t("dispatch.pages.hiddenCount", {
                         count: archivedApps.length,
@@ -128,7 +137,7 @@ export default function AppsRoute() {
                 </p>
               </div>
             </div>
-            {visibleApps.length > 0 ? (
+            {activeApps.length > 0 || pendingApps.length > 0 ? (
               <CreateAppPopover
                 align="end"
                 trigger={
@@ -148,16 +157,73 @@ export default function AppsRoute() {
             />
           ) : showAppSkeletons ? (
             <AppsSkeletonGrid />
-          ) : visibleApps.length > 0 ? (
+          ) : activeApps.length > 0 ? (
             <div className="grid auto-rows-fr gap-3 md:grid-cols-2 xl:grid-cols-3">
-              {visibleApps.map((app) => (
+              {activeApps.map((app) => (
                 <WorkspaceAppCard key={app.id} app={app} className="h-full" />
               ))}
             </div>
+          ) : pendingApps.length > 0 ? (
+            <EmptyActiveAppsState />
           ) : (
             <EmptyAppsState />
           )}
         </section>
+
+        {pendingApps.length > 0 ? (
+          <Collapsible open={showPending} onOpenChange={setShowPending}>
+            <section className="space-y-3 border-t pt-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-2">
+                  <IconClockHour4
+                    size={16}
+                    className="shrink-0 text-muted-foreground"
+                  />
+                  <div className="min-w-0">
+                    <h2 className="text-sm font-semibold text-foreground">
+                      {t("dispatch.pages.pendingApps")}
+                    </h2>
+                    <p className="text-xs text-muted-foreground">
+                      {t("dispatch.pages.pendingAppsDescription", {
+                        count: pendingApps.length,
+                      })}
+                    </p>
+                  </div>
+                </div>
+                <CollapsibleTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="gap-1.5"
+                  >
+                    {showPending
+                      ? t("dispatch.pages.hidePendingApps")
+                      : t("dispatch.pages.showPendingApps")}
+                    <IconChevronDown
+                      size={14}
+                      className={cn(
+                        "transition-transform",
+                        showPending && "rotate-180",
+                      )}
+                    />
+                  </Button>
+                </CollapsibleTrigger>
+              </div>
+              <CollapsibleContent>
+                <div className="grid auto-rows-fr gap-3 md:grid-cols-2 xl:grid-cols-3">
+                  {pendingApps.map((app) => (
+                    <WorkspaceAppCard
+                      key={app.id}
+                      app={app}
+                      className="h-full"
+                    />
+                  ))}
+                </div>
+              </CollapsibleContent>
+            </section>
+          </Collapsible>
+        ) : null}
 
         {curatedTemplatesQuery.isError ? (
           <section className="space-y-3 border-t pt-4">
@@ -397,6 +463,20 @@ function EmptyAppsState() {
           }
         />
       </div>
+    </div>
+  );
+}
+
+function EmptyActiveAppsState() {
+  const t = useT();
+  return (
+    <div className="rounded-lg border border-dashed bg-card px-4 py-10 text-center">
+      <p className="text-sm font-medium text-foreground">
+        {t("dispatch.pages.noActiveWorkspaceApps")}
+      </p>
+      <p className="mx-auto mt-1 max-w-md text-xs text-muted-foreground">
+        {t("dispatch.pages.noActiveWorkspaceAppsDescription")}
+      </p>
     </div>
   );
 }

--- a/packages/dispatch/src/server/lib/app-creation-store.ts
+++ b/packages/dispatch/src/server/lib/app-creation-store.ts
@@ -66,6 +66,9 @@ export interface WorkspaceAppSummary {
   builderUrl?: string | null;
   branchName?: string | null;
   createdAt?: string | null;
+  createdBy?: string | null;
+  owner?: string | null;
+  teams?: string[];
   agentCardUrl?: string | null;
   agentCardReachable?: boolean;
   a2aEndpointUrl?: string | null;
@@ -125,6 +128,9 @@ interface PendingWorkspaceApp {
   contextId: string | null;
   contextLabel: string | null;
   audience?: WorkspaceAppAudience;
+  createdBy?: string | null;
+  owner?: string | null;
+  teams?: string[];
   createdAt: string;
   updatedAt: string;
   expiresAt: string | null;
@@ -387,6 +393,12 @@ function applyWorkspaceAppMetadataOverride(
     ...app,
     ...(shouldApplyName ? { name } : {}),
     ...(shouldApplyDescription ? { description } : {}),
+    ...(app.status === "pending" && !app.createdBy && override.updatedBy
+      ? { createdBy: override.updatedBy }
+      : {}),
+    ...(app.status === "pending" && !app.owner && override.updatedBy
+      ? { owner: override.updatedBy }
+      : {}),
   };
 }
 
@@ -446,6 +458,75 @@ function normalizeWorkspaceAppPathList(value: unknown): string[] {
       entry.length > 1 && entry.endsWith("/") ? entry.slice(0, -1) : entry,
     );
   return Array.from(new Set(paths));
+}
+
+function normalizeWorkspaceAppTeams(value: unknown): string[] {
+  const rawTeams = Array.isArray(value)
+    ? value
+    : typeof value === "string"
+      ? value.split(",")
+      : [];
+  return Array.from(
+    new Set(
+      rawTeams
+        .map((team) => (typeof team === "string" ? team.trim() : ""))
+        .filter(Boolean),
+    ),
+  );
+}
+
+function workspaceAppMetadataFromRecord(
+  record: Record<string, any>,
+): Pick<WorkspaceAppSummary, "createdAt" | "createdBy" | "owner" | "teams"> {
+  const config = record["agent-native"] ?? record.agentNative;
+  const workspaceConfig =
+    config && typeof config === "object" && !Array.isArray(config)
+      ? (config.workspaceApp ?? config.workspace ?? config)
+      : {};
+  const metadata =
+    record.metadata &&
+    typeof record.metadata === "object" &&
+    !Array.isArray(record.metadata)
+      ? record.metadata
+      : {};
+  const pick = (...values: unknown[]) =>
+    values.map(cleanOptionalText).find((value) => value !== undefined);
+
+  const teams = normalizeWorkspaceAppTeams(
+    record.teams ??
+      record.team ??
+      metadata.teams ??
+      metadata.team ??
+      workspaceConfig.teams ??
+      workspaceConfig.team,
+  );
+  return {
+    createdAt: pick(
+      record.createdAt,
+      record.created_at,
+      metadata.createdAt,
+      workspaceConfig.createdAt,
+    ),
+    createdBy: pick(
+      record.createdBy,
+      record.createdByEmail,
+      record.created_by,
+      metadata.createdBy,
+      metadata.createdByEmail,
+      workspaceConfig.createdBy,
+      workspaceConfig.createdByEmail,
+    ),
+    owner: pick(
+      record.owner,
+      record.ownerEmail,
+      record.owner_email,
+      metadata.owner,
+      metadata.ownerEmail,
+      workspaceConfig.owner,
+      workspaceConfig.ownerEmail,
+    ),
+    teams,
+  };
 }
 
 function workspaceAppAudienceFromPackageJson(
@@ -513,6 +594,7 @@ function parseWorkspaceAppsManifest(parsed: any): WorkspaceAppSummary[] | null {
       const id = typeof entry.id === "string" ? entry.id.trim() : "";
       const pathValue = typeof entry.path === "string" ? entry.path.trim() : "";
       if (!id || !pathValue.startsWith("/")) return null;
+      const metadata = workspaceAppMetadataFromRecord(entry);
       return {
         id,
         name:
@@ -534,6 +616,7 @@ function parseWorkspaceAppsManifest(parsed: any): WorkspaceAppSummary[] | null {
         publicPaths: normalizeWorkspaceAppPathList(entry.publicPaths),
         protectedPaths: normalizeWorkspaceAppPathList(entry.protectedPaths),
         status: "ready",
+        ...metadata,
       } satisfies WorkspaceAppSummary;
     })
     .filter(
@@ -645,6 +728,9 @@ function parsePendingWorkspaceApps(value: unknown): PendingWorkspaceApp[] {
             : null,
         contextId: cleanOptionalString(record.contextId),
         contextLabel: cleanOptionalString(record.contextLabel),
+        createdBy: cleanOptionalString(record.createdBy),
+        owner: cleanOptionalString(record.owner ?? record.ownerEmail),
+        teams: normalizeWorkspaceAppTeams(record.teams ?? record.team),
         ...(record.audience === undefined
           ? {}
           : { audience: normalizeWorkspaceAppAudience(record.audience) }),
@@ -755,6 +841,9 @@ function pendingAppToSummary(app: PendingWorkspaceApp): WorkspaceAppSummary {
     builderUrl: app.builderUrl,
     branchName: app.branchName,
     createdAt: app.createdAt,
+    createdBy: app.createdBy,
+    owner: app.owner,
+    teams: app.teams,
   };
 }
 
@@ -918,6 +1007,8 @@ async function recordPendingWorkspaceApp(input: {
     projectId: input.projectId,
     contextId: context?.id ?? null,
     contextLabel: context?.label ?? null,
+    createdBy: currentOwnerEmail(),
+    owner: currentOwnerEmail(),
     createdAt: existing?.createdAt || now,
     updatedAt: now,
     expiresAt: pendingWorkspaceAppExpiresAt(existing?.createdAt || now),
@@ -1038,6 +1129,7 @@ function readWorkspaceAppsFromFilesystem(
       const pkg = readJson(path.join(appDir, "package.json"));
       if (!pkg) return null;
       const routeAccess = workspaceAppRouteAccessFromPackageJson(pkg);
+      const metadata = workspaceAppMetadataFromRecord(pkg);
       return {
         id: entry.name,
         name: pkg.displayName || titleCase(entry.name),
@@ -1051,6 +1143,7 @@ function readWorkspaceAppsFromFilesystem(
         publicPaths: routeAccess.publicPaths,
         protectedPaths: routeAccess.protectedPaths,
         status: "ready",
+        ...metadata,
       } satisfies WorkspaceAppSummary;
     })
     .filter((app): app is WorkspaceAppSummary => !!app)

--- a/packages/docs/app/components/Header.tsx
+++ b/packages/docs/app/components/Header.tsx
@@ -277,8 +277,6 @@ export default function Header() {
             </div>
             <div className="hidden shrink-0 items-center lg:flex">
               <DocsLanguagePicker />
-            </div>
-            <div className="hidden lg:block">
               <DocsLanguageSuggestion />
             </div>
             <div className="hidden lg:block">

--- a/packages/docs/app/i18n/en-US.ts
+++ b/packages/docs/app/i18n/en-US.ts
@@ -363,7 +363,7 @@ const enUS = {
       uiSurfaces: "UI surfaces",
       i18n: "i18n",
       mcpAuth: "MCP Auth",
-      battleTestedComponents: "Battle-tested building blocks",
+      battleTestedComponents: "Built-in building blocks",
       mcpA2a: "MCP + A2A",
       externalAgents: "External agents",
       a2aHandoffs: "A2A handoffs",

--- a/packages/toolkit/src/composer/TiptapComposer.spec.ts
+++ b/packages/toolkit/src/composer/TiptapComposer.spec.ts
@@ -22,6 +22,7 @@ import {
   resolveContextChipBackspaceAction,
   resolveComposerPrimaryAction,
   shouldShowModelSelectorSkeleton,
+  shouldShowOnlyConnectPath,
 } from "./TiptapComposer.js";
 
 describe("createTiptapComposerExtensions", () => {
@@ -347,6 +348,19 @@ describe("createTiptapComposerExtensions", () => {
     expect(shouldShowModelSelectorSkeleton(true, 0)).toBe(true);
     expect(shouldShowModelSelectorSkeleton(true, 2)).toBe(false);
     expect(shouldShowModelSelectorSkeleton(false, 0)).toBe(false);
+  });
+
+  it("replaces the model list with connect CTAs only when nothing is configured", () => {
+    const unconfigured = [{ configured: false }, { configured: false }];
+    expect(shouldShowOnlyConnectPath(true, unconfigured)).toBe(true);
+    expect(
+      shouldShowOnlyConnectPath(true, [
+        { configured: true },
+        { configured: false },
+      ]),
+    ).toBe(false);
+    // No CTA to fall back on — keep the list rather than empty the popover.
+    expect(shouldShowOnlyConnectPath(false, unconfigured)).toBe(false);
   });
 });
 

--- a/packages/toolkit/src/composer/TiptapComposer.tsx
+++ b/packages/toolkit/src/composer/TiptapComposer.tsx
@@ -839,6 +839,18 @@ export function shouldShowModelSelectorSkeleton(
   return isLoading && engineCount === 0;
 }
 
+/**
+ * With nothing connected, every family is a dead "needs API key" row, so the
+ * picker shows only the connect CTAs. Never hide the list unless a CTA is
+ * there to replace it — an empty popover reads as more broken, not less.
+ */
+export function shouldShowOnlyConnectPath(
+  showBuilderCta: boolean,
+  groups: ReadonlyArray<{ configured: boolean }>,
+): boolean {
+  return showBuilderCta && groups.every((group) => !group.configured);
+}
+
 function friendlyModelName(model: string): string {
   if (FRIENDLY_MODEL_NAMES[model]) return FRIENDLY_MODEL_NAMES[model];
   // Claude: claude-{tier}-{major}[-minor][-dateYYYYMMDD] → Tier Major[.Minor]
@@ -1081,6 +1093,10 @@ function ModelSelector({
     !builderFlow.configured &&
     !builderFlow.envManaged &&
     !hasConfiguredBuilderModels;
+  const onlyConnectPathAvailable = shouldShowOnlyConnectPath(
+    showBuilderCta,
+    providerGroups,
+  );
   const openLlmSettings = useCallback(() => {
     try {
       window.location.hash = "llm";
@@ -1161,6 +1177,14 @@ function ModelSelector({
                 </span>
               </span>
             </button>
+            {!onConnectProvider && builderFlow.error && (
+              <p
+                role="alert"
+                className="px-3 pb-2 ps-9 text-[11px] text-destructive"
+              >
+                {builderFlow.error}
+              </p>
+            )}
             <button
               type="button"
               onClick={openLlmSettings}
@@ -1181,7 +1205,9 @@ function ModelSelector({
                 </span>
               </span>
             </button>
-            <div className="my-1 border-t border-border" />
+            {!onlyConnectPathAvailable && (
+              <div className="my-1 border-t border-border" />
+            )}
           </>
         )}
         {imageModel && imageModel.options.length > 0 && (
@@ -1231,7 +1257,7 @@ function ModelSelector({
           </>
         )}
         {showModelListSkeleton && <ModelSelectorSkeleton />}
-        {autoModelGroup && (
+        {autoModelGroup && !onlyConnectPathAvailable && (
           <button
             type="button"
             onClick={() => {
@@ -1248,136 +1274,142 @@ function ModelSelector({
             )}
           </button>
         )}
-        {autoModelGroup && providerGroups.length > 0 && (
-          <div className="my-1 border-t border-border" />
-        )}
-        {providerGroups.map((group) => {
-          const models = latestModelsOnly(group.models);
-          const groupKey = `${group.engine}:${group.label}`;
-          const isExpanded = expandedGroups.has(groupKey);
-          const ChevronIcon = isExpanded ? IconChevronDown : IconChevronRight;
-          return (
-            <div key={groupKey}>
+        {autoModelGroup &&
+          providerGroups.length > 0 &&
+          !onlyConnectPathAvailable && (
+            <div className="my-1 border-t border-border" />
+          )}
+        {!onlyConnectPathAvailable &&
+          providerGroups.map((group) => {
+            const models = latestModelsOnly(group.models);
+            const groupKey = `${group.engine}:${group.label}`;
+            const isExpanded = expandedGroups.has(groupKey);
+            const ChevronIcon = isExpanded ? IconChevronDown : IconChevronRight;
+            return (
+              <div key={groupKey}>
+                <div className="flex items-center hover:bg-accent/30">
+                  <button
+                    type="button"
+                    aria-expanded={isExpanded}
+                    onClick={() => toggleGroup(groupKey)}
+                    className="flex flex-1 min-w-0 items-center gap-1.5 px-2 py-1.5 cursor-pointer text-start"
+                  >
+                    <ChevronIcon className="h-3 w-3 shrink-0 text-muted-foreground rtl:-scale-x-100" />
+                    <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide shrink-0">
+                      {group.label}
+                    </span>
+                    {!isExpanded && groupKey === selectedGroupKey && (
+                      <span className="text-[11px] text-muted-foreground/80 truncate">
+                        {friendlyModelName(model)}
+                      </span>
+                    )}
+                  </button>
+                  {!group.configured && (
+                    <button
+                      type="button"
+                      className="text-[10px] text-muted-foreground/60 hover:text-foreground cursor-pointer pe-3 py-1.5"
+                      onClick={() =>
+                        group.engine === "codex-cli" && onConnectLocalRuntime
+                          ? connectLocalRuntime(group.engine)
+                          : openLlmSettings()
+                      }
+                    >
+                      {group.engine === "codex-cli" && onConnectLocalRuntime
+                        ? "sign in"
+                        : "needs API key"}
+                    </button>
+                  )}
+                </div>
+                {isExpanded &&
+                  models.map((m) => (
+                    <button
+                      key={m}
+                      type="button"
+                      onClick={() => {
+                        if (!group.configured) {
+                          if (
+                            group.engine === "codex-cli" &&
+                            onConnectLocalRuntime
+                          ) {
+                            connectLocalRuntime(group.engine);
+                          } else {
+                            openLlmSettings();
+                          }
+                          return;
+                        }
+                        onChange(m, group.engine);
+                        const nextOptions =
+                          getReasoningEffortOptionsForModel(m);
+                        if (
+                          nextOptions.length > 0 &&
+                          !nextOptions.includes(selectedEffort)
+                        ) {
+                          onEffortChange?.(defaultEffort);
+                        }
+                        setOpen(false);
+                      }}
+                      className={`flex w-full items-center gap-3 ps-7 pe-3 py-1.5 text-start ${
+                        group.configured
+                          ? "hover:bg-accent/50"
+                          : "opacity-40 cursor-default"
+                      }`}
+                    >
+                      <span className="flex-1 min-w-0 text-[13px] text-foreground truncate">
+                        {friendlyModelName(m)}
+                      </span>
+                      {m === model && group.configured && (
+                        <IconCheck className="h-3.5 w-3.5 shrink-0 text-blue-500" />
+                      )}
+                    </button>
+                  ))}
+              </div>
+            );
+          })}
+        {!showModelListSkeleton &&
+          !onlyConnectPathAvailable &&
+          effortOptions.length > 0 && (
+            <>
+              <div className="my-1 border-t border-border" />
               <div className="flex items-center hover:bg-accent/30">
                 <button
                   type="button"
-                  aria-expanded={isExpanded}
-                  onClick={() => toggleGroup(groupKey)}
+                  aria-expanded={reasoningExpanded}
+                  onClick={() => setReasoningExpanded((prev) => !prev)}
                   className="flex flex-1 min-w-0 items-center gap-1.5 px-2 py-1.5 cursor-pointer text-start"
                 >
-                  <ChevronIcon className="h-3 w-3 shrink-0 text-muted-foreground rtl:-scale-x-100" />
+                  {reasoningExpanded ? (
+                    <IconChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
+                  ) : (
+                    <IconChevronRight className="h-3 w-3 shrink-0 text-muted-foreground rtl:-scale-x-100" />
+                  )}
                   <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide shrink-0">
-                    {group.label}
+                    Reasoning
                   </span>
-                  {!isExpanded && groupKey === selectedGroupKey && (
+                  {!reasoningExpanded && (
                     <span className="text-[11px] text-muted-foreground/80 truncate">
-                      {friendlyModelName(model)}
+                      {effortLabel(selectedEffort)}
                     </span>
                   )}
                 </button>
-                {!group.configured && (
-                  <button
-                    type="button"
-                    className="text-[10px] text-muted-foreground/60 hover:text-foreground cursor-pointer pe-3 py-1.5"
-                    onClick={() =>
-                      group.engine === "codex-cli" && onConnectLocalRuntime
-                        ? connectLocalRuntime(group.engine)
-                        : openLlmSettings()
-                    }
-                  >
-                    {group.engine === "codex-cli" && onConnectLocalRuntime
-                      ? "sign in"
-                      : "needs API key"}
-                  </button>
-                )}
               </div>
-              {isExpanded &&
-                models.map((m) => (
+              {reasoningExpanded &&
+                effortOptions.map((option) => (
                   <button
-                    key={m}
+                    key={option}
                     type="button"
-                    onClick={() => {
-                      if (!group.configured) {
-                        if (
-                          group.engine === "codex-cli" &&
-                          onConnectLocalRuntime
-                        ) {
-                          connectLocalRuntime(group.engine);
-                        } else {
-                          openLlmSettings();
-                        }
-                        return;
-                      }
-                      onChange(m, group.engine);
-                      const nextOptions = getReasoningEffortOptionsForModel(m);
-                      if (
-                        nextOptions.length > 0 &&
-                        !nextOptions.includes(selectedEffort)
-                      ) {
-                        onEffortChange?.(defaultEffort);
-                      }
-                      setOpen(false);
-                    }}
-                    className={`flex w-full items-center gap-3 ps-7 pe-3 py-1.5 text-start ${
-                      group.configured
-                        ? "hover:bg-accent/50"
-                        : "opacity-40 cursor-default"
-                    }`}
+                    onClick={() => onEffortChange?.(option)}
+                    className="flex w-full items-center gap-3 ps-7 pe-3 py-1.5 text-start hover:bg-accent/50"
                   >
                     <span className="flex-1 min-w-0 text-[13px] text-foreground truncate">
-                      {friendlyModelName(m)}
+                      {effortLabel(option)}
                     </span>
-                    {m === model && group.configured && (
+                    {option === selectedEffort && (
                       <IconCheck className="h-3.5 w-3.5 shrink-0 text-blue-500" />
                     )}
                   </button>
                 ))}
-            </div>
-          );
-        })}
-        {!showModelListSkeleton && effortOptions.length > 0 && (
-          <>
-            <div className="my-1 border-t border-border" />
-            <div className="flex items-center hover:bg-accent/30">
-              <button
-                type="button"
-                aria-expanded={reasoningExpanded}
-                onClick={() => setReasoningExpanded((prev) => !prev)}
-                className="flex flex-1 min-w-0 items-center gap-1.5 px-2 py-1.5 cursor-pointer text-start"
-              >
-                {reasoningExpanded ? (
-                  <IconChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
-                ) : (
-                  <IconChevronRight className="h-3 w-3 shrink-0 text-muted-foreground rtl:-scale-x-100" />
-                )}
-                <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide shrink-0">
-                  Reasoning
-                </span>
-                {!reasoningExpanded && (
-                  <span className="text-[11px] text-muted-foreground/80 truncate">
-                    {effortLabel(selectedEffort)}
-                  </span>
-                )}
-              </button>
-            </div>
-            {reasoningExpanded &&
-              effortOptions.map((option) => (
-                <button
-                  key={option}
-                  type="button"
-                  onClick={() => onEffortChange?.(option)}
-                  className="flex w-full items-center gap-3 ps-7 pe-3 py-1.5 text-start hover:bg-accent/50"
-                >
-                  <span className="flex-1 min-w-0 text-[13px] text-foreground truncate">
-                    {effortLabel(option)}
-                  </span>
-                  {option === selectedEffort && (
-                    <IconCheck className="h-3.5 w-3.5 shrink-0 text-blue-500" />
-                  )}
-                </button>
-              ))}
-          </>
-        )}
+            </>
+          )}
       </PopoverContent>
     </Popover>
   );

--- a/packages/toolkit/src/composer/runtime-adapters.tsx
+++ b/packages/toolkit/src/composer/runtime-adapters.tsx
@@ -43,6 +43,7 @@ export interface ComposerBuilderConnectFlow {
   envManaged: boolean;
   connecting: boolean;
   statusResolved: boolean;
+  error: string | null;
   start: () => void;
 }
 
@@ -196,6 +197,7 @@ const fallbackBuilderFlow = {
   envManaged: false,
   connecting: false,
   statusResolved: false,
+  error: null,
   start: () => {},
 };
 

--- a/templates/dispatch/changelog/2026-07-28-pending-apps-are-hidden-by-default-and-app-ownership-details.md
+++ b/templates/dispatch/changelog/2026-07-28-pending-apps-are-hidden-by-default-and-app-ownership-details.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-28
+---
+
+Pending apps are hidden by default and app ownership details are available from the overflow menu

--- a/templates/slides/app/components/editor/EditorSidebar.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.tsx
@@ -28,7 +28,10 @@ import { toast } from "sonner";
 
 import SlideRenderer from "@/components/deck/SlideRenderer";
 import { GoogleDocImportHint } from "@/components/editor/GoogleDocImportHint";
-import type { UploadedFile } from "@/components/editor/PromptDialog";
+import {
+  isInsidePortaledLayer,
+  type UploadedFile,
+} from "@/components/editor/PromptDialog";
 import {
   Tooltip,
   TooltipContent,
@@ -366,6 +369,7 @@ function AddSlidePopover({
   useEffect(() => {
     if (!open) return;
     const handleClick = (e: MouseEvent) => {
+      if (isInsidePortaledLayer(e.target)) return;
       if (
         panelRef.current &&
         !panelRef.current.contains(e.target as Node) &&

--- a/templates/slides/app/components/editor/EditorToolbar.tsx
+++ b/templates/slides/app/components/editor/EditorToolbar.tsx
@@ -64,6 +64,7 @@ import {
   type AspectRatio,
   DEFAULT_ASPECT_RATIO,
 } from "@/lib/aspect-ratios";
+import type { GoogleSlidesExportResult } from "@/lib/export-google-slides-client";
 import { parseUploadResponse } from "@/lib/upload-response";
 import { shortcutLabel } from "@/lib/utils";
 
@@ -134,6 +135,8 @@ interface EditorToolbarProps {
   onExportPdf?: () => void;
   /** Export the deck as PPTX */
   onExportPptx?: () => Promise<void> | void;
+  /** Create the deck in the user's Google Drive as native Google Slides */
+  onExportGoogleSlides?: () => Promise<GoogleSlidesExportResult>;
   /** Active deck aspect ratio (defaults to 16:9 when omitted) */
   aspectRatio?: AspectRatio;
   /** Change the deck's aspect ratio */
@@ -267,6 +270,7 @@ export default function EditorToolbar({
   onDuplicateDeck,
   onExportPdf,
   onExportPptx,
+  onExportGoogleSlides,
   aspectRatio,
   onSetAspectRatio,
   designSystemTitle,
@@ -998,6 +1002,7 @@ graph TD
           onDuplicate={onDuplicateDeck ?? (() => {})}
           onExportPdf={onExportPdf ?? (() => {})}
           onExportPptx={onExportPptx ?? (() => {})}
+          onExportGoogleSlides={onExportGoogleSlides}
         />
       </div>
 

--- a/templates/slides/app/components/editor/ExportMenu.test.tsx
+++ b/templates/slides/app/components/editor/ExportMenu.test.tsx
@@ -30,7 +30,10 @@ vi.mock("@agent-native/core/client/i18n", () => ({
   useT: () => (key: string) =>
     (
       ({
-        "editorExport.downloadGoogleSlides": "Download for Google Slides",
+        "editorExport.openInGoogleSlides": "Open in Google Slides",
+        "editorExport.googleSlidesCreated": "Opened in Google Slides",
+        "editorExport.googleSlidesCreatedHint":
+          "A copy of this deck was created in your Google Drive.",
         "editorExport.downloadHtml": "Download as HTML",
         "editorExport.duplicateDeck": "Duplicate deck",
         "editorExport.export": "Export",
@@ -68,6 +71,9 @@ function renderMenu(overrides: Partial<Parameters<typeof ExportMenu>[0]> = {}) {
       onDuplicate={vi.fn()}
       onExportPdf={vi.fn()}
       onExportPptx={vi.fn()}
+      onExportGoogleSlides={vi.fn().mockResolvedValue({
+        url: "https://docs.google.com/presentation/d/new-deck/edit",
+      })}
       {...overrides}
     />,
   );
@@ -112,17 +118,50 @@ describe("<ExportMenu>", () => {
     expect(window.open).not.toHaveBeenCalled();
   });
 
-  it("downloads Google Slides exports as PPTX without navigating away first", async () => {
-    const onExportPptx = vi.fn().mockResolvedValue(undefined);
-    renderMenu({ onExportPptx });
+  it("opens the converted deck in Google Slides", async () => {
+    const openedTab = { location: { href: "" }, close: vi.fn() };
+    vi.mocked(window.open).mockReturnValue(openedTab as unknown as Window);
+    const onExportGoogleSlides = vi.fn().mockResolvedValue({
+      url: "https://docs.google.com/presentation/d/new-deck/edit",
+    });
+    renderMenu({ onExportGoogleSlides });
 
     const trigger = screen.getByRole("button", { name: /export/i });
     fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
-    fireEvent.click(await screen.findByText("Download for Google Slides"));
+    fireEvent.click(await screen.findByText("Open in Google Slides"));
 
-    await waitFor(() => expect(onExportPptx).toHaveBeenCalledTimes(1));
-    expect(fetch).not.toHaveBeenCalled();
-    expect(window.open).not.toHaveBeenCalled();
+    await waitFor(() => expect(onExportGoogleSlides).toHaveBeenCalledTimes(1));
+    expect(openedTab.location.href).toBe(
+      "https://docs.google.com/presentation/d/new-deck/edit",
+    );
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "Opened in Google Slides",
+      expect.objectContaining({
+        description: "A copy of this deck was created in your Google Drive.",
+      }),
+    );
+  });
+
+  it("falls back to the import dialog when Drive is unavailable", async () => {
+    const openedTab = { location: { href: "" }, close: vi.fn() };
+    vi.mocked(window.open).mockReturnValue(openedTab as unknown as Window);
+    renderMenu({
+      onExportGoogleSlides: vi.fn().mockResolvedValue({
+        url: null,
+        downloaded: true,
+        reason: "No connected Google account.",
+      }),
+    });
+
+    const trigger = screen.getByRole("button", { name: /export/i });
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+    fireEvent.click(await screen.findByText("Open in Google Slides"));
+
+    await waitFor(() =>
+      expect(openedTab.location.href).toBe(
+        "https://docs.google.com/presentation/u/0/?usp=import",
+      ),
+    );
     expect(toastSuccessMock).toHaveBeenCalledWith(
       "Downloaded for Google Slides",
       expect.objectContaining({
@@ -131,15 +170,17 @@ describe("<ExportMenu>", () => {
     );
   });
 
-  it("does not open Google Slides when Google export fails", async () => {
+  it("does not open Google Slides when the export itself fails", async () => {
+    const openedTab = { location: { href: "" }, close: vi.fn() };
+    vi.mocked(window.open).mockReturnValue(openedTab as unknown as Window);
     renderMenu({
-      onExportPptx: vi.fn().mockRejectedValue(new Error("Could not render")),
+      onExportGoogleSlides: vi
+        .fn()
+        .mockRejectedValue(new Error("Could not render")),
     });
     const trigger = screen.getByRole("button", { name: /export/i });
     fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
-    fireEvent.click(await screen.findByText("Download for Google Slides"));
-
-    expect(window.open).not.toHaveBeenCalled();
+    fireEvent.click(await screen.findByText("Open in Google Slides"));
 
     await waitFor(() => {
       expect(toastErrorMock).toHaveBeenCalledWith(
@@ -147,7 +188,8 @@ describe("<ExportMenu>", () => {
         expect.objectContaining({ description: "Could not render" }),
       );
     });
-    expect(window.open).not.toHaveBeenCalled();
+    expect(openedTab.location.href).toBe("");
+    expect(openedTab.close).toHaveBeenCalled();
   });
 
   it("downloads HTML via the streamed POST endpoint, not the broken filename GET", async () => {

--- a/templates/slides/app/components/editor/ExportMenu.tsx
+++ b/templates/slides/app/components/editor/ExportMenu.tsx
@@ -18,6 +18,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import type { GoogleSlidesExportResult } from "@/lib/export-google-slides-client";
+
+/** Google Slides' File → Import dialog, primed to ask for a file. */
+const GOOGLE_SLIDES_IMPORT_URL =
+  "https://docs.google.com/presentation/u/0/?usp=import";
 
 interface ExportMenuProps {
   deckId: string;
@@ -25,6 +30,7 @@ interface ExportMenuProps {
   onDuplicate: () => void;
   onExportPdf: () => void;
   onExportPptx: () => Promise<void> | void;
+  onExportGoogleSlides?: () => Promise<GoogleSlidesExportResult>;
   onShareLink?: () => void;
   onShareTeam?: () => void;
 }
@@ -35,6 +41,7 @@ export function ExportMenu({
   onDuplicate,
   onExportPdf,
   onExportPptx,
+  onExportGoogleSlides,
   onShareLink,
   onShareTeam,
 }: ExportMenuProps) {
@@ -84,12 +91,26 @@ export function ExportMenu({
   };
 
   const handleExportGoogleSlides = async () => {
+    if (!onExportGoogleSlides) return;
+    // Opened up-front: browsers only honour window.open() inside the click
+    // gesture, and building the PPTX is async.
+    const target = window.open("", "_blank");
     try {
-      await onExportPptx();
+      const result = await onExportGoogleSlides();
+      if (result.url !== null) {
+        if (target) target.location.href = result.url;
+        toast.success(t("editorExport.googleSlidesCreated"), {
+          description: t("editorExport.googleSlidesCreatedHint"),
+        });
+        return;
+      }
+      console.warn("Google Slides upload unavailable:", result.reason);
+      if (target) target.location.href = GOOGLE_SLIDES_IMPORT_URL;
       toast.success(t("editorExport.googleSlidesDownloaded"), {
         description: t("editorExport.googleSlidesImportHint"),
       });
     } catch (err) {
+      target?.close();
       console.error("Export failed:", err);
       toast.error(t("editorExport.exportFailed"), {
         description:
@@ -166,13 +187,15 @@ export function ExportMenu({
           <IconDownload className="w-4 h-4 mr-2" />
           {t("editorExport.exportPptx")}
         </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={handleExportGoogleSlides}
-          className="cursor-pointer"
-        >
-          <IconBrandGoogle className="w-4 h-4 mr-2" />
-          {t("editorExport.downloadGoogleSlides")}
-        </DropdownMenuItem>
+        {onExportGoogleSlides && (
+          <DropdownMenuItem
+            onClick={handleExportGoogleSlides}
+            className="cursor-pointer"
+          >
+            <IconBrandGoogle className="w-4 h-4 mr-2" />
+            {t("editorExport.openInGoogleSlides")}
+          </DropdownMenuItem>
+        )}
         <DropdownMenuSeparator />
         <DropdownMenuItem onClick={onDuplicate} className="cursor-pointer">
           <IconCopy className="w-4 h-4 mr-2" />

--- a/templates/slides/app/components/editor/PromptDialog.test.tsx
+++ b/templates/slides/app/components/editor/PromptDialog.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+
+import { isInsidePortaledLayer } from "./PromptDialog";
+
+describe("isInsidePortaledLayer", () => {
+  it("matches nodes inside a Radix popper layer", () => {
+    const wrapper = document.createElement("div");
+    wrapper.setAttribute("data-radix-popper-content-wrapper", "");
+    const button = document.createElement("button");
+    wrapper.append(button);
+    document.body.append(wrapper);
+
+    expect(isInsidePortaledLayer(button)).toBe(true);
+    wrapper.remove();
+  });
+
+  it("ignores ordinary nodes and non-elements", () => {
+    const button = document.createElement("button");
+    document.body.append(button);
+
+    expect(isInsidePortaledLayer(button)).toBe(false);
+    expect(isInsidePortaledLayer(document.createTextNode("x"))).toBe(false);
+    expect(isInsidePortaledLayer(null)).toBe(false);
+    button.remove();
+  });
+});

--- a/templates/slides/app/components/editor/PromptDialog.tsx
+++ b/templates/slides/app/components/editor/PromptDialog.tsx
@@ -16,6 +16,20 @@ export interface UploadedFile {
   size: number;
 }
 
+/**
+ * Radix popovers portal to `document.body`, so a mousedown inside the model
+ * picker or attachment menu reads as "outside" any panel that hosts a composer.
+ * Closing on it unmounts the popover before its own click fires, which looks
+ * exactly like a dead button.
+ */
+export function isInsidePortaledLayer(target: EventTarget | null): boolean {
+  return Boolean(
+    (target as Element | null)?.closest?.(
+      "[data-radix-popper-content-wrapper]",
+    ),
+  );
+}
+
 interface PromptPopoverProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -98,6 +112,7 @@ export default function PromptPopover({
   useEffect(() => {
     if (!open) return;
     const handleClick = (e: MouseEvent) => {
+      if (isInsidePortaledLayer(e.target)) return;
       if (
         panelRef.current &&
         !panelRef.current.contains(e.target as Node) &&

--- a/templates/slides/app/components/presentation/PresentationView.tsx
+++ b/templates/slides/app/components/presentation/PresentationView.tsx
@@ -3,6 +3,7 @@ import {
   IconChevronLeft,
   IconChevronRight,
   IconMaximize,
+  IconNotes,
   IconX,
 } from "@tabler/icons-react";
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
@@ -19,6 +20,8 @@ import {
   findLegacyAnimationContainer,
   resolveSlideAnimationElement,
 } from "@/lib/slide-animation-elements";
+
+import { openPresentChannel, type PresentMessage } from "./present-channel";
 
 interface PresentationViewProps {
   slides: Slide[];
@@ -271,6 +274,58 @@ export default function PresentationView({
     }
   }, [navigate, deckId, isShared]);
 
+  // Presenter window: it owns no navigation state of its own, it just sends
+  // commands and mirrors whatever we echo back — so build steps stay
+  // authoritative here.
+  const channelRef = useRef<BroadcastChannel | null>(null);
+  const goNextRef = useRef(goNext);
+  const goPrevRef = useRef(goPrev);
+  goNextRef.current = goNext;
+  goPrevRef.current = goPrev;
+
+  const broadcastState = useCallback(() => {
+    channelRef.current?.postMessage({
+      type: "state",
+      index: currentIndex,
+    } satisfies PresentMessage);
+  }, [currentIndex]);
+  const broadcastStateRef = useRef(broadcastState);
+  broadcastStateRef.current = broadcastState;
+
+  useEffect(() => {
+    const channel = openPresentChannel(deckId);
+    channelRef.current = channel;
+    if (!channel) return;
+    channel.onmessage = (event: MessageEvent<PresentMessage>) => {
+      const message = event.data;
+      if (message?.type === "hello") {
+        broadcastStateRef.current();
+      } else if (message?.type === "command") {
+        if (message.command === "next") goNextRef.current();
+        else goPrevRef.current();
+      }
+    };
+    return () => {
+      channel.close();
+      channelRef.current = null;
+    };
+  }, [deckId]);
+
+  useEffect(() => {
+    broadcastState();
+  }, [broadcastState]);
+
+  const openPresenterWindow = useCallback(() => {
+    const url = new URL(window.location.href);
+    url.searchParams.set("presenter", "1");
+    url.searchParams.set("slide", String(currentIndex + 1));
+    window.open(
+      url.toString(),
+      `slides-presenter-${deckId}`,
+      "width=1200,height=760",
+    );
+  }, [currentIndex, deckId]);
+
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
       switch (e.key) {
@@ -294,6 +349,11 @@ export default function PresentationView({
             document.exitFullscreen().catch(() => {});
           }
           break;
+        case "s":
+        case "S":
+          e.preventDefault();
+          openPresenterWindow();
+          break;
         case "Escape":
           exit();
           break;
@@ -301,7 +361,7 @@ export default function PresentationView({
     };
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
-  }, [goNext, goPrev, exit]);
+  }, [goNext, goPrev, exit, openPresenterWindow]);
 
   // Try to enter fullscreen. Browsers require a user gesture; the click that
   // navigated to /present often counts, but Safari/Firefox sometimes block
@@ -501,13 +561,23 @@ export default function PresentationView({
             </button>
           </div>
 
-          <button
-            onClick={exit}
-            className="p-3 sm:p-2 rounded-lg bg-white/10 hover:bg-white/20 transition-colors"
-            aria-label={t("presentation.exitPresentation")}
-          >
-            <IconX className="w-5 h-5 sm:w-4 sm:h-4 text-white" />
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={openPresenterWindow}
+              className="p-3 sm:p-2 rounded-lg bg-white/10 hover:bg-white/20 transition-colors cursor-pointer"
+              aria-label={t("presentation.presenterView")}
+              title={t("presentation.presenterView")}
+            >
+              <IconNotes className="w-5 h-5 sm:w-4 sm:h-4 text-white" />
+            </button>
+            <button
+              onClick={exit}
+              className="p-3 sm:p-2 rounded-lg bg-white/10 hover:bg-white/20 transition-colors"
+              aria-label={t("presentation.exitPresentation")}
+            >
+              <IconX className="w-5 h-5 sm:w-4 sm:h-4 text-white" />
+            </button>
+          </div>
         </div>
 
         {/* Progress bar */}

--- a/templates/slides/app/components/presentation/PresenterView.tsx
+++ b/templates/slides/app/components/presentation/PresenterView.tsx
@@ -1,0 +1,179 @@
+import { useT } from "@agent-native/core/client/i18n";
+import { IconChevronLeft, IconChevronRight, IconX } from "@tabler/icons-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import SlideRenderer from "@/components/deck/SlideRenderer";
+import type { Slide } from "@/context/DeckContext";
+import type { AspectRatio } from "@/lib/aspect-ratios";
+
+import { openPresentChannel, type PresentMessage } from "./present-channel";
+
+interface PresenterViewProps {
+  slides: Slide[];
+  deckId: string;
+  startIndex?: number;
+  aspectRatio?: AspectRatio;
+}
+
+function formatElapsed(seconds: number) {
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
+}
+
+export default function PresenterView({
+  slides,
+  deckId,
+  startIndex = 0,
+  aspectRatio,
+}: PresenterViewProps) {
+  const t = useT();
+  const [index, setIndex] = useState(startIndex);
+  const [elapsed, setElapsed] = useState(0);
+  const channelRef = useRef<BroadcastChannel | null>(null);
+
+  useEffect(() => {
+    const channel = openPresentChannel(deckId);
+    channelRef.current = channel;
+    if (!channel) return;
+    channel.onmessage = (event: MessageEvent<PresentMessage>) => {
+      if (event.data?.type === "state") setIndex(event.data.index);
+    };
+    channel.postMessage({ type: "hello" } satisfies PresentMessage);
+    return () => {
+      channel.close();
+      channelRef.current = null;
+    };
+  }, [deckId]);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setElapsed((s) => s + 1), 1000);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  const send = useCallback((message: PresentMessage) => {
+    channelRef.current?.postMessage(message);
+  }, []);
+
+  const goNext = useCallback(
+    () => send({ type: "command", command: "next" }),
+    [send],
+  );
+  const goPrev = useCallback(
+    () => send({ type: "command", command: "prev" }),
+    [send],
+  );
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case "ArrowRight":
+        case "ArrowDown":
+        case " ":
+          e.preventDefault();
+          goNext();
+          break;
+        case "ArrowLeft":
+        case "ArrowUp":
+          e.preventDefault();
+          goPrev();
+          break;
+      }
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [goNext, goPrev]);
+
+  const safeSlides = useMemo(
+    () => (Array.isArray(slides) ? slides.filter(Boolean) : []),
+    [slides],
+  );
+  const current = safeSlides[index];
+  const next = safeSlides[index + 1];
+  const notes = current?.notes?.trim();
+
+  return (
+    <div className="fixed inset-0 flex flex-col bg-[hsl(240,6%,6%)] text-white">
+      <header className="flex items-center justify-between gap-4 border-b border-white/10 px-5 py-3">
+        <span className="font-mono text-sm text-white/50">
+          {index + 1} / {safeSlides.length}
+        </span>
+        <span className="font-mono text-2xl tabular-nums text-white/80">
+          {formatElapsed(elapsed)}
+        </span>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={goPrev}
+            disabled={index === 0}
+            className="cursor-pointer rounded-lg bg-white/10 p-2 hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-30"
+            aria-label={t("presentation.previousSlide")}
+          >
+            <IconChevronLeft className="h-4 w-4" />
+          </button>
+          <button
+            onClick={goNext}
+            disabled={index >= safeSlides.length - 1}
+            className="cursor-pointer rounded-lg bg-white/10 p-2 hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-30"
+            aria-label={t("presentation.nextSlide")}
+          >
+            <IconChevronRight className="h-4 w-4" />
+          </button>
+          <button
+            onClick={() => window.close()}
+            className="cursor-pointer rounded-lg bg-white/10 p-2 hover:bg-white/20"
+            aria-label={t("presentation.closePresenterView")}
+          >
+            <IconX className="h-4 w-4" />
+          </button>
+        </div>
+      </header>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-4 p-4">
+        <div className="flex gap-4">
+          <div className="w-2/3 overflow-hidden rounded-lg bg-black">
+            {current && (
+              <SlideRenderer
+                slide={current}
+                thumbnail
+                aspectRatio={aspectRatio}
+              />
+            )}
+          </div>
+          <div className="flex w-1/3 flex-col gap-2">
+            <div className="font-mono text-[11px] uppercase tracking-widest text-white/40">
+              {t("presentation.upNext")}
+            </div>
+            {next ? (
+              <div className="overflow-hidden rounded-lg bg-black">
+                <SlideRenderer
+                  slide={next}
+                  thumbnail
+                  aspectRatio={aspectRatio}
+                />
+              </div>
+            ) : (
+              <div className="rounded-lg bg-white/[0.04] p-4 text-sm text-white/40">
+                {t("presentation.endOfDeck")}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto rounded-lg bg-white/[0.04] p-5">
+          <div className="mb-2 font-mono text-[11px] uppercase tracking-widest text-white/40">
+            {t("presentation.speakerNotes")}
+          </div>
+          {notes ? (
+            <p className="whitespace-pre-wrap text-lg leading-relaxed text-white/90">
+              {notes}
+            </p>
+          ) : (
+            <p className="text-sm text-white/40">
+              {t("presentation.noNotesForSlide")}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/templates/slides/app/components/presentation/present-channel.ts
+++ b/templates/slides/app/components/presentation/present-channel.ts
@@ -1,0 +1,15 @@
+/**
+ * Cross-window channel between the fullscreen presentation and the presenter
+ * window. The presenter window never advances on its own — it sends commands
+ * and renders whatever state the presentation echoes back, so build steps
+ * (which move the step, not the slide) stay authoritative in one place.
+ */
+export type PresentMessage =
+  | { type: "state"; index: number }
+  | { type: "command"; command: "next" | "prev" }
+  | { type: "hello" };
+
+export function openPresentChannel(deckId: string): BroadcastChannel | null {
+  if (typeof BroadcastChannel === "undefined") return null;
+  return new BroadcastChannel(`slides-present:${deckId}`);
+}

--- a/templates/slides/app/i18n/ar-SA.ts
+++ b/templates/slides/app/i18n/ar-SA.ts
@@ -258,7 +258,10 @@ const messages = {
     downloadHtml: "تنزيل بصيغة HTML",
     exportPdf: "تصدير بصيغة PDF",
     exportPptx: "تصدير بصيغة PPTX",
-    downloadGoogleSlides: "تنزيل من أجل Google Slides",
+    openInGoogleSlides: "فتح في Google Slides",
+    googleSlidesCreated: "تم الفتح في Google Slides",
+    googleSlidesCreatedHint:
+      "تم إنشاء نسخة من هذا العرض في Google Drive الخاص بك.",
     duplicateDeck: "تكرار العرض",
   },
   share: {
@@ -479,6 +482,12 @@ const messages = {
     slides: "Diapositivas",
   },
   presentation: {
+    presenterView: "عرض مقدّم العرض",
+    speakerNotes: "ملاحظات المتحدث",
+    noNotesForSlide: "لا توجد ملاحظات لهذه الشريحة",
+    upNext: "التالي",
+    endOfDeck: "نهاية العرض",
+    closePresenterView: "إغلاق عرض مقدّم العرض",
     noSlides: "No hay diapositivas para presentar",
     previousSlide: "Diapositiva anterior",
     nextSlide: "Siguiente diapositiva",

--- a/templates/slides/app/i18n/de-DE.ts
+++ b/templates/slides/app/i18n/de-DE.ts
@@ -261,7 +261,10 @@ const messages = {
     downloadHtml: "Als HTML herunterladen",
     exportPdf: "Als PDF exportieren",
     exportPptx: "Als PPTX exportieren",
-    downloadGoogleSlides: "Für Google Slides herunterladen",
+    openInGoogleSlides: "In Google Slides öffnen",
+    googleSlidesCreated: "In Google Slides geöffnet",
+    googleSlidesCreatedHint:
+      "Eine Kopie dieser Präsentation wurde in deinem Google Drive erstellt.",
     duplicateDeck: "Deck duplizieren",
   },
   share: {
@@ -474,6 +477,12 @@ const messages = {
     slides: "Diapositivas",
   },
   presentation: {
+    presenterView: "Referentenansicht",
+    speakerNotes: "Sprechernotizen",
+    noNotesForSlide: "Keine Notizen für diese Folie",
+    upNext: "Als Nächstes",
+    endOfDeck: "Ende der Präsentation",
+    closePresenterView: "Referentenansicht schließen",
     noSlides: "No hay diapositivas para presentar",
     previousSlide: "Diapositiva anterior",
     nextSlide: "Siguiente diapositiva",

--- a/templates/slides/app/i18n/en-US.ts
+++ b/templates/slides/app/i18n/en-US.ts
@@ -256,7 +256,10 @@ const messages = {
     downloadHtml: "Download as HTML",
     exportPdf: "Export as PDF",
     exportPptx: "Export as PPTX",
-    downloadGoogleSlides: "Download for Google Slides",
+    openInGoogleSlides: "Open in Google Slides",
+    googleSlidesCreated: "Opened in Google Slides",
+    googleSlidesCreatedHint:
+      "A copy of this deck was created in your Google Drive.",
     duplicateDeck: "Duplicate deck",
   },
   share: {
@@ -467,6 +470,12 @@ const messages = {
     slides: "Slides",
   },
   presentation: {
+    presenterView: "Presenter view",
+    speakerNotes: "Speaker notes",
+    noNotesForSlide: "No notes for this slide",
+    upNext: "Up next",
+    endOfDeck: "End of deck",
+    closePresenterView: "Close presenter view",
     noSlides: "No slides to present",
     previousSlide: "Previous slide",
     nextSlide: "Next slide",

--- a/templates/slides/app/i18n/es-ES.ts
+++ b/templates/slides/app/i18n/es-ES.ts
@@ -262,7 +262,10 @@ const messages = {
     downloadHtml: "Descargar como HTML",
     exportPdf: "Exportar como PDF",
     exportPptx: "Exportar como PPTX",
-    downloadGoogleSlides: "Descargar para Google Slides",
+    openInGoogleSlides: "Abrir en Google Slides",
+    googleSlidesCreated: "Abierto en Google Slides",
+    googleSlidesCreatedHint:
+      "Se creó una copia de esta presentación en tu Google Drive.",
     duplicateDeck: "Duplicar deck",
   },
   share: {
@@ -478,6 +481,12 @@ const messages = {
     slides: "Diapositivas",
   },
   presentation: {
+    presenterView: "Vista del presentador",
+    speakerNotes: "Notas del orador",
+    noNotesForSlide: "No hay notas para esta diapositiva",
+    upNext: "A continuación",
+    endOfDeck: "Fin de la presentación",
+    closePresenterView: "Cerrar la vista del presentador",
     noSlides: "No hay diapositivas para presentar",
     previousSlide: "Diapositiva anterior",
     nextSlide: "Siguiente diapositiva",

--- a/templates/slides/app/i18n/fr-FR.ts
+++ b/templates/slides/app/i18n/fr-FR.ts
@@ -265,7 +265,10 @@ const messages = {
     downloadHtml: "Télécharger en HTML",
     exportPdf: "Exporter en PDF",
     exportPptx: "Exporter en PPTX",
-    downloadGoogleSlides: "Télécharger pour Google Slides",
+    openInGoogleSlides: "Ouvrir dans Google Slides",
+    googleSlidesCreated: "Ouvert dans Google Slides",
+    googleSlidesCreatedHint:
+      "Une copie de cette présentation a été créée dans votre Google Drive.",
     duplicateDeck: "Dupliquer le deck",
   },
   share: {
@@ -482,6 +485,12 @@ const messages = {
     slides: "Diapositivas",
   },
   presentation: {
+    presenterView: "Mode présentateur",
+    speakerNotes: "Notes du présentateur",
+    noNotesForSlide: "Aucune note pour cette diapositive",
+    upNext: "À suivre",
+    endOfDeck: "Fin de la présentation",
+    closePresenterView: "Fermer le mode présentateur",
     noSlides: "No hay diapositivas para presentar",
     previousSlide: "Diapositiva anterior",
     nextSlide: "Siguiente diapositiva",

--- a/templates/slides/app/i18n/hi-IN.ts
+++ b/templates/slides/app/i18n/hi-IN.ts
@@ -254,7 +254,9 @@ const messages = {
     downloadHtml: "HTML के रूप में डाउनलोड करें",
     exportPdf: "PDF के रूप में निर्यात करें",
     exportPptx: "PPTX के रूप में निर्यात करें",
-    downloadGoogleSlides: "Google Slides के लिए डाउनलोड करें",
+    openInGoogleSlides: "Google Slides में खोलें",
+    googleSlidesCreated: "Google Slides में खोला गया",
+    googleSlidesCreatedHint: "इस प्रस्तुति की एक प्रति आपके Google Drive में बनाई गई।",
     duplicateDeck: "डेक डुप्लिकेट करें",
   },
   share: {
@@ -463,6 +465,12 @@ const messages = {
     slides: "स्लाइड",
   },
   presentation: {
+    presenterView: "प्रस्तुतकर्ता दृश्य",
+    speakerNotes: "वक्ता नोट्स",
+    noNotesForSlide: "इस स्लाइड के लिए कोई नोट नहीं है",
+    upNext: "आगे",
+    endOfDeck: "प्रस्तुति का अंत",
+    closePresenterView: "प्रस्तुतकर्ता दृश्य बंद करें",
     noSlides: "प्रस्तुत करने के लिए कोई स्लाइड नहीं",
     previousSlide: "पिछली स्लाइड",
     nextSlide: "अगली स्लाइड",

--- a/templates/slides/app/i18n/ja-JP.ts
+++ b/templates/slides/app/i18n/ja-JP.ts
@@ -257,7 +257,10 @@ const messages = {
     downloadHtml: "HTML としてダウンロード",
     exportPdf: "PDF としてエクスポート",
     exportPptx: "PPTX としてエクスポート",
-    downloadGoogleSlides: "Google Slides 用にダウンロード",
+    openInGoogleSlides: "Google Slides で開く",
+    googleSlidesCreated: "Google Slides で開きました",
+    googleSlidesCreatedHint:
+      "このデッキのコピーを Google ドライブに作成しました。",
     duplicateDeck: "デッキを複製",
   },
   share: {
@@ -463,6 +466,12 @@ const messages = {
     slides: "幻灯片",
   },
   presentation: {
+    presenterView: "発表者ビュー",
+    speakerNotes: "発表者ノート",
+    noNotesForSlide: "このスライドのノートはありません",
+    upNext: "次のスライド",
+    endOfDeck: "スライドの最後です",
+    closePresenterView: "発表者ビューを閉じる",
     noSlides: "没有可演示的幻灯片",
     previousSlide: "上一张幻灯片",
     nextSlide: "下一张幻灯片",

--- a/templates/slides/app/i18n/ko-KR.ts
+++ b/templates/slides/app/i18n/ko-KR.ts
@@ -255,7 +255,9 @@ const messages = {
     downloadHtml: "HTML로 다운로드",
     exportPdf: "PDF로 내보내기",
     exportPptx: "PPTX로 내보내기",
-    downloadGoogleSlides: "Google Slides용 다운로드",
+    openInGoogleSlides: "Google Slides에서 열기",
+    googleSlidesCreated: "Google Slides에서 열었습니다",
+    googleSlidesCreatedHint: "이 덱의 사본이 Google 드라이브에 생성되었습니다.",
     duplicateDeck: "덱 복제",
   },
   share: {
@@ -461,6 +463,12 @@ const messages = {
     slides: "幻灯片",
   },
   presentation: {
+    presenterView: "발표자 보기",
+    speakerNotes: "발표자 노트",
+    noNotesForSlide: "이 슬라이드에는 노트가 없습니다",
+    upNext: "다음 순서",
+    endOfDeck: "덱의 끝",
+    closePresenterView: "발표자 보기 닫기",
     noSlides: "没有可演示的幻灯片",
     previousSlide: "上一张幻灯片",
     nextSlide: "下一张幻灯片",

--- a/templates/slides/app/i18n/pt-BR.ts
+++ b/templates/slides/app/i18n/pt-BR.ts
@@ -258,7 +258,10 @@ const messages = {
     downloadHtml: "Baixar como HTML",
     exportPdf: "Exportar como PDF",
     exportPptx: "Exportar como PPTX",
-    downloadGoogleSlides: "Baixar para Google Slides",
+    openInGoogleSlides: "Abrir no Google Slides",
+    googleSlidesCreated: "Aberto no Google Slides",
+    googleSlidesCreatedHint:
+      "Uma cópia desta apresentação foi criada no seu Google Drive.",
     duplicateDeck: "Duplicar deck",
   },
   share: {
@@ -473,6 +476,12 @@ const messages = {
     slides: "Diapositivas",
   },
   presentation: {
+    presenterView: "Modo apresentador",
+    speakerNotes: "Notas do apresentador",
+    noNotesForSlide: "Sem notas para este slide",
+    upNext: "A seguir",
+    endOfDeck: "Fim da apresentação",
+    closePresenterView: "Fechar o modo apresentador",
     noSlides: "No hay diapositivas para presentar",
     previousSlide: "Diapositiva anterior",
     nextSlide: "Siguiente diapositiva",

--- a/templates/slides/app/i18n/zh-CN.ts
+++ b/templates/slides/app/i18n/zh-CN.ts
@@ -251,7 +251,9 @@ const messages = {
     downloadHtml: "下载为 HTML",
     exportPdf: "导出为 PDF",
     exportPptx: "导出为 PPTX",
-    downloadGoogleSlides: "下载到 Google Slides",
+    openInGoogleSlides: "在 Google Slides 中打开",
+    googleSlidesCreated: "已在 Google Slides 中打开",
+    googleSlidesCreatedHint: "已在你的 Google 云端硬盘中创建此演示文稿的副本。",
     duplicateDeck: "复制幻灯片",
   },
   share: {
@@ -456,6 +458,12 @@ const messages = {
     slides: "幻灯片",
   },
   presentation: {
+    presenterView: "演讲者视图",
+    speakerNotes: "演讲者备注",
+    noNotesForSlide: "此幻灯片没有备注",
+    upNext: "下一张",
+    endOfDeck: "演示文稿结束",
+    closePresenterView: "关闭演讲者视图",
     noSlides: "没有可演示的幻灯片",
     previousSlide: "上一张幻灯片",
     nextSlide: "下一张幻灯片",

--- a/templates/slides/app/i18n/zh-TW.ts
+++ b/templates/slides/app/i18n/zh-TW.ts
@@ -246,7 +246,9 @@ const messages = {
     downloadHtml: "下載為 HTML",
     exportPdf: "匯出為 PDF",
     exportPptx: "匯出為 PPTX",
-    downloadGoogleSlides: "下載到 Google Slides",
+    openInGoogleSlides: "在 Google Slides 中開啟",
+    googleSlidesCreated: "已在 Google Slides 中開啟",
+    googleSlidesCreatedHint: "已在你的 Google 雲端硬碟中建立此簡報的副本。",
     duplicateDeck: "複製幻燈片",
   },
   share: {
@@ -451,6 +453,12 @@ const messages = {
     slides: "幻燈片",
   },
   presentation: {
+    presenterView: "簡報者檢視",
+    speakerNotes: "簡報者備忘稿",
+    noNotesForSlide: "此投影片沒有備忘稿",
+    upNext: "下一張",
+    endOfDeck: "簡報結束",
+    closePresenterView: "關閉簡報者檢視",
     noSlides: "沒有可播放的幻燈片",
     previousSlide: "上一張幻燈片",
     nextSlide: "下一張幻燈片",

--- a/templates/slides/app/lib/export-google-slides-client.ts
+++ b/templates/slides/app/lib/export-google-slides-client.ts
@@ -1,0 +1,67 @@
+import { appBasePath } from "@agent-native/core/client/api-path";
+
+import type { AspectRatio } from "./aspect-ratios";
+import { buildDeckPptxBlob } from "./export-pptx-client";
+
+interface GoogleSlidesExportSlide {
+  id: string;
+  notes?: string;
+}
+
+export type GoogleSlidesExportResult =
+  | { url: string }
+  /** Drive was unavailable, so the PPTX was downloaded for a manual import. */
+  | { url: null; downloaded: true; reason: string };
+
+function triggerBlobDownload(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.rel = "noopener";
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 60_000);
+}
+
+/**
+ * Creates a native Google Slides deck in the user's Drive when their Google
+ * account is connected. Without a connection — or if Drive rejects the upload —
+ * the PPTX is downloaded instead so the user can import it by hand, and the
+ * reason is reported rather than swallowed.
+ */
+export async function exportDeckToGoogleSlides(
+  deckTitle: string,
+  slides: GoogleSlidesExportSlide[],
+  aspectRatio?: AspectRatio,
+): Promise<GoogleSlidesExportResult> {
+  const { blob, filename } = await buildDeckPptxBlob(
+    deckTitle,
+    slides,
+    aspectRatio,
+  );
+
+  const form = new FormData();
+  form.append("file", blob, filename);
+  form.append("title", deckTitle);
+
+  const res = await fetch(`${appBasePath()}/api/exports/google-slides`, {
+    method: "POST",
+    body: form,
+  });
+
+  const payload = (await res.json().catch(() => null)) as {
+    url?: string;
+    error?: string;
+  } | null;
+
+  if (res.ok && payload?.url) return { url: payload.url };
+
+  triggerBlobDownload(blob, filename);
+  return {
+    url: null,
+    downloaded: true,
+    reason: payload?.error ?? `HTTP ${res.status}`,
+  };
+}

--- a/templates/slides/app/lib/export-pptx-client.ts
+++ b/templates/slides/app/lib/export-pptx-client.ts
@@ -313,11 +313,11 @@ function widenNoWrapTextElements(root: HTMLElement) {
   }
 }
 
-export async function exportDeckAsPptx(
+export async function buildDeckPptxBlob(
   deckTitle: string,
   slides: PptxExportSlide[],
   aspectRatio?: AspectRatio,
-): Promise<void> {
+): Promise<{ blob: Blob; filename: string }> {
   const { exportToPptx } = await importExportModule(
     () => import("dom-to-pptx"),
   );
@@ -359,10 +359,23 @@ export async function exportDeckAsPptx(
     );
 
     const blob = await addSpeakerNotesToPptxBlob(initialBlob, slides);
-    triggerBlobDownload(blob, safePptxName(deckTitle));
+    return { blob, filename: safePptxName(deckTitle) };
   } finally {
     for (const clone of exportClones) {
       clone.cleanup();
     }
   }
+}
+
+export async function exportDeckAsPptx(
+  deckTitle: string,
+  slides: PptxExportSlide[],
+  aspectRatio?: AspectRatio,
+): Promise<void> {
+  const { blob, filename } = await buildDeckPptxBlob(
+    deckTitle,
+    slides,
+    aspectRatio,
+  );
+  triggerBlobDownload(blob, filename);
 }

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -62,6 +62,7 @@ import {
 } from "@/hooks/use-slide-comments";
 import type { AspectRatio } from "@/lib/aspect-ratios";
 import { getPreset } from "@/lib/design-systems";
+import { exportDeckToGoogleSlides } from "@/lib/export-google-slides-client";
 import { exportDeckAsPdf } from "@/lib/export-pdf-client";
 import { exportDeckAsPptx } from "@/lib/export-pptx-client";
 import {
@@ -853,6 +854,16 @@ export default function DeckEditor() {
             throw new Error(t("deckEditor.deckHasNoSlides"));
           }
           await exportDeckAsPptx(deck.title, slides, deck.aspectRatio);
+        }}
+        onExportGoogleSlides={async () => {
+          const slides = deck.slides.map((s) => ({
+            id: s.id,
+            notes: s.notes,
+          }));
+          if (slides.length === 0) {
+            throw new Error(t("deckEditor.deckHasNoSlides"));
+          }
+          return exportDeckToGoogleSlides(deck.title, slides, deck.aspectRatio);
         }}
         aspectRatio={deck.aspectRatio}
         designSystemTitle={designSystemTitle}

--- a/templates/slides/app/pages/Presentation.tsx
+++ b/templates/slides/app/pages/Presentation.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useParams, Navigate, useSearchParams } from "react-router";
 
 import PresentationView from "@/components/presentation/PresentationView";
+import PresenterView from "@/components/presentation/PresenterView";
 import { useDecks } from "@/context/DeckContext";
 import type { Deck } from "@/context/DeckContext";
 
@@ -45,10 +46,14 @@ export default function Presentation() {
     };
   }, [contextDeck, id, loading]);
 
-  if (loading || fallbackState === "loading") {
+  if (!id) return <Navigate to="/" replace />;
+  // "Not fetched yet" is not "not found": on a cold load of this URL the deck
+  // context is empty and the fallback fetch has not run, so redirecting on a
+  // falsy deck bounced every direct/presenter/share link back to the index.
+  if (!deck && fallbackState !== "missing") {
     return <div className="h-screen bg-black" />;
   }
-  if (!deck || !id || fallbackState === "missing") {
+  if (!deck) {
     return <Navigate to="/" replace />;
   }
 
@@ -58,8 +63,11 @@ export default function Presentation() {
     ? Math.max(0, parsedSlide - 1)
     : 0;
 
+  const View =
+    searchParams.get("presenter") === "1" ? PresenterView : PresentationView;
+
   return (
-    <PresentationView
+    <View
       slides={Array.isArray(deck.slides) ? deck.slides : []}
       deckId={id}
       startIndex={startSlide}

--- a/templates/slides/changelog/2026-07-28-export-to-google-slides-now-creates-the-deck-directly-in-you.md
+++ b/templates/slides/changelog/2026-07-28-export-to-google-slides-now-creates-the-deck-directly-in-you.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-07-28
+---
+
+Export to Google Slides now creates the deck directly in your Google Drive when your Google account is connected, instead of only downloading a PPTX to import by hand.

--- a/templates/slides/changelog/2026-07-28-opening-a-presentation-link-directly-no-longer-bounces-back-.md
+++ b/templates/slides/changelog/2026-07-28-opening-a-presentation-link-directly-no-longer-bounces-back-.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-28
+---
+
+Opening a presentation link directly no longer bounces back to the deck list.

--- a/templates/slides/changelog/2026-07-28-presenter-view-open-a-second-window-while-presenting-to-see-.md
+++ b/templates/slides/changelog/2026-07-28-presenter-view-open-a-second-window-while-presenting-to-see-.md
@@ -1,0 +1,6 @@
+---
+type: added
+date: 2026-07-28
+---
+
+Presenter view: open a second window while presenting to see speaker notes, the next slide, and a timer, with both windows kept in sync.

--- a/templates/slides/server/routes/api/exports/google-slides.post.ts
+++ b/templates/slides/server/routes/api/exports/google-slides.post.ts
@@ -1,0 +1,90 @@
+import { getSession, runWithRequestContext } from "@agent-native/core/server";
+import {
+  defineEventHandler,
+  readMultipartFormData,
+  setResponseStatus,
+} from "h3";
+
+import { getGoogleDocsAccessToken } from "../../../lib/google-docs-oauth.js";
+
+const PPTX_CONTENT_TYPE =
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+const GOOGLE_SLIDES_MIME = "application/vnd.google-apps.presentation";
+const UPLOAD_URL =
+  "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id,webViewLink";
+
+/**
+ * Uploads a browser-generated PPTX into the user's Drive, letting Drive convert
+ * it to a native Google Slides deck. The PPTX comes from the client because the
+ * browser export renders the real slide DOM — the server-side pptxgenjs export
+ * is a lower-fidelity fallback and would ship a visibly worse deck to Google.
+ */
+export default defineEventHandler(async (event) => {
+  const session = await getSession(event).catch(() => null);
+  if (!session?.email) {
+    setResponseStatus(event, 401);
+    return { error: "Unauthorized" };
+  }
+
+  const parts = (await readMultipartFormData(event)) ?? [];
+  const file = parts.find((part) => part.name === "file");
+  const titlePart = parts.find((part) => part.name === "title");
+  const title = titlePart
+    ? new TextDecoder().decode(titlePart.data).trim() || "Untitled deck"
+    : "Untitled deck";
+
+  if (!file?.data?.length) {
+    setResponseStatus(event, 400);
+    return { error: "file required" };
+  }
+
+  // Same request context the actions run in — Google's client credentials can
+  // be org-scoped vault secrets, and resolving them without the org reports the
+  // integration as unconfigured.
+  const account = await runWithRequestContext(
+    { userEmail: session.email, orgId: session.orgId },
+    () => getGoogleDocsAccessToken(session.email),
+  );
+  if (!account) {
+    setResponseStatus(event, 409);
+    return {
+      error: "No connected Google account.",
+      code: "google-not-connected",
+    };
+  }
+
+  const boundary = `an-slides-${Math.random().toString(36).slice(2)}`;
+  const body = new Blob([
+    `--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n`,
+    JSON.stringify({ name: title, mimeType: GOOGLE_SLIDES_MIME }),
+    `\r\n--${boundary}\r\nContent-Type: ${PPTX_CONTENT_TYPE}\r\n\r\n`,
+    new Uint8Array(file.data),
+    `\r\n--${boundary}--`,
+  ]);
+
+  const response = await fetch(UPLOAD_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${account.accessToken}`,
+      "Content-Type": `multipart/related; boundary=${boundary}`,
+    },
+    body,
+  });
+
+  const result = (await response.json().catch(() => null)) as {
+    id?: string;
+    webViewLink?: string;
+    error?: { message?: string };
+  } | null;
+
+  if (!response.ok || !result?.webViewLink) {
+    setResponseStatus(event, 502);
+    return {
+      error:
+        result?.error?.message ??
+        `Google Drive returned HTTP ${response.status} while creating the deck.`,
+    };
+  }
+
+  return { url: result.webViewLink, accountEmail: account.accountEmail };
+});


### PR DESCRIPTION
## Summary

- Add guided connected-agent probing/auth diagnostics, shared-secret sync UX, remote-agent deduplication, and turn-wide abort behavior.
- Improve MCP tool branding, searchable connection keys, model-picker feedback, toolkit composer behavior, docs, and synchronized skills.
- Add Google Slides export, presenter view, direct presentation links, locale updates, and user-facing changelog entries.

## Validation

- `pnpm run prep`
- Focused Core, Dispatch, Toolkit, and Slides tests/typechecks
- `pnpm changeset status --since=origin/main`

A separate local `todo-app/` repository was preserved outside this framework PR.