### PR TITLE
Fix order-dependent url-safety mock collision in ical-fetcher spec

### DIFF
--- a/templates/calendar/server/lib/ical-fetcher.spec.ts
+++ b/templates/calendar/server/lib/ical-fetcher.spec.ts
@@ -1,15 +1,24 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const ssrfSafeFetchMock = vi.hoisted(() => vi.fn());
+const { ssrfSafeFetchMock, urlSafetyFactory } = vi.hoisted(() => {
+  const fetchMock = vi.fn();
+  return {
+    ssrfSafeFetchMock: fetchMock,
+    // core maps `tools/url-safety` and `extensions/url-safety` to the same
+    // file, so once its dist exists both specifiers resolve to one path and
+    // only one of these registrations survives. Both must return the full
+    // export set, or the surviving factory leaves the other's imports
+    // undefined and the fetcher fails as if the URL were rejected.
+    urlSafetyFactory: () => ({
+      isBlockedToolUrl: () => false,
+      ssrfSafeFetch: fetchMock,
+    }),
+  };
+});
 
-vi.mock("@agent-native/core/extensions/url-safety", () => ({
-  ssrfSafeFetch: ssrfSafeFetchMock,
-}));
+vi.mock("@agent-native/core/extensions/url-safety", urlSafetyFactory);
 
-vi.mock("@agent-native/core/tools/url-safety", () => ({
-  isBlockedToolUrl: () => false,
-  ssrfSafeFetch: ssrfSafeFetchMock,
-}));
+vi.mock("@agent-native/core/tools/url-safety", urlSafetyFactory);
 
 import { fetchICalEvents } from "./ical-fetcher.js";
 


### PR DESCRIPTION
Fixes the intermittent `Fast tests lane-3` failure:

```
FAIL server/lib/ical-fetcher.spec.ts > strict ICS inventory reads > distinguishes a valid empty feed from a failed request
AssertionError: promise rejected "Error: ICS feed URL is not allowed" instead of resolving
```

## Cause

`packages/core/package.json` maps two specifiers to the **same file**:

```json
"./extensions/url-safety": "./dist/extensions/url-safety.js",
"./tools/url-safety":      "./dist/extensions/url-safety.js",
```

There is no separate `dist/tools/url-safety.js` — `isBlockedToolUrl` is a re-export alias. The spec registered two *different* `vi.mock` factories for what is one module: one returning only `ssrfSafeFetch`, the other also returning `isBlockedToolUrl`.

Once core's `dist` exists, both specifiers resolve to one path, the registrations collapse, and only one factory survives. When the `extensions` factory wins, `isBlockedToolUrl` is undefined, so calling it throws a `TypeError` — which `assertSafeICalUrl`'s `catch` converts into `"ICS feed URL is not allowed"`. Which factory wins is registration-order dependent, hence the flake.

This is also why it never reproduced locally: without `packages/core/dist`, the factories short-circuit resolution and stay separate. CI restores a dist cache, so they collide.

## Verification

- Probe importing both namespaces: **without** dist it threw `No "isBlockedToolUrl" export is defined on the "…/extensions/url-safety" mock` (two entries); **with** dist it resolved (collapsed to one).
- Simulated the losing order (surviving factory omits `isBlockedToolUrl`) and `fetchICalEvents` rejected with exactly `"ICS feed URL is not allowed"` — the CI error, reproduced deterministically.
- Spec passes in both resolution modes (dist present and absent).

## Fix

Both specifiers now share one factory returning the full export set, so the surviving registration is correct regardless of order.

## Related, not included

`assertSafeICalUrl`'s bare `catch` (`ical-fetcher.ts:280-286`) turns *any* throw — including a `TypeError` from a broken mock — into `"ICS feed URL is not allowed"`, which is what made this misreport as a URL-policy rejection. The real `isBlockedExtensionUrl` does not block `calendar.example.test`, so the URL was never the issue. Narrowing that catch to preserve the deliberate no-echo behaviour for genuine policy rejections while letting unexpected errors surface is worth doing separately.