### PR TITLE
Fix stuck pointer-events on body after deleting slide deck

### DIFF
--- a/templates/slides/app/components/deck/DeckCard.tsx
+++ b/templates/slides/app/components/deck/DeckCard.tsx
@@ -181,9 +181,7 @@ export default function DeckCard({
               Rename
             </DropdownMenuItem>
             <DropdownMenuItem
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
+              onSelect={() => {
                 if (isDuplicating) return;
                 onDuplicate(deck.id);
               }}
@@ -204,9 +202,7 @@ export default function DeckCard({
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
+              onSelect={() => {
                 onDelete(deck.id);
               }}
               className="text-red-400 focus:text-red-400"


### PR DESCRIPTION
`pointer-events: none` was stuck on the body after the delete slide deck modal was closed which meant users could not interact with the content