### PR TITLE
fix: scope chats

### DIFF
--- a/.changeset/scope-chats-to-the-resource-they-run-in.md
+++ b/.changeset/scope-chats-to-the-resource-they-run-in.md
@@ -1,0 +1,28 @@
+---
+"@agent-native/core": patch
+---
+
+Keep each resource's agent chat to itself instead of showing one chat everywhere.
+
+A chat thread's `scope` carried two meanings at once: "general chat, visible in
+every resource" and "nobody has told the server this thread's scope yet". Because
+those were indistinguishable, a thread that lost its scope silently became a
+permanent global chat — it followed the user into every design/deck/form, and
+because an unscoped chat is allowed to stay visible, no per-resource chat was ever
+started.
+
+Two paths dropped the scope. The server created the row on the first message
+without one (`persistSubmittedUserMessage`), even though the client already sends
+it and `production-agent` had already normalized it onto
+`RequestRunContext.chatScope` — nothing read that field. The client then asserted
+`scope: null` on every save for any thread missing from its local list, which the
+`PUT` applies unconditionally, cementing the null.
+
+Now the run's scope is used when the row is created, a thread with no scope adopts
+the scope of the resource it is used in (`resolveRunThreadScope`, which never
+retags or clears an already-scoped thread), and the client only mirrors a scope it
+actually knows — `detachThread` remains the single path that clears one. Adoption
+also heals threads already stored with `scope: null`. A saved active-chat pointer
+is no longer trusted when the thread's known scope belongs to another resource.
+
+Genuinely general chats are unaffected until they are used inside a resource.

--- a/.changeset/scope-chats-to-the-resource-they-run-in.md
+++ b/.changeset/scope-chats-to-the-resource-they-run-in.md
@@ -22,7 +22,10 @@ Now the run's scope is used when the row is created, a thread with no scope adop
 the scope of the resource it is used in (`resolveRunThreadScope`, which never
 retags or clears an already-scoped thread), and the client only mirrors a scope it
 actually knows — `detachThread` remains the single path that clears one. Adoption
-also heals threads already stored with `scope: null`. A saved active-chat pointer
-is no longer trusted when the thread's known scope belongs to another resource.
+also heals threads already stored with `scope: null`, and claims the row with a
+compare-and-set on the unscoped state so two workers racing to adopt the same
+legacy thread cannot retag it to the wrong resource. A saved active-chat pointer
+is no longer trusted when the thread's known scope belongs to another resource,
+on a direct mount as well as when moving between resources.
 
 Genuinely general chats are unaffected until they are used inside a resource.

--- a/.changeset/scope-chats-to-the-resource-they-run-in.md
+++ b/.changeset/scope-chats-to-the-resource-they-run-in.md
@@ -21,11 +21,16 @@ it and `production-agent` had already normalized it onto
 Now the run's scope is used when the row is created, a thread with no scope adopts
 the scope of the resource it is used in (`resolveRunThreadScope`, which never
 retags or clears an already-scoped thread), and the client only mirrors a scope it
-actually knows — `detachThread` remains the single path that clears one. Adoption
-also heals threads already stored with `scope: null`, and claims the row with a
-compare-and-set on the unscoped state so two workers racing to adopt the same
-legacy thread cannot retag it to the wrong resource. A saved active-chat pointer
-is no longer trusted when the thread's known scope belongs to another resource,
-on a direct mount as well as when moving between resources.
+actually knows. Adoption also heals threads already stored with `scope: null`, and
+claims the row with a compare-and-set on the unscoped state so two workers racing
+to adopt the same legacy thread cannot retag it to the wrong resource.
+
+Scope now rides only on thread creation: a periodic save no longer sends it, so a
+stale client guess cannot move an existing thread between resources, and
+`detachThread` is the only client path that clears one. A restored active-chat
+pointer is checked against the thread's real scope on a direct mount as well as
+when moving between resources — and because the thread list is one page, a pointer
+naming a thread the page did not reach is resolved by id rather than assumed to be
+a never-messaged local tab.
 
 Genuinely general chats are unaffected until they are used inside a resource.

--- a/packages/core/src/chat-threads/store.spec.ts
+++ b/packages/core/src/chat-threads/store.spec.ts
@@ -21,6 +21,7 @@ import {
   grantThreadUserShare,
   listThreads,
   renameThread,
+  resolveRunThreadScope,
   revokeThreadShareLink,
   searchThreads,
   setThreadArchived,
@@ -990,5 +991,27 @@ describe("chat thread store", () => {
     expect(
       JSON.parse(rows.get("thread-forked-stale")!.thread_data).messages,
     ).toHaveLength(2);
+  });
+});
+
+describe("resolveRunThreadScope", () => {
+  const designA = { type: "design", id: "design-a" };
+  const designB = { type: "design", id: "design-b" };
+
+  it("adopts the run's scope when the thread has none", () => {
+    expect(resolveRunThreadScope(null, designA)).toEqual(designA);
+  });
+
+  it("keeps the thread's own scope when a run arrives from another resource", () => {
+    expect(resolveRunThreadScope(designA, designB)).toEqual(designA);
+  });
+
+  it("never clears a scope when the run carries none", () => {
+    expect(resolveRunThreadScope(designA, null)).toEqual(designA);
+    expect(resolveRunThreadScope(designA, undefined)).toEqual(designA);
+  });
+
+  it("leaves a general chat general when the run is also unscoped", () => {
+    expect(resolveRunThreadScope(null, null)).toBeNull();
   });
 });

