### PR TITLE
fix: element not found issue

### DIFF
--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -13507,7 +13507,14 @@ function DesignEditor() {
         typeof crypto !== "undefined" && "randomUUID" in crypto
           ? crypto.randomUUID()
           : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
-      if (!targetNode && elementInfoIsRuntimeOnly(targetInfo)) {
+      // Ambiguity is terminal for both writers below (each demands a unique
+      // match), but `absent` is not: the legacy DOM query still resolves
+      // selectors the projection missed, so it must fall through.
+      const commitTargetCannotResolve =
+        !targetNode &&
+        (targetResolution.status === "ambiguous" ||
+          elementInfoIsRuntimeOnly(targetInfo));
+      if (commitTargetCannotResolve) {
         // Fail LOUD (same contract as the resolveVisualStyleCommitContent
         // error branch below): patch-proof state alone is too quiet for a
         // user-initiated edit that will never persist.

--- a/templates/design/app/pages/design-editor/live-screen-commit-route-order.spec.ts
+++ b/templates/design/app/pages/design-editor/live-screen-commit-route-order.spec.ts
@@ -31,16 +31,37 @@ function commitVisualStylesSection(): string {
 
 describe("localhost style commit route order", () => {
   const LOCALHOST_ROUTE = 'if (activeCanvasSourceType === "localhost") {';
-  const RUNTIME_ONLY_REFUSAL =
-    "if (!targetNode && elementInfoIsRuntimeOnly(targetInfo)) {";
+  const RESOLUTION_REFUSAL = "if (commitTargetCannotResolve) {";
 
-  it("routes a localhost commit to the agent queue before the runtime-only refusal", () => {
+  it("routes a localhost commit to the agent queue before the resolution refusal", () => {
     const section = commitVisualStylesSection();
 
     expect(section).toContain(LOCALHOST_ROUTE);
-    expect(section).toContain(RUNTIME_ONLY_REFUSAL);
+    expect(section).toContain(RESOLUTION_REFUSAL);
     expect(section.indexOf(LOCALHOST_ROUTE)).toBeLessThan(
-      section.indexOf(RUNTIME_ONLY_REFUSAL),
+      section.indexOf(RESOLUTION_REFUSAL),
+    );
+  });
+
+  it("refuses an ambiguous target whether or not it is runtime-only", () => {
+    const section = commitVisualStylesSection();
+    const gate = section.slice(
+      section.indexOf("const commitTargetCannotResolve ="),
+      section.indexOf(RESOLUTION_REFUSAL),
+    );
+
+    // Gating solely on elementInfoIsRuntimeOnly let a source-backed element
+    // with a repeated selector fall through to the writers, which both refuse
+    // it anyway — after the preview had already painted the value.
+    expect(gate).toContain('targetResolution.status === "ambiguous"');
+    expect(gate).toContain("elementInfoIsRuntimeOnly(targetInfo)");
+  });
+
+  it("refuses before the runtime preview paints an edit that cannot persist", () => {
+    const section = commitVisualStylesSection();
+
+    expect(section.indexOf(RESOLUTION_REFUSAL)).toBeLessThan(
+      section.indexOf("sendRuntimeStylePreview();"),
     );
   });
 
@@ -72,7 +93,7 @@ describe("localhost style commit route order", () => {
 
   it("never blames the element when the projection is a mount shell", () => {
     const section = commitVisualStylesSection();
-    const refusal = section.slice(section.indexOf(RUNTIME_ONLY_REFUSAL));
+    const refusal = section.slice(section.indexOf(RESOLUTION_REFUSAL));
 
     // "no app markup to patch" and "element no longer exists" are different
     // facts with different remedies; a mount shell is the former.

--- a/templates/design/app/pages/design-editor/live-screen-url-preview-guard.spec.ts
+++ b/templates/design/app/pages/design-editor/live-screen-url-preview-guard.spec.ts
@@ -92,6 +92,29 @@ describe("live screen URL preview guard", () => {
     );
   });
 
+  it("refuses to PROJECT a route URL as the edit source when the snapshot is missing", () => {
+    // Read-direction counterpart of the guards above. Observed: a commit with no
+    // snapshot yet projected "http://localhost:3000/" as its source document, so
+    // the selection resolved `absent` and a load-timing miss was reported as an
+    // element with no editable source.
+    const section = sourceSection(
+      "const commitVisualStyles = useCallback(",
+      "const commitStylesToSelectedLayers = useCallback(",
+    );
+    const guard = "if (isStandaloneHttpUrl(baseContent))";
+
+    expect(section).toContain(guard);
+    // Must refuse BEFORE the projection is built, or the doomed 3-node parse
+    // still happens and the misleading "no editable match" wins the race.
+    expect(section.indexOf(guard)).toBeLessThan(
+      section.indexOf("buildCodeLayerProjection(baseContent)"),
+    );
+    // Named as a load-timing failure, not as a missing element.
+    expect(section).toMatch(
+      /if \(isStandaloneHttpUrl\(baseContent\)\) \{[\s\S]*?snapshotNotLoaded[\s\S]*?return;\s*\}/,
+    );
+  });
+
   it("refuses design-state preview and restore on a live screen", () => {
     const section = sourceSection(
       "const handleDesignStateSelect = useCallback(",

--- a/templates/design/changelog/2026-07-29-a-style-edit-on-an-element-that-repeats-in-the-source-is-now.md
+++ b/templates/design/changelog/2026-07-29-a-style-edit-on-an-element-that-repeats-in-the-source-is-now.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-29
+---
+
+A style edit on an element that repeats in the source is now refused up front instead of briefly showing a change that could never be saved.


### PR DESCRIPTION
Follow-up to #2498, which has since merged and absorbed most of what this branch originally carried. Rebuilt on current `main`, so the diff is now only what `main` does not already have.

## Refuse an ambiguous style commit before the preview

A style commit resolves its target with `resolveCodeLayerTargetFromElementInfo`, which reports `resolved` / `absent` / `ambiguous`. The branch that turns those into a specific refusal was gated on `elementInfoIsRuntimeOnly(targetInfo)`, and `sourceBacked` in the bridge is `hasStableOwnSource(el) || !!closestStableSourceElement(el)` — so a repeated card under a source-backed container reports `deterministic-style-edit`, the gate reads false, and an `ambiguous` resolution fell past it.

What the user got: `sendRuntimeStylePreview()` painted the value into the canvas, then both writers refused the non-unique match anyway (`resolveTarget` → `conflict`, `queryUniqueSelector` → `null`), and the toast surfaced the raw internal `Selector "…" matched N code layer nodes.` A change appeared on screen, could never be saved, and the message did not name the count the localized copy already has.

The gate is now a named predicate covering `ambiguous` as well. It is deliberately *not* widened to every non-`resolved` status: `ambiguous` is terminal for both writers, so refusing early loses no reachable edit, but `absent` on a source-backed element is not — the legacy DOM query still resolves selectors the projection missed and has to keep falling through.

## Guard the read direction on a live screen

A commit with no snapshot yet projected `http://localhost:3000/` as its source document, so the selection resolved `absent` and a load-timing miss was reported as an element with no editable source. `main` has the `isStandaloneHttpUrl(baseContent)` guard; this adds the regression test that pins it ahead of `buildCodeLayerProjection` and asserts it names `snapshotNotLoaded` rather than a missing element.

## Tests

`tsc --noEmit` clean. `pnpm --filter design exec vitest --run` → 409 files, 4781 tests passing.

Source-level assertions (matching the existing `live-screen-url-preview-guard.spec.ts` approach) because both guards live in closures inside `DesignEditor.tsx`. The `live-screen-commit-route-order.spec.ts` anchor moved from the old `elementInfoIsRuntimeOnly` conditional to the new named predicate, plus two new cases: the gate must cover both conditions, and the refusal must precede `sendRuntimeStylePreview();`.
