### PR TITLE
Ignore .netlify/ and .deploy-tmp/ in the chat template gitignore

### DIFF
--- a/templates/chat/_gitignore
+++ b/templates/chat/_gitignore
@@ -13,6 +13,8 @@ build/
 dist
 dist-ssr
 .output/
+.netlify/
+.deploy-tmp/
 *.local
 
 # Editor directories and files


### PR DESCRIPTION
Companion to #2471 (`build/` + `.output/`). `agent-native build`/deploy also emit `.netlify/` and `.deploy-tmp/`; add them to `templates/chat/_gitignore` so generated apps (and the starter mirror) never commit them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)