### PR TITLE
Fix keyboard-shortcuts panel not opening on macOS

### DIFF
--- a/templates/design/.generated/bridge/editor-chrome.generated.ts
+++ b/templates/design/.generated/bridge/editor-chrome.generated.ts
@@ -3403,7 +3403,12 @@ export const editorChromeBridgeScript: string = `"use strict";
         'input, textarea, select, [contenteditable], [role="textbox"], [data-agent-native-text-editing]'
       );
     }
+    function isShowShortcutsChord(e) {
+      if (!(e.metaKey || e.ctrlKey) || !e.shiftKey || e.altKey) return false;
+      return e.key === "?" || e.key === "/";
+    }
     function shouldForwardDesignHotkey(e) {
+      if (isShowShortcutsChord(e)) return true;
       if (readOnly) return false;
       if (activeTextEditEl || isEditorTypingTarget(e.target) || e.isComposing)
         return false;

--- a/templates/design/app/components/design/KeyboardShortcutsPanel.discoverability.test.ts
+++ b/templates/design/app/components/design/KeyboardShortcutsPanel.discoverability.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from "vitest";
+
+import { DESIGN_SHORTCUTS } from "@/components/design/keyboard-shortcuts";
+import { isShowKeyboardShortcutsHotkey } from "@/hooks/useDesignHotkeys";
+
+import { editorChromeBridgeScript } from "../../../.generated/bridge/editor-chrome.generated";
+
+function keydown(init: KeyboardEventInit) {
+  return new KeyboardEvent("keydown", init);
+}
+
+/**
+ * Mirrors isShowShortcutsChord in editor-chrome.bridge.ts. The bridge compiles
+ * to an injected string, so it cannot be imported directly; the generated-output
+ * assertion at the bottom is what keeps this copy honest.
+ */
+function shouldForwardShowShortcutsChord(e: KeyboardEvent) {
+  if (!(e.metaKey || e.ctrlKey) || !e.shiftKey || e.altKey) return false;
+  return e.key === "?" || e.key === "/";
+}
+
+describe("show-keyboard-shortcuts hotkey", () => {
+  it("matches the macOS chord, which arrives as '/' not '?'", () => {
+    // Control suppresses the shifted character on macOS, so Control+Shift+/
+    // never produces "?" there. Matching only "?" left Macs with no binding.
+    expect(
+      isShowKeyboardShortcutsHotkey(
+        keydown({ key: "/", code: "Slash", ctrlKey: true, shiftKey: true }),
+      ),
+    ).toBe(true);
+  });
+
+  it("matches the Windows chord, which arrives as '?'", () => {
+    expect(
+      isShowKeyboardShortcutsHotkey(
+        keydown({ key: "?", code: "Slash", ctrlKey: true, shiftKey: true }),
+      ),
+    ).toBe(true);
+  });
+
+  it("matches the Command variant so a host-level ⌘⇧? still resolves", () => {
+    expect(
+      isShowKeyboardShortcutsHotkey(
+        keydown({ key: "/", code: "Slash", metaKey: true, shiftKey: true }),
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores the chord without Shift", () => {
+    expect(
+      isShowKeyboardShortcutsHotkey(
+        keydown({ key: "/", code: "Slash", ctrlKey: true }),
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores the chord with Alt held", () => {
+    expect(
+      isShowKeyboardShortcutsHotkey(
+        keydown({
+          key: "/",
+          code: "Slash",
+          ctrlKey: true,
+          shiftKey: true,
+          altKey: true,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores a bare slash so typing '/' never opens the panel", () => {
+    expect(
+      isShowKeyboardShortcutsHotkey(keydown({ key: "/", code: "Slash" })),
+    ).toBe(false);
+  });
+});
+
+describe("canvas iframe forwarding", () => {
+  it("forwards the macOS chord out of the iframe", () => {
+    expect(
+      shouldForwardShowShortcutsChord(
+        keydown({ key: "/", code: "Slash", ctrlKey: true, shiftKey: true }),
+      ),
+    ).toBe(true);
+  });
+
+  it("forwards the Windows chord out of the iframe", () => {
+    expect(
+      shouldForwardShowShortcutsChord(
+        keydown({ key: "?", code: "Slash", ctrlKey: true, shiftKey: true }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not forward a bare slash typed inside the canvas", () => {
+    expect(
+      shouldForwardShowShortcutsChord(keydown({ key: "/", code: "Slash" })),
+    ).toBe(false);
+  });
+
+  it("agrees with the host matcher on every case", () => {
+    const cases: KeyboardEventInit[] = [
+      { key: "/", ctrlKey: true, shiftKey: true },
+      { key: "?", ctrlKey: true, shiftKey: true },
+      { key: "/", metaKey: true, shiftKey: true },
+      { key: "/", ctrlKey: true },
+      { key: "/", ctrlKey: true, shiftKey: true, altKey: true },
+      { key: "/" },
+      { key: "a", ctrlKey: true, shiftKey: true },
+    ];
+    for (const init of cases) {
+      const event = keydown({ code: "Slash", ...init });
+      expect(shouldForwardShowShortcutsChord(event)).toBe(
+        isShowKeyboardShortcutsHotkey(event),
+      );
+    }
+  });
+
+  it("is present in the generated bridge, not only the source", () => {
+    // The bridge edit is inert until `pnpm codegen:bridge` runs.
+    expect(editorChromeBridgeScript).toContain("isShowShortcutsChord");
+  });
+});
+
+describe("shortcut table", () => {
+  it("advertises the literal Control binding, not $mod", () => {
+    // ⌘⇧? is the macOS Help-menu shortcut and the browser eats it, so ⌃⇧? is
+    // the only pressable binding on a Mac. Do not "fix" this to $mod.
+    const showShortcuts = DESIGN_SHORTCUTS.find(
+      (entry) => entry.id === "show-shortcuts",
+    );
+    expect(showShortcuts?.bindings).toEqual(["ctrl+shift+?"]);
+  });
+});

--- a/templates/design/app/components/design/KeyboardShortcutsPanel.discoverability.test.ts
+++ b/templates/design/app/components/design/KeyboardShortcutsPanel.discoverability.test.ts
@@ -75,6 +75,23 @@ describe("show-keyboard-shortcuts hotkey", () => {
       isShowKeyboardShortcutsHotkey(keydown({ key: "/", code: "Slash" })),
     ).toBe(false);
   });
+
+  it("still matches auto-repeat, leaving repeat filtering to the caller", () => {
+    // The panel toggles, so DesignEditor drops repeats to keep one physical
+    // press to one toggle — but it swallows them first, otherwise a held chord
+    // leaks "/" into the agent composer. Filtering repeat here would undo that.
+    expect(
+      isShowKeyboardShortcutsHotkey(
+        keydown({
+          key: "/",
+          code: "Slash",
+          ctrlKey: true,
+          shiftKey: true,
+          repeat: true,
+        }),
+      ),
+    ).toBe(true);
+  });
 });
 
 describe("canvas iframe forwarding", () => {

--- a/templates/design/app/components/design/KeyboardShortcutsPanel.tsx
+++ b/templates/design/app/components/design/KeyboardShortcutsPanel.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/design/keyboard-shortcuts";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { isApplePlatform } from "@/hooks/useDesignHotkeys";
 
 interface KeyboardShortcutsPanelProps {
   onClose: () => void;
@@ -113,9 +114,10 @@ function KeycapGroup({
 
 function ShortcutBindings({ bindings }: { bindings: readonly string[] }) {
   const t = useT();
-  const applePlatform =
-    typeof navigator !== "undefined" &&
-    /Mac|iPhone|iPad/.test(navigator.platform);
+  // Shared with the hotkey matcher: navigator.platform alone is deprecated and
+  // blank in some browsers, which labelled Ctrl on Macs that the hotkey layer
+  // already treated as Apple.
+  const applePlatform = isApplePlatform();
   const accessibleBindings = bindings.map((binding) =>
     binding
       .split("+")

--- a/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
+++ b/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
@@ -5069,7 +5069,20 @@ declare var __SELECTED_LAYER_DRAG_PRIORITY__: boolean;
     );
   }
 
+  function isShowShortcutsChord(e) {
+    if (!(e.metaKey || e.ctrlKey) || !e.shiftKey || e.altKey) return false;
+    // macOS delivers Control+Shift+/ as "/" — Control suppresses the shifted
+    // character — while Windows sends "?". Match both; see
+    // isShowKeyboardShortcutsHotkey in useDesignHotkeys.ts.
+    return e.key === "?" || e.key === "/";
+  }
+
   function shouldForwardDesignHotkey(e) {
+    // Shortcut help is not an editing affordance, so it forwards ahead of the
+    // read-only and typing guards below — the host matcher is deliberately
+    // global for the same reason. Without this the chord never escapes the
+    // canvas iframe, which is where focus lands the moment you click a frame.
+    if (isShowShortcutsChord(e)) return true;
     // Read-only surfaces (e.g. background/inactive board screens) must never
     // forward edit hotkeys or preventDefault() native browser shortcuts —
     // Escape/Enter/Tab/Delete/arrow-key/undo-redo forwarding is an editing

--- a/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
+++ b/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
@@ -5082,6 +5082,9 @@ declare var __SELECTED_LAYER_DRAG_PRIORITY__: boolean;
     // read-only and typing guards below — the host matcher is deliberately
     // global for the same reason. Without this the chord never escapes the
     // canvas iframe, which is where focus lands the moment you click a frame.
+    // Not reached during a live text-edit session: that block returns before
+    // this function runs, deliberately — see the activeTextEditEl guard in
+    // the keydown listener.
     if (isShowShortcutsChord(e)) return true;
     // Read-only surfaces (e.g. background/inactive board screens) must never
     // forward edit hotkeys or preventDefault() native browser shortcuts —
@@ -10974,6 +10977,13 @@ declare var __SELECTED_LAYER_DRAG_PRIORITY__: boolean;
         }
         // While a live session exists, never forward hotkeys to the host
         // (matches shouldForwardDesignHotkey's activeTextEditEl guard).
+        // The shortcut-help chord is deliberately included in that exclusion:
+        // the panel lives in the parent document, so opening it moves focus
+        // out of the iframe, blurs the editable and commits the in-progress
+        // edit. Ending someone's text entry to show help is a worse trade
+        // than help being unavailable for the duration of a typing session;
+        // it stays available everywhere else, including while a text layer is
+        // merely selected.
         return;
       }
       if (!shouldForwardDesignHotkey(e)) return;

--- a/templates/design/app/components/design/keyboard-shortcuts.ts
+++ b/templates/design/app/components/design/keyboard-shortcuts.ts
@@ -49,6 +49,9 @@ export const DESIGN_SHORTCUTS: readonly DesignShortcutDefinition[] = [
   shortcut({
     id: "show-shortcuts",
     category: "essential",
+    // Literal ctrl, not $mod: on macOS ⌘⇧? is the system Help-menu shortcut and
+    // the browser consumes it before the page sees it, so ⌃⇧? is the only
+    // pressable binding there. Do not "fix" this to $mod.
     bindings: ["ctrl+shift+?"],
     labelKey: "designEditor.keyboardShortcuts.commands.showShortcuts",
     handler: "onShowKeyboardShortcuts",

--- a/templates/design/app/hooks/useDesignHotkeys.ts
+++ b/templates/design/app/hooks/useDesignHotkeys.ts
@@ -283,12 +283,16 @@ export function isDesignHotkeyEditableTarget(target: EventTarget | null) {
 }
 
 export function isShowKeyboardShortcutsHotkey(event: KeyboardEvent) {
-  return (
-    (event.ctrlKey || event.metaKey) &&
-    event.shiftKey &&
-    !event.altKey &&
-    normalizedKey(event) === "?"
-  );
+  if (!(event.ctrlKey || event.metaKey) || !event.shiftKey || event.altKey) {
+    return false;
+  }
+  // macOS never sends "?" for this chord: holding Control suppresses the
+  // shifted character, so Control+Shift+/ arrives as key "/" while Windows
+  // sends "?". Matching only "?" left Macs with no pressable combination —
+  // the obvious ⌘⇧? alternative is the system Help-menu shortcut and the
+  // browser consumes it before the page ever sees it.
+  const key = normalizedKey(event);
+  return key === "?" || key === "/";
 }
 
 function isFocusableChromeTarget(target: EventTarget | null) {
@@ -786,7 +790,7 @@ const ALT_CODE_KEYS: Record<string, string> = {
   BracketLeft: "[",
 };
 
-function isApplePlatform() {
+export function isApplePlatform() {
   if (typeof navigator === "undefined") return false;
   const userAgentDataPlatform = (
     navigator as Navigator & {

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -418,6 +418,7 @@ import {
 import { useQuestionFlow } from "@/hooks/use-question-flow";
 import {
   isDesignHotkeyEditableTarget,
+  isShowKeyboardShortcutsHotkey,
   useDesignHotkeys,
   type DesignHotkeyAlignEdge,
   type DesignHotkeyDistributeAxis,
@@ -22911,16 +22912,6 @@ function DesignEditor() {
     viewMode,
   ]);
 
-  const handleShowKeyboardShortcuts = useCallback(() => {
-    if (!keyboardShortcutsOpen) {
-      const activeElement = document.activeElement;
-      keyboardShortcutsReturnFocusRef.current =
-        activeElement instanceof HTMLElement ? activeElement : null;
-    }
-    setUiHidden(false);
-    setKeyboardShortcutsOpen(true);
-  }, [keyboardShortcutsOpen]);
-
   const handleShowKeyboardShortcutsFromMenu = useCallback(() => {
     keyboardShortcutsReturnFocusRef.current = projectMenuTriggerRef.current;
     suppressProjectMenuReturnFocusRef.current = true;
@@ -22938,6 +22929,42 @@ function DesignEditor() {
       }
     });
   }, []);
+
+  const handleToggleKeyboardShortcuts = useCallback(() => {
+    if (keyboardShortcutsOpen) {
+      handleCloseKeyboardShortcuts();
+      return;
+    }
+    const activeElement = document.activeElement;
+    keyboardShortcutsReturnFocusRef.current =
+      activeElement instanceof HTMLElement ? activeElement : null;
+    setUiHidden(false);
+    setKeyboardShortcutsOpen(true);
+  }, [handleCloseKeyboardShortcuts, keyboardShortcutsOpen]);
+
+  // Capture phase, and deliberately outside the useDesignHotkeys gate below.
+  // Two reasons, each of which broke this chord on its own: a bubble-phase
+  // listener runs after the agent composer has already inserted "/" and opened
+  // its slash menu, and that gate switches off during responsive-interact and
+  // agent question flows — it disables editing shortcuts, and shortcut help
+  // is not an editing shortcut.
+  useEffect(() => {
+    if (embedded) return;
+    const handleHelpHotkey = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.isComposing) return;
+      if (!isShowKeyboardShortcutsHotkey(event)) return;
+      // preventDefault also keeps the bubble-phase useDesignHotkeys listener
+      // from toggling a second time on the same keystroke.
+      event.preventDefault();
+      event.stopPropagation();
+      handleToggleKeyboardShortcuts();
+    };
+    window.addEventListener("keydown", handleHelpHotkey, { capture: true });
+    return () =>
+      window.removeEventListener("keydown", handleHelpHotkey, {
+        capture: true,
+      });
+  }, [embedded, handleToggleKeyboardShortcuts]);
 
   const handleEscapeHotkey = useCallback(() => {
     if (keyboardShortcutsOpen) {
@@ -23677,7 +23704,7 @@ function DesignEditor() {
     // editing actions, so they work regardless of canEditDesign.
     onToggleUi: handleToggleUi,
     onToggleComments: handleToggleComments,
-    onShowKeyboardShortcuts: handleShowKeyboardShortcuts,
+    onShowKeyboardShortcuts: handleToggleKeyboardShortcuts,
   });
 
   const startRetryGeneration = useCallback(
@@ -30175,6 +30202,8 @@ function DesignEditor() {
           <IconKeyboard className="mr-2 h-4 w-4" />
           {t("designEditor.keyboardShortcuts.title")}
           <DropdownMenuShortcut>
+            {/* Control, not Command: ⌘⇧? is the macOS Help-menu shortcut and
+                the browser consumes it before the page ever sees it. */}
             {"⌃⇧?" /* i18n-ignore keyboard shortcut */}
           </DropdownMenuShortcut>
         </DropdownMenuItem>
@@ -31071,7 +31100,7 @@ function DesignEditor() {
             />
           )}
 
-        {!embedded && keyboardShortcutsOpen && !questionFlowActive ? (
+        {!embedded && keyboardShortcutsOpen ? (
           <KeyboardShortcutsPanel onClose={handleCloseKeyboardShortcuts} />
         ) : null}
 

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -22957,6 +22957,10 @@ function DesignEditor() {
       // from toggling a second time on the same keystroke.
       event.preventDefault();
       event.stopPropagation();
+      // Swallowed above but not acted on: holding the chord auto-repeats
+      // keydown, and toggling per repeat would flap the panel open/closed.
+      // One physical press is one toggle.
+      if (event.repeat) return;
       handleToggleKeyboardShortcuts();
     };
     window.addEventListener("keydown", handleHelpHotkey, { capture: true });

--- a/templates/design/changelog/2026-07-30-fixed-the-keyboard-shortcuts-panel-not-opening-with-ctrl-shi.md
+++ b/templates/design/changelog/2026-07-30-fixed-the-keyboard-shortcuts-panel-not-opening-with-ctrl-shi.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-30
+---
+
+Fixed the keyboard shortcuts panel not opening with Ctrl+Shift+? on macOS, inside the canvas, or during agent question flows


### PR DESCRIPTION
### Summary
Fixes the design editor's keyboard-shortcuts panel (Ctrl/⌘+Shift+?) so it can actually be opened on macOS, from inside the canvas iframe, and while an agent question flow or responsive-interact mode is active.

### Problem
The shortcut appeared in the shortcuts table and rendered correctly, but was unreachable on macOS due to five independent, compounding defects:

1. `isShowKeyboardShortcutsHotkey` only matched `event.key === "?"`. On macOS, Control suppresses the shifted character, so Control+Shift+/ arrives as `"/"`, not `"?"`. The obvious alternative, ⌘⇧?, is intercepted by the OS as the Help-menu shortcut.
2. The canvas is rendered in iframes; the bridge's hand-picked allow-list of forwarded chords never included this one, so the keydown never reached the parent.
3. `useDesignHotkeys` is disabled during agent question flows and responsive-interact mode — a gate meant for editing shortcuts that also caught the (non-editing) help shortcut.
4. The panel's own render condition applied the same question-flow gate, suppressing it even if opened.
5. A bubble-phase listener ran after the agent composer had already consumed `/` and opened its slash-command menu.

### Solution
Each defect is fixed at its own layer: the matcher now accepts both key values macOS and Windows send, the iframe bridge forwards the chord ahead of its other guards, the panel toggle listens in the capture phase outside the editing-hotkey gate, and the panel's render condition no longer depends on question-flow state.

<img width="1091" height="723" alt="image" src="https://github.com/user-attachments/assets/03342236-086f-4d39-8ee4-7ffd32a7ae06" />


### Key Changes
- `useDesignHotkeys.ts`: `isShowKeyboardShortcutsHotkey` now matches `"?"` or `"/"`; `isApplePlatform` is exported for reuse.
- `editor-chrome.bridge.ts` (+ regenerated `.generated/bridge/editor-chrome.generated.ts`): adds `isShowShortcutsChord`, forwarded ahead of read-only/typing guards in `shouldForwardDesignHotkey`.
- `keyboard-shortcuts.ts`: adds a comment documenting why the binding is literal `ctrl+shift+?` and not `$mod`.
- `KeyboardShortcutsPanel.tsx`: uses the shared `isApplePlatform()` instead of a local, deprecated `navigator.platform` check.
- `DesignEditor.tsx`: replaces `handleShowKeyboardShortcuts` with `handleToggleKeyboardShortcuts`; adds a capture-phase `window` keydown listener (outside the `useDesignHotkeys` enable gate) that calls `preventDefault`/`stopPropagation` to stop the agent composer from consuming the chord; removes the `!questionFlowActive` condition from the panel's render check; updates the dropdown menu label comment to clarify why the shortcut shows `⌃⇧?` and not `⌘⇧?`.
- Adds `KeyboardShortcutsPanel.discoverability.test.ts` covering the matcher, the mirrored iframe-forwarding predicate, and the shortcut-table binding, including a check that the bridge fix is present in the generated output.
- Adds a changelog entry.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/aura-zone-a0fy3jfs"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-aura-zone-a0fy3jfs.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2538`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>aura-zone-a0fy3jfs</branchName>-->