### PR TITLE
Mirror HEAD with a publish gate; pin toolkit to core's compatible range

### DIFF
--- a/.github/workflows/push-starter-template.yml
+++ b/.github/workflows/push-starter-template.yml
@@ -35,10 +35,13 @@ jobs:
     name: Materialize and push template branch
     runs-on: ubuntu-latest
     steps:
-      # Every trigger materializes main HEAD (the default ref for push /
-      # repository_dispatch / workflow_dispatch), so the mirror only ever moves
-      # forward — it can't revert to an older commit.
+      # Always materialize main HEAD, so the mirror only ever moves forward.
+      # push and repository_dispatch already resolve to main HEAD, but
+      # workflow_dispatch lets the operator pick any branch/tag — pinning
+      # ref: main stops a manual run from pushing stale template content.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: main
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 

--- a/.github/workflows/push-starter-template.yml
+++ b/.github/workflows/push-starter-template.yml
@@ -57,7 +57,26 @@ jobs:
         run: |
           set -euo pipefail
           version="$(node -p "require('./packages/core/package.json').version")"
-          if npm view "@agent-native/core@${version}" version >/dev/null 2>&1; then
+          # Fetch the published version list. A successful query (exit 0) is an
+          # authoritative answer, so membership is definitive. A failed query
+          # means the registry was unreachable (timeout / DNS / 5xx / rate
+          # limit) — NOT that the version is unpublished; retry, then fail
+          # loudly, because a silent publishable=false on a template-only push
+          # has no guaranteed later dispatch to retry it.
+          versions=""; ok=""
+          for attempt in 1 2 3; do
+            if versions="$(npm view "@agent-native/core" versions --json --prefer-online 2>/dev/null)"; then
+              ok=1; break
+            fi
+            echo "npm registry lookup failed (attempt ${attempt}/3); retrying in 5s..."
+            sleep 5
+          done
+          if [ -z "$ok" ]; then
+            echo "::error::Could not reach npm to check @agent-native/core@${version}; failing rather than silently skipping."
+            exit 1
+          fi
+          if printf '%s' "$versions" \
+            | jq -e --arg v "$version" '(if type=="array" then . else [.] end) | index($v) != null' >/dev/null; then
             echo "core ${version} is on npm — mirroring HEAD."
             echo "publishable=true" >> "$GITHUB_OUTPUT"
           else
@@ -86,9 +105,26 @@ jobs:
         run: |
           set -euo pipefail
           version="$(node -p "require('./packages/core/package.json').version")"
-          range="$(npm view "@agent-native/core@${version}" dependencies.@agent-native/toolkit 2>/dev/null || true)"
+          # The exit code separates three cases; don't mask it with `|| true`:
+          #   exit 0, non-empty -> the range (pin it)
+          #   exit 0, empty     -> core declares no toolkit dep (benign; leave as
+          #                        materialized, which matches create's fallback)
+          #   exit != 0         -> registry error -> retry, then fail (never push
+          #                        an uncontrolled toolkit version)
+          range=""; ok=""
+          for attempt in 1 2 3; do
+            if range="$(npm view "@agent-native/core@${version}" dependencies.@agent-native/toolkit --prefer-online 2>/dev/null)"; then
+              ok=1; break
+            fi
+            echo "npm lookup failed (attempt ${attempt}/3); retrying in 5s..."
+            sleep 5
+          done
+          if [ -z "$ok" ]; then
+            echo "::error::Could not reach npm to read core ${version}'s toolkit range; failing rather than pushing an uncontrolled toolkit version."
+            exit 1
+          fi
           if [ -z "$range" ]; then
-            echo "::warning::core ${version} declares no @agent-native/toolkit range; leaving toolkit as materialized."
+            echo "::warning::core ${version} declares no @agent-native/toolkit dependency; leaving toolkit as materialized."
             exit 0
           fi
           # Surgical replace so the rest of package.json keeps materialize's exact

--- a/.github/workflows/push-starter-template.yml
+++ b/.github/workflows/push-starter-template.yml
@@ -4,21 +4,21 @@ name: Push chat template to starter
 # to builder-agent-native-starter's `template` branch. The starter's own
 # `sync.yml` (on that branch) then git-merges it into `main`. This workflow only
 # ever handles pristine, public template output — no private starter content.
