### PR TITLE
Add Content product knowledge graph and developer skill

### DIFF
--- a/.agents/skills/content-product-development
+++ b/.agents/skills/content-product-development
@@ -1,0 +1,1 @@
+../../templates/content/.agents/skills/content-product-development

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,6 +246,9 @@ searching the skill directory over guessing from nearby code.
 
 Two are entry points rather than area guides:
 
+- `content-product-development` — read before planning, implementing,
+  reviewing, testing, or documenting Content behavior or shared framework
+  behavior that changes Content's product contract.
 - `adding-a-feature` — the four-area checklist every feature must satisfy.
 - `writing-agent-instructions` — read before editing any `AGENTS.md`,
   `SKILL.md`, or tool/action description, including this file.

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
     "guard:template-list": "node scripts/guard-template-list.mjs",
     "guard:netlify-private-env": "tsx scripts/guard-netlify-private-env.ts",
     "guard:trusted-acceptance": "tsx scripts/guard-trusted-acceptance-workflow.ts",
+    "guard:content-product-docs": "tsx scripts/validate-content-product-docs.ts",
+    "test:content-product-docs": "tsx --test scripts/validate-content-product-docs.test.ts",
     "guard:workspace-skills": "tsx scripts/sync-workspace-core-skills.ts --check",
     "sync:template-standard": "tsx scripts/template-standard/index.ts",
     "guard:template-standard": "tsx scripts/template-standard/index.ts --check",

--- a/scripts/fixtures/content-product-docs/valid/capabilities/content.test.alpha.md
+++ b/scripts/fixtures/content-product-docs/valid/capabilities/content.test.alpha.md
@@ -1,8 +1,10 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.test.alpha"
 name: "Alpha"
 user_promise: "Alpha proves the required path."
+primary_user_job: "Complete the Alpha workflow without losing its result."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
@@ -11,10 +13,53 @@ dependencies: []
 related_features: ["content.feature.test"]
 roadmap_boundary: "feature"
 acceptance_summary: "The required path is proven."
-proof_requirements: ["Prove the required path."]
+proof_requirements:
+  [
+    "Prove the Action result",
+    "Prove reload and recovery",
+    "Prove the real interface",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
 ---
 
 # Alpha
+
+## Why this exists
+
+People need the Alpha result to survive the complete workflow.
+
+## Example workflow
+
+A person invokes Alpha, reloads the surface, and recovers the saved result.
+
+## Product contract
+
+Alpha uses the shared Action and retains one canonical result.
+
+## Boundaries and non-goals
+
+Alpha does not create a second persistence or permission system.
+
+## Acceptance stories
+
+### Complete Alpha
+
+Given an authorized person, when they invoke Alpha, then the canonical result is saved.
+
+### Recover Alpha
+
+Given a saved result, when the surface reloads, then the same result remains available.
+
+## Current evidence
+
+The fixture intentionally represents an approved shape with no implementation evidence.
+
+## Proof plan
+
+Exercise the Action, reload, recovery, and real interface.
+
+## Open questions
+
+No product question remains in this fixture.

--- a/scripts/fixtures/content-product-docs/valid/capabilities/content.test.alpha.md
+++ b/scripts/fixtures/content-product-docs/valid/capabilities/content.test.alpha.md
@@ -1,0 +1,20 @@
+---
+record_type: "capability"
+id: "content.test.alpha"
+name: "Alpha"
+user_promise: "Alpha proves the required path."
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: []
+related_features: ["content.feature.test"]
+roadmap_boundary: "feature"
+acceptance_summary: "The required path is proven."
+proof_requirements: ["Prove the required path."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Alpha

--- a/scripts/fixtures/content-product-docs/valid/capabilities/content.test.beta.md
+++ b/scripts/fixtures/content-product-docs/valid/capabilities/content.test.beta.md
@@ -1,0 +1,20 @@
+---
+record_type: "capability"
+id: "content.test.beta"
+name: "Beta"
+user_promise: "Beta proves the enhancing path."
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: []
+related_features: ["content.feature.test"]
+roadmap_boundary: "feature"
+acceptance_summary: "The enhancing path is proven."
+proof_requirements: ["Prove the enhancing path."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Beta

--- a/scripts/fixtures/content-product-docs/valid/chapters/content.chapter.test.md
+++ b/scripts/fixtures/content-product-docs/valid/chapters/content.chapter.test.md
@@ -1,0 +1,12 @@
+---
+record_type: "chapter"
+id: "content.chapter.test"
+name: "Test Chapter"
+order: 1
+promise: "A small deterministic catalog can be validated."
+features: ["content.feature.test"]
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Test Chapter

--- a/scripts/fixtures/content-product-docs/valid/features/content.feature.test.md
+++ b/scripts/fixtures/content-product-docs/valid/features/content.feature.test.md
@@ -1,0 +1,25 @@
+---
+record_type: "feature"
+id: "content.feature.test"
+number: 1
+name: "Test Feature"
+chapter: "content.chapter.test"
+order: 1
+roadmap_status: "planned"
+summary: "A complete test workflow."
+example_workflow: "A contributor validates the sample catalog."
+works_today: "The fixture can be parsed."
+remains: "The product implementation remains planned."
+required_capabilities: ["content.test.alpha"]
+enhancing_capabilities: ["content.test.beta"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 1: Test Feature
+
+## Product contract
+
+- **Validation:** The sample remains small and deterministic.

--- a/scripts/run-guards.ts
+++ b/scripts/run-guards.ts
@@ -13,6 +13,7 @@ const guards = [
   "guard:template-list",
   "guard:netlify-private-env",
   "guard:trusted-acceptance",
+  "guard:content-product-docs",
   "guard:workspace-skills",
   "guard:template-standard",
   "guard:public-packages",

--- a/scripts/validate-content-product-docs.test.ts
+++ b/scripts/validate-content-product-docs.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { cpSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { validateContentProductDocs } from "./validate-content-product-docs";
+
+const fixtureRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "fixtures/content-product-docs/valid",
+);
+
+test("accepts a coherent product graph", () => {
+  const result = validateContentProductDocs(fixtureRoot, {
+    strictCatalog: false,
+    checkProjections: false,
+  });
+
+  assert.deepEqual(result.errors, []);
+});
+
+test("reports unknown references and dependency cycles with exact fields", () => {
+  const root = copyFixture();
+  replace(
+    join(root, "capabilities/content.test.alpha.md"),
+    "dependencies: []",
+    'dependencies: ["content.test.beta"]',
+  );
+  replace(
+    join(root, "capabilities/content.test.beta.md"),
+    "dependencies: []",
+    'dependencies: ["content.test.alpha"]',
+  );
+  replace(
+    join(root, "features/content.feature.test.md"),
+    'enhancing_capabilities: ["content.test.beta"]',
+    'enhancing_capabilities: ["content.test.missing"]',
+  );
+
+  const result = validateContentProductDocs(root, {
+    strictCatalog: false,
+    checkProjections: false,
+  });
+
+  assert(
+    result.errors.some((error) =>
+      error.includes(
+        "enhancing_capabilities references unknown id content.test.missing",
+      ),
+    ),
+  );
+  assert(
+    result.errors.some((error) =>
+      error.includes(
+        "dependency cycle: content.test.alpha -> content.test.beta -> content.test.alpha",
+      ),
+    ),
+  );
+});
+
+test("rejects private paths and vault metadata", () => {
+  const root = copyFixture();
+  const file = join(root, "capabilities/content.test.alpha.md");
+  replace(file, 'name: "Alpha"', 'name: "Alpha"\ncontext: ["private"]');
+  writeFileSync(
+    file,
+    `${readFileSync(file, "utf8")}\nSee /Users/example/private-notes.\n`,
+  );
+
+  const result = validateContentProductDocs(root, {
+    strictCatalog: false,
+    checkProjections: false,
+  });
+
+  assert(
+    result.errors.some((error) =>
+      error.includes("remove vault-only frontmatter field context"),
+    ),
+  );
+  assert(
+    result.errors.some((error) =>
+      error.includes("remove absolute filesystem path"),
+    ),
+  );
+});
+
+test("requires complete proof before a Feature becomes available", () => {
+  const root = copyFixture();
+  replace(
+    join(root, "features/content.feature.test.md"),
+    'roadmap_status: "planned"',
+    'roadmap_status: "available"',
+  );
+
+  const result = validateContentProductDocs(root, {
+    strictCatalog: false,
+    checkProjections: false,
+  });
+
+  assert(
+    result.errors.some((error) =>
+      error.includes("available Feature has unverified required capabilities"),
+    ),
+  );
+  assert(
+    result.errors.some((error) =>
+      error.includes(
+        "available Feature requires a non-empty feature_proof receipt",
+      ),
+    ),
+  );
+});
+
+function copyFixture() {
+  const root = mkdtempSync(join(tmpdir(), "content-product-docs-"));
+  cpSync(fixtureRoot, root, { recursive: true });
+  return root;
+}
+
+function replace(file: string, find: string, replacement: string) {
+  const source = readFileSync(file, "utf8");
+  assert(source.includes(find), `Fixture text not found in ${file}: ${find}`);
+  writeFileSync(file, source.replace(find, replacement));
+}

--- a/scripts/validate-content-product-docs.test.ts
+++ b/scripts/validate-content-product-docs.test.ts
@@ -113,6 +113,178 @@ test("requires complete proof before a Feature becomes available", () => {
   );
 });
 
+test("rejects a version 2 capability that falls back to the generated shell", () => {
+  const root = copyFixture();
+  const file = join(root, "capabilities/content.test.alpha.md");
+  replace(file, "## Why this exists", "## Missing human problem");
+  replace(
+    file,
+    'acceptance_summary: "The required path is proven."',
+    'acceptance_summary: "A complete proof demonstrates: Alpha."',
+  );
+
+  const result = validateContentProductDocs(root, {
+    strictCatalog: false,
+    checkProjections: false,
+  });
+
+  assert(
+    result.errors.some((error) =>
+      error.includes("spec_version 2 requires ## Why this exists"),
+    ),
+  );
+  assert(
+    result.errors.some((error) =>
+      error.includes("must describe the observable completion boundary"),
+    ),
+  );
+});
+
+test("rejects a longer mini-spec built from generic workflow placeholders", () => {
+  const root = copyFixture();
+  const file = join(root, "capabilities/content.test.alpha.md");
+  replace(
+    file,
+    "A person invokes Alpha, reloads the surface, and recovers the saved result.",
+    "A person uses Alpha in an authorized document workflow, inspects the result, and keeps history legible.",
+  );
+  replace(file, "### Complete Alpha", "### Complete the ordinary workflow");
+  replace(file, "### Recover Alpha", "### Preserve the governing boundary");
+
+  const result = validateContentProductDocs(root, {
+    strictCatalog: false,
+    checkProjections: false,
+  });
+
+  assert(
+    result.errors.some((error) =>
+      error.includes("replace the generic example workflow"),
+    ),
+  );
+  assert(
+    result.errors.some((error) =>
+      error.includes("capability-specific scenario"),
+    ),
+  );
+  assert(
+    result.errors.some((error) =>
+      error.includes("actual authority, permission, or data boundary"),
+    ),
+  );
+});
+
+test("requires the primary user job to add intent beyond the promise", () => {
+  const root = copyFixture();
+  const file = join(root, "capabilities/content.test.alpha.md");
+  replace(
+    file,
+    'primary_user_job: "Complete the Alpha workflow without losing its result."',
+    'primary_user_job: "Alpha proves the required path."',
+  );
+
+  const result = validateContentProductDocs(root, {
+    strictCatalog: false,
+    checkProjections: false,
+  });
+
+  assert(
+    result.errors.some((error) =>
+      error.includes("rather than duplicate user_promise"),
+    ),
+  );
+});
+
+test("requires one copy of each mini-spec section and distinct problem framing", () => {
+  const root = copyFixture();
+  const file = join(root, "capabilities/content.test.alpha.md");
+  replace(
+    file,
+    "People need the Alpha result to survive the complete workflow.",
+    "Complete the Alpha workflow without losing its result.",
+  );
+  replace(
+    file,
+    "## Boundaries and non-goals\n",
+    "## Boundaries and non-goals\n\n## Boundaries and non-goals\n",
+  );
+
+  const result = validateContentProductDocs(root, {
+    strictCatalog: false,
+    checkProjections: false,
+  });
+
+  assert(
+    result.errors.some((error) =>
+      error.includes("requires exactly one ## Boundaries and non-goals"),
+    ),
+  );
+  assert(
+    result.errors.some((error) => error.includes("explain the human problem")),
+  );
+});
+
+test("requires every Capability in the canonical catalog to use version 2", () => {
+  const root = copyFixture();
+  const file = join(root, "capabilities/content.test.alpha.md");
+  replace(file, "spec_version: 2\n", "");
+
+  const result = validateContentProductDocs(root, {
+    strictCatalog: true,
+    checkProjections: false,
+  });
+
+  assert(
+    result.errors.some((error) =>
+      error.includes(
+        "every Capability must use spec_version 2; legacy records: content.test.alpha",
+      ),
+    ),
+  );
+  assert(
+    result.errors.some((error) =>
+      error.includes("expected 124 Capabilities, found 2"),
+    ),
+  );
+});
+
+test("requires supersession to terminate at a different active Capability", () => {
+  const root = copyFixture();
+  const alpha = join(root, "capabilities/content.test.alpha.md");
+  const beta = join(root, "capabilities/content.test.beta.md");
+  replace(alpha, 'state: "approved_shape"', 'state: "superseded"');
+  replace(alpha, "superseded_by: null", 'superseded_by: "content.test.beta"');
+  replace(beta, 'state: "approved_shape"', 'state: "superseded"');
+  replace(beta, "superseded_by: null", 'superseded_by: "content.test.alpha"');
+
+  const result = validateContentProductDocs(root, {
+    strictCatalog: false,
+    checkProjections: false,
+  });
+
+  assert(
+    result.errors.some((error) =>
+      error.includes(
+        "superseded_by must reference an active terminal Capability, not superseded content.test.beta",
+      ),
+    ),
+  );
+
+  replace(
+    alpha,
+    'superseded_by: "content.test.beta"',
+    'superseded_by: "content.test.alpha"',
+  );
+  const selfResult = validateContentProductDocs(root, {
+    strictCatalog: false,
+    checkProjections: false,
+  });
+  assert(
+    selfResult.errors.some((error) =>
+      error.includes("superseded_by cannot reference itself"),
+    ),
+  );
+});
+
 function copyFixture() {
   const root = mkdtempSync(join(tmpdir(), "content-product-docs-"));
   cpSync(fixtureRoot, root, { recursive: true });

--- a/scripts/validate-content-product-docs.test.ts
+++ b/scripts/validate-content-product-docs.test.ts
@@ -86,6 +86,104 @@ test("rejects private paths and vault metadata", () => {
   );
 });
 
+test("rejects private reference links and Slack client permalinks", () => {
+  const root = copyFixture();
+  const file = join(root, "capabilities/content.test.alpha.md");
+  writeFileSync(
+    file,
+    `${readFileSync(file, "utf8")}\n[private-notes]:/Users/example/private-notes.md\n[private-thread]: https://workspace.slack.com/client/T123/C456/thread\n`,
+  );
+
+  const result = validateContentProductDocs(root, {
+    strictCatalog: false,
+    checkProjections: false,
+  });
+
+  assert(
+    result.errors.some((error) =>
+      error.includes("remove absolute filesystem path"),
+    ),
+  );
+  assert(
+    result.errors.some((error) =>
+      error.includes("remove private Slack-shaped URL"),
+    ),
+  );
+});
+
+test("requires Chapter and Feature membership to agree in both directions", () => {
+  const root = copyFixture();
+  replace(
+    join(root, "chapters/content.chapter.test.md"),
+    'features: ["content.feature.test"]',
+    "features: []",
+  );
+
+  const result = validateContentProductDocs(root, {
+    strictCatalog: false,
+    checkProjections: false,
+  });
+
+  assert(
+    result.errors.some((error) =>
+      error.includes(
+        "features must include content.feature.test because the Feature declares chapter content.chapter.test",
+      ),
+    ),
+  );
+});
+
+test("requires Feature and Capability membership to agree in both directions", () => {
+  const root = copyFixture();
+  replace(
+    join(root, "features/content.feature.test.md"),
+    'enhancing_capabilities: ["content.test.beta"]',
+    "enhancing_capabilities: []",
+  );
+
+  const result = validateContentProductDocs(root, {
+    strictCatalog: false,
+    checkProjections: false,
+  });
+
+  assert(
+    result.errors.some((error) =>
+      error.includes(
+        "required_capabilities or enhancing_capabilities must include content.test.beta because the Capability declares related Feature content.feature.test",
+      ),
+    ),
+  );
+});
+
+test("rejects active graph edges to superseded Capabilities", () => {
+  const root = copyFixture();
+  const alpha = join(root, "capabilities/content.test.alpha.md");
+  const beta = join(root, "capabilities/content.test.beta.md");
+  replace(beta, 'state: "approved_shape"', 'state: "superseded"');
+  replace(beta, "superseded_by: null", 'superseded_by: "content.test.alpha"');
+  replace(alpha, "dependencies: []", 'dependencies: ["content.test.beta"]');
+
+  const result = validateContentProductDocs(root, {
+    strictCatalog: false,
+    checkProjections: false,
+  });
+
+  assert(
+    result.errors.some((error) =>
+      error.includes(
+        "active Capability dependencies must target active Capabilities, not superseded content.test.beta",
+      ),
+    ),
+  );
+  assert(
+    result.errors.some((error) =>
+      error.includes(
+        "Feature capability references must target active Capabilities, not superseded content.test.beta",
+      ),
+    ),
+  );
+});
+
 test("requires complete proof before a Feature becomes available", () => {
   const root = copyFixture();
   replace(

--- a/scripts/validate-content-product-docs.ts
+++ b/scripts/validate-content-product-docs.ts
@@ -227,15 +227,16 @@ export function renderEncyclopedia(catalog: ProductCatalog) {
     `- Named increments: ${catalog.features.reduce((total, feature) => total + stringArrayField(feature, "increments").length, 0)}`,
     `- Capabilities: ${capabilities.length}`,
     "",
-    "| Capability state | Count |",
-    "| --- | ---: |",
   ];
 
+  const stateRows = [["Capability state", "Count"]];
   for (const state of capabilityStates) {
-    lines.push(
-      `| ${displayCapabilityState(state)} | ${stateCounts.get(state) ?? 0} |`,
-    );
+    stateRows.push([
+      displayCapabilityState(state),
+      String(stateCounts.get(state) ?? 0),
+    ]);
   }
+  lines.push(...renderMarkdownTable(stateRows, ["left", "right"]));
 
   lines.push(
     "",
@@ -257,12 +258,15 @@ export function renderEncyclopedia(catalog: ProductCatalog) {
     left.localeCompare(right),
   )) {
     lines.push(`## ${displayCapabilityFamily(family)}`, "");
-    lines.push("| Capability | State | User promise |", "| --- | --- | --- |");
+    const rows = [["Capability", "State", "User promise"]];
     for (const capability of records) {
-      lines.push(
-        `| [${escapeTable(stringField(capability, "name"))}](capabilities/${capability.id}.md) | ${displayCapabilityState(stringField(capability, "state"))} | ${escapeTable(stringField(capability, "user_promise"))} |`,
-      );
+      rows.push([
+        `[${escapeTable(stringField(capability, "name"))}](capabilities/${capability.id}.md)`,
+        displayCapabilityState(stringField(capability, "state")),
+        escapeTable(stringField(capability, "user_promise")),
+      ]);
     }
+    lines.push(...renderMarkdownTable(rows));
     lines.push("");
   }
 
@@ -459,7 +463,11 @@ function validateCatalog(
       "related_features",
       errors,
     );
-    requireStringArray(capability, "proof_requirements", errors);
+    const proofRequirements = requireStringArray(
+      capability,
+      "proof_requirements",
+      errors,
+    );
     requireStringArray(capability, "evidence", errors);
     validateReferences(
       capability,
@@ -506,10 +514,30 @@ function validateCatalog(
           `${displayPath(capability.file)}: superseded_by references unknown id ${target}`,
         );
       }
+      if (target === capability.id) {
+        errors.push(
+          `${displayPath(capability.file)}: superseded_by cannot reference itself`,
+        );
+      }
+      if (target && recordsById.get(target)?.data.state === "superseded") {
+        errors.push(
+          `${displayPath(capability.file)}: superseded_by must reference an active terminal Capability, not superseded ${target}`,
+        );
+      }
     } else if (capability.data.superseded_by !== null) {
       errors.push(
         `${displayPath(capability.file)}: superseded_by must be null unless state is superseded`,
       );
+    }
+    if (capability.data.spec_version !== undefined) {
+      const specVersion = requireNumber(capability, "spec_version", errors);
+      if (specVersion !== 2) {
+        errors.push(
+          `${displayPath(capability.file)}: spec_version must be 2 when present`,
+        );
+      } else {
+        validateCapabilityMiniSpec(capability, proofRequirements, errors);
+      }
     }
   }
 
@@ -544,6 +572,16 @@ function validateCatalog(
   }
 
   if (strictCatalog) {
+    const legacyCapabilities = catalog.capabilities.filter(
+      (capability) => capability.data.spec_version !== 2,
+    );
+    if (legacyCapabilities.length > 0) {
+      errors.push(
+        `catalog: every Capability must use spec_version 2; legacy records: ${legacyCapabilities
+          .map((capability) => capability.id)
+          .join(", ")}`,
+      );
+    }
     if (catalog.chapters.length !== 6) {
       errors.push(
         `catalog: expected 6 Chapters, found ${catalog.chapters.length}`,
@@ -552,6 +590,11 @@ function validateCatalog(
     if (catalog.features.length !== 32) {
       errors.push(
         `catalog: expected 32 Features, found ${catalog.features.length}`,
+      );
+    }
+    if (catalog.capabilities.length !== 124) {
+      errors.push(
+        `catalog: expected 124 Capabilities, found ${catalog.capabilities.length}`,
       );
     }
     const incrementCount = catalog.features.reduce(
@@ -563,6 +606,154 @@ function validateCatalog(
       errors.push(
         `catalog: expected 1 named increment, found ${incrementCount}`,
       );
+    }
+  }
+}
+
+function validateCapabilityMiniSpec(
+  capability: ProductRecord,
+  proofRequirements: string[],
+  errors: string[],
+) {
+  const primaryUserJob = requireString(capability, "primary_user_job", errors);
+  if (
+    primaryUserJob &&
+    primaryUserJob === stringField(capability, "user_promise")
+  ) {
+    errors.push(
+      `${displayPath(capability.file)}: primary_user_job must explain the job in the user's terms rather than duplicate user_promise`,
+    );
+  }
+  if (proofRequirements.length < 3) {
+    errors.push(
+      `${displayPath(capability.file)}: spec_version 2 requires at least 3 concrete proof_requirements`,
+    );
+  }
+
+  const acceptanceSummary = stringField(capability, "acceptance_summary");
+  if (/^A complete proof demonstrates:/i.test(acceptanceSummary)) {
+    errors.push(
+      `${displayPath(capability.file)}: acceptance_summary must describe the observable completion boundary, not repeat the legacy generated prefix`,
+    );
+  }
+
+  const headings = [
+    "## Why this exists",
+    "## Example workflow",
+    "## Product contract",
+    "## Boundaries and non-goals",
+    "## Acceptance stories",
+    "## Current evidence",
+    "## Proof plan",
+    "## Open questions",
+  ];
+  let previousIndex = -1;
+  for (const heading of headings) {
+    const headingCount = capability.body
+      .split("\n")
+      .filter((line) => line === heading).length;
+    const index = capability.body.indexOf(heading);
+    if (index < 0) {
+      errors.push(
+        `${displayPath(capability.file)}: spec_version 2 requires ${heading}`,
+      );
+      continue;
+    }
+    if (headingCount !== 1) {
+      errors.push(
+        `${displayPath(capability.file)}: spec_version 2 requires exactly one ${heading}`,
+      );
+    }
+    if (index < previousIndex) {
+      errors.push(
+        `${displayPath(capability.file)}: ${heading} must follow the preceding mini-spec section`,
+      );
+    }
+    previousIndex = index;
+  }
+
+  const whyThisExists = extractSection(
+    capability.body,
+    "## Why this exists",
+    "## Example workflow",
+  ).trim();
+  if (
+    whyThisExists &&
+    (whyThisExists === primaryUserJob ||
+      whyThisExists === stringField(capability, "user_promise"))
+  ) {
+    errors.push(
+      `${displayPath(capability.file)}: Why this exists must explain the human problem rather than repeat frontmatter`,
+    );
+  }
+
+  const acceptanceStories = extractSection(
+    capability.body,
+    "## Acceptance stories",
+    "## Current evidence",
+  );
+  const scenarioCount = [...acceptanceStories.matchAll(/^### .+$/gm)].length;
+  if (scenarioCount < 2) {
+    errors.push(
+      `${displayPath(capability.file)}: spec_version 2 requires at least 2 independently named acceptance stories`,
+    );
+  }
+  if (
+    acceptanceStories &&
+    !/\bGiven\b[\s\S]*\bwhen\b[\s\S]*\bthen\b/i.test(acceptanceStories)
+  ) {
+    errors.push(
+      `${displayPath(capability.file)}: acceptance stories must include observable Given/when/then behavior`,
+    );
+  }
+
+  const currentEvidence = extractSection(
+    capability.body,
+    "## Current evidence",
+    "## Proof plan",
+  );
+  if (
+    !currentEvidence ||
+    /^Existing code may provide useful substrate/i.test(currentEvidence)
+  ) {
+    errors.push(
+      `${displayPath(capability.file)}: Current evidence must name concrete implementation truth or explicitly say that none exists`,
+    );
+  }
+
+  const genericPatterns: Array<[RegExp, string]> = [
+    [
+      /A person uses .+ in an authorized document workflow/i,
+      "replace the generic example workflow with a concrete actor, object, action, and outcome",
+    ],
+    [
+      /^### Complete the ordinary workflow$/m,
+      "replace the generic acceptance-story heading with a capability-specific scenario",
+    ],
+    [
+      /^### Preserve truth at the boundary$/m,
+      "replace the generic failure story with the actual boundary this capability must preserve",
+    ],
+    [
+      /^### Preserve the governing boundary$/m,
+      "name the actual authority, permission, or data boundary in the acceptance story",
+    ],
+    [
+      /^### Record an ordinary outcome$/m,
+      "name the observable capability-specific outcome in the acceptance story",
+    ],
+    [
+      /^1\. Exercise the typed contract, authorization, validation, Events, history, and recovery\.$/m,
+      "replace the generic proof plan with capability-specific evidence",
+    ],
+    [
+      /Implementation choices, exact controls, and rollout order remain open only where they preserve this contract/i,
+      "replace the generic open-questions sentence with real capability-specific questions or an explicit statement that none remain",
+    ],
+  ];
+  for (const [pattern, repair] of genericPatterns) {
+    if (pattern.test(capability.body)) {
+      errors.push(`${displayPath(capability.file)}: ${repair}`);
     }
   }
 }
@@ -922,6 +1113,33 @@ function titleCase(value: string) {
 
 function escapeTable(value: string) {
   return value.replace(/\|/g, "\\|").replace(/\s+/g, " ").trim();
+}
+
+function renderMarkdownTable(
+  rows: string[][],
+  alignments: Array<"left" | "right"> = [],
+) {
+  const widths = rows[0].map((_, column) =>
+    Math.max(3, ...rows.map((row) => row[column]?.length ?? 0)),
+  );
+  const renderRow = (row: string[]) =>
+    `| ${row
+      .map((cell, column) =>
+        alignments[column] === "right"
+          ? cell.padStart(widths[column])
+          : cell.padEnd(widths[column]),
+      )
+      .join(" | ")} |`;
+  const separator = widths.map((width, column) =>
+    alignments[column] === "right"
+      ? `${"-".repeat(Math.max(2, width - 1))}:`
+      : "-".repeat(width),
+  );
+  return [
+    renderRow(rows[0]),
+    renderRow(separator),
+    ...rows.slice(1).map(renderRow),
+  ];
 }
 
 function generatedNotice() {

--- a/scripts/validate-content-product-docs.ts
+++ b/scripts/validate-content-product-docs.ts
@@ -424,6 +424,13 @@ function validateCatalog(
       capabilityIds,
       errors,
     );
+    for (const capabilityId of [...required, ...enhancing]) {
+      if (recordsById.get(capabilityId)?.data.state === "superseded") {
+        errors.push(
+          `${displayPath(feature.file)}: Feature capability references must target active Capabilities, not superseded ${capabilityId}`,
+        );
+      }
+    }
     if (required.some((id) => enhancing.includes(id))) {
       errors.push(
         `${displayPath(feature.file)}: a capability cannot be both required and enhancing`,
@@ -488,6 +495,15 @@ function validateCatalog(
       errors.push(
         `${displayPath(capability.file)}: dependencies cannot include itself`,
       );
+    }
+    if (capability.data.state !== "superseded") {
+      for (const dependency of dependencies) {
+        if (recordsById.get(dependency)?.data.state === "superseded") {
+          errors.push(
+            `${displayPath(capability.file)}: active Capability dependencies must target active Capabilities, not superseded ${dependency}`,
+          );
+        }
+      }
     }
     if (
       relatedFeatures.length === 0 &&
@@ -555,6 +571,18 @@ function validateCatalog(
   }
 
   for (const feature of catalog.features) {
+    const chapter = recordsById.get(stringField(feature, "chapter"));
+    if (
+      chapter &&
+      !stringArrayField(chapter, "features").includes(feature.id)
+    ) {
+      errors.push(
+        `${displayPath(chapter.file)}: features must include ${feature.id} because the Feature declares chapter ${chapter.id}`,
+      );
+    }
+  }
+
+  for (const feature of catalog.features) {
     for (const capabilityId of [
       ...stringArrayField(feature, "required_capabilities"),
       ...stringArrayField(feature, "enhancing_capabilities"),
@@ -566,6 +594,23 @@ function validateCatalog(
       ) {
         errors.push(
           `${displayPath(capability.file)}: related_features must include ${feature.id} because the Feature references this capability`,
+        );
+      }
+    }
+  }
+
+  for (const capability of catalog.capabilities) {
+    for (const featureId of stringArrayField(capability, "related_features")) {
+      const feature = recordsById.get(featureId);
+      if (
+        feature &&
+        ![
+          ...stringArrayField(feature, "required_capabilities"),
+          ...stringArrayField(feature, "enhancing_capabilities"),
+        ].includes(capability.id)
+      ) {
+        errors.push(
+          `${displayPath(feature.file)}: required_capabilities or enhancing_capabilities must include ${capability.id} because the Capability declares related Feature ${feature.id}`,
         );
       }
     }
@@ -770,7 +815,7 @@ function validateLinksAndPrivacy(catalog: ProductCatalog, errors: string[]) {
     const source = readFileSync(file, "utf8");
     const privacyFindings: Array<[RegExp, string]> = [
       [
-        /(?:^|[\s('"`])\/(?:Users|home|private|Volumes)\//m,
+        /(?:^|[\s('"`:<>=])\/(?:Users|home|private|Volumes)\//m,
         "absolute filesystem path",
       ],
       [/\b[A-Za-z]:\\(?:Users|Documents|Desktop)\\/i, "absolute Windows path"],
@@ -786,7 +831,7 @@ function validateLinksAndPrivacy(catalog: ProductCatalog, errors: string[]) {
         "private Notion-shaped URL",
       ],
       [
-        /https?:\/\/[^\s)]+\.slack\.com\/archives\//i,
+        /https?:\/\/[^\s)>]+\.slack\.com\/(?:archives|client)\//i,
         "private Slack-shaped URL",
       ],
       [

--- a/scripts/validate-content-product-docs.ts
+++ b/scripts/validate-content-product-docs.ts
@@ -1,0 +1,985 @@
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { parse as parseYaml } from "yaml";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+export const defaultProductRoot = join(
+  repositoryRoot,
+  "templates/content/docs/product",
+);
+
+const roadmapStatuses = new Set([
+  "available",
+  "in_validation",
+  "partially_implemented",
+  "planned",
+  "paused",
+]);
+const capabilityStates = new Set([
+  "verified",
+  "failing",
+  "stale",
+  "in_progress",
+  "approved_shape",
+  "exploring",
+  "deferred",
+  "superseded",
+]);
+const capabilityKinds = new Set(["primitive", "surface", "workflow"]);
+const publicnessValues = new Set(["public", "internal"]);
+const availabilityValues = new Set([
+  "universal",
+  "configured",
+  "desktop",
+  "external_host",
+  "organization",
+  "development",
+]);
+const roadmapBoundaries = new Set([
+  "feature",
+  "supporting",
+  "deferred",
+  "superseded",
+]);
+
+type RecordKind = "chapter" | "feature" | "capability";
+
+type ProductRecord = {
+  file: string;
+  body: string;
+  data: Record<string, unknown>;
+  kind: RecordKind;
+  id: string;
+};
+
+type ProductCatalog = {
+  root: string;
+  chapters: ProductRecord[];
+  features: ProductRecord[];
+  capabilities: ProductRecord[];
+  records: ProductRecord[];
+};
+
+export type ValidationResult = {
+  catalog: ProductCatalog;
+  errors: string[];
+  roadmap: string;
+  encyclopedia: string;
+};
+
+export function validateContentProductDocs(
+  root = defaultProductRoot,
+  options: { strictCatalog?: boolean; checkProjections?: boolean } = {},
+): ValidationResult {
+  const strictCatalog = options.strictCatalog ?? root === defaultProductRoot;
+  const checkProjections = options.checkProjections ?? true;
+  const errors: string[] = [];
+  const catalog = loadCatalog(root, errors);
+
+  validateCatalog(catalog, errors, strictCatalog);
+  validateLinksAndPrivacy(catalog, errors);
+
+  const roadmap = renderRoadmap(catalog);
+  const encyclopedia = renderEncyclopedia(catalog);
+
+  if (checkProjections) {
+    compareProjection(join(root, "roadmap.md"), roadmap, errors);
+    compareProjection(join(root, "encyclopedia.md"), encyclopedia, errors);
+  }
+
+  return { catalog, errors, roadmap, encyclopedia };
+}
+
+export function writeContentProductProjections(root = defaultProductRoot) {
+  const result = validateContentProductDocs(root, { checkProjections: false });
+  if (result.errors.length > 0) throw new Error(formatErrors(result.errors));
+  writeFileSync(join(root, "roadmap.md"), result.roadmap);
+  writeFileSync(join(root, "encyclopedia.md"), result.encyclopedia);
+}
+
+export function renderRoadmap(catalog: ProductCatalog) {
+  const chapterById = new Map(
+    catalog.chapters.map((record) => [record.id, record]),
+  );
+  const capabilityById = new Map(
+    catalog.capabilities.map((record) => [record.id, record]),
+  );
+  const chapters = [...catalog.chapters].sort(
+    (left, right) => numberField(left, "order") - numberField(right, "order"),
+  );
+
+  const lines = [
+    "# Agent Native Content public roadmap",
+    "",
+    generatedNotice(),
+    "",
+    "Agent Native Content brings documents, data, connected sources, collaboration, and agent work into one durable place. People and agents work on the same real objects through the same permissions and operations. The result is a workspace that can begin as a Page, grow into a system, and remain understandable, portable, and recoverable as more people and automations become involved.",
+    "",
+    "## How to read this roadmap",
+    "",
+    "Content is grouped into six implementation Chapters. Numbered Features describe complete vertical workflows that people can understand and use. Atomic capabilities may arrive piece by piece, but a Feature is not complete until its example workflow works end to end.",
+    "",
+    "Feature statuses:",
+    "",
+    "- **Available:** The complete workflow works for people and agents with the correct permissions, persistence, recovery, accessibility, and polish.",
+    "- **In validation:** The complete workflow exists and is being hardened before becoming Available.",
+    "- **Partially implemented:** Meaningful parts exist, but the workflow is not yet reliable or proven end to end.",
+    "- **Planned:** The Feature is approved and ordered, but does not yet have enough implementation to describe as active.",
+    "- **Paused:** Work deliberately stopped while its research and implementation history remain preserved.",
+    "",
+    "No Feature is marked Available yet. Existing foundations are useful, but the complete workflows still need the polish and proof described below.",
+    "",
+  ];
+
+  for (const chapter of chapters) {
+    const order = numberField(chapter, "order");
+    lines.push(`## Chapter ${order}: ${stringField(chapter, "name")}`, "");
+    lines.push(stringField(chapter, "promise"), "");
+
+    const featureIds = stringArrayField(chapter, "features");
+    for (const featureId of featureIds) {
+      const feature = catalog.features.find(
+        (record) => record.id === featureId,
+      );
+      if (!feature) continue;
+      const number = numberField(feature, "number");
+      lines.push(`### Feature ${number}: ${stringField(feature, "name")}`, "");
+      lines.push(stringField(feature, "summary"), "");
+      lines.push(
+        `**Status:** ${displayRoadmapStatus(stringField(feature, "roadmap_status"))}`,
+        "",
+        `**Example workflow:** ${stringField(feature, "example_workflow")}`,
+        "",
+        `**What works today:** ${stringField(feature, "works_today")}`,
+        "",
+        `**What remains:** ${stringField(feature, "remains")}`,
+        "",
+      );
+
+      const productContract = extractSection(
+        feature.body,
+        "## Product contract",
+        "## Increment:",
+      );
+      lines.push("**What this Feature includes:**", "", productContract, "");
+
+      const required = stringArrayField(feature, "required_capabilities");
+      const enhancing = stringArrayField(feature, "enhancing_capabilities");
+      lines.push(
+        `**Required capability records:** ${renderCapabilityLinks(required, capabilityById)}`,
+        "",
+      );
+      if (enhancing.length > 0) {
+        lines.push(
+          `**Enhancing capability records:** ${renderCapabilityLinks(enhancing, capabilityById)}`,
+          "",
+        );
+      }
+
+      const increment = extractIncrement(feature.body);
+      if (increment) {
+        lines.push(
+          `### Increment to Feature ${number}: ${increment.name}`,
+          "",
+          increment.body,
+          "",
+        );
+      }
+    }
+  }
+
+  for (const feature of catalog.features) {
+    if (!chapterById.has(stringField(feature, "chapter"))) continue;
+  }
+
+  return `${lines.join("\n").trim()}\n`;
+}
+
+export function renderEncyclopedia(catalog: ProductCatalog) {
+  const capabilities = [...catalog.capabilities].sort((left, right) =>
+    left.id.localeCompare(right.id),
+  );
+  const stateCounts = new Map<string, number>();
+  for (const capability of capabilities) {
+    const state = stringField(capability, "state");
+    stateCounts.set(state, (stateCounts.get(state) ?? 0) + 1);
+  }
+
+  const lines = [
+    "# Agent Native Content capability encyclopedia",
+    "",
+    generatedNotice(),
+    "",
+    "This index summarizes the atomic product contracts beneath the public roadmap. Each linked record owns its promise, dependencies, state, proof boundary, and relationship to complete Features.",
+    "",
+    "## Catalog summary",
+    "",
+    `- Chapters: ${catalog.chapters.length}`,
+    `- Features: ${catalog.features.length}`,
+    `- Named increments: ${catalog.features.reduce((total, feature) => total + stringArrayField(feature, "increments").length, 0)}`,
+    `- Capabilities: ${capabilities.length}`,
+    "",
+    "| Capability state | Count |",
+    "| --- | ---: |",
+  ];
+
+  for (const state of capabilityStates) {
+    lines.push(
+      `| ${displayCapabilityState(state)} | ${stateCounts.get(state) ?? 0} |`,
+    );
+  }
+
+  lines.push(
+    "",
+    "## Dependency overview",
+    "",
+    renderFamilyGraph(capabilities),
+    "",
+  );
+
+  const families = new Map<string, ProductRecord[]>();
+  for (const capability of capabilities) {
+    const family = capability.id.split(".")[1] ?? "other";
+    const entries = families.get(family) ?? [];
+    entries.push(capability);
+    families.set(family, entries);
+  }
+
+  for (const [family, records] of [...families].sort(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    lines.push(`## ${displayCapabilityFamily(family)}`, "");
+    lines.push("| Capability | State | User promise |", "| --- | --- | --- |");
+    for (const capability of records) {
+      lines.push(
+        `| [${escapeTable(stringField(capability, "name"))}](capabilities/${capability.id}.md) | ${displayCapabilityState(stringField(capability, "state"))} | ${escapeTable(stringField(capability, "user_promise"))} |`,
+      );
+    }
+    lines.push("");
+  }
+
+  return `${lines.join("\n").trim()}\n`;
+}
+
+function loadCatalog(root: string, errors: string[]): ProductCatalog {
+  const records: ProductRecord[] = [];
+  for (const kind of ["chapter", "feature", "capability"] as const) {
+    const directory = join(
+      root,
+      kind === "capability" ? "capabilities" : `${kind}s`,
+    );
+    if (!existsSync(directory)) {
+      errors.push(
+        `${relative(repositoryRoot, directory)}: missing ${kind} directory`,
+      );
+      continue;
+    }
+    for (const filename of readdirSync(directory).filter((name) =>
+      name.endsWith(".md"),
+    )) {
+      const file = join(directory, filename);
+      try {
+        const parsed = parseRecord(file);
+        if (parsed.kind !== kind) {
+          errors.push(
+            `${displayPath(file)}: record_type must be ${kind}, found ${parsed.kind}`,
+          );
+        }
+        records.push(parsed);
+      } catch (error) {
+        errors.push(
+          `${displayPath(file)}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  }
+
+  return {
+    root,
+    chapters: records.filter((record) => record.kind === "chapter"),
+    features: records.filter((record) => record.kind === "feature"),
+    capabilities: records.filter((record) => record.kind === "capability"),
+    records,
+  };
+}
+
+function parseRecord(file: string): ProductRecord {
+  const source = readFileSync(file, "utf8");
+  const match = source.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);
+  if (!match) throw new Error("expected YAML frontmatter between --- markers");
+  const data = parseYaml(match[1]) as Record<string, unknown>;
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    throw new Error("frontmatter must be a mapping");
+  }
+  const kind = data.record_type;
+  if (kind !== "chapter" && kind !== "feature" && kind !== "capability") {
+    throw new Error(`record_type must be chapter, feature, or capability`);
+  }
+  if (typeof data.id !== "string") throw new Error("id must be a string");
+  return { file, body: match[2].trim(), data, kind, id: data.id };
+}
+
+function validateCatalog(
+  catalog: ProductCatalog,
+  errors: string[],
+  strictCatalog: boolean,
+) {
+  const recordsById = new Map<string, ProductRecord>();
+  for (const record of catalog.records) {
+    const expectedPattern =
+      record.kind === "chapter"
+        ? /^content\.chapter\.[a-z0-9-]+$/
+        : record.kind === "feature"
+          ? /^content\.feature\.[a-z0-9-]+$/
+          : /^content\.[a-z0-9]+(?:[.-][a-z0-9]+)+$/;
+    if (!expectedPattern.test(record.id)) {
+      errors.push(
+        `${displayPath(record.file)}: id has an invalid ${record.kind} format`,
+      );
+    }
+    if (recordsById.has(record.id)) {
+      errors.push(
+        `${displayPath(record.file)}: duplicate id ${record.id}; first declared in ${displayPath(recordsById.get(record.id)!.file)}`,
+      );
+    } else {
+      recordsById.set(record.id, record);
+    }
+    const expectedFilename = `${record.id}.md`;
+    if (!record.file.endsWith(`${sep}${expectedFilename}`)) {
+      errors.push(
+        `${displayPath(record.file)}: filename must be ${expectedFilename}`,
+      );
+    }
+    requireString(record, "name", errors);
+    requireEnum(record, "publicness", publicnessValues, errors);
+    requireDate(record, "last_reviewed", errors);
+    validateForbiddenFrontmatter(record, errors);
+  }
+
+  validateUniqueNumbers(catalog.chapters, "order", errors);
+  validateUniqueNumbers(catalog.features, "number", errors);
+  validateUniqueNumbers(catalog.features, "order", errors);
+
+  const chapterIds = new Set(catalog.chapters.map((record) => record.id));
+  const featureIds = new Set(catalog.features.map((record) => record.id));
+  const capabilityIds = new Set(
+    catalog.capabilities.map((record) => record.id),
+  );
+
+  for (const chapter of catalog.chapters) {
+    requireNumber(chapter, "order", errors);
+    requireString(chapter, "promise", errors);
+    const features = requireStringArray(chapter, "features", errors);
+    validateReferences(chapter, "features", features, featureIds, errors);
+  }
+
+  for (const feature of catalog.features) {
+    requireNumber(feature, "number", errors);
+    requireNumber(feature, "order", errors);
+    requireString(feature, "summary", errors);
+    requireString(feature, "example_workflow", errors);
+    requireString(feature, "works_today", errors);
+    requireString(feature, "remains", errors);
+    requireEnum(feature, "roadmap_status", roadmapStatuses, errors);
+    const chapter = requireString(feature, "chapter", errors);
+    if (chapter && !chapterIds.has(chapter)) {
+      errors.push(
+        `${displayPath(feature.file)}: chapter references unknown id ${chapter}`,
+      );
+    }
+    const required = requireStringArray(
+      feature,
+      "required_capabilities",
+      errors,
+    );
+    const enhancing = requireStringArray(
+      feature,
+      "enhancing_capabilities",
+      errors,
+    );
+    requireStringArray(feature, "increments", errors);
+    validateReferences(
+      feature,
+      "required_capabilities",
+      required,
+      capabilityIds,
+      errors,
+    );
+    validateReferences(
+      feature,
+      "enhancing_capabilities",
+      enhancing,
+      capabilityIds,
+      errors,
+    );
+    if (required.some((id) => enhancing.includes(id))) {
+      errors.push(
+        `${displayPath(feature.file)}: a capability cannot be both required and enhancing`,
+      );
+    }
+    if (feature.data.roadmap_status === "available") {
+      const incomplete = required.filter(
+        (id) => recordsById.get(id)?.data.state !== "verified",
+      );
+      if (incomplete.length > 0) {
+        errors.push(
+          `${displayPath(feature.file)}: available Feature has unverified required capabilities: ${incomplete.join(", ")}`,
+        );
+      }
+      if (
+        typeof feature.data.feature_proof !== "string" ||
+        !feature.data.feature_proof.trim()
+      ) {
+        errors.push(
+          `${displayPath(feature.file)}: available Feature requires a non-empty feature_proof receipt`,
+        );
+      }
+    }
+  }
+
+  const dependencyGraph = new Map<string, string[]>();
+  for (const capability of catalog.capabilities) {
+    requireString(capability, "user_promise", errors);
+    requireString(capability, "acceptance_summary", errors);
+    requireEnum(capability, "kind", capabilityKinds, errors);
+    requireEnum(capability, "state", capabilityStates, errors);
+    requireEnum(capability, "availability", availabilityValues, errors);
+    requireEnum(capability, "roadmap_boundary", roadmapBoundaries, errors);
+    const dependencies = requireStringArray(capability, "dependencies", errors);
+    const relatedFeatures = requireStringArray(
+      capability,
+      "related_features",
+      errors,
+    );
+    requireStringArray(capability, "proof_requirements", errors);
+    requireStringArray(capability, "evidence", errors);
+    validateReferences(
+      capability,
+      "dependencies",
+      dependencies,
+      capabilityIds,
+      errors,
+    );
+    validateReferences(
+      capability,
+      "related_features",
+      relatedFeatures,
+      featureIds,
+      errors,
+    );
+    dependencyGraph.set(capability.id, dependencies);
+    if (dependencies.includes(capability.id)) {
+      errors.push(
+        `${displayPath(capability.file)}: dependencies cannot include itself`,
+      );
+    }
+    if (
+      relatedFeatures.length === 0 &&
+      !["supporting", "deferred", "superseded"].includes(
+        String(capability.data.roadmap_boundary),
+      )
+    ) {
+      errors.push(
+        `${displayPath(capability.file)}: orphaned capability must declare a supporting, deferred, or superseded roadmap_boundary`,
+      );
+    }
+    if (capability.data.state === "verified") {
+      const evidence = stringArrayField(capability, "evidence");
+      if (evidence.length === 0) {
+        errors.push(
+          `${displayPath(capability.file)}: verified capability requires evidence`,
+        );
+      }
+    }
+    if (capability.data.state === "superseded") {
+      const target = requireString(capability, "superseded_by", errors);
+      if (target && !capabilityIds.has(target)) {
+        errors.push(
+          `${displayPath(capability.file)}: superseded_by references unknown id ${target}`,
+        );
+      }
+    } else if (capability.data.superseded_by !== null) {
+      errors.push(
+        `${displayPath(capability.file)}: superseded_by must be null unless state is superseded`,
+      );
+    }
+  }
+
+  validateDependencyCycles(dependencyGraph, recordsById, errors);
+
+  for (const chapter of catalog.chapters) {
+    for (const featureId of stringArrayField(chapter, "features")) {
+      const feature = recordsById.get(featureId);
+      if (feature && feature.data.chapter !== chapter.id) {
+        errors.push(
+          `${displayPath(chapter.file)}: Feature ${featureId} points back to ${String(feature.data.chapter)} instead of ${chapter.id}`,
+        );
+      }
+    }
+  }
+
+  for (const feature of catalog.features) {
+    for (const capabilityId of [
+      ...stringArrayField(feature, "required_capabilities"),
+      ...stringArrayField(feature, "enhancing_capabilities"),
+    ]) {
+      const capability = recordsById.get(capabilityId);
+      if (
+        capability &&
+        !stringArrayField(capability, "related_features").includes(feature.id)
+      ) {
+        errors.push(
+          `${displayPath(capability.file)}: related_features must include ${feature.id} because the Feature references this capability`,
+        );
+      }
+    }
+  }
+
+  if (strictCatalog) {
+    if (catalog.chapters.length !== 6) {
+      errors.push(
+        `catalog: expected 6 Chapters, found ${catalog.chapters.length}`,
+      );
+    }
+    if (catalog.features.length !== 32) {
+      errors.push(
+        `catalog: expected 32 Features, found ${catalog.features.length}`,
+      );
+    }
+    const incrementCount = catalog.features.reduce(
+      (total, feature) =>
+        total + stringArrayField(feature, "increments").length,
+      0,
+    );
+    if (incrementCount !== 1) {
+      errors.push(
+        `catalog: expected 1 named increment, found ${incrementCount}`,
+      );
+    }
+  }
+}
+
+function validateLinksAndPrivacy(catalog: ProductCatalog, errors: string[]) {
+  const files = collectMarkdownFiles(catalog.root);
+  const skillRoot = join(
+    repositoryRoot,
+    "templates/content/.agents/skills/content-product-development",
+  );
+  if (existsSync(skillRoot)) files.push(...collectMarkdownFiles(skillRoot));
+
+  for (const file of files) {
+    const source = readFileSync(file, "utf8");
+    const privacyFindings: Array<[RegExp, string]> = [
+      [
+        /(?:^|[\s('"`])\/(?:Users|home|private|Volumes)\//m,
+        "absolute filesystem path",
+      ],
+      [/\b[A-Za-z]:\\(?:Users|Documents|Desktop)\\/i, "absolute Windows path"],
+      [/\bfile:\/\//i, "file URL"],
+      [/\[\[[^\]]+\]\]/, "vault-style wikilink"],
+      [/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i, "email address"],
+      [
+        /\b(?:sk|ghp|gho|xoxb|xoxp|xoxa|xoxr)_[A-Za-z0-9_-]{12,}\b/,
+        "credential-shaped value",
+      ],
+      [
+        /https?:\/\/(?:www\.)?notion\.so\/[a-z0-9-]+\/[a-f0-9]{20,}/i,
+        "private Notion-shaped URL",
+      ],
+      [
+        /https?:\/\/[^\s)]+\.slack\.com\/archives\//i,
+        "private Slack-shaped URL",
+      ],
+      [
+        /https?:\/\/clips\.agent-native\.com\/share\//i,
+        "private Clips share URL",
+      ],
+    ];
+    for (const [pattern, label] of privacyFindings) {
+      const match = source.match(pattern);
+      if (match) {
+        errors.push(
+          `${displayPath(file)}:${lineNumber(source, match.index ?? 0)}: remove ${label}`,
+        );
+      }
+    }
+
+    for (const match of source.matchAll(/\[[^\]]*\]\(([^)]+)\)/g)) {
+      const target = match[1].trim();
+      if (
+        !target ||
+        target.startsWith("#") ||
+        /^(?:https?:|mailto:)/i.test(target)
+      ) {
+        continue;
+      }
+      const withoutAnchor = target.split("#")[0];
+      const resolved = resolve(dirname(file), withoutAnchor);
+      if (!isInside(repositoryRoot, resolved)) {
+        errors.push(
+          `${displayPath(file)}:${lineNumber(source, match.index ?? 0)}: link escapes the repository: ${target}`,
+        );
+      } else if (!existsSync(resolved)) {
+        errors.push(
+          `${displayPath(file)}:${lineNumber(source, match.index ?? 0)}: broken relative link: ${target}`,
+        );
+      }
+    }
+  }
+}
+
+function validateForbiddenFrontmatter(record: ProductRecord, errors: string[]) {
+  const forbidden = [
+    "type",
+    "context",
+    "authored-by",
+    "brief-kind",
+    "decision-stage",
+    "related-briefs",
+    "related-drafts",
+    "related-objectives",
+  ];
+  for (const key of forbidden) {
+    if (key in record.data) {
+      errors.push(
+        `${displayPath(record.file)}: remove vault-only frontmatter field ${key}`,
+      );
+    }
+  }
+}
+
+function validateUniqueNumbers(
+  records: ProductRecord[],
+  field: string,
+  errors: string[],
+) {
+  const seen = new Map<number, ProductRecord>();
+  for (const record of records) {
+    const value = record.data[field];
+    if (typeof value !== "number") continue;
+    const previous = seen.get(value);
+    if (previous) {
+      errors.push(
+        `${displayPath(record.file)}: ${field} ${value} collides with ${displayPath(previous.file)}`,
+      );
+    } else {
+      seen.set(value, record);
+    }
+  }
+}
+
+function validateReferences(
+  record: ProductRecord,
+  field: string,
+  values: string[],
+  known: Set<string>,
+  errors: string[],
+) {
+  for (const value of values) {
+    if (!known.has(value)) {
+      errors.push(
+        `${displayPath(record.file)}: ${field} references unknown id ${value}`,
+      );
+    }
+  }
+}
+
+function validateDependencyCycles(
+  graph: Map<string, string[]>,
+  recordsById: Map<string, ProductRecord>,
+  errors: string[],
+) {
+  const visited = new Set<string>();
+  const active = new Set<string>();
+  const path: string[] = [];
+
+  const visit = (id: string) => {
+    if (active.has(id)) {
+      const cycleStart = path.indexOf(id);
+      const cycle = [...path.slice(cycleStart), id];
+      errors.push(
+        `${displayPath(recordsById.get(id)?.file ?? id)}: dependency cycle: ${cycle.join(" -> ")}`,
+      );
+      return;
+    }
+    if (visited.has(id)) return;
+    visited.add(id);
+    active.add(id);
+    path.push(id);
+    for (const dependency of graph.get(id) ?? []) visit(dependency);
+    path.pop();
+    active.delete(id);
+  };
+
+  for (const id of graph.keys()) visit(id);
+}
+
+function compareProjection(file: string, expected: string, errors: string[]) {
+  if (!existsSync(file)) {
+    errors.push(
+      `${displayPath(file)}: missing generated projection; run pnpm guard:content-product-docs --write`,
+    );
+    return;
+  }
+  const actual = readFileSync(file, "utf8");
+  if (actual !== expected) {
+    errors.push(
+      `${displayPath(file)}: stale generated projection; run pnpm guard:content-product-docs --write`,
+    );
+  }
+}
+
+function collectMarkdownFiles(root: string) {
+  if (!existsSync(root)) return [];
+  const files: string[] = [];
+  const walk = (directory: string) => {
+    for (const name of readdirSync(directory)) {
+      const file = join(directory, name);
+      if (statSync(file).isDirectory()) walk(file);
+      else if (name.endsWith(".md")) files.push(file);
+    }
+  };
+  walk(root);
+  return files;
+}
+
+function requireString(record: ProductRecord, field: string, errors: string[]) {
+  const value = record.data[field];
+  if (typeof value !== "string" || !value.trim()) {
+    errors.push(
+      `${displayPath(record.file)}: ${field} must be a non-empty string`,
+    );
+    return "";
+  }
+  return value;
+}
+
+function requireNumber(record: ProductRecord, field: string, errors: string[]) {
+  const value = record.data[field];
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    errors.push(`${displayPath(record.file)}: ${field} must be a number`);
+    return 0;
+  }
+  return value;
+}
+
+function requireStringArray(
+  record: ProductRecord,
+  field: string,
+  errors: string[],
+) {
+  const value = record.data[field];
+  if (
+    !Array.isArray(value) ||
+    value.some((entry) => typeof entry !== "string")
+  ) {
+    errors.push(
+      `${displayPath(record.file)}: ${field} must be an array of strings`,
+    );
+    return [];
+  }
+  if (new Set(value).size !== value.length) {
+    errors.push(
+      `${displayPath(record.file)}: ${field} contains duplicate values`,
+    );
+  }
+  return value as string[];
+}
+
+function requireEnum(
+  record: ProductRecord,
+  field: string,
+  allowed: Set<string>,
+  errors: string[],
+) {
+  const value = requireString(record, field, errors);
+  if (value && !allowed.has(value)) {
+    errors.push(
+      `${displayPath(record.file)}: ${field} must be one of ${[...allowed].join(", ")}; found ${value}`,
+    );
+  }
+}
+
+function requireDate(record: ProductRecord, field: string, errors: string[]) {
+  const value = requireString(record, field, errors);
+  if (value && !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    errors.push(`${displayPath(record.file)}: ${field} must use YYYY-MM-DD`);
+  }
+}
+
+function stringField(record: ProductRecord, field: string) {
+  return typeof record.data[field] === "string"
+    ? (record.data[field] as string)
+    : "";
+}
+
+function numberField(record: ProductRecord, field: string) {
+  return typeof record.data[field] === "number"
+    ? (record.data[field] as number)
+    : 0;
+}
+
+function stringArrayField(record: ProductRecord, field: string) {
+  const value = record.data[field];
+  return Array.isArray(value) &&
+    value.every((entry) => typeof entry === "string")
+    ? (value as string[])
+    : [];
+}
+
+function extractSection(body: string, heading: string, endHeading: string) {
+  const start = body.indexOf(heading);
+  if (start < 0) return "";
+  const contentStart = start + heading.length;
+  const end = body.indexOf(endHeading, contentStart);
+  return body.slice(contentStart, end < 0 ? body.length : end).trim();
+}
+
+function extractIncrement(body: string) {
+  const match = body.match(/^## Increment: (.+)$/m);
+  if (!match || match.index === undefined) return null;
+  return {
+    name: match[1].trim(),
+    body: body.slice(match.index + match[0].length).trim(),
+  };
+}
+
+function renderCapabilityLinks(
+  ids: string[],
+  capabilityById: Map<string, ProductRecord>,
+) {
+  return ids
+    .map((id) => {
+      const record = capabilityById.get(id);
+      return `[${record ? stringField(record, "name") : id}](capabilities/${id}.md)`;
+    })
+    .join(", ");
+}
+
+function renderFamilyGraph(capabilities: ProductRecord[]) {
+  const edges = new Set<string>();
+  const labels = new Map<string, string>();
+  for (const capability of capabilities) {
+    const source = capability.id.split(".")[1] ?? "other";
+    labels.set(source, titleCase(source));
+    for (const dependency of stringArrayField(capability, "dependencies")) {
+      const target = dependency.split(".")[1] ?? "other";
+      labels.set(target, titleCase(target));
+      if (source !== target) edges.add(`${target}-->${source}`);
+    }
+  }
+  const lines = ["```mermaid", "graph LR"];
+  for (const [id, label] of [...labels].sort(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    lines.push(`  ${mermaidId(id)}[\"${label}\"]`);
+  }
+  for (const edge of [...edges].sort()) {
+    const [source, target] = edge.split("-->");
+    lines.push(`  ${mermaidId(source)} --> ${mermaidId(target)}`);
+  }
+  lines.push("```");
+  return lines.join("\n");
+}
+
+function mermaidId(value: string) {
+  return `family_${value.replace(/[^a-z0-9]/gi, "_")}`;
+}
+
+function displayRoadmapStatus(value: string) {
+  const labels: Record<string, string> = {
+    available: "Available",
+    in_validation: "In validation",
+    partially_implemented: "Partially implemented",
+    paused: "Paused",
+    planned: "Planned",
+  };
+  return labels[value] ?? titleCase(value.replace(/_/g, " "));
+}
+
+function displayCapabilityState(value: string) {
+  return titleCase(value.replace(/_/g, " "));
+}
+
+function displayCapabilityFamily(value: string) {
+  const labels: Record<string, string> = {
+    api: "API",
+  };
+  return labels[value] ?? titleCase(value);
+}
+
+function titleCase(value: string) {
+  return value.replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function escapeTable(value: string) {
+  return value.replace(/\|/g, "\\|").replace(/\s+/g, " ").trim();
+}
+
+function generatedNotice() {
+  return "<!-- Generated from the atomic records in chapters/, features/, and capabilities/. Do not edit this projection directly. -->";
+}
+
+function displayPath(file: string) {
+  return isInside(repositoryRoot, file) ? relative(repositoryRoot, file) : file;
+}
+
+function isInside(parent: string, child: string) {
+  const rel = relative(parent, child);
+  return rel === "" || (!rel.startsWith("..") && !rel.startsWith(sep));
+}
+
+function lineNumber(source: string, index: number) {
+  return source.slice(0, index).split("\n").length;
+}
+
+function formatErrors(errors: string[]) {
+  return `[content-product-docs] ${errors.length} error(s):\n${errors.map((error) => `- ${error}`).join("\n")}`;
+}
+
+function parseArgs(args: string[]) {
+  let root = defaultProductRoot;
+  let write = false;
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--write") {
+      write = true;
+      continue;
+    }
+    if (argument === "--root") {
+      const value = args[index + 1];
+      if (!value) throw new Error("--root requires a path");
+      root = resolve(value);
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${argument}`);
+  }
+  return { root, write };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.write) writeContentProductProjections(args.root);
+  const result = validateContentProductDocs(args.root);
+  if (result.errors.length > 0) {
+    console.error(formatErrors(result.errors));
+    process.exitCode = 1;
+    return;
+  }
+  console.log(
+    `[content-product-docs] Validated ${result.catalog.chapters.length} Chapters, ${result.catalog.features.length} Features, and ${result.catalog.capabilities.length} Capabilities`,
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  await main();
+}

--- a/templates/content/.agents/skills/content-product-development/SKILL.md
+++ b/templates/content/.agents/skills/content-product-development/SKILL.md
@@ -33,15 +33,19 @@ The repository source of truth lives in `templates/content/docs/product/`.
    rg -n "<workflow or Feature>" templates/content/docs/product/features
    ```
 
-3. Read the Feature's required and enhancing Capability records by stable ID.
+3. Read the Feature's required and enhancing Capability records by stable ID,
+   including each record's workflow, contract, boundaries, acceptance stories,
+   current evidence, proof plan, and open questions. The encyclopedia row is an
+   index, not enough implementation context.
 4. Inspect the current implementation, tests, feature flags, and provider state.
 
 Load only the relevant records. Do not paste the encyclopedia into the context
 and hope the important sentence floats to the top.
 
-If a required record is missing, name the missing ID. A narrow bug fix may still
-proceed when tests and existing behavior make the contract unambiguous; record
-the context gap in the handoff.
+If a required record is missing or still contains only the legacy generated
+shell, name the missing or incomplete ID. Do not manufacture edge behavior from
+its one-line summary. A narrow bug fix may still proceed when tests and existing
+behavior make the contract unambiguous; record the context gap in the handoff.
 
 ## Classify the change
 

--- a/templates/content/.agents/skills/content-product-development/SKILL.md
+++ b/templates/content/.agents/skills/content-product-development/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: content-product-development
+description: >-
+  Product contracts and proof boundaries for Agent Native Content. Use when
+  planning, implementing, reviewing, testing, or documenting Content behavior
+  or shared framework behavior that changes Content.
+scope: dev
+metadata:
+  internal: true
+---
+
+# Develop Agent Native Content
+
+## Rule
+
+Before changing Content, identify the user workflow, Feature, and atomic
+Capabilities the work touches. Implement through Content's shared primitives,
+then prove the affected workflow before claiming a Capability or Feature is
+complete.
+
+The roadmap is direction, not a substitute for current code. Current code is
+evidence, not permission to invent a conflicting product contract.
+
+## Retrieve the right context
+
+The repository source of truth lives in `templates/content/docs/product/`.
+
+1. Read [architecture.md](../../../docs/product/architecture.md).
+2. Find the workflow in [roadmap.md](../../../docs/product/roadmap.md), or search
+   the Feature records:
+
+   ```sh
+   rg -n "<workflow or Feature>" templates/content/docs/product/features
+   ```
+
+3. Read the Feature's required and enhancing Capability records by stable ID.
+4. Inspect the current implementation, tests, feature flags, and provider state.
+
+Load only the relevant records. Do not paste the encyclopedia into the context
+and hope the important sentence floats to the top.
+
+If a required record is missing, name the missing ID. A narrow bug fix may still
+proceed when tests and existing behavior make the contract unambiguous; record
+the context gap in the handoff.
+
+## Classify the change
+
+| Lane | Meaning | Response |
+| --- | --- | --- |
+| Contract repair | Existing behavior violates an accepted contract | Fix the smallest coherent path and prove the regression |
+| Contract fulfillment | Work implements or hardens an incomplete Capability | Follow its dependencies and proof requirements |
+| Local refinement | Reversible polish that does not change the promise | Implement without manufacturing a strategy meeting |
+| Product decision candidate | Work changes identity, access, source truth, a shared primitive, or the user promise | Preserve the user problem and tradeoff for review before making it architecture |
+
+The catalog welcomes new ideas. It prevents accidental decisions; it does not
+require a permission slip for every useful bug fix.
+
+## Preserve the architecture
+
+- Stable objects may have many Views, memberships, embeds, and source mappings.
+- People, agents, automations, APIs, and UI use one typed Action surface.
+- Access applies before search, traversal, Queries, aggregates, exports, or AI.
+- Sources declare truth and write-back policy; unknown provider data survives.
+- Meaningful change preserves actor, origin, history, recovery, and review.
+- Content remains portable and does not demand custody of connected originals.
+- Donor code and completed dependencies do not prove a whole contract.
+
+Load the domain skill for the work, especially `actions`, `security`, `sharing`,
+`storing-data`, `portability`, `real-time-collab`, or `real-time-sync`.
+
+## Prove and record the result
+
+Use the affected Capability's proof requirements and the Feature's example
+workflow. Read [references/verification.md](references/verification.md) for the
+cross-surface matrix.
+
+A Capability becomes `verified` only when its complete atomic contract passes.
+A Feature becomes `available` only when every required Capability is verified
+and its complete example workflow passes end to end. Useful machinery remains
+substrate until then.
+
+Update atomic records when work changes a contract, dependency, state, non-goal,
+proof boundary, or accepted Feature workflow. Regenerate projections and run:
+
+```sh
+pnpm guard:content-product-docs --write
+pnpm guard:content-product-docs
+```
+
+## Handoff
+
+```text
+Product context: <Feature and Capability IDs>
+Workflow: <what now works>
+Proof: <tests and real-interface evidence>
+Remaining gaps: <failures or missing evidence>
+Product decisions: <none or accepted/candidate decision>
+Record updates: <files changed or still needed>
+```

--- a/templates/content/.agents/skills/content-product-development/references/verification.md
+++ b/templates/content/.agents/skills/content-product-development/references/verification.md
@@ -8,18 +8,18 @@ actually usable.
 
 Verify the applicable rows:
 
-| Surface | Proof question |
-| --- | --- |
-| UI | Can a person complete the Feature's example workflow through the real interface? |
-| Actions | Can an agent perform the same authorized operations without a second mutation path? |
-| Application state | Does the agent receive the focused object, View, selection, and temporary filters the person sees? |
-| Access | Do reads, writes, direct links, derived results, public output, and embeds preserve authority? |
-| Persistence | Does the result survive reload, retry, interruption, and process boundaries appropriate to the Capability? |
-| History | Does the record name the actual human, agent, automation, or integration actor and remain recoverable? |
-| Sources | Does identity survive refresh and write-back without dropping unknown provider data? |
-| Portability | Does import, export, or static rendering preserve the accepted meaning or report explicit degradation? |
-| Accessibility | Do keyboard and assistive-technology paths support the primary workflow? |
-| Performance | Does the workflow stay inside its declared scale, time, memory, and output limits? |
+| Surface           | Proof question                                                                                             |
+| ----------------- | ---------------------------------------------------------------------------------------------------------- |
+| UI                | Can a person complete the Feature's example workflow through the real interface?                           |
+| Actions           | Can an agent perform the same authorized operations without a second mutation path?                        |
+| Application state | Does the agent receive the focused object, View, selection, and temporary filters the person sees?         |
+| Access            | Do reads, writes, direct links, derived results, public output, and embeds preserve authority?             |
+| Persistence       | Does the result survive reload, retry, interruption, and process boundaries appropriate to the Capability? |
+| History           | Does the record name the actual human, agent, automation, or integration actor and remain recoverable?     |
+| Sources           | Does identity survive refresh and write-back without dropping unknown provider data?                       |
+| Portability       | Does import, export, or static rendering preserve the accepted meaning or report explicit degradation?     |
+| Accessibility     | Do keyboard and assistive-technology paths support the primary workflow?                                   |
+| Performance       | Does the workflow stay inside its declared scale, time, memory, and output limits?                         |
 
 ## Status evidence
 

--- a/templates/content/.agents/skills/content-product-development/references/verification.md
+++ b/templates/content/.agents/skills/content-product-development/references/verification.md
@@ -1,0 +1,57 @@
+# Content product verification
+
+Choose proof in proportion to the affected contract. Deterministic tests prove
+data and Action semantics; real-interface testing proves that the workflow is
+actually usable.
+
+## Cross-surface matrix
+
+Verify the applicable rows:
+
+| Surface | Proof question |
+| --- | --- |
+| UI | Can a person complete the Feature's example workflow through the real interface? |
+| Actions | Can an agent perform the same authorized operations without a second mutation path? |
+| Application state | Does the agent receive the focused object, View, selection, and temporary filters the person sees? |
+| Access | Do reads, writes, direct links, derived results, public output, and embeds preserve authority? |
+| Persistence | Does the result survive reload, retry, interruption, and process boundaries appropriate to the Capability? |
+| History | Does the record name the actual human, agent, automation, or integration actor and remain recoverable? |
+| Sources | Does identity survive refresh and write-back without dropping unknown provider data? |
+| Portability | Does import, export, or static rendering preserve the accepted meaning or report explicit degradation? |
+| Accessibility | Do keyboard and assistive-technology paths support the primary workflow? |
+| Performance | Does the workflow stay inside its declared scale, time, memory, and output limits? |
+
+## Status evidence
+
+- `verified`: current proof covers the complete atomic contract.
+- `failing`: current behavior contradicts the promise.
+- `stale`: prior proof exists but no longer matches the implementation or
+  environment.
+- `in_progress`: implementation is actively being built or hardened.
+- `approved_shape`: the contract is accepted but lacks implementation or proof.
+- `exploring`: a material boundary remains unresolved.
+- `deferred`: the contract is intentionally sequenced later.
+- `superseded`: another record owns future work; follow `superseded_by`.
+
+Never promote a generic Capability because one provider-specific donor works.
+Never promote a Feature because several dependencies landed. The final proof is
+the actual car, not a tasteful arrangement of engine parts on the garage floor.
+
+## Updating the catalog
+
+Change the atomic record first. Keep dependencies complete even when they are
+already verified. Add public-safe evidence only: repository paths, tests, or
+public documentation that proves the claim without private transcripts or
+workspace links.
+
+After editing records:
+
+```sh
+pnpm test:content-product-docs
+pnpm guard:content-product-docs --write
+pnpm guard:content-product-docs
+```
+
+Inspect the generated roadmap and encyclopedia diff. A regenerated projection
+is not an editorial review; make sure the underlying record still says what a
+new contributor needs to know.

--- a/templates/content/AGENTS.md
+++ b/templates/content/AGENTS.md
@@ -8,6 +8,8 @@ actions and application state.
 
 Read the relevant skill before deeper work:
 
+- `content-product-development` — accepted product contracts, roadmap context,
+  dependency records, and proof boundaries for any Content change.
 - `content` — Markdown/MDX authoring, local folder sources, databases, intake
   forms, and Slack/A2A artifact replies.
 - `document-editing` — document and comment actions, screen context and IDs,

--- a/templates/content/docs/product/README.md
+++ b/templates/content/docs/product/README.md
@@ -1,0 +1,86 @@
+# Content product knowledge
+
+This folder is the repository source of truth for Agent Native Content's accepted
+product direction. It gives contributors and coding agents enough context to
+change Content without relying on private conversations or a particular
+person's computer.
+
+Start with:
+
+- [Architecture](architecture.md) for the product invariants.
+- [Roadmap](roadmap.md) for the six public Chapters and their complete user
+  workflows.
+- [Capability encyclopedia](encyclopedia.md) for the atomic contracts and
+  dependency graph beneath those workflows.
+
+The roadmap and encyclopedia are deterministic projections. Edit the atomic
+records in `chapters/`, `features/`, and `capabilities/`, then run:
+
+```sh
+pnpm guard:content-product-docs --write
+pnpm guard:content-product-docs
+```
+
+## The record hierarchy
+
+| Record | Meaning |
+| --- | --- |
+| Chapter | A large public promise and ordering boundary. |
+| Feature | A complete workflow an audience can understand and use. |
+| Capability | One reusable primitive, surface, or workflow with its own proof gate. |
+| Increment | A named deepening of one Feature, stored with that Feature. |
+
+A Feature can require several Capabilities, and one Capability can enable
+several Features. Completion therefore forms a graph rather than a ceremonial
+checklist. Dependencies describe the complete logical contract even when the
+dependency already exists.
+
+## Truthful status
+
+Roadmap status describes a whole Feature:
+
+- `available`: the complete example workflow has current end-to-end proof.
+- `in_validation`: the workflow exists and is being hardened.
+- `partially_implemented`: useful pieces exist, but the workflow is incomplete.
+- `planned`: the shape is approved and ordered.
+- `paused`: work deliberately stopped while its context remains preserved.
+
+Capability state describes one atomic contract:
+
+- `verified`, `failing`, `stale`, `in_progress`, `approved_shape`, `exploring`,
+  `deferred`, or `superseded`.
+
+Donor code and finished dependencies do not make a Feature complete. A Feature
+becomes `available` only when every required Capability is verified and the
+Feature's own example workflow passes end to end.
+
+## Normalization ledger
+
+The original research used a few provisional or partial names. This repository
+normalizes them deliberately:
+
+- The incomplete `content.diff` token and the provisional
+  `content.diff.in-place-review` name resolve to `content.diff.in-place`.
+- The provisional `content.query.typed` name resolves to
+  `content.query.object` for the durable object and `content.view.source-query`
+  for cross-source composition.
+- Presets collapsed into Templates. `content.preset.catalog` remains only as a
+  superseded lineage record.
+- Separate PDF and EPUB product identity collapsed into the shared Reader.
+  `content.reader.documents` points to `content.reader.surface`.
+- Local mode collapsed into governed Sources. `content.source.local-project`
+  points to `content.source.adapters`.
+- The materialized multi-source row-union interface is donor machinery rather
+  than the future product model. `content.source.row-union` points to
+  `content.view.source-query`.
+
+## Change policy
+
+Repairing a bug against an accepted record does not require a new product
+debate. A change to identity, permissions, source truth, shared primitives, or
+the user promise does. Preserve the concrete problem and tradeoff in the pull
+request, then update these records when the decision is accepted.
+
+The catalog is a compass, not a velvet rope. Good small fixes and new ideas are
+welcome; they simply should not arrive disguised as architecture that everyone
+already agreed to.

--- a/templates/content/docs/product/README.md
+++ b/templates/content/docs/product/README.md
@@ -23,17 +23,46 @@ pnpm guard:content-product-docs
 
 ## The record hierarchy
 
-| Record | Meaning |
-| --- | --- |
-| Chapter | A large public promise and ordering boundary. |
-| Feature | A complete workflow an audience can understand and use. |
+| Record     | Meaning                                                               |
+| ---------- | --------------------------------------------------------------------- |
+| Chapter    | A large public promise and ordering boundary.                         |
+| Feature    | A complete workflow an audience can understand and use.               |
 | Capability | One reusable primitive, surface, or workflow with its own proof gate. |
-| Increment | A named deepening of one Feature, stored with that Feature. |
+| Increment  | A named deepening of one Feature, stored with that Feature.           |
 
 A Feature can require several Capabilities, and one Capability can enable
 several Features. Completion therefore forms a graph rather than a ceremonial
 checklist. Dependencies describe the complete logical contract even when the
 dependency already exists.
+
+## Capability mini-specs
+
+A Capability record must stand on its own. Frontmatter makes the graph
+queryable; the body teaches a source-blind contributor what the contract
+actually means. Version 2 records include:
+
+- **Why this exists:** the human problem, not an architectural noun.
+- **Example workflow:** one concrete end-to-end use case.
+- **Product contract:** settled interactions, identities, authority, failure,
+  deletion, retry, concurrency, or degraded-state behavior that matters for
+  this Capability.
+- **Boundaries and non-goals:** which adjacent Capability owns neighboring
+  concerns and which tempting parallel systems must not be created.
+- **Acceptance stories:** at least two independently named Given/when/then
+  scenarios a developer can execute.
+- **Current evidence:** what the repository actually proves today, what is only
+  reusable donor machinery, and what is missing.
+- **Proof plan:** the deterministic and real-interface evidence required to
+  change the state.
+- **Open questions:** only decisions that are genuinely unresolved. A settled
+  decision omitted by an old summary is not an open question.
+
+Use `primary_user_job` to make the record discoverable by intent. Use several
+concrete `proof_requirements`, not one comma-heavy sentence pretending to be a
+test plan. A mini-spec may add relevant sections, but it must not omit the core
+ones above. These records preserve public product conclusions; private
+conversations, review mechanics, names, local paths, and source links stay out
+of the repository.
 
 ## Truthful status
 

--- a/templates/content/docs/product/architecture.md
+++ b/templates/content/docs/product/architecture.md
@@ -1,0 +1,98 @@
+# Agent Native Content architecture
+
+Agent Native Content is one composable system in which documents, structured
+records, connected data, human collaboration, and agent work share stable
+objects and one Action surface. A person chooses the surface that fits the
+moment: a Page for writing, a Database for governed records, a View for a
+particular presentation, a Query for derived collections, a Reference for
+reuse, an Expression for computation, or a Template for distributing a whole
+working system.
+
+```text
+Stable Pages, Blocks, Blocks fields, Databases, and References
+                              ↓
+              Typed Properties and one expression language
+                              ↓
+                  Queries, Views, and reusable renderers
+                              ↓
+                    Committed Events and typed Actions
+                              ↓
+             History, review, Rules, notifications, and agents
+                              ↓
+                 Templates compose and govern the same graph
+```
+
+Everything uses one Content object graph and one access model. Tasks,
+dashboards, public roadmaps, research systems, blogs, and editorial workflows
+are configurations of these primitives, not parallel engines.
+
+## Product principles
+
+1. **One object, many projections.** Views, memberships, References, embeds,
+   Sources, Graphs, and Canvases do not create accidental copies.
+2. **Simple gestures, composable machinery.** An `@` mention remains a
+   Reference; computation and automation appear only when requested.
+3. **Typed underneath, humane on top.** Values retain stable meaning while
+   renderers change how they look.
+4. **One Action surface.** People, agents, automations, APIs, and the interface
+   use the same permissions, validation, audit behavior, and mutation semantics.
+5. **Access before computation.** Search, Queries, relationships, aggregates,
+   exports, agents, and embedded hosts see only authorized information.
+6. **Source truth is explicit.** Every connected Source declares how reads,
+   synchronization, and write-back behave. Unknown provider data survives
+   faithful round-tripping.
+7. **Events describe committed meaning.** They record actors, origins,
+   causality, and recoverable change rather than every keypress.
+8. **Changes remain reviewable work.** Suggestions, typed diffs, Versions,
+   automation receipts, and History persist instead of evaporating with a
+   dialog.
+9. **Templates fork; they do not possess.** Instances are owned, editable
+   snapshots with provenance and optional reviewed updates.
+10. **Import and export are constitutional.** Collaborative Content may use SQL
+    as its working truth, but people can bring work in, take it out, and keep
+    connected originals where they belong.
+11. **Product status stays honest.** Donor code, dependencies, and isolated
+    tests never prove a whole Capability or Feature by association.
+
+## Object boundaries
+
+- A **Page** owns stable identity, title, access, top-level Properties, and one
+  or more Blocks fields.
+- A **Blocks field** owns one editable rich-content body and its attributable
+  revision history. Comments and Discussion messages use the same grammar
+  without becoming full Pages.
+- A **Database** owns membership, schema, defaults, validation, Rules, and the
+  canonical creation route for its records.
+- A **Query** derives a typed collection from Databases, Sources, or other
+  Queries without owning the source records.
+- A **View** belongs to one Database or Query and owns downstream filtering and
+  presentation. It may be shared or Only me, but it never grants access to its
+  input.
+- A **Relationship** is one canonical typed edge. Relation Properties, inline
+  references, Info, Queries, Graph, and Canvas are projections and editors of
+  that edge.
+- A **Source** is an adapter with explicit capabilities, provenance, access,
+  and synchronization policy. It never becomes a Page's identity or primary
+  Database.
+
+## Change and proof boundaries
+
+Every atomic Capability has its own proof requirements. A Feature is complete
+only when its required Capabilities are verified and its example workflow works
+end to end through the real interface and Actions. Existing provider-specific
+machinery may donate implementation, but it does not promote a generic contract
+until that contract is tested on its own terms.
+
+Named Page Versions sit above ordinary Blocks-field revision history. Revision
+history supports attribution, comparison, and recovery everywhere. Named
+Versions later provide deliberate alternatives, selective merge, access
+restriction, and canonical promotion under one Page identity.
+
+## Governance boundary
+
+Content provides flexible local objects and governed reusable catalogs.
+Organizations can approve Sources, Templates, Custom Properties, Expressions,
+Skills, and Custom Blocks without turning every ordinary object into a global
+type. Non-bypassable security and identity policy remains framework-wide;
+Content can be its best management surface without becoming an independent
+authority with conflicting answers.

--- a/templates/content/docs/product/capabilities/content.access.page-database.md
+++ b/templates/content/docs/product/capabilities/content.access.page-database.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.access.page-database"
+name: "Page and Database access"
+user_promise: "Page and Database access separates view/comment/data editing from schema authority"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: []
+related_features: []
+roadmap_boundary: "supporting"
+acceptance_summary: "A complete proof demonstrates: Page view/comment/edit; Database row and structure axes; deletion/select-option policy; shared action enforcement."
+proof_requirements: ["Page view/comment/edit; Database row and structure axes; deletion/select-option policy; shared action enforcement."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Page and Database access
+
+## Contract
+
+Page and Database access separates view/comment/data editing from schema authority
+
+## Acceptance boundary
+
+A complete proof demonstrates: Page view/comment/edit; Database row and structure axes; deletion/select-option policy; shared action enforcement.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.access.page-database.md
+++ b/templates/content/docs/product/capabilities/content.access.page-database.md
@@ -1,8 +1,10 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.access.page-database"
 name: "Page and Database access"
-user_promise: "Page and Database access separates view/comment/data editing from schema authority"
+user_promise: "Page and Database roles separate reading, commenting, entry editing, and structure authority."
+primary_user_job: "Share work at the appropriate level without accidentally granting collection-wide power."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
@@ -10,8 +12,14 @@ availability: "universal"
 dependencies: []
 related_features: []
 roadmap_boundary: "supporting"
-acceptance_summary: "A complete proof demonstrates: Page view/comment/edit; Database row and structure axes; deletion/select-option policy; shared action enforcement."
-proof_requirements: ["Page view/comment/edit; Database row and structure axes; deletion/select-option policy; shared action enforcement."]
+acceptance_summary: "Fixed Page and Database roles are enforced by the shared Action surface before every read or mutation, including deletion and structured-value policy."
+proof_requirements:
+  [
+    "Page role decisions for view, comment, edit, and full access",
+    "Database role decisions for entry versus schema authority",
+    "Identical UI, agent, API, and automation enforcement",
+    "Deletion, select-option, source-policy, and stale-capability failure coverage",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +27,50 @@ last_reviewed: "2026-07-29"
 
 # Page and Database access
 
-## Contract
+## Why this exists
 
-Page and Database access separates view/comment/data editing from schema authority
+Collaboration needs more than editor or viewer. A teammate may comment on a Page, edit a Database entry, or manage the Database structure—those are deliberately different powers.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Page view/comment/edit; Database row and structure axes; deletion/select-option policy; shared action enforcement.
+A manager gives a collaborator **Can edit entries** in a planning Database. The collaborator changes authorized rows but cannot alter Properties or delete the Database; a Page commenter can discuss a brief but cannot edit its body.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Page roles are **Can view**, **Can comment**, **Can edit**, and **Full access**.
+- Database roles are **Can view**, **Can comment**, **Can edit entries**, **Can edit database**, and **Full access**.
+- Roles are fixed product roles backed by internal capabilities, not custom checkbox combinations.
+- Every UI, agent, automation, and API operation calls the same Action authorization and operation-specific validation.
+- Source truth, Property locks, and policy can narrow authority; they never widen a role.
+- Deletion and option/schema mutation require the stronger authority their impact demands.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- This record defines role semantics, not row-specific overrides, public publication, or derived-result closure.
+- A personal Favorite or Only-me View is a private capability, not shared edit authority.
+- Seeing an object or relationship never grants authority to mutate it.
+
+## Acceptance stories
+
+### Edit entries but not structure
+
+Given a collaborator with **Can edit entries**, when they update an allowed row, then it succeeds through UI and Action. When they rename a Property or change a select option, then it is denied without a partial mutation.
+
+### Comment without editing body
+
+Given a Page commenter, when they add a comment, then it is permitted. When they submit a body edit or ask an agent to do it, then both surfaces return the same denial.
+
+## Current evidence
+
+Current Content actions and Database permission work provide role and ownership substrate, but the complete fixed-role matrix, shared effective operation capabilities, and all destructive/structured-value paths are not yet proven together. This remains `approved_shape`.
+
+## Proof plan
+
+1. Build a role-by-operation matrix for Page and Database actions and UI controls.
+2. Test direct, bulk, agent, automation, source-backed, and stale client capability paths.
+3. Verify denial is typed and leaves content, schema, and audit state unchanged.
+4. Test role changes during a pending mutation, reload, keyboard, and assistive technology.
+
+## Open questions
+
+Internal capability representation is an implementation detail. The fixed product role vocabulary and no-widening rule are settled.

--- a/templates/content/docs/product/capabilities/content.access.row-private.md
+++ b/templates/content/docs/product/capabilities/content.access.row-private.md
@@ -1,8 +1,10 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.access.row-private"
 name: "Row-level privacy"
-user_promise: "Row/Page sharing can override inherited Database visibility"
+user_promise: "A Page or Database row can be shared more narrowly than its collection's ordinary visibility."
+primary_user_job: "Keep a sensitive item in an otherwise shared workflow without copying it into a secret parallel system."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
@@ -10,8 +12,14 @@ availability: "universal"
 dependencies: ["content.access.page-database"]
 related_features: ["content.feature.explore-alternatives-safely"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Default inheritance, per-row principals, query behavior, source sync."
-proof_requirements: ["Default inheritance, per-row principals, query behavior, source sync."]
+acceptance_summary: "Default Database visibility can be narrowed by row/Page principals, and every read, query, source operation, and mutation applies the resulting access before returning data."
+proof_requirements:
+  [
+    "Default inheritance and explicit row/Page principal behavior",
+    "Access-first query, view, search, aggregate, and export behavior",
+    "Shared Action and UI mutation enforcement",
+    "Source synchronization, deletion, restore, and access-change tests",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +27,49 @@ last_reviewed: "2026-07-29"
 
 # Row-level privacy
 
-## Contract
+## Why this exists
 
-Row/Page sharing can override inherited Database visibility
+A shared tracker sometimes contains a draft, personnel matter, or private alternative. The item should remain in the governed workflow without becoming ambiently discoverable.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Default inheritance, per-row principals, query behavior, source sync.
+A team keeps a hiring Database visible to managers. One candidate row is restricted to a smaller panel. The panel can work with the row; other managers see neither its fields nor its contribution to counts.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A Database supplies ordinary default access; a Page/row may narrow that visibility through explicit principals.
+- Narrower row access applies before list, View, Query, relation traversal, search, aggregate, export, agent context, and source operations.
+- An authorized direct link opens the Page; an unauthorized known direct link returns an honest generic denial.
+- Row privacy does not make a Page's identity dependent on a Database or grant access through another membership.
+- All mutations use the shared Action decision and record attributable history.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- Row privacy narrows inherited access; it does not widen a Page beyond allowed policy.
+- It does not define public publishing or named-Version access, which have their own boundaries.
+- Hiding a View column is presentation, not row privacy.
+
+## Acceptance stories
+
+### Hide a restricted row from collection work
+
+Given one private row in a shared Database, when an unauthorized member opens a View, searches, groups, or exports it, then the row and its values do not appear or affect derived output.
+
+### Keep direct access honest
+
+Given an unauthorized person knows the private row's URL, when they open it or invoke an Action, then access is denied without reporting a successful empty Page or exposing its title.
+
+## Current evidence
+
+The repository has ownable records and access-aware Content surfaces, providing substrate. It does not yet prove complete per-row principals across every derived path and source policy, so the capability remains `approved_shape`.
+
+## Proof plan
+
+1. Exercise inheritance, restriction, principal changes, and recovery through UI and Actions.
+2. Re-run Views, Queries, search, relationships, exports, agents, and aggregates for each role.
+3. Test source sync/write-back and access changes during pending work.
+4. Verify trash, restore, audit/history, and generic denial behavior.
+
+## Open questions
+
+Exact principal-management controls remain a surface design choice; no implementation may turn unavailable data into a successful empty result.

--- a/templates/content/docs/product/capabilities/content.access.row-private.md
+++ b/templates/content/docs/product/capabilities/content.access.row-private.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.access.row-private"
+name: "Row-level privacy"
+user_promise: "Row/Page sharing can override inherited Database visibility"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.access.page-database"]
+related_features: ["content.feature.explore-alternatives-safely"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Default inheritance, per-row principals, query behavior, source sync."
+proof_requirements: ["Default inheritance, per-row principals, query behavior, source sync."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Row-level privacy
+
+## Contract
+
+Row/Page sharing can override inherited Database visibility
+
+## Acceptance boundary
+
+A complete proof demonstrates: Default inheritance, per-row principals, query behavior, source sync.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.access.safe-aggregate.md
+++ b/templates/content/docs/product/capabilities/content.access.safe-aggregate.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.access.safe-aggregate"
+name: "Access-safe computation"
+user_promise: "Access applies before relation traversal, count, rollup, group, and aggregate"
+kind: "primitive"
+state: "exploring"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.access.page-database"]
+related_features: ["content.feature.understand-what-your-data-says"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Repair relation-count asymmetry; prove private records cannot leak through derived values."
+proof_requirements: ["Repair relation-count asymmetry; prove private records cannot leak through derived values."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Access-safe computation
+
+## Contract
+
+Access applies before relation traversal, count, rollup, group, and aggregate
+
+## Acceptance boundary
+
+A complete proof demonstrates: Repair relation-count asymmetry; prove private records cannot leak through derived values.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.access.safe-aggregate.md
+++ b/templates/content/docs/product/capabilities/content.access.safe-aggregate.md
@@ -1,8 +1,10 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.access.safe-aggregate"
 name: "Access-safe computation"
-user_promise: "Access applies before relation traversal, count, rollup, group, and aggregate"
+user_promise: "Counts, rollups, groups, and aggregates reveal only records the viewer may access."
+primary_user_job: "Understand shared data without private records leaking through a total, relation count, or derived value."
 kind: "primitive"
 state: "exploring"
 publicness: "public"
@@ -10,8 +12,14 @@ availability: "universal"
 dependencies: ["content.access.page-database"]
 related_features: ["content.feature.understand-what-your-data-says"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Repair relation-count asymmetry; prove private records cannot leak through derived values."
-proof_requirements: ["Repair relation-count asymmetry; prove private records cannot leak through derived values."]
+acceptance_summary: "Every derived computation filters inaccessible records and endpoints before traversal, grouping, measure calculation, caching, or rendering."
+proof_requirements:
+  [
+    "Relation traversal and count asymmetry repair",
+    "Access-first rollup, group, Pivot, Chart, and expression tests",
+    "No leakage through empty, error, cache, drill-down, or export states",
+    "Equivalent UI, Action, agent, and API results under changing access",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +27,49 @@ last_reviewed: "2026-07-29"
 
 # Access-safe computation
 
-## Contract
+## Why this exists
 
-Access applies before relation traversal, count, rollup, group, and aggregate
+A total can betray a secret as surely as a sentence can. Analytics must count the authorized world, not calculate privately and hide only the rows.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Repair relation-count asymmetry; prove private records cannot leak through derived values.
+A manager groups a pipeline by stage and drills into a total. Restricted opportunities are absent from both the count and the drill-down, even though authorized peers see a larger total.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Access filters apply before relationship traversal, Query evaluation, grouping, rollup, count, measure, chart, pivot, expression, and export.
+- A result and its drill-down describe the same authorized input set.
+- Caches and precomputed indexes are implementation machinery and may not reveal an inaccessible cardinality or stale value.
+- Known inaccessible direct objects return denial; ambient derived work omits them without a side-channel.
+- UI, agents, APIs, and automations receive the same scoped result or typed failure.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- This record does not define query syntax, Chart presentation, or row-sharing controls.
+- It does not require hiding authorized zero results; a true zero remains meaningful.
+- Performance optimizations cannot weaken the access-before-computation ordering.
+
+## Acceptance stories
+
+### Count only visible relations
+
+Given a visible Page related to one visible and one private Page, when a viewer calculates a relation count, then it reports one and cannot infer the second endpoint from count, error, or timing behavior.
+
+### Drill into the same cohort
+
+Given a grouped aggregate with restricted rows, when a viewer opens drill-down, then every returned row and total matches the viewer-scoped aggregate rather than a wider cached cohort.
+
+## Current evidence
+
+The product architecture requires access before derived work, while the current audit identified relation-count asymmetry as a repair seam. No complete generic aggregate implementation proof exists; this capability remains `exploring`.
+
+## Proof plan
+
+1. Build adversarial fixtures for private rows/endpoints across counts, rollups, groups, expressions, pivots, charts, and exports.
+2. Compare results across UI, Actions, agents, APIs, cache refreshes, and changing access.
+3. Verify drill-down, pagination, empty/error states, and timing do not leak presence.
+4. Test source-backed values and concurrent access changes.
+
+## Open questions
+
+The evaluation and cache design are open. The access-first semantics and equal result/drill-down cohort are not.

--- a/templates/content/docs/product/capabilities/content.access.visibility-closure.md
+++ b/templates/content/docs/product/capabilities/content.access.visibility-closure.md
@@ -1,17 +1,29 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.access.visibility-closure"
 name: "Visibility closure"
-user_promise: "Traversal, export, embedding, search, and derived results omit inaccessible objects while known direct links return an honest denial."
+user_promise: "Ambient traversal and derived results omit inaccessible objects while known direct links receive an honest denial."
+primary_user_job: "Follow, search, embed, publish, and export work without private neighborhoods spilling into view."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.access.page-database","content.access.safe-aggregate"]
-related_features: ["content.feature.work-across-every-workspace","content.feature.publish-with-confidence"]
+dependencies: ["content.access.page-database", "content.access.safe-aggregate"]
+related_features:
+  [
+    "content.feature.work-across-every-workspace",
+    "content.feature.publish-with-confidence",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Traversal, export, embedding, search, and derived results omit inaccessible objects while known direct links return an honest denial."
-proof_requirements: ["Traversal, export, embedding, search, and derived results omit inaccessible objects while known direct links return an honest denial."]
+acceptance_summary: "All ambient discovery and derived surfaces close over authorized objects; direct known targets fail honestly without revealing private existence or contents."
+proof_requirements:
+  [
+    "Traversal, search, Query, embedding, and export closure",
+    "Aggregate and relationship endpoint closure",
+    "Direct-link generic denial distinct from successful absence",
+    "Public, agent, source, cache, and access-change regression coverage",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +31,49 @@ last_reviewed: "2026-07-29"
 
 # Visibility closure
 
-## Contract
+## Why this exists
 
-Traversal, export, embedding, search, and derived results omit inaccessible objects while known direct links return an honest denial.
+Access must remain true after information starts moving. A private object cannot become visible merely because a backlink, embed, export, or agent happened to pass nearby.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Traversal, export, embedding, search, and derived results omit inaccessible objects while known direct links return an honest denial.
+An author publishes a Page that references internal research. Public readers see the authorized Page with the private reference omitted or safely degraded; a person with the internal link gets a generic denial rather than a plausible empty success.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Search, traversal, Queries, Views, links, embeds, exports, public projections, and agents operate only over authorized closure.
+- A direct known target may return a generic denial; ambient lists and derived results do not confirm its existence.
+- Closure applies recursively to relationship endpoints and transcluded content before rendering or calculating.
+- Caches, previews, snippets, errors, counts, and pagination preserve the same boundary.
+- Access changes take effect before future reads and cannot be masked as normal emptiness.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- Visibility closure is not a replacement for Page/Database roles or row principals.
+- It does not decide how a public Page is published, only what its reachable projections may reveal.
+- It does not require every broken public reference to be silently invisible; authorized degradation can be meaningful.
+
+## Acceptance stories
+
+### Omit a private neighbor from export
+
+Given a Page with a reference or transclusion to a private neighbor, when an unauthorized viewer exports or opens a public projection, then the neighbor's content, title, and cardinality do not leak.
+
+### Differentiate denial from absence
+
+Given an unauthorized person has a direct private URL, when they request it, then they receive an honest generic denial rather than a successful empty result that callers may mistake for normal absence.
+
+## Current evidence
+
+The architecture and existing access-aware Content paths establish the required direction. Repository evidence does not yet prove closure across every traversal, export, embed, cache, and agent path; this remains `approved_shape`.
+
+## Proof plan
+
+1. Test recursive references, Relationships, transclusions, Views, search, exports, and public output under access changes.
+2. Inspect snippets, counts, errors, caches, pagination, previews, and agent summaries for side channels.
+3. Verify direct denial versus ambient omission through UI and Actions.
+4. Exercise source and integration paths plus reload and concurrent permission changes.
+
+## Open questions
+
+Exact degraded-reference presentation remains open; it must never disclose protected identity or turn denial into false success.

--- a/templates/content/docs/product/capabilities/content.access.visibility-closure.md
+++ b/templates/content/docs/product/capabilities/content.access.visibility-closure.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.access.visibility-closure"
+name: "Visibility closure"
+user_promise: "Traversal, export, embedding, search, and derived results omit inaccessible objects while known direct links return an honest denial."
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.access.page-database","content.access.safe-aggregate"]
+related_features: ["content.feature.work-across-every-workspace","content.feature.publish-with-confidence"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Traversal, export, embedding, search, and derived results omit inaccessible objects while known direct links return an honest denial."
+proof_requirements: ["Traversal, export, embedding, search, and derived results omit inaccessible objects while known direct links return an honest denial."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Visibility closure
+
+## Contract
+
+Traversal, export, embedding, search, and derived results omit inaccessible objects while known direct links return an honest denial.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Traversal, export, embedding, search, and derived results omit inaccessible objects while known direct links return an honest denial.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.action.button.md
+++ b/templates/content/docs/product/capabilities/content.action.button.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.action.button"
+name: "Action Buttons"
+user_promise: "An owner-governed Button invokes an ordinary action/Rule with typed inputs and visible authority"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.command.fabric","content.rule.deterministic"]
+related_features: ["content.feature.when-this-happens-that-follows"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Template insertion, access/edit restrictions, confirmation/undo, event and history receipt; no private button engine."
+proof_requirements: ["Template insertion, access/edit restrictions, confirmation/undo, event and history receipt; no private button engine."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Action Buttons
+
+## Contract
+
+An owner-governed Button invokes an ordinary action/Rule with typed inputs and visible authority
+
+## Acceptance boundary
+
+A complete proof demonstrates: Template insertion, access/edit restrictions, confirmation/undo, event and history receipt; no private button engine.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.action.button.md
+++ b/templates/content/docs/product/capabilities/content.action.button.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.action.button"
 name: "Action Buttons"
-user_promise: "An owner-governed Button invokes an ordinary action/Rule with typed inputs and visible authority"
+user_promise: "An owner-governed Button invokes an ordinary action or Rule with typed inputs and visible authority"
+primary_user_job: "Let people trigger a governed operation from the object where its result matters."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.command.fabric","content.rule.deterministic"]
+dependencies: ["content.command.fabric", "content.rule.deterministic"]
 related_features: ["content.feature.when-this-happens-that-follows"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Template insertion, access/edit restrictions, confirmation/undo, event and history receipt; no private button engine."
-proof_requirements: ["Template insertion, access/edit restrictions, confirmation/undo, event and history receipt; no private button engine."]
+acceptance_summary: "Buttons are owner-governed command bindings with stable IDs, typed inputs, can-run reasons, confirmation, permission checks, receipts, and Undo where supported."
+proof_requirements:
+  [
+    "Typed contract, authorization, validation, Event/history, and recovery coverage",
+    "Cross-surface UI, Action, agent-context, reload, and failure-state coverage",
+    "Real-interface keyboard and assistive-technology workflow coverage",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,42 @@ last_reviewed: "2026-07-29"
 
 # Action Buttons
 
-## Contract
+## Why this exists
 
-An owner-governed Button invokes an ordinary action/Rule with typed inputs and visible authority
+A repeated local decision should be visible where people encounter its consequence, with authority and confirmation clear before anyone acts.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Template insertion, access/edit restrictions, confirmation/undo, event and history receipt; no private button engine.
+A workspace owner adds an Approve button to a request Page. An editor sees its effect and required confirmation, invokes it, and receives an Event receipt with Undo when the action supports it.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+Buttons are owner-governed command bindings with stable IDs, typed inputs, can-run reasons, confirmation, permission checks, receipts, and Undo where supported. They invoke the ordinary command or Rule Action; a Button never owns a private mutation path.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Button configuration and target Actions own behavior. This is not a macro language, hidden automation engine, or permission bypass.
+
+## Acceptance stories
+
+### Deny a button that cannot run
+
+Given an editor without the target Action permission, when they view a Button, then it explains why it cannot run and cannot invoke the operation.
+
+### Receipt and undo after approval
+
+Given a confirmed reversible Button action, when it succeeds, then Content records one ordinary Event and exposes its supported Undo route.
+
+## Current evidence
+
+Template and Action substrate exist, but no complete button insertion, authority, confirmation, receipt, and recovery proof is recorded. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Insert template Buttons and test stable bindings, arguments, and unavailable targets.
+2. Exercise viewer, editor, owner, confirmation, cancellation, denial, receipts, Undo, and reload.
+3. Use keyboard and screen readers to discover a Button, read its effect, and recover from failure.
+
+## Open questions
+
+The exact first Button placement and confirmation copy need interaction design.

--- a/templates/content/docs/product/capabilities/content.agent.action-parity.md
+++ b/templates/content/docs/product/capabilities/content.agent.action-parity.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.agent.action-parity"
+name: "Agent and UI parity"
+user_promise: "Humans and agents use the same operations and visible state"
+kind: "primitive"
+state: "in_progress"
+publicness: "public"
+availability: "universal"
+dependencies: []
+related_features: ["content.feature.durable-foundations","content.feature.when-this-happens-that-follows","content.feature.collect-structured-input","content.feature.work-on-content-inside-another-application"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Per-capability parity/evals; no special Task action engine."
+proof_requirements: ["Per-capability parity/evals; no special Task action engine."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Agent and UI parity
+
+## Contract
+
+Humans and agents use the same operations and visible state
+
+## Acceptance boundary
+
+A complete proof demonstrates: Per-capability parity/evals; no special Task action engine.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.agent.action-parity.md
+++ b/templates/content/docs/product/capabilities/content.agent.action-parity.md
@@ -1,17 +1,30 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.agent.action-parity"
 name: "Agent and UI parity"
 user_promise: "Humans and agents use the same operations and visible state"
+primary_user_job: "Use an agent to do ordinary Content work with the same authority, validation, and truthful result a person would receive."
 kind: "primitive"
 state: "in_progress"
 publicness: "public"
 availability: "universal"
 dependencies: []
-related_features: ["content.feature.durable-foundations","content.feature.when-this-happens-that-follows","content.feature.collect-structured-input","content.feature.work-on-content-inside-another-application"]
+related_features:
+  [
+    "content.feature.durable-foundations",
+    "content.feature.when-this-happens-that-follows",
+    "content.feature.collect-structured-input",
+    "content.feature.work-on-content-inside-another-application",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Per-capability parity/evals; no special Task action engine."
-proof_requirements: ["Per-capability parity/evals; no special Task action engine."]
+acceptance_summary: "Every operation exposes one typed Action contract for UI, agent, automation, and API callers."
+proof_requirements:
+  [
+    "Typed contract, authorization, validation, Event/history, and recovery coverage",
+    "Cross-surface UI, Action, agent-context, reload, and failure-state coverage",
+    "Real-interface keyboard and assistive-technology workflow coverage",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +32,42 @@ last_reviewed: "2026-07-29"
 
 # Agent and UI parity
 
-## Contract
+## Why this exists
 
-Humans and agents use the same operations and visible state
+An assistant that succeeds where the editor would fail erodes trust in both surfaces. Content needs one accountable path from request to committed change.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Per-capability parity/evals; no special Task action engine.
+A person asks an agent to update a Database record. The agent calls the same Action as the editor, receives the same validation failure if it is invalid, and returns the canonical result.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+Every operation exposes one typed Action contract for UI, agent, automation, and API callers. Authorization, validation, Events, history, recovery, current context, and error states are shared; caller-specific presentation cannot invent a privileged task engine.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Individual capability records own their concrete workflows. Parity does not mean identical interface affordances or unrestricted agent context.
+
+## Acceptance stories
+
+### Reject an agent-only privilege
+
+Given a viewer denied an edit in the UI, when an agent attempts the same edit, then the same Action denies it without leaking unavailable fields.
+
+### Observe one change from both surfaces
+
+Given an Action succeeds through an agent, when the Page is opened, then it shows one canonical mutation and ordinary history rather than an agent-only copy.
+
+## Current evidence
+
+Existing Actions provide in-progress donor substrate, but per-capability parity evaluations and real-interface proof remain incomplete. This Capability remains `in_progress`.
+
+## Proof plan
+
+1. Compare Page, Database, and collaboration Action inputs, results, and failures.
+2. Test permission changes, field visibility, history, conflict, and unavailable sources in both callers.
+3. Run paired human and agent workflows with accessible UI evidence.
+
+## Open questions
+
+The first cross-surface parity fixture catalog needs implementation design.

--- a/templates/content/docs/product/capabilities/content.agent.audience-safe.md
+++ b/templates/content/docs/product/capabilities/content.agent.audience-safe.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.agent.audience-safe"
+name: "Audience-safe synthesis"
+user_promise: "A governed agent run can restrict its inputs to information every intended viewer of the output may access."
+kind: "workflow"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.agent.resource-consent","content.access.visibility-closure"]
+related_features: ["content.feature.keep-your-private-vault-private"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: A governed agent run can restrict its inputs to information every intended viewer of the output may access."
+proof_requirements: ["A governed agent run can restrict its inputs to information every intended viewer of the output may access."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Audience-safe synthesis
+
+## Contract
+
+A governed agent run can restrict its inputs to information every intended viewer of the output may access.
+
+## Acceptance boundary
+
+A complete proof demonstrates: A governed agent run can restrict its inputs to information every intended viewer of the output may access.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.agent.audience-safe.md
+++ b/templates/content/docs/product/capabilities/content.agent.audience-safe.md
@@ -1,17 +1,26 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.agent.audience-safe"
 name: "Audience-safe synthesis"
-user_promise: "A governed agent run can restrict its inputs to information every intended viewer of the output may access."
+user_promise: "A governed agent run can synthesize from only the resources every intended viewer may access and consent to use for that audience."
+primary_user_job: "Prepare a shared answer for a defined audience without borrowing an owner's private authority or silently carrying excluded material into the result."
 kind: "workflow"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.agent.resource-consent","content.access.visibility-closure"]
+dependencies:
+  ["content.agent.resource-consent", "content.access.visibility-closure"]
 related_features: ["content.feature.keep-your-private-vault-private"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: A governed agent run can restrict its inputs to information every intended viewer of the output may access."
-proof_requirements: ["A governed agent run can restrict its inputs to information every intended viewer of the output may access."]
+acceptance_summary: "A strict-audience run resolves its inputs through the intended audience's common authorized-and-consented intersection, rechecks it throughout the run, and never exposes excluded inputs through output, cache, metadata, or errors."
+proof_requirements:
+  [
+    "Audience identity and common authorized-and-consented input intersection resolved before retrieval and at every subsequent use",
+    "Strict-audience behavior that never borrows owner, author, agent, or cached private authority",
+    "Cache keys, invalidation, output handling, errors, counts, and provenance that cannot reveal excluded inputs",
+    "Real-interface workflow tests for changing audience membership, access, consent, source availability, and direct inspection",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +28,64 @@ last_reviewed: "2026-07-29"
 
 # Audience-safe synthesis
 
-## Contract
+## Why this exists
 
-A governed agent run can restrict its inputs to information every intended viewer of the output may access.
+An author can often see more than the people who will receive an agent's answer. Summarizing with the author's authority and then sharing the result can leak the very material the audience was not allowed to see. A warning after generation is too late; a careful-looking answer may already contain the private detail.
 
-## Acceptance boundary
+Audience-safe synthesis is a workflow over resource consent and access closure. It constrains the run's inputs to the common intersection for its stated audience before the agent reasons over them.
 
-A complete proof demonstrates: A governed agent run can restrict its inputs to information every intended viewer of the output may access.
+## Example workflow
 
-## Evidence boundary
+A project lead asks for a status update for three collaborators. The agent resolves the intended audience, then gathers only project resources that all three collaborators can access and that are consented for agent context. A private planning note and a resource one collaborator lost access to are excluded. When a fourth collaborator is added during the run, the remaining work is re-evaluated against the smaller intersection. The agent can state that its answer is based on the permitted shared material, but it does not name or count excluded inputs.
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+## Product contract
 
-## Non-goals
+### Audience-bound input closure
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- A strict-audience run names an intended audience and evaluates every candidate input as the intersection of that audience's current ordinary authorization and effective agent-context consent, including resource, source, and inherited policy ceilings.
+- The run may use only inputs in that common intersection. It does not borrow the initiating owner's, author's, operator's, or agent's broader authority to fill a gap.
+- Audience changes, access changes, consent revocation, source-policy changes, and unavailable authority state are re-evaluated before each remaining retrieval, tool call, context reuse, and output-affecting step. Unreadable authority state is not treated as an empty allowed intersection.
+- Strict-audience mode is an opt-in governed workflow. It may produce a narrower answer, a truthful unavailable state, or a request to revise the audience; it may not silently broaden the audience or switch to owner-authority mode.
+
+### Outputs, caches, and provenance
+
+- Excluded inputs cannot appear in generated output, citations, snippets, titles, tool traces, error messages, counts, timing summaries, or aggregate explanations. The output may identify its declared audience and describe authorized-source limitations only when doing so does not reveal excluded material.
+- Cached retrievals, intermediate context, embeddings, plans, and generated results are scoped to the exact audience/access/consent state that authorized them. Access or consent revocation invalidates them for affected viewers; an owner-private cached result is never reused for a strict-audience run.
+- The workflow records run identity, declared audience representation, policy mode, and safe provenance needed for inspection. Origin/provenance says where an authorized result came from; it is not a review, verification, or truth guarantee.
+- Audience-safe synthesis does not prove that its answer is complete, correct, endorsed, or fit for publication. Review and verification remain separate decisions.
+
+## Boundaries and non-goals
+
+- This is not a new sharing model, an audience-wide permission grant, a way to make private resources public, or an alternative to resource consent/access closure.
+- It does not make an agent's summary authoritative, verified, or approved merely because the input intersection was safe.
+- It does not disclose the identity, existence, count, or cached remnants of resources excluded by access or consent.
+- It does not authorize owner-credential fallbacks, privileged cache reuse, or source reads outside the audience's effective closure.
+
+## Acceptance stories
+
+### Synthesize only from the common intersection
+
+Given an author can access three resources and one intended viewer cannot access one of them, when a strict-audience run creates a status update for that audience, then it uses only the two common authorized-and-consented resources and does not mention the excluded resource or its absence.
+
+### Re-evaluate a changing audience
+
+Given a strict-audience run is gathering material for two viewers, when another viewer is added or a current viewer loses access before the next retrieval, then the run re-evaluates the remaining input closure and neither uses newly excluded context nor reuses a broader cached result.
+
+### Preserve the distinction between provenance and review
+
+Given a strict-audience run produces an answer with safe authorized provenance, when a recipient opens it, then they can inspect permitted origin information appropriate to their access but do not see a claim that the result was reviewed, verified, or true unless another Capability supplied that decision.
+
+## Current evidence
+
+`content.agent.resource-consent` and `content.access.visibility-closure` define required dependencies, but neither is verified as a complete implementation. Current architecture establishes access before computation in `templates/content/docs/product/architecture.md`; no repository evidence yet proves an intended-audience intersection resolver, strict-mode cache partitioning/invalidation, or non-leaking output behavior across agent tools. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Build deterministic resolver tests for multi-viewer intersections across Pages, Databases, Sources, inherited consent ceilings, membership changes, revocation, and authority-read failures.
+2. Verify agent retrieval, search, traversal, tool calls, aggregation, citations, error rendering, and final output use the same strict context and cannot observe excluded identity or counts.
+3. Test cache and intermediate-artifact keys against audience identity, membership/access epoch, consent epoch, source policy, and resource version; prove revocation and audience change invalidate unsafe reuse.
+4. Run real-interface workflows that define an audience, generate a result, alter its membership/access/consent mid-run, inspect safe provenance, and confirm that review/verification status remains distinct.
+
+## Open questions
+
+The durable representation of a dynamic audience, safe wording for partial-result notices, and retention rules for run intermediates remain open implementation choices. They must not weaken common-intersection input selection, strict cache isolation, or the distinction between safe provenance and verification.

--- a/templates/content/docs/product/capabilities/content.agent.automation.md
+++ b/templates/content/docs/product/capabilities/content.agent.automation.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.agent.automation"
 name: "Agent-run automation"
 user_promise: "AI work composes Event → expression/query → action → mutation → Event"
+primary_user_job: "Automate bounded AI work while preserving an accountable owner, visible context, and a recoverable causal chain."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.rule.deterministic","content.agent.action-parity"]
+dependencies: ["content.rule.deterministic", "content.agent.action-parity"]
 related_features: ["content.feature.when-this-happens-that-follows"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Owner authority, scoped context, chain/cost limits, dry run, receipts, undo/disable."
-proof_requirements: ["Owner authority, scoped context, chain/cost limits, dry run, receipts, undo/disable."]
+acceptance_summary: "An agent automation consumes an Event, evaluated expression or Query, scoped context, and typed Action."
+proof_requirements:
+  [
+    "Typed contract, authorization, validation, Event/history, and recovery coverage",
+    "Cross-surface UI, Action, agent-context, reload, and failure-state coverage",
+    "Real-interface keyboard and assistive-technology workflow coverage",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,42 @@ last_reviewed: "2026-07-29"
 
 # Agent-run automation
 
-## Contract
+## Why this exists
 
-AI work composes Event → expression/query → action → mutation → Event
+AI work can travel farther than its initiator intended. Its boundaries must remain inspectable, stoppable, and attributable.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Owner authority, scoped context, chain/cost limits, dry run, receipts, undo/disable.
+A Rule detects a new intake record, prepares an owner-scoped brief, and creates a draft through a shared Action. The run shows its inputs, cost limit, resulting Event, and disable control.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+An agent automation consumes an Event, evaluated expression or Query, scoped context, and typed Action. Owner authority, dry run, chain and cost limits, receipts, disablement, and supported Undo apply to every run.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Deterministic Rules own non-AI behavior and Action parity owns mutations. This is not background prompt execution without an owner or an unbounded self-triggering loop.
+
+## Acceptance stories
+
+### Stop a self-triggering chain
+
+Given a run reaches its chain limit, when it would emit another triggering Event, then Content stops it and records an explicit limit receipt.
+
+### Preview an owner-scoped draft
+
+Given a dry run, when the automation evaluates its context, then it returns proposed Actions and changes no canonical object.
+
+## Current evidence
+
+No complete owner, context, limit, dry-run, receipt, and recovery proof is recorded. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Test owner delegation and revocation with bounded context, dry runs, and effect previews.
+2. Drive chains through duplicate triggers, limits, Action failure, and disablement.
+3. Inspect receipts, retry state, supported Undo, and accessible supervision.
+
+## Open questions
+
+Cost accounting and the first safe context-preview surface need design.

--- a/templates/content/docs/product/capabilities/content.agent.automation.md
+++ b/templates/content/docs/product/capabilities/content.agent.automation.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.agent.automation"
+name: "Agent-run automation"
+user_promise: "AI work composes Event → expression/query → action → mutation → Event"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.rule.deterministic","content.agent.action-parity"]
+related_features: ["content.feature.when-this-happens-that-follows"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Owner authority, scoped context, chain/cost limits, dry run, receipts, undo/disable."
+proof_requirements: ["Owner authority, scoped context, chain/cost limits, dry run, receipts, undo/disable."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Agent-run automation
+
+## Contract
+
+AI work composes Event → expression/query → action → mutation → Event
+
+## Acceptance boundary
+
+A complete proof demonstrates: Owner authority, scoped context, chain/cost limits, dry run, receipts, undo/disable.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.agent.expression-authoring.md
+++ b/templates/content/docs/product/capabilities/content.agent.expression-authoring.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.agent.expression-authoring"
+name: "Agent-authored Expressions"
+user_promise: "AI generates, validates, previews, repairs, and saves typed expressions"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.expression.language","content.agent.action-parity"]
+related_features: ["content.feature.put-your-organizations-know-how-to-work"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Real schema introspection, typechecker, preview, explicit save."
+proof_requirements: ["Real schema introspection, typechecker, preview, explicit save."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Agent-authored Expressions
+
+## Contract
+
+AI generates, validates, previews, repairs, and saves typed expressions
+
+## Acceptance boundary
+
+A complete proof demonstrates: Real schema introspection, typechecker, preview, explicit save.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.agent.expression-authoring.md
+++ b/templates/content/docs/product/capabilities/content.agent.expression-authoring.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.agent.expression-authoring"
 name: "Agent-authored Expressions"
-user_promise: "AI generates, validates, previews, repairs, and saves typed expressions"
+user_promise: "Ask an agent to draft or repair a typed expression without giving it a private execution or save path."
+primary_user_job: "Collaborate on a validated expression before saving it."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.expression.language","content.agent.action-parity"]
+dependencies: ["content.expression.language", "content.agent.action-parity"]
 related_features: ["content.feature.put-your-organizations-know-how-to-work"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Real schema introspection, typechecker, preview, explicit save."
-proof_requirements: ["Real schema introspection, typechecker, preview, explicit save."]
+acceptance_summary: "The agent inspects authorized live schema and expression context, produces a typed candidate, validates and previews it, explains failures, and saves only through an explicit authorized action."
+proof_requirements:
+  [
+    "The agent uses the same expression language, validators, permissions, and mutation receipts as a person.",
+    "A candidate remains a preview until the user or authorized workflow explicitly saves it.",
+    "Missing schema, denied data, type errors, and unsafe dependencies are named failures, not invented expressions or successful empty previews.",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,46 @@ last_reviewed: "2026-07-29"
 
 # Agent-authored Expressions
 
-## Contract
+## Why this exists
 
-AI generates, validates, previews, repairs, and saves typed expressions
+An agent can make configuration more approachable, but a plausible-looking formula based on invented schema is worse than no formula. Its suggestions need the same evidence, preview, and save boundary as human-authored work.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Real schema introspection, typechecker, preview, explicit save.
+Sam asks for an overdue formula; the agent inspects authorized fields, previews dependencies, repairs an error, and saves only after confirmation.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- The agent uses the same expression language, validators, permissions, and mutation receipts as a person.
+- A candidate remains a preview until the user or authorized workflow explicitly saves it.
+- Missing schema, denied data, type errors, and unsafe dependencies are named failures, not invented expressions or successful empty previews.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- `content.expression.language` owns parsing, typechecking, preview semantics, and persistence; the agent is an authorized client of that contract.
+- Agent authoring does not invent schema, bypass confirmation, or persist speculative candidates.
+
+## Acceptance stories
+
+### Refuse invented schema
+
+Given a target is denied or deleted, when the agent reads its schema, then it reports it instead of guessing.
+
+### Save only deliberately
+
+Given a correct preview is declined, when Sam closes it, then no field changes; accepted save creates a normal receipt.
+
+## Current evidence
+
+`actions/configure-document-property.ts` and the action framework donate mutation seams; no authorized schema/agent preview action exists.
+
+## Proof plan
+
+1. Draft from live authorized schema and inspect AST/bindings/dependencies.
+2. Test type, cycle, denied, and unavailable failures without persistence.
+3. Compare agent and human preview diagnostics.
+4. Save, reject, and repair with receipt/history parity.
+
+## Open questions
+
+No product question remains.

--- a/templates/content/docs/product/capabilities/content.agent.presence.md
+++ b/templates/content/docs/product/capabilities/content.agent.presence.md
@@ -1,36 +1,103 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.agent.presence"
 name: "Agent presence"
-user_promise: "One accountable agent presence shows every location a run is editing without replacing durable attribution or delaying the real change."
+user_promise: "One accountable agent presence gives authorized collaborators an ephemeral view of a run's current locations without replacing durable attribution, review, or the real mutation."
+primary_user_job: "See where an active agent run is working right now, including concurrent locations, without exposing private work or mistaking a live indicator for history or approval."
 kind: "surface"
 state: "in_progress"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.agent.action-parity","content.event.committed"]
+dependencies: ["content.agent.action-parity", "content.event.committed"]
 related_features: ["content.feature.collaborate-in-context"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: One accountable agent presence shows every location a run is editing without replacing durable attribution or delaying the real change."
-proof_requirements: ["One accountable agent presence shows every location a run is editing without replacing durable attribution or delaying the real change."]
-evidence: []
+acceptance_summary: "Authorized collaborators can see one ephemeral presence for an accountable active run and its currently authorized locations; presence may degrade or fail without delaying an authorized mutation, while Events/History retain durable attribution and review state."
+proof_requirements:
+  [
+    "A run-scoped presence model that represents one run across multiple current locations and removes inaccessible locations per viewer",
+    "Lifecycle proof for starting, progressing, stopping, canceling, failure, completion, linger/expiry, and concurrent locations",
+    "Best-effort transport/storage behavior proving presence failure neither blocks nor reclassifies an authorized mutation",
+    "Real-interface and access tests that distinguish live presence from Events, History, review, and reversible change",
+  ]
+evidence:
+  [
+    "packages/core/src/collab/agent-presence.ts",
+    "packages/core/src/collab/agent-presence.spec.ts",
+    "packages/core/src/collab/awareness-store.ts",
+    "packages/core/src/collab/ydoc-manager.ts",
+    "packages/toolkit/src/collab-ui/AgentPresenceChip.tsx",
+  ]
 superseded_by: null
 last_reviewed: "2026-07-29"
 ---
 
 # Agent presence
 
-## Contract
+## Why this exists
 
-One accountable agent presence shows every location a run is editing without replacing durable attribution or delaying the real change.
+Live collaboration benefits from a small, current-state answer to “where is the agent working?” That answer is not the same as attribution, history, a review decision, or an audit record. Treating a transient cursor as any of those would make important work disappear with the network.
 
-## Acceptance boundary
+Agent presence therefore visualizes the present moment over an accountable run. Events, Revisions, Versions, receipts, and History remain the durable record of who changed what and what was reviewed.
 
-A complete proof demonstrates: One accountable agent presence shows every location a run is editing without replacing durable attribution or delaying the real change.
+## Example workflow
 
-## Evidence boundary
+An agent run updates two authorized Pages and a structured record. Collaborators who can access each location see one running agent with the applicable current locations and short-lived recent-edit cues. A collaborator without access to one Page sees only the locations they may access. If the presence channel drops, the authorized mutations still commit through the normal action path and later appear in History. Stopping a run prevents further work; canceling ends pending work; reverting is a later, separate authorized change to committed results.
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+## Product contract
 
-## Non-goals
+### Ephemeral, run-scoped current state
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- One accountable run has one presence identity and may report multiple simultaneous current locations. A location is a current working target, not a durable claim that every prior change belongs to the viewer's visible activity feed.
+- Presence is ephemeral and may linger briefly to make a just-completed change legible, then expires. Completion, failure, loss of transport, or process restart never erase the durable Events/History produced by real actions.
+- A viewer sees only locations and descriptors they are currently authorized to access. Hidden, revoked, or inaccessible locations are omitted without names, counts, ordering gaps, or other existence leaks.
+- Presence describes activity, not review state. It does not mark a change accepted, rejected, verified, reverted, or recoverable; those meanings belong to durable Events, Revisions, Versions, and their owning surfaces.
+
+### Lifecycle and mutation independence
+
+- Starting, progressing, completing, failing, stopping, and canceling a run have distinct current-state semantics. **Stop** requests no further work; **cancel** ends pending work according to the run contract; **revert** is a separate, authorized mutation over already committed work and does not mean that presence was stopped.
+- Presence publication, cross-instance mirroring, polling, and expiry are best effort. Their failure must not block, delay, roll back, or falsely report failure for an otherwise authorized real mutation.
+- An action may update presence before, during, or after its mutation, but its durable Event/Revision and result must not depend on presence transport success. A failed mutation must not leave a convincing active or completed presence state; the run reports its actual terminal condition when known.
+- A run that loses access to a location removes it from future presence projection and cannot use that loss as permission to continue work there.
+
+## Boundaries and non-goals
+
+- Presence is not a generic agent activity panel, run history, audit log, review queue, approval mechanism, or substitute for Events/Versions/History.
+- It does not expose per-character imitation as the primary collaboration model, and it does not make lingering visual cues durable attribution.
+- It does not broaden access, reveal inaccessible locations, guarantee delivery, or change a mutation's authorization/recoverability semantics.
+- It does not define stop, cancellation, rollback, or recovery mechanics beyond presenting their current run state accurately.
+
+## Acceptance stories
+
+### Show one run in several authorized locations
+
+Given one active agent run is modifying two Pages and a record that a collaborator can access, when the collaborator opens the relevant surfaces, then they see one run-scoped presence with its authorized current locations rather than separate unaccountable agents or a fabricated single location.
+
+### Hide private concurrent work
+
+Given the same run also works in a Page the collaborator cannot access, when presence updates arrive, then the collaborator sees no title, count, timing clue, placeholder, or recent-edit descriptor for that Page while authorized viewers can see their permitted projection.
+
+### Keep mutation truth durable when presence fails
+
+Given an authorized agent mutation succeeds while the presence mirror or poll transport fails, when the action completes, then the mutation result and durable Event/History remain available, the UI reports presence degradation truthfully if observable, and no mutation waits for presence to recover.
+
+### Keep stopping, canceling, and reverting distinct
+
+Given a run has committed one change and has later work pending, when a user stops it, cancels it, or separately reverts the committed change, then each operation has its own status and Event behavior; reverting does not claim the run was canceled, and canceling does not silently undo committed work.
+
+## Current evidence
+
+There is meaningful but narrower substrate. `packages/core/src/collab/agent-presence.ts` maintains per-document agent awareness, heartbeat, reference-counted enter/leave, lingering removal, and recent-edit metadata; `packages/core/src/collab/agent-presence.spec.ts` exercises those lifecycle details. `packages/core/src/collab/ydoc-manager.ts` automatically touches agent presence for agent-sourced collaborative writes. `packages/core/src/collab/awareness-store.ts` mirrors awareness best-effort and explicitly prevents presence failures from failing an edit. `packages/toolkit/src/collab-ui/AgentPresenceChip.tsx` provides a small reusable display component.
+
+This substrate is document-scoped, uses one agent client identity, and does not yet prove accountable run identity, multi-location aggregation, viewer-specific location filtering, terminal-state semantics, or a Content UI that distinguishes presence from durable attribution and review. The Capability therefore remains `in_progress`.
+
+## Proof plan
+
+1. Introduce deterministic run-scoped presence tests for one run across concurrent Pages/records, nested work, terminal states, linger/expiry, restart, and transport loss.
+2. Exercise access changes and viewer-specific projections across every presence surface; prove inaccessible locations and descriptors cannot leak through labels, counts, timing, events, or caches.
+3. Fault-inject awareness persistence, polling, and client rendering while running authorized mutations; prove action result, committed Event/Revision, and recovery semantics remain independent.
+4. Complete real-interface flows for active work, multiple locations, stop, cancel, failure, completion, and revert; verify the UI routes inspection/review/history to their durable surfaces instead of presence.
+
+## Open questions
+
+The exact run/location data shape, UI placement, stale indicator language, and cross-device aggregation strategy remain open. They must preserve one accountable ephemeral presence, access-safe projection, distinct terminal operations, and durable attribution outside the presence channel.

--- a/templates/content/docs/product/capabilities/content.agent.presence.md
+++ b/templates/content/docs/product/capabilities/content.agent.presence.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.agent.presence"
+name: "Agent presence"
+user_promise: "One accountable agent presence shows every location a run is editing without replacing durable attribution or delaying the real change."
+kind: "surface"
+state: "in_progress"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.agent.action-parity","content.event.committed"]
+related_features: ["content.feature.collaborate-in-context"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: One accountable agent presence shows every location a run is editing without replacing durable attribution or delaying the real change."
+proof_requirements: ["One accountable agent presence shows every location a run is editing without replacing durable attribution or delaying the real change."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Agent presence
+
+## Contract
+
+One accountable agent presence shows every location a run is editing without replacing durable attribution or delaying the real change.
+
+## Acceptance boundary
+
+A complete proof demonstrates: One accountable agent presence shows every location a run is editing without replacing durable attribution or delaying the real change.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.agent.resource-consent.md
+++ b/templates/content/docs/product/capabilities/content.agent.resource-consent.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.agent.resource-consent"
+name: "Agent resource consent"
+user_promise: "Resources independently declare whether agents may use them as context and whether agents may edit them, with inheritable policy ceilings."
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.access.page-database","content.event.committed"]
+related_features: ["content.feature.keep-your-private-vault-private"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Resources independently declare whether agents may use them as context and whether agents may edit them, with inheritable policy ceilings."
+proof_requirements: ["Resources independently declare whether agents may use them as context and whether agents may edit them, with inheritable policy ceilings."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Agent resource consent
+
+## Contract
+
+Resources independently declare whether agents may use them as context and whether agents may edit them, with inheritable policy ceilings.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Resources independently declare whether agents may use them as context and whether agents may edit them, with inheritable policy ceilings.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.agent.resource-consent.md
+++ b/templates/content/docs/product/capabilities/content.agent.resource-consent.md
@@ -1,17 +1,25 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.agent.resource-consent"
 name: "Agent resource consent"
-user_promise: "Resources independently declare whether agents may use them as context and whether agents may edit them, with inheritable policy ceilings."
+user_promise: "Resources independently declare whether agents may use them as context and whether agents may edit them, while inheritable ceilings can narrow either decision."
+primary_user_job: "Let an agent help with selected material without turning ordinary sharing access or a recoverable edit into blanket agent authority."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.access.page-database","content.event.committed"]
+dependencies: ["content.access.page-database", "content.event.committed"]
 related_features: ["content.feature.keep-your-private-vault-private"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Resources independently declare whether agents may use them as context and whether agents may edit them, with inheritable policy ceilings."
-proof_requirements: ["Resources independently declare whether agents may use them as context and whether agents may edit them, with inheritable policy ceilings."]
+acceptance_summary: "An authorized person can set distinct agent-context and agent-edit consent on a resource; inherited ceilings can only narrow them; every agent read or mutation rechecks the effective decision at use time."
+proof_requirements:
+  [
+    "Independent context and edit decisions through the shared resource/action surface, without adding a Page role",
+    "Inherited resource, container, workspace, and policy ceilings that only narrow effective consent and remain explainable",
+    "Access and consent re-evaluation before every agent read, traversal, synthesis input, and mutation, including mid-run revocation",
+    "Attributable Events and truthful typed failures for denial, revocation, unavailable policy state, and recoverability",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +27,64 @@ last_reviewed: "2026-07-29"
 
 # Agent resource consent
 
-## Contract
+## Why this exists
 
-Resources independently declare whether agents may use them as context and whether agents may edit them, with inheritable policy ceilings.
+Ordinary sharing answers who may access a resource. It does not answer whether an agent may use that resource as input, nor whether an agent may change it. Those are consequential decisions with different risks: a private note can be visible to its owner yet excluded from an agent's context, and an agent may be allowed to read a brief without being allowed to edit it.
 
-## Acceptance boundary
+Resource consent supplies those decisions without inventing another Page role or a parallel permission system. It composes with existing access, source policy, and workspace policy; it never broadens them.
 
-A complete proof demonstrates: Resources independently declare whether agents may use them as context and whether agents may edit them, with inheritable policy ceilings.
+## Example workflow
 
-## Evidence boundary
+A researcher shares a project brief with collaborators and asks an agent to draft a summary. The brief allows agent context but disallows agent edits. One linked personal note is excluded from agent context, so the run does not read it even though the researcher can. A folder-level policy later disables agent context for its children; the brief's own allowance cannot override that ceiling. If consent is revoked while the run is gathering inputs, its next read fails safely and the agent reports that it must continue without the resource or stop.
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+## Product contract
 
-## Non-goals
+### Separate, composable decisions
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- Each resource has distinct **agent context** and **agent edit** decisions. Context consent governs use as input, including search, traversal, retrieval, summarization, and synthesis; edit consent governs a proposed or committed agent mutation.
+- Edit consent does not imply context consent, and context consent does not imply edit consent. An edit must satisfy ordinary edit authority, applicable source/write-back policy, effective edit consent, and any required approval/confirmation gate.
+- Effective consent is the intersection of ordinary access, resource consent, source policy, and inherited container, workspace, organization, and framework-policy ceilings. A ceiling may narrow or disable a descendant decision but never grants or widens it.
+- The resource's own decision may be inherited where policy permits. An explicit descendant choice can narrow an inherited allowance, but it cannot escape an inherited denial or ceiling.
+- Consent is evaluated for the acting principal and current run at the point of use. Stored selection, search indexes, precomputed plans, queued work, and recovered runs do not carry a durable permission grant.
+
+### Revocation, accountability, and failure
+
+- Every agent read and every mutation preflight re-evaluates access and effective consent. A mid-run revocation prevents the next affected operation; already committed, authorized changes retain their ordinary Event and recovery history.
+- A denied or revoked resource is omitted from ambient discovery and aggregate inputs according to the normal access contract. A direct request receives a typed, non-leaking denial or unavailable state, never a fabricated empty success.
+- The run records the resource decision that authorized each committed mutation and an attributable Event/Revision. Recoverability makes an authorized mutation easier to undo; it neither grants consent nor substitutes for intent or access.
+- A person can inspect the applicable consent and the narrowest denying ceiling where they are authorized to see it. The explanation must not reveal inaccessible ancestors, resources, or policy details.
+
+## Boundaries and non-goals
+
+- This Capability is not another Page or Database role, a custom role builder, or a replacement for ordinary sharing and source authority.
+- It does not decide whether a request is truthful, appropriate for an audience, reversible, or subject to external confirmation; those are separate contracts.
+- It does not retain private context in a cache after consent or access changes, and it does not make a local device, vault, or provider available merely by recording consent.
+
+## Acceptance stories
+
+### Allow context without allowing edits
+
+Given a person can view a Page and its agent-context decision is allowed while its agent-edit decision is denied, when they ask an agent to summarize it and then ask the agent to rewrite it, then the summary may use the Page, the rewrite is denied before mutation, and no additional Page role has been created.
+
+### Respect an inherited ceiling
+
+Given a child resource allows agent context but an authorized parent policy denies it, when an agent attempts to retrieve the child, then the effective decision is denied, the child is not used, and an authorized policy editor can see that the parent ceiling prevailed without exposing unrelated private structure.
+
+### Stop on mid-run revocation
+
+Given an agent has begun an authorized multi-resource run, when context consent for one remaining resource is revoked, then the next read of that resource is denied, previously committed authorized changes remain attributable and recoverable, and the run neither reads cached private content nor reports an empty successful result.
+
+## Current evidence
+
+The shared architecture establishes access-before-computation and one Action surface in `templates/content/docs/product/architecture.md`. Current repository code contains access and collaboration substrate, but no evidence yet proves independent resource-level agent context/edit decisions, inherited consent ceilings, effective-decision explanations, or mid-run re-evaluation. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Add deterministic Action tests covering every combination of ordinary access, context consent, edit consent, source policy, and inherited ceilings; verify the result is an explicit allow, deny, or unavailable state.
+2. Exercise resource selection, search, traversal, agent context assembly, edits, bulk work, queued/recovered work, and provider-backed resources while consent changes; prove every path rechecks effective authority before use.
+3. Verify inherited decisions and explanation UI through the real interface, including child narrowing, parent denial, inaccessible ancestors, and policy changes.
+4. Verify Events/Revisions, receipts, recovery, and access-safe audit/history after allowed edits, denied writes, and mid-run revocation.
+
+## Open questions
+
+The storage representation for inheritable consent, the precise policy-editor vocabulary, and how a paused run offers its remaining authorized scope are implementation choices. They must preserve the separate decisions, narrowing-only inheritance, use-time re-evaluation, and non-leaking failures above.

--- a/templates/content/docs/product/capabilities/content.agent.skill-catalog.md
+++ b/templates/content/docs/product/capabilities/content.agent.skill-catalog.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.agent.skill-catalog"
+name: "Skills catalog"
+user_promise: "Governed reusable agent instructions/capabilities can be invoked against compatible Content targets"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.agent.action-parity","content.template.governance"]
+related_features: ["content.feature.put-your-organizations-know-how-to-work"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Personal or workspace ownership; stable identity and version; declared target scopes; visible effect/mutation contract; permissions; specificity-first contextual ranking; previews; agent-chat/run execution; Versions and Event receipts."
+proof_requirements: ["Personal or workspace ownership; stable identity and version; declared target scopes; visible effect/mutation contract; permissions; specificity-first contextual ranking; previews; agent-chat/run execution; Versions and Event receipts."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Skills catalog
+
+## Contract
+
+Governed reusable agent instructions/capabilities can be invoked against compatible Content targets
+
+## Acceptance boundary
+
+A complete proof demonstrates: Personal or workspace ownership; stable identity and version; declared target scopes; visible effect/mutation contract; permissions; specificity-first contextual ranking; previews; agent-chat/run execution; Versions and Event receipts.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.agent.skill-catalog.md
+++ b/templates/content/docs/product/capabilities/content.agent.skill-catalog.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.agent.skill-catalog"
 name: "Skills catalog"
-user_promise: "Governed reusable agent instructions/capabilities can be invoked against compatible Content targets"
+user_promise: "Governed reusable agent instructions and capabilities can be invoked against compatible Content targets"
+primary_user_job: "Reuse approved organizational know-how against the right target while seeing what it may do before it runs."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.agent.action-parity","content.template.governance"]
+dependencies: ["content.agent.action-parity", "content.template.governance"]
 related_features: ["content.feature.put-your-organizations-know-how-to-work"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Personal or workspace ownership; stable identity and version; declared target scopes; visible effect/mutation contract; permissions; specificity-first contextual ranking; previews; agent-chat/run execution; Versions and Event receipts."
-proof_requirements: ["Personal or workspace ownership; stable identity and version; declared target scopes; visible effect/mutation contract; permissions; specificity-first contextual ranking; previews; agent-chat/run execution; Versions and Event receipts."]
+acceptance_summary: "A Skill has stable identity, version, personal or workspace ownership, declared compatible targets, permissions, effect and mutation contract, preview, and specificity-first contextual ranking."
+proof_requirements:
+  [
+    "Typed contract, authorization, validation, Event/history, and recovery coverage",
+    "Cross-surface UI, Action, agent-context, reload, and failure-state coverage",
+    "Real-interface keyboard and assistive-technology workflow coverage",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,42 @@ last_reviewed: "2026-07-29"
 
 # Skills catalog
 
-## Contract
+## Why this exists
 
-Governed reusable agent instructions/capabilities can be invoked against compatible Content targets
+Reusable guidance becomes dangerous when its scope and effect are invisible. A catalog makes durable know-how legible as a governed tool.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Personal or workspace ownership; stable identity and version; declared target scopes; visible effect/mutation contract; permissions; specificity-first contextual ranking; previews; agent-chat/run execution; Versions and Event receipts.
+An organization publishes a versioned meeting-summary Skill for project Pages. A member previews its declared inputs and effects, invokes it in agent chat, and sees a Version and Event receipt.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+A Skill has stable identity, version, personal or workspace ownership, declared compatible targets, permissions, effect and mutation contract, preview, and specificity-first contextual ranking. Invocation uses agent chat and shared Actions with normal Versions and Events.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Template governance owns approval policy and action parity owns execution. This is not arbitrary hidden prompt injection, a secret capability grant, or universal auto-run.
+
+## Acceptance stories
+
+### Rank a compatible project skill
+
+Given two compatible Skills, when a project Page is focused, then the more specific authorized Skill ranks first and its scope is visible.
+
+### Preview a versioned skill before mutation
+
+Given a Skill proposes a mutation, when a person previews it, then the declared effect and required authority appear before any Action runs.
+
+## Current evidence
+
+No complete catalog identity, ranking, preview, execution, and receipt proof is recorded. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Test personal and workspace Skills through versioning, compatibility selection, and effect display.
+2. Verify ranking, approval, denial, preview, invocation, Events, Versions, and revocation.
+3. Run agent-chat discovery with incompatible targets and accessible previews.
+
+## Open questions
+
+The version-promotion and organization approval workflow needs design.

--- a/templates/content/docs/product/capabilities/content.api.cms.md
+++ b/templates/content/docs/product/capabilities/content.api.cms.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.api.cms"
 name: "Content API and CMS"
-user_promise: "External clients and websites can read and mutate Content through the same typed Actions, permissions, validation, and audit behavior as people and agents."
+user_promise: "External clients and websites can use Content without a second, weaker product contract."
+primary_user_job: "Read or change an authorized Content object from another client and receive the same truthful result as the Content interface."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.agent.action-parity","content.access.page-database"]
+dependencies: ["content.agent.action-parity", "content.access.page-database"]
 related_features: []
 roadmap_boundary: "supporting"
-acceptance_summary: "A complete proof demonstrates: External clients and websites can read and mutate Content through the same typed Actions, permissions, validation, and audit behavior as people and agents."
-proof_requirements: ["External clients and websites can read and mutate Content through the same typed Actions, permissions, validation, and audit behavior as people and agents."]
+acceptance_summary: "A documented typed client surface invokes the same Actions as people and agents, preserves actor and origin, enforces current access and validation, and returns distinguishable success, denial, conflict, and failure outcomes."
+proof_requirements:
+  [
+    "Contract tests proving client calls route through named typed Actions rather than parallel CRUD",
+    "Authorization, validation, audit, idempotency, and error-state parity tests across interface, agent, and external client",
+    "End-to-end client workflow covering read, mutation, denied access, conflict, and receipt",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,45 @@ last_reviewed: "2026-07-29"
 
 # Content API and CMS
 
-## Contract
+## Why this exists
 
-External clients and websites can read and mutate Content through the same typed Actions, permissions, validation, and audit behavior as people and agents.
+CMS consumers need Content truth without a shadow datastore or a special permission lane.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: External clients and websites can read and mutate Content through the same typed Actions, permissions, validation, and audit behavior as people and agents.
+A site editor loads an authorized Page through a typed client, changes its title through an Action, and receives the same validation error or committed receipt they would see in Content.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- The API is a client of the shared typed Action surface; it does not expose route-shaped CRUD as a rival contract.
+- Each request resolves the acting identity and current access before reading, traversing, or mutating Content.
+- Mutations retain actor, origin, idempotency, validation, Events, history, and receipts. Unsupported, denied, conflict, and failed outcomes remain distinct.
+- Public reading is governed by publication and visibility contracts, not by an API key that bypasses them.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+This is not a generic database proxy, a provider API replacement, or a promise that every internal Action is public. Publication owns public URLs; embeds own host grants.
+
+## Acceptance stories
+
+### Use the same mutation boundary
+
+Given an authorized external client, when it changes a Page through the typed Action, then Content applies the ordinary validation and records the client origin in the committed receipt.
+
+### Refuse a hidden record
+
+Given a client token without access to a Page, when it requests that Page or a Query containing it, then the result reveals neither the record nor its derived data.
+
+## Current evidence
+
+Donor evidence: `actions/` contains Content operations and shared Action use. No repository proof yet demonstrates a complete external typed client contract, parity matrix, or end-to-end CMS workflow; this record remains `approved_shape`.
+
+## Proof plan
+
+1. Define a public, versioned typed client boundary over selected Actions.
+2. Test authorization, validation, audit, idempotency, and error parity.
+3. Run a real client read/change/denial/conflict workflow and retain receipts.
+
+## Open questions
+
+- The initial authentication and client packaging boundary remains to be selected without creating a second authority model.

--- a/templates/content/docs/product/capabilities/content.api.cms.md
+++ b/templates/content/docs/product/capabilities/content.api.cms.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.api.cms"
+name: "Content API and CMS"
+user_promise: "External clients and websites can read and mutate Content through the same typed Actions, permissions, validation, and audit behavior as people and agents."
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.agent.action-parity","content.access.page-database"]
+related_features: []
+roadmap_boundary: "supporting"
+acceptance_summary: "A complete proof demonstrates: External clients and websites can read and mutate Content through the same typed Actions, permissions, validation, and audit behavior as people and agents."
+proof_requirements: ["External clients and websites can read and mutate Content through the same typed Actions, permissions, validation, and audit behavior as people and agents."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Content API and CMS
+
+## Contract
+
+External clients and websites can read and mutate Content through the same typed Actions, permissions, validation, and audit behavior as people and agents.
+
+## Acceptance boundary
+
+A complete proof demonstrates: External clients and websites can read and mutate Content through the same typed Actions, permissions, validation, and audit behavior as people and agents.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.author.code.md
+++ b/templates/content/docs/product/capabilities/content.author.code.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.author.code"
 name: "Executable Code blocks"
-user_promise: "Powerful inline Code blocks highlight any recognized language and may become isolated, composable mini-sandboxes with compatible renderers and execution runtimes"
+user_promise: "Let me author, inspect, and deliberately run code in an ordinary document without hidden notebook state."
+primary_user_job: "Author and run bounded code with explicit inputs and inspectable output."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.object.block","content.author.media"]
+dependencies: ["content.object.block", "content.author.media"]
 related_features: ["content.feature.build-new-surfaces"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Source/Rendered/Console/Split views; page-scoped referenced source tabs; explicit promotion for workspace-reusable code; manual execution plus opt-in preview hot reload; strict no-network sandbox; bounded resources/output; durable run receipts, approved cached outputs, and stale-output state; portable fences and eventual `.ipynb` interoperability. Mermaid is the first built-in renderer."
-proof_requirements: ["Source/Rendered/Console/Split views; page-scoped referenced source tabs; explicit promotion for workspace-reusable code; manual execution plus opt-in preview hot reload; strict no-network sandbox; bounded resources/output; durable run receipts, approved cached outputs, and stale-output state; portable fences and eventual `.ipynb` interoperability. Mermaid is the first built-in renderer."]
+acceptance_summary: "Code blocks keep portable source and optional typed rendering or execution; runs are explicit, isolated, bounded, receipted, and their approved output can become stale."
+proof_requirements:
+  [
+    "Source/highlighting is universal; compatible renderers and runtimes are declared rather than inferred.",
+    "Run never happens on paste, load, collaboration, or public reading; each run pins explicit page-scoped source references.",
+    "Outputs are bounded handles with receipts; changing source or a referenced tab marks prior output stale without erasing history.",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,46 @@ last_reviewed: "2026-07-29"
 
 # Executable Code blocks
 
-## Contract
+## Why this exists
 
-Powerful inline Code blocks highlight any recognized language and may become isolated, composable mini-sandboxes with compatible renderers and execution runtimes
+Code belongs beside an explanation, but ordinary document code must not inherit the hidden state, ambient authority, or unreadable output of a notebook. Authors need to see exactly what source was run, with which inputs, and whether a displayed result is still trustworthy.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Source/Rendered/Console/Split views; page-scoped referenced source tabs; explicit promotion for workspace-reusable code; manual execution plus opt-in preview hot reload; strict no-network sandbox; bounded resources/output; durable run receipts, approved cached outputs, and stale-output state; portable fences and eventual `.ipynb` interoperability. Mermaid is the first built-in renderer.
+Ava adds a Mermaid Code block to a design Page, changes a referenced Code tab, and sees the prior approved diagram marked stale until a deliberate new run.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Source/highlighting is universal; compatible renderers and runtimes are declared rather than inferred.
+- Run never happens on paste, load, collaboration, or public reading; each run pins explicit page-scoped source references.
+- Outputs are bounded handles with receipts; changing source or a referenced tab marks prior output stale without erasing history.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- `content.object.block` owns Code Block identity and portable source; renderer and runtime adapters add capabilities without changing that identity.
+- Code Blocks do not create an ambient kernel, execute on open/paste/public render, or turn successful runs into Custom Blocks automatically.
+
+## Acceptance stories
+
+### Reject ambient execution
+
+Given pasted JavaScript, when another collaborator or a public reader opens the Page, then no runtime starts.
+
+### Pin source inputs
+
+Given a run with referenced tabs, when one tab changes, then the receipt keeps the original revisions and the output becomes stale.
+
+## Current evidence
+
+`app/components/editor/extensions/CodeBlockNode.tsx` provides Lowlight Code source; no tabs, isolated runtime, receipts, or approved-output state exists.
+
+## Proof plan
+
+1. Test Source/Rendered/Console/Split capability gating.
+2. Run explicit tabs and verify hashes, stale invalidation, and cycles.
+3. Deny network, secrets, filesystem, DOM, worker, timeout, and oversized output.
+4. Test manual Run, preview rerun, saved output, export fallback, and fences.
+
+## Open questions
+
+First runtime scope is open; a shared notebook kernel is not.

--- a/templates/content/docs/product/capabilities/content.author.code.md
+++ b/templates/content/docs/product/capabilities/content.author.code.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.author.code"
+name: "Executable Code blocks"
+user_promise: "Powerful inline Code blocks highlight any recognized language and may become isolated, composable mini-sandboxes with compatible renderers and execution runtimes"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.object.block","content.author.media"]
+related_features: ["content.feature.build-new-surfaces"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Source/Rendered/Console/Split views; page-scoped referenced source tabs; explicit promotion for workspace-reusable code; manual execution plus opt-in preview hot reload; strict no-network sandbox; bounded resources/output; durable run receipts, approved cached outputs, and stale-output state; portable fences and eventual `.ipynb` interoperability. Mermaid is the first built-in renderer."
+proof_requirements: ["Source/Rendered/Console/Split views; page-scoped referenced source tabs; explicit promotion for workspace-reusable code; manual execution plus opt-in preview hot reload; strict no-network sandbox; bounded resources/output; durable run receipts, approved cached outputs, and stale-output state; portable fences and eventual `.ipynb` interoperability. Mermaid is the first built-in renderer."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Executable Code blocks
+
+## Contract
+
+Powerful inline Code blocks highlight any recognized language and may become isolated, composable mini-sandboxes with compatible renderers and execution runtimes
+
+## Acceptance boundary
+
+A complete proof demonstrates: Source/Rendered/Console/Split views; page-scoped referenced source tabs; explicit promotion for workspace-reusable code; manual execution plus opt-in preview hot reload; strict no-network sandbox; bounded resources/output; durable run receipts, approved cached outputs, and stale-output state; portable fences and eventual `.ipynb` interoperability. Mermaid is the first built-in renderer.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.author.document-editor.md
+++ b/templates/content/docs/product/capabilities/content.author.document-editor.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.author.document-editor"
+name: "Document editor"
+user_promise: "A humane visual document editor with blocks, comments, media, collaboration, and agent co-editing"
+kind: "primitive"
+state: "in_progress"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.object.page","content.object.blocks-field"]
+related_features: ["content.feature.durable-foundations"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Freeze current editor story across editing, reload, collaboration, comments, agent action, and export."
+proof_requirements: ["Freeze current editor story across editing, reload, collaboration, comments, agent action, and export."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Document editor
+
+## Contract
+
+A humane visual document editor with blocks, comments, media, collaboration, and agent co-editing
+
+## Acceptance boundary
+
+A complete proof demonstrates: Freeze current editor story across editing, reload, collaboration, comments, agent action, and export.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.author.document-editor.md
+++ b/templates/content/docs/product/capabilities/content.author.document-editor.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.author.document-editor"
 name: "Document editor"
-user_promise: "A humane visual document editor with blocks, comments, media, collaboration, and agent co-editing"
+user_promise: "Write and revise a rich document with blocks, comments, collaboration, media, and agent help in one humane surface."
+primary_user_job: "Revise a shared rich document without losing structure or history."
 kind: "primitive"
 state: "in_progress"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.object.page","content.object.blocks-field"]
+dependencies: ["content.object.page", "content.object.blocks-field"]
 related_features: ["content.feature.durable-foundations"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Freeze current editor story across editing, reload, collaboration, comments, agent action, and export."
-proof_requirements: ["Freeze current editor story across editing, reload, collaboration, comments, agent action, and export."]
+acceptance_summary: "The visual editor preserves canonical document content through edits, reloads, collaboration, comments, authorized agent changes, and export."
+proof_requirements:
+  [
+    "One visual document surface edits the canonical Blocks field and retains stable Page and block identity.",
+    "Agent proposals use the ordinary action, review, and history path; they are not a private inline editor.",
+    "Collaborators see reconciliation and failures honestly rather than silently losing edits.",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,46 @@ last_reviewed: "2026-07-29"
 
 # Document editor
 
-## Contract
+## Why this exists
 
-A humane visual document editor with blocks, comments, media, collaboration, and agent co-editing
+Writing falls apart when the editor treats structure, comments, collaboration, media, and agent edits as separate temporary surfaces. A Page needs one humane place where those changes remain attributable and recoverable after the tab closes.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Freeze current editor story across editing, reload, collaboration, comments, agent action, and export.
+Ravi turns a paragraph into a callout, anchors a Comment, accepts an agent edit, reloads, and finds both the block and comment anchor intact.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- One visual document surface edits the canonical Blocks field and retains stable Page and block identity.
+- Agent proposals use the ordinary action, review, and history path; they are not a private inline editor.
+- Collaborators see reconciliation and failures honestly rather than silently losing edits.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- `content.object.page` and `content.object.blocks-field` own identity and body history; Comments, media, and agent actions use their own shared contracts.
+- This does not add a raw-source editing mode, a second agent composer, or a private inline mutation engine.
+
+## Acceptance stories
+
+### Reconcile collaboration
+
+Given two editors change adjacent text while one is offline, when reconnecting, then no edit is silently lost.
+
+### Export canonical content
+
+Given media, comments, and an agent mutation, when export runs, then visible content reflects the canonical body.
+
+## Current evidence
+
+`app/components/editor/VisualEditor.tsx`, `DocumentEditor.tsx`, `actions/edit-document.ts`, and `actions/update-document.ts` are donors; a joined end-to-end workflow is unproved.
+
+## Proof plan
+
+1. Edit rich blocks and media then reload and compare canonical serialization.
+2. Test reconnect, anchors, and attribution.
+3. Compare UI and Action edits for access/history parity.
+4. Export mixed content with declared fallbacks.
+
+## Open questions
+
+A minimal real-interface collaboration script needs selection.

--- a/templates/content/docs/product/capabilities/content.author.footnotes.md
+++ b/templates/content/docs/product/capabilities/content.author.footnotes.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.author.footnotes"
+name: "Footnotes"
+user_promise: "Footnotes remain humane to author, navigate, render, and round-trip"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.object.block","content.object.reference"]
+related_features: ["content.feature.cite-what-you-found"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Stable anchors, visual insertion/editing, automatic numbering, bidirectional navigation, provider-neutral source/export syntax, editor/reader/export parity, accessibility."
+proof_requirements: ["Stable anchors, visual insertion/editing, automatic numbering, bidirectional navigation, provider-neutral source/export syntax, editor/reader/export parity, accessibility."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Footnotes
+
+## Contract
+
+Footnotes remain humane to author, navigate, render, and round-trip
+
+## Acceptance boundary
+
+A complete proof demonstrates: Stable anchors, visual insertion/editing, automatic numbering, bidirectional navigation, provider-neutral source/export syntax, editor/reader/export parity, accessibility.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.author.footnotes.md
+++ b/templates/content/docs/product/capabilities/content.author.footnotes.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.author.footnotes"
 name: "Footnotes"
-user_promise: "Footnotes remain humane to author, navigate, render, and round-trip"
+user_promise: "Add a durable explanatory or citation note without manually managing superscript text."
+primary_user_job: "Add and navigate durable semantic notes beside prose."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.object.block","content.object.reference"]
+dependencies: ["content.object.block", "content.object.reference"]
 related_features: ["content.feature.cite-what-you-found"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Stable anchors, visual insertion/editing, automatic numbering, bidirectional navigation, provider-neutral source/export syntax, editor/reader/export parity, accessibility."
-proof_requirements: ["Stable anchors, visual insertion/editing, automatic numbering, bidirectional navigation, provider-neutral source/export syntax, editor/reader/export parity, accessibility."]
+acceptance_summary: "Footnotes have stable anchors, visual editing, automatic numbering, bidirectional navigation, accessibility, and provider-neutral source/export parity."
+proof_requirements:
+  [
+    "A footnote reference and body are semantic authoring objects, not ordinary superscript text.",
+    "Numbering and back-links derive from the document order while anchors retain identity through edits.",
+    "Editor, reader, and export use the shared source representation and expose an accessible fallback.",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,46 @@ last_reviewed: "2026-07-29"
 
 # Footnotes
 
-## Contract
+## Why this exists
 
-Footnotes remain humane to author, navigate, render, and round-trip
+Writers need to qualify a claim without breaking the reading flow or hand-numbering fragile markers. Notes need to stay attached through revision and remain usable to readers who navigate by keyboard or assistive technology.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Stable anchors, visual insertion/editing, automatic numbering, bidirectional navigation, provider-neutral source/export syntax, editor/reader/export parity, accessibility.
+A historian inserts a footnote, reorders paragraphs, and exports; numbering updates while readers can move from reference to note and back.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A footnote reference and body are semantic authoring objects, not ordinary superscript text.
+- Numbering and back-links derive from the document order while anchors retain identity through edits.
+- Editor, reader, and export use the shared source representation and expose an accessible fallback.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- Citation records own source metadata and bibliography policy; Footnotes own inline note anchors, authoring, navigation, and source representation.
+- Footnotes are not superscript text, Custom Blocks, or a reason to add general raw-source editing.
+
+## Acceptance stories
+
+### Preserve anchor identity
+
+Given prose is revised and notes reorder, when saving, then identity survives while numbering updates.
+
+### Export a readable fallback
+
+Given a destination lacks footnotes, when exporting, then the note is not flattened into unexplained superscript text.
+
+## Current evidence
+
+No footnote extension exists under `app/components/editor/extensions/`; `app/components/editor/VisualEditor.tsx` and `shared/nfm.ts` are donors.
+
+## Proof plan
+
+1. Insert/edit/delete/reorder notes and verify anchors and links.
+2. Test keyboard and screen-reader traversal.
+3. Round-trip through source and export adapters.
+4. Test copy/paste and concurrent edits.
+
+## Open questions
+
+No product question remains.

--- a/templates/content/docs/product/capabilities/content.author.math.md
+++ b/templates/content/docs/product/capabilities/content.author.math.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.author.math"
 name: "Math and equations"
-user_promise: "Inline and block math render faithfully in editor, reader, and export"
+user_promise: "Write an equation inline or as a block and have it stay intelligible everywhere I read or export it."
+primary_user_job: "Create equations that remain readable across representations."
 kind: "primitive"
 state: "in_progress"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.object.block","content.renderer.typed"]
+dependencies: ["content.object.block", "content.renderer.typed"]
 related_features: []
 roadmap_boundary: "supporting"
-acceptance_summary: "A complete proof demonstrates: Current code has KaTeX rendering with accessible MathML, inline `$…$` promotion, slash composers with live validation, NFM round trips, visible invalid-source fallback, and HTML/PDF-ready export tests. Verify the shipped editor, public reader, copy/paste, Notion sync, and export surfaces together before calling the capability fully verified."
-proof_requirements: ["Current code has KaTeX rendering with accessible MathML, inline `$…$` promotion, slash composers with live validation, NFM round trips, visible invalid-source fallback, and HTML/PDF-ready export tests. Verify the shipped editor, public reader, copy/paste, Notion sync, and export surfaces together before calling the capability fully verified."]
+acceptance_summary: "Inline and display math use one editable source value with KaTeX rendering, accessible MathML, visible invalid-source fallback, and source/export parity."
+proof_requirements:
+  [
+    "Inline selection can become an equation and reopen the same source editor.",
+    "Invalid math preserves visible source and a diagnostic instead of disappearing or looking valid.",
+    "Math remains a built-in Block identity and is not a Custom Block.",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,46 @@ last_reviewed: "2026-07-29"
 
 # Math and equations
 
-## Contract
+## Why this exists
 
-Inline and block math render faithfully in editor, reader, and export
+An equation is both source a writer must correct and meaning a reader must understand. Rendering cannot be allowed to hide malformed notation or make one surface silently disagree with another.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Current code has KaTeX rendering with accessible MathML, inline `$…$` promotion, slash composers with live validation, NFM round trips, visible invalid-source fallback, and HTML/PDF-ready export tests. Verify the shipped editor, public reader, copy/paste, Notion sync, and export surfaces together before calling the capability fully verified.
+A scientist selects `E = mc^2`, corrects LaTeX in the inline equation editor, and exports readable math; invalid source stays visible with its error.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Inline selection can become an equation and reopen the same source editor.
+- Invalid math preserves visible source and a diagnostic instead of disappearing or looking valid.
+- Math remains a built-in Block identity and is not a Custom Block.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- The typed renderer substrate owns presentation; Math owns equation source, inline/display authoring, and accessible fallback.
+- Math is a built-in Block capability, not a Custom Block, arbitrary code executor, or a new formula language.
+
+## Acceptance stories
+
+### Show invalid source
+
+Given malformed LaTeX, when KaTeX rejects it, then the source and diagnostic stay visible.
+
+### Preserve one value
+
+Given copied math is read in editable and read-only surfaces, then both derive from the same LaTeX.
+
+## Current evidence
+
+`app/components/editor/MathRenderer.tsx`, `math-rendering.spec.ts`, `MathRenderer.test.tsx`, and `SlashCommandMenu.tsx` prove KaTeX, MathML, and creation; public/export parity remains unjoined.
+
+## Proof plan
+
+1. Test selection promotion, slash insertion, source editing, and display mode.
+2. Assert MathML and invalid fallback in SSR/client output.
+3. Copy/paste, source-round-trip, and provider-sync equations.
+4. Verify HTML/PDF rendering or fallback.
+
+## Open questions
+
+No product question remains; surface proof is pending.

--- a/templates/content/docs/product/capabilities/content.author.math.md
+++ b/templates/content/docs/product/capabilities/content.author.math.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.author.math"
+name: "Math and equations"
+user_promise: "Inline and block math render faithfully in editor, reader, and export"
+kind: "primitive"
+state: "in_progress"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.object.block","content.renderer.typed"]
+related_features: []
+roadmap_boundary: "supporting"
+acceptance_summary: "A complete proof demonstrates: Current code has KaTeX rendering with accessible MathML, inline `$…$` promotion, slash composers with live validation, NFM round trips, visible invalid-source fallback, and HTML/PDF-ready export tests. Verify the shipped editor, public reader, copy/paste, Notion sync, and export surfaces together before calling the capability fully verified."
+proof_requirements: ["Current code has KaTeX rendering with accessible MathML, inline `$…$` promotion, slash composers with live validation, NFM round trips, visible invalid-source fallback, and HTML/PDF-ready export tests. Verify the shipped editor, public reader, copy/paste, Notion sync, and export surfaces together before calling the capability fully verified."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Math and equations
+
+## Contract
+
+Inline and block math render faithfully in editor, reader, and export
+
+## Acceptance boundary
+
+A complete proof demonstrates: Current code has KaTeX rendering with accessible MathML, inline `$…$` promotion, slash composers with live validation, NFM round trips, visible invalid-source fallback, and HTML/PDF-ready export tests. Verify the shipped editor, public reader, copy/paste, Notion sync, and export surfaces together before calling the capability fully verified.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.author.media.md
+++ b/templates/content/docs/product/capabilities/content.author.media.md
@@ -1,8 +1,10 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.author.media"
 name: "Media Blocks"
-user_promise: "Images, audio, video, files, embeds, captions, and source-aware assets travel through one storage/rendering contract"
+user_promise: "Put images, audio, video, files, embeds, captions, and source-aware assets in a document without losing access or provenance."
+primary_user_job: "Attach authorized media with provenance and honest fallbacks."
 kind: "primitive"
 state: "in_progress"
 publicness: "public"
@@ -10,8 +12,13 @@ availability: "universal"
 dependencies: ["content.object.block"]
 related_features: ["content.feature.read-and-annotate-anything"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Blob handles, access, upload/paste/drop, export degradation, source provenance."
-proof_requirements: ["Blob handles, access, upload/paste/drop, export degradation, source provenance."]
+acceptance_summary: "Media Blocks use stable asset handles, access-aware rendering, upload/paste/drop intake, captions and provenance, and honest export degradation."
+proof_requirements:
+  [
+    "Large media lives in configured blob storage; records retain handles and metadata, never embedded payload bodies.",
+    "Every view checks access before loading or previewing an asset and carries captions and known source provenance.",
+    "Unsupported destinations expose a declared fallback rather than silently dropping the media.",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,46 @@ last_reviewed: "2026-07-29"
 
 # Media Blocks
 
-## Contract
+## Why this exists
 
-Images, audio, video, files, embeds, captions, and source-aware assets travel through one storage/rendering contract
+An asset is not just a preview: it has storage, access, caption, provenance, and export consequences. Authors need to place media naturally without leaking a private asset or losing the context that makes it useful.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Blob handles, access, upload/paste/drop, export degradation, source provenance.
+Leah drops an interview recording on a research Page, captions it, shares it with an editor, and exports a linked fallback.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Large media lives in configured blob storage; records retain handles and metadata, never embedded payload bodies.
+- Every view checks access before loading or previewing an asset and carries captions and known source provenance.
+- Unsupported destinations expose a declared fallback rather than silently dropping the media.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- Storage owns bytes and Content stores only handles/metadata; source adapters own source truth and write-back policy.
+- Media Blocks do not grant access through Page embedding or promise identical playback on every export destination.
+
+## Acceptance stories
+
+### Enforce asset access
+
+Given a private asset appears on a shared Page, when an unauthorized viewer opens it, then no bytes or hidden metadata leak.
+
+### Keep bytes in storage
+
+Given a large pasted video, when saved, then Content stores only a stable handle and metadata.
+
+## Current evidence
+
+`app/components/editor/extensions/AudioBlock.tsx`, `VideoBlock.tsx`, and `ImageBlock.tsx` are donors; unified handle/access/provenance/export behavior is absent.
+
+## Proof plan
+
+1. Upload, paste, and drop supported media and verify handles/captions/provenance.
+2. Test owner, shared, and denied reader behavior.
+3. Export every class with its declared fallback.
+4. Exercise replacement, deletion, retry, and unavailable storage.
+
+## Open questions
+
+Initial embed providers remain open.

--- a/templates/content/docs/product/capabilities/content.author.media.md
+++ b/templates/content/docs/product/capabilities/content.author.media.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.author.media"
+name: "Media Blocks"
+user_promise: "Images, audio, video, files, embeds, captions, and source-aware assets travel through one storage/rendering contract"
+kind: "primitive"
+state: "in_progress"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.object.block"]
+related_features: ["content.feature.read-and-annotate-anything"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Blob handles, access, upload/paste/drop, export degradation, source provenance."
+proof_requirements: ["Blob handles, access, upload/paste/drop, export degradation, source provenance."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Media Blocks
+
+## Contract
+
+Images, audio, video, files, embeds, captions, and source-aware assets travel through one storage/rendering contract
+
+## Acceptance boundary
+
+A complete proof demonstrates: Blob handles, access, upload/paste/drop, export degradation, source provenance.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.author.mermaid.md
+++ b/templates/content/docs/product/capabilities/content.author.mermaid.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.author.mermaid"
 name: "Mermaid diagrams"
-user_promise: "Mermaid source renders through a normal built-in Code-block renderer and round-trips through ordinary fenced source"
+user_promise: "Insert a diagram as ordinary Mermaid source and read a faithful rendered diagram when possible."
+primary_user_job: "Create portable Mermaid diagrams from ordinary Code source."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.author.code","content.renderer.typed"]
+dependencies: ["content.author.code", "content.renderer.typed"]
 related_features: []
 roadmap_boundary: "supporting"
-acceptance_summary: "A complete proof demonstrates: Present Mermaid as `/Diagram (Mermaid)` over `language = mermaid`, with Source/Rendered views and the shared renderer/export substrate. Current block donates source/caption editing, Excalidraw-style SVG with strict Mermaid fallback, visible errors, lightbox, dark mode, sanitization, and MDX migration. Add ordinary fence mapping, static/accessibility fallback, public SSR strategy, and shared HTML/PDF rendering."
-proof_requirements: ["Present Mermaid as `/Diagram (Mermaid)` over `language = mermaid`, with Source/Rendered views and the shared renderer/export substrate. Current block donates source/caption editing, Excalidraw-style SVG with strict Mermaid fallback, visible errors, lightbox, dark mode, sanitization, and MDX migration. Add ordinary fence mapping, static/accessibility fallback, public SSR strategy, and shared HTML/PDF rendering."]
+acceptance_summary: "`/Diagram (Mermaid)` creates a normal Code block with `language = mermaid`; the built-in renderer provides Source and Rendered views, source round trips, accessible/static fallback, and shared export behavior."
+proof_requirements:
+  [
+    "Mermaid is a Code language plus built-in renderer, not a Custom Block or a separate diagram datastore.",
+    "The renderer may prefer an Agent Native style but falls back to faithful Mermaid; errors preserve source and diagnostics.",
+    "Public and exported documents never execute source and use a pinned static rendering or readable source fallback.",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,46 @@ last_reviewed: "2026-07-29"
 
 # Mermaid diagrams
 
-## Contract
+## Why this exists
 
-Mermaid source renders through a normal built-in Code-block renderer and round-trips through ordinary fenced source
+A diagram should remain editable, portable source rather than becoming a picture that only one editor understands. Authors also need an honest fallback when a renderer does not support the diagram they wrote.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Present Mermaid as `/Diagram (Mermaid)` over `language = mermaid`, with Source/Rendered views and the shared renderer/export substrate. Current block donates source/caption editing, Excalidraw-style SVG with strict Mermaid fallback, visible errors, lightbox, dark mode, sanitization, and MDX migration. Add ordinary fence mapping, static/accessibility fallback, public SSR strategy, and shared HTML/PDF rendering.
+Noor uses `/Diagram (Mermaid)`, edits its ordinary Code source, and exports a diagram that either renders faithfully or retains source and error.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Mermaid is a Code language plus built-in renderer, not a Custom Block or a separate diagram datastore.
+- The renderer may prefer an Agent Native style but falls back to faithful Mermaid; errors preserve source and diagnostics.
+- Public and exported documents never execute source and use a pinned static rendering or readable source fallback.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- `content.author.code` owns source and optional runtime behavior; Mermaid owns a compatible built-in renderer for `language = mermaid`.
+- Mermaid is not a Custom Block, graph database, Canvas replacement, or a license to execute diagram source for viewers.
+
+## Acceptance stories
+
+### Preserve Code identity
+
+Given an imported fenced Mermaid file, when re-exported, then it remains `language = mermaid` Code, not a Custom Block.
+
+### Try compatible fallbacks
+
+Given preferred styling fails, when rendering, then Mermaid fallback runs before source/error display.
+
+## Current evidence
+
+`app/blocks/contentBlockRegistry.tsx` is the Mermaid donor; `app/components/editor/extensions/CodeBlockNode.tsx` supplies Code identity. Fence mapping, SSR, accessibility, and export remain gaps.
+
+## Proof plan
+
+1. Create/import Mermaid blocks and verify fences/captions.
+2. Test preferred, Mermaid, and double-failure paths.
+3. Verify sanitizer, theme, accessibility, SSR, and static export.
+4. Confirm no Custom Block catalog entry.
+
+## Open questions
+
+Renderer Auto versus explicit preference remains open.

--- a/templates/content/docs/product/capabilities/content.author.mermaid.md
+++ b/templates/content/docs/product/capabilities/content.author.mermaid.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.author.mermaid"
+name: "Mermaid diagrams"
+user_promise: "Mermaid source renders through a normal built-in Code-block renderer and round-trips through ordinary fenced source"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.author.code","content.renderer.typed"]
+related_features: []
+roadmap_boundary: "supporting"
+acceptance_summary: "A complete proof demonstrates: Present Mermaid as `/Diagram (Mermaid)` over `language = mermaid`, with Source/Rendered views and the shared renderer/export substrate. Current block donates source/caption editing, Excalidraw-style SVG with strict Mermaid fallback, visible errors, lightbox, dark mode, sanitization, and MDX migration. Add ordinary fence mapping, static/accessibility fallback, public SSR strategy, and shared HTML/PDF rendering."
+proof_requirements: ["Present Mermaid as `/Diagram (Mermaid)` over `language = mermaid`, with Source/Rendered views and the shared renderer/export substrate. Current block donates source/caption editing, Excalidraw-style SVG with strict Mermaid fallback, visible errors, lightbox, dark mode, sanitization, and MDX migration. Add ordinary fence mapping, static/accessibility fallback, public SSR strategy, and shared HTML/PDF rendering."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Mermaid diagrams
+
+## Contract
+
+Mermaid source renders through a normal built-in Code-block renderer and round-trips through ordinary fenced source
+
+## Acceptance boundary
+
+A complete proof demonstrates: Present Mermaid as `/Diagram (Mermaid)` over `language = mermaid`, with Source/Rendered views and the shared renderer/export substrate. Current block donates source/caption editing, Excalidraw-style SVG with strict Mermaid fallback, visible errors, lightbox, dark mode, sanitization, and MDX migration. Add ordinary fence mapping, static/accessibility fallback, public SSR strategy, and shared HTML/PDF rendering.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.automation.scheduled.md
+++ b/templates/content/docs/product/capabilities/content.automation.scheduled.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.automation.scheduled"
+name: "Scheduled automation"
+user_promise: "Scheduled queries and recurring heartbeats over current state"
+kind: "workflow"
+state: "in_progress"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.rule.deterministic","content.time.types"]
+related_features: ["content.feature.when-this-happens-that-follows"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: One scheduler, timezone semantics, bounded queries, dedupe and causal lineage."
+proof_requirements: ["One scheduler, timezone semantics, bounded queries, dedupe and causal lineage."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Scheduled automation
+
+## Contract
+
+Scheduled queries and recurring heartbeats over current state
+
+## Acceptance boundary
+
+A complete proof demonstrates: One scheduler, timezone semantics, bounded queries, dedupe and causal lineage.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.automation.scheduled.md
+++ b/templates/content/docs/product/capabilities/content.automation.scheduled.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.automation.scheduled"
 name: "Scheduled automation"
 user_promise: "Scheduled queries and recurring heartbeats over current state"
+primary_user_job: "Run a bounded recurring check at the intended time without duplicate work or timezone ambiguity."
 kind: "workflow"
 state: "in_progress"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.rule.deterministic","content.time.types"]
+dependencies: ["content.rule.deterministic", "content.time.types"]
 related_features: ["content.feature.when-this-happens-that-follows"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: One scheduler, timezone semantics, bounded queries, dedupe and causal lineage."
-proof_requirements: ["One scheduler, timezone semantics, bounded queries, dedupe and causal lineage."]
+acceptance_summary: "One scheduler evaluates bounded current-state Queries with explicit timezone semantics, schedule identity, idempotency keys, retry policy, and causal lineage."
+proof_requirements:
+  [
+    "Typed contract, authorization, validation, Event/history, and recovery coverage",
+    "Cross-surface UI, Action, agent-context, reload, and failure-state coverage",
+    "Real-interface keyboard and assistive-technology workflow coverage",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,42 @@ last_reviewed: "2026-07-29"
 
 # Scheduled automation
 
-## Contract
+## Why this exists
 
-Scheduled queries and recurring heartbeats over current state
+Recurring work should survive restarts, retries, and clock changes. A client timer cannot carry that promise.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: One scheduler, timezone semantics, bounded queries, dedupe and causal lineage.
+A project owner schedules a weekday overdue-task query in its selected timezone. The scheduler records a causal run, deduplicates a retry, and invokes the ordinary Rule Action once.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+One scheduler evaluates bounded current-state Queries with explicit timezone semantics, schedule identity, idempotency keys, retry policy, and causal lineage. Scheduled work uses Rules and shared Actions.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Time types own date semantics and Rules own subscriptions. This is not a client timer, a second queue, or permissionless background execution.
+
+## Acceptance stories
+
+### Deduplicate a repeated schedule window
+
+Given a delayed retry for a scheduled run, when the same schedule window repeats, then idempotency prevents a duplicate mutation and retains the original lineage.
+
+### Run across a daylight-saving boundary
+
+Given a DST transition, when a recurring schedule reaches its local time, then Content applies its declared timezone policy and records the actual run time.
+
+## Current evidence
+
+Current scheduler substrate is in progress, but complete timezone, bounded-query, dedupe, and lineage proof is absent. This Capability remains `in_progress`.
+
+## Proof plan
+
+1. Test timezone recurrence, bounded query windows, schedule edits, pauses, and restart behavior.
+2. Simulate duplicate delivery, retries, missed windows, DST, and failed Rules.
+3. Verify owner controls, receipts, disablement, and unavailable-state recovery.
+
+## Open questions
+
+The missed-run and DST policy vocabulary needs design.

--- a/templates/content/docs/product/capabilities/content.capture.enrich.md
+++ b/templates/content/docs/product/capabilities/content.capture.enrich.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.capture.enrich"
+name: "Capture and enrichment"
+user_promise: "Send anything to a chosen Content Database and let its Rules and agents immediately turn it into durable, structured context"
+kind: "workflow"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.source.catalog","content.template.graph","content.event.committed"]
+related_features: ["content.feature.capture-into-action"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Browser, share-sheet, Clips, file, identifier, agent, email, and provider entrances share one deterministic capture action; explicit/remembered target; template and unambiguous view defaults; canonical URL/identifier deduplication; snapshots/assets outside SQL; provenance; committed entry/membership Events; target-owned Rules/agent enrichment; retry, causality, repair, and visible receipts. Inbox is an optional user/template design, not infrastructure."
+proof_requirements: ["Browser, share-sheet, Clips, file, identifier, agent, email, and provider entrances share one deterministic capture action; explicit/remembered target; template and unambiguous view defaults; canonical URL/identifier deduplication; snapshots/assets outside SQL; provenance; committed entry/membership Events; target-owned Rules/agent enrichment; retry, causality, repair, and visible receipts. Inbox is an optional user/template design, not infrastructure."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Capture and enrichment
+
+## Contract
+
+Send anything to a chosen Content Database and let its Rules and agents immediately turn it into durable, structured context
+
+## Acceptance boundary
+
+A complete proof demonstrates: Browser, share-sheet, Clips, file, identifier, agent, email, and provider entrances share one deterministic capture action; explicit/remembered target; template and unambiguous view defaults; canonical URL/identifier deduplication; snapshots/assets outside SQL; provenance; committed entry/membership Events; target-owned Rules/agent enrichment; retry, causality, repair, and visible receipts. Inbox is an optional user/template design, not infrastructure.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.capture.enrich.md
+++ b/templates/content/docs/product/capabilities/content.capture.enrich.md
@@ -1,17 +1,29 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.capture.enrich"
 name: "Capture and enrichment"
-user_promise: "Send anything to a chosen Content Database and let its Rules and agents immediately turn it into durable, structured context"
+user_promise: "Send material to a chosen Database and let its own rules turn it into durable context."
+primary_user_job: "Capture a link, file, identifier, or note once without later wondering where it went or whether enrichment changed the original capture."
 kind: "workflow"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.source.catalog","content.template.graph","content.event.committed"]
+dependencies:
+  [
+    "content.source.catalog",
+    "content.template.graph",
+    "content.event.committed",
+  ]
 related_features: ["content.feature.capture-into-action"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Browser, share-sheet, Clips, file, identifier, agent, email, and provider entrances share one deterministic capture action; explicit/remembered target; template and unambiguous view defaults; canonical URL/identifier deduplication; snapshots/assets outside SQL; provenance; committed entry/membership Events; target-owned Rules/agent enrichment; retry, causality, repair, and visible receipts. Inbox is an optional user/template design, not infrastructure."
-proof_requirements: ["Browser, share-sheet, Clips, file, identifier, agent, email, and provider entrances share one deterministic capture action; explicit/remembered target; template and unambiguous view defaults; canonical URL/identifier deduplication; snapshots/assets outside SQL; provenance; committed entry/membership Events; target-owned Rules/agent enrichment; retry, causality, repair, and visible receipts. Inbox is an optional user/template design, not infrastructure."]
+acceptance_summary: "Every entrance resolves or creates one canonical Page in an explicit or remembered Database, preserves provenance and idempotency, commits its own receipt, and starts target-owned enrichment that can retry independently."
+proof_requirements:
+  [
+    "Cross-entrance idempotency and canonical identifier tests",
+    "Database destination, template, permission, provenance, Event, and receipt tests",
+    "End-to-end capture with delayed enrichment failure, retry, and repair",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +31,45 @@ last_reviewed: "2026-07-29"
 
 # Capture and enrichment
 
-## Contract
+## Why this exists
 
-Send anything to a chosen Content Database and let its Rules and agents immediately turn it into durable, structured context
+Capture should be one reliable doorway, not a collection of tiny inboxes that lose provenance in the rain.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Browser, share-sheet, Clips, file, identifier, agent, email, and provider entrances share one deterministic capture action; explicit/remembered target; template and unambiguous view defaults; canonical URL/identifier deduplication; snapshots/assets outside SQL; provenance; committed entry/membership Events; target-owned Rules/agent enrichment; retry, causality, repair, and visible receipts. Inbox is an optional user/template design, not infrastructure.
+A person shares an interview URL to Research. Capture reuses its canonical Page, records the URL and snapshot handle, adds Database membership, and a Research rule later extracts questions; a failed extraction is visible and retryable.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Browser, share sheet, Clips, file, identifier, agent, email, and provider entrances call one deterministic Capture contract.
+- The caller chooses a Database or uses a visible remembered default; destination permissions, templates, defaults, and validation apply before membership commits.
+- Canonical URLs and identifiers deduplicate idempotently, with a deliberate-copy escape hatch. Large assets and snapshots live in file storage, not SQL bodies.
+- Capture commits provenance, causality, membership, and a receipt before target-owned Rules or agents enrich. Enrichment never makes capture appear incomplete and retries without duplicating the Page.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+The Database owns rules and routing; Sources own provider fidelity. An Inbox is a user or template choice, not capture infrastructure.
+
+## Acceptance stories
+
+### Reuse a canonical capture
+
+Given the same normalized URL already exists in the chosen Database, when it is captured again, then Capture reuses the Page and records a new provenance-aware receipt unless the caller explicitly asks for a copy.
+
+### Repair enrichment separately
+
+Given Capture committed a Page but its downstream classifier fails, when the person retries classification, then the original Page and capture receipt remain intact and only enrichment reruns.
+
+## Current evidence
+
+Donor evidence: `actions/import-content-source.ts`, `actions/import-content-source.db.test.ts`, and source actions establish several intake paths. No common Capture Action or complete entrance-to-enrichment proof exists; this record remains `approved_shape`.
+
+## Proof plan
+
+1. Route representative entrances through one Action and test identity normalization.
+2. Test destination selection, access, assets, provenance, Events, and receipts.
+3. Exercise delayed enrichment, retry, duplicate delivery, and repair in the interface.
+
+## Open questions
+
+- The exact remembered-destination scope per entrance remains open.

--- a/templates/content/docs/product/capabilities/content.command.fabric.md
+++ b/templates/content/docs/product/capabilities/content.command.fabric.md
@@ -1,8 +1,10 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.command.fabric"
 name: "Unified commands"
-user_promise: "Slash, Cmd+K, menus, shortcuts, Buttons, and agents discover the same scoped commands/actions"
+user_promise: "Slash, Cmd+K, menus, shortcuts, Buttons, and agents discover the same scoped commands and Actions"
+primary_user_job: "Discover the right permitted operation from any surface and understand its effect before committing it."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
@@ -10,8 +12,13 @@ availability: "universal"
 dependencies: ["content.agent.action-parity"]
 related_features: ["content.feature.put-your-organizations-know-how-to-work"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Stable command IDs, args, can-run reasons, side effects, confirmation, undo, permissions, ranking, tests."
-proof_requirements: ["Stable command IDs, args, can-run reasons, side effects, confirmation, undo, permissions, ranking, tests."]
+acceptance_summary: "Commands have stable IDs, typed arguments, scope, ranking, can-run reasons, effects, confirmation, permission, receipt, and Undo metadata."
+proof_requirements:
+  [
+    "Typed contract, authorization, validation, Event/history, and recovery coverage",
+    "Cross-surface UI, Action, agent-context, reload, and failure-state coverage",
+    "Real-interface keyboard and assistive-technology workflow coverage",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,42 @@ last_reviewed: "2026-07-29"
 
 # Unified commands
 
-## Contract
+## Why this exists
 
-Slash, Cmd+K, menus, shortcuts, Buttons, and agents discover the same scoped commands/actions
+The same verb should not change its authority or side effect when reached through a palette, shortcut, menu, Button, or agent.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Stable command IDs, args, can-run reasons, side effects, confirmation, undo, permissions, ranking, tests.
+A person opens Cmd+K on a Page, finds Archive, sees that confirmation is needed, and runs the same command available from the page menu and agent chat.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+Commands have stable IDs, typed arguments, scope, ranking, can-run reasons, effects, confirmation, permission, receipt, and Undo metadata. Every invocation resolves to the same shared Action.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Action parity owns operation semantics and Buttons bind commands. This is not a separate menu mutation API or a guarantee that every command appears in every surface.
+
+## Acceptance stories
+
+### Explain a disabled command
+
+Given a command unavailable for the focused Page, when it is searched in Cmd+K, then Content explains the scope or permission reason and does not run it.
+
+### Invoke Archive from two entry points
+
+Given an agent and menu invoke the same command, when both are authorized, then they produce equivalent Action results and Events.
+
+## Current evidence
+
+No complete command discovery, ranking, confirmation, and cross-surface proof is recorded. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Test command ID stability, arguments, ranking, and can-run explanations.
+2. Compare menu, palette, shortcut, Button, slash, and agent invocation results.
+3. Test confirmation, cancellation, denial, Undo, shortcut collisions, and reload.
+
+## Open questions
+
+The command ranking model and shortcut conflict policy need design.

--- a/templates/content/docs/product/capabilities/content.command.fabric.md
+++ b/templates/content/docs/product/capabilities/content.command.fabric.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.command.fabric"
+name: "Unified commands"
+user_promise: "Slash, Cmd+K, menus, shortcuts, Buttons, and agents discover the same scoped commands/actions"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.agent.action-parity"]
+related_features: ["content.feature.put-your-organizations-know-how-to-work"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Stable command IDs, args, can-run reasons, side effects, confirmation, undo, permissions, ranking, tests."
+proof_requirements: ["Stable command IDs, args, can-run reasons, side effects, confirmation, undo, permissions, ranking, tests."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Unified commands
+
+## Contract
+
+Slash, Cmd+K, menus, shortcuts, Buttons, and agents discover the same scoped commands/actions
+
+## Acceptance boundary
+
+A complete proof demonstrates: Stable command IDs, args, can-run reasons, side effects, confirmation, undo, permissions, ranking, tests.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.comment.page-owned.md
+++ b/templates/content/docs/product/capabilities/content.comment.page-owned.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.comment.page-owned"
+name: "Comments"
+user_promise: "Page-owned threaded comments targeting one or several Blocks"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.object.page","content.object.blocks-field"]
+related_features: ["content.feature.collaborate-in-context"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Preserve authoritative page context across embeds and references."
+proof_requirements: ["Preserve authoritative page context across embeds and references."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Comments
+
+## Contract
+
+Page-owned threaded comments targeting one or several Blocks
+
+## Acceptance boundary
+
+A complete proof demonstrates: Preserve authoritative page context across embeds and references.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.comment.page-owned.md
+++ b/templates/content/docs/product/capabilities/content.comment.page-owned.md
@@ -1,17 +1,25 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.comment.page-owned"
 name: "Comments"
-user_promise: "Page-owned threaded comments targeting one or several Blocks"
+user_promise: "Threaded Comments stay owned by a Page while targeting one or more precise Blocks."
+primary_user_job: "Give exact feedback that remains intelligible after the document changes or appears elsewhere."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.object.page","content.object.blocks-field"]
+dependencies: ["content.object.page", "content.object.blocks-field"]
 related_features: ["content.feature.collaborate-in-context"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Preserve authoritative page context across embeds and references."
-proof_requirements: ["Preserve authoritative page context across embeds and references."]
+acceptance_summary: "Comments preserve authoritative Page context, thread identity, rich body, precise historical Block anchors, access, and resolution across references, embeds, edits, and deletion."
+proof_requirements:
+  [
+    "Page-owned thread and multi-Block anchor identity",
+    "Anchor repair and historical target behavior after edits/deletion",
+    "Access, mentions, replies, resolution, and notification behavior",
+    "Shared Action/UI, embed/reference, concurrency, and recovery tests",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +27,49 @@ last_reviewed: "2026-07-29"
 
 # Comments
 
-## Contract
+## Why this exists
 
-Page-owned threaded comments targeting one or several Blocks
+Feedback should remain attached to the sentence, image, or Block it concerns, even when the work is embedded in another place. Otherwise discussion becomes a trail of vague ghosts.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Preserve authoritative page context across embeds and references.
+A reviewer comments on two Blocks in a brief, replies with a Page reference, and resolves the thread after revision. Later the brief is embedded elsewhere; the comment still opens under the original Page context and its historical target.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A Comment thread is owned by one Page and may target one or several Blocks or ranges in its Blocks fields.
+- Rich Comment bodies use the shared Blocks-field grammar; replies and mentions retain the same Page authority.
+- Anchors follow stable Block identity where possible and preserve historical target context after deletion rather than attaching to plausible new text.
+- Resolve, reopen, edit, reply, and notification operations use shared Actions and record attributable change.
+- References and embeds display the authoritative Page-owned thread; they do not clone or re-home it.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- Comments are exact-material feedback, not the Page-wide Discussion timeline.
+- A comment does not create a Page, Database membership, or independent share policy.
+- This capability does not define named Version access, although Comments retain Version context.
+
+## Acceptance stories
+
+### Preserve a deleted anchor
+
+Given a Comment on a Block range, when the range and Block are deleted, then the Comment remains resolvable and opens authorized historical context instead of moving to a new nearby range.
+
+### Keep one authoritative thread across an embed
+
+Given a Page with a Comment thread is referenced or embedded elsewhere, when a viewer opens the thread from either occurrence, then they see the same Page-owned thread and access decision.
+
+## Current evidence
+
+`document_comments` schema and editor Comment UI/actions provide anchored threaded-comment substrate. Stable multi-Block anchors, rich universal fields, historical repair, and embed authority are not fully proven; this remains `approved_shape`.
+
+## Proof plan
+
+1. Create, reply, mention, resolve, reopen, edit, and delete Comments through UI and Actions.
+2. Test anchors through Block editing, move, split, deletion, restore, and named-Version context.
+3. Verify references, embeds, access changes, notifications, agents, and exports.
+4. Exercise concurrent replies/resolution, reload, keyboard, and assistive technology.
+
+## Open questions
+
+Anchor matching heuristics may evolve, but they may never silently claim a new target is the old one.

--- a/templates/content/docs/product/capabilities/content.diff.ai-assist.md
+++ b/templates/content/docs/product/capabilities/content.diff.ai-assist.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.diff.ai-assist"
+name: "Agent-assisted review"
+user_promise: "AI summaries and guided review for large change sets"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.diff.filtered-review","content.agent.action-parity"]
+related_features: ["content.feature.review-changes-in-place"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Trustworthy typed change graph and scoped evidence; never bypass review authority."
+proof_requirements: ["Trustworthy typed change graph and scoped evidence; never bypass review authority."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Agent-assisted review
+
+## Contract
+
+AI summaries and guided review for large change sets
+
+## Acceptance boundary
+
+A complete proof demonstrates: Trustworthy typed change graph and scoped evidence; never bypass review authority.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.diff.ai-assist.md
+++ b/templates/content/docs/product/capabilities/content.diff.ai-assist.md
@@ -1,17 +1,25 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.diff.ai-assist"
 name: "Agent-assisted review"
-user_promise: "AI summaries and guided review for large change sets"
+user_promise: "Agents can summarize and guide large review sets without bypassing the authority to decide them."
+primary_user_job: "Understand a large proposal quickly while keeping evidence, scope, and final review control visible."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.diff.filtered-review","content.agent.action-parity"]
+dependencies: ["content.diff.filtered-review", "content.agent.action-parity"]
 related_features: ["content.feature.review-changes-in-place"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Trustworthy typed change graph and scoped evidence; never bypass review authority."
-proof_requirements: ["Trustworthy typed change graph and scoped evidence; never bypass review authority."]
+acceptance_summary: "Agent assistance consumes an access-scoped typed change graph, cites inspectable change evidence and uncertainty, and uses the same authorized review Actions as a person."
+proof_requirements:
+  [
+    "Access-scoped typed change graph and evidence links",
+    "Summary, grouping, risk, and uncertainty behavior grounded in actual changes",
+    "No authority bypass; shared confirmation and decision Actions",
+    "Stale context, adversarial input, retry, audit, and human-interface tests",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +27,49 @@ last_reviewed: "2026-07-29"
 
 # Agent-assisted review
 
-## Contract
+## Why this exists
 
-AI summaries and guided review for large change sets
+Large review sets exhaust attention. An agent can make the shape visible, but it must remain a lamp beside the road, not a hand on the steering wheel.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Trustworthy typed change graph and scoped evidence; never bypass review authority.
+An editor asks an agent to summarize a large proposed update. The agent groups changes, links each claim to typed diffs, identifies uncertain or risky items, and prepares a filtered review; the editor still makes every decision through the same authorized Actions.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Assistance reads only the viewer-authorized typed change graph and its scoped evidence.
+- Summaries distinguish observed change facts, inferences, risks, and uncertainty; each recommendation links back to inspectable changes.
+- An agent may prepare filters and explain dependencies but cannot bypass review authority or fabricate a completion receipt.
+- Accept/reject/defer operations call the same Action surface, policy, confirmation, Events, and History as human review.
+- Stale, unavailable, or incomplete evidence is reported as such, not coerced to a clean summary.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- This is not an autonomous publishing or approval capability.
+- It does not replace in-place diffs, filtered review, or human accountability.
+- Model choice and prose style are not proof of review correctness.
+
+## Acceptance stories
+
+### Ground a recommendation in visible evidence
+
+Given an agent recommends accepting a Property change, when the editor opens the recommendation, then it identifies the exact typed diff, dependencies, and uncertainty rather than citing inaccessible or invented context.
+
+### Preserve review authority
+
+Given an agent prepares an all-visible acceptance, when it lacks the editor's authority or confirmation, then no change applies and the same Action denial/confirmation boundary appears as in the UI.
+
+## Current evidence
+
+Current agent Action infrastructure and source review substrate demonstrate adjacent machinery. A trustworthy generic typed change graph, scoped evidence synthesis, and end-to-end review parity are not yet proven; this remains `approved_shape`.
+
+## Proof plan
+
+1. Test summaries against known typed change fixtures, including omissions, uncertainty, and conflicting changes.
+2. Verify every cited item is accessible and opens its ordinary diff.
+3. Exercise authorization, confirmation, stale context, adversarial content, retries, and audit receipts.
+4. Validate the complete UI-plus-agent review workflow with accessible controls.
+
+## Open questions
+
+Ranking and summary presentation remain open. The agent may never substitute a plausible narrative for evidence or authority.

--- a/templates/content/docs/product/capabilities/content.diff.filtered-review.md
+++ b/templates/content/docs/product/capabilities/content.diff.filtered-review.md
@@ -1,17 +1,29 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.diff.filtered-review"
 name: "Filtered change review"
-user_promise: "Accept/reject individual or all visible changes in a filtered set"
+user_promise: "A reviewer can accept or reject one change or an exact visible set without accidentally deciding newer or hidden changes."
+primary_user_job: "Review a manageable subset of a large proposal while preserving dependency safety and auditability."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
 dependencies: ["content.diff.in-place"]
-related_features: ["content.feature.review-changes-in-place","content.feature.explore-alternatives-safely"]
+related_features:
+  [
+    "content.feature.review-changes-in-place",
+    "content.feature.explore-alternatives-safely",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Filter snapshot semantics, dependent-change safety, event receipts, idempotent apply."
-proof_requirements: ["Filter snapshot semantics, dependent-change safety, event receipts, idempotent apply."]
+acceptance_summary: "Filtered bulk review snapshots the exact eligible change identities and bases, validates dependencies and authority atomically, and records idempotent decisions without sweeping in concurrent matches."
+proof_requirements:
+  [
+    "Exact filter/selection snapshot semantics",
+    "Dependency and mixed-authority preflight",
+    "Idempotent atomic apply with durable Event receipts",
+    "Concurrent additions, stale changes, retry, undo, and UI/Action coverage",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +31,49 @@ last_reviewed: "2026-07-29"
 
 # Filtered change review
 
-## Contract
+## Why this exists
 
-Accept/reject individual or all visible changes in a filtered set
+Large change sets need a humane slice, but “accept all visible” must mean exactly what the reviewer saw—not whatever happened to match later.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Filter snapshot semantics, dependent-change safety, event receipts, idempotent apply.
+An editor filters an agent proposal to changes in one section, selects the visible compatible changes, and accepts them. A new change that arrives while review is open remains pending; a hidden prerequisite is surfaced rather than silently applied.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A filtered decision resolves exact eligible change IDs, observed bases, and filter context at selection time.
+- New matching changes do not enter an already prepared bulk decision.
+- Preflight checks dependencies, stale bases, source policy, and authority for the full intended set.
+- Mixed permissions or incompatible dependencies produce an explicit repair/narrowing state, never an invisible partial commit.
+- Repeated delivery of the same approved decision is idempotent and emits durable receipts.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- This does not decide the typed rendering of a single change or generate proposals.
+- It is not a generic Database bulk-edit engine, though both need exact selection semantics.
+- Agents may narrow scope only when faithful to the request and must report skipped work.
+
+## Acceptance stories
+
+### Freeze the visible set
+
+Given a reviewer filters to five pending changes, when a sixth matching change arrives before **Accept visible** completes, then only the five resolved IDs are decided and the sixth remains pending.
+
+### Refuse unsafe partial approval
+
+Given a selected change depends on an inaccessible or stale prerequisite, when the reviewer accepts the set, then no subset silently applies and Content explains the dependency or authority repair path.
+
+## Current evidence
+
+Existing source-review and bulk-operation machinery offers useful examples of selection and audit behavior. It does not prove generic filtered review snapshot, dependency, and idempotent decision semantics; this remains `approved_shape`.
+
+## Proof plan
+
+1. Exercise single, selected, filtered, and all-visible decisions across typed change kinds.
+2. Race concurrent additions, edits, removals, retries, and duplicate requests.
+3. Test dependencies, mixed authority, source locks, stale bases, undo, and Event/History receipts.
+4. Verify UI and agent Action parity, accessibility, and clear scope reporting.
+
+## Open questions
+
+Filter language and progress presentation may vary; exact selection snapshot and no-silent-partial behavior may not.

--- a/templates/content/docs/product/capabilities/content.diff.filtered-review.md
+++ b/templates/content/docs/product/capabilities/content.diff.filtered-review.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.diff.filtered-review"
+name: "Filtered change review"
+user_promise: "Accept/reject individual or all visible changes in a filtered set"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.diff.in-place"]
+related_features: ["content.feature.review-changes-in-place","content.feature.explore-alternatives-safely"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Filter snapshot semantics, dependent-change safety, event receipts, idempotent apply."
+proof_requirements: ["Filter snapshot semantics, dependent-change safety, event receipts, idempotent apply."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Filtered change review
+
+## Contract
+
+Accept/reject individual or all visible changes in a filtered set
+
+## Acceptance boundary
+
+A complete proof demonstrates: Filter snapshot semantics, dependent-change safety, event receipts, idempotent apply.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.diff.in-place.md
+++ b/templates/content/docs/product/capabilities/content.diff.in-place.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.diff.in-place"
+name: "In-place typed review"
+user_promise: "Typed changes rendered inside the ordinary editor/view"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.event.committed","content.renderer.typed"]
+related_features: ["content.feature.review-changes-in-place","content.feature.explore-alternatives-safely","content.feature.evolve-systems-safely"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Change identity/dependencies, inline renderers, durable review decisions."
+proof_requirements: ["Change identity/dependencies, inline renderers, durable review decisions."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# In-place typed review
+
+## Contract
+
+Typed changes rendered inside the ordinary editor/view
+
+## Acceptance boundary
+
+A complete proof demonstrates: Change identity/dependencies, inline renderers, durable review decisions.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.diff.in-place.md
+++ b/templates/content/docs/product/capabilities/content.diff.in-place.md
@@ -1,17 +1,30 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.diff.in-place"
 name: "In-place typed review"
-user_promise: "Typed changes rendered inside the ordinary editor/view"
+user_promise: "Changes are reviewed inside the ordinary Page, Database, Board, template, source, or code surface that gives them meaning."
+primary_user_job: "Evaluate a proposed change in context rather than translating it from a generic red/green destination."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.event.committed","content.renderer.typed"]
-related_features: ["content.feature.review-changes-in-place","content.feature.explore-alternatives-safely","content.feature.evolve-systems-safely"]
+dependencies: ["content.event.committed", "content.renderer.typed"]
+related_features:
+  [
+    "content.feature.review-changes-in-place",
+    "content.feature.explore-alternatives-safely",
+    "content.feature.evolve-systems-safely",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Change identity/dependencies, inline renderers, durable review decisions."
-proof_requirements: ["Change identity/dependencies, inline renderers, durable review decisions."]
+acceptance_summary: "Typed change identities and dependencies render in the normal object surface, retain causal/actor context, and record durable authorized review decisions."
+proof_requirements:
+  [
+    "Typed change model for bodies, Blocks, Properties, memberships, and structured values",
+    "Ordinary renderer integration and accessible in-place comparison",
+    "Durable accept/reject/defer/supersede Events with authority",
+    "Stale, dependency, conflict, source, and agent-run coverage",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +32,49 @@ last_reviewed: "2026-07-29"
 
 # In-place typed review
 
-## Contract
+## Why this exists
 
-Typed changes rendered inside the ordinary editor/view
+A property, Block, membership, and source proposal carry different meaning. Review should meet each where it lives instead of flattening all work into an unreadable universal diff.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Change identity/dependencies, inline renderers, durable review decisions.
+An agent proposes article copy and Status changes. The editor sees copy changes in the Page editor, the Status change in its Property renderer, accepts one, rejects the other, and History records the durable decisions with the run context.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A change has stable identity, target type, dependencies, actor/origin, causal context, before/after material, and disposition.
+- Body, Block, Property, membership, and structured changes render through their ordinary typed surfaces.
+- Accept, reject, defer, and supersede are authorized durable decisions that emit Events and preserve why a proposal ended.
+- A stale target, incompatible dependency, source authority restriction, or conflict is explicit; no review button silently applies a plausible partial result.
+- Agent and human proposals use the same review model and Actions.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- This capability does not define filtered-set selection, AI assistance, or named Version branching.
+- It does not replace low-level Events, logical Revisions, or recovery snapshots.
+- A typed renderer may degrade honestly; review may not discard unknown source content.
+
+## Acceptance stories
+
+### Review mixed typed changes in context
+
+Given a proposal changes a paragraph and a select Property, when an editor opens review, then each difference renders in its ordinary surface and the editor can decide independently where dependencies allow.
+
+### Surface a stale conflict honestly
+
+Given a proposal is based on a Block another editor changed, when review attempts acceptance, then Content shows a stale/rebase/conflict state and does not overwrite the newer change.
+
+## Current evidence
+
+Source change sets, document snapshots, and Builder review machinery are donor substrate. The repository does not yet prove one generic typed in-place diff system across Content objects, so this remains `approved_shape`.
+
+## Proof plan
+
+1. Propose and render each supported change type through UI and shared Actions.
+2. Test dependency ordering, stale bases, conflicts, source locks, permission changes, and Undo.
+3. Verify Events, History, agent attribution, recovery, and accessible comparison.
+4. Exercise reload, concurrent decisions, portable output, and unavailable renderers.
+
+## Open questions
+
+The internal change representation and exact visual affordances remain open; typed context and durable authorized disposition are settled.

--- a/templates/content/docs/product/capabilities/content.discussion.page.md
+++ b/templates/content/docs/product/capabilities/content.discussion.page.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.discussion.page"
+name: "Page Discussion"
+user_promise: "One universal Page Discussion combining threaded collaboration with curated activity context"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.object.page","content.object.blocks-field","content.event.committed"]
+related_features: ["content.feature.collaborate-in-context"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Page identity, message/thread/reaction primitives, revision cursor, Event/History projection, grouped comment activity, access and notifications; Discussion and Comments appear as distinct modes in one Collaboration rail, alongside separate Info, Annotations, and Versions rails."
+proof_requirements: ["Page identity, message/thread/reaction primitives, revision cursor, Event/History projection, grouped comment activity, access and notifications; Discussion and Comments appear as distinct modes in one Collaboration rail, alongside separate Info, Annotations, and Versions rails."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Page Discussion
+
+## Contract
+
+One universal Page Discussion combining threaded collaboration with curated activity context
+
+## Acceptance boundary
+
+A complete proof demonstrates: Page identity, message/thread/reaction primitives, revision cursor, Event/History projection, grouped comment activity, access and notifications; Discussion and Comments appear as distinct modes in one Collaboration rail, alongside separate Info, Annotations, and Versions rails.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.discussion.page.md
+++ b/templates/content/docs/product/capabilities/content.discussion.page.md
@@ -1,17 +1,30 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.discussion.page"
 name: "Page Discussion"
-user_promise: "One universal Page Discussion combining threaded collaboration with curated activity context"
+user_promise: "Every Page has one continuing Discussion for humane, Page-wide collaboration and curated activity."
+primary_user_job: "Discuss the larger meaning of work without losing the Page and revision context that gives the conversation sense."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.object.page","content.object.blocks-field","content.event.committed"]
+dependencies:
+  [
+    "content.object.page",
+    "content.object.blocks-field",
+    "content.event.committed",
+  ]
 related_features: ["content.feature.collaborate-in-context"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Page identity, message/thread/reaction primitives, revision cursor, Event/History projection, grouped comment activity, access and notifications; Discussion and Comments appear as distinct modes in one Collaboration rail, alongside separate Info, Annotations, and Versions rails."
-proof_requirements: ["Page identity, message/thread/reaction primitives, revision cursor, Event/History projection, grouped comment activity, access and notifications; Discussion and Comments appear as distinct modes in one Collaboration rail, alongside separate Info, Annotations, and Versions rails."]
+acceptance_summary: "A lazily materialized canonical Page Discussion supports rich messages, bounded threads, reactions, Page-version cursors, selected Event/Comment activity, access, and notifications without replacing Comments or History."
+proof_requirements:
+  [
+    "Canonical Page Discussion identity across current and future Versions",
+    "Rich message, reply, mention, reaction, and bounded-thread behavior",
+    "Revision/Event cursor and curated activity projection",
+    "Access, notification, permalink, UI/Action, and concurrency coverage",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +32,49 @@ last_reviewed: "2026-07-29"
 
 # Page Discussion
 
-## Contract
+## Why this exists
 
-One universal Page Discussion combining threaded collaboration with curated activity context
+Exact comments are not enough for the larger conversation: why the change matters, what was decided, and what should happen next. Discussion gives that conversation one durable home.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Page identity, message/thread/reaction primitives, revision cursor, Event/History projection, grouped comment activity, access and notifications; Discussion and Comments appear as distinct modes in one Collaboration rail, alongside separate Info, Annotations, and Versions rails.
+A teammate starts a Page Discussion about an unclear strategy, replies in one focused sub-thread, links a relevant Comment thread, and later opens “view the Page then” to see the revision cursor that existed when the message was posted.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Every Page has one canonical Discussion identity, created lazily on first use and authoritative across current and future Page Versions.
+- Messages use Blocks fields; they may reply to or mention a message or actor, while one message opens at most one focused sub-conversation rather than infinite nesting.
+- A message may connect to Comment threads without moving those Comments out of their Page-owned context.
+- Each message records quiet Page Version and Revision/Event cursor context; UI reveals historical Page/diff on demand.
+- Discussion curates selected collaboration Events and grouped Comment activity. History remains exhaustive; Comments remain exact anchors.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- Discussion is not another body Block, Database membership, task engine, or named Version.
+- It does not replace Comments, Info, Annotations, Versions, or History; these are separate rails/modes.
+- Curated activity does not duplicate Event authority or expose inaccessible details.
+
+## Acceptance stories
+
+### Continue one conversation across Versions
+
+Given a Page has a Discussion and later receives a named Version, when a collaborator opens either Version, then the same Discussion is available with each message's appropriate Version cursor preserved.
+
+### Keep a focused thread bounded
+
+Given a Discussion message has replies, when a reply starts a sub-conversation, then subsequent replies remain understandable in that bounded thread and do not build an infinitely nested tree.
+
+## Current evidence
+
+Current Comments, mentions, notifications substrate, and document history provide adjacent pieces. A universal canonical Discussion, rich message grammar, cursors, and curated activity projection are not yet proven; this remains `approved_shape`.
+
+## Proof plan
+
+1. Create canonical Discussions, messages, replies, mentions, reactions, and Comment links across Page lifecycle operations.
+2. Verify cursors, historical Page/diff links, selected Event grouping, and History separation.
+3. Test access changes, notifications, permalinks, agents, external continuation boundaries, and deletion.
+4. Exercise concurrent messages/reactions, reload, keyboard, and assistive technology.
+
+## Open questions
+
+Default grouping and activity-selection rules remain product refinement; they cannot make Discussion the recovery authority or create a second Page identity.

--- a/templates/content/docs/product/capabilities/content.embed.host-grant.md
+++ b/templates/content/docs/product/capabilities/content.embed.host-grant.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.embed.host-grant"
 name: "Embedded host grants"
-user_promise: "An embedded host receives only the named mount and Action capabilities it needs and can never widen the signed-in viewer's authority."
+user_promise: "An embedded host gets only the mount and Actions it was granted, never more authority than the viewer."
+primary_user_job: "Use Content inside another application without silently giving that application broad access to my work."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "configured"
-dependencies: ["content.embed.surface","content.access.visibility-closure"]
+dependencies: ["content.embed.surface", "content.access.visibility-closure"]
 related_features: ["content.feature.work-on-content-inside-another-application"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: An embedded host receives only the named mount and Action capabilities it needs and can never widen the signed-in viewer's authority."
-proof_requirements: ["An embedded host receives only the named mount and Action capabilities it needs and can never widen the signed-in viewer's authority."]
+acceptance_summary: "A named host grant scopes mount identity, permitted Actions, audience, expiry and revocation; every call is additionally constrained by the signed-in viewer's current Content authority."
+proof_requirements:
+  [
+    "Grant issuance, scope, expiry, revocation, origin, and audience validation tests",
+    "Cross-host authorization tests proving host grants cannot widen viewer access",
+    "Embedded mutation and denied-action interface workflow with audit receipts",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,45 @@ last_reviewed: "2026-07-29"
 
 # Embedded host grants
 
-## Contract
+## Why this exists
 
-An embedded host receives only the named mount and Action capabilities it needs and can never widen the signed-in viewer's authority.
+An embed is a borrowed room, not a spare key to the building.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: An embedded host receives only the named mount and Action capabilities it needs and can never widen the signed-in viewer's authority.
+A planner mounts one project brief in a sibling app. The host may render and edit that brief through its grant; a request for another Page is denied even if the host knows its ID.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A grant names host, mount, permitted Action capability, audience, lifetime, and revocation state.
+- Every host request validates its grant and then resolves the current viewer's Content access; a host can only narrow, never widen, that authority.
+- The shared Actions retain validation, Events, history, and honest outcomes. Hosts receive no database credentials or bypass route.
+- Grant changes take effect for subsequent calls and do not retroactively publish cached material.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Embed surface owns rendering and lifecycle; sharing owns ordinary resource access. This does not make all hosts trusted or grant a host blanket workspace access.
+
+## Acceptance stories
+
+### Limit a mounted brief
+
+Given a host grant for one Page and read permission, when the host requests a different Page, then Content denies it even if the viewer could open that Page directly.
+
+### Revoke a host capability
+
+Given a host has edit permission, when the owner revokes the grant, then its next mutation is denied and no new Event is committed.
+
+## Current evidence
+
+Donor evidence: shared toolkit components and Content access primitives can support reuse. No repository proof yet covers signed grants, origin validation, revocation, or host/viewer intersection; this record remains `approved_shape`.
+
+## Proof plan
+
+1. Define signed or server-resolved grants with narrow capability claims.
+2. Test expiry, revocation, origin, mount substitution, and authority intersection.
+3. Verify an embedded edit and denial path with receipts and accessible status.
+
+## Open questions
+
+- The host identity handshake remains open provided it cannot widen viewer authority.

--- a/templates/content/docs/product/capabilities/content.embed.host-grant.md
+++ b/templates/content/docs/product/capabilities/content.embed.host-grant.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.embed.host-grant"
+name: "Embedded host grants"
+user_promise: "An embedded host receives only the named mount and Action capabilities it needs and can never widen the signed-in viewer's authority."
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "configured"
+dependencies: ["content.embed.surface","content.access.visibility-closure"]
+related_features: ["content.feature.work-on-content-inside-another-application"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: An embedded host receives only the named mount and Action capabilities it needs and can never widen the signed-in viewer's authority."
+proof_requirements: ["An embedded host receives only the named mount and Action capabilities it needs and can never widen the signed-in viewer's authority."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Embedded host grants
+
+## Contract
+
+An embedded host receives only the named mount and Action capabilities it needs and can never widen the signed-in viewer's authority.
+
+## Acceptance boundary
+
+A complete proof demonstrates: An embedded host receives only the named mount and Action capabilities it needs and can never widen the signed-in viewer's authority.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.embed.mcp-app.md
+++ b/templates/content/docs/product/capabilities/content.embed.mcp-app.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.embed.mcp-app"
+name: "MCP App embedding"
+user_promise: "Content itself can appear as a focused MCP App inside compatible external agent hosts"
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "external_host"
+dependencies: ["content.embed.surface","content.embed.host-grant"]
+related_features: ["content.feature.work-on-content-inside-another-application"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Project a real access-scoped Content route with deep-link fallback; this is an external-host presentation, not another normal in-Content block or navigation surface."
+proof_requirements: ["Project a real access-scoped Content route with deep-link fallback; this is an external-host presentation, not another normal in-Content block or navigation surface."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# MCP App embedding
+
+## Contract
+
+Content itself can appear as a focused MCP App inside compatible external agent hosts
+
+## Acceptance boundary
+
+A complete proof demonstrates: Project a real access-scoped Content route with deep-link fallback; this is an external-host presentation, not another normal in-Content block or navigation surface.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.embed.mcp-app.md
+++ b/templates/content/docs/product/capabilities/content.embed.mcp-app.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.embed.mcp-app"
 name: "MCP App embedding"
-user_promise: "Content itself can appear as a focused MCP App inside compatible external agent hosts"
+user_promise: "Compatible agent hosts can show a focused Content surface without receiving a copied object or broader authority."
+primary_user_job: "Open the same governed Content object from a compatible agent host and understand what the host may do."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
 availability: "external_host"
-dependencies: ["content.embed.surface","content.embed.host-grant"]
+dependencies: ["content.embed.surface", "content.embed.host-grant"]
 related_features: ["content.feature.work-on-content-inside-another-application"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Project a real access-scoped Content route with deep-link fallback; this is an external-host presentation, not another normal in-Content block or navigation surface."
-proof_requirements: ["Project a real access-scoped Content route with deep-link fallback; this is an external-host presentation, not another normal in-Content block or navigation surface."]
+acceptance_summary: "An MCP App integration adapts the canonical embed mount and host-grant contract to compatible hosts, preserves viewer-scoped actions and receipts, and fails clearly when host capabilities are absent."
+proof_requirements:
+  [
+    "Protocol compatibility and host capability-negotiation tests",
+    "Grant and viewer-authority parity tests against the ordinary embedded surface",
+    "Compatible-host mount, mutation, unavailable-host, and revocation workflow",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,44 @@ last_reviewed: "2026-07-29"
 
 # MCP App embedding
 
-## Contract
+## Why this exists
 
-Content itself can appear as a focused MCP App inside compatible external agent hosts
+MCP App support should widen where Content can appear, not what an outside host may possess.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Project a real access-scoped Content route with deep-link fallback; this is an external-host presentation, not another normal in-Content block or navigation surface.
+An agent host opens a granted Page as an MCP App. It renders the canonical mount, calls only granted Actions, and reports an unavailable capability when the host cannot provide the required presentation feature.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- This surface adapts `content.embed.surface` and `content.embed.host-grant`; it does not invent a parallel object, auth, or mutation path.
+- Host capability negotiation names what the host can render or invoke. Missing capability is unavailable, not a successful empty mount.
+- Viewer access, grant scope, validation, Events, history, and receipts remain Content-owned.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+This does not make every MCP client a supported editor, expose all Actions as tools, or replace native sibling-app embedding.
+
+## Acceptance stories
+
+### Mount the canonical object
+
+Given a compatible host and a grant for one Page, when it opens the MCP App, then it sees the canonical Page state rather than a copied snapshot.
+
+### Tell the truth about host limits
+
+Given a host that lacks a required interaction capability, when it requests that mount mode, then Content reports it unavailable and does not silently substitute broader access.
+
+## Current evidence
+
+Donor evidence: `changelog/2026-07-28-builder-content-reads-now-negotiate-the-newest-mcp-protocol-.md` records protocol-related substrate. No complete Content MCP App mount and grant proof exists; this record remains `approved_shape`.
+
+## Proof plan
+
+1. Implement narrow protocol negotiation over the canonical embed contract.
+2. Test compatible, incompatible, revoked, and viewer-denied cases.
+3. Verify a real host mount and mutation receipt without a copied authority path.
+
+## Open questions
+
+- The first compatible host and supported interaction subset remain open.

--- a/templates/content/docs/product/capabilities/content.embed.surface.md
+++ b/templates/content/docs/product/capabilities/content.embed.surface.md
@@ -1,36 +1,74 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.embed.surface"
-name: "Embeddable Content surfaces"
-user_promise: "Mountable editor/page/view/expression/history surface across Agent Native apps"
+name: "Embedded Content surface"
+user_promise: "The same Page, View, or focused Content experience can appear in another app without splitting identity, history, or permissions."
+primary_user_job: "Work on a canonical Content object in the application where my work is happening."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
-availability: "external_host"
-dependencies: ["content.object.page","content.agent.action-parity"]
-related_features: ["content.feature.build-living-dashboards","content.feature.work-on-content-inside-another-application"]
+availability: "configured"
+dependencies: ["content.agent.action-parity", "content.access.page-database"]
+related_features:
+  [
+    "content.feature.work-on-content-inside-another-application",
+    "content.feature.build-living-dashboards",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Stable object APIs, capability-scoped host contract, shared renderer runtime."
-proof_requirements: ["Stable object APIs, capability-scoped host contract, shared renderer runtime."]
+acceptance_summary: "A stable mount contract renders a selected canonical Content surface responsively and routes its allowed interactions through shared Actions, current access, history, and application state without cloning the object."
+proof_requirements:
+  [
+    "Mount identity, lifecycle, responsive rendering, and application-state tests",
+    "Shared Action, access, history, and concurrent-update parity tests",
+    "Host workflow covering read, edit, navigation, unsupported mode, and unmount/remount",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
 ---
 
-# Embeddable Content surfaces
+# Embedded Content surface
 
-## Contract
+## Why this exists
 
-Mountable editor/page/view/expression/history surface across Agent Native apps
+Work often happens beside Content; moving the window should not create another truth.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Stable object APIs, capability-scoped host contract, shared renderer runtime.
+A planning app mounts a project Database View. A person filters it and opens a Page; the same object, access checks, and history are visible when they later return to Content.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A mount identifies one Page, View, or focused surface and uses stable Content identity, not serialized copies.
+- Rendering, navigation, application state, accessibility, and responsive layout have explicit mount boundaries.
+- Reads and mutations use shared Actions and current viewer access; concurrent changes remain observable through the ordinary sync model.
+- Unsupported surface modes say so explicitly instead of becoming a half-functional clone.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Host grants own host authority; this record owns the reusable UI and lifecycle. It is not an iframe-only requirement or a new Content shell for every host.
+
+## Acceptance stories
+
+### Continue the same edit
+
+Given a Page mounted in a host, when an editor changes it through the mount, then Content records the ordinary change and the canonical editor shows it after synchronization.
+
+### Preserve mount limits
+
+Given a host requests a surface mode that is not supported by the mount contract, when it renders, then it receives an explicit unavailable state rather than a copied fallback editor.
+
+## Current evidence
+
+Donor evidence: Content components, Actions, and application-state patterns already support reuse. No stable mount lifecycle, cross-host state, or full responsive proof exists; this record remains `approved_shape`.
+
+## Proof plan
+
+1. Define mount inputs, lifecycle, state ownership, and supported surfaces.
+2. Test parity under changing access and concurrent canonical edits.
+3. Run host read/edit/navigation/remount workflows at responsive sizes.
+
+## Open questions
+
+- The first transport and host component packaging remain open.

--- a/templates/content/docs/product/capabilities/content.embed.surface.md
+++ b/templates/content/docs/product/capabilities/content.embed.surface.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.embed.surface"
+name: "Embeddable Content surfaces"
+user_promise: "Mountable editor/page/view/expression/history surface across Agent Native apps"
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "external_host"
+dependencies: ["content.object.page","content.agent.action-parity"]
+related_features: ["content.feature.build-living-dashboards","content.feature.work-on-content-inside-another-application"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Stable object APIs, capability-scoped host contract, shared renderer runtime."
+proof_requirements: ["Stable object APIs, capability-scoped host contract, shared renderer runtime."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Embeddable Content surfaces
+
+## Contract
+
+Mountable editor/page/view/expression/history surface across Agent Native apps
+
+## Acceptance boundary
+
+A complete proof demonstrates: Stable object APIs, capability-scoped host contract, shared renderer runtime.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.event.committed.md
+++ b/templates/content/docs/product/capabilities/content.event.committed.md
@@ -1,17 +1,35 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.event.committed"
 name: "Committed Events"
-user_promise: "Canonical actor-aware committed Event spine"
+user_promise: "Meaningful committed changes have one durable, actor-aware Event spine."
+primary_user_job: "Understand what changed, by whom and why, without mistaking every keystroke or snapshot for intentional work."
 kind: "primitive"
 state: "in_progress"
 publicness: "public"
 availability: "universal"
 dependencies: []
-related_features: ["content.feature.durable-foundations","content.feature.collaborate-in-context","content.feature.review-changes-in-place","content.feature.trust-your-connected-sources","content.feature.evolve-systems-safely","content.feature.when-this-happens-that-follows","content.feature.collect-structured-input","content.feature.move-without-starting-over"]
+related_features:
+  [
+    "content.feature.durable-foundations",
+    "content.feature.collaborate-in-context",
+    "content.feature.review-changes-in-place",
+    "content.feature.trust-your-connected-sources",
+    "content.feature.evolve-systems-safely",
+    "content.feature.when-this-happens-that-follows",
+    "content.feature.collect-structured-input",
+    "content.feature.move-without-starting-over",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Atomic outbox, mutation-path coverage, actor/authority/origin/causality, one runtime."
-proof_requirements: ["Atomic outbox, mutation-path coverage, actor/authority/origin/causality, one runtime."]
+acceptance_summary: "Every meaningful committed mutation writes an atomic durable Event with actor, authority, origin, causality, target, and recoverable outcome in the same transaction or reliable outbox."
+proof_requirements:
+  [
+    "Atomic outbox or equivalent commit coupling for mutation paths",
+    "Actor, authority, origin, target, causality, and outcome attribution",
+    "Human, agent, Rule, automation, API, and source mutation coverage",
+    "Failure, retry, idempotency, access, and recovery evidence",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +37,49 @@ last_reviewed: "2026-07-29"
 
 # Committed Events
 
-## Contract
+## Why this exists
 
-Canonical actor-aware committed Event spine
+People need a trustworthy account of meaningful work. A cursor twitch is not history, and an untraceable automated change is a ghost in the machinery.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Atomic outbox, mutation-path coverage, actor/authority/origin/causality, one runtime.
+An agent updates several Blocks and a Property in one authorized run. Content commits atomic Events for the actual mutations, ties them to the authorizing context and causal run, and lets a reviewer later inspect the grouped Revision without claiming the run was a single database write.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A committed Event records one meaningful atomic change after it commits, not every keystroke or cursor move.
+- It retains actor, authority, origin, target, causal context, outcome, and recoverable change information appropriate to the operation.
+- Human editing coalesces at logical commit boundaries; agents, Rules, source syncs, and automation carry explicit causality.
+- Event emission couples to mutation through one transaction or reliable outbox so a committed change cannot quietly lose its Event.
+- Events are atomic facts. Logical Revisions group related Events; snapshots protect recovery; named Versions are deliberate alternatives.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- Events do not make every persistence snapshot a reviewable Revision.
+- They do not replace Discussion's curated collaboration timeline or History's queryable projection.
+- The spine does not authorize an operation or expose inaccessible Event contents.
+
+## Acceptance stories
+
+### Attribute an agent run accurately
+
+Given an authorized agent run changes two Blocks and one Property, when it commits, then each meaningful mutation has an Event with agent origin and causal run, and the signed-in person is retained as authority rather than substituted as the actor.
+
+### Fail without a phantom success
+
+Given a mutation cannot persist its Event/outbox record, when the commit fails, then the mutation is not reported as success and retry cannot create duplicate live meaning.
+
+## Current evidence
+
+Existing document actions, snapshots, source audit machinery, and action infrastructure are useful donors. The repository does not yet demonstrate one atomic actor-aware Event spine across mutation paths; this remains `in_progress`.
+
+## Proof plan
+
+1. Inventory and exercise Page, Database, comment, source, Rule, automation, and review mutations.
+2. Simulate transaction/outbox interruption, retry, duplicate delivery, and partial failure.
+3. Verify attribution, causal grouping inputs, access-scoped reads, recovery, and Undo.
+4. Test real UI and shared agent/API Actions under concurrent commits.
+
+## Open questions
+
+Outbox transport and payload storage can vary. The atomic fact, attribution, and no-dropped-success contract cannot.

--- a/templates/content/docs/product/capabilities/content.event.committed.md
+++ b/templates/content/docs/product/capabilities/content.event.committed.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.event.committed"
+name: "Committed Events"
+user_promise: "Canonical actor-aware committed Event spine"
+kind: "primitive"
+state: "in_progress"
+publicness: "public"
+availability: "universal"
+dependencies: []
+related_features: ["content.feature.durable-foundations","content.feature.collaborate-in-context","content.feature.review-changes-in-place","content.feature.trust-your-connected-sources","content.feature.evolve-systems-safely","content.feature.when-this-happens-that-follows","content.feature.collect-structured-input","content.feature.move-without-starting-over"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Atomic outbox, mutation-path coverage, actor/authority/origin/causality, one runtime."
+proof_requirements: ["Atomic outbox, mutation-path coverage, actor/authority/origin/causality, one runtime."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Committed Events
+
+## Contract
+
+Canonical actor-aware committed Event spine
+
+## Acceptance boundary
+
+A complete proof demonstrates: Atomic outbox, mutation-path coverage, actor/authority/origin/causality, one runtime.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.expression.cached-result.md
+++ b/templates/content/docs/product/capabilities/content.expression.cached-result.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.expression.cached-result"
 name: "Cached expression results"
-user_promise: "Content renders the last valid expression result immediately, marks it stale, and refreshes it without turning ordinary loading into an error."
+user_promise: "See the last valid computed value quickly while knowing whether it still reflects current inputs."
+primary_user_job: "Read a last valid result while understanding freshness."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.expression.language","content.event.committed"]
+dependencies: ["content.expression.language", "content.event.committed"]
 related_features: ["content.feature.data-that-keeps-itself-right"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Content renders the last valid expression result immediately, marks it stale, and refreshes it without turning ordinary loading into an error."
-proof_requirements: ["Content renders the last valid expression result immediately, marks it stale, and refreshes it without turning ordinary loading into an error."]
+acceptance_summary: "Expression consumers render the last valid result stale-first, mark freshness and failure truthfully, refresh in the background, and retain the previous valid value when refresh is ordinary work."
+proof_requirements:
+  [
+    "A valid cached result is distinct from a missing value, a failed evaluation, and an unavailable input.",
+    "Input or dependency changes make cached output visibly stale; successful refresh replaces it atomically.",
+    "A failed refresh preserves the last valid result with an error state and retry path rather than reporting a clean empty value.",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,46 @@ last_reviewed: "2026-07-29"
 
 # Cached expression results
 
-## Contract
+## Why this exists
 
-Content renders the last valid expression result immediately, marks it stale, and refreshes it without turning ordinary loading into an error.
+A blank dashboard during an ordinary refresh is less useful than the last known answer, but a stale answer must never masquerade as current. People need both speed and a clear account of freshness or failure.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Content renders the last valid expression result immediately, marks it stale, and refreshes it without turning ordinary loading into an error.
+Priya opens a dashboard after an upstream change, sees yesterday's total marked stale, and keeps it beside a retryable refresh failure.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A valid cached result is distinct from a missing value, a failed evaluation, and an unavailable input.
+- Input or dependency changes make cached output visibly stale; successful refresh replaces it atomically.
+- A failed refresh preserves the last valid result with an error state and retry path rather than reporting a clean empty value.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- `content.expression.language` owns evaluation and dependency semantics; cached-result behavior owns freshness, replacement, and stale/error presentation.
+- A cache is not a source of truth, must not bypass access, and must not turn a failed refresh into an empty successful value.
+
+## Acceptance stories
+
+### Do not collapse failed refresh
+
+Given refresh fails after a valid value, then the prior value remains stale with error, not blank or zero.
+
+### Respect viewer access
+
+Given a result was cached for a broader audience, when a narrower viewer opens it, then it is withheld or reevaluated.
+
+## Current evidence
+
+No cache implementation exists. `actions/update-document.ts` and committed mutation paths donate invalidation inputs, not freshness or audience-safe cache behavior.
+
+## Proof plan
+
+1. Change direct/transitive input and verify stale-first replacement.
+2. Distinguish evaluator, provider, timeout, and access failures.
+3. Change viewer access and prove no cache leakage.
+4. Test retry, invalidation, and eviction.
+
+## Open questions
+
+Lifetime, scheduling, and offline policy remain open.

--- a/templates/content/docs/product/capabilities/content.expression.cached-result.md
+++ b/templates/content/docs/product/capabilities/content.expression.cached-result.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.expression.cached-result"
+name: "Cached expression results"
+user_promise: "Content renders the last valid expression result immediately, marks it stale, and refreshes it without turning ordinary loading into an error."
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.expression.language","content.event.committed"]
+related_features: ["content.feature.data-that-keeps-itself-right"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Content renders the last valid expression result immediately, marks it stale, and refreshes it without turning ordinary loading into an error."
+proof_requirements: ["Content renders the last valid expression result immediately, marks it stale, and refreshes it without turning ordinary loading into an error."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Cached expression results
+
+## Contract
+
+Content renders the last valid expression result immediately, marks it stale, and refreshes it without turning ordinary loading into an error.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Content renders the last valid expression result immediately, marks it stale, and refreshes it without turning ordinary loading into an error.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.expression.catalog.md
+++ b/templates/content/docs/product/capabilities/content.expression.catalog.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.expression.catalog"
 name: "Expression catalog"
-user_promise: "Governed reusable Expressions and Variables"
+user_promise: "Promote a useful expression or variable into a governed reusable definition with clear ownership and version."
+primary_user_job: "Promote reusable expressions with controlled version adoption."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.expression.language","content.template.governance"]
+dependencies: ["content.expression.language", "content.template.governance"]
 related_features: ["content.feature.put-your-organizations-know-how-to-work"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Catalog/template governance, version semantics, approvals, references."
-proof_requirements: ["Catalog/template governance, version semantics, approvals, references."]
+acceptance_summary: "The catalog governs named Expressions and zero-input Variables with stable identity, scope, descriptions, versions, approvals, provenance, references, inspection, and deliberate adoption."
+proof_requirements:
+  [
+    "An inline expression may be promoted when reuse is real; a zero-input expression is a Variable, not a separate language.",
+    "Catalog discovery and mutation honor scope and access, while callers can inspect type, dependencies, provenance, and version.",
+    "Adoption records a pinned or following version choice and never silently rewrites a consumer.",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,46 @@ last_reviewed: "2026-07-29"
 
 # Expression catalog
 
-## Contract
+## Why this exists
 
-Governed reusable Expressions and Variables
+A useful computation should be reusable without becoming an invisible shared global that changes under its consumers. Teams need to know what it accepts, who owns it, and which version each workflow chose.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Catalog/template governance, version semantics, approvals, references.
+Omar promotes `businessDays(start, end)`, adopts version 1 in two databases, and sees both consumers before publishing a signature-changing version 2.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- An inline expression may be promoted when reuse is real; a zero-input expression is a Variable, not a separate language.
+- Catalog discovery and mutation honor scope and access, while callers can inspect type, dependencies, provenance, and version.
+- Adoption records a pinned or following version choice and never silently rewrites a consumer.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- `content.expression.language` owns AST/type semantics; catalog governance owns named definition identity, approval, adoption, and version provenance.
+- The catalog does not make expressions ambient globals, silently update callers, or create a second Variable language.
+
+## Acceptance stories
+
+### Variables share the language
+
+Given a zero-input entry, when cataloged, then it is a Variable with the same AST and version rules.
+
+### Preserve consumer choice
+
+Given a signature changes, then consumers stay pinned or explicitly follow after impact review.
+
+## Current evidence
+
+`actions/configure-document-property.ts` and template records are donors; no expression catalog, version, or adoption records exist.
+
+## Proof plan
+
+1. Promote inline expressions/Variables with ID, scope, signature, dependencies, provenance.
+2. Adopt pinned/following versions in formulas/templates/Rules.
+3. Publish signature changes with impact and consumer choice.
+4. Test denied scope and unavailable dependencies.
+
+## Open questions
+
+Organization approval requirements remain open.

--- a/templates/content/docs/product/capabilities/content.expression.catalog.md
+++ b/templates/content/docs/product/capabilities/content.expression.catalog.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.expression.catalog"
+name: "Expression catalog"
+user_promise: "Governed reusable Expressions and Variables"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.expression.language","content.template.governance"]
+related_features: ["content.feature.put-your-organizations-know-how-to-work"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Catalog/template governance, version semantics, approvals, references."
+proof_requirements: ["Catalog/template governance, version semantics, approvals, references."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Expression catalog
+
+## Contract
+
+Governed reusable Expressions and Variables
+
+## Acceptance boundary
+
+A complete proof demonstrates: Catalog/template governance, version semantics, approvals, references.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.expression.language.md
+++ b/templates/content/docs/product/capabilities/content.expression.language.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.expression.language"
+name: "Typed expression language"
+user_promise: "One typed language across formulas, views, validation, Rules, schedules, and body"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: []
+related_features: ["content.feature.make-the-workspace-yours","content.feature.data-that-keeps-itself-right","content.feature.build-living-dashboards"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Type system, access-scoped query handles, dependency/cycle analysis, one editor."
+proof_requirements: ["Type system, access-scoped query handles, dependency/cycle analysis, one editor."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Typed expression language
+
+## Contract
+
+One typed language across formulas, views, validation, Rules, schedules, and body
+
+## Acceptance boundary
+
+A complete proof demonstrates: Type system, access-scoped query handles, dependency/cycle analysis, one editor.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.expression.language.md
+++ b/templates/content/docs/product/capabilities/content.expression.language.md
@@ -1,17 +1,29 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.expression.language"
 name: "Typed expression language"
-user_promise: "One typed language across formulas, views, validation, Rules, schedules, and body"
+user_promise: "Use one understandable expression language whenever a configuration needs computation."
+primary_user_job: "Configure computation once across Content surfaces."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
 dependencies: []
-related_features: ["content.feature.make-the-workspace-yours","content.feature.data-that-keeps-itself-right","content.feature.build-living-dashboards"]
+related_features:
+  [
+    "content.feature.make-the-workspace-yours",
+    "content.feature.data-that-keeps-itself-right",
+    "content.feature.build-living-dashboards",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Type system, access-scoped query handles, dependency/cycle analysis, one editor."
-proof_requirements: ["Type system, access-scoped query handles, dependency/cycle analysis, one editor."]
+acceptance_summary: "Expressions share one typed AST and editor across formulas, views, validation, Rules, schedules, body configuration, and reusable definitions; zero-input expressions are Variables, while references remain stored typed values."
+proof_requirements:
+  [
+    "Stored references preserve identity without executing; expressions can return, compare, traverse, or render typed values.",
+    "The type system, dependency graph, and access checks are shared by every consumer rather than each surface inventing a dialect.",
+    "Compile, type, cycle, unavailable-input, and access failures stay distinguishable from a valid empty result.",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +31,46 @@ last_reviewed: "2026-07-29"
 
 # Typed expression language
 
-## Contract
+## Why this exists
 
-One typed language across formulas, views, validation, Rules, schedules, and body
+Configuration becomes untrustworthy when each surface invents its own formula, filter, or rule syntax. People need one way to understand computation and one set of honest diagnostics when it cannot be evaluated.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Type system, access-scoped query handles, dependency/cycle analysis, one editor.
+Inez previews a formula against a row, reuses its AST in validation, and sees a cycle before saving either configuration.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Stored references preserve identity without executing; expressions can return, compare, traverse, or render typed values.
+- The type system, dependency graph, and access checks are shared by every consumer rather than each surface inventing a dialect.
+- Compile, type, cycle, unavailable-input, and access failures stay distinguishable from a valid empty result.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- Typed Properties, Views, Rules, and Templates consume this language; none owns a competing evaluator or private grammar.
+- Expressions do not replace stable References, bypass access, or collapse invalid, unavailable, and empty values into one result.
+
+## Acceptance stories
+
+### Keep references distinct
+
+Given `@Project`, when stored, then it remains a typed reference; `@Project.Status` is computation.
+
+### Explain impossible computation
+
+Given a cycle or unreadable query, then typechecking reports that distinct cause.
+
+## Current evidence
+
+`actions/configure-document-property.ts`, `shared/properties.ts`, and `shared/nfm.ts` are donors; common AST/typechecking/access-scoped query semantics are absent.
+
+## Proof plan
+
+1. Parse/typecheck/round-trip formulas, filters, validation, Rules, schedules, and body contexts.
+2. Test references and access separately.
+3. Detect cycles, missing values, stale input, and denied query handles.
+4. Compare two editors' persisted AST and diagnostics.
+
+## Open questions
+
+Syntax and initial built-ins remain open.

--- a/templates/content/docs/product/capabilities/content.feedback.signal.md
+++ b/templates/content/docs/product/capabilities/content.feedback.signal.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.feedback.signal"
 name: "Reactions and Polls"
 user_promise: "Structured reactions and option-based Polls live inside the Page Discussion and can render through views or embeds"
+primary_user_job: "Collect lightweight feedback in the discussion where its context and access belong."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.discussion.page","content.access.safe-aggregate"]
+dependencies: ["content.discussion.page", "content.access.safe-aggregate"]
 related_features: ["content.feature.collaborate-in-context"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Many Poll messages per Discussion; at most one featured Poll per Page; stable option identities, response rules, results visibility, close state, access-safe aggregates, anti-abuse, and view/block renderers over the same Poll."
-proof_requirements: ["Many Poll messages per Discussion; at most one featured Poll per Page; stable option identities, response rules, results visibility, close state, access-safe aggregates, anti-abuse, and view/block renderers over the same Poll."]
+acceptance_summary: "Reactions and Polls are Discussion messages with stable option identities, response and close rules, one featured Poll per Page, access-safe results, anti-abuse controls, and shared View or embed rendering.."
+proof_requirements:
+  [
+    "Typed contract, authorization, validation, Event/history, and recovery coverage",
+    "Cross-surface UI, Action, agent-context, reload, and failure-state coverage",
+    "Real-interface keyboard and assistive-technology workflow coverage",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,42 @@ last_reviewed: "2026-07-29"
 
 # Reactions and Polls
 
-## Contract
+## Why this exists
 
-Structured reactions and option-based Polls live inside the Page Discussion and can render through views or embeds
+Votes and reactions make sense beside the conversation that gave them meaning; a survey silo loses both context and access boundaries.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Many Poll messages per Discussion; at most one featured Poll per Page; stable option identities, response rules, results visibility, close state, access-safe aggregates, anti-abuse, and view/block renderers over the same Poll.
+A Page owner posts a Poll with stable options in Discussion, features it on the Page, and later closes it. A View renders the same result without creating another poll.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+Reactions and Polls are Discussion messages with stable option identities, response and close rules, one featured Poll per Page, access-safe results, anti-abuse controls, and shared View or embed rendering.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Discussion owns message identity and safe aggregates own totals. This is not a survey silo, anonymous access bypass, or a new Page type.
+
+## Acceptance stories
+
+### Close a featured decision poll
+
+Given private respondents, when another viewer opens the featured Poll, then results reveal only the aggregation allowed by their access.
+
+### Hide private votes in a rollup
+
+Given a closed Poll, when a late response is attempted, then Content refuses it while preserving the Poll and prior attributed responses.
+
+## Current evidence
+
+No complete Poll identity, response, visibility, renderer, and recovery proof is recorded. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Test Discussion Poll identity, featured limits, stable options, close state, and responses.
+2. Verify visibility, safe aggregates, abuse controls, Views, and embeds.
+3. Exercise late responses, unavailable Discussions, keyboard voting, and result announcements.
+
+## Open questions
+
+The initial reaction vocabulary and anonymous-response policy need design.

--- a/templates/content/docs/product/capabilities/content.feedback.signal.md
+++ b/templates/content/docs/product/capabilities/content.feedback.signal.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.feedback.signal"
+name: "Reactions and Polls"
+user_promise: "Structured reactions and option-based Polls live inside the Page Discussion and can render through views or embeds"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.discussion.page","content.access.safe-aggregate"]
+related_features: ["content.feature.collaborate-in-context"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Many Poll messages per Discussion; at most one featured Poll per Page; stable option identities, response rules, results visibility, close state, access-safe aggregates, anti-abuse, and view/block renderers over the same Poll."
+proof_requirements: ["Many Poll messages per Discussion; at most one featured Poll per Page; stable option identities, response rules, results visibility, close state, access-safe aggregates, anti-abuse, and view/block renderers over the same Poll."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Reactions and Polls
+
+## Contract
+
+Structured reactions and option-based Polls live inside the Page Discussion and can render through views or embeds
+
+## Acceptance boundary
+
+A complete proof demonstrates: Many Poll messages per Discussion; at most one featured Poll per Page; stable option identities, response rules, results visibility, close state, access-safe aggregates, anti-abuse, and view/block renderers over the same Poll.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.form.shared-engine.md
+++ b/templates/content/docs/product/capabilities/content.form.shared-engine.md
@@ -1,17 +1,29 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.form.shared-engine"
 name: "Shared Form engine"
 user_promise: "Content Form Views and Agent Native Forms use one schema, validation, permission, and idempotent submission engine."
+primary_user_job: "Collect structured input once with the same contract whether it arrives from a Form View, an embedded Form, or an agent."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.property.constraints","content.agent.action-parity","content.event.committed"]
+dependencies:
+  [
+    "content.property.constraints",
+    "content.agent.action-parity",
+    "content.event.committed",
+  ]
 related_features: ["content.feature.collect-structured-input"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Content Form Views and Agent Native Forms use one schema, validation, permission, and idempotent submission engine."
-proof_requirements: ["Content Form Views and Agent Native Forms use one schema, validation, permission, and idempotent submission engine."]
+acceptance_summary: "Form schemas define typed fields, validation, permission, submission target, idempotency, and receipts."
+proof_requirements:
+  [
+    "Typed contract, authorization, validation, Event/history, and recovery coverage",
+    "Cross-surface UI, Action, agent-context, reload, and failure-state coverage",
+    "Real-interface keyboard and assistive-technology workflow coverage",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +31,42 @@ last_reviewed: "2026-07-29"
 
 # Shared Form engine
 
-## Contract
+## Why this exists
 
-Content Form Views and Agent Native Forms use one schema, validation, permission, and idempotent submission engine.
+A question should not become less trustworthy because it appears in an embed instead of a Form View. One submission contract keeps duplicate and invalid input honest.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Content Form Views and Agent Native Forms use one schema, validation, permission, and idempotent submission engine.
+A requester submits an intake Form from an embed. The same schema validates it as the internal Form View, rejects a duplicate idempotency key, and creates one canonical record with an Event.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+Form schemas define typed fields, validation, permission, submission target, idempotency, and receipts. Content Form Views, Agent Native Forms, and agents call one submission Action.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Property constraints own field rules and Events own committed receipts. This is not a second forms datastore, raw endpoint bypass, or a promise that every form is public.
+
+## Acceptance stories
+
+### Return the original receipt on retry
+
+Given the same submission is retried, when the idempotency key matches, then Content returns the original receipt and creates no duplicate record.
+
+### Reject a hidden field from an embed
+
+Given an unauthorized field value, when it is submitted from an embed or agent, then shared validation denies it with the same typed failure.
+
+## Current evidence
+
+No complete shared schema, idempotency, cross-surface permission, and recovery proof is recorded. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Define one schema and submit it from Form Views, embeds, and agents.
+2. Test validation, permissions, idempotency, receipts, retries, and target availability.
+3. Run keyboard and screen-reader completion flows with rejected-field recovery.
+
+## Open questions
+
+Public-form identity and draft-save policy need design.

--- a/templates/content/docs/product/capabilities/content.form.shared-engine.md
+++ b/templates/content/docs/product/capabilities/content.form.shared-engine.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.form.shared-engine"
+name: "Shared Form engine"
+user_promise: "Content Form Views and Agent Native Forms use one schema, validation, permission, and idempotent submission engine."
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.property.constraints","content.agent.action-parity","content.event.committed"]
+related_features: ["content.feature.collect-structured-input"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Content Form Views and Agent Native Forms use one schema, validation, permission, and idempotent submission engine."
+proof_requirements: ["Content Form Views and Agent Native Forms use one schema, validation, permission, and idempotent submission engine."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Shared Form engine
+
+## Contract
+
+Content Form Views and Agent Native Forms use one schema, validation, permission, and idempotent submission engine.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Content Form Views and Agent Native Forms use one schema, validation, permission, and idempotent submission engine.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.history.queryable.md
+++ b/templates/content/docs/product/capabilities/content.history.queryable.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.history.queryable"
+name: "History"
+user_promise: "Full-height queryable History surface over revisions/events"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.event.committed"]
+related_features: ["content.feature.durable-foundations","content.feature.review-changes-in-place"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Event spine, revision payload boundaries, access, filter/group/sort, body/property diff rendering."
+proof_requirements: ["Event spine, revision payload boundaries, access, filter/group/sort, body/property diff rendering."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# History
+
+## Contract
+
+Full-height queryable History surface over revisions/events
+
+## Acceptance boundary
+
+A complete proof demonstrates: Event spine, revision payload boundaries, access, filter/group/sort, body/property diff rendering.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.history.queryable.md
+++ b/templates/content/docs/product/capabilities/content.history.queryable.md
@@ -1,17 +1,29 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.history.queryable"
 name: "History"
-user_promise: "Full-height queryable History surface over revisions/events"
+user_promise: "History is a full-height, access-scoped surface for inspecting and recovering meaningful change."
+primary_user_job: "Find what changed, compare it in context, and recover safely without reconstructing the story from notifications."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
 dependencies: ["content.event.committed"]
-related_features: ["content.feature.durable-foundations","content.feature.review-changes-in-place"]
+related_features:
+  [
+    "content.feature.durable-foundations",
+    "content.feature.review-changes-in-place",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Event spine, revision payload boundaries, access, filter/group/sort, body/property diff rendering."
-proof_requirements: ["Event spine, revision payload boundaries, access, filter/group/sort, body/property diff rendering."]
+acceptance_summary: "History queries access-scoped Events, logical Revisions, snapshots, and receipts with filters, grouping, typed diffs, and recovery routes while preserving their distinct meanings."
+proof_requirements:
+  [
+    "Access-scoped event/revision/snapshot/receipt query model",
+    "Filter, group, sort, and stable permalink behavior",
+    "Typed body and property diff plus recovery routes",
+    "UI/Action parity, denial, concurrency, and export evidence",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +31,49 @@ last_reviewed: "2026-07-29"
 
 # History
 
-## Contract
+## Why this exists
 
-Full-height queryable History surface over revisions/events
+Collaboration needs an exhaustive place to ask what happened and recover from it. A friendly timeline can summarize, but it cannot quietly become the only evidence.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Event spine, revision payload boundaries, access, filter/group/sort, body/property diff rendering.
+An editor filters a Page's History to one agent run, expands its logical Revision into atomic Events, compares a changed Property and Block in their ordinary renderers, then restores only the authorized field.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- History is an access-scoped projection over committed Events, logical Revisions, recovery snapshots, and execution receipts.
+- It supports filtering, grouping, sorting, stable links, and typed comparison in the normal Page/Database renderer.
+- Events are atomic facts; Revisions are causal review units; snapshots are recovery mechanics; named Versions are deliberate alternatives. History preserves those distinctions.
+- Recovery invokes shared Actions and creates attributable new change rather than rewriting the past.
+- Inaccessible history is denial or omission according to access context, never a successful empty timeline.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- Discussion is a curated collaboration projection, not the exhaustive recovery authority.
+- History does not decide suggestion review disposition or Page Version promotion.
+- It does not require every low-level persistence operation to be user-visible.
+
+## Acceptance stories
+
+### Compare a causal Revision in place
+
+Given an agent Revision containing Block and Property changes, when an editor opens it in History, then they can inspect grouped Events and typed diffs in the ordinary surface without losing actor or causal context.
+
+### Recover without leaking another Version
+
+Given a person can read a Revision but lacks authority to edit a narrower Version, when they choose restore, then it is denied and the current content remains unchanged.
+
+## Current evidence
+
+Current document versions, restore actions, and editor history UI demonstrate snapshot-oriented substrate. They do not prove access-scoped Event/Revision queryability, typed diffs, or complete recovery semantics; this remains `approved_shape`.
+
+## Proof plan
+
+1. Query and compare Events, Revisions, snapshots, and receipts across Page, Database, source, and agent work.
+2. Test filters, grouping, sort, links, pagination, access changes, and private data closure.
+3. Restore fields and whole states under conflict, undo, and concurrent editing.
+4. Verify UI and Actions with keyboard and assistive-technology paths.
+
+## Open questions
+
+Retention, compaction, and default grouping are implementation choices as long as authorized history stays attributable and recoverable.

--- a/templates/content/docs/product/capabilities/content.home.global.md
+++ b/templates/content/docs/product/capabilities/content.home.global.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.home.global"
+name: "Global Home"
+user_promise: "Home belongs to the person and composes authorized work across Personal and organization contexts without pretending it all shares one Workspace."
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.workspace.multi-scope","content.query.object"]
+related_features: ["content.feature.find-your-place-again","content.feature.work-across-every-workspace"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Home belongs to the person and composes authorized work across Personal and organization contexts without pretending it all shares one Workspace."
+proof_requirements: ["Home belongs to the person and composes authorized work across Personal and organization contexts without pretending it all shares one Workspace."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Global Home
+
+## Contract
+
+Home belongs to the person and composes authorized work across Personal and organization contexts without pretending it all shares one Workspace.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Home belongs to the person and composes authorized work across Personal and organization contexts without pretending it all shares one Workspace.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.home.global.md
+++ b/templates/content/docs/product/capabilities/content.home.global.md
@@ -1,17 +1,28 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.home.global"
 name: "Global Home"
 user_promise: "Home belongs to the person and composes authorized work across Personal and organization contexts without pretending it all shares one Workspace."
+primary_user_job: "See my authorized work across contexts while retaining clear provenance and the ability to stay within one context."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.workspace.multi-scope","content.query.object"]
-related_features: ["content.feature.find-your-place-again","content.feature.work-across-every-workspace"]
+dependencies: ["content.workspace.multi-scope", "content.query.object"]
+related_features:
+  [
+    "content.feature.find-your-place-again",
+    "content.feature.work-across-every-workspace",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Home belongs to the person and composes authorized work across Personal and organization contexts without pretending it all shares one Workspace."
-proof_requirements: ["Home belongs to the person and composes authorized work across Personal and organization contexts without pretending it all shares one Workspace."]
+acceptance_summary: "Person-owned Home composes explicitly scoped, authorized Personal and organization results with visible origin and opt-in cross-context retrieval."
+proof_requirements:
+  [
+    "Personal, current-context, and explicit global scope selection and provenance coverage",
+    "Access, organization opt-out, result isolation, agent-context, and audit coverage",
+    "Real-interface empty, unavailable, revoked-access, reload, keyboard, and recovery workflow",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +30,51 @@ last_reviewed: "2026-07-29"
 
 # Global Home
 
-## Contract
+## Why this exists
 
-Home belongs to the person and composes authorized work across Personal and organization contexts without pretending it all shares one Workspace.
+A person's work often crosses contexts, but a useful overview must not flatten Personal
+and organization ownership into one imaginary Workspace.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Home belongs to the person and composes authorized work across Personal and organization contexts without pretending it all shares one Workspace.
+A person opens Home, selects an explicitly global task section, sees origin badges, and
+opens one result in its owning context. An organization that opts out contributes nothing.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Home is owned by the person; it composes authorized results rather than owning their objects.
+- Current-context and global retrieval are visible modes, with origin/provenance for every result.
+- Cross-context retrieval is opt-in and honors organization policy, access, and audit boundaries.
+- Revoked, deleted, unavailable, and stale items disappear or report their state without residue.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Multi-scope owns context and access semantics. Home is not a super-workspace, shared
+organization dashboard, or cross-context mutation shortcut.
+
+## Acceptance stories
+
+### Keep origins visible
+
+Given authorized work in Personal and two organizations, when a person opens global Home,
+then each result identifies its origin and opens with that context's authority.
+
+### Honor an opt-out
+
+Given an organization that disallows global retrieval, when Home refreshes, then no row,
+count, search suggestion, or agent context exposes its work.
+
+## Current evidence
+
+No complete person-owned cross-context Home proof is recorded. This Capability remains
+`approved_shape`.
+
+## Proof plan
+
+1. Test current/global mode, provenance, opt-in policy, access changes, and audit records.
+2. Verify result isolation through cards, counts, search, agents, and direct navigation.
+3. Exercise empty, unavailable, revoked, reload, keyboard, and recovery workflows.
+
+## Open questions
+
+The initial Home modules and per-context opt-in controls need implementation design.

--- a/templates/content/docs/product/capabilities/content.job.durable.md
+++ b/templates/content/docs/product/capabilities/content.job.durable.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.job.durable"
+name: "Durable background jobs"
+user_promise: "Imports, exports, migrations, capture, and backfills survive interruption, report honest progress, and resume without duplicate work."
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.event.committed","content.agent.action-parity"]
+related_features: ["content.feature.collect-structured-input","content.feature.capture-into-action","content.feature.take-the-whole-vault-with-you","content.feature.move-without-starting-over"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Imports, exports, migrations, capture, and backfills survive interruption, report honest progress, and resume without duplicate work."
+proof_requirements: ["Imports, exports, migrations, capture, and backfills survive interruption, report honest progress, and resume without duplicate work."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Durable background jobs
+
+## Contract
+
+Imports, exports, migrations, capture, and backfills survive interruption, report honest progress, and resume without duplicate work.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Imports, exports, migrations, capture, and backfills survive interruption, report honest progress, and resume without duplicate work.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.job.durable.md
+++ b/templates/content/docs/product/capabilities/content.job.durable.md
@@ -1,36 +1,76 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.job.durable"
-name: "Durable background jobs"
-user_promise: "Imports, exports, migrations, capture, and backfills survive interruption, report honest progress, and resume without duplicate work."
+name: "Durable Content jobs"
+user_promise: "Long-running import, export, sync, and enrichment work survives interruption and tells the truth about partial progress."
+primary_user_job: "Start substantial Content work, leave it safely, and later resume or repair it without duplicates or a false completed state."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
-availability: "universal"
-dependencies: ["content.event.committed","content.agent.action-parity"]
-related_features: ["content.feature.collect-structured-input","content.feature.capture-into-action","content.feature.take-the-whole-vault-with-you","content.feature.move-without-starting-over"]
+availability: "configured"
+dependencies: ["content.event.committed", "content.agent.action-parity"]
+related_features:
+  [
+    "content.feature.capture-into-action",
+    "content.feature.collect-structured-input",
+    "content.feature.move-without-starting-over",
+    "content.feature.take-the-whole-vault-with-you",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Imports, exports, migrations, capture, and backfills survive interruption, report honest progress, and resume without duplicate work."
-proof_requirements: ["Imports, exports, migrations, capture, and backfills survive interruption, report honest progress, and resume without duplicate work."]
+acceptance_summary: "Durable jobs persist an authorized immutable intent, checkpoints, item outcomes, cancellation and recovery state; retries are idempotent and completion is reported only after the declared closure is terminal."
+proof_requirements:
+  [
+    "Persistence, lease, checkpoint, idempotency, cancellation, resume, and duplicate-delivery tests",
+    "Authorization, bounded payload, progress visibility, partial-failure, and receipt tests",
+    "Interrupted import or export workflow resumed through the real interface",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
 ---
 
-# Durable background jobs
+# Durable Content jobs
 
-## Contract
+## Why this exists
 
-Imports, exports, migrations, capture, and backfills survive interruption, report honest progress, and resume without duplicate work.
+Large work needs a memory longer than a browser tab.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Imports, exports, migrations, capture, and backfills survive interruption, report honest progress, and resume without duplicate work.
+An administrator exports an authorized vault, closes the browser midway, returns later, and resumes from checkpoints. The report distinguishes exported, skipped, failed, and still-pending objects.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A job persists authorized intent, stable idempotency keys, declared scope, checkpoints, leases, item outcomes, and receipts outside a request lifetime.
+- Workers re-check access and freshness at safe boundaries. Retry cannot duplicate accepted effects.
+- Progress is granular enough to repair partial failure. Cancelled, paused, queued, failed, conflicted, and complete are different states.
+- Completion means the declared work reached terminal item outcomes; a truncated run never masquerades as success.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Individual Actions own domain semantics; jobs provide orchestration, not a second mutation policy. This is not an unbounded background-agent channel.
+
+## Acceptance stories
+
+### Resume without duplicates
+
+Given an import stops after accepted items, when it resumes with the same job identity, then it continues at the checkpoint and does not create duplicate Pages or memberships.
+
+### Report a partial export honestly
+
+Given one authorized asset cannot be resolved during export, when the job finishes, then the package report identifies that unresolved item and the job is not presented as a complete archive.
+
+## Current evidence
+
+Donor evidence: Builder source execution and refresh actions include progress and recovery-focused tests, including `actions/execute-builder-source-execution.test.ts`. No shared durable job substrate proves all Content workloads; this record remains `approved_shape`.
+
+## Proof plan
+
+1. Define persisted job, item, checkpoint, lease, and receipt models.
+2. Test interruption, retries, authorization changes, cancellation, and partial failure.
+3. Verify a real large import or export resume and conversion report.
+
+## Open questions
+
+- Queue backend and retention policy remain open while preserving portable job semantics.

--- a/templates/content/docs/product/capabilities/content.knowledge.graph.md
+++ b/templates/content/docs/product/capabilities/content.knowledge.graph.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.knowledge.graph"
 name: "Graph queries"
 user_promise: "Graph navigation and query over typed links, mentions, relations, and authority edges"
+primary_user_job: "Traverse a meaningful authorized network without confusing observed connection with declared governance."
 kind: "primitive"
 state: "exploring"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.relationship.edge","content.access.visibility-closure"]
+dependencies: ["content.relationship.edge", "content.access.visibility-closure"]
 related_features: ["content.feature.sketch-connections-keep-whats-true"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Stable identity and edge vocabulary; access-scoped recursive traversal, paths, ranking, and pattern matching; graph/canvas renderers; separate observed usage from declared governance; no second canonical datastore."
-proof_requirements: ["Stable identity and edge vocabulary; access-scoped recursive traversal, paths, ranking, and pattern matching; graph/canvas renderers; separate observed usage from declared governance; no second canonical datastore."]
+acceptance_summary: "Graph queries use stable object and typed-edge vocabulary for access-scoped traversal, paths, ranking, and pattern matching."
+proof_requirements:
+  [
+    "Typed contract, authorization, validation, Event/history, and recovery coverage",
+    "Cross-surface UI, Action, agent-context, reload, and failure-state coverage",
+    "Real-interface keyboard and assistive-technology workflow coverage",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,42 @@ last_reviewed: "2026-07-29"
 
 # Graph queries
 
-## Contract
+## Why this exists
 
-Graph navigation and query over typed links, mentions, relations, and authority edges
+Citation, governance, mention, and observed use carry different meanings that must remain distinct even when people explore them together.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Stable identity and edge vocabulary; access-scoped recursive traversal, paths, ranking, and pattern matching; graph/canvas renderers; separate observed usage from declared governance; no second canonical datastore.
+A researcher starts at a source Page, follows `cites` and `supports` edges, filters the path to a decision, and opens the same canonical objects in Graph and Canvas.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+Graph queries use stable object and typed-edge vocabulary for access-scoped traversal, paths, ranking, and pattern matching. They distinguish observed usage from declared governance and feed renderers without a second canonical datastore.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Relationships own edge truth and visibility closure owns disclosure. This is not a graph database replacement, automatic authority inference, or a renderer-specific relation store.
+
+## Acceptance stories
+
+### Traverse without exposing a private bridge
+
+Given a traversal with an inaccessible intermediate node, when a viewer asks for a path, then no endpoint, degree, path length, or ranking leaks that node.
+
+### Keep observed use distinct from authority
+
+Given a declared governance edge and an observed usage edge, when they are queried together, then Content labels their distinct semantics rather than treating usage as authority.
+
+## Current evidence
+
+This remains `exploring`; no complete recursive query, ranking, access-closure, and renderer proof is recorded.
+
+## Proof plan
+
+1. Test typed traversal, paths, patterns, ranks, cycles, and stable-object resolution.
+2. Verify closure through expansions, counts, exports, Graph, Canvas, and agents.
+3. Exercise inaccessible bridges, unavailable edges, stale indexes, and path inspection.
+
+## Open questions
+
+The initial graph query grammar and ranking semantics remain exploratory.

--- a/templates/content/docs/product/capabilities/content.knowledge.graph.md
+++ b/templates/content/docs/product/capabilities/content.knowledge.graph.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.knowledge.graph"
+name: "Graph queries"
+user_promise: "Graph navigation and query over typed links, mentions, relations, and authority edges"
+kind: "primitive"
+state: "exploring"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.relationship.edge","content.access.visibility-closure"]
+related_features: ["content.feature.sketch-connections-keep-whats-true"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Stable identity and edge vocabulary; access-scoped recursive traversal, paths, ranking, and pattern matching; graph/canvas renderers; separate observed usage from declared governance; no second canonical datastore."
+proof_requirements: ["Stable identity and edge vocabulary; access-scoped recursive traversal, paths, ranking, and pattern matching; graph/canvas renderers; separate observed usage from declared governance; no second canonical datastore."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Graph queries
+
+## Contract
+
+Graph navigation and query over typed links, mentions, relations, and authority edges
+
+## Acceptance boundary
+
+A complete proof demonstrates: Stable identity and edge vocabulary; access-scoped recursive traversal, paths, ranking, and pattern matching; graph/canvas renderers; separate observed usage from declared governance; no second canonical datastore.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.knowledge.links.md
+++ b/templates/content/docs/product/capabilities/content.knowledge.links.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.knowledge.links"
+name: "Links and backlinks"
+user_promise: "Stable links, outline, backlinks, forward links, external-link health, and link-aware navigation through the Page Info rail"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.object.reference"]
+related_features: ["content.feature.living-references"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: ID references, portable links, access, source links, target-state taxonomy, cached health checks, embedded renderer."
+proof_requirements: ["ID references, portable links, access, source links, target-state taxonomy, cached health checks, embedded renderer."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Links and backlinks
+
+## Contract
+
+Stable links, outline, backlinks, forward links, external-link health, and link-aware navigation through the Page Info rail
+
+## Acceptance boundary
+
+A complete proof demonstrates: ID references, portable links, access, source links, target-state taxonomy, cached health checks, embedded renderer.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.knowledge.links.md
+++ b/templates/content/docs/product/capabilities/content.knowledge.links.md
@@ -1,8 +1,10 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.knowledge.links"
 name: "Links and backlinks"
 user_promise: "Stable links, outline, backlinks, forward links, external-link health, and link-aware navigation through the Page Info rail"
+primary_user_job: "Follow and maintain references that survive renames and reveal whether a target is still usable."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
@@ -10,8 +12,13 @@ availability: "universal"
 dependencies: ["content.object.reference"]
 related_features: ["content.feature.living-references"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: ID references, portable links, access, source links, target-state taxonomy, cached health checks, embedded renderer."
-proof_requirements: ["ID references, portable links, access, source links, target-state taxonomy, cached health checks, embedded renderer."]
+acceptance_summary: "Internal links use stable identities and portable links; outlines, forward links, backlinks, source links, and target-state taxonomy are access-scoped."
+proof_requirements:
+  [
+    "Typed contract, authorization, validation, Event/history, and recovery coverage",
+    "Cross-surface UI, Action, agent-context, reload, and failure-state coverage",
+    "Real-interface keyboard and assistive-technology workflow coverage",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,42 @@ last_reviewed: "2026-07-29"
 
 # Links and backlinks
 
-## Contract
+## Why this exists
 
-Stable links, outline, backlinks, forward links, external-link health, and link-aware navigation through the Page Info rail
+A reference promises a route back to the right thing after titles move and sources age. Backlinks make that promise visible from the other side.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: ID references, portable links, access, source links, target-state taxonomy, cached health checks, embedded renderer.
+An editor links a Page by stable ID, renames the target, then opens its backlinks in the Info rail. An external link health check reports stale status without changing the original URL.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+Internal links use stable identities and portable links; outlines, forward links, backlinks, source links, and target-state taxonomy are access-scoped. External health is cached observation, not a rewrite of source content.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+References own link targets. This is not a crawler, an access bypass, or a claim that a failed external check deletes the link.
+
+## Acceptance stories
+
+### Resolve a link after a rename
+
+Given a renamed Page, when a backlink is opened, then its stable link resolves to the renamed canonical target.
+
+### Report a stale external target without rewriting it
+
+Given an inaccessible backlink source, when a viewer opens Info, then it contributes no title, count, or preview.
+
+## Current evidence
+
+No complete link taxonomy, health, embedded rendering, and recovery proof is recorded. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Test ID links through rename, move, delete, outline, and backlink changes.
+2. Verify Info rail, embeds, access changes, health states, and URL preservation.
+3. Exercise stale targets, reload, keyboard navigation, and target-state announcements.
+
+## Open questions
+
+The initial external-health cadence and status-retention policy need design.

--- a/templates/content/docs/product/capabilities/content.knowledge.search.md
+++ b/templates/content/docs/product/capabilities/content.knowledge.search.md
@@ -1,8 +1,10 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.knowledge.search"
 name: "Search"
 user_promise: "Fast access-aware search across titles, bodies, rows, sources, and later comments/review"
+primary_user_job: "Find the most useful authorized evidence quickly and understand where it came from and how fresh it is."
 kind: "primitive"
 state: "in_progress"
 publicness: "public"
@@ -10,8 +12,13 @@ availability: "universal"
 dependencies: ["content.access.visibility-closure"]
 related_features: ["content.feature.durable-foundations"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Indexed lexical retrieval first, snippets/highlights, source/freshness, shared human/agent ranking."
-proof_requirements: ["Indexed lexical retrieval first, snippets/highlights, source/freshness, shared human/agent ranking."]
+acceptance_summary: "Search performs indexed lexical retrieval first across eligible objects, returns access-scoped snippets and highlights with source and freshness, and shares ranking semantics between people and agents.."
+proof_requirements:
+  [
+    "Typed contract, authorization, validation, Event/history, and recovery coverage",
+    "Cross-surface UI, Action, agent-context, reload, and failure-state coverage",
+    "Real-interface keyboard and assistive-technology workflow coverage",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,42 @@ last_reviewed: "2026-07-29"
 
 # Search
 
-## Contract
+## Why this exists
 
-Fast access-aware search across titles, bodies, rows, sources, and later comments/review
+Search is how a system remembers aloud. It must be quick without ever pronouncing information a viewer may not read.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Indexed lexical retrieval first, snippets/highlights, source/freshness, shared human/agent ranking.
+A contributor searches a phrase, opens an indexed Page snippet, filters to a connected Source, and sees that one result is stale rather than treating it as current.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+Search performs indexed lexical retrieval first across eligible objects, returns access-scoped snippets and highlights with source and freshness, and shares ranking semantics between people and agents.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Visibility closure owns authorization. This is not semantic-answer generation, a source-truth override, or a leakage-prone global index.
+
+## Acceptance stories
+
+### Suppress a private matching title
+
+Given a private matching Page, when a viewer searches its title and body, then no result, highlight, count, or ranking inference exposes it.
+
+### Label a stale connected result
+
+Given a stale connected Source result, when it appears, then its freshness state is visible and opening it follows the Source policy.
+
+## Current evidence
+
+Existing search paths are in progress donor substrate, but complete indexed, freshness, ranking, and agent-parity proof is incomplete. This Capability remains `in_progress`.
+
+## Proof plan
+
+1. Index titles, bodies, rows, and Sources; test lexical queries, snippets, highlights, and pages.
+2. Verify private-match suppression, human/agent ranking, freshness, provenance, and opening.
+3. Exercise stale indexes, source refresh, reload, keyboard traversal, and result summaries.
+
+## Open questions
+
+The first ranking signals beyond lexical relevance need design.

--- a/templates/content/docs/product/capabilities/content.knowledge.search.md
+++ b/templates/content/docs/product/capabilities/content.knowledge.search.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.knowledge.search"
+name: "Search"
+user_promise: "Fast access-aware search across titles, bodies, rows, sources, and later comments/review"
+kind: "primitive"
+state: "in_progress"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.access.visibility-closure"]
+related_features: ["content.feature.durable-foundations"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Indexed lexical retrieval first, snippets/highlights, source/freshness, shared human/agent ranking."
+proof_requirements: ["Indexed lexical retrieval first, snippets/highlights, source/freshness, shared human/agent ranking."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Search
+
+## Contract
+
+Fast access-aware search across titles, bodies, rows, sources, and later comments/review
+
+## Acceptance boundary
+
+A complete proof demonstrates: Indexed lexical retrieval first, snippets/highlights, source/freshness, shared human/agent ranking.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.layout.responsive.md
+++ b/templates/content/docs/product/capabilities/content.layout.responsive.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.layout.responsive"
+name: "Responsive Page layout"
+user_promise: "Pages arrange, resize, and reorder Blocks in columns that remain coherent on smaller screens and in exports."
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.object.blocks-field","content.renderer.typed"]
+related_features: ["content.feature.build-living-dashboards","content.feature.work-on-content-inside-another-application"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Pages arrange, resize, and reorder Blocks in columns that remain coherent on smaller screens and in exports."
+proof_requirements: ["Pages arrange, resize, and reorder Blocks in columns that remain coherent on smaller screens and in exports."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Responsive Page layout
+
+## Contract
+
+Pages arrange, resize, and reorder Blocks in columns that remain coherent on smaller screens and in exports.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Pages arrange, resize, and reorder Blocks in columns that remain coherent on smaller screens and in exports.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.layout.responsive.md
+++ b/templates/content/docs/product/capabilities/content.layout.responsive.md
@@ -1,17 +1,28 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.layout.responsive"
 name: "Responsive Page layout"
 user_promise: "Pages arrange, resize, and reorder Blocks in columns that remain coherent on smaller screens and in exports."
+primary_user_job: "Arrange a Page for the work at hand while retaining readable, accessible content on any supported surface."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.object.blocks-field","content.renderer.typed"]
-related_features: ["content.feature.build-living-dashboards","content.feature.work-on-content-inside-another-application"]
+dependencies: ["content.object.blocks-field", "content.renderer.typed"]
+related_features:
+  [
+    "content.feature.build-living-dashboards",
+    "content.feature.work-on-content-inside-another-application",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Pages arrange, resize, and reorder Blocks in columns that remain coherent on smaller screens and in exports."
-proof_requirements: ["Pages arrange, resize, and reorder Blocks in columns that remain coherent on smaller screens and in exports."]
+acceptance_summary: "Page layout stores responsive Block arrangement separately from Block content and renders coherent, accessible columns across supported sizes and exports."
+proof_requirements:
+  [
+    "Column create, resize, reorder, persistence, conflict, and recovery coverage",
+    "Responsive, embed, export, keyboard, and assistive-technology coverage",
+    "Shared Action authorization, history, and canonical Block identity coverage",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +30,51 @@ last_reviewed: "2026-07-29"
 
 # Responsive Page layout
 
-## Contract
+## Why this exists
 
-Pages arrange, resize, and reorder Blocks in columns that remain coherent on smaller screens and in exports.
+Pages need room to breathe on a wide screen without becoming a pile of clipped fragments
+on a narrow one.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Pages arrange, resize, and reorder Blocks in columns that remain coherent on smaller screens and in exports.
+An editor arranges live Blocks in two columns, reorders one, then opens the Page on a
+smaller screen. The readable order is preserved; each Block remains its canonical content.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Layout stores arrangement and responsive rules separately from canonical Blocks and their content.
+- Authorized edits use shared Actions, history, recovery, and concurrent-change behavior.
+- Small surfaces and exports use a deterministic readable order, not hidden or duplicated content.
+- Keyboard and assistive technology can inspect and change supported layout operations.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Blocks fields own content. This is not a freeform Canvas, slide engine, or alternate Page
+identity.
+
+## Acceptance stories
+
+### Reflow a column layout
+
+Given a two-column Page, when a viewer opens it on a narrow surface, then Blocks appear
+once in a readable deterministic order without inaccessible overflow.
+
+### Keep Blocks canonical
+
+Given an editor reorders a Block, when another authorized View opens the Page, then it
+observes the same Block identity and changed layout without copied content.
+
+## Current evidence
+
+The product boundary is shaped, but no complete layout, responsive, export, and recovery
+proof is recorded. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Test layout edits, persistence, undo, conflicts, and canonical Block identity.
+2. Test responsive and embed/export rendering across supported breakpoints.
+3. Exercise keyboard, screen reader, permission, reload, and failure recovery workflows.
+
+## Open questions
+
+The initial supported layout primitives and export fidelity thresholds need design.

--- a/templates/content/docs/product/capabilities/content.navigation.sidebar.md
+++ b/templates/content/docs/product/capabilities/content.navigation.sidebar.md
@@ -1,36 +1,86 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.navigation.sidebar"
 name: "Personal sidebar"
 user_promise: "The sidebar is a personal navigation surface with pinned references and query-backed dynamic sections, not object hierarchy."
+primary_user_job: "Return to my important work and discover authorized dynamic collections without changing shared object structure."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.object.reference","content.query.object"]
-related_features: ["content.feature.find-your-place-again","content.feature.make-the-workspace-yours"]
+dependencies: ["content.object.reference", "content.query.object"]
+related_features:
+  [
+    "content.feature.find-your-place-again",
+    "content.feature.make-the-workspace-yours",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: The sidebar is a personal navigation surface with pinned references and query-backed dynamic sections, not object hierarchy."
-proof_requirements: ["The sidebar is a personal navigation surface with pinned references and query-backed dynamic sections, not object hierarchy."]
-evidence: []
+acceptance_summary: "A personal sidebar stores pinned References and dynamic query sections, supports intentional expansion and order, and never treats navigation placement as object parentage or shared mutation."
+proof_requirements:
+  [
+    "Personal pin, order, expand, collapse, query-section, and reload coverage",
+    "Access-safe section results, counts, previews, stale references, and dynamic recovery coverage",
+    "Keyboard, screen-reader, responsive, agent-context, and shared-mutation-denial workflows",
+  ]
+evidence:
+  [
+    "../../../app/components/sidebar/document-sidebar-sections.test.ts",
+    "../../../app/components/editor/database/sidebar.tsx",
+  ]
 superseded_by: null
 last_reviewed: "2026-07-29"
 ---
 
 # Personal sidebar
 
-## Contract
+## Why this exists
 
-The sidebar is a personal navigation surface with pinned references and query-backed dynamic sections, not object hierarchy.
+Navigation should remember what matters to a person without quietly rewriting the
+workspace's structure. The sidebar is a map, not the territory; maps are allowed taste.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: The sidebar is a personal navigation surface with pinned references and query-backed dynamic sections, not object hierarchy.
+A viewer pins a Page, reorders their personal references, expands an intentional
+reference, and opens a dynamic query section. Another viewer's order and the Page's
+parentage remain unchanged.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Pinned entries are personal References; dynamic sections are access-scoped query results.
+- Personal ordering, expansion, and collapse do not reparent Pages, change Database membership, or grant shared edit authority.
+- Intentional references may expand; the sidebar is not a general-purpose object renderer.
+- Missing, deleted, inaccessible, stale, and unavailable entries are handled honestly and recoverably.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+References and Queries own target and result meaning. This does not define Page hierarchy,
+general Tree View, or a hidden shared workspace organizer.
+
+## Acceptance stories
+
+### Reorder a personal pin
+
+Given two pinned References, when a viewer changes their order, then only that person's
+navigation preference changes and neither target Page's parentage nor membership changes.
+
+### Open an access-scoped section
+
+Given a dynamic section with inaccessible items, when a viewer expands it, then its rows,
+counts, and previews disclose only authorized results.
+
+## Current evidence
+
+Existing sidebar section tests and sidebar rendering show useful donor behavior. They do
+not prove the full Reference/query, access, recovery, and personal-state contract; this
+Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Test pin, reorder, expand, query sections, reload, and stale-reference recovery.
+2. Verify access closure and that personal operations cannot mutate shared structure.
+3. Exercise keyboard, ARIA navigation, responsive behavior, agent context, and unavailable sources.
+
+## Open questions
+
+The first dynamic-section catalog and section-level personalization controls need design.

--- a/templates/content/docs/product/capabilities/content.navigation.sidebar.md
+++ b/templates/content/docs/product/capabilities/content.navigation.sidebar.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.navigation.sidebar"
+name: "Personal sidebar"
+user_promise: "The sidebar is a personal navigation surface with pinned references and query-backed dynamic sections, not object hierarchy."
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.object.reference","content.query.object"]
+related_features: ["content.feature.find-your-place-again","content.feature.make-the-workspace-yours"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: The sidebar is a personal navigation surface with pinned references and query-backed dynamic sections, not object hierarchy."
+proof_requirements: ["The sidebar is a personal navigation surface with pinned references and query-backed dynamic sections, not object hierarchy."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Personal sidebar
+
+## Contract
+
+The sidebar is a personal navigation surface with pinned references and query-backed dynamic sections, not object hierarchy.
+
+## Acceptance boundary
+
+A complete proof demonstrates: The sidebar is a personal navigation surface with pinned references and query-backed dynamic sections, not object hierarchy.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.notification.source.md
+++ b/templates/content/docs/product/capabilities/content.notification.source.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.notification.source"
+name: "Notifications"
+user_promise: "Canonical notifications exposed as queryable Content source/views"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.event.committed"]
+related_features: ["content.feature.collaborate-in-context","content.feature.run-projects-your-way"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Stable identity/read/archive state, access, routing Rules, My Tasks remains separate."
+proof_requirements: ["Stable identity/read/archive state, access, routing Rules, My Tasks remains separate."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Notifications
+
+## Contract
+
+Canonical notifications exposed as queryable Content source/views
+
+## Acceptance boundary
+
+A complete proof demonstrates: Stable identity/read/archive state, access, routing Rules, My Tasks remains separate.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.notification.source.md
+++ b/templates/content/docs/product/capabilities/content.notification.source.md
@@ -1,17 +1,28 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.notification.source"
 name: "Notifications"
-user_promise: "Canonical notifications exposed as queryable Content source/views"
+user_promise: "Canonical notifications exposed as queryable Content source and Views"
+primary_user_job: "Receive and organize meaningful notices without confusing them with Tasks or losing their read state."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
 dependencies: ["content.event.committed"]
-related_features: ["content.feature.collaborate-in-context","content.feature.run-projects-your-way"]
+related_features:
+  [
+    "content.feature.collaborate-in-context",
+    "content.feature.run-projects-your-way",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Stable identity/read/archive state, access, routing Rules, My Tasks remains separate."
-proof_requirements: ["Stable identity/read/archive state, access, routing Rules, My Tasks remains separate."]
+acceptance_summary: "Notifications have stable identity, actor and origin, read and archive state, access-scoped routing Rules, and queryable Source/View representation."
+proof_requirements:
+  [
+    "Typed contract, authorization, validation, Event/history, and recovery coverage",
+    "Cross-surface UI, Action, agent-context, reload, and failure-state coverage",
+    "Real-interface keyboard and assistive-technology workflow coverage",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +30,42 @@ last_reviewed: "2026-07-29"
 
 # Notifications
 
-## Contract
+## Why this exists
 
-Canonical notifications exposed as queryable Content source/views
+A notification is a trace of something that happened to a person, not an assignment pretending to be urgent. Its read state belongs to that trace.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Stable identity/read/archive state, access, routing Rules, My Tasks remains separate.
+A person receives a comment notification, opens its canonical target, marks the notice read, and archives it. A notification View updates without turning the item into My Tasks.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+Notifications have stable identity, actor and origin, read and archive state, access-scoped routing Rules, and queryable Source/View representation. Their target remains canonical and My Tasks stays separate.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Committed Events own origins and routing owns delivery. This is not a task assignment engine, a duplicated inbox record, or a bypass around target access.
+
+## Acceptance stories
+
+### Read a comment notice without creating a task
+
+Given a notification target becomes inaccessible, when the list refreshes, then the notice follows its policy without leaking the target title or preview.
+
+### Remove a notice when target access is revoked
+
+Given a person marks one notice read, when they reopen another View, then the same canonical notification state appears without altering task membership.
+
+## Current evidence
+
+No complete notification identity, routing, state, and recovery proof is recorded. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Test committed-event notices, target routes, read/archive state, and routing Rules.
+2. Verify target access changes, queryable Views, duplicate delivery, and task separation.
+3. Exercise revocation, archive retention, device conflicts, and accessible navigation.
+
+## Open questions
+
+The archive-retention and multi-device read-conflict policies need design.

--- a/templates/content/docs/product/capabilities/content.object.block.md
+++ b/templates/content/docs/product/capabilities/content.object.block.md
@@ -1,17 +1,26 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.object.block"
 name: "Blocks"
-user_promise: "Stable addressable Block inside a Page"
+user_promise: "A Block is a stable addressable unit of rich content inside its owning field."
+primary_user_job: "Edit and point to a meaningful part of content without fragile position-only anchors."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
 dependencies: []
-related_features: ["content.feature.durable-foundations","content.feature.living-references"]
+related_features:
+  ["content.feature.durable-foundations", "content.feature.living-references"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Stable block IDs, history boundary, reference serialization, page-owned comments."
-proof_requirements: ["Stable block IDs, history boundary, reference serialization, page-owned comments."]
+acceptance_summary: "Every rich-content Block keeps a stable identity through edits, reordering, deletion, recovery, references, and Page-owned collaboration anchors."
+proof_requirements:
+  [
+    "Stable Block IDs across text and structured edits, reorder, deletion, and recovery",
+    "Reference serialization and rendering resolve by ID with access checks",
+    "Comment anchors retain historical target context",
+    "Shared Action/UI editing, conflict, undo, and reload behavior",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +28,49 @@ last_reviewed: "2026-07-29"
 
 # Blocks
 
-## Contract
+## Why this exists
 
-Stable addressable Block inside a Page
+People comment on a paragraph, reuse a callout, and return to an exact idea. Positional text ranges alone drift; stable Blocks give those gestures a durable address.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Stable block IDs, history boundary, reference serialization, page-owned comments.
+An editor moves a callout above a heading while a reviewer comments on it and another Page references it. The callout keeps its identity; the comment and reference still lead to the same material or its authorized historical context.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A Block is a stable, typed content unit owned by one Blocks field; it is not a Page.
+- Editing text or typed props and reordering Blocks preserve identity whenever the logical Block survives.
+- References store Block identity, not renderer position. Comments remain Page-owned while targeting one or more Block anchors.
+- Deletion records an attributable historical target; recovery never silently reassigns an old anchor to unrelated new text.
+- One Action surface applies validation, access, Events, and concurrency behavior for people and agents.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- Blocks do not own independent Page access, Database membership, or top-level Properties.
+- A Block reference is not automatically a synced editable transclusion.
+- Blocks-field history owns the field revision sequence; this record owns the stable local unit.
+
+## Acceptance stories
+
+### Keep the comment on the intended material
+
+Given a comment anchored to a Block, when the Block is reordered and edited, then the anchor follows that Block. When it is deleted, then the comment opens authorized historical context rather than a similarly placed replacement.
+
+### Resolve a reference safely
+
+Given a Block reference in another Page, when an authorized reader opens it, then it resolves the canonical Block. When access is lost, then the renderer degrades without exposing its content.
+
+## Current evidence
+
+The current editor stores rich document content and supports anchored comments, but the repository does not yet demonstrate stable universal Block IDs, reference serialization, or recovery across all typed Block operations. This remains `approved_shape`.
+
+## Proof plan
+
+1. Test typed Block creation, edit, split, merge, move, deletion, restore, and undo.
+2. Verify comment, reference, and history anchors through each operation and reload.
+3. Exercise concurrent edits and stale restore through UI and shared Actions.
+4. Test inaccessible, unknown-renderer, and portable-export degradation.
+
+## Open questions
+
+Storage encoding and identity assignment timing remain implementation choices, provided logical Block identity and historical anchors survive.

--- a/templates/content/docs/product/capabilities/content.object.block.md
+++ b/templates/content/docs/product/capabilities/content.object.block.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.object.block"
+name: "Blocks"
+user_promise: "Stable addressable Block inside a Page"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: []
+related_features: ["content.feature.durable-foundations","content.feature.living-references"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Stable block IDs, history boundary, reference serialization, page-owned comments."
+proof_requirements: ["Stable block IDs, history boundary, reference serialization, page-owned comments."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Blocks
+
+## Contract
+
+Stable addressable Block inside a Page
+
+## Acceptance boundary
+
+A complete proof demonstrates: Stable block IDs, history boundary, reference serialization, page-owned comments.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.object.blocks-field.md
+++ b/templates/content/docs/product/capabilities/content.object.blocks-field.md
@@ -1,17 +1,29 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.object.blocks-field"
 name: "Blocks fields"
-user_promise: "Every editable rich-content body uses the same Blocks-field grammar and owns its own stable revision history."
+user_promise: "Every editable rich-content body uses one Blocks-field grammar and keeps its own stable revision boundary."
+primary_user_job: "Write rich content in Pages and collaboration surfaces without each body inventing incompatible editing and history rules."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
 dependencies: ["content.object.block"]
-related_features: ["content.feature.durable-foundations","content.feature.collaborate-in-context"]
+related_features:
+  [
+    "content.feature.durable-foundations",
+    "content.feature.collaborate-in-context",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Every editable rich-content body uses the same Blocks-field grammar and owns its own stable revision history."
-proof_requirements: ["Every editable rich-content body uses the same Blocks-field grammar and owns its own stable revision history."]
+acceptance_summary: "Pages, additional rich fields, Comments, and Discussion messages use compatible typed Blocks while retaining distinct owner, field identity, access, and attributable revision history."
+proof_requirements:
+  [
+    "One grammar across each supported editable body",
+    "Stable field and Block identity with independent revision/recovery boundaries",
+    "Owner-scoped access and typed rendering including unavailable content",
+    "Shared Action/UI behavior for concurrency, history, and portable output",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +31,49 @@ last_reviewed: "2026-07-29"
 
 # Blocks fields
 
-## Contract
+## Why this exists
 
-Every editable rich-content body uses the same Blocks-field grammar and owns its own stable revision history.
+An article, a comment, and a Discussion message should support the same useful content rather than forcing people into a plain-text side channel or making every small body a full Page.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Every editable rich-content body uses the same Blocks-field grammar and owns its own stable revision history.
+A reviewer writes a Comment containing a Page reference and a code Block, while an author keeps a research-notes field beside the Page body. Each body renders through the same grammar, but only the intended field is revised or recovered.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A Blocks field is one editable rich-content body with stable identity and a canonical owning object.
+- Page bodies, additional rich fields, Comments, and Discussion messages reuse the grammar; their ownership and access do not collapse into one Page.
+- Field history distinguishes atomic Events, logical Revisions, recovery snapshots, and named Page Versions.
+- Typed Blocks preserve source when a renderer is unavailable and report a degraded state rather than dropping content.
+- A multi-field action can share causality while retaining which field changed.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- A Blocks field does not become a top-level Page, Database row, or sharing principal.
+- It does not decide Page Version branching, cross-field merge, or generic query history.
+- Shared grammar does not imply every renderer is supported in every host.
+
+## Acceptance stories
+
+### Reuse grammar without merging ownership
+
+Given a Page body and a Comment body containing references, when each is edited, then both use compatible Blocks while Comment access and history remain owned by the Comment's Page context.
+
+### Recover exactly one body
+
+Given a Page with two Blocks fields, when an authorized editor restores one field, then the other field, title, Properties, and memberships remain unchanged and a new attributable Revision records the recovery.
+
+## Current evidence
+
+The document editor proves rich Page-body editing and comments provide collaboration substrate. The repository does not yet prove one generalized Blocks-field grammar or independent field history across all owners; this remains `approved_shape`.
+
+## Proof plan
+
+1. Author equivalent typed content in every supported field owner and compare serialization/rendering.
+2. Verify per-field identity, history, recovery, deletion, and inaccessible rendering.
+3. Test agent, human, and automation edits with causal attribution and concurrent writes.
+4. Exercise UI, Actions, export, import, keyboard, and assistive technology paths.
+
+## Open questions
+
+The exact first set of non-Page field owners can grow incrementally; no owner may claim grammar compatibility without its own proof.

--- a/templates/content/docs/product/capabilities/content.object.blocks-field.md
+++ b/templates/content/docs/product/capabilities/content.object.blocks-field.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.object.blocks-field"
+name: "Blocks fields"
+user_promise: "Every editable rich-content body uses the same Blocks-field grammar and owns its own stable revision history."
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.object.block"]
+related_features: ["content.feature.durable-foundations","content.feature.collaborate-in-context"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Every editable rich-content body uses the same Blocks-field grammar and owns its own stable revision history."
+proof_requirements: ["Every editable rich-content body uses the same Blocks-field grammar and owns its own stable revision history."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Blocks fields
+
+## Contract
+
+Every editable rich-content body uses the same Blocks-field grammar and owns its own stable revision history.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Every editable rich-content body uses the same Blocks-field grammar and owns its own stable revision history.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.object.database.md
+++ b/templates/content/docs/product/capabilities/content.object.database.md
@@ -1,8 +1,10 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.object.database"
 name: "Databases"
 user_promise: "Database as a Page-backed typed collection"
+primary_user_job: "Keep a durable set of Pages together with shared structure, rules, permissions, and one dependable place for new records to belong."
 kind: "primitive"
 state: "verified"
 publicness: "public"
@@ -10,8 +12,14 @@ availability: "universal"
 dependencies: []
 related_features: ["content.feature.durable-foundations"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Access-scoped rows, schema/actions, full-page and inline surfaces."
-proof_requirements: ["Access-scoped rows, schema/actions, full-page and inline surfaces."]
+acceptance_summary: "A Database owns canonical membership, membership-specific values, structure, validation, permissions, Rules, source bindings, and creation while every View evaluates its access-scoped base collection."
+proof_requirements:
+  [
+    "Stable Page-backed Database identity, membership, schema, and membership-specific values",
+    "Access-scoped implicit base Query shared by full-page and inline Views",
+    "Canonical creation and write Actions with validation, Rules, and source ownership",
+    "Reload, recovery, permissions, accessibility, and agent/UI parity",
+  ]
 evidence: ["../../../server/db/schema.ts"]
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +27,66 @@ last_reviewed: "2026-07-29"
 
 # Databases
 
-## Contract
+## Why this exists
 
-Database as a Page-backed typed collection
+A collection is more than a table-shaped result. People need one governed place that owns which Pages belong, what shared structure applies, where a new item is created, and which rules or sources control its values.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Access-scoped rows, schema/actions, full-page and inline surfaces.
+A marketing team creates a Content Calendar Database, adds Page records, defines Status and Publish date Properties, and builds Table and Calendar Views. Both Views show the same authorized members. Creating through either View creates one Page in the Database and applies its defaults and validation; changing presentation never manufactures a second collection.
 
-## Evidence boundary
+## Product contract
 
-The repository evidence linked in frontmatter supports the complete atomic contract. Feature completion still requires its own end-to-end proof.
+- A Database is a Page-backed, stable Content object with its own identity, access, description, and Views.
+- It owns durable Page membership, membership-specific Property values, Property definitions, defaults, validation, Rules, source bindings, canonical creation, and canonical write routing.
+- A Page may belong to several Databases. Each Database owns only its membership and membership-local values; no Database becomes the Page's identity, primary parent, or universal read context.
+- Opening a Database evaluates an implicit base Query: every member the current viewer may access. This base relation is execution machinery, not a hidden named Query object.
+- Every Table, List, Board, Gallery, Calendar, Timeline, Form, Chart, or other Database View consumes that same base relation and adds downstream presentation and View filters.
+- Schema and values bind through stable Property IDs, never display names alone. Renaming preserves dependencies.
+- Creating through a Database or an unambiguous Database View creates the Page in this Database and applies safe defaults, View-derived seeds, validation, and Rules atomically.
+- UI, agents, automations, and APIs use the same typed Actions and authorization. A screen does not own a second mutation path.
 
-## Non-goals
+## Permissions and source behavior
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- The fixed roles are **Can view**, **Can comment**, **Can edit entries**, **Can edit database**, and **Full access**.
+- Personal filters and presentation do not require schema authority. Editing shared Views and structure follows Database-edit authority.
+- Source truth policy, provider grants, Property locks, and operation-specific guards may narrow an actor's role but never widen it.
+- A Database View or shared link reveals only rows and fields already authorized for that viewer.
+- Removing a Page from a Database removes that membership and its membership-local values; it does not delete the Page or its other memberships.
+
+## Boundaries and non-goals
+
+- A Database owns records and structure; a Query derives a collection without taking ownership; a View presents and refines one Database or Query.
+- The common query engine does not make every Database a named Query.
+- Database membership is not Page hierarchy, sidebar placement, or an access grant to other memberships.
+- A multi-source Query may compose several Databases, but it does not become a new Database unless someone explicitly creates a governed writable collection.
+
+## Acceptance stories
+
+### Render one collection several ways
+
+Given one Database with authorized and private members, when a viewer opens its Table and Calendar Views, then both evaluate the same access-scoped membership, preserve stable record identity, and reveal no private rows through counts or groups.
+
+### Create through the owning collection
+
+Given a Database View with unambiguous positive creation seeds, when an editor creates a row, then one Page gains this Database membership, valid seeds/defaults apply atomically, and the shared Action returns the same result as the UI.
+
+### Remove membership without deleting the Page
+
+Given a Page in two Databases, when an authorized editor removes it from one, then that membership and its local values disappear while the Page, its other membership, and Page-owned content remain intact and recoverable.
+
+## Current evidence
+
+The linked schema and existing Content actions implement Page-backed Databases, access-scoped rows, schema/value operations, and full-page and inline surfaces. This record remains `verified` for that atomic foundation. Derived Query composition, advanced View families, complete renderer conformance, and multi-source workflows retain their own proof gates.
+
+## Proof plan
+
+1. Exercise Database creation, membership, schema, values, defaults, validation, Rules, permissions, and deletion through UI and Actions.
+2. Verify the implicit base Query across full-page and embedded Views under row and field access changes.
+3. Create and edit through several View renderers; confirm one canonical Page and write path.
+4. Add and remove multi-membership while preserving Page identity and unrelated memberships.
+5. Test reload, concurrent edits, rollback, Undo, accessibility, agent context, and source-policy intersections.
+
+## Open questions
+
+No open product question changes this atomic foundation. Advanced query composition, custom reusable Properties, heterogeneous source collections, and renderer-specific behavior are documented separately.

--- a/templates/content/docs/product/capabilities/content.object.database.md
+++ b/templates/content/docs/product/capabilities/content.object.database.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.object.database"
+name: "Databases"
+user_promise: "Database as a Page-backed typed collection"
+kind: "primitive"
+state: "verified"
+publicness: "public"
+availability: "universal"
+dependencies: []
+related_features: ["content.feature.durable-foundations"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Access-scoped rows, schema/actions, full-page and inline surfaces."
+proof_requirements: ["Access-scoped rows, schema/actions, full-page and inline surfaces."]
+evidence: ["../../../server/db/schema.ts"]
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Databases
+
+## Contract
+
+Database as a Page-backed typed collection
+
+## Acceptance boundary
+
+A complete proof demonstrates: Access-scoped rows, schema/actions, full-page and inline surfaces.
+
+## Evidence boundary
+
+The repository evidence linked in frontmatter supports the complete atomic contract. Feature completion still requires its own end-to-end proof.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.object.multi-membership.md
+++ b/templates/content/docs/product/capabilities/content.object.multi-membership.md
@@ -1,17 +1,25 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.object.multi-membership"
 name: "Multiple Database memberships"
-user_promise: "One Page participating in several Databases without copies"
+user_promise: "One Page can belong to several Databases without copies or a hidden primary home."
+primary_user_job: "Organize the same work for several legitimate collections without choosing which copy is true."
 kind: "primitive"
 state: "in_progress"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.object.page","content.object.database"]
+dependencies: ["content.object.page", "content.object.database"]
 related_features: ["content.feature.make-the-workspace-yours"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Plural APIs, grouped Info panel, no primary-membership inference."
-proof_requirements: ["Plural APIs, grouped Info panel, no primary-membership inference."]
+acceptance_summary: "A Page retains one identity while each Database independently owns membership, membership-local values, access-scoped presentation, addition, and removal."
+proof_requirements:
+  [
+    "Plural membership reads and writes through UI and Actions",
+    "No primary-membership inference in identity, URL, access, or export",
+    "Remove one membership without deleting Page-owned content or other memberships",
+    "Grouped Info and recovery behavior under access and concurrent changes",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +27,49 @@ last_reviewed: "2026-07-29"
 
 # Multiple Database memberships
 
-## Contract
+## Why this exists
 
-One Page participating in several Databases without copies
+A project can belong to a roadmap, a client portfolio, and a quarterly review. Copies make those lists disagree; a false primary home makes one view accidentally sovereign.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Plural APIs, grouped Info panel, no primary-membership inference.
+An initiative Page appears in Projects and Launches. Each Database shows its own membership-specific fields. Removing it from Launches leaves the Page and Projects entry intact; Info groups the two memberships without naming one primary.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A Page may have zero, one, or many Database memberships while keeping one Page identity.
+- Each Database owns its membership and membership-local values; Page-owned body, title, access, comments, and references remain common.
+- Adding or removing membership uses the Database's authorized Action, validation, source policy, and Events.
+- No URL, parent, export, agent context, or access decision infers a primary Database from membership order.
+- Info presents authorized memberships as a group; inaccessible memberships do not leak.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- Membership is not hierarchy, sidebar placement, a reference, or a share grant.
+- It does not merge conflicting Database schemas or values into Page properties.
+- Personal View order is separate from shared membership order.
+
+## Acceptance stories
+
+### Keep one Page across two collections
+
+Given a Page in two Databases, when it is edited from either, then both show the same Page-owned content while retaining their own membership-local values.
+
+### Remove only the selected membership
+
+Given a Page in two Databases, when an authorized editor removes it from one, then only that membership disappears and the Page, other membership, comments, and history remain recoverable.
+
+## Current evidence
+
+The Database data model and actions provide Page-backed collection substrate, and current product behavior supports several membership contexts. Complete plural APIs, grouped Info, and proof that no path infers a primary membership remain incomplete; this is `in_progress`.
+
+## Proof plan
+
+1. Add, display, edit, and remove memberships through all supported Views and Actions.
+2. Verify identity, URLs, access, export, search, and agent context with several memberships.
+3. Test source-managed membership, mixed permissions, trash/restore, and concurrent add/remove.
+4. Inspect Info grouping, keyboard, and assistive-technology behavior.
+
+## Open questions
+
+Membership-local property conflict presentation is owned by Database and typed-property work; it must not create a primary Page home.

--- a/templates/content/docs/product/capabilities/content.object.multi-membership.md
+++ b/templates/content/docs/product/capabilities/content.object.multi-membership.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.object.multi-membership"
+name: "Multiple Database memberships"
+user_promise: "One Page participating in several Databases without copies"
+kind: "primitive"
+state: "in_progress"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.object.page","content.object.database"]
+related_features: ["content.feature.make-the-workspace-yours"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Plural APIs, grouped Info panel, no primary-membership inference."
+proof_requirements: ["Plural APIs, grouped Info panel, no primary-membership inference."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Multiple Database memberships
+
+## Contract
+
+One Page participating in several Databases without copies
+
+## Acceptance boundary
+
+A complete proof demonstrates: Plural APIs, grouped Info panel, no primary-membership inference.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.object.page.md
+++ b/templates/content/docs/product/capabilities/content.object.page.md
@@ -1,8 +1,10 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.object.page"
 name: "Pages"
-user_promise: "Durable Page with body, properties, permissions, comments, URL, and source/export identity"
+user_promise: "A durable Page keeps its identity, body, properties, access, discussion, and portable representation wherever it appears."
+primary_user_job: "Create work that can be found, shared, revised, and reused without losing what the work is."
 kind: "primitive"
 state: "verified"
 publicness: "public"
@@ -10,27 +12,65 @@ availability: "universal"
 dependencies: []
 related_features: ["content.feature.durable-foundations"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Keep ordinary Markdown/MDX readable and portable."
-proof_requirements: ["Keep ordinary Markdown/MDX readable and portable."]
-evidence: ["../../../server/db/schema.ts"]
+acceptance_summary: "A Page has one stable identity and owner-governed content/access context across editing, Database membership, URLs, comments, source operations, trash, and export."
+proof_requirements:
+  [
+    "Stable Page identity through move, rename, membership, trash, restore, and export",
+    "Authorized UI and Action reads/writes with identical access decisions",
+    "Portable Markdown/MDX body behavior without making serialization the live identity",
+    "Reload and recovery preserve Page content, context, and access boundaries",
+  ]
+evidence:
+  ["../../../server/db/schema.ts", "../../../actions/update-document.ts"]
 superseded_by: null
 last_reviewed: "2026-07-29"
 ---
 
 # Pages
 
-## Contract
+## Why this exists
 
-Durable Page with body, properties, permissions, comments, URL, and source/export identity
+A person needs a durable home for a piece of work, not a row that changes identity with its location or a file that cannot carry access and collaboration context.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Keep ordinary Markdown/MDX readable and portable.
+An editor creates a brief, adds body content and Properties, places it in two Databases, shares it with a colleague, then moves it in the sidebar. The same Page URL, comments, history, and source/export identity continue to refer to the brief.
 
-## Evidence boundary
+## Product contract
 
-The repository evidence linked in frontmatter supports the complete atomic contract. Feature completion still requires its own end-to-end proof.
+- A Page owns stable identity, title, access, top-level Properties, and one or more Blocks fields.
+- A Database row is a Page; membership supplies collection context but never replaces Page identity or creates a primary membership.
+- UI, agents, automations, and APIs use shared Actions and the same authorization boundary.
+- References, comments, Discussion, history, Versions, sources, and exports target the Page identity, not a transient renderer or location.
+- Trash suspends ordinary use without silently reusing the identity; restore returns the Page with its durable context.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- A Page is not a Blocks field, Database membership, Query result, or named Version.
+- Page identity does not grant access to a source, another membership, or a referenced object.
+- The Page foundation does not itself define stable Block anchors, source synchronization, or Version branching.
+
+## Acceptance stories
+
+### Move without becoming another document
+
+Given a Page in two Databases, when an editor moves it in navigation or removes one membership, then its URL, body, comments, and remaining membership still resolve to the same Page.
+
+### Deny before revealing context
+
+Given a person who knows a Page link but lacks access, when they open it through UI or an Action, then they receive an honest denial and no title, body, membership, or comment data leaks.
+
+## Current evidence
+
+`server/db/schema.ts` defines durable document rows with IDs, content, ownership, source context, and trash fields. `update-document` persists Page changes through Actions and snapshots prior content; this proves the current Page foundation, not the future Block or Version contracts.
+
+## Proof plan
+
+1. Create, rename, move, multi-home, trash, restore, and export Pages through UI and Actions.
+2. Verify identical access decisions for direct links, search, memberships, comments, and agent reads.
+3. Reload during edits and recovery, confirming stable identity and no duplicate Page.
+4. Check keyboard and assistive-technology navigation and portable Markdown/MDX output.
+
+## Open questions
+
+No open product question changes the verified Page foundation. Richer Page property and source behavior belongs to its adjacent records.

--- a/templates/content/docs/product/capabilities/content.object.page.md
+++ b/templates/content/docs/product/capabilities/content.object.page.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.object.page"
+name: "Pages"
+user_promise: "Durable Page with body, properties, permissions, comments, URL, and source/export identity"
+kind: "primitive"
+state: "verified"
+publicness: "public"
+availability: "universal"
+dependencies: []
+related_features: ["content.feature.durable-foundations"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Keep ordinary Markdown/MDX readable and portable."
+proof_requirements: ["Keep ordinary Markdown/MDX readable and portable."]
+evidence: ["../../../server/db/schema.ts"]
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Pages
+
+## Contract
+
+Durable Page with body, properties, permissions, comments, URL, and source/export identity
+
+## Acceptance boundary
+
+A complete proof demonstrates: Keep ordinary Markdown/MDX readable and portable.
+
+## Evidence boundary
+
+The repository evidence linked in frontmatter supports the complete atomic contract. Feature completion still requires its own end-to-end proof.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.object.reference.md
+++ b/templates/content/docs/product/capabilities/content.object.reference.md
@@ -1,17 +1,25 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.object.reference"
 name: "References"
-user_promise: "Stable Page/Database/Block references distinct from expressions"
+user_promise: "A compact reference points to a stable Page, Database, or Block without pretending to be computation."
+primary_user_job: "Mention and reuse a known object so people can navigate, render, and index the same identity everywhere."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.object.page","content.object.block"]
+dependencies: ["content.object.page", "content.object.block"]
 related_features: ["content.feature.living-references"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: ID-based resolution, access, portable encoding, renderer inheritance."
-proof_requirements: ["ID-based resolution, access, portable encoding, renderer inheritance."]
+acceptance_summary: "References store stable target identity plus presentation configuration, resolve under access control, remain portable, and stay distinct from expressions and semantic Relationships."
+proof_requirements:
+  [
+    "ID-based Page, Database, and Block resolution",
+    "Access-safe rendering, search, and backlinks",
+    "Portable encoding and explicit broken/deleted target states",
+    "Renderer inheritance and UI/Action parity",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +27,49 @@ last_reviewed: "2026-07-29"
 
 # References
 
-## Contract
+## Why this exists
 
-Stable Page/Database/Block references distinct from expressions
+People need an effortless `@`-style mention that is indexable and portable. Turning a simple reference into a program makes it harder to inspect, secure, and preserve.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: ID-based resolution, access, portable encoding, renderer inheritance.
+An author mentions a project Page in a brief and chooses a compact pill presentation. The target is later renamed and appears in another Database; the mention still resolves the stable Page and Connections can find it.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A Reference stores the stable ID of a Page, Database, or Block with presentation configuration.
+- `@Page` is a Reference; accessing a Property, comparing, or traversing it is expression work.
+- Renderers may change presentation without changing target identity.
+- Resolution, backlinks, search, export, and agents apply target access before showing data.
+- Deleted, unavailable, and inaccessible targets are distinguishable only as far as authorization permits and degrade honestly.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- A Reference does not add Database membership, grant access, or create a semantic Relationship.
+- It is not a live embed or synced editable content; transclusion owns that behavior.
+- Expressions can consume references but do not replace the simple stored primitive.
+
+## Acceptance stories
+
+### Keep identity through a rename
+
+Given a Page reference rendered as a pill, when the target is renamed and moved, then the same reference resolves the renamed target without rewriting it as an expression or a new reference.
+
+### Do not leak a private target
+
+Given a reference to a Page a reader cannot access, when the reader opens, searches, exports, or asks an agent about the host Page, then the target's private content and metadata do not appear.
+
+## Current evidence
+
+Current Content can link Pages and has reference-like editor substrate. It does not yet prove a generic stable Reference value across Page, Database, and Block targets, portable degradation, or universal access-safe indexing; this remains `approved_shape`.
+
+## Proof plan
+
+1. Create and resolve each target kind through editor, Actions, search, backlinks, and agents.
+2. Rename, move, trash, restore, delete, and export targets; inspect encoded identity and degradation.
+3. Test access loss and restoration across every projection.
+4. Verify renderer variants, keyboard navigation, and assistive labels.
+
+## Open questions
+
+Presentation variants and source codecs may differ, but they cannot alter Reference identity or bypass access.

--- a/templates/content/docs/product/capabilities/content.object.reference.md
+++ b/templates/content/docs/product/capabilities/content.object.reference.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.object.reference"
+name: "References"
+user_promise: "Stable Page/Database/Block references distinct from expressions"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.object.page","content.object.block"]
+related_features: ["content.feature.living-references"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: ID-based resolution, access, portable encoding, renderer inheritance."
+proof_requirements: ["ID-based resolution, access, portable encoding, renderer inheritance."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# References
+
+## Contract
+
+Stable Page/Database/Block references distinct from expressions
+
+## Acceptance boundary
+
+A complete proof demonstrates: ID-based resolution, access, portable encoding, renderer inheritance.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.object.transclusion.md
+++ b/templates/content/docs/product/capabilities/content.object.transclusion.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.object.transclusion"
+name: "Synced Blocks and live embeds"
+user_promise: "A Page or Block can be included by reference and edited from every authorized rendering without creating synchronized copies"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.object.reference"]
+related_features: ["content.feature.living-references"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Stable object/block identity; reference versus live-embed versus snapshot/fork modes; renderer inheritance; source/provenance affordance; access intersection; comment and version context; portable degradation."
+proof_requirements: ["Stable object/block identity; reference versus live-embed versus snapshot/fork modes; renderer inheritance; source/provenance affordance; access intersection; comment and version context; portable degradation."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Synced Blocks and live embeds
+
+## Contract
+
+A Page or Block can be included by reference and edited from every authorized rendering without creating synchronized copies
+
+## Acceptance boundary
+
+A complete proof demonstrates: Stable object/block identity; reference versus live-embed versus snapshot/fork modes; renderer inheritance; source/provenance affordance; access intersection; comment and version context; portable degradation.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.object.transclusion.md
+++ b/templates/content/docs/product/capabilities/content.object.transclusion.md
@@ -1,8 +1,10 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.object.transclusion"
 name: "Synced Blocks and live embeds"
-user_promise: "A Page or Block can be included by reference and edited from every authorized rendering without creating synchronized copies"
+user_promise: "A Page or Block can appear by reference in several places and authorized edits change the one canonical object."
+primary_user_job: "Reuse maintained material without copy-and-paste drift."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
@@ -10,8 +12,14 @@ availability: "universal"
 dependencies: ["content.object.reference"]
 related_features: ["content.feature.living-references"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Stable object/block identity; reference versus live-embed versus snapshot/fork modes; renderer inheritance; source/provenance affordance; access intersection; comment and version context; portable degradation."
-proof_requirements: ["Stable object/block identity; reference versus live-embed versus snapshot/fork modes; renderer inheritance; source/provenance affordance; access intersection; comment and version context; portable degradation."]
+acceptance_summary: "Live inclusion preserves canonical Page or Block identity, access intersection, provenance, history, and editing behavior while making fork and static snapshot modes explicit."
+proof_requirements:
+  [
+    "Canonical target identity and occurrence rendering",
+    "Explicit live, snapshot, and fork semantics",
+    "Access intersection and source/provenance affordances",
+    "Comment, Version, deletion, and portable-degradation behavior",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +27,49 @@ last_reviewed: "2026-07-29"
 
 # Synced Blocks and live embeds
 
-## Contract
+## Why this exists
 
-A Page or Block can be included by reference and edited from every authorized rendering without creating synchronized copies
+Repeated canonical language should update once. A copied paragraph grows quiet forks; a live inclusion keeps the work one living thing.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Stable object/block identity; reference versus live-embed versus snapshot/fork modes; renderer inheritance; source/provenance affordance; access intersection; comment and version context; portable degradation.
+A team includes its approved product-description Block in three guides. An authorized editor changes it from any occurrence, all authorized renderings update, and each occurrence offers the source/provenance context.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A live transclusion renders one canonical Page or Block identity in another authorized host.
+- Editing a live occurrence invokes the target's shared Action and authority, never a synchronized copy.
+- Live inclusion, static snapshot, and editable fork are explicit modes with different update and provenance behavior.
+- The viewer must satisfy both host and target access; the render cannot widen either object's audience.
+- Comments, Discussion context, history, and Versions identify the canonical target and the viewing occurrence where useful.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- A compact Reference may preview a target but is not necessarily an editable live transclusion.
+- A transclusion does not merge Page identity, membership, access, or history with its host.
+- This record does not define source synchronization or arbitrary remote embeds.
+
+## Acceptance stories
+
+### Edit one canonical Block
+
+Given a live Block included in three Pages, when an authorized editor changes it from one occurrence, then every authorized occurrence shows the canonical update and one attributable history records the target change.
+
+### Preserve an intentional fork
+
+Given an editor chooses fork instead of live inclusion, when the source later changes, then the fork remains independent, retains provenance, and is not silently overwritten.
+
+## Current evidence
+
+Existing Page references and ordinary embedded Database surfaces are useful substrate. The repository does not yet prove stable editable Block transclusion, explicit mode selection, access intersection, or complete history behavior; this remains `approved_shape`.
+
+## Proof plan
+
+1. Render and edit live Page and Block inclusions from multiple hosts.
+2. Test live, snapshot, and fork conversion, source deletion, and portable export.
+3. Verify access changes, private hosts/targets, comments, Versions, and agent actions.
+4. Exercise concurrent target edits, undo, reload, keyboard, and assistive technology.
+
+## Open questions
+
+The exact occurrence controls and portable encoding can vary; the target identity and explicit mode distinctions cannot.

--- a/templates/content/docs/product/capabilities/content.organization.teams.md
+++ b/templates/content/docs/product/capabilities/content.organization.teams.md
@@ -1,17 +1,28 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.organization.teams"
 name: "Organization teams"
 user_promise: "Canonical framework-wide Team membership can be managed through Content without giving each app a conflicting identity system."
+primary_user_job: "Manage organizational Teams where work is configured while preserving one framework identity authority."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "organization"
-dependencies: ["content.workspace.multi-scope","content.access.page-database"]
-related_features: ["content.feature.work-across-every-workspace","content.feature.share-how-your-organization-works"]
+dependencies: ["content.workspace.multi-scope", "content.access.page-database"]
+related_features:
+  [
+    "content.feature.work-across-every-workspace",
+    "content.feature.share-how-your-organization-works",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Canonical framework-wide Team membership can be managed through Content without giving each app a conflicting identity system."
-proof_requirements: ["Canonical framework-wide Team membership can be managed through Content without giving each app a conflicting identity system."]
+acceptance_summary: "Content manages the framework-wide Team representation through canonical organization identity and membership services."
+proof_requirements:
+  [
+    "Typed contract, authorization, validation, Event/history, and recovery coverage",
+    "Cross-surface UI, Action, agent-context, reload, and failure-state coverage",
+    "Real-interface keyboard and assistive-technology workflow coverage",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +30,42 @@ last_reviewed: "2026-07-29"
 
 # Organization teams
 
-## Contract
+## Why this exists
 
-Canonical framework-wide Team membership can be managed through Content without giving each app a conflicting identity system.
+One Team membership truth prevents each app from growing a conflicting roster. Content may manage it without becoming a second identity provider.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Canonical framework-wide Team membership can be managed through Content without giving each app a conflicting identity system.
+An organization administrator creates a Team in Content, assigns members under the existing organization, and uses it in a Page access rule. Another app reads the same canonical Team membership.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+Content manages the framework-wide Team representation through canonical organization identity and membership services. Team changes use authorized Actions, audit history, and propagate to compatible access and workflow surfaces.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Multi-scope and page/database access own context and authorization. This is not an app-local roster, automatic organization creation, or an alternate identity provider.
+
+## Acceptance stories
+
+### Deny an app-local roster edit
+
+Given a non-administrator, when they try to change Team membership, then the canonical Action denies it and no app-local fallback is created.
+
+### Propagate a canonical Team change
+
+Given a Team is used in a Page rule, when an authorized administrator changes membership, then compatible consumers observe the canonical membership with attributable audit history.
+
+## Current evidence
+
+No complete framework-wide Team management and consumer-consistency proof is recorded. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Test canonical Team membership changes for administrators and non-administrators.
+2. Verify consumer reads, access rules, audit records, propagation, and no local fallback.
+3. Exercise revocation, sync conflict, organization boundaries, and accessible management.
+
+## Open questions
+
+The organization-admin delegation and membership-sync conflict policy need design.

--- a/templates/content/docs/product/capabilities/content.organization.teams.md
+++ b/templates/content/docs/product/capabilities/content.organization.teams.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.organization.teams"
+name: "Organization teams"
+user_promise: "Canonical framework-wide Team membership can be managed through Content without giving each app a conflicting identity system."
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "organization"
+dependencies: ["content.workspace.multi-scope","content.access.page-database"]
+related_features: ["content.feature.work-across-every-workspace","content.feature.share-how-your-organization-works"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Canonical framework-wide Team membership can be managed through Content without giving each app a conflicting identity system."
+proof_requirements: ["Canonical framework-wide Team membership can be managed through Content without giving each app a conflicting identity system."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Organization teams
+
+## Contract
+
+Canonical framework-wide Team membership can be managed through Content without giving each app a conflicting identity system.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Canonical framework-wide Team membership can be managed through Content without giving each app a conflicting identity system.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.portability.pdf-export.md
+++ b/templates/content/docs/product/capabilities/content.portability.pdf-export.md
@@ -1,36 +1,78 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.portability.pdf-export"
-name: "PDF and print export"
-user_promise: "Real PDF export uses the same rendering truth as editor, reader, and HTML export"
-kind: "primitive"
-state: "approved_shape"
+name: "PDF export"
+user_promise: "Create a readable PDF of an authorized Content representation without confusing it with the editable or lossless export."
+primary_user_job: "Hand someone a stable, readable document that faithfully represents what I am authorized to share."
+kind: "workflow"
+state: "in_progress"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.renderer.typed","content.publish.reading"]
-related_features: ["content.feature.publish-with-confidence","content.feature.take-the-whole-vault-with-you"]
+dependencies: ["content.renderer.typed", "content.access.visibility-closure"]
+related_features:
+  [
+    "content.feature.publish-with-confidence",
+    "content.feature.take-the-whole-vault-with-you",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Unified renderer, fonts/assets, math/diagrams/rich-block fidelity, deterministic failure/degradation."
-proof_requirements: ["Unified renderer, fonts/assets, math/diagrams/rich-block fidelity, deterministic failure/degradation."]
-evidence: []
+acceptance_summary: "PDF export resolves the acting user's authorized representation through shared rendering, gives supported blocks a faithful layout or explicit fallback, and returns a durable file with clear scope and failure reporting."
+proof_requirements:
+  [
+    "Renderer fidelity tests for supported blocks, media, math, code, and explicit fallbacks",
+    "Access-closure, asset, pagination, metadata, and error reporting tests",
+    "Interface export workflow validated against the selected representation and downloaded PDF",
+  ]
+evidence:
+  [
+    "../../../shared/document-export.ts",
+    "../../../shared/document-export.spec.ts",
+  ]
 superseded_by: null
 last_reviewed: "2026-07-29"
 ---
 
-# PDF and print export
+# PDF export
 
-## Contract
+## Why this exists
 
-Real PDF export uses the same rendering truth as editor, reader, and HTML export
+PDF is a dependable reading artifact, not a promise that a flat page can carry every living behavior.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Unified renderer, fonts/assets, math/diagrams/rich-block fidelity, deterministic failure/degradation.
+An editor exports the approved article revision. Content renders the same authorized blocks, reports an unavailable protected asset, and produces a PDF whose scope identifies the selected representation.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Export materializes the acting user's authorized closure at export time; it never borrows a collaborator's access.
+- It uses shared semantic rendering where possible and provides deliberate, readable fallbacks for unsupported interactive behavior.
+- The artifact records enough representation and generation context to explain what it contains. Asset failures are reported, not silently omitted.
+- A PDF is read-oriented output, separate from editable source and lossless archive formats.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Publication owns stable public URLs; vault export owns complete package closure. PDF export does not promise round-trip editing or live embeds.
+
+## Acceptance stories
+
+### Export only the viewer's closure
+
+Given a Page references an inaccessible private asset, when a permitted editor exports it, then the PDF does not expose the asset and reports the unavailable representation.
+
+### Render a deliberate fallback
+
+Given a supported Page contains an interactive Block without a print equivalent, when it exports, then the PDF includes a labeled safe fallback rather than pretending the interaction survived.
+
+## Current evidence
+
+Implementation evidence: `shared/document-export.ts` and `shared/document-export.spec.ts` cover current document export machinery. Donor evidence does not yet prove all block fidelity, access closure, or interface-level PDF behavior, so this record remains `in_progress`.
+
+## Proof plan
+
+1. Expand fixture coverage across supported blocks and intentional fallbacks.
+2. Test access changes, media resolution, metadata, pagination, and failures.
+3. Compare a real export against the selected authorized representation.
+
+## Open questions
+
+- Print styling and accessibility metadata policy need final acceptance criteria.

--- a/templates/content/docs/product/capabilities/content.portability.pdf-export.md
+++ b/templates/content/docs/product/capabilities/content.portability.pdf-export.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.portability.pdf-export"
+name: "PDF and print export"
+user_promise: "Real PDF export uses the same rendering truth as editor, reader, and HTML export"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.renderer.typed","content.publish.reading"]
+related_features: ["content.feature.publish-with-confidence","content.feature.take-the-whole-vault-with-you"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Unified renderer, fonts/assets, math/diagrams/rich-block fidelity, deterministic failure/degradation."
+proof_requirements: ["Unified renderer, fonts/assets, math/diagrams/rich-block fidelity, deterministic failure/degradation."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# PDF and print export
+
+## Contract
+
+Real PDF export uses the same rendering truth as editor, reader, and HTML export
+
+## Acceptance boundary
+
+A complete proof demonstrates: Unified renderer, fonts/assets, math/diagrams/rich-block fidelity, deterministic failure/degradation.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.portability.roundtrip.md
+++ b/templates/content/docs/product/capabilities/content.portability.roundtrip.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.portability.roundtrip"
+name: "Faithful round-tripping"
+user_promise: "Canonical Content data imports/exports through humane Markdown/MDX and structured sidecars"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.portability.source-representation"]
+related_features: ["content.feature.trust-your-connected-sources","content.feature.cite-what-you-found","content.feature.take-the-whole-vault-with-you","content.feature.move-without-starting-over"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Expressions/references/custom blocks/comments/block IDs need exact encodings."
+proof_requirements: ["Expressions/references/custom blocks/comments/block IDs need exact encodings."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Faithful round-tripping
+
+## Contract
+
+Canonical Content data imports/exports through humane Markdown/MDX and structured sidecars
+
+## Acceptance boundary
+
+A complete proof demonstrates: Expressions/references/custom blocks/comments/block IDs need exact encodings.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.portability.roundtrip.md
+++ b/templates/content/docs/product/capabilities/content.portability.roundtrip.md
@@ -1,17 +1,30 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.portability.roundtrip"
 name: "Faithful round-tripping"
-user_promise: "Canonical Content data imports/exports through humane Markdown/MDX and structured sidecars"
+user_promise: "Content preserves provider-owned meaning it cannot safely render or edit, so a supported change never silently destroys the rest of the work."
+primary_user_job: "Edit what Content understands while keeping connected and portable work recoverable and intelligible outside one application."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
 dependencies: ["content.portability.source-representation"]
-related_features: ["content.feature.trust-your-connected-sources","content.feature.cite-what-you-found","content.feature.take-the-whole-vault-with-you","content.feature.move-without-starting-over"]
+related_features:
+  [
+    "content.feature.trust-your-connected-sources",
+    "content.feature.cite-what-you-found",
+    "content.feature.take-the-whole-vault-with-you",
+    "content.feature.move-without-starting-over",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Expressions/references/custom blocks/comments/block IDs need exact encodings."
-proof_requirements: ["Expressions/references/custom blocks/comments/block IDs need exact encodings."]
+acceptance_summary: "Authorized imports, edits, exports, and provider write-back preserve stable identity, known semantics, provenance, and unknown provider structures through explicit raw or typed fallback representations, while reporting unsupported or unresolved material instead of silently flattening it."
+proof_requirements:
+  [
+    "Golden import-edit-export and provider write-back fixtures covering known, unknown, mixed, and malformed representations",
+    "Stable identity, provenance, block/comment/reference/custom structure, and source mapping preservation or explicit unresolved reporting",
+    "Conflict, access, recovery, and lossless archive verification across at least two independently certified adapter formats",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +32,123 @@ last_reviewed: "2026-07-29"
 
 # Faithful round-tripping
 
-## Contract
+## Why this exists
 
-Canonical Content data imports/exports through humane Markdown/MDX and structured sidecars
+People bring work with structure Content may not yet understand: provider
+components, bindings, embeds, custom blocks, references, comments, and other
+format-specific detail. A friendly editable view is not permission to discard
+what it cannot represent. Lossy simplicity has excellent manners right up to
+the moment it loses a component.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Expressions/references/custom blocks/comments/block IDs need exact encodings.
+An editor opens a provider article containing ordinary text and an unsupported
+component. Content renders and edits the text through its native grammar while
+retaining the unsupported component as a preserved source-backed representation.
+After the editor changes the text and completes the Source's allowed write-back
+flow, the provider receives the changed text and the unknown component remains
+unchanged. A later export includes the information needed to preserve both the
+known Content semantics and unresolved provider material.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+### Preserve what is known and what is not
 
-## Non-goals
+- A source representation maps known semantics into typed Content structures
+  only when that mapping is safe. It retains stable source identity,
+  provenance, ordering, and enough fidelity information to reconstruct the
+  provider-facing representation.
+- Unknown, unsupported, or not-yet-safe provider material survives as an
+  explicit raw or typed fallback with source identity and an inspectable status.
+  It is not flattened into ordinary text, silently dropped, or presented as a
+  fully editable native Block.
+- Known native-like semantics may render through ordinary Content Blocks while
+  retaining their source binding. Provider-specific reusable or custom
+  components remain source-backed until explicitly forked with provenance.
+- Expressions, references, custom blocks, comments, block identities, and
+  other typed Content structures need exact encodings or an explicit unresolved
+  representation; a best-effort export may not claim lossless completion.
 
-This capability does not create a parallel datastore, permission model, or action surface.
+### Round trips retain authority and recoverability
+
+- Import, refresh, edit, export, and provider write-back retain the source
+  mapping, baseline, ownership, and policy needed to route later work safely.
+- A compatible Content edit changes only the mapped authorized portion. It
+  preserves unknown siblings and provider-owned fields outside that mapping.
+- Access applies before import preview, export, provider write-back, raw
+  fallback inspection, and recovery. Export includes only material the acting
+  user may access and reports unavailable or excluded dependencies.
+- A failed conversion, stale base, malformed input, or missing payload produces
+  an explicit failure or unresolved state. It never returns an empty or clean
+  representation that callers can mistake for a completed round trip.
+
+### Provider and portable forms remain distinct
+
+- The portable source representation owns provider-neutral interchange;
+  adapters and codecs own provider-specific mapping details. A provider codec
+  is not the universal Content authoring grammar.
+- A lossless archive may carry structured sidecars and stable asset handles in
+  addition to humane Markdown/MDX. Raw payloads and assets use appropriate file
+  or blob storage, not shared SQL fields.
+- Detaching or converting source-backed content into Content-managed work is an
+  explicit fork with provenance and policy consequences, never an accidental
+  outcome of opening or editing it.
+
+## Boundaries and non-goals
+
+- Sync policy decides whether and when outbound work may cross a Source
+  boundary; adapters certify a provider's codec and operations. This record
+  defines the fidelity obligation shared by those paths.
+- Faithful preservation does not promise a native editor for every provider
+  feature, universal raw-source editing, or byte-identical output where the
+  provider itself normalizes content.
+- Publication and other provider lifecycle changes are separate guarded actions.
+
+## Acceptance stories
+
+### Preserve an unknown sibling during a supported edit
+
+Given a provider representation with one editable text region and one unknown
+component, when an authorized editor changes the text and completes permitted
+write-back, then the provider receives the text change while the unknown
+component, ordering, and source identity remain intact.
+
+### Report an incomplete conversion honestly
+
+Given an import whose typed extension cannot be encoded by the target format,
+when a person exports it, then Content either emits the declared lossless
+sidecar/fallback or reports that representation as unresolved; it does not
+produce a clean-looking export that silently omits the extension.
+
+### Recover identity through a mixed-format round trip
+
+Given a Source with mapped Blocks, references, comments, and preserved raw
+provider material, when an authorized lossless archive is exported and restored,
+then stable identities, provenance, supported semantics, fallback material, and
+source mappings remain coherent or each unresolved dependency is reported.
+
+## Current evidence
+
+Content exports editable text formats and existing source machinery includes
+raw sidecars, hashes, and guarded provider paths. Those prove useful pieces,
+not a generic lossless contract across representations, access, recovery, and
+independently certified adapters. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Build golden fixtures for known, unknown, mixed, reordered, malformed, and
+   partially unavailable representations across at least two adapter formats.
+2. Run import, refresh, native edit, review/write-back, export, restore, and
+   re-import; compare stable identity, provenance, mapped semantics, fallback
+   payloads, source mappings, and explicit unresolved reports.
+3. Exercise stale bases, provider normalization, interrupted conversion,
+   conflicts, retries, access denial, redaction, and missing assets or handles.
+4. Verify fallback status and recovery paths in the real interface and shared
+   Actions, including accessible inspection of unsupported material.
+
+## Open questions
+
+- The canonical sidecar envelope and the exact portable encoding for every
+  typed Content structure remain implementation work.
+- Fidelity equivalence must define when provider normalization is acceptable
+  without weakening the obligation to preserve unknown meaning.

--- a/templates/content/docs/product/capabilities/content.portability.source-representation.md
+++ b/templates/content/docs/product/capabilities/content.portability.source-representation.md
@@ -1,36 +1,70 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.portability.source-representation"
-name: "Portable source representation"
-user_promise: "One lossless, provider-neutral Content source representation with humane Markdown as its base"
+name: "Portable Source representation"
+user_promise: "Connected and local material has a portable Content representation without pretending Content owns every original."
+primary_user_job: "Move between local, hosted, and provider-backed work while retaining identity, provenance, fidelity limits, and a readable recovery path."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
-availability: "universal"
-dependencies: ["content.object.page","content.object.blocks-field"]
+availability: "configured"
+dependencies: ["content.source.adapters"]
 related_features: ["content.feature.bring-your-local-work"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Shared import/export/agent/local-source contract; stable identities and explicit typed extensions; Notion-Flavored Markdown remains an adapter dialect. A general raw-source editing UI is not part of the approved product promise."
-proof_requirements: ["Shared import/export/agent/local-source contract; stable identities and explicit typed extensions; Notion-Flavored Markdown remains an adapter dialect. A general raw-source editing UI is not part of the approved product promise."]
+acceptance_summary: "A portable representation separates stable Content identity from source bindings, preserves source-owned unknown data and baselines, records fidelity and access limits, and can be materialized or repaired without default dual truth."
+proof_requirements:
+  [
+    "Representation schema and round-trip fixtures for native, provider, and local sources",
+    "Identity, provenance, unknown-data, baseline, conflict, access, and repair tests",
+    "Cross-client materialization and recovery workflow without raw local handles in shared state",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
 ---
 
-# Portable source representation
+# Portable Source representation
 
-## Contract
+## Why this exists
 
-One lossless, provider-neutral Content source representation with humane Markdown as its base
+Portability needs a map of what Content knows and what remains somewhere else, not an accidental second original.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Shared import/export/agent/local-source contract; stable identities and explicit typed extensions; Notion-Flavored Markdown remains an adapter dialect. A general raw-source editing UI is not part of the approved product promise.
+A local document is materialized for browser reading. Its Page identity, source binding, baseline, and unavailable local bytes remain distinguishable; an authorized bridge can later refresh or repair it.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Stable Content identity is distinct from source connection, provider item identity, representation, baseline, and field ownership.
+- Source-owned unknown structures survive as faithful opaque data or explicit unsupported state; Content does not flatten them into editable guesses.
+- Materializations retain provenance, freshness, fidelity, and access boundaries. Local paths and handles do not enter shared state.
+- A source policy declares which direction may write and how conflict/recovery works; default SQL and filesystem dual truth is prohibited.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Adapters own provider behavior; round-trip owns conversion fidelity; local bridge owns device authority. This is not a universal file format or a claim of byte-perfect representation for every provider.
+
+## Acceptance stories
+
+### Preserve an unknown provider structure
+
+Given a source representation contains an unsupported provider component, when a mapped Content field changes, then the unknown component remains tied to its source identity and is not rewritten as ordinary Content data.
+
+### Keep local custody local
+
+Given a local file is materialized for another client, when that client inspects its Source metadata, then it can identify freshness and availability without receiving a raw path or filesystem handle.
+
+## Current evidence
+
+Donor evidence: `shared/content-source.ts`, `actions/_document-source.ts`, and source adapter actions model present source metadata. No complete portable representation, cross-client recovery, and fidelity proof exists; this record remains `approved_shape`.
+
+## Proof plan
+
+1. Specify representation, baseline, opaque payload, fidelity, and access fields.
+2. Test source identities, unknown preservation, conflicts, repair, and redaction.
+3. Verify local and provider materialization across clients with no dual truth claim.
+
+## Open questions
+
+- The exact portable archive encoding for opaque provider payloads remains open.

--- a/templates/content/docs/product/capabilities/content.portability.source-representation.md
+++ b/templates/content/docs/product/capabilities/content.portability.source-representation.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.portability.source-representation"
+name: "Portable source representation"
+user_promise: "One lossless, provider-neutral Content source representation with humane Markdown as its base"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.object.page","content.object.blocks-field"]
+related_features: ["content.feature.bring-your-local-work"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Shared import/export/agent/local-source contract; stable identities and explicit typed extensions; Notion-Flavored Markdown remains an adapter dialect. A general raw-source editing UI is not part of the approved product promise."
+proof_requirements: ["Shared import/export/agent/local-source contract; stable identities and explicit typed extensions; Notion-Flavored Markdown remains an adapter dialect. A general raw-source editing UI is not part of the approved product promise."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Portable source representation
+
+## Contract
+
+One lossless, provider-neutral Content source representation with humane Markdown as its base
+
+## Acceptance boundary
+
+A complete proof demonstrates: Shared import/export/agent/local-source contract; stable identities and explicit typed extensions; Notion-Flavored Markdown remains an adapter dialect. A general raw-source editing UI is not part of the approved product promise.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.portability.vault-export.md
+++ b/templates/content/docs/product/capabilities/content.portability.vault-export.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.portability.vault-export"
+name: "Whole-vault export"
+user_promise: "An authorized person can export a static snapshot as an open vault, a lossless Content archive, or a destination-specific package."
+kind: "workflow"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.portability.roundtrip","content.job.durable","content.access.visibility-closure"]
+related_features: ["content.feature.bring-your-local-work","content.feature.take-the-whole-vault-with-you","content.feature.keep-your-private-vault-private"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: An authorized person can export a static snapshot as an open vault, a lossless Content archive, or a destination-specific package."
+proof_requirements: ["An authorized person can export a static snapshot as an open vault, a lossless Content archive, or a destination-specific package."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Whole-vault export
+
+## Contract
+
+An authorized person can export a static snapshot as an open vault, a lossless Content archive, or a destination-specific package.
+
+## Acceptance boundary
+
+A complete proof demonstrates: An authorized person can export a static snapshot as an open vault, a lossless Content archive, or a destination-specific package.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.portability.vault-export.md
+++ b/templates/content/docs/product/capabilities/content.portability.vault-export.md
@@ -1,36 +1,80 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.portability.vault-export"
-name: "Whole-vault export"
-user_promise: "An authorized person can export a static snapshot as an open vault, a lossless Content archive, or a destination-specific package."
+name: "Portable vault export"
+user_promise: "Take the authorized Content vault away in open files plus a lossless archive instead of remaining dependent on one service."
+primary_user_job: "Export my authorized work with enough meaning, assets, provenance, and verification to use or recover it elsewhere."
 kind: "workflow"
 state: "approved_shape"
 publicness: "public"
-availability: "universal"
-dependencies: ["content.portability.roundtrip","content.job.durable","content.access.visibility-closure"]
-related_features: ["content.feature.bring-your-local-work","content.feature.take-the-whole-vault-with-you","content.feature.keep-your-private-vault-private"]
+availability: "configured"
+dependencies:
+  [
+    "content.portability.roundtrip",
+    "content.job.durable",
+    "content.access.visibility-closure",
+  ]
+related_features:
+  [
+    "content.feature.take-the-whole-vault-with-you",
+    "content.feature.bring-your-local-work",
+    "content.feature.keep-your-private-vault-private",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: An authorized person can export a static snapshot as an open vault, a lossless Content archive, or a destination-specific package."
-proof_requirements: ["An authorized person can export a static snapshot as an open vault, a lossless Content archive, or a destination-specific package."]
+acceptance_summary: "A resumable export materializes only the acting user's authorized closure into readable open files and a lossless Content archive, includes or reports assets and source handles, and supplies a verifiable conversion report."
+proof_requirements:
+  [
+    "Authorized-closure, dependency, asset, and inaccessible-reference tests",
+    "Open-package, lossless-archive, manifest, integrity, and conversion-report verification",
+    "Interrupted whole-vault export and resume workflow on a realistic corpus",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
 ---
 
-# Whole-vault export
+# Portable vault export
 
-## Contract
+## Why this exists
 
-An authorized person can export a static snapshot as an open vault, a lossless Content archive, or a destination-specific package.
+Portable work should leave with its meaning, not merely a pile of filenames.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: An authorized person can export a static snapshot as an open vault, a lossless Content archive, or a destination-specific package.
+An administrator exports their authorized workspace. The package includes readable Markdown or MDX, tabular files, assets or stable handles, a manifest, and a Content archive; the report names inaccessible or unresolved dependencies.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Export resolves the acting user's authorized closure at run time. It neither leaks inaccessible relations nor silently treats them as successfully included.
+- The open package uses readable files and a small manifest for stable identity and richer semantics; the lossless archive retains Content-specific history, annotations, discussion, rules, and provenance where authorized.
+- Assets are included when authorized and resolvable, otherwise represented by an honest report entry. Connected originals remain governed by Source policy.
+- Work is durable, resumable, verifiable, and separated from a disposable local cache.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+PDF export is a reading artifact; round-trip owns format conversion; private vault owns encryption and keys. This does not promise every destination understands every Content feature.
+
+## Acceptance stories
+
+### Export only an authorized graph
+
+Given a Page references a record the exporter cannot access, when the vault exports, then the package does not include that record and the manifest reports the unresolved relationship without revealing hidden content.
+
+### Resume a large package
+
+Given export stops after writing a subset of assets, when the job resumes, then it verifies prior outputs and continues without duplicate objects or a false complete receipt.
+
+## Current evidence
+
+Donor evidence: `actions/export-document.ts`, `actions/export-content-source.ts`, and `shared/document-export.ts` cover bounded exports. No whole-vault authorized closure, lossless archive, or resume proof exists; this record remains `approved_shape`.
+
+## Proof plan
+
+1. Define package layout, manifest, archive semantics, and verification tool.
+2. Test closure, inaccessible dependencies, assets, source handles, and integrity.
+3. Run interrupted export/resume and validate the package outside Content.
+
+## Open questions
+
+- The first destination-compatible package and archive encryption handling remain open.

--- a/templates/content/docs/product/capabilities/content.presentation.mode.md
+++ b/templates/content/docs/product/capabilities/content.presentation.mode.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.presentation.mode"
 name: "Presentation mode"
 user_promise: "Pages and ordered records can present through shared Slides primitives without creating slide-only content."
+primary_user_job: "Present existing Content in a focused sequence without copying it into a separate slide document."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.layout.responsive","content.renderer.typed"]
+dependencies: ["content.layout.responsive", "content.renderer.typed"]
 related_features: ["content.feature.build-living-dashboards"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Pages and ordered records can present through shared Slides primitives without creating slide-only content."
-proof_requirements: ["Pages and ordered records can present through shared Slides primitives without creating slide-only content."]
+acceptance_summary: "Presentation mode sequences canonical Pages or ordered records through shared slide primitives while preserving source identity, access, and ordinary editing."
+proof_requirements:
+  [
+    "Source selection, ordering, navigation, speaker-focus, and configuration persistence coverage",
+    "Canonical edit, access, sharing, export, reload, and recovery coverage",
+    "Real-interface keyboard, assistive-technology, responsive, and embedded presentation workflow",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,51 @@ last_reviewed: "2026-07-29"
 
 # Presentation mode
 
-## Contract
+## Why this exists
 
-Pages and ordered records can present through shared Slides primitives without creating slide-only content.
+Presenting should reveal a useful sequence, not ask people to maintain a shadow copy of
+their work in a slide-only silo.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Pages and ordered records can present through shared Slides primitives without creating slide-only content.
+An editor presents an ordered set of Pages, advances with the keyboard, and corrects a
+fact through the ordinary Page editor. The next presentation uses that canonical change.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Presentation mode is a View configuration over canonical Pages, Blocks, or ordered records.
+- Sequence, focus, and presenter controls are presentation state; source content retains identity and access.
+- Edits, sharing, export, and agent context use the same object and Action boundaries as ordinary Content.
+- Empty, unavailable, denied, and stale source states are visible rather than replaced by a blank deck.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Responsive layout supplies primitives. Presentation mode is not a slide-only document
+type, an animation authoring suite, or a bypass around source permissions.
+
+## Acceptance stories
+
+### Present canonical pages
+
+Given ordered authorized Pages, when a presenter enters presentation mode, then each
+slide reflects the canonical source and a viewer sees only Pages they may access.
+
+### Edit without forking
+
+Given a visible slide, when an editor changes its source Page, then the source history
+records one ordinary edit and the presentation refreshes without a duplicate slide copy.
+
+## Current evidence
+
+No complete Slides primitive or cross-surface proof is recorded. This Capability remains
+`approved_shape`.
+
+## Proof plan
+
+1. Test source selection, ordering, presenter navigation, persistence, and source mutation.
+2. Verify access, sharing, export, agent context, stale state, and recovery.
+3. Exercise keyboard, screen-reader, responsive, embedded, and reload workflows.
+
+## Open questions
+
+Speaker notes and transition scope need separate design without changing source truth.

--- a/templates/content/docs/product/capabilities/content.presentation.mode.md
+++ b/templates/content/docs/product/capabilities/content.presentation.mode.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.presentation.mode"
+name: "Presentation mode"
+user_promise: "Pages and ordered records can present through shared Slides primitives without creating slide-only content."
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.layout.responsive","content.renderer.typed"]
+related_features: ["content.feature.build-living-dashboards"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Pages and ordered records can present through shared Slides primitives without creating slide-only content."
+proof_requirements: ["Pages and ordered records can present through shared Slides primitives without creating slide-only content."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Presentation mode
+
+## Contract
+
+Pages and ordered records can present through shared Slides primitives without creating slide-only content.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Pages and ordered records can present through shared Slides primitives without creating slide-only content.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.preset.catalog.md
+++ b/templates/content/docs/product/capabilities/content.preset.catalog.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.preset.catalog"
+name: "Presets"
+user_promise: "Governed preassembled ordinary primitives, always inspectable"
+kind: "primitive"
+state: "superseded"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.template.graph"]
+related_features: []
+roadmap_boundary: "superseded"
+acceptance_summary: "A complete proof demonstrates: Catalog governance and shared primitive editors; no alternate hidden engine."
+proof_requirements: ["Catalog governance and shared primitive editors; no alternate hidden engine."]
+evidence: []
+superseded_by: "content.template.graph"
+last_reviewed: "2026-07-29"
+---
+
+# Presets
+
+## Contract
+
+Governed preassembled ordinary primitives, always inspectable
+
+## Acceptance boundary
+
+A complete proof demonstrates: Catalog governance and shared primitive editors; no alternate hidden engine.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This record no longer defines new product work. Continue through `content.template.graph`.

--- a/templates/content/docs/product/capabilities/content.preset.catalog.md
+++ b/templates/content/docs/product/capabilities/content.preset.catalog.md
@@ -1,8 +1,10 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.preset.catalog"
 name: "Presets"
-user_promise: "Governed preassembled ordinary primitives, always inspectable"
+user_promise: "Understand that older preassembled configurations now live as inspectable Templates rather than a competing product type."
+primary_user_job: "Follow historical Preset lineage to its Template successor."
 kind: "primitive"
 state: "superseded"
 publicness: "public"
@@ -10,8 +12,13 @@ availability: "universal"
 dependencies: ["content.template.graph"]
 related_features: []
 roadmap_boundary: "superseded"
-acceptance_summary: "A complete proof demonstrates: Catalog governance and shared primitive editors; no alternate hidden engine."
-proof_requirements: ["Catalog governance and shared primitive editors; no alternate hidden engine."]
+acceptance_summary: "Presets are superseded by Multi-object Templates: governed preassembled ordinary primitives continue through the Template graph and governance contracts with no alternate hidden engine."
+proof_requirements:
+  [
+    "All new reusable-system work belongs to content.template.graph and its governance/update capabilities.",
+    "A former preset must remain inspectable as ordinary Pages, Databases, Views, Properties, Rules, expressions, and bodies.",
+    "This record preserves lineage only and does not create a second catalog or migration requirement.",
+  ]
 evidence: []
 superseded_by: "content.template.graph"
 last_reviewed: "2026-07-29"
@@ -19,18 +26,46 @@ last_reviewed: "2026-07-29"
 
 # Presets
 
-## Contract
+## Why this exists
 
-Governed preassembled ordinary primitives, always inspectable
+Historical Preset terminology can mislead people into looking for a separate engine that no longer exists. The lineage needs to remain legible while all real reuse work proceeds through Templates.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Catalog governance and shared primitive editors; no alternate hidden engine.
+A team follows a legacy Preset link to its Template graph lineage and adopts a Template version rather than creating a Preset instance.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- All new reusable-system work belongs to content.template.graph and its governance/update capabilities.
+- A former preset must remain inspectable as ordinary Pages, Databases, Views, Properties, Rules, expressions, and bodies.
+- This record preserves lineage only and does not create a second catalog or migration requirement.
 
-## Non-goals
+## Boundaries and non-goals
 
-This record no longer defines new product work. Continue through `content.template.graph`.
+- `content.template.graph`, Template governance, and Template updates own every successor workflow; this record preserves only the historical mapping.
+- Presets do not retain a separate catalog, instance type, mutation surface, or migration engine.
+
+## Acceptance stories
+
+### Preserve lineage only
+
+Given historical Preset provenance, when a person opens the legacy entry, then the record points to Template successor and exposes no Preset mutation action.
+
+### Use Template updates
+
+Given an old configuration changes, when its owner reviews it, then Template pinning, diff, selective apply, and detach govern it.
+
+## Current evidence
+
+`docs/product/architecture.md` and `content.template.graph.md` define the successor; no separate Presets implementation is intended.
+
+## Proof plan
+
+1. Resolve historic links to Template records.
+2. Confirm no separate Preset discovery/mutation engine.
+3. Exercise inspection/adoption/update through Template contracts.
+4. Preserve legacy provenance in export/history.
+
+## Open questions
+
+No product question remains.

--- a/templates/content/docs/product/capabilities/content.property.actor.md
+++ b/templates/content/docs/product/capabilities/content.property.actor.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.property.actor"
+name: "Actor properties"
+user_promise: "Created by and Last edited by record the actual human, agent, automation, or integration actor."
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.event.committed"]
+related_features: ["content.feature.durable-foundations","content.feature.data-that-keeps-itself-right"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Created by and Last edited by record the actual human, agent, automation, or integration actor."
+proof_requirements: ["Created by and Last edited by record the actual human, agent, automation, or integration actor."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Actor properties
+
+## Contract
+
+Created by and Last edited by record the actual human, agent, automation, or integration actor.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Created by and Last edited by record the actual human, agent, automation, or integration actor.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.property.actor.md
+++ b/templates/content/docs/product/capabilities/content.property.actor.md
@@ -1,17 +1,28 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.property.actor"
 name: "Actor properties"
-user_promise: "Created by and Last edited by record the actual human, agent, automation, or integration actor."
+user_promise: "Know who actually created or last changed a record, whether that actor was a person, agent, automation, or integration."
+primary_user_job: "Understand actual creators and editors across actor kinds."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
 dependencies: ["content.event.committed"]
-related_features: ["content.feature.durable-foundations","content.feature.data-that-keeps-itself-right"]
+related_features:
+  [
+    "content.feature.durable-foundations",
+    "content.feature.data-that-keeps-itself-right",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Created by and Last edited by record the actual human, agent, automation, or integration actor."
-proof_requirements: ["Created by and Last edited by record the actual human, agent, automation, or integration actor."]
+acceptance_summary: "Created by and Last edited by are typed actor properties derived from committed mutations and retain actual actor and origin rather than a misleading shared account."
+proof_requirements:
+  [
+    "Actor values identify the actual human, agent, automation, or integration that committed the change.",
+    "Creation sets Created by once; later committed changes update Last edited by without overwriting provenance.",
+    "Denied, imported, or unavailable actor identity is represented honestly and does not collapse into a false personal attribution.",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +30,46 @@ last_reviewed: "2026-07-29"
 
 # Actor properties
 
-## Contract
+## Why this exists
 
-Created by and Last edited by record the actual human, agent, automation, or integration actor.
+Collaboration loses accountability when automation and agents are flattened into a generic service identity. People need to distinguish who first created a record from who most recently changed it and how that change arrived.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Created by and Last edited by record the actual human, agent, automation, or integration actor.
+A coordinator creates a request, automation enriches it, and an agent edits status; Created by stays coordinator while Last edited by names the agent.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Actor values identify the actual human, agent, automation, or integration that committed the change.
+- Creation sets Created by once; later committed changes update Last edited by without overwriting provenance.
+- Denied, imported, or unavailable actor identity is represented honestly and does not collapse into a false personal attribution.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- Committed events own mutation attribution and origin; Actor Properties project that record into stable created/last-edited fields.
+- Actor fields are not a permissions mechanism and do not fabricate a current-person identity when provenance is unresolved.
+
+## Acceptance stories
+
+### Keep creation provenance
+
+Given imported work is later edited, when a person commits the change, then Created by remains imported origin.
+
+### Admit unknown identity
+
+Given legacy resolution fails, when the actor Property renders, then the actor field says unresolved rather than current viewer.
+
+## Current evidence
+
+`actions/create-document.ts`, `update-document.ts`, and `edit-document.ts` are donors; `server/db/schema.ts` timestamps do not prove actor fields.
+
+## Proof plan
+
+1. Exercise person/agent/automation/integration/import/restore.
+2. Render access-aware actor and unresolved states.
+3. Export/import without identity leakage.
+4. Compare receipts and displayed actor.
+
+## Open questions
+
+Actor card versus text renderer remains open.

--- a/templates/content/docs/product/capabilities/content.property.catalog.md
+++ b/templates/content/docs/product/capabilities/content.property.catalog.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.property.catalog"
+name: "Custom Properties"
+user_promise: "Governed Custom Properties can be deliberately reused across Databases without making ordinary same-named columns secretly equivalent"
+kind: "primitive"
+state: "exploring"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.property.typed","content.template.governance"]
+related_features: ["content.feature.connect-your-sources","content.feature.share-how-your-organization-works","content.feature.evolve-systems-safely"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Add-column picker distinguishes built-in local types, source-backed fields, and personal/workspace/org Custom Properties; stable definition and owner/scope; typed configuration and descriptions; provenance; query identity; version/update diff; detach-to-local; safe value migration; agent-legible semantics."
+proof_requirements: ["Add-column picker distinguishes built-in local types, source-backed fields, and personal/workspace/org Custom Properties; stable definition and owner/scope; typed configuration and descriptions; provenance; query identity; version/update diff; detach-to-local; safe value migration; agent-legible semantics."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Custom Properties
+
+## Contract
+
+Governed Custom Properties can be deliberately reused across Databases without making ordinary same-named columns secretly equivalent
+
+## Acceptance boundary
+
+A complete proof demonstrates: Add-column picker distinguishes built-in local types, source-backed fields, and personal/workspace/org Custom Properties; stable definition and owner/scope; typed configuration and descriptions; provenance; query identity; version/update diff; detach-to-local; safe value migration; agent-legible semantics.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.property.catalog.md
+++ b/templates/content/docs/product/capabilities/content.property.catalog.md
@@ -1,17 +1,29 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.property.catalog"
 name: "Custom Properties"
-user_promise: "Governed Custom Properties can be deliberately reused across Databases without making ordinary same-named columns secretly equivalent"
+user_promise: "Reuse an approved field definition deliberately without making same-named local columns secretly equal."
+primary_user_job: "Reuse a governed field and safely update or detach it."
 kind: "primitive"
 state: "exploring"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.property.typed","content.template.governance"]
-related_features: ["content.feature.connect-your-sources","content.feature.share-how-your-organization-works","content.feature.evolve-systems-safely"]
+dependencies: ["content.property.typed", "content.template.governance"]
+related_features:
+  [
+    "content.feature.connect-your-sources",
+    "content.feature.share-how-your-organization-works",
+    "content.feature.evolve-systems-safely",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Add-column picker distinguishes built-in local types, source-backed fields, and personal/workspace/org Custom Properties; stable definition and owner/scope; typed configuration and descriptions; provenance; query identity; version/update diff; detach-to-local; safe value migration; agent-legible semantics."
-proof_requirements: ["Add-column picker distinguishes built-in local types, source-backed fields, and personal/workspace/org Custom Properties; stable definition and owner/scope; typed configuration and descriptions; provenance; query identity; version/update diff; detach-to-local; safe value migration; agent-legible semantics."]
+acceptance_summary: "Custom Properties are governed, scoped reusable typed definitions with stable identity, description, provenance, query semantics, versioned updates, impact preview, safe migration, and detachable local copies."
+proof_requirements:
+  [
+    "The add-column picker distinguishes built-in local types, source-backed fields, and personal, workspace, or organization Custom Properties.",
+    "A definition's stable identity—not its name—controls query meaning, provenance, and compatible updates.",
+    "A consumer may detach to a local field; updates are reviewed and impact-previewed, never silently applied.",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +31,46 @@ last_reviewed: "2026-07-29"
 
 # Custom Properties
 
-## Contract
+## Why this exists
 
-Governed Custom Properties can be deliberately reused across Databases without making ordinary same-named columns secretly equivalent
+Same-named columns are not shared meaning. Organizations need a way to reuse a field deliberately, understand where it came from, and evolve it without silently rewriting a local database.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Add-column picker distinguishes built-in local types, source-backed fields, and personal/workspace/org Custom Properties; stable definition and owner/scope; typed configuration and descriptions; provenance; query identity; version/update diff; detach-to-local; safe value migration; agent-legible semantics.
+Marta publishes Customer tier, a database adopts it, previews an enum update, and another database detaches locally while keeping values.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- The add-column picker distinguishes built-in local types, source-backed fields, and personal, workspace, or organization Custom Properties.
+- A definition's stable identity—not its name—controls query meaning, provenance, and compatible updates.
+- A consumer may detach to a local field; updates are reviewed and impact-previewed, never silently applied.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- `content.property.typed` owns type semantics and Template governance owns catalog policy; Custom Properties own reusable definition/adoption identity.
+- The catalog does not equate columns by name, make local columns secretly global, or auto-migrate incompatible values.
+
+## Acceptance stories
+
+### Labels are not identity
+
+Given local and organization Status fields, when an author opens Add column, then Add column distinguishes their IDs and origins.
+
+### Stage risky migration
+
+Given a breaking type/option update, when its owner proposes publication, then Content previews impact and blocks or stages unsafe conversion.
+
+## Current evidence
+
+`server/plugins/db.ts`, `actions/configure-document-property.ts`, `actions/bind-content-database-source-field.ts`, and `DocumentProperties.tsx` are donors; catalog/adoption/detach/migration do not exist.
+
+## Proof plan
+
+1. Build scoped Add column discovery with IDs/provenance.
+2. Adopt across databases and test semantics/access.
+3. Publish compatible/breaking versions with impact/migration/receipts.
+4. Detach without losing values.
+
+## Open questions
+
+Scope names need root judgment.

--- a/templates/content/docs/product/capabilities/content.property.constraints.md
+++ b/templates/content/docs/product/capabilities/content.property.constraints.md
@@ -1,17 +1,28 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.property.constraints"
 name: "Property validation and defaults"
-user_promise: "Required, default, validation, formatting, edit policy in column configuration"
+user_promise: "Configure requiredness, defaults, validation, formatting, and edit policy once and trust every write path to enforce them."
+primary_user_job: "Set constraints and defaults every mutation path enforces."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.property.typed","content.expression.language"]
-related_features: ["content.feature.data-that-keeps-itself-right","content.feature.collect-structured-input"]
+dependencies: ["content.property.typed", "content.expression.language"]
+related_features:
+  [
+    "content.feature.data-that-keeps-itself-right",
+    "content.feature.collect-structured-input",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Atomic validation across every mutation path."
-proof_requirements: ["Atomic validation across every mutation path."]
+acceptance_summary: "Property configuration validates every mutation atomically; formulas remain live, while defaults evaluate once during a successful creation transaction and become stored values."
+proof_requirements:
+  [
+    "Constraints, format, requiredness, and edit policy are typed configuration interpreted by the shared mutation boundary.",
+    "Defaults evaluate exactly once only after the creation transaction has enough context to succeed; they are not live formulas.",
+    "Validation failure returns typed field diagnostics and commits no partial mutation through UI, agent, import, source sync, or API.",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +30,46 @@ last_reviewed: "2026-07-29"
 
 # Property validation and defaults
 
-## Contract
+## Why this exists
 
-Required, default, validation, formatting, edit policy in column configuration
+A rule that only the form enforces is not a data rule. Authors need defaults and validation to behave predictably whether a record comes from a person, agent, import, or source synchronization.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Atomic validation across every mutation path.
+Elena creates a Form row with required Priority and a Due date default; the default stores once while a formula remains live.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Constraints, format, requiredness, and edit policy are typed configuration interpreted by the shared mutation boundary.
+- Defaults evaluate exactly once only after the creation transaction has enough context to succeed; they are not live formulas.
+- Validation failure returns typed field diagnostics and commits no partial mutation through UI, agent, import, source sync, or API.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- Typed Properties own field type and Expressions own live computation; this record owns transaction-time defaults, constraints, format, and edit policy.
+- Defaults are not formulas, and client-side form checks are not a substitute for the shared mutation boundary.
+
+## Acceptance stories
+
+### Roll back atomically
+
+Given an agent changes two fields and one is invalid, when the mutation commits, then neither commits and the failing field is identified.
+
+### Do not turn defaults live
+
+Given a current-actor default, when the actor later changes, then later actor changes do not rewrite the stored value.
+
+## Current evidence
+
+`actions/configure-document-property.ts`, `set-document-property.ts`, and lifecycle tests are donors; cross-origin rule semantics are unproved.
+
+## Proof plan
+
+1. Configure/test via forms, UI, actions, import, and sync.
+2. Verify defaults evaluate once and formulas remain live.
+3. Test invalid multi-field rollback and typed errors.
+4. Exercise denied dependencies and retry.
+
+## Open questions
+
+Default dependency ordering needs shaping.

--- a/templates/content/docs/product/capabilities/content.property.constraints.md
+++ b/templates/content/docs/product/capabilities/content.property.constraints.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.property.constraints"
+name: "Property validation and defaults"
+user_promise: "Required, default, validation, formatting, edit policy in column configuration"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.property.typed","content.expression.language"]
+related_features: ["content.feature.data-that-keeps-itself-right","content.feature.collect-structured-input"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Atomic validation across every mutation path."
+proof_requirements: ["Atomic validation across every mutation path."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Property validation and defaults
+
+## Contract
+
+Required, default, validation, formatting, edit policy in column configuration
+
+## Acceptance boundary
+
+A complete proof demonstrates: Atomic validation across every mutation path.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.property.guarded-change.md
+++ b/templates/content/docs/product/capabilities/content.property.guarded-change.md
@@ -1,17 +1,29 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.property.guarded-change"
 name: "Guarded property changes"
-user_promise: "Any Property can validate values and require an explained confirmation or policy check before a sensitive transition."
+user_promise: "Require an explained confirmation or policy check before a sensitive field transition while keeping one general validation engine."
+primary_user_job: "Satisfy a clear shared safeguard before sensitive changes."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.property.constraints","content.event.committed"]
-related_features: ["content.feature.trust-your-connected-sources","content.feature.data-that-keeps-itself-right","content.feature.publish-with-confidence"]
+dependencies: ["content.property.constraints", "content.event.committed"]
+related_features:
+  [
+    "content.feature.trust-your-connected-sources",
+    "content.feature.data-that-keeps-itself-right",
+    "content.feature.publish-with-confidence",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Any Property can validate values and require an explained confirmation or policy check before a sensitive transition."
-proof_requirements: ["Any Property can validate values and require an explained confirmation or policy check before a sensitive transition."]
+acceptance_summary: "Any Property can declare validation and safeguards for sensitive transitions; the shared mutation boundary evaluates them, explains required confirmation or policy failure, and records committed changes normally."
+proof_requirements:
+  [
+    "Status is a useful UI for a guarded change but is not the exclusive safeguard engine.",
+    "UI, agent, automation, source sync, import, and API calls use the same validation and policy boundary.",
+    "A blocked transition produces an actionable reason and no partial write; accepted confirmation or policy result is attributable in history.",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +31,46 @@ last_reviewed: "2026-07-29"
 
 # Guarded property changes
 
-## Contract
+## Why this exists
 
-Any Property can validate values and require an explained confirmation or policy check before a sensitive transition.
+Some values carry consequences that deserve more than an accidental click, yet a special status dialog cannot protect the same change made by automation. People need one explainable safeguard at the mutation boundary.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Any Property can validate values and require an explained confirmation or policy check before a sensitive transition.
+A release manager moves Draft to Published with required confirmation and sees the same policy apply to agent and source-sync changes.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Status is a useful UI for a guarded change but is not the exclusive safeguard engine.
+- UI, agent, automation, source sync, import, and API calls use the same validation and policy boundary.
+- A blocked transition produces an actionable reason and no partial write; accepted confirmation or policy result is attributable in history.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- Constraints own ordinary validity; committed events own attribution/history; guarded change owns the added safeguard decision and explanation.
+- Status is only one useful surface: safeguards are not status-only workflows, a new permission system, or a client-only confirmation.
+
+## Acceptance stories
+
+### Guard every origin
+
+Given source sync attempts a sensitive transition, when it reaches the mutation boundary, then it receives the same decision as UI.
+
+### Explain refusal
+
+Given confirmation is absent, when an editor requests the transition, then no mutation occurs and the rule/next action are clear.
+
+## Current evidence
+
+`actions/change-content-database-source-role.ts` and `set-document-property.ts` are donors; general safeguard evaluation is absent.
+
+## Proof plan
+
+1. Configure safeguards on status, date, relation, and ordinary fields.
+2. Compare UI/action/agent/automation/import/sync decisions.
+3. Test expiry, retry, concurrency, no partial writes.
+4. Verify explanations and actor history.
+
+## Open questions
+
+Vocabulary and separate-reviewer policy remain open.

--- a/templates/content/docs/product/capabilities/content.property.guarded-change.md
+++ b/templates/content/docs/product/capabilities/content.property.guarded-change.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.property.guarded-change"
+name: "Guarded property changes"
+user_promise: "Any Property can validate values and require an explained confirmation or policy check before a sensitive transition."
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.property.constraints","content.event.committed"]
+related_features: ["content.feature.trust-your-connected-sources","content.feature.data-that-keeps-itself-right","content.feature.publish-with-confidence"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Any Property can validate values and require an explained confirmation or policy check before a sensitive transition."
+proof_requirements: ["Any Property can validate values and require an explained confirmation or policy check before a sensitive transition."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Guarded property changes
+
+## Contract
+
+Any Property can validate values and require an explained confirmation or policy check before a sensitive transition.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Any Property can validate values and require an explained confirmation or policy check before a sensitive transition.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.property.location.md
+++ b/templates/content/docs/product/capabilities/content.property.location.md
@@ -1,8 +1,10 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.property.location"
 name: "Typed locations"
-user_promise: "Location Properties preserve structured places and coordinates for maps, queries, sources, and portable export."
+user_promise: "Store a place or coordinates as a meaningful location that maps, queries, sources, and export can understand."
+primary_user_job: "Capture a place at known precision for portable use."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
@@ -10,8 +12,13 @@ availability: "universal"
 dependencies: ["content.property.typed"]
 related_features: []
 roadmap_boundary: "supporting"
-acceptance_summary: "A complete proof demonstrates: Location Properties preserve structured places and coordinates for maps, queries, sources, and portable export."
-proof_requirements: ["Location Properties preserve structured places and coordinates for maps, queries, sources, and portable export."]
+acceptance_summary: "Location Properties preserve a typed structured place and coordinates with clear precision, display, query, source mapping, and portable export behavior."
+proof_requirements:
+  [
+    "A location is typed structured data, not a display string or map pin owned by one renderer.",
+    "Authors can keep a human place, coordinates, and known precision without fabricating missing geocoding data.",
+    "Maps and sources are projections/adapters; access, queries, and export use the canonical value and disclose unsupported fields honestly.",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,46 @@ last_reviewed: "2026-07-29"
 
 # Typed locations
 
-## Contract
+## Why this exists
 
-Location Properties preserve structured places and coordinates for maps, queries, sources, and portable export.
+A place has more meaning than an address string, but false precision is actively misleading. Authors need to preserve what they know about a location while letting maps and exports consume it without inventing details.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Location Properties preserve structured places and coordinates for maps, queries, sources, and portable export.
+Nia records a field visit with label, coordinates, and approximate precision; map and nearby query use it while export retains known data.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A location is typed structured data, not a display string or map pin owned by one renderer.
+- Authors can keep a human place, coordinates, and known precision without fabricating missing geocoding data.
+- Maps and sources are projections/adapters; access, queries, and export use the canonical value and disclose unsupported fields honestly.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- Typed Properties own the value contract; map Views and provider adapters consume or map locations without becoming the source of truth.
+- Locations do not imply geocoding, tracking, hidden precision, or an automatic map-provider dependency.
+
+## Acceptance stories
+
+### Do not invent precision
+
+Given a source only provides a city, when Content imports it, then Content keeps city/precision without fabricating coordinates.
+
+### Maps are projections
+
+Given a renderer fails, when a person opens the Location Property, then the location remains queryable and exportable.
+
+## Current evidence
+
+`app/components/editor/DocumentProperties.tsx` maps location to `place`; `shared/properties.ts` includes `place`, but no structured location schema exists.
+
+## Proof plan
+
+1. Author labels/coordinates/precision and serialize them.
+2. Query/render in map and non-map surfaces.
+3. Import partial provider values without invented geocoding.
+4. Export/import with access-aware coordinates.
+
+## Open questions
+
+Points versus polygons/routes is open.

--- a/templates/content/docs/product/capabilities/content.property.location.md
+++ b/templates/content/docs/product/capabilities/content.property.location.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.property.location"
+name: "Typed locations"
+user_promise: "Location Properties preserve structured places and coordinates for maps, queries, sources, and portable export."
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.property.typed"]
+related_features: []
+roadmap_boundary: "supporting"
+acceptance_summary: "A complete proof demonstrates: Location Properties preserve structured places and coordinates for maps, queries, sources, and portable export."
+proof_requirements: ["Location Properties preserve structured places and coordinates for maps, queries, sources, and portable export."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Typed locations
+
+## Contract
+
+Location Properties preserve structured places and coordinates for maps, queries, sources, and portable export.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Location Properties preserve structured places and coordinates for maps, queries, sources, and portable export.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.property.typed.md
+++ b/templates/content/docs/product/capabilities/content.property.typed.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.property.typed"
+name: "Typed Properties"
+user_promise: "Typed stored and computed properties with descriptions"
+kind: "primitive"
+state: "in_progress"
+publicness: "public"
+availability: "universal"
+dependencies: []
+related_features: ["content.feature.data-that-keeps-itself-right"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Expand typed output declarations and normal authoring where missing."
+proof_requirements: ["Expand typed output declarations and normal authoring where missing."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Typed Properties
+
+## Contract
+
+Typed stored and computed properties with descriptions
+
+## Acceptance boundary
+
+A complete proof demonstrates: Expand typed output declarations and normal authoring where missing.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.property.typed.md
+++ b/templates/content/docs/product/capabilities/content.property.typed.md
@@ -1,8 +1,10 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.property.typed"
 name: "Typed Properties"
-user_promise: "Typed stored and computed properties with descriptions"
+user_promise: "Define stored and computed fields whose values and descriptions stay meaningful in every surface."
+primary_user_job: "Define fields whose types survive every Content operation."
 kind: "primitive"
 state: "in_progress"
 publicness: "public"
@@ -10,8 +12,13 @@ availability: "universal"
 dependencies: []
 related_features: ["content.feature.data-that-keeps-itself-right"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Expand typed output declarations and normal authoring where missing."
-proof_requirements: ["Expand typed output declarations and normal authoring where missing."]
+acceptance_summary: "Properties declare stable stored or computed types, descriptions, configuration, and renderer contracts so values can be authored, queried, validated, rendered, and exported without ambiguous coercion."
+proof_requirements:
+  [
+    "Stored values and computed results both declare exact output types; presentation is a renderer choice, not a hidden data conversion.",
+    "Descriptions and typed semantics are available to people, agents, queries, validation, and export.",
+    "Unknown, invalid, absent, and unreadable values remain distinct.",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,46 @@ last_reviewed: "2026-07-29"
 
 # Typed Properties
 
-## Contract
+## Why this exists
 
-Typed stored and computed properties with descriptions
+A field label alone cannot tell a database, export, or agent what a value means. Without durable types, dates become text and missing access becomes an innocent blank, quietly corrupting later work.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Expand typed output declarations and normal authoring where missing.
+Dara adds a place field, describes it, and sees the same typed value in property panel, database view, and export.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Stored values and computed results both declare exact output types; presentation is a renderer choice, not a hidden data conversion.
+- Descriptions and typed semantics are available to people, agents, queries, validation, and export.
+- Unknown, invalid, absent, and unreadable values remain distinct.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- `content.property.constraints` owns validation/default behavior and `content.expression.language` owns computed semantics; Typed Properties own declared value/output types.
+- A renderer may change presentation but cannot change stored meaning or coerce denied/invalid/absent states into a normal value.
+
+## Acceptance stories
+
+### Keep computed type
+
+Given a date formula, when sorted/rendered/exported, then each consumer gets a declared date.
+
+### Do not coerce absence
+
+Given unreadable relation and blank text, then renderers keep them distinct.
+
+## Current evidence
+
+`shared/properties.ts`, `actions/configure-document-property.ts`, and `app/components/editor/DocumentProperties.tsx` are donors; formula output types are not durable general declarations.
+
+## Proof plan
+
+1. Create/query/render/export stored and computed types.
+2. Propagate descriptions to UI/actions/agents/serialization.
+3. Test absent, invalid, unreadable, unsupported values.
+4. Compare UI/action validation.
+
+## Open questions
+
+Computed output taxonomy needs root judgment.

--- a/templates/content/docs/product/capabilities/content.publish.public.md
+++ b/templates/content/docs/product/capabilities/content.publish.public.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.publish.public"
+name: "Public publishing"
+user_promise: "Internal sharing and public publishing remain separate, explicit, auditable planes"
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.publish.reading","content.access.visibility-closure","content.event.committed"]
+related_features: ["content.feature.publish-with-confidence"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Share-state language, polished landing/reading, request-access completion path, exposure inventory, private-asset warnings."
+proof_requirements: ["Share-state language, polished landing/reading, request-access completion path, exposure inventory, private-asset warnings."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Public publishing
+
+## Contract
+
+Internal sharing and public publishing remain separate, explicit, auditable planes
+
+## Acceptance boundary
+
+A complete proof demonstrates: Share-state language, polished landing/reading, request-access completion path, exposure inventory, private-asset warnings.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.publish.public.md
+++ b/templates/content/docs/product/capabilities/content.publish.public.md
@@ -1,36 +1,75 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.publish.public"
-name: "Public publishing"
-user_promise: "Internal sharing and public publishing remain separate, explicit, auditable planes"
-kind: "surface"
+name: "Public publication"
+user_promise: "Publish one chosen Page revision at a stable public destination while private work continues safely."
+primary_user_job: "Make an approved version public without accidentally publishing draft edits, comments, or private dependencies."
+kind: "workflow"
 state: "approved_shape"
 publicness: "public"
-availability: "universal"
-dependencies: ["content.publish.reading","content.access.visibility-closure","content.event.committed"]
+availability: "configured"
+dependencies:
+  [
+    "content.access.visibility-closure",
+    "content.version.branching",
+    "content.renderer.typed",
+  ]
 related_features: ["content.feature.publish-with-confidence"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Share-state language, polished landing/reading, request-access completion path, exposure inventory, private-asset warnings."
-proof_requirements: ["Share-state language, polished landing/reading, request-access completion path, exposure inventory, private-asset warnings."]
+acceptance_summary: "A Page-first publication object binds a stable destination to one Page, selected Version, and exact revision, previews the actual audience closure, records lifecycle events, and changes only when an authorized publisher explicitly updates or withdraws it."
+proof_requirements:
+  [
+    "Publication identity, revision binding, lifecycle, URL, and rollback tests",
+    "Audience-closure and private-collaboration leakage tests",
+    "Publisher preview, publish, private follow-on edit, update, and unpublish interface workflow",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
 ---
 
-# Public publishing
+# Public publication
 
-## Contract
+## Why this exists
 
-Internal sharing and public publishing remain separate, explicit, auditable planes
+Public truth deserves a deliberate pin, not whatever happened to be in the editor when the wind changed.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Share-state language, polished landing/reading, request-access completion path, exposure inventory, private-asset warnings.
+An editor previews the approved article revision, publishes it at a stable URL, continues private revision work, then explicitly replaces the public revision after another preview.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Publication is Page-first and binds Page identity, selected Version, exact revision, destination, audience closure, and lifecycle history.
+- The stable URL serves the last explicitly published revision; private edits, comments, unpublished Versions, and inaccessible assets do not follow it automatically.
+- Preview evaluates the real audience closure and renderer fallback before publish. Publish, update, and unpublish are explicit guarded actions with actor/origin receipts.
+- Provider publishing remains a separate Source lifecycle action, not a consequence of public Content publication.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Public reading owns rendering; sharing owns access; provider adapters own external publishing. This does not turn every shared Page into a public publication.
+
+## Acceptance stories
+
+### Hold a public revision steady
+
+Given a published Page and a private draft edit, when the draft changes, then the public URL keeps serving the prior bound revision until an authorized publisher updates it.
+
+### Prevent private closure leaks
+
+Given the selected revision references a private comment and inaccessible asset, when preview runs, then it identifies their public treatment and publishing does not expose either.
+
+## Current evidence
+
+Donor evidence: `server/lib/public-documents.ts`, `server/lib/public-documents.spec.ts`, and `app/routes/p.$id.tsx` implement public Page substrate. They do not prove Page/Version/revision publication identity or lifecycle isolation; this record remains `approved_shape`.
+
+## Proof plan
+
+1. Model publication bindings and guarded lifecycle Actions.
+2. Test revision stability, closure, rollback, update, withdrawal, and provider separation.
+3. Verify preview and full public lifecycle in the browser.
+
+## Open questions
+
+- Publication scheduling and multiple destinations are future decisions.

--- a/templates/content/docs/product/capabilities/content.publish.reading.md
+++ b/templates/content/docs/product/capabilities/content.publish.reading.md
@@ -1,36 +1,74 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.publish.reading"
 name: "Public reading"
-user_promise: "Shareable/public reading surfaces render the same document truth as the editor/exporter"
+user_promise: "A shareable reading surface faithfully renders the intended public Content truth."
+primary_user_job: "Let readers open a public document quickly and understand the same meaningful content an editor approved."
 kind: "surface"
 state: "in_progress"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.renderer.typed","content.access.visibility-closure"]
+dependencies: ["content.renderer.typed", "content.access.visibility-closure"]
 related_features: ["content.feature.publish-with-confidence"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: SSR/access rules, shared renderer pipeline, metadata, embeds, portable fallbacks."
-proof_requirements: ["SSR/access rules, shared renderer pipeline, metadata, embeds, portable fallbacks."]
-evidence: []
+acceptance_summary: "A cache-safe public shell resolves only public reading data, renders supported Content blocks through the shared semantic pipeline with safe fallbacks, and preserves metadata, accessible navigation, embeds, and portable links without personalized SSR."
+proof_requirements:
+  [
+    "SSR shell, access, cache, metadata, and no-personalization regression tests",
+    "Shared renderer fidelity and fallback tests for public blocks, media, and embeds",
+    "Browser reading workflow for public, unavailable, and changed-public-content states",
+  ]
+evidence:
+  [
+    "../../../app/routes/p.$id.tsx",
+    "../../../app/__tests__/public-document-route.test.ts",
+  ]
 superseded_by: null
 last_reviewed: "2026-07-29"
 ---
 
 # Public reading
 
-## Contract
+## Why this exists
 
-Shareable/public reading surfaces render the same document truth as the editor/exporter
+Publication needs a reader, not merely a route that happens to return HTML.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: SSR/access rules, shared renderer pipeline, metadata, embeds, portable fallbacks.
+A visitor opens a public article link, reads a faithful server-rendered shell, uses accessible headings and media fallbacks, and gets an honest unavailable state for a withdrawn page.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Public SSR remains one impersonal cacheable shell; personal state and authorization branches happen after load, never by cookie-varying the shell.
+- The reader uses shared semantic rendering and deliberate fallbacks so public reading, export, and editor meaning do not drift gratuitously.
+- Metadata, canonical links, embeds, assets, and accessible navigation reflect the published public closure.
+- Missing, withdrawn, or inaccessible public artifacts are explicit states, not stale content or empty success.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Publication owns exact revision choice; this owns rendering that choice. It does not make private editor capabilities public or duplicate the Reader surface.
+
+## Acceptance stories
+
+### Serve a public shell safely
+
+Given a public Page, when an anonymous reader opens it, then the server returns public content without a personalized cache branch and the client may add only viewer-local behavior after load.
+
+### Handle withdrawal honestly
+
+Given a published destination has been withdrawn, when a reader follows its stable URL, then it receives an explicit unavailable page rather than stale prior content.
+
+## Current evidence
+
+Implementation evidence: `app/routes/p.$id.tsx` and `app/__tests__/public-document-route.test.ts` cover current public route behavior. Donor evidence does not yet prove full renderer fidelity, publication-version integration, or all fallback cases, so this record remains `in_progress`.
+
+## Proof plan
+
+1. Test public cache-shell and access invariants against all public route paths.
+2. Add renderer fixtures for supported blocks, assets, embeds, and fallbacks.
+3. Browser-test public read, unavailable, and updated-public-revision states.
+
+## Open questions
+
+- The public reading typography and optional interactive enhancement set remain open.

--- a/templates/content/docs/product/capabilities/content.publish.reading.md
+++ b/templates/content/docs/product/capabilities/content.publish.reading.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.publish.reading"
+name: "Public reading"
+user_promise: "Shareable/public reading surfaces render the same document truth as the editor/exporter"
+kind: "surface"
+state: "in_progress"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.renderer.typed","content.access.visibility-closure"]
+related_features: ["content.feature.publish-with-confidence"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: SSR/access rules, shared renderer pipeline, metadata, embeds, portable fallbacks."
+proof_requirements: ["SSR/access rules, shared renderer pipeline, metadata, embeds, portable fallbacks."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Public reading
+
+## Contract
+
+Shareable/public reading surfaces render the same document truth as the editor/exporter
+
+## Acceptance boundary
+
+A complete proof demonstrates: SSR/access rules, shared renderer pipeline, metadata, embeds, portable fallbacks.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.query.object.md
+++ b/templates/content/docs/product/capabilities/content.query.object.md
@@ -1,17 +1,32 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.query.object"
 name: "Reusable Query objects"
 user_promise: "A one-off inline Query can be promoted into a named reusable Content object that behaves like a dynamic Database without owning its source records"
+primary_user_job: "Define a reusable live collection across one or more authorized inputs without copying or taking ownership of their records."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.expression.language","content.access.visibility-closure"]
-related_features: ["content.feature.make-the-workspace-yours","content.feature.connect-your-sources","content.feature.work-across-every-workspace","content.feature.sketch-connections-keep-whats-true"]
+dependencies:
+  ["content.expression.language", "content.access.visibility-closure"]
+related_features:
+  [
+    "content.feature.make-the-workspace-yours",
+    "content.feature.connect-your-sources",
+    "content.feature.work-across-every-workspace",
+    "content.feature.sketch-connections-keep-whats-true",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Stable identity/title/description/access; typed query AST and output schema; variables; views/renderers; reference/embed/template support; catalog discovery; Query-as-source composition with cycle/scale guards; source-owned values and explicit create/write routing."
-proof_requirements: ["Stable identity/title/description/access; typed query AST and output schema; variables; views/renderers; reference/embed/template support; catalog discovery; Query-as-source composition with cycle/scale guards; source-owned values and explicit create/write routing."]
+acceptance_summary: "Inline and named Queries derive access-scoped typed collections with stable output contracts, composable inputs, explicit write-through and creation routes, and no ownership of source records."
+proof_requirements:
+  [
+    "Stable inline/named Query identity, typed AST, variables, output schema, history, reference, embed, and template behavior",
+    "Access-first composition of Databases, Sources, and Queries with cycle, scale, stale, and unavailable states",
+    "Canonical provenance plus unambiguous field write-through and explicit creation routes",
+    "Visual editor and agent manipulation of the same validated typed representation",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +34,81 @@ last_reviewed: "2026-07-29"
 
 # Reusable Query objects
 
-## Contract
+## Why this exists
 
-A one-off inline Query can be promoted into a named reusable Content object that behaves like a dynamic Database without owning its source records
+People often need a live collection whose members come from several places or satisfy reusable conditions. Copying those records into another Database creates stale duplicates and ambiguous ownership. A Query composes the originals while keeping their identity, permissions, and write authority intact.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Stable identity/title/description/access; typed query AST and output schema; variables; views/renderers; reference/embed/template support; catalog discovery; Query-as-source composition with cycle/scale guards; source-owned values and explicit create/write routing.
+A team combines Blog articles and Resources, aligns each source's title field into one output called `Title`, filters to published material, and renders the result as a List. The inline result can be saved as a named Query, embedded on another Page, and reused by a later Query. Editing an article title writes to that article's canonical owner; the aligned `Title` definition remains Query-owned presentation.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A Query derives a typed collection from Databases, approved Sources, other Queries, or access-scoped graph traversal.
+- Its definition may include unions, joins, intrinsic filters, projected fields, aliases, computed fields, output types, variables, documentation, limits, and ordering that is part of the result's meaning.
+- Query filters define the reusable input contract. A View may filter that result further but can never unfilter records the Query excluded.
+- One-off Queries may remain inline in a View or Block. **Save as Query** gives the same typed definition stable identity, title, description, access, history, discoverability, references, embeds, templates, Views, and Query-as-input reuse.
+- A named Query owns its AST, variables, output-field identities, aliases, computed fields, documentation, compatible default renderers, and history.
+- Input Databases and Sources exclusively own canonical records, memberships, schemas, stored values, source permissions, and provider write authority.
+- Every result retains canonical record identity, source provenance, stable field mapping, freshness, access, and write capability.
+- The visual builder and agents manipulate the same validated typed AST. Faux SQL or a typed inspector may help power users, but there is no separate AI-only query language.
+- A Query's complete definition is visible to its readers. It never runs with its owner's authority; each dependency and result is evaluated for the current viewer.
 
-## Non-goals
+## Editing and creation
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- An ordinary mapped field may write through only when canonical record identity, field mapping, actor permission, source policy, and provider capability are unambiguous.
+- Computed fields, aggregates, lossy alignments, and ambiguous joined fields are read-only.
+- A Query declares zero or more permitted creation routes that end at writable Databases or Sources. A Query never pretends to own new rows.
+- When exactly one route applies, creation proceeds with safe defaults and contextual seeds. When several apply, the View may choose an allowed default or Content asks for a compact destination choice. With no route, the Query is truthfully read-only.
+- Human, agent, automation, and API creation use the same route analysis and committed Action.
+
+## Failure and scale behavior
+
+- Missing access at any dependency is applied before evaluation. The Query does not borrow owner credentials or leak excluded records through counts, groups, aggregates, errors, or metadata.
+- A required inaccessible, stale, or unavailable dependency produces a typed degraded or Unavailable state according to the Query contract; it is never silently pruned into a plausible partial answer.
+- Query-to-Query composition performs dependency and cycle analysis before save.
+- Pagination, limits, traversal bounds, aggregation bounds, and cancellation prevent one reusable Query from becoming an unbounded background job.
+- A failed write-through or mixed provider outcome remains distinguishable from a successful read-only result.
+
+## Boundaries and non-goals
+
+- A Database owns a governed writable collection; a Query derives a collection; a View presents and downstream-filters either input.
+- An ordinary Database View does not hide a named Query beneath it. **Create Query from this View** is an explicit builder flow that confirms sources, output schema, variables, and write behavior.
+- Query output aliases never rename source fields, and computed output never becomes stored source data by implication.
+- Saving a Query does not materialize or duplicate its records.
+- A Query is not an access grant. If someone needs a fixed result that recipients may see without source access, they create an explicitly published/materialized snapshot.
+
+## Acceptance stories
+
+### Promote an inline Query without copying records
+
+Given an inline Query over two Databases, when an editor chooses **Save as Query**, then the definition gains stable identity and the original occurrence references it while every result still points to its canonical source record.
+
+### Preserve authority during composed writes
+
+Given a result with one mapped source field, one computed field, and two possible creation routes, when an editor changes each field and creates a record, then the mapped edit follows its authorized owner, the computed edit is refused, and creation uses an explicit permitted destination rather than guessing.
+
+### Re-evaluate for every viewer
+
+Given a shared cross-workspace Query whose readers have different source access, when each opens it, then both see the full definition but only their authorized result intersection. Counts, aggregates, and nested Queries reveal no inaccessible records.
+
+### Fail honestly on a broken dependency
+
+Given a required nested Query becomes unavailable or cyclic, when the parent evaluates, then it reports the typed dependency failure and preserves the saved definition instead of returning a clean-looking partial or empty result.
+
+## Current evidence
+
+Existing filters, saved Views, source federation, row-union, joined-detail, and write-routing code provide useful donor machinery. They do not yet prove one reusable Query object, a common typed AST, Query-as-source composition, access-first nested evaluation, explicit output contracts, or the complete write/create model. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Build equivalent inline and named Queries through visual controls and agent Actions; compare their typed AST and output schema.
+2. Compose Databases, provider Sources, graph traversal, and nested Queries with aliases, computed fields, variables, joins, unions, limits, and cycle checks.
+3. Verify record/field provenance, mapped writes, read-only derived fields, zero/one/many creation routes, defaults, validation, Events, and retries.
+4. Run every Query under differing Page, Database, Source, row, field, and workspace access and verify access before all computation.
+5. Exercise unavailable, stale, partial-provider, scale-bound, cancellation, and recovery behavior without losing the saved definition.
+6. Link, embed, template, version, export, and reuse the named Query through the real interface and shared Actions.
+
+## Open questions
+
+The stable `content.view.source-query` ID currently names the cross-source specialization even though it is semantically a Query. Preserve it until a deliberate normalization supplies a replacement ID. The internal common query engine may eventually deserve a private substrate record, but it must not become a fourth user-facing object beside Database, Query, and View.

--- a/templates/content/docs/product/capabilities/content.query.object.md
+++ b/templates/content/docs/product/capabilities/content.query.object.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.query.object"
+name: "Reusable Query objects"
+user_promise: "A one-off inline Query can be promoted into a named reusable Content object that behaves like a dynamic Database without owning its source records"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.expression.language","content.access.visibility-closure"]
+related_features: ["content.feature.make-the-workspace-yours","content.feature.connect-your-sources","content.feature.work-across-every-workspace","content.feature.sketch-connections-keep-whats-true"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Stable identity/title/description/access; typed query AST and output schema; variables; views/renderers; reference/embed/template support; catalog discovery; Query-as-source composition with cycle/scale guards; source-owned values and explicit create/write routing."
+proof_requirements: ["Stable identity/title/description/access; typed query AST and output schema; variables; views/renderers; reference/embed/template support; catalog discovery; Query-as-source composition with cycle/scale guards; source-owned values and explicit create/write routing."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Reusable Query objects
+
+## Contract
+
+A one-off inline Query can be promoted into a named reusable Content object that behaves like a dynamic Database without owning its source records
+
+## Acceptance boundary
+
+A complete proof demonstrates: Stable identity/title/description/access; typed query AST and output schema; variables; views/renderers; reference/embed/template support; catalog discovery; Query-as-source composition with cycle/scale guards; source-owned values and explicit create/write routing.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.reader.documents.md
+++ b/templates/content/docs/product/capabilities/content.reader.documents.md
@@ -1,8 +1,10 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.reader.documents"
 name: "Document Reader"
-user_promise: "Native PDF/EPUB reading and annotation"
+user_promise: "The earlier separate PDF/EPUB reader proposal remains readable lineage rather than an active second product contract."
+primary_user_job: "Understand where native document-reading work belongs without building a separate reader identity or data system."
 kind: "surface"
 state: "superseded"
 publicness: "public"
@@ -10,8 +12,13 @@ availability: "universal"
 dependencies: ["content.reader.surface"]
 related_features: []
 roadmap_boundary: "superseded"
-acceptance_summary: "A complete proof demonstrates: Separate from PDF export; revisit after core editor/search/renderer work."
-proof_requirements: ["Separate from PDF export; revisit after core editor/search/renderer work."]
+acceptance_summary: "This lineage record directs new reading and annotation work to the unified Reader surface, keeps PDF export distinct, and prevents a separate document-reader app or source model from becoming an active requirement."
+proof_requirements:
+  [
+    "Catalog validation that supersession target remains present",
+    "Review of new reader work confirming it targets content.reader.surface",
+    "Regression review ensuring PDF export is not represented as native annotation support",
+  ]
 evidence: []
 superseded_by: "content.reader.surface"
 last_reviewed: "2026-07-29"
@@ -19,18 +26,44 @@ last_reviewed: "2026-07-29"
 
 # Document Reader
 
-## Contract
+## Why this exists
 
-Native PDF/EPUB reading and annotation
+The original narrow reader idea captured a real need but split the product where one Reader surface now carries the contract.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Separate from PDF export; revisit after core editor/search/renderer work.
+A contributor looking for PDF annotation requirements follows this record to `content.reader.surface` and `content.research.annotation`, rather than creating a new PDF/EPUB app and data model.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- This record is lineage only. New reading work targets the unified Reader surface over Content objects and source representations.
+- PDF export remains a read-oriented output path, not a substitute for reading state, selectors, or annotations.
+- Any later separate app shell may reuse the Reader contract without creating separate Content identity or custody.
 
-## Non-goals
+## Boundaries and non-goals
 
-This record no longer defines new product work. Continue through `content.reader.surface`.
+This record does not specify new implementation, verify a reader, or preserve a separate document-only roadmap.
+
+## Acceptance stories
+
+### Route a new request correctly
+
+Given a proposal for EPUB highlighting, when it is classified, then it is evaluated against Reader surface and Annotation contracts rather than this superseded record.
+
+### Keep export distinct
+
+Given a PDF export improvement, when it is documented, then it does not claim native reading progress or annotation support.
+
+## Current evidence
+
+Repository product records identify `content.reader.surface` as the active unified target. This superseded record has no implementation proof and intentionally makes no delivery claim.
+
+## Proof plan
+
+1. Keep the supersession link valid in the product-doc guard.
+2. Review future reader records for unified identity and annotation ownership.
+3. Reject any new separate reader contract unless a later Shape explicitly changes this boundary.
+
+## Open questions
+
+- None; implementation questions belong to `content.reader.surface`.

--- a/templates/content/docs/product/capabilities/content.reader.documents.md
+++ b/templates/content/docs/product/capabilities/content.reader.documents.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.reader.documents"
+name: "Document Reader"
+user_promise: "Native PDF/EPUB reading and annotation"
+kind: "surface"
+state: "superseded"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.reader.surface"]
+related_features: []
+roadmap_boundary: "superseded"
+acceptance_summary: "A complete proof demonstrates: Separate from PDF export; revisit after core editor/search/renderer work."
+proof_requirements: ["Separate from PDF export; revisit after core editor/search/renderer work."]
+evidence: []
+superseded_by: "content.reader.surface"
+last_reviewed: "2026-07-29"
+---
+
+# Document Reader
+
+## Contract
+
+Native PDF/EPUB reading and annotation
+
+## Acceptance boundary
+
+A complete proof demonstrates: Separate from PDF export; revisit after core editor/search/renderer work.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This record no longer defines new product work. Continue through `content.reader.surface`.

--- a/templates/content/docs/product/capabilities/content.reader.surface.md
+++ b/templates/content/docs/product/capabilities/content.reader.surface.md
@@ -1,17 +1,29 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.reader.surface"
 name: "Reader surface"
-user_promise: "One specialized Reader surface renders and annotates Content Sources across text, PDF, EPUB, web, audio, video, and transcripts"
+user_promise: "Read and annotate text, documents, web material, and media through one specialized Content surface."
+primary_user_job: "Read comfortably, find my place, and mark exact material without creating a separate copy of the source."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.author.media","content.research.annotation","content.source.adapters"]
+dependencies:
+  [
+    "content.author.media",
+    "content.research.annotation",
+    "content.source.adapters",
+  ]
 related_features: ["content.feature.read-and-annotate-anything"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Shared Content identity, attachment/source handles, multimodal selectors, annotation objects, paged/flowed modes, per-viewer typography, playback/transcript sync, reading progress, offline/cache policy, accessibility, text-to-speech and dictation actions, source adapters, embeddable surface contract; may later receive a separate Agent Native app shell without separate data."
-proof_requirements: ["Shared Content identity, attachment/source handles, multimodal selectors, annotation objects, paged/flowed modes, per-viewer typography, playback/transcript sync, reading progress, offline/cache policy, accessibility, text-to-speech and dictation actions, source adapters, embeddable surface contract; may later receive a separate Agent Native app shell without separate data."]
+acceptance_summary: "A specialized, embeddable Reader renders stable Content and source representations with accessible personal reading preferences, durable progress, multimodal selectors, synchronized media/transcript modes, and Actions for annotation and assistive features."
+proof_requirements:
+  [
+    "Representation, selector, progress, preference, accessibility, and offline/cache policy tests across text and media",
+    "Annotation, version-change, source-availability, playback/transcript, and assistive-action tests",
+    "End-to-end read, annotate, resume, re-anchor, and embedded-reader workflow",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +31,45 @@ last_reviewed: "2026-07-29"
 
 # Reader surface
 
-## Contract
+## Why this exists
 
-One specialized Reader surface renders and annotates Content Sources across text, PDF, EPUB, web, audio, video, and transcripts
+Reading has its own rhythm: the work should be quiet, personal, and still connected to the object it interprets.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Shared Content identity, attachment/source handles, multimodal selectors, annotation objects, paged/flowed modes, per-viewer typography, playback/transcript sync, reading progress, offline/cache policy, accessibility, text-to-speech and dictation actions, source adapters, embeddable surface contract; may later receive a separate Agent Native app shell without separate data.
+A researcher opens a PDF representation, adjusts width and type, highlights a page range, adds an Annotation, resumes later at progress, and can follow a transcript while audio plays.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Reader is an embeddable Content surface, not necessarily a separate application or dataset.
+- It renders text, PDFs, EPUBs, web material, audio, video, and transcripts through stable representation handles and source-aware fallbacks.
+- Per-viewer typography, theme, pagination/flow, progress, accessibility, cache/offline policy, text-to-speech, and dictation are personal surface state; they do not change shared source truth.
+- Annotations use durable selectors and version/revision context. Media playback and transcript positions remain synchronized where representations support them.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Annotations own contribution identity; adapters own representations and source availability; public reading owns public pages. Reader does not promise every format is editable or locally available.
+
+## Acceptance stories
+
+### Resume without changing the source
+
+Given two readers of the same source, when one changes typography and progress, then their preferences persist for that viewer without mutating the shared Page or other reader's layout.
+
+### Mark exact media material
+
+Given a source video with a transcript, when a researcher annotates a transcript range, then the Annotation retains the source representation and time/range selector and can reopen the corresponding media location.
+
+## Current evidence
+
+Donor evidence: editor media and source representations provide foundations for rendering. No dedicated multimodal Reader, personal progress model, or end-to-end annotation proof exists; this record remains `approved_shape`.
+
+## Proof plan
+
+1. Define reader representation, personal state, selector, accessibility, and cache contracts.
+2. Test text, paged, transcript, audio/video, unavailable source, revision, and assistive paths.
+3. Verify reading, annotation, resume, and embed workflows in a real interface.
+
+## Open questions
+
+- The first format sequence and offline storage limits remain open.

--- a/templates/content/docs/product/capabilities/content.reader.surface.md
+++ b/templates/content/docs/product/capabilities/content.reader.surface.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.reader.surface"
+name: "Reader surface"
+user_promise: "One specialized Reader surface renders and annotates Content Sources across text, PDF, EPUB, web, audio, video, and transcripts"
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.author.media","content.research.annotation","content.source.adapters"]
+related_features: ["content.feature.read-and-annotate-anything"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Shared Content identity, attachment/source handles, multimodal selectors, annotation objects, paged/flowed modes, per-viewer typography, playback/transcript sync, reading progress, offline/cache policy, accessibility, text-to-speech and dictation actions, source adapters, embeddable surface contract; may later receive a separate Agent Native app shell without separate data."
+proof_requirements: ["Shared Content identity, attachment/source handles, multimodal selectors, annotation objects, paged/flowed modes, per-viewer typography, playback/transcript sync, reading progress, offline/cache policy, accessibility, text-to-speech and dictation actions, source adapters, embeddable surface contract; may later receive a separate Agent Native app shell without separate data."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Reader surface
+
+## Contract
+
+One specialized Reader surface renders and annotates Content Sources across text, PDF, EPUB, web, audio, video, and transcripts
+
+## Acceptance boundary
+
+A complete proof demonstrates: Shared Content identity, attachment/source handles, multimodal selectors, annotation objects, paged/flowed modes, per-viewer typography, playback/transcript sync, reading progress, offline/cache policy, accessibility, text-to-speech and dictation actions, source adapters, embeddable surface contract; may later receive a separate Agent Native app shell without separate data.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.relationship.edge.md
+++ b/templates/content/docs/product/capabilities/content.relationship.edge.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.relationship.edge"
+name: "Typed Relationships"
+user_promise: "One typed edge substrate powers relation Properties, inline typed Page references, backlinks, Info, graph queries, and Graph editing"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.object.page"]
+related_features: ["content.feature.living-references","content.feature.run-projects-your-way","content.feature.plan-work-across-time","content.feature.sketch-connections-keep-whats-true"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Current code models/displays relation values but omits relation from user-creatable properties and treats Notion relations as unsupported. Add stable relationship-type identity (the technical graph term is predicate), target constraints, inverse labels, cardinality, access, relation-property UI/actions, automatic structural edges, workspace-defined semantic relationships, and one mutation path shared by columns, Info, inline references, Canvas promotion, and Graph."
+proof_requirements: ["Current code models/displays relation values but omits relation from user-creatable properties and treats Notion relations as unsupported. Add stable relationship-type identity (the technical graph term is predicate), target constraints, inverse labels, cardinality, access, relation-property UI/actions, automatic structural edges, workspace-defined semantic relationships, and one mutation path shared by columns, Info, inline references, Canvas promotion, and Graph."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Typed Relationships
+
+## Contract
+
+One typed edge substrate powers relation Properties, inline typed Page references, backlinks, Info, graph queries, and Graph editing
+
+## Acceptance boundary
+
+A complete proof demonstrates: Current code models/displays relation values but omits relation from user-creatable properties and treats Notion relations as unsupported. Add stable relationship-type identity (the technical graph term is predicate), target constraints, inverse labels, cardinality, access, relation-property UI/actions, automatic structural edges, workspace-defined semantic relationships, and one mutation path shared by columns, Info, inline references, Canvas promotion, and Graph.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.relationship.edge.md
+++ b/templates/content/docs/product/capabilities/content.relationship.edge.md
@@ -1,17 +1,38 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.relationship.edge"
 name: "Typed Relationships"
 user_promise: "One typed edge substrate powers relation Properties, inline typed Page references, backlinks, Info, graph queries, and Graph editing"
+primary_user_job: "Connect two Pages once, give that connection a useful meaning, and manage it consistently from any Content surface."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.object.page"]
-related_features: ["content.feature.living-references","content.feature.run-projects-your-way","content.feature.plan-work-across-time","content.feature.sketch-connections-keep-whats-true"]
+dependencies:
+  [
+    "content.object.page",
+    "content.object.reference",
+    "content.property.typed",
+    "content.access.page-database",
+    "content.event.committed",
+  ]
+related_features:
+  [
+    "content.feature.living-references",
+    "content.feature.run-projects-your-way",
+    "content.feature.plan-work-across-time",
+    "content.feature.sketch-connections-keep-whats-true",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Current code models/displays relation values but omits relation from user-creatable properties and treats Notion relations as unsupported. Add stable relationship-type identity (the technical graph term is predicate), target constraints, inverse labels, cardinality, access, relation-property UI/actions, automatic structural edges, workspace-defined semantic relationships, and one mutation path shared by columns, Info, inline references, Canvas promotion, and Graph."
-proof_requirements: ["Current code models/displays relation values but omits relation from user-creatable properties and treats Notion relations as unsupported. Add stable relationship-type identity (the technical graph term is predicate), target constraints, inverse labels, cardinality, access, relation-property UI/actions, automatic structural edges, workspace-defined semantic relationships, and one mutation path shared by columns, Info, inline references, Canvas promotion, and Graph."]
+acceptance_summary: "People can create, inspect, edit, bulk-remove, restore, and query one canonical Relationship through every authorized surface without duplicated truth, silent partial mutation, access leaks, or lost concurrent history."
+proof_requirements:
+  [
+    "Canonical identity and projection parity across Relation Properties, Connections, inline references, Graph, Canvas promotion, agents, Rules, imports, and Sources",
+    "Directional cardinality, uniqueness, local-to-governed lifecycle, deletion, bulk mutation, and causal concurrency behavior",
+    "Access-first traversal and aggregation plus identical permission decisions through UI and Actions",
+    "Real-interface keyboard, accessibility, recovery, and Undo workflows",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +40,144 @@ last_reviewed: "2026-07-29"
 
 # Typed Relationships
 
-## Contract
+## Why this exists
 
-One typed edge substrate powers relation Properties, inline typed Page references, backlinks, Info, graph queries, and Graph editing
+People encounter connections in many places: a Relation column, an `@` mention, a backlink, a project dependency, a Graph edge, or a line drawn on a Canvas. If each surface stores its own version of the connection, the workspace develops several incompatible kinds of truth.
 
-## Acceptance boundary
+Content instead stores one canonical typed Relationship between stable Page identities. Relation Properties, Info, Queries, Graph, Canvas, agents, Rules, imports, and source adapters are projections and editing routes over that same edge.
 
-A complete proof demonstrates: Current code models/displays relation values but omits relation from user-creatable properties and treats Notion relations as unsupported. Add stable relationship-type identity (the technical graph term is predicate), target constraints, inverse labels, cardinality, access, relation-property UI/actions, automatic structural edges, workspace-defined semantic relationships, and one mutation path shared by columns, Info, inline references, Canvas promotion, and Graph.
+## Example workflow
 
-## Evidence boundary
+A team has a Tasks Database and a Projects Database. Adding a `Project` Relation Property to Tasks creates a local Relationship type and its first visible projection. A task editor connects a task to a project from the cell. The project immediately shows the inverse connection in **Info → Connections**, and an optional inverse Relation Property can expose the same edge as an editable `Tasks` column.
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+Later, the team selects several tasks and assigns the same project in one bulk edit. Removing the `Project` column does not erase those relationships. If the team truly wants to remove both the column and its knowledge, the removal dialog offers **Remove Property and its N relationships**, reports the exact authorized impact, commits one Revision, and supports Undo.
 
-## Non-goals
+## Product contract
 
-This capability does not create a parallel datastore, permission model, or action surface.
+### One relationship, many projections
+
+- Every semantic Relationship is one durable edge between stable Page IDs.
+- Both directions are always access-scoped and queryable. Content has no semantically one-way relationship whose inverse disappears from the system; people decide only where each direction is displayed and editable.
+- A directional Relationship type has a forward label and an optional inverse label. A symmetric type such as `Related to` has one canonical unordered edge, not two mirrored writable values.
+- A Relationship type and a visible Relation Property have separate stable identities. The type owns meaning, labels, per-direction cardinality, target constraints, provenance policy, and governing scope. The Property is one Database's editable projection of that type in one direction.
+- Databases own Relation Properties, not Relationships. Pages may be related without belonging to a Database, and removing a Property does not make the underlying edge anonymous or inaccessible.
+- Every editing surface invokes the same typed Relationship Action. No UI, agent, Rule, import, provider, Graph, or Canvas receives a private mutation engine.
+
+### Where people manage relationships
+
+- Adding an ordinary Relation column creates a local Relationship type and its first Property projection. It feels like adding any other column; no catalog ceremony is required.
+- **Info → Connections** is the universal relationship surface. It shows every accessible incoming and outgoing connection, including types not exposed as columns.
+- A Relation picker may use a Database or Query to narrow candidates, but the stored endpoint is the selected Page's stable ID. The edge remains if that Page later leaves the picker Query.
+- Ordinary Page mentions and transclusions create system-managed structural edges with their own mutation rules. An advanced inline action may create a semantic typed reference. Removing one anchored mention does not delete an independently asserted semantic Relationship.
+- In freeform Canvas mode, a drawn connector is view-local brainstorming state until someone explicitly promotes it to a Relationship type. In semantic Graph mode, the active edge tool requires a Relationship type before drawing commits an edge.
+- Existing relationships may be projected as Graph or Canvas lines. Deleting the visual occurrence or removing an object from one View never deletes the canonical Relationship.
+
+### Local and governed definitions
+
+- A local Relationship type belongs to the Content space where it was created and remains resolvable in Connections after its last visible Property is removed.
+- **Save as Custom Property** promotes the definition into the governed Custom Properties catalog at an allowed Personal, Workspace, or Organization scope.
+- Another Database may adopt the governed Property, creating another projection of the same Relationship type rather than copying its semantic identity.
+- Each projection may choose a local display alias, formatting, renderer, and visibility without changing the shared definition.
+- **Detach to local Property** preserves the projected data while creating an independent local definition.
+- Shared definitions are version-pinned. Label, cardinality, constraint, or inverse changes are proposed as readable updates that consuming Database owners adopt explicitly; catalog edits never silently rewrite every relationship system.
+- Provider-backed Relation fields use the same projection model while retaining source identity and synchronization authority.
+
+## Cardinality and identity
+
+- Cardinality is defined independently in each direction. A Task may have one Parent task while a parent has many children; a symmetric `Related to` type may be many-to-many.
+- Requiredness is separate Database/Property validation. `At most one` does not mean `must have one`.
+- Selecting a new target in a single-value Relation Property replaces the observed existing edge as one atomic change.
+- Moving a one-to-one target that is already related elsewhere requires an explicit replacement confirmation and permission to remove the old edge as well as create the new one.
+- Tightening a type from many to one never deletes existing edges. Existing violations become **Needs attention**; new mutations cannot worsen them, and authorized owners can resolve a filtered set.
+- A directional type permits at most one live edge for the same type, source, and target. Adding it again is idempotent. Symmetric types treat `(A, B)` and `(B, A)` as the same pair.
+- Different Relationship types remain independent, and reversed directional edges may coexist. Cycle rules are explicit validation on types or workflows, not deduplication and not a universal ban.
+- Self-relationships are disabled by default and can be enabled as an advanced Relationship-type option.
+- Repeated anchored citations or mentions retain their own occurrences and history while Connections may summarize them as one Page-to-Page relationship.
+- A connection that needs several independent instances with dates, roles, or state becomes an intermediate Page with Properties rather than several indistinguishable parallel edges.
+
+## Permissions and authority
+
+- Editing a forward Relation Property requires **Can edit entries** in the Database owning that projection, access to the target Page, permission to use the Relationship type, and satisfaction of its constraints.
+- An explicitly editable inverse Relation Property grants the matching inverse-side editing route. An inverse shown only in Connections remains read-only from that side.
+- On an ordinary Page, **Can edit** permits outgoing directional Relationship changes through Connections. Incoming directional edges remain read-only unless the actor also has an authorized source-side or editable-inverse route.
+- A symmetric Relationship may be changed through an authorized edit route on either endpoint.
+- Seeing an endpoint or an incoming edge never grants authority to sever it. Owning a Relationship type does not grant access to every private edge that uses it.
+- Same-Organization cross-Workspace edges may be allowed by policy. Cross-Organization canonical edges are prohibited by default until federation can preserve both organizations' access, deletion, and governance guarantees.
+- Source-managed edges additionally obey the Source's **View only**, **Keep in sync**, or **Review before write-back** policy and provider capabilities. A local relationship pointing to a source-backed Page does not automatically become provider-owned.
+- Counts, rollups, graph degree, Queries, expressions, agents, inverse projections, exports, and graph traversal are computed only over edges and endpoints the viewer may access. Physical inverse indexes may improve performance but never become a second truth.
+
+## Bulk operations, deletion, and concurrency
+
+- Multi-cell selection, row bulk edit, paste/fill, and filtered selection may add Relationships. Delete/Backspace, **Clear relationships**, target removal, and filtered bulk editing remove the exact selected edges.
+- Bulk mutation preflights the complete selection. Ambiguous input or mixed permissions never produces a silent partial commit. Content identifies conflicts or locked items and lets the person narrow explicitly; an agent may narrow only when that remains faithful to the request and must report skipped scope.
+- A filtered bulk removal resolves exact edge IDs and activation states when the selection is made. New concurrent matches are not swept in later.
+- Removing a Relation Property preserves its Relationships by default. The destructive dialog offers **Remove Property** or **Remove Property and its N relationships**, with an access-scoped impact count, one attributable Revision, and Undo. **Manage relationships** opens a filterable collection before removal.
+- Removing an edge removes the activation state the operation observed. A genuinely concurrent authorized addition that the remover did not observe survives. A later removal made after observing that addition wins.
+- Re-adding a removed Relationship continues one stable lineage with another activation period. Concurrent duplicate additions converge on that same live lineage.
+- Successful single-value replacements serialize through committed-event order so only one target remains live; history and Undo preserve the displaced choices.
+- Trashing a Page suspends its active Relationships and restoring it restores them. Permanent deletion retains only inaccessible audit/history evidence.
+- Relationship definitions archive rather than cascading deletion across their edges.
+
+## Failure behavior
+
+- Constraint, permission, access, source-authority, and cardinality failures are typed failures, never successful empty results.
+- A bulk operation with ambiguous values, mixed authority, or an invalid cardinality change does not half-commit.
+- When a one-to-one move cannot remove the old edge, Content leaves both prior states unchanged and explains the required authority.
+- Broken, trashed, inaccessible, and permanently deleted endpoints remain distinguishable according to the viewer's authority without leaking private identity.
+- Ordinary concurrent convergence does not interrupt people with a conflict dialog. Intervention appears only when no valid authorized state can be committed.
+
+## Boundaries and non-goals
+
+- Relationships do not create a parallel graph datastore, permission model, Action surface, or task-dependency engine.
+- Relation Properties are projections, not the owners of the underlying knowledge.
+- Graph owns semantic graph layout and editing; Canvas owns intentional spatial arrangement and draft connectors; Queries own access-scoped traversal and result contracts.
+- Schedule constraints may interpret dependency Relationships, but this Capability does not calculate critical paths or repair dates.
+- Merely drawing a freeform Canvas line does not assert semantic truth.
+- A relationship never grants access to either endpoint.
+- Provider synchronization is proven separately for each adapter and cannot stand in for the generic Relationship contract.
+
+## Acceptance stories
+
+### Create once and edit from either direction
+
+Given two authorized Pages and a directional Relationship type with forward and inverse projections, when an editor creates the edge from the forward Relation Property and later removes it through the editable inverse projection, then Info, both Properties, Queries, Graph, and the shared Action surface show one canonical edge and one coherent history.
+
+### Preserve knowledge when a column disappears
+
+Given a Relation Property containing several Relationships, when a Database editor removes only the Property, then the Relationships remain visible in authorized Connections and Queries. When the editor instead chooses **Remove Property and its N relationships**, the exact authorized edges are removed in one reversible Revision and newer concurrent edges are preserved.
+
+### Enforce directional cardinality atomically
+
+Given a one-parent Relationship and a bulk paste containing several proposed parents for one Task, when the edit is submitted, then no subset commits and Content identifies the conflicting input. Given one valid replacement, the observed prior parent is replaced atomically and the inverse projection updates.
+
+### Keep authority attached to the route
+
+Given a person who may view both endpoints but may edit only the target Page, when they inspect an incoming directional edge in Connections, then they can see it but cannot remove it unless an editable inverse Property or other authorized route exists. Graph, Canvas, agents, and Rules return the same decision.
+
+### Converge without inventing history
+
+Given one client removes the edge it observed while another concurrently re-adds it, when both commits settle, then the unseen addition remains live, no duplicate appears, and Versions shows the actual removal and re-add. A subsequent informed removal makes the edge inactive.
+
+### Protect private neighborhoods
+
+Given an authorized Page related to an endpoint the viewer cannot access, when the viewer opens Connections, runs a Query, inspects Graph, calculates counts or rollups, or exports the Page, then the private endpoint and its existence do not leak. A known direct reference returns an honest access denial.
+
+## Current evidence
+
+Current code can model and display some relation values, which is useful donor substrate. Relation is not yet a generally user-creatable Property, and the current Notion path treats relations as unsupported. No evidence currently proves the shared type identity, universal Connections editor, bulk/deletion semantics, cardinality, access closure, source policy, or causal concurrency contract. This Capability therefore remains `approved_shape`.
+
+## Proof plan
+
+Proof requires deterministic Action and persistence tests plus real-interface workflows:
+
+1. Create local, governed, symmetric, directional, self-enabled, and source-backed Relationship types; rename and version them without changing stable identity.
+2. Create, edit, and remove the same edge through forward and inverse Properties, Connections, inline typed references, Graph, Canvas promotion, agents, Rules, and imports; verify identical permission and Event behavior.
+3. Exercise one-to-one, one-to-many, many-to-many, replacement, tightening, cycle validation, duplicate addition, and invalid-target cases.
+4. Exercise bulk add/remove, mixed permissions, filtered selection, property-only removal, destructive property-plus-edge removal, Undo, and new concurrent matches.
+5. Race add/add, add/remove, replacement/replacement, deletion/restoration, and definition updates; verify one valid live state and complete causal history.
+6. Re-run cells, Connections, backlinks, Queries, traversal, Graph, counts, rollups, aggregates, exports, public output, and agent reads under changing access; verify access is applied before computation.
+7. Verify keyboard and assistive-technology paths for relation pickers, Connections, impact dialogs, bulk selection, and repair states.
+
+## Open questions
+
+The core product behavior above is settled. Implementation may still choose storage layout, index strategy, causal metadata representation, and exact control placement provided those choices satisfy this contract. Federation must be separately designed before enabling canonical cross-Organization Relationships.

--- a/templates/content/docs/product/capabilities/content.renderer.artifact-block.md
+++ b/templates/content/docs/product/capabilities/content.renderer.artifact-block.md
@@ -1,8 +1,10 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.renderer.artifact-block"
 name: "Artifact Blocks"
-user_promise: "Page-owned one-off HTML/CSS/JS artifact using the Custom Block sandbox format without entering the reusable catalog"
+user_promise: "Make a one-off interactive or visual artifact on one page, then promote it only if reuse becomes real."
+primary_user_job: "Build a safe page-local artifact before deliberate promotion."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
@@ -10,8 +12,13 @@ availability: "universal"
 dependencies: ["content.renderer.custom-block"]
 related_features: ["content.feature.build-new-surfaces"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Empty or typed prop schema, stable asset handles, no ambient data/network access, static export fallback, explicit Save as Custom Block promotion."
-proof_requirements: ["Empty or typed prop schema, stable asset handles, no ambient data/network access, static export fallback, explicit Save as Custom Block promotion."]
+acceptance_summary: "An Artifact Block is page-owned HTML/CSS/JS in the shared Custom Block sandbox format, with optional typed props, stable asset handles, export fallback, and explicit Save as Custom Block promotion."
+proof_requirements:
+  [
+    "Artifact Blocks have no catalog identity until a user explicitly saves one as a Custom Block.",
+    "The sandbox receives only bound typed props and has no ambient Content data, actions, cookies, filesystem, parent DOM, secrets, or network.",
+    "Export uses a declared static fallback; promotion preserves provenance rather than silently changing reuse scope.",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,46 @@ last_reviewed: "2026-07-29"
 
 # Artifact Blocks
 
-## Contract
+## Why this exists
 
-Page-owned one-off HTML/CSS/JS artifact using the Custom Block sandbox format without entering the reusable catalog
+Many useful artifacts begin as one-page experiments, before anyone can justify governing them for reuse. That early experiment still needs a sandbox strong enough that a decorative widget cannot acquire host authority.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Empty or typed prop schema, stable asset handles, no ambient data/network access, static export fallback, explicit Save as Custom Block promotion.
+Tess builds a scoring widget on a planning Page, verifies static export, then chooses Save as Custom Block; the original remains local.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Artifact Blocks have no catalog identity until a user explicitly saves one as a Custom Block.
+- The sandbox receives only bound typed props and has no ambient Content data, actions, cookies, filesystem, parent DOM, secrets, or network.
+- Export uses a declared static fallback; promotion preserves provenance rather than silently changing reuse scope.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- `content.renderer.custom-block` owns reusable catalog definitions; Artifact Blocks own a page/block-local instance and explicit promotion.
+- Artifacts are not Extensions, do not receive ambient host grants, and do not enter a catalog merely because they ran.
+
+## Acceptance stories
+
+### Keep it page-owned
+
+Given the artifact is copied, when the original changes, then the copy is not silently shared.
+
+### Deny ambient authority
+
+Given artifact code requests cookies, Content actions, parent DOM, or network, then the sandbox rejects it.
+
+## Current evidence
+
+`app/blocks/contentBlockRegistry.tsx` and Extension sandbox code donate substrate; no Artifact Block lifecycle is implemented.
+
+## Proof plan
+
+1. Create empty and typed-prop artifacts with no catalog record.
+2. Deny SQL/actions/cookies/secrets/DOM/filesystem/network.
+3. Verify copy and static export never execute for readers.
+4. Promote and inspect distinct catalog provenance.
+
+## Open questions
+
+No question remains: network is out of the first contract.

--- a/templates/content/docs/product/capabilities/content.renderer.artifact-block.md
+++ b/templates/content/docs/product/capabilities/content.renderer.artifact-block.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.renderer.artifact-block"
+name: "Artifact Blocks"
+user_promise: "Page-owned one-off HTML/CSS/JS artifact using the Custom Block sandbox format without entering the reusable catalog"
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.renderer.custom-block"]
+related_features: ["content.feature.build-new-surfaces"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Empty or typed prop schema, stable asset handles, no ambient data/network access, static export fallback, explicit Save as Custom Block promotion."
+proof_requirements: ["Empty or typed prop schema, stable asset handles, no ambient data/network access, static export fallback, explicit Save as Custom Block promotion."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Artifact Blocks
+
+## Contract
+
+Page-owned one-off HTML/CSS/JS artifact using the Custom Block sandbox format without entering the reusable catalog
+
+## Acceptance boundary
+
+A complete proof demonstrates: Empty or typed prop schema, stable asset handles, no ambient data/network access, static export fallback, explicit Save as Custom Block promotion.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.renderer.custom-block.md
+++ b/templates/content/docs/product/capabilities/content.renderer.custom-block.md
@@ -1,17 +1,25 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.renderer.custom-block"
 name: "Custom Blocks"
-user_promise: "One Custom Block model for Content-managed and source-backed reusable components, with optional typed props and a strict origin-aware runtime boundary"
+user_promise: "Name, govern, and reuse a safe renderer without making it a hidden application."
+primary_user_job: "Adopt a governed renderer with explicit inputs and origin."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.renderer.typed","content.source.adapters"]
+dependencies: ["content.renderer.typed", "content.source.adapters"]
 related_features: ["content.feature.build-new-surfaces"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Managed sandbox bundles, source/provider adapter identity, versioning, slash insertion, permissions, deterministic export fallback; never blindly execute arbitrary external code in hosted Content."
-proof_requirements: ["Managed sandbox bundles, source/provider adapter identity, versioning, slash insertion, permissions, deterministic export fallback; never blindly execute arbitrary external code in hosted Content."]
+acceptance_summary: "Custom Blocks have one catalog identity with personal or organization ownership and Content-managed, repository-backed, or provider-backed origin; typed props are optional, discovery is shared, runtime authority is origin-aware, one-off Artifacts promote explicitly, and export is deterministic."
+proof_requirements:
+  [
+    "Ownership scope governs reuse and approval; origin says where source truth lives, and the axes remain independent.",
+    "Slash discovery exposes governed metadata, optional typed inputs, provenance, availability, and a useful preview or fallback.",
+    "Content-managed bundles receive explicit props only in a strict sandbox; source-backed code needs a trusted adapter renderer or visible fallback, and Artifact promotion creates a new catalog identity.",
+    "Extensions retain their visible grants and identity; deterministic export never grants execution authority.",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +27,55 @@ last_reviewed: "2026-07-29"
 
 # Custom Blocks
 
-## Contract
+## Why this exists
 
-One Custom Block model for Content-managed and source-backed reusable components, with optional typed props and a strict origin-aware runtime boundary
+Reusable components must be discoverable and governable without becoming opaque bundles of code with accidental powers. The source of a component and the people allowed to reuse it are separate questions that must remain visible.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Managed sandbox bundles, source/provider adapter identity, versioning, slash insertion, permissions, deterministic export fallback; never blindly execute arbitrary external code in hosted Content.
+An operations lead approves a repository-backed status card, inserts it from slash search, binds typed props, and gets adapter fallback instead of repository execution.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Ownership scope governs reuse and approval; origin says where source truth lives, and the axes remain independent.
+- Every entry has stable identity plus name, description, aliases, category, compatibility, icon, ownership, origin, and optional preview metadata. Slash insertion searches that contract; `@` remains for references and expressions.
+- Props are optional. A block may be a fixed renderer with no inputs or expose typed inputs that the editor validates and binds explicitly.
+- Content-managed bundles receive explicit props only in a strict sandbox; source-backed code needs a trusted adapter renderer or visible fallback.
+- **Save as Custom Block** promotes a page-owned Artifact into a new catalog entry while preserving provenance. Copying an Artifact alone never enrolls it in the catalog.
+- An Extension is a more capable application with grants and is never silently presented as a Custom Block.
+- Public or static output uses a deterministic declared fallback and never executes merely because the Custom Block is visible.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- Source adapters own repository/provider synchronization; the Custom Block catalog owns reusable renderer identity, governance, origin metadata, and typed props.
+- Artifact Blocks own one-off page-local HTML/CSS/JS and promotion. Built-in Blocks may implement the same discovery contract but do not masquerade as editable Custom Blocks.
+- Custom Blocks are renderers, not Extensions: they do not acquire arbitrary Actions, ambient Content data, filesystem, parent DOM, secrets, cookies, or network authority.
+
+## Acceptance stories
+
+### Keep axes independent
+
+Given a personal repository-backed block is shared, when scope changes, then repository origin remains unchanged.
+
+### Do not disguise Extensions
+
+Given an Extension has grants, when embedded, then it remains a visible Extension embed.
+
+### Promote one Artifact deliberately
+
+Given a page-owned Artifact has no catalog record, when its owner chooses Save as Custom Block, then Content creates one governed catalog identity with provenance and leaves ordinary copied Artifacts local.
+
+## Current evidence
+
+`app/components/editor/extensions/LocalMdxComponentNode.tsx`, `actions/list-local-component-files.ts`, `actions/write-local-component-file.ts`, and `app/blocks/contentBlockRegistry.tsx` are donors, not a hosted catalog.
+
+## Proof plan
+
+1. Test managed, repository, and provider origins with no props, typed props, local aliases, and origin-preserving scope changes.
+2. Test slash discovery and insertion across compatibility, permissions, preview, validation, unavailable origin, Versions, and provenance.
+3. Deny ambient data, Actions, cookies, secrets, DOM, filesystem, and network; verify trusted adapter fallback without executing repository code in the sandbox.
+4. Promote a one-off Artifact, copy it without promotion, export every origin deterministically, and distinguish built-ins and Extensions.
+
+## Open questions
+
+Catalog version/update policy and the first trusted-adapter eligibility rules still need a dedicated Shape. Network grants remain Extension territory rather than a Custom Block option.

--- a/templates/content/docs/product/capabilities/content.renderer.custom-block.md
+++ b/templates/content/docs/product/capabilities/content.renderer.custom-block.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.renderer.custom-block"
+name: "Custom Blocks"
+user_promise: "One Custom Block model for Content-managed and source-backed reusable components, with optional typed props and a strict origin-aware runtime boundary"
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.renderer.typed","content.source.adapters"]
+related_features: ["content.feature.build-new-surfaces"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Managed sandbox bundles, source/provider adapter identity, versioning, slash insertion, permissions, deterministic export fallback; never blindly execute arbitrary external code in hosted Content."
+proof_requirements: ["Managed sandbox bundles, source/provider adapter identity, versioning, slash insertion, permissions, deterministic export fallback; never blindly execute arbitrary external code in hosted Content."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Custom Blocks
+
+## Contract
+
+One Custom Block model for Content-managed and source-backed reusable components, with optional typed props and a strict origin-aware runtime boundary
+
+## Acceptance boundary
+
+A complete proof demonstrates: Managed sandbox bundles, source/provider adapter identity, versioning, slash insertion, permissions, deterministic export fallback; never blindly execute arbitrary external code in hosted Content.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.renderer.graph.md
+++ b/templates/content/docs/product/capabilities/content.renderer.graph.md
@@ -1,36 +1,71 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.renderer.graph"
-name: "Collection graph renderers"
-user_promise: "Graph/chart renderers for typed collection results"
+name: "Collection graph renderers (superseded)"
+user_promise: "Historical umbrella for graph and chart rendering, now split into distinct semantic Graph and analytical Chart capabilities"
+primary_user_job: "Follow the lineage from the former combined renderer concept to the precise modern capability that owns the work."
 kind: "surface"
-state: "exploring"
+state: "superseded"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.renderer.typed","content.view.grouping-aggregation"]
+dependencies: ["content.renderer.typed", "content.view.grouping-aggregation"]
 related_features: []
-roadmap_boundary: "supporting"
-acceptance_summary: "A complete proof demonstrates: Typed collections, renderer registry, bounded queries, accessible export."
-proof_requirements: ["Typed collections, renderer registry, bounded queries, accessible export."]
+roadmap_boundary: "superseded"
+acceptance_summary: "No implementation should target this ambiguous umbrella; analytical rendering belongs to Chart View, semantic relationship exploration belongs to Graph View, and reusable compatibility/export mechanics belong to Typed Renderers."
+proof_requirements:
+  [
+    "Every former analytical responsibility resolves to content.view.chart or content.renderer.typed",
+    "Every former semantic-relationship responsibility resolves to content.view.graph",
+    "No Feature or implementation treats this record as an active contract",
+  ]
 evidence: []
-superseded_by: null
+superseded_by: "content.view.chart"
 last_reviewed: "2026-07-29"
 ---
 
-# Collection graph renderers
+# Collection graph renderers (superseded)
 
-## Contract
+## Why this exists
 
-Graph/chart renderers for typed collection results
+The early catalog used `Graph` to mean both an analytical chart over grouped records and a semantic network of Pages and Relationships. Those are different user jobs, interaction models, dependencies, and proof gates. Keeping the umbrella active would make an implementer guess which meaning was intended.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Typed collections, renderer registry, bounded queries, accessible export.
+A developer asked to add a bar chart follows `content.view.chart`. A developer asked to let someone explore and edit `supports` relationships follows `content.view.graph`. Both reuse `content.renderer.typed` for compatibility, accessibility, and export behavior.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- `content.view.chart` owns analytical visualizations over typed Query results, grouping, measures, drill-down, saved Views, embedded Blocks, dashboards, and static output.
+- `content.view.graph` owns query-selected canonical nodes, typed Relationship edges, semantic exploration, and authorized edge editing.
+- `content.view.canvas` owns intentional spatial arrangement, view-local connectors, and explicit connector promotion.
+- `content.renderer.typed` owns the shared renderer registry, typed compatibility, inheritance, accessible degradation, and export fallback.
+- Authored Mermaid diagrams remain Code blocks with a Mermaid renderer; they are neither analytical Charts nor semantic Graphs.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- Do not add new dependencies, Features, or implementation evidence to this record.
+- Do not use `Graph` as a synonym for `Chart` in new product contracts.
+- Do not delete this record; it preserves stable-ID lineage for older references.
+
+## Acceptance stories
+
+### Route analytical work correctly
+
+Given a change that renders grouped measures as bars, lines, or another statistical graphic, when product context is resolved, then the active contract is Chart View plus Typed Renderers and this record is not treated as implementable.
+
+### Route semantic work correctly
+
+Given a change that traverses or edits typed Page Relationships, when product context is resolved, then the active contract is Graph View plus the graph-query and Relationship capabilities.
+
+## Current evidence
+
+The modern catalog already contains separate Chart, Graph, Canvas, and Typed Renderer records. This lineage correction changes no runtime behavior and makes no implementation claim.
+
+## Proof plan
+
+Validate that no Feature requires this ID, repository guidance resolves both historical meanings to active records, generated projections label it superseded, and the dependency graph retains valid one-target lineage through `content.view.chart` while naming `content.view.graph` in this body.
+
+## Open questions
+
+The schema currently permits one `superseded_by` target. This record points to Chart because its original dependencies were analytical; the body preserves the separate Graph lineage. Supporting several replacement IDs may be considered later if the broader catalog needs it.

--- a/templates/content/docs/product/capabilities/content.renderer.graph.md
+++ b/templates/content/docs/product/capabilities/content.renderer.graph.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.renderer.graph"
+name: "Collection graph renderers"
+user_promise: "Graph/chart renderers for typed collection results"
+kind: "surface"
+state: "exploring"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.renderer.typed","content.view.grouping-aggregation"]
+related_features: []
+roadmap_boundary: "supporting"
+acceptance_summary: "A complete proof demonstrates: Typed collections, renderer registry, bounded queries, accessible export."
+proof_requirements: ["Typed collections, renderer registry, bounded queries, accessible export."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Collection graph renderers
+
+## Contract
+
+Graph/chart renderers for typed collection results
+
+## Acceptance boundary
+
+A complete proof demonstrates: Typed collections, renderer registry, bounded queries, accessible export.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.renderer.typed.md
+++ b/templates/content/docs/product/capabilities/content.renderer.typed.md
@@ -1,17 +1,30 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.renderer.typed"
 name: "Typed renderers"
-user_promise: "Render any typed value using compatible built-in presentations"
+user_promise: "Compatible renderers present typed Content values consistently across surfaces while preserving meaning, accessibility, inheritance, and export fallback."
+primary_user_job: "Choose or inherit a useful presentation for a typed value and still understand or export it when the preferred visual renderer is unavailable."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
 dependencies: ["content.property.typed"]
-related_features: ["content.feature.see-your-information-your-way","content.feature.build-new-surfaces","content.feature.understand-what-your-data-says"]
+related_features:
+  [
+    "content.feature.see-your-information-your-way",
+    "content.feature.build-new-surfaces",
+    "content.feature.understand-what-your-data-says",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Output-type contract, renderer registry, inheritance, accessibility/export."
-proof_requirements: ["Output-type contract, renderer registry, inheritance, accessibility/export."]
+acceptance_summary: "Typed Renderers provide a registry that validates compatible presentations for typed values, resolves inherited choices predictably, and supplies accessible and export-safe fallbacks without changing query or relationship semantics."
+proof_requirements:
+  [
+    "Typed renderer registry, compatibility checks, registration failure behavior, and stable renderer identity",
+    "Inheritance and local override resolution across property, View, Block, embed, and output contexts",
+    "Accessible semantic presentation, keyboard behavior, text alternatives, and degraded-runtime fallback",
+    "Portable export, SSR or static output, unavailable-renderer behavior, and preservation of canonical typed values",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +32,61 @@ last_reviewed: "2026-07-29"
 
 # Typed renderers
 
-## Contract
+## Why this exists
 
-Render any typed value using compatible built-in presentations
+The same typed value may be useful as text, a badge, a date, a chart mark, a map point, or an accessible export summary. Without a shared compatibility and fallback contract, each surface invents a display rule and eventually treats a renderer failure as missing data. Typed Renderers make presentation reusable while leaving the underlying value and its meaning intact.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Output-type contract, renderer registry, inheritance, accessibility/export.
+A workspace uses a status renderer for a typed status Property in a table, card, and embedded record. A saved View locally overrides the renderer for a compact display without changing the Property’s value or other Views. When the record is exported to a static format where that renderer cannot run, Content emits a compatible text representation and accessible label. An incompatible renderer selection is rejected before it can produce a misleading display.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A renderer has a stable identity, declared accepted typed inputs, presentation capabilities, semantic text alternative, and supported interactive, static, and export behaviors.
+- The registry accepts only compatible renderer/value pairings. An unsupported or unavailable renderer returns a typed failure or compatible fallback; it never silently converts a value to empty content.
+- Renderer selection resolves through explicit local override and inherited defaults. A View, Block, embed, or export context may choose a compatible presentation without mutating the canonical Property definition or typed value.
+- Renderers present values; they do not own query evaluation, aggregation, relationship traversal, access decisions, or source synchronization. Those inputs arrive already authorized and typed.
+- Every interactive renderer has keyboard and assistive-technology behavior appropriate to its semantic role. Every nontextual presentation provides a meaningful text alternative or accessible equivalent.
+- Public, SSR, static, and export contexts use a compatible renderer or declared fallback from the same typed value. A rendering runtime failure is visible as a failure state where no safe fallback exists.
+- Custom and built-in renderers use the same registry contract; registration does not create a second Action surface or grant access to values.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- `content.property.typed` owns value types, validation, and canonical storage. Typed Renderers own presentation compatibility, not coercion of an invalid stored value.
+- Chart owns analytical specifications and drill-down; Graph owns relationship exploration; Canvas owns spatial arrangement. This Capability supplies their common presentation substrate only.
+- Mermaid remains an authored code renderer. Typed Renderers do not define a diagram language, query syntax, semantic edge model, or analytics engine.
+- This Capability does not make every renderer universally applicable, bypass access control, duplicate source data, or turn a visual fallback into proof that interactive behavior worked.
+
+## Acceptance stories
+
+### Reject incompatible presentation honestly
+
+Given a renderer that accepts numeric measures and a text Property, when a person selects that renderer, then Content rejects the incompatible pairing with repair guidance and preserves the existing typed value and renderer choice.
+
+### Inherit without rewriting the source
+
+Given a Property default renderer and a saved View with a compatible local override, when the View is rendered beside another View, then each uses its resolved presentation while both retain the same canonical value and Property identity.
+
+### Keep information available when a renderer cannot run
+
+Given an export or static context where an interactive renderer is unavailable, when the value is rendered, then Content uses its declared compatible fallback with accessible text. If none exists, it shows a distinct unavailable-renderer state rather than blank content.
+
+### Preserve authorization at the input boundary
+
+Given a renderer used by a Chart, Graph, or embedded View, when the viewer lacks access to part of the input, then the renderer receives only the authorized typed result and cannot expose omitted values through labels, summaries, or fallback output.
+
+## Current evidence
+
+The repository already identifies typed properties and several presentation surfaces, and individual renderer implementations may be reusable donor substrate. No evidence currently proves one registry, cross-surface inheritance, accessible degradation, export behavior, and failure handling as an atomic capability. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Register built-in and custom renderer fixtures, validate accepted input types and capabilities, and verify incompatible, missing, and runtime-failure states.
+2. Resolve defaults and overrides across Properties, Views, Blocks, embeds, dashboards, and export contexts without mutating canonical values.
+3. Test interactive keyboard behavior, semantic roles, accessible names, text alternatives, reduced-capability modes, and assistive-technology reading paths.
+4. Render compatible static, SSR, and export outputs; verify declared fallbacks and distinct unavailable states when no fallback exists.
+5. Exercise Charts, Graphs, Canvas, and ordinary Properties with access changes to prove renderers cannot widen their typed authorized input.
+
+## Open questions
+
+Registry storage, extension packaging, renderer sandboxing, and the exact inheritance precedence are implementation choices. They must retain stable renderer identity, explicit compatibility, accessible fallback, and the separation from query and relationship semantics.

--- a/templates/content/docs/product/capabilities/content.renderer.typed.md
+++ b/templates/content/docs/product/capabilities/content.renderer.typed.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.renderer.typed"
+name: "Typed renderers"
+user_promise: "Render any typed value using compatible built-in presentations"
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.property.typed"]
+related_features: ["content.feature.see-your-information-your-way","content.feature.build-new-surfaces","content.feature.understand-what-your-data-says"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Output-type contract, renderer registry, inheritance, accessibility/export."
+proof_requirements: ["Output-type contract, renderer registry, inheritance, accessibility/export."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Typed renderers
+
+## Contract
+
+Render any typed value using compatible built-in presentations
+
+## Acceptance boundary
+
+A complete proof demonstrates: Output-type contract, renderer registry, inheritance, accessibility/export.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.research.annotation.md
+++ b/templates/content/docs/product/capabilities/content.research.annotation.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.research.annotation"
+name: "Annotations"
+user_promise: "Highlights, excerpts, and research notes remain anchored to the exact source representation and named Page version they interpret"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.object.reference","content.version.field-history"]
+related_features: ["content.feature.explore-alternatives-safely","content.feature.read-and-annotate-anything","content.feature.sketch-connections-keep-whats-true"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: One anchored-contribution substrate shared with Comments and revision notes, with distinct purpose/lifecycle; stable text/range anchors; named-version and exact-revision context; quiet in-content marks plus a searchable/filterable Annotation rail; private/shared scope; relocation after ordinary edits; explicit behavior across parallel versions; annotation-on-canvas and Database projections; export and source-adapter behavior."
+proof_requirements: ["One anchored-contribution substrate shared with Comments and revision notes, with distinct purpose/lifecycle; stable text/range anchors; named-version and exact-revision context; quiet in-content marks plus a searchable/filterable Annotation rail; private/shared scope; relocation after ordinary edits; explicit behavior across parallel versions; annotation-on-canvas and Database projections; export and source-adapter behavior."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Annotations
+
+## Contract
+
+Highlights, excerpts, and research notes remain anchored to the exact source representation and named Page version they interpret
+
+## Acceptance boundary
+
+A complete proof demonstrates: One anchored-contribution substrate shared with Comments and revision notes, with distinct purpose/lifecycle; stable text/range anchors; named-version and exact-revision context; quiet in-content marks plus a searchable/filterable Annotation rail; private/shared scope; relocation after ordinary edits; explicit behavior across parallel versions; annotation-on-canvas and Database projections; export and source-adapter behavior.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.research.annotation.md
+++ b/templates/content/docs/product/capabilities/content.research.annotation.md
@@ -1,17 +1,29 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.research.annotation"
 name: "Annotations"
-user_promise: "Highlights, excerpts, and research notes remain anchored to the exact source representation and named Page version they interpret"
+user_promise: "Highlights, excerpts, and research notes remain anchored to the exact material and revision they interpret."
+primary_user_job: "Mark a precise passage or moment, add meaning, and find it later without pretending an edited source is unchanged."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.object.reference","content.version.field-history"]
-related_features: ["content.feature.explore-alternatives-safely","content.feature.read-and-annotate-anything","content.feature.sketch-connections-keep-whats-true"]
+dependencies: ["content.object.reference", "content.version.field-history"]
+related_features:
+  [
+    "content.feature.explore-alternatives-safely",
+    "content.feature.read-and-annotate-anything",
+    "content.feature.sketch-connections-keep-whats-true",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: One anchored-contribution substrate shared with Comments and revision notes, with distinct purpose/lifecycle; stable text/range anchors; named-version and exact-revision context; quiet in-content marks plus a searchable/filterable Annotation rail; private/shared scope; relocation after ordinary edits; explicit behavior across parallel versions; annotation-on-canvas and Database projections; export and source-adapter behavior."
-proof_requirements: ["One anchored-contribution substrate shared with Comments and revision notes, with distinct purpose/lifecycle; stable text/range anchors; named-version and exact-revision context; quiet in-content marks plus a searchable/filterable Annotation rail; private/shared scope; relocation after ordinary edits; explicit behavior across parallel versions; annotation-on-canvas and Database projections; export and source-adapter behavior."]
+acceptance_summary: "Annotations are durable anchored contributions with purpose distinct from comments, stable text/page/region/time selectors, source representation and named Version/revision context, explicit visibility, relocation and orphan states, and searchable projections."
+proof_requirements:
+  [
+    "Selector, revision/version, visibility, persistence, and anchored-contribution data tests",
+    "Edit relocation, orphan repair, parallel-version, source-adapter, export, and access tests",
+    "Reader and annotation-rail workflow with search, filtering, re-anchor, and shared/private scope",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +31,45 @@ last_reviewed: "2026-07-29"
 
 # Annotations
 
-## Contract
+## Why this exists
 
-Highlights, excerpts, and research notes remain anchored to the exact source representation and named Page version they interpret
+An annotation is evidence of attention, not a comment that happens to sit near a sentence.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: One anchored-contribution substrate shared with Comments and revision notes, with distinct purpose/lifecycle; stable text/range anchors; named-version and exact-revision context; quiet in-content marks plus a searchable/filterable Annotation rail; private/shared scope; relocation after ordinary edits; explicit behavior across parallel versions; annotation-on-canvas and Database projections; export and source-adapter behavior.
+A researcher highlights a paragraph on a named Version, writes a private note, later searches the Annotation rail, and chooses whether to carry a repaired anchor to a new Version.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Annotations share an anchored-contribution substrate with Comments and revision notes but retain their own purpose and lifecycle.
+- Each records source representation, selector, named Version and exact revision context where available, author, scope, and provenance.
+- Quiet in-content marks open to a searchable, filterable Annotation rail; annotations can project to Databases and Canvas without becoming copies.
+- Ordinary edits attempt relocation. Unresolved anchors are explicit orphan/repair states; parallel Versions never silently merge annotation meaning.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Reader owns reading interaction; citations own formal source references; comments own feedback threads. An Annotation is not automatically public, shared, or portable to an incompatible source.
+
+## Acceptance stories
+
+### Preserve an exact revision anchor
+
+Given a highlight on a named Page Version, when that Page later changes, then the Annotation retains its original revision context and either relocates with evidence or appears as needing repair.
+
+### Respect private scope
+
+Given a private Annotation on a shared Page, when another collaborator opens the Page or an aggregate, then the Annotation and any derived count are not exposed.
+
+## Current evidence
+
+Donor evidence: anchored Comments and revision history provide related primitives. No durable Annotation object, rail, revision-aware selector, or carry-forward proof exists; this record remains `approved_shape`.
+
+## Proof plan
+
+1. Define anchored contribution and multimodal selector models.
+2. Test scope, edits, orphaning, re-anchor, parallel Versions, exports, and access-safe projections.
+3. Verify Reader highlight-to-rail-to-repair workflow.
+
+## Open questions
+
+- Automatic relocation confidence thresholds and batch carry-forward UI remain open.

--- a/templates/content/docs/product/capabilities/content.research.citation.md
+++ b/templates/content/docs/product/capabilities/content.research.citation.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.research.citation"
 name: "Citations"
-user_promise: "A semantic citation references a durable source record plus an optional locator, independently of how it is rendered"
+user_promise: "A citation retains a durable source-and-locator identity even when its style or surrounding document changes."
+primary_user_job: "Cite exact evidence once and render it as a link, footnote, number, author-date reference, or bibliography without re-entering the source."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.object.reference","content.knowledge.links"]
+dependencies: ["content.object.reference", "content.knowledge.links"]
 related_features: ["content.feature.cite-what-you-found"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Stable source identity; page/section/time/range locators; one-click promotion from ordinary link; CSL-compatible style rendering; footnote, author-date, numeric, linked-blog, and bibliography presentations; access and round-trip behavior."
-proof_requirements: ["Stable source identity; page/section/time/range locators; one-click promotion from ordinary link; CSL-compatible style rendering; footnote, author-date, numeric, linked-blog, and bibliography presentations; access and round-trip behavior."]
+acceptance_summary: "A semantic citation references a stable source record plus optional page, section, figure, timestamp, transcript, or range locator; rendering styles and bibliographies derive from that identity while access and round-trip behavior remain explicit."
+proof_requirements:
+  [
+    "Citation identity, locator, promotion, style, bibliography, and round-trip tests",
+    "Access, missing-source, locator-validation, import/export, and renderer-separation tests",
+    "Writer workflow promoting a link, changing style, and verifying bibliography output",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,45 @@ last_reviewed: "2026-07-29"
 
 # Citations
 
-## Contract
+## Why this exists
 
-A semantic citation references a durable source record plus an optional locator, independently of how it is rendered
+A footnote is a costume; the citation is the durable relationship underneath it.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Stable source identity; page/section/time/range locators; one-click promotion from ordinary link; CSL-compatible style rendering; footnote, author-date, numeric, linked-blog, and bibliography presentations; access and round-trip behavior.
+A writer promotes a research link, adds a page locator, switches from author-date to footnotes, and sees a bibliography recompute from the same cited source identity.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Citation identity points to a durable source record and optional precise locator: page, chapter, section, figure, timestamp, transcript range, or text range.
+- An ordinary link can be promoted without losing its original anchor. The citation remains separate from its renderer and bibliography placement.
+- Styles may render linked blog, numeric, author-date, footnote, and bibliography forms, including CSL-compatible behavior where supported.
+- Access is checked when source details render or export; missing or inaccessible data is represented honestly rather than fabricated.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Annotations record interpretation; references link Content objects; this record owns formal citation identity. It does not promise to maintain every bibliography style by hand.
+
+## Acceptance stories
+
+### Change style without changing evidence
+
+Given a document with semantic citations, when the writer changes its style from author-date to footnotes, then the cited source identities and locators remain unchanged while rendered references and bibliography update.
+
+### Preserve a locator through export
+
+Given a citation to a video timestamp, when the document exports to a supported format, then the source identity and timestamp survive or the conversion report identifies the fidelity limit.
+
+## Current evidence
+
+Donor evidence: ordinary links, references, source metadata, rich text, and export machinery can support citation work. No first-class citation object, locator, bibliography, or end-to-end rendering proof exists; this record remains `approved_shape`.
+
+## Proof plan
+
+1. Define citation/source/locator identity and link-promotion behavior.
+2. Test styles, bibliography, access, imports, exports, and unavailable sources.
+3. Verify writer promotion and style-switch workflow in the editor and public/export renderers.
+
+## Open questions
+
+- The initial CSL engine and Zotero interchange scope remain open.

--- a/templates/content/docs/product/capabilities/content.research.citation.md
+++ b/templates/content/docs/product/capabilities/content.research.citation.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.research.citation"
+name: "Citations"
+user_promise: "A semantic citation references a durable source record plus an optional locator, independently of how it is rendered"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.object.reference","content.knowledge.links"]
+related_features: ["content.feature.cite-what-you-found"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Stable source identity; page/section/time/range locators; one-click promotion from ordinary link; CSL-compatible style rendering; footnote, author-date, numeric, linked-blog, and bibliography presentations; access and round-trip behavior."
+proof_requirements: ["Stable source identity; page/section/time/range locators; one-click promotion from ordinary link; CSL-compatible style rendering; footnote, author-date, numeric, linked-blog, and bibliography presentations; access and round-trip behavior."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Citations
+
+## Contract
+
+A semantic citation references a durable source record plus an optional locator, independently of how it is rendered
+
+## Acceptance boundary
+
+A complete proof demonstrates: Stable source identity; page/section/time/range locators; one-click promotion from ordinary link; CSL-compatible style rendering; footnote, author-date, numeric, linked-blog, and bibliography presentations; access and round-trip behavior.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.review.code.md
+++ b/templates/content/docs/product/capabilities/content.review.code.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.review.code"
 name: "Code review"
-user_promise: "Review typed code/file changes in the same in-place, filterable, durable-decision interface"
+user_promise: "Review typed code and file changes in the same in-place, filterable, durable-decision interface"
+primary_user_job: "Review a portable code change in context and leave decisions attached to stable files and hunks."
 kind: "primitive"
 state: "exploring"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.diff.in-place","content.author.code"]
+dependencies: ["content.diff.in-place", "content.author.code"]
 related_features: ["content.feature.review-changes-in-place"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Portable file/source model, change graph, syntax renderers, authority, AI summaries later."
-proof_requirements: ["Portable file/source model, change graph, syntax renderers, authority, AI summaries later."]
+acceptance_summary: "Code review uses a portable file/source model, typed change graph, syntax-aware renderers, authority checks, durable in-place decisions, and canonical source provenance."
+proof_requirements:
+  [
+    "Typed contract, authorization, validation, Event/history, and recovery coverage",
+    "Cross-surface UI, Action, agent-context, reload, and failure-state coverage",
+    "Real-interface keyboard and assistive-technology workflow coverage",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,42 @@ last_reviewed: "2026-07-29"
 
 # Code review
 
-## Contract
+## Why this exists
 
-Review typed code/file changes in the same in-place, filterable, durable-decision interface
+Review decisions need durable anchors that survive refreshes without claiming custody of the underlying repository.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Portable file/source model, change graph, syntax renderers, authority, AI summaries later.
+A reviewer opens a proposed file change, filters to unresolved hunks, leaves an in-place decision, and later reopens the same decision after the source refreshes.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+Code review uses a portable file/source model, typed change graph, syntax-aware renderers, authority checks, durable in-place decisions, and canonical source provenance. AI summaries are enhancing work, not a prerequisite claim.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+In-place diffs and code authoring own their primitives. This is not a Git-host replacement, provider custody claim, or auto-merge authority.
+
+## Acceptance stories
+
+### Reattach a decision after an unrelated refresh
+
+Given a source refresh changes unrelated lines, when a reviewer reopens a decision, then its stable change anchor either resolves or reports a truthful orphaned state.
+
+### Report an orphaned hunk truthfully
+
+Given a viewer lacking file access, when they open a review, then no code, hunk count, or summary leaks through filters or review metadata.
+
+## Current evidence
+
+This remains `exploring`; no complete portable-source, syntax, authority, and durable-decision proof is recorded.
+
+## Proof plan
+
+1. Test portable file identities, change graphs, syntax rendering, filters, and anchors.
+2. Verify decisions, authority, provenance, refresh reconciliation, and inaccessible files.
+3. Exercise orphaned hunks, unavailable sources, keyboard review, and diff navigation.
+
+## Open questions
+
+The initial portable file identity and change-anchor strategy remain exploratory.

--- a/templates/content/docs/product/capabilities/content.review.code.md
+++ b/templates/content/docs/product/capabilities/content.review.code.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.review.code"
+name: "Code review"
+user_promise: "Review typed code/file changes in the same in-place, filterable, durable-decision interface"
+kind: "primitive"
+state: "exploring"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.diff.in-place","content.author.code"]
+related_features: ["content.feature.review-changes-in-place"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Portable file/source model, change graph, syntax renderers, authority, AI summaries later."
+proof_requirements: ["Portable file/source model, change graph, syntax renderers, authority, AI summaries later."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Code review
+
+## Contract
+
+Review typed code/file changes in the same in-place, filterable, durable-decision interface
+
+## Acceptance boundary
+
+A complete proof demonstrates: Portable file/source model, change graph, syntax renderers, authority, AI summaries later.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.revision.suggestions.md
+++ b/templates/content/docs/product/capabilities/content.revision.suggestions.md
@@ -1,17 +1,25 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.revision.suggestions"
 name: "Suggestions"
-user_promise: "Suggested changes as authored pending revisions with accept/reject history"
+user_promise: "Suggested changes remain authored pending Revisions until an authorized person accepts, rejects, defers, or supersedes them."
+primary_user_job: "Propose reversible human or agent work without mutating the canonical Page before review."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.diff.in-place","content.history.queryable"]
+dependencies: ["content.diff.in-place", "content.history.queryable"]
 related_features: ["content.feature.review-changes-in-place"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Event/history/diff spine, author/time window, permissions, conflict handling."
-proof_requirements: ["Event/history/diff spine, author/time window, permissions, conflict handling."]
+acceptance_summary: "Suggestions preserve authored pending Revision identity, target/basis, scope, permissions, conflict state, and durable disposition through in-place review and History."
+proof_requirements:
+  [
+    "Pending Revision identity with actor, time, origin, target, basis, and change set",
+    "In-place typed review and Event/History disposition",
+    "Permission, author edit window, stale basis, and conflict behavior",
+    "Human/agent parity, concurrent review, recovery, and notification coverage",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +27,50 @@ last_reviewed: "2026-07-29"
 
 # Suggestions
 
-## Contract
+## Why this exists
 
-Suggested changes as authored pending revisions with accept/reject history
+People and agents need room to offer work before it becomes canonical. A suggestion is a real authored proposal, not an ephemeral chat message or a secret second document.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Event/history/diff spine, author/time window, permissions, conflict handling.
+An agent proposes edits to an article and its metadata. The proposal remains pending as one authored Revision. The editor accepts stronger passages, rejects an incorrect Property change, leaves another suggestion pending, and can later see every decision in History.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A Suggestion is a pending logical Revision with stable identity, author, authority/origin, time, targets, observed basis, typed change set, and disposition.
+- Human and agent suggestions use one model; neither receives a private document or review path.
+- Pending suggestions do not mutate canonical target state until authorized acceptance.
+- Author editing follows an explicit time/permission policy and preserves visible history rather than erasing the proposal.
+- Acceptance, rejection, deferment, supersession, conflict, and expiry are durable Events/History states.
+- A stale target exposes rebase, refresh, or conflict behavior; it never silently applies to a moved target.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- Suggestions are not every Event, snapshot, or named Page Version.
+- This record does not define filtered-set review or AI summaries.
+- A pending suggestion does not widen access to its target or its underlying evidence.
+
+## Acceptance stories
+
+### Keep a proposal pending until review
+
+Given an agent proposes a Block and Property change, when the proposal is created, then the canonical Page is unchanged and the editor can inspect one attributable pending Revision in place.
+
+### Handle a moved target without overwrite
+
+Given an editor changes a target after a suggestion's observed basis, when another reviewer accepts the suggestion, then Content presents a rebase, refresh, or conflict state and does not silently overwrite the newer canonical change.
+
+## Current evidence
+
+Current document snapshots and source-review machinery provide useful proposed-change donors. The repository does not yet prove generic authored pending Revisions, typed suggestion review, or conflict semantics across Content; this remains `approved_shape`.
+
+## Proof plan
+
+1. Create, edit, submit, accept, reject, defer, supersede, and expire human and agent suggestions.
+2. Test author windows, target permissions, access changes, Notifications, History, and recovery.
+3. Race concurrent author edits, reviewer decisions, target edits, and retries.
+4. Verify typed body/Property/Block rendering through UI and shared Actions.
+
+## Open questions
+
+The exact author edit window and rebase UX remain open. Pending identity, durable disposition, and no-silent-overwrite behavior are settled.

--- a/templates/content/docs/product/capabilities/content.revision.suggestions.md
+++ b/templates/content/docs/product/capabilities/content.revision.suggestions.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.revision.suggestions"
+name: "Suggestions"
+user_promise: "Suggested changes as authored pending revisions with accept/reject history"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.diff.in-place","content.history.queryable"]
+related_features: ["content.feature.review-changes-in-place"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Event/history/diff spine, author/time window, permissions, conflict handling."
+proof_requirements: ["Event/history/diff spine, author/time window, permissions, conflict handling."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Suggestions
+
+## Contract
+
+Suggested changes as authored pending revisions with accept/reject history
+
+## Acceptance boundary
+
+A complete proof demonstrates: Event/history/diff spine, author/time window, permissions, conflict handling.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.rule.deterministic.md
+++ b/templates/content/docs/product/capabilities/content.rule.deterministic.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.rule.deterministic"
+name: "Rules"
+user_promise: "Event + typed condition + action"
+kind: "workflow"
+state: "in_progress"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.event.committed","content.expression.language","content.agent.action-parity"]
+related_features: ["content.feature.when-this-happens-that-follows","content.feature.collect-structured-input","content.feature.capture-into-action"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: One expression language, versioned subscriptions, authority, idempotency, receipts."
+proof_requirements: ["One expression language, versioned subscriptions, authority, idempotency, receipts."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Rules
+
+## Contract
+
+Event + typed condition + action
+
+## Acceptance boundary
+
+A complete proof demonstrates: One expression language, versioned subscriptions, authority, idempotency, receipts.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.rule.deterministic.md
+++ b/templates/content/docs/product/capabilities/content.rule.deterministic.md
@@ -1,17 +1,34 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.rule.deterministic"
 name: "Rules"
-user_promise: "Event + typed condition + action"
+user_promise: "Event plus typed condition plus action"
+primary_user_job: "Define repeatable operational behavior that is explicit, authorized, idempotent, and explainable."
 kind: "workflow"
 state: "in_progress"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.event.committed","content.expression.language","content.agent.action-parity"]
-related_features: ["content.feature.when-this-happens-that-follows","content.feature.collect-structured-input","content.feature.capture-into-action"]
+dependencies:
+  [
+    "content.event.committed",
+    "content.expression.language",
+    "content.agent.action-parity",
+  ]
+related_features:
+  [
+    "content.feature.when-this-happens-that-follows",
+    "content.feature.collect-structured-input",
+    "content.feature.capture-into-action",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: One expression language, versioned subscriptions, authority, idempotency, receipts."
-proof_requirements: ["One expression language, versioned subscriptions, authority, idempotency, receipts."]
+acceptance_summary: "Rules are versioned subscriptions from committed Events through one expression language to typed Actions."
+proof_requirements:
+  [
+    "Typed contract, authorization, validation, Event/history, and recovery coverage",
+    "Cross-surface UI, Action, agent-context, reload, and failure-state coverage",
+    "Real-interface keyboard and assistive-technology workflow coverage",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +36,44 @@ last_reviewed: "2026-07-29"
 
 # Rules
 
-## Contract
+## Why this exists
 
-Event + typed condition + action
+A Rule turns a recurring intention into a visible promise: one committed event, one typed condition, and one authorized action.
 
-## Acceptance boundary
+A Rule makes an operational promise visible: one committed event, one typed condition, one authorized action.
 
-A complete proof demonstrates: One expression language, versioned subscriptions, authority, idempotency, receipts.
+## Example workflow
 
-## Evidence boundary
+A Database update emits a committed Event, a versioned Rule evaluates a typed condition, and an Action assigns a follow-up property once. The receipt identifies the event, Rule version, authority, and outcome.
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+## Product contract
 
-## Non-goals
+Rules are versioned subscriptions from committed Events through one expression language to typed Actions. They have owner authority, idempotency, causal receipts, disablement, retries, and visible failures.
 
-This capability does not create a parallel datastore, permission model, or action surface.
+## Boundaries and non-goals
+
+Events own committed triggers, expressions own conditions, and Actions own mutations. This is not client-side scripting, hidden retries that look successful, or unrestricted recursive automation.
+
+## Acceptance stories
+
+### Record a duplicate Event delivery
+
+Given the same Event is delivered twice, when a Rule would mutate a record, then idempotency commits at most one canonical effect and records the duplicate receipt.
+
+### Surface an unevaluable condition
+
+Given a Rule condition cannot be evaluated, when its source is unavailable, then Content records an explicit failure or retry state rather than an empty successful run.
+
+## Current evidence
+
+Rule substrate is in progress, but complete subscription, idempotency, authority, receipt, and recovery proof is incomplete. This Capability remains `in_progress`.
+
+## Proof plan
+
+1. Test versioned subscriptions from committed Events through typed expressions to Actions.
+2. Simulate duplicates, false and unevaluable conditions, retries, recursion, and disablement.
+3. Inspect causal history, owner controls, failure states, reload recovery, and no-success-on-failure.
+
+## Open questions
+
+The initial retry and dead-letter policy need design.

--- a/templates/content/docs/product/capabilities/content.schedule.constraints.md
+++ b/templates/content/docs/product/capabilities/content.schedule.constraints.md
@@ -1,17 +1,29 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.schedule.constraints"
 name: "Schedule constraints"
 user_promise: "Planning surfaces detect dependency and date violations, explain them, and apply only explicit policy or accepted repairs."
+primary_user_job: "Understand whether a plan conflicts with its dates and dependencies, then choose a visible repair rather than accepting a hidden schedule rewrite."
 kind: "primitive"
 state: "exploring"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.relationship.edge","content.time.types","content.expression.language"]
+dependencies:
+  [
+    "content.relationship.edge",
+    "content.time.types",
+    "content.expression.language",
+  ]
 related_features: ["content.feature.plan-work-across-time"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Planning surfaces detect dependency and date violations, explain them, and apply only explicit policy or accepted repairs."
-proof_requirements: ["Planning surfaces detect dependency and date violations, explain them, and apply only explicit policy or accepted repairs."]
+acceptance_summary: "Planning Views evaluate typed date and dependency constraints, explain violations and uncertainty, and apply only explicit policy or accepted canonical repairs."
+proof_requirements:
+  [
+    "Typed date/range and Relationship constraint evaluation, cycle, missing-data, and uncertainty coverage",
+    "Access-safe violation disclosure, repair proposal, policy, Action, history, and recovery coverage",
+    "Real-interface planning workflow for Timeline composition, unavailable inputs, reload, and assistive access",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +31,51 @@ last_reviewed: "2026-07-29"
 
 # Schedule constraints
 
-## Contract
+## Why this exists
 
-Planning surfaces detect dependency and date violations, explain them, and apply only explicit policy or accepted repairs.
+Planning needs honest friction: a date conflict should be explainable, not silently “fixed”
+by a renderer that decides on behalf of the work.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Planning surfaces detect dependency and date violations, explain them, and apply only explicit policy or accepted repairs.
+A planner moves a task before a blocking task ends. Timeline identifies the violation,
+shows the dependency and dates involved, and offers a policy-backed repair only for approval.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Constraint evaluation consumes canonical typed Relationships, dates, ranges, and expressions.
+- Planning Views distinguish violation, uncertainty, missing input, unavailable source, and no conflict.
+- A policy may propose repairs; only an explicit accepted shared Action changes canonical records.
+- Access applies before constraints, explanations, counts, previews, exports, and agent context.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Dependencies and time types own inputs; Timeline is a consumer. This is not automatic
+project management, a hidden date inference system, or a separate scheduler datastore.
+
+## Acceptance stories
+
+### Explain a blocking conflict
+
+Given a task scheduled before an accessible blocker completes, when a planner opens the
+planning View, then Content identifies the typed dependency and conflicting dates clearly.
+
+### Refuse a hidden repair
+
+Given a policy offers a later start date, when the planner declines it, then no canonical
+date changes; accepting it creates one attributable shared Action and history entry.
+
+## Current evidence
+
+This record remains `exploring`; no complete constraint evaluator or repair contract is
+proven by current Timeline donor code.
+
+## Proof plan
+
+1. Test dates, ranges, dependencies, cycles, missing inputs, and uncertainty.
+2. Verify access-safe explanations, explicit repair Actions, history, and recovery.
+3. Exercise planning UI, Timeline composition, unavailable sources, reload, and accessibility.
+
+## Open questions
+
+The initial constraint policy catalog and repair proposal language remain exploratory.

--- a/templates/content/docs/product/capabilities/content.schedule.constraints.md
+++ b/templates/content/docs/product/capabilities/content.schedule.constraints.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.schedule.constraints"
+name: "Schedule constraints"
+user_promise: "Planning surfaces detect dependency and date violations, explain them, and apply only explicit policy or accepted repairs."
+kind: "primitive"
+state: "exploring"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.relationship.edge","content.time.types","content.expression.language"]
+related_features: ["content.feature.plan-work-across-time"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Planning surfaces detect dependency and date violations, explain them, and apply only explicit policy or accepted repairs."
+proof_requirements: ["Planning surfaces detect dependency and date violations, explain them, and apply only explicit policy or accepted repairs."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Schedule constraints
+
+## Contract
+
+Planning surfaces detect dependency and date violations, explain them, and apply only explicit policy or accepted repairs.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Planning surfaces detect dependency and date violations, explain them, and apply only explicit policy or accepted repairs.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.security.private-vault.md
+++ b/templates/content/docs/product/capabilities/content.security.private-vault.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.security.private-vault"
+name: "Private vault encryption"
+user_promise: "User-held private-vault/E2EE custody with fail-closed enrollment, recovery, and authorization"
+kind: "primitive"
+state: "in_progress"
+publicness: "public"
+availability: "desktop"
+dependencies: ["content.agent.resource-consent","content.portability.vault-export"]
+related_features: ["content.feature.keep-your-private-vault-private"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Protocol/implementation wayfinder, cross-architecture proof, recovery and agent-authority stories, merge and production gates."
+proof_requirements: ["Protocol/implementation wayfinder, cross-architecture proof, recovery and agent-authority stories, merge and production gates."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Private vault encryption
+
+## Contract
+
+User-held private-vault/E2EE custody with fail-closed enrollment, recovery, and authorization
+
+## Acceptance boundary
+
+A complete proof demonstrates: Protocol/implementation wayfinder, cross-architecture proof, recovery and agent-authority stories, merge and production gates.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.security.private-vault.md
+++ b/templates/content/docs/product/capabilities/content.security.private-vault.md
@@ -1,17 +1,25 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.security.private-vault"
 name: "Private vault encryption"
-user_promise: "User-held private-vault/E2EE custody with fail-closed enrollment, recovery, and authorization"
+user_promise: "Private-vault custody can be user-held and fail closed without disguising unresolved recovery, collaboration, or agent authority problems."
+primary_user_job: "Keep selected work unreadable to the service while retaining understandable device, recovery, sharing, agent, and exit choices."
 kind: "primitive"
 state: "in_progress"
 publicness: "public"
 availability: "desktop"
-dependencies: ["content.agent.resource-consent","content.portability.vault-export"]
+dependencies:
+  ["content.agent.resource-consent", "content.portability.vault-export"]
 related_features: ["content.feature.keep-your-private-vault-private"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Protocol/implementation wayfinder, cross-architecture proof, recovery and agent-authority stories, merge and production gates."
-proof_requirements: ["Protocol/implementation wayfinder, cross-architecture proof, recovery and agent-authority stories, merge and production gates."]
+acceptance_summary: "A reviewed private-vault system establishes user-held cryptographic custody, explicit enrollment and device authorization, fail-closed decryption and recovery, bounded agent plaintext access, revocation, collaboration semantics, and portable exit without claiming readiness before production proof."
+proof_requirements:
+  [
+    "Threat model, protocol, key lifecycle, enrollment, recovery, revocation, and fail-closed tests across supported architectures",
+    "Agent-consent, collaboration, merge, export, and unavailable-key authorization tests",
+    "Independent security review plus production-like end-to-end device, recovery, revocation, and exit evidence",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +27,45 @@ last_reviewed: "2026-07-29"
 
 # Private vault encryption
 
-## Contract
+## Why this exists
 
-User-held private-vault/E2EE custody with fail-closed enrollment, recovery, and authorization
+Private custody is a promise about who can read, not a decorative lock icon.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Protocol/implementation wayfinder, cross-architecture proof, recovery and agent-authority stories, merge and production gates.
+A person enrolls a trusted device, opens a private vault locally, grants one local agent a bounded task, revokes the device, and exports readable authorized material without exposing plaintext to the service.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- User-held cryptographic custody, key enrollment, device authorization, rotation, revocation, and recovery are explicit ceremonies with fail-closed behavior.
+- Clients decrypt only vaults and operations they are currently authorized to handle; unavailable keys never coerce to empty or apparently successful content.
+- Agent plaintext access is separate bounded consent, not an implication of ordinary sharing or recoverable edit access.
+- Collaboration, Versions, comments, access changes, and portable exit must preserve the custody claim or state their limitation plainly.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+This is a paused product lane, not a claim that current experiments are production-ready. Vault export owns package semantics; resource consent owns agent scope.
+
+## Acceptance stories
+
+### Fail closed on an unenrolled device
+
+Given a device without the vault key, when it opens a private-vault resource, then it receives an explicit unavailable/enrollment state and no plaintext or plausible empty document.
+
+### Revoke bounded access
+
+Given a device and an agent were separately authorized, when the owner revokes their grants, then subsequent decrypt or task attempts fail and the audit record distinguishes device revocation from agent consent.
+
+## Current evidence
+
+Donor evidence: repository feature records retain the historical research and fork boundary. No repository-local audited protocol, integration, cross-architecture proof, or production receipt supports a complete claim; this record remains `in_progress` and the Feature is paused.
+
+## Proof plan
+
+1. Publish a sanitized protocol and implementation wayfinder with threat boundaries.
+2. Test key lifecycle, recovery, revocation, agent consent, collaboration, and portable exit across architectures.
+3. Obtain independent review and production-like end-to-end evidence before changing state.
+
+## Open questions
+
+- Recovery ceremony, collaboration cryptography, and supported-device order remain material decisions.

--- a/templates/content/docs/product/capabilities/content.share.views.md
+++ b/templates/content/docs/product/capabilities/content.share.views.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.share.views"
+name: "Shared Views"
+user_promise: "A shared Database view preserves its configuration while defaulting to the viewer's existing row access"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.view.query","content.access.page-database"]
+related_features: ["content.feature.make-the-workspace-yours"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Intersection-by-default, explicit audited capability-view grants later, field projection, future-row semantics and revocation."
+proof_requirements: ["Intersection-by-default, explicit audited capability-view grants later, field projection, future-row semantics and revocation."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Shared Views
+
+## Contract
+
+A shared Database view preserves its configuration while defaulting to the viewer's existing row access
+
+## Acceptance boundary
+
+A complete proof demonstrates: Intersection-by-default, explicit audited capability-view grants later, field projection, future-row semantics and revocation.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.share.views.md
+++ b/templates/content/docs/product/capabilities/content.share.views.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.share.views"
 name: "Shared Views"
-user_promise: "A shared Database view preserves its configuration while defaulting to the viewer's existing row access"
+user_promise: "A shared View gives collaborators a dependable starting presentation while preserving each viewer's existing access and personal exploration."
+primary_user_job: "Share a useful way of seeing a collection without changing the records, exposing private rows, or trapping collaborators in my arrangement."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.view.query","content.access.page-database"]
+dependencies: ["content.view.query", "content.access.page-database"]
 related_features: ["content.feature.make-the-workspace-yours"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Intersection-by-default, explicit audited capability-view grants later, field projection, future-row semantics and revocation."
-proof_requirements: ["Intersection-by-default, explicit audited capability-view grants later, field projection, future-row semantics and revocation."]
+acceptance_summary: "Shared named Views preserve one reusable presentation over a Database or Query; every viewer sees only their authorized intersection, may retain one automatic personal arrangement, and can create explicit named alternatives without forking data or granting source rows."
+proof_requirements:
+  [
+    "Stable shared and Only-me View identity, links, embeds, defaults, revisions, deletion, and personal-arrangement lifecycle",
+    "Viewer-specific access intersection across View, owner input, Source, row, field, and current authorization",
+    "UI and Action workflows for personal changes, reset, save-as-new, permitted shared updates, and access-safe degraded states",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,115 @@ last_reviewed: "2026-07-29"
 
 # Shared Views
 
-## Contract
+## Why this exists
 
-A shared Database view preserves its configuration while defaulting to the viewer's existing row access
+Teams need a dependable shared starting point, but a collaborator's filter,
+sort, grouping, density, or column choice should not accidentally rearrange
+everyone else's work. Sharing a presentation must also never smuggle access to
+the records behind it; a polished View is not a diplomatic passport.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Intersection-by-default, explicit audited capability-view grants later, field projection, future-row semantics and revocation.
+A team shares a Board over a Database. One person privately filters it to work
+assigned to them and changes column widths. Content remembers that one personal
+arrangement and marks **Viewing with personal changes**. They can reset to the
+shared View, save an explicit Only-me alternative, or—if authorized—update the
+shared default. A teammate follows the ordinary shared link and receives the
+saved Board definition, not the first person's unnamed arrangement, and sees
+only rows they can already access.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+### One shared definition, personal exploration
 
-## Non-goals
+- A shared saved View owns its Database or Query input, renderer, visible
+  fields, downstream filters, sorts, groups, layout, formatting, and permitted
+  creation behavior. It never owns the input records or Query output contract.
+- Each person has at most one unnamed automatically remembered personal
+  arrangement for a shared View. It may alter presentation and downstream
+  refinement without mutating the shared definition or other viewers' state.
+- The focused View Instance carries the immediate effective state while someone
+  works. Content quietly indicates when it differs from the shared default.
+- **Reset to shared View** removes the personal arrangement. **Save as new
+  View** creates a named Only-me or otherwise permitted shared alternative.
+  **Update shared View** requires the owning input's relevant edit authority
+  and records one reversible attributable Revision.
+- Agents may inspect the shared definition, personal arrangement, effective
+  View, and delta; they may explore with ephemeral typed Queries without
+  changing UI state. They change personal, named, or shared state only when the
+  person explicitly asks and authority permits it.
 
-This capability does not create a parallel datastore, permission model, or action surface.
+### Sharing narrows or intersects; it never grants rows
+
+- A named View may be shared or **Only me** and may narrow access below its
+  owning Database or Query, never widen it.
+- Effective visibility is the intersection of View access, Database/Query
+  access, Source and row access, field access, and the current viewer's
+  authorization. The View never runs with its creator's authority.
+- Counts, groups, aggregates, search, source state, field visibility, embeds,
+  agents, exports, and creation choices use that same intersection. A View does
+  not reveal inaccessible rows by their count or failure shape.
+- Restricting a View protects its configuration and surface. It does not revoke
+  independent access to the underlying Database, Query, or records elsewhere.
+- A fixed output for recipients is a separate explicitly published or
+  materialized snapshot capability, not a shared View that grants access.
+
+## Boundaries and non-goals
+
+- Database and Query Views owns generic View identity and presentation;
+  Personal View State owns detailed local persistence; this Capability owns the
+  shared/personal collaboration policy over that primitive.
+- Queries derive collections and output contracts; Views refine and render
+  them. A shared View cannot widen a Query or become a second collection.
+- This Capability does not define access-granting Views, snapshot publication,
+  a second sharing model, or copied private data.
+
+## Acceptance stories
+
+### Share a starting point without sharing a private arrangement
+
+Given a shared View and one viewer's saved personal filters, grouping, and
+column sizes, when another authorized viewer follows the ordinary View link,
+then they receive the shared definition and their own effective state, never
+the first viewer's unnamed arrangement.
+
+### Preserve row access under a shared link
+
+Given two people with different access to rows and fields of a shared View's
+input, when each opens the View, searches it, inspects group counts, asks an
+agent, or exports it, then each sees only their authorized intersection and no
+inaccessible item is exposed through metadata or aggregates.
+
+### Save an alternative without forking work
+
+Given a person changes a shared View's arrangement, when they choose **Save as
+new View** with **Only me**, then the new View has its own stable configuration
+over the same input, the shared default remains unchanged, and canonical rows
+and source authority are not copied or widened.
+
+## Current evidence
+
+Saved Database Views, filters, sorting, grouping, several renderers, and
+ordinary access checks are useful substrate. They do not yet prove the complete
+one-person arrangement lifecycle, View-configuration narrowing, shared Action
+parity, or access-safe outputs across every consumer. This Capability remains
+`approved_shape`.
+
+## Proof plan
+
+1. Create shared and Only-me Views; link, embed, pin, select defaults, update,
+   reset, save alternatives, delete, restore, and verify Revision history.
+2. Exercise one automatic personal arrangement per viewer across filters, sorts,
+   groups, layout, formatting, focus, reload, concurrent changes, and agents.
+3. Run the full access matrix through direct View reads, rows, fields, counts,
+   aggregates, search, embeds, agents, exports, creation, permission changes,
+   and source unavailability.
+4. Verify keyboard and assistive-technology behavior for personal-change state,
+   reset, save, shared update, access denial, and degraded states.
+
+## Open questions
+
+- The exact personal-arrangement storage, conflict resolution for concurrent
+  shared updates, and display of the effective-state delta remain open.
+- Snapshot publication needs its own capability contract before a fixed output
+  can be offered to recipients outside source access.

--- a/templates/content/docs/product/capabilities/content.source.adapters.md
+++ b/templates/content/docs/product/capabilities/content.source.adapters.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.source.adapters"
+name: "Source adapters"
+user_promise: "Local folder, Builder, Notion, and future typed source adapters"
+kind: "primitive"
+state: "in_progress"
+publicness: "public"
+availability: "configured"
+dependencies: ["content.source.catalog","content.source.sync-policy"]
+related_features: ["content.feature.connect-your-sources","content.feature.trust-your-connected-sources","content.feature.bring-your-local-work","content.feature.read-and-annotate-anything","content.feature.cite-what-you-found","content.feature.move-without-starting-over"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Capability declarations, truth policy, provenance, refresh/conflict/write gates."
+proof_requirements: ["Capability declarations, truth policy, provenance, refresh/conflict/write gates."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Source adapters
+
+## Contract
+
+Local folder, Builder, Notion, and future typed source adapters
+
+## Acceptance boundary
+
+A complete proof demonstrates: Capability declarations, truth policy, provenance, refresh/conflict/write gates.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.source.adapters.md
+++ b/templates/content/docs/product/capabilities/content.source.adapters.md
@@ -1,17 +1,32 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.source.adapters"
 name: "Source adapters"
-user_promise: "Local folder, Builder, Notion, and future typed source adapters"
+user_promise: "Local, native, and provider Sources use one typed contract while each adapter proves only the operations it can safely perform."
+primary_user_job: "Use connected work through one Content experience without losing its provider identity, authority, or meaning."
 kind: "primitive"
 state: "in_progress"
 publicness: "public"
 availability: "configured"
-dependencies: ["content.source.catalog","content.source.sync-policy"]
-related_features: ["content.feature.connect-your-sources","content.feature.trust-your-connected-sources","content.feature.bring-your-local-work","content.feature.read-and-annotate-anything","content.feature.cite-what-you-found","content.feature.move-without-starting-over"]
+dependencies: ["content.source.catalog", "content.source.sync-policy"]
+related_features:
+  [
+    "content.feature.connect-your-sources",
+    "content.feature.trust-your-connected-sources",
+    "content.feature.bring-your-local-work",
+    "content.feature.read-and-annotate-anything",
+    "content.feature.cite-what-you-found",
+    "content.feature.move-without-starting-over",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Capability declarations, truth policy, provenance, refresh/conflict/write gates."
-proof_requirements: ["Capability declarations, truth policy, provenance, refresh/conflict/write gates."]
+acceptance_summary: "Adapters declare and certify their read, watch, write, create, move, delete, review, publish, fidelity, and bridge requirements; shared Content behavior routes through those declarations and preserves provenance, ownership, conflicts, and truthful outcomes."
+proof_requirements:
+  [
+    "Typed adapter declaration, validation, and action routing for identity, provenance, ownership, capabilities, policy, and receipts",
+    "Independent certification of declared operations, authorization, conflict, retry, and unknown-data behavior for each adapter",
+    "Cross-adapter interface and Action workflows that distinguish unsupported, unavailable, queued, failed, conflicted, and provider-confirmed states",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +34,121 @@ last_reviewed: "2026-07-29"
 
 # Source adapters
 
-## Contract
+## Why this exists
 
-Local folder, Builder, Notion, and future typed source adapters
+People should be able to work with local folders, native Content data, and
+provider collections without treating every integration as a separate product.
+The common experience must not erase the important differences: which system
+owns a representation, what a provider permits, whether a device is available,
+and what Content cannot safely interpret.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Capability declarations, truth policy, provenance, refresh/conflict/write gates.
+A team selects two provider collections and one local folder from the Sources
+catalog. Content shows them in one Query while retaining each result's origin.
+An edit to a mapped writable field routes to its one declared adapter; an
+unknown provider component remains preserved and read-only; a local-only
+operation reports that the current device lacks bridge authority. The Query is
+not a new owner and does not send the same edit to all three Sources.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+### One contract, declared capabilities
 
-## Non-goals
+- A Source adapter declares stable Source and item identity, provenance,
+  supported representations, field ownership, freshness/baseline behavior,
+  authenticated grant requirements, and its certified operations.
+- Operations are explicit rather than implied by a connection: read, watch,
+  write, create, move, delete, review, publish, fidelity/export behavior, and
+  whether a trusted local bridge is required.
+- Content exposes only operations that pass the adapter declaration and the
+  current access, approval, grant, policy, and device checks. Unsupported and
+  unavailable are distinct states; neither is represented as an empty success.
+- UI, agents, automations, and APIs use the same typed Action surface and see
+  the same capability decision. Adapters do not receive private mutation paths.
 
-This capability does not create a parallel datastore, permission model, or action surface.
+### Preserve one owner and one route
+
+- Adapter bindings connect an external item to stable Content identity without
+  making the provider the Page's identity or copying it into a rival datastore.
+- Source-owned fields and representations retain their adapter identity;
+  Content-owned properties, comments, memberships, views, and collaboration
+  remain Content-owned unless explicitly mapped otherwise.
+- Queries and Views project adapter-backed records but do not own canonical
+  values or provider write authority. An edit routes only through an
+  unambiguous authorized binding; ambiguous projections are read-only.
+- Provider lifecycle actions such as publish are declared separately and remain
+  guarded. An adapter's ordinary write capability never implies publish.
+
+### Certify behavior, not a provider name
+
+- An adapter may implement a narrow subset of the contract. A read-only source
+  can certify refresh without claiming write or review; a local adapter may
+  require a bridge for watch or physical writes.
+- Certification tests each declared operation's identity, authorization,
+  policy, base revision, conflict, retry, receipt, and fidelity behavior.
+  Passing one adapter's tests is evidence for that adapter, not generic proof.
+- Adapters preserve provider-owned structures they cannot safely render or edit
+  through the faithful round-tripping contract. They must not flatten unknown
+  data into a normal editable representation.
+
+## Boundaries and non-goals
+
+- The Sources catalog owns governed discovery and connection records; sync
+  policy owns user-facing write-back modes; this record owns the provider and
+  local implementation boundary between them.
+- Provider-specific codecs may define exact format mappings. They cannot widen
+  the generic adapter promise without independent contract proof.
+- Adapters are not a second access system, a generic REST proxy, or a promise
+  that all providers support the same operations.
+- Git branches, commits, pull requests, and provider publishing may be
+  adapter-specific review or lifecycle work; they are not universal Versions.
+
+## Acceptance stories
+
+### Route an edit to its sole declared owner
+
+Given a Query containing records from two writable Sources and one read-only
+Source, when an editor changes an unambiguously mapped field on one result,
+then only that result's authorized adapter receives the change, the other
+memberships do not fan out, and the receipt identifies the destination.
+
+### Reject an unavailable operation honestly
+
+Given a local Source whose current client lacks its required bridge, when a
+person asks to reveal or immediately write a local-only file, then Content
+reports the unavailable device capability and offers the applicable route; it
+does not claim the operation completed or make unrelated Content work fail.
+
+### Keep unknown provider content intact
+
+Given an adapter reads a provider representation containing an unsupported
+component, when an editor changes a separately mapped supported field and the
+adapter writes it back, then the unsupported component survives with its source
+identity and the adapter's receipt records the actual provider result.
+
+## Current evidence
+
+Content has source-backed data, provenance, local material, and provider
+adapters that are valuable substrate. Existing provider-specific behavior does
+not yet certify the common declaration model, every operation, or cross-source
+authorization and fidelity behavior. This Capability remains `in_progress`.
+
+## Proof plan
+
+1. Validate adapter declarations and Action routing for a read-only provider,
+   a writable provider, native Content, and a bridge-dependent local Source.
+2. Certify every declared operation independently, including denied grants,
+   stale bases, conflicts, retry after interrupted delivery, and provider
+   receipts; assert undeclared operations cannot be invoked.
+3. Test identity/provenance, field ownership, Query routing, access-first
+   results, unknown preservation, and lifecycle separation across adapters.
+4. Complete real-interface connection, refresh, edit, review, failure, and
+   recovery flows with assistive-technology and keyboard coverage.
+
+## Open questions
+
+- The exact adapter declaration schema and certification fixture format remain
+  implementation work.
+- Which provider operations graduate from review-only to automatic support must
+  be decided adapter by adapter after certification.

--- a/templates/content/docs/product/capabilities/content.source.builder-codec.md
+++ b/templates/content/docs/product/capabilities/content.source.builder-codec.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.source.builder-codec"
+name: "Builder round-trip codec"
+user_promise: "Builder JSON blocks round-trip through one pure typed codec shared by repo-backed docs and CMS-backed databases"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "configured"
+dependencies: ["content.portability.roundtrip","content.source.adapters"]
+related_features: ["content.feature.trust-your-connected-sources"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Known block mappings, raw unknown fallback, hashes/conflicts, structured body field, golden round trips; truth/write policy remains source-lane-specific."
+proof_requirements: ["Known block mappings, raw unknown fallback, hashes/conflicts, structured body field, golden round trips; truth/write policy remains source-lane-specific."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Builder round-trip codec
+
+## Contract
+
+Builder JSON blocks round-trip through one pure typed codec shared by repo-backed docs and CMS-backed databases
+
+## Acceptance boundary
+
+A complete proof demonstrates: Known block mappings, raw unknown fallback, hashes/conflicts, structured body field, golden round trips; truth/write policy remains source-lane-specific.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.source.builder-codec.md
+++ b/templates/content/docs/product/capabilities/content.source.builder-codec.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.source.builder-codec"
 name: "Builder round-trip codec"
-user_promise: "Builder JSON blocks round-trip through one pure typed codec shared by repo-backed docs and CMS-backed databases"
+user_promise: "Builder JSON blocks can pass through one typed codec without supported edits erasing unfamiliar provider content."
+primary_user_job: "Edit supported Builder content in Content while keeping unsupported components and provider lifecycle decisions intact."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "configured"
-dependencies: ["content.portability.roundtrip","content.source.adapters"]
+dependencies: ["content.portability.roundtrip", "content.source.adapters"]
 related_features: ["content.feature.trust-your-connected-sources"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Known block mappings, raw unknown fallback, hashes/conflicts, structured body field, golden round trips; truth/write policy remains source-lane-specific."
-proof_requirements: ["Known block mappings, raw unknown fallback, hashes/conflicts, structured body field, golden round trips; truth/write policy remains source-lane-specific."]
+acceptance_summary: "A pure typed codec maps supported Builder blocks and structured bodies in both directions, retains unknown raw components with stable provenance, detects baseline/hash conflicts, and produces deterministic golden round trips while source policy governs writes and publish."
+proof_requirements:
+  [
+    "Golden codec fixtures for supported blocks, structured bodies, unknown raw fallbacks, and deterministic output",
+    "Hash/baseline conflict, preservation, malformed input, and fidelity-report tests",
+    "Builder source workflow editing a supported field while preserving an unknown component and keeping publish guarded",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,45 @@ last_reviewed: "2026-07-29"
 
 # Builder round-trip codec
 
-## Contract
+## Why this exists
 
-Builder JSON blocks round-trip through one pure typed codec shared by repo-backed docs and CMS-backed databases
+Connected editing is only trustworthy if unfamiliar provider material survives the journey home.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Known block mappings, raw unknown fallback, hashes/conflicts, structured body field, golden round trips; truth/write policy remains source-lane-specific.
+An editor changes a mapped Builder article body. The codec writes supported blocks, preserves an unknown component as raw source-owned data, detects a changed provider baseline, and leaves publishing as a separate review action.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- One pure typed codec is shared by repo-backed docs and CMS-backed databases where the representation applies.
+- Known blocks map to typed Content structures; unknown components retain raw payload, provider identity, ordering, and fidelity state.
+- Baselines and hashes detect stale/conflicting writes. Codec output is deterministic and covered by golden fixtures.
+- Codec conversion does not decide source truth, write mode, review, or provider publication; adapter and sync policy own those decisions.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+This is Builder-specific format machinery, not generic Source behavior or a guarantee that every Builder component becomes editable.
+
+## Acceptance stories
+
+### Preserve an unknown component
+
+Given a Builder article contains one unknown component and one supported text block, when the editor changes the text and writes back, then the unknown component remains unchanged with provider provenance.
+
+### Stop on a stale baseline
+
+Given Builder changes the source after Content reads it, when Content attempts write-back, then the codec reports a baseline conflict and does not overwrite the newer provider representation.
+
+## Current evidence
+
+Donor evidence: `actions/_builder-cms-source-adapter.ts`, `actions/_builder-cms-source-adapter.test.ts`, and `shared/builder-source-component-registry.ts` provide concrete Builder conversion substrate. No single certified pure codec and complete golden/conflict workflow proof exists; this record remains `approved_shape`.
+
+## Proof plan
+
+1. Extract or define pure codec inputs, outputs, opaque fallbacks, and fidelity reports.
+2. Add golden, malformed, hash, conflict, and unknown-preservation fixtures.
+3. Verify a supported edit, unknown preservation, review, and guarded publish workflow.
+
+## Open questions
+
+- The first supported component matrix and raw-payload archive encoding remain open.

--- a/templates/content/docs/product/capabilities/content.source.catalog.md
+++ b/templates/content/docs/product/capabilities/content.source.catalog.md
@@ -1,17 +1,29 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.source.catalog"
 name: "Sources catalog"
-user_promise: "One governed top-level Content Database of local, provider, and native Sources"
+user_promise: "One governed top-level Content Database makes approved local, provider, and native Sources discoverable without hiding their scope, authority, or freshness."
+primary_user_job: "Find and choose the right authorized Source for a Query, capture flow, or connection while understanding what it can do."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "configured"
 dependencies: ["content.access.page-database"]
-related_features: ["content.feature.connect-your-sources","content.feature.capture-into-action","content.feature.move-without-starting-over"]
+related_features:
+  [
+    "content.feature.connect-your-sources",
+    "content.feature.capture-into-action",
+    "content.feature.move-without-starting-over",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Personal/workspace/organization scope; stable source identity, owner/access, approval, capabilities, truth policy, freshness, credentials/grants, write gates; visual query builder and capture flows select from this catalog."
-proof_requirements: ["Personal/workspace/organization scope; stable source identity, owner/access, approval, capabilities, truth policy, freshness, credentials/grants, write gates; visual query builder and capture flows select from this catalog."]
+acceptance_summary: "A governed Sources Database retains stable identity, owner, scope, approval, adapter capabilities, synchronization policy, freshness, grant reference, and write gates; authorized Query and capture flows select from it without treating a catalog row as provider or filesystem authority."
+proof_requirements:
+  [
+    "Access-scoped catalog creation, discovery, approval, revocation, and selection through UI and Actions",
+    "Stable Source identity and complete governance metadata propagated into Query, capture, adapter, and audit paths",
+    "Viewer-specific results, counts, searches, and selection behavior across personal, workspace, and organization scope",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +31,119 @@ last_reviewed: "2026-07-29"
 
 # Sources catalog
 
-## Contract
+## Why this exists
 
-One governed top-level Content Database of local, provider, and native Sources
+People need a single place to discover the work they can connect or reuse,
+instead of a separate picker for each provider or an ungoverned list of hidden
+credentials. A Source must be recognizable as a durable governed object while
+still making clear that external content, grants, and physical files retain
+their own authority.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Personal/workspace/organization scope; stable source identity, owner/access, approval, capabilities, truth policy, freshness, credentials/grants, write gates; visual query builder and capture flows select from this catalog.
+An editor opens **Add sources** in a Query. The catalog leads with approved
+organization Sources, also shows their authorized personal Sources, and labels
+each candidate's scope, freshness, adapter capabilities, and sync policy. They
+select two collections. The saved Query retains stable Source references and
+each row's provenance; it does not copy the collections or grant access to a
+colleague who cannot see one of them.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+### A governed top-level database
 
-## Non-goals
+- Sources is a top-level governed Content Database, parallel to other reusable
+  catalogs. Its rows represent native, local, and provider Sources rather than
+  Pages, credentials, or copied provider records.
+- Each row has stable identity plus owner, personal/workspace/organization
+  scope, approval state, adapter identity and certified capabilities, sync
+  policy, freshness, credential or grant reference, and write gates.
+- Credential and grant references are opaque configuration references. The
+  catalog never exposes secret values, raw local paths, or device handles.
+- Approval affects discovery and permitted use but does not bypass Content
+  access, provider grants, adapter capability, Source policy, or device
+  authority. A catalog row is not itself permission to read or write a Source.
 
-This capability does not create a parallel datastore, permission model, or action surface.
+### Selection remains access-scoped
+
+- Query builders, capture flows, and other Source selectors choose from this
+  catalog and retain stable Source IDs, not titles or inferred provider names.
+- Organization-approved Sources may lead discovery without hiding authorized
+  personal Sources. Scope changes do not silently move a Source or widen who
+  can use it.
+- Search, counts, suggestions, source previews, and aggregate metadata are
+  evaluated for the current viewer. An inaccessible Source does not leak by
+  title, existence, capability, freshness, or count.
+- A saved Query stores references and output configuration only. Its results
+  still evaluate each Source's current access and authority for the viewer.
+
+### Governance supports safe change
+
+- Catalog changes use the shared Action surface, preserve actor and origin, and
+  make approval, policy, capability, freshness, and write-gate state legible.
+- Revoking a grant, disconnecting a Source, or losing a device does not erase
+  external originals. The dependent experience reports the resulting access,
+  stale, unavailable, or disconnected state truthfully.
+- Source policy governs sync behavior; human roles govern access; adapters
+  declare provider operations. The catalog records and exposes these distinct
+  layers without collapsing them into one misleading status.
+
+## Boundaries and non-goals
+
+- This catalog does not define provider protocol behavior, codecs, write
+  routing, or local bridge security; those belong to adapters, sync policy,
+  round-tripping, and the Local Source Bridge.
+- A catalog row is not a Source Page identity, a Query, a second permissions
+  engine, or a storage location for raw provider payloads and credentials.
+- Adding a Source does not automatically approve it for every scope, synchronize
+  it, publish it, or create a shared mirror.
+
+## Acceptance stories
+
+### Select Sources without widening access
+
+Given a person with access to an organization Source and a personal Source but
+not a colleague's Source, when they open a Query or capture selector, then the
+first two are eligible according to policy and the colleague's Source is absent
+from results, counts, and suggestions.
+
+### Preserve the distinct governance layers
+
+Given an approved writable Source whose provider grant has expired, when an
+editor selects it from the catalog and attempts a write, then Content identifies
+the grant failure without claiming the Source is unapproved, changing its sync
+policy, or treating the catalog row as successful provider authority.
+
+### Disconnect without deleting the original
+
+Given a Source with materialized Content representations, when an authorized
+owner disconnects it, then Content requires the defined treatment of its local
+materialization, records the decision, and never deletes the provider or local
+original merely because the catalog connection was removed.
+
+## Current evidence
+
+Content has source-backed data, source metadata, and several connection flows.
+Those are donor substrate, not proof of one governed top-level catalog,
+scope-aware selection, or the complete governance metadata and access contract.
+This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Create, approve, scope, update, revoke, and disconnect Sources through UI
+   and Actions; verify stable identity, provenance, audit history, and no raw
+   credential, path, or handle disclosure.
+2. Test catalog discovery, search, counts, Query selection, capture selection,
+   and saved Query evaluation for personal, workspace, and organization users
+   with changing access and approval.
+3. Verify capability, policy, freshness, grant, and write-gate metadata remains
+   distinct through adapter calls, error states, exports, and reconnects.
+4. Complete a real Query and capture workflow using catalog-selected Sources,
+   including keyboard and accessible selection states.
+
+## Open questions
+
+- The detailed approval workflow, ownership transfer rules, and organization
+  governance roles remain to be specified with the broader catalog system.
+- The exact presentation and retention of stale/disconnected materializations
+  require coordination with portability and local bridge behavior.

--- a/templates/content/docs/product/capabilities/content.source.catalog.md
+++ b/templates/content/docs/product/capabilities/content.source.catalog.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.source.catalog"
+name: "Sources catalog"
+user_promise: "One governed top-level Content Database of local, provider, and native Sources"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "configured"
+dependencies: ["content.access.page-database"]
+related_features: ["content.feature.connect-your-sources","content.feature.capture-into-action","content.feature.move-without-starting-over"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Personal/workspace/organization scope; stable source identity, owner/access, approval, capabilities, truth policy, freshness, credentials/grants, write gates; visual query builder and capture flows select from this catalog."
+proof_requirements: ["Personal/workspace/organization scope; stable source identity, owner/access, approval, capabilities, truth policy, freshness, credentials/grants, write gates; visual query builder and capture flows select from this catalog."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Sources catalog
+
+## Contract
+
+One governed top-level Content Database of local, provider, and native Sources
+
+## Acceptance boundary
+
+A complete proof demonstrates: Personal/workspace/organization scope; stable source identity, owner/access, approval, capabilities, truth policy, freshness, credentials/grants, write gates; visual query builder and capture flows select from this catalog.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.source.file-folder.md
+++ b/templates/content/docs/product/capabilities/content.source.file-folder.md
@@ -1,17 +1,25 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.source.file-folder"
 name: "Files and folders as Sources"
-user_promise: "A person can open a folder as a Source without assuming every file shares one Database schema."
+user_promise: "Open a selected file tree as a Source without forcing heterogeneous files into one Database schema."
+primary_user_job: "Browse and work with a local folder through Content while retaining file identity, hierarchy, device limits, and source ownership."
 kind: "primitive"
 state: "exploring"
 publicness: "public"
 availability: "configured"
-dependencies: ["content.source.adapters","content.portability.source-representation"]
+dependencies:
+  ["content.source.adapters", "content.portability.source-representation"]
 related_features: ["content.feature.bring-your-local-work"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: A person can open a folder as a Source without assuming every file shares one Database schema."
-proof_requirements: ["A person can open a folder as a Source without assuming every file shares one Database schema."]
+acceptance_summary: "A folder Source models a selected root and heterogeneous file representations with stable source identity and hierarchy, materializes only supported authorized content, and delegates physical authority, sync, and write-back to the Source adapter and local bridge."
+proof_requirements:
+  [
+    "Folder identity, hierarchy, heterogeneous representation, and source-metadata tests",
+    "Access, local-path redaction, add/change/delete/rename/conflict/degraded-client tests",
+    "Selected-folder workflow covering browse, open, external change, unavailable device, and disconnect",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +27,45 @@ last_reviewed: "2026-07-29"
 
 # Files and folders as Sources
 
-## Contract
+## Why this exists
 
-A person can open a folder as a Source without assuming every file shares one Database schema.
+A folder is a living landscape of unlike things; it should not have to masquerade as one spreadsheet.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: A person can open a folder as a Source without assuming every file shares one Database schema.
+A developer selects a documentation folder. Content shows a source-root hierarchy, opens supported files as Pages, keeps unknown files identifiable, and shows last synchronized material when a browser lacks the local bridge.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A folder Source retains selected-root, relative hierarchy, file identity, representation kind, baseline, and provenance without exporting raw paths or handles to shared clients.
+- Files may map to different Content representations or remain opaque/unavailable; no common Database schema is assumed.
+- Physical reads, watches, writes, rename/delete behavior, conflict, and bridge availability follow adapter and local-bridge policy.
+- Removing a connection stops future source access without silently deleting external originals.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Local bridge owns device authority; portable representation owns materialization; Files UI is a projection. This is not a universal filesystem browser or arbitrary directory access grant.
+
+## Acceptance stories
+
+### Browse heterogeneous material
+
+Given a selected folder with Markdown, PDF, and unsupported binary files, when it materializes, then Content preserves hierarchy and source identity while exposing only the representations each file supports.
+
+### Degrade without exposing paths
+
+Given a browser without bridge authority, when it opens a materialized folder item, then it can read the last authorized representation but cannot reveal the local path or invoke physical file operations.
+
+## Current evidence
+
+Donor evidence: `actions/connect-local-folder-source.ts`, `actions/sync-local-folder-source.ts`, `actions/local-folder-source.db.test.ts`, and sidebar source handling establish local-folder substrate. The common heterogeneous folder contract and complete authority/recovery proof remain exploratory.
+
+## Proof plan
+
+1. Define folder/file representation and hierarchy contract independent of one Database schema.
+2. Test file lifecycle, path redaction, bridge absence, conflicts, and disconnect.
+3. Verify selection, browse, sync, external change, and repair through the interface.
+
+## Open questions
+
+- Supported file-family order and directory-scale behavior remain open.

--- a/templates/content/docs/product/capabilities/content.source.file-folder.md
+++ b/templates/content/docs/product/capabilities/content.source.file-folder.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.source.file-folder"
+name: "Files and folders as Sources"
+user_promise: "A person can open a folder as a Source without assuming every file shares one Database schema."
+kind: "primitive"
+state: "exploring"
+publicness: "public"
+availability: "configured"
+dependencies: ["content.source.adapters","content.portability.source-representation"]
+related_features: ["content.feature.bring-your-local-work"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: A person can open a folder as a Source without assuming every file shares one Database schema."
+proof_requirements: ["A person can open a folder as a Source without assuming every file shares one Database schema."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Files and folders as Sources
+
+## Contract
+
+A person can open a folder as a Source without assuming every file shares one Database schema.
+
+## Acceptance boundary
+
+A complete proof demonstrates: A person can open a folder as a Source without assuming every file shares one Database schema.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.source.local-bridge.md
+++ b/templates/content/docs/product/capabilities/content.source.local-bridge.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.source.local-bridge"
+name: "Local Source bridge"
+user_promise: "A desktop app or small trusted service can synchronize selected local Sources for browsers that cannot access files directly."
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "desktop"
+dependencies: ["content.source.adapters","content.source.sync-policy"]
+related_features: ["content.feature.bring-your-local-work","content.feature.take-the-whole-vault-with-you","content.feature.keep-your-private-vault-private"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: A desktop app or small trusted service can synchronize selected local Sources for browsers that cannot access files directly."
+proof_requirements: ["A desktop app or small trusted service can synchronize selected local Sources for browsers that cannot access files directly."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Local Source bridge
+
+## Contract
+
+A desktop app or small trusted service can synchronize selected local Sources for browsers that cannot access files directly.
+
+## Acceptance boundary
+
+A complete proof demonstrates: A desktop app or small trusted service can synchronize selected local Sources for browsers that cannot access files directly.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.source.local-bridge.md
+++ b/templates/content/docs/product/capabilities/content.source.local-bridge.md
@@ -1,17 +1,29 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.source.local-bridge"
 name: "Local Source bridge"
-user_promise: "A desktop app or small trusted service can synchronize selected local Sources for browsers that cannot access files directly."
+user_promise: "A trusted device can synchronize explicitly selected local Sources while browsers remain useful without inheriting filesystem authority."
+primary_user_job: "Work with a local folder across devices without exposing its path, handles, or direct filesystem power to every browser."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
 availability: "desktop"
-dependencies: ["content.source.adapters","content.source.sync-policy"]
-related_features: ["content.feature.bring-your-local-work","content.feature.take-the-whole-vault-with-you","content.feature.keep-your-private-vault-private"]
+dependencies: ["content.source.adapters", "content.source.sync-policy"]
+related_features:
+  [
+    "content.feature.bring-your-local-work",
+    "content.feature.take-the-whole-vault-with-you",
+    "content.feature.keep-your-private-vault-private",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: A desktop app or small trusted service can synchronize selected local Sources for browsers that cannot access files directly."
-proof_requirements: ["A desktop app or small trusted service can synchronize selected local Sources for browsers that cannot access files directly."]
+acceptance_summary: "A device-authorized bridge holds selected-root authority locally, synchronizes access-scoped materializations through the Source contract, validates every physical operation and base revision, queues permitted write-back truthfully, and lets unsupported clients use the last authorized representation without receiving filesystem authority."
+proof_requirements:
+  [
+    "Device pairing, root grants, capability revocation, path containment, payload bounds, and origin/client authorization tests",
+    "End-to-end bridge synchronization, base-version conflict, queue, retry, receipt, disconnect, and degraded-client workflows",
+    "Security and privacy review proving raw paths/handles stay local and no webpage or browser client gains general filesystem or command authority",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +31,126 @@ last_reviewed: "2026-07-29"
 
 # Local Source bridge
 
-## Contract
+## Why this exists
 
-A desktop app or small trusted service can synchronize selected local Sources for browsers that cannot access files directly.
+A local folder should participate in the same Content workspace without making
+the folder a shared database or granting every browser the ability to inspect a
+device. Some clients can hold a user-granted folder capability; many cannot.
+The bridge keeps that difference honest while preserving ordinary Content work.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: A desktop app or small trusted service can synchronize selected local Sources for browsers that cannot access files directly.
+A person grants a trusted desktop app access to one documentation folder. The
+bridge materializes authorized files into Content and watches the granted root.
+Later, a browser without local-file capability reads the last synchronized
+representation, adds a permitted source-owned edit, and sees **waiting for
+local access** rather than **synced**. When the trusted device returns, the
+bridge checks the base revision, writes or raises a conflict, and emits a
+receipt. The browser never receives the folder path or direct file handle.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+### One narrow device-authorized protocol
 
-## Non-goals
+- The Local Source Bridge is one Source-adapter protocol. A trusted desktop app
+  implements it first; a lightweight helper or optional browser transport may
+  later use the same contract rather than create separate sync engines.
+- A person explicitly selects roots and grants read and write capability
+  separately. Hosted Content stores opaque connection IDs, Source metadata,
+  baselines, and access-scoped materializations, never raw paths or operating
+  system handles.
+- Every physical operation validates the paired client/origin, connection,
+  granted root, operation capability, normalized relative path, payload bound,
+  and base version. Traversal, root escape through symlinks, arbitrary shell
+  execution, and a general webpage-to-native command channel are prohibited.
+- The bridge reads, watches, and writes only declared Source representations;
+  it uses the same policy, conflict, Event, and receipt contract as other
+  adapters.
 
-This capability does not create a parallel datastore, permission model, or action surface.
+### Degrade without pretending authority exists
+
+- A browser or device that lacks persistent folder access can read the last
+  access-authorized SQL materialization and continue SQL-owned work such as
+  Views, Queries, memberships, collaboration, and Content-owned properties.
+- It does not inherit desktop filesystem authority. Direct local-only actions,
+  such as immediate physical writes or opening bytes never materialized, are
+  unavailable on that client and identify the applicable trusted route.
+- When policy permits, source-owned outbound edits can queue with their base
+  version until an authorized bridge returns. Queued, stale, unavailable,
+  conflict, failed, and provider-confirmed states remain distinct.
+- The normal interface stays quiet until a requested operation genuinely needs
+  unavailable local bytes or authority. Loss of a bridge narrows the Source on
+  that client; it does not hide the Source or make unrelated Content read-only.
+
+### Keep custody and recovery explicit
+
+- Reconnection refreshes freshness before applying queued work. Incompatible
+  upstream edits enter review rather than overwriting local files.
+- Each bridge operation produces ordinary actor/origin-aware Events and sync
+  receipts. Retries use stable identity and must not duplicate physical effects.
+- Disconnecting or revoking a bridge grant stops future device access and never
+  deletes external originals. Treatment of any Content materialization is an
+  explicit separate decision under Source policy and portability rules.
+
+## Boundaries and non-goals
+
+- Files and folders as Sources owns how a selected tree materializes as Content
+  records. This bridge owns device authority and transport, not a second Files
+  product.
+- Sync policy owns View only, Keep in sync, and Review before write-back;
+  adapters own capability declarations. The bridge implements those contracts
+  for local authority.
+- This Capability does not require every browser to install an extension, make
+  a browser's folder picker equivalent to desktop authority, or expose a
+  loopback service to arbitrary webpages.
+
+## Acceptance stories
+
+### Synchronize without disclosing a local path
+
+Given a person grants one root to a paired bridge, when the bridge synchronizes
+an authorized file into Content, then shared records contain only opaque Source
+connection and representation metadata, while the raw path and handle remain
+on the device.
+
+### Queue honestly on an unsupported client
+
+Given a browser without local bridge capability and a Source policy that permits
+write-back, when an editor changes a source-owned field, then Content records a
+base-versioned queued change and shows a waiting state; it does not claim the
+file changed or grant the browser direct access to the folder.
+
+### Block root escape and preserve the original on disconnect
+
+Given a paired bridge receives a write request whose path escapes the granted
+root, when it validates the request, then it rejects the operation with no file
+mutation and an honest failure. Given the owner later disconnects the Source,
+then the bridge stops access without deleting the original local file.
+
+## Current evidence
+
+Local File Mode, connected-folder Sources, conflict records, and trusted local
+bridge pieces provide substantial foundation. They do not yet prove dependable
+background synchronization, uniform device pairing/revocation, browser queue
+behavior, or the complete protocol security and recovery contract. This
+Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Test root selection, pairing, origin/client allowlists, separate read/write
+   grants, revocation, normalized paths, symlink escapes, oversized payloads,
+   and rejected operations without filesystem side effects.
+2. Exercise initial materialization, watch refresh, authorized write-back,
+   queues, reconnect freshness checks, conflicts, retries, receipts, pauses,
+   and disconnect across a desktop bridge and an unsupported browser client.
+3. Verify access-scoped materialization and changing Content permissions never
+   convert one person's device grant into another person's filesystem access.
+4. Complete the real interface workflow for selection, degraded states,
+   contextual unavailable operations, recovery, and accessible status text.
+
+## Open questions
+
+- The exact pairing ceremony, background-service packaging, and optional
+  browser transport remain open provided they preserve the one narrow protocol.
+- Cache retention, offline capacity, and the detailed user choice for retaining
+  materialized Content on disconnect need portability design.

--- a/templates/content/docs/product/capabilities/content.source.local-project.md
+++ b/templates/content/docs/product/capabilities/content.source.local-project.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.source.local-project"
+name: "Local project mode"
+user_promise: "Opt-in local/git workspace where files are the single truth domain"
+kind: "primitive"
+state: "superseded"
+publicness: "public"
+availability: "configured"
+dependencies: ["content.source.adapters","content.portability.source-representation"]
+related_features: []
+roadmap_boundary: "superseded"
+acceptance_summary: "A complete proof demonstrates: Canonical portable representation, deliberately constrained feature contract, explicit hosted/local migrations, no default SQL/git dual truth."
+proof_requirements: ["Canonical portable representation, deliberately constrained feature contract, explicit hosted/local migrations, no default SQL/git dual truth."]
+evidence: []
+superseded_by: "content.source.adapters"
+last_reviewed: "2026-07-29"
+---
+
+# Local project mode
+
+## Contract
+
+Opt-in local/git workspace where files are the single truth domain
+
+## Acceptance boundary
+
+A complete proof demonstrates: Canonical portable representation, deliberately constrained feature contract, explicit hosted/local migrations, no default SQL/git dual truth.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This record no longer defines new product work. Continue through `content.source.adapters`.

--- a/templates/content/docs/product/capabilities/content.source.local-project.md
+++ b/templates/content/docs/product/capabilities/content.source.local-project.md
@@ -1,17 +1,25 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.source.local-project"
 name: "Local project mode"
-user_promise: "Opt-in local/git workspace where files are the single truth domain"
+user_promise: "The former local-project proposal remains lineage for file-truth work, not an active dual-truth product contract."
+primary_user_job: "Understand that selected local Sources use the common Source model and portable representation rather than a separate local-project system."
 kind: "primitive"
 state: "superseded"
 publicness: "public"
 availability: "configured"
-dependencies: ["content.source.adapters","content.portability.source-representation"]
+dependencies:
+  ["content.source.adapters", "content.portability.source-representation"]
 related_features: []
 roadmap_boundary: "superseded"
-acceptance_summary: "A complete proof demonstrates: Canonical portable representation, deliberately constrained feature contract, explicit hosted/local migrations, no default SQL/git dual truth."
-proof_requirements: ["Canonical portable representation, deliberately constrained feature contract, explicit hosted/local migrations, no default SQL/git dual truth."]
+acceptance_summary: "This lineage record directs new local-file work to Source adapters, portable representations, folder Sources, and the local bridge; it preserves the no-default-SQL/git-dual-truth constraint and does not define a separate active mode."
+proof_requirements:
+  [
+    "Catalog validation of the supersession target",
+    "Review of new local-source work for one Source contract and explicit truth/write policy",
+    "Regression review that rejects default SQL and filesystem or git dual truth",
+  ]
 evidence: []
 superseded_by: "content.source.adapters"
 last_reviewed: "2026-07-29"
@@ -19,18 +27,44 @@ last_reviewed: "2026-07-29"
 
 # Local project mode
 
-## Contract
+## Why this exists
 
-Opt-in local/git workspace where files are the single truth domain
+The early local-project label is useful history, but a separate mode would make files and hosted Content argue over who is real.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Canonical portable representation, deliberately constrained feature contract, explicit hosted/local migrations, no default SQL/git dual truth.
+A contributor planning local repository support follows the active Source adapter, file/folder, representation, and bridge records rather than adding a special project datastore.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- This is lineage only; active local work uses the common Source model.
+- A selected source declares its truth, representation, and write policy. SQL materialization and filesystem or git originals are not default competing truths.
+- Migration between local and hosted forms must be explicit and preserve provenance, conflict, and recovery semantics.
 
-## Non-goals
+## Boundaries and non-goals
 
-This record no longer defines new product work. Continue through `content.source.adapters`.
+This does not specify a new local mode, branch workflow, repository UI, or source synchronization engine.
+
+## Acceptance stories
+
+### Route new local work to active contracts
+
+Given a request to add a local file workflow, when it is planned, then it names Source adapter and representation boundaries rather than creating a `local-project` mutation path.
+
+### Refuse accidental dual truth
+
+Given a proposed feature stores editable copies in SQL and a repository by default, when reviewed, then it is rejected until one authoritative write and recovery policy is explicit.
+
+## Current evidence
+
+Repository product records identify `content.source.adapters` as the active target. This superseded record makes no implementation or verification claim.
+
+## Proof plan
+
+1. Keep the supersession edge valid.
+2. Review local-source changes for explicit source truth and migration policy.
+3. Require adapter/representation proof for any future local workflow.
+
+## Open questions
+
+- None; active design questions belong to the successor records.

--- a/templates/content/docs/product/capabilities/content.source.page-link.md
+++ b/templates/content/docs/product/capabilities/content.source.page-link.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.source.page-link"
 name: "Page-linked Sources"
-user_promise: "A single Page can bind to one external source item without inventing a separate source architecture."
+user_promise: "A Page can bind to one external item while keeping Content identity and the provider's ownership clear."
+primary_user_job: "Open a connected item as a Page and know which values come from its Source, which Content owns, and where an edit will go."
 kind: "primitive"
 state: "exploring"
 publicness: "public"
 availability: "configured"
-dependencies: ["content.source.adapters","content.object.page"]
+dependencies: ["content.source.adapters", "content.object.page"]
 related_features: ["content.feature.connect-your-sources"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: A single Page can bind to one external source item without inventing a separate source architecture."
-proof_requirements: ["A single Page can bind to one external source item without inventing a separate source architecture."]
+acceptance_summary: "A Page may carry one explicit external-item binding with stable source and provider identity, representation and baseline metadata, ownership-aware fields and actions, provenance, and source-policy routing without creating a parallel page-source architecture."
+proof_requirements:
+  [
+    "Binding identity, uniqueness, provenance, access, and Page lifecycle tests",
+    "Field ownership, write routing, baseline/conflict, detach, and source-unavailable tests",
+    "Page workflow opening a connected item, inspecting provenance, editing a mapped value, and resolving a conflict",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,45 @@ last_reviewed: "2026-07-29"
 
 # Page-linked Sources
 
-## Contract
+## Why this exists
 
-A single Page can bind to one external source item without inventing a separate source architecture.
+A connected item deserves a familiar Page without asking it to surrender where it came from.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: A single Page can bind to one external source item without inventing a separate source architecture.
+A person opens a provider article as a Page, sees source provenance and mapped fields, edits one writable field, and receives a source receipt or a conflict rather than an ambiguous local save.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A Page has one explicit external item binding when this capability applies; the binding carries Source, provider identity, representation, baseline, and provenance.
+- Content identity, comments, memberships, views, and Content-owned fields remain Content-owned. Source-owned values route only through declared adapter policy.
+- The page shows freshness, availability, ownership, conflict, and write outcome honestly. Detach is explicit and preserves provenance/history.
+- The binding is a normalized use of the Source adapter model, not a separate data architecture.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Multi-source composition belongs to Queries; folder hierarchy belongs to folder Sources. This does not assert that all Pages have or need an external binding.
+
+## Acceptance stories
+
+### Route a mapped edit
+
+Given a Page linked to one writable external item, when an editor changes a source-owned mapped field, then the adapter receives that one authorized change and the receipt names the provider outcome.
+
+### Keep Content work after source loss
+
+Given the linked Source becomes unavailable, when a reader opens the Page, then Content shows the last authorized representation and source status while preserving Content-owned comments and memberships.
+
+## Current evidence
+
+Donor evidence: `actions/_document-source.ts`, `shared/content-source.ts`, and source-backed database actions model parts of binding/provenance. No normalized Page binding, ownership UI, or full conflict proof exists; this record remains `exploring`.
+
+## Proof plan
+
+1. Define binding cardinality, provenance, ownership, detach, and state model.
+2. Test access, route selection, base revisions, conflicts, unavailable source, and detachment.
+3. Verify linked Page workflow through the editor and source receipts.
+
+## Open questions
+
+- Whether a Page may bind multiple representations of one provider item needs a later Shape.

--- a/templates/content/docs/product/capabilities/content.source.page-link.md
+++ b/templates/content/docs/product/capabilities/content.source.page-link.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.source.page-link"
+name: "Page-linked Sources"
+user_promise: "A single Page can bind to one external source item without inventing a separate source architecture."
+kind: "primitive"
+state: "exploring"
+publicness: "public"
+availability: "configured"
+dependencies: ["content.source.adapters","content.object.page"]
+related_features: ["content.feature.connect-your-sources"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: A single Page can bind to one external source item without inventing a separate source architecture."
+proof_requirements: ["A single Page can bind to one external source item without inventing a separate source architecture."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Page-linked Sources
+
+## Contract
+
+A single Page can bind to one external source item without inventing a separate source architecture.
+
+## Acceptance boundary
+
+A complete proof demonstrates: A single Page can bind to one external source item without inventing a separate source architecture.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.source.row-union.md
+++ b/templates/content/docs/product/capabilities/content.source.row-union.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.source.row-union"
 name: "Materialized multi-source Databases"
-user_promise: "One Database materializing rows from several source-owned collections with a Source tag and per-source column bindings"
+user_promise: "The former multi-source row-union model remains migration evidence, while active composition moves toward source Queries."
+primary_user_job: "Understand the proven source-scoped row behavior without mistaking it for the active composition contract."
 kind: "primitive"
 state: "superseded"
 publicness: "public"
 availability: "configured"
-dependencies: ["content.source.adapters","content.object.database"]
+dependencies: ["content.source.adapters", "content.object.database"]
 related_features: []
 roadmap_boundary: "superseded"
-acceptance_summary: "A complete proof demonstrates: Current code and the June 25 brief prove source-scoped row identity/writes, source selection for new rows, a user-visible Source property, and per-source field bindings; retain as migration/donor evidence while evaluating saved source queries as the simpler composition model."
-proof_requirements: ["Current code and the June 25 brief prove source-scoped row identity/writes, source selection for new rows, a user-visible Source property, and per-source field bindings; retain as migration/donor evidence while evaluating saved source queries as the simpler composition model."]
+acceptance_summary: "This lineage record preserves donor evidence for source-scoped rows, per-source field bindings, source selection, and guarded writes while directing new multi-source composition to saved source Queries and their access-safe semantics."
+proof_requirements:
+  [
+    "Catalog validation of the supersession target",
+    "Regression tests retaining source-scoped identity and guarded writes while legacy behavior remains",
+    "Design review that routes new multi-source composition to content.view.source-query",
+  ]
 evidence: []
 superseded_by: "content.view.source-query"
 last_reviewed: "2026-07-29"
@@ -19,18 +26,44 @@ last_reviewed: "2026-07-29"
 
 # Materialized multi-source Databases
 
-## Contract
+## Why this exists
 
-One Database materializing rows from several source-owned collections with a Source tag and per-source column bindings
+The row-union experiment taught useful boundaries, but its configuration surface is not the chosen future composition model.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Current code and the June 25 brief prove source-scoped row identity/writes, source selection for new rows, a user-visible Source property, and per-source field bindings; retain as migration/donor evidence while evaluating saved source queries as the simpler composition model.
+A maintainer fixing a legacy multi-source row preserves its source-scoped identity and write route, while a new combined view is designed as a saved source Query.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- This record is donor and migration lineage, not new feature direction.
+- Legacy rows preserve source-scoped identity, selected source for new rows, visible Source provenance, per-source field bindings, and guarded source writes.
+- New composition evaluates through `content.view.source-query`, where access and ownership are explicit rather than materialized into a confusing universal row surface.
 
-## Non-goals
+## Boundaries and non-goals
 
-This record no longer defines new product work. Continue through `content.view.source-query`.
+This does not revive multi-source Database configuration, prove Query behavior, or authorize a bulk migration without its own recovery plan.
+
+## Acceptance stories
+
+### Preserve a legacy row route
+
+Given a legacy row from a writable Source, when it is edited through its mapped binding, then only that Source receives the guarded change and the row retains source identity.
+
+### Design new composition as a Query
+
+Given a request to combine two Sources, when a new experience is planned, then it uses the saved source Query contract instead of adding another row-union configuration path.
+
+## Current evidence
+
+Donor evidence: `actions/_content-database-source-adapters.ts`, `actions/content-database-source-actions.test.ts`, and Builder source tests cover source-backed row behavior. This record is superseded and makes no active whole-contract claim.
+
+## Proof plan
+
+1. Keep source-scoped legacy tests while the model remains supported.
+2. Validate the supersession link and review new composition work for Query ownership.
+3. Plan any migration with identity, access, conflict, and rollback evidence.
+
+## Open questions
+
+- Legacy removal timing is intentionally not decided here.

--- a/templates/content/docs/product/capabilities/content.source.row-union.md
+++ b/templates/content/docs/product/capabilities/content.source.row-union.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.source.row-union"
+name: "Materialized multi-source Databases"
+user_promise: "One Database materializing rows from several source-owned collections with a Source tag and per-source column bindings"
+kind: "primitive"
+state: "superseded"
+publicness: "public"
+availability: "configured"
+dependencies: ["content.source.adapters","content.object.database"]
+related_features: []
+roadmap_boundary: "superseded"
+acceptance_summary: "A complete proof demonstrates: Current code and the June 25 brief prove source-scoped row identity/writes, source selection for new rows, a user-visible Source property, and per-source field bindings; retain as migration/donor evidence while evaluating saved source queries as the simpler composition model."
+proof_requirements: ["Current code and the June 25 brief prove source-scoped row identity/writes, source selection for new rows, a user-visible Source property, and per-source field bindings; retain as migration/donor evidence while evaluating saved source queries as the simpler composition model."]
+evidence: []
+superseded_by: "content.view.source-query"
+last_reviewed: "2026-07-29"
+---
+
+# Materialized multi-source Databases
+
+## Contract
+
+One Database materializing rows from several source-owned collections with a Source tag and per-source column bindings
+
+## Acceptance boundary
+
+A complete proof demonstrates: Current code and the June 25 brief prove source-scoped row identity/writes, source selection for new rows, a user-visible Source property, and per-source field bindings; retain as migration/donor evidence while evaluating saved source queries as the simpler composition model.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This record no longer defines new product work. Continue through `content.view.source-query`.

--- a/templates/content/docs/product/capabilities/content.source.spaces-files.md
+++ b/templates/content/docs/product/capabilities/content.source.spaces-files.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.source.spaces-files"
+name: "Content spaces and Files"
+user_promise: "Database-backed Content spaces, Files, Workspaces, and Sidebar views"
+kind: "primitive"
+state: "verified"
+publicness: "public"
+availability: "configured"
+dependencies: []
+related_features: ["content.feature.find-your-place-again"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Maintain explicit per-space access and source-as-adapter model."
+proof_requirements: ["Maintain explicit per-space access and source-as-adapter model."]
+evidence: ["../../../server/db/schema.ts"]
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Content spaces and Files
+
+## Contract
+
+Database-backed Content spaces, Files, Workspaces, and Sidebar views
+
+## Acceptance boundary
+
+A complete proof demonstrates: Maintain explicit per-space access and source-as-adapter model.
+
+## Evidence boundary
+
+The repository evidence linked in frontmatter supports the complete atomic contract. Feature completion still requires its own end-to-end proof.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.source.spaces-files.md
+++ b/templates/content/docs/product/capabilities/content.source.spaces-files.md
@@ -1,8 +1,10 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.source.spaces-files"
 name: "Content spaces and Files"
-user_promise: "Database-backed Content spaces, Files, Workspaces, and Sidebar views"
+user_promise: "Personal and organization-backed Content spaces and Files views keep work navigable without becoming a second permission system."
+primary_user_job: "Find, enter, and organize authorized work in the right space while knowing that sidebar arrangement does not rewrite shared ownership."
 kind: "primitive"
 state: "verified"
 publicness: "public"
@@ -10,27 +12,64 @@ availability: "configured"
 dependencies: []
 related_features: ["content.feature.find-your-place-again"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Maintain explicit per-space access and source-as-adapter model."
-proof_requirements: ["Maintain explicit per-space access and source-as-adapter model."]
-evidence: ["../../../server/db/schema.ts"]
+acceptance_summary: "Content provides database-backed personal and organization spaces, Files and Workspace/sidebar projections, explicit scope-aware selection, and source-as-adapter handling while access remains enforced by the shared resource model."
+proof_requirements:
+  [
+    "Schema and action tests for scope-aware spaces, Files membership, and source handling",
+    "Sidebar selection, ordering, drag/drop, and access-boundary regression tests",
+    "Interface workflow entering a space, organizing Files, reopening a source-backed item, and handling unavailable scope",
+  ]
+evidence:
+  [
+    "../../../server/db/schema.ts",
+    "../../../app/components/sidebar/DocumentSidebar.tsx",
+    "../../../app/components/sidebar/DocumentSidebar.layout.test.ts",
+  ]
 superseded_by: null
 last_reviewed: "2026-07-29"
 ---
 
 # Content spaces and Files
 
-## Contract
+## Why this exists
 
-Database-backed Content spaces, Files, Workspaces, and Sidebar views
+People need a place to arrive and a way to arrange it, without mistaking a sidebar for the constitution.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Maintain explicit per-space access and source-as-adapter model.
+A teammate enters an organization space, opens its Files view, reorders a personal sidebar preference, and opens a source-backed item without changing the source's ownership or another person's arrangement.
 
-## Evidence boundary
+## Product contract
 
-The repository evidence linked in frontmatter supports the complete atomic contract. Feature completion still requires its own end-to-end proof.
+- Personal and organization-backed spaces organize Content navigation and memberships; shared access remains the resource/access model's responsibility.
+- Files, Workspaces, and sidebar sections are projections over Content objects and source-backed items, not a rival Source architecture.
+- Scope selection and saved personal navigation state are explicit. Personal ordering does not silently mutate shared Database membership or reparent a Page.
+- Source-backed entries retain source-adapter boundaries and unavailable states rather than pretending all files are native Content.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Global Home and session restore own cross-space arrival; source adapters own provider behavior. Spaces do not grant access merely because an item appears in a sidebar.
+
+## Acceptance stories
+
+### Keep a personal reorder personal
+
+Given two people share a Files view, when one reorders their custom sidebar arrangement, then their preference persists without changing the other person's order or shared membership positions.
+
+### Respect space access
+
+Given a stale link to an organization-backed item, when a person without current access opens it, then the interface gives an honest access state and does not expose the item's title or source data.
+
+## Current evidence
+
+Implementation evidence: `server/db/schema.ts`, `app/components/sidebar/DocumentSidebar.tsx`, and `app/components/sidebar/DocumentSidebar.layout.test.ts` cover database-backed sidebar/Files behavior and source handling. The cited tests support the present atomic contract; Feature-level arrival proof remains separate.
+
+## Proof plan
+
+1. Maintain schema/action coverage for personal and organization scope boundaries.
+2. Run sidebar ordering and source-backed-item regression suites.
+3. Periodically verify the real interface workflow across scope changes and denied links.
+
+## Open questions
+
+- Broader Home and cross-space resumption improvements belong to their dedicated capabilities.

--- a/templates/content/docs/product/capabilities/content.source.sync-policy.md
+++ b/templates/content/docs/product/capabilities/content.source.sync-policy.md
@@ -1,17 +1,28 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.source.sync-policy"
 name: "Source sync policy"
-user_promise: "Each connected Source declares one plain-language truth policy: view only, keep in sync, or review before write-back."
+user_promise: "Each connected Source declares one plain-language policy for refresh and write-back: View only, Keep in sync, or Review before write-back."
+primary_user_job: "Connect work that remains trustworthy without deciding on every edit whether it should leave Content."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "configured"
-dependencies: ["content.source.catalog","content.event.committed"]
-related_features: ["content.feature.trust-your-connected-sources","content.feature.bring-your-local-work"]
+dependencies: ["content.source.catalog", "content.event.committed"]
+related_features:
+  [
+    "content.feature.trust-your-connected-sources",
+    "content.feature.bring-your-local-work",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Each connected Source declares one plain-language truth policy: view only, keep in sync, or review before write-back."
-proof_requirements: ["Each connected Source declares one plain-language truth policy: view only, keep in sync, or review before write-back."]
+acceptance_summary: "A Source has one inspectable policy, applies only authorized compatible changes through its declared ownership routes, stops real conflicts for review, and records receipts without confusing queued, failed, or unreviewed work with synchronization."
+proof_requirements:
+  [
+    "Policy selection and enforcement through shared Actions and the interface",
+    "Per-field or representation ownership, access intersection, base revisions, deterministic routing, conflict, retry, and receipt behavior",
+    "End-to-end View only, Keep in sync, and Review before write-back workflows with provider-side verification",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +30,132 @@ last_reviewed: "2026-07-29"
 
 # Source sync policy
 
-## Contract
+## Why this exists
 
-Each connected Source declares one plain-language truth policy: view only, keep in sync, or review before write-back.
+Connected work should not turn every ordinary edit into a synchronization
+dialog. People need to understand whether Content is only showing a Source,
+keeping compatible work aligned automatically, or preparing a deliberate
+outbound review. A familiar access role such as **Can view** answers who may
+read Content; it does not answer whether Content may write to a provider.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Each connected Source declares one plain-language truth policy: view only, keep in sync, or review before write-back.
+An editor connects a collection whose body is provider-owned and whose
+annotations are Content-owned. They choose **Review before write-back**. A
+body edit becomes one typed outbound change set with its base revision, while
+an annotation saves in Content immediately. After review, the provider accepts
+the body change and Content records a receipt. If the provider changed the
+same body incompatibly, automatic application stops and the editor sees a
+typed conflict rather than a plausible but incorrect "synced" state.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+### Configure once, follow predictably
 
-## Non-goals
+- Every Source declares exactly one user-facing policy: **View only**, **Keep
+  in sync**, or **Review before write-back**. Adapters may offer only the
+  policies their certified capabilities can honor.
+- **View only** refreshes authorized inbound Source changes into Content and
+  never writes Content-originated changes back to that Source.
+- **Keep in sync** automatically applies compatible, authorized inbound and
+  outbound changes. It is not permission for last-writer-wins: a real conflict
+  stops automatic application for review.
+- **Review before write-back** may refresh inbound changes according to the
+  adapter contract, but bundles Content-originated changes into a typed,
+  reviewable outbound change set before provider mutation.
+- The policy configures synchronization, not human access. An operation must
+  satisfy Content access, Source scope and approval, adapter capability,
+  provider grant, field or representation ownership, and the selected policy.
+  Passing one layer never implies the others.
 
-This capability does not create a parallel datastore, permission model, or action surface.
+### Ownership routes one edit once
+
+- Each Source-backed value declares its Source/property or representation
+  identity, baseline, writable directions, and conflict rule. A Source can own
+  a body while Content owns comments, view configuration, or other native
+  metadata on the same Page.
+- An ordinary edit follows that declared route without repeated prompts. A
+  Database membership or a Query projection never fans the edit out to other
+  Sources; intentional multi-destination work belongs to an explicit Rule,
+  mirror, or Automation with per-destination outcomes.
+- A computed, aligned, or otherwise ambiguous projection is read-only until an
+  authorized unambiguous route is declared. Creating through a composite
+  surface requires one inferable target or a choice of target.
+- Provider lifecycle transitions, including publication, remain separate
+  guarded operations. Editing content or successfully syncing it never
+  silently changes Draft, Published, or another provider lifecycle state.
+
+### Conflict, retry, and receipts tell the truth
+
+- Outbound work carries the relevant base revision and identity. The adapter
+  checks freshness before applying it; an incompatible upstream change becomes
+  a visible conflict or rebase/review state, not a silent overwrite.
+- A queued change is waiting for authority or transport and is not synced. A
+  reviewable change is not sent until approved. A failed or unknown outcome is
+  distinguishable from a provider-confirmed success.
+- Each attempt records actor, origin, policy, affected representations, base,
+  destination outcome, and a provider receipt when available. Retrying uses
+  stable operation identity so a recovered request does not duplicate effects.
+
+## Boundaries and non-goals
+
+- The Sources catalog owns Source discovery, approval, scope, and connection
+  metadata. Adapters own provider-specific operations and certification.
+- Human roles and Page/Database access are owned by the access capabilities;
+  this policy adds no second permission system.
+- Portable representations and unknown-data preservation belong to faithful
+  round-tripping. This record decides when a permitted write may travel, not
+  how every provider format is encoded.
+- This Capability does not promise every adapter automatic bidirectional sync,
+  offline write queue, lifecycle transition, or generic conflict UI.
+
+## Acceptance stories
+
+### Keep compatible work synchronized without accidental publication
+
+Given an authorized writable Source with **Keep in sync** and compatible
+field ownership, when an editor changes a supported Source-owned field, then
+the adapter applies the change once, records an Event and provider receipt,
+and leaves provider publication state unchanged.
+
+### Stop a genuine conflict instead of overwriting it
+
+Given a queued outbound change based on revision A and an incompatible provider
+change since A, when synchronization resumes, then Content marks the work as a
+typed conflict for review, preserves both inputs, and does not report it as
+synced or retry it as if the base still matched.
+
+### Keep reviewable write-back reviewable
+
+Given a Source configured for **Review before write-back**, when an authorized
+editor changes two compatible provider-owned representations, then Content
+creates one typed change set with both changes and their bases; no provider
+mutation occurs until the required review decision succeeds.
+
+## Current evidence
+
+Existing change sets, guarded writes, source metadata, local synchronization,
+and audit records provide useful donor machinery. They do not yet prove one
+plain-language policy across adapters, ownership-aware routing everywhere,
+reliable receipt semantics, or the full interface workflow. This Capability
+therefore remains `approved_shape`.
+
+## Proof plan
+
+1. Exercise each policy through shared Actions and the interface with
+   authorized and unauthorized read, write, review, and lifecycle requests.
+2. Verify per-field and representation ownership, projected-value routing,
+   multi-membership non-fan-out, base checks, retries, idempotency, and durable
+   receipts under refresh, disconnect, and restart.
+3. Create compatible concurrent changes and incompatible conflicts for at least
+   two independently certified adapters; verify neither generic behavior nor a
+   provider success is inferred from the other.
+4. Run access, approval, grant, capability, and policy intersection tests
+   through searches, Queries, agents, UI edits, and background work.
+
+## Open questions
+
+- The advanced presentation of directional read, watch, and write controls is
+  still open, provided it cannot contradict the three plain-language policies.
+- The common conflict-resolution vocabulary and retention rules for provider
+  receipts need design alongside the review surface.

--- a/templates/content/docs/product/capabilities/content.source.sync-policy.md
+++ b/templates/content/docs/product/capabilities/content.source.sync-policy.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.source.sync-policy"
+name: "Source sync policy"
+user_promise: "Each connected Source declares one plain-language truth policy: view only, keep in sync, or review before write-back."
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "configured"
+dependencies: ["content.source.catalog","content.event.committed"]
+related_features: ["content.feature.trust-your-connected-sources","content.feature.bring-your-local-work"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Each connected Source declares one plain-language truth policy: view only, keep in sync, or review before write-back."
+proof_requirements: ["Each connected Source declares one plain-language truth policy: view only, keep in sync, or review before write-back."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Source sync policy
+
+## Contract
+
+Each connected Source declares one plain-language truth policy: view only, keep in sync, or review before write-back.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Each connected Source declares one plain-language truth policy: view only, keep in sync, or review before write-back.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.system.dependencies.md
+++ b/templates/content/docs/product/capabilities/content.system.dependencies.md
@@ -1,17 +1,28 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.system.dependencies"
 name: "Task dependencies"
 user_promise: "Parent/subtask and blocked/blocking relations with constraints"
+primary_user_job: "Express what contains or blocks work and see trustworthy consequences across project and planning Views."
 kind: "workflow"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.relationship.edge","content.expression.language"]
-related_features: ["content.feature.run-projects-your-way","content.feature.plan-work-across-time"]
+dependencies: ["content.relationship.edge", "content.expression.language"]
+related_features:
+  [
+    "content.feature.run-projects-your-way",
+    "content.feature.plan-work-across-time",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Inverse/self-relations, cardinality, cycle rules, related-record expressions."
-proof_requirements: ["Inverse/self-relations, cardinality, cycle rules, related-record expressions."]
+acceptance_summary: "Task hierarchy and blocking are typed Relationships with inverse, cardinality, self-edge, and cycle rules; expressions and planning consume those edges rather than copied dependency fields."
+proof_requirements:
+  [
+    "Typed dependency and hierarchy create, inverse, cardinality, self-edge, cycle, and deletion coverage",
+    "Access-safe Relationship Actions, expressions, rollups, history, and recovery coverage",
+    "Project, List, Timeline, and agent-context workflow with unavailable or stale relations",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +30,51 @@ last_reviewed: "2026-07-29"
 
 # Task dependencies
 
-## Contract
+## Why this exists
 
-Parent/subtask and blocked/blocking relations with constraints
+Projects need to say what blocks what without making a task dependency engine that drifts
+away from the rest of Content.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Inverse/self-relations, cardinality, cycle rules, related-record expressions.
+An editor marks one task as blocking another and groups subtasks beneath a parent. The
+same typed edges inform task Views, expressions, and later scheduling surfaces.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Parent/subtask and blocked/blocking are canonical typed Relationships with declared inverses and constraints.
+- Creation and edits use the shared Relationship Action, access checks, history, and recovery.
+- Expressions and scheduling consume canonical edges; Views project them without copying dependency truth.
+- Cycles, self-relations, cardinality, missing endpoints, and inaccessible endpoints receive explicit policy.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Relationships own edges; schedule constraints consume them. This is not a Page-parent
+system, a hidden status mutation engine, or a parallel task graph.
+
+## Acceptance stories
+
+### Reject a forbidden cycle
+
+Given a relationship type that forbids cycles, when an editor creates a blocking cycle,
+then the shared Action rejects it with an actionable explanation and no partial edge.
+
+### Project an authorized blocker
+
+Given a task whose blocker is inaccessible, when a viewer opens a task View, then no
+endpoint title, count, or inference leaks through dependency presentation.
+
+## Current evidence
+
+Relationship and expression primitives are prerequisite substrate; no complete task
+dependency workflow is proven. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Test inverse, self-edge, cardinality, cycle, deletion, and concurrent relationship edits.
+2. Verify access closure, expressions, history, agent context, and recovery.
+3. Exercise List, project, Timeline, unavailable-relation, and keyboard workflows.
+
+## Open questions
+
+Which dependency types are blessed by the initial Task template needs template design.

--- a/templates/content/docs/product/capabilities/content.system.dependencies.md
+++ b/templates/content/docs/product/capabilities/content.system.dependencies.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.system.dependencies"
+name: "Task dependencies"
+user_promise: "Parent/subtask and blocked/blocking relations with constraints"
+kind: "workflow"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.relationship.edge","content.expression.language"]
+related_features: ["content.feature.run-projects-your-way","content.feature.plan-work-across-time"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Inverse/self-relations, cardinality, cycle rules, related-record expressions."
+proof_requirements: ["Inverse/self-relations, cardinality, cycle rules, related-record expressions."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Task dependencies
+
+## Contract
+
+Parent/subtask and blocked/blocking relations with constraints
+
+## Acceptance boundary
+
+A complete proof demonstrates: Inverse/self-relations, cardinality, cycle rules, related-record expressions.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.system.my-tasks.md
+++ b/templates/content/docs/product/capabilities/content.system.my-tasks.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.system.my-tasks"
+name: "My Tasks"
+user_promise: "“My Tasks” as an access-scoped dynamic saved view"
+kind: "workflow"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.system.task-project","content.view.query"]
+related_features: ["content.feature.run-projects-your-way"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Current-user expressions, access-safe cross-membership query, fast List."
+proof_requirements: ["Current-user expressions, access-safe cross-membership query, fast List."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# My Tasks
+
+## Contract
+
+“My Tasks” as an access-scoped dynamic saved view
+
+## Acceptance boundary
+
+A complete proof demonstrates: Current-user expressions, access-safe cross-membership query, fast List.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.system.my-tasks.md
+++ b/templates/content/docs/product/capabilities/content.system.my-tasks.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.system.my-tasks"
 name: "My Tasks"
 user_promise: "“My Tasks” as an access-scoped dynamic saved view"
+primary_user_job: "See the work assigned to me across eligible task memberships without maintaining a copied personal queue."
 kind: "workflow"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.system.task-project","content.view.query"]
+dependencies: ["content.system.task-project", "content.view.query"]
 related_features: ["content.feature.run-projects-your-way"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Current-user expressions, access-safe cross-membership query, fast List."
-proof_requirements: ["Current-user expressions, access-safe cross-membership query, fast List."]
+acceptance_summary: "My Tasks is a fast, access-scoped saved View using current-user expressions across eligible task memberships and preserving each task's canonical origin."
+proof_requirements:
+  [
+    "Current-user expression, multi-membership, sort, filter, and canonical-origin coverage",
+    "Access-safe result, count, cross-context policy, Action, and agent-context coverage",
+    "Real-interface fast List, empty, stale, unavailable, reload, and recovery workflow",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,50 @@ last_reviewed: "2026-07-29"
 
 # My Tasks
 
-## Contract
+## Why this exists
 
-“My Tasks” as an access-scoped dynamic saved view
+Assigned work should gather itself, not require a person to keep a second queue in sync.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Current-user expressions, access-safe cross-membership query, fast List.
+A contributor opens My Tasks, filters to due work, edits one task, and opens its Project.
+The task remains its one canonical record in the source Database.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- My Tasks is a saved dynamic View using current-user expressions over eligible canonical task memberships.
+- It evaluates access before results, counts, sort, filters, agent context, or cross-context display.
+- Every row retains its task and project origin; edits use ordinary shared Actions.
+- Empty, unavailable, stale, and revoked results are distinct from a complete empty queue.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+The Task template defines task meaning and Queries define result execution. My Tasks is
+not a copied inbox, assignment authority, or implicit cross-context search.
+
+## Acceptance stories
+
+### Gather assignments without duplication
+
+Given assigned tasks in two eligible projects, when a person opens My Tasks, then each
+authorized canonical task appears once according to saved View semantics.
+
+### Remove revoked work
+
+Given access to a task is revoked, when My Tasks refreshes, then that task and any count
+or preview inference disappear from the person and agent context.
+
+## Current evidence
+
+No current-user cross-membership query and fast List proof is recorded. This Capability
+remains `approved_shape`.
+
+## Proof plan
+
+1. Test current-user expressions, memberships, origin, filters, sort, and canonical edits.
+2. Verify access, policy, counts, cross-context behavior, and agent disclosure.
+3. Exercise fast List, empty, stale, unavailable, reload, and recovery workflows.
+
+## Open questions
+
+The default inclusion rule for unassigned and delegated tasks needs template design.

--- a/templates/content/docs/product/capabilities/content.system.project-status.md
+++ b/templates/content/docs/product/capabilities/content.system.project-status.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.system.project-status"
+name: "Project status"
+user_promise: "Project status updates and rollups as ordinary Content views/pages"
+kind: "workflow"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.system.task-project","content.view.grouping-aggregation"]
+related_features: ["content.feature.run-projects-your-way"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Task/project relations, access-safe aggregation, schedules/reminders, renderers."
+proof_requirements: ["Task/project relations, access-safe aggregation, schedules/reminders, renderers."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Project status
+
+## Contract
+
+Project status updates and rollups as ordinary Content views/pages
+
+## Acceptance boundary
+
+A complete proof demonstrates: Task/project relations, access-safe aggregation, schedules/reminders, renderers.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.system.project-status.md
+++ b/templates/content/docs/product/capabilities/content.system.project-status.md
@@ -1,17 +1,25 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.system.project-status"
 name: "Project status"
 user_promise: "Project status updates and rollups as ordinary Content views/pages"
+primary_user_job: "Understand a project's current state and next concern from canonical tasks and updates without a separate reporting system."
 kind: "workflow"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.system.task-project","content.view.grouping-aggregation"]
+dependencies:
+  ["content.system.task-project", "content.view.grouping-aggregation"]
 related_features: ["content.feature.run-projects-your-way"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Task/project relations, access-safe aggregation, schedules/reminders, renderers."
-proof_requirements: ["Task/project relations, access-safe aggregation, schedules/reminders, renderers."]
+acceptance_summary: "Project Pages and ordinary Views compose canonical task relationships, access-safe rollups, status updates, schedules or reminders, and suitable renderers."
+proof_requirements:
+  [
+    "Task/project relation, status update, rollup, and canonical drill-in coverage",
+    "Access-safe aggregation, schedule/reminder policy, Actions, history, and recovery coverage",
+    "Real-interface project status, empty/stale/unavailable, renderer, and agent-context workflow",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +27,51 @@ last_reviewed: "2026-07-29"
 
 # Project status
 
-## Contract
+## Why this exists
 
-Project status updates and rollups as ordinary Content views/pages
+A status page should tell a truthful story from work already happening, not become an
+orphaned dashboard that someone must remember to reconcile.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Task/project relations, access-safe aggregation, schedules/reminders, renderers.
+A lead opens a Project Page, reads its latest update and access-safe task rollup, drills
+into a concerning group, and schedules a reminder through the project's ordinary rules.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Project status is composed from canonical Task/Project relations, Pages, Views, and access-safe aggregates.
+- Status updates remain ordinary attributable Content with history and permissions.
+- Rollups and drill-in evaluate access before measures, labels, counts, reminders, exports, or agent context.
+- Empty, stale, unavailable, and partially complete inputs are represented truthfully.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Task templates own task shape; grouping owns measures. This is not a separate reporting
+warehouse, management-only data model, or inferred status authority.
+
+## Acceptance stories
+
+### Read a safe project rollup
+
+Given a Project with private tasks, when a viewer opens its status, then rollups and
+counts include only authorized task information and drill-in remains scoped.
+
+### Publish an update canonically
+
+Given an authorized project editor, when they add a status update, then it is an ordinary
+attributable Content change with history and no copied dashboard record.
+
+## Current evidence
+
+No complete project status composition, aggregation, reminder, and renderer proof is
+recorded. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Test task/project relations, updates, rollups, drill-in, and status history.
+2. Verify access, reminders, exports, agents, stale inputs, and recovery.
+3. Exercise project Page and renderer workflows under empty and unavailable conditions.
+
+## Open questions
+
+The initial status vocabulary and reminder integration policy need template design.

--- a/templates/content/docs/product/capabilities/content.system.research-workspace.md
+++ b/templates/content/docs/product/capabilities/content.system.research-workspace.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.system.research-workspace"
+name: "Research workspace Template"
+user_promise: "A blessed editable research template composes Sources, Notes, Projects, reading queues, citations, capture, and synthesis views over one Content datastore"
+kind: "workflow"
+state: "exploring"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.template.graph","content.research.annotation","content.research.citation"]
+related_features: []
+roadmap_boundary: "supporting"
+acceptance_summary: "A complete proof demonstrates: Generic citation/capture/annotation primitives, links/backlinks, templates, source adapters, access-scoped search, and typed renderers; no parallel research engine."
+proof_requirements: ["Generic citation/capture/annotation primitives, links/backlinks, templates, source adapters, access-scoped search, and typed renderers; no parallel research engine."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Research workspace Template
+
+## Contract
+
+A blessed editable research template composes Sources, Notes, Projects, reading queues, citations, capture, and synthesis views over one Content datastore
+
+## Acceptance boundary
+
+A complete proof demonstrates: Generic citation/capture/annotation primitives, links/backlinks, templates, source adapters, access-scoped search, and typed renderers; no parallel research engine.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.system.research-workspace.md
+++ b/templates/content/docs/product/capabilities/content.system.research-workspace.md
@@ -1,17 +1,29 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.system.research-workspace"
 name: "Research workspace Template"
 user_promise: "A blessed editable research template composes Sources, Notes, Projects, reading queues, citations, capture, and synthesis views over one Content datastore"
+primary_user_job: "Adapt a research system to my practice while keeping sources, notes, citations, and synthesis connected to their canonical evidence."
 kind: "workflow"
 state: "exploring"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.template.graph","content.research.annotation","content.research.citation"]
+dependencies:
+  [
+    "content.template.graph",
+    "content.research.annotation",
+    "content.research.citation",
+  ]
 related_features: []
 roadmap_boundary: "supporting"
-acceptance_summary: "A complete proof demonstrates: Generic citation/capture/annotation primitives, links/backlinks, templates, source adapters, access-scoped search, and typed renderers; no parallel research engine."
-proof_requirements: ["Generic citation/capture/annotation primitives, links/backlinks, templates, source adapters, access-scoped search, and typed renderers; no parallel research engine."]
+acceptance_summary: "An editable research Template composes generic sources, notes, projects, reading queues, citations, capture, and synthesis Views without a parallel research engine."
+proof_requirements:
+  [
+    "Template instantiation, editable provenance, and source/note/project/citation composition coverage",
+    "Access-scoped search, capture, annotation, citation, links, backlinks, and source-policy coverage",
+    "Real-interface reading, synthesis, export, unavailable-source, and recovery workflow",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +31,50 @@ last_reviewed: "2026-07-29"
 
 # Research workspace Template
 
-## Contract
+## Why this exists
 
-A blessed editable research template composes Sources, Notes, Projects, reading queues, citations, capture, and synthesis views over one Content datastore
+Research benefits from a coherent starting shape, but the shape must remain editable and
+must not seize custody of connected originals.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Generic citation/capture/annotation primitives, links/backlinks, templates, source adapters, access-scoped search, and typed renderers; no parallel research engine.
+A researcher instantiates the Template, captures a source-backed note, adds an annotation
+and citation, connects it to a project, and opens a synthesis View with provenance intact.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- The research workspace is an editable Template composition over generic Content primitives.
+- Sources declare truth and write-back policy; notes, citations, annotations, links, and Views retain canonical identity.
+- Search, capture, synthesis, export, and agent context are access-scoped and provenance-aware.
+- Source unavailability, sync staleness, deletion, and citation failure report honestly and recoverably.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Research primitives own annotations and citations; the Template is not a new research
+database, provider lock-in, or a claim that every source can be written back.
+
+## Acceptance stories
+
+### Adapt without losing provenance
+
+Given an instantiated research Template, when a researcher changes its Views or schema,
+then source notes and citations retain their canonical provenance and policy.
+
+### Synthesize authorized evidence
+
+Given mixed-access sources, when a researcher opens a synthesis View or asks an agent,
+then only authorized evidence and citations are available to the result.
+
+## Current evidence
+
+This record remains `exploring`; no complete generic research composition is proven.
+
+## Proof plan
+
+1. Test Template instantiation, edits, provenance, Sources, notes, citations, and projects.
+2. Verify access, source policy, search, export, agents, stale data, and recovery.
+3. Exercise capture-to-synthesis and unavailable-source workflows in the real interface.
+
+## Open questions
+
+The initial blessed template contents and source-adapter selection remain exploratory.

--- a/templates/content/docs/product/capabilities/content.system.task-project.md
+++ b/templates/content/docs/product/capabilities/content.system.task-project.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.system.task-project"
+name: "Blessed Task and Project Template"
+user_promise: "Blessed editable Task/Project template over Content"
+kind: "workflow"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.template.graph","content.view.fast-capture"]
+related_features: ["content.feature.run-projects-your-way"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Templates, fast List, dynamic filters/defaults, relations, Rules, status renderer, History."
+proof_requirements: ["Templates, fast List, dynamic filters/defaults, relations, Rules, status renderer, History."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Blessed Task and Project Template
+
+## Contract
+
+Blessed editable Task/Project template over Content
+
+## Acceptance boundary
+
+A complete proof demonstrates: Templates, fast List, dynamic filters/defaults, relations, Rules, status renderer, History.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.system.task-project.md
+++ b/templates/content/docs/product/capabilities/content.system.task-project.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.system.task-project"
 name: "Blessed Task and Project Template"
 user_promise: "Blessed editable Task/Project template over Content"
+primary_user_job: "Start a useful project system quickly, then adapt Tasks and Projects without forking into a separate task product."
 kind: "workflow"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.template.graph","content.view.fast-capture"]
+dependencies: ["content.template.graph", "content.view.fast-capture"]
 related_features: ["content.feature.run-projects-your-way"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Templates, fast List, dynamic filters/defaults, relations, Rules, status renderer, History."
-proof_requirements: ["Templates, fast List, dynamic filters/defaults, relations, Rules, status renderer, History."]
+acceptance_summary: "An editable Task/Project Template composes fast capture, dynamic Views and defaults, typed relations, Rules, status rendering, and History over canonical Content objects."
+proof_requirements:
+  [
+    "Template install, editable schema/View provenance, Task/Project creation, and fast-capture coverage",
+    "Relations, dynamic filters/defaults, Rules, status renderer, history, access, and recovery coverage",
+    "Real-interface project workflow from capture through status, reload, and agent context",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,51 @@ last_reviewed: "2026-07-29"
 
 # Blessed Task and Project Template
 
-## Contract
+## Why this exists
 
-Blessed editable Task/Project template over Content
+People need a credible place to start projects, then room to make the system fit the work
+without being trapped in a parallel task engine.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Templates, fast List, dynamic filters/defaults, relations, Rules, status renderer, History.
+A team instantiates the Template, captures a task from a List, assigns it to a Project,
+uses a status View, and later adjusts the template's Properties and Views for its practice.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- The Template forks editable Task and Project configuration with provenance, not a possessed shared product type.
+- Tasks, Projects, relations, Rules, status rendering, History, and Views use canonical Content objects and Actions.
+- Dynamic filters and creation defaults are contextual helpers, never hidden validation or source-of-truth copies.
+- Access, source policy, deletion, stale state, and recovery retain ordinary Content behavior.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Templates compose primitives; dependencies and scheduling have separate contracts. This is
+not a fixed task taxonomy, a proprietary workflow engine, or a permission bypass.
+
+## Acceptance stories
+
+### Start then adapt
+
+Given a new workspace, when an editor instantiates the Template and later changes a View,
+then canonical task/project identity and template provenance remain intact.
+
+### Capture into a project
+
+Given an authorized fast List, when a person captures a task and assigns its Project,
+then shared Actions apply defaults, Rules, history, and access without creating a duplicate.
+
+## Current evidence
+
+Existing Template and Database machinery are donor substrate, but the complete Task/Project
+workflow is not yet proven. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Test instantiation, provenance, editable schema and Views, and fast capture.
+2. Verify relations, Rules, defaults, status, history, access, deletion, and recovery.
+3. Exercise capture-to-project-to-status through UI and agent context after reload.
+
+## Open questions
+
+The initial Task/Project Property set and opinionated Views need Template design.

--- a/templates/content/docs/product/capabilities/content.template.governance.md
+++ b/templates/content/docs/product/capabilities/content.template.governance.md
@@ -1,17 +1,29 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.template.governance"
 name: "Template governance"
-user_promise: "Private/org-approved/Agent Native–published template catalog"
+user_promise: "Find and adopt a reusable working system with clear ownership, approval, version, provenance, and access."
+primary_user_job: "Choose a reusable system with visible ownership and approval."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.template.graph","content.access.page-database"]
-related_features: ["content.feature.share-how-your-organization-works","content.feature.put-your-organizations-know-how-to-work","content.feature.evolve-systems-safely"]
+dependencies: ["content.template.graph", "content.access.page-database"]
+related_features:
+  [
+    "content.feature.share-how-your-organization-works",
+    "content.feature.put-your-organizations-know-how-to-work",
+    "content.feature.evolve-systems-safely",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Ownership, approval, provenance, versions, discoverability, access."
-proof_requirements: ["Ownership, approval, provenance, versions, discoverability, access."]
+acceptance_summary: "Template governance provides private, organization-approved, and published catalogs with stable identity, ownership scope, inspectable content, versioning, approval, discovery, provenance, and access-aware adoption."
+proof_requirements:
+  [
+    "Catalog scope determines discoverability, editing, approval, and audit; it does not bypass object access.",
+    "Templates are inspectable snapshots of ordinary primitives, not opaque packages or a second authority system.",
+    "Adoption preserves origin and version choice; a later update is handled through review rather than possession.",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +31,46 @@ last_reviewed: "2026-07-29"
 
 # Template governance
 
-## Contract
+## Why this exists
 
-Private/org-approved/Agent Native–published template catalog
+A reusable system is only trustworthy when adopters can inspect who made it, what version they are taking, and who approved it. Discovery must not turn a catalog entry into a permission bypass.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Ownership, approval, provenance, versions, discoverability, access.
+Kai inspects an organization-approved editorial Template, then adopts its version into a workspace with visible owner, approval, and provenance.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Catalog scope determines discoverability, editing, approval, and audit; it does not bypass object access.
+- Templates are inspectable snapshots of ordinary primitives, not opaque packages or a second authority system.
+- Adoption preserves origin and version choice; a later update is handled through review rather than possession.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- `content.template.graph` owns snapshot/instantiation; Template updates own adopted-instance diffs and selective application.
+- Governance does not grant access to referenced objects, auto-update instances, or turn Templates into opaque packages.
+
+## Acceptance stories
+
+### Scope does not bypass access
+
+Given one referenced object is inaccessible, when a person inspects or adopts the Template, then inspection/adoption does not leak it.
+
+### Make approval history visible
+
+Given a new version is published, when an adopter opens catalog detail, then adopters distinguish draft, approved, and adopted versions without auto-update.
+
+## Current evidence
+
+`docs/product/features/content.feature.share-how-your-organization-works.md` names Template substrate; no unified catalog, approval action, or adoption implementation exists.
+
+## Proof plan
+
+1. Create private/org/published entries with scope, owner, version, provenance.
+2. Test discovery, approval, audit, and edit permissions.
+3. Adopt under mixed access without leaking hidden references.
+4. Hand updates to Template update workflow.
+
+## Open questions
+
+Publisher-role policy remains open.

--- a/templates/content/docs/product/capabilities/content.template.governance.md
+++ b/templates/content/docs/product/capabilities/content.template.governance.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.template.governance"
+name: "Template governance"
+user_promise: "Private/org-approved/Agent Native–published template catalog"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.template.graph","content.access.page-database"]
+related_features: ["content.feature.share-how-your-organization-works","content.feature.put-your-organizations-know-how-to-work","content.feature.evolve-systems-safely"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Ownership, approval, provenance, versions, discoverability, access."
+proof_requirements: ["Ownership, approval, provenance, versions, discoverability, access."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Template governance
+
+## Contract
+
+Private/org-approved/Agent Native–published template catalog
+
+## Acceptance boundary
+
+A complete proof demonstrates: Ownership, approval, provenance, versions, discoverability, access.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.template.graph.md
+++ b/templates/content/docs/product/capabilities/content.template.graph.md
@@ -1,17 +1,29 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.template.graph"
 name: "Multi-object Templates"
-user_promise: "Multi-object template snapshots Pages/Databases/views/Rules/expressions/body templates"
+user_promise: "Start from a reusable system of Pages, Databases, Views, Properties, Rules, expressions, and bodies, then own the result."
+primary_user_job: "Create an owned system from a reusable object graph."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.object.page","content.object.database","content.object.reference"]
-related_features: ["content.feature.share-how-your-organization-works","content.feature.capture-into-action"]
+dependencies:
+  ["content.object.page", "content.object.database", "content.object.reference"]
+related_features:
+  [
+    "content.feature.share-how-your-organization-works",
+    "content.feature.capture-into-action",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Stable references, portable graph serialization, owned instance identity."
-proof_requirements: ["Stable references, portable graph serialization, owned instance identity."]
+acceptance_summary: "A Template serializes a portable graph of ordinary Content primitives and creates an owned, editable instance with stable internal references, provenance, and optional version pinning."
+proof_requirements:
+  [
+    "Templates fork; they do not possess the instance or create a live hidden copy.",
+    "Instantiation remaps graph-local identities while preserving declared external references and access checks.",
+    "The instance remains ordinary editable Content with provenance to the source Template and version used.",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +31,46 @@ last_reviewed: "2026-07-29"
 
 # Multi-object Templates
 
-## Contract
+## Why this exists
 
-Multi-object template snapshots Pages/Databases/views/Rules/expressions/body templates
+A working system spans more than one page, yet copying a folder of loose objects loses the relationships that make it work. Teams need a reusable starting graph that becomes genuinely theirs after installation.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Stable references, portable graph serialization, owned instance identity.
+Kai installs a research Template graph, edits its new database and view freely, and traces the owned instance to the source version.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Templates fork; they do not possess the instance or create a live hidden copy.
+- Instantiation remaps graph-local identities while preserving declared external references and access checks.
+- The instance remains ordinary editable Content with provenance to the source Template and version used.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- Pages, Databases, Views, Properties, Rules, Expressions, and Blocks remain the canonical objects; the Template records their portable graph and provenance.
+- Templates fork rather than possess; they do not create a parallel datastore, fixed singleton, or hidden live synchronization channel.
+
+## Acceptance stories
+
+### Fork, do not possess
+
+Given two teams adopt the Template, when one team edits its local database, then one local database edit does not affect the other or source.
+
+### Remap internal identity
+
+Given internal links and an external reference, when the graph instantiates, then new links point locally and external reference remains declared/access-checked.
+
+## Current evidence
+
+`docs/product/architecture.md` defines graph snapshots; Page, Database, and Reference records are donors, not graph serialization/instance recovery.
+
+## Proof plan
+
+1. Serialize ordinary objects, rules, expressions, bodies, and references.
+2. Instantiate twice and verify independent IDs/provenance/access.
+3. Test unavailable dependencies and recovery without half graphs.
+4. Round-trip portable graph export/import.
+
+## Open questions
+
+All-or-nothing versus staged recovery needs root judgment.

--- a/templates/content/docs/product/capabilities/content.template.graph.md
+++ b/templates/content/docs/product/capabilities/content.template.graph.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.template.graph"
+name: "Multi-object Templates"
+user_promise: "Multi-object template snapshots Pages/Databases/views/Rules/expressions/body templates"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.object.page","content.object.database","content.object.reference"]
+related_features: ["content.feature.share-how-your-organization-works","content.feature.capture-into-action"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Stable references, portable graph serialization, owned instance identity."
+proof_requirements: ["Stable references, portable graph serialization, owned instance identity."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Multi-object Templates
+
+## Contract
+
+Multi-object template snapshots Pages/Databases/views/Rules/expressions/body templates
+
+## Acceptance boundary
+
+A complete proof demonstrates: Stable references, portable graph serialization, owned instance identity.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.template.item-body.md
+++ b/templates/content/docs/product/capabilities/content.template.item-body.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.template.item-body"
+name: "Database item Templates"
+user_promise: "Multiple database-item body templates with one default and dynamic embedded views"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.template.graph","content.object.blocks-field"]
+related_features: ["content.feature.share-how-your-organization-works"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Template graph, current-page expression, view-derived creation defaults."
+proof_requirements: ["Template graph, current-page expression, view-derived creation defaults."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Database item Templates
+
+## Contract
+
+Multiple database-item body templates with one default and dynamic embedded views
+
+## Acceptance boundary
+
+A complete proof demonstrates: Template graph, current-page expression, view-derived creation defaults.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.template.item-body.md
+++ b/templates/content/docs/product/capabilities/content.template.item-body.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.template.item-body"
 name: "Database item Templates"
-user_promise: "Multiple database-item body templates with one default and dynamic embedded views"
+user_promise: "Offer more than one useful starting body for a database record, including a clear default and context-aware embedded views."
+primary_user_job: "Start a database item with a governed body and context."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.template.graph","content.object.blocks-field"]
+dependencies: ["content.template.graph", "content.object.blocks-field"]
 related_features: ["content.feature.share-how-your-organization-works"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Template graph, current-page expression, view-derived creation defaults."
-proof_requirements: ["Template graph, current-page expression, view-derived creation defaults."]
+acceptance_summary: "Database item Templates are Template graph variants for a Database with one selected default, typed creation context, dynamic embedded views, and view-derived creation defaults."
+proof_requirements:
+  [
+    "Each body template is an ordinary graph-backed snapshot associated with the Database, not a parallel content type.",
+    "Creation applies the chosen template and defaults once within a successful transaction; dynamic views bind the newly created record context.",
+    "Changing the database default affects future creation only and never overwrites existing item bodies.",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,46 @@ last_reviewed: "2026-07-29"
 
 # Database item Templates
 
-## Contract
+## Why this exists
 
-Multiple database-item body templates with one default and dynamic embedded views
+One database can hold several kinds of work, and a blank page makes each new record start from nothing. Authors need a chosen starting body that carries the new item's actual context without rewriting existing records.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Template graph, current-page expression, view-derived creation defaults.
+Kai creates a request from a Bug report body Template; its embedded view binds the new record and later default changes affect only future rows.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Each body template is an ordinary graph-backed snapshot associated with the Database, not a parallel content type.
+- Creation applies the chosen template and defaults once within a successful transaction; dynamic views bind the newly created record context.
+- Changing the database default affects future creation only and never overwrites existing item bodies.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- `content.template.graph` owns template snapshot identity and `content.object.blocks-field` owns the item body; this record owns Database-specific choice and creation context.
+- Item Templates do not rewrite existing bodies when a default changes or create a hidden global-current-page binding.
+
+## Acceptance stories
+
+### Keep existing bodies
+
+Given default body changes, when an existing item opens, then existing item bodies remain unchanged.
+
+### Bind current item explicitly
+
+Given an embedded view, when the item Template creates a record, then it uses declared new-item context, not hidden global page state.
+
+## Current evidence
+
+`actions/create-document.ts` and `app/components/editor/DocumentBlockFields.tsx` are donors; per-database variants are absent.
+
+## Proof plan
+
+1. Create variants, choose default, test every creation route.
+2. Apply defaults/current-record binding in one transaction.
+3. Change defaults and verify future-only behavior.
+4. Test missing context/incompatible view/failed creation.
+
+## Open questions
+
+Context-sensitive default selection beyond one explicit default remains open.

--- a/templates/content/docs/product/capabilities/content.template.update.md
+++ b/templates/content/docs/product/capabilities/content.template.update.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.template.update"
+name: "Template updates"
+user_promise: "Never-auto update notice, structural diff, selective apply/reset"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.template.graph","content.diff.in-place"]
+related_features: ["content.feature.evolve-systems-safely"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Typed diff/events, provenance, local-addition preservation, dependency-safe partial apply."
+proof_requirements: ["Typed diff/events, provenance, local-addition preservation, dependency-safe partial apply."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Template updates
+
+## Contract
+
+Never-auto update notice, structural diff, selective apply/reset
+
+## Acceptance boundary
+
+A complete proof demonstrates: Typed diff/events, provenance, local-addition preservation, dependency-safe partial apply.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.template.update.md
+++ b/templates/content/docs/product/capabilities/content.template.update.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.template.update"
 name: "Template updates"
-user_promise: "Never-auto update notice, structural diff, selective apply/reset"
+user_promise: "Review what changed in a template and selectively bring compatible improvements into my owned instance."
+primary_user_job: "Selectively apply template improvements without losing local work."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.template.graph","content.diff.in-place"]
+dependencies: ["content.template.graph", "content.diff.in-place"]
 related_features: ["content.feature.evolve-systems-safely"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Typed diff/events, provenance, local-addition preservation, dependency-safe partial apply."
-proof_requirements: ["Typed diff/events, provenance, local-addition preservation, dependency-safe partial apply."]
+acceptance_summary: "Template instances never auto-update; they show a structural, typed, provenance-aware diff and permit dependency-safe selective apply or reset while preserving local additions."
+proof_requirements:
+  [
+    "An update compares the pinned/adopted source version with the proposed version and identifies affected objects, formulas, Rules, Views, and dependencies.",
+    "The owner chooses follow, pin, selectively apply, or reset; local additions remain unless the owner deliberately removes them.",
+    "Partial apply is dependency-safe, receipt-backed, previewed for impact, and never a silent remote overwrite.",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,46 @@ last_reviewed: "2026-07-29"
 
 # Template updates
 
-## Contract
+## Why this exists
 
-Never-auto update notice, structural diff, selective apply/reset
+A template improvement is useful only if an instance owner can see its consequences before accepting it. Remote changes must not overwrite the local adaptations that made the template fit real work.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Typed diff/events, provenance, local-addition preservation, dependency-safe partial apply.
+Kai reviews a template update, applies a formula but not a view, and keeps a locally added property untouched.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- An update compares the pinned/adopted source version with the proposed version and identifies affected objects, formulas, Rules, Views, and dependencies.
+- The owner chooses follow, pin, selectively apply, or reset; local additions remain unless the owner deliberately removes them.
+- Partial apply is dependency-safe, receipt-backed, previewed for impact, and never a silent remote overwrite.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- `content.template.graph` owns source/instance graph identity and `content.diff.in-place` owns review presentation; this record owns update notice, impact, and selective apply/reset.
+- Updates never auto-apply, overwrite local additions silently, or use a remote version as a new permission authority.
+
+## Acceptance stories
+
+### Never auto-update
+
+Given a new approved version, when an owner opens the instance, then instance remains pinned until owner acts.
+
+### Require dependencies
+
+Given selected change needs a property, when the owner applies it, then Content applies it or explains why partial apply cannot commit.
+
+## Current evidence
+
+`docs/product/features/content.feature.evolve-systems-safely.md` records donors; typed graph diff/impact/apply/recovery are absent.
+
+## Proof plan
+
+1. Diff graph versions including formulas, Rules, views, dependencies.
+2. Preview consumers and local additions.
+3. Selectively apply/reset with receipts/recovery.
+4. Test conflicts, denial, and retry without overwrite.
+
+## Open questions
+
+Conflict presentation and reset granularity remain open.

--- a/templates/content/docs/product/capabilities/content.time.types.md
+++ b/templates/content/docs/product/capabilities/content.time.types.md
@@ -1,36 +1,85 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.time.types"
 name: "Dates, times, and durations"
 user_promise: "Date, Instant, ranges, Duration, and explicit timezone conversion"
+primary_user_job: "Represent time accurately for the meaning I intend and see its conversion, filtering, rendering, and export without silent timezone drift."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
 dependencies: ["content.property.typed"]
-related_features: ["content.feature.data-that-keeps-itself-right","content.feature.plan-work-across-time"]
+related_features:
+  [
+    "content.feature.data-that-keeps-itself-right",
+    "content.feature.plan-work-across-time",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Separate date-only and timestamp semantics through storage, filters, rendering, export."
-proof_requirements: ["Separate date-only and timestamp semantics through storage, filters, rendering, export."]
-evidence: []
+acceptance_summary: "Typed Date, Instant, ranges, Duration, and explicit timezone conversion preserve distinct semantics through storage, filters, rendering, Actions, and export."
+proof_requirements:
+  [
+    "Date-only, instant, range, duration, timezone, validation, storage, and round-trip coverage",
+    "Filter, sort, expression, renderer, Action, export, import, and agent-context semantic coverage",
+    "DST, locale, invalid value, missing zone, reload, and recovery workflows",
+  ]
+evidence:
+  [
+    "../../../app/components/editor/database/calendar-timeline.ts",
+    "../../../app/components/editor/DocumentDatabase.test.ts",
+  ]
 superseded_by: null
 last_reviewed: "2026-07-29"
 ---
 
 # Dates, times, and durations
 
-## Contract
+## Why this exists
 
-Date, Instant, ranges, Duration, and explicit timezone conversion
+“Tuesday” and “Tuesday at 09:00 in a zone” are different promises. Content must retain
+that difference from storage to a person reading an export months later.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Separate date-only and timestamp semantics through storage, filters, rendering, export.
+An editor records a date-only deadline and a zoned meeting instant, filters both in a
+Timeline, travels to another timezone, and exports them with their distinct meaning intact.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Date, Instant, range, Duration, and timezone are typed values with non-interchangeable semantics.
+- Date-only values do not acquire a hidden timezone; Instants retain an explicit conversion context.
+- Filters, sorts, expressions, renderers, Actions, import/export, and agents preserve the declared type.
+- Invalid, ambiguous, missing-zone, stale, and unavailable values are explicit rather than coerced into success.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Typed Properties own general value storage. This is not a calendar provider, scheduling
+policy, or permission model.
+
+## Acceptance stories
+
+### Preserve a date-only value
+
+Given a date-only deadline, when a viewer changes timezone and filters or exports it,
+then Content retains the same calendar date rather than shifting it as an Instant.
+
+### Convert an Instant explicitly
+
+Given a zoned meeting Instant, when a viewer changes display timezone, then its displayed
+local time changes by explicit conversion while its stored instant and history remain stable.
+
+## Current evidence
+
+`calendar-timeline.ts` and Database tests provide date-window donor behavior. They do
+not prove the complete typed storage, timezone, expression, import/export, and recovery
+contract; this Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Test every type through validation, storage, round trip, filters, sorts, and expressions.
+2. Verify rendering, Actions, import/export, agents, and type-preserving history.
+3. Exercise DST, locale, invalid/missing zone, reload, unavailable input, and recovery workflows.
+
+## Open questions
+
+The serialized interchange representation and display-zone preference policy need design.

--- a/templates/content/docs/product/capabilities/content.time.types.md
+++ b/templates/content/docs/product/capabilities/content.time.types.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.time.types"
+name: "Dates, times, and durations"
+user_promise: "Date, Instant, ranges, Duration, and explicit timezone conversion"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.property.typed"]
+related_features: ["content.feature.data-that-keeps-itself-right","content.feature.plan-work-across-time"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Separate date-only and timestamp semantics through storage, filters, rendering, export."
+proof_requirements: ["Separate date-only and timestamp semantics through storage, filters, rendering, export."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Dates, times, and durations
+
+## Contract
+
+Date, Instant, ranges, Duration, and explicit timezone conversion
+
+## Acceptance boundary
+
+A complete proof demonstrates: Separate date-only and timestamp semantics through storage, filters, rendering, export.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.version.branching.md
+++ b/templates/content/docs/product/capabilities/content.version.branching.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.version.branching"
+name: "Named Page Versions"
+user_promise: "Multiple named body versions evolve in parallel under one Page identity and shared properties"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.version.field-history","content.diff.in-place"]
+related_features: ["content.feature.living-references","content.feature.explore-alternatives-safely","content.feature.read-and-annotate-anything","content.feature.publish-with-confidence"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: One Discussion across versions, message version anchors, revision graph, version identity, compare/selective merge, promote/current, archive/restore, source/export, access and recovery."
+proof_requirements: ["One Discussion across versions, message version anchors, revision graph, version identity, compare/selective merge, promote/current, archive/restore, source/export, access and recovery."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Named Page Versions
+
+## Contract
+
+Multiple named body versions evolve in parallel under one Page identity and shared properties
+
+## Acceptance boundary
+
+A complete proof demonstrates: One Discussion across versions, message version anchors, revision graph, version identity, compare/selective merge, promote/current, archive/restore, source/export, access and recovery.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.version.branching.md
+++ b/templates/content/docs/product/capabilities/content.version.branching.md
@@ -1,17 +1,31 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.version.branching"
 name: "Named Page Versions"
 user_promise: "Multiple named body versions evolve in parallel under one Page identity and shared properties"
+primary_user_job: "Explore and review a substantial alternative without disturbing the current Page or splitting the work across duplicate Pages."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.version.field-history","content.diff.in-place"]
-related_features: ["content.feature.living-references","content.feature.explore-alternatives-safely","content.feature.read-and-annotate-anything","content.feature.publish-with-confidence"]
+dependencies: ["content.version.field-history", "content.diff.in-place"]
+related_features:
+  [
+    "content.feature.living-references",
+    "content.feature.explore-alternatives-safely",
+    "content.feature.read-and-annotate-anything",
+    "content.feature.publish-with-confidence",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: One Discussion across versions, message version anchors, revision graph, version identity, compare/selective merge, promote/current, archive/restore, source/export, access and recovery."
-proof_requirements: ["One Discussion across versions, message version anchors, revision graph, version identity, compare/selective merge, promote/current, archive/restore, source/export, access and recovery."]
+acceptance_summary: "One Page can hold named alternative bodies with narrower access, independent history, in-place comparison and selective merge, explicit canonical promotion, Version-aware collaboration, and lossless recovery."
+proof_requirements:
+  [
+    "Stable Page and Version identity with shared title, Properties, sharing ceiling, and Discussion",
+    "Independent body history, in-place compare, bidirectional selective merge, durable review decisions, and canonical promotion",
+    "Version-aware Comments, Discussion, Annotations, receipts, search, agents, publication, and exports under access intersection",
+    "Archive, restore, failure recovery, and lossless round-trip of the Version graph",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +33,119 @@ last_reviewed: "2026-07-29"
 
 # Named Page Versions
 
-## Contract
+## Why this exists
 
-Multiple named body versions evolve in parallel under one Page identity and shared properties
+People need to explore a meaningful alternative without changing the current or published work before the alternative is ready. Copying the Page solves isolation by breaking everything else: identity, Properties, access, Discussion, source provenance, and history drift into parallel objects.
 
-## Acceptance boundary
+Named Versions keep the work on one Page. They add deliberate alternative bodies and review workflows above ordinary Blocks-field history; they do not turn every autosave into a branch.
 
-A complete proof demonstrates: One Discussion across versions, message version anchors, revision graph, version identity, compare/selective merge, promote/current, archive/restore, source/export, access and recovery.
+## Example workflow
 
-## Evidence boundary
+A team has a published article and wants to attempt a larger rewrite. An editor creates a private Version called `Rewrite`, leaves Comments for an agent, and lets the agent edit that Version while the canonical article remains unchanged. The team compares `Rewrite` with the current Version inside the ordinary Page interface, accepts some changes and rejects others, then promotes `Rewrite` when it is ready. The former current Version remains intact and addressable, and publication stays pinned until someone explicitly updates it.
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+## Product contract
 
-## Non-goals
+### One Page, deliberate alternatives
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- The Page retains one stable ID and URL across every Version.
+- The Page title, top-level Properties, Database memberships, source identity, and sharing boundary remain Page-owned and common across Versions.
+- Each named Version has stable identity, a human label, Version-specific body state, its own revision history, and a place in the Page's Version graph.
+- Exactly one authorized Version is current or canonical. Promoting another Version changes that pointer; it does not overwrite or delete the former current Version.
+- A named Version is not an Event, logical Revision, recovery snapshot, duplicate Page, source representation, or publication. Those concepts may refer to a Version but retain their own identities and lifecycles.
+- Ordinary Blocks-field history continues independently beneath every named Version and exists even on Pages that never create an alternative.
+
+### Versions in the ordinary Page interface
+
+- Opening Versions changes the normal Page surface. Selecting a Version renders that body in the ordinary editor rather than in a separate diff application.
+- Comparing two authorized Versions shows typed differences in place while retaining unchanged context.
+- Review may accept or reject one change, all currently visible changes, or a safe filtered set. Compatible changes may move in either direction.
+- Accepted and rejected decisions persist immediately with actor, origin, and Version context. Retrying an already-applied decision is idempotent.
+- Selective merge does not collapse the two Version identities. Each body and its history remain independently addressable afterward.
+- If either side changes after a comparison was prepared, Content shows a stale, refresh, rebase, or typed conflict state. It never silently applies a change against a different base or converts a failed comparison into `no differences`.
+
+### Collaboration stays with the Page
+
+- A Page has one Discussion across all Versions. It is not cloned per alternative.
+- A Discussion message records the named Version and exact Revision/Event cursor visible when it was posted. The shared feed may be filtered to the current Version or all authorized Versions.
+- Replies inherit the root message's Version scope. A person who cannot access a private Version cannot infer its messages through counts, unread state, participants, notifications, search, summaries, or agents.
+- Comments remain Page-owned and target stable Blocks, precise ranges, the named Version and Revision, and quoted fallback context. Deleting or replacing the target text never deletes the Comment.
+- Annotations retain exact Version and source-revision context. Ordinary edits may relocate an anchor within that Version; sibling Versions never inherit it silently.
+- A filtered visible set of Comments or Annotations may be carried to another Version. Preview distinguishes exact matches, proposed relocations, and unresolved anchors. Accepting a mapping adds a destination target to the same contribution identity and preserves the original target and conversation.
+- Execution receipts and other Version-aware contributions keep the Version context visible when reviewed later.
+
+## Access and publication
+
+- Versions inherit Page access by default. A named Version may restrict access to fewer people but can never be shared more broadly than its Page.
+- Effective authority is the intersection of Page access and the Version restriction. Page identity and top-level Properties remain visible according to Page access; the Version body, history, diffs, attachments, receipts, and Version-scoped contributions inherit the narrower boundary.
+- Inaccessible Versions are absent from ambient discovery. Their labels, participants, counts, backlinks, Query membership, search results, notifications, summaries, and agent context do not leak.
+- A known opaque Version link returns an honest access-denied state without exposing private metadata and may offer the normal request-access path when policy permits.
+- Search, Queries, references, embeds, agents, compare, merge, export, and source synchronization apply Version access before reading or computing.
+- Ordinary Revisions inherit their named Version's access and are not independently shareable.
+- Publication is separately pinned to an explicitly selected Version and exact Revision. Promoting the collaborative current Version does not silently alter what is public.
+
+## Promotion, archive, recovery, and export
+
+- Promotion requires the relevant edit/structural authority, commits atomically, and leaves exactly one current Version.
+- The replaced current Version remains a normal alternative with its body, history, access, and collaboration anchors intact.
+- Non-current Versions can be archived and restored without changing stable identity or losing history.
+- Recovery failures cannot leave a half-promoted state or a Page with ambiguous current identity.
+- A lossless Content archive preserves authorized Version identities, graph/ancestry information, bodies, per-field history, Discussion, Comments, Annotations, receipts, access metadata, provenance, and assets or stable handles.
+- Static or compatibility exports resolve as the acting user. They include only authorized material and report unresolved dependencies rather than silently presenting an incomplete export as complete.
+
+## Boundaries and non-goals
+
+- Named Versions do not replace per-Blocks-field revision history, Undo, recovery snapshots, or queryable History.
+- Versions is the product surface; typed diffs, filtered review, merge, and comparison are modes or supporting capabilities beneath it.
+- Creating a Version does not duplicate the Page, title, Properties, membership, source identity, or Discussion.
+- Publication state is not inferred from which Version is current.
+- Comments and Annotations are not copied automatically into sibling Versions. Carry-forward is an explicit, provenance-preserving operation.
+- This Capability does not define a second permission, event, Action, or export engine.
+
+## Acceptance stories
+
+### Work privately beside a stable canonical body
+
+Given a Page with a current Version, when an editor creates a restricted `Rewrite` Version and changes its body, then the Page ID, title, Properties, memberships, sharing ceiling, and Discussion remain common while the current body's content remains unchanged.
+
+### Compare and merge without destroying either alternative
+
+Given two authorized Versions containing typed Block additions, edits, moves, and deletions, when a reviewer compares them in the normal Page interface and accepts only selected changes, then only those compatible changes move, both Version identities remain, and every decision has durable attribution. Retrying an accepted decision does not duplicate it.
+
+### Promote without publishing by accident
+
+Given a public artifact pinned to Version A at revision R, when an authorized editor promotes Version B to current, then B becomes the sole collaborative current Version, A remains addressable, and the public artifact remains pinned to A/R until explicitly updated.
+
+### Keep private Versions truly private
+
+Given a Page viewer without access to restricted Version B, when they open Discussion, search, run a Query, ask an agent, follow an embed, inspect notifications, compare Versions, or export the Page, then neither B nor its derived counts, labels, participants, content, or contributions are disclosed. A known direct link yields only an honest denial.
+
+### Carry forward research without losing its origin
+
+Given a filtered Annotation rail containing exact, relocatable, and unresolved anchors from Version A, when an authorized person chooses **Carry visible to this version** for Version B and accepts a subset, then accepted contributions gain B targets with mapping provenance, unresolved anchors remain unresolved, and every original A target and conversation stays intact.
+
+### Recover the complete Page state
+
+Given a Page with several Versions, independent Blocks-field histories, archived alternatives, Version-scoped collaboration, and assets, when an authorized lossless export is restored, then stable Page and Version identities, current designation, bodies, access, histories, anchors, receipts, and authorized dependencies remain coherent.
+
+## Current evidence
+
+Content currently preserves whole-document snapshots and can restore earlier title/body state. Those snapshots are useful recovery donor machinery, not named Versions: they do not prove stable alternative identities, parallel bodies, Version-specific access, a revision graph, in-place selective merge, promotion, or Version-aware collaboration. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Create, rename, edit, compare, merge, promote, archive, restore, and address named Versions through both the interface and shared Actions.
+2. Verify Page-shared title, Properties, memberships, source identity, access ceiling, and Discussion while independently editing Version bodies and Blocks-field histories.
+3. Exercise additions, deletions, moves, structured Blocks, partial review, all-visible review, retries, stale bases, incompatible dependencies, concurrent promotion, and persistence failure.
+4. Verify Discussion, Comments, Annotations, receipts, carry-forward, orphan recovery, and exact Version/Revision links across ordinary edits and promotion.
+5. Run the complete access matrix through direct reads, search, Queries, counts, notifications, references, embeds, agents, comparisons, publication, and exports.
+6. Round-trip a lossless archive and verify stable identity, current state, access, histories, collaboration, provenance, and authorized assets.
+7. Complete the Feature workflow through the real Page UI with keyboard and assistive technology, not only schema or Action tests.
+
+## Open questions
+
+- A named Version's exact payload still needs one decision: the primary body only, every Page-owned Blocks field, or an explicitly selected set. Whatever is chosen must not overload Versions to represent separate media/source formats.
+- Branch-from rules, ancestry representation, naming collisions, rename behavior, and whether merge creates a distinct graph node remain open.
+- Dependency behavior for partially accepting structurally dependent changes needs a precise oracle.
+- Concurrent promotion and archiving/restoring the current Version need atomic rules.
+- The exact portable Markdown/MDX representation of several named Versions and per-field histories remains open even though the lossless archive obligation is settled.
+- Version-specific role grammar, carry-forward authority, anchor relocation thresholds, and the detailed filter/re-anchor controls remain product decisions.

--- a/templates/content/docs/product/capabilities/content.version.field-history.md
+++ b/templates/content/docs/product/capabilities/content.version.field-history.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.version.field-history"
+name: "Blocks-field revision history"
+user_promise: "Every Blocks field preserves attributable comparison and recovery independently of later named Page Versions."
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.object.blocks-field","content.event.committed"]
+related_features: ["content.feature.durable-foundations","content.feature.explore-alternatives-safely"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Every Blocks field preserves attributable comparison and recovery independently of later named Page Versions."
+proof_requirements: ["Every Blocks field preserves attributable comparison and recovery independently of later named Page Versions."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Blocks-field revision history
+
+## Contract
+
+Every Blocks field preserves attributable comparison and recovery independently of later named Page Versions.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Every Blocks field preserves attributable comparison and recovery independently of later named Page Versions.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.version.field-history.md
+++ b/templates/content/docs/product/capabilities/content.version.field-history.md
@@ -1,17 +1,29 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.version.field-history"
 name: "Blocks-field revision history"
 user_promise: "Every Blocks field preserves attributable comparison and recovery independently of later named Page Versions."
+primary_user_job: "Understand, compare, and recover how any rich-content field changed without turning every edit into a named alternative."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.object.blocks-field","content.event.committed"]
-related_features: ["content.feature.durable-foundations","content.feature.explore-alternatives-safely"]
+dependencies: ["content.object.blocks-field", "content.event.committed"]
+related_features:
+  [
+    "content.feature.durable-foundations",
+    "content.feature.explore-alternatives-safely",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Every Blocks field preserves attributable comparison and recovery independently of later named Page Versions."
-proof_requirements: ["Every Blocks field preserves attributable comparison and recovery independently of later named Page Versions."]
+acceptance_summary: "Every editable Blocks field retains stable Block identity, attributable causal Revisions, comparison, and recovery across ordinary editing and named-Version operations."
+proof_requirements:
+  [
+    "Independent attributable revision history for every Blocks field",
+    "Stable Block and field identity through edits, reorder, deletion, and recovery",
+    "Causal Revision grouping distinct from Events, snapshots, and named Versions",
+    "In-place comparison and recovery through UI and shared Actions",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +31,73 @@ last_reviewed: "2026-07-29"
 
 # Blocks-field revision history
 
-## Contract
+## Why this exists
 
-Every Blocks field preserves attributable comparison and recovery independently of later named Page Versions.
+Rich content appears in Page bodies, additional Blocks Properties, Comments, Discussion messages, annotations, and other Content objects. People need to know what changed and recover mistakes in any of those bodies without making every keystroke a named Version or every field a miniature Page.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Every Blocks field preserves attributable comparison and recovery independently of later named Page Versions.
+A Page contains a primary article body and a separate research-notes Blocks field. An agent edits both in one run. The editor can inspect each field's attributable history, compare the relevant Revisions in place, and restore only the research notes without replacing the article body, Page title, or Properties. If the Page later gains named Versions, each alternative continues to retain its own field history.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Every editable rich-content body is a Blocks field with stable identity and one canonical owning object.
+- Every Block retains stable identity through ordinary text edits, structured edits, and reordering. Deleted content remains addressable through authorized history.
+- A committed Event is one atomic fact. A logical Revision groups causally related edits by actor, intent, action, or agent run. A recovery snapshot is persistence machinery. A named Version is a deliberate alternative. The interface never treats these as synonyms merely because they happened near the same time.
+- Each Blocks field owns its own attributable revision sequence, comparison, and recovery boundary.
+- A single action may causally touch several fields while preserving which changes belong to each field. Restoring one field does not silently replace unrelated Page state.
+- History records the actual actor, authority, origin, and causal run. Agent work is attributable as agent work rather than being flattened into the signed-in person's authorship.
+- Comparison renders through the ordinary typed editor and renderer for that field. Unknown or unavailable Block renderers preserve their source and produce an explicit degraded state rather than dropping content.
+- Creating, promoting, archiving, restoring, or merging a named Page Version never erases the underlying field histories.
+- Comments, Annotations, references, and other anchors retain their historical Block/field/Revision targets even when current content changes or is deleted.
 
-## Non-goals
+## Permissions and failure behavior
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- History reads and restores use the owning object's access plus any narrower named-Version boundary.
+- A person or agent cannot recover a field into a state they may inspect but lack authority to edit.
+- Inaccessible or pruned history is not reported as an empty successful timeline. Known direct references return an honest denial without leaking content.
+- A failed restore leaves the current field and its history unchanged. Recovery is one atomic, attributable Revision and can itself be inspected or undone.
+- Concurrent current edits cannot be silently overwritten by a restore prepared against an older state; Content exposes a stale/conflict state or applies a contractually safe merge.
+
+## Boundaries and non-goals
+
+- Field history does not create a named Version for every edit.
+- Snapshot timing does not decide Revision boundaries; causality and editing intent do.
+- A Blocks field is not a full Page and does not acquire independent top-level Properties, sharing, or Database membership.
+- This Capability does not define the Page-level branching graph, selective cross-Version merge, or canonical promotion owned by `content.version.branching`.
+- Queryable History may project these Revisions across objects, but it is not the source of truth for the field's identity.
+
+## Acceptance stories
+
+### Recover one field without replacing its Page
+
+Given a Page with two Blocks fields and unrelated top-level Properties, when an editor restores an earlier Revision of one field, then only that field changes, the other field and Properties remain intact, and the restore produces a new attributable Revision.
+
+### Preserve anchors after deletion
+
+Given a Comment anchored to a Block range, when the range and then the Block are deleted, then the Comment remains durable and can open the historical field Revision showing the original target rather than being auto-archived or attached to plausible-looking new text.
+
+### Keep agent edits attributable
+
+Given one agent run edits several Blocks in two fields, when a reviewer opens History, then the changes are grouped by causal run while remaining inspectable per field and are attributed to the agent and authorizing context.
+
+### Survive named-Version operations
+
+Given two named Versions with independent edits to the same logical field, when one is promoted and the other archived and restored, then both field histories, Block identities, anchors, and actors remain intact.
+
+## Current evidence
+
+Current whole-document snapshots and restore behavior demonstrate useful recovery substrate. They do not prove independently addressable Blocks-field history, causal Revision grouping, stable Block identity across every edit, cross-field selective recovery, or preservation through named Versions. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Exercise text and structured Block edits, moves, deletions, and restores in every Blocks-field-owning object.
+2. Verify Event-to-Revision grouping for human, agent, automation, API, and integration actors.
+3. Compare and restore one field while other fields, title, Properties, memberships, and concurrent edits remain intact.
+4. Verify Comment, Annotation, reference, and execution-receipt anchors before and after edits, deletion, restore, and named-Version operations.
+5. Test access denial, stale restore, persistence interruption, Undo, reload, export, and lossless round-trip.
+6. Run the workflow through the real editor and shared Actions, including keyboard and assistive-technology inspection.
+
+## Open questions
+
+The remaining major seam is how one named Page Version selects or groups several independently versioned Blocks fields. Physical snapshot cadence, storage layout, compaction, and indexing remain implementation choices as long as the causal and recovery contract survives.

--- a/templates/content/docs/product/capabilities/content.view.canvas.md
+++ b/templates/content/docs/product/capabilities/content.view.canvas.md
@@ -1,17 +1,30 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.view.canvas"
 name: "Canvas"
-user_promise: "A spatial Canvas, semantic Graph, and mind-map family arranges reusable Pages, Blocks, Sources, Annotations, views, and media without copying them"
+user_promise: "Canvas lets people intentionally arrange reusable Content objects in a spatial View without copying them or accidentally asserting semantic relationships."
+primary_user_job: "Lay out notes, sources, media, and views to think visually, while deciding explicitly which tentative connections should become durable shared knowledge."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.object.reference","content.relationship.edge","content.view.query"]
+dependencies:
+  [
+    "content.object.reference",
+    "content.relationship.edge",
+    "content.view.query",
+  ]
 related_features: ["content.feature.sketch-connections-keep-whats-true"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: View-owned position/size/sections/connectors; freeform draft connectors versus typed semantic Graph editing; explicit relationship type on semantic edges; manual, hierarchical, radial, and force-directed/physics layouts; pin/unpin, expand, freeze/save, and reset; multi-canvas membership; auto-population from graph queries; filter/group/sort by edge type; bounded loading and collaborative layout."
-proof_requirements: ["View-owned position/size/sections/connectors; freeform draft connectors versus typed semantic Graph editing; explicit relationship type on semantic edges; manual, hierarchical, radial, and force-directed/physics layouts; pin/unpin, expand, freeze/save, and reset; multi-canvas membership; auto-population from graph queries; filter/group/sort by edge type; bounded loading and collaborative layout."]
+acceptance_summary: "Canvas stores an intentional View-local arrangement of canonical objects, sections, and freeform connectors; only an explicit promotion creates a typed Relationship, and its visual layout never changes shared semantics."
+proof_requirements:
+  [
+    "Stable object reuse, multi-Canvas membership, position and section persistence, and canonical-record drill-in without copies",
+    "View-local connector creation, editing, deletion, and explicit promotion to a selected typed Relationship",
+    "Access-scoped placement, query-backed population, collaboration, deletion, unavailable-object, and recovery behavior",
+    "Keyboard and assistive-technology spatial navigation plus bounded loading and real-interface arrangement workflows",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +32,63 @@ last_reviewed: "2026-07-29"
 
 # Canvas
 
-## Contract
+## Why this exists
 
-A spatial Canvas, semantic Graph, and mind-map family arranges reusable Pages, Blocks, Sources, Annotations, views, and media without copying them
+People often need to arrange evidence, ideas, and work spatially before they know what every connection means. Canvas supplies that intentional visual workspace without copying the underlying Content objects or turning each sketch into a database fact. A line can remain a private-to-the-View thought until someone deliberately promotes it.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: View-owned position/size/sections/connectors; freeform draft connectors versus typed semantic Graph editing; explicit relationship type on semantic edges; manual, hierarchical, radial, and force-directed/physics layouts; pin/unpin, expand, freeze/save, and reset; multi-canvas membership; auto-population from graph queries; filter/group/sort by edge type; bounded loading and collaborative layout.
+A researcher drags canonical notes, source excerpts, images, and a saved query onto a Canvas. They place material into sections for competing explanations, draw informal lines between pieces of evidence, and add a small annotation. Once a line clearly means `contradicts`, they choose **Promote to relationship**, select that type, and confirm the authorized endpoints. The semantic edge then appears in Graph and Connections; removing the original Canvas line later does not remove it.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Canvas is a View over reusable canonical Pages, Blocks, Sources, Annotations, media handles, and embedded Views. It owns placement, size, sections, stacks, presentation overrides, and view-local connectors, never a duplicate of the object’s data or identity.
+- An object may appear in many Canvases. Moving, resizing, grouping, or removing its occurrence changes only that Canvas unless a separate canonical edit is made.
+- Drawing a freeform line creates a view-local connector by default. It may be renamed, styled, moved, or deleted without invoking the Relationship system.
+- **Promote to relationship** requires an explicit typed Relationship selection and an authorized shared mutation. Promotion creates or connects to the canonical edge; it does not silently reinterpret every similar line.
+- A Canvas may intentionally show canonical semantic edges alongside freeform connectors, but the two remain distinguishable and independently editable.
+- A Canvas may populate from an authorized saved query and may filter, group, or style visible semantic edges by type. Query membership does not give the Canvas authority to change source records.
+- Manual arrangement, mind-map hierarchy, and optional auto-layout adjust View-owned layout only. They never manufacture or rewrite semantic Relationships.
+- Canvas preserves an honest distinction among removed objects, inaccessible objects, unavailable sources, and empty query results; it does not convert each into a generic blank card.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- `content.view.graph` owns semantic relationship exploration and editing over a relationship query; Canvas is not a semantic Graph mode.
+- `content.relationship.edge` owns canonical typed edges and their authorization. Canvas owns draft connector lifecycle and invokes that Capability only on explicit promotion.
+- `content.view.query` owns typed query definitions and access-scoped result contracts; Canvas consumes authorized results.
+- `content.view.chart` owns analytical charts, and Mermaid remains an authored code diagram rather than a Canvas feature.
+- Canvas does not create a parallel datastore, permissions model, relationship inference engine, or a promise that every spatial arrangement is a shared semantic model.
+
+## Acceptance stories
+
+### Reuse one object in two contexts
+
+Given a Page placed on two Canvases, when an editor rearranges it or removes it from one Canvas, then the other Canvas and the canonical Page stay unchanged. Opening either occurrence reaches the same authorized record.
+
+### Keep brainstorming local until promotion
+
+Given two objects connected by a freeform Canvas line, when a contributor deletes or restyles the line, then no canonical Relationship changes. When they explicitly promote it with an authorized `supports` type, then one typed edge is created and remains after the local line is removed.
+
+### Preserve access and source truth
+
+Given a query-populated Canvas whose source later becomes unavailable and one result becomes inaccessible, when the viewer returns, then Canvas identifies each condition without leaking the inaccessible object or silently presenting the unavailable query as empty.
+
+### Collaborate without layout becoming a semantic conflict
+
+Given two collaborators arranging the same Canvas while one edits a canonical Relationship through another authorized surface, when changes settle, then layout updates merge or surface a recoverable View conflict and the canonical relationship retains its own history.
+
+## Current evidence
+
+Existing object references, Views, and relationship concepts are useful substrate. There is no current evidence that proves multi-Canvas identity, connector promotion, collaboration, access closure, or accessible spatial interaction as one complete workflow. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Place each supported object kind in multiple Canvases, edit its canonical source, and verify occurrence reuse, source truth, deletion, and restoration behavior.
+2. Create, edit, remove, and promote freeform connectors; prove that only explicit typed promotion invokes the Relationship Action and that visual deletion never removes an edge.
+3. Exercise query-backed population, filters, semantic-edge overlays, empty results, access changes, source unavailability, bounded loading, and retry.
+4. Test concurrent arrangement, section changes, stack changes, and canonical edits with durable history and recovery behavior.
+5. Complete keyboard and assistive-technology workflows for placement, selection, grouping, connectors, promotion, errors, and opening canonical records.
+
+## Open questions
+
+The exact spatial input model, collision behavior, collaboration merge representation, and supported media affordances remain implementation choices. They must not weaken object reuse, explicit promotion, access closure, or layout-only semantics.

--- a/templates/content/docs/product/capabilities/content.view.canvas.md
+++ b/templates/content/docs/product/capabilities/content.view.canvas.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.view.canvas"
+name: "Canvas"
+user_promise: "A spatial Canvas, semantic Graph, and mind-map family arranges reusable Pages, Blocks, Sources, Annotations, views, and media without copying them"
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.object.reference","content.relationship.edge","content.view.query"]
+related_features: ["content.feature.sketch-connections-keep-whats-true"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: View-owned position/size/sections/connectors; freeform draft connectors versus typed semantic Graph editing; explicit relationship type on semantic edges; manual, hierarchical, radial, and force-directed/physics layouts; pin/unpin, expand, freeze/save, and reset; multi-canvas membership; auto-population from graph queries; filter/group/sort by edge type; bounded loading and collaborative layout."
+proof_requirements: ["View-owned position/size/sections/connectors; freeform draft connectors versus typed semantic Graph editing; explicit relationship type on semantic edges; manual, hierarchical, radial, and force-directed/physics layouts; pin/unpin, expand, freeze/save, and reset; multi-canvas membership; auto-population from graph queries; filter/group/sort by edge type; bounded loading and collaborative layout."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Canvas
+
+## Contract
+
+A spatial Canvas, semantic Graph, and mind-map family arranges reusable Pages, Blocks, Sources, Annotations, views, and media without copying them
+
+## Acceptance boundary
+
+A complete proof demonstrates: View-owned position/size/sections/connectors; freeform draft connectors versus typed semantic Graph editing; explicit relationship type on semantic edges; manual, hierarchical, radial, and force-directed/physics layouts; pin/unpin, expand, freeze/save, and reset; multi-canvas membership; auto-population from graph queries; filter/group/sort by edge type; bounded loading and collaborative layout.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.view.chart.md
+++ b/templates/content/docs/product/capabilities/content.view.chart.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.view.chart"
+name: "Chart View"
+user_promise: "Charts share one typed specification across saved Views, embeddable Blocks, dashboards, Analytics, static output, and drill-down."
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.view.grouping-aggregation","content.view.renderer-conformance"]
+related_features: ["content.feature.understand-what-your-data-says","content.feature.build-living-dashboards"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Charts share one typed specification across saved Views, embeddable Blocks, dashboards, Analytics, static output, and drill-down."
+proof_requirements: ["Charts share one typed specification across saved Views, embeddable Blocks, dashboards, Analytics, static output, and drill-down."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Chart View
+
+## Contract
+
+Charts share one typed specification across saved Views, embeddable Blocks, dashboards, Analytics, static output, and drill-down.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Charts share one typed specification across saved Views, embeddable Blocks, dashboards, Analytics, static output, and drill-down.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.view.chart.md
+++ b/templates/content/docs/product/capabilities/content.view.chart.md
@@ -1,17 +1,30 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.view.chart"
 name: "Chart View"
-user_promise: "Charts share one typed specification across saved Views, embeddable Blocks, dashboards, Analytics, static output, and drill-down."
+user_promise: "Chart turns authorized typed query results into understandable analytical visualizations that remain usable as saved Views, embedded Blocks, dashboards, and static output."
+primary_user_job: "See a trustworthy pattern in typed records, inspect the contributing canonical rows, and reuse the same analysis wherever the work is discussed."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.view.grouping-aggregation","content.view.renderer-conformance"]
-related_features: ["content.feature.understand-what-your-data-says","content.feature.build-living-dashboards"]
+dependencies:
+  ["content.view.grouping-aggregation", "content.view.renderer-conformance"]
+related_features:
+  [
+    "content.feature.understand-what-your-data-says",
+    "content.feature.build-living-dashboards",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Charts share one typed specification across saved Views, embeddable Blocks, dashboards, Analytics, static output, and drill-down."
-proof_requirements: ["Charts share one typed specification across saved Views, embeddable Blocks, dashboards, Analytics, static output, and drill-down."]
+acceptance_summary: "Chart uses a typed analytical specification over access-scoped query results, supports saved View, embedded Block, dashboard, and static-output presentations, and drills into the canonical records that produced each mark."
+proof_requirements:
+  [
+    "Typed chart specification validation for dimensions, measures, grouping, aggregation, sort, missing values, and incompatible input",
+    "Identical saved-View, embedded-Block, dashboard, and static-output behavior from one specification",
+    "Access-safe marks, aggregates, drill-down, empty, stale, unavailable, and export-fallback behavior",
+    "Real-interface interaction, keyboard, accessibility, responsive, and renderer-conformance workflows",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +32,60 @@ last_reviewed: "2026-07-29"
 
 # Chart View
 
-## Contract
+## Why this exists
 
-Charts share one typed specification across saved Views, embeddable Blocks, dashboards, Analytics, static output, and drill-down.
+Tables expose records; Charts make patterns in typed measures and groups easier to see. Chart View provides analytical visualization without creating a separate analytics datastore or a snapshot that loses its route back to the canonical records.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Charts share one typed specification across saved Views, embeddable Blocks, dashboards, Analytics, static output, and drill-down.
+A manager saves a Chart View that groups authorized work by status and measures item count over time. They embed the same typed chart as a Block in a weekly document and place it on a dashboard. Clicking a bar opens the access-scoped canonical rows that contributed to that mark. When the dashboard is exported or viewed where the interactive renderer is unavailable, the same specification provides a readable static fallback and accessible summary.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A Chart is a typed analytical specification over an authorized Database or Query result: dimensions, measures, grouping, aggregation, sort, filters, display choices, and drill-down mapping are validated against typed input.
+- One specification can render as a saved View, embedded Block, dashboard component, and static output. These are presentations of the same analysis, not separately maintained charts.
+- A mark drills into the canonical records contributing to it through an access-scoped query. A chart never grants access to records that its viewer could not otherwise read.
+- Aggregates, labels, totals, empty states, and exported summaries are computed only from authorized input. Hidden rows cannot leak through counts, bins, axes, or a drill-down result.
+- Incompatible fields, invalid aggregation, no data, stale results, unavailable sources, and renderer failures remain distinct states with repair or retry guidance; none is rendered as a convincing zero.
+- Chart supports analytical visuals such as bars, lines, areas, and other compatible presentations chosen by the specification. Compatibility, accessibility, and export fallback are provided through Typed Renderers.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- `content.view.grouping-aggregation` owns typed grouping and aggregate semantics; Chart owns their analytical visual presentation and mark-to-record interaction.
+- `content.renderer.typed` and `content.view.renderer-conformance` own renderer compatibility, inheritance, accessibility, and output conformance; Chart does not define a new renderer registry.
+- `content.view.graph` explores typed Relationships, while `content.view.canvas` arranges objects spatially. Mermaid is authored diagram source, not a Chart input or output model.
+- Chart does not create a parallel business-intelligence warehouse, change query semantics, expose unauthorized data, or replace custom dashboard layout ownership.
+
+## Acceptance stories
+
+### Reuse one analysis across surfaces
+
+Given a valid chart specification saved on an authorized Query, when a person opens it as a View, embeds it as a Block, and adds it to a dashboard, then each surface renders the same measure, grouping, filters, labels, and drill-down contract.
+
+### Drill into only contributing records
+
+Given a bar representing an aggregate over accessible and inaccessible source rows, when a viewer activates that bar, then the drill-down contains only accessible canonical records and the aggregate, axis, and accessible-text summary reveal no hidden contribution.
+
+### Fail loudly rather than imply no work
+
+Given a saved chart whose required field was removed or source is temporarily unavailable, when it renders, then it shows a typed invalid or unavailable state with repair or retry guidance rather than a zero-valued chart.
+
+### Produce an accessible static presentation
+
+Given a chart rendered in a noninteractive export context, when the interactive renderer is unavailable, then the output includes a compatible static representation and accessible textual summary derived from the same authorized specification.
+
+## Current evidence
+
+The catalog defines typed properties, views, grouping, aggregation, renderer conformance, and dashboards as related substrate. Current code may include isolated charts or visualization components, but no evidence proves the unified typed specification across all surfaces, safe drill-down, static fallback, or full failure contract. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Validate specifications across compatible and incompatible fields, grouping, measures, aggregation, sorting, filtering, missing values, and schema changes.
+2. Render one specification as a saved View, embedded Block, dashboard item, responsive surface, and static export; verify semantic and visual conformance.
+3. Exercise mark drill-down, totals, labels, bins, empty data, access changes, stale data, deleted fields, source failure, renderer failure, and retry.
+4. Verify access-first aggregates and drill-down under changing permissions, including export and agent-accessible output.
+5. Complete mouse, keyboard, and assistive-technology interaction tests, including an accessible static fallback.
+
+## Open questions
+
+Supported chart families, formatting controls, sampling thresholds, and exact static-output formats remain open. They must fit the typed specification and preserve access-safe drill-down and truthful failure behavior.

--- a/templates/content/docs/product/capabilities/content.view.dynamic-create.md
+++ b/templates/content/docs/product/capabilities/content.view.dynamic-create.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.view.dynamic-create"
 name: "View-derived creation defaults"
-user_promise: "New rows inherit unambiguous equality constraints from the active view"
+user_promise: "Creating through a View starts new records with safe contextual values without turning that View's filters into hidden validation."
+primary_user_job: "Capture a new record where I am working and have it start in the right context without losing the ability to make a valid exception."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.view.query","content.property.constraints"]
+dependencies: ["content.view.query", "content.property.constraints"]
 related_features: ["content.feature.data-that-keeps-itself-right"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Typed query analysis; refuse ambiguous OR/range/negation inference."
-proof_requirements: ["Typed query analysis; refuse ambiguous OR/range/negation inference."]
+acceptance_summary: "Creation through an effective View seeds only deterministic positive equality, membership, contextual, and renderer-placement values; Database validation remains the sole hard gate, and valid edits may move records into or out of results with truthful feedback."
+proof_requirements:
+  [
+    "Typed effective-View analysis for positive seeds and refusal of ambiguous inference",
+    "Shared UI and Action creation with Database permissions, validation, defaults, Events, revisions, and Undo",
+    "Real-interface workflows for conflicting seeds, post-create exclusion, and valid edits that leave or re-enter results",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,112 @@ last_reviewed: "2026-07-29"
 
 # View-derived creation defaults
 
-## Contract
+## Why this exists
 
-New rows inherit unambiguous equality constraints from the active view
+People often create work from a focused list, Board lane, or Calendar date.
+That surface should provide a useful starting context, but a filter only says
+which records are included in a result. Treating it as a hidden mutation rule
+would make a View unexpectedly own data validity and block legitimate work.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Typed query analysis; refuse ambiguous OR/range/negation inference.
+An editor opens an `Active` Board filtered to `Active = true` and chooses a
+lane for `Status = Planned`. New work begins with both values. The editor then
+turns `Active` off because that is the correct valid state. Content commits the
+change through the Database, removes the record from the active View, and shows
+**Moved out of this View · Undo**; it does not reject the change or delete the
+record.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+### Seed only what is deterministic
 
-## Non-goals
+- Creation uses the effective View: its saved definition, applicable personal
+  arrangement, and renderer placement. Human and agent creation receive the
+  same analysis and shared Action behavior.
+- Exact positive equality, positive membership, contextual equality, and an
+  explicit renderer placement may seed stored values when they have an
+  unambiguous writable route. Examples include `Active = true`, `Tags contains
+Urgent`, `Assignee = current actor`, a Board lane, or a Calendar date.
+- `OR`, negation, ranges, full-text search, aggregate conditions, arbitrary
+  formulas, and other non-deterministic expressions never manufacture a stored
+  value merely because a record might satisfy them.
+- Seeds are starting values, not locked fields. Explicit user intent may change
+  them before or after creation whenever the owning Database permits the
+  resulting mutation.
 
-This capability does not create a parallel datastore, permission model, or action surface.
+### Inclusion is not validation
+
+- Query and View filters control result inclusion. The owning Database owns
+  membership, Properties, defaults, constraints, permissions, Rules, and the
+  canonical create/write path; only those rules decide whether a value is
+  valid.
+- A View over a Query cannot seed or validate outside the Query's declared
+  creation routes. A composed Query with no applicable route is truthfully
+  read-only, and a View cannot invent a target.
+- If valid creation or a later valid edit no longer matches the effective
+  result, Content preserves the record, refreshes the result, and gives light
+  feedback such as **Created, but not shown in this View** or **Moved out of
+  this View**, with an appropriate Open or Undo route.
+- Conflicting automatic seeds never cause a guess. Quick capture expands to the
+  normal creation editor, explains the conflict, and lets Database validation
+  and explicit intent resolve it.
+
+## Boundaries and non-goals
+
+- Database and Query Views own presentation, downstream filters, and the
+  effective View; Database constraints and Rules own validity.
+- Reusable Queries own intrinsic filters and creation routes. This Capability
+  applies those routes in a View; it does not define cross-source write routing.
+- This is not a bulk-update, schema-default, task-template, permission, or
+  second Action system.
+
+## Acceptance stories
+
+### Seed a Board capture without locking it
+
+Given an authorized Board View filtered to `Active = true` with a `Planned`
+lane, when a person creates a record in that lane, then the record starts with
+`Active = true` and `Status = Planned`. When they validly set `Active = false`,
+then the Database commits it and the record leaves the View with Undo feedback.
+
+### Refuse to infer an ambiguous filter
+
+Given a View filtered by `Priority = High OR Priority = Urgent` and a date
+range, when a person starts quick capture, then Content does not choose a
+priority or fabricate a date from those expressions; it opens the normal editor
+with only independently deterministic defaults.
+
+### Resolve conflicting seeds visibly
+
+Given a View's positive filter and renderer placement propose incompatible
+writable values, when an authorized person creates a record, then no arbitrary
+value is committed and the normal editor identifies the mismatch. If the person
+chooses a valid value outside the View, the record is created and truthfully
+reported as not shown.
+
+## Current evidence
+
+Existing filters, saved Views, Board/Calendar rendering, and creation paths are
+useful donor substrate. They do not yet prove typed seed analysis, identical
+human/agent behavior, conflict expansion, result-transition feedback, or the
+complete Database-validation boundary. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Test equality, membership, contextual, Board, and Calendar seeds through UI
+   and Actions, including permissions, defaults, constraints, Rules, Events,
+   revisions, reload, and Undo.
+2. Assert that OR, negation, ranges, search, aggregates, formulas, unavailable
+   fields, ambiguous routes, and inaccessible values produce no invented seed.
+3. Exercise post-create exclusion, editing records out of and back into Database
+   and Query Views, conflicting seeds, and composed Query zero/one/many routes.
+4. Verify accessible feedback and keyboard capture without turning View
+   inclusion into a hidden mutation failure.
+
+## Open questions
+
+- The exact precedence and presentation for multiple compatible defaults,
+  Database defaults, and renderer placement need implementation design.
+- The compact creation editor for conflicting seeds and the exact Undo scope
+  need interaction design, while preserving the settled ownership boundary.

--- a/templates/content/docs/product/capabilities/content.view.dynamic-create.md
+++ b/templates/content/docs/product/capabilities/content.view.dynamic-create.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.view.dynamic-create"
+name: "View-derived creation defaults"
+user_promise: "New rows inherit unambiguous equality constraints from the active view"
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.view.query","content.property.constraints"]
+related_features: ["content.feature.data-that-keeps-itself-right"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Typed query analysis; refuse ambiguous OR/range/negation inference."
+proof_requirements: ["Typed query analysis; refuse ambiguous OR/range/negation inference."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# View-derived creation defaults
+
+## Contract
+
+New rows inherit unambiguous equality constraints from the active view
+
+## Acceptance boundary
+
+A complete proof demonstrates: Typed query analysis; refuse ambiguous OR/range/negation inference.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.view.fast-capture.md
+++ b/templates/content/docs/product/capabilities/content.view.fast-capture.md
@@ -1,17 +1,28 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.view.fast-capture"
 name: "Fast keyboard capture"
 user_promise: "Keyboard-fluent List and Table capture"
+primary_user_job: "Capture and revise a record at keyboard speed without leaving the current authorized View."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.view.query","content.agent.action-parity"]
-related_features: ["content.feature.see-your-information-your-way","content.feature.run-projects-your-way"]
+dependencies: ["content.view.query", "content.agent.action-parity"]
+related_features:
+  [
+    "content.feature.see-your-information-your-way",
+    "content.feature.run-projects-your-way",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Enter/Tab/navigation/editing behavior and optimistic rollback tests."
-proof_requirements: ["Enter/Tab/navigation/editing behavior and optimistic rollback tests."]
+acceptance_summary: "List and Table capture create and edit canonical records through the shared Action surface, preserve keyboard focus, and roll back an unsuccessful optimistic update visibly."
+proof_requirements:
+  [
+    "Keyboard-only create, edit, Enter, Tab, escape, navigation, and focus-return coverage",
+    "Shared Action authorization, validation, history, error, and optimistic rollback coverage",
+    "Real-interface assistive-technology and concurrent-refresh workflow",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +30,53 @@ last_reviewed: "2026-07-29"
 
 # Fast keyboard capture
 
-## Contract
+## Why this exists
 
-Keyboard-fluent List and Table capture
+Quick capture keeps a small thought from becoming a ceremony while retaining the
+Database's rules and the record's canonical identity.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Enter/Tab/navigation/editing behavior and optimistic rollback tests.
+An editor tabs to the last row of a filtered List, presses Enter, types a title,
+and moves through editable cells with Tab. A rejected change returns focus and
+an explanation; it does not leave a convincing but unsaved row behind.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- List and Table are keyboard editors of canonical Database records, not local drafts.
+- Enter, Tab, arrow navigation, escape, selection, and focus restoration are predictable and accessible.
+- Creation and edits use the same authorized Action, validation, Events, history, and failure behavior as an agent.
+- Optimistic UI is reversible; denied, invalid, stale, or unavailable work is visibly distinct from success.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+View-derived creation defaults own contextual seeds. This Capability does not define
+bulk editing, a new inline data store, or a permission bypass.
+
+## Acceptance stories
+
+### Capture a record without a mouse
+
+Given an editable List, when a person enters a title and tabs through a writable field,
+then one valid canonical record is created and focus advances predictably.
+
+### Recover from a rejected edit
+
+Given an optimistic inline edit that fails validation, when the Action rejects it, then
+the rendered value rolls back, focus remains useful, and the failure is announced.
+
+## Current evidence
+
+Existing Database editing and View machinery are donor substrate. No complete proof yet
+covers keyboard semantics, Action parity, rollback, accessibility, and recovery; this
+Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Test keyboard creation and editing across List and Table with validation and permissions.
+2. Verify Action/UI parity, Events, history, stale writes, rollback, and reload.
+3. Exercise screen-reader announcements, focus order, and concurrent result refreshes.
+
+## Open questions
+
+The compact editor's exact escape and multi-cell paste semantics need interaction design.

--- a/templates/content/docs/product/capabilities/content.view.fast-capture.md
+++ b/templates/content/docs/product/capabilities/content.view.fast-capture.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.view.fast-capture"
+name: "Fast keyboard capture"
+user_promise: "Keyboard-fluent List and Table capture"
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.view.query","content.agent.action-parity"]
+related_features: ["content.feature.see-your-information-your-way","content.feature.run-projects-your-way"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Enter/Tab/navigation/editing behavior and optimistic rollback tests."
+proof_requirements: ["Enter/Tab/navigation/editing behavior and optimistic rollback tests."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Fast keyboard capture
+
+## Contract
+
+Keyboard-fluent List and Table capture
+
+## Acceptance boundary
+
+A complete proof demonstrates: Enter/Tab/navigation/editing behavior and optimistic rollback tests.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.view.graph.md
+++ b/templates/content/docs/product/capabilities/content.view.graph.md
@@ -1,17 +1,30 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.view.graph"
 name: "Graph View"
 user_promise: "Graph lays out query-selected canonical objects and typed Relationships for access-safe exploration and editing."
+primary_user_job: "Explore a meaningful neighborhood of connected records, understand why they relate, and make an authorized semantic change without treating a visual line as the source of truth."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.knowledge.graph","content.relationship.edge","content.view.renderer-conformance"]
+dependencies:
+  [
+    "content.knowledge.graph",
+    "content.relationship.edge",
+    "content.view.renderer-conformance",
+  ]
 related_features: ["content.feature.sketch-connections-keep-whats-true"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Graph lays out query-selected canonical objects and typed Relationships for access-safe exploration and editing."
-proof_requirements: ["Graph lays out query-selected canonical objects and typed Relationships for access-safe exploration and editing."]
+acceptance_summary: "Graph renders an access-scoped saved relationship query as canonical nodes and typed edges, supports authorized typed-edge editing, and keeps every layout operation separate from semantic truth."
+proof_requirements:
+  [
+    "Access-scoped graph-query results, traversal, expansion, filtering, and empty or unavailable states",
+    "Typed-edge creation, editing, removal, permission denial, and history through the shared Relationship Action",
+    "Manual and physics-assisted layouts, pinning, saved arrangements, reset, and proof that layout never mutates semantic relationships",
+    "Keyboard, assistive-technology, dense-neighborhood, and drill-in workflows in the real interface",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +32,64 @@ last_reviewed: "2026-07-29"
 
 # Graph View
 
-## Contract
+## Why this exists
 
-Graph lays out query-selected canonical objects and typed Relationships for access-safe exploration and editing.
+A list can show that records are related without making the surrounding structure legible. Graph View lets people explore an access-scoped semantic neighborhood: canonical records are nodes, and each visible line is a real typed Relationship rather than decoration.
 
-## Acceptance boundary
+It is for questions such as “what supports this claim?” or “which work is blocked by this decision?” It is not a drawing board, a statistical chart, or an authored diagram.
 
-A complete proof demonstrates: Graph lays out query-selected canonical objects and typed Relationships for access-safe exploration and editing.
+## Example workflow
 
-## Evidence boundary
+A project lead opens a saved graph query centered on a decision Page and expands one relationship type at a time. They pin the Pages relevant to a review, use a force-assisted layout to separate a crowded neighborhood, and save that arrangement for later. With the `blocks` type selected in the edge tool, they draw from one authorized Page to another; Content creates the corresponding canonical Relationship and shows it in Connections and other authorized projections. Resetting the layout changes only positions, never the relationship.
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+## Product contract
 
-## Non-goals
+- Graph renders a saved, typed, access-scoped relationship query. Nodes retain their canonical Page, Block, Source, or query-result identity; Graph owns only its View configuration and arrangement.
+- Each semantic edge displays a Relationship type and is a projection of the canonical edge. Editing, removing, or creating an edge uses the shared typed Relationship Action and records normal history.
+- The edge tool requires a Relationship type before it can create an edge. A line never becomes a semantic assertion merely because it was drawn.
+- People may filter, group, and style by relationship type; expand authorized neighbors; open canonical records; pin or unpin nodes; save a useful arrangement; and reset it.
+- Manual, hierarchical, radial, and physics-assisted layouts may change positions only. Layout algorithms never infer, create, rewrite, or delete Relationships.
+- Graph applies access before query evaluation, traversal, counts, labels, previews, export, or agent use. An inaccessible endpoint is not exposed through a visible placeholder, degree, or hidden-edge count.
+- An empty query is an honest empty Graph. A failed, stale, or unavailable query reports that state distinctly and does not masquerade as no relationships.
 
-This capability does not create a parallel datastore, permission model, or action surface.
+## Boundaries and non-goals
+
+- `content.relationship.edge` owns canonical edge identity, cardinality, authority, mutation, and history; Graph is an authorized editor and projection.
+- `content.knowledge.graph` owns relationship-query semantics and traversal; Graph owns visual exploration and layout.
+- `content.view.canvas` owns intentional spatial composition and view-local freeform connectors. Canvas lines require explicit promotion before they become Relationships.
+- `content.view.chart` owns analytical visualizations over measures and grouped data. Authored Mermaid diagrams belong to code-authoring and Mermaid rendering, not Graph.
+- Graph does not create a parallel graph datastore, access model, permission bypass, task dependency engine, or diagram language.
+
+## Acceptance stories
+
+### Explore only what the viewer may know
+
+Given a saved graph query that includes both accessible and inaccessible relationships, when a viewer opens and expands Graph, then the graph, counts, labels, previews, and exports contain only authorized nodes and edges, while a direct unauthorized request receives an honest denial.
+
+### Create a semantic edge deliberately
+
+Given an editor authorized to change two Pages and use the `supports` Relationship type, when they select `supports` and draw an edge, then one canonical typed Relationship is created and appears in Connections and other authorized projections. When no type is selected, drawing cannot commit an edge.
+
+### Separate arrangement from meaning
+
+Given a dense saved Graph, when a viewer pins nodes, runs a force-assisted layout, saves the arrangement, and later resets it, then node positions change as requested but the relationship query and canonical edge history remain unchanged.
+
+### Report unavailable work truthfully
+
+Given a graph query that cannot complete because its source is unavailable, when Graph opens, then it reports the unavailable state and retry path rather than rendering a plausible empty neighborhood.
+
+## Current evidence
+
+The repository defines the shared object, query, Relationship, and renderer boundaries that Graph will need. Existing code may offer useful visualization or relation substrate, but no current evidence proves the complete Graph query, edge-editing, access-closure, layout, or recovery contract. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Exercise saved graph queries with filtering, expansion, grouping, pagination or bounds, empty results, stale inputs, and unavailable sources.
+2. Create, edit, and remove typed edges through Graph alongside Connections and another projection; verify one identity, permission decision, and committed history.
+3. Verify manual, hierarchical, radial, and physics-assisted layouts across pin, save, reload, reset, and concurrent semantic edits; assert that no layout path changes an edge.
+4. Run keyboard and assistive-technology workflows for navigation, node inspection, edge-type selection, editing, errors, and dense-graph recovery.
+5. Re-run traversal, labels, counts, previews, export, and agent reads with changing endpoint access to prove access precedes every computation.
+
+## Open questions
+
+The contract leaves rendering-engine choice, layout implementation, graph-size limits, and exact controls open. Those choices must preserve bounded loading, explicit failure states, and the semantic/layout separation above.

--- a/templates/content/docs/product/capabilities/content.view.graph.md
+++ b/templates/content/docs/product/capabilities/content.view.graph.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.view.graph"
+name: "Graph View"
+user_promise: "Graph lays out query-selected canonical objects and typed Relationships for access-safe exploration and editing."
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.knowledge.graph","content.relationship.edge","content.view.renderer-conformance"]
+related_features: ["content.feature.sketch-connections-keep-whats-true"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Graph lays out query-selected canonical objects and typed Relationships for access-safe exploration and editing."
+proof_requirements: ["Graph lays out query-selected canonical objects and typed Relationships for access-safe exploration and editing."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Graph View
+
+## Contract
+
+Graph lays out query-selected canonical objects and typed Relationships for access-safe exploration and editing.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Graph lays out query-selected canonical objects and typed Relationships for access-safe exploration and editing.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.view.grouping-aggregation.md
+++ b/templates/content/docs/product/capabilities/content.view.grouping-aggregation.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.view.grouping-aggregation"
+name: "Grouping and aggregation"
+user_promise: "Views group across several dimensions and compute access-safe totals, subtotals, rollups, and measures."
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.view.query","content.access.safe-aggregate"]
+related_features: ["content.feature.see-your-information-your-way","content.feature.plan-work-across-time","content.feature.understand-what-your-data-says"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Views group across several dimensions and compute access-safe totals, subtotals, rollups, and measures."
+proof_requirements: ["Views group across several dimensions and compute access-safe totals, subtotals, rollups, and measures."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Grouping and aggregation
+
+## Contract
+
+Views group across several dimensions and compute access-safe totals, subtotals, rollups, and measures.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Views group across several dimensions and compute access-safe totals, subtotals, rollups, and measures.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.view.grouping-aggregation.md
+++ b/templates/content/docs/product/capabilities/content.view.grouping-aggregation.md
@@ -1,17 +1,29 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.view.grouping-aggregation"
 name: "Grouping and aggregation"
 user_promise: "Views group across several dimensions and compute access-safe totals, subtotals, rollups, and measures."
+primary_user_job: "Understand meaningful totals and their contributing records without learning information I cannot access."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.view.query","content.access.safe-aggregate"]
-related_features: ["content.feature.see-your-information-your-way","content.feature.plan-work-across-time","content.feature.understand-what-your-data-says"]
+dependencies: ["content.view.query", "content.access.safe-aggregate"]
+related_features:
+  [
+    "content.feature.see-your-information-your-way",
+    "content.feature.plan-work-across-time",
+    "content.feature.understand-what-your-data-says",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Views group across several dimensions and compute access-safe totals, subtotals, rollups, and measures."
-proof_requirements: ["Views group across several dimensions and compute access-safe totals, subtotals, rollups, and measures."]
+acceptance_summary: "Authorized View results can be grouped by typed dimensions and measured with access-safe totals, subtotals, rollups, and drill-in."
+proof_requirements:
+  [
+    "Typed multi-dimension grouping, ordering, empty groups, and measure semantics",
+    "Access-before-grouping, totals, rollups, drill-in, export, and agent-context tests",
+    "Real-interface refresh, unavailable-source, dense-result, and accessible-table workflows",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +31,53 @@ last_reviewed: "2026-07-29"
 
 # Grouping and aggregation
 
-## Contract
+## Why this exists
 
-Views group across several dimensions and compute access-safe totals, subtotals, rollups, and measures.
+People need a useful shape for many records, but a subtotal must never reveal a row,
+field, or inference that its viewer may not know.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Views group across several dimensions and compute access-safe totals, subtotals, rollups, and measures.
+A lead groups authorized work by project and status, reads each subtotal, and opens a
+group to inspect its canonical records. A private task contributes nowhere: not to a
+count, a sum, an empty-group hint, or an export.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Views group their canonical Query result by typed dimensions and compute declared measures.
+- Access applies before grouping, aggregation, rollup, count, labels, drill-in, export, or agent context.
+- Groups retain stable query semantics; sorting, collapse, and presentation do not mutate records.
+- Empty, stale, unavailable, and partially loaded inputs are explicitly represented.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Queries own result semantics and safe aggregates own disclosure rules. This is not a
+spreadsheet engine, a new analytics datastore, or permission-derived guessing.
+
+## Acceptance stories
+
+### Read an authorized subtotal
+
+Given a grouped View with private rows, when a viewer opens it, then every group and
+total is computed only from authorized rows and fields.
+
+### Drill into a measure
+
+Given a visible aggregate cell, when a viewer drills in, then Content opens the exact
+authorized contributing records rather than an inferred or copied collection.
+
+## Current evidence
+
+Existing filters and renderer utilities are donor substrate. The repository does not
+yet prove multi-dimensional measure semantics or disclosure closure, so this remains
+`approved_shape`.
+
+## Proof plan
+
+1. Test typed grouping, measures, ordering, nulls, empty groups, and rollups.
+2. Test access changes through results, counts, drill-in, exports, and agent context.
+3. Exercise reload, source failure, pagination, dense views, keyboard, and assistive technology.
+
+## Open questions
+
+The initial measure catalog and treatment of mixed-source precision need implementation design.

--- a/templates/content/docs/product/capabilities/content.view.map.md
+++ b/templates/content/docs/product/capabilities/content.view.map.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.view.map"
 name: "Map View"
 user_promise: "Map renders typed locations with points, clustering, filtering, and record previews before adding richer geographic layers."
+primary_user_job: "See authorized records in their meaningful places and open the underlying record without making map coordinates a second source of truth."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.property.location","content.view.renderer-conformance"]
+dependencies: ["content.property.location", "content.view.renderer-conformance"]
 related_features: []
 roadmap_boundary: "supporting"
-acceptance_summary: "A complete proof demonstrates: Map renders typed locations with points, clustering, filtering, and record previews before adding richer geographic layers."
-proof_requirements: ["Map renders typed locations with points, clustering, filtering, and record previews before adding richer geographic layers."]
+acceptance_summary: "Map projects access-scoped canonical results with typed locations, filters, clustering, previews, and shared record actions."
+proof_requirements:
+  [
+    "Typed location selection, invalid or absent location, viewport, filter, and cluster behavior",
+    "Access-safe markers, counts, previews, search, export, and shared Action editing",
+    "Real-interface keyboard, assistive alternative, provider-unavailable, and reload workflows",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,52 @@ last_reviewed: "2026-07-29"
 
 # Map View
 
-## Contract
+## Why this exists
 
-Map renders typed locations with points, clustering, filtering, and record previews before adding richer geographic layers.
+Place can be the clearest way to find work, provided a pin remains a projection of a
+typed location on a canonical record.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Map renders typed locations with points, clustering, filtering, and record previews before adding richer geographic layers.
+A coordinator filters locations to an authorized region, selects a cluster, previews a
+record, and opens it. Changing the record's location uses the ordinary shared Action;
+the pin updates after the canonical change.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Map consumes a canonical Database or Query result and a declared typed location field.
+- Markers, clusters, viewport filters, previews, and counts are access-scoped.
+- Selecting a pin opens or edits the canonical record through shared View Actions.
+- Missing, invalid, stale, and provider-unavailable locations report honestly.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+`content.property.location` owns location meaning. Map is not geocoding custody, route
+planning, a geographic layer editor, or a second record store.
+
+## Acceptance stories
+
+### Explore only authorized places
+
+Given a result containing private locations, when a viewer opens Map, then no marker,
+cluster count, preview, or viewport query exposes those records.
+
+### Edit a location through its record
+
+Given an authorized marker, when an editor changes its typed location, then the shared
+Action updates one canonical record and the Map refreshes without duplicate state.
+
+## Current evidence
+
+No current implementation evidence proves Map's location, access, interaction, and
+recovery contract. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Test typed locations, invalid values, filters, clusters, and canonical preview/open.
+2. Verify access closure through markers, counts, viewport changes, exports, and agents.
+3. Exercise keyboard alternatives, source/provider failure, reload, and dense geographic results.
+
+## Open questions
+
+The first provider boundary and offline geographic behavior remain implementation questions.

--- a/templates/content/docs/product/capabilities/content.view.map.md
+++ b/templates/content/docs/product/capabilities/content.view.map.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.view.map"
+name: "Map View"
+user_promise: "Map renders typed locations with points, clustering, filtering, and record previews before adding richer geographic layers."
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.property.location","content.view.renderer-conformance"]
+related_features: []
+roadmap_boundary: "supporting"
+acceptance_summary: "A complete proof demonstrates: Map renders typed locations with points, clustering, filtering, and record previews before adding richer geographic layers."
+proof_requirements: ["Map renders typed locations with points, clustering, filtering, and record previews before adding richer geographic layers."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Map View
+
+## Contract
+
+Map renders typed locations with points, clustering, filtering, and record previews before adding richer geographic layers.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Map renders typed locations with points, clustering, filtering, and record previews before adding richer geographic layers.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.view.personal-state.md
+++ b/templates/content/docs/product/capabilities/content.view.personal-state.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.view.personal-state"
+name: "Personal View state"
+user_promise: "A shared View remembers one private arrangement per person and supports named Only-me Views without copying records."
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.view.query","content.share.views"]
+related_features: ["content.feature.make-the-workspace-yours"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: A shared View remembers one private arrangement per person and supports named Only-me Views without copying records."
+proof_requirements: ["A shared View remembers one private arrangement per person and supports named Only-me Views without copying records."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Personal View state
+
+## Contract
+
+A shared View remembers one private arrangement per person and supports named Only-me Views without copying records.
+
+## Acceptance boundary
+
+A complete proof demonstrates: A shared View remembers one private arrangement per person and supports named Only-me Views without copying records.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.view.personal-state.md
+++ b/templates/content/docs/product/capabilities/content.view.personal-state.md
@@ -1,17 +1,25 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.view.personal-state"
 name: "Personal View state"
 user_promise: "A shared View remembers one private arrangement per person and supports named Only-me Views without copying records."
+primary_user_job: "Explore and remember a useful personal arrangement without changing the dependable View everyone else shares."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.view.query","content.share.views"]
+dependencies: ["content.view.query", "content.share.views"]
 related_features: ["content.feature.make-the-workspace-yours"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: A shared View remembers one private arrangement per person and supports named Only-me Views without copying records."
-proof_requirements: ["A shared View remembers one private arrangement per person and supports named Only-me Views without copying records."]
+acceptance_summary: "Each shared View remembers one unnamed personal arrangement per user, supports any number of named Only-me Views, exposes effective state to agents, and never publishes personal exploration accidentally."
+proof_requirements:
+  [
+    "One automatically persisted personal arrangement per user and shared View",
+    "Reset, Save as new View, and permissioned Update shared View behavior",
+    "Focused View Instance containing shared, personal, effective, and delta state for UI and agents",
+    "Access isolation, link behavior, persistence, multi-device recovery, and no record copying",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +27,73 @@ last_reviewed: "2026-07-29"
 
 # Personal View state
 
-## Contract
+## Why this exists
 
-A shared View remembers one private arrangement per person and supports named Only-me Views without copying records.
+Shared Views need dependable defaults, but people also need to sort, filter, group, resize, and collapse data while they work. Requiring a save decision after every exploration creates meta-work; publishing every experiment creates chaos.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: A shared View remembers one private arrangement per person and supports named Only-me Views without copying records.
+An editor opens the team's shared Content Calendar, filters to their own recent articles, resizes columns, and groups by status. Content quietly remembers that arrangement and shows **Viewing with personal changes**. The editor can reset, save it as a named **Only me** View, or deliberately update the shared View if they have permission.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Every shared saved View may remember at most one unnamed personal arrangement for each user.
+- The arrangement automatically persists filters, sorting, grouping, column order/size, collapsed sections, and other supported presentation state without a recurring **Save for me** action.
+- When personal state differs, the interface quietly shows **Viewing with personal changes**.
+- **Reset to shared View** removes the remembered override.
+- **Save as new View** creates a stable named View over the same owner input with visibility **Only me** or an allowed shared destination. A person may create many named private Views.
+- **Update shared View** deliberately replaces the shared default only with the required Database/Query authority and records an ordinary reversible Revision.
+- The focused View Instance contains the shared definition, remembered personal override, effective state, and delta between them.
+- Agents receive that effective focused state so they understand what the person sees. They may run arbitrary ephemeral Queries behind the scenes without changing the visible arrangement.
+- An agent changes the personal arrangement only when asked to show a result, saves a named View only when asked, and updates the shared default only through the explicit permitted action.
+- Ordinary copied View links resolve to the saved View definition, never the sender's unnamed personal arrangement.
+- Personal state changes presentation and safe creation seeds only. It never copies records, changes source truth, grants access, or creates a private fork of the Database/Query.
 
-## Non-goals
+## Permissions and failure behavior
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- Personal arrangements and Only-me Views are visible only to their owner and system processes acting within that person's authority.
+- Saving a shared destination or updating a shared View requires the normal owner permissions; personal state cannot bypass them.
+- Effective results still intersect all View, input, row, field, Source, and viewer access.
+- If personal configuration temporarily references an unavailable field, Content preserves it in a degraded state when the absence may be temporary. Intentional field deletion follows the atomic cleanup contract.
+- Persistence failure leaves the shared View unchanged and reports that the personal arrangement was not remembered; it must not silently publish the state instead.
+
+## Boundaries and non-goals
+
+- This Capability owns personal presentation state, not Query semantics or Database values.
+- It does not make copied links carry hidden sender state.
+- It does not restrict a person to one named private View; the one-item limit applies only to the automatic unnamed arrangement per shared View.
+- Ephemeral agent exploration is not a saved View and does not mutate UI unless requested.
+
+## Acceptance stories
+
+### Remember without publishing
+
+Given two people open the same shared View, when one changes filters, grouping, and column sizing, then only that person's effective arrangement changes and persists across reload while the other person and shared definition remain unchanged.
+
+### Save several private alternatives
+
+Given one personal arrangement, when its owner chooses **Save as new View** twice with **Only me**, then two stable private Views exist over the same canonical records while the shared View still retains only one unnamed override for that person.
+
+### Keep links predictable
+
+Given a person copies the URL while viewing personal changes, when another authorized viewer opens it, then they receive the saved View definition plus their own personal state, never the sender's override.
+
+### Give agents the real focused surface
+
+Given a focused View with temporary personal filters, when an agent is asked about what is visible, then it receives shared, personal, effective, and delta state and may query further without publishing or changing the arrangement unless asked.
+
+## Current evidence
+
+Existing View controls and application-state patterns are useful substrate, but the complete unnamed persistence model, named Only-me Views, delta indication, scoped save/update actions, multi-device behavior, and agent-effective context are not proven. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Persist and reset each supported personal filter, sort, group, layout, sizing, and collapsed-state override across reload and devices.
+2. Create several Only-me Views, attempt shared saves with and without authority, and verify one reversible shared Revision.
+3. Copy links under personal changes and verify predictable recipient behavior.
+4. Inspect application state and agent actions for shared/personal/effective/delta parity and non-mutating exploration.
+5. Exercise schema deletion, temporary unavailability, access revocation, persistence failure, Undo, accessibility, and recovery.
+
+## Open questions
+
+Exact cross-device conflict resolution for simultaneous personal arrangements and the retention policy for long-unused unnamed overrides remain open implementation/product details.

--- a/templates/content/docs/product/capabilities/content.view.pivot.md
+++ b/templates/content/docs/product/capabilities/content.view.pivot.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.view.pivot"
+name: "Pivot View"
+user_promise: "Pivot places dimensions on rows and columns, typed aggregations in cells, and drills back to canonical records."
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.view.grouping-aggregation"]
+related_features: ["content.feature.understand-what-your-data-says"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Pivot places dimensions on rows and columns, typed aggregations in cells, and drills back to canonical records."
+proof_requirements: ["Pivot places dimensions on rows and columns, typed aggregations in cells, and drills back to canonical records."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Pivot View
+
+## Contract
+
+Pivot places dimensions on rows and columns, typed aggregations in cells, and drills back to canonical records.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Pivot places dimensions on rows and columns, typed aggregations in cells, and drills back to canonical records.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.view.pivot.md
+++ b/templates/content/docs/product/capabilities/content.view.pivot.md
@@ -1,8 +1,10 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.view.pivot"
 name: "Pivot View"
 user_promise: "Pivot places dimensions on rows and columns, typed aggregations in cells, and drills back to canonical records."
+primary_user_job: "Compare an authorized measure across two meaningful dimensions and inspect the records behind any result."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
@@ -10,8 +12,13 @@ availability: "universal"
 dependencies: ["content.view.grouping-aggregation"]
 related_features: ["content.feature.understand-what-your-data-says"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Pivot places dimensions on rows and columns, typed aggregations in cells, and drills back to canonical records."
-proof_requirements: ["Pivot places dimensions on rows and columns, typed aggregations in cells, and drills back to canonical records."]
+acceptance_summary: "Pivot configures typed row and column dimensions with access-safe measures, totals, and drill-in to canonical contributing records."
+proof_requirements:
+  [
+    "Typed dimensions, measure selection, totals, nulls, ordering, and configuration persistence",
+    "Access-safe cells, totals, drill-in, export, agent context, and empty or unavailable input tests",
+    "Real-interface keyboard table navigation, responsive overflow, reload, and dense-data workflow",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,51 @@ last_reviewed: "2026-07-29"
 
 # Pivot View
 
-## Contract
+## Why this exists
 
-Pivot places dimensions on rows and columns, typed aggregations in cells, and drills back to canonical records.
+One flat group can answer “how much?”; a pivot makes the crossing of two questions
+legible without detaching its cells from the records that made them.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Pivot places dimensions on rows and columns, typed aggregations in cells, and drills back to canonical records.
+A lead puts project on rows, status on columns, and estimate sum in cells. Selecting a
+cell opens its authorized contributing records rather than a copied spreadsheet range.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Pivot is a saved View configuration over canonical, access-scoped Query results.
+- Row and column dimensions and typed measures use grouping and aggregation semantics.
+- Cells, totals, labels, drill-in, export, and agent context reveal only authorized input.
+- Configuration persists independently of the canonical records and reports unavailable data honestly.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Grouping and aggregation own measure semantics. Pivot is not a formula grid, a writable
+cell store, or a replacement for Chart.
+
+## Acceptance stories
+
+### Compare two dimensions
+
+Given an authorized task result, when a viewer pivots project by status, then each cell
+and total reflects only eligible records and preserves the selected typed measure.
+
+### Inspect a cell
+
+Given a visible cell, when the viewer drills in, then the resulting collection contains
+only its authorized contributors and maintains canonical record identity.
+
+## Current evidence
+
+The grouping dependency establishes intended substrate; no repository evidence proves a
+complete Pivot renderer. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Test dimensions, measures, totals, nulls, ordering, persistence, and drill-in.
+2. Verify disclosure closure across cells, totals, exports, and agents.
+3. Exercise responsive table navigation, dense data, reload, and unavailable sources.
+
+## Open questions
+
+The initial dimension-depth limit and display policy for sparse matrices need design.

--- a/templates/content/docs/product/capabilities/content.view.query.md
+++ b/templates/content/docs/product/capabilities/content.view.query.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.view.query"
+name: "Database and Query Views"
+user_promise: "Saved typed queries rendered as Table/Board/List/Gallery/Calendar/Timeline/Form/Sidebar and later Graph/Canvas views"
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.query.object","content.property.typed"]
+related_features: ["content.feature.make-the-workspace-yours","content.feature.see-your-information-your-way","content.feature.understand-what-your-data-says"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Reconcile existing filter grammar into typed expressions without breaking saved views. Resolve local and source-backed properties by stable identity, never display name alone; expose source/membership provenance in cross-Database queries; support explicit query-local field unions and ambiguity repair without introducing a normal-user shared-definition system."
+proof_requirements: ["Reconcile existing filter grammar into typed expressions without breaking saved views. Resolve local and source-backed properties by stable identity, never display name alone; expose source/membership provenance in cross-Database queries; support explicit query-local field unions and ambiguity repair without introducing a normal-user shared-definition system."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Database and Query Views
+
+## Contract
+
+Saved typed queries rendered as Table/Board/List/Gallery/Calendar/Timeline/Form/Sidebar and later Graph/Canvas views
+
+## Acceptance boundary
+
+A complete proof demonstrates: Reconcile existing filter grammar into typed expressions without breaking saved views. Resolve local and source-backed properties by stable identity, never display name alone; expose source/membership provenance in cross-Database queries; support explicit query-local field unions and ambiguity repair without introducing a normal-user shared-definition system.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.view.query.md
+++ b/templates/content/docs/product/capabilities/content.view.query.md
@@ -1,17 +1,30 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.view.query"
 name: "Database and Query Views"
-user_promise: "Saved typed queries rendered as Table/Board/List/Gallery/Calendar/Timeline/Form/Sidebar and later Graph/Canvas views"
+user_promise: "A View is one stable presentation over exactly one Database or Query, with its own downstream filters, layout, and renderer"
+primary_user_job: "Present and refine one collection for a particular workflow without changing the collection's identity or upstream meaning."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.query.object","content.property.typed"]
-related_features: ["content.feature.make-the-workspace-yours","content.feature.see-your-information-your-way","content.feature.understand-what-your-data-says"]
+dependencies: ["content.query.object", "content.property.typed"]
+related_features:
+  [
+    "content.feature.make-the-workspace-yours",
+    "content.feature.see-your-information-your-way",
+    "content.feature.understand-what-your-data-says",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Reconcile existing filter grammar into typed expressions without breaking saved views. Resolve local and source-backed properties by stable identity, never display name alone; expose source/membership provenance in cross-Database queries; support explicit query-local field unions and ambiguity repair without introducing a normal-user shared-definition system."
-proof_requirements: ["Reconcile existing filter grammar into typed expressions without breaking saved views. Resolve local and source-backed properties by stable identity, never display name alone; expose source/membership provenance in cross-Database queries; support explicit query-local field unions and ambiguity repair without introducing a normal-user shared-definition system."]
+acceptance_summary: "Named Views retain stable identity and presentation over one owner input, bind configuration to stable fields, refine but never widen that input, and remain reusable without becoming collections or granting access."
+proof_requirements:
+  [
+    "Stable View identity, one owning Database/Query, default selection, links, embeds, templates, deletion, and copying",
+    "Renderer, visible fields, filters, sorts, groups, formatting, layout, and creation-seed ownership",
+    "Stable field bindings plus atomic cleanup or truthful degraded state during schema evolution",
+    "Access narrowing, shared Action parity, personal/effective state, accessibility, persistence, and recovery",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +32,75 @@ last_reviewed: "2026-07-29"
 
 # Database and Query Views
 
-## Contract
+## Why this exists
 
-Saved typed queries rendered as Table/Board/List/Gallery/Calendar/Timeline/Form/Sidebar and later Graph/Canvas views
+The same collection can support very different work: quick List capture, a grouped Board, a Calendar, or an analytical Chart. People need to save those presentations without duplicating records, hiding a second collection beneath the screen, or confusing a temporary filter with the Query's meaning.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Reconcile existing filter grammar into typed expressions without breaking saved views. Resolve local and source-backed properties by stable identity, never display name alone; expose source/membership provenance in cross-Database queries; support explicit query-local field unions and ambiguity repair without introducing a normal-user shared-definition system.
+A Projects Database has a shared Board grouped by Status and a private List showing only the current person's recent projects. Both are stable Views over the same Database. Changing the List filter does not change the Database or Board, and changing a project so it no longer matches simply moves it out of the List while preserving the record.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- A named View has stable identity and an addressable URL while belonging to exactly one Database or Query.
+- A Database or Query selects one default View. A link, embed, template, sidebar pin, or agent may address another named View directly.
+- The View owns renderer, visible fields, downstream filters, sorting, grouping, layout, formatting, collapsed state, and safe creation seeds.
+- Query filters define the upstream result contract. View filters refine what this presentation shows and can never widen past that input.
+- An ordinary View directly over a Database uses its implicit base Query; no hidden named Query is created.
+- **Save as new View** creates another View over the same owner. **Save as Query** appears on Query-building surfaces, not as ordinary View promotion.
+- **Create Query from this View** may prefill a builder with owner, filters, fields, and sorting, but the person confirms sources, output schema, variables, and write behavior before saving a separate Query.
+- A View binds to stable Property and Query-output IDs. Local aliases and formatting remain View-owned; matching display names never create semantic equivalence.
+- An embedding occurrence may select a named View and apply occurrence-local presentation overrides without mutating the saved View.
+- Deleting a View deletes only its configuration. Copying a View to another input creates a new View and explicitly maps compatible stable fields; a View never silently retargets itself.
 
-## Non-goals
+## Schema evolution and access
 
-This capability does not create a parallel datastore, permission model, or action surface.
+- Renaming a bound field preserves the View automatically.
+- Before intentional deletion or incompatible type change, Content gives one compact impact summary. Confirmation applies the schema change and dependent cleanup as one attributable Revision.
+- Intentional deletion removes only affected filter leaves, sorts, groups, columns, seeds, or renderer bindings; unaffected configuration remains. Nested groups simplify and empty groups disappear.
+- Temporary source unavailability, permission loss, or stale provider schema is not deletion. The View preserves configuration and shows a typed degraded or Unavailable state rather than widening itself.
+- A View may be shared or **Only me** and may narrow access below its owner, never widen it. Effective visibility intersects View, Database/Query, Source, row, field, and viewer access.
+- Restricting a View protects the saved surface; it does not revoke access someone independently has to the underlying records elsewhere.
+- Private View cleanup and impact counts never expose private configuration to a schema editor.
+
+## Boundaries and non-goals
+
+- A View does not own records, source schemas, canonical values, Query variables, or provider write authority.
+- View filters control visibility, not validity. Database validation alone decides whether a mutation may commit.
+- A View never grants row access or runs with its creator's authority.
+- Sidebar is a navigation projection that may render a View; it is not a general View renderer owned here.
+- Renderer-specific behavior belongs to each View-family Capability and the shared conformance contract.
+
+## Acceptance stories
+
+### Preserve upstream meaning
+
+Given a Query that admits only published records and two Views with different downstream filters, when one View filter is removed, then it may reveal only other published Query results and never records excluded upstream.
+
+### Survive schema change coherently
+
+Given a View whose nested filter, grouping, and displayed column use one Property, when an authorized editor deletes that Property after one impact confirmation, then only the affected configuration is removed in the same Revision, unaffected settings remain, and Undo restores both schema and View.
+
+### Narrow without granting access
+
+Given an Only-me View over a shared Database and a shared link to another View, when readers open either, then each receives only the intersection they may already access and no View reveals private counts or records.
+
+### Delete presentation without deleting data
+
+Given a named View linked and embedded in several places, when it is deleted, then its configuration and references enter the normal broken/recovery state while the owner Database/Query and canonical records remain unchanged.
+
+## Current evidence
+
+Content already has useful saved Database Views, filters, sorting, grouping, and several renderers. The complete stable View identity, Database-or-Query ownership, private/shared alternatives, typed field bindings, schema-evolution cleanup, occurrence overrides, and renderer-conformance contract are not yet proven end to end. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Create, link, embed, pin, copy, delete, restore, and select default named Views over both Databases and Queries.
+2. Exercise every shared renderer setting, downstream filter, sort, group, layout, formatting, and occurrence override through UI and Actions.
+3. Rename, delete, restore, and change types of local, custom, source, and Query-output fields; verify atomic cleanup versus degraded preservation.
+4. Run shared, Only-me, and occurrence-local Views under changing record/field/source access; verify no widening or derived leaks.
+5. Verify personal overrides, agent context, creation seeds, reload, concurrent shared edits, accessibility, export, and recovery.
+
+## Open questions
+
+The stable ID `content.view.query` sounds Query-specific even though the accepted concept is a general View over a Database or Query. Preserve the ID until a deliberate normalization provides a replacement. Exact ownership of named-View identity across this record, Shared Views, and Personal View State should remain this record for the generic primitive, with the others adding their focused policy.

--- a/templates/content/docs/product/capabilities/content.view.renderer-conformance.md
+++ b/templates/content/docs/product/capabilities/content.view.renderer-conformance.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.view.renderer-conformance"
 name: "View renderer conformance"
 user_promise: "Every View obeys the same permissions, Actions, agent context, accessibility, persistence, performance, and recovery contract."
+primary_user_job: "Move between Views confidently because changing the renderer never changes what I may know, do, recover, or ask an agent to do."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.renderer.typed","content.view.query"]
+dependencies: ["content.renderer.typed", "content.view.query"]
 related_features: ["content.feature.see-your-information-your-way"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Every View obeys the same permissions, Actions, agent context, accessibility, persistence, performance, and recovery contract."
-proof_requirements: ["Every View obeys the same permissions, Actions, agent context, accessibility, persistence, performance, and recovery contract."]
+acceptance_summary: "Every renderer consumes canonical access-scoped results and implements shared Actions, agent context, accessible interaction, persisted configuration, bounded performance, and truthful recovery."
+proof_requirements:
+  [
+    "Reusable conformance suite for result, permission, Action, and agent-context parity",
+    "Keyboard and assistive-technology, persistence, reload, failure, stale, and recovery fixtures",
+    "Representative renderer real-interface and performance-budget workflows",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,52 @@ last_reviewed: "2026-07-29"
 
 # View renderer conformance
 
-## Contract
+## Why this exists
 
-Every View obeys the same permissions, Actions, agent context, accessibility, persistence, performance, and recovery contract.
+Changing how a collection looks must not quietly change its authority. A renderer is a
+projection, not a new application hiding behind a pretty icon.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Every View obeys the same permissions, Actions, agent context, accessibility, persistence, performance, and recovery contract.
+An editor switches the same Database from Table to Timeline, asks the agent about the
+focused result, then reloads. Both surfaces use the same authorized records and Actions;
+each preserves only its own presentation settings.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Every View renders its canonical Database or Query result after access evaluation.
+- Renderers use one typed Action and agent-context contract; UI affordances never widen authority.
+- Configuration, focused selection, empty, stale, unavailable, denied, and recovery states are explicit.
+- Keyboard and assistive-technology access, bounded loading, and persistence are conformance requirements.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Typed renderers and Queries supply common substrate. This does not force identical
+layouts, make every renderer writable, or replace renderer-specific product contracts.
+
+## Acceptance stories
+
+### Keep authority while changing renderer
+
+Given a viewer with partial row and field access, when they switch Views, then results,
+counts, previews, Actions, exports, and agent context disclose no additional information.
+
+### Recover consistently
+
+Given an unavailable query or a failed mutation, when any conforming View renders it,
+then it reports the state and retry or recovery route without presenting empty success.
+
+## Current evidence
+
+Timeline and existing Database renderers provide useful donor paths, but they do not
+prove a cross-renderer suite or complete contract. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Create reusable fixtures for permissions, results, Actions, agent context, and state transitions.
+2. Run keyboard, assistive technology, persistence, recovery, and reload checks per renderer.
+3. Measure representative large-result workflows and test unavailable or stale inputs.
+
+## Open questions
+
+The first enforceable conformance-harness API and performance budgets need implementation design.

--- a/templates/content/docs/product/capabilities/content.view.renderer-conformance.md
+++ b/templates/content/docs/product/capabilities/content.view.renderer-conformance.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.view.renderer-conformance"
+name: "View renderer conformance"
+user_promise: "Every View obeys the same permissions, Actions, agent context, accessibility, persistence, performance, and recovery contract."
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.renderer.typed","content.view.query"]
+related_features: ["content.feature.see-your-information-your-way"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Every View obeys the same permissions, Actions, agent context, accessibility, persistence, performance, and recovery contract."
+proof_requirements: ["Every View obeys the same permissions, Actions, agent context, accessibility, persistence, performance, and recovery contract."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# View renderer conformance
+
+## Contract
+
+Every View obeys the same permissions, Actions, agent context, accessibility, persistence, performance, and recovery contract.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Every View obeys the same permissions, Actions, agent context, accessibility, persistence, performance, and recovery contract.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.view.scale.md
+++ b/templates/content/docs/product/capabilities/content.view.scale.md
@@ -1,8 +1,10 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.view.scale"
 name: "Large Database performance"
 user_promise: "Databases stay responsive and incrementally queryable well beyond a few hundred rows"
+primary_user_job: "Find, change, and navigate a large authorized collection without waiting for every row to arrive or trusting an incomplete result as final."
 kind: "surface"
 state: "failing"
 publicness: "public"
@@ -10,8 +12,13 @@ availability: "universal"
 dependencies: ["content.view.query"]
 related_features: ["content.feature.see-your-information-your-way"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Server-side typed queries, pagination/windowing, indexes, bounded aggregates, performance budgets and real UI traces."
-proof_requirements: ["Server-side typed queries, pagination/windowing, indexes, bounded aggregates, performance budgets and real UI traces."]
+acceptance_summary: "Views use server-side typed queries, bounded windows and aggregates, indexes, explicit partial states, and measured interaction budgets for large authorized collections."
+proof_requirements:
+  [
+    "Server-side filter, sort, pagination/window, index, cursor, and bounded-aggregate coverage",
+    "Partial-result, mutation, refresh, access-change, and unavailable-source correctness tests",
+    "Real-interface performance traces for representative large collections and renderer interactions",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,52 @@ last_reviewed: "2026-07-29"
 
 # Large Database performance
 
-## Contract
+## Why this exists
 
-Databases stay responsive and incrementally queryable well beyond a few hundred rows
+A View that feels quick only while its collection is small has not yet earned the word
+View. Scale must preserve both responsiveness and truthful result boundaries.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Server-side typed queries, pagination/windowing, indexes, bounded aggregates, performance budgets and real UI traces.
+An editor filters a large Database, scrolls to another window, edits a visible record,
+and refreshes after another editor changes the result. The interface identifies partial
+loading and does not count unseen rows as if it had completed the query.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Filtering, sorting, access evaluation, pagination, and aggregates execute against bounded typed results.
+- Windows, cursors, counts, totals, and loading state state whether results are complete, partial, stale, or unavailable.
+- Mutations reconcile with canonical results and do not silently retain a record that no longer matches.
+- Performance work preserves renderer conformance, accessible navigation, and Action parity.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Query execution owns collection semantics. This Capability is not a client-side cache
+excuse, a permission shortcut, or a promise of unbounded instant export.
+
+## Acceptance stories
+
+### Navigate a partial result honestly
+
+Given a large authorized result, when a viewer opens and scrolls it, then they can
+navigate incremental windows and distinguish loaded rows and totals from incomplete work.
+
+### Reconcile a changing collection
+
+Given a visible record changed to no longer match a filter, when the Action succeeds,
+then the View removes or repositions it truthfully without stale duplicate rows.
+
+## Current evidence
+
+The prior record is `failing`; existing View code does not constitute measured server-side
+query, budget, or real-interface proof. It remains `failing`.
+
+## Proof plan
+
+1. Benchmark indexed filters, sorts, cursors, windows, and bounded aggregates at representative sizes.
+2. Test partial, stale, access-changing, unavailable, and mutation-reconciliation states.
+3. Capture real UI traces for initial load, navigation, edit, refresh, and accessible keyboard use.
+
+## Open questions
+
+Target data sizes and interaction budgets need an agreed workload before a verified claim.

--- a/templates/content/docs/product/capabilities/content.view.scale.md
+++ b/templates/content/docs/product/capabilities/content.view.scale.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.view.scale"
+name: "Large Database performance"
+user_promise: "Databases stay responsive and incrementally queryable well beyond a few hundred rows"
+kind: "surface"
+state: "failing"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.view.query"]
+related_features: ["content.feature.see-your-information-your-way"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Server-side typed queries, pagination/windowing, indexes, bounded aggregates, performance budgets and real UI traces."
+proof_requirements: ["Server-side typed queries, pagination/windowing, indexes, bounded aggregates, performance budgets and real UI traces."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Large Database performance
+
+## Contract
+
+Databases stay responsive and incrementally queryable well beyond a few hundred rows
+
+## Acceptance boundary
+
+A complete proof demonstrates: Server-side typed queries, pagination/windowing, indexes, bounded aggregates, performance budgets and real UI traces.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.view.source-query.md
+++ b/templates/content/docs/product/capabilities/content.view.source-query.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.view.source-query"
+name: "Cross-source Queries"
+user_promise: "One saved typed query composes local Databases and provider collections through unions, joins, filters, relations, and explicit field alignment, then renders through any compatible view"
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.query.object","content.source.catalog"]
+related_features: ["content.feature.connect-your-sources"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Visual builder reuses source picker, filter/sort/group/expression controls, live preview, output-field alignment, and compatible renderers; preserve source/row/field identity and access before composition; query-local output schema; explicit write-through and create-target rules; source-qualified ambiguity; pagination/scale; migration from materialized multi-source Databases without data loss."
+proof_requirements: ["Visual builder reuses source picker, filter/sort/group/expression controls, live preview, output-field alignment, and compatible renderers; preserve source/row/field identity and access before composition; query-local output schema; explicit write-through and create-target rules; source-qualified ambiguity; pagination/scale; migration from materialized multi-source Databases without data loss."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Cross-source Queries
+
+## Contract
+
+One saved typed query composes local Databases and provider collections through unions, joins, filters, relations, and explicit field alignment, then renders through any compatible view
+
+## Acceptance boundary
+
+A complete proof demonstrates: Visual builder reuses source picker, filter/sort/group/expression controls, live preview, output-field alignment, and compatible renderers; preserve source/row/field identity and access before composition; query-local output schema; explicit write-through and create-target rules; source-qualified ambiguity; pagination/scale; migration from materialized multi-source Databases without data loss.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.view.source-query.md
+++ b/templates/content/docs/product/capabilities/content.view.source-query.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.view.source-query"
 name: "Cross-source Queries"
-user_promise: "One saved typed query composes local Databases and provider collections through unions, joins, filters, relations, and explicit field alignment, then renders through any compatible view"
+user_promise: "One visual typed Query composes authorized Databases, Sources, and Queries without copying their records or hiding where values come from."
+primary_user_job: "Combine related work from several places into one useful live result while keeping each record's owner, access, and write route clear."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.query.object","content.source.catalog"]
+dependencies: ["content.query.object", "content.source.catalog"]
 related_features: ["content.feature.connect-your-sources"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Visual builder reuses source picker, filter/sort/group/expression controls, live preview, output-field alignment, and compatible renderers; preserve source/row/field identity and access before composition; query-local output schema; explicit write-through and create-target rules; source-qualified ambiguity; pagination/scale; migration from materialized multi-source Databases without data loss."
-proof_requirements: ["Visual builder reuses source picker, filter/sort/group/expression controls, live preview, output-field alignment, and compatible renderers; preserve source/row/field identity and access before composition; query-local output schema; explicit write-through and create-target rules; source-qualified ambiguity; pagination/scale; migration from materialized multi-source Databases without data loss."]
+acceptance_summary: "A visual builder composes access-scoped Databases, governed Sources, and Queries with explicit stable-identity alignment and Query-owned outputs; every result retains provenance, and edits or creation route only through declared unambiguous authorized owners."
+proof_requirements:
+  [
+    "Visual and agent editing of one validated typed Query representation with sources, alignment, filters, joins, preview, renderers, scale, and cycle checks",
+    "Access-first provenance, source-qualified field identity, aliases/computed outputs, write-through, read-only derived outputs, and creation-route behavior",
+    "Lossless migration and compatibility verification from row-union and joined-detail donor machinery without treating either donor UI as the product contract",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,134 @@ last_reviewed: "2026-07-29"
 
 # Cross-source Queries
 
-## Contract
+## Why this exists
 
-One saved typed query composes local Databases and provider collections through unions, joins, filters, relations, and explicit field alignment, then renders through any compatible view
+Work often lives in several collections that people need to read together.
+Copying it into a third table produces stale duplicates and ambiguous writes.
+A cross-source Query provides one visual composition surface while leaving
+canonical records, stored values, access, and provider authority with the
+Databases and Sources that already own them.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Visual builder reuses source picker, filter/sort/group/expression controls, live preview, output-field alignment, and compatible renderers; preserve source/row/field identity and access before composition; query-local output schema; explicit write-through and create-target rules; source-qualified ambiguity; pagination/scale; migration from materialized multi-source Databases without data loss.
+An editor creates a Query, adds two governed provider collections and a local
+Database, then aligns two stable title fields into an output field named
+`Title`. They add a relation-based join, a filter, and a Board renderer. Each
+result shows its Source provenance. Editing a mapped provider field routes only
+to its authorized owner; the `Title` alias and a computed score are Query-owned
+output and cannot be mistaken for stored source fields. Creating a new result
+uses a declared route or asks which source should own it.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+### One visual builder and typed representation
 
-## Non-goals
+- A Query may compose authorized Databases, catalog-selected Sources, and other
+  Queries through unions, joins, relationships, filters, grouping, sorting,
+  limits, variables, and compatible renderers without creating a third
+  canonical row store.
+- The visual builder and agents manipulate the same validated typed Query AST.
+  Source selection, field alignment, rules, preview, and rendering remain
+  editable through ordinary controls; a textual inspector is optional, not a
+  separate authoring language.
+- Live preview places ambiguity, access exclusions, stale Sources,
+  write-through limits, cycle failures, and scale bounds beside the relevant
+  builder stage rather than returning an unexplained empty result.
+- Query-as-input remains lazy and access-scoped. Dependency and cycle analysis
+  occurs before save; pagination, traversal, aggregation, and cancellation
+  bounds prevent unbounded background work.
 
-This capability does not create a parallel datastore, permission model, or action surface.
+### Align fields explicitly and retain provenance
+
+- Exact Custom Property or Source Property identities may align automatically.
+  Same display names do not establish equivalence: unrelated fields stay
+  source-qualified until a person or agent explicitly aligns them.
+- A named Query owns stable output-field identities, aliases, computed fields,
+  output types, documentation, ordering that is part of result meaning, and
+  compatible renderer defaults. Renaming `Title` changes the projection, not
+  either source schema.
+- Every result retains canonical record identity, source and field provenance,
+  freshness, access, and declared write capability. Viewer access applies before
+  results, groups, aggregates, counts, errors, and previews are computed.
+- A View presents and downstream-refines the Query result. It cannot widen the
+  Query contract or turn an output alias into a canonical source field.
+
+### Write and create only through an owner
+
+- An ordinary mapped field writes through only when canonical identity, stable
+  field mapping, authorization, Source policy, and provider capability are
+  unambiguous. Computed fields, aggregates, lossy alignments, and ambiguous
+  joined fields are read-only.
+- A Query declares zero or more creation routes terminating in writable
+  Databases or Sources. A View may select an applicable declared default but
+  cannot invent a destination; zero routes is read-only, one route proceeds,
+  and several routes require a permitted default or an explicit choice.
+- Existing row-union source identity, guarded writes, per-source bindings,
+  joined detail records, and source selection are donor and migration substrate.
+  Their specialized configuration surfaces are not the long-term product model.
+
+## Boundaries and non-goals
+
+- A Database owns a writable collection, schema, membership, validation, and
+  canonical create route. A Query derives a result and output contract. A View
+  presents and refines either input.
+- Sources catalog owns governed Source discovery; Source adapters own provider
+  operations and policy; this Capability does not create a generic provider API
+  or change source ownership.
+- A Query is not an access grant, static share, materialized clone, or a way to
+  infer field equivalence from names.
+
+## Acceptance stories
+
+### Align separate titles without changing either source
+
+Given two authorized collections expose distinct stable fields both labeled
+`Title`, when an editor explicitly aligns them into a Query output called
+`Title`, then the output has Query-owned identity while both source fields,
+schemas, provenance, and writes remain separate.
+
+### Write only when the route is clear
+
+Given a result with a mapped source field, a computed field, and an ambiguous
+joined field, when an authorized editor changes each one, then only the mapped
+field reaches its canonical owner; the computed and ambiguous fields remain
+read-only with an explanatory state.
+
+### Create through a declared source route
+
+Given a Query with two writable creation routes and a View with no applicable
+default, when a person creates a record, then Content presents a compact source
+choice and records the chosen owner's outcome. Given no route, creation is
+truthfully unavailable rather than guessed.
+
+## Current evidence
+
+Existing row-union and joined-detail machinery, source identity, guarded
+writes, field bindings, and source selection provide substantial donor
+implementation. They do not yet prove one visual typed Query experience,
+explicit output ownership, access-first nested composition, or complete
+write/create behavior. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Build equivalent Queries through visual controls and agent Actions across
+   Databases, governed Sources, and nested Queries; compare AST, output schema,
+   preview, cycle checks, and compatible renderer behavior.
+2. Test stable field identities, qualified collisions, explicit alignments,
+   aliases, computed outputs, joins, filters, variables, provenance, freshness,
+   access-first results, counts, aggregates, pagination, and scale bounds.
+3. Exercise mapped write-through, derived-field refusal, zero/one/many creation
+   routes, defaults, validation, Source policy, provider receipts, conflicts,
+   retries, and mixed permissions.
+4. Migrate representative row-union and joined-detail configurations without
+   losing local rows, identities, write settings, review history, or Source
+   mappings, then complete the workflow through the real interface.
+
+## Open questions
+
+- The stable ID `content.view.source-query` lives in the View namespace even
+  though the accepted concept is a Query specialization. Preserve it for
+  compatibility until a deliberate graph-wide normalization defines a safe
+  replacement and migration path.
+- Exact materialization/cache strategy and the detailed visual controls for
+  complex joins, traversal, and scale warnings remain implementation work.

--- a/templates/content/docs/product/capabilities/content.view.timeline.md
+++ b/templates/content/docs/product/capabilities/content.view.timeline.md
@@ -1,36 +1,86 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.view.timeline"
 name: "Timeline View"
 user_promise: "Timeline places and directly edits canonical records across typed dates and ranges while obeying the View conformance contract."
+primary_user_job: "See work across time, adjust an authorized date or range directly, and understand what the timeline cannot safely infer."
 kind: "surface"
 state: "in_progress"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.time.types","content.view.renderer-conformance"]
-related_features: ["content.feature.see-your-information-your-way","content.feature.plan-work-across-time"]
+dependencies: ["content.time.types", "content.view.renderer-conformance"]
+related_features:
+  [
+    "content.feature.see-your-information-your-way",
+    "content.feature.plan-work-across-time",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Timeline places and directly edits canonical records across typed dates and ranges while obeying the View conformance contract."
-proof_requirements: ["Timeline places and directly edits canonical records across typed dates and ranges while obeying the View conformance contract."]
-evidence: []
+acceptance_summary: "Timeline renders canonical, access-scoped records across selected typed date or range Properties and edits them through shared Actions with conformance, recovery, and accessible navigation."
+proof_requirements:
+  [
+    "Typed date/range placement, end-date, undated, overlap, range navigation, and configuration persistence coverage",
+    "Shared Action edit, permission, history, optimistic recovery, and agent-context parity coverage",
+    "Real-interface keyboard, assistive-technology, responsive, reload, and unavailable-state workflow",
+  ]
+evidence:
+  [
+    "../../../app/components/editor/database/TimelineView.tsx",
+    "../../../app/components/editor/DocumentDatabase.test.ts",
+  ]
 superseded_by: null
 last_reviewed: "2026-07-29"
 ---
 
 # Timeline View
 
-## Contract
+## Why this exists
 
-Timeline places and directly edits canonical records across typed dates and ranges while obeying the View conformance contract.
+Time is an important projection of work, but a bar is never a schedule engine or a
+second record. Timeline makes typed temporal values visible and editable in place.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Timeline places and directly edits canonical records across typed dates and ranges while obeying the View conformance contract.
+An editor selects a date Property and optional end-date Property, moves to the next
+range, creates a dated record, and edits a card. The shared Action changes the canonical
+record; undated and unavailable records are reported rather than invented into a lane.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Timeline consumes canonical, access-scoped results and configured typed dates or ranges.
+- Cards, overlap lanes, range controls, counts, and previews reflect authorized records only.
+- Direct edits and creation use shared Actions, validation, history, and recovery behavior.
+- Timeline is the current shallow renderer donor; Gantt is a composed mode/Feature, not proof of scheduling or a separate renderer contract.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Time types own temporal meaning; schedule constraints own dependency evaluation. Timeline
+does not infer dates, create a Gantt engine, or claim runtime feature-flag work not proven here.
+
+## Acceptance stories
+
+### Place a dated range
+
+Given authorized records with start and end date Properties, when a viewer opens Timeline,
+then overlapping cards appear in the selected range and an undated state is explicit.
+
+### Edit one canonical date
+
+Given an editable timeline card, when an editor changes its date, then the shared Action
+updates one canonical record, records history, and refreshes every authorized projection.
+
+## Current evidence
+
+`TimelineView.tsx` and `DocumentDatabase.test.ts` show a current Timeline renderer and
+date-window donor behavior. They do not prove the complete typed-time, Action-parity,
+conformance, accessibility, or recovery contract; this Capability remains `in_progress`.
+
+## Proof plan
+
+1. Test date-only, instant, ranges, end dates, undated records, overlaps, and range navigation.
+2. Verify Action edits, access closure, history, error rollback, and agent context.
+3. Run keyboard, assistive technology, responsive, reload, and unavailable-source workflows.
+
+## Open questions
+
+Precise Gantt composition and schedule-constraint visualization belong to their own Feature work.

--- a/templates/content/docs/product/capabilities/content.view.timeline.md
+++ b/templates/content/docs/product/capabilities/content.view.timeline.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.view.timeline"
+name: "Timeline View"
+user_promise: "Timeline places and directly edits canonical records across typed dates and ranges while obeying the View conformance contract."
+kind: "surface"
+state: "in_progress"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.time.types","content.view.renderer-conformance"]
+related_features: ["content.feature.see-your-information-your-way","content.feature.plan-work-across-time"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Timeline places and directly edits canonical records across typed dates and ranges while obeying the View conformance contract."
+proof_requirements: ["Timeline places and directly edits canonical records across typed dates and ranges while obeying the View conformance contract."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Timeline View
+
+## Contract
+
+Timeline places and directly edits canonical records across typed dates and ranges while obeying the View conformance contract.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Timeline places and directly edits canonical records across typed dates and ranges while obeying the View conformance contract.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.view.tree.md
+++ b/templates/content/docs/product/capabilities/content.view.tree.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.view.tree"
+name: "Tree View"
+user_promise: "Tree renders any suitable hierarchical Relationship without creating a parallel parent system."
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.relationship.edge","content.view.renderer-conformance"]
+related_features: []
+roadmap_boundary: "supporting"
+acceptance_summary: "A complete proof demonstrates: Tree renders any suitable hierarchical Relationship without creating a parallel parent system."
+proof_requirements: ["Tree renders any suitable hierarchical Relationship without creating a parallel parent system."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Tree View
+
+## Contract
+
+Tree renders any suitable hierarchical Relationship without creating a parallel parent system.
+
+## Acceptance boundary
+
+A complete proof demonstrates: Tree renders any suitable hierarchical Relationship without creating a parallel parent system.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.view.tree.md
+++ b/templates/content/docs/product/capabilities/content.view.tree.md
@@ -1,17 +1,24 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.view.tree"
 name: "Tree View"
 user_promise: "Tree renders any suitable hierarchical Relationship without creating a parallel parent system."
+primary_user_job: "Navigate and change an authorized hierarchy while knowing that its structure is a typed relationship, not an accidental page parent."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
-dependencies: ["content.relationship.edge","content.view.renderer-conformance"]
+dependencies: ["content.relationship.edge", "content.view.renderer-conformance"]
 related_features: []
 roadmap_boundary: "supporting"
-acceptance_summary: "A complete proof demonstrates: Tree renders any suitable hierarchical Relationship without creating a parallel parent system."
-proof_requirements: ["Tree renders any suitable hierarchical Relationship without creating a parallel parent system."]
+acceptance_summary: "Tree renders a chosen hierarchical Relationship over canonical access-scoped results, supports authorized relationship edits, and preserves typed edge truth across expansion and arrangement."
+proof_requirements:
+  [
+    "Hierarchical relationship selection, roots, cycles, multi-parent or orphan policy, expansion, and configuration coverage",
+    "Shared typed Relationship Action, access-safe disclosure, history, and recovery coverage",
+    "Real-interface keyboard tree semantics, assistive technology, lazy loading, reload, and dense hierarchy workflow",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,52 @@ last_reviewed: "2026-07-29"
 
 # Tree View
 
-## Contract
+## Why this exists
 
-Tree renders any suitable hierarchical Relationship without creating a parallel parent system.
+Some relationships are best read as nesting. Tree makes that shape useful without
+smuggling a universal parent field into Pages.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Tree renders any suitable hierarchical Relationship without creating a parallel parent system.
+A manager selects the `contains` relationship for a project View, expands a branch,
+and moves a task through the shared Relationship Action. The same edge remains visible
+in Connections and other authorized projections.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Tree selects a suitable typed hierarchical Relationship and renders canonical nodes and edges.
+- Expansion, collapse, order, and focused state are View presentation; they do not redefine hierarchy.
+- Relationship creation, removal, and move use the shared typed Action with its constraints and history.
+- Access applies before roots, branch counts, labels, traversal, export, or agent context.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Relationships own semantic truth and cardinality. Tree is not Page-parent ownership,
+a sidebar model, a file system, or a separate hierarchy datastore.
+
+## Acceptance stories
+
+### Expand an authorized branch
+
+Given a hierarchy with inaccessible descendants, when a viewer expands a node, then no
+child label, count, or placeholder leaks inaccessible relationships.
+
+### Change a typed edge
+
+Given an editor allowed to alter a hierarchical edge, when they move a node, then the
+shared Relationship Action applies its cycle and cardinality rules and records history.
+
+## Current evidence
+
+The shared relationship boundary is prerequisite substrate; no complete Tree renderer
+contract is proven in the repository. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Test roots, cycles, multiple parents, orphans, expansion, configuration, and lazy loading.
+2. Verify Action parity, access closure, history, concurrent changes, and recovery.
+3. Exercise ARIA tree navigation, keyboard moves, screen readers, reload, and dense branches.
+
+## Open questions
+
+The default policy for a relationship type that permits multiple parents needs design.

--- a/templates/content/docs/product/capabilities/content.workspace.multi-scope.md
+++ b/templates/content/docs/product/capabilities/content.workspace.multi-scope.md
@@ -1,17 +1,28 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.workspace.multi-scope"
 name: "Personal and organization contexts"
 user_promise: "One identity can hold personal Content plus several workspaces without account switching"
+primary_user_job: "Work in Personal and organization contexts under one identity without confusing their ownership, authority, or source of truth."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
 availability: "universal"
 dependencies: ["content.access.page-database"]
-related_features: ["content.feature.find-your-place-again","content.feature.work-across-every-workspace"]
+related_features:
+  [
+    "content.feature.find-your-place-again",
+    "content.feature.work-across-every-workspace",
+  ]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Visible current/global scope, opt-in cross-workspace retrieval, workspace opt-out policy, provenance and audit."
-proof_requirements: ["Visible current/global scope, opt-in cross-workspace retrieval, workspace opt-out policy, provenance and audit."]
+acceptance_summary: "One identity supports distinct Personal and organization contexts with visible current scope, explicit cross-context retrieval, organization opt-out, provenance, and audit."
+proof_requirements:
+  [
+    "Distinct context identity, current-scope switching, and ownership persistence coverage",
+    "Explicit cross-context retrieval, opt-out, access, provenance, and audit coverage",
+    "Revoked membership, unavailable context, agent context, reload, and recovery workflows",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +30,51 @@ last_reviewed: "2026-07-29"
 
 # Personal and organization contexts
 
-## Contract
+## Why this exists
 
-One identity can hold personal Content plus several workspaces without account switching
+One person may carry private work and belong to many organizations. Convenience must not
+turn those distinct contexts into one leaking room.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Visible current/global scope, opt-in cross-workspace retrieval, workspace opt-out policy, provenance and audit.
+A person switches from Personal to an organization, then asks for an explicitly global
+search. Results carry their origin; an organization policy can exclude its work entirely.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- Personal and organization contexts remain distinct ownership and access domains under one identity.
+- Current context is visible; cross-context retrieval is explicit, access-scoped, policy-governed, and auditable.
+- Every returned object retains origin and opens under its owning context's authority.
+- Membership loss, deletion, stale state, and unavailable contexts are not restored as usable state.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+This primitive informs Home and working sets. It does not create an organization, merge
+contexts, duplicate records, or make cross-context write implicit.
+
+## Acceptance stories
+
+### Switch without merging
+
+Given Personal and organization work, when a person changes current context, then only
+that scope is shown until they deliberately choose an allowed global retrieval.
+
+### Revoke a membership
+
+Given a previously visible organization item, when membership is revoked, then it no
+longer appears in navigation, Home, agent context, or session restoration.
+
+## Current evidence
+
+The architecture establishes the required distinction; no complete multi-scope interface,
+policy, provenance, and recovery proof is recorded. This remains `approved_shape`.
+
+## Proof plan
+
+1. Test scope switching, ownership, origin badges, global opt-in, and audit events.
+2. Verify organization opt-out and access changes across UI, Actions, search, and agents.
+3. Exercise revoked membership, unavailable context, reload, and recovery workflows.
+
+## Open questions
+
+The user-facing scope selector and default global-search posture need design.

--- a/templates/content/docs/product/capabilities/content.workspace.multi-scope.md
+++ b/templates/content/docs/product/capabilities/content.workspace.multi-scope.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.workspace.multi-scope"
+name: "Personal and organization contexts"
+user_promise: "One identity can hold personal Content plus several workspaces without account switching"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.access.page-database"]
+related_features: ["content.feature.find-your-place-again","content.feature.work-across-every-workspace"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Visible current/global scope, opt-in cross-workspace retrieval, workspace opt-out policy, provenance and audit."
+proof_requirements: ["Visible current/global scope, opt-in cross-workspace retrieval, workspace opt-out policy, provenance and audit."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Personal and organization contexts
+
+## Contract
+
+One identity can hold personal Content plus several workspaces without account switching
+
+## Acceptance boundary
+
+A complete proof demonstrates: Visible current/global scope, opt-in cross-workspace retrieval, workspace opt-out policy, provenance and audit.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/capabilities/content.workspace.session-restore.md
+++ b/templates/content/docs/product/capabilities/content.workspace.session-restore.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.workspace.session-restore"
+name: "Session resumption"
+user_promise: "Content reopens the authorized object and focused View a person was using without requiring them to reconstruct the route."
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.workspace.working-set"]
+related_features: ["content.feature.find-your-place-again"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates that authorized navigation and focused View state survive a normal interruption and inaccessible state is discarded safely."
+proof_requirements: ["Reopen the last authorized object and focused View after a normal application restart without leaking or reviving inaccessible state."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Session resumption
+
+## Contract
+
+Content reopens the authorized object and focused View a person was using without requiring them to reconstruct the route.
+
+## Acceptance boundary
+
+A complete proof covers restart, stale or deleted objects, changed permissions, and restoration of the focused saved or personal View.
+
+## Evidence boundary
+
+Persisted navigation donors do not verify this contract until the full return workflow passes.
+
+## Non-goals
+
+Session resumption does not preserve unauthorized data or keep every inactive renderer mounted.

--- a/templates/content/docs/product/capabilities/content.workspace.session-restore.md
+++ b/templates/content/docs/product/capabilities/content.workspace.session-restore.md
@@ -1,8 +1,10 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.workspace.session-restore"
 name: "Session resumption"
 user_promise: "Content reopens the authorized object and focused View a person was using without requiring them to reconstruct the route."
+primary_user_job: "Resume interrupted work quickly without reopening stale, deleted, or newly unauthorized information."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
@@ -10,8 +12,13 @@ availability: "universal"
 dependencies: ["content.workspace.working-set"]
 related_features: ["content.feature.find-your-place-again"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates that authorized navigation and focused View state survive a normal interruption and inaccessible state is discarded safely."
-proof_requirements: ["Reopen the last authorized object and focused View after a normal application restart without leaking or reviving inaccessible state."]
+acceptance_summary: "Session restoration reopens the last authorized object and focused saved or personal View after a normal interruption, discarding stale or inaccessible UI state safely."
+proof_requirements:
+  [
+    "Restart restoration of focus, View configuration, selection, and authorized route coverage",
+    "Deleted, stale, changed-permission, unavailable, and cross-context invalidation coverage",
+    "Real-interface reload, crash/restart, keyboard focus, agent-context, and recovery workflow",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,51 @@ last_reviewed: "2026-07-29"
 
 # Session resumption
 
-## Contract
+## Why this exists
 
-Content reopens the authorized object and focused View a person was using without requiring them to reconstruct the route.
+Returning to work should feel like a held thread, not a scavenger hunt—and never like a
+resurrection spell for information a person may no longer open.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof covers restart, stale or deleted objects, changed permissions, and restoration of the focused saved or personal View.
+An editor leaves a focused Timeline View, restarts the application, and returns there.
+If the Page was deleted or access changed, Content opens a safe fallback and explains it.
 
-## Evidence boundary
+## Product contract
 
-Persisted navigation donors do not verify this contract until the full return workflow passes.
+- Session state stores UI references and focus, never a substitute copy of object truth.
+- Restoration reauthorizes every target before reopening it and drops invalid state safely.
+- Saved or personal View focus restores when still authorized; ephemeral renderer state is bounded.
+- Recovery distinguishes normal restoration, missing target, denied target, and unavailable source.
 
-## Non-goals
+## Boundaries and non-goals
 
-Session resumption does not preserve unauthorized data or keep every inactive renderer mounted.
+Working set owns persisted UI state. Session restoration is not a guarantee to preserve
+every inactive renderer, unsaved local draft, or unauthorized content.
+
+## Acceptance stories
+
+### Resume an authorized View
+
+Given an editor focused on an authorized saved View, when the app restarts normally, then
+Content reopens that object and View with a usable focus target.
+
+### Discard revoked state
+
+Given saved state for an object whose access is revoked, when the session restores, then
+Content omits the object and does not reveal its title, preview, or prior selection.
+
+## Current evidence
+
+Persisted navigation donors do not prove reauthorization, fallback, and recovery. This
+Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Test normal restart, focused Views, selections, and bounded renderer restoration.
+2. Test deleted, stale, denied, unavailable, and cross-context state invalidation.
+3. Exercise reload/crash recovery, keyboard focus, agents, and accessible explanations.
+
+## Open questions
+
+The exact safe fallback order needs interaction design.

--- a/templates/content/docs/product/capabilities/content.workspace.view-instance.md
+++ b/templates/content/docs/product/capabilities/content.workspace.view-instance.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.workspace.view-instance"
+name: "View instances"
+user_promise: "Tabs, panes, embeds, and windows can show independent focused instances of the same canonical object without duplicating it."
+kind: "surface"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.workspace.working-set", "content.view.query"]
+related_features: ["content.feature.find-your-place-again"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates independent presentation state, shared canonical data, explicit focus, and bounded lazy rendering across View instances."
+proof_requirements: ["Open the same canonical object in two View instances, change presentation independently, edit once, and observe the canonical change in both."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# View instances
+
+## Contract
+
+Tabs, panes, embeds, and windows can show independent focused instances of the same canonical object without duplicating it.
+
+## Acceptance boundary
+
+Proof covers independent navigation and presentation, shared canonical mutations, focus and selection, lazy rendering, and recovery.
+
+## Evidence boundary
+
+Existing tabs or embed donors do not verify the shared contract until two live instances pass the same workflow.
+
+## Non-goals
+
+A View instance is not another Page, Database, Query, or permission boundary.

--- a/templates/content/docs/product/capabilities/content.workspace.view-instance.md
+++ b/templates/content/docs/product/capabilities/content.workspace.view-instance.md
@@ -1,8 +1,10 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.workspace.view-instance"
 name: "View instances"
 user_promise: "Tabs, panes, embeds, and windows can show independent focused instances of the same canonical object without duplicating it."
+primary_user_job: "Compare or work through the same object in several places while keeping presentation state independent and data canonical."
 kind: "surface"
 state: "approved_shape"
 publicness: "public"
@@ -10,8 +12,13 @@ availability: "universal"
 dependencies: ["content.workspace.working-set", "content.view.query"]
 related_features: ["content.feature.find-your-place-again"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates independent presentation state, shared canonical data, explicit focus, and bounded lazy rendering across View instances."
-proof_requirements: ["Open the same canonical object in two View instances, change presentation independently, edit once, and observe the canonical change in both."]
+acceptance_summary: "Independent View instances hold their own focus and presentation state over shared canonical objects, reconcile shared mutations, and render lazily within one bounded working set."
+proof_requirements:
+  [
+    "Two-instance identity, independent View state, focus, selection, and persistence coverage",
+    "Shared mutation reconciliation, permission change, close, embed, and recovery coverage",
+    "Lazy-rendering, keyboard, assistive-technology, reload, and agent-context workflow",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,51 @@ last_reviewed: "2026-07-29"
 
 # View instances
 
-## Contract
+## Why this exists
 
-Tabs, panes, embeds, and windows can show independent focused instances of the same canonical object without duplicating it.
+Two windows can hold two questions about one Page. They should not create two Pages in
+order to do it.
 
-## Acceptance boundary
+## Example workflow
 
-Proof covers independent navigation and presentation, shared canonical mutations, focus and selection, lazy rendering, and recovery.
+An editor opens one Database in a Table tab and a Timeline pane, changes a record in the
+Table, and sees the Timeline reconcile while its range and focus remain independent.
 
-## Evidence boundary
+## Product contract
 
-Existing tabs or embed donors do not verify the shared contract until two live instances pass the same workflow.
+- A View instance references a canonical object plus instance-local presentation, focus, and selection state.
+- Tabs, panes, embeds, and later windows may show the same object without duplicating it.
+- Canonical mutations, permissions, and deletion reconcile across instances through shared Actions and state sync.
+- Lazy rendering bounds resource use without falsely treating an unmounted instance as closed or complete.
 
-## Non-goals
+## Boundaries and non-goals
 
-A View instance is not another Page, Database, Query, or permission boundary.
+Working set owns instance persistence. A View instance is not a Page, Database, Query,
+permission boundary, or a fork of data.
+
+## Acceptance stories
+
+### Compare two presentations
+
+Given a Database open in a Table and Timeline instance, when a person changes Timeline
+range, then Table configuration is unchanged while both retain the same canonical records.
+
+### Reconcile one edit
+
+Given two authorized instances of one record, when an editor changes it through one, then
+the other reflects the canonical result without duplicate history or stale copy.
+
+## Current evidence
+
+Existing tabs or embeds are donor substrate only; no complete multi-instance contract is
+proven. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Test two-instance focus, presentation, selection, close, persistence, and lazy rendering.
+2. Verify mutations, permission changes, deletion, errors, and recovery across instances.
+3. Exercise keyboard, assistive technology, reload, embed, and agent-context workflows.
+
+## Open questions
+
+Cross-window synchronization and focus-transfer policy need separate implementation design.

--- a/templates/content/docs/product/capabilities/content.workspace.working-set.md
+++ b/templates/content/docs/product/capabilities/content.workspace.working-set.md
@@ -1,8 +1,10 @@
 ---
 record_type: "capability"
+spec_version: 2
 id: "content.workspace.working-set"
 name: "Working set"
 user_promise: "Tabs, split panes, and later windows are views over one persisted working set with explicit agent scope"
+primary_user_job: "Keep the few things I am actively using together without turning temporary UI state into object truth or hidden agent context."
 kind: "primitive"
 state: "approved_shape"
 publicness: "public"
@@ -10,8 +12,13 @@ availability: "universal"
 dependencies: ["content.workspace.multi-scope"]
 related_features: ["content.feature.find-your-place-again"]
 roadmap_boundary: "feature"
-acceptance_summary: "A complete proof demonstrates: Stable view references/state, lazy rendering, focus/selection, workspace/source boundaries."
-proof_requirements: ["Stable view references/state, lazy rendering, focus/selection, workspace/source boundaries."]
+acceptance_summary: "A persisted working set holds stable, authorized View references and local presentation state for tabs and panes, with explicit focus, bounded lazy rendering, and visible agent scope."
+proof_requirements:
+  [
+    "Stable references, focus, selection, ordering, pane layout, and persistence coverage",
+    "Scope, access revocation, source boundary, agent-context consent, close, and recovery coverage",
+    "Lazy rendering, reload, keyboard, assistive-technology, and concurrent UI workflow",
+  ]
 evidence: []
 superseded_by: null
 last_reviewed: "2026-07-29"
@@ -19,18 +26,52 @@ last_reviewed: "2026-07-29"
 
 # Working set
 
-## Contract
+## Why this exists
 
-Tabs, split panes, and later windows are views over one persisted working set with explicit agent scope
+Active work deserves continuity, but a tab strip must not become a secret database or an
+unannounced briefing packet for an agent.
 
-## Acceptance boundary
+## Example workflow
 
-A complete proof demonstrates: Stable view references/state, lazy rendering, focus/selection, workspace/source boundaries.
+A person keeps a project, a filtered task View, and a note in split panes, focuses the
+task View, and chooses which focused context an agent may use. Reordering panes changes
+only their working set.
 
-## Evidence boundary
+## Product contract
 
-Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+- The working set persists stable authorized View references and UI state, not object copies or truth.
+- Tabs, panes, and future windows share one explicit focus and selection model with bounded lazy rendering.
+- Current context and explicit consent govern what an agent receives; background tabs are not implied context.
+- Access loss, deletion, source unavailability, and scope changes invalidate or annotate state safely.
 
-## Non-goals
+## Boundaries and non-goals
 
-This capability does not create a parallel datastore, permission model, or action surface.
+Multi-scope owns ownership boundaries and View instances own a rendering occurrence. This
+is not shared document structure, an agent surveillance feed, or a second navigation tree.
+
+## Acceptance stories
+
+### Keep temporary arrangement personal
+
+Given two people viewing the same project, when one rearranges tabs and panes, then the
+other person's layout and the project's canonical structure remain unchanged.
+
+### Make agent scope explicit
+
+Given several open panes, when a person asks an agent about the focused task View, then
+only the explicitly selected authorized context is supplied and its origin remains visible.
+
+## Current evidence
+
+No complete persisted working-set, consent, access-invalidating, and recovery proof is
+recorded. This Capability remains `approved_shape`.
+
+## Proof plan
+
+1. Test references, focus, panes, ordering, persistence, close, and lazy rendering.
+2. Verify access and context changes, source boundaries, agent consent, and recovery.
+3. Exercise reload, concurrent UI changes, keyboard, and assistive-technology workflows.
+
+## Open questions
+
+The first explicit agent-context selector and cross-device persistence policy need design.

--- a/templates/content/docs/product/capabilities/content.workspace.working-set.md
+++ b/templates/content/docs/product/capabilities/content.workspace.working-set.md
@@ -1,0 +1,36 @@
+---
+record_type: "capability"
+id: "content.workspace.working-set"
+name: "Working set"
+user_promise: "Tabs, split panes, and later windows are views over one persisted working set with explicit agent scope"
+kind: "primitive"
+state: "approved_shape"
+publicness: "public"
+availability: "universal"
+dependencies: ["content.workspace.multi-scope"]
+related_features: ["content.feature.find-your-place-again"]
+roadmap_boundary: "feature"
+acceptance_summary: "A complete proof demonstrates: Stable view references/state, lazy rendering, focus/selection, workspace/source boundaries."
+proof_requirements: ["Stable view references/state, lazy rendering, focus/selection, workspace/source boundaries."]
+evidence: []
+superseded_by: null
+last_reviewed: "2026-07-29"
+---
+
+# Working set
+
+## Contract
+
+Tabs, split panes, and later windows are views over one persisted working set with explicit agent scope
+
+## Acceptance boundary
+
+A complete proof demonstrates: Stable view references/state, lazy rendering, focus/selection, workspace/source boundaries.
+
+## Evidence boundary
+
+Existing code may provide useful substrate, but this record is not verified until the complete atomic contract passes its proof requirements.
+
+## Non-goals
+
+This capability does not create a parallel datastore, permission model, or action surface.

--- a/templates/content/docs/product/chapters/content.chapter.capture-research.md
+++ b/templates/content/docs/product/chapters/content.chapter.capture-research.md
@@ -4,7 +4,13 @@ id: "content.chapter.capture-research"
 name: "Capture anything. Keep the thread"
 order: 5
 promise: "Chapter 5 turns the things people encounter into research they can keep using. Material can enter from many capture points, retain its source and exact context, become comfortable to read and annotate, and connect to citations, claims, and other knowledge without losing the original thread. The following Features support that path from capture to understanding."
-features: ["content.feature.capture-into-action","content.feature.read-and-annotate-anything","content.feature.cite-what-you-found","content.feature.sketch-connections-keep-whats-true"]
+features:
+  [
+    "content.feature.capture-into-action",
+    "content.feature.read-and-annotate-anything",
+    "content.feature.cite-what-you-found",
+    "content.feature.sketch-connections-keep-whats-true",
+  ]
 publicness: "public"
 last_reviewed: "2026-07-29"
 ---

--- a/templates/content/docs/product/chapters/content.chapter.capture-research.md
+++ b/templates/content/docs/product/chapters/content.chapter.capture-research.md
@@ -1,0 +1,14 @@
+---
+record_type: "chapter"
+id: "content.chapter.capture-research"
+name: "Capture anything. Keep the thread"
+order: 5
+promise: "Chapter 5 turns the things people encounter into research they can keep using. Material can enter from many capture points, retain its source and exact context, become comfortable to read and annotate, and connect to citations, claims, and other knowledge without losing the original thread. The following Features support that path from capture to understanding."
+features: ["content.feature.capture-into-action","content.feature.read-and-annotate-anything","content.feature.cite-what-you-found","content.feature.sketch-connections-keep-whats-true"]
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Capture anything. Keep the thread
+
+Chapter 5 turns the things people encounter into research they can keep using. Material can enter from many capture points, retain its source and exact context, become comfortable to read and annotate, and connect to citations, claims, and other knowledge without losing the original thread. The following Features support that path from capture to understanding.

--- a/templates/content/docs/product/chapters/content.chapter.connected-sources.md
+++ b/templates/content/docs/product/chapters/content.chapter.connected-sources.md
@@ -1,0 +1,14 @@
+---
+record_type: "chapter"
+id: "content.chapter.connected-sources"
+name: "One workspace across every source"
+order: 3
+promise: "Chapter 3 lets people work across Content, local files, and connected providers without rebuilding everything in one proprietary home. A team can combine information from several Sources, edit it through one predictable interface, and keep supported changes synchronized while preserving ownership, access, and provider-specific meaning. The following Features make that shared workspace possible."
+features: ["content.feature.connect-your-sources","content.feature.trust-your-connected-sources","content.feature.work-across-every-workspace","content.feature.bring-your-local-work"]
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# One workspace across every source
+
+Chapter 3 lets people work across Content, local files, and connected providers without rebuilding everything in one proprietary home. A team can combine information from several Sources, edit it through one predictable interface, and keep supported changes synchronized while preserving ownership, access, and provider-specific meaning. The following Features make that shared workspace possible.

--- a/templates/content/docs/product/chapters/content.chapter.connected-sources.md
+++ b/templates/content/docs/product/chapters/content.chapter.connected-sources.md
@@ -4,7 +4,13 @@ id: "content.chapter.connected-sources"
 name: "One workspace across every source"
 order: 3
 promise: "Chapter 3 lets people work across Content, local files, and connected providers without rebuilding everything in one proprietary home. A team can combine information from several Sources, edit it through one predictable interface, and keep supported changes synchronized while preserving ownership, access, and provider-specific meaning. The following Features make that shared workspace possible."
-features: ["content.feature.connect-your-sources","content.feature.trust-your-connected-sources","content.feature.work-across-every-workspace","content.feature.bring-your-local-work"]
+features:
+  [
+    "content.feature.connect-your-sources",
+    "content.feature.trust-your-connected-sources",
+    "content.feature.work-across-every-workspace",
+    "content.feature.bring-your-local-work",
+  ]
 publicness: "public"
 last_reviewed: "2026-07-29"
 ---

--- a/templates/content/docs/product/chapters/content.chapter.consensus.md
+++ b/templates/content/docs/product/chapters/content.chapter.consensus.md
@@ -4,7 +4,12 @@ id: "content.chapter.consensus"
 name: "Come to consensus without losing the evidence"
 order: 2
 promise: "Chapter 2 keeps collaboration attached to the work being shaped. People and agents can discuss a Page or Database, leave precise feedback, review attributable changes, explore alternatives, and preserve how the team reached its conclusion without rescuing the useful parts from a separate chat afterward. The following Features create that collaboration loop."
-features: ["content.feature.collaborate-in-context","content.feature.review-changes-in-place","content.feature.explore-alternatives-safely"]
+features:
+  [
+    "content.feature.collaborate-in-context",
+    "content.feature.review-changes-in-place",
+    "content.feature.explore-alternatives-safely",
+  ]
 publicness: "public"
 last_reviewed: "2026-07-29"
 ---

--- a/templates/content/docs/product/chapters/content.chapter.consensus.md
+++ b/templates/content/docs/product/chapters/content.chapter.consensus.md
@@ -1,0 +1,14 @@
+---
+record_type: "chapter"
+id: "content.chapter.consensus"
+name: "Come to consensus without losing the evidence"
+order: 2
+promise: "Chapter 2 keeps collaboration attached to the work being shaped. People and agents can discuss a Page or Database, leave precise feedback, review attributable changes, explore alternatives, and preserve how the team reached its conclusion without rescuing the useful parts from a separate chat afterward. The following Features create that collaboration loop."
+features: ["content.feature.collaborate-in-context","content.feature.review-changes-in-place","content.feature.explore-alternatives-safely"]
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Come to consensus without losing the evidence
+
+Chapter 2 keeps collaboration attached to the work being shaped. People and agents can discuss a Page or Database, leave precise feedback, review attributable changes, explore alternatives, and preserve how the team reached its conclusion without rescuing the useful parts from a separate chat afterward. The following Features create that collaboration loop.

--- a/templates/content/docs/product/chapters/content.chapter.durable-home.md
+++ b/templates/content/docs/product/chapters/content.chapter.durable-home.md
@@ -1,0 +1,14 @@
+---
+record_type: "chapter"
+id: "content.chapter.durable-home"
+name: "A durable home for your thinking"
+order: 1
+promise: "Chapter 1 gives people and agents a dependable place to create, organize, find, reshape, and recover their work. Pages and Databases remain understandable after an interruption, important material can be reused without drifting copies, and every authorized collaborator can return to the same durable context. The following Features establish that foundation."
+features: ["content.feature.durable-foundations","content.feature.find-your-place-again","content.feature.living-references","content.feature.make-the-workspace-yours","content.feature.see-your-information-your-way"]
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# A durable home for your thinking
+
+Chapter 1 gives people and agents a dependable place to create, organize, find, reshape, and recover their work. Pages and Databases remain understandable after an interruption, important material can be reused without drifting copies, and every authorized collaborator can return to the same durable context. The following Features establish that foundation.

--- a/templates/content/docs/product/chapters/content.chapter.durable-home.md
+++ b/templates/content/docs/product/chapters/content.chapter.durable-home.md
@@ -4,7 +4,14 @@ id: "content.chapter.durable-home"
 name: "A durable home for your thinking"
 order: 1
 promise: "Chapter 1 gives people and agents a dependable place to create, organize, find, reshape, and recover their work. Pages and Databases remain understandable after an interruption, important material can be reused without drifting copies, and every authorized collaborator can return to the same durable context. The following Features establish that foundation."
-features: ["content.feature.durable-foundations","content.feature.find-your-place-again","content.feature.living-references","content.feature.make-the-workspace-yours","content.feature.see-your-information-your-way"]
+features:
+  [
+    "content.feature.durable-foundations",
+    "content.feature.find-your-place-again",
+    "content.feature.living-references",
+    "content.feature.make-the-workspace-yours",
+    "content.feature.see-your-information-your-way",
+  ]
 publicness: "public"
 last_reviewed: "2026-07-29"
 ---

--- a/templates/content/docs/product/chapters/content.chapter.publishing-portability.md
+++ b/templates/content/docs/product/chapters/content.chapter.publishing-portability.md
@@ -1,0 +1,14 @@
+---
+record_type: "chapter"
+id: "content.chapter.publishing-portability"
+name: "Write once, keep it yours, publish faithfully"
+order: 6
+promise: "Chapter 6 carries the same canonical work from private thought into public reading, other applications, portable archives, and future systems. People can publish or embed what they choose, move their full body of work without starting over, and retain meaningful control over custody without creating a second truth that quietly drifts away. The following Features make Content useful beyond Content itself."
+features: ["content.feature.publish-with-confidence","content.feature.take-the-whole-vault-with-you","content.feature.move-without-starting-over","content.feature.work-on-content-inside-another-application","content.feature.keep-your-private-vault-private"]
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Write once, keep it yours, publish faithfully
+
+Chapter 6 carries the same canonical work from private thought into public reading, other applications, portable archives, and future systems. People can publish or embed what they choose, move their full body of work without starting over, and retain meaningful control over custody without creating a second truth that quietly drifts away. The following Features make Content useful beyond Content itself.

--- a/templates/content/docs/product/chapters/content.chapter.publishing-portability.md
+++ b/templates/content/docs/product/chapters/content.chapter.publishing-portability.md
@@ -4,7 +4,14 @@ id: "content.chapter.publishing-portability"
 name: "Write once, keep it yours, publish faithfully"
 order: 6
 promise: "Chapter 6 carries the same canonical work from private thought into public reading, other applications, portable archives, and future systems. People can publish or embed what they choose, move their full body of work without starting over, and retain meaningful control over custody without creating a second truth that quietly drifts away. The following Features make Content useful beyond Content itself."
-features: ["content.feature.publish-with-confidence","content.feature.take-the-whole-vault-with-you","content.feature.move-without-starting-over","content.feature.work-on-content-inside-another-application","content.feature.keep-your-private-vault-private"]
+features:
+  [
+    "content.feature.publish-with-confidence",
+    "content.feature.take-the-whole-vault-with-you",
+    "content.feature.move-without-starting-over",
+    "content.feature.work-on-content-inside-another-application",
+    "content.feature.keep-your-private-vault-private",
+  ]
 publicness: "public"
 last_reviewed: "2026-07-29"
 ---

--- a/templates/content/docs/product/chapters/content.chapter.working-systems.md
+++ b/templates/content/docs/product/chapters/content.chapter.working-systems.md
@@ -4,7 +4,20 @@ id: "content.chapter.working-systems"
 name: "Shape your own working system"
 order: 4
 promise: "Chapter 4 turns flexible Pages and Databases into working systems a team can trust. People with the right expertise can shape data, Views, Templates, Rules, Skills, and agent workflows for everyone else, while validation, governance, and safe evolution keep that flexibility from becoming organizational confetti. The following Features provide those building blocks."
-features: ["content.feature.data-that-keeps-itself-right","content.feature.share-how-your-organization-works","content.feature.put-your-organizations-know-how-to-work","content.feature.evolve-systems-safely","content.feature.when-this-happens-that-follows","content.feature.run-projects-your-way","content.feature.plan-work-across-time","content.feature.build-new-surfaces","content.feature.collect-structured-input","content.feature.understand-what-your-data-says","content.feature.build-living-dashboards"]
+features:
+  [
+    "content.feature.data-that-keeps-itself-right",
+    "content.feature.share-how-your-organization-works",
+    "content.feature.put-your-organizations-know-how-to-work",
+    "content.feature.evolve-systems-safely",
+    "content.feature.when-this-happens-that-follows",
+    "content.feature.run-projects-your-way",
+    "content.feature.plan-work-across-time",
+    "content.feature.build-new-surfaces",
+    "content.feature.collect-structured-input",
+    "content.feature.understand-what-your-data-says",
+    "content.feature.build-living-dashboards",
+  ]
 publicness: "public"
 last_reviewed: "2026-07-29"
 ---

--- a/templates/content/docs/product/chapters/content.chapter.working-systems.md
+++ b/templates/content/docs/product/chapters/content.chapter.working-systems.md
@@ -1,0 +1,14 @@
+---
+record_type: "chapter"
+id: "content.chapter.working-systems"
+name: "Shape your own working system"
+order: 4
+promise: "Chapter 4 turns flexible Pages and Databases into working systems a team can trust. People with the right expertise can shape data, Views, Templates, Rules, Skills, and agent workflows for everyone else, while validation, governance, and safe evolution keep that flexibility from becoming organizational confetti. The following Features provide those building blocks."
+features: ["content.feature.data-that-keeps-itself-right","content.feature.share-how-your-organization-works","content.feature.put-your-organizations-know-how-to-work","content.feature.evolve-systems-safely","content.feature.when-this-happens-that-follows","content.feature.run-projects-your-way","content.feature.plan-work-across-time","content.feature.build-new-surfaces","content.feature.collect-structured-input","content.feature.understand-what-your-data-says","content.feature.build-living-dashboards"]
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Shape your own working system
+
+Chapter 4 turns flexible Pages and Databases into working systems a team can trust. People with the right expertise can shape data, Views, Templates, Rules, Skills, and agent workflows for everyone else, while validation, governance, and safe evolution keep that flexibility from becoming organizational confetti. The following Features provide those building blocks.

--- a/templates/content/docs/product/encyclopedia.md
+++ b/templates/content/docs/product/encyclopedia.md
@@ -1,0 +1,558 @@
+# Agent Native Content capability encyclopedia
+
+<!-- Generated from the atomic records in chapters/, features/, and capabilities/. Do not edit this projection directly. -->
+
+This index summarizes the atomic product contracts beneath the public roadmap. Each linked record owns its promise, dependencies, state, proof boundary, and relationship to complete Features.
+
+## Catalog summary
+
+- Chapters: 6
+- Features: 32
+- Named increments: 1
+- Capabilities: 124
+
+| Capability state | Count |
+| --- | ---: |
+| Verified | 3 |
+| Failing | 1 |
+| Stale | 0 |
+| In Progress | 15 |
+| Approved Shape | 92 |
+| Exploring | 9 |
+| Deferred | 0 |
+| Superseded | 4 |
+
+## Dependency overview
+
+```mermaid
+graph LR
+  family_access["Access"]
+  family_action["Action"]
+  family_agent["Agent"]
+  family_api["Api"]
+  family_author["Author"]
+  family_automation["Automation"]
+  family_capture["Capture"]
+  family_command["Command"]
+  family_comment["Comment"]
+  family_diff["Diff"]
+  family_discussion["Discussion"]
+  family_embed["Embed"]
+  family_event["Event"]
+  family_expression["Expression"]
+  family_feedback["Feedback"]
+  family_form["Form"]
+  family_history["History"]
+  family_home["Home"]
+  family_job["Job"]
+  family_knowledge["Knowledge"]
+  family_layout["Layout"]
+  family_navigation["Navigation"]
+  family_notification["Notification"]
+  family_object["Object"]
+  family_organization["Organization"]
+  family_portability["Portability"]
+  family_presentation["Presentation"]
+  family_preset["Preset"]
+  family_property["Property"]
+  family_publish["Publish"]
+  family_query["Query"]
+  family_reader["Reader"]
+  family_relationship["Relationship"]
+  family_renderer["Renderer"]
+  family_research["Research"]
+  family_review["Review"]
+  family_revision["Revision"]
+  family_rule["Rule"]
+  family_schedule["Schedule"]
+  family_security["Security"]
+  family_share["Share"]
+  family_source["Source"]
+  family_system["System"]
+  family_template["Template"]
+  family_time["Time"]
+  family_version["Version"]
+  family_view["View"]
+  family_workspace["Workspace"]
+  family_access --> family_agent
+  family_access --> family_api
+  family_access --> family_embed
+  family_access --> family_feedback
+  family_access --> family_knowledge
+  family_access --> family_organization
+  family_access --> family_portability
+  family_access --> family_publish
+  family_access --> family_query
+  family_access --> family_share
+  family_access --> family_source
+  family_access --> family_template
+  family_access --> family_view
+  family_access --> family_workspace
+  family_agent --> family_api
+  family_agent --> family_command
+  family_agent --> family_diff
+  family_agent --> family_embed
+  family_agent --> family_form
+  family_agent --> family_job
+  family_agent --> family_rule
+  family_agent --> family_security
+  family_agent --> family_view
+  family_author --> family_reader
+  family_author --> family_review
+  family_command --> family_action
+  family_diff --> family_review
+  family_diff --> family_revision
+  family_diff --> family_template
+  family_diff --> family_version
+  family_discussion --> family_feedback
+  family_event --> family_agent
+  family_event --> family_capture
+  family_event --> family_diff
+  family_event --> family_discussion
+  family_event --> family_expression
+  family_event --> family_form
+  family_event --> family_history
+  family_event --> family_job
+  family_event --> family_notification
+  family_event --> family_property
+  family_event --> family_publish
+  family_event --> family_rule
+  family_event --> family_source
+  family_event --> family_version
+  family_expression --> family_agent
+  family_expression --> family_property
+  family_expression --> family_query
+  family_expression --> family_rule
+  family_expression --> family_schedule
+  family_expression --> family_system
+  family_history --> family_revision
+  family_job --> family_portability
+  family_knowledge --> family_research
+  family_knowledge --> family_view
+  family_layout --> family_presentation
+  family_object --> family_author
+  family_object --> family_comment
+  family_object --> family_discussion
+  family_object --> family_embed
+  family_object --> family_knowledge
+  family_object --> family_layout
+  family_object --> family_navigation
+  family_object --> family_portability
+  family_object --> family_relationship
+  family_object --> family_research
+  family_object --> family_source
+  family_object --> family_template
+  family_object --> family_version
+  family_object --> family_view
+  family_portability --> family_security
+  family_portability --> family_source
+  family_property --> family_form
+  family_property --> family_renderer
+  family_property --> family_time
+  family_property --> family_view
+  family_publish --> family_portability
+  family_query --> family_home
+  family_query --> family_navigation
+  family_query --> family_view
+  family_relationship --> family_knowledge
+  family_relationship --> family_schedule
+  family_relationship --> family_system
+  family_relationship --> family_view
+  family_renderer --> family_author
+  family_renderer --> family_diff
+  family_renderer --> family_layout
+  family_renderer --> family_portability
+  family_renderer --> family_presentation
+  family_renderer --> family_publish
+  family_renderer --> family_view
+  family_research --> family_reader
+  family_research --> family_system
+  family_rule --> family_action
+  family_rule --> family_agent
+  family_rule --> family_automation
+  family_share --> family_view
+  family_source --> family_capture
+  family_source --> family_reader
+  family_source --> family_renderer
+  family_source --> family_view
+  family_template --> family_agent
+  family_template --> family_capture
+  family_template --> family_expression
+  family_template --> family_preset
+  family_template --> family_property
+  family_template --> family_system
+  family_time --> family_automation
+  family_time --> family_schedule
+  family_time --> family_view
+  family_version --> family_research
+  family_view --> family_renderer
+  family_view --> family_share
+  family_view --> family_system
+  family_view --> family_workspace
+  family_workspace --> family_home
+  family_workspace --> family_organization
+```
+
+## Access
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Page and Database access](capabilities/content.access.page-database.md) | Approved Shape | Page and Database access separates view/comment/data editing from schema authority |
+| [Row-level privacy](capabilities/content.access.row-private.md) | Approved Shape | Row/Page sharing can override inherited Database visibility |
+| [Access-safe computation](capabilities/content.access.safe-aggregate.md) | Exploring | Access applies before relation traversal, count, rollup, group, and aggregate |
+| [Visibility closure](capabilities/content.access.visibility-closure.md) | Approved Shape | Traversal, export, embedding, search, and derived results omit inaccessible objects while known direct links return an honest denial. |
+
+## Action
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Action Buttons](capabilities/content.action.button.md) | Approved Shape | An owner-governed Button invokes an ordinary action/Rule with typed inputs and visible authority |
+
+## Agent
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Agent and UI parity](capabilities/content.agent.action-parity.md) | In Progress | Humans and agents use the same operations and visible state |
+| [Audience-safe synthesis](capabilities/content.agent.audience-safe.md) | Approved Shape | A governed agent run can restrict its inputs to information every intended viewer of the output may access. |
+| [Agent-run automation](capabilities/content.agent.automation.md) | Approved Shape | AI work composes Event → expression/query → action → mutation → Event |
+| [Agent-authored Expressions](capabilities/content.agent.expression-authoring.md) | Approved Shape | AI generates, validates, previews, repairs, and saves typed expressions |
+| [Agent presence](capabilities/content.agent.presence.md) | In Progress | One accountable agent presence shows every location a run is editing without replacing durable attribution or delaying the real change. |
+| [Agent resource consent](capabilities/content.agent.resource-consent.md) | Approved Shape | Resources independently declare whether agents may use them as context and whether agents may edit them, with inheritable policy ceilings. |
+| [Skills catalog](capabilities/content.agent.skill-catalog.md) | Approved Shape | Governed reusable agent instructions/capabilities can be invoked against compatible Content targets |
+
+## API
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Content API and CMS](capabilities/content.api.cms.md) | Approved Shape | External clients and websites can read and mutate Content through the same typed Actions, permissions, validation, and audit behavior as people and agents. |
+
+## Author
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Executable Code blocks](capabilities/content.author.code.md) | Approved Shape | Powerful inline Code blocks highlight any recognized language and may become isolated, composable mini-sandboxes with compatible renderers and execution runtimes |
+| [Document editor](capabilities/content.author.document-editor.md) | In Progress | A humane visual document editor with blocks, comments, media, collaboration, and agent co-editing |
+| [Footnotes](capabilities/content.author.footnotes.md) | Approved Shape | Footnotes remain humane to author, navigate, render, and round-trip |
+| [Math and equations](capabilities/content.author.math.md) | In Progress | Inline and block math render faithfully in editor, reader, and export |
+| [Media Blocks](capabilities/content.author.media.md) | In Progress | Images, audio, video, files, embeds, captions, and source-aware assets travel through one storage/rendering contract |
+| [Mermaid diagrams](capabilities/content.author.mermaid.md) | Approved Shape | Mermaid source renders through a normal built-in Code-block renderer and round-trips through ordinary fenced source |
+
+## Automation
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Scheduled automation](capabilities/content.automation.scheduled.md) | In Progress | Scheduled queries and recurring heartbeats over current state |
+
+## Capture
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Capture and enrichment](capabilities/content.capture.enrich.md) | Approved Shape | Send anything to a chosen Content Database and let its Rules and agents immediately turn it into durable, structured context |
+
+## Command
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Unified commands](capabilities/content.command.fabric.md) | Approved Shape | Slash, Cmd+K, menus, shortcuts, Buttons, and agents discover the same scoped commands/actions |
+
+## Comment
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Comments](capabilities/content.comment.page-owned.md) | Approved Shape | Page-owned threaded comments targeting one or several Blocks |
+
+## Diff
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Agent-assisted review](capabilities/content.diff.ai-assist.md) | Approved Shape | AI summaries and guided review for large change sets |
+| [Filtered change review](capabilities/content.diff.filtered-review.md) | Approved Shape | Accept/reject individual or all visible changes in a filtered set |
+| [In-place typed review](capabilities/content.diff.in-place.md) | Approved Shape | Typed changes rendered inside the ordinary editor/view |
+
+## Discussion
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Page Discussion](capabilities/content.discussion.page.md) | Approved Shape | One universal Page Discussion combining threaded collaboration with curated activity context |
+
+## Embed
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Embedded host grants](capabilities/content.embed.host-grant.md) | Approved Shape | An embedded host receives only the named mount and Action capabilities it needs and can never widen the signed-in viewer's authority. |
+| [MCP App embedding](capabilities/content.embed.mcp-app.md) | Approved Shape | Content itself can appear as a focused MCP App inside compatible external agent hosts |
+| [Embeddable Content surfaces](capabilities/content.embed.surface.md) | Approved Shape | Mountable editor/page/view/expression/history surface across Agent Native apps |
+
+## Event
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Committed Events](capabilities/content.event.committed.md) | In Progress | Canonical actor-aware committed Event spine |
+
+## Expression
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Cached expression results](capabilities/content.expression.cached-result.md) | Approved Shape | Content renders the last valid expression result immediately, marks it stale, and refreshes it without turning ordinary loading into an error. |
+| [Expression catalog](capabilities/content.expression.catalog.md) | Approved Shape | Governed reusable Expressions and Variables |
+| [Typed expression language](capabilities/content.expression.language.md) | Approved Shape | One typed language across formulas, views, validation, Rules, schedules, and body |
+
+## Feedback
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Reactions and Polls](capabilities/content.feedback.signal.md) | Approved Shape | Structured reactions and option-based Polls live inside the Page Discussion and can render through views or embeds |
+
+## Form
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Shared Form engine](capabilities/content.form.shared-engine.md) | Approved Shape | Content Form Views and Agent Native Forms use one schema, validation, permission, and idempotent submission engine. |
+
+## History
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [History](capabilities/content.history.queryable.md) | Approved Shape | Full-height queryable History surface over revisions/events |
+
+## Home
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Global Home](capabilities/content.home.global.md) | Approved Shape | Home belongs to the person and composes authorized work across Personal and organization contexts without pretending it all shares one Workspace. |
+
+## Job
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Durable background jobs](capabilities/content.job.durable.md) | Approved Shape | Imports, exports, migrations, capture, and backfills survive interruption, report honest progress, and resume without duplicate work. |
+
+## Knowledge
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Graph queries](capabilities/content.knowledge.graph.md) | Exploring | Graph navigation and query over typed links, mentions, relations, and authority edges |
+| [Links and backlinks](capabilities/content.knowledge.links.md) | Approved Shape | Stable links, outline, backlinks, forward links, external-link health, and link-aware navigation through the Page Info rail |
+| [Search](capabilities/content.knowledge.search.md) | In Progress | Fast access-aware search across titles, bodies, rows, sources, and later comments/review |
+
+## Layout
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Responsive Page layout](capabilities/content.layout.responsive.md) | Approved Shape | Pages arrange, resize, and reorder Blocks in columns that remain coherent on smaller screens and in exports. |
+
+## Navigation
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Personal sidebar](capabilities/content.navigation.sidebar.md) | Approved Shape | The sidebar is a personal navigation surface with pinned references and query-backed dynamic sections, not object hierarchy. |
+
+## Notification
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Notifications](capabilities/content.notification.source.md) | Approved Shape | Canonical notifications exposed as queryable Content source/views |
+
+## Object
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Blocks](capabilities/content.object.block.md) | Approved Shape | Stable addressable Block inside a Page |
+| [Blocks fields](capabilities/content.object.blocks-field.md) | Approved Shape | Every editable rich-content body uses the same Blocks-field grammar and owns its own stable revision history. |
+| [Databases](capabilities/content.object.database.md) | Verified | Database as a Page-backed typed collection |
+| [Multiple Database memberships](capabilities/content.object.multi-membership.md) | In Progress | One Page participating in several Databases without copies |
+| [Pages](capabilities/content.object.page.md) | Verified | Durable Page with body, properties, permissions, comments, URL, and source/export identity |
+| [References](capabilities/content.object.reference.md) | Approved Shape | Stable Page/Database/Block references distinct from expressions |
+| [Synced Blocks and live embeds](capabilities/content.object.transclusion.md) | Approved Shape | A Page or Block can be included by reference and edited from every authorized rendering without creating synchronized copies |
+
+## Organization
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Organization teams](capabilities/content.organization.teams.md) | Approved Shape | Canonical framework-wide Team membership can be managed through Content without giving each app a conflicting identity system. |
+
+## Portability
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [PDF and print export](capabilities/content.portability.pdf-export.md) | Approved Shape | Real PDF export uses the same rendering truth as editor, reader, and HTML export |
+| [Faithful round-tripping](capabilities/content.portability.roundtrip.md) | Approved Shape | Canonical Content data imports/exports through humane Markdown/MDX and structured sidecars |
+| [Portable source representation](capabilities/content.portability.source-representation.md) | Approved Shape | One lossless, provider-neutral Content source representation with humane Markdown as its base |
+| [Whole-vault export](capabilities/content.portability.vault-export.md) | Approved Shape | An authorized person can export a static snapshot as an open vault, a lossless Content archive, or a destination-specific package. |
+
+## Presentation
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Presentation mode](capabilities/content.presentation.mode.md) | Approved Shape | Pages and ordered records can present through shared Slides primitives without creating slide-only content. |
+
+## Preset
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Presets](capabilities/content.preset.catalog.md) | Superseded | Governed preassembled ordinary primitives, always inspectable |
+
+## Property
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Actor properties](capabilities/content.property.actor.md) | Approved Shape | Created by and Last edited by record the actual human, agent, automation, or integration actor. |
+| [Custom Properties](capabilities/content.property.catalog.md) | Exploring | Governed Custom Properties can be deliberately reused across Databases without making ordinary same-named columns secretly equivalent |
+| [Property validation and defaults](capabilities/content.property.constraints.md) | Approved Shape | Required, default, validation, formatting, edit policy in column configuration |
+| [Guarded property changes](capabilities/content.property.guarded-change.md) | Approved Shape | Any Property can validate values and require an explained confirmation or policy check before a sensitive transition. |
+| [Typed locations](capabilities/content.property.location.md) | Approved Shape | Location Properties preserve structured places and coordinates for maps, queries, sources, and portable export. |
+| [Typed Properties](capabilities/content.property.typed.md) | In Progress | Typed stored and computed properties with descriptions |
+
+## Publish
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Public publishing](capabilities/content.publish.public.md) | Approved Shape | Internal sharing and public publishing remain separate, explicit, auditable planes |
+| [Public reading](capabilities/content.publish.reading.md) | In Progress | Shareable/public reading surfaces render the same document truth as the editor/exporter |
+
+## Query
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Reusable Query objects](capabilities/content.query.object.md) | Approved Shape | A one-off inline Query can be promoted into a named reusable Content object that behaves like a dynamic Database without owning its source records |
+
+## Reader
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Document Reader](capabilities/content.reader.documents.md) | Superseded | Native PDF/EPUB reading and annotation |
+| [Reader surface](capabilities/content.reader.surface.md) | Approved Shape | One specialized Reader surface renders and annotates Content Sources across text, PDF, EPUB, web, audio, video, and transcripts |
+
+## Relationship
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Typed Relationships](capabilities/content.relationship.edge.md) | Approved Shape | One typed edge substrate powers relation Properties, inline typed Page references, backlinks, Info, graph queries, and Graph editing |
+
+## Renderer
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Artifact Blocks](capabilities/content.renderer.artifact-block.md) | Approved Shape | Page-owned one-off HTML/CSS/JS artifact using the Custom Block sandbox format without entering the reusable catalog |
+| [Custom Blocks](capabilities/content.renderer.custom-block.md) | Approved Shape | One Custom Block model for Content-managed and source-backed reusable components, with optional typed props and a strict origin-aware runtime boundary |
+| [Collection graph renderers](capabilities/content.renderer.graph.md) | Exploring | Graph/chart renderers for typed collection results |
+| [Typed renderers](capabilities/content.renderer.typed.md) | Approved Shape | Render any typed value using compatible built-in presentations |
+
+## Research
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Annotations](capabilities/content.research.annotation.md) | Approved Shape | Highlights, excerpts, and research notes remain anchored to the exact source representation and named Page version they interpret |
+| [Citations](capabilities/content.research.citation.md) | Approved Shape | A semantic citation references a durable source record plus an optional locator, independently of how it is rendered |
+
+## Review
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Code review](capabilities/content.review.code.md) | Exploring | Review typed code/file changes in the same in-place, filterable, durable-decision interface |
+
+## Revision
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Suggestions](capabilities/content.revision.suggestions.md) | Approved Shape | Suggested changes as authored pending revisions with accept/reject history |
+
+## Rule
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Rules](capabilities/content.rule.deterministic.md) | In Progress | Event + typed condition + action |
+
+## Schedule
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Schedule constraints](capabilities/content.schedule.constraints.md) | Exploring | Planning surfaces detect dependency and date violations, explain them, and apply only explicit policy or accepted repairs. |
+
+## Security
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Private vault encryption](capabilities/content.security.private-vault.md) | In Progress | User-held private-vault/E2EE custody with fail-closed enrollment, recovery, and authorization |
+
+## Share
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Shared Views](capabilities/content.share.views.md) | Approved Shape | A shared Database view preserves its configuration while defaulting to the viewer's existing row access |
+
+## Source
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Source adapters](capabilities/content.source.adapters.md) | In Progress | Local folder, Builder, Notion, and future typed source adapters |
+| [Builder round-trip codec](capabilities/content.source.builder-codec.md) | Approved Shape | Builder JSON blocks round-trip through one pure typed codec shared by repo-backed docs and CMS-backed databases |
+| [Sources catalog](capabilities/content.source.catalog.md) | Approved Shape | One governed top-level Content Database of local, provider, and native Sources |
+| [Files and folders as Sources](capabilities/content.source.file-folder.md) | Exploring | A person can open a folder as a Source without assuming every file shares one Database schema. |
+| [Local Source bridge](capabilities/content.source.local-bridge.md) | Approved Shape | A desktop app or small trusted service can synchronize selected local Sources for browsers that cannot access files directly. |
+| [Local project mode](capabilities/content.source.local-project.md) | Superseded | Opt-in local/git workspace where files are the single truth domain |
+| [Page-linked Sources](capabilities/content.source.page-link.md) | Exploring | A single Page can bind to one external source item without inventing a separate source architecture. |
+| [Materialized multi-source Databases](capabilities/content.source.row-union.md) | Superseded | One Database materializing rows from several source-owned collections with a Source tag and per-source column bindings |
+| [Content spaces and Files](capabilities/content.source.spaces-files.md) | Verified | Database-backed Content spaces, Files, Workspaces, and Sidebar views |
+| [Source sync policy](capabilities/content.source.sync-policy.md) | Approved Shape | Each connected Source declares one plain-language truth policy: view only, keep in sync, or review before write-back. |
+
+## System
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Task dependencies](capabilities/content.system.dependencies.md) | Approved Shape | Parent/subtask and blocked/blocking relations with constraints |
+| [My Tasks](capabilities/content.system.my-tasks.md) | Approved Shape | “My Tasks” as an access-scoped dynamic saved view |
+| [Project status](capabilities/content.system.project-status.md) | Approved Shape | Project status updates and rollups as ordinary Content views/pages |
+| [Research workspace Template](capabilities/content.system.research-workspace.md) | Exploring | A blessed editable research template composes Sources, Notes, Projects, reading queues, citations, capture, and synthesis views over one Content datastore |
+| [Blessed Task and Project Template](capabilities/content.system.task-project.md) | Approved Shape | Blessed editable Task/Project template over Content |
+
+## Template
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Template governance](capabilities/content.template.governance.md) | Approved Shape | Private/org-approved/Agent Native–published template catalog |
+| [Multi-object Templates](capabilities/content.template.graph.md) | Approved Shape | Multi-object template snapshots Pages/Databases/views/Rules/expressions/body templates |
+| [Database item Templates](capabilities/content.template.item-body.md) | Approved Shape | Multiple database-item body templates with one default and dynamic embedded views |
+| [Template updates](capabilities/content.template.update.md) | Approved Shape | Never-auto update notice, structural diff, selective apply/reset |
+
+## Time
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Dates, times, and durations](capabilities/content.time.types.md) | Approved Shape | Date, Instant, ranges, Duration, and explicit timezone conversion |
+
+## Version
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Named Page Versions](capabilities/content.version.branching.md) | Approved Shape | Multiple named body versions evolve in parallel under one Page identity and shared properties |
+| [Blocks-field revision history](capabilities/content.version.field-history.md) | Approved Shape | Every Blocks field preserves attributable comparison and recovery independently of later named Page Versions. |
+
+## View
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Canvas](capabilities/content.view.canvas.md) | Approved Shape | A spatial Canvas, semantic Graph, and mind-map family arranges reusable Pages, Blocks, Sources, Annotations, views, and media without copying them |
+| [Chart View](capabilities/content.view.chart.md) | Approved Shape | Charts share one typed specification across saved Views, embeddable Blocks, dashboards, Analytics, static output, and drill-down. |
+| [View-derived creation defaults](capabilities/content.view.dynamic-create.md) | Approved Shape | New rows inherit unambiguous equality constraints from the active view |
+| [Fast keyboard capture](capabilities/content.view.fast-capture.md) | Approved Shape | Keyboard-fluent List and Table capture |
+| [Graph View](capabilities/content.view.graph.md) | Approved Shape | Graph lays out query-selected canonical objects and typed Relationships for access-safe exploration and editing. |
+| [Grouping and aggregation](capabilities/content.view.grouping-aggregation.md) | Approved Shape | Views group across several dimensions and compute access-safe totals, subtotals, rollups, and measures. |
+| [Map View](capabilities/content.view.map.md) | Approved Shape | Map renders typed locations with points, clustering, filtering, and record previews before adding richer geographic layers. |
+| [Personal View state](capabilities/content.view.personal-state.md) | Approved Shape | A shared View remembers one private arrangement per person and supports named Only-me Views without copying records. |
+| [Pivot View](capabilities/content.view.pivot.md) | Approved Shape | Pivot places dimensions on rows and columns, typed aggregations in cells, and drills back to canonical records. |
+| [Database and Query Views](capabilities/content.view.query.md) | Approved Shape | Saved typed queries rendered as Table/Board/List/Gallery/Calendar/Timeline/Form/Sidebar and later Graph/Canvas views |
+| [View renderer conformance](capabilities/content.view.renderer-conformance.md) | Approved Shape | Every View obeys the same permissions, Actions, agent context, accessibility, persistence, performance, and recovery contract. |
+| [Large Database performance](capabilities/content.view.scale.md) | Failing | Databases stay responsive and incrementally queryable well beyond a few hundred rows |
+| [Cross-source Queries](capabilities/content.view.source-query.md) | Approved Shape | One saved typed query composes local Databases and provider collections through unions, joins, filters, relations, and explicit field alignment, then renders through any compatible view |
+| [Timeline View](capabilities/content.view.timeline.md) | In Progress | Timeline places and directly edits canonical records across typed dates and ranges while obeying the View conformance contract. |
+| [Tree View](capabilities/content.view.tree.md) | Approved Shape | Tree renders any suitable hierarchical Relationship without creating a parallel parent system. |
+
+## Workspace
+
+| Capability | State | User promise |
+| --- | --- | --- |
+| [Personal and organization contexts](capabilities/content.workspace.multi-scope.md) | Approved Shape | One identity can hold personal Content plus several workspaces without account switching |
+| [Session resumption](capabilities/content.workspace.session-restore.md) | Approved Shape | Content reopens the authorized object and focused View a person was using without requiring them to reconstruct the route. |
+| [View instances](capabilities/content.workspace.view-instance.md) | Approved Shape | Tabs, panes, embeds, and windows can show independent focused instances of the same canonical object without duplicating it. |
+| [Working set](capabilities/content.workspace.working-set.md) | Approved Shape | Tabs, split panes, and later windows are views over one persisted working set with explicit agent scope |

--- a/templates/content/docs/product/encyclopedia.md
+++ b/templates/content/docs/product/encyclopedia.md
@@ -12,15 +12,15 @@ This index summarizes the atomic product contracts beneath the public roadmap. E
 - Capabilities: 124
 
 | Capability state | Count |
-| --- | ---: |
-| Verified | 3 |
-| Failing | 1 |
-| Stale | 0 |
-| In Progress | 15 |
-| Approved Shape | 92 |
-| Exploring | 9 |
-| Deferred | 0 |
-| Superseded | 4 |
+| ---------------- | ----: |
+| Verified         |     3 |
+| Failing          |     1 |
+| Stale            |     0 |
+| In Progress      |    16 |
+| Approved Shape   |    91 |
+| Exploring        |     8 |
+| Deferred         |     0 |
+| Superseded       |     5 |
 
 ## Dependency overview
 
@@ -83,6 +83,7 @@ graph LR
   family_access --> family_portability
   family_access --> family_publish
   family_access --> family_query
+  family_access --> family_relationship
   family_access --> family_share
   family_access --> family_source
   family_access --> family_template
@@ -115,7 +116,7 @@ graph LR
   family_event --> family_job
   family_event --> family_notification
   family_event --> family_property
-  family_event --> family_publish
+  family_event --> family_relationship
   family_event --> family_rule
   family_event --> family_source
   family_event --> family_version
@@ -133,11 +134,9 @@ graph LR
   family_object --> family_author
   family_object --> family_comment
   family_object --> family_discussion
-  family_object --> family_embed
   family_object --> family_knowledge
   family_object --> family_layout
   family_object --> family_navigation
-  family_object --> family_portability
   family_object --> family_relationship
   family_object --> family_research
   family_object --> family_source
@@ -147,10 +146,10 @@ graph LR
   family_portability --> family_security
   family_portability --> family_source
   family_property --> family_form
+  family_property --> family_relationship
   family_property --> family_renderer
   family_property --> family_time
   family_property --> family_view
-  family_publish --> family_portability
   family_query --> family_home
   family_query --> family_navigation
   family_query --> family_view
@@ -172,6 +171,7 @@ graph LR
   family_rule --> family_automation
   family_share --> family_view
   family_source --> family_capture
+  family_source --> family_portability
   family_source --> family_reader
   family_source --> family_renderer
   family_source --> family_view
@@ -184,6 +184,7 @@ graph LR
   family_time --> family_automation
   family_time --> family_schedule
   family_time --> family_view
+  family_version --> family_publish
   family_version --> family_research
   family_view --> family_renderer
   family_view --> family_share
@@ -195,364 +196,364 @@ graph LR
 
 ## Access
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Page and Database access](capabilities/content.access.page-database.md) | Approved Shape | Page and Database access separates view/comment/data editing from schema authority |
-| [Row-level privacy](capabilities/content.access.row-private.md) | Approved Shape | Row/Page sharing can override inherited Database visibility |
-| [Access-safe computation](capabilities/content.access.safe-aggregate.md) | Exploring | Access applies before relation traversal, count, rollup, group, and aggregate |
-| [Visibility closure](capabilities/content.access.visibility-closure.md) | Approved Shape | Traversal, export, embedding, search, and derived results omit inaccessible objects while known direct links return an honest denial. |
+| Capability                                                               | State          | User promise                                                                                                       |
+| ------------------------------------------------------------------------ | -------------- | ------------------------------------------------------------------------------------------------------------------ |
+| [Page and Database access](capabilities/content.access.page-database.md) | Approved Shape | Page and Database roles separate reading, commenting, entry editing, and structure authority.                      |
+| [Row-level privacy](capabilities/content.access.row-private.md)          | Approved Shape | A Page or Database row can be shared more narrowly than its collection's ordinary visibility.                      |
+| [Access-safe computation](capabilities/content.access.safe-aggregate.md) | Exploring      | Counts, rollups, groups, and aggregates reveal only records the viewer may access.                                 |
+| [Visibility closure](capabilities/content.access.visibility-closure.md)  | Approved Shape | Ambient traversal and derived results omit inaccessible objects while known direct links receive an honest denial. |
 
 ## Action
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Action Buttons](capabilities/content.action.button.md) | Approved Shape | An owner-governed Button invokes an ordinary action/Rule with typed inputs and visible authority |
+| Capability                                              | State          | User promise                                                                                        |
+| ------------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------- |
+| [Action Buttons](capabilities/content.action.button.md) | Approved Shape | An owner-governed Button invokes an ordinary action or Rule with typed inputs and visible authority |
 
 ## Agent
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Agent and UI parity](capabilities/content.agent.action-parity.md) | In Progress | Humans and agents use the same operations and visible state |
-| [Audience-safe synthesis](capabilities/content.agent.audience-safe.md) | Approved Shape | A governed agent run can restrict its inputs to information every intended viewer of the output may access. |
-| [Agent-run automation](capabilities/content.agent.automation.md) | Approved Shape | AI work composes Event → expression/query → action → mutation → Event |
-| [Agent-authored Expressions](capabilities/content.agent.expression-authoring.md) | Approved Shape | AI generates, validates, previews, repairs, and saves typed expressions |
-| [Agent presence](capabilities/content.agent.presence.md) | In Progress | One accountable agent presence shows every location a run is editing without replacing durable attribution or delaying the real change. |
-| [Agent resource consent](capabilities/content.agent.resource-consent.md) | Approved Shape | Resources independently declare whether agents may use them as context and whether agents may edit them, with inheritable policy ceilings. |
-| [Skills catalog](capabilities/content.agent.skill-catalog.md) | Approved Shape | Governed reusable agent instructions/capabilities can be invoked against compatible Content targets |
+| Capability                                                                       | State          | User promise                                                                                                                                                                      |
+| -------------------------------------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Agent and UI parity](capabilities/content.agent.action-parity.md)               | In Progress    | Humans and agents use the same operations and visible state                                                                                                                       |
+| [Audience-safe synthesis](capabilities/content.agent.audience-safe.md)           | Approved Shape | A governed agent run can synthesize from only the resources every intended viewer may access and consent to use for that audience.                                                |
+| [Agent-run automation](capabilities/content.agent.automation.md)                 | Approved Shape | AI work composes Event → expression/query → action → mutation → Event                                                                                                             |
+| [Agent-authored Expressions](capabilities/content.agent.expression-authoring.md) | Approved Shape | Ask an agent to draft or repair a typed expression without giving it a private execution or save path.                                                                            |
+| [Agent presence](capabilities/content.agent.presence.md)                         | In Progress    | One accountable agent presence gives authorized collaborators an ephemeral view of a run's current locations without replacing durable attribution, review, or the real mutation. |
+| [Agent resource consent](capabilities/content.agent.resource-consent.md)         | Approved Shape | Resources independently declare whether agents may use them as context and whether agents may edit them, while inheritable ceilings can narrow either decision.                   |
+| [Skills catalog](capabilities/content.agent.skill-catalog.md)                    | Approved Shape | Governed reusable agent instructions and capabilities can be invoked against compatible Content targets                                                                           |
 
 ## API
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Content API and CMS](capabilities/content.api.cms.md) | Approved Shape | External clients and websites can read and mutate Content through the same typed Actions, permissions, validation, and audit behavior as people and agents. |
+| Capability                                             | State          | User promise                                                                             |
+| ------------------------------------------------------ | -------------- | ---------------------------------------------------------------------------------------- |
+| [Content API and CMS](capabilities/content.api.cms.md) | Approved Shape | External clients and websites can use Content without a second, weaker product contract. |
 
 ## Author
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Executable Code blocks](capabilities/content.author.code.md) | Approved Shape | Powerful inline Code blocks highlight any recognized language and may become isolated, composable mini-sandboxes with compatible renderers and execution runtimes |
-| [Document editor](capabilities/content.author.document-editor.md) | In Progress | A humane visual document editor with blocks, comments, media, collaboration, and agent co-editing |
-| [Footnotes](capabilities/content.author.footnotes.md) | Approved Shape | Footnotes remain humane to author, navigate, render, and round-trip |
-| [Math and equations](capabilities/content.author.math.md) | In Progress | Inline and block math render faithfully in editor, reader, and export |
-| [Media Blocks](capabilities/content.author.media.md) | In Progress | Images, audio, video, files, embeds, captions, and source-aware assets travel through one storage/rendering contract |
-| [Mermaid diagrams](capabilities/content.author.mermaid.md) | Approved Shape | Mermaid source renders through a normal built-in Code-block renderer and round-trips through ordinary fenced source |
+| Capability                                                        | State          | User promise                                                                                                                  |
+| ----------------------------------------------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| [Executable Code blocks](capabilities/content.author.code.md)     | Approved Shape | Let me author, inspect, and deliberately run code in an ordinary document without hidden notebook state.                      |
+| [Document editor](capabilities/content.author.document-editor.md) | In Progress    | Write and revise a rich document with blocks, comments, collaboration, media, and agent help in one humane surface.           |
+| [Footnotes](capabilities/content.author.footnotes.md)             | Approved Shape | Add a durable explanatory or citation note without manually managing superscript text.                                        |
+| [Math and equations](capabilities/content.author.math.md)         | In Progress    | Write an equation inline or as a block and have it stay intelligible everywhere I read or export it.                          |
+| [Media Blocks](capabilities/content.author.media.md)              | In Progress    | Put images, audio, video, files, embeds, captions, and source-aware assets in a document without losing access or provenance. |
+| [Mermaid diagrams](capabilities/content.author.mermaid.md)        | Approved Shape | Insert a diagram as ordinary Mermaid source and read a faithful rendered diagram when possible.                               |
 
 ## Automation
 
-| Capability | State | User promise |
-| --- | --- | --- |
+| Capability                                                           | State       | User promise                                                  |
+| -------------------------------------------------------------------- | ----------- | ------------------------------------------------------------- |
 | [Scheduled automation](capabilities/content.automation.scheduled.md) | In Progress | Scheduled queries and recurring heartbeats over current state |
 
 ## Capture
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Capture and enrichment](capabilities/content.capture.enrich.md) | Approved Shape | Send anything to a chosen Content Database and let its Rules and agents immediately turn it into durable, structured context |
+| Capability                                                       | State          | User promise                                                                           |
+| ---------------------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------- |
+| [Capture and enrichment](capabilities/content.capture.enrich.md) | Approved Shape | Send material to a chosen Database and let its own rules turn it into durable context. |
 
 ## Command
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Unified commands](capabilities/content.command.fabric.md) | Approved Shape | Slash, Cmd+K, menus, shortcuts, Buttons, and agents discover the same scoped commands/actions |
+| Capability                                                 | State          | User promise                                                                                      |
+| ---------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------- |
+| [Unified commands](capabilities/content.command.fabric.md) | Approved Shape | Slash, Cmd+K, menus, shortcuts, Buttons, and agents discover the same scoped commands and Actions |
 
 ## Comment
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Comments](capabilities/content.comment.page-owned.md) | Approved Shape | Page-owned threaded comments targeting one or several Blocks |
+| Capability                                             | State          | User promise                                                                       |
+| ------------------------------------------------------ | -------------- | ---------------------------------------------------------------------------------- |
+| [Comments](capabilities/content.comment.page-owned.md) | Approved Shape | Threaded Comments stay owned by a Page while targeting one or more precise Blocks. |
 
 ## Diff
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Agent-assisted review](capabilities/content.diff.ai-assist.md) | Approved Shape | AI summaries and guided review for large change sets |
-| [Filtered change review](capabilities/content.diff.filtered-review.md) | Approved Shape | Accept/reject individual or all visible changes in a filtered set |
-| [In-place typed review](capabilities/content.diff.in-place.md) | Approved Shape | Typed changes rendered inside the ordinary editor/view |
+| Capability                                                             | State          | User promise                                                                                                               |
+| ---------------------------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| [Agent-assisted review](capabilities/content.diff.ai-assist.md)        | Approved Shape | Agents can summarize and guide large review sets without bypassing the authority to decide them.                           |
+| [Filtered change review](capabilities/content.diff.filtered-review.md) | Approved Shape | A reviewer can accept or reject one change or an exact visible set without accidentally deciding newer or hidden changes.  |
+| [In-place typed review](capabilities/content.diff.in-place.md)         | Approved Shape | Changes are reviewed inside the ordinary Page, Database, Board, template, source, or code surface that gives them meaning. |
 
 ## Discussion
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Page Discussion](capabilities/content.discussion.page.md) | Approved Shape | One universal Page Discussion combining threaded collaboration with curated activity context |
+| Capability                                                 | State          | User promise                                                                                       |
+| ---------------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------------- |
+| [Page Discussion](capabilities/content.discussion.page.md) | Approved Shape | Every Page has one continuing Discussion for humane, Page-wide collaboration and curated activity. |
 
 ## Embed
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Embedded host grants](capabilities/content.embed.host-grant.md) | Approved Shape | An embedded host receives only the named mount and Action capabilities it needs and can never widen the signed-in viewer's authority. |
-| [MCP App embedding](capabilities/content.embed.mcp-app.md) | Approved Shape | Content itself can appear as a focused MCP App inside compatible external agent hosts |
-| [Embeddable Content surfaces](capabilities/content.embed.surface.md) | Approved Shape | Mountable editor/page/view/expression/history surface across Agent Native apps |
+| Capability                                                        | State          | User promise                                                                                                                      |
+| ----------------------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| [Embedded host grants](capabilities/content.embed.host-grant.md)  | Approved Shape | An embedded host gets only the mount and Actions it was granted, never more authority than the viewer.                            |
+| [MCP App embedding](capabilities/content.embed.mcp-app.md)        | Approved Shape | Compatible agent hosts can show a focused Content surface without receiving a copied object or broader authority.                 |
+| [Embedded Content surface](capabilities/content.embed.surface.md) | Approved Shape | The same Page, View, or focused Content experience can appear in another app without splitting identity, history, or permissions. |
 
 ## Event
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Committed Events](capabilities/content.event.committed.md) | In Progress | Canonical actor-aware committed Event spine |
+| Capability                                                  | State       | User promise                                                            |
+| ----------------------------------------------------------- | ----------- | ----------------------------------------------------------------------- |
+| [Committed Events](capabilities/content.event.committed.md) | In Progress | Meaningful committed changes have one durable, actor-aware Event spine. |
 
 ## Expression
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Cached expression results](capabilities/content.expression.cached-result.md) | Approved Shape | Content renders the last valid expression result immediately, marks it stale, and refreshes it without turning ordinary loading into an error. |
-| [Expression catalog](capabilities/content.expression.catalog.md) | Approved Shape | Governed reusable Expressions and Variables |
-| [Typed expression language](capabilities/content.expression.language.md) | Approved Shape | One typed language across formulas, views, validation, Rules, schedules, and body |
+| Capability                                                                    | State          | User promise                                                                                                  |
+| ----------------------------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------- |
+| [Cached expression results](capabilities/content.expression.cached-result.md) | Approved Shape | See the last valid computed value quickly while knowing whether it still reflects current inputs.             |
+| [Expression catalog](capabilities/content.expression.catalog.md)              | Approved Shape | Promote a useful expression or variable into a governed reusable definition with clear ownership and version. |
+| [Typed expression language](capabilities/content.expression.language.md)      | Approved Shape | Use one understandable expression language whenever a configuration needs computation.                        |
 
 ## Feedback
 
-| Capability | State | User promise |
-| --- | --- | --- |
+| Capability                                                     | State          | User promise                                                                                                       |
+| -------------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------ |
 | [Reactions and Polls](capabilities/content.feedback.signal.md) | Approved Shape | Structured reactions and option-based Polls live inside the Page Discussion and can render through views or embeds |
 
 ## Form
 
-| Capability | State | User promise |
-| --- | --- | --- |
+| Capability                                                       | State          | User promise                                                                                                        |
+| ---------------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------- |
 | [Shared Form engine](capabilities/content.form.shared-engine.md) | Approved Shape | Content Form Views and Agent Native Forms use one schema, validation, permission, and idempotent submission engine. |
 
 ## History
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [History](capabilities/content.history.queryable.md) | Approved Shape | Full-height queryable History surface over revisions/events |
+| Capability                                           | State          | User promise                                                                                     |
+| ---------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------ |
+| [History](capabilities/content.history.queryable.md) | Approved Shape | History is a full-height, access-scoped surface for inspecting and recovering meaningful change. |
 
 ## Home
 
-| Capability | State | User promise |
-| --- | --- | --- |
+| Capability                                         | State          | User promise                                                                                                                                      |
+| -------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Global Home](capabilities/content.home.global.md) | Approved Shape | Home belongs to the person and composes authorized work across Personal and organization contexts without pretending it all shares one Workspace. |
 
 ## Job
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Durable background jobs](capabilities/content.job.durable.md) | Approved Shape | Imports, exports, migrations, capture, and backfills survive interruption, report honest progress, and resume without duplicate work. |
+| Capability                                                  | State          | User promise                                                                                                             |
+| ----------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| [Durable Content jobs](capabilities/content.job.durable.md) | Approved Shape | Long-running import, export, sync, and enrichment work survives interruption and tells the truth about partial progress. |
 
 ## Knowledge
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Graph queries](capabilities/content.knowledge.graph.md) | Exploring | Graph navigation and query over typed links, mentions, relations, and authority edges |
+| Capability                                                     | State          | User promise                                                                                                                |
+| -------------------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| [Graph queries](capabilities/content.knowledge.graph.md)       | Exploring      | Graph navigation and query over typed links, mentions, relations, and authority edges                                       |
 | [Links and backlinks](capabilities/content.knowledge.links.md) | Approved Shape | Stable links, outline, backlinks, forward links, external-link health, and link-aware navigation through the Page Info rail |
-| [Search](capabilities/content.knowledge.search.md) | In Progress | Fast access-aware search across titles, bodies, rows, sources, and later comments/review |
+| [Search](capabilities/content.knowledge.search.md)             | In Progress    | Fast access-aware search across titles, bodies, rows, sources, and later comments/review                                    |
 
 ## Layout
 
-| Capability | State | User promise |
-| --- | --- | --- |
+| Capability                                                          | State          | User promise                                                                                                 |
+| ------------------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------ |
 | [Responsive Page layout](capabilities/content.layout.responsive.md) | Approved Shape | Pages arrange, resize, and reorder Blocks in columns that remain coherent on smaller screens and in exports. |
 
 ## Navigation
 
-| Capability | State | User promise |
-| --- | --- | --- |
+| Capability                                                     | State          | User promise                                                                                                                 |
+| -------------------------------------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | [Personal sidebar](capabilities/content.navigation.sidebar.md) | Approved Shape | The sidebar is a personal navigation surface with pinned references and query-backed dynamic sections, not object hierarchy. |
 
 ## Notification
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Notifications](capabilities/content.notification.source.md) | Approved Shape | Canonical notifications exposed as queryable Content source/views |
+| Capability                                                   | State          | User promise                                                          |
+| ------------------------------------------------------------ | -------------- | --------------------------------------------------------------------- |
+| [Notifications](capabilities/content.notification.source.md) | Approved Shape | Canonical notifications exposed as queryable Content source and Views |
 
 ## Object
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Blocks](capabilities/content.object.block.md) | Approved Shape | Stable addressable Block inside a Page |
-| [Blocks fields](capabilities/content.object.blocks-field.md) | Approved Shape | Every editable rich-content body uses the same Blocks-field grammar and owns its own stable revision history. |
-| [Databases](capabilities/content.object.database.md) | Verified | Database as a Page-backed typed collection |
-| [Multiple Database memberships](capabilities/content.object.multi-membership.md) | In Progress | One Page participating in several Databases without copies |
-| [Pages](capabilities/content.object.page.md) | Verified | Durable Page with body, properties, permissions, comments, URL, and source/export identity |
-| [References](capabilities/content.object.reference.md) | Approved Shape | Stable Page/Database/Block references distinct from expressions |
-| [Synced Blocks and live embeds](capabilities/content.object.transclusion.md) | Approved Shape | A Page or Block can be included by reference and edited from every authorized rendering without creating synchronized copies |
+| Capability                                                                       | State          | User promise                                                                                                              |
+| -------------------------------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| [Blocks](capabilities/content.object.block.md)                                   | Approved Shape | A Block is a stable addressable unit of rich content inside its owning field.                                             |
+| [Blocks fields](capabilities/content.object.blocks-field.md)                     | Approved Shape | Every editable rich-content body uses one Blocks-field grammar and keeps its own stable revision boundary.                |
+| [Databases](capabilities/content.object.database.md)                             | Verified       | Database as a Page-backed typed collection                                                                                |
+| [Multiple Database memberships](capabilities/content.object.multi-membership.md) | In Progress    | One Page can belong to several Databases without copies or a hidden primary home.                                         |
+| [Pages](capabilities/content.object.page.md)                                     | Verified       | A durable Page keeps its identity, body, properties, access, discussion, and portable representation wherever it appears. |
+| [References](capabilities/content.object.reference.md)                           | Approved Shape | A compact reference points to a stable Page, Database, or Block without pretending to be computation.                     |
+| [Synced Blocks and live embeds](capabilities/content.object.transclusion.md)     | Approved Shape | A Page or Block can appear by reference in several places and authorized edits change the one canonical object.           |
 
 ## Organization
 
-| Capability | State | User promise |
-| --- | --- | --- |
+| Capability                                                       | State          | User promise                                                                                                                   |
+| ---------------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | [Organization teams](capabilities/content.organization.teams.md) | Approved Shape | Canonical framework-wide Team membership can be managed through Content without giving each app a conflicting identity system. |
 
 ## Portability
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [PDF and print export](capabilities/content.portability.pdf-export.md) | Approved Shape | Real PDF export uses the same rendering truth as editor, reader, and HTML export |
-| [Faithful round-tripping](capabilities/content.portability.roundtrip.md) | Approved Shape | Canonical Content data imports/exports through humane Markdown/MDX and structured sidecars |
-| [Portable source representation](capabilities/content.portability.source-representation.md) | Approved Shape | One lossless, provider-neutral Content source representation with humane Markdown as its base |
-| [Whole-vault export](capabilities/content.portability.vault-export.md) | Approved Shape | An authorized person can export a static snapshot as an open vault, a lossless Content archive, or a destination-specific package. |
+| Capability                                                                                  | State          | User promise                                                                                                                                  |
+| ------------------------------------------------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| [PDF export](capabilities/content.portability.pdf-export.md)                                | In Progress    | Create a readable PDF of an authorized Content representation without confusing it with the editable or lossless export.                      |
+| [Faithful round-tripping](capabilities/content.portability.roundtrip.md)                    | Approved Shape | Content preserves provider-owned meaning it cannot safely render or edit, so a supported change never silently destroys the rest of the work. |
+| [Portable Source representation](capabilities/content.portability.source-representation.md) | Approved Shape | Connected and local material has a portable Content representation without pretending Content owns every original.                            |
+| [Portable vault export](capabilities/content.portability.vault-export.md)                   | Approved Shape | Take the authorized Content vault away in open files plus a lossless archive instead of remaining dependent on one service.                   |
 
 ## Presentation
 
-| Capability | State | User promise |
-| --- | --- | --- |
+| Capability                                                     | State          | User promise                                                                                                |
+| -------------------------------------------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------- |
 | [Presentation mode](capabilities/content.presentation.mode.md) | Approved Shape | Pages and ordered records can present through shared Slides primitives without creating slide-only content. |
 
 ## Preset
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Presets](capabilities/content.preset.catalog.md) | Superseded | Governed preassembled ordinary primitives, always inspectable |
+| Capability                                        | State      | User promise                                                                                                              |
+| ------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------- |
+| [Presets](capabilities/content.preset.catalog.md) | Superseded | Understand that older preassembled configurations now live as inspectable Templates rather than a competing product type. |
 
 ## Property
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Actor properties](capabilities/content.property.actor.md) | Approved Shape | Created by and Last edited by record the actual human, agent, automation, or integration actor. |
-| [Custom Properties](capabilities/content.property.catalog.md) | Exploring | Governed Custom Properties can be deliberately reused across Databases without making ordinary same-named columns secretly equivalent |
-| [Property validation and defaults](capabilities/content.property.constraints.md) | Approved Shape | Required, default, validation, formatting, edit policy in column configuration |
-| [Guarded property changes](capabilities/content.property.guarded-change.md) | Approved Shape | Any Property can validate values and require an explained confirmation or policy check before a sensitive transition. |
-| [Typed locations](capabilities/content.property.location.md) | Approved Shape | Location Properties preserve structured places and coordinates for maps, queries, sources, and portable export. |
-| [Typed Properties](capabilities/content.property.typed.md) | In Progress | Typed stored and computed properties with descriptions |
+| Capability                                                                       | State          | User promise                                                                                                                       |
+| -------------------------------------------------------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| [Actor properties](capabilities/content.property.actor.md)                       | Approved Shape | Know who actually created or last changed a record, whether that actor was a person, agent, automation, or integration.            |
+| [Custom Properties](capabilities/content.property.catalog.md)                    | Exploring      | Reuse an approved field definition deliberately without making same-named local columns secretly equal.                            |
+| [Property validation and defaults](capabilities/content.property.constraints.md) | Approved Shape | Configure requiredness, defaults, validation, formatting, and edit policy once and trust every write path to enforce them.         |
+| [Guarded property changes](capabilities/content.property.guarded-change.md)      | Approved Shape | Require an explained confirmation or policy check before a sensitive field transition while keeping one general validation engine. |
+| [Typed locations](capabilities/content.property.location.md)                     | Approved Shape | Store a place or coordinates as a meaningful location that maps, queries, sources, and export can understand.                      |
+| [Typed Properties](capabilities/content.property.typed.md)                       | In Progress    | Define stored and computed fields whose values and descriptions stay meaningful in every surface.                                  |
 
 ## Publish
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Public publishing](capabilities/content.publish.public.md) | Approved Shape | Internal sharing and public publishing remain separate, explicit, auditable planes |
-| [Public reading](capabilities/content.publish.reading.md) | In Progress | Shareable/public reading surfaces render the same document truth as the editor/exporter |
+| Capability                                                   | State          | User promise                                                                                         |
+| ------------------------------------------------------------ | -------------- | ---------------------------------------------------------------------------------------------------- |
+| [Public publication](capabilities/content.publish.public.md) | Approved Shape | Publish one chosen Page revision at a stable public destination while private work continues safely. |
+| [Public reading](capabilities/content.publish.reading.md)    | In Progress    | A shareable reading surface faithfully renders the intended public Content truth.                    |
 
 ## Query
 
-| Capability | State | User promise |
-| --- | --- | --- |
+| Capability                                                     | State          | User promise                                                                                                                                       |
+| -------------------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Reusable Query objects](capabilities/content.query.object.md) | Approved Shape | A one-off inline Query can be promoted into a named reusable Content object that behaves like a dynamic Database without owning its source records |
 
 ## Reader
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Document Reader](capabilities/content.reader.documents.md) | Superseded | Native PDF/EPUB reading and annotation |
-| [Reader surface](capabilities/content.reader.surface.md) | Approved Shape | One specialized Reader surface renders and annotates Content Sources across text, PDF, EPUB, web, audio, video, and transcripts |
+| Capability                                                  | State          | User promise                                                                                                          |
+| ----------------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------- |
+| [Document Reader](capabilities/content.reader.documents.md) | Superseded     | The earlier separate PDF/EPUB reader proposal remains readable lineage rather than an active second product contract. |
+| [Reader surface](capabilities/content.reader.surface.md)    | Approved Shape | Read and annotate text, documents, web material, and media through one specialized Content surface.                   |
 
 ## Relationship
 
-| Capability | State | User promise |
-| --- | --- | --- |
+| Capability                                                       | State          | User promise                                                                                                                         |
+| ---------------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | [Typed Relationships](capabilities/content.relationship.edge.md) | Approved Shape | One typed edge substrate powers relation Properties, inline typed Page references, backlinks, Info, graph queries, and Graph editing |
 
 ## Renderer
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Artifact Blocks](capabilities/content.renderer.artifact-block.md) | Approved Shape | Page-owned one-off HTML/CSS/JS artifact using the Custom Block sandbox format without entering the reusable catalog |
-| [Custom Blocks](capabilities/content.renderer.custom-block.md) | Approved Shape | One Custom Block model for Content-managed and source-backed reusable components, with optional typed props and a strict origin-aware runtime boundary |
-| [Collection graph renderers](capabilities/content.renderer.graph.md) | Exploring | Graph/chart renderers for typed collection results |
-| [Typed renderers](capabilities/content.renderer.typed.md) | Approved Shape | Render any typed value using compatible built-in presentations |
+| Capability                                                                        | State          | User promise                                                                                                                                              |
+| --------------------------------------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Artifact Blocks](capabilities/content.renderer.artifact-block.md)                | Approved Shape | Make a one-off interactive or visual artifact on one page, then promote it only if reuse becomes real.                                                    |
+| [Custom Blocks](capabilities/content.renderer.custom-block.md)                    | Approved Shape | Name, govern, and reuse a safe renderer without making it a hidden application.                                                                           |
+| [Collection graph renderers (superseded)](capabilities/content.renderer.graph.md) | Superseded     | Historical umbrella for graph and chart rendering, now split into distinct semantic Graph and analytical Chart capabilities                               |
+| [Typed renderers](capabilities/content.renderer.typed.md)                         | Approved Shape | Compatible renderers present typed Content values consistently across surfaces while preserving meaning, accessibility, inheritance, and export fallback. |
 
 ## Research
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Annotations](capabilities/content.research.annotation.md) | Approved Shape | Highlights, excerpts, and research notes remain anchored to the exact source representation and named Page version they interpret |
-| [Citations](capabilities/content.research.citation.md) | Approved Shape | A semantic citation references a durable source record plus an optional locator, independently of how it is rendered |
+| Capability                                                 | State          | User promise                                                                                                  |
+| ---------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------- |
+| [Annotations](capabilities/content.research.annotation.md) | Approved Shape | Highlights, excerpts, and research notes remain anchored to the exact material and revision they interpret.   |
+| [Citations](capabilities/content.research.citation.md)     | Approved Shape | A citation retains a durable source-and-locator identity even when its style or surrounding document changes. |
 
 ## Review
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Code review](capabilities/content.review.code.md) | Exploring | Review typed code/file changes in the same in-place, filterable, durable-decision interface |
+| Capability                                         | State     | User promise                                                                                    |
+| -------------------------------------------------- | --------- | ----------------------------------------------------------------------------------------------- |
+| [Code review](capabilities/content.review.code.md) | Exploring | Review typed code and file changes in the same in-place, filterable, durable-decision interface |
 
 ## Revision
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Suggestions](capabilities/content.revision.suggestions.md) | Approved Shape | Suggested changes as authored pending revisions with accept/reject history |
+| Capability                                                  | State          | User promise                                                                                                                 |
+| ----------------------------------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| [Suggestions](capabilities/content.revision.suggestions.md) | Approved Shape | Suggested changes remain authored pending Revisions until an authorized person accepts, rejects, defers, or supersedes them. |
 
 ## Rule
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Rules](capabilities/content.rule.deterministic.md) | In Progress | Event + typed condition + action |
+| Capability                                          | State       | User promise                           |
+| --------------------------------------------------- | ----------- | -------------------------------------- |
+| [Rules](capabilities/content.rule.deterministic.md) | In Progress | Event plus typed condition plus action |
 
 ## Schedule
 
-| Capability | State | User promise |
-| --- | --- | --- |
+| Capability                                                           | State     | User promise                                                                                                               |
+| -------------------------------------------------------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------- |
 | [Schedule constraints](capabilities/content.schedule.constraints.md) | Exploring | Planning surfaces detect dependency and date violations, explain them, and apply only explicit policy or accepted repairs. |
 
 ## Security
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Private vault encryption](capabilities/content.security.private-vault.md) | In Progress | User-held private-vault/E2EE custody with fail-closed enrollment, recovery, and authorization |
+| Capability                                                                 | State       | User promise                                                                                                                               |
+| -------------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| [Private vault encryption](capabilities/content.security.private-vault.md) | In Progress | Private-vault custody can be user-held and fail closed without disguising unresolved recovery, collaboration, or agent authority problems. |
 
 ## Share
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Shared Views](capabilities/content.share.views.md) | Approved Shape | A shared Database view preserves its configuration while defaulting to the viewer's existing row access |
+| Capability                                          | State          | User promise                                                                                                                                  |
+| --------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Shared Views](capabilities/content.share.views.md) | Approved Shape | A shared View gives collaborators a dependable starting presentation while preserving each viewer's existing access and personal exploration. |
 
 ## Source
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Source adapters](capabilities/content.source.adapters.md) | In Progress | Local folder, Builder, Notion, and future typed source adapters |
-| [Builder round-trip codec](capabilities/content.source.builder-codec.md) | Approved Shape | Builder JSON blocks round-trip through one pure typed codec shared by repo-backed docs and CMS-backed databases |
-| [Sources catalog](capabilities/content.source.catalog.md) | Approved Shape | One governed top-level Content Database of local, provider, and native Sources |
-| [Files and folders as Sources](capabilities/content.source.file-folder.md) | Exploring | A person can open a folder as a Source without assuming every file shares one Database schema. |
-| [Local Source bridge](capabilities/content.source.local-bridge.md) | Approved Shape | A desktop app or small trusted service can synchronize selected local Sources for browsers that cannot access files directly. |
-| [Local project mode](capabilities/content.source.local-project.md) | Superseded | Opt-in local/git workspace where files are the single truth domain |
-| [Page-linked Sources](capabilities/content.source.page-link.md) | Exploring | A single Page can bind to one external source item without inventing a separate source architecture. |
-| [Materialized multi-source Databases](capabilities/content.source.row-union.md) | Superseded | One Database materializing rows from several source-owned collections with a Source tag and per-source column bindings |
-| [Content spaces and Files](capabilities/content.source.spaces-files.md) | Verified | Database-backed Content spaces, Files, Workspaces, and Sidebar views |
-| [Source sync policy](capabilities/content.source.sync-policy.md) | Approved Shape | Each connected Source declares one plain-language truth policy: view only, keep in sync, or review before write-back. |
+| Capability                                                                      | State          | User promise                                                                                                                                                 |
+| ------------------------------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [Source adapters](capabilities/content.source.adapters.md)                      | In Progress    | Local, native, and provider Sources use one typed contract while each adapter proves only the operations it can safely perform.                              |
+| [Builder round-trip codec](capabilities/content.source.builder-codec.md)        | Approved Shape | Builder JSON blocks can pass through one typed codec without supported edits erasing unfamiliar provider content.                                            |
+| [Sources catalog](capabilities/content.source.catalog.md)                       | Approved Shape | One governed top-level Content Database makes approved local, provider, and native Sources discoverable without hiding their scope, authority, or freshness. |
+| [Files and folders as Sources](capabilities/content.source.file-folder.md)      | Exploring      | Open a selected file tree as a Source without forcing heterogeneous files into one Database schema.                                                          |
+| [Local Source bridge](capabilities/content.source.local-bridge.md)              | Approved Shape | A trusted device can synchronize explicitly selected local Sources while browsers remain useful without inheriting filesystem authority.                     |
+| [Local project mode](capabilities/content.source.local-project.md)              | Superseded     | The former local-project proposal remains lineage for file-truth work, not an active dual-truth product contract.                                            |
+| [Page-linked Sources](capabilities/content.source.page-link.md)                 | Exploring      | A Page can bind to one external item while keeping Content identity and the provider's ownership clear.                                                      |
+| [Materialized multi-source Databases](capabilities/content.source.row-union.md) | Superseded     | The former multi-source row-union model remains migration evidence, while active composition moves toward source Queries.                                    |
+| [Content spaces and Files](capabilities/content.source.spaces-files.md)         | Verified       | Personal and organization-backed Content spaces and Files views keep work navigable without becoming a second permission system.                             |
+| [Source sync policy](capabilities/content.source.sync-policy.md)                | Approved Shape | Each connected Source declares one plain-language policy for refresh and write-back: View only, Keep in sync, or Review before write-back.                   |
 
 ## System
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Task dependencies](capabilities/content.system.dependencies.md) | Approved Shape | Parent/subtask and blocked/blocking relations with constraints |
-| [My Tasks](capabilities/content.system.my-tasks.md) | Approved Shape | “My Tasks” as an access-scoped dynamic saved view |
-| [Project status](capabilities/content.system.project-status.md) | Approved Shape | Project status updates and rollups as ordinary Content views/pages |
-| [Research workspace Template](capabilities/content.system.research-workspace.md) | Exploring | A blessed editable research template composes Sources, Notes, Projects, reading queues, citations, capture, and synthesis views over one Content datastore |
-| [Blessed Task and Project Template](capabilities/content.system.task-project.md) | Approved Shape | Blessed editable Task/Project template over Content |
+| Capability                                                                       | State          | User promise                                                                                                                                               |
+| -------------------------------------------------------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Task dependencies](capabilities/content.system.dependencies.md)                 | Approved Shape | Parent/subtask and blocked/blocking relations with constraints                                                                                             |
+| [My Tasks](capabilities/content.system.my-tasks.md)                              | Approved Shape | “My Tasks” as an access-scoped dynamic saved view                                                                                                          |
+| [Project status](capabilities/content.system.project-status.md)                  | Approved Shape | Project status updates and rollups as ordinary Content views/pages                                                                                         |
+| [Research workspace Template](capabilities/content.system.research-workspace.md) | Exploring      | A blessed editable research template composes Sources, Notes, Projects, reading queues, citations, capture, and synthesis views over one Content datastore |
+| [Blessed Task and Project Template](capabilities/content.system.task-project.md) | Approved Shape | Blessed editable Task/Project template over Content                                                                                                        |
 
 ## Template
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Template governance](capabilities/content.template.governance.md) | Approved Shape | Private/org-approved/Agent Native–published template catalog |
-| [Multi-object Templates](capabilities/content.template.graph.md) | Approved Shape | Multi-object template snapshots Pages/Databases/views/Rules/expressions/body templates |
-| [Database item Templates](capabilities/content.template.item-body.md) | Approved Shape | Multiple database-item body templates with one default and dynamic embedded views |
-| [Template updates](capabilities/content.template.update.md) | Approved Shape | Never-auto update notice, structural diff, selective apply/reset |
+| Capability                                                            | State          | User promise                                                                                                                |
+| --------------------------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| [Template governance](capabilities/content.template.governance.md)    | Approved Shape | Find and adopt a reusable working system with clear ownership, approval, version, provenance, and access.                   |
+| [Multi-object Templates](capabilities/content.template.graph.md)      | Approved Shape | Start from a reusable system of Pages, Databases, Views, Properties, Rules, expressions, and bodies, then own the result.   |
+| [Database item Templates](capabilities/content.template.item-body.md) | Approved Shape | Offer more than one useful starting body for a database record, including a clear default and context-aware embedded views. |
+| [Template updates](capabilities/content.template.update.md)           | Approved Shape | Review what changed in a template and selectively bring compatible improvements into my owned instance.                     |
 
 ## Time
 
-| Capability | State | User promise |
-| --- | --- | --- |
+| Capability                                                        | State          | User promise                                                      |
+| ----------------------------------------------------------------- | -------------- | ----------------------------------------------------------------- |
 | [Dates, times, and durations](capabilities/content.time.types.md) | Approved Shape | Date, Instant, ranges, Duration, and explicit timezone conversion |
 
 ## Version
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Named Page Versions](capabilities/content.version.branching.md) | Approved Shape | Multiple named body versions evolve in parallel under one Page identity and shared properties |
+| Capability                                                                     | State          | User promise                                                                                                  |
+| ------------------------------------------------------------------------------ | -------------- | ------------------------------------------------------------------------------------------------------------- |
+| [Named Page Versions](capabilities/content.version.branching.md)               | Approved Shape | Multiple named body versions evolve in parallel under one Page identity and shared properties                 |
 | [Blocks-field revision history](capabilities/content.version.field-history.md) | Approved Shape | Every Blocks field preserves attributable comparison and recovery independently of later named Page Versions. |
 
 ## View
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Canvas](capabilities/content.view.canvas.md) | Approved Shape | A spatial Canvas, semantic Graph, and mind-map family arranges reusable Pages, Blocks, Sources, Annotations, views, and media without copying them |
-| [Chart View](capabilities/content.view.chart.md) | Approved Shape | Charts share one typed specification across saved Views, embeddable Blocks, dashboards, Analytics, static output, and drill-down. |
-| [View-derived creation defaults](capabilities/content.view.dynamic-create.md) | Approved Shape | New rows inherit unambiguous equality constraints from the active view |
-| [Fast keyboard capture](capabilities/content.view.fast-capture.md) | Approved Shape | Keyboard-fluent List and Table capture |
-| [Graph View](capabilities/content.view.graph.md) | Approved Shape | Graph lays out query-selected canonical objects and typed Relationships for access-safe exploration and editing. |
-| [Grouping and aggregation](capabilities/content.view.grouping-aggregation.md) | Approved Shape | Views group across several dimensions and compute access-safe totals, subtotals, rollups, and measures. |
-| [Map View](capabilities/content.view.map.md) | Approved Shape | Map renders typed locations with points, clustering, filtering, and record previews before adding richer geographic layers. |
-| [Personal View state](capabilities/content.view.personal-state.md) | Approved Shape | A shared View remembers one private arrangement per person and supports named Only-me Views without copying records. |
-| [Pivot View](capabilities/content.view.pivot.md) | Approved Shape | Pivot places dimensions on rows and columns, typed aggregations in cells, and drills back to canonical records. |
-| [Database and Query Views](capabilities/content.view.query.md) | Approved Shape | Saved typed queries rendered as Table/Board/List/Gallery/Calendar/Timeline/Form/Sidebar and later Graph/Canvas views |
-| [View renderer conformance](capabilities/content.view.renderer-conformance.md) | Approved Shape | Every View obeys the same permissions, Actions, agent context, accessibility, persistence, performance, and recovery contract. |
-| [Large Database performance](capabilities/content.view.scale.md) | Failing | Databases stay responsive and incrementally queryable well beyond a few hundred rows |
-| [Cross-source Queries](capabilities/content.view.source-query.md) | Approved Shape | One saved typed query composes local Databases and provider collections through unions, joins, filters, relations, and explicit field alignment, then renders through any compatible view |
-| [Timeline View](capabilities/content.view.timeline.md) | In Progress | Timeline places and directly edits canonical records across typed dates and ranges while obeying the View conformance contract. |
-| [Tree View](capabilities/content.view.tree.md) | Approved Shape | Tree renders any suitable hierarchical Relationship without creating a parallel parent system. |
+| Capability                                                                     | State          | User promise                                                                                                                                                                |
+| ------------------------------------------------------------------------------ | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Canvas](capabilities/content.view.canvas.md)                                  | Approved Shape | Canvas lets people intentionally arrange reusable Content objects in a spatial View without copying them or accidentally asserting semantic relationships.                  |
+| [Chart View](capabilities/content.view.chart.md)                               | Approved Shape | Chart turns authorized typed query results into understandable analytical visualizations that remain usable as saved Views, embedded Blocks, dashboards, and static output. |
+| [View-derived creation defaults](capabilities/content.view.dynamic-create.md)  | Approved Shape | Creating through a View starts new records with safe contextual values without turning that View's filters into hidden validation.                                          |
+| [Fast keyboard capture](capabilities/content.view.fast-capture.md)             | Approved Shape | Keyboard-fluent List and Table capture                                                                                                                                      |
+| [Graph View](capabilities/content.view.graph.md)                               | Approved Shape | Graph lays out query-selected canonical objects and typed Relationships for access-safe exploration and editing.                                                            |
+| [Grouping and aggregation](capabilities/content.view.grouping-aggregation.md)  | Approved Shape | Views group across several dimensions and compute access-safe totals, subtotals, rollups, and measures.                                                                     |
+| [Map View](capabilities/content.view.map.md)                                   | Approved Shape | Map renders typed locations with points, clustering, filtering, and record previews before adding richer geographic layers.                                                 |
+| [Personal View state](capabilities/content.view.personal-state.md)             | Approved Shape | A shared View remembers one private arrangement per person and supports named Only-me Views without copying records.                                                        |
+| [Pivot View](capabilities/content.view.pivot.md)                               | Approved Shape | Pivot places dimensions on rows and columns, typed aggregations in cells, and drills back to canonical records.                                                             |
+| [Database and Query Views](capabilities/content.view.query.md)                 | Approved Shape | A View is one stable presentation over exactly one Database or Query, with its own downstream filters, layout, and renderer                                                 |
+| [View renderer conformance](capabilities/content.view.renderer-conformance.md) | Approved Shape | Every View obeys the same permissions, Actions, agent context, accessibility, persistence, performance, and recovery contract.                                              |
+| [Large Database performance](capabilities/content.view.scale.md)               | Failing        | Databases stay responsive and incrementally queryable well beyond a few hundred rows                                                                                        |
+| [Cross-source Queries](capabilities/content.view.source-query.md)              | Approved Shape | One visual typed Query composes authorized Databases, Sources, and Queries without copying their records or hiding where values come from.                                  |
+| [Timeline View](capabilities/content.view.timeline.md)                         | In Progress    | Timeline places and directly edits canonical records across typed dates and ranges while obeying the View conformance contract.                                             |
+| [Tree View](capabilities/content.view.tree.md)                                 | Approved Shape | Tree renders any suitable hierarchical Relationship without creating a parallel parent system.                                                                              |
 
 ## Workspace
 
-| Capability | State | User promise |
-| --- | --- | --- |
-| [Personal and organization contexts](capabilities/content.workspace.multi-scope.md) | Approved Shape | One identity can hold personal Content plus several workspaces without account switching |
-| [Session resumption](capabilities/content.workspace.session-restore.md) | Approved Shape | Content reopens the authorized object and focused View a person was using without requiring them to reconstruct the route. |
-| [View instances](capabilities/content.workspace.view-instance.md) | Approved Shape | Tabs, panes, embeds, and windows can show independent focused instances of the same canonical object without duplicating it. |
-| [Working set](capabilities/content.workspace.working-set.md) | Approved Shape | Tabs, split panes, and later windows are views over one persisted working set with explicit agent scope |
+| Capability                                                                          | State          | User promise                                                                                                                 |
+| ----------------------------------------------------------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| [Personal and organization contexts](capabilities/content.workspace.multi-scope.md) | Approved Shape | One identity can hold personal Content plus several workspaces without account switching                                     |
+| [Session resumption](capabilities/content.workspace.session-restore.md)             | Approved Shape | Content reopens the authorized object and focused View a person was using without requiring them to reconstruct the route.   |
+| [View instances](capabilities/content.workspace.view-instance.md)                   | Approved Shape | Tabs, panes, embeds, and windows can show independent focused instances of the same canonical object without duplicating it. |
+| [Working set](capabilities/content.workspace.working-set.md)                        | Approved Shape | Tabs, split panes, and later windows are views over one persisted working set with explicit agent scope                      |

--- a/templates/content/docs/product/features/content.feature.bring-your-local-work.md
+++ b/templates/content/docs/product/features/content.feature.bring-your-local-work.md
@@ -1,0 +1,32 @@
+---
+record_type: "feature"
+id: "content.feature.bring-your-local-work"
+number: 12
+name: "Bring your local work"
+chapter: "content.chapter.connected-sources"
+order: 12
+roadmap_status: "partially_implemented"
+summary: "Open a folder or repository through the same Source model while keeping device authority and browser limitations honest."
+example_workflow: "A developer opens a local documentation folder in Content Desktop, edits the files through Content, sees external file changes synchronize back, and later reads the last synchronized representation from Safari without exposing the folder path."
+works_today: "Local File Mode, manifest-declared workspaces, connected-folder Sources, source-backed Pages, conflict records, and a trusted local bridge already establish substantial foundations."
+remains: "Opening a folder must become effortless, Desktop needs dependable background sync and caching, browser clients need graceful read and queued-write behavior, and the portable vault workflow needs full product polish."
+required_capabilities: ["content.source.local-bridge","content.source.file-folder","content.portability.source-representation","content.portability.vault-export"]
+enhancing_capabilities: ["content.source.adapters","content.source.sync-policy"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 12: Bring your local work
+
+Open a folder or repository through the same Source model while keeping device authority and browser limitations honest.
+
+## Product contract
+
+- **Local Source Bridge:** Grants access to explicitly selected folders without storing raw paths or file handles in shared SQL.
+- **Folders and repositories:** Materialize local files as ordinary Content records while preserving their source identity and structure.
+- **Background synchronization:** Lets Desktop or a lightweight helper keep shared representations fresh for browser clients.
+- **Browser degradation:** Shows the last authorized Content representation when Safari, Firefox, or another client cannot access local bytes.
+- **Queued edits:** Holds permitted source-owned changes with their base revision until an authorized bridge returns.
+- **Portable vault:** Keeps the human-readable folder separate from disposable caches and any particular desktop application bundle.

--- a/templates/content/docs/product/features/content.feature.bring-your-local-work.md
+++ b/templates/content/docs/product/features/content.feature.bring-your-local-work.md
@@ -10,8 +10,15 @@ summary: "Open a folder or repository through the same Source model while keepin
 example_workflow: "A developer opens a local documentation folder in Content Desktop, edits the files through Content, sees external file changes synchronize back, and later reads the last synchronized representation from Safari without exposing the folder path."
 works_today: "Local File Mode, manifest-declared workspaces, connected-folder Sources, source-backed Pages, conflict records, and a trusted local bridge already establish substantial foundations."
 remains: "Opening a folder must become effortless, Desktop needs dependable background sync and caching, browser clients need graceful read and queued-write behavior, and the portable vault workflow needs full product polish."
-required_capabilities: ["content.source.local-bridge","content.source.file-folder","content.portability.source-representation","content.portability.vault-export"]
-enhancing_capabilities: ["content.source.adapters","content.source.sync-policy"]
+required_capabilities:
+  [
+    "content.source.local-bridge",
+    "content.source.file-folder",
+    "content.portability.source-representation",
+    "content.portability.vault-export",
+  ]
+enhancing_capabilities:
+  ["content.source.adapters", "content.source.sync-policy"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.build-living-dashboards.md
+++ b/templates/content/docs/product/features/content.feature.build-living-dashboards.md
@@ -1,0 +1,32 @@
+---
+record_type: "feature"
+id: "content.feature.build-living-dashboards"
+number: 23
+name: "Build living dashboards"
+chapter: "content.chapter.working-systems"
+order: 23
+roadmap_status: "planned"
+summary: "Compose responsive Views, Charts, expressions, controls, and prose into durable operating surfaces."
+example_workflow: "A go-to-market lead assembles a responsive Page with pipeline Charts, filtered account Views, explanatory prose, and personal controls so people and agents can inspect the same operating picture and discuss it in context."
+works_today: "Pages can already combine prose, Blocks, references, expressions, and embedded Database Views, while saved Views provide reusable filtered presentations."
+remains: "Responsive Page columns, resizable View and Chart Blocks, dashboard controls, chart conformance, personal interaction state, presentation behavior, and export fidelity still need implementation."
+required_capabilities: ["content.layout.responsive","content.view.chart","content.embed.surface"]
+enhancing_capabilities: ["content.presentation.mode","content.expression.language"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 23: Build living dashboards
+
+Compose responsive Views, Charts, expressions, controls, and prose into durable operating surfaces.
+
+## Product contract
+
+- **Ordinary Pages:** Serve as the dashboard canvas without introducing a separate dashboard datastore.
+- **Embedded Views and Charts:** Reference saved configurations while allowing each occurrence to override size and presentation.
+- **Responsive columns:** Arrange, resize, and reorder Blocks with a layout that linearizes coherently on smaller screens and in exports.
+- **Controls and Expressions:** Let viewers change authorized filters or inputs without mutating the shared default accidentally.
+- **Live context:** Keeps prose, decisions, metrics, and the underlying records together for people and agents.
+- **Presentation mode:** Reuses shared Slides primitives to present Pages or ordered records without inventing slide-only content.

--- a/templates/content/docs/product/features/content.feature.build-living-dashboards.md
+++ b/templates/content/docs/product/features/content.feature.build-living-dashboards.md
@@ -10,8 +10,10 @@ summary: "Compose responsive Views, Charts, expressions, controls, and prose int
 example_workflow: "A go-to-market lead assembles a responsive Page with pipeline Charts, filtered account Views, explanatory prose, and personal controls so people and agents can inspect the same operating picture and discuss it in context."
 works_today: "Pages can already combine prose, Blocks, references, expressions, and embedded Database Views, while saved Views provide reusable filtered presentations."
 remains: "Responsive Page columns, resizable View and Chart Blocks, dashboard controls, chart conformance, personal interaction state, presentation behavior, and export fidelity still need implementation."
-required_capabilities: ["content.layout.responsive","content.view.chart","content.embed.surface"]
-enhancing_capabilities: ["content.presentation.mode","content.expression.language"]
+required_capabilities:
+  ["content.layout.responsive", "content.view.chart", "content.embed.surface"]
+enhancing_capabilities:
+  ["content.presentation.mode", "content.expression.language"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.build-new-surfaces.md
+++ b/templates/content/docs/product/features/content.feature.build-new-surfaces.md
@@ -1,0 +1,32 @@
+---
+record_type: "feature"
+id: "content.feature.build-new-surfaces"
+number: 20
+name: "Build new surfaces"
+chapter: "content.chapter.working-systems"
+order: 20
+roadmap_status: "partially_implemented"
+summary: "Create a one-off artifact, then promote it into a governed reusable Custom Block when it earns reuse."
+example_workflow: "An agent creates a one-off interactive calculator inside a Page; its owner inspects the source and rendered result, then promotes it to an approved Custom Block that coworkers can insert from the slash menu."
+works_today: "Sandboxed Extensions, local MDX components, HTML artifacts, executable-code foundations, and shared component toolkits already demonstrate several rendering and execution modes."
+remains: "These pieces need one Custom Block lifecycle with inspectable source, secure sandboxing, optional typed props, one-off artifacts, promotion, governed catalogs, source-backed origins, and slash-command discovery."
+required_capabilities: ["content.renderer.artifact-block","content.renderer.custom-block"]
+enhancing_capabilities: ["content.author.code","content.renderer.typed"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 20: Build new surfaces
+
+Create a one-off artifact, then promote it into a governed reusable Custom Block when it earns reuse.
+
+## Product contract
+
+- **Artifact Block:** Stores Page-owned HTML, styles, and behavior without requiring props or a catalog entry.
+- **Source and rendered views:** Lets authors inspect the code underneath and the output it produces.
+- **Sandbox:** Denies network and application authority by default while enforcing time, memory, output, and asset limits.
+- **Save as Custom Block:** Promotes a useful one-off into a governed reusable definition with stable identity.
+- **Custom Blocks catalog:** Controls discovery, ownership, versions, permissions, compatibility, and typed props where useful.
+- **Source-backed origins:** Lets repository, Builder, or later Source adapters provide the implementation without creating another product identity.

--- a/templates/content/docs/product/features/content.feature.build-new-surfaces.md
+++ b/templates/content/docs/product/features/content.feature.build-new-surfaces.md
@@ -10,8 +10,9 @@ summary: "Create a one-off artifact, then promote it into a governed reusable Cu
 example_workflow: "An agent creates a one-off interactive calculator inside a Page; its owner inspects the source and rendered result, then promotes it to an approved Custom Block that coworkers can insert from the slash menu."
 works_today: "Sandboxed Extensions, local MDX components, HTML artifacts, executable-code foundations, and shared component toolkits already demonstrate several rendering and execution modes."
 remains: "These pieces need one Custom Block lifecycle with inspectable source, secure sandboxing, optional typed props, one-off artifacts, promotion, governed catalogs, source-backed origins, and slash-command discovery."
-required_capabilities: ["content.renderer.artifact-block","content.renderer.custom-block"]
-enhancing_capabilities: ["content.author.code","content.renderer.typed"]
+required_capabilities:
+  ["content.renderer.artifact-block", "content.renderer.custom-block"]
+enhancing_capabilities: ["content.author.code", "content.renderer.typed"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.capture-into-action.md
+++ b/templates/content/docs/product/features/content.feature.capture-into-action.md
@@ -10,8 +10,9 @@ summary: "Resolve or create one canonical Page in the chosen Database, preserve 
 example_workflow: "Someone shares a customer interview URL from their phone to the Research Database; Content reuses the canonical Source Page, preserves the transcript and provenance, and lets the Database's Rules extract companies and open questions."
 works_today: "Content can already import or create Pages from files, URLs, providers, local Sources, and Agent Actions, with useful provenance and Database destinations in several paths."
 remains: "Every entrance needs one Capture contract with remembered destination, canonical deduplication, idempotency, snapshot handling, Template application, receipts, and clean downstream enrichment."
-required_capabilities: ["content.capture.enrich","content.source.catalog","content.job.durable"]
-enhancing_capabilities: ["content.rule.deterministic","content.template.graph"]
+required_capabilities:
+  ["content.capture.enrich", "content.source.catalog", "content.job.durable"]
+enhancing_capabilities: ["content.rule.deterministic", "content.template.graph"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.capture-into-action.md
+++ b/templates/content/docs/product/features/content.feature.capture-into-action.md
@@ -1,0 +1,33 @@
+---
+record_type: "feature"
+id: "content.feature.capture-into-action"
+number: 24
+name: "Capture into action"
+chapter: "content.chapter.capture-research"
+order: 24
+roadmap_status: "partially_implemented"
+summary: "Resolve or create one canonical Page in the chosen Database, preserve provenance, and hand it to that Database's Rules and agents."
+example_workflow: "Someone shares a customer interview URL from their phone to the Research Database; Content reuses the canonical Source Page, preserves the transcript and provenance, and lets the Database's Rules extract companies and open questions."
+works_today: "Content can already import or create Pages from files, URLs, providers, local Sources, and Agent Actions, with useful provenance and Database destinations in several paths."
+remains: "Every entrance needs one Capture contract with remembered destination, canonical deduplication, idempotency, snapshot handling, Template application, receipts, and clean downstream enrichment."
+required_capabilities: ["content.capture.enrich","content.source.catalog","content.job.durable"]
+enhancing_capabilities: ["content.rule.deterministic","content.template.graph"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 24: Capture into action
+
+Resolve or create one canonical Page in the chosen Database, preserve provenance, and hand it to that Database's Rules and agents.
+
+## Product contract
+
+- **Many entrances:** Accepts browser capture, share sheets, Clips, URLs, files, email, identifiers, providers, and Agent Actions through one contract.
+- **Remembered destination:** Defaults to the last Database used for that entrance while keeping the destination easy to change.
+- **Idempotent resolution:** Finds an existing canonical Page or creates exactly one, with a deliberate-copy escape hatch.
+- **Provenance:** Preserves the original URL, identifier, provider identity, capture time, snapshot, and available representations.
+- **Database handoff:** Applies the destination's Template, defaults, memberships, validation, and permissions.
+- **Downstream enrichment:** Lets target-owned Rules and agents summarize, classify, extract, or route the record without making Capture wait for them.
+- **Receipts and repair:** Reports what Capture created or reused and allows failed later enrichment to retry independently.

--- a/templates/content/docs/product/features/content.feature.cite-what-you-found.md
+++ b/templates/content/docs/product/features/content.feature.cite-what-you-found.md
@@ -10,8 +10,9 @@ summary: "Turn a link into one durable source-and-locator identity that can rend
 example_workflow: "A writer promotes an ordinary research link to a citation, adds a page locator, switches the article from author-date to footnote style, and watches the bibliography update without re-entering the source."
 works_today: "Content has ordinary links, Page references, source metadata, rich text, equations, and import and export machinery that can donate to citation rendering."
 remains: "First-class citation identity, locators, promote-to-citation, automatic bibliographies, selectable styles, Zotero interoperability, and semantic portability need implementation."
-required_capabilities: ["content.research.citation","content.author.footnotes"]
-enhancing_capabilities: ["content.portability.roundtrip","content.source.adapters"]
+required_capabilities: ["content.research.citation", "content.author.footnotes"]
+enhancing_capabilities:
+  ["content.portability.roundtrip", "content.source.adapters"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.cite-what-you-found.md
+++ b/templates/content/docs/product/features/content.feature.cite-what-you-found.md
@@ -1,0 +1,33 @@
+---
+record_type: "feature"
+id: "content.feature.cite-what-you-found"
+number: 26
+name: "Cite what you found"
+chapter: "content.chapter.capture-research"
+order: 26
+roadmap_status: "planned"
+summary: "Turn a link into one durable source-and-locator identity that can render in different citation styles."
+example_workflow: "A writer promotes an ordinary research link to a citation, adds a page locator, switches the article from author-date to footnote style, and watches the bibliography update without re-entering the source."
+works_today: "Content has ordinary links, Page references, source metadata, rich text, equations, and import and export machinery that can donate to citation rendering."
+remains: "First-class citation identity, locators, promote-to-citation, automatic bibliographies, selectable styles, Zotero interoperability, and semantic portability need implementation."
+required_capabilities: ["content.research.citation","content.author.footnotes"]
+enhancing_capabilities: ["content.portability.roundtrip","content.source.adapters"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 26: Cite what you found
+
+Turn a link into one durable source-and-locator identity that can render in different citation styles.
+
+## Product contract
+
+- **Promote to citation:** Converts an ordinary link without losing its anchor or source identity.
+- **Source Page:** Resolves or creates the canonical record for the paper, book, website, video, dataset, or other source.
+- **Locators:** Preserve page, chapter, figure, timestamp, transcript range, or another precise place within the source.
+- **Style rendering:** Presents one semantic citation as a link, author-date reference, number, footnote, or bibliography entry.
+- **Bibliographies:** Recompute from the citations actually present rather than maintaining a second manual list.
+- **Zotero interoperability:** Uses Zotero identities and CSL styles instead of volunteering to personally maintain civilization's citation formats.
+- **Portability:** Keeps citation identity intact across supported imports and exports even when the destination renders it differently.

--- a/templates/content/docs/product/features/content.feature.collaborate-in-context.md
+++ b/templates/content/docs/product/features/content.feature.collaborate-in-context.md
@@ -1,0 +1,52 @@
+---
+record_type: "feature"
+id: "content.feature.collaborate-in-context"
+number: 6
+name: "Collaborate in context"
+chapter: "content.chapter.consensus"
+order: 6
+roadmap_status: "partially_implemented"
+summary: "Comments, Discussion, messages, notifications, and history stay anchored to the Page or Database being shaped."
+example_workflow: "A teammate comments on an unclear paragraph, discusses the larger issue in the Page's Discussion, links the conversation to Slack, and returns later to see the Comment, replies, and resulting changes together."
+works_today: "Content supports anchored Comment threads, replies, resolution, mentions, notifications substrate, and document history. These already keep precise feedback closer to the artifact than an external chat can."
+remains: "Every Page and Database needs its universal Discussion, rich Blocks-field messages, stable permalinks, access-safe Slack continuation, and clearly attributable message revisions."
+required_capabilities: ["content.discussion.page","content.comment.page-owned","content.object.blocks-field","content.notification.source","content.event.committed"]
+enhancing_capabilities: ["content.agent.presence","content.feedback.signal"]
+increments: ["decide-together"]
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 6: Collaborate in context
+
+Comments, Discussion, messages, notifications, and history stay anchored to the Page or Database being shaped.
+
+## Product contract
+
+- **Comments:** Attach precise feedback to text, Blocks, media, or other exact material and preserve the historical target if that material changes.
+- **Discussion:** Gives every Page and Database one continuing channel for collaboration about the whole artifact.
+- **Rich messages:** Use Blocks fields so messages and Comments can contain the same references, embeds, Expressions, and structured content as Pages.
+- **Threads and replies:** Keep focused sub-conversations understandable without infinite nesting.
+- **Permalinks:** Make every message and Comment addressable from Content, Slack, or another Page.
+- **Notifications:** Route attention through durable, queryable records without inventing another inbox engine.
+- **Attributable revisions:** Let message owners edit their work while preserving visible history instead of erasing what was said.
+
+## Increment: Decide together
+
+Polls and explicit outcome state deepen the same Discussion rather than creating a separate decision system.
+
+**Status:** Planned
+
+**Example workflow:** A team posts a Poll in the Database Discussion, allows each person to choose up to two priorities, closes voting on Friday, records the outcome, and links directly to that result from the resulting plan.
+
+**What works today:** Comments, reactions, rich content, Database Views, and permission-aware collaboration provide pieces of the eventual interaction.
+
+**What remains:** Poll messages, bounded multi-select, stable options, closing behavior, access-safe aggregates, featured Poll rendering, and superseding outcomes still need implementation.
+
+- **Poll messages:** Use the shared rich-message grammar and remain linkable like any other Discussion item.
+- **Single or bounded multi-select:** Lets the poll author decide whether responders may choose one answer or a fixed number.
+- **Stable options:** Preserves the meaning of existing responses when wording or presentation changes.
+- **Close and freeze:** Stops new responses at a deliberate boundary and keeps the resulting aggregate inspectable.
+- **Access-safe totals:** Never leak inaccessible participants through counts or aggregates.
+- **Outcome state:** Records the current conclusion and allows a later outcome to supersede it without manufacturing a Decision object.

--- a/templates/content/docs/product/features/content.feature.collaborate-in-context.md
+++ b/templates/content/docs/product/features/content.feature.collaborate-in-context.md
@@ -10,8 +10,15 @@ summary: "Comments, Discussion, messages, notifications, and history stay anchor
 example_workflow: "A teammate comments on an unclear paragraph, discusses the larger issue in the Page's Discussion, links the conversation to Slack, and returns later to see the Comment, replies, and resulting changes together."
 works_today: "Content supports anchored Comment threads, replies, resolution, mentions, notifications substrate, and document history. These already keep precise feedback closer to the artifact than an external chat can."
 remains: "Every Page and Database needs its universal Discussion, rich Blocks-field messages, stable permalinks, access-safe Slack continuation, and clearly attributable message revisions."
-required_capabilities: ["content.discussion.page","content.comment.page-owned","content.object.blocks-field","content.notification.source","content.event.committed"]
-enhancing_capabilities: ["content.agent.presence","content.feedback.signal"]
+required_capabilities:
+  [
+    "content.discussion.page",
+    "content.comment.page-owned",
+    "content.object.blocks-field",
+    "content.notification.source",
+    "content.event.committed",
+  ]
+enhancing_capabilities: ["content.agent.presence", "content.feedback.signal"]
 increments: ["decide-together"]
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.collect-structured-input.md
+++ b/templates/content/docs/product/features/content.feature.collect-structured-input.md
@@ -1,0 +1,32 @@
+---
+record_type: "feature"
+id: "content.feature.collect-structured-input"
+number: 21
+name: "Collect structured input"
+chapter: "content.chapter.working-systems"
+order: 21
+roadmap_status: "in_validation"
+summary: "Build Forms over the same schema, validation, and submission Actions as the Database they populate."
+example_workflow: "A research team publishes an intake Form that validates required fields, lets an external participant submit without reading the Database, creates exactly one record, and triggers the Database's enrichment Rule."
+works_today: "Content already has a Form View, ordered and required questions, schema-backed controls, and an atomic Action that creates and verifies an ordinary Database record."
+remains: "Content and Agent Native Forms need one shared engine, with polished public submission, richer validation, conditional behavior, permissions, spam protection, receipts, and dependable downstream Rule handoff."
+required_capabilities: ["content.form.shared-engine","content.property.constraints","content.agent.action-parity","content.event.committed"]
+enhancing_capabilities: ["content.rule.deterministic","content.job.durable"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 21: Collect structured input
+
+Build Forms over the same schema, validation, and submission Actions as the Database they populate.
+
+## Product contract
+
+- **Form View:** Saves field selection, order, presentation, and submission behavior over one Database.
+- **Shared schema:** Reuses the same Property types and validation as Agent Native Forms and ordinary record editing.
+- **Conditional fields:** Shows or requires inputs through the typed expression language rather than custom form-only logic.
+- **Submission grants:** Allow a person to submit without silently granting broad access to the underlying Database.
+- **Idempotent submission:** Prevents duplicate records when a request retries or returns ambiguously.
+- **Receipts:** Records the submitted values, actor, resulting Page, and downstream Actions the submitter may inspect.

--- a/templates/content/docs/product/features/content.feature.collect-structured-input.md
+++ b/templates/content/docs/product/features/content.feature.collect-structured-input.md
@@ -10,8 +10,14 @@ summary: "Build Forms over the same schema, validation, and submission Actions a
 example_workflow: "A research team publishes an intake Form that validates required fields, lets an external participant submit without reading the Database, creates exactly one record, and triggers the Database's enrichment Rule."
 works_today: "Content already has a Form View, ordered and required questions, schema-backed controls, and an atomic Action that creates and verifies an ordinary Database record."
 remains: "Content and Agent Native Forms need one shared engine, with polished public submission, richer validation, conditional behavior, permissions, spam protection, receipts, and dependable downstream Rule handoff."
-required_capabilities: ["content.form.shared-engine","content.property.constraints","content.agent.action-parity","content.event.committed"]
-enhancing_capabilities: ["content.rule.deterministic","content.job.durable"]
+required_capabilities:
+  [
+    "content.form.shared-engine",
+    "content.property.constraints",
+    "content.agent.action-parity",
+    "content.event.committed",
+  ]
+enhancing_capabilities: ["content.rule.deterministic", "content.job.durable"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.connect-your-sources.md
+++ b/templates/content/docs/product/features/content.feature.connect-your-sources.md
@@ -10,8 +10,14 @@ summary: "Choose governed native and provider Sources, preserve their identity, 
 example_workflow: "A content lead connects Builder blog articles and resources, aligns their compatible fields in one Query, and works from a shared editorial View without losing which provider owns each record."
 works_today: "Content already models source-backed Databases, source fields and rows, provenance, multi-source composition, and adapters for Builder, Notion, and local material."
 remains: "Sources need one governed catalog, Queries need to replace the confusing multi-source configuration surface, and field alignment, write routing, and access behavior need end-to-end proof."
-required_capabilities: ["content.source.catalog","content.source.adapters","content.view.source-query","content.query.object"]
-enhancing_capabilities: ["content.source.page-link","content.property.catalog"]
+required_capabilities:
+  [
+    "content.source.catalog",
+    "content.source.adapters",
+    "content.view.source-query",
+    "content.query.object",
+  ]
+enhancing_capabilities: ["content.source.page-link", "content.property.catalog"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.connect-your-sources.md
+++ b/templates/content/docs/product/features/content.feature.connect-your-sources.md
@@ -1,0 +1,32 @@
+---
+record_type: "feature"
+id: "content.feature.connect-your-sources"
+number: 9
+name: "Connect your sources"
+chapter: "content.chapter.connected-sources"
+order: 9
+roadmap_status: "partially_implemented"
+summary: "Choose governed native and provider Sources, preserve their identity, and compose them through Queries and Views."
+example_workflow: "A content lead connects Builder blog articles and resources, aligns their compatible fields in one Query, and works from a shared editorial View without losing which provider owns each record."
+works_today: "Content already models source-backed Databases, source fields and rows, provenance, multi-source composition, and adapters for Builder, Notion, and local material."
+remains: "Sources need one governed catalog, Queries need to replace the confusing multi-source configuration surface, and field alignment, write routing, and access behavior need end-to-end proof."
+required_capabilities: ["content.source.catalog","content.source.adapters","content.view.source-query","content.query.object"]
+enhancing_capabilities: ["content.source.page-link","content.property.catalog"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 9: Connect your sources
+
+Choose governed native and provider Sources, preserve their identity, and compose them through Queries and Views.
+
+## Product contract
+
+- **Sources catalog:** Lists approved personal, workspace, and organization connections with their capabilities and policy.
+- **Provider adapters:** Give Builder, Notion, Drive, Agent Native apps, and later providers one shared contract with independent certification.
+- **Item binding:** Maps each provider item to one stable Content identity without turning the provider into the Page's owner.
+- **Typed Queries:** Combine Databases, Sources, and other Queries through one visual selection and alignment model.
+- **Provenance:** Shows where each value or representation came from and which system owns changes to it.
+- **Access-safe results:** Evaluate every result and aggregate with the current viewer's authority rather than the Query owner's.

--- a/templates/content/docs/product/features/content.feature.data-that-keeps-itself-right.md
+++ b/templates/content/docs/product/features/content.feature.data-that-keeps-itself-right.md
@@ -10,8 +10,20 @@ summary: "Use typed defaults, formulas, validation, and rendering so ordinary da
 example_workflow: "An operations lead creates a request Database whose defaults fill the creator and timestamp, formulas calculate cost, validation rejects an impossible quantity, and a guarded budget change explains its consequences before committing."
 works_today: "Content has a broad typed Property system, formulas and computed fields, editable values, form-required fields, audit fields, and several useful validation donors."
 remains: "Defaults, formulas, validation, conditional rendering, guarded changes, typed errors, and time semantics need one expression language and one coherent configuration surface across every Property type."
-required_capabilities: ["content.property.typed","content.property.constraints","content.property.guarded-change","content.expression.language","content.time.types"]
-enhancing_capabilities: ["content.view.dynamic-create","content.property.actor","content.expression.cached-result"]
+required_capabilities:
+  [
+    "content.property.typed",
+    "content.property.constraints",
+    "content.property.guarded-change",
+    "content.expression.language",
+    "content.time.types",
+  ]
+enhancing_capabilities:
+  [
+    "content.view.dynamic-create",
+    "content.property.actor",
+    "content.expression.cached-result",
+  ]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.data-that-keeps-itself-right.md
+++ b/templates/content/docs/product/features/content.feature.data-that-keeps-itself-right.md
@@ -1,0 +1,33 @@
+---
+record_type: "feature"
+id: "content.feature.data-that-keeps-itself-right"
+number: 13
+name: "Data that keeps itself right"
+chapter: "content.chapter.working-systems"
+order: 13
+roadmap_status: "partially_implemented"
+summary: "Use typed defaults, formulas, validation, and rendering so ordinary data stays consistent."
+example_workflow: "An operations lead creates a request Database whose defaults fill the creator and timestamp, formulas calculate cost, validation rejects an impossible quantity, and a guarded budget change explains its consequences before committing."
+works_today: "Content has a broad typed Property system, formulas and computed fields, editable values, form-required fields, audit fields, and several useful validation donors."
+remains: "Defaults, formulas, validation, conditional rendering, guarded changes, typed errors, and time semantics need one expression language and one coherent configuration surface across every Property type."
+required_capabilities: ["content.property.typed","content.property.constraints","content.property.guarded-change","content.expression.language","content.time.types"]
+enhancing_capabilities: ["content.view.dynamic-create","content.property.actor","content.expression.cached-result"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 13: Data that keeps itself right
+
+Use typed defaults, formulas, validation, and rendering so ordinary data stays consistent.
+
+## Product contract
+
+- **Typed Properties:** Give text, numbers, choices, dates, people, relationships, files, and rich Blocks explicit behavior.
+- **Creation defaults:** Evaluate one-time typed Expressions inside the successful creation transaction.
+- **Formulas:** Derive live values from the current row and related data without storing a second truth.
+- **Validation:** Reject invalid values consistently across the interface, Actions, API, agents, imports, and Forms.
+- **Safeguards:** Add customizable consequence text, confirmation, approval, or conditional authority before sensitive changes commit.
+- **Typed errors:** Keep null, error, unavailable, and stale cached values distinct and understandable.
+- **Time semantics:** Separate Dates from timezone-aware Instants and quarantine ambiguous legacy floating times honestly.

--- a/templates/content/docs/product/features/content.feature.durable-foundations.md
+++ b/templates/content/docs/product/features/content.feature.durable-foundations.md
@@ -10,8 +10,23 @@ summary: "Pages, Blocks, Databases, Search, history, and recovery form one trust
 example_workflow: "A teammate creates a project brief, turns its action items into Database records with owners and due dates, closes the app, finds the work again through Search, restores an accidentally deleted Block, and asks an agent to continue from the same durable context."
 works_today: "Content already has SQL-backed Pages, rich Blocks, Databases, Search, document snapshots, and a broad agent Action surface. People and agents can perform much of the ordinary creation and editing loop on the same durable objects."
 remains: "Stable Block identity, actor-aware history, dependable recovery across every object type, and complete end-to-end action parity still need to become one polished foundation."
-required_capabilities: ["content.object.page","content.object.block","content.object.blocks-field","content.object.database","content.knowledge.search","content.event.committed","content.history.queryable","content.agent.action-parity"]
-enhancing_capabilities: ["content.version.field-history","content.property.actor","content.author.document-editor"]
+required_capabilities:
+  [
+    "content.object.page",
+    "content.object.block",
+    "content.object.blocks-field",
+    "content.object.database",
+    "content.knowledge.search",
+    "content.event.committed",
+    "content.history.queryable",
+    "content.agent.action-parity",
+  ]
+enhancing_capabilities:
+  [
+    "content.version.field-history",
+    "content.property.actor",
+    "content.author.document-editor",
+  ]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.durable-foundations.md
+++ b/templates/content/docs/product/features/content.feature.durable-foundations.md
@@ -1,0 +1,33 @@
+---
+record_type: "feature"
+id: "content.feature.durable-foundations"
+number: 1
+name: "Durable foundations"
+chapter: "content.chapter.durable-home"
+order: 1
+roadmap_status: "in_validation"
+summary: "Pages, Blocks, Databases, Search, history, and recovery form one trustworthy material loop."
+example_workflow: "A teammate creates a project brief, turns its action items into Database records with owners and due dates, closes the app, finds the work again through Search, restores an accidentally deleted Block, and asks an agent to continue from the same durable context."
+works_today: "Content already has SQL-backed Pages, rich Blocks, Databases, Search, document snapshots, and a broad agent Action surface. People and agents can perform much of the ordinary creation and editing loop on the same durable objects."
+remains: "Stable Block identity, actor-aware history, dependable recovery across every object type, and complete end-to-end action parity still need to become one polished foundation."
+required_capabilities: ["content.object.page","content.object.block","content.object.blocks-field","content.object.database","content.knowledge.search","content.event.committed","content.history.queryable","content.agent.action-parity"]
+enhancing_capabilities: ["content.version.field-history","content.property.actor","content.author.document-editor"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 1: Durable foundations
+
+Pages, Blocks, Databases, Search, history, and recovery form one trustworthy material loop.
+
+## Product contract
+
+- **Pages:** Hold durable identity, access, properties, rich content, and the context required to resume work.
+- **Blocks:** Give every editable rich-content body the same composable grammar, whether it belongs to a Page, Property, Comment, or message.
+- **Databases:** Govern writable collections, membership, typed Properties, validation, defaults, Rules, and the canonical path for creating records.
+- **Search:** Finds only what the current person can access and opens the exact object or context they were looking for.
+- **History:** Records attributable committed Events and logical Revisions without turning every keystroke into a fake milestone.
+- **Recovery:** Restores deleted or changed work without discarding the history that explains what happened.
+- **Agent parity:** Lets agents perform the same authorized operations through the same Action surface rather than a second, weaker API.

--- a/templates/content/docs/product/features/content.feature.evolve-systems-safely.md
+++ b/templates/content/docs/product/features/content.feature.evolve-systems-safely.md
@@ -10,8 +10,14 @@ summary: "Review upstream changes to adopted systems, keep local work intact, an
 example_workflow: "A new version of the editorial Template adds one Property and changes a Rule; each Database owner sees the impact, accepts the Property, declines the Rule, preserves local changes, and stops seeing the same declined update."
 works_today: "Version history, diff donors, stable identifiers, Templates, and source change-review machinery provide the pieces needed to compare evolving systems."
 remains: "Governed building blocks need version pinning, affected-object previews, owner-scoped adoption, selective apply and reset, remembered declines, deprecation, and safe permanent divergence."
-required_capabilities: ["content.template.update","content.property.catalog","content.diff.in-place"]
-enhancing_capabilities: ["content.template.governance","content.event.committed"]
+required_capabilities:
+  [
+    "content.template.update",
+    "content.property.catalog",
+    "content.diff.in-place",
+  ]
+enhancing_capabilities:
+  ["content.template.governance", "content.event.committed"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.evolve-systems-safely.md
+++ b/templates/content/docs/product/features/content.feature.evolve-systems-safely.md
@@ -1,0 +1,32 @@
+---
+record_type: "feature"
+id: "content.feature.evolve-systems-safely"
+number: 16
+name: "Evolve systems safely"
+chapter: "content.chapter.working-systems"
+order: 16
+roadmap_status: "planned"
+summary: "Review upstream changes to adopted systems, keep local work intact, and choose what to accept or detach."
+example_workflow: "A new version of the editorial Template adds one Property and changes a Rule; each Database owner sees the impact, accepts the Property, declines the Rule, preserves local changes, and stops seeing the same declined update."
+works_today: "Version history, diff donors, stable identifiers, Templates, and source change-review machinery provide the pieces needed to compare evolving systems."
+remains: "Governed building blocks need version pinning, affected-object previews, owner-scoped adoption, selective apply and reset, remembered declines, deprecation, and safe permanent divergence."
+required_capabilities: ["content.template.update","content.property.catalog","content.diff.in-place"]
+enhancing_capabilities: ["content.template.governance","content.event.committed"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 16: Evolve systems safely
+
+Review upstream changes to adopted systems, keep local work intact, and choose what to accept or detach.
+
+## Product contract
+
+- **Version pinning:** Keeps each adopted Template or Custom Property on the version its owner trusts.
+- **Impact preview:** Shows affected Databases, Views, Queries, formulas, Rules, Templates, and agent workflows before publication.
+- **Three-way comparison:** Distinguishes the old shared definition, the proposed update, and local changes.
+- **Selective adoption:** Lets each owner accept compatible changes, decline others, or apply a safe batch.
+- **Quiet decline memory:** Avoids repeatedly demanding review until the upstream change materially differs.
+- **Detach to local:** Ends the shared lineage without breaking the current system or losing provenance.

--- a/templates/content/docs/product/features/content.feature.explore-alternatives-safely.md
+++ b/templates/content/docs/product/features/content.feature.explore-alternatives-safely.md
@@ -1,0 +1,32 @@
+---
+record_type: "feature"
+id: "content.feature.explore-alternatives-safely"
+number: 8
+name: "Explore alternatives safely"
+chapter: "content.chapter.consensus"
+order: 8
+roadmap_status: "planned"
+summary: "Create named Versions, compare them, selectively merge them, and promote one without losing the others."
+example_workflow: "A team keeps the published article canonical while creating a private rewrite, compares the two Versions in the normal editor, selectively merges the best changes, and promotes the rewrite only when it is ready."
+works_today: "Content preserves whole-document snapshots and can restore earlier revisions, while the broader event and diff architecture establishes the lower-level history foundation."
+remains: "Named Page Versions, Version-specific access, in-place comparison, selective merge, canonical promotion, and Version-aware collaboration are still planned."
+required_capabilities: ["content.version.branching","content.version.field-history","content.diff.in-place","content.access.row-private"]
+enhancing_capabilities: ["content.diff.filtered-review","content.research.annotation"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 8: Explore alternatives safely
+
+Create named Versions, compare them, selectively merge them, and promote one without losing the others.
+
+## Product contract
+
+- **One stable Page:** Keeps identity, title, top-level Properties, sharing, and Discussion common across its Versions.
+- **Named Versions:** Hold deliberate alternative bodies such as a published article and a new working draft.
+- **Version-specific access:** Allows a Version to be more private than its Page, but never more broadly shared.
+- **Compare and merge:** Shows differences in the ordinary Page interface and supports selective acceptance in either direction.
+- **Canonical promotion:** Makes any authorized Version current without destroying the Version it replaces.
+- **Version context:** Quietly anchors Comments, Discussion messages, Annotations, and execution receipts to the Version being viewed.

--- a/templates/content/docs/product/features/content.feature.explore-alternatives-safely.md
+++ b/templates/content/docs/product/features/content.feature.explore-alternatives-safely.md
@@ -10,8 +10,15 @@ summary: "Create named Versions, compare them, selectively merge them, and promo
 example_workflow: "A team keeps the published article canonical while creating a private rewrite, compares the two Versions in the normal editor, selectively merges the best changes, and promotes the rewrite only when it is ready."
 works_today: "Content preserves whole-document snapshots and can restore earlier revisions, while the broader event and diff architecture establishes the lower-level history foundation."
 remains: "Named Page Versions, Version-specific access, in-place comparison, selective merge, canonical promotion, and Version-aware collaboration are still planned."
-required_capabilities: ["content.version.branching","content.version.field-history","content.diff.in-place","content.access.row-private"]
-enhancing_capabilities: ["content.diff.filtered-review","content.research.annotation"]
+required_capabilities:
+  [
+    "content.version.branching",
+    "content.version.field-history",
+    "content.diff.in-place",
+    "content.access.row-private",
+  ]
+enhancing_capabilities:
+  ["content.diff.filtered-review", "content.research.annotation"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.find-your-place-again.md
+++ b/templates/content/docs/product/features/content.feature.find-your-place-again.md
@@ -1,0 +1,32 @@
+---
+record_type: "feature"
+id: "content.feature.find-your-place-again"
+number: 2
+name: "Find your place again"
+chapter: "content.chapter.durable-home"
+order: 2
+roadmap_status: "partially_implemented"
+summary: "Content makes arrival, navigation, and resumption feel dependable instead of asking people to remember where they left everything."
+example_workflow: "A new teammate follows an invitation, lands in the correct organization and Workspace, pins the project they care about, and later returns directly to the exact Database View they were using."
+works_today: "Content has Personal and organization-backed spaces, Workspace navigation, invitations, sidebar structure, and saved location state in varying degrees of maturity."
+remains: "Global Home, clearer context switching, intentional pinning and dynamic sidebar sections, and reliable resumption into the exact focused View need to work as one arrival experience."
+required_capabilities: ["content.source.spaces-files","content.workspace.multi-scope","content.home.global","content.navigation.sidebar","content.workspace.session-restore"]
+enhancing_capabilities: ["content.workspace.working-set","content.workspace.view-instance"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 2: Find your place again
+
+Content makes arrival, navigation, and resumption feel dependable instead of asking people to remember where they left everything.
+
+## Product contract
+
+- **Home:** Gives each person a top-level view across the Personal and organization contexts they can access.
+- **Workspaces:** Organize Pages and Databases beneath Personal or an Organization without becoming the permission model themselves.
+- **Sidebar:** Pins important Pages, Databases, and Queries while allowing dynamic sections such as Recent and Shared with me.
+- **Recent work:** Restores the objects and views a person was actually using, scoped by current access.
+- **Known links and invitations:** Land on the intended object with an honest access-denied state when permission is missing.
+- **Session resumption:** Reopens enough navigation and View state to pick up the work without reconstructing the route manually.

--- a/templates/content/docs/product/features/content.feature.find-your-place-again.md
+++ b/templates/content/docs/product/features/content.feature.find-your-place-again.md
@@ -10,8 +10,16 @@ summary: "Content makes arrival, navigation, and resumption feel dependable inst
 example_workflow: "A new teammate follows an invitation, lands in the correct organization and Workspace, pins the project they care about, and later returns directly to the exact Database View they were using."
 works_today: "Content has Personal and organization-backed spaces, Workspace navigation, invitations, sidebar structure, and saved location state in varying degrees of maturity."
 remains: "Global Home, clearer context switching, intentional pinning and dynamic sidebar sections, and reliable resumption into the exact focused View need to work as one arrival experience."
-required_capabilities: ["content.source.spaces-files","content.workspace.multi-scope","content.home.global","content.navigation.sidebar","content.workspace.session-restore"]
-enhancing_capabilities: ["content.workspace.working-set","content.workspace.view-instance"]
+required_capabilities:
+  [
+    "content.source.spaces-files",
+    "content.workspace.multi-scope",
+    "content.home.global",
+    "content.navigation.sidebar",
+    "content.workspace.session-restore",
+  ]
+enhancing_capabilities:
+  ["content.workspace.working-set", "content.workspace.view-instance"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.keep-your-private-vault-private.md
+++ b/templates/content/docs/product/features/content.feature.keep-your-private-vault-private.md
@@ -1,0 +1,33 @@
+---
+record_type: "feature"
+id: "content.feature.keep-your-private-vault-private"
+number: 32
+name: "Keep your private vault private"
+chapter: "content.chapter.publishing-portability"
+order: 32
+roadmap_status: "paused"
+summary: "Add user-controlled encrypted custody without abandoning collaboration, recovery, or ordinary agent workflows."
+example_workflow: "A person enrolls a trusted laptop, opens an encrypted private vault locally, grants a local agent bounded access for one task, then revokes the device without exposing the vault to the service."
+works_today: "The private-vault lane has substantial research and fork implementation history around enrollment, encrypted custody, device authorization, fail-closed behavior, and cross-architecture verification."
+remains: "The complete user product still needs audited cryptographic integration, understandable recovery and revocation, collaboration, agent access boundaries, portable exit, current-main reconciliation, and production proof. Work remains deliberately paused."
+required_capabilities: ["content.security.private-vault","content.agent.resource-consent","content.portability.vault-export"]
+enhancing_capabilities: ["content.source.local-bridge","content.agent.audience-safe"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 32: Keep your private vault private
+
+Add user-controlled encrypted custody without abandoning collaboration, recovery, or ordinary agent workflows.
+
+## Product contract
+
+- **End-to-end encryption:** Keeps private content unreadable to the service outside explicitly authorized plaintext boundaries.
+- **Enrollment and recovery:** Gives people understandable key setup, device addition, rotation, revocation, and recovery ceremonies.
+- **Device authority:** Lets trusted local clients decrypt only the vaults and operations they are authorized to handle.
+- **Agent access:** Makes private-vault availability explicit and bounded rather than silently handing an agent plaintext.
+- **Collaboration:** Preserves sharing, Versions, comments, and revocation without weakening the custody promise.
+- **Portable exit:** Allows the owner to export readable authorized content and keys without permanent service dependence.
+- **Paused boundary:** Retains the existing E2EE research and implementation history without claiming the complete workflow is ready.

--- a/templates/content/docs/product/features/content.feature.keep-your-private-vault-private.md
+++ b/templates/content/docs/product/features/content.feature.keep-your-private-vault-private.md
@@ -10,8 +10,14 @@ summary: "Add user-controlled encrypted custody without abandoning collaboration
 example_workflow: "A person enrolls a trusted laptop, opens an encrypted private vault locally, grants a local agent bounded access for one task, then revokes the device without exposing the vault to the service."
 works_today: "The private-vault lane has substantial research and fork implementation history around enrollment, encrypted custody, device authorization, fail-closed behavior, and cross-architecture verification."
 remains: "The complete user product still needs audited cryptographic integration, understandable recovery and revocation, collaboration, agent access boundaries, portable exit, current-main reconciliation, and production proof. Work remains deliberately paused."
-required_capabilities: ["content.security.private-vault","content.agent.resource-consent","content.portability.vault-export"]
-enhancing_capabilities: ["content.source.local-bridge","content.agent.audience-safe"]
+required_capabilities:
+  [
+    "content.security.private-vault",
+    "content.agent.resource-consent",
+    "content.portability.vault-export",
+  ]
+enhancing_capabilities:
+  ["content.source.local-bridge", "content.agent.audience-safe"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.living-references.md
+++ b/templates/content/docs/product/features/content.feature.living-references.md
@@ -1,0 +1,32 @@
+---
+record_type: "feature"
+id: "content.feature.living-references"
+number: 3
+name: "Living references"
+chapter: "content.chapter.durable-home"
+order: 3
+roadmap_status: "partially_implemented"
+summary: "Reuse canonical Pages and Blocks without producing copies that quietly drift apart."
+example_workflow: "The Docs team maintains one canonical product-description Block that appears across several guides and blog posts, edits it from any occurrence, and sees every authorized location update without copy and paste."
+works_today: "Content can reference Pages, embed ordinary Database Views, and preserve multi-membership without copying canonical records. Existing reference Blocks and source-aware identities provide useful substrate."
+remains: "Stable Block references, editable Synced Blocks, canonical Page embeds, a complete Connections surface, and typed relationship behavior still need to converge."
+required_capabilities: ["content.object.reference","content.object.transclusion","content.knowledge.links","content.relationship.edge"]
+enhancing_capabilities: ["content.object.block","content.version.branching"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 3: Living references
+
+Reuse canonical Pages and Blocks without producing copies that quietly drift apart.
+
+## Product contract
+
+- **References:** Link to a Page or Block as a compact mention, card, or embedded preview.
+- **Synced Blocks:** Render one canonical Block in several places and allow authorized edits from any occurrence.
+- **Embedded Pages:** Place a canonical Page inside another surface while preserving its identity and access.
+- **Backlinks and forward links:** Show where an object is mentioned and what it intentionally references through Info → Connections.
+- **Typed Relationships:** Give important connections explicit meaning that Databases, Queries, Graphs, and agents can use.
+- **Graceful degradation:** Omit inaccessible references and preserve understandable broken or deleted-reference states.

--- a/templates/content/docs/product/features/content.feature.living-references.md
+++ b/templates/content/docs/product/features/content.feature.living-references.md
@@ -10,8 +10,14 @@ summary: "Reuse canonical Pages and Blocks without producing copies that quietly
 example_workflow: "The Docs team maintains one canonical product-description Block that appears across several guides and blog posts, edits it from any occurrence, and sees every authorized location update without copy and paste."
 works_today: "Content can reference Pages, embed ordinary Database Views, and preserve multi-membership without copying canonical records. Existing reference Blocks and source-aware identities provide useful substrate."
 remains: "Stable Block references, editable Synced Blocks, canonical Page embeds, a complete Connections surface, and typed relationship behavior still need to converge."
-required_capabilities: ["content.object.reference","content.object.transclusion","content.knowledge.links","content.relationship.edge"]
-enhancing_capabilities: ["content.object.block","content.version.branching"]
+required_capabilities:
+  [
+    "content.object.reference",
+    "content.object.transclusion",
+    "content.knowledge.links",
+    "content.relationship.edge",
+  ]
+enhancing_capabilities: ["content.object.block", "content.version.branching"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.make-the-workspace-yours.md
+++ b/templates/content/docs/product/features/content.feature.make-the-workspace-yours.md
@@ -10,8 +10,16 @@ summary: "Personal arrangements and private Views reshape shared work without ch
 example_workflow: "A sales leader privately filters and groups the shared customer Database around this quarter's accounts, saves that arrangement as an Only-me View, and never changes what the rest of the company sees."
 works_today: "Saved Database Views already support filtering, sorting, grouping, density, and several renderers, while the data model supports Pages belonging to multiple Databases."
 remains: "Automatic personal overrides, named Only-me Views, reusable typed Queries, and predictable pinning and sharing behavior need complete product surfaces."
-required_capabilities: ["content.view.query","content.query.object","content.view.personal-state","content.share.views","content.object.multi-membership"]
-enhancing_capabilities: ["content.navigation.sidebar","content.expression.language"]
+required_capabilities:
+  [
+    "content.view.query",
+    "content.query.object",
+    "content.view.personal-state",
+    "content.share.views",
+    "content.object.multi-membership",
+  ]
+enhancing_capabilities:
+  ["content.navigation.sidebar", "content.expression.language"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.make-the-workspace-yours.md
+++ b/templates/content/docs/product/features/content.feature.make-the-workspace-yours.md
@@ -1,0 +1,32 @@
+---
+record_type: "feature"
+id: "content.feature.make-the-workspace-yours"
+number: 4
+name: "Make the workspace yours"
+chapter: "content.chapter.durable-home"
+order: 4
+roadmap_status: "partially_implemented"
+summary: "Personal arrangements and private Views reshape shared work without changing it for everyone else."
+example_workflow: "A sales leader privately filters and groups the shared customer Database around this quarter's accounts, saves that arrangement as an Only-me View, and never changes what the rest of the company sees."
+works_today: "Saved Database Views already support filtering, sorting, grouping, density, and several renderers, while the data model supports Pages belonging to multiple Databases."
+remains: "Automatic personal overrides, named Only-me Views, reusable typed Queries, and predictable pinning and sharing behavior need complete product surfaces."
+required_capabilities: ["content.view.query","content.query.object","content.view.personal-state","content.share.views","content.object.multi-membership"]
+enhancing_capabilities: ["content.navigation.sidebar","content.expression.language"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 4: Make the workspace yours
+
+Personal arrangements and private Views reshape shared work without changing it for everyone else.
+
+## Product contract
+
+- **Personal View changes:** Remember one person's filters, sorting, grouping, density, and presentation over a shared View.
+- **Only-me Views:** Save named private Views over shared records without forking their data.
+- **Shared Views:** Give collaborators a dependable starting presentation while preserving personal exploration.
+- **Saved Queries:** Turn reusable selection and output logic into durable Content objects that can be linked and embedded.
+- **Multiple Database memberships:** Let one Page participate in several collections without gaining a primary Database identity.
+- **Pinned navigation:** Let each person choose the working set that deserves persistent space in the sidebar.

--- a/templates/content/docs/product/features/content.feature.move-without-starting-over.md
+++ b/templates/content/docs/product/features/content.feature.move-without-starting-over.md
@@ -1,0 +1,33 @@
+---
+record_type: "feature"
+id: "content.feature.move-without-starting-over"
+number: 30
+name: "Move without starting over"
+chapter: "content.chapter.publishing-portability"
+order: 30
+roadmap_status: "partially_implemented"
+summary: "Import or migrate a foreign corpus with resumable progress, provenance, repair, and a readable conversion report."
+example_workflow: "A team imports a large Notion workspace, closes the browser halfway through, resumes without duplicate Pages, and reviews a conversion report showing transformed Properties and unresolved assets."
+works_today: "Markdown and MDX import, Notion workflows, Builder pulls, local-folder synchronization, provenance, and provider identities already support several bounded migration paths."
+remains: "Large migrations need durable server-side orchestration, checkpoints, idempotent deduplication, broader schema fidelity, conversion reports, asset repair, resumability, and explicit partial-failure recovery."
+required_capabilities: ["content.job.durable","content.source.adapters","content.portability.roundtrip"]
+enhancing_capabilities: ["content.source.catalog","content.event.committed"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 30: Move without starting over
+
+Import or migrate a foreign corpus with resumable progress, provenance, repair, and a readable conversion report.
+
+## Product contract
+
+- **Canonical import model:** Maps Pages, Databases, Properties, Blocks, relationships, files, and metadata into stable Content objects.
+- **Provider-specific adapters:** Interpret Notion, local vaults, Builder, Drive, and later formats without making any provider's dialect the core model.
+- **Checkpoint and resume:** Continues large migrations after interruption without duplicating already accepted records.
+- **Identity and deduplication:** Preserves stable source IDs and makes repeated imports repair or update the intended objects.
+- **Conversion report:** Explains unsupported or transformed semantics instead of quietly dropping them.
+- **Repair workflows:** Lets people and agents inspect unresolved mappings, missing assets, conflicts, and partial failures.
+- **Provenance:** Keeps enough source context to compare, refresh, or understand the imported material later.

--- a/templates/content/docs/product/features/content.feature.move-without-starting-over.md
+++ b/templates/content/docs/product/features/content.feature.move-without-starting-over.md
@@ -10,8 +10,13 @@ summary: "Import or migrate a foreign corpus with resumable progress, provenance
 example_workflow: "A team imports a large Notion workspace, closes the browser halfway through, resumes without duplicate Pages, and reviews a conversion report showing transformed Properties and unresolved assets."
 works_today: "Markdown and MDX import, Notion workflows, Builder pulls, local-folder synchronization, provenance, and provider identities already support several bounded migration paths."
 remains: "Large migrations need durable server-side orchestration, checkpoints, idempotent deduplication, broader schema fidelity, conversion reports, asset repair, resumability, and explicit partial-failure recovery."
-required_capabilities: ["content.job.durable","content.source.adapters","content.portability.roundtrip"]
-enhancing_capabilities: ["content.source.catalog","content.event.committed"]
+required_capabilities:
+  [
+    "content.job.durable",
+    "content.source.adapters",
+    "content.portability.roundtrip",
+  ]
+enhancing_capabilities: ["content.source.catalog", "content.event.committed"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.plan-work-across-time.md
+++ b/templates/content/docs/product/features/content.feature.plan-work-across-time.md
@@ -10,8 +10,15 @@ summary: "Edit dates and dependencies through Timeline and Gantt-style planning 
 example_workflow: "A project manager opens a Timeline, drags a blocked launch task into the following week, sees the dependency conflict, accepts a proposed schedule repair, and preserves the updated dates and Relationships everywhere else."
 works_today: "A Timeline renderer, typed date Properties, drag editing, relations, grouping, and shared View configuration already exist as partially proven pieces."
 remains: "Timeline needs full renderer conformance and polish, while dependency metadata, schedule constraints, milestones, repair proposals, critical path, and Gantt-style interaction remain planned layers."
-required_capabilities: ["content.view.timeline","content.time.types","content.relationship.edge","content.schedule.constraints"]
-enhancing_capabilities: ["content.system.dependencies","content.view.grouping-aggregation"]
+required_capabilities:
+  [
+    "content.view.timeline",
+    "content.time.types",
+    "content.relationship.edge",
+    "content.schedule.constraints",
+  ]
+enhancing_capabilities:
+  ["content.system.dependencies", "content.view.grouping-aggregation"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.plan-work-across-time.md
+++ b/templates/content/docs/product/features/content.feature.plan-work-across-time.md
@@ -1,0 +1,32 @@
+---
+record_type: "feature"
+id: "content.feature.plan-work-across-time"
+number: 19
+name: "Plan work across time"
+chapter: "content.chapter.working-systems"
+order: 19
+roadmap_status: "planned"
+summary: "Edit dates and dependencies through Timeline and Gantt-style planning while preserving the same typed records underneath."
+example_workflow: "A project manager opens a Timeline, drags a blocked launch task into the following week, sees the dependency conflict, accepts a proposed schedule repair, and preserves the updated dates and Relationships everywhere else."
+works_today: "A Timeline renderer, typed date Properties, drag editing, relations, grouping, and shared View configuration already exist as partially proven pieces."
+remains: "Timeline needs full renderer conformance and polish, while dependency metadata, schedule constraints, milestones, repair proposals, critical path, and Gantt-style interaction remain planned layers."
+required_capabilities: ["content.view.timeline","content.time.types","content.relationship.edge","content.schedule.constraints"]
+enhancing_capabilities: ["content.system.dependencies","content.view.grouping-aggregation"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 19: Plan work across time
+
+Edit dates and dependencies through Timeline and Gantt-style planning while preserving the same typed records underneath.
+
+## Product contract
+
+- **Timeline:** Places records across typed dates, Instants, ranges, and durations.
+- **Direct manipulation:** Moves or resizes permitted work through ordinary typed Actions.
+- **Dependency connectors:** Renders the same Relationships used by Queries and project workflows.
+- **Schedule constraints:** Detects invalid ordering and either refuses, explains, or proposes a repair according to policy.
+- **Gantt mode:** Combines Timeline, dependencies, milestones, grouping, and schedule behavior without becoming another View family.
+- **Critical path:** Remains a later planning layer after dependency and constraint semantics are dependable.

--- a/templates/content/docs/product/features/content.feature.publish-with-confidence.md
+++ b/templates/content/docs/product/features/content.feature.publish-with-confidence.md
@@ -10,8 +10,18 @@ summary: "Publish one chosen revision faithfully while private collaborative wor
 example_workflow: "An editor publishes the current approved article revision, continues working privately on a new Version, previews exactly what public readers can see, and updates the stable URL only when the replacement is ready."
 works_today: "Content already supports sharing, public Pages, stable links, several exports, access checks, and server-rendered public surfaces."
 remains: "Publication must bind to an exact revision or named Version, preview the real audience closure, render every Block faithfully, isolate private collaboration, preserve lifecycle history, and become polished enough for dependable CMS use."
-required_capabilities: ["content.publish.public","content.publish.reading","content.access.visibility-closure"]
-enhancing_capabilities: ["content.version.branching","content.portability.pdf-export","content.property.guarded-change"]
+required_capabilities:
+  [
+    "content.publish.public",
+    "content.publish.reading",
+    "content.access.visibility-closure",
+  ]
+enhancing_capabilities:
+  [
+    "content.version.branching",
+    "content.portability.pdf-export",
+    "content.property.guarded-change",
+  ]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.publish-with-confidence.md
+++ b/templates/content/docs/product/features/content.feature.publish-with-confidence.md
@@ -1,0 +1,33 @@
+---
+record_type: "feature"
+id: "content.feature.publish-with-confidence"
+number: 28
+name: "Publish with confidence"
+chapter: "content.chapter.publishing-portability"
+order: 28
+roadmap_status: "partially_implemented"
+summary: "Publish one chosen revision faithfully while private collaborative work continues behind it."
+example_workflow: "An editor publishes the current approved article revision, continues working privately on a new Version, previews exactly what public readers can see, and updates the stable URL only when the replacement is ready."
+works_today: "Content already supports sharing, public Pages, stable links, several exports, access checks, and server-rendered public surfaces."
+remains: "Publication must bind to an exact revision or named Version, preview the real audience closure, render every Block faithfully, isolate private collaboration, preserve lifecycle history, and become polished enough for dependable CMS use."
+required_capabilities: ["content.publish.public","content.publish.reading","content.access.visibility-closure"]
+enhancing_capabilities: ["content.version.branching","content.portability.pdf-export","content.property.guarded-change"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 28: Publish with confidence
+
+Publish one chosen revision faithfully while private collaborative work continues behind it.
+
+## Product contract
+
+- **Publication object:** Binds one public destination to a Page, selected Version, and exact revision.
+- **Page-first publishing:** Keeps Publish, Update publication, and Unpublish inside the familiar Page sharing surface.
+- **Stable public URL:** Serves the last explicitly published truth rather than following every private edit automatically.
+- **Rich Block fidelity:** Renders every accepted Block family or a deliberate safe fallback through the shared semantic renderer.
+- **Audience preview:** Shows what the public reader can actually access before publication.
+- **Private-work separation:** Prevents Comments, Discussion, unpublished Versions, inaccessible assets, and internal Properties from leaking.
+- **Lifecycle history:** Records who published, updated, or withdrew which revision and preserves the public artifact's provenance.

--- a/templates/content/docs/product/features/content.feature.put-your-organizations-know-how-to-work.md
+++ b/templates/content/docs/product/features/content.feature.put-your-organizations-know-how-to-work.md
@@ -1,0 +1,32 @@
+---
+record_type: "feature"
+id: "content.feature.put-your-organizations-know-how-to-work"
+number: 15
+name: "Put your organization's know-how to work"
+chapter: "content.chapter.working-systems"
+order: 15
+roadmap_status: "planned"
+summary: "Govern reusable Skills so the agent offers the right instructions for the current person and object."
+example_workflow: "A writer selects a paragraph and opens Ask Agent; Content prioritizes the organization's approved voice-and-style Skill, explains that it will propose a replacement, and records the resulting edits when invoked."
+works_today: "The Agent Native framework already loads governed developer Skills, and Content provides selection context and the shared Agent chat for carrying out authorized work."
+remains: "Content needs a user-manageable Skills catalog, scope and compatibility rules, contextual discovery, specific-over-general ranking, clear mutation previews, and shared invocation for people and agents."
+required_capabilities: ["content.expression.catalog","content.agent.skill-catalog","content.agent.expression-authoring"]
+enhancing_capabilities: ["content.template.governance","content.command.fabric"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 15: Put your organization's know-how to work
+
+Govern reusable Skills so the agent offers the right instructions for the current person and object.
+
+## Product contract
+
+- **Skills catalog:** Stores governed instructions with personal, workspace, organization, or public-core scope.
+- **Compatibility:** Surfaces only Skills that apply to the current selection, Block, Page, Database, Property, or View.
+- **Scope precedence:** Ranks the most relevant allowed instruction without flooding the interface with the entire catalog.
+- **Declared effects:** Explains whether invocation proposes edits, replaces content, adds a Comment, or acts elsewhere.
+- **Shared invocation:** Lets people and agents use the same Skill through the ordinary Agent chat and Action fabric.
+- **Receipts:** Records what instruction ran, against which context, with which resulting actions.

--- a/templates/content/docs/product/features/content.feature.put-your-organizations-know-how-to-work.md
+++ b/templates/content/docs/product/features/content.feature.put-your-organizations-know-how-to-work.md
@@ -10,8 +10,14 @@ summary: "Govern reusable Skills so the agent offers the right instructions for 
 example_workflow: "A writer selects a paragraph and opens Ask Agent; Content prioritizes the organization's approved voice-and-style Skill, explains that it will propose a replacement, and records the resulting edits when invoked."
 works_today: "The Agent Native framework already loads governed developer Skills, and Content provides selection context and the shared Agent chat for carrying out authorized work."
 remains: "Content needs a user-manageable Skills catalog, scope and compatibility rules, contextual discovery, specific-over-general ranking, clear mutation previews, and shared invocation for people and agents."
-required_capabilities: ["content.expression.catalog","content.agent.skill-catalog","content.agent.expression-authoring"]
-enhancing_capabilities: ["content.template.governance","content.command.fabric"]
+required_capabilities:
+  [
+    "content.expression.catalog",
+    "content.agent.skill-catalog",
+    "content.agent.expression-authoring",
+  ]
+enhancing_capabilities:
+  ["content.template.governance", "content.command.fabric"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.read-and-annotate-anything.md
+++ b/templates/content/docs/product/features/content.feature.read-and-annotate-anything.md
@@ -10,8 +10,13 @@ summary: "Read comfortably, mark exact material, preserve revision context, and 
 example_workflow: "A researcher opens a PDF, adjusts the reading layout, highlights an exact passage, adds a durable Annotation, and later finds it from the Annotations rail even after the source receives a new revision."
 works_today: "Content already renders rich documents and media Blocks, supports anchored Comments, stores source representations, and has ordinary reading and export foundations."
 remains: "The dedicated Reader experience, durable Annotation object and rail, precise selectors across media, revision-aware anchoring, carry-forward, reading preferences, progress, dictation, and read-aloud are still planned."
-required_capabilities: ["content.reader.surface","content.research.annotation","content.author.media"]
-enhancing_capabilities: ["content.version.branching","content.source.adapters"]
+required_capabilities:
+  [
+    "content.reader.surface",
+    "content.research.annotation",
+    "content.author.media",
+  ]
+enhancing_capabilities: ["content.version.branching", "content.source.adapters"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.read-and-annotate-anything.md
+++ b/templates/content/docs/product/features/content.feature.read-and-annotate-anything.md
@@ -1,0 +1,33 @@
+---
+record_type: "feature"
+id: "content.feature.read-and-annotate-anything"
+number: 25
+name: "Read and annotate anything"
+chapter: "content.chapter.capture-research"
+order: 25
+roadmap_status: "planned"
+summary: "Read comfortably, mark exact material, preserve revision context, and find those Annotations again."
+example_workflow: "A researcher opens a PDF, adjusts the reading layout, highlights an exact passage, adds a durable Annotation, and later finds it from the Annotations rail even after the source receives a new revision."
+works_today: "Content already renders rich documents and media Blocks, supports anchored Comments, stores source representations, and has ordinary reading and export foundations."
+remains: "The dedicated Reader experience, durable Annotation object and rail, precise selectors across media, revision-aware anchoring, carry-forward, reading preferences, progress, dictation, and read-aloud are still planned."
+required_capabilities: ["content.reader.surface","content.research.annotation","content.author.media"]
+enhancing_capabilities: ["content.version.branching","content.source.adapters"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 25: Read and annotate anything
+
+Read comfortably, mark exact material, preserve revision context, and find those Annotations again.
+
+## Product contract
+
+- **Reader surface:** Provides personal typography, width, pagination, theme, progress, and distraction-free modes.
+- **Document and media representations:** Supports text, transcripts, PDFs, EPUBs, audio, video, and source-aware fallbacks over stable asset handles.
+- **Annotations:** Store durable highlights, notes, tags, reactions, or structured extractions independently from resolvable Comments.
+- **Precise selectors:** Anchor to text ranges, pages, regions, timestamps, transcript ranges, and the source revision being viewed.
+- **Annotations rail:** Reveals highlights only when opened and supports search, filtering, grouping, re-anchoring, and orphan repair.
+- **Carry-forward:** Moves a filtered set of relevant Annotations to another named Version without pretending every old anchor still exists.
+- **Speech:** Adds dictation and read-aloud through shared Agent Native capabilities rather than a Reader-only AI system.

--- a/templates/content/docs/product/features/content.feature.review-changes-in-place.md
+++ b/templates/content/docs/product/features/content.feature.review-changes-in-place.md
@@ -10,8 +10,15 @@ summary: "Accept or reject proposed human and agent changes in the ordinary Cont
 example_workflow: "An agent revises a live article and its metadata; the editor reviews the rendered Page, accepts the stronger passages, rejects an incorrect Property change, and leaves the remaining suggestions pending for another pass."
 works_today: "Source change sets, Builder review machinery, audit records, and document snapshots prove several parts of the review loop and provide useful donor implementations."
 remains: "Content needs one generic typed diff and suggestion system that reviews bodies, Properties, Blocks, and filtered record sets directly in their ordinary renderers."
-required_capabilities: ["content.diff.in-place","content.diff.filtered-review","content.revision.suggestions","content.event.committed","content.history.queryable"]
-enhancing_capabilities: ["content.diff.ai-assist","content.review.code"]
+required_capabilities:
+  [
+    "content.diff.in-place",
+    "content.diff.filtered-review",
+    "content.revision.suggestions",
+    "content.event.committed",
+    "content.history.queryable",
+  ]
+enhancing_capabilities: ["content.diff.ai-assist", "content.review.code"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.review-changes-in-place.md
+++ b/templates/content/docs/product/features/content.feature.review-changes-in-place.md
@@ -1,0 +1,32 @@
+---
+record_type: "feature"
+id: "content.feature.review-changes-in-place"
+number: 7
+name: "Review changes in place"
+chapter: "content.chapter.consensus"
+order: 7
+roadmap_status: "partially_implemented"
+summary: "Accept or reject proposed human and agent changes in the ordinary Content interface."
+example_workflow: "An agent revises a live article and its metadata; the editor reviews the rendered Page, accepts the stronger passages, rejects an incorrect Property change, and leaves the remaining suggestions pending for another pass."
+works_today: "Source change sets, Builder review machinery, audit records, and document snapshots prove several parts of the review loop and provide useful donor implementations."
+remains: "Content needs one generic typed diff and suggestion system that reviews bodies, Properties, Blocks, and filtered record sets directly in their ordinary renderers."
+required_capabilities: ["content.diff.in-place","content.diff.filtered-review","content.revision.suggestions","content.event.committed","content.history.queryable"]
+enhancing_capabilities: ["content.diff.ai-assist","content.review.code"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 7: Review changes in place
+
+Accept or reject proposed human and agent changes in the ordinary Content interface.
+
+## Product contract
+
+- **Suggestions:** Preserve a pending change set without mutating the canonical Page immediately.
+- **Typed diffs:** Compare body content, Properties, Blocks, and structured values through their normal renderers.
+- **Filtered review:** Review only the affected or relevant subset without losing dependent changes outside the current filter.
+- **Selective acceptance:** Accept all, reject all, or choose individual compatible changes without seven ceremonial confirmation screens.
+- **Stale changes:** Detect when the underlying material has moved and offer an honest rebase, refresh, or conflict state.
+- **Agent-authored work:** Group an agent run into one inspectable Revision whose changes remain attributable and recoverable.

--- a/templates/content/docs/product/features/content.feature.run-projects-your-way.md
+++ b/templates/content/docs/product/features/content.feature.run-projects-your-way.md
@@ -1,0 +1,33 @@
+---
+record_type: "feature"
+id: "content.feature.run-projects-your-way"
+number: 18
+name: "Run projects your way"
+chapter: "content.chapter.working-systems"
+order: 18
+roadmap_status: "partially_implemented"
+summary: "Use an editable Task and Project system built from ordinary Content rather than a second hidden engine."
+example_workflow: "A product team installs the blessed project Template, captures tasks from the keyboard, assigns owners, links subtasks and dependencies, and uses My Tasks while every task remains an ordinary editable Page."
+works_today: "Pages, Databases, status and person Properties, relations, Board and Calendar Views, Templates, Comments, and agent Actions already let teams assemble useful project systems."
+remains: "The blessed Template needs fast capture, polished defaults, task and subtask Views, My Tasks, activity, dependencies, permissions, and end-to-end Builder dogfooding without introducing a separate task engine."
+required_capabilities: ["content.system.task-project","content.system.my-tasks","content.system.dependencies","content.system.project-status"]
+enhancing_capabilities: ["content.view.fast-capture","content.relationship.edge","content.notification.source"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 18: Run projects your way
+
+Use an editable Task and Project system built from ordinary Content rather than a second hidden engine.
+
+## Product contract
+
+- **Blessed Template:** Provides a strong starting system that remains inspectable and editable like any other Content setup.
+- **Fast capture:** Creates work quickly with unambiguous View-derived defaults and useful keyboard navigation.
+- **Assignments:** Use ordinary typed Person and Team Properties with access-safe attention and notifications.
+- **Subtasks and dependencies:** Store hierarchy and blocking relationships through typed Relations with cycle protection.
+- **My Tasks:** Queries assigned work across authorized memberships without inventing a private task datastore.
+- **Project status:** Combines explicit owner judgment with useful rollups rather than pretending a formula can manage the project.
+- **Ordinary Pages:** Lets every Task retain rich content, Properties, Discussion, Versions, and the ability to join other Databases.

--- a/templates/content/docs/product/features/content.feature.run-projects-your-way.md
+++ b/templates/content/docs/product/features/content.feature.run-projects-your-way.md
@@ -10,8 +10,19 @@ summary: "Use an editable Task and Project system built from ordinary Content ra
 example_workflow: "A product team installs the blessed project Template, captures tasks from the keyboard, assigns owners, links subtasks and dependencies, and uses My Tasks while every task remains an ordinary editable Page."
 works_today: "Pages, Databases, status and person Properties, relations, Board and Calendar Views, Templates, Comments, and agent Actions already let teams assemble useful project systems."
 remains: "The blessed Template needs fast capture, polished defaults, task and subtask Views, My Tasks, activity, dependencies, permissions, and end-to-end Builder dogfooding without introducing a separate task engine."
-required_capabilities: ["content.system.task-project","content.system.my-tasks","content.system.dependencies","content.system.project-status"]
-enhancing_capabilities: ["content.view.fast-capture","content.relationship.edge","content.notification.source"]
+required_capabilities:
+  [
+    "content.system.task-project",
+    "content.system.my-tasks",
+    "content.system.dependencies",
+    "content.system.project-status",
+  ]
+enhancing_capabilities:
+  [
+    "content.view.fast-capture",
+    "content.relationship.edge",
+    "content.notification.source",
+  ]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.see-your-information-your-way.md
+++ b/templates/content/docs/product/features/content.feature.see-your-information-your-way.md
@@ -10,8 +10,19 @@ summary: "Move among compatible Database and Query Views without changing the re
 example_workflow: "A marketing team edits its editorial Database as a Table, plans work on a Board and Calendar, then gives executives a compact List of the same canonical articles."
 works_today: "Table, List, Board, Gallery, Calendar, Timeline, and Form renderers already exist, along with shared filters, sorts, grouping, calculations, and visible-field controls."
 remains: "Every renderer needs the same proven permissions, Actions, agent context, accessibility, persistence, performance, keyboard behavior, and recovery. Incomplete Views should remain gated until they pass that contract."
-required_capabilities: ["content.renderer.typed","content.view.query","content.view.renderer-conformance","content.view.scale"]
-enhancing_capabilities: ["content.view.fast-capture","content.view.grouping-aggregation","content.view.timeline"]
+required_capabilities:
+  [
+    "content.renderer.typed",
+    "content.view.query",
+    "content.view.renderer-conformance",
+    "content.view.scale",
+  ]
+enhancing_capabilities:
+  [
+    "content.view.fast-capture",
+    "content.view.grouping-aggregation",
+    "content.view.timeline",
+  ]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.see-your-information-your-way.md
+++ b/templates/content/docs/product/features/content.feature.see-your-information-your-way.md
@@ -1,0 +1,33 @@
+---
+record_type: "feature"
+id: "content.feature.see-your-information-your-way"
+number: 5
+name: "See your information your way"
+chapter: "content.chapter.durable-home"
+order: 5
+roadmap_status: "in_validation"
+summary: "Move among compatible Database and Query Views without changing the records underneath."
+example_workflow: "A marketing team edits its editorial Database as a Table, plans work on a Board and Calendar, then gives executives a compact List of the same canonical articles."
+works_today: "Table, List, Board, Gallery, Calendar, Timeline, and Form renderers already exist, along with shared filters, sorts, grouping, calculations, and visible-field controls."
+remains: "Every renderer needs the same proven permissions, Actions, agent context, accessibility, persistence, performance, keyboard behavior, and recovery. Incomplete Views should remain gated until they pass that contract."
+required_capabilities: ["content.renderer.typed","content.view.query","content.view.renderer-conformance","content.view.scale"]
+enhancing_capabilities: ["content.view.fast-capture","content.view.grouping-aggregation","content.view.timeline"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 5: See your information your way
+
+Move among compatible Database and Query Views without changing the records underneath.
+
+## Product contract
+
+- **Table and List:** Support fast scanning, keyboard navigation, inline editing, and flexible visible fields.
+- **Board and Gallery:** Arrange records by workflow state or visual identity while preserving canonical records.
+- **Calendar and Timeline:** Place records across dates and ranges through the same typed time Properties.
+- **Form:** Collect new records through a saved presentation of the Database's schema and validation.
+- **View controls:** Filter, sort, group, format, and conditionally style each presentation.
+- **Density:** Adjust compact, cozy, or comfortable spacing and secondary information without creating another View type.
+- **Renderer conformance:** Gives every View the same permissions, Actions, agent context, accessibility, persistence, and recovery contract.

--- a/templates/content/docs/product/features/content.feature.share-how-your-organization-works.md
+++ b/templates/content/docs/product/features/content.feature.share-how-your-organization-works.md
@@ -10,8 +10,14 @@ summary: "Govern reusable Templates, Properties, Expressions, and Custom Blocks 
 example_workflow: "An administrator publishes an approved editorial Template with governed Properties and Expressions; any team can inspect and adopt it, customize the local system, or detach without losing its existing records."
 works_today: "Content already has Templates and several reusable configuration surfaces, while source Properties and local components demonstrate governed and source-backed reuse patterns."
 remains: "Templates, Custom Properties, Expressions, and Custom Blocks need one understandable catalog model with ownership scope, inspection, adoption, local aliasing, provenance, and faithful detachment."
-required_capabilities: ["content.template.graph","content.template.governance","content.template.item-body"]
-enhancing_capabilities: ["content.property.catalog","content.organization.teams"]
+required_capabilities:
+  [
+    "content.template.graph",
+    "content.template.governance",
+    "content.template.item-body",
+  ]
+enhancing_capabilities:
+  ["content.property.catalog", "content.organization.teams"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.share-how-your-organization-works.md
+++ b/templates/content/docs/product/features/content.feature.share-how-your-organization-works.md
@@ -1,0 +1,32 @@
+---
+record_type: "feature"
+id: "content.feature.share-how-your-organization-works"
+number: 14
+name: "Share how your organization works"
+chapter: "content.chapter.working-systems"
+order: 14
+roadmap_status: "partially_implemented"
+summary: "Govern reusable Templates, Properties, Expressions, and Custom Blocks without taking ownership away from adopters."
+example_workflow: "An administrator publishes an approved editorial Template with governed Properties and Expressions; any team can inspect and adopt it, customize the local system, or detach without losing its existing records."
+works_today: "Content already has Templates and several reusable configuration surfaces, while source Properties and local components demonstrate governed and source-backed reuse patterns."
+remains: "Templates, Custom Properties, Expressions, and Custom Blocks need one understandable catalog model with ownership scope, inspection, adoption, local aliasing, provenance, and faithful detachment."
+required_capabilities: ["content.template.graph","content.template.governance","content.template.item-body"]
+enhancing_capabilities: ["content.property.catalog","content.organization.teams"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 14: Share how your organization works
+
+Govern reusable Templates, Properties, Expressions, and Custom Blocks without taking ownership away from adopters.
+
+## Product contract
+
+- **Templates:** Package Pages, Databases, Views, Properties, Rules, and content into reusable starting systems.
+- **Custom Properties:** Offer approved reusable field definitions without making every ordinary local column secretly global.
+- **Expressions:** Store reusable typed logic with personal, workspace, or organization scope.
+- **Catalog discovery:** Uses consistent names, descriptions, aliases, ownership, compatibility, and previews.
+- **Adoption:** Lets someone inspect a governed building block before binding it into their local system.
+- **Detachment:** Preserves the current data and behavior as a faithful local copy when someone leaves the shared lineage.

--- a/templates/content/docs/product/features/content.feature.sketch-connections-keep-whats-true.md
+++ b/templates/content/docs/product/features/content.feature.sketch-connections-keep-whats-true.md
@@ -10,8 +10,14 @@ summary: "Arrange canonical Content on a Canvas, sketch possible connections, an
 example_workflow: "A researcher arranges Sources, claims, and Annotations on a Canvas, draws tentative lines while thinking, and promotes only the strongest line into a typed Supports relationship that Queries and agents can use."
 works_today: "Canonical Pages, Blocks, references, relation Properties, Queries, and embeddable Views provide the objects and edges a spatial surface can eventually arrange."
 remains: "Canvas, view-local connectors, promotion into typed Relationships, semantic Graph editing, mind maps, force-directed layouts, and graph traversal remain planned capabilities."
-required_capabilities: ["content.view.canvas","content.view.graph","content.knowledge.graph","content.relationship.edge"]
-enhancing_capabilities: ["content.query.object","content.research.annotation"]
+required_capabilities:
+  [
+    "content.view.canvas",
+    "content.view.graph",
+    "content.knowledge.graph",
+    "content.relationship.edge",
+  ]
+enhancing_capabilities: ["content.query.object", "content.research.annotation"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.sketch-connections-keep-whats-true.md
+++ b/templates/content/docs/product/features/content.feature.sketch-connections-keep-whats-true.md
@@ -1,0 +1,33 @@
+---
+record_type: "feature"
+id: "content.feature.sketch-connections-keep-whats-true"
+number: 27
+name: "Sketch connections, keep what's true"
+chapter: "content.chapter.capture-research"
+order: 27
+roadmap_status: "planned"
+summary: "Arrange canonical Content on a Canvas, sketch possible connections, and promote only meaningful typed Relationships."
+example_workflow: "A researcher arranges Sources, claims, and Annotations on a Canvas, draws tentative lines while thinking, and promotes only the strongest line into a typed Supports relationship that Queries and agents can use."
+works_today: "Canonical Pages, Blocks, references, relation Properties, Queries, and embeddable Views provide the objects and edges a spatial surface can eventually arrange."
+remains: "Canvas, view-local connectors, promotion into typed Relationships, semantic Graph editing, mind maps, force-directed layouts, and graph traversal remain planned capabilities."
+required_capabilities: ["content.view.canvas","content.view.graph","content.knowledge.graph","content.relationship.edge"]
+enhancing_capabilities: ["content.query.object","content.research.annotation"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 27: Sketch connections, keep what's true
+
+Arrange canonical Content on a Canvas, sketch possible connections, and promote only meaningful typed Relationships.
+
+## Product contract
+
+- **Canvas:** Places Pages, Blocks, Sources, Annotations, media, Views, and Query results in an intentional spatial arrangement.
+- **Reusable objects:** Keeps every card or node connected to its canonical Content identity instead of becoming a canvas-only copy.
+- **Visual connectors:** Supports brainstorming lines that remain local to the Canvas until their meaning is known.
+- **Promote to Relationship:** Turns a chosen connector into a named typed edge that becomes queryable everywhere.
+- **Semantic Graph mode:** Creates an already-selected Relationship type directly when the person is deliberately editing the graph.
+- **Mind maps and layouts:** Offer hierarchical, grouped, and force-directed arrangements over the same objects and edges.
+- **Graph exploration:** Later adds traversal, paths, cycles, ranking, and pattern queries after the relationship substrate is proven.

--- a/templates/content/docs/product/features/content.feature.take-the-whole-vault-with-you.md
+++ b/templates/content/docs/product/features/content.feature.take-the-whole-vault-with-you.md
@@ -1,0 +1,33 @@
+---
+record_type: "feature"
+id: "content.feature.take-the-whole-vault-with-you"
+number: 29
+name: "Take the whole vault with you"
+chapter: "content.chapter.publishing-portability"
+order: 29
+roadmap_status: "partially_implemented"
+summary: "Export the complete authorized vault into open, understandable formats and a lossless Content archive."
+example_workflow: "An organization exports every object the acting administrator can access into an open Markdown, CSV, assets, and manifest vault plus a lossless Content archive, then verifies the package without Content."
+works_today: "Content exports Page bodies as Markdown, HTML, and PDF-shaped output and can export editable Markdown or MDX source, with local-file workflows already proving part of the portability model."
+remains: "Whole-vault export needs CSV, assets, an open manifest, a lossless Content archive, Notion-compatible packaging, authorized dependency closure, resumable jobs, verification, and Desktop backup."
+required_capabilities: ["content.portability.vault-export","content.portability.roundtrip","content.job.durable"]
+enhancing_capabilities: ["content.portability.pdf-export","content.source.local-bridge"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 29: Take the whole vault with you
+
+Export the complete authorized vault into open, understandable formats and a lossless Content archive.
+
+## Product contract
+
+- **Open vault:** Uses Markdown or MDX, CSV, ordinary asset folders, and a small manifest for stable IDs and richer semantics.
+- **Lossless Content archive:** Preserves Versions, Discussion, Comments, Annotations, Rules, provenance, and other Content-specific meaning.
+- **Target packages:** Produces destination-aware exports, beginning with a Notion-compatible package and conversion report.
+- **Authorized closure:** Materializes exactly what the exporter can currently see without leaking inaccessible dependencies.
+- **Assets and Sources:** Includes authorized files or stable handles and reports anything that could not be resolved.
+- **Durable transfer job:** Supports progress, interruption, retry, and resume without duplicating work.
+- **Local backup:** Lets Desktop maintain a user-chosen portable vault separately from its fast disposable cache.

--- a/templates/content/docs/product/features/content.feature.take-the-whole-vault-with-you.md
+++ b/templates/content/docs/product/features/content.feature.take-the-whole-vault-with-you.md
@@ -10,8 +10,14 @@ summary: "Export the complete authorized vault into open, understandable formats
 example_workflow: "An organization exports every object the acting administrator can access into an open Markdown, CSV, assets, and manifest vault plus a lossless Content archive, then verifies the package without Content."
 works_today: "Content exports Page bodies as Markdown, HTML, and PDF-shaped output and can export editable Markdown or MDX source, with local-file workflows already proving part of the portability model."
 remains: "Whole-vault export needs CSV, assets, an open manifest, a lossless Content archive, Notion-compatible packaging, authorized dependency closure, resumable jobs, verification, and Desktop backup."
-required_capabilities: ["content.portability.vault-export","content.portability.roundtrip","content.job.durable"]
-enhancing_capabilities: ["content.portability.pdf-export","content.source.local-bridge"]
+required_capabilities:
+  [
+    "content.portability.vault-export",
+    "content.portability.roundtrip",
+    "content.job.durable",
+  ]
+enhancing_capabilities:
+  ["content.portability.pdf-export", "content.source.local-bridge"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.trust-your-connected-sources.md
+++ b/templates/content/docs/product/features/content.feature.trust-your-connected-sources.md
@@ -1,0 +1,33 @@
+---
+record_type: "feature"
+id: "content.feature.trust-your-connected-sources"
+number: 10
+name: "Trust your connected Sources"
+chapter: "content.chapter.connected-sources"
+order: 10
+roadmap_status: "partially_implemented"
+summary: "Keep supported edits synchronized according to one plain-language policy without silently losing provider-specific content."
+example_workflow: "An editor updates a Builder article from Content; the supported changes synchronize, an unknown Builder component survives untouched, and changing Draft to Published remains a separate guarded action."
+works_today: "Builder change sets, guarded writes, raw sidecars, local-folder synchronization, and source metadata already preserve several difficult round-trip and conflict boundaries."
+remains: "Every adapter needs certification against one plain-language sync policy, seamless automatic synchronization where safe, faithful unknown-content preservation, explicit lifecycle changes, and dependable receipts."
+required_capabilities: ["content.source.sync-policy","content.portability.roundtrip","content.source.adapters","content.source.builder-codec"]
+enhancing_capabilities: ["content.property.guarded-change","content.event.committed"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 10: Trust your connected Sources
+
+Keep supported edits synchronized according to one plain-language policy without silently losing provider-specific content.
+
+## Product contract
+
+- **View only:** Pulls authorized changes into Content and never writes back.
+- **Keep in sync:** Moves compatible changes in both directions automatically and interrupts only for a genuine conflict.
+- **Review before write-back:** Bundles Content-originated changes into one reviewable set when the workflow requires care.
+- **Faithful round-tripping:** Preserves unknown provider-owned structures even when Content cannot render or edit them.
+- **Conflict handling:** Uses stable identity and base revisions to prevent silent last-writer-wins data loss.
+- **Provider lifecycle:** Treats states such as Draft and Published as explicit guarded changes rather than side effects of ordinary editing.
+- **Receipts and retries:** Confirms what the provider actually accepted and retries without duplicating effects.

--- a/templates/content/docs/product/features/content.feature.trust-your-connected-sources.md
+++ b/templates/content/docs/product/features/content.feature.trust-your-connected-sources.md
@@ -10,8 +10,15 @@ summary: "Keep supported edits synchronized according to one plain-language poli
 example_workflow: "An editor updates a Builder article from Content; the supported changes synchronize, an unknown Builder component survives untouched, and changing Draft to Published remains a separate guarded action."
 works_today: "Builder change sets, guarded writes, raw sidecars, local-folder synchronization, and source metadata already preserve several difficult round-trip and conflict boundaries."
 remains: "Every adapter needs certification against one plain-language sync policy, seamless automatic synchronization where safe, faithful unknown-content preservation, explicit lifecycle changes, and dependable receipts."
-required_capabilities: ["content.source.sync-policy","content.portability.roundtrip","content.source.adapters","content.source.builder-codec"]
-enhancing_capabilities: ["content.property.guarded-change","content.event.committed"]
+required_capabilities:
+  [
+    "content.source.sync-policy",
+    "content.portability.roundtrip",
+    "content.source.adapters",
+    "content.source.builder-codec",
+  ]
+enhancing_capabilities:
+  ["content.property.guarded-change", "content.event.committed"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.understand-what-your-data-says.md
+++ b/templates/content/docs/product/features/content.feature.understand-what-your-data-says.md
@@ -1,0 +1,33 @@
+---
+record_type: "feature"
+id: "content.feature.understand-what-your-data-says"
+number: 22
+name: "Understand what your data says"
+chapter: "content.chapter.working-systems"
+order: 22
+roadmap_status: "partially_implemented"
+summary: "Use Charts, Pivots, grouping, measures, and drill-down without creating a separate analytics datastore."
+example_workflow: "A marketing analyst groups campaigns by channel, compares spend and conversions in a Chart and Pivot, then drills into one surprising aggregate to inspect the canonical campaigns behind it."
+works_today: "Database calculations, grouping, rollup foundations, and chart tooling elsewhere in the Agent Native framework provide useful implementation donors."
+remains: "Content needs typed aggregations, multi-dimensional grouping, Pivot, a shared Chart specification and renderer library, saved Chart Views, embeddable Chart Blocks, and drill-down to canonical records."
+required_capabilities: ["content.view.grouping-aggregation","content.view.pivot","content.view.chart","content.access.safe-aggregate"]
+enhancing_capabilities: ["content.renderer.typed","content.view.query"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 22: Understand what your data says
+
+Use Charts, Pivots, grouping, measures, and drill-down without creating a separate analytics datastore.
+
+## Product contract
+
+- **Multiple grouping dimensions:** Partitions typed Query results consistently across Views.
+- **Measures and totals:** Compute access-safe counts, sums, averages, subtotals, and grand totals.
+- **Charts:** Share one typed chart specification and renderer toolkit with Agent Native Analytics.
+- **Pivot:** Places dimensions on rows and columns with typed aggregations in cells.
+- **Drill-down:** Opens the canonical records behind an aggregate instead of turning cells into independent data.
+- **Accessible summaries:** Explains the chart or pivot meaning beyond color, shape, or pointer interaction.
+- **Static fidelity:** Preserves useful output in public Pages, presentations, and exports.

--- a/templates/content/docs/product/features/content.feature.understand-what-your-data-says.md
+++ b/templates/content/docs/product/features/content.feature.understand-what-your-data-says.md
@@ -10,8 +10,14 @@ summary: "Use Charts, Pivots, grouping, measures, and drill-down without creatin
 example_workflow: "A marketing analyst groups campaigns by channel, compares spend and conversions in a Chart and Pivot, then drills into one surprising aggregate to inspect the canonical campaigns behind it."
 works_today: "Database calculations, grouping, rollup foundations, and chart tooling elsewhere in the Agent Native framework provide useful implementation donors."
 remains: "Content needs typed aggregations, multi-dimensional grouping, Pivot, a shared Chart specification and renderer library, saved Chart Views, embeddable Chart Blocks, and drill-down to canonical records."
-required_capabilities: ["content.view.grouping-aggregation","content.view.pivot","content.view.chart","content.access.safe-aggregate"]
-enhancing_capabilities: ["content.renderer.typed","content.view.query"]
+required_capabilities:
+  [
+    "content.view.grouping-aggregation",
+    "content.view.pivot",
+    "content.view.chart",
+    "content.access.safe-aggregate",
+  ]
+enhancing_capabilities: ["content.renderer.typed", "content.view.query"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.when-this-happens-that-follows.md
+++ b/templates/content/docs/product/features/content.feature.when-this-happens-that-follows.md
@@ -10,8 +10,18 @@ summary: "React to committed Events with visible, governed Actions, retries, not
 example_workflow: "When a qualified lead enters a Database, a Rule assigns the owner, asks an agent for a bounded summary, sends the right notification, and leaves one receipt showing every action and retry."
 works_today: "Shared Actions, audit history, a framework scheduler, notifications, Automations, provider effects, and active Event and Rule work already cover much of the execution substrate."
 remains: "Content needs one durable Event spine and Rule model with atomic claims, retries, idempotency, agent effects, notification routing, receipts, and a humane inspection surface."
-required_capabilities: ["content.event.committed","content.rule.deterministic","content.agent.action-parity"]
-enhancing_capabilities: ["content.automation.scheduled","content.action.button","content.agent.automation"]
+required_capabilities:
+  [
+    "content.event.committed",
+    "content.rule.deterministic",
+    "content.agent.action-parity",
+  ]
+enhancing_capabilities:
+  [
+    "content.automation.scheduled",
+    "content.action.button",
+    "content.agent.automation",
+  ]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.when-this-happens-that-follows.md
+++ b/templates/content/docs/product/features/content.feature.when-this-happens-that-follows.md
@@ -1,0 +1,33 @@
+---
+record_type: "feature"
+id: "content.feature.when-this-happens-that-follows"
+number: 17
+name: "When this happens, that follows"
+chapter: "content.chapter.working-systems"
+order: 17
+roadmap_status: "partially_implemented"
+summary: "React to committed Events with visible, governed Actions, retries, notifications, and receipts."
+example_workflow: "When a qualified lead enters a Database, a Rule assigns the owner, asks an agent for a bounded summary, sends the right notification, and leaves one receipt showing every action and retry."
+works_today: "Shared Actions, audit history, a framework scheduler, notifications, Automations, provider effects, and active Event and Rule work already cover much of the execution substrate."
+remains: "Content needs one durable Event spine and Rule model with atomic claims, retries, idempotency, agent effects, notification routing, receipts, and a humane inspection surface."
+required_capabilities: ["content.event.committed","content.rule.deterministic","content.agent.action-parity"]
+enhancing_capabilities: ["content.automation.scheduled","content.action.button","content.agent.automation"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 17: When this happens, that follows
+
+React to committed Events with visible, governed Actions, retries, notifications, and receipts.
+
+## Product contract
+
+- **Events:** Provide atomic facts about what committed, who or what caused it, and which objects changed.
+- **Rules:** Match typed conditions after commit without becoming a second expression or permission engine.
+- **Actions:** Invoke the same operations available to the interface and agents.
+- **Schedules and heartbeats:** Use the framework's single scheduler for time-based conditions and missed-run policy.
+- **Buttons:** Give owners an explicit interface for invoking governed Actions with known inputs and consequences.
+- **Agent effects:** Delegate bounded work without granting the Rule more authority than its actor or policy permits.
+- **Receipts and retries:** Preserve exactly-once claims, crash recovery, honest skips, and queryable outcomes.

--- a/templates/content/docs/product/features/content.feature.work-across-every-workspace.md
+++ b/templates/content/docs/product/features/content.feature.work-across-every-workspace.md
@@ -10,8 +10,13 @@ summary: "Search and save Queries across Personal and organization contexts with
 example_workflow: "A person searches their current Workspace, deliberately expands to all accessible contexts, saves a Query spanning Personal and two organizations, and shares it with someone who sees only their own authorized intersection."
 works_today: "Content has Personal and organization spaces, Workspace membership, scoped access checks, and the beginnings of cross-space navigation and search."
 remains: "Active working context must separate cleanly from retrieval scope, while global Home, cross-context Queries, counts, aggregates, and viewer-specific evaluation need complete implementation."
-required_capabilities: ["content.workspace.multi-scope","content.query.object","content.access.visibility-closure"]
-enhancing_capabilities: ["content.home.global","content.organization.teams"]
+required_capabilities:
+  [
+    "content.workspace.multi-scope",
+    "content.query.object",
+    "content.access.visibility-closure",
+  ]
+enhancing_capabilities: ["content.home.global", "content.organization.teams"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.work-across-every-workspace.md
+++ b/templates/content/docs/product/features/content.feature.work-across-every-workspace.md
@@ -1,0 +1,32 @@
+---
+record_type: "feature"
+id: "content.feature.work-across-every-workspace"
+number: 11
+name: "Work across every workspace"
+chapter: "content.chapter.connected-sources"
+order: 11
+roadmap_status: "partially_implemented"
+summary: "Search and save Queries across Personal and organization contexts without widening anyone's access."
+example_workflow: "A person searches their current Workspace, deliberately expands to all accessible contexts, saves a Query spanning Personal and two organizations, and shares it with someone who sees only their own authorized intersection."
+works_today: "Content has Personal and organization spaces, Workspace membership, scoped access checks, and the beginnings of cross-space navigation and search."
+remains: "Active working context must separate cleanly from retrieval scope, while global Home, cross-context Queries, counts, aggregates, and viewer-specific evaluation need complete implementation."
+required_capabilities: ["content.workspace.multi-scope","content.query.object","content.access.visibility-closure"]
+enhancing_capabilities: ["content.home.global","content.organization.teams"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 11: Work across every workspace
+
+Search and save Queries across Personal and organization contexts without widening anyone's access.
+
+## Product contract
+
+- **Active context:** Determines where new work is created and which organization or Personal surface governs it.
+- **Retrieval scope:** Can widen deliberately beyond the active context without moving or re-authorizing objects.
+- **Cross-workspace Search:** Expands from the current Workspace to every accessible context through an explicit control.
+- **Cross-workspace Queries:** Save durable, shareable definitions that retain each source object's location and provenance.
+- **Viewer evaluation:** Shows every reader only the intersection they can access, including counts and aggregates.
+- **Global Home:** Composes authorized recent work, Queries, and dashboards without pretending everything belongs to one giant Workspace.

--- a/templates/content/docs/product/features/content.feature.work-on-content-inside-another-application.md
+++ b/templates/content/docs/product/features/content.feature.work-on-content-inside-another-application.md
@@ -10,8 +10,13 @@ summary: "Mount and edit the same canonical Content object inside an authorized 
 example_workflow: "A planner mounts the canonical project brief inside another Agent Native app, edits it through the same Actions, and sees the change, history, and permissions remain identical when opening it later in Content."
 works_today: "Agent Native toolkits already share Content components across sibling apps, and Content exposes reusable Actions and object identities that hosts can call without duplicating business logic."
 remains: "A canonical embeddable surface needs host grants, viewer-scoped authorization, shared editing and history, stable mounting contracts, responsive presentation, and later MCP App compatibility."
-required_capabilities: ["content.embed.surface","content.embed.host-grant","content.agent.action-parity"]
-enhancing_capabilities: ["content.embed.mcp-app","content.layout.responsive"]
+required_capabilities:
+  [
+    "content.embed.surface",
+    "content.embed.host-grant",
+    "content.agent.action-parity",
+  ]
+enhancing_capabilities: ["content.embed.mcp-app", "content.layout.responsive"]
 increments: []
 feature_proof: null
 publicness: "public"

--- a/templates/content/docs/product/features/content.feature.work-on-content-inside-another-application.md
+++ b/templates/content/docs/product/features/content.feature.work-on-content-inside-another-application.md
@@ -1,0 +1,32 @@
+---
+record_type: "feature"
+id: "content.feature.work-on-content-inside-another-application"
+number: 31
+name: "Work on Content inside another application"
+chapter: "content.chapter.publishing-portability"
+order: 31
+roadmap_status: "planned"
+summary: "Mount and edit the same canonical Content object inside an authorized host without forking identity or permissions."
+example_workflow: "A planner mounts the canonical project brief inside another Agent Native app, edits it through the same Actions, and sees the change, history, and permissions remain identical when opening it later in Content."
+works_today: "Agent Native toolkits already share Content components across sibling apps, and Content exposes reusable Actions and object identities that hosts can call without duplicating business logic."
+remains: "A canonical embeddable surface needs host grants, viewer-scoped authorization, shared editing and history, stable mounting contracts, responsive presentation, and later MCP App compatibility."
+required_capabilities: ["content.embed.surface","content.embed.host-grant","content.agent.action-parity"]
+enhancing_capabilities: ["content.embed.mcp-app","content.layout.responsive"]
+increments: []
+feature_proof: null
+publicness: "public"
+last_reviewed: "2026-07-29"
+---
+
+# Feature 31: Work on Content inside another application
+
+Mount and edit the same canonical Content object inside an authorized host without forking identity or permissions.
+
+## Product contract
+
+- **Canonical mount:** Renders the actual Page, View, or focused Content surface rather than a copied snapshot.
+- **Host grant:** Gives one named application only the mount and Action capabilities it needs.
+- **Viewer authority:** Never lets the host widen what the signed-in person could see or edit in Content itself.
+- **Shared Actions:** Routes edits through the same validation, permissions, Events, history, and agent surface.
+- **Agent Native toolkits:** Reuse common components and behavior across sibling applications without coupling them to the Content app shell.
+- **MCP App widening:** Later exposes the same governed surface to compatible external agent hosts once identity and presentation contracts are proven.

--- a/templates/content/docs/product/roadmap.md
+++ b/templates/content/docs/product/roadmap.md
@@ -349,7 +349,7 @@ Open a folder or repository through the same Source model while keeping device a
 - **Queued edits:** Holds permitted source-owned changes with their base revision until an authorized bridge returns.
 - **Portable vault:** Keeps the human-readable folder separate from disposable caches and any particular desktop application bundle.
 
-**Required capability records:** [Local Source bridge](capabilities/content.source.local-bridge.md), [Files and folders as Sources](capabilities/content.source.file-folder.md), [Portable source representation](capabilities/content.portability.source-representation.md), [Whole-vault export](capabilities/content.portability.vault-export.md)
+**Required capability records:** [Local Source bridge](capabilities/content.source.local-bridge.md), [Files and folders as Sources](capabilities/content.source.file-folder.md), [Portable Source representation](capabilities/content.portability.source-representation.md), [Portable vault export](capabilities/content.portability.vault-export.md)
 
 **Enhancing capability records:** [Source adapters](capabilities/content.source.adapters.md), [Source sync policy](capabilities/content.source.sync-policy.md)
 
@@ -583,7 +583,7 @@ Build Forms over the same schema, validation, and submission Actions as the Data
 
 **Required capability records:** [Shared Form engine](capabilities/content.form.shared-engine.md), [Property validation and defaults](capabilities/content.property.constraints.md), [Agent and UI parity](capabilities/content.agent.action-parity.md), [Committed Events](capabilities/content.event.committed.md)
 
-**Enhancing capability records:** [Rules](capabilities/content.rule.deterministic.md), [Durable background jobs](capabilities/content.job.durable.md)
+**Enhancing capability records:** [Rules](capabilities/content.rule.deterministic.md), [Durable Content jobs](capabilities/content.job.durable.md)
 
 ### Feature 22: Understand what your data says
 
@@ -632,7 +632,7 @@ Compose responsive Views, Charts, expressions, controls, and prose into durable 
 - **Live context:** Keeps prose, decisions, metrics, and the underlying records together for people and agents.
 - **Presentation mode:** Reuses shared Slides primitives to present Pages or ordered records without inventing slide-only content.
 
-**Required capability records:** [Responsive Page layout](capabilities/content.layout.responsive.md), [Chart View](capabilities/content.view.chart.md), [Embeddable Content surfaces](capabilities/content.embed.surface.md)
+**Required capability records:** [Responsive Page layout](capabilities/content.layout.responsive.md), [Chart View](capabilities/content.view.chart.md), [Embedded Content surface](capabilities/content.embed.surface.md)
 
 **Enhancing capability records:** [Presentation mode](capabilities/content.presentation.mode.md), [Typed expression language](capabilities/content.expression.language.md)
 
@@ -662,7 +662,7 @@ Resolve or create one canonical Page in the chosen Database, preserve provenance
 - **Downstream enrichment:** Lets target-owned Rules and agents summarize, classify, extract, or route the record without making Capture wait for them.
 - **Receipts and repair:** Reports what Capture created or reused and allows failed later enrichment to retry independently.
 
-**Required capability records:** [Capture and enrichment](capabilities/content.capture.enrich.md), [Sources catalog](capabilities/content.source.catalog.md), [Durable background jobs](capabilities/content.job.durable.md)
+**Required capability records:** [Capture and enrichment](capabilities/content.capture.enrich.md), [Sources catalog](capabilities/content.source.catalog.md), [Durable Content jobs](capabilities/content.job.durable.md)
 
 **Enhancing capability records:** [Rules](capabilities/content.rule.deterministic.md), [Multi-object Templates](capabilities/content.template.graph.md)
 
@@ -770,9 +770,9 @@ Publish one chosen revision faithfully while private collaborative work continue
 - **Private-work separation:** Prevents Comments, Discussion, unpublished Versions, inaccessible assets, and internal Properties from leaking.
 - **Lifecycle history:** Records who published, updated, or withdrew which revision and preserves the public artifact's provenance.
 
-**Required capability records:** [Public publishing](capabilities/content.publish.public.md), [Public reading](capabilities/content.publish.reading.md), [Visibility closure](capabilities/content.access.visibility-closure.md)
+**Required capability records:** [Public publication](capabilities/content.publish.public.md), [Public reading](capabilities/content.publish.reading.md), [Visibility closure](capabilities/content.access.visibility-closure.md)
 
-**Enhancing capability records:** [Named Page Versions](capabilities/content.version.branching.md), [PDF and print export](capabilities/content.portability.pdf-export.md), [Guarded property changes](capabilities/content.property.guarded-change.md)
+**Enhancing capability records:** [Named Page Versions](capabilities/content.version.branching.md), [PDF export](capabilities/content.portability.pdf-export.md), [Guarded property changes](capabilities/content.property.guarded-change.md)
 
 ### Feature 29: Take the whole vault with you
 
@@ -796,9 +796,9 @@ Export the complete authorized vault into open, understandable formats and a los
 - **Durable transfer job:** Supports progress, interruption, retry, and resume without duplicating work.
 - **Local backup:** Lets Desktop maintain a user-chosen portable vault separately from its fast disposable cache.
 
-**Required capability records:** [Whole-vault export](capabilities/content.portability.vault-export.md), [Faithful round-tripping](capabilities/content.portability.roundtrip.md), [Durable background jobs](capabilities/content.job.durable.md)
+**Required capability records:** [Portable vault export](capabilities/content.portability.vault-export.md), [Faithful round-tripping](capabilities/content.portability.roundtrip.md), [Durable Content jobs](capabilities/content.job.durable.md)
 
-**Enhancing capability records:** [PDF and print export](capabilities/content.portability.pdf-export.md), [Local Source bridge](capabilities/content.source.local-bridge.md)
+**Enhancing capability records:** [PDF export](capabilities/content.portability.pdf-export.md), [Local Source bridge](capabilities/content.source.local-bridge.md)
 
 ### Feature 30: Move without starting over
 
@@ -822,7 +822,7 @@ Import or migrate a foreign corpus with resumable progress, provenance, repair, 
 - **Repair workflows:** Lets people and agents inspect unresolved mappings, missing assets, conflicts, and partial failures.
 - **Provenance:** Keeps enough source context to compare, refresh, or understand the imported material later.
 
-**Required capability records:** [Durable background jobs](capabilities/content.job.durable.md), [Source adapters](capabilities/content.source.adapters.md), [Faithful round-tripping](capabilities/content.portability.roundtrip.md)
+**Required capability records:** [Durable Content jobs](capabilities/content.job.durable.md), [Source adapters](capabilities/content.source.adapters.md), [Faithful round-tripping](capabilities/content.portability.roundtrip.md)
 
 **Enhancing capability records:** [Sources catalog](capabilities/content.source.catalog.md), [Committed Events](capabilities/content.event.committed.md)
 
@@ -847,7 +847,7 @@ Mount and edit the same canonical Content object inside an authorized host witho
 - **Agent Native toolkits:** Reuse common components and behavior across sibling applications without coupling them to the Content app shell.
 - **MCP App widening:** Later exposes the same governed surface to compatible external agent hosts once identity and presentation contracts are proven.
 
-**Required capability records:** [Embeddable Content surfaces](capabilities/content.embed.surface.md), [Embedded host grants](capabilities/content.embed.host-grant.md), [Agent and UI parity](capabilities/content.agent.action-parity.md)
+**Required capability records:** [Embedded Content surface](capabilities/content.embed.surface.md), [Embedded host grants](capabilities/content.embed.host-grant.md), [Agent and UI parity](capabilities/content.agent.action-parity.md)
 
 **Enhancing capability records:** [MCP App embedding](capabilities/content.embed.mcp-app.md), [Responsive Page layout](capabilities/content.layout.responsive.md)
 
@@ -873,6 +873,6 @@ Add user-controlled encrypted custody without abandoning collaboration, recovery
 - **Portable exit:** Allows the owner to export readable authorized content and keys without permanent service dependence.
 - **Paused boundary:** Retains the existing E2EE research and implementation history without claiming the complete workflow is ready.
 
-**Required capability records:** [Private vault encryption](capabilities/content.security.private-vault.md), [Agent resource consent](capabilities/content.agent.resource-consent.md), [Whole-vault export](capabilities/content.portability.vault-export.md)
+**Required capability records:** [Private vault encryption](capabilities/content.security.private-vault.md), [Agent resource consent](capabilities/content.agent.resource-consent.md), [Portable vault export](capabilities/content.portability.vault-export.md)
 
 **Enhancing capability records:** [Local Source bridge](capabilities/content.source.local-bridge.md), [Audience-safe synthesis](capabilities/content.agent.audience-safe.md)

--- a/templates/content/docs/product/roadmap.md
+++ b/templates/content/docs/product/roadmap.md
@@ -1,0 +1,878 @@
+# Agent Native Content public roadmap
+
+<!-- Generated from the atomic records in chapters/, features/, and capabilities/. Do not edit this projection directly. -->
+
+Agent Native Content brings documents, data, connected sources, collaboration, and agent work into one durable place. People and agents work on the same real objects through the same permissions and operations. The result is a workspace that can begin as a Page, grow into a system, and remain understandable, portable, and recoverable as more people and automations become involved.
+
+## How to read this roadmap
+
+Content is grouped into six implementation Chapters. Numbered Features describe complete vertical workflows that people can understand and use. Atomic capabilities may arrive piece by piece, but a Feature is not complete until its example workflow works end to end.
+
+Feature statuses:
+
+- **Available:** The complete workflow works for people and agents with the correct permissions, persistence, recovery, accessibility, and polish.
+- **In validation:** The complete workflow exists and is being hardened before becoming Available.
+- **Partially implemented:** Meaningful parts exist, but the workflow is not yet reliable or proven end to end.
+- **Planned:** The Feature is approved and ordered, but does not yet have enough implementation to describe as active.
+- **Paused:** Work deliberately stopped while its research and implementation history remain preserved.
+
+No Feature is marked Available yet. Existing foundations are useful, but the complete workflows still need the polish and proof described below.
+
+## Chapter 1: A durable home for your thinking
+
+Chapter 1 gives people and agents a dependable place to create, organize, find, reshape, and recover their work. Pages and Databases remain understandable after an interruption, important material can be reused without drifting copies, and every authorized collaborator can return to the same durable context. The following Features establish that foundation.
+
+### Feature 1: Durable foundations
+
+Pages, Blocks, Databases, Search, history, and recovery form one trustworthy material loop.
+
+**Status:** In validation
+
+**Example workflow:** A teammate creates a project brief, turns its action items into Database records with owners and due dates, closes the app, finds the work again through Search, restores an accidentally deleted Block, and asks an agent to continue from the same durable context.
+
+**What works today:** Content already has SQL-backed Pages, rich Blocks, Databases, Search, document snapshots, and a broad agent Action surface. People and agents can perform much of the ordinary creation and editing loop on the same durable objects.
+
+**What remains:** Stable Block identity, actor-aware history, dependable recovery across every object type, and complete end-to-end action parity still need to become one polished foundation.
+
+**What this Feature includes:**
+
+- **Pages:** Hold durable identity, access, properties, rich content, and the context required to resume work.
+- **Blocks:** Give every editable rich-content body the same composable grammar, whether it belongs to a Page, Property, Comment, or message.
+- **Databases:** Govern writable collections, membership, typed Properties, validation, defaults, Rules, and the canonical path for creating records.
+- **Search:** Finds only what the current person can access and opens the exact object or context they were looking for.
+- **History:** Records attributable committed Events and logical Revisions without turning every keystroke into a fake milestone.
+- **Recovery:** Restores deleted or changed work without discarding the history that explains what happened.
+- **Agent parity:** Lets agents perform the same authorized operations through the same Action surface rather than a second, weaker API.
+
+**Required capability records:** [Pages](capabilities/content.object.page.md), [Blocks](capabilities/content.object.block.md), [Blocks fields](capabilities/content.object.blocks-field.md), [Databases](capabilities/content.object.database.md), [Search](capabilities/content.knowledge.search.md), [Committed Events](capabilities/content.event.committed.md), [History](capabilities/content.history.queryable.md), [Agent and UI parity](capabilities/content.agent.action-parity.md)
+
+**Enhancing capability records:** [Blocks-field revision history](capabilities/content.version.field-history.md), [Actor properties](capabilities/content.property.actor.md), [Document editor](capabilities/content.author.document-editor.md)
+
+### Feature 2: Find your place again
+
+Content makes arrival, navigation, and resumption feel dependable instead of asking people to remember where they left everything.
+
+**Status:** Partially implemented
+
+**Example workflow:** A new teammate follows an invitation, lands in the correct organization and Workspace, pins the project they care about, and later returns directly to the exact Database View they were using.
+
+**What works today:** Content has Personal and organization-backed spaces, Workspace navigation, invitations, sidebar structure, and saved location state in varying degrees of maturity.
+
+**What remains:** Global Home, clearer context switching, intentional pinning and dynamic sidebar sections, and reliable resumption into the exact focused View need to work as one arrival experience.
+
+**What this Feature includes:**
+
+- **Home:** Gives each person a top-level view across the Personal and organization contexts they can access.
+- **Workspaces:** Organize Pages and Databases beneath Personal or an Organization without becoming the permission model themselves.
+- **Sidebar:** Pins important Pages, Databases, and Queries while allowing dynamic sections such as Recent and Shared with me.
+- **Recent work:** Restores the objects and views a person was actually using, scoped by current access.
+- **Known links and invitations:** Land on the intended object with an honest access-denied state when permission is missing.
+- **Session resumption:** Reopens enough navigation and View state to pick up the work without reconstructing the route manually.
+
+**Required capability records:** [Content spaces and Files](capabilities/content.source.spaces-files.md), [Personal and organization contexts](capabilities/content.workspace.multi-scope.md), [Global Home](capabilities/content.home.global.md), [Personal sidebar](capabilities/content.navigation.sidebar.md), [Session resumption](capabilities/content.workspace.session-restore.md)
+
+**Enhancing capability records:** [Working set](capabilities/content.workspace.working-set.md), [View instances](capabilities/content.workspace.view-instance.md)
+
+### Feature 3: Living references
+
+Reuse canonical Pages and Blocks without producing copies that quietly drift apart.
+
+**Status:** Partially implemented
+
+**Example workflow:** The Docs team maintains one canonical product-description Block that appears across several guides and blog posts, edits it from any occurrence, and sees every authorized location update without copy and paste.
+
+**What works today:** Content can reference Pages, embed ordinary Database Views, and preserve multi-membership without copying canonical records. Existing reference Blocks and source-aware identities provide useful substrate.
+
+**What remains:** Stable Block references, editable Synced Blocks, canonical Page embeds, a complete Connections surface, and typed relationship behavior still need to converge.
+
+**What this Feature includes:**
+
+- **References:** Link to a Page or Block as a compact mention, card, or embedded preview.
+- **Synced Blocks:** Render one canonical Block in several places and allow authorized edits from any occurrence.
+- **Embedded Pages:** Place a canonical Page inside another surface while preserving its identity and access.
+- **Backlinks and forward links:** Show where an object is mentioned and what it intentionally references through Info → Connections.
+- **Typed Relationships:** Give important connections explicit meaning that Databases, Queries, Graphs, and agents can use.
+- **Graceful degradation:** Omit inaccessible references and preserve understandable broken or deleted-reference states.
+
+**Required capability records:** [References](capabilities/content.object.reference.md), [Synced Blocks and live embeds](capabilities/content.object.transclusion.md), [Links and backlinks](capabilities/content.knowledge.links.md), [Typed Relationships](capabilities/content.relationship.edge.md)
+
+**Enhancing capability records:** [Blocks](capabilities/content.object.block.md), [Named Page Versions](capabilities/content.version.branching.md)
+
+### Feature 4: Make the workspace yours
+
+Personal arrangements and private Views reshape shared work without changing it for everyone else.
+
+**Status:** Partially implemented
+
+**Example workflow:** A sales leader privately filters and groups the shared customer Database around this quarter's accounts, saves that arrangement as an Only-me View, and never changes what the rest of the company sees.
+
+**What works today:** Saved Database Views already support filtering, sorting, grouping, density, and several renderers, while the data model supports Pages belonging to multiple Databases.
+
+**What remains:** Automatic personal overrides, named Only-me Views, reusable typed Queries, and predictable pinning and sharing behavior need complete product surfaces.
+
+**What this Feature includes:**
+
+- **Personal View changes:** Remember one person's filters, sorting, grouping, density, and presentation over a shared View.
+- **Only-me Views:** Save named private Views over shared records without forking their data.
+- **Shared Views:** Give collaborators a dependable starting presentation while preserving personal exploration.
+- **Saved Queries:** Turn reusable selection and output logic into durable Content objects that can be linked and embedded.
+- **Multiple Database memberships:** Let one Page participate in several collections without gaining a primary Database identity.
+- **Pinned navigation:** Let each person choose the working set that deserves persistent space in the sidebar.
+
+**Required capability records:** [Database and Query Views](capabilities/content.view.query.md), [Reusable Query objects](capabilities/content.query.object.md), [Personal View state](capabilities/content.view.personal-state.md), [Shared Views](capabilities/content.share.views.md), [Multiple Database memberships](capabilities/content.object.multi-membership.md)
+
+**Enhancing capability records:** [Personal sidebar](capabilities/content.navigation.sidebar.md), [Typed expression language](capabilities/content.expression.language.md)
+
+### Feature 5: See your information your way
+
+Move among compatible Database and Query Views without changing the records underneath.
+
+**Status:** In validation
+
+**Example workflow:** A marketing team edits its editorial Database as a Table, plans work on a Board and Calendar, then gives executives a compact List of the same canonical articles.
+
+**What works today:** Table, List, Board, Gallery, Calendar, Timeline, and Form renderers already exist, along with shared filters, sorts, grouping, calculations, and visible-field controls.
+
+**What remains:** Every renderer needs the same proven permissions, Actions, agent context, accessibility, persistence, performance, keyboard behavior, and recovery. Incomplete Views should remain gated until they pass that contract.
+
+**What this Feature includes:**
+
+- **Table and List:** Support fast scanning, keyboard navigation, inline editing, and flexible visible fields.
+- **Board and Gallery:** Arrange records by workflow state or visual identity while preserving canonical records.
+- **Calendar and Timeline:** Place records across dates and ranges through the same typed time Properties.
+- **Form:** Collect new records through a saved presentation of the Database's schema and validation.
+- **View controls:** Filter, sort, group, format, and conditionally style each presentation.
+- **Density:** Adjust compact, cozy, or comfortable spacing and secondary information without creating another View type.
+- **Renderer conformance:** Gives every View the same permissions, Actions, agent context, accessibility, persistence, and recovery contract.
+
+**Required capability records:** [Typed renderers](capabilities/content.renderer.typed.md), [Database and Query Views](capabilities/content.view.query.md), [View renderer conformance](capabilities/content.view.renderer-conformance.md), [Large Database performance](capabilities/content.view.scale.md)
+
+**Enhancing capability records:** [Fast keyboard capture](capabilities/content.view.fast-capture.md), [Grouping and aggregation](capabilities/content.view.grouping-aggregation.md), [Timeline View](capabilities/content.view.timeline.md)
+
+## Chapter 2: Come to consensus without losing the evidence
+
+Chapter 2 keeps collaboration attached to the work being shaped. People and agents can discuss a Page or Database, leave precise feedback, review attributable changes, explore alternatives, and preserve how the team reached its conclusion without rescuing the useful parts from a separate chat afterward. The following Features create that collaboration loop.
+
+### Feature 6: Collaborate in context
+
+Comments, Discussion, messages, notifications, and history stay anchored to the Page or Database being shaped.
+
+**Status:** Partially implemented
+
+**Example workflow:** A teammate comments on an unclear paragraph, discusses the larger issue in the Page's Discussion, links the conversation to Slack, and returns later to see the Comment, replies, and resulting changes together.
+
+**What works today:** Content supports anchored Comment threads, replies, resolution, mentions, notifications substrate, and document history. These already keep precise feedback closer to the artifact than an external chat can.
+
+**What remains:** Every Page and Database needs its universal Discussion, rich Blocks-field messages, stable permalinks, access-safe Slack continuation, and clearly attributable message revisions.
+
+**What this Feature includes:**
+
+- **Comments:** Attach precise feedback to text, Blocks, media, or other exact material and preserve the historical target if that material changes.
+- **Discussion:** Gives every Page and Database one continuing channel for collaboration about the whole artifact.
+- **Rich messages:** Use Blocks fields so messages and Comments can contain the same references, embeds, Expressions, and structured content as Pages.
+- **Threads and replies:** Keep focused sub-conversations understandable without infinite nesting.
+- **Permalinks:** Make every message and Comment addressable from Content, Slack, or another Page.
+- **Notifications:** Route attention through durable, queryable records without inventing another inbox engine.
+- **Attributable revisions:** Let message owners edit their work while preserving visible history instead of erasing what was said.
+
+**Required capability records:** [Page Discussion](capabilities/content.discussion.page.md), [Comments](capabilities/content.comment.page-owned.md), [Blocks fields](capabilities/content.object.blocks-field.md), [Notifications](capabilities/content.notification.source.md), [Committed Events](capabilities/content.event.committed.md)
+
+**Enhancing capability records:** [Agent presence](capabilities/content.agent.presence.md), [Reactions and Polls](capabilities/content.feedback.signal.md)
+
+### Increment to Feature 6: Decide together
+
+Polls and explicit outcome state deepen the same Discussion rather than creating a separate decision system.
+
+**Status:** Planned
+
+**Example workflow:** A team posts a Poll in the Database Discussion, allows each person to choose up to two priorities, closes voting on Friday, records the outcome, and links directly to that result from the resulting plan.
+
+**What works today:** Comments, reactions, rich content, Database Views, and permission-aware collaboration provide pieces of the eventual interaction.
+
+**What remains:** Poll messages, bounded multi-select, stable options, closing behavior, access-safe aggregates, featured Poll rendering, and superseding outcomes still need implementation.
+
+- **Poll messages:** Use the shared rich-message grammar and remain linkable like any other Discussion item.
+- **Single or bounded multi-select:** Lets the poll author decide whether responders may choose one answer or a fixed number.
+- **Stable options:** Preserves the meaning of existing responses when wording or presentation changes.
+- **Close and freeze:** Stops new responses at a deliberate boundary and keeps the resulting aggregate inspectable.
+- **Access-safe totals:** Never leak inaccessible participants through counts or aggregates.
+- **Outcome state:** Records the current conclusion and allows a later outcome to supersede it without manufacturing a Decision object.
+
+### Feature 7: Review changes in place
+
+Accept or reject proposed human and agent changes in the ordinary Content interface.
+
+**Status:** Partially implemented
+
+**Example workflow:** An agent revises a live article and its metadata; the editor reviews the rendered Page, accepts the stronger passages, rejects an incorrect Property change, and leaves the remaining suggestions pending for another pass.
+
+**What works today:** Source change sets, Builder review machinery, audit records, and document snapshots prove several parts of the review loop and provide useful donor implementations.
+
+**What remains:** Content needs one generic typed diff and suggestion system that reviews bodies, Properties, Blocks, and filtered record sets directly in their ordinary renderers.
+
+**What this Feature includes:**
+
+- **Suggestions:** Preserve a pending change set without mutating the canonical Page immediately.
+- **Typed diffs:** Compare body content, Properties, Blocks, and structured values through their normal renderers.
+- **Filtered review:** Review only the affected or relevant subset without losing dependent changes outside the current filter.
+- **Selective acceptance:** Accept all, reject all, or choose individual compatible changes without seven ceremonial confirmation screens.
+- **Stale changes:** Detect when the underlying material has moved and offer an honest rebase, refresh, or conflict state.
+- **Agent-authored work:** Group an agent run into one inspectable Revision whose changes remain attributable and recoverable.
+
+**Required capability records:** [In-place typed review](capabilities/content.diff.in-place.md), [Filtered change review](capabilities/content.diff.filtered-review.md), [Suggestions](capabilities/content.revision.suggestions.md), [Committed Events](capabilities/content.event.committed.md), [History](capabilities/content.history.queryable.md)
+
+**Enhancing capability records:** [Agent-assisted review](capabilities/content.diff.ai-assist.md), [Code review](capabilities/content.review.code.md)
+
+### Feature 8: Explore alternatives safely
+
+Create named Versions, compare them, selectively merge them, and promote one without losing the others.
+
+**Status:** Planned
+
+**Example workflow:** A team keeps the published article canonical while creating a private rewrite, compares the two Versions in the normal editor, selectively merges the best changes, and promotes the rewrite only when it is ready.
+
+**What works today:** Content preserves whole-document snapshots and can restore earlier revisions, while the broader event and diff architecture establishes the lower-level history foundation.
+
+**What remains:** Named Page Versions, Version-specific access, in-place comparison, selective merge, canonical promotion, and Version-aware collaboration are still planned.
+
+**What this Feature includes:**
+
+- **One stable Page:** Keeps identity, title, top-level Properties, sharing, and Discussion common across its Versions.
+- **Named Versions:** Hold deliberate alternative bodies such as a published article and a new working draft.
+- **Version-specific access:** Allows a Version to be more private than its Page, but never more broadly shared.
+- **Compare and merge:** Shows differences in the ordinary Page interface and supports selective acceptance in either direction.
+- **Canonical promotion:** Makes any authorized Version current without destroying the Version it replaces.
+- **Version context:** Quietly anchors Comments, Discussion messages, Annotations, and execution receipts to the Version being viewed.
+
+**Required capability records:** [Named Page Versions](capabilities/content.version.branching.md), [Blocks-field revision history](capabilities/content.version.field-history.md), [In-place typed review](capabilities/content.diff.in-place.md), [Row-level privacy](capabilities/content.access.row-private.md)
+
+**Enhancing capability records:** [Filtered change review](capabilities/content.diff.filtered-review.md), [Annotations](capabilities/content.research.annotation.md)
+
+## Chapter 3: One workspace across every source
+
+Chapter 3 lets people work across Content, local files, and connected providers without rebuilding everything in one proprietary home. A team can combine information from several Sources, edit it through one predictable interface, and keep supported changes synchronized while preserving ownership, access, and provider-specific meaning. The following Features make that shared workspace possible.
+
+### Feature 9: Connect your sources
+
+Choose governed native and provider Sources, preserve their identity, and compose them through Queries and Views.
+
+**Status:** Partially implemented
+
+**Example workflow:** A content lead connects Builder blog articles and resources, aligns their compatible fields in one Query, and works from a shared editorial View without losing which provider owns each record.
+
+**What works today:** Content already models source-backed Databases, source fields and rows, provenance, multi-source composition, and adapters for Builder, Notion, and local material.
+
+**What remains:** Sources need one governed catalog, Queries need to replace the confusing multi-source configuration surface, and field alignment, write routing, and access behavior need end-to-end proof.
+
+**What this Feature includes:**
+
+- **Sources catalog:** Lists approved personal, workspace, and organization connections with their capabilities and policy.
+- **Provider adapters:** Give Builder, Notion, Drive, Agent Native apps, and later providers one shared contract with independent certification.
+- **Item binding:** Maps each provider item to one stable Content identity without turning the provider into the Page's owner.
+- **Typed Queries:** Combine Databases, Sources, and other Queries through one visual selection and alignment model.
+- **Provenance:** Shows where each value or representation came from and which system owns changes to it.
+- **Access-safe results:** Evaluate every result and aggregate with the current viewer's authority rather than the Query owner's.
+
+**Required capability records:** [Sources catalog](capabilities/content.source.catalog.md), [Source adapters](capabilities/content.source.adapters.md), [Cross-source Queries](capabilities/content.view.source-query.md), [Reusable Query objects](capabilities/content.query.object.md)
+
+**Enhancing capability records:** [Page-linked Sources](capabilities/content.source.page-link.md), [Custom Properties](capabilities/content.property.catalog.md)
+
+### Feature 10: Trust your connected Sources
+
+Keep supported edits synchronized according to one plain-language policy without silently losing provider-specific content.
+
+**Status:** Partially implemented
+
+**Example workflow:** An editor updates a Builder article from Content; the supported changes synchronize, an unknown Builder component survives untouched, and changing Draft to Published remains a separate guarded action.
+
+**What works today:** Builder change sets, guarded writes, raw sidecars, local-folder synchronization, and source metadata already preserve several difficult round-trip and conflict boundaries.
+
+**What remains:** Every adapter needs certification against one plain-language sync policy, seamless automatic synchronization where safe, faithful unknown-content preservation, explicit lifecycle changes, and dependable receipts.
+
+**What this Feature includes:**
+
+- **View only:** Pulls authorized changes into Content and never writes back.
+- **Keep in sync:** Moves compatible changes in both directions automatically and interrupts only for a genuine conflict.
+- **Review before write-back:** Bundles Content-originated changes into one reviewable set when the workflow requires care.
+- **Faithful round-tripping:** Preserves unknown provider-owned structures even when Content cannot render or edit them.
+- **Conflict handling:** Uses stable identity and base revisions to prevent silent last-writer-wins data loss.
+- **Provider lifecycle:** Treats states such as Draft and Published as explicit guarded changes rather than side effects of ordinary editing.
+- **Receipts and retries:** Confirms what the provider actually accepted and retries without duplicating effects.
+
+**Required capability records:** [Source sync policy](capabilities/content.source.sync-policy.md), [Faithful round-tripping](capabilities/content.portability.roundtrip.md), [Source adapters](capabilities/content.source.adapters.md), [Builder round-trip codec](capabilities/content.source.builder-codec.md)
+
+**Enhancing capability records:** [Guarded property changes](capabilities/content.property.guarded-change.md), [Committed Events](capabilities/content.event.committed.md)
+
+### Feature 11: Work across every workspace
+
+Search and save Queries across Personal and organization contexts without widening anyone's access.
+
+**Status:** Partially implemented
+
+**Example workflow:** A person searches their current Workspace, deliberately expands to all accessible contexts, saves a Query spanning Personal and two organizations, and shares it with someone who sees only their own authorized intersection.
+
+**What works today:** Content has Personal and organization spaces, Workspace membership, scoped access checks, and the beginnings of cross-space navigation and search.
+
+**What remains:** Active working context must separate cleanly from retrieval scope, while global Home, cross-context Queries, counts, aggregates, and viewer-specific evaluation need complete implementation.
+
+**What this Feature includes:**
+
+- **Active context:** Determines where new work is created and which organization or Personal surface governs it.
+- **Retrieval scope:** Can widen deliberately beyond the active context without moving or re-authorizing objects.
+- **Cross-workspace Search:** Expands from the current Workspace to every accessible context through an explicit control.
+- **Cross-workspace Queries:** Save durable, shareable definitions that retain each source object's location and provenance.
+- **Viewer evaluation:** Shows every reader only the intersection they can access, including counts and aggregates.
+- **Global Home:** Composes authorized recent work, Queries, and dashboards without pretending everything belongs to one giant Workspace.
+
+**Required capability records:** [Personal and organization contexts](capabilities/content.workspace.multi-scope.md), [Reusable Query objects](capabilities/content.query.object.md), [Visibility closure](capabilities/content.access.visibility-closure.md)
+
+**Enhancing capability records:** [Global Home](capabilities/content.home.global.md), [Organization teams](capabilities/content.organization.teams.md)
+
+### Feature 12: Bring your local work
+
+Open a folder or repository through the same Source model while keeping device authority and browser limitations honest.
+
+**Status:** Partially implemented
+
+**Example workflow:** A developer opens a local documentation folder in Content Desktop, edits the files through Content, sees external file changes synchronize back, and later reads the last synchronized representation from Safari without exposing the folder path.
+
+**What works today:** Local File Mode, manifest-declared workspaces, connected-folder Sources, source-backed Pages, conflict records, and a trusted local bridge already establish substantial foundations.
+
+**What remains:** Opening a folder must become effortless, Desktop needs dependable background sync and caching, browser clients need graceful read and queued-write behavior, and the portable vault workflow needs full product polish.
+
+**What this Feature includes:**
+
+- **Local Source Bridge:** Grants access to explicitly selected folders without storing raw paths or file handles in shared SQL.
+- **Folders and repositories:** Materialize local files as ordinary Content records while preserving their source identity and structure.
+- **Background synchronization:** Lets Desktop or a lightweight helper keep shared representations fresh for browser clients.
+- **Browser degradation:** Shows the last authorized Content representation when Safari, Firefox, or another client cannot access local bytes.
+- **Queued edits:** Holds permitted source-owned changes with their base revision until an authorized bridge returns.
+- **Portable vault:** Keeps the human-readable folder separate from disposable caches and any particular desktop application bundle.
+
+**Required capability records:** [Local Source bridge](capabilities/content.source.local-bridge.md), [Files and folders as Sources](capabilities/content.source.file-folder.md), [Portable source representation](capabilities/content.portability.source-representation.md), [Whole-vault export](capabilities/content.portability.vault-export.md)
+
+**Enhancing capability records:** [Source adapters](capabilities/content.source.adapters.md), [Source sync policy](capabilities/content.source.sync-policy.md)
+
+## Chapter 4: Shape your own working system
+
+Chapter 4 turns flexible Pages and Databases into working systems a team can trust. People with the right expertise can shape data, Views, Templates, Rules, Skills, and agent workflows for everyone else, while validation, governance, and safe evolution keep that flexibility from becoming organizational confetti. The following Features provide those building blocks.
+
+### Feature 13: Data that keeps itself right
+
+Use typed defaults, formulas, validation, and rendering so ordinary data stays consistent.
+
+**Status:** Partially implemented
+
+**Example workflow:** An operations lead creates a request Database whose defaults fill the creator and timestamp, formulas calculate cost, validation rejects an impossible quantity, and a guarded budget change explains its consequences before committing.
+
+**What works today:** Content has a broad typed Property system, formulas and computed fields, editable values, form-required fields, audit fields, and several useful validation donors.
+
+**What remains:** Defaults, formulas, validation, conditional rendering, guarded changes, typed errors, and time semantics need one expression language and one coherent configuration surface across every Property type.
+
+**What this Feature includes:**
+
+- **Typed Properties:** Give text, numbers, choices, dates, people, relationships, files, and rich Blocks explicit behavior.
+- **Creation defaults:** Evaluate one-time typed Expressions inside the successful creation transaction.
+- **Formulas:** Derive live values from the current row and related data without storing a second truth.
+- **Validation:** Reject invalid values consistently across the interface, Actions, API, agents, imports, and Forms.
+- **Safeguards:** Add customizable consequence text, confirmation, approval, or conditional authority before sensitive changes commit.
+- **Typed errors:** Keep null, error, unavailable, and stale cached values distinct and understandable.
+- **Time semantics:** Separate Dates from timezone-aware Instants and quarantine ambiguous legacy floating times honestly.
+
+**Required capability records:** [Typed Properties](capabilities/content.property.typed.md), [Property validation and defaults](capabilities/content.property.constraints.md), [Guarded property changes](capabilities/content.property.guarded-change.md), [Typed expression language](capabilities/content.expression.language.md), [Dates, times, and durations](capabilities/content.time.types.md)
+
+**Enhancing capability records:** [View-derived creation defaults](capabilities/content.view.dynamic-create.md), [Actor properties](capabilities/content.property.actor.md), [Cached expression results](capabilities/content.expression.cached-result.md)
+
+### Feature 14: Share how your organization works
+
+Govern reusable Templates, Properties, Expressions, and Custom Blocks without taking ownership away from adopters.
+
+**Status:** Partially implemented
+
+**Example workflow:** An administrator publishes an approved editorial Template with governed Properties and Expressions; any team can inspect and adopt it, customize the local system, or detach without losing its existing records.
+
+**What works today:** Content already has Templates and several reusable configuration surfaces, while source Properties and local components demonstrate governed and source-backed reuse patterns.
+
+**What remains:** Templates, Custom Properties, Expressions, and Custom Blocks need one understandable catalog model with ownership scope, inspection, adoption, local aliasing, provenance, and faithful detachment.
+
+**What this Feature includes:**
+
+- **Templates:** Package Pages, Databases, Views, Properties, Rules, and content into reusable starting systems.
+- **Custom Properties:** Offer approved reusable field definitions without making every ordinary local column secretly global.
+- **Expressions:** Store reusable typed logic with personal, workspace, or organization scope.
+- **Catalog discovery:** Uses consistent names, descriptions, aliases, ownership, compatibility, and previews.
+- **Adoption:** Lets someone inspect a governed building block before binding it into their local system.
+- **Detachment:** Preserves the current data and behavior as a faithful local copy when someone leaves the shared lineage.
+
+**Required capability records:** [Multi-object Templates](capabilities/content.template.graph.md), [Template governance](capabilities/content.template.governance.md), [Database item Templates](capabilities/content.template.item-body.md)
+
+**Enhancing capability records:** [Custom Properties](capabilities/content.property.catalog.md), [Organization teams](capabilities/content.organization.teams.md)
+
+### Feature 15: Put your organization's know-how to work
+
+Govern reusable Skills so the agent offers the right instructions for the current person and object.
+
+**Status:** Planned
+
+**Example workflow:** A writer selects a paragraph and opens Ask Agent; Content prioritizes the organization's approved voice-and-style Skill, explains that it will propose a replacement, and records the resulting edits when invoked.
+
+**What works today:** The Agent Native framework already loads governed developer Skills, and Content provides selection context and the shared Agent chat for carrying out authorized work.
+
+**What remains:** Content needs a user-manageable Skills catalog, scope and compatibility rules, contextual discovery, specific-over-general ranking, clear mutation previews, and shared invocation for people and agents.
+
+**What this Feature includes:**
+
+- **Skills catalog:** Stores governed instructions with personal, workspace, organization, or public-core scope.
+- **Compatibility:** Surfaces only Skills that apply to the current selection, Block, Page, Database, Property, or View.
+- **Scope precedence:** Ranks the most relevant allowed instruction without flooding the interface with the entire catalog.
+- **Declared effects:** Explains whether invocation proposes edits, replaces content, adds a Comment, or acts elsewhere.
+- **Shared invocation:** Lets people and agents use the same Skill through the ordinary Agent chat and Action fabric.
+- **Receipts:** Records what instruction ran, against which context, with which resulting actions.
+
+**Required capability records:** [Expression catalog](capabilities/content.expression.catalog.md), [Skills catalog](capabilities/content.agent.skill-catalog.md), [Agent-authored Expressions](capabilities/content.agent.expression-authoring.md)
+
+**Enhancing capability records:** [Template governance](capabilities/content.template.governance.md), [Unified commands](capabilities/content.command.fabric.md)
+
+### Feature 16: Evolve systems safely
+
+Review upstream changes to adopted systems, keep local work intact, and choose what to accept or detach.
+
+**Status:** Planned
+
+**Example workflow:** A new version of the editorial Template adds one Property and changes a Rule; each Database owner sees the impact, accepts the Property, declines the Rule, preserves local changes, and stops seeing the same declined update.
+
+**What works today:** Version history, diff donors, stable identifiers, Templates, and source change-review machinery provide the pieces needed to compare evolving systems.
+
+**What remains:** Governed building blocks need version pinning, affected-object previews, owner-scoped adoption, selective apply and reset, remembered declines, deprecation, and safe permanent divergence.
+
+**What this Feature includes:**
+
+- **Version pinning:** Keeps each adopted Template or Custom Property on the version its owner trusts.
+- **Impact preview:** Shows affected Databases, Views, Queries, formulas, Rules, Templates, and agent workflows before publication.
+- **Three-way comparison:** Distinguishes the old shared definition, the proposed update, and local changes.
+- **Selective adoption:** Lets each owner accept compatible changes, decline others, or apply a safe batch.
+- **Quiet decline memory:** Avoids repeatedly demanding review until the upstream change materially differs.
+- **Detach to local:** Ends the shared lineage without breaking the current system or losing provenance.
+
+**Required capability records:** [Template updates](capabilities/content.template.update.md), [Custom Properties](capabilities/content.property.catalog.md), [In-place typed review](capabilities/content.diff.in-place.md)
+
+**Enhancing capability records:** [Template governance](capabilities/content.template.governance.md), [Committed Events](capabilities/content.event.committed.md)
+
+### Feature 17: When this happens, that follows
+
+React to committed Events with visible, governed Actions, retries, notifications, and receipts.
+
+**Status:** Partially implemented
+
+**Example workflow:** When a qualified lead enters a Database, a Rule assigns the owner, asks an agent for a bounded summary, sends the right notification, and leaves one receipt showing every action and retry.
+
+**What works today:** Shared Actions, audit history, a framework scheduler, notifications, Automations, provider effects, and active Event and Rule work already cover much of the execution substrate.
+
+**What remains:** Content needs one durable Event spine and Rule model with atomic claims, retries, idempotency, agent effects, notification routing, receipts, and a humane inspection surface.
+
+**What this Feature includes:**
+
+- **Events:** Provide atomic facts about what committed, who or what caused it, and which objects changed.
+- **Rules:** Match typed conditions after commit without becoming a second expression or permission engine.
+- **Actions:** Invoke the same operations available to the interface and agents.
+- **Schedules and heartbeats:** Use the framework's single scheduler for time-based conditions and missed-run policy.
+- **Buttons:** Give owners an explicit interface for invoking governed Actions with known inputs and consequences.
+- **Agent effects:** Delegate bounded work without granting the Rule more authority than its actor or policy permits.
+- **Receipts and retries:** Preserve exactly-once claims, crash recovery, honest skips, and queryable outcomes.
+
+**Required capability records:** [Committed Events](capabilities/content.event.committed.md), [Rules](capabilities/content.rule.deterministic.md), [Agent and UI parity](capabilities/content.agent.action-parity.md)
+
+**Enhancing capability records:** [Scheduled automation](capabilities/content.automation.scheduled.md), [Action Buttons](capabilities/content.action.button.md), [Agent-run automation](capabilities/content.agent.automation.md)
+
+### Feature 18: Run projects your way
+
+Use an editable Task and Project system built from ordinary Content rather than a second hidden engine.
+
+**Status:** Partially implemented
+
+**Example workflow:** A product team installs the blessed project Template, captures tasks from the keyboard, assigns owners, links subtasks and dependencies, and uses My Tasks while every task remains an ordinary editable Page.
+
+**What works today:** Pages, Databases, status and person Properties, relations, Board and Calendar Views, Templates, Comments, and agent Actions already let teams assemble useful project systems.
+
+**What remains:** The blessed Template needs fast capture, polished defaults, task and subtask Views, My Tasks, activity, dependencies, permissions, and end-to-end Builder dogfooding without introducing a separate task engine.
+
+**What this Feature includes:**
+
+- **Blessed Template:** Provides a strong starting system that remains inspectable and editable like any other Content setup.
+- **Fast capture:** Creates work quickly with unambiguous View-derived defaults and useful keyboard navigation.
+- **Assignments:** Use ordinary typed Person and Team Properties with access-safe attention and notifications.
+- **Subtasks and dependencies:** Store hierarchy and blocking relationships through typed Relations with cycle protection.
+- **My Tasks:** Queries assigned work across authorized memberships without inventing a private task datastore.
+- **Project status:** Combines explicit owner judgment with useful rollups rather than pretending a formula can manage the project.
+- **Ordinary Pages:** Lets every Task retain rich content, Properties, Discussion, Versions, and the ability to join other Databases.
+
+**Required capability records:** [Blessed Task and Project Template](capabilities/content.system.task-project.md), [My Tasks](capabilities/content.system.my-tasks.md), [Task dependencies](capabilities/content.system.dependencies.md), [Project status](capabilities/content.system.project-status.md)
+
+**Enhancing capability records:** [Fast keyboard capture](capabilities/content.view.fast-capture.md), [Typed Relationships](capabilities/content.relationship.edge.md), [Notifications](capabilities/content.notification.source.md)
+
+### Feature 19: Plan work across time
+
+Edit dates and dependencies through Timeline and Gantt-style planning while preserving the same typed records underneath.
+
+**Status:** Planned
+
+**Example workflow:** A project manager opens a Timeline, drags a blocked launch task into the following week, sees the dependency conflict, accepts a proposed schedule repair, and preserves the updated dates and Relationships everywhere else.
+
+**What works today:** A Timeline renderer, typed date Properties, drag editing, relations, grouping, and shared View configuration already exist as partially proven pieces.
+
+**What remains:** Timeline needs full renderer conformance and polish, while dependency metadata, schedule constraints, milestones, repair proposals, critical path, and Gantt-style interaction remain planned layers.
+
+**What this Feature includes:**
+
+- **Timeline:** Places records across typed dates, Instants, ranges, and durations.
+- **Direct manipulation:** Moves or resizes permitted work through ordinary typed Actions.
+- **Dependency connectors:** Renders the same Relationships used by Queries and project workflows.
+- **Schedule constraints:** Detects invalid ordering and either refuses, explains, or proposes a repair according to policy.
+- **Gantt mode:** Combines Timeline, dependencies, milestones, grouping, and schedule behavior without becoming another View family.
+- **Critical path:** Remains a later planning layer after dependency and constraint semantics are dependable.
+
+**Required capability records:** [Timeline View](capabilities/content.view.timeline.md), [Dates, times, and durations](capabilities/content.time.types.md), [Typed Relationships](capabilities/content.relationship.edge.md), [Schedule constraints](capabilities/content.schedule.constraints.md)
+
+**Enhancing capability records:** [Task dependencies](capabilities/content.system.dependencies.md), [Grouping and aggregation](capabilities/content.view.grouping-aggregation.md)
+
+### Feature 20: Build new surfaces
+
+Create a one-off artifact, then promote it into a governed reusable Custom Block when it earns reuse.
+
+**Status:** Partially implemented
+
+**Example workflow:** An agent creates a one-off interactive calculator inside a Page; its owner inspects the source and rendered result, then promotes it to an approved Custom Block that coworkers can insert from the slash menu.
+
+**What works today:** Sandboxed Extensions, local MDX components, HTML artifacts, executable-code foundations, and shared component toolkits already demonstrate several rendering and execution modes.
+
+**What remains:** These pieces need one Custom Block lifecycle with inspectable source, secure sandboxing, optional typed props, one-off artifacts, promotion, governed catalogs, source-backed origins, and slash-command discovery.
+
+**What this Feature includes:**
+
+- **Artifact Block:** Stores Page-owned HTML, styles, and behavior without requiring props or a catalog entry.
+- **Source and rendered views:** Lets authors inspect the code underneath and the output it produces.
+- **Sandbox:** Denies network and application authority by default while enforcing time, memory, output, and asset limits.
+- **Save as Custom Block:** Promotes a useful one-off into a governed reusable definition with stable identity.
+- **Custom Blocks catalog:** Controls discovery, ownership, versions, permissions, compatibility, and typed props where useful.
+- **Source-backed origins:** Lets repository, Builder, or later Source adapters provide the implementation without creating another product identity.
+
+**Required capability records:** [Artifact Blocks](capabilities/content.renderer.artifact-block.md), [Custom Blocks](capabilities/content.renderer.custom-block.md)
+
+**Enhancing capability records:** [Executable Code blocks](capabilities/content.author.code.md), [Typed renderers](capabilities/content.renderer.typed.md)
+
+### Feature 21: Collect structured input
+
+Build Forms over the same schema, validation, and submission Actions as the Database they populate.
+
+**Status:** In validation
+
+**Example workflow:** A research team publishes an intake Form that validates required fields, lets an external participant submit without reading the Database, creates exactly one record, and triggers the Database's enrichment Rule.
+
+**What works today:** Content already has a Form View, ordered and required questions, schema-backed controls, and an atomic Action that creates and verifies an ordinary Database record.
+
+**What remains:** Content and Agent Native Forms need one shared engine, with polished public submission, richer validation, conditional behavior, permissions, spam protection, receipts, and dependable downstream Rule handoff.
+
+**What this Feature includes:**
+
+- **Form View:** Saves field selection, order, presentation, and submission behavior over one Database.
+- **Shared schema:** Reuses the same Property types and validation as Agent Native Forms and ordinary record editing.
+- **Conditional fields:** Shows or requires inputs through the typed expression language rather than custom form-only logic.
+- **Submission grants:** Allow a person to submit without silently granting broad access to the underlying Database.
+- **Idempotent submission:** Prevents duplicate records when a request retries or returns ambiguously.
+- **Receipts:** Records the submitted values, actor, resulting Page, and downstream Actions the submitter may inspect.
+
+**Required capability records:** [Shared Form engine](capabilities/content.form.shared-engine.md), [Property validation and defaults](capabilities/content.property.constraints.md), [Agent and UI parity](capabilities/content.agent.action-parity.md), [Committed Events](capabilities/content.event.committed.md)
+
+**Enhancing capability records:** [Rules](capabilities/content.rule.deterministic.md), [Durable background jobs](capabilities/content.job.durable.md)
+
+### Feature 22: Understand what your data says
+
+Use Charts, Pivots, grouping, measures, and drill-down without creating a separate analytics datastore.
+
+**Status:** Partially implemented
+
+**Example workflow:** A marketing analyst groups campaigns by channel, compares spend and conversions in a Chart and Pivot, then drills into one surprising aggregate to inspect the canonical campaigns behind it.
+
+**What works today:** Database calculations, grouping, rollup foundations, and chart tooling elsewhere in the Agent Native framework provide useful implementation donors.
+
+**What remains:** Content needs typed aggregations, multi-dimensional grouping, Pivot, a shared Chart specification and renderer library, saved Chart Views, embeddable Chart Blocks, and drill-down to canonical records.
+
+**What this Feature includes:**
+
+- **Multiple grouping dimensions:** Partitions typed Query results consistently across Views.
+- **Measures and totals:** Compute access-safe counts, sums, averages, subtotals, and grand totals.
+- **Charts:** Share one typed chart specification and renderer toolkit with Agent Native Analytics.
+- **Pivot:** Places dimensions on rows and columns with typed aggregations in cells.
+- **Drill-down:** Opens the canonical records behind an aggregate instead of turning cells into independent data.
+- **Accessible summaries:** Explains the chart or pivot meaning beyond color, shape, or pointer interaction.
+- **Static fidelity:** Preserves useful output in public Pages, presentations, and exports.
+
+**Required capability records:** [Grouping and aggregation](capabilities/content.view.grouping-aggregation.md), [Pivot View](capabilities/content.view.pivot.md), [Chart View](capabilities/content.view.chart.md), [Access-safe computation](capabilities/content.access.safe-aggregate.md)
+
+**Enhancing capability records:** [Typed renderers](capabilities/content.renderer.typed.md), [Database and Query Views](capabilities/content.view.query.md)
+
+### Feature 23: Build living dashboards
+
+Compose responsive Views, Charts, expressions, controls, and prose into durable operating surfaces.
+
+**Status:** Planned
+
+**Example workflow:** A go-to-market lead assembles a responsive Page with pipeline Charts, filtered account Views, explanatory prose, and personal controls so people and agents can inspect the same operating picture and discuss it in context.
+
+**What works today:** Pages can already combine prose, Blocks, references, expressions, and embedded Database Views, while saved Views provide reusable filtered presentations.
+
+**What remains:** Responsive Page columns, resizable View and Chart Blocks, dashboard controls, chart conformance, personal interaction state, presentation behavior, and export fidelity still need implementation.
+
+**What this Feature includes:**
+
+- **Ordinary Pages:** Serve as the dashboard canvas without introducing a separate dashboard datastore.
+- **Embedded Views and Charts:** Reference saved configurations while allowing each occurrence to override size and presentation.
+- **Responsive columns:** Arrange, resize, and reorder Blocks with a layout that linearizes coherently on smaller screens and in exports.
+- **Controls and Expressions:** Let viewers change authorized filters or inputs without mutating the shared default accidentally.
+- **Live context:** Keeps prose, decisions, metrics, and the underlying records together for people and agents.
+- **Presentation mode:** Reuses shared Slides primitives to present Pages or ordered records without inventing slide-only content.
+
+**Required capability records:** [Responsive Page layout](capabilities/content.layout.responsive.md), [Chart View](capabilities/content.view.chart.md), [Embeddable Content surfaces](capabilities/content.embed.surface.md)
+
+**Enhancing capability records:** [Presentation mode](capabilities/content.presentation.mode.md), [Typed expression language](capabilities/content.expression.language.md)
+
+## Chapter 5: Capture anything. Keep the thread
+
+Chapter 5 turns the things people encounter into research they can keep using. Material can enter from many capture points, retain its source and exact context, become comfortable to read and annotate, and connect to citations, claims, and other knowledge without losing the original thread. The following Features support that path from capture to understanding.
+
+### Feature 24: Capture into action
+
+Resolve or create one canonical Page in the chosen Database, preserve provenance, and hand it to that Database's Rules and agents.
+
+**Status:** Partially implemented
+
+**Example workflow:** Someone shares a customer interview URL from their phone to the Research Database; Content reuses the canonical Source Page, preserves the transcript and provenance, and lets the Database's Rules extract companies and open questions.
+
+**What works today:** Content can already import or create Pages from files, URLs, providers, local Sources, and Agent Actions, with useful provenance and Database destinations in several paths.
+
+**What remains:** Every entrance needs one Capture contract with remembered destination, canonical deduplication, idempotency, snapshot handling, Template application, receipts, and clean downstream enrichment.
+
+**What this Feature includes:**
+
+- **Many entrances:** Accepts browser capture, share sheets, Clips, URLs, files, email, identifiers, providers, and Agent Actions through one contract.
+- **Remembered destination:** Defaults to the last Database used for that entrance while keeping the destination easy to change.
+- **Idempotent resolution:** Finds an existing canonical Page or creates exactly one, with a deliberate-copy escape hatch.
+- **Provenance:** Preserves the original URL, identifier, provider identity, capture time, snapshot, and available representations.
+- **Database handoff:** Applies the destination's Template, defaults, memberships, validation, and permissions.
+- **Downstream enrichment:** Lets target-owned Rules and agents summarize, classify, extract, or route the record without making Capture wait for them.
+- **Receipts and repair:** Reports what Capture created or reused and allows failed later enrichment to retry independently.
+
+**Required capability records:** [Capture and enrichment](capabilities/content.capture.enrich.md), [Sources catalog](capabilities/content.source.catalog.md), [Durable background jobs](capabilities/content.job.durable.md)
+
+**Enhancing capability records:** [Rules](capabilities/content.rule.deterministic.md), [Multi-object Templates](capabilities/content.template.graph.md)
+
+### Feature 25: Read and annotate anything
+
+Read comfortably, mark exact material, preserve revision context, and find those Annotations again.
+
+**Status:** Planned
+
+**Example workflow:** A researcher opens a PDF, adjusts the reading layout, highlights an exact passage, adds a durable Annotation, and later finds it from the Annotations rail even after the source receives a new revision.
+
+**What works today:** Content already renders rich documents and media Blocks, supports anchored Comments, stores source representations, and has ordinary reading and export foundations.
+
+**What remains:** The dedicated Reader experience, durable Annotation object and rail, precise selectors across media, revision-aware anchoring, carry-forward, reading preferences, progress, dictation, and read-aloud are still planned.
+
+**What this Feature includes:**
+
+- **Reader surface:** Provides personal typography, width, pagination, theme, progress, and distraction-free modes.
+- **Document and media representations:** Supports text, transcripts, PDFs, EPUBs, audio, video, and source-aware fallbacks over stable asset handles.
+- **Annotations:** Store durable highlights, notes, tags, reactions, or structured extractions independently from resolvable Comments.
+- **Precise selectors:** Anchor to text ranges, pages, regions, timestamps, transcript ranges, and the source revision being viewed.
+- **Annotations rail:** Reveals highlights only when opened and supports search, filtering, grouping, re-anchoring, and orphan repair.
+- **Carry-forward:** Moves a filtered set of relevant Annotations to another named Version without pretending every old anchor still exists.
+- **Speech:** Adds dictation and read-aloud through shared Agent Native capabilities rather than a Reader-only AI system.
+
+**Required capability records:** [Reader surface](capabilities/content.reader.surface.md), [Annotations](capabilities/content.research.annotation.md), [Media Blocks](capabilities/content.author.media.md)
+
+**Enhancing capability records:** [Named Page Versions](capabilities/content.version.branching.md), [Source adapters](capabilities/content.source.adapters.md)
+
+### Feature 26: Cite what you found
+
+Turn a link into one durable source-and-locator identity that can render in different citation styles.
+
+**Status:** Planned
+
+**Example workflow:** A writer promotes an ordinary research link to a citation, adds a page locator, switches the article from author-date to footnote style, and watches the bibliography update without re-entering the source.
+
+**What works today:** Content has ordinary links, Page references, source metadata, rich text, equations, and import and export machinery that can donate to citation rendering.
+
+**What remains:** First-class citation identity, locators, promote-to-citation, automatic bibliographies, selectable styles, Zotero interoperability, and semantic portability need implementation.
+
+**What this Feature includes:**
+
+- **Promote to citation:** Converts an ordinary link without losing its anchor or source identity.
+- **Source Page:** Resolves or creates the canonical record for the paper, book, website, video, dataset, or other source.
+- **Locators:** Preserve page, chapter, figure, timestamp, transcript range, or another precise place within the source.
+- **Style rendering:** Presents one semantic citation as a link, author-date reference, number, footnote, or bibliography entry.
+- **Bibliographies:** Recompute from the citations actually present rather than maintaining a second manual list.
+- **Zotero interoperability:** Uses Zotero identities and CSL styles instead of volunteering to personally maintain civilization's citation formats.
+- **Portability:** Keeps citation identity intact across supported imports and exports even when the destination renders it differently.
+
+**Required capability records:** [Citations](capabilities/content.research.citation.md), [Footnotes](capabilities/content.author.footnotes.md)
+
+**Enhancing capability records:** [Faithful round-tripping](capabilities/content.portability.roundtrip.md), [Source adapters](capabilities/content.source.adapters.md)
+
+### Feature 27: Sketch connections, keep what's true
+
+Arrange canonical Content on a Canvas, sketch possible connections, and promote only meaningful typed Relationships.
+
+**Status:** Planned
+
+**Example workflow:** A researcher arranges Sources, claims, and Annotations on a Canvas, draws tentative lines while thinking, and promotes only the strongest line into a typed Supports relationship that Queries and agents can use.
+
+**What works today:** Canonical Pages, Blocks, references, relation Properties, Queries, and embeddable Views provide the objects and edges a spatial surface can eventually arrange.
+
+**What remains:** Canvas, view-local connectors, promotion into typed Relationships, semantic Graph editing, mind maps, force-directed layouts, and graph traversal remain planned capabilities.
+
+**What this Feature includes:**
+
+- **Canvas:** Places Pages, Blocks, Sources, Annotations, media, Views, and Query results in an intentional spatial arrangement.
+- **Reusable objects:** Keeps every card or node connected to its canonical Content identity instead of becoming a canvas-only copy.
+- **Visual connectors:** Supports brainstorming lines that remain local to the Canvas until their meaning is known.
+- **Promote to Relationship:** Turns a chosen connector into a named typed edge that becomes queryable everywhere.
+- **Semantic Graph mode:** Creates an already-selected Relationship type directly when the person is deliberately editing the graph.
+- **Mind maps and layouts:** Offer hierarchical, grouped, and force-directed arrangements over the same objects and edges.
+- **Graph exploration:** Later adds traversal, paths, cycles, ranking, and pattern queries after the relationship substrate is proven.
+
+**Required capability records:** [Canvas](capabilities/content.view.canvas.md), [Graph View](capabilities/content.view.graph.md), [Graph queries](capabilities/content.knowledge.graph.md), [Typed Relationships](capabilities/content.relationship.edge.md)
+
+**Enhancing capability records:** [Reusable Query objects](capabilities/content.query.object.md), [Annotations](capabilities/content.research.annotation.md)
+
+## Chapter 6: Write once, keep it yours, publish faithfully
+
+Chapter 6 carries the same canonical work from private thought into public reading, other applications, portable archives, and future systems. People can publish or embed what they choose, move their full body of work without starting over, and retain meaningful control over custody without creating a second truth that quietly drifts away. The following Features make Content useful beyond Content itself.
+
+### Feature 28: Publish with confidence
+
+Publish one chosen revision faithfully while private collaborative work continues behind it.
+
+**Status:** Partially implemented
+
+**Example workflow:** An editor publishes the current approved article revision, continues working privately on a new Version, previews exactly what public readers can see, and updates the stable URL only when the replacement is ready.
+
+**What works today:** Content already supports sharing, public Pages, stable links, several exports, access checks, and server-rendered public surfaces.
+
+**What remains:** Publication must bind to an exact revision or named Version, preview the real audience closure, render every Block faithfully, isolate private collaboration, preserve lifecycle history, and become polished enough for dependable CMS use.
+
+**What this Feature includes:**
+
+- **Publication object:** Binds one public destination to a Page, selected Version, and exact revision.
+- **Page-first publishing:** Keeps Publish, Update publication, and Unpublish inside the familiar Page sharing surface.
+- **Stable public URL:** Serves the last explicitly published truth rather than following every private edit automatically.
+- **Rich Block fidelity:** Renders every accepted Block family or a deliberate safe fallback through the shared semantic renderer.
+- **Audience preview:** Shows what the public reader can actually access before publication.
+- **Private-work separation:** Prevents Comments, Discussion, unpublished Versions, inaccessible assets, and internal Properties from leaking.
+- **Lifecycle history:** Records who published, updated, or withdrew which revision and preserves the public artifact's provenance.
+
+**Required capability records:** [Public publishing](capabilities/content.publish.public.md), [Public reading](capabilities/content.publish.reading.md), [Visibility closure](capabilities/content.access.visibility-closure.md)
+
+**Enhancing capability records:** [Named Page Versions](capabilities/content.version.branching.md), [PDF and print export](capabilities/content.portability.pdf-export.md), [Guarded property changes](capabilities/content.property.guarded-change.md)
+
+### Feature 29: Take the whole vault with you
+
+Export the complete authorized vault into open, understandable formats and a lossless Content archive.
+
+**Status:** Partially implemented
+
+**Example workflow:** An organization exports every object the acting administrator can access into an open Markdown, CSV, assets, and manifest vault plus a lossless Content archive, then verifies the package without Content.
+
+**What works today:** Content exports Page bodies as Markdown, HTML, and PDF-shaped output and can export editable Markdown or MDX source, with local-file workflows already proving part of the portability model.
+
+**What remains:** Whole-vault export needs CSV, assets, an open manifest, a lossless Content archive, Notion-compatible packaging, authorized dependency closure, resumable jobs, verification, and Desktop backup.
+
+**What this Feature includes:**
+
+- **Open vault:** Uses Markdown or MDX, CSV, ordinary asset folders, and a small manifest for stable IDs and richer semantics.
+- **Lossless Content archive:** Preserves Versions, Discussion, Comments, Annotations, Rules, provenance, and other Content-specific meaning.
+- **Target packages:** Produces destination-aware exports, beginning with a Notion-compatible package and conversion report.
+- **Authorized closure:** Materializes exactly what the exporter can currently see without leaking inaccessible dependencies.
+- **Assets and Sources:** Includes authorized files or stable handles and reports anything that could not be resolved.
+- **Durable transfer job:** Supports progress, interruption, retry, and resume without duplicating work.
+- **Local backup:** Lets Desktop maintain a user-chosen portable vault separately from its fast disposable cache.
+
+**Required capability records:** [Whole-vault export](capabilities/content.portability.vault-export.md), [Faithful round-tripping](capabilities/content.portability.roundtrip.md), [Durable background jobs](capabilities/content.job.durable.md)
+
+**Enhancing capability records:** [PDF and print export](capabilities/content.portability.pdf-export.md), [Local Source bridge](capabilities/content.source.local-bridge.md)
+
+### Feature 30: Move without starting over
+
+Import or migrate a foreign corpus with resumable progress, provenance, repair, and a readable conversion report.
+
+**Status:** Partially implemented
+
+**Example workflow:** A team imports a large Notion workspace, closes the browser halfway through, resumes without duplicate Pages, and reviews a conversion report showing transformed Properties and unresolved assets.
+
+**What works today:** Markdown and MDX import, Notion workflows, Builder pulls, local-folder synchronization, provenance, and provider identities already support several bounded migration paths.
+
+**What remains:** Large migrations need durable server-side orchestration, checkpoints, idempotent deduplication, broader schema fidelity, conversion reports, asset repair, resumability, and explicit partial-failure recovery.
+
+**What this Feature includes:**
+
+- **Canonical import model:** Maps Pages, Databases, Properties, Blocks, relationships, files, and metadata into stable Content objects.
+- **Provider-specific adapters:** Interpret Notion, local vaults, Builder, Drive, and later formats without making any provider's dialect the core model.
+- **Checkpoint and resume:** Continues large migrations after interruption without duplicating already accepted records.
+- **Identity and deduplication:** Preserves stable source IDs and makes repeated imports repair or update the intended objects.
+- **Conversion report:** Explains unsupported or transformed semantics instead of quietly dropping them.
+- **Repair workflows:** Lets people and agents inspect unresolved mappings, missing assets, conflicts, and partial failures.
+- **Provenance:** Keeps enough source context to compare, refresh, or understand the imported material later.
+
+**Required capability records:** [Durable background jobs](capabilities/content.job.durable.md), [Source adapters](capabilities/content.source.adapters.md), [Faithful round-tripping](capabilities/content.portability.roundtrip.md)
+
+**Enhancing capability records:** [Sources catalog](capabilities/content.source.catalog.md), [Committed Events](capabilities/content.event.committed.md)
+
+### Feature 31: Work on Content inside another application
+
+Mount and edit the same canonical Content object inside an authorized host without forking identity or permissions.
+
+**Status:** Planned
+
+**Example workflow:** A planner mounts the canonical project brief inside another Agent Native app, edits it through the same Actions, and sees the change, history, and permissions remain identical when opening it later in Content.
+
+**What works today:** Agent Native toolkits already share Content components across sibling apps, and Content exposes reusable Actions and object identities that hosts can call without duplicating business logic.
+
+**What remains:** A canonical embeddable surface needs host grants, viewer-scoped authorization, shared editing and history, stable mounting contracts, responsive presentation, and later MCP App compatibility.
+
+**What this Feature includes:**
+
+- **Canonical mount:** Renders the actual Page, View, or focused Content surface rather than a copied snapshot.
+- **Host grant:** Gives one named application only the mount and Action capabilities it needs.
+- **Viewer authority:** Never lets the host widen what the signed-in person could see or edit in Content itself.
+- **Shared Actions:** Routes edits through the same validation, permissions, Events, history, and agent surface.
+- **Agent Native toolkits:** Reuse common components and behavior across sibling applications without coupling them to the Content app shell.
+- **MCP App widening:** Later exposes the same governed surface to compatible external agent hosts once identity and presentation contracts are proven.
+
+**Required capability records:** [Embeddable Content surfaces](capabilities/content.embed.surface.md), [Embedded host grants](capabilities/content.embed.host-grant.md), [Agent and UI parity](capabilities/content.agent.action-parity.md)
+
+**Enhancing capability records:** [MCP App embedding](capabilities/content.embed.mcp-app.md), [Responsive Page layout](capabilities/content.layout.responsive.md)
+
+### Feature 32: Keep your private vault private
+
+Add user-controlled encrypted custody without abandoning collaboration, recovery, or ordinary agent workflows.
+
+**Status:** Paused
+
+**Example workflow:** A person enrolls a trusted laptop, opens an encrypted private vault locally, grants a local agent bounded access for one task, then revokes the device without exposing the vault to the service.
+
+**What works today:** The private-vault lane has substantial research and fork implementation history around enrollment, encrypted custody, device authorization, fail-closed behavior, and cross-architecture verification.
+
+**What remains:** The complete user product still needs audited cryptographic integration, understandable recovery and revocation, collaboration, agent access boundaries, portable exit, current-main reconciliation, and production proof. Work remains deliberately paused.
+
+**What this Feature includes:**
+
+- **End-to-end encryption:** Keeps private content unreadable to the service outside explicitly authorized plaintext boundaries.
+- **Enrollment and recovery:** Gives people understandable key setup, device addition, rotation, revocation, and recovery ceremonies.
+- **Device authority:** Lets trusted local clients decrypt only the vaults and operations they are authorized to handle.
+- **Agent access:** Makes private-vault availability explicit and bounded rather than silently handing an agent plaintext.
+- **Collaboration:** Preserves sharing, Versions, comments, and revocation without weakening the custody promise.
+- **Portable exit:** Allows the owner to export readable authorized content and keys without permanent service dependence.
+- **Paused boundary:** Retains the existing E2EE research and implementation history without claiming the complete workflow is ready.
+
+**Required capability records:** [Private vault encryption](capabilities/content.security.private-vault.md), [Agent resource consent](capabilities/content.agent.resource-consent.md), [Whole-vault export](capabilities/content.portability.vault-export.md)
+
+**Enhancing capability records:** [Local Source bridge](capabilities/content.source.local-bridge.md), [Audience-safe synthesis](capabilities/content.agent.audience-safe.md)


### PR DESCRIPTION
## Problem

Content's accepted product direction needs a repository-native source of truth. Contributors can inspect the implementation, but implementation alone cannot explain which user workflow a change belongs to, which contracts it depends on, which edge cases are settled, or what proof remains before the workflow is complete.

The first draft of this PR established the graph, but its Capability records were too terse for a source-blind developer or agent to implement safely. Phrases such as “typed collections” and “bounded queries” named architecture without teaching the product behavior.

## Approach

Atomic Chapter, Feature, and Capability records own the editable truth. The roadmap and encyclopedia are deterministic projections. The Content developer skill retrieves the exact relevant records rather than loading the entire encyclopedia.

Every Capability is now a self-contained version 2 mini-spec with:

- the human problem and one concrete workflow;
- settled interactions, authority, failure, deletion, retry, concurrency, and degraded-state behavior where applicable;
- explicit boundaries and non-goals;
- at least two named Given/when/then acceptance stories;
- honest current evidence versus donor substrate;
- an executable proof plan and only genuinely open questions.

## What changed

- Rebuilt all 124 Capability records in the detailed version 2 format.
- Clarified the former ambiguous `content.renderer.graph` record as superseded lineage: analytical work belongs to Chart, semantic relationship work belongs to Graph, spatial composition belongs to Canvas, and shared compatibility/export behavior belongs to Typed Renderers.
- Strengthened Custom Blocks with the settled ownership-versus-origin model, optional typed props, slash discovery contract, strict sandbox boundary, one-off Artifact promotion, deterministic export, and visible separation from Extensions.
- Updated the developer skill to require reading the complete Capability record; encyclopedia rows are indexes, not implementation context.
- Expanded validation to reject legacy shells, known generated boilerplate, repeated sections, duplicated promise/problem framing, incomplete proof requirements, broken references, dependency cycles, non-terminal supersession, catalog-count drift, stale projections, and privacy-sensitive residue.
- Enforced bidirectional Chapter/Feature and Feature/Capability membership, active-only dependency/reference targets, and privacy detection for reference links and Slack client permalinks.
- Made generated encyclopedia tables formatter-stable.

## Verification

- `pnpm test:content-product-docs`: 14/14 tests pass.
- `pnpm guard:content-product-docs`: validates 6 Chapters, 32 Features, and 124 Capabilities.
- `pnpm guard:workspace-skills`: passes.
- `pnpm fmt:check`: passes across the complete repository on the prior head; the review repair was formatted directly and is returning through CI.
- `git diff --check`: passes.
- Task-specific privacy scans: no personal names, vault identifiers, machine paths, private provider links, or private review-process residue.
- Isolated clean-context agents successfully explained Relationships, named Versions, Graph View, Custom Blocks, and Page-linked Sources from one Capability record at a time. Their questions surfaced explicit implementation choices rather than missing settled behavior.
- Independent reviews surfaced six deterministic regression-guard gaps. All are fixed and covered: the 124-record inventory is pinned; supersession terminates at a different active Capability; graph membership is bidirectional; active records cannot depend on superseded ones; and reference-style/private Slack links are rejected.

## Safety and scope

This changes product documentation and repository tooling only. It does not change runtime behavior, schemas, permissions, publishing, providers, or package releases. Capability state remains conservative: working pieces are named as donor substrate and do not verify an end-to-end contract.

The future Content conformance-CI pilot remains a separate follow-up. This PR supplies the product-contract substrate; it does not auto-edit the roadmap or make semantic agent verdicts blocking.

## Review focus

- Can a developer implement one Capability without private context or invented product behavior?
- Are Page, Database, Query, View, Source, collaboration, relationship, and agent-permission boundaries preserved?
- Do evidence and state avoid claiming that donor code proves a complete workflow?
- Are the validator's deterministic regression checks strict enough without pretending to judge prose semantically?
