### PR TITLE
Ignore build/ and .output/ in the chat template gitignore

### DIFF
--- a/templates/chat/_gitignore
+++ b/templates/chat/_gitignore
@@ -9,8 +9,10 @@ npm-debug.log*
 pnpm-debug.log*
 
 node_modules
+build/
 dist
 dist-ssr
+.output/
 *.local
 
 # Editor directories and files


### PR DESCRIPTION
Adds `build/` and `.output/` to `templates/chat/_gitignore` so generated chat apps don't track build output.

```
node_modules
build/
dist
dist-ssr
.output/
*.local
```

Only touches `_gitignore` (the file that ships into generated apps); the template's own `.gitignore` is unchanged.