### PR TITLE
fix: slide deck name saved properly

### DIFF
--- a/templates/slides/actions/patch-deck.test.ts
+++ b/templates/slides/actions/patch-deck.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
-import { applyOperation, withDeckLock, type Operation } from "./patch-deck";
+import {
+  applyOperation,
+  resolveDeckColumnUpdates,
+  withDeckLock,
+  type Operation,
+} from "./patch-deck";
 
 // ---------------------------------------------------------------------------
 // normalizeSlidePadding is a pass-through in tests
@@ -302,5 +307,53 @@ describe("withDeckLock", () => {
     resolveA();
     await a;
     expect(order).toContain("a-end");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveDeckColumnUpdates — SQL columns must match the deck JSON
+// ---------------------------------------------------------------------------
+
+describe("resolveDeckColumnUpdates", () => {
+  const current = { title: "Old", designSystemId: null };
+
+  const renameOp = (title: string): Operation => ({
+    op: "patch-deck-fields",
+    fields: { title },
+  });
+
+  it("takes the last title in a debounced rename burst", () => {
+    // One keystroke per op — the column must land on the final value, or the
+    // deck list shows a truncated name once the JSON and column disagree.
+    const burst = ["N", "Ne", "New", "New ", "New Name"].map(renameOp);
+    expect(resolveDeckColumnUpdates(current, burst).title).toBe("New Name");
+  });
+
+  it("takes the last designSystemId in a batch", () => {
+    const ops: Operation[] = [
+      { op: "patch-deck-fields", fields: { designSystemId: "ds-1" } },
+      { op: "patch-deck-fields", fields: { designSystemId: "ds-2" } },
+    ];
+    expect(resolveDeckColumnUpdates(current, ops).designSystemId).toBe("ds-2");
+  });
+
+  it("keeps current values when no field op touches them", () => {
+    const ops: Operation[] = [
+      { op: "delete-slide", slideId: "s1" },
+      { op: "patch-deck-fields", fields: { visibility: "org" } },
+    ];
+    expect(
+      resolveDeckColumnUpdates({ title: "Keep", designSystemId: "ds-9" }, ops),
+    ).toEqual({ title: "Keep", designSystemId: "ds-9" });
+  });
+
+  it("treats an explicit null designSystemId as a clear", () => {
+    const ops: Operation[] = [
+      { op: "patch-deck-fields", fields: { designSystemId: null } },
+    ];
+    expect(
+      resolveDeckColumnUpdates({ title: "T", designSystemId: "ds-1" }, ops)
+        .designSystemId,
+    ).toBeNull();
   });
 });

--- a/templates/slides/actions/patch-deck.ts
+++ b/templates/slides/actions/patch-deck.ts
@@ -289,6 +289,30 @@ export function applyOperation(deck: any, op: Operation): void {
   }
 }
 
+/**
+ * Resolve the last operation in a sequence. For example, when typing a new name
+ * this will be the latest name of the deck in a sequence of keystrokes.
+ */
+export function resolveDeckColumnUpdates(
+  current: { title: string; designSystemId: string | null },
+  operations: Operation[],
+): { title: string; designSystemId: string | null } {
+  const fieldOps = operations
+    .filter(
+      (op): op is z.infer<typeof PatchDeckFieldsOp> =>
+        op.op === "patch-deck-fields",
+    )
+    .reverse();
+  const titleOp = fieldOps.find((op) => typeof op.fields.title === "string");
+  const dsOp = fieldOps.find((op) => "designSystemId" in op.fields);
+  return {
+    title: titleOp?.fields.title ?? current.title,
+    designSystemId: dsOp
+      ? (dsOp.fields.designSystemId ?? null)
+      : current.designSystemId,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Action definition
 // ---------------------------------------------------------------------------
@@ -342,23 +366,11 @@ export default defineAction({
       const now = new Date().toISOString();
       deck.updatedAt = now;
 
-      // For patch-deck-fields ops that include a title, also update the
-      // SQL title column (kept in sync with deck.title for list queries).
-      const titleOp = operations.find(
-        (op): op is z.infer<typeof PatchDeckFieldsOp> =>
-          op.op === "patch-deck-fields" && typeof op.fields.title === "string",
-      );
-      const sqlTitle = titleOp?.fields.title ?? row.title;
-
-      // For patch-deck-fields ops that include designSystemId, update the
-      // SQL designSystemId column (used by list queries and sharing checks).
-      const dsOp = operations.find(
-        (op): op is z.infer<typeof PatchDeckFieldsOp> =>
-          op.op === "patch-deck-fields" && "designSystemId" in op.fields,
-      );
-      const sqlDesignSystemId = dsOp
-        ? (dsOp.fields.designSystemId ?? null)
-        : row.designSystemId;
+      const { title: sqlTitle, designSystemId: sqlDesignSystemId } =
+        resolveDeckColumnUpdates(
+          { title: row.title, designSystemId: row.designSystemId },
+          operations,
+        );
 
       let generationRecord:
         | {


### PR DESCRIPTION
When typing to update a slide deck name, the server was saving an old keystroke in the sequence as the name. As a result, an incorrect name was saved. If I had a deck named "foo" and I typed "1" then "2" then "3" the server would save "foo1" instead of "foo123".