### PR TITLE
Fix first-start meeting microphone transcription

### DIFF
--- a/templates/clips/changelog/2026-07-30-meeting-microphone-transcription-works-reliably-from-the-fir.md
+++ b/templates/clips/changelog/2026-07-30-meeting-microphone-transcription-works-reliably-from-the-fir.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-30
+---
+
+Meeting microphone transcription works reliably from the first start.

--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -128,6 +128,8 @@ const NATIVE_CAPTURE_FPS: u32 = 24;
 #[cfg(target_os = "macos")]
 mod custom_capture;
 #[cfg(target_os = "macos")]
+pub(crate) use custom_capture::extract_mono_audio;
+#[cfg(target_os = "macos")]
 use custom_capture::{
     prepare_clip_sink, start_custom_screencapturekit_backend_at, ClosedSegmentFile,
     CustomCaptureResume, CustomScreenCaptureWriter, PreparedClipSink, SegmentFence,

--- a/templates/clips/desktop/src-tauri/src/native_screen/custom_capture.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen/custom_capture.rs
@@ -2743,6 +2743,19 @@ fn extract_interleaved_stereo(
     Some((out, pts_seconds))
 }
 
+pub(crate) fn extract_mono_audio(
+    sample: &screencapturekit::cm::CMSampleBuffer,
+    label: &str,
+) -> Option<Vec<f32>> {
+    let (interleaved, _) = extract_interleaved_stereo(sample, label)?;
+    Some(
+        interleaved
+            .chunks_exact(2)
+            .map(|channels| (channels[0] + channels[1]) * 0.5)
+            .collect(),
+    )
+}
+
 /// Record whether decoded source PCM contains a real signal before it reaches
 /// the timeline mixer. This distinguishes capture/format failures from mixer
 /// or writer failures without persisting any audio content.

--- a/templates/clips/desktop/src-tauri/src/system_audio.rs
+++ b/templates/clips/desktop/src-tauri/src/system_audio.rs
@@ -11,8 +11,8 @@
 //! renderer's `LiveTranscript` tagged `source: "system"`.
 //!
 //! Uses the safe `screencapturekit` Rust crate. Its `SCStreamOutputTrait`
-//! callback hands us a `CMSampleBuffer` per audio frame; SCK delivers stereo
-//! 48 kHz float, which we mono-mix on the way out.
+//! callback hands us a `CMSampleBuffer` per audio frame; each source is decoded
+//! from its advertised format, normalized to 48 kHz, and mono-mixed.
 //!
 //! ## Tauri commands
 //!
@@ -163,9 +163,6 @@ pub(crate) mod macos {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use objc2::rc::Retained;
-    use objc2::AnyThread;
-    use objc2_avf_audio::{AVAudioFormat, AVAudioPCMBuffer};
     use objc2_foundation::NSProcessInfo;
     use serde::Serialize;
     use tauri::{AppHandle, Emitter};
@@ -260,7 +257,6 @@ pub(crate) mod macos {
     // ----------------------------------------------------------------------
     struct RawAudioForwarder {
         on_samples: Arc<dyn Fn(&[f32]) + Send + Sync>,
-        speech_format: Retained<AVAudioFormat>,
         app: AppHandle,
         cancelled: Arc<AtomicBool>,
         level_tick: Arc<AtomicU32>,
@@ -268,10 +264,8 @@ pub(crate) mod macos {
         source: &'static str,
     }
 
-    // SAFETY: `Retained<SFSpeech*>` and `Retained<AVAudioFormat>` wrap
-    // refcounted ObjC objects that Apple documents as message-thread-safe.
-    // SCK calls our handler from its own dispatch queue; we never alias
-    // these via `&` across threads.
+    // SAFETY: SCK calls this handler from its dispatch queue; all shared
+    // fields are immutable handles or atomics.
     unsafe impl Send for RawAudioForwarder {}
     unsafe impl Sync for RawAudioForwarder {}
 
@@ -287,30 +281,30 @@ pub(crate) mod macos {
             if self.cancelled.load(Ordering::SeqCst) {
                 return;
             }
-            let Some(buf) = build_pcm_buffer_from_sample(&sample_buffer, &self.speech_format)
+            let Some(samples) =
+                crate::native_screen::extract_mono_audio(&sample_buffer, self.source)
             else {
                 return;
             };
-            // Hand channel 0 (mono mix) to the callback continuously — no level
-            // gate, so the Whisper buffer stays a contiguous stream.
-            let frames = unsafe { buf.frameLength() } as usize;
-            if frames > 0 {
-                let ch_ptr = unsafe { buf.floatChannelData() };
-                if !ch_ptr.is_null() {
-                    let slice = unsafe { std::slice::from_raw_parts((*ch_ptr).as_ptr(), frames) };
-                    (self.on_samples)(slice);
-                }
-                let n = self.level_tick.fetch_add(1, Ordering::Relaxed);
-                if n % 3 == 0 {
-                    let level = crate::native_speech::macos::peak_level_for_pcm(&buf);
-                    let _ = self.app.emit(
-                        "voice:audio-level",
-                        AudioLevelPayload {
-                            level,
-                            source: self.source,
-                        },
-                    );
-                }
+            if samples.is_empty() {
+                return;
+            }
+            (self.on_samples)(&samples);
+            let n = self.level_tick.fetch_add(1, Ordering::Relaxed);
+            if n % 3 == 0 {
+                let level = samples
+                    .iter()
+                    .copied()
+                    .map(f32::abs)
+                    .fold(0.0_f32, f32::max)
+                    .min(1.0);
+                let _ = self.app.emit(
+                    "voice:audio-level",
+                    AudioLevelPayload {
+                        level,
+                        source: self.source,
+                    },
+                );
             }
         }
     }
@@ -448,19 +442,11 @@ pub(crate) mod macos {
             );
         }
 
-        // Mono float32 @ 48 kHz destination format for the mono-mix.
-        let speech_format = unsafe {
-            let allocated = AVAudioFormat::alloc();
-            AVAudioFormat::initStandardFormatWithSampleRate_channels(allocated, 48000.0, 1)
-        }
-        .ok_or_else(|| "AVAudioFormat init failed for raw system capture".to_string())?;
-
         let cancelled = Arc::new(AtomicBool::new(false));
         let mut stream = SCStream::new(&filter, &config);
         if let Some(on_samples) = on_system_samples {
             let forwarder = RawAudioForwarder {
                 on_samples,
-                speech_format: speech_format.clone(),
                 app: app.clone(),
                 cancelled: cancelled.clone(),
                 level_tick: Arc::new(AtomicU32::new(0)),
@@ -472,7 +458,6 @@ pub(crate) mod macos {
         if let Some(on_samples) = on_mic_samples {
             let forwarder = RawAudioForwarder {
                 on_samples,
-                speech_format,
                 app: app.clone(),
                 cancelled: cancelled.clone(),
                 level_tick: Arc::new(AtomicU32::new(0)),
@@ -494,97 +479,5 @@ pub(crate) mod macos {
     struct AudioLevelPayload {
         level: f32,
         source: &'static str,
-    }
-
-    /// Pull the PCM bytes out of a SCK CMSampleBuffer and copy them into a
-    /// freshly-allocated AVAudioPCMBuffer matching `speech_format`
-    /// (single-channel float32 at the SCK sample rate). SCK delivers stereo
-    /// non-interleaved float32 by default — we mono-mix by averaging the
-    /// two channels. Returns `None` if the sample buffer's audio layout
-    /// can't be interpreted (rare; only happens if SCK changes its output
-    /// shape mid-stream).
-    fn build_pcm_buffer_from_sample(
-        sample: &CMSampleBuffer,
-        speech_format: &AVAudioFormat,
-    ) -> Option<Retained<AVAudioPCMBuffer>> {
-        let num_samples = sample.num_samples();
-        if num_samples == 0 {
-            return None;
-        }
-        let abl = sample.audio_buffer_list()?;
-        let n_buffers = abl.num_buffers();
-        if n_buffers == 0 {
-            return None;
-        }
-
-        // Allocate the destination buffer.
-        // SAFETY: standard AVAudioPCMBuffer init; we control the format and
-        // capacity.
-        #[allow(clippy::cast_possible_truncation)]
-        let frame_capacity = num_samples as u32;
-        let allocated = AVAudioPCMBuffer::alloc();
-        let dest = unsafe {
-            AVAudioPCMBuffer::initWithPCMFormat_frameCapacity(
-                allocated,
-                speech_format,
-                frame_capacity,
-            )
-        }?;
-        unsafe { dest.setFrameLength(frame_capacity) };
-
-        // SAFETY: the format is the one we constructed below — float, mono,
-        // non-interleaved — so `floatChannelData` is non-null and points at
-        // `channelCount=1` pointers, each to `frame_capacity` floats.
-        let dest_ch_ptr = unsafe { dest.floatChannelData() };
-        if dest_ch_ptr.is_null() {
-            return None;
-        }
-        let dest_slice =
-            unsafe { std::slice::from_raw_parts_mut((*dest_ch_ptr).as_ptr(), num_samples) };
-
-        if n_buffers >= 2 {
-            // Stereo non-interleaved — average the two channels.
-            let l = abl.get(0)?;
-            let r = abl.get(1)?;
-            let l_bytes = l.data();
-            let r_bytes = r.data();
-            // Treat as f32 little-endian (host byte order on every Apple
-            // platform we ship).
-            let l_floats = bytes_as_f32(l_bytes);
-            let r_floats = bytes_as_f32(r_bytes);
-            let n = num_samples.min(l_floats.len()).min(r_floats.len());
-            for i in 0..n {
-                dest_slice[i] = 0.5 * (l_floats[i] + r_floats[i]);
-            }
-            for v in dest_slice.iter_mut().take(num_samples).skip(n) {
-                *v = 0.0;
-            }
-        } else {
-            // Mono — just copy.
-            let only = abl.get(0)?;
-            let src = bytes_as_f32(only.data());
-            let n = num_samples.min(src.len());
-            dest_slice[..n].copy_from_slice(&src[..n]);
-            for v in dest_slice.iter_mut().take(num_samples).skip(n) {
-                *v = 0.0;
-            }
-        }
-
-        Some(dest)
-    }
-
-    /// Reinterpret a `&[u8]` as `&[f32]`. Length is rounded down to the
-    /// nearest multiple of 4. Safe because `f32` has no invalid
-    /// bit-patterns and the caller only uses the elements they're
-    /// indexing into.
-    fn bytes_as_f32(b: &[u8]) -> &[f32] {
-        let n = b.len() / 4;
-        if n == 0 {
-            return &[];
-        }
-        // SAFETY: `f32` is plain old data with alignment 4; CoreAudio's
-        // AudioBuffer pointers are 16-byte aligned in practice. We cap the
-        // length at `n` so we never read past the end.
-        unsafe { std::slice::from_raw_parts(b.as_ptr().cast::<f32>(), n) }
     }
 }


### PR DESCRIPTION
Makes meeting microphone transcription reliable from the moment recording starts on macOS.

## Summary

Fixes meeting microphone transcription failing on the first start on macOS, especially when microphones use different audio formats or sample rates. Meeting audio now uses the same reliable audio normalization as native recording, while keeping microphone and system audio correctly separated for transcription. Adds a user-facing changelog entry for the fix.
