### PR TITLE
Recover stale React Router route graphs without process restart

### DIFF
--- a/.changeset/fresh-routes-recover.md
+++ b/.changeset/fresh-routes-recover.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Recover stale React Router route graphs in development without restarting the app process.

--- a/packages/core/src/server/react-router-dev-recovery.spec.ts
+++ b/packages/core/src/server/react-router-dev-recovery.spec.ts
@@ -281,9 +281,10 @@ describe("React Router recovery coordinator", () => {
     );
   });
 
-  it("serializes mixed pending requests without bypassing fallback bounds", async () => {
+  it("coalesces pending fallback modules and topology into one bounded rerun", async () => {
     vi.useFakeTimers();
     const finishes: Array<() => void> = [];
+    const onOutcome = vi.fn();
     const restart = vi.fn(
       () =>
         new Promise<void>((resolve) => {
@@ -294,12 +295,25 @@ describe("React Router recovery coordinator", () => {
       restart,
       cooldownMs: 0,
       maxConsecutiveAttempts: 1,
+      onOutcome,
     });
-    const module = "/app/routes/deleted.tsx";
+    const moduleA = "/app/routes/a.tsx";
+    const moduleB = "/app/routes/b.tsx";
+    const moduleC = "/app/routes/c.tsx";
 
-    expect(requestFallback(coordinator, module, "/broken")).toBe("started");
+    expect(requestFallback(coordinator, moduleA, "/a", "module A")).toBe(
+      "started",
+    );
+    expect(requestFallback(coordinator, moduleB, "/b", "module B")).toBe(
+      "pending",
+    );
+    expect(requestFallback(coordinator, moduleC, "/c", "module C")).toBe(
+      "pending",
+    );
+    expect(requestFallback(coordinator, moduleB, "/b-again", "module B")).toBe(
+      "pending",
+    );
     expect(coordinator.requestTopology("route added")).toBe("pending");
-    expect(requestFallback(coordinator, module, "/other")).toBe("bounded");
     expect(restart).toHaveBeenCalledOnce();
 
     finishes[0]?.();
@@ -307,8 +321,19 @@ describe("React Router recovery coordinator", () => {
     await Promise.resolve();
     await vi.runOnlyPendingTimersAsync();
     expect(restart).toHaveBeenCalledTimes(2);
-    expect(requestFallback(coordinator, module, "/still-stale")).toBe(
-      "bounded",
-    );
+    expect(requestFallback(coordinator, moduleB, "/b-third")).toBe("bounded");
+    expect(requestFallback(coordinator, moduleC, "/c-second")).toBe("bounded");
+
+    finishes[1]?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.runOnlyPendingTimersAsync();
+    expect(restart).toHaveBeenCalledTimes(2);
+    const coalescedOutcome = onOutcome.mock.calls
+      .map(([message]) => String(message))
+      .find((message) => message.includes("route added"));
+    expect(coalescedOutcome).toContain("module B");
+    expect(coalescedOutcome).toContain("module C");
+    expect(coalescedOutcome?.match(/module B/g)).toHaveLength(1);
   });
 });

--- a/packages/core/src/server/react-router-dev-recovery.spec.ts
+++ b/packages/core/src/server/react-router-dev-recovery.spec.ts
@@ -281,6 +281,188 @@ describe("React Router recovery coordinator", () => {
     );
   });
 
+  it("merges into an overdue cooldown timer without starting a concurrent or extra restart", async () => {
+    vi.useFakeTimers();
+    let now = 1_000;
+    const finishes: Array<() => void> = [];
+    const restart = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishes.push(resolve);
+        }),
+    );
+    const coordinator = createReactRouterRecoveryCoordinator(EMPTY_SCOPE, {
+      restart,
+      now: () => now,
+      cooldownMs: 100,
+    });
+
+    expect(coordinator.requestTopology("initial")).toBe("started");
+    finishes[0]?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(coordinator.requestTopology("pending one")).toBe("cooldown");
+
+    now = 1_200;
+    expect(coordinator.requestTopology("pending two")).toBe("cooldown");
+    expect(restart).toHaveBeenCalledOnce();
+    await vi.runOnlyPendingTimersAsync();
+    expect(restart).toHaveBeenCalledTimes(2);
+
+    finishes[1]?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.runOnlyPendingTimersAsync();
+    expect(restart).toHaveBeenCalledTimes(2);
+  });
+
+  it("cancels a pending module after matching SSR success", async () => {
+    vi.useFakeTimers();
+    let now = 1_000;
+    const finishes: Array<() => void> = [];
+    const restart = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishes.push(resolve);
+        }),
+    );
+    const coordinator = createReactRouterRecoveryCoordinator(EMPTY_SCOPE, {
+      restart,
+      now: () => now,
+      cooldownMs: 100,
+      maxConsecutiveAttempts: 1,
+    });
+    const moduleA = "/app/routes/a.tsx";
+    const moduleB = "/app/routes/b.tsx";
+
+    expect(requestFallback(coordinator, moduleA, "/a", "module A")).toBe(
+      "started",
+    );
+    expect(requestFallback(coordinator, moduleB, "/b", "module B")).toBe(
+      "pending",
+    );
+    finishes[0]?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    coordinator.markSsrSuccess("/b");
+    now = 1_100;
+    await vi.runOnlyPendingTimersAsync();
+    expect(restart).toHaveBeenCalledOnce();
+    expect(requestFallback(coordinator, moduleB, "/b-next", "module B")).toBe(
+      "started",
+    );
+  });
+
+  it("removes a successful pending module while preserving topology and other modules", async () => {
+    vi.useFakeTimers();
+    let now = 1_000;
+    const finishes: Array<() => void> = [];
+    const onOutcome = vi.fn();
+    const restart = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishes.push(resolve);
+        }),
+    );
+    const coordinator = createReactRouterRecoveryCoordinator(EMPTY_SCOPE, {
+      restart,
+      now: () => now,
+      cooldownMs: 100,
+      maxConsecutiveAttempts: 1,
+      onOutcome,
+    });
+    const moduleA = "/app/routes/a.tsx";
+    const moduleB = "/app/routes/b.tsx";
+    const moduleC = "/app/routes/c.tsx";
+
+    expect(requestFallback(coordinator, moduleA, "/a", "module A")).toBe(
+      "started",
+    );
+    expect(requestFallback(coordinator, moduleB, "/b", "module B")).toBe(
+      "pending",
+    );
+    expect(requestFallback(coordinator, moduleC, "/c", "module C")).toBe(
+      "pending",
+    );
+    expect(coordinator.requestTopology("route added")).toBe("pending");
+    finishes[0]?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    coordinator.markSsrSuccess("/b");
+    now = 1_100;
+    await vi.runOnlyPendingTimersAsync();
+    expect(restart).toHaveBeenCalledTimes(2);
+    finishes[1]?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const pendingOutcome = onOutcome.mock.calls
+      .map(([message]) => String(message))
+      .find((message) => message.includes("route added"));
+    expect(pendingOutcome).toContain("module C");
+    expect(pendingOutcome).not.toContain("module B");
+    expect(requestFallback(coordinator, moduleC, "/c-next")).toBe("bounded");
+    expect(requestFallback(coordinator, moduleB, "/b-next")).toBe("cooldown");
+  });
+
+  it("never has more than one active restart across timers and pending merges", async () => {
+    vi.useFakeTimers();
+    let now = 1_000;
+    let active = 0;
+    let maxActive = 0;
+    const finishes: Array<() => void> = [];
+    const restart = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          finishes.push(() => {
+            active -= 1;
+            resolve();
+          });
+        }),
+    );
+    const coordinator = createReactRouterRecoveryCoordinator(EMPTY_SCOPE, {
+      restart,
+      now: () => now,
+      cooldownMs: 100,
+    });
+
+    expect(coordinator.requestTopology("initial")).toBe("started");
+    expect(requestFallback(coordinator, "/app/routes/b.tsx", "/b")).toBe(
+      "pending",
+    );
+    finishes[0]?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    now = 1_200;
+    expect(coordinator.requestTopology("overdue merge")).toBe("cooldown");
+    await vi.runOnlyPendingTimersAsync();
+    expect(active).toBe(1);
+    expect(requestFallback(coordinator, "/app/routes/c.tsx", "/c")).toBe(
+      "pending",
+    );
+    expect(coordinator.requestTopology("running merge")).toBe("pending");
+    await vi.runOnlyPendingTimersAsync();
+    expect(active).toBe(1);
+
+    finishes[1]?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    now = 1_300;
+    await vi.runOnlyPendingTimersAsync();
+    expect(active).toBe(1);
+    finishes[2]?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(maxActive).toBe(1);
+    expect(restart).toHaveBeenCalledTimes(3);
+  });
+
   it("coalesces pending fallback modules and topology into one bounded rerun", async () => {
     vi.useFakeTimers();
     const finishes: Array<() => void> = [];

--- a/packages/core/src/server/react-router-dev-recovery.spec.ts
+++ b/packages/core/src/server/react-router-dev-recovery.spec.ts
@@ -8,7 +8,36 @@ import {
   classifyStaleReactRouterRouteError,
   createReactRouterRecoveryCoordinator,
   extractViteLoadUrlPath,
+  type ReactRouterRecoveryCoordinator,
+  type ReactRouterRouteScope,
 } from "./react-router-dev-recovery.js";
+
+const EMPTY_SCOPE: ReactRouterRouteScope = {
+  exactRouteFiles: [],
+  discoveryRoots: [],
+};
+
+function discoveryScope(routes: string): ReactRouterRouteScope {
+  return {
+    exactRouteFiles: [],
+    discoveryRoots: [
+      {
+        appDirectory: path.dirname(routes),
+        directory: routes,
+        ignoredRouteFiles: [],
+      },
+    ],
+  };
+}
+
+function requestFallback(
+  coordinator: ReactRouterRecoveryCoordinator,
+  modulePath: string,
+  requestPathname: string,
+  reason = "stale SSR",
+) {
+  return coordinator.requestFallback({ modulePath, requestPathname, reason });
+}
 
 function loadError(file: string, overrides: Record<string, unknown> = {}) {
   return Object.assign(
@@ -33,35 +62,31 @@ describe("stale React Router route classification", () => {
     tempDirs.push(root);
     const routes = path.join(root, "app", "routes");
     fs.mkdirSync(routes, { recursive: true });
-    return { root, routes };
+    return { root, routes, scope: discoveryScope(routes) };
   }
 
   it("extracts resolved absolute and /@fs/ load paths", () => {
     const file = path.join(os.tmpdir(), "missing-route.tsx");
     expect(extractViteLoadUrlPath(loadError(file))).toBe(file);
     expect(
-      extractViteLoadUrlPath(
-        loadError(file, {
-          id: `/@fs/${file}?v=1`,
-        }),
-      ),
+      extractViteLoadUrlPath(loadError(file, { id: `/@fs/${file}?v=1` })),
     ).toBe(file);
   });
 
   it("finds a strict stale route error through nested causes", () => {
-    const { routes } = routeFixture();
+    const { routes, scope } = routeFixture();
     const file = path.join(routes, "deleted.tsx");
     const wrapped = new Error("SSR import failed", {
       cause: new Error("runner failed", { cause: loadError(file) }),
     });
 
-    expect(classifyStaleReactRouterRouteError(wrapped, [routes])).toEqual({
+    expect(classifyStaleReactRouterRouteError(wrapped, scope)).toEqual({
       file,
     });
   });
 
   it("combines code, importer, and route path evidence within one cause chain", () => {
-    const { routes } = routeFixture();
+    const { routes, scope } = routeFixture();
     const file = path.join(routes, "deleted.tsx");
     const pathError = Object.assign(new Error(`Failed to load url ${file}`), {
       id: file,
@@ -72,18 +97,16 @@ describe("stale React Router route classification", () => {
     });
     const wrapped = Object.assign(
       new Error("SSR import failed", { cause: codeError }),
-      {
-        importer: "virtual:react-router/server-build",
-      },
+      { importer: "virtual:react-router/server-build" },
     );
 
-    expect(classifyStaleReactRouterRouteError(wrapped, [routes])).toEqual({
+    expect(classifyStaleReactRouterRouteError(wrapped, scope)).toEqual({
       file,
     });
   });
 
   it("does not combine stale-load evidence across sibling error branches", () => {
-    const { routes } = routeFixture();
+    const { routes, scope } = routeFixture();
     const file = path.join(routes, "deleted.tsx");
     const wrapped = new AggregateError([
       Object.assign(new Error("Vite transform failed"), {
@@ -95,33 +118,31 @@ describe("stale React Router route classification", () => {
       }),
     ]);
 
-    expect(
-      classifyStaleReactRouterRouteError(wrapped, [routes]),
-    ).toBeUndefined();
+    expect(classifyStaleReactRouterRouteError(wrapped, scope)).toBeUndefined();
   });
 
   it.each([
     ["wrong code", { code: "ERR_MODULE_NOT_FOUND" }],
     ["wrong importer", { message: "Failed to load url /tmp/nope.tsx" }],
   ])("rejects %s", (_label, overrides) => {
-    const { routes } = routeFixture();
+    const { routes, scope } = routeFixture();
     const file = path.join(routes, "deleted.tsx");
     expect(
-      classifyStaleReactRouterRouteError(loadError(file, overrides), [routes]),
+      classifyStaleReactRouterRouteError(loadError(file, overrides), scope),
     ).toBeUndefined();
   });
 
-  it("rejects existing route transforms and missing imports outside route roots", () => {
-    const { root, routes } = routeFixture();
+  it("rejects existing transforms and missing imports outside route scope", () => {
+    const { root, routes, scope } = routeFixture();
     const existing = path.join(routes, "syntax-error.tsx");
     fs.writeFileSync(existing, "export default (");
     const outside = path.join(root, "lib", "missing.ts");
 
     expect(
-      classifyStaleReactRouterRouteError(loadError(existing), [routes]),
+      classifyStaleReactRouterRouteError(loadError(existing), scope),
     ).toBeUndefined();
     expect(
-      classifyStaleReactRouterRouteError(loadError(outside), [routes]),
+      classifyStaleReactRouterRouteError(loadError(outside), scope),
     ).toBeUndefined();
     expect(
       classifyStaleReactRouterRouteError(
@@ -129,8 +150,24 @@ describe("stale React Router route classification", () => {
           code: "ERR_LOAD_URL",
           importer: "virtual:react-router/server-build",
         }),
-        [routes],
+        scope,
       ),
+    ).toBeUndefined();
+  });
+
+  it("accepts an absent exact explicit route without broadening its parent", () => {
+    const { root } = routeFixture();
+    const exact = path.join(root, "app", "dashboard.tsx");
+    const sibling = path.join(root, "app", "not-a-route.tsx");
+    const scope = { exactRouteFiles: [exact], discoveryRoots: [] };
+
+    expect(classifyStaleReactRouterRouteError(loadError(exact), scope)).toEqual(
+      {
+        file: exact,
+      },
+    );
+    expect(
+      classifyStaleReactRouterRouteError(loadError(sibling), scope),
     ).toBeUndefined();
   });
 });
@@ -148,7 +185,7 @@ describe("React Router recovery coordinator", () => {
           finishRestart = resolve;
         }),
     );
-    const coordinator = createReactRouterRecoveryCoordinator(["/app/routes"], {
+    const coordinator = createReactRouterRecoveryCoordinator(EMPTY_SCOPE, {
       restart,
       now: () => now,
       cooldownMs: 100,
@@ -169,7 +206,7 @@ describe("React Router recovery coordinator", () => {
 
   it("continues proactive topology rebuilds beyond the fallback bound", async () => {
     const restart = vi.fn(async () => {});
-    const coordinator = createReactRouterRecoveryCoordinator(["/app/routes"], {
+    const coordinator = createReactRouterRecoveryCoordinator(EMPTY_SCOPE, {
       restart,
       cooldownMs: 0,
       maxConsecutiveAttempts: 3,
@@ -179,30 +216,69 @@ describe("React Router recovery coordinator", () => {
       expect(coordinator.requestTopology(`topology ${index}`)).toBe("started");
       await new Promise((resolve) => setImmediate(resolve));
     }
-
     expect(restart).toHaveBeenCalledTimes(5);
   });
 
-  it("keeps attempt bounds across coordinator replacement", () => {
+  it("shares fallback bounds by module across request paths", async () => {
+    const restart = vi.fn(async () => {});
+    const coordinator = createReactRouterRecoveryCoordinator(EMPTY_SCOPE, {
+      restart,
+      cooldownMs: 0,
+      maxConsecutiveAttempts: 2,
+    });
+    const module = "/app/routes/deleted.tsx";
+
+    expect(requestFallback(coordinator, module, "/one")).toBe("started");
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(requestFallback(coordinator, module, "/two")).toBe("started");
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(requestFallback(coordinator, module, "/three")).toBe("bounded");
+  });
+
+  it("does not reset a stale module bound after unrelated healthy SSR", async () => {
+    const restart = vi.fn(async () => {});
+    const coordinator = createReactRouterRecoveryCoordinator(EMPTY_SCOPE, {
+      restart,
+      cooldownMs: 0,
+      maxConsecutiveAttempts: 2,
+    });
+    const module = "/app/routes/deleted.tsx";
+
+    expect(requestFallback(coordinator, module, "/broken")).toBe("started");
+    await new Promise((resolve) => setImmediate(resolve));
+    coordinator.markSsrSuccess("/healthy");
+    expect(requestFallback(coordinator, module, "/also-broken")).toBe(
+      "started",
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(requestFallback(coordinator, module, "/third-path")).toBe("bounded");
+
+    coordinator.markSsrSuccess("/broken");
+    expect(requestFallback(coordinator, module, "/third-path")).toBe("started");
+  });
+
+  it("keeps module attempt bounds across coordinator replacement", () => {
     const key = `route-recovery-${crypto.randomUUID()}`;
-    const first = createReactRouterRecoveryCoordinator(["/app/routes"], {
+    const options = {
       restart: async () => {},
       cooldownMs: 0,
       maxConsecutiveAttempts: 1,
       persistentStateKey: key,
-    });
-    expect(first.requestFallback("first")).toBe("started");
+    };
+    const module = "/app/routes/deleted.tsx";
+    const first = createReactRouterRecoveryCoordinator(EMPTY_SCOPE, options);
+    expect(requestFallback(first, module, "/broken")).toBe("started");
     first.dispose();
 
-    const replacement = createReactRouterRecoveryCoordinator(["/app/routes"], {
-      restart: async () => {},
-      cooldownMs: 0,
-      maxConsecutiveAttempts: 1,
-      persistentStateKey: key,
-    });
-    expect(replacement.requestFallback("loop")).toBe("bounded");
-    replacement.markSsrSuccess();
-    expect(replacement.requestFallback("after success")).toBe("started");
+    const replacement = createReactRouterRecoveryCoordinator(
+      EMPTY_SCOPE,
+      options,
+    );
+    expect(requestFallback(replacement, module, "/other")).toBe("bounded");
+    replacement.markSsrSuccess("/broken");
+    expect(requestFallback(replacement, module, "/after-success")).toBe(
+      "started",
+    );
   });
 
   it("serializes mixed pending requests without bypassing fallback bounds", async () => {
@@ -214,15 +290,16 @@ describe("React Router recovery coordinator", () => {
           finishes.push(resolve);
         }),
     );
-    const coordinator = createReactRouterRecoveryCoordinator(["/app/routes"], {
+    const coordinator = createReactRouterRecoveryCoordinator(EMPTY_SCOPE, {
       restart,
       cooldownMs: 0,
       maxConsecutiveAttempts: 1,
     });
+    const module = "/app/routes/deleted.tsx";
 
-    expect(coordinator.requestFallback("stale SSR")).toBe("started");
+    expect(requestFallback(coordinator, module, "/broken")).toBe("started");
     expect(coordinator.requestTopology("route added")).toBe("pending");
-    expect(coordinator.requestFallback("another stale SSR")).toBe("bounded");
+    expect(requestFallback(coordinator, module, "/other")).toBe("bounded");
     expect(restart).toHaveBeenCalledOnce();
 
     finishes[0]?.();
@@ -230,33 +307,8 @@ describe("React Router recovery coordinator", () => {
     await Promise.resolve();
     await vi.runOnlyPendingTimersAsync();
     expect(restart).toHaveBeenCalledTimes(2);
-    expect(coordinator.requestFallback("still stale")).toBe("bounded");
-  });
-
-  it("enforces cooldown and a bounded consecutive fallback count", async () => {
-    vi.useFakeTimers();
-    let now = 1_000;
-    const restart = vi.fn(async () => {});
-    const coordinator = createReactRouterRecoveryCoordinator(["/app/routes"], {
-      restart,
-      now: () => now,
-      cooldownMs: 50,
-      maxConsecutiveAttempts: 2,
-    });
-
-    expect(coordinator.requestFallback("first")).toBe("started");
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(coordinator.requestFallback("too soon")).toBe("cooldown");
-    now += 50;
-    await vi.runOnlyPendingTimersAsync();
-    expect(restart).toHaveBeenCalledTimes(2);
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(coordinator.requestFallback("third")).toBe("bounded");
-
-    coordinator.markSsrSuccess();
-    now += 50;
-    expect(coordinator.requestFallback("after success")).toBe("started");
+    expect(requestFallback(coordinator, module, "/still-stale")).toBe(
+      "bounded",
+    );
   });
 });

--- a/packages/core/src/server/react-router-dev-recovery.spec.ts
+++ b/packages/core/src/server/react-router-dev-recovery.spec.ts
@@ -60,6 +60,46 @@ describe("stale React Router route classification", () => {
     });
   });
 
+  it("combines code, importer, and route path evidence within one cause chain", () => {
+    const { routes } = routeFixture();
+    const file = path.join(routes, "deleted.tsx");
+    const pathError = Object.assign(new Error(`Failed to load url ${file}`), {
+      id: file,
+    });
+    const codeError = Object.assign(new Error("Vite transform failed"), {
+      code: "ERR_LOAD_URL",
+      cause: pathError,
+    });
+    const wrapped = Object.assign(
+      new Error("SSR import failed", { cause: codeError }),
+      {
+        importer: "virtual:react-router/server-build",
+      },
+    );
+
+    expect(classifyStaleReactRouterRouteError(wrapped, [routes])).toEqual({
+      file,
+    });
+  });
+
+  it("does not combine stale-load evidence across sibling error branches", () => {
+    const { routes } = routeFixture();
+    const file = path.join(routes, "deleted.tsx");
+    const wrapped = new AggregateError([
+      Object.assign(new Error("Vite transform failed"), {
+        code: "ERR_LOAD_URL",
+      }),
+      Object.assign(new Error(`Failed to load url ${file}`), {
+        id: file,
+        importer: "virtual:react-router/server-build",
+      }),
+    ]);
+
+    expect(
+      classifyStaleReactRouterRouteError(wrapped, [routes]),
+    ).toBeUndefined();
+  });
+
   it.each([
     ["wrong code", { code: "ERR_MODULE_NOT_FOUND" }],
     ["wrong importer", { message: "Failed to load url /tmp/nope.tsx" }],
@@ -114,9 +154,9 @@ describe("React Router recovery coordinator", () => {
       cooldownMs: 100,
     });
 
-    expect(coordinator.request("delete a")).toBe("started");
-    expect(coordinator.request("add b")).toBe("pending");
-    expect(coordinator.request("add c")).toBe("pending");
+    expect(coordinator.requestTopology("delete a")).toBe("started");
+    expect(coordinator.requestTopology("add b")).toBe("pending");
+    expect(coordinator.requestTopology("add c")).toBe("pending");
     expect(restart).toHaveBeenCalledOnce();
 
     finishRestart?.();
@@ -127,27 +167,73 @@ describe("React Router recovery coordinator", () => {
     expect(restart).toHaveBeenCalledTimes(2);
   });
 
+  it("continues proactive topology rebuilds beyond the fallback bound", async () => {
+    const restart = vi.fn(async () => {});
+    const coordinator = createReactRouterRecoveryCoordinator(["/app/routes"], {
+      restart,
+      cooldownMs: 0,
+      maxConsecutiveAttempts: 3,
+    });
+
+    for (let index = 0; index < 5; index += 1) {
+      expect(coordinator.requestTopology(`topology ${index}`)).toBe("started");
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+
+    expect(restart).toHaveBeenCalledTimes(5);
+  });
+
   it("keeps attempt bounds across coordinator replacement", () => {
     const key = `route-recovery-${crypto.randomUUID()}`;
     const first = createReactRouterRecoveryCoordinator(["/app/routes"], {
       restart: async () => {},
+      cooldownMs: 0,
       maxConsecutiveAttempts: 1,
       persistentStateKey: key,
     });
-    expect(first.request("first")).toBe("started");
+    expect(first.requestFallback("first")).toBe("started");
     first.dispose();
 
     const replacement = createReactRouterRecoveryCoordinator(["/app/routes"], {
       restart: async () => {},
+      cooldownMs: 0,
       maxConsecutiveAttempts: 1,
       persistentStateKey: key,
     });
-    expect(replacement.request("loop")).toBe("bounded");
+    expect(replacement.requestFallback("loop")).toBe("bounded");
     replacement.markSsrSuccess();
-    expect(replacement.request("after success")).toBe("started");
+    expect(replacement.requestFallback("after success")).toBe("started");
   });
 
-  it("enforces cooldown and a bounded consecutive attempt count", async () => {
+  it("serializes mixed pending requests without bypassing fallback bounds", async () => {
+    vi.useFakeTimers();
+    const finishes: Array<() => void> = [];
+    const restart = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishes.push(resolve);
+        }),
+    );
+    const coordinator = createReactRouterRecoveryCoordinator(["/app/routes"], {
+      restart,
+      cooldownMs: 0,
+      maxConsecutiveAttempts: 1,
+    });
+
+    expect(coordinator.requestFallback("stale SSR")).toBe("started");
+    expect(coordinator.requestTopology("route added")).toBe("pending");
+    expect(coordinator.requestFallback("another stale SSR")).toBe("bounded");
+    expect(restart).toHaveBeenCalledOnce();
+
+    finishes[0]?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.runOnlyPendingTimersAsync();
+    expect(restart).toHaveBeenCalledTimes(2);
+    expect(coordinator.requestFallback("still stale")).toBe("bounded");
+  });
+
+  it("enforces cooldown and a bounded consecutive fallback count", async () => {
     vi.useFakeTimers();
     let now = 1_000;
     const restart = vi.fn(async () => {});
@@ -158,19 +244,19 @@ describe("React Router recovery coordinator", () => {
       maxConsecutiveAttempts: 2,
     });
 
-    expect(coordinator.request("first")).toBe("started");
+    expect(coordinator.requestFallback("first")).toBe("started");
     await Promise.resolve();
     await Promise.resolve();
-    expect(coordinator.request("too soon")).toBe("cooldown");
+    expect(coordinator.requestFallback("too soon")).toBe("cooldown");
     now += 50;
     await vi.runOnlyPendingTimersAsync();
     expect(restart).toHaveBeenCalledTimes(2);
     await Promise.resolve();
     await Promise.resolve();
-    expect(coordinator.request("third")).toBe("bounded");
+    expect(coordinator.requestFallback("third")).toBe("bounded");
 
     coordinator.markSsrSuccess();
     now += 50;
-    expect(coordinator.request("after success")).toBe("started");
+    expect(coordinator.requestFallback("after success")).toBe("started");
   });
 });

--- a/packages/core/src/server/react-router-dev-recovery.spec.ts
+++ b/packages/core/src/server/react-router-dev-recovery.spec.ts
@@ -1,0 +1,176 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  classifyStaleReactRouterRouteError,
+  createReactRouterRecoveryCoordinator,
+  extractViteLoadUrlPath,
+} from "./react-router-dev-recovery.js";
+
+function loadError(file: string, overrides: Record<string, unknown> = {}) {
+  return Object.assign(
+    new Error(
+      `Failed to load url ${file} (resolved id: ${file}) in virtual:react-router/server-build. Does the file exist?`,
+    ),
+    { code: "ERR_LOAD_URL", ...overrides },
+  );
+}
+
+describe("stale React Router route classification", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs)
+      fs.rmSync(dir, { recursive: true, force: true });
+    tempDirs.length = 0;
+  });
+
+  function routeFixture() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "an-route-recovery-"));
+    tempDirs.push(root);
+    const routes = path.join(root, "app", "routes");
+    fs.mkdirSync(routes, { recursive: true });
+    return { root, routes };
+  }
+
+  it("extracts resolved absolute and /@fs/ load paths", () => {
+    const file = path.join(os.tmpdir(), "missing-route.tsx");
+    expect(extractViteLoadUrlPath(loadError(file))).toBe(file);
+    expect(
+      extractViteLoadUrlPath(
+        loadError(file, {
+          id: `/@fs/${file}?v=1`,
+        }),
+      ),
+    ).toBe(file);
+  });
+
+  it("finds a strict stale route error through nested causes", () => {
+    const { routes } = routeFixture();
+    const file = path.join(routes, "deleted.tsx");
+    const wrapped = new Error("SSR import failed", {
+      cause: new Error("runner failed", { cause: loadError(file) }),
+    });
+
+    expect(classifyStaleReactRouterRouteError(wrapped, [routes])).toEqual({
+      file,
+    });
+  });
+
+  it.each([
+    ["wrong code", { code: "ERR_MODULE_NOT_FOUND" }],
+    ["wrong importer", { message: "Failed to load url /tmp/nope.tsx" }],
+  ])("rejects %s", (_label, overrides) => {
+    const { routes } = routeFixture();
+    const file = path.join(routes, "deleted.tsx");
+    expect(
+      classifyStaleReactRouterRouteError(loadError(file, overrides), [routes]),
+    ).toBeUndefined();
+  });
+
+  it("rejects existing route transforms and missing imports outside route roots", () => {
+    const { root, routes } = routeFixture();
+    const existing = path.join(routes, "syntax-error.tsx");
+    fs.writeFileSync(existing, "export default (");
+    const outside = path.join(root, "lib", "missing.ts");
+
+    expect(
+      classifyStaleReactRouterRouteError(loadError(existing), [routes]),
+    ).toBeUndefined();
+    expect(
+      classifyStaleReactRouterRouteError(loadError(outside), [routes]),
+    ).toBeUndefined();
+    expect(
+      classifyStaleReactRouterRouteError(
+        Object.assign(new Error("loader failed"), {
+          code: "ERR_LOAD_URL",
+          importer: "virtual:react-router/server-build",
+        }),
+        [routes],
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("React Router recovery coordinator", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("serializes restart requests with one pending rerun", async () => {
+    vi.useFakeTimers();
+    let now = 1_000;
+    let finishRestart: (() => void) | undefined;
+    const restart = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRestart = resolve;
+        }),
+    );
+    const coordinator = createReactRouterRecoveryCoordinator(["/app/routes"], {
+      restart,
+      now: () => now,
+      cooldownMs: 100,
+    });
+
+    expect(coordinator.request("delete a")).toBe("started");
+    expect(coordinator.request("add b")).toBe("pending");
+    expect(coordinator.request("add c")).toBe("pending");
+    expect(restart).toHaveBeenCalledOnce();
+
+    finishRestart?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    now += 100;
+    await vi.runOnlyPendingTimersAsync();
+    expect(restart).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps attempt bounds across coordinator replacement", () => {
+    const key = `route-recovery-${crypto.randomUUID()}`;
+    const first = createReactRouterRecoveryCoordinator(["/app/routes"], {
+      restart: async () => {},
+      maxConsecutiveAttempts: 1,
+      persistentStateKey: key,
+    });
+    expect(first.request("first")).toBe("started");
+    first.dispose();
+
+    const replacement = createReactRouterRecoveryCoordinator(["/app/routes"], {
+      restart: async () => {},
+      maxConsecutiveAttempts: 1,
+      persistentStateKey: key,
+    });
+    expect(replacement.request("loop")).toBe("bounded");
+    replacement.markSsrSuccess();
+    expect(replacement.request("after success")).toBe("started");
+  });
+
+  it("enforces cooldown and a bounded consecutive attempt count", async () => {
+    vi.useFakeTimers();
+    let now = 1_000;
+    const restart = vi.fn(async () => {});
+    const coordinator = createReactRouterRecoveryCoordinator(["/app/routes"], {
+      restart,
+      now: () => now,
+      cooldownMs: 50,
+      maxConsecutiveAttempts: 2,
+    });
+
+    expect(coordinator.request("first")).toBe("started");
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(coordinator.request("too soon")).toBe("cooldown");
+    now += 50;
+    await vi.runOnlyPendingTimersAsync();
+    expect(restart).toHaveBeenCalledTimes(2);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(coordinator.request("third")).toBe("bounded");
+
+    coordinator.markSsrSuccess();
+    now += 50;
+    expect(coordinator.request("after success")).toBe("started");
+  });
+});

--- a/packages/core/src/server/react-router-dev-recovery.ts
+++ b/packages/core/src/server/react-router-dev-recovery.ts
@@ -15,7 +15,7 @@ export type ReactRouterRecoveryRequest =
 
 export interface ReactRouterDevRecoveryBridge {
   routeRoots: readonly string[];
-  request(reason: string): ReactRouterRecoveryRequest;
+  requestFallback(reason: string): ReactRouterRecoveryRequest;
   markSsrSuccess(): void;
 }
 
@@ -30,11 +30,17 @@ interface RecoveryCoordinatorOptions {
 }
 
 interface RecoveryAttemptState {
-  attempts: number;
+  fallbackAttempts: number;
   lastStartedAt: number;
 }
 
+interface RecoveryRequest {
+  fallback: boolean;
+  reason: string;
+}
+
 export interface ReactRouterRecoveryCoordinator extends ReactRouterDevRecoveryBridge {
+  requestTopology(reason: string): ReactRouterRecoveryRequest;
   dispose(): void;
 }
 
@@ -50,13 +56,16 @@ function globalBridgeStore(): typeof globalThis & {
 
 function recoveryAttemptState(key?: string): RecoveryAttemptState {
   if (!key) {
-    return { attempts: 0, lastStartedAt: Number.NEGATIVE_INFINITY };
+    return { fallbackAttempts: 0, lastStartedAt: Number.NEGATIVE_INFINITY };
   }
   const store = globalBridgeStore();
   store[ATTEMPT_STATE_KEY] ??= new Map();
   const existing = store[ATTEMPT_STATE_KEY].get(key);
   if (existing) return existing;
-  const state = { attempts: 0, lastStartedAt: Number.NEGATIVE_INFINITY };
+  const state = {
+    fallbackAttempts: 0,
+    lastStartedAt: Number.NEGATIVE_INFINITY,
+  };
   store[ATTEMPT_STATE_KEY].set(key, state);
   return state;
 }
@@ -88,102 +97,123 @@ export function createReactRouterRecoveryCoordinator(
   const setTimer = options.setTimer ?? setTimeout;
   const attemptState = recoveryAttemptState(options.persistentStateKey);
   let running = false;
-  let pendingReason: string | undefined;
+  let pendingRequest: RecoveryRequest | undefined;
   let pendingTimer: ReturnType<typeof setTimeout> | undefined;
   let disposed = false;
 
   const schedulePending = () => {
-    if (!pendingReason || pendingTimer || disposed) return;
+    if (!pendingRequest || pendingTimer || disposed) return;
     const delay = Math.max(
       0,
       cooldownMs - (now() - attemptState.lastStartedAt),
     );
     pendingTimer = setTimer(() => {
       pendingTimer = undefined;
-      const reason = pendingReason;
-      pendingReason = undefined;
-      if (reason) run(reason);
+      const request = pendingRequest;
+      pendingRequest = undefined;
+      if (request) run(request);
     }, delay);
     pendingTimer.unref?.();
   };
 
-  const run = (reason: string) => {
-    if (disposed || attemptState.attempts >= maxConsecutiveAttempts) return;
+  const run = (request: RecoveryRequest) => {
+    if (disposed) return;
     running = true;
-    attemptState.attempts += 1;
+    if (request.fallback) attemptState.fallbackAttempts += 1;
     attemptState.lastStartedAt = now();
     void options
       .restart()
       .then(
         () =>
           options.onOutcome?.(
-            `React Router route recovery completed: ${reason}`,
+            `React Router route recovery completed: ${request.reason}`,
           ),
         (error) =>
           options.onOutcome?.(
-            `React Router route recovery failed: ${reason}`,
+            `React Router route recovery failed: ${request.reason}`,
             error,
           ),
       )
       .finally(() => {
         running = false;
-        if (!pendingReason || disposed) return;
-        if (attemptState.attempts >= maxConsecutiveAttempts) {
-          pendingReason = undefined;
-          return;
-        }
+        if (!pendingRequest || disposed) return;
         schedulePending();
       });
   };
 
+  const request = (
+    nextRequest: RecoveryRequest,
+  ): ReactRouterRecoveryRequest => {
+    if (disposed) return "bounded";
+    if (
+      nextRequest.fallback &&
+      attemptState.fallbackAttempts >= maxConsecutiveAttempts
+    ) {
+      return "bounded";
+    }
+    if (running) {
+      pendingRequest = pendingRequest
+        ? {
+            fallback: pendingRequest.fallback || nextRequest.fallback,
+            reason: nextRequest.reason,
+          }
+        : nextRequest;
+      return "pending";
+    }
+    if (now() - attemptState.lastStartedAt < cooldownMs) {
+      pendingRequest = pendingRequest
+        ? {
+            fallback: pendingRequest.fallback || nextRequest.fallback,
+            reason: nextRequest.reason,
+          }
+        : nextRequest;
+      schedulePending();
+      return "cooldown";
+    }
+    run(nextRequest);
+    return "started";
+  };
+
   return {
     routeRoots: routeRoots.map((root) => path.resolve(root)),
-    request(reason) {
-      if (disposed || attemptState.attempts >= maxConsecutiveAttempts) {
-        return "bounded";
-      }
-      if (running) {
-        pendingReason ??= reason;
-        return "pending";
-      }
-      if (now() - attemptState.lastStartedAt < cooldownMs) {
-        pendingReason ??= reason;
-        schedulePending();
-        return "cooldown";
-      }
-      run(reason);
-      return "started";
+    requestFallback(reason) {
+      return request({ fallback: true, reason });
+    },
+    requestTopology(reason) {
+      return request({ fallback: false, reason });
     },
     markSsrSuccess() {
-      attemptState.attempts = 0;
-      attemptState.lastStartedAt = Number.NEGATIVE_INFINITY;
-      pendingReason = undefined;
-      if (pendingTimer) clearTimeout(pendingTimer);
-      pendingTimer = undefined;
+      attemptState.fallbackAttempts = 0;
     },
     dispose() {
       disposed = true;
-      pendingReason = undefined;
+      pendingRequest = undefined;
       if (pendingTimer) clearTimeout(pendingTimer);
       pendingTimer = undefined;
     },
   };
 }
 
-function errorChain(error: unknown): Record<string, unknown>[] {
-  const chain: Record<string, unknown>[] = [];
-  const pending = [error];
-  const seen = new Set<unknown>();
-  while (pending.length > 0) {
-    const current = pending.shift();
-    if (!current || typeof current !== "object" || seen.has(current)) continue;
-    seen.add(current);
+function errorChains(error: unknown): Record<string, unknown>[][] {
+  const visit = (
+    current: unknown,
+    chain: Record<string, unknown>[],
+    seen: Set<unknown>,
+  ): Record<string, unknown>[][] => {
+    if (!current || typeof current !== "object" || seen.has(current)) {
+      return chain.length > 0 ? [chain] : [];
+    }
+    const nextSeen = new Set(seen).add(current);
     const record = current as Record<string, unknown>;
-    chain.push(record);
-    pending.push(record.cause);
-    if (Array.isArray(record.errors)) pending.push(...record.errors);
-  }
-  return chain;
+    const nextChain = [...chain, record];
+    const children = [
+      record.cause,
+      ...(Array.isArray(record.errors) ? record.errors : []),
+    ].filter(Boolean);
+    if (children.length === 0) return [nextChain];
+    return children.flatMap((child) => visit(child, nextChain, nextSeen));
+  };
+  return visit(error, [], new Set());
 }
 
 function cleanReferencedPath(value: string): string | undefined {
@@ -239,24 +269,27 @@ export function classifyStaleReactRouterRouteError(
   error: unknown,
   routeRoots: readonly string[],
 ): { file: string } | undefined {
-  for (const candidate of errorChain(error)) {
-    if (candidate.code !== "ERR_LOAD_URL") continue;
-    const context = [
-      candidate.message,
-      candidate.importer,
-      candidate.plugin,
-      candidate.id,
-      candidate.url,
-    ]
+  for (const chain of errorChains(error)) {
+    if (!chain.some((candidate) => candidate.code === "ERR_LOAD_URL")) continue;
+    const context = chain
+      .flatMap((candidate) => [
+        candidate.message,
+        candidate.importer,
+        candidate.plugin,
+        candidate.id,
+        candidate.url,
+      ])
       .filter((value): value is string => typeof value === "string")
       .join(" ");
     if (!context.includes("virtual:react-router/server-build")) continue;
-    const file = extractViteLoadUrlPath(candidate);
-    if (!file) continue;
-    if (!routeRoots.some((root) => isWithinRoot(file, path.resolve(root))))
-      continue;
-    if (fs.existsSync(file)) continue;
-    return { file };
+    for (const candidate of chain) {
+      const file = extractViteLoadUrlPath(candidate);
+      if (!file) continue;
+      if (!routeRoots.some((root) => isWithinRoot(file, path.resolve(root))))
+        continue;
+      if (fs.existsSync(file)) continue;
+      return { file };
+    }
   }
   return undefined;
 }

--- a/packages/core/src/server/react-router-dev-recovery.ts
+++ b/packages/core/src/server/react-router-dev-recovery.ts
@@ -70,8 +70,9 @@ interface RecoveryAttemptState {
 }
 
 interface RecoveryRequest {
-  fallbackModule?: string;
-  reason: string;
+  fallbackModules: Set<string>;
+  topology: boolean;
+  reasons: Set<string>;
 }
 
 export interface ReactRouterRecoveryCoordinator extends ReactRouterDevRecoveryBridge {
@@ -218,9 +219,15 @@ export function createReactRouterRecoveryCoordinator(
   let disposed = false;
 
   const mergePending = (request: RecoveryRequest) => {
-    if (!pendingRequest || request.fallbackModule) {
+    if (!pendingRequest) {
       pendingRequest = request;
+      return;
     }
+    pendingRequest.topology ||= request.topology;
+    for (const module of request.fallbackModules) {
+      pendingRequest.fallbackModules.add(module);
+    }
+    for (const reason of request.reasons) pendingRequest.reasons.add(reason);
   };
 
   const schedulePending = () => {
@@ -241,13 +248,9 @@ export function createReactRouterRecoveryCoordinator(
   const run = (request: RecoveryRequest) => {
     if (disposed) return;
     running = true;
-    if (request.fallbackModule) {
-      const attempts =
-        attemptState.fallbackAttemptsByModule.get(request.fallbackModule) ?? 0;
-      attemptState.fallbackAttemptsByModule.set(
-        request.fallbackModule,
-        attempts + 1,
-      );
+    for (const module of request.fallbackModules) {
+      const attempts = attemptState.fallbackAttemptsByModule.get(module) ?? 0;
+      attemptState.fallbackAttemptsByModule.set(module, attempts + 1);
     }
     attemptState.lastStartedAt = now();
     void options
@@ -255,11 +258,11 @@ export function createReactRouterRecoveryCoordinator(
       .then(
         () =>
           options.onOutcome?.(
-            `React Router route recovery completed: ${request.reason}`,
+            `React Router route recovery completed: ${[...request.reasons].join(", ")}`,
           ),
         (error) =>
           options.onOutcome?.(
-            `React Router route recovery failed: ${request.reason}`,
+            `React Router route recovery failed: ${[...request.reasons].join(", ")}`,
             error,
           ),
       )
@@ -301,10 +304,18 @@ export function createReactRouterRecoveryCoordinator(
       attemptState.pathnameModules.set(requestPathname, module);
       const attempts = attemptState.fallbackAttemptsByModule.get(module) ?? 0;
       if (attempts >= maxConsecutiveAttempts) return "bounded";
-      return request({ fallbackModule: module, reason });
+      return request({
+        fallbackModules: new Set([module]),
+        topology: false,
+        reasons: new Set([reason]),
+      });
     },
     requestTopology(reason) {
-      return request({ reason });
+      return request({
+        fallbackModules: new Set(),
+        topology: true,
+        reasons: new Set([reason]),
+      });
     },
     markSsrSuccess(requestPathname) {
       const module = attemptState.pathnameModules.get(requestPathname);

--- a/packages/core/src/server/react-router-dev-recovery.ts
+++ b/packages/core/src/server/react-router-dev-recovery.ts
@@ -70,9 +70,8 @@ interface RecoveryAttemptState {
 }
 
 interface RecoveryRequest {
-  fallbackModules: Set<string>;
-  topology: boolean;
-  reasons: Set<string>;
+  fallbackReasons: Map<string, string>;
+  topologyReason?: string;
 }
 
 export interface ReactRouterRecoveryCoordinator extends ReactRouterDevRecoveryBridge {
@@ -218,26 +217,54 @@ export function createReactRouterRecoveryCoordinator(
   let pendingTimer: ReturnType<typeof setTimeout> | undefined;
   let disposed = false;
 
+  const hasWork = (request: RecoveryRequest | undefined) =>
+    Boolean(
+      request && (request.topologyReason || request.fallbackReasons.size > 0),
+    );
+
+  const recoveryReason = (request: RecoveryRequest) =>
+    [request.topologyReason, ...request.fallbackReasons.values()]
+      .filter(Boolean)
+      .join(", ");
+
+  const clearPending = () => {
+    pendingRequest = undefined;
+    if (pendingTimer) clearTimeout(pendingTimer);
+    pendingTimer = undefined;
+  };
+
   const mergePending = (request: RecoveryRequest) => {
     if (!pendingRequest) {
-      pendingRequest = request;
+      pendingRequest = {
+        fallbackReasons: new Map(request.fallbackReasons),
+        topologyReason: request.topologyReason,
+      };
       return;
     }
-    pendingRequest.topology ||= request.topology;
-    for (const module of request.fallbackModules) {
-      pendingRequest.fallbackModules.add(module);
+    if (request.topologyReason) {
+      pendingRequest.topologyReason = request.topologyReason;
     }
-    for (const reason of request.reasons) pendingRequest.reasons.add(reason);
+    for (const [module, reason] of request.fallbackReasons) {
+      pendingRequest.fallbackReasons.set(module, reason);
+    }
   };
 
   const schedulePending = () => {
-    if (!pendingRequest || pendingTimer || disposed) return;
+    if (!hasWork(pendingRequest) || pendingTimer || disposed) return;
     const delay = Math.max(
       0,
       cooldownMs - (now() - attemptState.lastStartedAt),
     );
     pendingTimer = setTimer(() => {
       pendingTimer = undefined;
+      if (disposed || !hasWork(pendingRequest)) return;
+      if (running) return;
+      const remainingCooldown =
+        cooldownMs - (now() - attemptState.lastStartedAt);
+      if (remainingCooldown > 0) {
+        schedulePending();
+        return;
+      }
       const request = pendingRequest;
       pendingRequest = undefined;
       if (request) run(request);
@@ -247,28 +274,37 @@ export function createReactRouterRecoveryCoordinator(
 
   const run = (request: RecoveryRequest) => {
     if (disposed) return;
+    if (running) {
+      mergePending(request);
+      return;
+    }
     running = true;
-    for (const module of request.fallbackModules) {
+    for (const module of request.fallbackReasons.keys()) {
       const attempts = attemptState.fallbackAttemptsByModule.get(module) ?? 0;
       attemptState.fallbackAttemptsByModule.set(module, attempts + 1);
     }
     attemptState.lastStartedAt = now();
-    void options
-      .restart()
+    let restart: Promise<void>;
+    try {
+      restart = options.restart();
+    } catch (error) {
+      restart = Promise.reject(error);
+    }
+    void restart
       .then(
         () =>
           options.onOutcome?.(
-            `React Router route recovery completed: ${[...request.reasons].join(", ")}`,
+            `React Router route recovery completed: ${recoveryReason(request)}`,
           ),
         (error) =>
           options.onOutcome?.(
-            `React Router route recovery failed: ${[...request.reasons].join(", ")}`,
+            `React Router route recovery failed: ${recoveryReason(request)}`,
             error,
           ),
       )
       .finally(() => {
         running = false;
-        if (!pendingRequest || disposed) return;
+        if (disposed || !hasWork(pendingRequest)) return;
         schedulePending();
       });
   };
@@ -277,6 +313,11 @@ export function createReactRouterRecoveryCoordinator(
     nextRequest: RecoveryRequest,
   ): ReactRouterRecoveryRequest => {
     if (disposed) return "bounded";
+    if (hasWork(pendingRequest) || pendingTimer) {
+      mergePending(nextRequest);
+      if (!running) schedulePending();
+      return running ? "pending" : "cooldown";
+    }
     if (running) {
       mergePending(nextRequest);
       return "pending";
@@ -305,16 +346,13 @@ export function createReactRouterRecoveryCoordinator(
       const attempts = attemptState.fallbackAttemptsByModule.get(module) ?? 0;
       if (attempts >= maxConsecutiveAttempts) return "bounded";
       return request({
-        fallbackModules: new Set([module]),
-        topology: false,
-        reasons: new Set([reason]),
+        fallbackReasons: new Map([[module, reason]]),
       });
     },
     requestTopology(reason) {
       return request({
-        fallbackModules: new Set(),
-        topology: true,
-        reasons: new Set([reason]),
+        fallbackReasons: new Map(),
+        topologyReason: reason,
       });
     },
     markSsrSuccess(requestPathname) {
@@ -326,12 +364,12 @@ export function createReactRouterRecoveryCoordinator(
           attemptState.pathnameModules.delete(pathname);
         }
       }
+      pendingRequest?.fallbackReasons.delete(module);
+      if (!hasWork(pendingRequest)) clearPending();
     },
     dispose() {
       disposed = true;
-      pendingRequest = undefined;
-      if (pendingTimer) clearTimeout(pendingTimer);
-      pendingTimer = undefined;
+      clearPending();
     },
   };
 }

--- a/packages/core/src/server/react-router-dev-recovery.ts
+++ b/packages/core/src/server/react-router-dev-recovery.ts
@@ -1,0 +1,262 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const BRIDGE_KEY = Symbol.for("agent-native.react-router-dev-recovery");
+const ATTEMPT_STATE_KEY = Symbol.for(
+  "agent-native.react-router-dev-recovery-attempts",
+);
+
+export type ReactRouterRecoveryRequest =
+  | "started"
+  | "pending"
+  | "cooldown"
+  | "bounded";
+
+export interface ReactRouterDevRecoveryBridge {
+  routeRoots: readonly string[];
+  request(reason: string): ReactRouterRecoveryRequest;
+  markSsrSuccess(): void;
+}
+
+interface RecoveryCoordinatorOptions {
+  restart: () => Promise<void>;
+  cooldownMs?: number;
+  maxConsecutiveAttempts?: number;
+  now?: () => number;
+  setTimer?: typeof setTimeout;
+  onOutcome?: (message: string, error?: unknown) => void;
+  persistentStateKey?: string;
+}
+
+interface RecoveryAttemptState {
+  attempts: number;
+  lastStartedAt: number;
+}
+
+export interface ReactRouterRecoveryCoordinator extends ReactRouterDevRecoveryBridge {
+  dispose(): void;
+}
+
+function globalBridgeStore(): typeof globalThis & {
+  [BRIDGE_KEY]?: ReactRouterDevRecoveryBridge;
+  [ATTEMPT_STATE_KEY]?: Map<string, RecoveryAttemptState>;
+} {
+  return globalThis as typeof globalThis & {
+    [BRIDGE_KEY]?: ReactRouterDevRecoveryBridge;
+    [ATTEMPT_STATE_KEY]?: Map<string, RecoveryAttemptState>;
+  };
+}
+
+function recoveryAttemptState(key?: string): RecoveryAttemptState {
+  if (!key) {
+    return { attempts: 0, lastStartedAt: Number.NEGATIVE_INFINITY };
+  }
+  const store = globalBridgeStore();
+  store[ATTEMPT_STATE_KEY] ??= new Map();
+  const existing = store[ATTEMPT_STATE_KEY].get(key);
+  if (existing) return existing;
+  const state = { attempts: 0, lastStartedAt: Number.NEGATIVE_INFINITY };
+  store[ATTEMPT_STATE_KEY].set(key, state);
+  return state;
+}
+
+export function registerReactRouterDevRecovery(
+  bridge: ReactRouterDevRecoveryBridge,
+): () => void {
+  const store = globalBridgeStore();
+  store[BRIDGE_KEY] = bridge;
+  return () => {
+    if (store[BRIDGE_KEY] === bridge) delete store[BRIDGE_KEY];
+  };
+}
+
+export function getReactRouterDevRecovery():
+  | ReactRouterDevRecoveryBridge
+  | undefined {
+  if (process.env.NODE_ENV === "production") return undefined;
+  return globalBridgeStore()[BRIDGE_KEY];
+}
+
+export function createReactRouterRecoveryCoordinator(
+  routeRoots: readonly string[],
+  options: RecoveryCoordinatorOptions,
+): ReactRouterRecoveryCoordinator {
+  const cooldownMs = options.cooldownMs ?? 500;
+  const maxConsecutiveAttempts = options.maxConsecutiveAttempts ?? 3;
+  const now = options.now ?? Date.now;
+  const setTimer = options.setTimer ?? setTimeout;
+  const attemptState = recoveryAttemptState(options.persistentStateKey);
+  let running = false;
+  let pendingReason: string | undefined;
+  let pendingTimer: ReturnType<typeof setTimeout> | undefined;
+  let disposed = false;
+
+  const schedulePending = () => {
+    if (!pendingReason || pendingTimer || disposed) return;
+    const delay = Math.max(
+      0,
+      cooldownMs - (now() - attemptState.lastStartedAt),
+    );
+    pendingTimer = setTimer(() => {
+      pendingTimer = undefined;
+      const reason = pendingReason;
+      pendingReason = undefined;
+      if (reason) run(reason);
+    }, delay);
+    pendingTimer.unref?.();
+  };
+
+  const run = (reason: string) => {
+    if (disposed || attemptState.attempts >= maxConsecutiveAttempts) return;
+    running = true;
+    attemptState.attempts += 1;
+    attemptState.lastStartedAt = now();
+    void options
+      .restart()
+      .then(
+        () =>
+          options.onOutcome?.(
+            `React Router route recovery completed: ${reason}`,
+          ),
+        (error) =>
+          options.onOutcome?.(
+            `React Router route recovery failed: ${reason}`,
+            error,
+          ),
+      )
+      .finally(() => {
+        running = false;
+        if (!pendingReason || disposed) return;
+        if (attemptState.attempts >= maxConsecutiveAttempts) {
+          pendingReason = undefined;
+          return;
+        }
+        schedulePending();
+      });
+  };
+
+  return {
+    routeRoots: routeRoots.map((root) => path.resolve(root)),
+    request(reason) {
+      if (disposed || attemptState.attempts >= maxConsecutiveAttempts) {
+        return "bounded";
+      }
+      if (running) {
+        pendingReason ??= reason;
+        return "pending";
+      }
+      if (now() - attemptState.lastStartedAt < cooldownMs) {
+        pendingReason ??= reason;
+        schedulePending();
+        return "cooldown";
+      }
+      run(reason);
+      return "started";
+    },
+    markSsrSuccess() {
+      attemptState.attempts = 0;
+      attemptState.lastStartedAt = Number.NEGATIVE_INFINITY;
+      pendingReason = undefined;
+      if (pendingTimer) clearTimeout(pendingTimer);
+      pendingTimer = undefined;
+    },
+    dispose() {
+      disposed = true;
+      pendingReason = undefined;
+      if (pendingTimer) clearTimeout(pendingTimer);
+      pendingTimer = undefined;
+    },
+  };
+}
+
+function errorChain(error: unknown): Record<string, unknown>[] {
+  const chain: Record<string, unknown>[] = [];
+  const pending = [error];
+  const seen = new Set<unknown>();
+  while (pending.length > 0) {
+    const current = pending.shift();
+    if (!current || typeof current !== "object" || seen.has(current)) continue;
+    seen.add(current);
+    const record = current as Record<string, unknown>;
+    chain.push(record);
+    pending.push(record.cause);
+    if (Array.isArray(record.errors)) pending.push(...record.errors);
+  }
+  return chain;
+}
+
+function cleanReferencedPath(value: string): string | undefined {
+  let candidate = value.trim().replace(/^['"]|['"]$/g, "");
+  candidate = candidate.split(/[?#]/, 1)[0] ?? candidate;
+  if (candidate.startsWith("file://")) {
+    try {
+      candidate = fileURLToPath(candidate);
+    } catch {
+      return undefined;
+    }
+  }
+  if (candidate.startsWith("/@fs/")) candidate = candidate.slice(4);
+  if (!path.isAbsolute(candidate)) return undefined;
+  try {
+    return path.resolve(decodeURIComponent(candidate));
+  } catch {
+    return undefined;
+  }
+}
+
+export function extractViteLoadUrlPath(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const record = error as Record<string, unknown>;
+  const direct = [record.id, record.file, record.url].find(
+    (value): value is string => typeof value === "string",
+  );
+  if (direct) {
+    const cleaned = cleanReferencedPath(direct);
+    if (cleaned) return cleaned;
+  }
+  const message = typeof record.message === "string" ? record.message : "";
+  const resolved = message.match(/\(resolved id:\s*([^\)]+)\)/)?.[1];
+  if (resolved) {
+    const cleaned = cleanReferencedPath(resolved);
+    if (cleaned) return cleaned;
+  }
+  const loaded = message.match(
+    /Failed to load url\s+(.+?)(?:\s+\(resolved id:|\s+in\s+)/,
+  )?.[1];
+  return loaded ? cleanReferencedPath(loaded) : undefined;
+}
+
+function isWithinRoot(file: string, root: string): boolean {
+  const relative = path.relative(root, file);
+  return (
+    relative === "" ||
+    (!relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}
+
+export function classifyStaleReactRouterRouteError(
+  error: unknown,
+  routeRoots: readonly string[],
+): { file: string } | undefined {
+  for (const candidate of errorChain(error)) {
+    if (candidate.code !== "ERR_LOAD_URL") continue;
+    const context = [
+      candidate.message,
+      candidate.importer,
+      candidate.plugin,
+      candidate.id,
+      candidate.url,
+    ]
+      .filter((value): value is string => typeof value === "string")
+      .join(" ");
+    if (!context.includes("virtual:react-router/server-build")) continue;
+    const file = extractViteLoadUrlPath(candidate);
+    if (!file) continue;
+    if (!routeRoots.some((root) => isWithinRoot(file, path.resolve(root))))
+      continue;
+    if (fs.existsSync(file)) continue;
+    return { file };
+  }
+  return undefined;
+}

--- a/packages/core/src/server/react-router-dev-recovery.ts
+++ b/packages/core/src/server/react-router-dev-recovery.ts
@@ -17,15 +17,6 @@ const ROUTE_MODULE_EXTENSIONS = new Set([
   ".md",
   ".mdx",
 ]);
-const NON_ROUTE_PATTERNS = [
-  "**/*.test.{js,jsx,ts,tsx,md,mdx}",
-  "**/*.spec.{js,jsx,ts,tsx,md,mdx}",
-  "**/*.test/**",
-  "**/*.spec/**",
-  "**/__tests__/**",
-  "**/__snapshots__/**",
-];
-
 export type ReactRouterRecoveryRequest =
   | "started"
   | "pending"
@@ -143,14 +134,10 @@ function hasDotPathSegment(relative: string): boolean {
 function isIgnoredRoutePath(
   relativeToApp: string,
   ignoredRouteFiles: readonly string[],
-  directory = false,
 ): boolean {
   if (hasDotPathSegment(relativeToApp)) return true;
-  return [...NON_ROUTE_PATTERNS, ...ignoredRouteFiles].some(
-    (pattern) =>
-      minimatch(relativeToApp, pattern, { dot: true }) ||
-      (directory &&
-        minimatch(`${relativeToApp}/__route.tsx`, pattern, { dot: true })),
+  return ignoredRouteFiles.some((pattern) =>
+    minimatch(relativeToApp, pattern, { dot: true }),
   );
 }
 
@@ -181,6 +168,10 @@ export function isReactRouterRouteModulePath(
     if (segments.length === 2) {
       const moduleName = path.basename(segments[1], path.extname(segments[1]));
       if (moduleName !== "route" && moduleName !== "index") return false;
+      return !isIgnoredRoutePath(
+        path.posix.dirname(relativeToApp),
+        root.ignoredRouteFiles,
+      );
     }
     return !isIgnoredRoutePath(relativeToApp, root.ignoredRouteFiles);
   });
@@ -199,7 +190,7 @@ export function isReactRouterRouteDirectoryPath(
     if (relativeToRoot === undefined || relativeToApp === undefined)
       return false;
     if (relativeToRoot && relativeToRoot.includes("/")) return false;
-    return !isIgnoredRoutePath(relativeToApp, root.ignoredRouteFiles, true);
+    return !isIgnoredRoutePath(relativeToApp, root.ignoredRouteFiles);
   });
 }
 

--- a/packages/core/src/server/react-router-dev-recovery.ts
+++ b/packages/core/src/server/react-router-dev-recovery.ts
@@ -417,7 +417,7 @@ export function extractViteLoadUrlPath(error: unknown): string | undefined {
     if (cleaned) return cleaned;
   }
   const message = typeof record.message === "string" ? record.message : "";
-  const resolved = message.match(/\(resolved id:\s*([^\)]+)\)/)?.[1];
+  const resolved = message.match(/\(resolved id:\s*([^)]+)\)/)?.[1];
   if (resolved) {
     const cleaned = cleanReferencedPath(resolved);
     if (cleaned) return cleaned;

--- a/packages/core/src/server/react-router-dev-recovery.ts
+++ b/packages/core/src/server/react-router-dev-recovery.ts
@@ -2,10 +2,29 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { minimatch } from "minimatch";
+
 const BRIDGE_KEY = Symbol.for("agent-native.react-router-dev-recovery");
 const ATTEMPT_STATE_KEY = Symbol.for(
   "agent-native.react-router-dev-recovery-attempts",
 );
+
+const ROUTE_MODULE_EXTENSIONS = new Set([
+  ".js",
+  ".jsx",
+  ".ts",
+  ".tsx",
+  ".md",
+  ".mdx",
+]);
+const NON_ROUTE_PATTERNS = [
+  "**/*.test.{js,jsx,ts,tsx,md,mdx}",
+  "**/*.spec.{js,jsx,ts,tsx,md,mdx}",
+  "**/*.test/**",
+  "**/*.spec/**",
+  "**/__tests__/**",
+  "**/__snapshots__/**",
+];
 
 export type ReactRouterRecoveryRequest =
   | "started"
@@ -13,10 +32,25 @@ export type ReactRouterRecoveryRequest =
   | "cooldown"
   | "bounded";
 
+export interface ReactRouterDiscoveryRoot {
+  appDirectory: string;
+  directory: string;
+  ignoredRouteFiles: readonly string[];
+}
+
+export interface ReactRouterRouteScope {
+  exactRouteFiles: readonly string[];
+  discoveryRoots: readonly ReactRouterDiscoveryRoot[];
+}
+
 export interface ReactRouterDevRecoveryBridge {
-  routeRoots: readonly string[];
-  requestFallback(reason: string): ReactRouterRecoveryRequest;
-  markSsrSuccess(): void;
+  routeScope: ReactRouterRouteScope;
+  requestFallback(input: {
+    modulePath: string;
+    requestPathname: string;
+    reason: string;
+  }): ReactRouterRecoveryRequest;
+  markSsrSuccess(requestPathname: string): void;
 }
 
 interface RecoveryCoordinatorOptions {
@@ -30,12 +64,13 @@ interface RecoveryCoordinatorOptions {
 }
 
 interface RecoveryAttemptState {
-  fallbackAttempts: number;
+  fallbackAttemptsByModule: Map<string, number>;
+  pathnameModules: Map<string, string>;
   lastStartedAt: number;
 }
 
 interface RecoveryRequest {
-  fallback: boolean;
+  fallbackModule?: string;
   reason: string;
 }
 
@@ -54,18 +89,21 @@ function globalBridgeStore(): typeof globalThis & {
   };
 }
 
+function newAttemptState(): RecoveryAttemptState {
+  return {
+    fallbackAttemptsByModule: new Map(),
+    pathnameModules: new Map(),
+    lastStartedAt: Number.NEGATIVE_INFINITY,
+  };
+}
+
 function recoveryAttemptState(key?: string): RecoveryAttemptState {
-  if (!key) {
-    return { fallbackAttempts: 0, lastStartedAt: Number.NEGATIVE_INFINITY };
-  }
+  if (!key) return newAttemptState();
   const store = globalBridgeStore();
   store[ATTEMPT_STATE_KEY] ??= new Map();
   const existing = store[ATTEMPT_STATE_KEY].get(key);
   if (existing) return existing;
-  const state = {
-    fallbackAttempts: 0,
-    lastStartedAt: Number.NEGATIVE_INFINITY,
-  };
+  const state = newAttemptState();
   store[ATTEMPT_STATE_KEY].set(key, state);
   return state;
 }
@@ -87,8 +125,86 @@ export function getReactRouterDevRecovery():
   return globalBridgeStore()[BRIDGE_KEY];
 }
 
+function normalizeFile(file: string): string {
+  return path.resolve(file);
+}
+
+function relativeInside(file: string, root: string): string | undefined {
+  const relative = path.relative(root, file);
+  if (relative === "") return "";
+  if (relative.startsWith("..") || path.isAbsolute(relative)) return undefined;
+  return relative.replaceAll(path.sep, "/");
+}
+
+function hasDotPathSegment(relative: string): boolean {
+  return relative.split("/").some((segment) => segment.startsWith("."));
+}
+
+function isIgnoredRoutePath(
+  relativeToApp: string,
+  ignoredRouteFiles: readonly string[],
+  directory = false,
+): boolean {
+  if (hasDotPathSegment(relativeToApp)) return true;
+  return [...NON_ROUTE_PATTERNS, ...ignoredRouteFiles].some(
+    (pattern) =>
+      minimatch(relativeToApp, pattern, { dot: true }) ||
+      (directory &&
+        minimatch(`${relativeToApp}/__route.tsx`, pattern, { dot: true })),
+  );
+}
+
+export function isReactRouterRouteModulePath(
+  file: string,
+  scope: ReactRouterRouteScope,
+): boolean {
+  const absolute = normalizeFile(file);
+  if (
+    scope.exactRouteFiles.some(
+      (candidate) => normalizeFile(candidate) === absolute,
+    )
+  ) {
+    return true;
+  }
+  if (!ROUTE_MODULE_EXTENSIONS.has(path.extname(absolute).toLowerCase())) {
+    return false;
+  }
+  return scope.discoveryRoots.some((root) => {
+    const directory = normalizeFile(root.directory);
+    const appDirectory = normalizeFile(root.appDirectory);
+    const relativeToRoot = relativeInside(absolute, directory);
+    const relativeToApp = relativeInside(absolute, appDirectory);
+    if (relativeToRoot === undefined || relativeToApp === undefined)
+      return false;
+    const segments = relativeToRoot.split("/");
+    if (segments.length > 2) return false;
+    if (segments.length === 2) {
+      const moduleName = path.basename(segments[1], path.extname(segments[1]));
+      if (moduleName !== "route" && moduleName !== "index") return false;
+    }
+    return !isIgnoredRoutePath(relativeToApp, root.ignoredRouteFiles);
+  });
+}
+
+export function isReactRouterRouteDirectoryPath(
+  directory: string,
+  scope: ReactRouterRouteScope,
+): boolean {
+  const absolute = normalizeFile(directory);
+  return scope.discoveryRoots.some((root) => {
+    const discoveryRoot = normalizeFile(root.directory);
+    const appDirectory = normalizeFile(root.appDirectory);
+    const relativeToRoot = relativeInside(absolute, discoveryRoot);
+    const relativeToApp = relativeInside(absolute, appDirectory);
+    if (relativeToRoot === undefined || relativeToApp === undefined)
+      return false;
+    if (relativeToRoot && relativeToRoot.includes("/")) return false;
+    return !isIgnoredRoutePath(relativeToApp, root.ignoredRouteFiles, true);
+  });
+}
+
 export function createReactRouterRecoveryCoordinator(
-  routeRoots: readonly string[],
+  routeScope: ReactRouterRouteScope,
   options: RecoveryCoordinatorOptions,
 ): ReactRouterRecoveryCoordinator {
   const cooldownMs = options.cooldownMs ?? 500;
@@ -100,6 +216,12 @@ export function createReactRouterRecoveryCoordinator(
   let pendingRequest: RecoveryRequest | undefined;
   let pendingTimer: ReturnType<typeof setTimeout> | undefined;
   let disposed = false;
+
+  const mergePending = (request: RecoveryRequest) => {
+    if (!pendingRequest || request.fallbackModule) {
+      pendingRequest = request;
+    }
+  };
 
   const schedulePending = () => {
     if (!pendingRequest || pendingTimer || disposed) return;
@@ -119,7 +241,14 @@ export function createReactRouterRecoveryCoordinator(
   const run = (request: RecoveryRequest) => {
     if (disposed) return;
     running = true;
-    if (request.fallback) attemptState.fallbackAttempts += 1;
+    if (request.fallbackModule) {
+      const attempts =
+        attemptState.fallbackAttemptsByModule.get(request.fallbackModule) ?? 0;
+      attemptState.fallbackAttemptsByModule.set(
+        request.fallbackModule,
+        attempts + 1,
+      );
+    }
     attemptState.lastStartedAt = now();
     void options
       .restart()
@@ -145,28 +274,12 @@ export function createReactRouterRecoveryCoordinator(
     nextRequest: RecoveryRequest,
   ): ReactRouterRecoveryRequest => {
     if (disposed) return "bounded";
-    if (
-      nextRequest.fallback &&
-      attemptState.fallbackAttempts >= maxConsecutiveAttempts
-    ) {
-      return "bounded";
-    }
     if (running) {
-      pendingRequest = pendingRequest
-        ? {
-            fallback: pendingRequest.fallback || nextRequest.fallback,
-            reason: nextRequest.reason,
-          }
-        : nextRequest;
+      mergePending(nextRequest);
       return "pending";
     }
     if (now() - attemptState.lastStartedAt < cooldownMs) {
-      pendingRequest = pendingRequest
-        ? {
-            fallback: pendingRequest.fallback || nextRequest.fallback,
-            reason: nextRequest.reason,
-          }
-        : nextRequest;
+      mergePending(nextRequest);
       schedulePending();
       return "cooldown";
     }
@@ -175,15 +288,33 @@ export function createReactRouterRecoveryCoordinator(
   };
 
   return {
-    routeRoots: routeRoots.map((root) => path.resolve(root)),
-    requestFallback(reason) {
-      return request({ fallback: true, reason });
+    routeScope: {
+      exactRouteFiles: routeScope.exactRouteFiles.map(normalizeFile),
+      discoveryRoots: routeScope.discoveryRoots.map((root) => ({
+        appDirectory: normalizeFile(root.appDirectory),
+        directory: normalizeFile(root.directory),
+        ignoredRouteFiles: [...root.ignoredRouteFiles],
+      })),
+    },
+    requestFallback({ modulePath, requestPathname, reason }) {
+      const module = normalizeFile(modulePath);
+      attemptState.pathnameModules.set(requestPathname, module);
+      const attempts = attemptState.fallbackAttemptsByModule.get(module) ?? 0;
+      if (attempts >= maxConsecutiveAttempts) return "bounded";
+      return request({ fallbackModule: module, reason });
     },
     requestTopology(reason) {
-      return request({ fallback: false, reason });
+      return request({ reason });
     },
-    markSsrSuccess() {
-      attemptState.fallbackAttempts = 0;
+    markSsrSuccess(requestPathname) {
+      const module = attemptState.pathnameModules.get(requestPathname);
+      if (!module) return;
+      attemptState.fallbackAttemptsByModule.delete(module);
+      for (const [pathname, associatedModule] of attemptState.pathnameModules) {
+        if (associatedModule === module) {
+          attemptState.pathnameModules.delete(pathname);
+        }
+      }
     },
     dispose() {
       disposed = true;
@@ -257,17 +388,9 @@ export function extractViteLoadUrlPath(error: unknown): string | undefined {
   return loaded ? cleanReferencedPath(loaded) : undefined;
 }
 
-function isWithinRoot(file: string, root: string): boolean {
-  const relative = path.relative(root, file);
-  return (
-    relative === "" ||
-    (!relative.startsWith("..") && !path.isAbsolute(relative))
-  );
-}
-
 export function classifyStaleReactRouterRouteError(
   error: unknown,
-  routeRoots: readonly string[],
+  routeScope: ReactRouterRouteScope,
 ): { file: string } | undefined {
   for (const chain of errorChains(error)) {
     if (!chain.some((candidate) => candidate.code === "ERR_LOAD_URL")) continue;
@@ -284,9 +407,7 @@ export function classifyStaleReactRouterRouteError(
     if (!context.includes("virtual:react-router/server-build")) continue;
     for (const candidate of chain) {
       const file = extractViteLoadUrlPath(candidate);
-      if (!file) continue;
-      if (!routeRoots.some((root) => isWithinRoot(file, path.resolve(root))))
-        continue;
+      if (!file || !isReactRouterRouteModulePath(file, routeScope)) continue;
       if (fs.existsSync(file)) continue;
       return { file };
     }

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -10,6 +10,7 @@ import {
   AGENT_NATIVE_SOCIAL_IMAGE_PATH,
 } from "../shared/social-meta.js";
 import { registerErrorCaptureProvider } from "./capture-error.js";
+import { registerReactRouterDevRecovery } from "./react-router-dev-recovery.js";
 import { getRequestUserEmail } from "./request-context.js";
 import {
   createH3SSRHandler,
@@ -102,6 +103,81 @@ describe("createH3SSRHandler", () => {
 
     await expect(response.text()).resolves.toBe("GET /inbox?view=unread");
     expect(mocks.requestHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a complete no-store 503 for a stale route and succeeds on retry", async () => {
+    const missingRoute = "/tmp/agent-native-routes/deleted.tsx";
+    const request = vi.fn(() => "started" as const);
+    const markSsrSuccess = vi.fn();
+    const unregister = registerReactRouterDevRecovery({
+      routeRoots: ["/tmp/agent-native-routes"],
+      request,
+      markSsrSuccess,
+    });
+    mocks.requestHandler.mockRejectedValueOnce(
+      Object.assign(
+        new Error(
+          `Failed to load url ${missingRoute} (resolved id: ${missingRoute}) in virtual:react-router/server-build. Does the file exist?`,
+        ),
+        { code: "ERR_LOAD_URL" },
+      ),
+    );
+    try {
+      const handler = createH3SSRHandler(() => ({})) as any;
+
+      const fallback = await handler(createEvent("/deleted"));
+      expect(fallback.status).toBe(503);
+      expect(fallback.headers.get("cache-control")).toBe("no-store");
+      expect(fallback.headers.get("retry-after")).toBe("1");
+      expect(fallback.headers.get("content-type")).toBe(
+        "text/plain; charset=utf-8",
+      );
+      await expect(fallback.text()).resolves.toBe(
+        "Route graph is refreshing. Retry shortly.\n",
+      );
+      expect(request).toHaveBeenCalledOnce();
+      expect(markSsrSuccess).not.toHaveBeenCalled();
+
+      const recovered = await handler(createEvent("/recovered"));
+      expect(recovered.status).toBe(200);
+      await expect(recovered.text()).resolves.toBe("GET /recovered");
+      expect(markSsrSuccess).toHaveBeenCalledOnce();
+    } finally {
+      unregister();
+    }
+  });
+
+  it("preserves the original SSR failure after recovery attempts are bounded", async () => {
+    const missingRoute = "/tmp/agent-native-routes/deleted.tsx";
+    const unregister = registerReactRouterDevRecovery({
+      routeRoots: ["/tmp/agent-native-routes"],
+      request: () => "bounded",
+      markSsrSuccess: vi.fn(),
+    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mocks.requestHandler.mockRejectedValueOnce(
+      Object.assign(
+        new Error(
+          `Failed to load url ${missingRoute} (resolved id: ${missingRoute}) in virtual:react-router/server-build. Does the file exist?`,
+        ),
+        { code: "ERR_LOAD_URL" },
+      ),
+    );
+    try {
+      const handler = createH3SSRHandler(() => ({})) as any;
+      const response = await handler(createEvent("/deleted"));
+
+      expect(response.status).toBe(500);
+      expect(consoleError).toHaveBeenCalledWith(
+        "[ssr-handler] SSR error:",
+        expect.objectContaining({ code: "ERR_LOAD_URL" }),
+      );
+    } finally {
+      unregister();
+      consoleError.mockRestore();
+    }
   });
 
   it("captures SSR exceptions with request context before returning a safe 500", async () => {

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -110,7 +110,10 @@ describe("createH3SSRHandler", () => {
     const request = vi.fn(() => "started" as const);
     const markSsrSuccess = vi.fn();
     const unregister = registerReactRouterDevRecovery({
-      routeRoots: ["/tmp/agent-native-routes"],
+      routeScope: {
+        exactRouteFiles: [missingRoute],
+        discoveryRoots: [],
+      },
       requestFallback: request,
       markSsrSuccess,
     });
@@ -128,6 +131,10 @@ describe("createH3SSRHandler", () => {
       const fallback = await handler(createEvent("/deleted"));
       expect(fallback.status).toBe(503);
       expect(fallback.headers.get("cache-control")).toBe("no-store");
+      expect(fallback.headers.get("cdn-cache-control")).toBe("no-store");
+      expect(fallback.headers.get("netlify-cdn-cache-control")).toBe(
+        "no-store",
+      );
       expect(fallback.headers.get("retry-after")).toBe("1");
       expect(fallback.headers.get("content-type")).toBe(
         "text/plain; charset=utf-8",
@@ -135,13 +142,17 @@ describe("createH3SSRHandler", () => {
       await expect(fallback.text()).resolves.toBe(
         "Route graph is refreshing. Retry shortly.\n",
       );
-      expect(request).toHaveBeenCalledOnce();
+      expect(request).toHaveBeenCalledWith({
+        modulePath: missingRoute,
+        requestPathname: "/deleted",
+        reason: `missing route module ${missingRoute}`,
+      });
       expect(markSsrSuccess).not.toHaveBeenCalled();
 
       const recovered = await handler(createEvent("/recovered"));
       expect(recovered.status).toBe(200);
       await expect(recovered.text()).resolves.toBe("GET /recovered");
-      expect(markSsrSuccess).toHaveBeenCalledOnce();
+      expect(markSsrSuccess).toHaveBeenCalledWith("/recovered");
     } finally {
       unregister();
     }
@@ -150,7 +161,10 @@ describe("createH3SSRHandler", () => {
   it("preserves the original SSR failure after recovery attempts are bounded", async () => {
     const missingRoute = "/tmp/agent-native-routes/deleted.tsx";
     const unregister = registerReactRouterDevRecovery({
-      routeRoots: ["/tmp/agent-native-routes"],
+      routeScope: {
+        exactRouteFiles: [missingRoute],
+        discoveryRoots: [],
+      },
       requestFallback: () => "bounded",
       markSsrSuccess: vi.fn(),
     });

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -111,7 +111,7 @@ describe("createH3SSRHandler", () => {
     const markSsrSuccess = vi.fn();
     const unregister = registerReactRouterDevRecovery({
       routeRoots: ["/tmp/agent-native-routes"],
-      request,
+      requestFallback: request,
       markSsrSuccess,
     });
     mocks.requestHandler.mockRejectedValueOnce(
@@ -151,7 +151,7 @@ describe("createH3SSRHandler", () => {
     const missingRoute = "/tmp/agent-native-routes/deleted.tsx";
     const unregister = registerReactRouterDevRecovery({
       routeRoots: ["/tmp/agent-native-routes"],
-      request: () => "bounded",
+      requestFallback: () => "bounded",
       markSsrSuccess: vi.fn(),
     });
     const consoleError = vi

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -21,7 +21,7 @@ import { createRequestHandler } from "react-router";
 import { isMcpPublicPath } from "../mcp/route-paths.js";
 import {
   DEFAULT_SPECULATION_RULES_PATH,
-  DISABLED_SSR_CACHE_CONTROL,
+  DISABLED_SSR_CACHE_HEADERS,
   resolveSsrCacheHeaders,
 } from "../shared/cache-control.js";
 import {
@@ -466,23 +466,25 @@ export function createH3SSRHandler(getBuild: () => Promise<unknown> | unknown) {
         );
       }
       if (response.status < 500) {
-        getReactRouterDevRecovery()?.markSsrSuccess();
+        getReactRouterDevRecovery()?.markSsrSuccess(p);
       }
       return response;
     } catch (err) {
       const recovery = getReactRouterDevRecovery();
       const staleRoute =
         recovery &&
-        classifyStaleReactRouterRouteError(err, recovery.routeRoots);
+        classifyStaleReactRouterRouteError(err, recovery.routeScope);
       if (recovery && staleRoute) {
-        const result = recovery.requestFallback(
-          `missing route module ${staleRoute.file}`,
-        );
+        const result = recovery.requestFallback({
+          modulePath: staleRoute.file,
+          requestPathname: p,
+          reason: `missing route module ${staleRoute.file}`,
+        });
         if (result !== "bounded") {
           return new Response("Route graph is refreshing. Retry shortly.\n", {
             status: 503,
             headers: {
-              "cache-control": DISABLED_SSR_CACHE_CONTROL,
+              ...DISABLED_SSR_CACHE_HEADERS,
               "content-type": "text/plain; charset=utf-8",
               "retry-after": "1",
             },

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -21,6 +21,7 @@ import { createRequestHandler } from "react-router";
 import { isMcpPublicPath } from "../mcp/route-paths.js";
 import {
   DEFAULT_SPECULATION_RULES_PATH,
+  DISABLED_SSR_CACHE_CONTROL,
   resolveSsrCacheHeaders,
 } from "../shared/cache-control.js";
 import {
@@ -36,6 +37,10 @@ import {
   stripAppBasePath as canonicalStripAppBasePath,
 } from "./app-base-path.js";
 import { captureError } from "./capture-error.js";
+import {
+  classifyStaleReactRouterRouteError,
+  getReactRouterDevRecovery,
+} from "./react-router-dev-recovery.js";
 import { runWithRequestContext } from "./request-context.js";
 import {
   getRealtimeClientConfigScript,
@@ -432,33 +437,58 @@ export function createH3SSRHandler(getBuild: () => Promise<unknown> | unknown) {
       // session here to "fix" a per-user page — that silently makes the page
       // uncacheable and/or leaks one user's data into another's cached copy.
       const ctx = { userEmail: undefined, orgId: undefined };
+      let response: Response;
       if (request.method === "HEAD") {
         const getRequest = new Request(request.url, {
           method: "GET",
           headers: request.headers,
           signal: request.signal,
         });
-        const response = await runWithRequestContext(ctx, () =>
+        const headResponse = await runWithRequestContext(ctx, () =>
           handler(getRequest),
         );
-        return await rewriteMountedResponse(
+        response = await rewriteMountedResponse(
           new Response(null, {
-            status: response.status,
-            statusText: response.statusText,
-            headers: response.headers,
+            status: headResponse.status,
+            statusText: headResponse.statusText,
+            headers: headResponse.headers,
           }),
           basePath,
           p,
           request.url,
         );
+      } else {
+        response = await rewriteMountedResponse(
+          await runWithRequestContext(ctx, () => handler(request)),
+          basePath,
+          p,
+          request.url,
+        );
       }
-      return await rewriteMountedResponse(
-        await runWithRequestContext(ctx, () => handler(request)),
-        basePath,
-        p,
-        request.url,
-      );
+      if (response.status < 500) {
+        getReactRouterDevRecovery()?.markSsrSuccess();
+      }
+      return response;
     } catch (err) {
+      const recovery = getReactRouterDevRecovery();
+      const staleRoute =
+        recovery &&
+        classifyStaleReactRouterRouteError(err, recovery.routeRoots);
+      if (recovery && staleRoute) {
+        const result = recovery.request(
+          `missing route module ${staleRoute.file}`,
+        );
+        if (result !== "bounded") {
+          return new Response("Route graph is refreshing. Retry shortly.\n", {
+            status: 503,
+            headers: {
+              "cache-control": DISABLED_SSR_CACHE_CONTROL,
+              "content-type": "text/plain; charset=utf-8",
+              "retry-after": "1",
+            },
+          });
+        }
+      }
       // Log the full stack server-side, but never leak it to the client.
       // Stack traces expose file paths, library versions, and code structure
       // that aid reconnaissance attacks. In dev we surface the message text

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -475,7 +475,7 @@ export function createH3SSRHandler(getBuild: () => Promise<unknown> | unknown) {
         recovery &&
         classifyStaleReactRouterRouteError(err, recovery.routeRoots);
       if (recovery && staleRoute) {
-        const result = recovery.request(
+        const result = recovery.requestFallback(
           `missing route module ${staleRoute.file}`,
         );
         if (result !== "bounded") {

--- a/packages/core/src/vite/client.spec.ts
+++ b/packages/core/src/vite/client.spec.ts
@@ -832,6 +832,7 @@ describe("agentNative Vite plugin preset", () => {
     expect(pluginNames).toContain("agent-native-app-changelog-raw");
     expect(pluginNames).toContain("agent-native-action-types");
     expect(pluginNames).toContain("agent-native-agents-bundle");
+    expect(pluginNames).toContain("agent-native-react-router-route-recovery");
     expect(pluginNames).toContain("agent-native-auto-reload-optimize-dep");
     expect(pluginNames).toContain("agent-native-port-exposer");
   });

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -47,6 +47,7 @@ import {
 } from "../shared/route-warmup-config.js";
 import { actionTypesPlugin } from "./action-types-plugin.js";
 import { agentsBundlePlugin } from "./agents-bundle-plugin.js";
+import { reactRouterRouteRecoveryPlugin } from "./react-router-route-recovery-plugin.js";
 
 const require = createRequire(import.meta.url);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -3012,6 +3013,7 @@ function createAgentNativePlugins(
     appChangelogRawPlugin(),
     actionTypesPlugin(),
     agentsBundlePlugin(),
+    reactRouterRouteRecoveryPlugin(),
     autoReloadOnOptimizeDep(),
     fullReloadOnOptimizeDep504(),
     embedDevFrameHeaders(),
@@ -3434,4 +3436,5 @@ export {
   nitroStartupRecovery as _nitroStartupRecovery,
   nitroModuleGraphSignature as _nitroModuleGraphSignature,
   debounceNitroFullReloadHotUpdate as _debounceNitroFullReloadHotUpdate,
+  reactRouterRouteRecoveryPlugin as _reactRouterRouteRecoveryPlugin,
 };

--- a/packages/core/src/vite/react-router-route-recovery-plugin.spec.ts
+++ b/packages/core/src/vite/react-router-route-recovery-plugin.spec.ts
@@ -6,6 +6,10 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  isReactRouterRouteDirectoryPath,
+  isReactRouterRouteModulePath,
+} from "../server/react-router-dev-recovery.js";
+import {
   parseFlatRoutesDiscovery,
   reactRouterRouteRecoveryPlugin,
   resolveReactRouterRecoveryPaths,
@@ -132,6 +136,70 @@ describe("React Router route recovery Vite plugin", () => {
     );
   });
 
+  it("treats test-named files as routes unless caller ignores them", () => {
+    const { root, appDirectory } = fixture(
+      'import { flatRoutes } from "@react-router/fs-routes";\nexport default flatRoutes();\n',
+    );
+    const plainScope = resolveReactRouterRecoveryPaths(
+      resolvedConfig(root),
+    )!.routeScope;
+    expect(
+      isReactRouterRouteModulePath(
+        path.join(appDirectory, "routes", "report.test.tsx"),
+        plainScope,
+      ),
+    ).toBe(true);
+
+    fs.writeFileSync(
+      path.join(appDirectory, "routes.ts"),
+      'import { flatRoutes } from "@react-router/fs-routes";\nexport default flatRoutes({ ignoredRouteFiles: ["routes/**/*.test.tsx", "routes/**/*.spec.tsx"] });\n',
+    );
+    const ignoredScope = resolveReactRouterRecoveryPaths(
+      resolvedConfig(root),
+    )!.routeScope;
+    expect(
+      isReactRouterRouteModulePath(
+        path.join(appDirectory, "routes", "report.test.tsx"),
+        ignoredScope,
+      ),
+    ).toBe(false);
+    expect(
+      isReactRouterRouteModulePath(
+        path.join(appDirectory, "routes", "report.spec.tsx"),
+        ignoredScope,
+      ),
+    ).toBe(false);
+  });
+
+  it("matches folder ignores against the folder entry like fs-routes", () => {
+    const { root, appDirectory } = fixture(
+      'import { flatRoutes } from "@react-router/fs-routes";\nexport default flatRoutes({ ignoredRouteFiles: ["routes/admin", "**/route.tsx"] });\n',
+    );
+    const scope = resolveReactRouterRecoveryPaths(
+      resolvedConfig(root),
+    )!.routeScope;
+    const routes = path.join(appDirectory, "routes");
+
+    expect(
+      isReactRouterRouteDirectoryPath(path.join(routes, "admin"), scope),
+    ).toBe(false);
+    expect(
+      isReactRouterRouteModulePath(
+        path.join(routes, "admin", "route.tsx"),
+        scope,
+      ),
+    ).toBe(false);
+    expect(
+      isReactRouterRouteDirectoryPath(path.join(routes, "public"), scope),
+    ).toBe(true);
+    expect(
+      isReactRouterRouteModulePath(
+        path.join(routes, "public", "route.tsx"),
+        scope,
+      ),
+    ).toBe(true);
+  });
+
   it("uses exact route files only for unrecognized route config", () => {
     const { root, appDirectory } = fixture(
       'export default [route("dashboard", "dashboard.tsx")];\n',
@@ -150,7 +218,13 @@ describe("React Router route recovery Vite plugin", () => {
       `import { flatRoutes } from "@react-router/fs-routes";
       export default flatRoutes({
         rootDirectory: "pages",
-        ignoredRouteFiles: ["pages/**/*.ignored.tsx"],
+        ignoredRouteFiles: [
+          "pages/**/*.ignored.tsx",
+          "pages/**/*.test.tsx",
+          "pages/**/*.spec.ts",
+          "pages/__tests__",
+          "pages/__snapshots__",
+        ],
       });\n`,
     );
     const pages = path.join(appDirectory, "pages");

--- a/packages/core/src/vite/react-router-route-recovery-plugin.spec.ts
+++ b/packages/core/src/vite/react-router-route-recovery-plugin.spec.ts
@@ -1,81 +1,215 @@
 import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  parseFlatRoutesDiscovery,
   reactRouterRouteRecoveryPlugin,
   resolveReactRouterRecoveryPaths,
 } from "./react-router-route-recovery-plugin.js";
 
-function resolvedConfig(root: string) {
-  const appDirectory = path.join(root, "web");
+const tempDirs: string[] = [];
+
+function fixture(routeConfig?: string) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "an-route-plugin-"));
+  tempDirs.push(root);
+  const appDirectory = path.join(root, "app");
+  fs.mkdirSync(appDirectory, { recursive: true });
+  if (routeConfig !== undefined) {
+    fs.writeFileSync(path.join(appDirectory, "routes.ts"), routeConfig);
+  }
+  return { root, appDirectory };
+}
+
+function resolvedConfig(
+  root: string,
+  routes: Record<string, { file: string }> = {
+    root: { file: "root.tsx" },
+    dashboard: { file: "dashboard.tsx" },
+  },
+) {
   return {
     __reactRouterPluginContext: {
       rootDirectory: root,
       reactRouterConfig: {
-        appDirectory,
-        routes: {
-          root: { file: "root.tsx" },
-          dashboard: { file: "screens/dashboard.tsx" },
-        },
+        appDirectory: path.join(root, "app"),
+        routes,
       },
     },
   } as never;
 }
 
-describe("React Router route recovery Vite plugin", () => {
-  afterEach(() => vi.useRealTimers());
+async function flushRestart() {
+  await vi.advanceTimersByTimeAsync(100);
+  await Promise.resolve();
+  await Promise.resolve();
+  await vi.advanceTimersByTimeAsync(500);
+}
 
-  it("derives route roots and config inputs from React Router's resolved context", () => {
-    const root = path.resolve("/workspace/app");
+describe("React Router route recovery Vite plugin", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    for (const dir of tempDirs)
+      fs.rmSync(dir, { recursive: true, force: true });
+    tempDirs.length = 0;
+  });
+
+  it("parses default and literal custom flatRoutes discovery options", () => {
+    const { appDirectory } = fixture();
+    expect(
+      parseFlatRoutesDiscovery(
+        'import { flatRoutes } from "@react-router/fs-routes";\nexport default flatRoutes();',
+        appDirectory,
+      ),
+    ).toEqual({
+      appDirectory,
+      directory: path.join(appDirectory, "routes"),
+      ignoredRouteFiles: [],
+    });
+    expect(
+      parseFlatRoutesDiscovery(
+        `import { flatRoutes } from "@react-router/fs-routes";
+        export default flatRoutes({
+          rootDirectory: "pages",
+          ignoredRouteFiles: ["pages/**/*.test.tsx", 'pages/private/**'],
+        });`,
+        appDirectory,
+      ),
+    ).toEqual({
+      appDirectory,
+      directory: path.join(appDirectory, "pages"),
+      ignoredRouteFiles: ["pages/**/*.test.tsx", "pages/private/**"],
+    });
+  });
+
+  it("fails closed for dynamic or out-of-app flatRoutes options", () => {
+    const { appDirectory } = fixture();
+    expect(
+      parseFlatRoutesDiscovery(
+        'import { flatRoutes } from "@react-router/fs-routes";\nexport default flatRoutes({ rootDirectory });',
+        appDirectory,
+      ),
+    ).toBeUndefined();
+    expect(
+      parseFlatRoutesDiscovery(
+        'import { flatRoutes } from "@react-router/fs-routes";\nexport default flatRoutes({ rootDirectory: getRoutes() });',
+        appDirectory,
+      ),
+    ).toBeUndefined();
+    expect(
+      parseFlatRoutesDiscovery(
+        'import { flatRoutes } from "@react-router/fs-routes";\nexport default flatRoutes({ rootDirectory: "../outside" });',
+        appDirectory,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("keeps exact explicit routes separate from an empty custom discovery root", () => {
+    const { root, appDirectory } = fixture(
+      'import { flatRoutes } from "@react-router/fs-routes";\nexport default flatRoutes({ rootDirectory: "pages" });\n',
+    );
     const paths = resolveReactRouterRecoveryPaths(resolvedConfig(root));
 
-    expect(paths?.routeRoots).toEqual(
-      expect.arrayContaining([
-        path.join(root, "web", "routes"),
-        path.join(root, "web", "screens"),
-      ]),
+    expect(paths?.routeScope.discoveryRoots).toEqual([
+      {
+        appDirectory,
+        directory: path.join(appDirectory, "pages"),
+        ignoredRouteFiles: [],
+      },
+    ]);
+    expect(paths?.routeScope.exactRouteFiles).toEqual([
+      path.join(appDirectory, "dashboard.tsx"),
+    ]);
+    expect(paths?.routeScope.discoveryRoots).not.toContainEqual(
+      expect.objectContaining({ directory: appDirectory }),
     );
+    expect(paths?.configFiles).toContain(path.join(appDirectory, "routes.mjs"));
     expect(paths?.configFiles).toContain(
       path.join(root, "react-router.config.ts"),
     );
-    expect(paths?.routeRoots).not.toContain(path.join(root, "web"));
   });
 
-  it("debounces topology bursts and ignores ordinary route changes", async () => {
+  it("uses exact route files only for unrecognized route config", () => {
+    const { root, appDirectory } = fixture(
+      'export default [route("dashboard", "dashboard.tsx")];\n',
+    );
+    const paths = resolveReactRouterRecoveryPaths(resolvedConfig(root));
+
+    expect(paths?.routeScope.discoveryRoots).toEqual([]);
+    expect(paths?.routeScope.exactRouteFiles).toEqual([
+      path.join(appDirectory, "dashboard.tsx"),
+    ]);
+  });
+
+  it("filters non-routes and handles exact routes plus every config event", async () => {
     vi.useFakeTimers();
-    const root = path.resolve("/workspace/app");
+    const { root, appDirectory } = fixture(
+      `import { flatRoutes } from "@react-router/fs-routes";
+      export default flatRoutes({
+        rootDirectory: "pages",
+        ignoredRouteFiles: ["pages/**/*.ignored.tsx"],
+      });\n`,
+    );
+    const pages = path.join(appDirectory, "pages");
     const watcher = new EventEmitter();
     const restart = vi.fn(async () => {});
     const plugin = reactRouterRouteRecoveryPlugin();
-    const config = resolvedConfig(root);
-    plugin.configResolved?.(config);
+    plugin.configResolved?.(resolvedConfig(root));
     plugin.configureServer?.({
-      config: {
-        root,
-        logger: { error: vi.fn(), info: vi.fn() },
-      },
+      config: { root, logger: { error: vi.fn(), info: vi.fn() } },
       restart,
       watcher,
     } as never);
 
-    watcher.emit("change", path.join(root, "web", "routes", "home.tsx"));
+    for (const file of [
+      path.join(pages, "image.png"),
+      path.join(pages, "route.test.tsx"),
+      path.join(pages, "route.spec.ts"),
+      path.join(pages, "route.tsx~"),
+      path.join(pages, ".draft.tsx"),
+      path.join(pages, "nested", "thing.ignored.tsx"),
+      path.join(pages, "__tests__", "route.tsx"),
+      path.join(pages, "__snapshots__", "route.tsx"),
+    ]) {
+      watcher.emit("add", file);
+    }
+    watcher.emit("addDir", path.join(pages, ".drafts"));
     await vi.advanceTimersByTimeAsync(150);
     expect(restart).not.toHaveBeenCalled();
 
-    watcher.emit("unlink", path.join(root, "web", "routes", "old.tsx"));
-    watcher.emit("add", path.join(root, "web", "routes", "new.tsx"));
-    watcher.emit("addDir", path.join(root, "web", "routes", "admin"));
-    await vi.advanceTimersByTimeAsync(99);
-    expect(restart).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(1);
-    expect(restart).toHaveBeenCalledOnce();
+    watcher.emit("add", path.join(pages, "home.mdx"));
+    await flushRestart();
+    expect(restart).toHaveBeenCalledTimes(1);
 
-    await vi.advanceTimersByTimeAsync(500);
-    watcher.emit("change", path.join(root, "react-router.config.ts"));
-    await vi.advanceTimersByTimeAsync(100);
+    watcher.emit("addDir", path.join(pages, "admin"));
+    await flushRestart();
     expect(restart).toHaveBeenCalledTimes(2);
+
+    watcher.emit("unlink", path.join(appDirectory, "dashboard.tsx"));
+    await flushRestart();
+    expect(restart).toHaveBeenCalledTimes(3);
+
+    const reactRouterConfig = path.join(root, "react-router.config.ts");
+    watcher.emit("add", reactRouterConfig);
+    await flushRestart();
+    watcher.emit("unlink", reactRouterConfig);
+    await flushRestart();
+    watcher.emit("add", path.join(root, "react-router.config.mjs"));
+    await flushRestart();
+    watcher.emit("change", path.join(appDirectory, "routes.ts"));
+    await flushRestart();
+    watcher.emit("unlink", path.join(appDirectory, "routes.ts"));
+    await flushRestart();
+    watcher.emit("add", path.join(appDirectory, "routes.mjs"));
+    await flushRestart();
+    expect(restart).toHaveBeenCalledTimes(9);
+
+    watcher.emit("change", path.join(pages, "home.mdx"));
+    await vi.advanceTimersByTimeAsync(150);
+    expect(restart).toHaveBeenCalledTimes(9);
     watcher.emit("close");
   });
 });

--- a/packages/core/src/vite/react-router-route-recovery-plugin.spec.ts
+++ b/packages/core/src/vite/react-router-route-recovery-plugin.spec.ts
@@ -1,0 +1,81 @@
+import { EventEmitter } from "node:events";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  reactRouterRouteRecoveryPlugin,
+  resolveReactRouterRecoveryPaths,
+} from "./react-router-route-recovery-plugin.js";
+
+function resolvedConfig(root: string) {
+  const appDirectory = path.join(root, "web");
+  return {
+    __reactRouterPluginContext: {
+      rootDirectory: root,
+      reactRouterConfig: {
+        appDirectory,
+        routes: {
+          root: { file: "root.tsx" },
+          dashboard: { file: "screens/dashboard.tsx" },
+        },
+      },
+    },
+  } as never;
+}
+
+describe("React Router route recovery Vite plugin", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("derives route roots and config inputs from React Router's resolved context", () => {
+    const root = path.resolve("/workspace/app");
+    const paths = resolveReactRouterRecoveryPaths(resolvedConfig(root));
+
+    expect(paths?.routeRoots).toEqual(
+      expect.arrayContaining([
+        path.join(root, "web", "routes"),
+        path.join(root, "web", "screens"),
+      ]),
+    );
+    expect(paths?.configFiles).toContain(
+      path.join(root, "react-router.config.ts"),
+    );
+    expect(paths?.routeRoots).not.toContain(path.join(root, "web"));
+  });
+
+  it("debounces topology bursts and ignores ordinary route changes", async () => {
+    vi.useFakeTimers();
+    const root = path.resolve("/workspace/app");
+    const watcher = new EventEmitter();
+    const restart = vi.fn(async () => {});
+    const plugin = reactRouterRouteRecoveryPlugin();
+    const config = resolvedConfig(root);
+    plugin.configResolved?.(config);
+    plugin.configureServer?.({
+      config: {
+        root,
+        logger: { error: vi.fn(), info: vi.fn() },
+      },
+      restart,
+      watcher,
+    } as never);
+
+    watcher.emit("change", path.join(root, "web", "routes", "home.tsx"));
+    await vi.advanceTimersByTimeAsync(150);
+    expect(restart).not.toHaveBeenCalled();
+
+    watcher.emit("unlink", path.join(root, "web", "routes", "old.tsx"));
+    watcher.emit("add", path.join(root, "web", "routes", "new.tsx"));
+    watcher.emit("addDir", path.join(root, "web", "routes", "admin"));
+    await vi.advanceTimersByTimeAsync(99);
+    expect(restart).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(restart).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(500);
+    watcher.emit("change", path.join(root, "react-router.config.ts"));
+    await vi.advanceTimersByTimeAsync(100);
+    expect(restart).toHaveBeenCalledTimes(2);
+    watcher.emit("close");
+  });
+});

--- a/packages/core/src/vite/react-router-route-recovery-plugin.ts
+++ b/packages/core/src/vite/react-router-route-recovery-plugin.ts
@@ -5,8 +5,12 @@ import type { Plugin, ResolvedConfig, ViteDevServer } from "vite";
 
 import {
   createReactRouterRecoveryCoordinator,
+  isReactRouterRouteDirectoryPath,
+  isReactRouterRouteModulePath,
   registerReactRouterDevRecovery,
+  type ReactRouterDiscoveryRoot,
   type ReactRouterRecoveryCoordinator,
+  type ReactRouterRouteScope,
 } from "../server/react-router-dev-recovery.js";
 
 const ROUTE_RESTART_DEBOUNCE_MS = 100;
@@ -25,14 +29,91 @@ type ReactRouterResolvedConfig = ResolvedConfig & {
 };
 
 export interface ReactRouterRecoveryPaths {
-  routeRoots: string[];
+  routeScope: ReactRouterRouteScope;
   configFiles: string[];
 }
 
-function existingConfigCandidate(base: string): string[] {
-  return CONFIG_EXTENSIONS.map((extension) => `${base}${extension}`).filter(
-    fs.existsSync,
-  );
+function relativeInside(file: string, root: string): string | undefined {
+  const relative = path.relative(root, file);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) return undefined;
+  return relative;
+}
+
+function configCandidates(base: string): string[] {
+  return CONFIG_EXTENSIONS.map((extension) => `${base}${extension}`);
+}
+
+function parseLiteralString(value: string): string | undefined {
+  const trimmed = value.trim();
+  const quote = trimmed[0];
+  if ((quote !== '"' && quote !== "'") || trimmed.at(-1) !== quote) {
+    return undefined;
+  }
+  const body = trimmed.slice(1, -1);
+  if (/\\(?![\\'"nrtbfv0])/.test(body)) return undefined;
+  return body.replace(/\\(['"\\])/g, "$1");
+}
+
+function parseLiteralStringArray(value: string): string[] | undefined {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) return undefined;
+  const body = trimmed.slice(1, -1).trim();
+  if (!body) return [];
+  const values: string[] = [];
+  let remaining = body;
+  const literal = /^\s*((?:"(?:[^"\\]|\\.)*")|(?:'(?:[^'\\]|\\.)*'))\s*(?:,|$)/;
+  while (remaining) {
+    const match = remaining.match(literal);
+    if (!match) return undefined;
+    const parsed = parseLiteralString(match[1]);
+    if (parsed === undefined) return undefined;
+    values.push(parsed);
+    remaining = remaining.slice(match[0].length);
+  }
+  return values;
+}
+
+export function parseFlatRoutesDiscovery(
+  source: string,
+  appDirectory: string,
+): ReactRouterDiscoveryRoot | undefined {
+  const hasFsRoutesImport =
+    /import\s*\{[^}]*\bflatRoutes\b[^}]*\}\s*from\s*["']@react-router\/fs-routes["']/.test(
+      source,
+    );
+  if (!hasFsRoutesImport) return undefined;
+  const call = source.match(/\bflatRoutes\s*\(\s*(\{[\s\S]*?\})?\s*\)/);
+  if (!call) return undefined;
+  const options = call[1];
+  let rootDirectory = "routes";
+  let ignoredRouteFiles: string[] = [];
+  if (options) {
+    if (options.includes("...")) return undefined;
+    const rootMatch = options.match(/\brootDirectory\s*:\s*([^,}]+)/);
+    if (rootMatch) {
+      const parsed = parseLiteralString(rootMatch[1]);
+      if (parsed === undefined) return undefined;
+      rootDirectory = parsed;
+    }
+    const ignoredMatch = options.match(
+      /\bignoredRouteFiles\s*:\s*(\[[\s\S]*?\])/,
+    );
+    if (ignoredMatch) {
+      const parsed = parseLiteralStringArray(ignoredMatch[1]);
+      if (!parsed) return undefined;
+      ignoredRouteFiles = parsed;
+    }
+    if (/\brootDirectory\s*:/.test(options) && !rootMatch) return undefined;
+    if (/\bignoredRouteFiles\s*:/.test(options) && !ignoredMatch)
+      return undefined;
+    let remaining = options.slice(1, -1);
+    if (rootMatch) remaining = remaining.replace(rootMatch[0], "");
+    if (ignoredMatch) remaining = remaining.replace(ignoredMatch[0], "");
+    if (remaining.replace(/[\s,]/g, "")) return undefined;
+  }
+  const directory = path.resolve(appDirectory, rootDirectory);
+  if (relativeInside(directory, appDirectory) === undefined) return undefined;
+  return { appDirectory, directory, ignoredRouteFiles };
 }
 
 export function resolveReactRouterRecoveryPaths(
@@ -41,29 +122,28 @@ export function resolveReactRouterRecoveryPaths(
   const context = config.__reactRouterPluginContext;
   if (!context) return undefined;
   const appDirectory = path.resolve(context.reactRouterConfig.appDirectory);
-  const routeRoots = new Set<string>([path.join(appDirectory, "routes")]);
-  for (const [id, route] of Object.entries(context.reactRouterConfig.routes)) {
-    if (id === "root") continue;
-    routeRoots.add(path.dirname(path.resolve(appDirectory, route.file)));
+  const rootDirectory = path.resolve(context.rootDirectory);
+  const routeConfigFiles = configCandidates(path.join(appDirectory, "routes"));
+  const routeConfigFile = routeConfigFiles.find(fs.existsSync);
+  const discoveryRoots: ReactRouterDiscoveryRoot[] = [];
+  if (routeConfigFile) {
+    const discovery = parseFlatRoutesDiscovery(
+      fs.readFileSync(routeConfigFile, "utf8"),
+      appDirectory,
+    );
+    if (discovery) discoveryRoots.push(discovery);
   }
-  const configFiles = new Set<string>([
-    ...CONFIG_EXTENSIONS.map((extension) =>
-      path.join(context.rootDirectory, `react-router.config${extension}`),
-    ),
-    ...existingConfigCandidate(path.join(appDirectory, "routes")),
-  ]);
+  const exactRouteFiles = Object.entries(context.reactRouterConfig.routes)
+    .filter(([id]) => id !== "root")
+    .map(([, route]) => path.resolve(appDirectory, route.file))
+    .filter((file) => relativeInside(file, appDirectory) !== undefined);
   return {
-    routeRoots: [...routeRoots].map((root) => path.resolve(root)),
-    configFiles: [...configFiles].map((file) => path.resolve(file)),
+    routeScope: { exactRouteFiles, discoveryRoots },
+    configFiles: [
+      ...configCandidates(path.join(rootDirectory, "react-router.config")),
+      ...routeConfigFiles,
+    ].map((file) => path.resolve(file)),
   };
-}
-
-function isWithin(file: string, root: string): boolean {
-  const relative = path.relative(root, file);
-  return (
-    relative === "" ||
-    (!relative.startsWith("..") && !path.isAbsolute(relative))
-  );
 }
 
 export function reactRouterRouteRecoveryPlugin(): Plugin {
@@ -92,7 +172,7 @@ export function reactRouterRouteRecoveryPlugin(): Plugin {
     configureServer(server: ViteDevServer) {
       if (!paths || process.env.NODE_ENV === "production") return;
       cleanup();
-      coordinator = createReactRouterRecoveryCoordinator(paths.routeRoots, {
+      coordinator = createReactRouterRecoveryCoordinator(paths.routeScope, {
         restart: () => server.restart(),
         persistentStateKey: server.config.root,
         onOutcome(message, error) {
@@ -116,7 +196,19 @@ export function reactRouterRouteRecoveryPlugin(): Plugin {
       };
       const onTopology = (file: string) => {
         const absolute = path.resolve(file);
-        if (paths?.routeRoots.some((root) => isWithin(absolute, root))) {
+        if (
+          paths?.configFiles.includes(absolute) ||
+          (paths && isReactRouterRouteModulePath(absolute, paths.routeScope))
+        ) {
+          schedule(absolute);
+        }
+      };
+      const onDirectory = (directory: string) => {
+        const absolute = path.resolve(directory);
+        if (
+          paths &&
+          isReactRouterRouteDirectoryPath(absolute, paths.routeScope)
+        ) {
           schedule(absolute);
         }
       };
@@ -126,8 +218,8 @@ export function reactRouterRouteRecoveryPlugin(): Plugin {
       };
       server.watcher.on("add", onTopology);
       server.watcher.on("unlink", onTopology);
-      server.watcher.on("addDir", onTopology);
-      server.watcher.on("unlinkDir", onTopology);
+      server.watcher.on("addDir", onDirectory);
+      server.watcher.on("unlinkDir", onDirectory);
       server.watcher.on("change", onChange);
       server.watcher.once("close", cleanup);
     },

--- a/packages/core/src/vite/react-router-route-recovery-plugin.ts
+++ b/packages/core/src/vite/react-router-route-recovery-plugin.ts
@@ -1,0 +1,136 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { Plugin, ResolvedConfig, ViteDevServer } from "vite";
+
+import {
+  createReactRouterRecoveryCoordinator,
+  registerReactRouterDevRecovery,
+  type ReactRouterRecoveryCoordinator,
+} from "../server/react-router-dev-recovery.js";
+
+const ROUTE_RESTART_DEBOUNCE_MS = 100;
+const CONFIG_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
+
+interface ReactRouterPluginContext {
+  rootDirectory: string;
+  reactRouterConfig: {
+    appDirectory: string;
+    routes: Record<string, { file: string }>;
+  };
+}
+
+type ReactRouterResolvedConfig = ResolvedConfig & {
+  __reactRouterPluginContext?: ReactRouterPluginContext;
+};
+
+export interface ReactRouterRecoveryPaths {
+  routeRoots: string[];
+  configFiles: string[];
+}
+
+function existingConfigCandidate(base: string): string[] {
+  return CONFIG_EXTENSIONS.map((extension) => `${base}${extension}`).filter(
+    fs.existsSync,
+  );
+}
+
+export function resolveReactRouterRecoveryPaths(
+  config: ReactRouterResolvedConfig,
+): ReactRouterRecoveryPaths | undefined {
+  const context = config.__reactRouterPluginContext;
+  if (!context) return undefined;
+  const appDirectory = path.resolve(context.reactRouterConfig.appDirectory);
+  const routeRoots = new Set<string>([path.join(appDirectory, "routes")]);
+  for (const [id, route] of Object.entries(context.reactRouterConfig.routes)) {
+    if (id === "root") continue;
+    routeRoots.add(path.dirname(path.resolve(appDirectory, route.file)));
+  }
+  const configFiles = new Set<string>([
+    ...CONFIG_EXTENSIONS.map((extension) =>
+      path.join(context.rootDirectory, `react-router.config${extension}`),
+    ),
+    ...existingConfigCandidate(path.join(appDirectory, "routes")),
+  ]);
+  return {
+    routeRoots: [...routeRoots].map((root) => path.resolve(root)),
+    configFiles: [...configFiles].map((file) => path.resolve(file)),
+  };
+}
+
+function isWithin(file: string, root: string): boolean {
+  const relative = path.relative(root, file);
+  return (
+    relative === "" ||
+    (!relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}
+
+export function reactRouterRouteRecoveryPlugin(): Plugin {
+  let paths: ReactRouterRecoveryPaths | undefined;
+  let coordinator: ReactRouterRecoveryCoordinator | undefined;
+  let unregister: (() => void) | undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const cleanup = () => {
+    if (timer) clearTimeout(timer);
+    timer = undefined;
+    unregister?.();
+    unregister = undefined;
+    coordinator?.dispose();
+    coordinator = undefined;
+  };
+
+  return {
+    name: "agent-native-react-router-route-recovery",
+    apply: "serve",
+    configResolved(config) {
+      paths = resolveReactRouterRecoveryPaths(
+        config as ReactRouterResolvedConfig,
+      );
+    },
+    configureServer(server: ViteDevServer) {
+      if (!paths || process.env.NODE_ENV === "production") return;
+      cleanup();
+      coordinator = createReactRouterRecoveryCoordinator(paths.routeRoots, {
+        restart: () => server.restart(),
+        persistentStateKey: server.config.root,
+        onOutcome(message, error) {
+          if (error) {
+            const detail = error instanceof Error ? `: ${error.message}` : "";
+            server.config.logger.error(`[agent-native] ${message}${detail}`);
+          } else {
+            server.config.logger.info(`[agent-native] ${message}`);
+          }
+        },
+      });
+      unregister = registerReactRouterDevRecovery(coordinator);
+      const schedule = (file: string) => {
+        if (!coordinator) return;
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(() => {
+          timer = undefined;
+          coordinator?.request(path.relative(server.config.root, file));
+        }, ROUTE_RESTART_DEBOUNCE_MS);
+        timer.unref?.();
+      };
+      const onTopology = (file: string) => {
+        const absolute = path.resolve(file);
+        if (paths?.routeRoots.some((root) => isWithin(absolute, root))) {
+          schedule(absolute);
+        }
+      };
+      const onChange = (file: string) => {
+        const absolute = path.resolve(file);
+        if (paths?.configFiles.includes(absolute)) schedule(absolute);
+      };
+      server.watcher.on("add", onTopology);
+      server.watcher.on("unlink", onTopology);
+      server.watcher.on("addDir", onTopology);
+      server.watcher.on("unlinkDir", onTopology);
+      server.watcher.on("change", onChange);
+      server.watcher.once("close", cleanup);
+    },
+    closeBundle: cleanup,
+  };
+}

--- a/packages/core/src/vite/react-router-route-recovery-plugin.ts
+++ b/packages/core/src/vite/react-router-route-recovery-plugin.ts
@@ -110,7 +110,7 @@ export function reactRouterRouteRecoveryPlugin(): Plugin {
         if (timer) clearTimeout(timer);
         timer = setTimeout(() => {
           timer = undefined;
-          coordinator?.request(path.relative(server.config.root, file));
+          coordinator?.requestTopology(path.relative(server.config.root, file));
         }, ROUTE_RESTART_DEBOUNCE_MS);
         timer.unref?.();
       };

--- a/packages/core/src/vite/react-router-route-recovery.integration.spec.ts
+++ b/packages/core/src/vite/react-router-route-recovery.integration.spec.ts
@@ -61,7 +61,7 @@ describe("React Router route topology recovery", () => {
     fixture = fs.mkdtempSync(
       path.join(process.cwd(), ".tmp-route-recovery-integration-"),
     );
-    routes = path.join(fixture, "app", "routes");
+    routes = path.join(fixture, "app", "pages");
     fs.mkdirSync(routes, { recursive: true });
     fs.writeFileSync(
       path.join(fixture, "react-router.config.ts"),
@@ -69,7 +69,7 @@ describe("React Router route topology recovery", () => {
     );
     fs.writeFileSync(
       path.join(fixture, "app", "routes.ts"),
-      'import { flatRoutes } from "@react-router/fs-routes";\nexport default flatRoutes();\n',
+      'import { flatRoutes } from "@react-router/fs-routes";\nexport default flatRoutes({ rootDirectory: "pages", ignoredRouteFiles: ["pages/**/*.ignored.tsx"] });\n',
     );
     fs.writeFileSync(
       path.join(fixture, "app", "root.tsx"),
@@ -90,7 +90,6 @@ export default function handleRequest(request, status, headers, context) {
 }
 `,
     );
-    fs.writeFileSync(path.join(routes, "old.tsx"), routeSource("Old v1"));
     const recoveryPluginUrl = pathToFileURL(
       path.join(
         process.cwd(),
@@ -141,25 +140,50 @@ export default defineConfig({
     delete (globalThis as Record<string, unknown>)[restartCountKey];
   });
 
-  it("updates route topology in-process while ordinary edits and failures stay HMR-only", async () => {
+  it("updates an initially empty custom route root while ordinary edits and failures stay HMR-only", async () => {
+    await eventuallyFetch(baseUrl, (response) => response.status === 200);
+    expect(process.pid).toBe(initialPid);
+    expect((globalThis as Record<string, number>)[restartCountKey]).toBe(0);
+
+    fs.writeFileSync(path.join(routes, "image.png"), "not a route");
+    fs.writeFileSync(
+      path.join(routes, "draft.test.tsx"),
+      routeSource("ignored"),
+    );
+    fs.writeFileSync(
+      path.join(routes, "draft.ignored.tsx"),
+      routeSource("ignored"),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    expect((globalThis as Record<string, number>)[restartCountKey]).toBe(0);
+
+    fs.writeFileSync(path.join(routes, "old.tsx"), routeSource("Old v1"));
     await eventuallyFetch(`${baseUrl}/old`, (_response, body) =>
       body.includes("Old v1"),
     );
-    expect(process.pid).toBe(initialPid);
-    expect((globalThis as Record<string, number>)[restartCountKey]).toBe(0);
+    await eventually(
+      () => (globalThis as Record<string, number>)[restartCountKey] >= 1,
+    );
+    const afterInitialAdd = (globalThis as Record<string, number>)[
+      restartCountKey
+    ];
 
     fs.writeFileSync(path.join(routes, "old.tsx"), routeSource("Old v2"));
     await eventuallyFetch(`${baseUrl}/old`, (_response, body) =>
       body.includes("Old v2"),
     );
-    expect((globalThis as Record<string, number>)[restartCountKey]).toBe(0);
+    expect((globalThis as Record<string, number>)[restartCountKey]).toBe(
+      afterInitialAdd,
+    );
 
     fs.renameSync(path.join(routes, "old.tsx"), path.join(routes, "new.tsx"));
     await eventuallyFetch(`${baseUrl}/new`, (_response, body) =>
       body.includes("Old v2"),
     );
     await eventually(
-      () => (globalThis as Record<string, number>)[restartCountKey] >= 1,
+      () =>
+        (globalThis as Record<string, number>)[restartCountKey] >
+        afterInitialAdd,
     );
     const afterRename = (globalThis as Record<string, number>)[restartCountKey];
     expect(process.pid).toBe(initialPid);
@@ -185,6 +209,7 @@ export default defineConfig({
     expect((globalThis as Record<string, number>)[restartCountKey]).toBe(
       afterRename,
     );
+    await new Promise((resolve) => setTimeout(resolve, 300));
 
     fs.unlinkSync(path.join(routes, "new.tsx"));
     await eventuallyFetch(

--- a/packages/core/src/vite/react-router-route-recovery.integration.spec.ts
+++ b/packages/core/src/vite/react-router-route-recovery.integration.spec.ts
@@ -69,7 +69,7 @@ describe("React Router route topology recovery", () => {
     );
     fs.writeFileSync(
       path.join(fixture, "app", "routes.ts"),
-      'import { flatRoutes } from "@react-router/fs-routes";\nexport default flatRoutes({ rootDirectory: "pages", ignoredRouteFiles: ["pages/**/*.ignored.tsx"] });\n',
+      'import { flatRoutes } from "@react-router/fs-routes";\nexport default flatRoutes({ rootDirectory: "pages", ignoredRouteFiles: ["pages/**/*.ignored.tsx", "pages/**/*.test.tsx"] });\n',
     );
     fs.writeFileSync(
       path.join(fixture, "app", "root.tsx"),

--- a/packages/core/src/vite/react-router-route-recovery.integration.spec.ts
+++ b/packages/core/src/vite/react-router-route-recovery.integration.spec.ts
@@ -1,0 +1,214 @@
+import fs from "node:fs";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { createServer, type ViteDevServer } from "vite";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const restartCountKey = "__agentNativeRouteRecoveryRestartCount";
+
+function routeSource(label: string, loaderFailure = false): string {
+  return `${
+    loaderFailure
+      ? 'export function loader() { throw new Error("loader exploded"); }\n'
+      : ""
+  }export default function Route() { return <main>${label}</main>; }\n`;
+}
+
+async function eventually(
+  predicate: () => boolean,
+  timeoutMs = 15_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("Timed out waiting for condition");
+}
+
+async function eventuallyFetch(
+  url: string,
+  predicate: (response: Response, body: string) => boolean,
+  timeoutMs = 15_000,
+): Promise<{ response: Response; body: string }> {
+  const deadline = Date.now() + timeoutMs;
+  let last: { status?: number; body?: string; error?: unknown } = {};
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      const body = await response.text();
+      last = { status: response.status, body };
+      if (predicate(response, body)) return { response, body };
+    } catch (error) {
+      last = { error };
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Timed out waiting for ${url}: ${JSON.stringify(last)}`);
+}
+
+describe("React Router route topology recovery", () => {
+  let fixture = "";
+  let routes = "";
+  let server: ViteDevServer;
+  let baseUrl = "";
+  const initialPid = process.pid;
+
+  beforeAll(async () => {
+    fixture = fs.mkdtempSync(
+      path.join(process.cwd(), ".tmp-route-recovery-integration-"),
+    );
+    routes = path.join(fixture, "app", "routes");
+    fs.mkdirSync(routes, { recursive: true });
+    fs.writeFileSync(
+      path.join(fixture, "react-router.config.ts"),
+      'export default { appDirectory: "app", ssr: true };\n',
+    );
+    fs.writeFileSync(
+      path.join(fixture, "app", "routes.ts"),
+      'import { flatRoutes } from "@react-router/fs-routes";\nexport default flatRoutes();\n',
+    );
+    fs.writeFileSync(
+      path.join(fixture, "app", "root.tsx"),
+      `import { Links, Meta, Outlet, Scripts } from "react-router";
+export function Layout({ children }: { children: React.ReactNode }) {
+  return <html><head><Meta/><Links/></head><body>{children}<Scripts/></body></html>;
+}
+export default function Root() { return <Outlet/>; }
+`,
+    );
+    fs.writeFileSync(
+      path.join(fixture, "app", "entry.server.tsx"),
+      `import { ServerRouter } from "react-router";
+import { renderToString } from "react-dom/server";
+export default function handleRequest(request, status, headers, context) {
+  headers.set("content-type", "text/html");
+  return new Response("<!DOCTYPE html>" + renderToString(<ServerRouter context={context} url={request.url}/>), { status, headers });
+}
+`,
+    );
+    fs.writeFileSync(path.join(routes, "old.tsx"), routeSource("Old v1"));
+    const recoveryPluginUrl = pathToFileURL(
+      path.join(
+        process.cwd(),
+        "src/vite/react-router-route-recovery-plugin.ts",
+      ),
+    ).href;
+    fs.writeFileSync(
+      path.join(fixture, "vite.config.ts"),
+      `import { defineConfig } from "vite";
+import { reactRouter } from "@react-router/dev/vite";
+import { reactRouterRouteRecoveryPlugin } from ${JSON.stringify(recoveryPluginUrl)};
+const key = ${JSON.stringify(restartCountKey)};
+export default defineConfig({
+  logLevel: "silent",
+  plugins: [
+    reactRouter(),
+    reactRouterRouteRecoveryPlugin(),
+    {
+      name: "count-route-recovery-restarts",
+      configureServer(server) {
+        if ((server as any).__restartCountWrapped) return;
+        (server as any).__restartCountWrapped = true;
+        const restart = server.restart.bind(server);
+        server.restart = async (...args) => {
+          (globalThis as any)[key] = ((globalThis as any)[key] ?? 0) + 1;
+          return restart(...args);
+        };
+      },
+    },
+  ],
+});
+`,
+    );
+    (globalThis as Record<string, unknown>)[restartCountKey] = 0;
+    server = await createServer({
+      root: fixture,
+      configFile: path.join(fixture, "vite.config.ts"),
+      server: { host: "127.0.0.1", port: 0 },
+    });
+    await server.listen();
+    const address = server.httpServer?.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  }, 30_000);
+
+  afterAll(async () => {
+    await server?.close();
+    if (fixture) fs.rmSync(fixture, { recursive: true, force: true });
+    delete (globalThis as Record<string, unknown>)[restartCountKey];
+  });
+
+  it("updates route topology in-process while ordinary edits and failures stay HMR-only", async () => {
+    await eventuallyFetch(`${baseUrl}/old`, (_response, body) =>
+      body.includes("Old v1"),
+    );
+    expect(process.pid).toBe(initialPid);
+    expect((globalThis as Record<string, number>)[restartCountKey]).toBe(0);
+
+    fs.writeFileSync(path.join(routes, "old.tsx"), routeSource("Old v2"));
+    await eventuallyFetch(`${baseUrl}/old`, (_response, body) =>
+      body.includes("Old v2"),
+    );
+    expect((globalThis as Record<string, number>)[restartCountKey]).toBe(0);
+
+    fs.renameSync(path.join(routes, "old.tsx"), path.join(routes, "new.tsx"));
+    await eventuallyFetch(`${baseUrl}/new`, (_response, body) =>
+      body.includes("Old v2"),
+    );
+    await eventually(
+      () => (globalThis as Record<string, number>)[restartCountKey] >= 1,
+    );
+    const afterRename = (globalThis as Record<string, number>)[restartCountKey];
+    expect(process.pid).toBe(initialPid);
+
+    fs.writeFileSync(path.join(routes, "new.tsx"), "export default function (");
+    await eventuallyFetch(
+      `${baseUrl}/new`,
+      (response) => response.status >= 500,
+    );
+    expect((globalThis as Record<string, number>)[restartCountKey]).toBe(
+      afterRename,
+    );
+
+    fs.writeFileSync(
+      path.join(routes, "new.tsx"),
+      routeSource("Loader failure", true),
+    );
+    await eventuallyFetch(
+      `${baseUrl}/new`,
+      (response, body) =>
+        response.status >= 500 && body.includes("loader exploded"),
+    );
+    expect((globalThis as Record<string, number>)[restartCountKey]).toBe(
+      afterRename,
+    );
+
+    fs.unlinkSync(path.join(routes, "new.tsx"));
+    await eventuallyFetch(
+      `${baseUrl}/new`,
+      (response) => response.status === 404,
+    );
+    await eventually(
+      () =>
+        (globalThis as Record<string, number>)[restartCountKey] > afterRename,
+    );
+    const afterDelete = (globalThis as Record<string, number>)[restartCountKey];
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    fs.writeFileSync(
+      path.join(routes, "final.tsx"),
+      routeSource("Final route"),
+    );
+    await eventuallyFetch(`${baseUrl}/final`, (_response, body) =>
+      body.includes("Final route"),
+    );
+    await eventually(
+      () =>
+        (globalThis as Record<string, number>)[restartCountKey] > afterDelete,
+    );
+    expect(process.pid).toBe(initialPid);
+  }, 45_000);
+});

--- a/packages/core/src/vite/react-router-route-recovery.integration.spec.ts
+++ b/packages/core/src/vite/react-router-route-recovery.integration.spec.ts
@@ -12,7 +12,7 @@ const restartCountKey = "__agentNativeRouteRecoveryRestartCount";
 function routeSource(label: string, loaderFailure = false): string {
   return `${
     loaderFailure
-      ? 'export function loader() { throw new Error("loader exploded"); }\n'
+      ? 'export function loader() { throw new Response("loader exploded", { status: 598 }); }\n'
       : ""
   }export default function Route() { return <main>${label}</main>; }\n`;
 }
@@ -90,23 +90,32 @@ export default function handleRequest(request, status, headers, context) {
 }
 `,
     );
-    const recoveryPluginUrl = pathToFileURL(
-      path.join(
-        process.cwd(),
-        "src/vite/react-router-route-recovery-plugin.ts",
-      ),
+    const ssrHandlerUrl = pathToFileURL(
+      path.join(process.cwd(), "src/server/ssr-handler.ts"),
+    ).href;
+    fs.mkdirSync(path.join(fixture, "server", "routes"), { recursive: true });
+    fs.writeFileSync(
+      path.join(fixture, "server", "routes", "[...page].get.ts"),
+      `import { createH3SSRHandler } from ${JSON.stringify(ssrHandlerUrl)};
+export default createH3SSRHandler(
+  () => import("virtual:react-router/server-build"),
+);
+`,
+    );
+    const agentNativePresetUrl = pathToFileURL(
+      path.join(process.cwd(), "src/vite/client.ts"),
     ).href;
     fs.writeFileSync(
       path.join(fixture, "vite.config.ts"),
       `import { defineConfig } from "vite";
 import { reactRouter } from "@react-router/dev/vite";
-import { reactRouterRouteRecoveryPlugin } from ${JSON.stringify(recoveryPluginUrl)};
+import { agentNative } from ${JSON.stringify(agentNativePresetUrl)};
 const key = ${JSON.stringify(restartCountKey)};
 export default defineConfig({
   logLevel: "silent",
   plugins: [
     reactRouter(),
-    reactRouterRouteRecoveryPlugin(),
+    agentNative(),
     {
       name: "count-route-recovery-restarts",
       configureServer(server) {
@@ -196,6 +205,7 @@ export default defineConfig({
     expect((globalThis as Record<string, number>)[restartCountKey]).toBe(
       afterRename,
     );
+    await new Promise((resolve) => setTimeout(resolve, 400));
 
     fs.writeFileSync(
       path.join(routes, "new.tsx"),
@@ -203,8 +213,7 @@ export default defineConfig({
     );
     await eventuallyFetch(
       `${baseUrl}/new`,
-      (response, body) =>
-        response.status >= 500 && body.includes("loader exploded"),
+      (response) => response.status === 598,
     );
     expect((globalThis as Record<string, number>)[restartCountKey]).toBe(
       afterRename,


### PR DESCRIPTION
### Summary
Adds automatic recovery for stale React Router route graphs during `agent-native dev`, plus unit and integration tests covering the classifier, recovery coordinator, and end-to-end Vite dev server behavior.

### Problem
During `agent-native dev`, deleting or renaming a route file could leave React Router's `virtual:react-router/server-build` referencing a now-missing file, causing repeated `ERR_LOAD_URL` SSR failures until the dev server was manually restarted, interrupting the dev workflow.

### Solution
Introduce a recovery coordinator that classifies stale route errors from the SSR error chain and serializes Vite restarts triggered either proactively by route file watcher topology changes (add/unlink) or reactively as an SSR fallback when a stale-load error is detected. Ordinary content edits, syntax errors, and application-level failures are left untouched to continue using normal HMR.

### Key Changes
- Added `react-router-dev-recovery.ts`/`.spec.ts` with `classifyStaleReactRouterRouteError`, `extractViteLoadUrlPath`, and `createReactRouterRecoveryCoordinator`:
  - Classifier walks nested error causes to strictly match `ERR_LOAD_URL` + `virtual:react-router/server-build` importer + a path within the configured route scope that is actually absent on disk.
  - Coordinator serializes restart calls with a single in-flight promise plus one pending rerun, supports a cooldown and per-module bounded consecutive fallback attempts, and can persist attempt state across coordinator replacement via a `persistentStateKey`.
  - Fallback attempt bounds are tracked per stale module and only cleared when that specific module's request path is later marked healthy via `markSsrSuccess`.
- Added a Vite watcher integration (in `react-router-dev-recovery.ts`) that watches route discovery roots and config files, triggers debounced/serialized rebuilds on `add`/`unlink`/`addDir`/`unlinkDir` topology events, and leaves `change` events to normal HMR.
- Added `react-router-route-recovery.integration.spec.ts`, a real Vite + React Router dev-server integration test verifying:
  - Non-route file changes and ignored route files do not trigger a restart.
  - Adding, editing, renaming, and deleting routes correctly trigger (or avoid) restarts as appropriate.
  - Syntax errors and loader failures do not trigger recovery.
  - The process PID remains unchanged throughout all recovery scenarios.
- Added a changeset documenting the patch for `@agent-native/core`.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/druid-well-i3o4epgq"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-druid-well-i3o4epgq.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2564`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>druid-well-i3o4epgq</branchName>-->