### PR TITLE
feat(core): paginate progress run listings

### DIFF
--- a/.changeset/calm-runs-page.md
+++ b/.changeset/calm-runs-page.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": minor
+---
+
+Add keyset pagination to progress-run listing through `ListRunsOptions.before` and the `beforeStartedAt`/`beforeId` HTTP query parameters.

--- a/packages/core/src/progress/progress.spec.ts
+++ b/packages/core/src/progress/progress.spec.ts
@@ -198,6 +198,34 @@ describe("progress routes", () => {
     });
   });
 
+  it("forwards a complete keyset cursor for subsequent run pages", async () => {
+    const handler = createProgressHandler() as any;
+    const event = createEvent(
+      "/?limit=200&active=true&beforeStartedAt=2026-07-30T12%3A00%3A00.000Z&beforeId=run-0200",
+    );
+
+    await handler(event);
+
+    expect(mockListRuns).toHaveBeenCalledWith("boni@local", {
+      activeOnly: true,
+      before: {
+        startedAt: "2026-07-30T12:00:00.000Z",
+        id: "run-0200",
+      },
+      event,
+      limit: 200,
+    });
+  });
+
+  it("rejects incomplete keyset cursors instead of repeating the first page", async () => {
+    const handler = createProgressHandler() as any;
+
+    await expect(
+      handler(createEvent("/?beforeStartedAt=2026-07-30T12%3A00%3A00.000Z")),
+    ).rejects.toMatchObject({ statusCode: 400 });
+    expect(mockListRuns).not.toHaveBeenCalled();
+  });
+
   it("short-circuits OPTIONS before auth", async () => {
     const handler = createProgressHandler() as any;
     mockGetSession.mockRejectedValue(new Error("should not authenticate"));

--- a/packages/core/src/progress/routes.ts
+++ b/packages/core/src/progress/routes.ts
@@ -3,7 +3,7 @@
  *
  * Mounted under `/_agent-native/runs/*` by `core-routes-plugin`.
  *
- *   GET    /_agent-native/runs?active=true&limit=50
+ *   GET    /_agent-native/runs?active=true&limit=50&beforeStartedAt=<iso>&beforeId=<id>
  *   GET    /_agent-native/runs/:id
  *   DELETE /_agent-native/runs/:id
  *
@@ -28,6 +28,22 @@ function parseLimit(value: unknown, fallback = 50): number {
   const n = Number(value);
   if (!Number.isFinite(n) || n <= 0) return fallback;
   return Math.min(Math.floor(n), 200);
+}
+
+function parseBefore(
+  startedAt: unknown,
+  id: unknown,
+): { startedAt: string; id: string } | undefined {
+  if (startedAt == null && id == null) return undefined;
+  if (
+    typeof startedAt !== "string" ||
+    !Number.isFinite(Date.parse(startedAt)) ||
+    typeof id !== "string" ||
+    id.length === 0
+  ) {
+    throw new Error("Invalid progress run cursor");
+  }
+  return { startedAt, id };
 }
 
 async function resolveOwner(event: H3Event): Promise<string> {
@@ -56,8 +72,20 @@ export function createProgressHandler() {
     // GET /  — list
     if (method === "GET" && parts.length === 0) {
       const q = getQuery(event);
+      let before: ReturnType<typeof parseBefore>;
+      try {
+        before = parseBefore(q.beforeStartedAt, q.beforeId);
+      } catch {
+        const { createError } = await import("h3");
+        throw createError({
+          statusCode: 400,
+          statusMessage:
+            "beforeStartedAt and beforeId must form a valid run cursor",
+        });
+      }
       return listRuns(owner, {
         activeOnly: q.active === "true" || q.active === "1",
+        ...(before ? { before } : {}),
         limit: parseLimit(q.limit),
         event,
       });

--- a/packages/core/src/progress/store.spec.ts
+++ b/packages/core/src/progress/store.spec.ts
@@ -66,6 +66,38 @@ describe("progress store", () => {
     expect(call.args).toEqual(["alice@example.com", 50]);
   });
 
+  it("uses a deterministic keyset cursor to retrieve rows after the first 200", async () => {
+    await listRuns("alice@example.com", {
+      activeOnly: true,
+      limit: 200,
+      before: {
+        startedAt: "2026-07-30T12:00:00.000Z",
+        id: "run-0200",
+      },
+    });
+
+    const call = lastSelect();
+    expect(call.sql).toMatch(
+      /started_at < \? OR \(started_at = \? AND id < \?\)/,
+    );
+    expect(call.sql).toMatch(/ORDER BY started_at DESC, id DESC LIMIT \?/);
+    expect(call.args).toEqual([
+      "alice@example.com",
+      Date.parse("2026-07-30T12:00:00.000Z"),
+      Date.parse("2026-07-30T12:00:00.000Z"),
+      "run-0200",
+      200,
+    ]);
+  });
+
+  it("rejects an invalid keyset cursor instead of repeating the first page", async () => {
+    await expect(
+      listRuns("alice@example.com", {
+        before: { startedAt: "not-a-timestamp", id: "run-0200" },
+      }),
+    ).rejects.toThrow(/before\.startedAt/);
+  });
+
   it("marks stale running rows cancelled before listing active runs", async () => {
     const now = Date.UTC(2026, 4, 8, 16, 0, 0);
     vi.spyOn(Date, "now").mockReturnValue(now);

--- a/packages/core/src/progress/store.ts
+++ b/packages/core/src/progress/store.ts
@@ -63,8 +63,8 @@ async function ensureTable(): Promise<void> {
         // avoid ACCESS EXCLUSIVE lock contention in fresh background-worker processes.
         await ensureTableExists("progress_runs", createSql);
         await ensureIndexExists(
-          "idx_progress_runs_owner_status",
-          `CREATE INDEX IF NOT EXISTS idx_progress_runs_owner_status ON progress_runs (owner, status, started_at)`,
+          "idx_progress_runs_owner_status_started_id",
+          `CREATE INDEX IF NOT EXISTS idx_progress_runs_owner_status_started_id ON progress_runs (owner, status, started_at DESC, id DESC)`,
         );
         return;
       }
@@ -78,7 +78,7 @@ async function ensureTable(): Promise<void> {
       await client.execute(createSql);
       try {
         await client.execute(
-          `CREATE INDEX IF NOT EXISTS idx_progress_runs_owner_status ON progress_runs (owner, status, started_at)`,
+          `CREATE INDEX IF NOT EXISTS idx_progress_runs_owner_status_started_id ON progress_runs (owner, status, started_at DESC, id DESC)`,
         );
       } catch {
         // Index already exists or the dialect rejected a duplicate.
@@ -331,9 +331,20 @@ export async function listRuns(
   let where = `owner = ?`;
   const args: Array<string | number> = [owner];
   if (options.activeOnly) where += ` AND status = 'running'`;
+  if (options.before) {
+    const beforeStartedAt = Date.parse(options.before.startedAt);
+    if (!Number.isFinite(beforeStartedAt)) {
+      throw new TypeError("before.startedAt must be a valid timestamp");
+    }
+    if (!options.before.id) {
+      throw new TypeError("before.id must be a non-empty string");
+    }
+    where += ` AND (started_at < ? OR (started_at = ? AND id < ?))`;
+    args.push(beforeStartedAt, beforeStartedAt, options.before.id);
+  }
   args.push(limit);
   const { rows } = await client.execute({
-    sql: `SELECT * FROM progress_runs WHERE ${where} ORDER BY started_at DESC LIMIT ?`,
+    sql: `SELECT * FROM progress_runs WHERE ${where} ORDER BY started_at DESC, id DESC LIMIT ?`,
     args,
   });
   return rows.map((r) => parseRow(r as Record<string, unknown>));

--- a/packages/core/src/progress/types.ts
+++ b/packages/core/src/progress/types.ts
@@ -54,6 +54,11 @@ export interface ListRunsOptions {
   activeOnly?: boolean;
   /** Max rows. Default 50. */
   limit?: number;
+  /**
+   * Return rows strictly older than this run in `(startedAt, id)` order.
+   * Pass the final row from the previous page to continue listing.
+   */
+  before?: Pick<AgentRun, "startedAt" | "id">;
   /** Optional request event for producers that need to self-dispatch work. */
   event?: unknown;
 }


### PR DESCRIPTION
## Summary

Add bounded keyset pagination to progress-run listing while preserving the existing 200-row per-request cap and array response shape.

- `listRuns(owner, { before: { startedAt, id } })` retrieves the next page.
- `GET /_agent-native/runs?beforeStartedAt=<iso>&beforeId=<id>` exposes the same cursor over HTTP.
- Ordering is now deterministic by `(started_at DESC, id DESC)`.
- A matching owner/status/start/id index supports the traversal.
- Incomplete or invalid cursors fail instead of silently repeating page one.

## Problem / deterministic reproduction

Current `@agent-native/core` clamps `limit` to 200 in both the route and store, then runs a single query with no offset or cursor. With 201 owner-scoped rows:

```bash
curl -s "$BASE/_agent-native/runs?active=true&limit=1000" | jq length
# 200

curl -s "$BASE/_agent-native/runs?active=true&limit=200&offset=200" | jq '.[0].id'
# same first row: offset is not a supported parameter
```

This means row 201 cannot be discovered through the public API. The issue surfaced while building a supervision dashboard that must not lose long-lived active work behind newer rows.

With this change, callers pass the final row from page one:

```text
GET /_agent-native/runs?active=true&limit=200&beforeStartedAt=<last.startedAt>&beforeId=<last.id>
```

The per-page safety bound remains 200.

## Compatibility

- Existing callers still receive `AgentRun[]` and need no changes.
- Existing requests without cursor parameters behave the same apart from deterministic ID tie-breaking.
- Owner and `activeOnly` filters remain part of every page query.

## Verification

- RED before implementation: 4 new cursor assertions failed (route forwarding, incomplete-cursor rejection, store keyset SQL, invalid-cursor rejection).
- Revert-to-RED after implementation: the same 4 assertions failed again with production changes removed.
- Targeted: `20 passed`.
- Core typecheck: passed.
- Core build: passed.
- Core non-E2E suite at 2 workers: `736 files passed`, `10,070 tests passed`, `1 skipped`.
- The unfiltered core suite reached `742 passed` files but failed in browser E2E infrastructure with `EMFILE: too many open files`; the low-worker non-E2E rerun is green.
