### PR TITLE
Fix flaky pinpoint FileStore update() timestamp test

### DIFF
--- a/.changeset/pinpoint-file-store-timestamp-test.md
+++ b/.changeset/pinpoint-file-store-timestamp-test.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/pinpoint": patch
+---
+
+Test-only: the `FileStore.update()` spec now drives the clock with fake timers instead of assuming wall-clock advances between two back-to-back writes, which made it flake when both landed in the same millisecond. No runtime behavior change.

--- a/packages/pinpoint/src/storage/file-store.spec.ts
+++ b/packages/pinpoint/src/storage/file-store.spec.ts
@@ -6,7 +6,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { Pin } from "../types/index.js";
 import { FileStore } from "./file-store.js";
@@ -14,6 +14,7 @@ import { FileStore } from "./file-store.js";
 const tmpRoots: string[] = [];
 
 afterEach(() => {
+  vi.useRealTimers();
   for (const root of tmpRoots.splice(0)) {
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -61,17 +62,24 @@ describe("FileStore", () => {
   });
 
   it("update() overwrites the pin atomically without leaving temp files behind", async () => {
+    // `updatedAt` is wall-clock at millisecond resolution, so two back-to-back
+    // writes can share a timestamp on a fast runner. Drive the clock instead of
+    // assuming it advances between save() and update().
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
     const dataDir = tmpDataDir();
     const store = new FileStore(dataDir);
     const pin = makePin({ comment: "original" });
     await store.save(pin);
 
+    vi.setSystemTime(new Date("2026-01-01T00:00:01.000Z"));
     await store.update(pin.id, { comment: "revised" });
 
     const pins = await store.list();
     expect(pins).toHaveLength(1);
     expect(pins[0]?.comment).toBe("revised");
-    expect(pins[0]?.updatedAt).not.toBe(pin.updatedAt);
+    expect(pins[0]?.updatedAt).toBe("2026-01-01T00:00:01.000Z");
 
     // No stray temp/staging files should remain in the data directory.
     const files = fs.readdirSync(dataDir);


### PR DESCRIPTION
## Problem

`packages/pinpoint/src/storage/file-store.spec.ts` fails intermittently in CI:

```
packages/pinpoint/src/storage/file-store.spec.ts:74
expect(pins[0]?.updatedAt).not.toBe(pin.updatedAt);
AssertionError: expected '2026-07-28T15:11:10.704Z' not to be '2026-07-28T15:11:10.704Z'
```

The test `save()`s a pin, `update()`s it, and asserts `updatedAt` changed. `updatedAt` is wall-clock at millisecond resolution, so on a fast runner both writes land in the same millisecond and the two ISO strings are identical. The assertion depends on the clock ticking between two back-to-back writes, which is not guaranteed.

## Fix

Drive the clock instead of assuming it advances: freeze `Date` with fake timers for the `save()`, advance one second, then `update()`. That also lets the assertion check the exact expected timestamp rather than mere inequality.

This is a test-only change. Two pins sharing a timestamp is fine in production — `list-sessions.ts` is the only consumer that compares `updatedAt`, and it tolerates ties — so the storage adapters are untouched and no changeset is needed.

## Verification

- 5/5 tests in the file pass, green across 5 consecutive runs.
- Mutation-checked: deleting the `updatedAt:` line from `FileStore.update()` makes the test fail, so the assertion still catches a real regression rather than passing vacuously.
- `oxfmt --check` clean.

One trade worth noting: faking `Date` makes the assertion exact but means the test no longer exercises real-clock behavior — if `update()` were changed to stamp from something other than `Date`, this test would go quiet.