+#
+# The mirror always materializes main HEAD (freshest template content), but only
+# when the @agent-native/core version pinned in source is already on npm. During
+# the few-minute window between a Version Packages PR merging (which bumps the
+# source version) and its publish finishing, HEAD's pin isn't installable yet, so
+# the gate skips — and the publish dispatch re-runs the mirror the moment it lands.
 on:
   push:
     branches: [main]
-    # Template-only changes mirror promptly on push. Changes that also touch a
-    # template-pinned package (core / creative-context / toolkit) are deferred to
-    # the publish dispatch by the `decide` gate below — mirroring them now would
-    # pin the previously-published version (the bump lands only when the Version
-    # Packages PR merges). Post-processor (CLI) changes go out that way too.
     paths:
       - "templates/chat/**"
       - ".github/workflows/push-starter-template.yml"
-  # Fired by "Publish packages" only on an actual npm publish (published == true)
-  # of a package the template pins — not on every successful release run (a run
-  # that merely opens the Version Packages PR publishes nothing). Carries the
-  # published commit sha in client_payload.
+  # Fires when a publish completes (published == true). This is the reliable
+  # second chance for anything the gate skipped during a publish-in-flight
+  # window: by the time it fires, the just-published version is on npm.
   repository_dispatch:
     types: [agent-native-packages-published]
   workflow_dispatch:
@@ -31,48 +31,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # A push that touches a template-pinned package will publish and re-mirror via
-  # repository_dispatch with the correct pin. Mirroring on that push would emit
-  # new template source pinned to the *old* published version, leaving the
-  # starter temporarily inconsistent until the dispatch. Defer those pushes.
-  decide:
-    name: Decide whether to mirror this push
-    runs-on: ubuntu-latest
-    outputs:
-      skip: ${{ steps.gate.outputs.skip }}
-    steps:
-      - id: gate
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          set -euo pipefail
-          if [ "$EVENT_NAME" != "push" ]; then
-            # Dispatch/manual runs always mirror.
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          files=$(jq -r '.commits[]? | (.added // [])[], (.modified // [])[], (.removed // [])[]' "$GITHUB_EVENT_PATH")
-          if printf '%s\n' "$files" | grep -qE '^packages/(core|creative-context|toolkit)/'; then
-            echo "Template-pinned package changed; deferring to the post-publish dispatch."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
   push:
     name: Materialize and push template branch
-    needs: [decide]
-    if: needs.decide.outputs.skip != 'true'
     runs-on: ubuntu-latest
     steps:
+      # Every trigger materializes main HEAD (the default ref for push /
+      # repository_dispatch / workflow_dispatch), so the mirror only ever moves
+      # forward — it can't revert to an older commit.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          # On a publish dispatch, materialize the exact commit that was just
-          # published (carried in client_payload) rather than whatever main's
-          # HEAD happens to be — so the pinned version matches what's on npm.
-          ref: >-
-            ${{ github.event_name == 'repository_dispatch'
-            && github.event.client_payload.sha || github.sha }}
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
@@ -81,15 +47,37 @@ jobs:
           node-version: "24"
           cache: "pnpm"
 
-      - run: pnpm install --frozen-lockfile
+      # materialize pins @agent-native/core to the version in source. If that
+      # version isn't on npm yet (a publish is in flight), pushing it would make
+      # the starter's sync fail its install/build. Skip; the publish dispatch
+      # re-runs this once the version lands, and because we mirror HEAD it sweeps
+      # up everything that merged in the meantime.
+      - name: Gate on the pinned core version being published
+        id: gate
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./packages/core/package.json').version")"
+          if npm view "@agent-native/core@${version}" version >/dev/null 2>&1; then
+            echo "core ${version} is on npm — mirroring HEAD."
+            echo "publishable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "core ${version} is not on npm yet (publish in flight); skipping."
+            echo "The publish dispatch will re-run this once ${version} lands."
+            echo "publishable=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - if: steps.gate.outputs.publishable == 'true'
+        run: pnpm install --frozen-lockfile
 
       - name: Materialize post-processed templates/chat
