### PR TITLE
fix(core): report workspace file truncation accurately

### DIFF
--- a/.changeset/accurate-workspace-file-pagination.md
+++ b/.changeset/accurate-workspace-file-pagination.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Report workspace files as truncated only when more content exists beyond the requested read page.

--- a/.changeset/accurate-workspace-file-pagination.md
+++ b/.changeset/accurate-workspace-file-pagination.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Report workspace files as truncated only when more content exists beyond the requested read page.
+Report workspace files as truncated only when more content exists beyond the requested read page, and normalize paging arguments to integer boundaries.

--- a/packages/core/src/workspace-files/tool.spec.ts
+++ b/packages/core/src/workspace-files/tool.spec.ts
@@ -127,4 +127,37 @@ describe("workspace-files tool", () => {
       { offset: 0, maxChars: 5 },
     );
   });
+
+  it("normalizes fractional paging values to advancing integer boundaries", async () => {
+    mockStoredContent("abcdef");
+    const entry = createWorkspaceFilesTool()["workspace-files"];
+
+    expect(entry!.tool.parameters?.properties).toMatchObject({
+      offset: { type: "integer" },
+      maxChars: { type: "integer" },
+    });
+
+    const result = await runWithRequestContext(
+      { userEmail: "alice@example.com" },
+      () =>
+        entry!.run({
+          action: "read",
+          path: metadata.path,
+          offset: 1.9,
+          maxChars: 0.5,
+        }),
+    );
+
+    expect(JSON.parse(String(result))).toMatchObject({
+      ok: true,
+      content: "b",
+      truncated: true,
+      nextOffset: 2,
+    });
+    expect(mockReadWorkspaceFile).toHaveBeenCalledWith(
+      expect.anything(),
+      metadata.path,
+      { offset: 1, maxChars: 2 },
+    );
+  });
 });

--- a/packages/core/src/workspace-files/tool.spec.ts
+++ b/packages/core/src/workspace-files/tool.spec.ts
@@ -2,11 +2,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockWriteWorkspaceFile = vi.hoisted(() => vi.fn());
 const mockAppendWorkspaceFile = vi.hoisted(() => vi.fn());
