### PR TITLE
Ignore build/ and .output/ in the remaining template gitignores

### DIFF
--- a/scripts/template-standard/assets/_gitignore
+++ b/scripts/template-standard/assets/_gitignore
@@ -8,8 +8,10 @@ npm-debug.log*
 pnpm-debug.log*
 
 node_modules
+build/
 dist
 dist-ssr
+.output/
 *.local
 
 # Editor directories and files

--- a/templates/analytics/_gitignore
+++ b/templates/analytics/_gitignore
@@ -8,8 +8,10 @@ npm-debug.log*
 pnpm-debug.log*
 
 node_modules
+build/
 dist
 dist-ssr
+.output/
 *.local
 
 # Editor directories and files

--- a/templates/assets/_gitignore
+++ b/templates/assets/_gitignore
@@ -10,8 +10,10 @@ npm-debug.log*
 pnpm-debug.log*
 
 node_modules
+build/
 dist
 dist-ssr
+.output/
 *.local
 
 # Editor directories and files

--- a/templates/calendar/_gitignore
+++ b/templates/calendar/_gitignore
@@ -8,8 +8,10 @@ npm-debug.log*
 pnpm-debug.log*
 
 node_modules
+build/
 dist
 dist-ssr
+.output/
 *.local
 
 # Editor directories and files

--- a/templates/clips/_gitignore
+++ b/templates/clips/_gitignore
@@ -8,8 +8,10 @@ npm-debug.log*
 pnpm-debug.log*
 
 node_modules
+build/
 dist
 dist-ssr
+.output/
 *.local
 
 # Editor directories and files

--- a/templates/content/_gitignore
+++ b/templates/content/_gitignore
@@ -8,8 +8,10 @@ npm-debug.log*
 pnpm-debug.log*
 
 node_modules
+build/
 dist
 dist-ssr
+.output/
 *.local
 
 # Editor directories and files

--- a/templates/design/_gitignore
+++ b/templates/design/_gitignore
@@ -8,8 +8,10 @@ npm-debug.log*
 pnpm-debug.log*
 
 node_modules
+build/
 dist
 dist-ssr
+.output/
 *.local
 
 # Editor directories and files

--- a/templates/dispatch/_gitignore
+++ b/templates/dispatch/_gitignore
@@ -9,8 +9,10 @@ npm-debug.log*
 pnpm-debug.log*
 
 node_modules
+build/
 dist
 dist-ssr
+.output/
 *.local
 
 # Editor directories and files

--- a/templates/forms/_gitignore
+++ b/templates/forms/_gitignore
@@ -8,8 +8,10 @@ npm-debug.log*
 pnpm-debug.log*
 
 node_modules
+build/
 dist
 dist-ssr
+.output/
 *.local
 
 # Editor directories and files

--- a/templates/macros/_gitignore
+++ b/templates/macros/_gitignore
@@ -8,8 +8,10 @@ npm-debug.log*
 pnpm-debug.log*
 
 node_modules
+build/
 dist
 dist-ssr
+.output/
 *.local
 
 # Editor directories and files

--- a/templates/mail/_gitignore
+++ b/templates/mail/_gitignore
@@ -8,8 +8,10 @@ npm-debug.log*
 pnpm-debug.log*
 
 node_modules
+build/
 dist
 dist-ssr
+.output/
 *.local
 
 # Editor directories and files

--- a/templates/plan/_gitignore
+++ b/templates/plan/_gitignore
@@ -9,8 +9,10 @@ npm-debug.log*
 pnpm-debug.log*
 
 node_modules
+build/
 dist
 dist-ssr
+.output/
 *.local
 
 # Editor directories and files

--- a/templates/slides/_gitignore
+++ b/templates/slides/_gitignore
@@ -8,8 +8,10 @@ npm-debug.log*
 pnpm-debug.log*
 
 node_modules
+build/
 dist
 dist-ssr
+.output/
 *.local
 
 # Editor directories and files

--- a/templates/tasks/_gitignore
+++ b/templates/tasks/_gitignore
@@ -8,8 +8,10 @@ npm-debug.log*
 pnpm-debug.log*
 
 node_modules
+build/
 dist
 dist-ssr
+.output/
 *.local
 
 # Editor directories and files


### PR DESCRIPTION
Follow-up to #2471, which made this change for `templates/chat`. Applies the same two entries to every other template that ships a `_gitignore`:

```
node_modules
build/
dist
dist-ssr
.output/
*.local
```

13 templates: analytics, assets, calendar, clips, content, design, dispatch, forms, macros, mail, plan, slides, tasks.

Not changed, and worth a look:

- **brain** and **crm** already ignore build output, but as bare `build` / `.output` with no trailing slash. Functionally equivalent here; left alone rather than normalized. Their `_gitignore` files are also much shorter than the other templates' and don't share the common block.
- **videos** and **voice** have no `_gitignore` at all — they currently contain only `.agents/` (plus a `netlify.toml` for videos), so there is no app to ignore build output for yet.
- `templates/assets/_gitignore` uses CRLF line endings; the patch preserves them, so the diff there is 2 added lines and no line-ending churn.