+        if: steps.gate.outputs.publishable == 'true'
         run: >-
           pnpm exec tsx packages/core/src/cli/index.ts template materialize
           --template chat --out ./dist/template
 
       - name: Generate app token
         id: app-token
+        if: steps.gate.outputs.publishable == 'true'
         uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.BUILDER_BOT_FOR_LINT_APP_ID }}
@@ -98,6 +86,7 @@ jobs:
           repositories: builder-agent-native-starter
 
       - name: Push to starter template branch
+        if: steps.gate.outputs.publishable == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |

--- a/.github/workflows/push-starter-template.yml
+++ b/.github/workflows/push-starter-template.yml
@@ -75,6 +75,32 @@ jobs:
           pnpm exec tsx packages/core/src/cli/index.ts template materialize
           --template chat --out ./dist/template
 
+      # materialize pins toolkit to "latest", because core declares it as
+      # workspace:^ in source and the resolver falls back to "latest" when it
+      # can't read a concrete range. A real `create` from a *published* core pins
+      # the compatible range changesets locked at release time, keeping toolkit in
+      # lockstep with core. Reproduce that: read the range the published core
+      # we're pinning declares, and rewrite it into the materialized package.json.
+      - name: Pin toolkit to the published core's compatible range
+        if: steps.gate.outputs.publishable == 'true'
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./packages/core/package.json').version")"
+          range="$(npm view "@agent-native/core@${version}" dependencies.@agent-native/toolkit 2>/dev/null || true)"
+          if [ -z "$range" ]; then
+            echo "::warning::core ${version} declares no @agent-native/toolkit range; leaving toolkit as materialized."
+            exit 0
+          fi
+          # Surgical replace so the rest of package.json keeps materialize's exact
+          # formatting (no churn on the template branch).
+          sed -i "s#\"@agent-native/toolkit\": \"[^\"]*\"#\"@agent-native/toolkit\": \"${range}\"#" \
+            ./dist/template/package.json
+          if ! grep -q "\"@agent-native/toolkit\": \"${range}\"" ./dist/template/package.json; then
+            echo "::error::Failed to pin @agent-native/toolkit to ${range}."
+            exit 1
+          fi
+          echo "Pinned @agent-native/toolkit to ${range} (from core ${version})."
+
       - name: Generate app token
         id: app-token
         if: steps.gate.outputs.publishable == 'true'


### PR DESCRIPTION
## What

Reworks the starter mirror (`push-starter-template.yml`) into one coherent rule and closes a toolkit fidelity gap.

### 1. Mirror HEAD, skip when the pinned core version isn't on npm yet
Every trigger (push / dispatch / manual) materializes **main HEAD**, but the job only proceeds when the `@agent-native/core` version pinned in source is already published. During the brief window between a Version Packages PR merging (which bumps the source version) and its publish finishing, HEAD's pin isn't installable — so the mirror **skips** (green, no-op). The publish dispatch re-runs it the moment the version lands, and because it always mirrors HEAD it sweeps up everything that merged in the meantime.

This fixes two real failures observed in production:
- **phantom pin → failed sync** (a push mirrored `core@X` before `X` was on npm → starter `pnpm install` failed);
- **publish-dispatch revert** (the dispatch used to check out the *publish commit*, which could be behind HEAD, reverting newer template content — e.g. #2513's skill edit was delivered then reverted).

Replaces **both** the `decide` gate and the `client_payload.sha` checkout — net simpler (−47/+36 before the toolkit step).

### 2. Pin toolkit to the published core's compatible range
`materialize` pins `@agent-native/toolkit` to `"latest"` (source declares it `workspace:^`, so the resolver falls back to `latest`). A real `create` from a *published* core pins the concrete range changesets locked at release time — keeping toolkit in lockstep with core. The mirror now reproduces that: after materialize, read the range the published core declares (`npm view`) and rewrite it into the template's `package.json` (surgical `sed`, no formatting churn). So the starter matches `create@<version>` output instead of drifting to a possibly-incompatible `latest`.

## Scope
For the chat template the complete set of framework-version resolutions is exactly **core** (gate) and **toolkit** (range pin); `react-router` deps are exact third-party pins. If a future template adds another `@agent-native/*` dep it'd hit the same `latest` fallback — a follow-up could generalize the toolkit step to all `@agent-native/*` deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)