+const mockReadWorkspaceFile = vi.hoisted(() => vi.fn());
 
 vi.mock("./store.js", () => ({
   writeWorkspaceFile: mockWriteWorkspaceFile,
   appendWorkspaceFile: mockAppendWorkspaceFile,
-  readWorkspaceFile: vi.fn(),
+  readWorkspaceFile: mockReadWorkspaceFile,
   listWorkspaceFiles: vi.fn(),
   deleteWorkspaceFile: vi.fn(),
   grepWorkspaceFiles: vi.fn(),
@@ -23,6 +24,26 @@ const metadata = {
   createdAt: "2026-07-29T12:00:00.000Z",
   updatedAt: "2026-07-29T12:00:00.000Z",
 };
+
+function mockStoredContent(content: string) {
+  mockReadWorkspaceFile.mockImplementation(
+    async (
+      _scope: unknown,
+      _path: unknown,
+      options?: { offset?: number; maxChars?: number },
+    ) => {
+      const offset = options?.offset ?? 0;
+      const end =
+        options?.maxChars === undefined ? undefined : offset + options.maxChars;
+      return {
+        ...metadata,
+        scope: "user",
+        scopeId: "alice@example.com",
+        content: content.slice(offset, end),
+      };
+    },
+  );
+}
 
 describe("workspace-files tool", () => {
   beforeEach(() => {
@@ -57,4 +78,53 @@ describe("workspace-files tool", () => {
       });
     },
   );
+
+  it("does not mark a file as truncated when it exactly fills the requested page", async () => {
+    mockStoredContent("abcd");
+    const entry = createWorkspaceFilesTool()["workspace-files"];
+
+    const result = await runWithRequestContext(
+      { userEmail: "alice@example.com" },
+      () =>
+        entry!.run({
+          action: "read",
+          path: metadata.path,
+          maxChars: 4,
+        }),
+    );
+
+    const parsed = JSON.parse(String(result));
+    expect(parsed).toMatchObject({
+      ok: true,
+      content: "abcd",
+    });
+    expect(parsed).not.toHaveProperty("truncated");
+  });
+
+  it("returns only the requested page and a next offset when more content exists", async () => {
+    mockStoredContent("abcde");
+    const entry = createWorkspaceFilesTool()["workspace-files"];
+
+    const result = await runWithRequestContext(
+      { userEmail: "alice@example.com" },
+      () =>
+        entry!.run({
+          action: "read",
+          path: metadata.path,
+          maxChars: 4,
+        }),
+    );
+
+    expect(JSON.parse(String(result))).toMatchObject({
+      ok: true,
+      content: "abcd",
+      truncated: true,
+      nextOffset: 4,
+    });
+    expect(mockReadWorkspaceFile).toHaveBeenCalledWith(
+      expect.anything(),
+      metadata.path,
+      { offset: 0, maxChars: 5 },
+    );
+  });
 });

--- a/packages/core/src/workspace-files/tool.ts
+++ b/packages/core/src/workspace-files/tool.ts
@@ -86,13 +86,16 @@ export function createWorkspaceFilesTool(): Record<string, ActionEntry> {
                 'MIME type for new files. Default: "text/plain". Use "application/json" for JSON, "text/markdown" for Markdown.',
             },
             offset: {
-              type: "number",
+              type: "integer",
+              minimum: 0,
               description:
-                "Character offset to start reading from (for paging large files). Default: 0.",
+                "Non-negative character offset to start reading from (for paging large files). Default: 0.",
             },
             maxChars: {
-              type: "number",
-              description: `Maximum characters to return when reading. Default: ${DEFAULT_READ_CHARS}. Max: ${MAX_READ_CHARS}.`,
+              type: "integer",
+              minimum: 1,
+              maximum: MAX_READ_CHARS,
+              description: `Positive maximum characters to return when reading. Default: ${DEFAULT_READ_CHARS}. Max: ${MAX_READ_CHARS}.`,
             },
             pattern: {
               type: "string",
@@ -168,11 +171,13 @@ export function createWorkspaceFilesTool(): Record<string, ActionEntry> {
               if (!path) return "Error: path is required for read.";
               const rawOffset = Number(args.offset);
               const offset =
-                Number.isFinite(rawOffset) && rawOffset > 0 ? rawOffset : 0;
+                Number.isFinite(rawOffset) && rawOffset > 0
+                  ? Math.floor(rawOffset)
+                  : 0;
               const rawMax = Number(args.maxChars);
               const maxChars =
                 Number.isFinite(rawMax) && rawMax > 0
-                  ? Math.min(rawMax, MAX_READ_CHARS)
+                  ? Math.min(Math.max(1, Math.floor(rawMax)), MAX_READ_CHARS)
                   : DEFAULT_READ_CHARS;
 
               // The sentinel character distinguishes an exact page from a truncated one.

--- a/packages/core/src/workspace-files/tool.ts
+++ b/packages/core/src/workspace-files/tool.ts
@@ -175,9 +175,10 @@ export function createWorkspaceFilesTool(): Record<string, ActionEntry> {
                   ? Math.min(rawMax, MAX_READ_CHARS)
                   : DEFAULT_READ_CHARS;
 
+              // The sentinel character distinguishes an exact page from a truncated one.
               const file = await readWorkspaceFile(scope, path, {
                 offset,
-                maxChars,
+                maxChars: maxChars + 1,
               });
               if (!file) {
                 return JSON.stringify({
@@ -186,19 +187,20 @@ export function createWorkspaceFilesTool(): Record<string, ActionEntry> {
                 });
               }
 
-              const truncated = file.content.length >= maxChars;
+              const truncated = file.content.length > maxChars;
+              const content = file.content.slice(0, maxChars);
               return JSON.stringify({
                 ok: true,
                 path: file.path,
                 contentType: file.contentType,
                 sizeBytes: file.sizeBytes,
                 updatedAt: file.updatedAt,
-                content: file.content,
+                content,
                 ...(truncated
                   ? {
                       truncated: true,
-                      nextOffset: offset + file.content.length,
-                      hint: `File has more content. Call again with offset: ${offset + file.content.length}`,
+                      nextOffset: offset + content.length,
+                      hint: `File has more content. Call again with offset: ${offset + content.length}`,
                     }
                   : {}),
               });


### PR DESCRIPTION
## Summary

- use a one-character lookahead when paging `workspace-files` reads
- return only the requested page while reporting `truncated` only when more content exists
- declare paging coordinates as integers and defensively normalize direct calls
- add regression coverage for exact-boundary, genuinely truncated, and fractional reads
- include a patch changeset for `@agent-native/core`

## Problem

The read path requested exactly `maxChars` characters and then treated
`content.length >= maxChars` as proof that more content existed. An exact-size
page and a truncated page therefore looked identical, so a complete file whose
remaining length matched the page size was incorrectly returned with
`truncated: true` and a follow-up offset that produced an empty page.

The paging schema also accepted fractional numbers. With the sentinel read, a
fractional `maxChars` could return `truncated: true` with empty content and an
unchanged `nextOffset`, so a caller following the pagination hint could repeat
the same page indefinitely.

## Fix

Read one sentinel character beyond the requested page, use it to determine
whether more content exists, and slice the response back to `maxChars`.
Declare `offset` and `maxChars` as integer coordinates with bounds, while
defensively flooring direct-call inputs and keeping `maxChars` at least one.

## Impact

This does not change the response schema, storage format, or database queries.
The request schema now reflects the integer code-unit positions required by
string slicing. Exact-boundary files no longer trigger unnecessary follow-up
reads, and direct fractional calls cannot produce a non-advancing truncated
page.

## Validation

- `corepack pnpm --filter @agent-native/core exec vitest --run src/workspace-files --maxWorkers=25%` (17 passed)
- `corepack pnpm --filter @agent-native/core typecheck`
- `corepack pnpm exec oxfmt --check packages/core/src/workspace-files/tool.ts packages/core/src/workspace-files/tool.spec.ts .changeset/accurate-workspace-file-pagination.md`
- `corepack pnpm changeset status`

The full Core suite was also attempted in this Windows checkout; it reported
unrelated process-spawn, path, and temporary SQLite locking failures outside
these files. The focused suite and typecheck above pass, and CI remains the
authoritative full-suite result.
