### PR TITLE
[CANARY — FAKE ISSUE — DO NOT MERGE] Clarify grouped-view empty-state privacy

### DIFF
--- a/templates/content/docs/product/capabilities/content.view.grouping-aggregation.md
+++ b/templates/content/docs/product/capabilities/content.view.grouping-aggregation.md
@@ -66,6 +66,12 @@ total is computed only from authorized rows and fields.
 Given a visible aggregate cell, when a viewer drills in, then Content opens the exact
 authorized contributing records rather than an inferred or copied collection.
 
+### Hide private records in an empty group
+
+Given a grouped View whose filters leave only private records in a possible group,
+when an unauthorized viewer opens it, then Content reveals neither the group nor an
+empty-state hint that matching private records exist.
+
 ## Current evidence
 
 Existing filters and renderer utilities are donor substrate. The repository does not


### PR DESCRIPTION
> [!CAUTION]
> PRODUCTION CONFORMANCE CANARY — FAKE ISSUE — DO NOT REVIEW, APPROVE, OR MERGE.
> This PR is a disposable test of advisory Content CI. It will be closed unmerged and its branch deleted after evidence capture.

## Problem

The grouped-View Capability requires access to be applied before grouping and already excludes private rows from counts and hints, but it does not state that boundary as an atomic empty-group acceptance story. Without that story, conformance evidence could miss an empty state that reveals filtered private records exist.

## Approach

Add the smallest documentation-only acceptance story: when a filter leaves only private records in a possible group, an unauthorized viewer sees neither the group nor an empty-state hint that matching records exist.

This does not change runtime behavior, generated projections, roadmap status, Capability state, or any record lifecycle state.

## What changed

- Added one acceptance story to `content.view.grouping-aggregation`.
- Kept the existing access-first contract and proof plan unchanged.

## Content impact declaration

```yaml
content_product_impact:
  lane: contract_repair
  features:
    - content.feature.see-your-information-your-way
    - content.feature.plan-work-across-time
    - content.feature.understand-what-your-data-says
  capabilities:
    - content.view.grouping-aggregation
  record_change: included
  proof:
    - pnpm test:content-product-docs
    - pnpm guard:content-product-docs
    - pnpm test:content-product-impact
  rationale: The record repair makes the accepted empty-group privacy boundary directly testable without changing product or runtime state.
```

## Safety and operations

Documentation only. There are no runtime, data, migration, credential, permission, deployment, or record-lifecycle effects. This draft exists solely as a disposable production conformance canary and must be closed unmerged after evidence capture.

## Verification

- `pnpm test:content-product-docs` — passed all 14 product-document tests.
- `pnpm guard:content-product-docs` — validated 6 Chapters, 32 Features, and 124 Capabilities without changing generated projections.
- `pnpm test:content-product-impact` — passed all 30 declaration, applicability, analysis, CLI, and workflow-boundary tests.
- `pnpm exec oxfmt --check templates/content/docs/product/capabilities/content.view.grouping-aggregation.md` — confirmed the changed record is formatted.
- `git diff --check` — found no whitespace errors.
