### PR TITLE
 Fix Clips desktop recordings stuck on uploading

### DIFF
--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -3995,7 +3995,7 @@ const SCK_FINALIZE_TIMEOUT: Duration = Duration::from_secs(10);
 const CUSTOM_SCK_STOP_TIMEOUT: Duration = Duration::from_secs(3);
 
 #[cfg(target_os = "macos")]
-fn run_bounded_capture_stop<F>(stop: F, timeout: Duration) -> Result<(), String>
+pub(crate) fn run_bounded_capture_stop<F>(stop: F, timeout: Duration) -> Result<(), String>
 where
     F: FnOnce() -> Result<(), String> + Send + 'static,
 {

--- a/templates/clips/desktop/src-tauri/src/system_audio.rs
+++ b/templates/clips/desktop/src-tauri/src/system_audio.rs
@@ -161,6 +161,7 @@ pub async fn audio_transcription_reset_timeline() -> Result<(), String> {
 pub(crate) mod macos {
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
     use std::sync::Arc;
+    use std::time::Duration;
 
     use objc2::rc::Retained;
     use objc2::AnyThread;
@@ -314,6 +315,15 @@ pub(crate) mod macos {
         }
     }
 
+    /// `SCStream::stop_capture()` occasionally never returns when the stream's
+    /// underlying connection was already interrupted (same ScreenCaptureKit
+    /// flakiness `native_screen::run_bounded_capture_stop` bounds for the video
+    /// stream). This capture has no delegate to observe that ahead of time, so
+    /// bound the stop call itself — otherwise a hung stop blocks the
+    /// `audio_transcription_stop` Tauri command, which blocks the recorder's
+    /// finalize await, forever.
+    const SYSTEM_AUDIO_SCK_STOP_TIMEOUT: Duration = Duration::from_secs(3);
+
     /// Handle for a running raw SCK audio capture. A meeting capture can carry
     /// both system and microphone output handlers on this one stream.
     pub(crate) struct RawSckAudioCapture {
@@ -328,7 +338,17 @@ pub(crate) mod macos {
     impl RawSckAudioCapture {
         pub(crate) fn stop(self) {
             self.cancelled.store(true, Ordering::SeqCst);
-            let _ = self.stream.stop_capture();
+            let stream = self.stream;
+            if let Err(err) = crate::native_screen::run_bounded_capture_stop(
+                move || {
+                    stream
+                        .stop_capture()
+                        .map_err(|e| format!("system audio SCStream stop failed: {e:?}"))
+                },
+                SYSTEM_AUDIO_SCK_STOP_TIMEOUT,
+            ) {
+                eprintln!("[system-audio] bounded stop_capture: {err}");
+            }
         }
     }
 


### PR DESCRIPTION
Some Clips desktop recordings never finished uploading. The share page stayed
stuck on "Uploading and assembling your video" forever, even though the video
had already uploaded.

This happened when stopping the background audio capture used for live
transcription got stuck. When that happened, the app never sent the final
request needed to finish the upload, so the recording was left unfinished
with no error shown to the user.

## What changed

Stopping that audio capture now has a time limit. If it does not stop within
a few seconds, the app moves on and finishes the recording anyway, instead of
waiting forever.

This uses the same safeguard the app already has for stopping video capture,
applied to audio capture as well.

## Why it matters

Users no longer lose a recording, or get stuck watching an upload spinner
with no way to recover, when this happens.