--- a/packages/core/src/chat-threads/store.spec.ts
+++ b/packages/core/src/chat-threads/store.spec.ts
@@ -15,6 +15,7 @@ vi.mock("./emitter.js", () => ({
 }));
 
 import {
+  adoptThreadScopeIfUnscoped,
   createThreadShareLink,
   forkThread,
   getThreadByShareToken,
@@ -1013,5 +1014,76 @@ describe("resolveRunThreadScope", () => {
 
   it("leaves a general chat general when the run is also unscoped", () => {
     expect(resolveRunThreadScope(null, null)).toBeNull();
+  });
+});
+
+describe("adoptThreadScopeIfUnscoped", () => {
+  const designA = { type: "design", id: "design-a" };
+  const designB = { type: "design", id: "design-b" };
+
+  function mockRow(scopeType: string | null, scopeId: string | null) {
+    const row = {
+      id: "thread-1",
+      owner_email: "user@example.com",
+      title: "Thread",
+      preview: "",
+      thread_data: "{}",
+      message_count: 1,
+      created_at: 1,
+      updated_at: 1,
+      scope_type: scopeType,
+      scope_id: scopeId,
+      scope_label: null,
+      pinned_at: null,
+      archived_at: null,
+      org_id: null,
+      visibility: "private" as const,
+    };
+    executeMock.mockReset();
+    emitChatThreadChangeMock.mockReset();
+    executeMock.mockImplementation(async (query: string | any) => {
+      const sql = typeof query === "string" ? query : query.sql;
+      const args = typeof query === "string" ? [] : query.args;
+      if (/CREATE TABLE/i.test(sql) || /CREATE INDEX/i.test(sql)) {
+        return { rows: [], rowsAffected: 0 };
+      }
+      if (/SELECT id, thread_data, message_count/i.test(sql)) {
+        return { rows: [], rowsAffected: 0 };
+      }
+      if (/UPDATE chat_threads SET scope_type/i.test(sql)) {
+        // Honour the compare-and-set guard the real statement carries.
+        if (/AND scope_type IS NULL/i.test(sql) && row.scope_type !== null) {
+          return { rows: [], rowsAffected: 0 };
+        }
+        row.scope_type = args[0];
+        row.scope_id = args[1];
+        row.scope_label = args[2];
+        return { rows: [], rowsAffected: 1 };
+      }
+      if (/SELECT id, owner_email/i.test(sql)) {
+        return { rows: [row], rowsAffected: 0 };
+      }
+      throw new Error(`Unexpected SQL: ${sql}`);
+    });
+    return row;
+  }
+
+  it("claims an unscoped thread and reports the scope it won", async () => {
+    const row = mockRow(null, null);
+
+    expect(await adoptThreadScopeIfUnscoped("thread-1", designA)).toEqual(
+      designA,
+    );
+    expect(row.scope_id).toBe("design-a");
+  });
+
+  it("reports the winner's scope instead of retagging when another worker won", async () => {
+    const row = mockRow("design", "design-a");
+
+    expect(await adoptThreadScopeIfUnscoped("thread-1", designB)).toEqual({
+      type: "design",
+      id: "design-a",
+    });
+    expect(row.scope_id).toBe("design-a");
   });
 });

--- a/packages/core/src/chat-threads/store.ts
+++ b/packages/core/src/chat-threads/store.ts
@@ -767,10 +767,9 @@ export async function searchThreads(
 }
 
 /**
- * Scope a thread should carry after a run inside a resource. A thread that
- * already has a scope keeps it — a run reaching a chat from somewhere else must
- * never retag or clear it, which is what turns one chat into every resource's
- * chat.
+ * Scope a thread should carry after a run inside a resource: adopt when it has
+ * none, otherwise keep what it has. An unscoped thread reads as general, and a
+ * general chat renders inside every resource — so never retag, never clear.
  */
 export function resolveRunThreadScope(
   existing: ChatThreadScope | null,

--- a/packages/core/src/chat-threads/store.ts
+++ b/packages/core/src/chat-threads/store.ts
@@ -781,6 +781,35 @@ export function resolveRunThreadScope(
 }
 
 /**
+ * Claim an unscoped thread for `scope`, returning the scope it actually ends up
+ * with. `withThreadDataLock` only serializes one process, so two workers can
+ * both read the same unscoped row; the `scope_type IS NULL` guard makes the
+ * first writer win and the loser reports the winner instead of retagging.
+ */
+export async function adoptThreadScopeIfUnscoped(
+  id: string,
+  scope: ChatThreadScope,
+): Promise<ChatThreadScope | null> {
+  await ensureTable();
+  const client = getDbExec();
+  const result = await client.execute({
+    sql: `UPDATE chat_threads SET scope_type = ?, scope_id = ?, scope_label = ?, updated_at = ? WHERE id = ? AND scope_type IS NULL`,
+    args: [
+      scope.type,
+      scope.id,
+      scope.label ?? null,
+      Math.max(Date.now(), 1),
+      id,
+    ],
+  });
+  if (result.rowsAffected > 0) {
+    emitChatThreadChange(id);
+    return scope;
+  }
+  return (await getThread(id))?.scope ?? null;
+}
+
+/**
  * Detach or rebind a chat's scope. Used by the UI's "Detach from <resource>"
  * action and by templates that need to retag a chat after a rename. Pass
  * `null` to clear the scope (chat becomes general).

--- a/packages/core/src/chat-threads/store.ts
+++ b/packages/core/src/chat-threads/store.ts
@@ -767,6 +767,20 @@ export async function searchThreads(
 }
 
 /**
+ * Scope a thread should carry after a run inside a resource. A thread that
+ * already has a scope keeps it — a run reaching a chat from somewhere else must
+ * never retag or clear it, which is what turns one chat into every resource's
+ * chat.
+ */
+export function resolveRunThreadScope(
+  existing: ChatThreadScope | null,
+  incoming: ChatThreadScope | null | undefined,
+): ChatThreadScope | null {
+  if (existing) return existing;
+  return incoming ?? null;
+}
+
+/**
  * Detach or rebind a chat's scope. Used by the UI's "Detach from <resource>"
  * action and by templates that need to retag a chat after a rename. Pass
  * `null` to clear the scope (chat becomes general).

--- a/packages/core/src/client/use-chat-threads.spec.tsx
+++ b/packages/core/src/client/use-chat-threads.spec.tsx
@@ -829,8 +829,6 @@ describe("useChatThreads", () => {
   });
 
   it("ignores a saved active chat that belongs to a different resource", async () => {
-    // The pointer under design B's key names a thread scoped to design A —
-    // what an older unscoped pointer looks like once the thread gains a scope.
     window.localStorage.setItem(
       "agent-chat-active-thread:design-app:scope:design:design-b",
       "design-a-thread",
@@ -886,8 +884,6 @@ describe("useChatThreads", () => {
   });
 
   it("ignores a restored pointer for another resource's thread on a direct mount", async () => {
-    // No scope flip here — a fresh load straight into design B, where the
-    // pointer was written before the thread gained design A's scope.
     window.localStorage.setItem(
       "agent-chat-active-thread:design-app:scope:design:design-b",
       "design-a-thread",
@@ -1013,8 +1009,7 @@ describe("useChatThreads", () => {
       await Promise.resolve();
     });
 
-    // A thread this client has never listed — a null here would clear the
-    // server's scope and make the chat render inside every design.
+    // Deliberately absent from the list this client loaded.
     await act(async () => {
       await hook!.saveThreadData("thread-from-another-tab", {
         threadData: JSON.stringify({ messages: [{ id: "m-1" }] }),

--- a/packages/core/src/client/use-chat-threads.spec.tsx
+++ b/packages/core/src/client/use-chat-threads.spec.tsx
@@ -828,6 +828,140 @@ describe("useChatThreads", () => {
     });
   });
 
+  it("ignores a saved active chat that belongs to a different resource", async () => {
+    // The pointer under design B's key names a thread scoped to design A —
+    // what an older unscoped pointer looks like once the thread gains a scope.
+    window.localStorage.setItem(
+      "agent-chat-active-thread:design-app:scope:design:design-b",
+      "design-a-thread",
+    );
+    const designAThread: ChatThreadSummary = {
+      id: "design-a-thread",
+      title: "Design A edits",
+      preview: "make the button brighter",
+      messageCount: 2,
+      createdAt: 1,
+      updatedAt: 2,
+      scope: { type: "design", id: "design-a", label: "Design A" },
+    };
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/chat/threads" && !init) {
+        return jsonResponse({ threads: [designAThread] });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let hook: ReturnType<typeof useChatThreads> | null = null;
+    function Harness({ scope }: { scope: ChatThreadScope }) {
+      hook = useChatThreads("/chat", "design-app", scope);
+      return null;
+    }
+
+    await act(async () => {
+      root.render(
+        <Harness
+          scope={{ type: "design", id: "design-a", label: "Design A" }}
+        />,
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      root.render(
+        <Harness
+          scope={{ type: "design", id: "design-b", label: "Design B" }}
+        />,
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(hook!.activeThreadId).toBe("forked-thread");
+  });
+
+  it("omits scope when saving a thread whose scope this client does not know", async () => {
+    const scopedThread: ChatThreadSummary = {
+      id: "scoped-thread",
+      title: "Design A edits",
+      preview: "make the button brighter",
+      messageCount: 2,
+      createdAt: 1,
+      updatedAt: 2,
+      scope: { type: "design", id: "design-a", label: "Design A" },
+    };
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/chat/threads" && !init) {
+        return jsonResponse({ threads: [scopedThread] });
+      }
+      if (init?.method === "PUT") return jsonResponse({ ok: true });
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let hook: ReturnType<typeof useChatThreads> | null = null;
+    function Harness() {
+      hook = useChatThreads("/chat", "design-app", {
+        type: "design",
+        id: "design-a",
+      });
+      return null;
+    }
+
+    await act(async () => {
+      root.render(<Harness />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // A thread this client has never listed — a null here would clear the
+    // server's scope and make the chat render inside every design.
+    await act(async () => {
+      await hook!.saveThreadData("thread-from-another-tab", {
+        threadData: JSON.stringify({ messages: [{ id: "m-1" }] }),
+        title: "Elsewhere",
+        preview: "hello",
+        messageCount: 1,
+      });
+    });
+
+    const unknownPut = fetchMock.mock.calls.find(
+      ([url, init]) =>
+        url === "/chat/threads/thread-from-another-tab" &&
+        init?.method === "PUT",
+    );
+    expect(JSON.parse(unknownPut![1]!.body as string)).not.toHaveProperty(
+      "scope",
+    );
+
+    // A thread it does know still mirrors the scope so the server catches up.
+    await act(async () => {
+      await hook!.saveThreadData("scoped-thread", {
+        threadData: JSON.stringify({ messages: [{ id: "m-2" }] }),
+        title: "Design A edits",
+        preview: "make the button brighter",
+        messageCount: 3,
+      });
+    });
+
+    const knownPut = fetchMock.mock.calls.find(
+      ([url, init]) =>
+        url === "/chat/threads/scoped-thread" && init?.method === "PUT",
+    );
+    expect(JSON.parse(knownPut![1]!.body as string).scope).toEqual({
+      type: "design",
+      id: "design-a",
+      label: "Design A",
+    });
+  });
+
   it("sends the current client snapshot when forking a thread", async () => {
     const sourceThread: ChatThreadSummary = {
       id: "source-thread",

--- a/packages/core/src/client/use-chat-threads.spec.tsx
+++ b/packages/core/src/client/use-chat-threads.spec.tsx
@@ -390,6 +390,14 @@ describe("useChatThreads", () => {
       if (url === "/chat/threads" && !init) {
         return jsonResponse({ threads: [existingThread] });
       }
+      // The server denying it exists is what makes this a local tab and not an
+      // older thread the list page simply did not reach.
+      if (url === "/chat/threads/empty-sidebar-tab") {
+        return new Response(JSON.stringify({ error: "Thread not found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
       throw new Error(`Unexpected fetch: ${url}`);
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -973,7 +981,148 @@ describe("useChatThreads", () => {
     expect(hook!.activeThreadId).toBe("general-thread");
   });
 
-  it("omits scope when saving a thread whose scope this client does not know", async () => {
+  it("rejects an older thread the list page missed once its scope resolves elsewhere", async () => {
+    window.localStorage.setItem(
+      "agent-chat-active-thread:design-app:scope:design:design-b",
+      "older-design-a-thread",
+    );
+    const pageOneThread: ChatThreadSummary = {
+      id: "recent-thread",
+      title: "Recent",
+      preview: "something else",
+      messageCount: 1,
+      createdAt: 9,
+      updatedAt: 9,
+      scope: null,
+    };
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/chat/threads" && !init) {
+        return jsonResponse({ threads: [pageOneThread] });
+      }
+      if (url === "/chat/threads/older-design-a-thread") {
+        return jsonResponse({
+          id: "older-design-a-thread",
+          title: "Design A edits",
+          preview: "make the button brighter",
+          messageCount: 4,
+          createdAt: 1,
+          updatedAt: 2,
+          scope: { type: "design", id: "design-a", label: "Design A" },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let hook: ReturnType<typeof useChatThreads> | null = null;
+    function Harness() {
+      hook = useChatThreads("/chat", "design-app", {
+        type: "design",
+        id: "design-b",
+      });
+      return null;
+    }
+
+    await act(async () => {
+      root.render(<Harness />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(hook!.activeThreadId).toBe("forked-thread");
+    expect(hook!.isNewThread("older-design-a-thread")).toBe(false);
+  });
+
+  it("keeps an older thread the list page missed when its scope matches", async () => {
+    window.localStorage.setItem(
+      "agent-chat-active-thread:design-app:scope:design:design-a",
+      "older-design-a-thread",
+    );
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/chat/threads" && !init) {
+        return jsonResponse({ threads: [] });
+      }
+      if (url === "/chat/threads/older-design-a-thread") {
+        return jsonResponse({
+          id: "older-design-a-thread",
+          title: "Design A edits",
+          preview: "make the button brighter",
+          messageCount: 4,
+          createdAt: 1,
+          updatedAt: 2,
+          scope: { type: "design", id: "design-a" },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let hook: ReturnType<typeof useChatThreads> | null = null;
+    function Harness() {
+      hook = useChatThreads("/chat", "design-app", {
+        type: "design",
+        id: "design-a",
+      });
+      return null;
+    }
+
+    await act(async () => {
+      root.render(<Harness />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(hook!.activeThreadId).toBe("older-design-a-thread");
+    // A real thread, so it must not be reclassified as a never-messaged tab.
+    expect(hook!.isNewThread("older-design-a-thread")).toBe(false);
+  });
+
+  it("leaves a restored thread alone when the by-id lookup is unreachable", async () => {
+    window.localStorage.setItem(
+      "agent-chat-active-thread:design-app:scope:design:design-b",
+      "unresolved-thread",
+    );
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/chat/threads" && !init) {
+        return jsonResponse({ threads: [] });
+      }
+      if (url === "/chat/threads/unresolved-thread") {
+        throw new Error("network down");
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let hook: ReturnType<typeof useChatThreads> | null = null;
+    function Harness() {
+      hook = useChatThreads("/chat", "design-app", {
+        type: "design",
+        id: "design-b",
+      });
+      return null;
+    }
+
+    await act(async () => {
+      root.render(<Harness />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Not reclassified and not stamped with design B on a guess.
+    expect(hook!.activeThreadId).toBe("unresolved-thread");
+    expect(hook!.isNewThread("unresolved-thread")).toBe(false);
+  });
+
+  it("never sends scope when saving thread data, so a save cannot move a thread", async () => {
     const scopedThread: ChatThreadSummary = {
       id: "scoped-thread",
       title: "Design A edits",
@@ -1028,7 +1177,7 @@ describe("useChatThreads", () => {
       "scope",
     );
 
-    // A thread it does know still mirrors the scope so the server catches up.
+    // Knowing the scope makes no difference: an update may not carry one.
     await act(async () => {
       await hook!.saveThreadData("scoped-thread", {
         threadData: JSON.stringify({ messages: [{ id: "m-2" }] }),
@@ -1042,11 +1191,9 @@ describe("useChatThreads", () => {
       ([url, init]) =>
         url === "/chat/threads/scoped-thread" && init?.method === "PUT",
     );
-    expect(JSON.parse(knownPut![1]!.body as string).scope).toEqual({
-      type: "design",
-      id: "design-a",
-      label: "Design A",
-    });
+    expect(JSON.parse(knownPut![1]!.body as string)).not.toHaveProperty(
+      "scope",
+    );
   });
 
   it("sends the current client snapshot when forking a thread", async () => {

--- a/packages/core/src/client/use-chat-threads.spec.tsx
+++ b/packages/core/src/client/use-chat-threads.spec.tsx
@@ -885,6 +885,98 @@ describe("useChatThreads", () => {
     expect(hook!.activeThreadId).toBe("forked-thread");
   });
 
+  it("ignores a restored pointer for another resource's thread on a direct mount", async () => {
+    // No scope flip here — a fresh load straight into design B, where the
+    // pointer was written before the thread gained design A's scope.
+    window.localStorage.setItem(
+      "agent-chat-active-thread:design-app:scope:design:design-b",
+      "design-a-thread",
+    );
+    const designAThread: ChatThreadSummary = {
+      id: "design-a-thread",
+      title: "Design A edits",
+      preview: "make the button brighter",
+      messageCount: 2,
+      createdAt: 1,
+      updatedAt: 2,
+      scope: { type: "design", id: "design-a", label: "Design A" },
+    };
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/chat/threads" && !init) {
+        return jsonResponse({ threads: [designAThread] });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let hook: ReturnType<typeof useChatThreads> | null = null;
+    function Harness() {
+      hook = useChatThreads("/chat", "design-app", {
+        type: "design",
+        id: "design-b",
+        label: "Design B",
+      });
+      return null;
+    }
+
+    await act(async () => {
+      root.render(<Harness />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(hook!.activeThreadId).toBe("forked-thread");
+    expect(
+      window.localStorage.getItem(
+        "agent-chat-active-thread:design-app:scope:design:design-b",
+      ),
+    ).toBe("forked-thread");
+  });
+
+  it("keeps a restored general chat on a direct mount into a resource", async () => {
+    window.localStorage.setItem(
+      "agent-chat-active-thread:design-app:scope:design:design-b",
+      "general-thread",
+    );
+    const generalThread: ChatThreadSummary = {
+      id: "general-thread",
+      title: "Create a design",
+      preview: "make me a landing page",
+      messageCount: 2,
+      createdAt: 1,
+      updatedAt: 2,
+      scope: null,
+    };
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/chat/threads" && !init) {
+        return jsonResponse({ threads: [generalThread] });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let hook: ReturnType<typeof useChatThreads> | null = null;
+    function Harness() {
+      hook = useChatThreads("/chat", "design-app", {
+        type: "design",
+        id: "design-b",
+      });
+      return null;
+    }
+
+    await act(async () => {
+      root.render(<Harness />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(hook!.activeThreadId).toBe("general-thread");
+  });
+
   it("omits scope when saving a thread whose scope this client does not know", async () => {
     const scopedThread: ChatThreadSummary = {
       id: "scoped-thread",

--- a/packages/core/src/client/use-chat-threads.ts
+++ b/packages/core/src/client/use-chat-threads.ts
@@ -595,7 +595,7 @@ export function useChatThreads(
 
     (async () => {
       const loadedThreads = await fetchThreads();
-      const savedId = activeThreadIdRef.current;
+      const restoredId = activeThreadIdRef.current;
       if (loadedThreads === undefined) {
         // Thread-list fetch failed. Do not reclassify a saved id as a new
         // optimistic tab; AssistantChat should still get a chance to restore
@@ -603,6 +603,22 @@ export function useChatThreads(
         setIsLoading(false);
         return;
       }
+      // The synchronous restore trusts a pointer written under an older key,
+      // which can name a thread that has since gained its own scope. Route-owned
+      // threads are exempt: the URL names the thread the user asked for.
+      const restoredThread = restoredId
+        ? loadedThreads.find((t) => t.id === restoredId)
+        : undefined;
+      const restoredBelongsElsewhere = Boolean(
+        !routeControlsActiveThread &&
+        restoredThread &&
+        !threadCanStayVisibleInScope(
+          restoredThread.scope ?? null,
+          scopeRef.current,
+        ),
+      );
+      if (restoredBelongsElsewhere) setActiveThreadId(null);
+      const savedId = restoredBelongsElsewhere ? null : restoredId;
       const loadedHasSavedId = Boolean(
         savedId && loadedThreads.some((t) => t.id === savedId),
       );

--- a/packages/core/src/client/use-chat-threads.ts
+++ b/packages/core/src/client/use-chat-threads.ts
@@ -91,6 +91,25 @@ async function fetchThreadListPage(
   });
 }
 
+/**
+ * Look up one thread the list page did not carry. Distinguishes the three states
+ * the caller must not collapse: the thread (found), `null` (the server denies it
+ * exists), and `undefined` (unreachable — nothing was learned).
+ */
+async function fetchThreadById(
+  apiUrl: string,
+  id: string,
+): Promise<ChatThreadSummary | null | undefined> {
+  try {
+    const res = await fetch(`${apiUrl}/threads/${encodeURIComponent(id)}`);
+    if (res.status === 404) return null;
+    if (!res.ok) return undefined;
+    return (await res.json()) as ChatThreadSummary;
+  } catch {
+    return undefined;
+  }
+}
+
 function emitThreadsUpdated() {
   if (typeof window === "undefined") return;
   window.dispatchEvent(new CustomEvent(THREADS_UPDATED_EVENT));
@@ -602,13 +621,29 @@ export function useChatThreads(
         setIsLoading(false);
         return;
       }
-      // Route-owned threads are exempt: the URL names the thread the user asked
-      // for, whatever its scope.
-      const restoredThread = restoredId
+      // Exempts route-owned threads (the URL names what the user asked for) and
+      // ids this client generated, which have never reached the server.
+      const lookupRestored = Boolean(
+        restoredId &&
+        !routeControlsActiveThread &&
+        !newlyCreatedRef.current.has(restoredId),
+      );
+      const restoredOnPage = restoredId
         ? loadedThreads.find((t) => t.id === restoredId)
         : undefined;
+      // One page, so absence from it is not absence from the server — this is what
+      // separates an older real thread from the ghost tab reclassified below.
+      const restoredThread =
+        lookupRestored && !restoredOnPage
+          ? await fetchThreadById(apiUrl, restoredId!)
+          : restoredOnPage;
+      if (restoredThread === undefined && lookupRestored && !restoredOnPage) {
+        // Lookup unreachable. Reclassifying now would stamp this thread with the
+        // current scope on a guess; leave it untouched for the next mount.
+        setIsLoading(false);
+        return;
+      }
       const restoredBelongsElsewhere = Boolean(
-        !routeControlsActiveThread &&
         restoredThread &&
         !threadCanStayVisibleInScope(
           restoredThread.scope ?? null,
@@ -618,7 +653,8 @@ export function useChatThreads(
       if (restoredBelongsElsewhere) setActiveThreadId(null);
       const savedId = restoredBelongsElsewhere ? null : restoredId;
       const loadedHasSavedId = Boolean(
-        savedId && loadedThreads.some((t) => t.id === savedId),
+        savedId &&
+        (restoredThread || loadedThreads.some((t) => t.id === savedId)),
       );
       const savedIdCameFromRoute =
         Boolean(savedId) &&
@@ -672,6 +708,7 @@ export function useChatThreads(
       setIsLoading(false);
     })();
   }, [
+    apiUrl,
     fetchThreads,
     addOptimisticThread,
     autoCreate,
@@ -974,9 +1011,9 @@ export function useChatThreads(
     [apiUrl, clearUserRenamedThread, createThread],
   );
 
-  // Reads scope through refs so this callback survives every setThreads. Sends
-  // only a scope this client knows: a `null` clears the server's, which only
-  // `detachThread` may do.
+  // Reads scope through refs so this callback survives every setThreads. Scope
+  // rides only on creation: a periodic save must never move an existing thread
+  // between resources, however stale this client's guess is.
   const saveThreadData = useCallback(
     async (
       id: string,
@@ -1000,11 +1037,7 @@ export function useChatThreads(
           titleSource,
           { preserveUserTitle },
         );
-        const payload = {
-          ...threadDataPayload,
-          title,
-          ...(knownScope ? { scope: knownScope } : {}),
-        };
+        const payload = { ...threadDataPayload, title };
         let response = await fetch(
           `${apiUrl}/threads/${encodeURIComponent(id)}`,
           {

--- a/packages/core/src/client/use-chat-threads.ts
+++ b/packages/core/src/client/use-chat-threads.ts
@@ -411,6 +411,18 @@ export function useChatThreads(
       } catch {
         nextActiveThreadId = null;
       }
+      // A thread that gained a scope after this pointer was written is still
+      // named by the older key. Only a known mismatch disqualifies it — an
+      // unresolved scope must not be read as "belongs here".
+      if (nextActiveThreadId) {
+        const savedScope = readKnownThreadScope(nextActiveThreadId);
+        if (
+          savedScope !== undefined &&
+          !threadCanStayVisibleInScope(savedScope, scopeRef.current)
+        ) {
+          nextActiveThreadId = null;
+        }
+      }
       if (!nextActiveThreadId && autoCreate) {
         nextActiveThreadId = createLocalThreadId();
         newlyCreatedRef.current.add(nextActiveThreadId);
@@ -948,12 +960,9 @@ export function useChatThreads(
     [apiUrl, clearUserRenamedThread, createThread],
   );
 
-  // Ref to look up the latest scope of a known thread inside
-  // saveThreadData without making the callback re-create on every
-  // setThreads. The thread's scope is owned by createThread /
-  // detachThread / fetchThreads — saveThreadData just mirrors it on
-  // every save so the server eventually catches up after
-  // persistSubmittedUserMessage creates the row sans scope.
+  // Mirrors only a scope this client actually knows: `scope: null` for a thread
+  // missing from the local list would clear the server's, and an unscoped chat
+  // renders in every resource. `detachThread` is the one path that may clear it.
   const saveThreadData = useCallback(
     async (
       id: string,
@@ -968,7 +977,7 @@ export function useChatThreads(
       try {
         const { titleSource, ...threadDataPayload } = data;
         const localThread = threadsRef.current.find((t) => t.id === id);
-        const localScope = localThread?.scope ?? null;
+        const knownScope = readKnownThreadScope(id) ?? null;
         const preserveUserTitle = userRenamedThreadIdsRef.current.has(id);
         const title = nextThreadTitle(
           localThread?.title,
@@ -980,7 +989,7 @@ export function useChatThreads(
         const payload = {
           ...threadDataPayload,
           title,
-          scope: localScope,
+          ...(knownScope ? { scope: knownScope } : {}),
         };
         let response = await fetch(
           `${apiUrl}/threads/${encodeURIComponent(id)}`,
@@ -997,7 +1006,11 @@ export function useChatThreads(
           const created = await fetch(`${apiUrl}/threads`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ id, title, scope: localScope }),
+            body: JSON.stringify({
+              id,
+              title,
+              ...(knownScope ? { scope: knownScope } : {}),
+            }),
           });
           if (!created.ok) return;
           response = await fetch(
@@ -1059,7 +1072,7 @@ export function useChatThreads(
         });
       } catch {}
     },
-    [apiUrl],
+    [apiUrl, readKnownThreadScope],
   );
 
   const generateTitle = useCallback(

--- a/packages/core/src/client/use-chat-threads.ts
+++ b/packages/core/src/client/use-chat-threads.ts
@@ -411,9 +411,8 @@ export function useChatThreads(
       } catch {
         nextActiveThreadId = null;
       }
-      // A thread that gained a scope after this pointer was written is still
-      // named by the older key. Only a known mismatch disqualifies it — an
-      // unresolved scope must not be read as "belongs here".
+      // Only a known mismatch disqualifies the pointer — an unresolved scope
+      // must not be read as "belongs here".
       if (nextActiveThreadId) {
         const savedScope = readKnownThreadScope(nextActiveThreadId);
         if (
@@ -603,9 +602,8 @@ export function useChatThreads(
         setIsLoading(false);
         return;
       }
-      // The synchronous restore trusts a pointer written under an older key,
-      // which can name a thread that has since gained its own scope. Route-owned
-      // threads are exempt: the URL names the thread the user asked for.
+      // Route-owned threads are exempt: the URL names the thread the user asked
+      // for, whatever its scope.
       const restoredThread = restoredId
         ? loadedThreads.find((t) => t.id === restoredId)
         : undefined;
@@ -976,9 +974,9 @@ export function useChatThreads(
     [apiUrl, clearUserRenamedThread, createThread],
   );
 
-  // Mirrors only a scope this client actually knows: `scope: null` for a thread
-  // missing from the local list would clear the server's, and an unscoped chat
-  // renders in every resource. `detachThread` is the one path that may clear it.
+  // Reads scope through refs so this callback survives every setThreads. Sends
+  // only a scope this client knows: a `null` clears the server's, which only
+  // `detachThread` may do.
   const saveThreadData = useCallback(
     async (
       id: string,

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -106,6 +106,7 @@ import type {
 import { readAppStateForCurrentTab } from "../application-state/script-helpers.js";
 import { runChatThreadDataMigrations } from "../chat-threads/migrations.js";
 import {
+  adoptThreadScopeIfUnscoped,
   createThread,
   forkThread,
   getThread,
@@ -2549,9 +2550,11 @@ export function createAgentChatPlugin(
           // every resource — leave it unscoped and one chat follows the user
           // into all of them.
           const nextScope = resolveRunThreadScope(thread.scope, runScope);
-          if (nextScope !== thread.scope) {
-            await setThreadScope(threadId, nextScope);
-            thread = { ...thread, scope: nextScope };
+          if (nextScope && nextScope !== thread.scope) {
+            thread = {
+              ...thread,
+              scope: await adoptThreadScopeIfUnscoped(threadId, nextScope),
+            };
           }
 
           let repo: any;

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -110,6 +110,7 @@ import {
   forkThread,
   getThread,
   registerChatThreadsShareable,
+  resolveRunThreadScope,
   resolveThreadAccess,
   listThreads,
   searchThreads,
@@ -2511,11 +2512,16 @@ export function createAgentChatPlugin(
           getRequestRunContext()?.owner ?? getRequestUserEmail();
         if (!ownerEmail) return;
 
+        const runScope = getRequestRunContext()?.chatScope ?? null;
+
         await withThreadDataLock(threadId, async () => {
           let thread = await getThread(threadId);
           if (!thread) {
             try {
-              thread = await createThread(ownerEmail, { id: threadId });
+              thread = await createThread(ownerEmail, {
+                id: threadId,
+                scope: runScope,
+              });
             } catch {
               thread = await getThread(threadId);
             }
@@ -2537,6 +2543,15 @@ export function createAgentChatPlugin(
               statusCode: 404,
               statusMessage: "Thread not found",
             });
+          }
+
+          // An unscoped thread reads as general, and general renders inside
+          // every resource — leave it unscoped and one chat follows the user
+          // into all of them.
+          const nextScope = resolveRunThreadScope(thread.scope, runScope);
+          if (nextScope !== thread.scope) {
+            await setThreadScope(threadId, nextScope);
+            thread = { ...thread, scope: nextScope };
           }
 
           let repo: any;

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -2546,9 +2546,6 @@ export function createAgentChatPlugin(
             });
           }
 
-          // An unscoped thread reads as general, and general renders inside
-          // every resource — leave it unscoped and one chat follows the user
-          // into all of them.
           const nextScope = resolveRunThreadScope(thread.scope, runScope);
           if (nextScope && nextScope !== thread.scope) {
             thread = {


### PR DESCRIPTION
## Summary

A chat thread's `scope` column meant two different things — "general chat, visible everywhere" and "the server hasn't been told this thread's scope yet" — and nothing could tell them apart, so a thread that lost its scope silently became a permanent global chat. It showed up inside every design, and because an unscoped chat is allowed to stay visible, no per-design chat was ever created.

Three things changed: the run's scope now reaches the row when it is created, a thread with no scope adopts the resource it is used in, and the client no longer asserts a scope it does not know. This is in `packages/core`, so it covers every template with scoped chats — design, forms, slides, content, clips, analytics — not just Design.

## Behavior

| Situation | Before | Now |
| --- | --- | --- |
| First message in a chat opened inside a design | row created with no scope | row created with the run's scope |
| Thread with no scope, used inside a design | stays general forever, shows in every design | adopts that design |
| Thread already scoped to another resource | a client save could retag or clear it | left alone |
| Save for a thread missing from the client's local list | asserted `scope: null`, clearing the server's | field omitted, server untouched |
| Saved active-chat pointer naming another resource's thread | restored, dragging that chat onto the wrong surface | ignored |

## Changes

**The scope the request already carried now reaches the row** — `packages/core/src/server/agent-chat-plugin.ts`
- `persistSubmittedUserMessage` created the thread row with no scope, even though the client sends one, `production-agent.ts:7294` normalizes it onto `RequestRunContext.chatScope`, and nothing read that field. It is now passed to `createThread`.
- A thread with no scope adopts the resource it is used in. This is what heals threads already stored with `scope: null`, including the one in the clip — lazily, on the next turn sent inside a resource, not on deploy.
- Adoption runs after `resolveThreadAccess`, so a caller without editor access cannot write a scope onto someone else's thread.

**One function owns what scope a thread has after a run** — `packages/core/src/chat-threads/store.ts`
- `resolveRunThreadScope` adopts when the thread has none and otherwise keeps what it has: never retag, never clear. The rule lives in one place instead of being restated at each call site.

**The client only mirrors a scope it actually knows** — `packages/core/src/client/use-chat-threads.ts`
- `saveThreadData` read scope only from the local thread list, so any thread missing from it yielded `null`, which the `PUT` applies unconditionally — cementing the null on every save. It now resolves through the existing tri-state `readKnownThreadScope` and omits the field unless it has a real scope; the server already treats omission as "don't touch". `detachThread` stays the single path allowed to clear a scope.
- A saved active-chat pointer whose thread has a *known* scope belonging to another resource is now rejected. An unknown scope still falls through to the previous behavior rather than guessing.

`threadCanStayVisibleInScope` is deliberately untouched — general chats staying visible inside a resource is intended, and the existing test pinning it still passes.

## Tests

`cd packages/core && ./node_modules/.bin/vitest --run --dir src --maxWorkers=25%` → 745 files, 10097 passed, 1 skipped.

Six new tests. `resolveRunThreadScope` covers adopt-when-unscoped, keep-when-already-scoped, never-clear, and general-stays-general. Two client tests pin the parts that regressed: I confirmed each fails with its fix disabled — `expected 'design-a-thread' to be 'forked-thread'` without the pointer guard, and `expected { …(5) } to not have property "scope"` without the omission.