### PR TITLE
Make create organization popover more compact

### DIFF
--- a/.changeset/compact-organization-popover.md
+++ b/.changeset/compact-organization-popover.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep the create organization and invite member popovers compact instead of allowing long helper text to expand their width.

--- a/packages/core/src/client/org/OrgSwitcher.tsx
+++ b/packages/core/src/client/org/OrgSwitcher.tsx
@@ -418,7 +418,7 @@ export function OrgSwitcher({
           align="start"
           sideOffset={6}
           collisionPadding={12}
-          className={POPOVER_CONTENT_CLASS}
+          className={`${POPOVER_CONTENT_CLASS} ${mode === "list" ? "" : "w-64"}`}
           onOpenAutoFocus={(e) => {
             // Don't auto-focus the first item — feels heavy on a switcher.
             if (mode === "list") e.preventDefault();

--- a/packages/core/src/client/org/OrgSwitcher.tsx
+++ b/packages/core/src/client/org/OrgSwitcher.tsx
@@ -692,9 +692,9 @@ export function OrgSwitcher({
               <div className="px-0.5 pb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
                 New organization
               </div>
-              <p className="flex items-start gap-1.5 pe-0.5 pb-1.5 ps-2 text-[11px] leading-snug text-muted-foreground">
-                <IconKey className="mt-0.5 h-3 w-3 shrink-0" />
-                <span>{t("org.createOrgVaultNotice")}</span>
+              <p className="pe-0.5 pb-1.5 ps-2 text-[11px] leading-snug text-muted-foreground">
+                <IconKey className="me-1.5 inline-block h-3 w-3 align-text-top" />
+                {t("org.createOrgVaultNotice")}
               </p>
               <input
                 autoFocus

--- a/packages/core/src/client/org/OrgSwitcher.tsx
+++ b/packages/core/src/client/org/OrgSwitcher.tsx
@@ -692,7 +692,7 @@ export function OrgSwitcher({
               <div className="px-0.5 pb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
                 New organization
               </div>
-              <p className="flex items-start gap-1.5 px-0.5 pb-1.5 text-[11px] leading-snug text-muted-foreground">
+              <p className="flex items-start gap-1.5 pe-0.5 pb-1.5 ps-2 text-[11px] leading-snug text-muted-foreground">
                 <IconKey className="mt-0.5 h-3 w-3 shrink-0" />
                 <span>{t("org.createOrgVaultNotice")}</span>
               </p>


### PR DESCRIPTION
### Summary
Fixes the create organization popover so it no longer widen to fit long helper text.

### Problem
The new organization popover was too wide because the helper text and its icon used a flex layout that expanded to accommodate the content, resulting in a poor UX.

### Solution
Constrained the popover width for non-list modes and reworked the helper text markup so the key icon is inline with the text, allowing the text to wrap naturally beneath the icon instead of stretching the container.

### Key Changes
- Added `w-64` width constraint to `OrgSwitcher`'s popover content when not in "list" mode.
- Replaced the flex-based helper text layout with an inline icon (`IconKey`) positioned via `align-text-top` and `me-1.5`, so wrapped text flows beneath it.
- Added a changeset documenting the compact popover fix for `@agent-native/core`.

## BEFORE

<img width="1090" height="439" alt="image" src="https://github.com/user-attachments/assets/8ae98ab1-fc4e-423b-acc8-5cc015f85fa4" />


## AFTER

<img width="559" height="422" alt="image" src="https://github.com/user-attachments/assets/43f87b05-21e5-46ba-af95-e1d90da9da33" />



---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/bronze-camp-mpypyl7q"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-bronze-camp-mpypyl7q.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2480`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>bronze-camp-mpypyl7q</branchName>-->