### PR TITLE
test: remove vendor-branch mirror test marker

### DIFF
--- a/templates/chat/README.md
+++ b/templates/chat/README.md
@@ -30,5 +30,3 @@ pnpm dev
 ```
 
 Full docs: [agent-native.com/docs/template-chat](https://agent-native.com/docs/template-chat).
-
-<!-- vendor-branch mirror end-to-end test — safe to remove -->


### PR DESCRIPTION
Removes the harmless README marker added in #2491 now that the vendor-branch mirror is validated end-to-end (mirror → template → clean sync-merge → starter main; plus the publish→dispatch path fired for real).

This deletion flows through the same pipeline and cleans the marker off the starter's `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)