### PR TITLE
Add shared settings rows and honest activity email notifications

### DIFF
--- a/.changeset/flat-settings-honest-activity-emails.md
+++ b/.changeset/flat-settings-honest-activity-emails.md
@@ -1,0 +1,20 @@
+---
+"@agent-native/core": minor
+---
+
+Add shared settings and activity-notification primitives.
+
+- `SettingsGroup` / `SettingsRow` (`@agent-native/core/client/settings`) render
+  several one-line settings inside a single card instead of one card per
+  control. Each row keeps its own `id`, so existing settings-search hashes
+  still resolve after a card collapses into a row.
+- `resolveActivityRecipients` and `notifyActivity`
+  (`@agent-native/core/server`) resolve who should receive a collaboration
+  email — owner, thread participants, mentions, never the actor — filter them
+  by an app-owned preference key, and report delivery as `delivered`,
+  `no-recipients`, or `email-not-configured` rather than collapsing all three
+  into an empty success.
+- Review threads now send comment, reply, and mention emails from core
+  (`notifyReviewComment`), so every app built on the review surface gets them.
+  `ReviewableResourceRegistration` gained an optional `resolveUrl` so those
+  emails can deep-link to the resource instead of the app root.

--- a/.changeset/flat-settings-honest-activity-emails.md
+++ b/.changeset/flat-settings-honest-activity-emails.md
@@ -12,8 +12,21 @@ Add shared settings and activity-notification primitives.
   (`@agent-native/core/server`) resolve who should receive a collaboration
   email — owner, thread participants, mentions, never the actor — filter them
   by an app-owned preference key, and report delivery as `delivered`,
-  `no-recipients`, or `email-not-configured` rather than collapsing all three
-  into an empty success.
+  `delivery-failed`, `no-recipients`, `email-not-configured`, or
+  `notification-error` rather than collapsing them into an empty success. A
+  batch where every send threw is reported as `delivery-failed`, never as a
+  delivery.
+- `runActivityNotification` (`@agent-native/core/server`) runs a notification
+  without letting it reject the write that caused it. The comment is already
+  persisted when notification runs, so throwing made the client retry and
+  duplicate the row; the failure now surfaces as `notification-error`.
+- `filterRecipientsByResourceAccess` (`@agent-native/core/sharing`) keeps only
+  the addresses that can open a resource right now. Notification recipients
+  come from history — stored mentions, past thread authors — and none of that
+  is an access grant, so mentioning an arbitrary address no longer mails it the
+  comment body and a revoked collaborator stops receiving the thread.
+- `isOrgMember` (`@agent-native/core/org`) is now one exported resolver instead
+  of two private copies of the same query.
 - Review threads now send comment, reply, and mention emails from core
   (`notifyReviewComment`), so every app built on the review surface gets them.
   `ReviewableResourceRegistration` gained an optional `resolveUrl` so those

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "guard:additive-migrations": "node scripts/guard-additive-migrations.mjs",
     "guard:no-silent-coercion": "node scripts/guard-no-silent-coercion.mjs",
     "guard:no-raw-colors": "node scripts/guard-no-raw-colors.mjs",
+    "guard:dead-settings-keys": "node scripts/guard-dead-settings-keys.mjs",
     "guards": "tsx scripts/run-guards.ts",
     "contribute:template": "tsx scripts/contribute-template-changes.ts",
     "sync:netlify-env": "tsx scripts/sync-template-netlify-env.ts",

--- a/packages/core/src/client/settings/SettingsRow.spec.tsx
+++ b/packages/core/src/client/settings/SettingsRow.spec.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { SettingsGroup, SettingsRow } from "./SettingsRow.js";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("SettingsGroup / SettingsRow", () => {
+  it("renders each row under its own anchor id", async () => {
+    await act(async () => {
+      root.render(
+        <SettingsGroup id="preferences" title="Preferences">
+          <SettingsRow
+            id="language"
+            label="Interface language"
+            description="Language used across the app."
+            control={<button type="button">English</button>}
+          />
+          <SettingsRow
+            id="notifications"
+            label="Email notifications"
+            control={<input type="checkbox" />}
+          />
+        </SettingsGroup>,
+      );
+    });
+
+    expect(container.querySelector("#preferences")).not.toBeNull();
+    expect(container.querySelector("#language")).not.toBeNull();
+    expect(container.querySelector("#notifications")).not.toBeNull();
+    expect(container.textContent).toContain("Interface language");
+    expect(container.textContent).toContain("Language used across the app.");
+    expect(container.querySelector("#language button")?.textContent).toBe(
+      "English",
+    );
+  });
+
+  it("omits the header when the group has no title or description", async () => {
+    await act(async () => {
+      root.render(
+        <SettingsGroup>
+          <SettingsRow id="only" label="Only setting" />
+        </SettingsGroup>,
+      );
+    });
+
+    expect(container.querySelector("header")).toBeNull();
+  });
+});

--- a/packages/core/src/client/settings/SettingsRow.tsx
+++ b/packages/core/src/client/settings/SettingsRow.tsx
@@ -1,0 +1,113 @@
+import type { ReactNode } from "react";
+
+import { cn } from "../utils.js";
+
+export interface SettingsGroupProps {
+  /** Anchor target so a settings search hit can scroll the whole group. */
+  id?: string;
+  title?: string;
+  description?: string;
+  className?: string;
+  children: ReactNode;
+}
+
+/**
+ * A bordered card holding several one-line settings instead of one card per
+ * control. Copy is passed in already translated — core components do not
+ * resolve an app's i18n keys.
+ */
+export function SettingsGroup({
+  id,
+  title,
+  description,
+  className,
+  children,
+}: SettingsGroupProps) {
+  return (
+    <section
+      id={id}
+      className={cn(
+        "scroll-mt-16 overflow-hidden rounded-lg border border-border bg-card text-card-foreground shadow-sm",
+        className,
+      )}
+    >
+      {(title || description) && (
+        <header className="border-b border-border/60 px-5 py-4 sm:px-6">
+          {title && (
+            <h2 className="text-base font-semibold leading-none tracking-tight">
+              {title}
+            </h2>
+          )}
+          {description && (
+            <p className="mt-1.5 text-sm leading-snug text-muted-foreground">
+              {description}
+            </p>
+          )}
+        </header>
+      )}
+      <div className="divide-y divide-border/60">{children}</div>
+    </section>
+  );
+}
+
+export interface SettingsRowProps {
+  /**
+   * Anchor target. Rows keep the ids their former standalone cards used, so
+   * existing settings-search hashes still resolve after a card collapses into
+   * a row.
+   */
+  id?: string;
+  label: ReactNode;
+  description?: ReactNode;
+  icon?: ReactNode;
+  /** Badge or pill rendered beside the label. */
+  status?: ReactNode;
+  /** The input itself: switch, select, button, link. */
+  control?: ReactNode;
+  /** Extra content below the row, e.g. a disclosure panel. */
+  children?: ReactNode;
+  className?: string;
+}
+
+/** One setting: label and description on the start side, control on the end. */
+export function SettingsRow({
+  id,
+  label,
+  description,
+  icon,
+  status,
+  control,
+  children,
+  className,
+}: SettingsRowProps) {
+  return (
+    <div id={id} className={cn("scroll-mt-16 px-5 py-4 sm:px-6", className)}>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 gap-3">
+          {icon && (
+            <span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md border border-border bg-background text-muted-foreground [&>svg]:size-[18px]">
+              {icon}
+            </span>
+          )}
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-sm font-medium text-foreground">
+                {label}
+              </span>
+              {status}
+            </div>
+            {description && (
+              <p className="mt-1 max-w-xl text-sm leading-6 text-muted-foreground">
+                {description}
+              </p>
+            )}
+          </div>
+        </div>
+        {control && (
+          <div className="shrink-0 sm:ms-4 sm:text-end">{control}</div>
+        )}
+      </div>
+      {children && <div className="mt-4">{children}</div>}
+    </div>
+  );
+}

--- a/packages/core/src/client/settings/index.ts
+++ b/packages/core/src/client/settings/index.ts
@@ -35,6 +35,12 @@ export {
 } from "./useBuilderStatus.js";
 export { SecretsSection, type SecretsSectionProps } from "./SecretsSection.js";
 export {
+  SettingsGroup,
+  SettingsRow,
+  type SettingsGroupProps,
+  type SettingsRowProps,
+} from "./SettingsRow.js";
+export {
   normalizeSettingsSection,
   settingsSectionDomId,
   useSettingsPanelController,

--- a/packages/core/src/integrations/identity.ts
+++ b/packages/core/src/integrations/identity.ts
@@ -1,4 +1,4 @@
-import { getDbExec } from "../db/client.js";
+import { isOrgMember as isMemberOfOrg } from "../org/membership.js";
 import { upsertVerifiedIntegrationIdentity } from "./identity-links-store.js";
 import {
   getActiveIntegrationInstallationByKey,
@@ -74,16 +74,6 @@ async function resolveSlackInstallation(incoming: IncomingMessage) {
     : null;
 }
 
-async function isMemberOfOrg(email: string, orgId: string): Promise<boolean> {
-  const { rows } = await getDbExec().execute({
-    sql: `SELECT 1 FROM org_members
-        WHERE org_id = ? AND LOWER(email) = ?
-        LIMIT 1`,
-    args: [orgId, email],
-  });
-  return rows.length > 0;
-}
-
 /**
  * Resolve the default integration principal.
  *
@@ -150,7 +140,7 @@ export async function resolveDefaultIntegrationExecutionContext(
     incoming.tenantId
   ) {
     try {
-      isOrgMember = await isMemberOfOrg(email, installation.orgId);
+      isOrgMember = await isMemberOfOrg(installation.orgId, email);
     } catch {
       // A membership-store outage is not evidence that the sender is merely
       // unlinked. Fail closed instead of widening them to org-wide access.

--- a/packages/core/src/org/app-roles-handlers.ts
+++ b/packages/core/src/org/app-roles-handlers.ts
@@ -5,7 +5,6 @@ import {
   type H3Event,
 } from "h3";
 
-import { getDbExec } from "../db/client.js";
 import { readBody } from "../server/h3-helpers.js";
 import {
   getRegisteredAppRoles,
@@ -14,6 +13,7 @@ import {
   type AppRolesDescriptor,
 } from "./app-roles.js";
 import { getOrgContext } from "./context.js";
+import { isOrgMember } from "./membership.js";
 import { canManageOrg } from "./permissions.js";
 
 /**
@@ -44,14 +44,6 @@ function extractMemberEmail(event: H3Event): string | undefined {
   const match =
     path.match(/^\/([^/]+)\/?$/) ?? path.match(/\/app-roles\/([^/]+)\/?$/);
   return match?.[1] ? decodeURIComponent(match[1]) : undefined;
-}
-
-async function isOrgMember(orgId: string, email: string): Promise<boolean> {
-  const { rows } = await getDbExec().execute({
-    sql: `SELECT 1 FROM org_members WHERE org_id = ? AND LOWER(email) = ? LIMIT 1`,
-    args: [orgId, email.trim().toLowerCase()],
-  });
-  return rows.length > 0;
 }
 
 /**

--- a/packages/core/src/org/index.ts
+++ b/packages/core/src/org/index.ts
@@ -92,3 +92,5 @@ export {
 } from "./app-roles-handlers.js";
 
 export { isFreeEmailProvider } from "./free-email-providers.js";
+
+export { isOrgMember } from "./membership.js";

--- a/packages/core/src/org/membership.ts
+++ b/packages/core/src/org/membership.ts
@@ -1,0 +1,18 @@
+import { getDbExec } from "../db/client.js";
+
+/**
+ * One resolver for "is this email in this org". Two private copies of this
+ * query already existed; a third would be the one that drifts.
+ */
+export async function isOrgMember(
+  orgId: string,
+  email: string,
+): Promise<boolean> {
+  const normalized = email.trim().toLowerCase();
+  if (!orgId || !normalized) return false;
+  const { rows } = await getDbExec().execute({
+    sql: `SELECT 1 FROM org_members WHERE org_id = ? AND LOWER(email) = ? LIMIT 1`,
+    args: [orgId, normalized],
+  });
+  return rows.length > 0;
+}

--- a/packages/core/src/review/actions/create-review-comment.ts
+++ b/packages/core/src/review/actions/create-review-comment.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { defineAction } from "../../action.js";
 import { reviewAuthorNameFromContext } from "../identity.js";
 import { extractReviewMentions, normalizeReviewMentions } from "../mentions.js";
+import { notifyReviewComment } from "../notifications.js";
 import {
   assertReviewableResourceAccess,
   normalizeReviewVisibility,
@@ -61,7 +62,7 @@ export default defineAction({
     const resolutionTarget =
       args.resolutionTarget ?? (mentions.length > 0 ? "human" : "agent");
 
-    return insertReviewComment({
+    const comment = await insertReviewComment({
       resourceType: args.resourceType,
       resourceId: args.resourceId,
       targetId: args.targetId ?? null,
@@ -78,6 +79,8 @@ export default defineAction({
       visibility: normalizeReviewVisibility(access.visibility),
       metadata: args.metadata,
     });
+
+    return { ...comment, notified: await notifyReviewComment(comment) };
   },
   audit: {
     target: (args, result) => {

--- a/packages/core/src/review/actions/reply-review-comment.ts
+++ b/packages/core/src/review/actions/reply-review-comment.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { defineAction } from "../../action.js";
 import { reviewAuthorNameFromContext } from "../identity.js";
 import { extractReviewMentions, normalizeReviewMentions } from "../mentions.js";
+import { notifyReviewComment } from "../notifications.js";
 import {
   assertReviewableResourceAccess,
   normalizeReviewVisibility,
@@ -62,7 +63,7 @@ export default defineAction({
 
     const routeTarget =
       args.resolutionTarget ?? (mentions.length > 0 ? "human" : null);
-    return insertReviewReply(
+    const reply = await insertReviewReply(
       {
         resourceType: args.resourceType,
         resourceId: args.resourceId,
@@ -88,6 +89,8 @@ export default defineAction({
         resourceId: args.resourceId,
       },
     );
+
+    return { ...reply, notified: await notifyReviewComment(reply) };
   },
   audit: {
     target: (args, result) => {

--- a/packages/core/src/review/actions/review-actions.spec.ts
+++ b/packages/core/src/review/actions/review-actions.spec.ts
@@ -22,6 +22,7 @@ const rawClient = {
 vi.mock("../../db/client.js", () => ({
   getDbExec: () => rawClient,
   isPostgres: () => false,
+  intType: () => "INTEGER",
 }));
 
 const createReviewCommentAction = (await import("./create-review-comment.js"))

--- a/packages/core/src/review/index.ts
+++ b/packages/core/src/review/index.ts
@@ -21,6 +21,11 @@ export {
 } from "./identity.js";
 export { extractReviewMentions, normalizeReviewMentions } from "./mentions.js";
 export {
+  notifyReviewComment,
+  REVIEW_NOTIFICATION_PREFS_KEY,
+  type ReviewNotificationResult,
+} from "./notifications.js";
+export {
   __resetReviewableResourcesForTests,
   assertReviewableResourceAccess,
   getReviewableResource,

--- a/packages/core/src/review/notifications.spec.ts
+++ b/packages/core/src/review/notifications.spec.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  notifyActivity: vi.fn(),
+  sendEmail: vi.fn(),
+  queryReviewComments: vi.fn(),
+  getReviewableResource: vi.fn(),
+}));
+
+vi.mock("../server/activity-notifications.js", () => ({
+  notifyActivity: (...args: unknown[]) => mocks.notifyActivity(...args),
+}));
+
+vi.mock("../server/app-url.js", () => ({
+  getAppProductionUrl: () => "https://app.test",
+}));
+
+vi.mock("../server/email-template.js", () => ({
+  emailStrong: (value: string) => value,
+  renderEmail: (args: { heading: string; paragraphs: string[] }) => ({
+    html: `<h1>${args.heading}</h1>`,
+    text: [args.heading, ...args.paragraphs].join("\n"),
+  }),
+}));
+
+vi.mock("../server/email.js", () => ({
+  sendEmail: (...args: unknown[]) => mocks.sendEmail(...args),
+}));
+
+vi.mock("./registry.js", () => ({
+  getReviewableResource: (...args: unknown[]) =>
+    mocks.getReviewableResource(...args),
+}));
+
+vi.mock("./store.js", () => ({
+  queryReviewComments: (...args: unknown[]) =>
+    mocks.queryReviewComments(...args),
+}));
+
+import {
+  notifyReviewComment,
+  REVIEW_NOTIFICATION_PREFS_KEY,
+} from "./notifications.js";
+import type { ReviewComment } from "./types.js";
+
+function comment(overrides: Partial<ReviewComment> = {}): ReviewComment {
+  return {
+    id: "c1",
+    resourceType: "design",
+    resourceId: "design_1",
+    threadId: "t1",
+    parentCommentId: null,
+    targetId: null,
+    kind: "comment",
+    status: "open",
+    anchor: null,
+    body: "The spacing here is off",
+    authorEmail: "reviewer@example.com",
+    authorName: "Reviewer",
+    createdBy: "human",
+    resolutionTarget: "agent",
+    mentions: [],
+    ownerEmail: "owner@example.com",
+    orgId: null,
+    visibility: "private",
+    ...(overrides as Partial<ReviewComment>),
+  } as ReviewComment;
+}
+
+function notifyArgs() {
+  return mocks.notifyActivity.mock.calls[0]?.[0] as {
+    candidates: (string | null | undefined)[];
+    actorEmail?: string | null;
+    preferenceKey: string;
+    send: (to: string) => Promise<unknown>;
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.notifyActivity.mockResolvedValue({
+    status: "delivered",
+    sent: [],
+    failed: [],
+  });
+  mocks.queryReviewComments.mockResolvedValue([]);
+  mocks.getReviewableResource.mockReturnValue(undefined);
+});
+
+describe("notifyReviewComment", () => {
+  it("notifies the owner and mentions against the shared preference key", async () => {
+    await notifyReviewComment(
+      comment({
+        mentions: [{ label: "Dana", email: "Dana@Example.com" }],
+      }),
+    );
+
+    const args = notifyArgs();
+    expect(args.candidates).toEqual(["owner@example.com", "dana@example.com"]);
+    expect(args.actorEmail).toBe("reviewer@example.com");
+    expect(args.preferenceKey).toBe(REVIEW_NOTIFICATION_PREFS_KEY);
+    expect(mocks.queryReviewComments).not.toHaveBeenCalled();
+  });
+
+  it("adds thread participants on a reply", async () => {
+    mocks.queryReviewComments.mockResolvedValue([
+      { threadId: "t1", authorEmail: "first@example.com" },
+      { threadId: "other", authorEmail: "unrelated@example.com" },
+    ]);
+
+    await notifyReviewComment(comment({ parentCommentId: "c0" }));
+
+    expect(notifyArgs().candidates).toEqual([
+      "owner@example.com",
+      "first@example.com",
+    ]);
+  });
+
+  it("uses the registered deep link when the resource provides one", async () => {
+    mocks.getReviewableResource.mockReturnValue({
+      type: "design",
+      displayName: "design",
+      resolveUrl: (id: string) => `https://app.test/design/${id}`,
+    });
+
+    await notifyReviewComment(comment());
+    await notifyArgs().send("owner@example.com");
+
+    const email = mocks.sendEmail.mock.calls[0][0] as { text: string };
+    expect(email.text).toContain("The spacing here is off");
+    expect(mocks.getReviewableResource).toHaveBeenCalledWith("design");
+  });
+
+  it("reports a resolution failure instead of failing the comment write", async () => {
+    mocks.notifyActivity.mockRejectedValue(new Error("settings store down"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await notifyReviewComment(comment());
+
+    expect(result.status).toBe("notification-error");
+  });
+});

--- a/packages/core/src/review/notifications.spec.ts
+++ b/packages/core/src/review/notifications.spec.ts
@@ -5,10 +5,23 @@ const mocks = vi.hoisted(() => ({
   sendEmail: vi.fn(),
   queryReviewComments: vi.fn(),
   getReviewableResource: vi.fn(),
+  resolveReviewableResourceAccess: vi.fn(),
+  filterRecipientsByResourceAccess: vi.fn(),
 }));
 
-vi.mock("../server/activity-notifications.js", () => ({
-  notifyActivity: (...args: unknown[]) => mocks.notifyActivity(...args),
+vi.mock("../server/activity-notifications.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../server/activity-notifications.js")
+  >("../server/activity-notifications.js");
+  return {
+    runActivityNotification: actual.runActivityNotification,
+    notifyActivity: (...args: unknown[]) => mocks.notifyActivity(...args),
+  };
+});
+
+vi.mock("../sharing/recipients.js", () => ({
+  filterRecipientsByResourceAccess: (...args: unknown[]) =>
+    mocks.filterRecipientsByResourceAccess(...args),
 }));
 
 vi.mock("../server/app-url.js", () => ({
@@ -30,6 +43,8 @@ vi.mock("../server/email.js", () => ({
 vi.mock("./registry.js", () => ({
   getReviewableResource: (...args: unknown[]) =>
     mocks.getReviewableResource(...args),
+  resolveReviewableResourceAccess: (...args: unknown[]) =>
+    mocks.resolveReviewableResourceAccess(...args),
 }));
 
 vi.mock("./store.js", () => ({
@@ -85,6 +100,12 @@ beforeEach(() => {
   });
   mocks.queryReviewComments.mockResolvedValue([]);
   mocks.getReviewableResource.mockReturnValue(undefined);
+  // Default: everyone offered still has access. Access filtering has its own
+  // tests; these assert who is *offered*.
+  mocks.filterRecipientsByResourceAccess.mockImplementation(
+    async ({ emails }: { emails: string[] }) =>
+      [...emails].map((email) => email.trim().toLowerCase()),
+  );
 });
 
 describe("notifyReviewComment", () => {
@@ -129,6 +150,24 @@ describe("notifyReviewComment", () => {
     const email = mocks.sendEmail.mock.calls[0][0] as { text: string };
     expect(email.text).toContain("The spacing here is off");
     expect(mocks.getReviewableResource).toHaveBeenCalledWith("design");
+  });
+
+  it("drops recipients who can no longer open the resource", async () => {
+    mocks.filterRecipientsByResourceAccess.mockResolvedValue([
+      "owner@example.com",
+    ]);
+
+    await notifyReviewComment(
+      comment({
+        mentions: [{ label: "Outsider", email: "outsider@evil.test" }],
+      }),
+    );
+
+    expect(notifyArgs().candidates).toEqual(["owner@example.com"]);
+    const filterArgs = mocks.filterRecipientsByResourceAccess.mock
+      .calls[0][0] as { emails: string[]; resourceId: string };
+    expect(filterArgs.emails).toContain("outsider@evil.test");
+    expect(filterArgs.resourceId).toBe("design_1");
   });
 
   it("reports a resolution failure instead of failing the comment write", async () => {

--- a/packages/core/src/review/notifications.ts
+++ b/packages/core/src/review/notifications.ts
@@ -9,12 +9,17 @@
 
 import {
   notifyActivity,
+  runActivityNotification,
   type ActivityNotificationResult,
 } from "../server/activity-notifications.js";
 import { getAppProductionUrl } from "../server/app-url.js";
 import { emailStrong, renderEmail } from "../server/email-template.js";
 import { sendEmail } from "../server/email.js";
-import { getReviewableResource } from "./registry.js";
+import { filterRecipientsByResourceAccess } from "../sharing/recipients.js";
+import {
+  getReviewableResource,
+  resolveReviewableResourceAccess,
+} from "./registry.js";
 import { queryReviewComments } from "./store.js";
 import type { ReviewComment } from "./types.js";
 
@@ -65,35 +70,19 @@ async function threadParticipants(comment: ReviewComment): Promise<string[]> {
     .filter((email): email is string => Boolean(email));
 }
 
-/**
- * `notification-error` keeps a broken notification distinguishable from a
- * delivered one, without failing the write that produced the comment: the
- * comment really was saved, and the caller can see that only the email leg
- * failed.
- */
-export type ReviewNotificationResult =
-  | ActivityNotificationResult
-  | { status: "notification-error"; error: string; sent: []; failed: [] };
+export type ReviewNotificationResult = ActivityNotificationResult;
 
 /**
  * Email the resource owner, mentioned people, and — on a reply — everyone else
- * already in the thread. Never throws: the comment is already persisted.
+ * already in the thread. Never throws: the comment is already persisted, and a
+ * rejection here would make the client retry and duplicate it.
  */
 export async function notifyReviewComment(
   comment: ReviewComment,
 ): Promise<ReviewNotificationResult> {
-  try {
-    return await deliverReviewCommentEmails(comment);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(`${LOG_LABEL} could not be resolved: ${message}`);
-    return {
-      status: "notification-error",
-      error: message,
-      sent: [],
-      failed: [],
-    };
-  }
+  return runActivityNotification(LOG_LABEL, () =>
+    deliverReviewCommentEmails(comment),
+  );
 }
 
 async function deliverReviewCommentEmails(
@@ -111,12 +100,30 @@ async function deliverReviewCommentEmails(
     candidates.push(...(await threadParticipants(comment)));
   }
 
+  // Mentions are caller-supplied and thread rows are historical; neither is an
+  // access grant. Re-check every address against the resource's current ACL
+  // before it can receive the comment body.
+  const allowed = await filterRecipientsByResourceAccess({
+    resourceType: comment.resourceType,
+    resourceId: comment.resourceId,
+    emails: candidates.filter((email): email is string => Boolean(email)),
+    orgId: comment.orgId,
+    // The review registry owns access for its types; unregistered ones resolve
+    // to null there, so nobody is notified rather than everybody.
+    resolveRole: (ctx) =>
+      resolveReviewableResourceAccess(
+        comment.resourceType,
+        comment.resourceId,
+        ctx,
+      ),
+  });
+
   const actor = comment.authorName?.trim() || comment.authorEmail || "Someone";
   const label = resourceLabel(comment);
   const url = await resourceUrl(comment);
 
   return notifyActivity({
-    candidates,
+    candidates: allowed,
     actorEmail: comment.authorEmail,
     preferenceKey: REVIEW_NOTIFICATION_PREFS_KEY,
     logLabel: LOG_LABEL,

--- a/packages/core/src/review/notifications.ts
+++ b/packages/core/src/review/notifications.ts
@@ -1,0 +1,156 @@
+/**
+ * Email notifications for review threads.
+ *
+ * Implemented here rather than in one app so every surface built on review
+ * comments (Design's review threads today) gets the same behavior. Recipient
+ * resolution, preference filtering, and delivery reporting come from the
+ * shared activity-notification helpers.
+ */
+
+import {
+  notifyActivity,
+  type ActivityNotificationResult,
+} from "../server/activity-notifications.js";
+import { getAppProductionUrl } from "../server/app-url.js";
+import { emailStrong, renderEmail } from "../server/email-template.js";
+import { sendEmail } from "../server/email.js";
+import { getReviewableResource } from "./registry.js";
+import { queryReviewComments } from "./store.js";
+import type { ReviewComment } from "./types.js";
+
+/**
+ * Shared across every review surface. Apps that want a user-facing toggle
+ * write `{ emailNotifications: boolean }` under this key; an absent value
+ * means opted in.
+ */
+export const REVIEW_NOTIFICATION_PREFS_KEY = "activity-notification-prefs";
+
+const LOG_LABEL = "[review] comment notification";
+const EXCERPT_LIMIT = 240;
+
+function excerpt(body: string): string {
+  const collapsed = body.replace(/\s+/g, " ").trim();
+  return collapsed.length > EXCERPT_LIMIT
+    ? `${collapsed.slice(0, EXCERPT_LIMIT - 1)}…`
+    : collapsed;
+}
+
+async function resourceUrl(comment: ReviewComment): Promise<string> {
+  const registration = getReviewableResource(comment.resourceType);
+  const resolved = await registration?.resolveUrl?.(comment.resourceId);
+  return resolved?.trim() || getAppProductionUrl();
+}
+
+function resourceLabel(comment: ReviewComment): string {
+  return (
+    getReviewableResource(comment.resourceType)?.displayName?.trim() ||
+    comment.resourceType
+  );
+}
+
+async function threadParticipants(comment: ReviewComment): Promise<string[]> {
+  // Scope is already established by the action that inserted the comment;
+  // participants are read unscoped so a viewer's narrower scope cannot hide a
+  // person who is genuinely in the thread.
+  const comments = await queryReviewComments({
+    resourceType: comment.resourceType,
+    resourceId: comment.resourceId,
+    scope: { userEmail: null, orgId: null },
+    bypassScope: true,
+    includeResolved: true,
+  });
+  return comments
+    .filter((entry) => entry.threadId === comment.threadId)
+    .map((entry) => entry.authorEmail)
+    .filter((email): email is string => Boolean(email));
+}
+
+/**
+ * `notification-error` keeps a broken notification distinguishable from a
+ * delivered one, without failing the write that produced the comment: the
+ * comment really was saved, and the caller can see that only the email leg
+ * failed.
+ */
+export type ReviewNotificationResult =
+  | ActivityNotificationResult
+  | { status: "notification-error"; error: string; sent: []; failed: [] };
+
+/**
+ * Email the resource owner, mentioned people, and — on a reply — everyone else
+ * already in the thread. Never throws: the comment is already persisted.
+ */
+export async function notifyReviewComment(
+  comment: ReviewComment,
+): Promise<ReviewNotificationResult> {
+  try {
+    return await deliverReviewCommentEmails(comment);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`${LOG_LABEL} could not be resolved: ${message}`);
+    return {
+      status: "notification-error",
+      error: message,
+      sent: [],
+      failed: [],
+    };
+  }
+}
+
+async function deliverReviewCommentEmails(
+  comment: ReviewComment,
+): Promise<ActivityNotificationResult> {
+  const mentioned = new Set(
+    comment.mentions
+      .map((mention) => mention.email?.trim().toLowerCase())
+      .filter((email): email is string => Boolean(email)),
+  );
+
+  const candidates = [comment.ownerEmail, ...mentioned];
+  const isReply = Boolean(comment.parentCommentId);
+  if (isReply) {
+    candidates.push(...(await threadParticipants(comment)));
+  }
+
+  const actor = comment.authorName?.trim() || comment.authorEmail || "Someone";
+  const label = resourceLabel(comment);
+  const url = await resourceUrl(comment);
+
+  return notifyActivity({
+    candidates,
+    actorEmail: comment.authorEmail,
+    preferenceKey: REVIEW_NOTIFICATION_PREFS_KEY,
+    logLabel: LOG_LABEL,
+    send: async (to) => {
+      const wasMentioned = mentioned.has(to);
+      const lead = wasMentioned
+        ? `${emailStrong(actor)} mentioned you in a review comment on this ${label}.`
+        : isReply
+          ? `${emailStrong(actor)} replied in a review thread on this ${label}.`
+          : `${emailStrong(actor)} left a review comment on this ${label}.`;
+
+      const { html, text } = renderEmail({
+        preheader: `${actor} commented on this ${label}.`,
+        heading: wasMentioned
+          ? "You were mentioned in a review"
+          : isReply
+            ? "New reply in a review thread"
+            : "New review comment",
+        paragraphs: [lead, `"${excerpt(comment.body)}"`],
+        cta: { label: "Open review", url },
+        footer:
+          "You received this because you own, were mentioned in, or participated in this review thread.",
+      });
+
+      await sendEmail({
+        to,
+        subject: wasMentioned
+          ? `${actor} mentioned you in a review comment`
+          : isReply
+            ? `${actor} replied to a review thread`
+            : `${actor} left a review comment`,
+        html,
+        text,
+      });
+    },
+  });
+}

--- a/packages/core/src/review/types.ts
+++ b/packages/core/src/review/types.ts
@@ -36,6 +36,13 @@ export interface ReviewResourceContext {
 export interface ReviewableResourceRegistration {
   type: string;
   displayName?: string;
+  /**
+   * Deep link to the resource, used by review notification emails. Without it
+   * an email can only link to the app root.
+   */
+  resolveUrl?: (
+    resourceId: string,
+  ) => Promise<string | null | undefined> | string | null | undefined;
   resolveAccess?: (
     resourceId: string,
     ctx?: ReviewResourceContext,

--- a/packages/core/src/server/activity-notifications.spec.ts
+++ b/packages/core/src/server/activity-notifications.spec.ts
@@ -15,6 +15,7 @@ vi.mock("./email.js", () => ({
 
 import {
   notifyActivity,
+  runActivityNotification,
   resolveActivityRecipients,
 } from "./activity-notifications.js";
 
@@ -141,5 +142,46 @@ describe("notifyActivity", () => {
     expect(result.failed).toEqual([
       { email: "broken@example.com", error: "SMTP 550" },
     ]);
+  });
+
+  it("reports a batch where every send failed as undelivered", async () => {
+    const send = vi.fn(async () => {
+      throw new Error("SMTP 550");
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await notifyActivity({
+      candidates: ["a@example.com", "b@example.com"],
+      preferenceKey: PREFERENCE_KEY,
+      send,
+    });
+
+    expect(result.status).toBe("delivery-failed");
+    expect(result.sent).toEqual([]);
+    expect(result.failed).toHaveLength(2);
+  });
+});
+
+describe("runActivityNotification", () => {
+  it("passes a resolved result straight through", async () => {
+    const result = await runActivityNotification("[test]", async () => ({
+      status: "delivered" as const,
+      sent: ["a@example.com"],
+      failed: [],
+    }));
+
+    expect(result.status).toBe("delivered");
+  });
+
+  it("turns a thrown resolution into a distinct notification-error", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await runActivityNotification("[test]", async () => {
+      throw new Error("participants query failed");
+    });
+
+    expect(result.status).toBe("notification-error");
+    expect(result).toMatchObject({ error: "participants query failed" });
+    expect(result.sent).toEqual([]);
   });
 });

--- a/packages/core/src/server/activity-notifications.spec.ts
+++ b/packages/core/src/server/activity-notifications.spec.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getUserSetting: vi.fn(),
+  isEmailConfigured: vi.fn(),
+}));
+
+vi.mock("../settings/user-settings.js", () => ({
+  getUserSetting: (...args: unknown[]) => mocks.getUserSetting(...args),
+}));
+
+vi.mock("./email.js", () => ({
+  isEmailConfigured: (...args: unknown[]) => mocks.isEmailConfigured(...args),
+}));
+
+import {
+  notifyActivity,
+  resolveActivityRecipients,
+} from "./activity-notifications.js";
+
+const PREFERENCE_KEY = "example-user-prefs";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getUserSetting.mockResolvedValue(null);
+  mocks.isEmailConfigured.mockResolvedValue(true);
+});
+
+describe("resolveActivityRecipients", () => {
+  it("excludes the actor regardless of casing or padding", async () => {
+    const recipients = await resolveActivityRecipients({
+      candidates: ["Owner@Example.com", "viewer@example.com"],
+      actorEmail: "  owner@example.COM ",
+      preferenceKey: PREFERENCE_KEY,
+    });
+
+    expect(recipients).toEqual(["viewer@example.com"]);
+  });
+
+  it("collapses duplicates and drops blanks and non-addresses", async () => {
+    const recipients = await resolveActivityRecipients({
+      candidates: [
+        "owner@example.com",
+        "OWNER@example.com",
+        "",
+        null,
+        undefined,
+        "not-an-email",
+      ],
+      preferenceKey: PREFERENCE_KEY,
+    });
+
+    expect(recipients).toEqual(["owner@example.com"]);
+  });
+
+  it("treats a missing preference blob as opted in", async () => {
+    const recipients = await resolveActivityRecipients({
+      candidates: ["owner@example.com"],
+      preferenceKey: PREFERENCE_KEY,
+    });
+
+    expect(recipients).toEqual(["owner@example.com"]);
+  });
+
+  it("excludes users who turned the preference off", async () => {
+    mocks.getUserSetting.mockImplementation(async (email: string) =>
+      email === "quiet@example.com" ? { emailNotifications: false } : null,
+    );
+
+    const recipients = await resolveActivityRecipients({
+      candidates: ["quiet@example.com", "loud@example.com"],
+      preferenceKey: PREFERENCE_KEY,
+    });
+
+    expect(recipients).toEqual(["loud@example.com"]);
+  });
+
+  it("honors a custom preference field", async () => {
+    mocks.getUserSetting.mockResolvedValue({
+      emailNotifications: false,
+      commentEmails: true,
+    });
+
+    const recipients = await resolveActivityRecipients({
+      candidates: ["owner@example.com"],
+      preferenceKey: PREFERENCE_KEY,
+      preferenceField: "commentEmails",
+    });
+
+    expect(recipients).toEqual(["owner@example.com"]);
+  });
+});
+
+describe("notifyActivity", () => {
+  it("reports email-not-configured distinctly and sends nothing", async () => {
+    mocks.isEmailConfigured.mockResolvedValue(false);
+    const send = vi.fn();
+
+    const result = await notifyActivity({
+      candidates: ["owner@example.com"],
+      preferenceKey: PREFERENCE_KEY,
+      send,
+    });
+
+    expect(send).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      status: "email-not-configured",
+      sent: [],
+      failed: [],
+    });
+  });
+
+  it("reports no-recipients when everyone opted out", async () => {
+    mocks.getUserSetting.mockResolvedValue({ emailNotifications: false });
+    const send = vi.fn();
+
+    const result = await notifyActivity({
+      candidates: ["owner@example.com"],
+      preferenceKey: PREFERENCE_KEY,
+      send,
+    });
+
+    expect(send).not.toHaveBeenCalled();
+    expect(result.status).toBe("no-recipients");
+  });
+
+  it("keeps a failed send out of the sent list", async () => {
+    const send = vi.fn(async (to: string) => {
+      if (to === "broken@example.com") throw new Error("SMTP 550");
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await notifyActivity({
+      candidates: ["ok@example.com", "broken@example.com"],
+      preferenceKey: PREFERENCE_KEY,
+      send,
+    });
+
+    expect(result.status).toBe("delivered");
+    expect(result.sent).toEqual(["ok@example.com"]);
+    expect(result.failed).toEqual([
+      { email: "broken@example.com", error: "SMTP 550" },
+    ]);
+  });
+});

--- a/packages/core/src/server/activity-notifications.ts
+++ b/packages/core/src/server/activity-notifications.ts
@@ -1,0 +1,133 @@
+/**
+ * Shared plumbing for collaboration emails (comments, replies, reactions,
+ * mentions).
+ *
+ * Two things every app was about to reimplement live here: resolving who
+ * should receive an activity email, and reporting delivery honestly. A
+ * workspace with no email provider is a *different* outcome from "nobody
+ * wanted this email" — collapsing both into an empty success is what let a
+ * dead notification toggle ship unnoticed.
+ */
+
+import { getUserSetting } from "../settings/user-settings.js";
+import { isEmailConfigured } from "./email.js";
+
+export type ActivityDeliveryFailure = { email: string; error: string };
+
+export type ActivityNotificationStatus =
+  | "delivered"
+  | "email-not-configured"
+  | "no-recipients";
+
+export type ActivityNotificationResult = {
+  status: ActivityNotificationStatus;
+  sent: string[];
+  failed: ActivityDeliveryFailure[];
+};
+
+/** Default field read from an app's per-user preference blob. */
+const DEFAULT_PREFERENCE_FIELD = "emailNotifications";
+
+export interface ResolveActivityRecipientsInput {
+  /** Owner, thread participants, mentions — duplicates and blanks are fine. */
+  candidates: (string | null | undefined)[];
+  /** The person who caused the activity. Never emailed about their own action. */
+  actorEmail?: string | null;
+  /** App-owned user settings key, e.g. `clips-user-prefs`. */
+  preferenceKey: string;
+  /** Field inside that blob. Absent or non-`false` means opted in. */
+  preferenceField?: string;
+}
+
+function normalizeEmail(value: string | null | undefined): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+async function wantsActivityEmail(
+  email: string,
+  preferenceKey: string,
+  preferenceField: string,
+): Promise<boolean> {
+  const prefs = await getUserSetting(email, preferenceKey);
+  // A user who never opened settings has no stored blob; treat that as opted
+  // in rather than silently dropping their notifications.
+  return prefs?.[preferenceField] !== false;
+}
+
+/**
+ * Normalize, dedupe, drop the actor, and filter by each recipient's stored
+ * preference. Order follows first appearance in `candidates`.
+ */
+export async function resolveActivityRecipients({
+  candidates,
+  actorEmail,
+  preferenceKey,
+  preferenceField = DEFAULT_PREFERENCE_FIELD,
+}: ResolveActivityRecipientsInput): Promise<string[]> {
+  const actor = normalizeEmail(actorEmail);
+  const unique = new Set<string>();
+  for (const candidate of candidates) {
+    const email = normalizeEmail(candidate);
+    if (!email || email === actor || !email.includes("@")) continue;
+    unique.add(email);
+  }
+
+  const decisions = await Promise.all(
+    [...unique].map(async (email) =>
+      (await wantsActivityEmail(email, preferenceKey, preferenceField))
+        ? email
+        : null,
+    ),
+  );
+  return decisions.filter((email): email is string => email !== null);
+}
+
+export interface NotifyActivityInput extends ResolveActivityRecipientsInput {
+  /** Sends one email. Throwing marks that recipient failed, not the batch. */
+  send: (to: string) => Promise<unknown>;
+  /** Prefix for the delivery-failure log line, e.g. `[slides]`. */
+  logLabel?: string;
+}
+
+/**
+ * Resolve recipients and deliver one email each. Returns a status that
+ * distinguishes "no email provider" from "nobody to email" from a real send.
+ */
+export async function notifyActivity({
+  send,
+  logLabel,
+  ...resolve
+}: NotifyActivityInput): Promise<ActivityNotificationResult> {
+  if (!(await isEmailConfigured())) {
+    return { status: "email-not-configured", sent: [], failed: [] };
+  }
+
+  const recipients = await resolveActivityRecipients(resolve);
+  if (recipients.length === 0) {
+    return { status: "no-recipients", sent: [], failed: [] };
+  }
+
+  const sent: string[] = [];
+  const failed: ActivityDeliveryFailure[] = [];
+  for (const to of recipients) {
+    try {
+      await send(to);
+      sent.push(to);
+    } catch (error) {
+      failed.push({
+        email: to,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  if (failed.length > 0) {
+    console.error(
+      `${logLabel ?? "[activity-notifications]"} delivery failed for ${failed
+        .map((failure) => `${failure.email} (${failure.error})`)
+        .join(", ")}`,
+    );
+  }
+
+  return { status: "delivered", sent, failed };
+}

--- a/packages/core/src/server/activity-notifications.ts
+++ b/packages/core/src/server/activity-notifications.ts
@@ -16,13 +16,17 @@ export type ActivityDeliveryFailure = { email: string; error: string };
 
 export type ActivityNotificationStatus =
   | "delivered"
+  | "delivery-failed"
   | "email-not-configured"
-  | "no-recipients";
+  | "no-recipients"
+  | "notification-error";
 
 export type ActivityNotificationResult = {
   status: ActivityNotificationStatus;
   sent: string[];
   failed: ActivityDeliveryFailure[];
+  /** Set only on `notification-error`: why recipients could not be resolved. */
+  error?: string;
 };
 
 /** Default field read from an app's per-user preference blob. */
@@ -129,5 +133,42 @@ export async function notifyActivity({
     );
   }
 
-  return { status: "delivered", sent, failed };
+  // Every recipient failing is an outage, not a delivery. Callers that log or
+  // surface this must not see it as the same outcome as a successful send.
+  return {
+    status: sent.length === 0 ? "delivery-failed" : "delivered",
+    sent,
+    failed,
+  };
+}
+
+/**
+ * Run an activity notification without letting it fail the write that caused
+ * it. The comment/reaction is already persisted by the time notification runs;
+ * rejecting here makes the client roll back and retry, which duplicates the
+ * row. The error still surfaces — as a distinct `notification-error` status,
+ * never as a silent success.
+ */
+export async function runActivityNotification<
+  T extends {
+    status: string;
+    sent: string[];
+    failed: ActivityDeliveryFailure[];
+  },
+>(
+  logLabel: string,
+  resolve: () => Promise<T>,
+): Promise<T | ActivityNotificationResult> {
+  try {
+    return await resolve();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`${logLabel} could not be resolved: ${message}`);
+    return {
+      status: "notification-error",
+      error: message,
+      sent: [],
+      failed: [],
+    };
+  }
 }

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -548,6 +548,15 @@ export {
   type SendEmailArgs,
 } from "./email.js";
 export {
+  notifyActivity,
+  resolveActivityRecipients,
+  type ActivityDeliveryFailure,
+  type ActivityNotificationResult,
+  type ActivityNotificationStatus,
+  type NotifyActivityInput,
+  type ResolveActivityRecipientsInput,
+} from "./activity-notifications.js";
+export {
   renderEmail,
   emailStrong,
   emailLink,

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -549,6 +549,7 @@ export {
 } from "./email.js";
 export {
   notifyActivity,
+  runActivityNotification,
   resolveActivityRecipients,
   type ActivityDeliveryFailure,
   type ActivityNotificationResult,

--- a/packages/core/src/sharing/index.ts
+++ b/packages/core/src/sharing/index.ts
@@ -34,3 +34,8 @@ export {
   type AccessContext,
   type ResolvedAccess,
 } from "./access.js";
+
+export {
+  filterRecipientsByResourceAccess,
+  type FilterRecipientsInput,
+} from "./recipients.js";

--- a/packages/core/src/sharing/recipients.spec.ts
+++ b/packages/core/src/sharing/recipients.spec.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  resolveAccess: vi.fn(),
+  isOrgMember: vi.fn(),
+}));
+
+vi.mock("./access.js", () => ({
+  resolveAccess: (...args: unknown[]) => mocks.resolveAccess(...args),
+}));
+
+vi.mock("../org/membership.js", () => ({
+  isOrgMember: (...args: unknown[]) => mocks.isOrgMember(...args),
+}));
+
+import { filterRecipientsByResourceAccess } from "./recipients.js";
+
+beforeEach(() => {
+  mocks.resolveAccess.mockReset().mockResolvedValue(null);
+  mocks.isOrgMember.mockReset().mockResolvedValue(false);
+});
+
+describe("filterRecipientsByResourceAccess", () => {
+  it("drops an address with no access to the resource", async () => {
+    mocks.resolveAccess.mockImplementation(async (_type, _id, ctx) =>
+      ctx.userEmail === "owner@example.com" ? { role: "owner" } : null,
+    );
+
+    const allowed = await filterRecipientsByResourceAccess({
+      resourceType: "design",
+      resourceId: "d1",
+      emails: ["Owner@example.com", "outsider@evil.test"],
+    });
+
+    expect(allowed).toEqual(["owner@example.com"]);
+  });
+
+  it("never resolves an arbitrary address with the resource's org", async () => {
+    mocks.resolveAccess.mockResolvedValue(null);
+
+    await filterRecipientsByResourceAccess({
+      resourceType: "design",
+      resourceId: "d1",
+      emails: ["outsider@evil.test"],
+      orgId: "org_1",
+    });
+
+    // Only the no-org probe runs: a non-member never gets an org-scoped check.
+    expect(mocks.resolveAccess).toHaveBeenCalledTimes(1);
+    expect(mocks.resolveAccess.mock.calls[0][2]).toEqual({
+      userEmail: "outsider@evil.test",
+    });
+  });
+
+  it("lets an org member through on an org-visible resource", async () => {
+    mocks.isOrgMember.mockResolvedValue(true);
+    mocks.resolveAccess.mockImplementation(async (_type, _id, ctx) =>
+      ctx.orgId ? { role: "viewer" } : null,
+    );
+
+    const allowed = await filterRecipientsByResourceAccess({
+      resourceType: "design",
+      resourceId: "d1",
+      emails: ["teammate@example.com"],
+      orgId: "org_1",
+    });
+
+    expect(allowed).toEqual(["teammate@example.com"]);
+  });
+
+  it("enforces the minimum role", async () => {
+    mocks.resolveAccess.mockResolvedValue({ role: "viewer" });
+
+    const allowed = await filterRecipientsByResourceAccess({
+      resourceType: "design",
+      resourceId: "d1",
+      emails: ["viewer@example.com"],
+      minimumRole: "editor",
+    });
+
+    expect(allowed).toEqual([]);
+  });
+
+  it("uses a supplied resolver instead of the sharing registry", async () => {
+    const resolveRole = vi.fn().mockResolvedValue({ role: "viewer" });
+
+    const allowed = await filterRecipientsByResourceAccess({
+      resourceType: "custom",
+      resourceId: "x1",
+      emails: ["someone@example.com"],
+      resolveRole,
+    });
+
+    expect(allowed).toEqual(["someone@example.com"]);
+    expect(mocks.resolveAccess).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/sharing/recipients.ts
+++ b/packages/core/src/sharing/recipients.ts
@@ -1,0 +1,67 @@
+import { isOrgMember } from "../org/membership.js";
+import { resolveAccess } from "./access.js";
+import { roleSatisfies, type ShareRole } from "./schema.js";
+
+export interface FilterRecipientsInput {
+  resourceType: string;
+  resourceId: string;
+  emails: Iterable<string>;
+  /** The resource's org, needed to honor `org` visibility. */
+  orgId?: string | null;
+  minimumRole?: ShareRole;
+  /**
+   * Override for resources that are not registered through `registerShareableResource`
+   * (the review registry resolves its own). Must honor `userEmail`/`orgId`
+   * rather than the ambient request, or the filter checks the wrong principal.
+   */
+  resolveRole?: (ctx: {
+    userEmail: string;
+    orgId?: string;
+  }) => Promise<{ role: string } | null>;
+}
+
+/**
+ * Keep only the addresses that can still open the resource *right now*.
+ *
+ * Notification recipient lists are built from historical rows — thread
+ * authors, stored mentions, caller-supplied addresses — none of which are an
+ * access grant. Without this, mentioning an arbitrary address mails it the
+ * comment body, and a collaborator whose share was revoked keeps receiving the
+ * thread. Access is re-resolved per address against the live ACL.
+ */
+export async function filterRecipientsByResourceAccess({
+  resourceType,
+  resourceId,
+  emails,
+  orgId,
+  minimumRole = "viewer",
+  resolveRole,
+}: FilterRecipientsInput): Promise<string[]> {
+  const resolve =
+    resolveRole ??
+    ((ctx: { userEmail: string; orgId?: string }) =>
+      resolveAccess(resourceType, resourceId, ctx));
+  const unique = new Set<string>();
+  for (const raw of emails) {
+    const email = raw.trim().toLowerCase();
+    if (email) unique.add(email);
+  }
+  if (unique.size === 0) return [];
+
+  const decisions = await Promise.all(
+    [...unique].map(async (email) => {
+      // Resolve without an org first: passing the resource's org up front
+      // would hand org-visibility access to anyone who is not in it.
+      const direct = await resolve({ userEmail: email });
+      if (direct && roleSatisfies(direct.role as ShareRole, minimumRole)) {
+        return email;
+      }
+      if (!orgId || !(await isOrgMember(orgId, email))) return null;
+      const viaOrg = await resolve({ userEmail: email, orgId });
+      return viaOrg && roleSatisfies(viaOrg.role as ShareRole, minimumRole)
+        ? email
+        : null;
+    }),
+  );
+  return decisions.filter((email): email is string => email !== null);
+}

--- a/scripts/guard-dead-settings-keys.mjs
+++ b/scripts/guard-dead-settings-keys.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+/**
+ * guard-dead-settings-keys.mjs
+ *
+ * A settings toggle is a promise: flip it and the app behaves differently.
+ * The failure this guard exists for is the toggle that persists a value
+ * nothing ever reads. Clips shipped an "Email notifications" switch whose key
+ * was only ever written, and Brain still carries two of them
+ * (`autoArchiveResolved`, `notifyOnSourceErrors`). Nothing errors; the user
+ * simply believes something is configured that is not. That is
+ * indistinguishable from working software until someone goes looking.
+ *
+ * Every persisted preference key a template declares must have at least one
+ * reader OUTSIDE the places that merely declare, display, translate, or save
+ * it.
+ *
+ * Declaration sites scanned per template:
+ *   - `actions/set-settings.ts` top-level zod schema keys
+ *   - `shared/*-prefs.ts` exported preference type fields
+ *
+ * Occurrences that do NOT count as a reader:
+ *   - the declaring file itself
+ *   - settings UI (app/routes/*settings*, app/pages/*Settings*)
+ *   - i18n catalogs (app/i18n*)
+ *   - the generic user-prefs HTTP routes, which pass the whole blob through
+ *   - tests and specs
+ *
+ * Opt-out for a key that is intentionally forward-declared, or read somewhere
+ * this heuristic cannot see. Put on the declaration line or the line above:
+ *
+ *   // settings-key-unused-ok - short reason
+ *
+ * Reviewed exceptions live in KNOWN_DEAD_KEYS below so they stay a visible
+ * decision rather than a silent one.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+/**
+ * Dead keys we are knowingly carrying. Each entry is a decision to revisit:
+ * wire it up or delete it, but not silently.
+ */
+const KNOWN_DEAD_KEYS = [
+  {
+    template: "brain",
+    key: "autoArchiveResolved",
+    reason:
+      "Persisted and shown in Settings but never read; kept pending review archival.",
+  },
+  {
+    template: "brain",
+    key: "notifyOnSourceErrors",
+    reason:
+      "Persisted and shown in Settings but never read; kept pending source-error notifications.",
+  },
+];
+
+const OPT_OUT = /settings-key-unused-ok/;
+
+function templates() {
+  const dir = path.join(REPO_ROOT, "templates");
+  return readdirSync(dir).filter((name) =>
+    existsSync(path.join(dir, name, "package.json")),
+  );
+}
+
+/** Top-level `key: z....` entries in the set-settings zod schema. */
+function zodSchemaKeys(source) {
+  const start = source.indexOf("schema: z.object({");
+  if (start === -1) return [];
+  const lines = source.slice(start).split("\n");
+  const keys = [];
+  let depth = 0;
+  let baseline = null;
+  for (const [index, line] of lines.entries()) {
+    const before = depth;
+    depth += (line.match(/[({[]/g) ?? []).length;
+    depth -= (line.match(/[)}\]]/g) ?? []).length;
+    if (index === 0) {
+      baseline = depth;
+      continue;
+    }
+    // A key is top-level only when the line starts at the schema's own depth.
+    if (before === baseline) {
+      const match = line.match(/^ {4}([A-Za-z_]\w*)\s*:/);
+      if (match) keys.push({ key: match[1], line });
+    }
+    if (depth < baseline) break;
+  }
+  return keys;
+}
+
+/** Field names inside an exported preferences type alias. */
+function prefsTypeKeys(source) {
+  const block = source.match(
+    /export type \w*Prefs\w* = [^;]*?\{([\s\S]*?)\n\};/,
+  );
+  if (!block) return [];
+  const keys = [];
+  for (const line of block[1].split("\n")) {
+    const match = line.match(/^ {2}([A-Za-z_]\w*)\??\s*:/);
+    if (match) keys.push({ key: match[1], line });
+  }
+  return keys;
+}
+
+function declarationFiles(template) {
+  const root = path.join(REPO_ROOT, "templates", template);
+  const files = [];
+
+  const setSettings = path.join(root, "actions/set-settings.ts");
+  if (existsSync(setSettings)) files.push({ file: setSettings, kind: "zod" });
+
+  const sharedDir = path.join(root, "shared");
+  if (existsSync(sharedDir)) {
+    for (const name of readdirSync(sharedDir)) {
+      if (/-prefs\.ts$/.test(name)) {
+        files.push({ file: path.join(sharedDir, name), kind: "type" });
+      }
+    }
+  }
+  return files;
+}
+
+function isReaderPath(rel) {
+  if (/\.(spec|test)\.tsx?$/.test(rel)) return false;
+  if (rel.startsWith("app/i18n")) return false;
+  if (/^app\/routes\/.*settings.*\.tsx?$/i.test(rel)) return false;
+  if (/^app\/pages\/.*settings.*\.tsx?$/i.test(rel)) return false;
+  if (/user-prefs\.(get|put)\.ts$/.test(rel)) return false;
+  return true;
+}
+
+function hasReader(template, key, declaringFile) {
+  const root = path.join(REPO_ROOT, "templates", template);
+  let output = "";
+  try {
+    output = execFileSync(
+      "grep",
+      [
+        "-rl",
+        "--include=*.ts",
+        "--include=*.tsx",
+        "--exclude-dir=node_modules",
+        "--exclude-dir=dist",
+        "--exclude-dir=.output",
+        "--",
+        key,
+        root,
+      ],
+      { encoding: "utf8" },
+    );
+  } catch {
+    // grep exits 1 when nothing matches at all.
+    return false;
+  }
+
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .some(
+      (file) =>
+        path.resolve(file) !== path.resolve(declaringFile) &&
+        isReaderPath(path.relative(root, file)),
+    );
+}
+
+const failures = [];
+const knownSeen = new Set();
+
+for (const template of templates()) {
+  for (const { file, kind } of declarationFiles(template)) {
+    const source = readFileSync(file, "utf8");
+    const lines = source.split("\n");
+    const keys = kind === "zod" ? zodSchemaKeys(source) : prefsTypeKeys(source);
+
+    for (const { key, line } of keys) {
+      const index = lines.indexOf(line);
+      const previous = index > 0 ? lines[index - 1] : "";
+      if (OPT_OUT.test(line) || OPT_OUT.test(previous)) continue;
+
+      if (
+        KNOWN_DEAD_KEYS.some(
+          (entry) => entry.template === template && entry.key === key,
+        )
+      ) {
+        knownSeen.add(`${template}.${key}`);
+        continue;
+      }
+
+      if (!hasReader(template, key, file)) {
+        failures.push({ template, key, file: path.relative(REPO_ROOT, file) });
+      }
+    }
+  }
+}
+
+const staleKnown = KNOWN_DEAD_KEYS.filter(
+  (entry) => !knownSeen.has(`${entry.template}.${entry.key}`),
+);
+
+if (failures.length === 0 && staleKnown.length === 0) {
+  console.log("guard-dead-settings-keys: OK");
+  process.exit(0);
+}
+
+if (failures.length > 0) {
+  console.error(
+    `guard-dead-settings-keys: ${failures.length} persisted settings key(s) with no reader.`,
+  );
+  console.error(
+    "A key that is only written and displayed is a promise the app does not keep.",
+  );
+  console.error("Wire it up, delete it, or record the exception.\n");
+  for (const failure of failures) {
+    console.error(`  ${failure.template}: ${failure.key}  (${failure.file})`);
+  }
+  console.error(
+    "\nTo opt out for a reviewed exception, put this on the declaration line or the line above:",
+  );
+  console.error("  // settings-key-unused-ok - <reason>");
+}
+
+if (staleKnown.length > 0) {
+  console.error(
+    "\nguard-dead-settings-keys: KNOWN_DEAD_KEYS entries no longer match a declared key.",
+  );
+  console.error("Remove them so the list keeps meaning something:");
+  for (const entry of staleKnown) {
+    console.error(`  ${entry.template}: ${entry.key}`);
+  }
+}
+
+process.exit(1);

--- a/scripts/run-guards.ts
+++ b/scripts/run-guards.ts
@@ -43,6 +43,7 @@ const guards = [
   "guard:additive-migrations",
   "guard:no-silent-coercion",
   "guard:no-raw-colors",
+  "guard:dead-settings-keys",
 ] as const;
 
 type GuardName = (typeof guards)[number];

--- a/templates/analytics/app/pages/Settings.spec.tsx
+++ b/templates/analytics/app/pages/Settings.spec.tsx
@@ -32,6 +32,26 @@ vi.mock("@agent-native/core/client/i18n", () => ({
 
 vi.mock("@agent-native/core/client/settings", () => ({
   AccountSettingsCard: () => <div>settings-user@example.com</div>,
+  SettingsGroup: ({ children }: { children: React.ReactNode }) => (
+    <section>{children}</section>
+  ),
+  SettingsRow: ({
+    id,
+    label,
+    description,
+    control,
+  }: {
+    id?: string;
+    label: React.ReactNode;
+    description?: React.ReactNode;
+    control?: React.ReactNode;
+  }) => (
+    <div id={id}>
+      {label}
+      {description}
+      {control}
+    </div>
+  ),
   SettingsTabsPage: ({
     account,
     general,

--- a/templates/analytics/app/pages/Settings.tsx
+++ b/templates/analytics/app/pages/Settings.tsx
@@ -3,6 +3,8 @@ import { LanguagePicker, useT } from "@agent-native/core/client/i18n";
 import { TeamPage } from "@agent-native/core/client/org";
 import {
   AccountSettingsCard,
+  SettingsGroup,
+  SettingsRow,
   SettingsTabsPage,
   useAgentSettingsTabs,
   type SettingsTabItem,
@@ -68,47 +70,41 @@ export default function Settings() {
       generalSearchEntries={generalSearchEntries}
       general={
         <div className="mx-auto w-full max-w-2xl space-y-6">
-          <Card
-            id="credentials"
-            className="bg-card border-border/50 scroll-mt-16"
-          >
-            <CardHeader>
-              <CardTitle className="text-base">
-                {t("settings.credentials")}
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-sm text-muted-foreground mb-3">
-                {t("settings.credentialsDescription")}
-              </p>
-              <Button variant="outline" size="sm" asChild>
-                <Link to="/data-sources">
-                  {t("settings.manageDataSources")}
-                </Link>
-              </Button>
-            </CardContent>
-          </Card>
-
-          <Card
-            id="dashboard-templates"
-            className="bg-card border-border/50 scroll-mt-16"
-          >
-            <CardHeader>
-              <CardTitle className="text-base">
-                {t("settings.dashboardTemplates")}
-              </CardTitle>
-              <CardDescription>
-                {t("settings.dashboardTemplatesDescription")}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <Button variant="outline" size="sm" asChild>
-                <Link to="/catalog">
-                  {t("settings.openDashboardTemplates")}
-                </Link>
-              </Button>
-            </CardContent>
-          </Card>
+          <SettingsGroup className="bg-card border-border/50">
+            <SettingsRow
+              id="credentials"
+              label={t("settings.credentials")}
+              description={t("settings.credentialsDescription")}
+              control={
+                <Button variant="outline" size="sm" asChild>
+                  <Link to="/data-sources">
+                    {t("settings.manageDataSources")}
+                  </Link>
+                </Button>
+              }
+            />
+            <SettingsRow
+              id="dashboard-templates"
+              label={t("settings.dashboardTemplates")}
+              description={t("settings.dashboardTemplatesDescription")}
+              control={
+                <Button variant="outline" size="sm" asChild>
+                  <Link to="/catalog">
+                    {t("settings.openDashboardTemplates")}
+                  </Link>
+                </Button>
+              }
+            />
+            <SettingsRow
+              id="language"
+              label={t("settings.languageTitle")}
+              control={
+                <div className="w-56">
+                  <LanguagePicker label={t("settings.languageLabel")} />
+                </div>
+              }
+            />
+          </SettingsGroup>
 
           {replayStorageStatus.data?.configured ? (
             <Card
@@ -128,18 +124,6 @@ export default function Settings() {
               </CardContent>
             </Card>
           ) : null}
-
-          <Card id="language" className="bg-card border-border/50 scroll-mt-16">
-            <CardHeader>
-              <CardTitle className="text-base">
-                {t("settings.languageTitle")}
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="max-w-xs space-y-1.5">
-              <Label>{t("settings.languageLabel")}</Label>
-              <LanguagePicker label={t("settings.languageLabel")} />
-            </CardContent>
-          </Card>
 
           <Card id="about" className="bg-card border-border/50 scroll-mt-16">
             <CardHeader>

--- a/templates/analytics/changelog/2026-08-01-new-error-alerts-now-reach-you-by-email-and-a-scheduled-dash.md
+++ b/templates/analytics/changelog/2026-08-01-new-error-alerts-now-reach-you-by-email-and-a-scheduled-dash.md
@@ -1,0 +1,6 @@
+---
+type: added
+date: 2026-08-01
+---
+
+New error alerts now reach you by email, and a scheduled dashboard report that gives up retrying tells its owner instead of only logging

--- a/templates/analytics/server/jobs/dashboard-report.spec.ts
+++ b/templates/analytics/server/jobs/dashboard-report.spec.ts
@@ -9,6 +9,11 @@ const mocks = vi.hoisted(() => ({
   recordDashboardReportCaptureOutcome: vi.fn(),
   runWithRequestContext: vi.fn(),
   sendDashboardReportSubscription: vi.fn(),
+  notifyWithDelivery: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/notifications", () => ({
+  notifyWithDelivery: mocks.notifyWithDelivery,
 }));
 
 vi.mock("@agent-native/core/server/request-context", () => ({
@@ -82,6 +87,7 @@ describe("dashboard report sweep", () => {
     mocks.dashboardReportRetryAt.mockReturnValue(null);
     mocks.markDashboardReportResult.mockReset();
     mocks.recordDashboardReportCaptureOutcome.mockReset();
+    mocks.notifyWithDelivery.mockReset();
     mocks.recordDashboardReportCaptureOutcome.mockResolvedValue(true);
     mocks.runWithRequestContext.mockImplementation(
       async (_ctx, run: () => Promise<unknown>) => run(),
@@ -195,6 +201,32 @@ describe("dashboard report sweep", () => {
       "error",
       "panels unavailable: panel_revenue",
     );
+    expect(mocks.notifyWithDelivery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channels: ["inbox", "email"],
+        metadata: expect.objectContaining({
+          emailRecipients: [sub.ownerEmail],
+        }),
+      }),
+      { owner: sub.ownerEmail },
+    );
+  });
+
+  it("stays quiet while a retry is still scheduled", async () => {
+    const sub = subscription();
+    mocks.claimDueDashboardReportSubscriptions.mockResolvedValue([sub]);
+    mocks.dashboardReportRetryAt.mockReturnValue("2026-07-13T11:16:00.000Z");
+    mocks.sendDashboardReportSubscription.mockResolvedValue(
+      completeResult({
+        reportMode: "degraded",
+        degradedPanelIds: ["panel_revenue"],
+        emailsSent: false,
+      }),
+    );
+
+    await runDashboardReportsOnce();
+
+    expect(mocks.notifyWithDelivery).not.toHaveBeenCalled();
   });
 
   it("marks the subscription failed when send throws and persists the thrown message", async () => {

--- a/templates/analytics/server/jobs/dashboard-report.ts
+++ b/templates/analytics/server/jobs/dashboard-report.ts
@@ -64,7 +64,12 @@ async function persistDashboardReportCaptureOutcome(
  * never arrive, and a log line alone leaves them waiting on nothing.
  */
 async function notifyDashboardReportGaveUp(
-  sub: { id: string; ownerEmail: string; orgId?: string | null; dashboardId?: string },
+  sub: {
+    id: string;
+    ownerEmail: string;
+    orgId?: string | null;
+    dashboardId?: string;
+  },
   reason: string,
 ): Promise<void> {
   try {

--- a/templates/analytics/server/jobs/dashboard-report.ts
+++ b/templates/analytics/server/jobs/dashboard-report.ts
@@ -1,3 +1,4 @@
+import { notifyWithDelivery } from "@agent-native/core/notifications";
 import { runWithRequestContext } from "@agent-native/core/server/request-context";
 
 import { sendDashboardReportSubscription } from "../lib/dashboard-report";
@@ -52,6 +53,41 @@ async function persistDashboardReportCaptureOutcome(
   } catch (err) {
     console.error(
       `[dashboard-report] Failed to persist capture checkpoint for subscription ${args[0].id}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+/**
+ * Tell the owner when a scheduled report is finally given up on. Retries stay
+ * silent — only an exhausted retry window means the report they expected will
+ * never arrive, and a log line alone leaves them waiting on nothing.
+ */
+async function notifyDashboardReportGaveUp(
+  sub: { id: string; ownerEmail: string; orgId?: string | null; dashboardId?: string },
+  reason: string,
+): Promise<void> {
+  try {
+    await notifyWithDelivery(
+      {
+        severity: "warning",
+        title: "Scheduled dashboard report failed",
+        body: `The scheduled report for subscription ${sub.id} could not be delivered: ${reason}`,
+        channels: ["inbox", "email"],
+        metadata: {
+          kind: "dashboard_report_failure",
+          subscriptionId: sub.id,
+          path: "/dashboard-reports",
+          // The email channel is a no-op without explicit recipients.
+          emailRecipients: [sub.ownerEmail],
+          emailSubject: "Your scheduled dashboard report did not send",
+        },
+      },
+      { owner: sub.ownerEmail },
+    );
+  } catch (err) {
+    console.error(
+      `[dashboard-report] Could not notify owner of subscription ${sub.id} about the failure:`,
       err instanceof Error ? err.message : String(err),
     );
   }
@@ -127,6 +163,7 @@ export async function runDashboardReportsOnce(): Promise<{
             });
           } else {
             await persistDashboardReportResult(sub, "error", retryMessage);
+            await notifyDashboardReportGaveUp(sub, degradedReason);
           }
           continue;
         }
@@ -155,6 +192,7 @@ export async function runDashboardReportsOnce(): Promise<{
           });
         } else {
           await persistDashboardReportResult(sub, "error", message);
+          await notifyDashboardReportGaveUp(sub, message);
         }
       }
     }

--- a/templates/analytics/server/lib/error-capture.ts
+++ b/templates/analytics/server/lib/error-capture.ts
@@ -996,12 +996,16 @@ async function notifyNewIssue(
       severity: issue.level === "fatal" ? "critical" : "warning",
       title: `New error: ${issue.title}`,
       body: "A new JavaScript error was captured in your app.",
-      channels: ["inbox"],
+      channels: ["inbox", "email"],
       metadata: {
         kind: "error_issue",
         issueId: issue.issueId,
         level: issue.level,
         path: `/monitoring?view=errors&issue=${issue.issueId}`,
+        // The email channel is a no-op without explicit recipients, so a
+        // captured issue would otherwise never leave the in-app inbox.
+        emailRecipients: [scope.ownerEmail],
+        emailSubject: `New error in your app: ${issue.title}`,
       },
     },
     // The notification inbox is owner-scoped; the issue's owner is the analytics

--- a/templates/assets/actions/refresh-generation-run.ts
+++ b/templates/assets/actions/refresh-generation-run.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import { notifyGenerationRunFinished } from "../server/lib/generation-run-notifications.js";
 import { nowIso, parseJson } from "../server/lib/json.js";
 import { completeVideoGenerationRun } from "../server/lib/video-runs.js";
 import { serializeAsset, serializeGenerationRun } from "./_helpers.js";
@@ -88,6 +89,7 @@ async function refreshImageRun(
         .set({ status: "completed", completedAt })
         .where(eq(schema.assetGenerationRuns.id, run.id));
       nextRun = { ...run, status: "completed", completedAt };
+      await notifyGenerationRunFinished(nextRun, "completed");
     }
     await syncImageVariantSlot(nextRun, "ready", { asset: outputAsset });
     return { run: nextRun, assets };
@@ -119,6 +121,7 @@ async function refreshImageRun(
     await syncImageVariantSlot(failedRun, "failed", {
       error: INTERRUPTED_IMAGE_RUN_ERROR,
     });
+    await notifyGenerationRunFinished(failedRun, "failed");
     return { run: failedRun, assets: [] };
   }
 

--- a/templates/assets/app/components/ui/switch.tsx
+++ b/templates/assets/app/components/ui/switch.tsx
@@ -1,0 +1,1 @@
+export * from "@agent-native/toolkit/ui/switch";

--- a/templates/assets/app/hooks/use-assets-prefs.ts
+++ b/templates/assets/app/hooks/use-assets-prefs.ts
@@ -1,0 +1,55 @@
+import { agentNativePath } from "@agent-native/core/client/api-path";
+import type { AssetsUserPrefs } from "@shared/assets-user-prefs";
+import { useCallback, useEffect, useState } from "react";
+
+const PREFS_PATH = "/_agent-native/assets/user-prefs";
+
+export interface AssetsPrefsState {
+  prefs: AssetsUserPrefs;
+  loading: boolean;
+  /** Applies the patch optimistically and rolls back if the write fails. */
+  save: (patch: AssetsUserPrefs) => Promise<void>;
+}
+
+export function useAssetsPrefs(): AssetsPrefsState {
+  const [prefs, setPrefs] = useState<AssetsUserPrefs>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(agentNativePath(PREFS_PATH));
+        const json = res.ok ? await res.json() : null;
+        if (cancelled) return;
+        if (json && typeof json === "object" && !("error" in json)) {
+          setPrefs(json as AssetsUserPrefs);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const save = useCallback(
+    async (patch: AssetsUserPrefs) => {
+      const previous = prefs;
+      setPrefs((current) => ({ ...current, ...patch }));
+      const res = await fetch(agentNativePath(PREFS_PATH), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+      });
+      if (!res.ok) {
+        setPrefs(previous);
+        throw new Error(`Save failed (${res.status})`);
+      }
+    },
+    [prefs],
+  );
+
+  return { prefs, loading, save };
+}

--- a/templates/assets/app/i18n-data.ts
+++ b/templates/assets/app/i18n-data.ts
@@ -628,6 +628,9 @@ const enUS = {
     languageDescription:
       "Choose the interface language for this Assets workspace.",
     languageLabel: "Interface language",
+    emailNotifications: "Email notifications",
+    emailNotificationsDescription:
+      "Get an email when a generation you started finishes or fails.",
     setupTitle: "Assets setup",
     setupDescription: "Two essentials: generation and durable storage.",
     setupReady: "ready",
@@ -3926,6 +3929,9 @@ export const messagesByLocale = {
       languageTitle: "语言",
       languageDescription: "选择此 Assets 工作区的界面语言。",
       languageLabel: "界面语言",
+      emailNotifications: "邮件通知",
+      emailNotificationsDescription:
+        "当你发起的生成完成或失败时，收到邮件通知。",
 
       addBuilderGeminiOrOpenAI:
         "在生成新资产之前添加 Builder、Gemini 或 OpenAI。",
@@ -4727,6 +4733,9 @@ export const messagesByLocale = {
       languageDescription:
         "Elige el idioma de la interfaz para este workspace.",
       languageLabel: "Idioma de la interfaz",
+      emailNotifications: "Notificaciones por correo",
+      emailNotificationsDescription:
+        "Recibe un correo cuando una generación que iniciaste termine o falle.",
 
       addBuilderGeminiOrOpenAI:
         "Agregue Builder, Gemini o OpenAI antes de generar nuevos activos.",
@@ -5191,6 +5200,9 @@ export const messagesByLocale = {
       languageDescription:
         "Choisissez la langue de l'interface pour cet espace Assets.",
       languageLabel: "Langue de l'interface",
+      emailNotifications: "Notifications par e-mail",
+      emailNotificationsDescription:
+        "Recevez un e-mail lorsqu’une génération que vous avez lancée se termine ou échoue.",
 
       addBuilderGeminiOrOpenAI:
         "Ajoutez Builder, Gemini ou OpenAI avant de générer de nouveaux actifs.",
@@ -5644,6 +5656,9 @@ export const messagesByLocale = {
       languageDescription:
         "Wähle die Oberflächensprache für diesen Assets-Workspace.",
       languageLabel: "Oberflächensprache",
+      emailNotifications: "E-Mail-Benachrichtigungen",
+      emailNotificationsDescription:
+        "Erhalte eine E-Mail, wenn eine von dir gestartete Generierung fertig ist oder fehlschlägt.",
       setupTitle: "Assets-Einrichtung",
       setupDescription:
         "Zwei Grundlagen: Generierung und dauerhafter Speicher.",
@@ -5993,6 +6008,9 @@ export const messagesByLocale = {
       languageDescription:
         "この Assets ワークスペースのインターフェース言語を選択します。",
       languageLabel: "インターフェース言語",
+      emailNotifications: "メール通知",
+      emailNotificationsDescription:
+        "開始した生成が完了または失敗したときにメールを受け取ります。",
       setupTitle: "Assets の設定",
       setupDescription: "必要なものは生成と永続ストレージの 2 つです。",
       setupReady: "準備完了",
@@ -6338,6 +6356,9 @@ export const messagesByLocale = {
       languageDescription:
         "이 Assets 워크스페이스의 인터페이스 언어를 선택하세요.",
       languageLabel: "인터페이스 언어",
+      emailNotifications: "이메일 알림",
+      emailNotificationsDescription:
+        "내가 시작한 생성이 완료되거나 실패하면 이메일을 받습니다.",
       setupTitle: "Assets 설정",
       setupDescription: "필수 항목 두 가지: 생성과 영구 저장소.",
       setupReady: "준비됨",
@@ -6685,6 +6706,9 @@ export const messagesByLocale = {
       languageDescription:
         "Escolha o idioma da interface deste workspace de Assets.",
       languageLabel: "Idioma da interface",
+      emailNotifications: "Notificações por e-mail",
+      emailNotificationsDescription:
+        "Receba um e-mail quando uma geração que você iniciou terminar ou falhar.",
 
       addBuilderGeminiOrOpenAI:
         "Adicione Builder, Gemini ou OpenAI antes de gerar novos ativos.",
@@ -7130,6 +7154,9 @@ export const messagesByLocale = {
       languageTitle: "भाषा",
       languageDescription: "इस Assets workspace की इंटरफ़ेस भाषा चुनें।",
       languageLabel: "इंटरफ़ेस भाषा",
+      emailNotifications: "ईमेल सूचनाएँ",
+      emailNotificationsDescription:
+        "आपके द्वारा शुरू किया गया जनरेशन पूरा या विफल होने पर ईमेल पाएँ।",
       setupTitle: "Assets सेटअप",
       setupDescription: "दो जरूरी चीजें: generation और durable storage.",
       setupReady: "तैयार",
@@ -7475,6 +7502,9 @@ export const messagesByLocale = {
       languageTitle: "اللغة",
       languageDescription: "اختر لغة الواجهة لمساحة عمل Assets هذه.",
       languageLabel: "لغة الواجهة",
+      emailNotifications: "إشعارات البريد الإلكتروني",
+      emailNotificationsDescription:
+        "احصل على بريد إلكتروني عند اكتمال عملية إنشاء بدأتها أو فشلها.",
 
       addBuilderGeminiOrOpenAI:
         "قم بإضافة Builder، أو Gemini، أو OpenAI قبل إنشاء أصول جديدة.",

--- a/templates/assets/app/i18n/zh-TW.ts
+++ b/templates/assets/app/i18n/zh-TW.ts
@@ -32,6 +32,8 @@ const messages = {
     languageTitle: "語言",
     languageDescription: "選取此 Assets 工作區的介面語言。",
     languageLabel: "介面語言",
+    emailNotifications: "郵件通知",
+    emailNotificationsDescription: "當你發起的生成完成或失敗時，收到郵件通知。",
     setupTitle: "Assets 設定",
     setupDescription: "兩個要素：生成和持久儲存。",
     setupReady: "就緒",

--- a/templates/assets/app/routes/settings.tsx
+++ b/templates/assets/app/routes/settings.tsx
@@ -38,6 +38,7 @@ import {
   type FormEvent,
   type ReactNode,
 } from "react";
+import { toast } from "sonner";
 
 import { PageShell } from "@/components/layout/PageShell";
 import { Button } from "@/components/ui/button";
@@ -58,6 +59,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { useAssetsPrefs } from "@/hooks/use-assets-prefs";
 import { cn } from "@/lib/utils";
 
 import changelog from "../../CHANGELOG.md?raw";
@@ -83,6 +86,7 @@ export default function SettingsPage() {
   const { data } = useActionQuery("list-libraries", { compact: true }) as {
     data?: { count?: number };
   };
+  const { prefs, loading: prefsLoading, save: savePrefs } = useAssetsPrefs();
 
   const generalSearchEntries = useMemo<SettingsSearchEntry[]>(
     () => [
@@ -91,6 +95,12 @@ export default function SettingsPage() {
         label: t("settings.languageTitle"),
         keywords: "language locale translation i18n",
         hash: "language",
+      },
+      {
+        id: "assets-notifications",
+        label: t("settings.emailNotifications"),
+        keywords: "email notification generation finished failed alert",
+        hash: "notifications",
       },
       {
         id: "assets-generation-setup",
@@ -136,6 +146,29 @@ export default function SettingsPage() {
                   <div className="w-56">
                     <LanguagePicker label={t("settings.languageLabel")} />
                   </div>
+                }
+              />
+              <SettingsRow
+                id="notifications"
+                label={t("settings.emailNotifications")}
+                description={t("settings.emailNotificationsDescription")}
+                control={
+                  <Switch
+                    aria-label={t("settings.emailNotifications")}
+                    checked={prefs.emailNotifications !== false}
+                    disabled={prefsLoading}
+                    onCheckedChange={(checked) => {
+                      savePrefs({ emailNotifications: checked }).catch(
+                        (err) => {
+                          toast.error(
+                            err instanceof Error
+                              ? err.message
+                              : t("settings.saveFailed"),
+                          );
+                        },
+                      );
+                    }}
+                  />
                 }
               />
             </SettingsGroup>

--- a/templates/assets/app/routes/settings.tsx
+++ b/templates/assets/app/routes/settings.tsx
@@ -10,6 +10,8 @@ import {
 import { TeamPage } from "@agent-native/core/client/org";
 import {
   AccountSettingsCard,
+  SettingsGroup,
+  SettingsRow,
   SettingsTabsPage,
   useAgentSettingsTabs,
   useBuilderConnectFlow,
@@ -125,20 +127,18 @@ export default function SettingsPage() {
               </p>
             </div>
 
-            <Card id="language" className="scroll-mt-4">
-              <CardHeader>
-                <CardTitle className="text-base">
-                  {t("settings.languageTitle")}
-                </CardTitle>
-                <CardDescription>
-                  {t("settings.languageDescription")}
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="max-w-xs space-y-1.5">
-                <Label>{t("settings.languageLabel")}</Label>
-                <LanguagePicker label={t("settings.languageLabel")} />
-              </CardContent>
-            </Card>
+            <SettingsGroup className="scroll-mt-4">
+              <SettingsRow
+                id="language"
+                label={t("settings.languageTitle")}
+                description={t("settings.languageDescription")}
+                control={
+                  <div className="w-56">
+                    <LanguagePicker label={t("settings.languageLabel")} />
+                  </div>
+                }
+              />
+            </SettingsGroup>
 
             <section id="asset-generation-setup" className="scroll-mt-4">
               <AssetsSetupCard libraryCount={data?.count ?? 0} />
@@ -243,8 +243,9 @@ function AssetsSetupCard({ libraryCount }: { libraryCount: number }) {
 
       <CardContent className="p-0">
         <SettingsRow
+          className="border-b border-border/70 last:border-b-0"
           icon={<IconKey className="size-4" />}
-          title="Builder"
+          label="Builder"
           description={
             builderConnected
               ? orgName
@@ -261,7 +262,7 @@ function AssetsSetupCard({ libraryCount }: { libraryCount: number }) {
                 : t("settings.optional")}
             </StatusPill>
           }
-          action={
+          control={
             builderEnabled ? (
               <Button
                 type="button"
@@ -295,8 +296,9 @@ function AssetsSetupCard({ libraryCount }: { libraryCount: number }) {
         {setupIssue ? <SetupIssueCallout message={setupIssue} /> : null}
 
         <SettingsRow
+          className="border-b border-border/70 last:border-b-0"
           icon={<IconPhoto className="size-4" />}
-          title={t("settings.generation")}
+          label={t("settings.generation")}
           description={generationSummary(configData, builderConnected, t)}
           status={
             <StatusPill tone={generationReady ? "ready" : "attention"}>
@@ -305,7 +307,7 @@ function AssetsSetupCard({ libraryCount }: { libraryCount: number }) {
                 : t("settings.generationNeedsSetup")}
             </StatusPill>
           }
-          action={
+          control={
             generationStep ? (
               <DisclosureButton
                 open={manualGenerationOpen}
@@ -326,8 +328,9 @@ function AssetsSetupCard({ libraryCount }: { libraryCount: number }) {
         ) : null}
 
         <SettingsRow
+          className="border-b border-border/70 last:border-b-0"
           icon={<IconCloudUpload className="size-4" />}
-          title={t("settings.storage")}
+          label={t("settings.storage")}
           description={
             storageReady
               ? t("settings.storageReady")
@@ -340,7 +343,7 @@ function AssetsSetupCard({ libraryCount }: { libraryCount: number }) {
                 : t("settings.generationNeedsSetup")}
             </StatusPill>
           }
-          action={
+          control={
             storageStep ? (
               <DisclosureButton
                 open={manualStorageOpen}
@@ -361,8 +364,9 @@ function AssetsSetupCard({ libraryCount }: { libraryCount: number }) {
         ) : null}
 
         <SettingsRow
+          className="border-b border-border/70 last:border-b-0"
           icon={<IconLibraryPhoto className="size-4" />}
-          title={t("settings.brandKits")}
+          label={t("settings.brandKits")}
           description={`${libraryCount} accessible ${
             libraryCount === 1 ? "brand kit" : "brand kits"
           }.`}
@@ -372,40 +376,6 @@ function AssetsSetupCard({ libraryCount }: { libraryCount: number }) {
         />
       </CardContent>
     </Card>
-  );
-}
-
-function SettingsRow({
-  icon,
-  title,
-  description,
-  status,
-  action,
-}: {
-  icon: ReactNode;
-  title: string;
-  description: string;
-  status: ReactNode;
-  action?: ReactNode;
-}) {
-  return (
-    <div className="flex flex-col gap-3 border-b border-border/70 px-5 py-4 last:border-b-0 sm:flex-row sm:items-center sm:justify-between">
-      <div className="flex min-w-0 gap-3">
-        <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md border border-border bg-background text-muted-foreground">
-          {icon}
-        </div>
-        <div className="min-w-0">
-          <div className="flex flex-wrap items-center gap-2">
-            <h3 className="text-sm font-medium">{title}</h3>
-            {status}
-          </div>
-          <p className="mt-1 max-w-xl text-sm leading-6 text-muted-foreground">
-            {description}
-          </p>
-        </div>
-      </div>
-      {action ? <div className="shrink-0 sm:ms-4">{action}</div> : null}
-    </div>
   );
 }
 

--- a/templates/assets/changelog/2026-08-01-get-an-email-when-a-generation-you-started-finishes-or-fails.md
+++ b/templates/assets/changelog/2026-08-01-get-an-email-when-a-generation-you-started-finishes-or-fails.md
@@ -1,0 +1,6 @@
+---
+type: added
+date: 2026-08-01
+---
+
+Get an email when a generation you started finishes or fails, with a new toggle in Settings

--- a/templates/assets/server/lib/generation-run-notifications.spec.ts
+++ b/templates/assets/server/lib/generation-run-notifications.spec.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  notifyWithDelivery: vi.fn(),
+  getUserSetting: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/notifications", () => ({
+  notifyWithDelivery: mocks.notifyWithDelivery,
+}));
+
+vi.mock("@agent-native/core/settings", () => ({
+  getUserSetting: mocks.getUserSetting,
+}));
+
+const { notifyGenerationRunFinished } =
+  await import("./generation-run-notifications.js");
+
+function run(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "run_1",
+    libraryId: "lib_1",
+    prompt: "A red bicycle",
+    mediaType: "video",
+    status: "completed",
+    error: null,
+    ownerEmail: "Owner@Example.com",
+    ...overrides,
+  } as never;
+}
+
+describe("notifyGenerationRunFinished", () => {
+  beforeEach(() => {
+    mocks.notifyWithDelivery.mockReset().mockResolvedValue(undefined);
+    mocks.getUserSetting.mockReset().mockResolvedValue(null);
+  });
+
+  it("does nothing when the run has no owner", async () => {
+    const result = await notifyGenerationRunFinished(
+      run({ ownerEmail: null }),
+      "completed",
+    );
+
+    expect(result).toEqual({ status: "no-recipient", emailed: false });
+    expect(mocks.notifyWithDelivery).not.toHaveBeenCalled();
+  });
+
+  it("emails the requester when no preference is stored", async () => {
+    const result = await notifyGenerationRunFinished(run(), "completed");
+
+    expect(result).toEqual({ status: "notified", emailed: true });
+    const [input, meta] = mocks.notifyWithDelivery.mock.calls[0];
+    expect(meta).toEqual({ owner: "owner@example.com" });
+    expect(input.channels).toEqual(["inbox", "email"]);
+    expect(input.metadata.emailRecipients).toEqual(["owner@example.com"]);
+    expect(input.severity).toBe("info");
+  });
+
+  it("keeps the inbox entry but skips email when opted out", async () => {
+    mocks.getUserSetting.mockResolvedValue({ emailNotifications: false });
+
+    const result = await notifyGenerationRunFinished(run(), "completed");
+
+    expect(result).toEqual({ status: "notified", emailed: false });
+    const [input] = mocks.notifyWithDelivery.mock.calls[0];
+    expect(input.channels).toEqual(["inbox"]);
+    expect(input.metadata.emailRecipients).toBeUndefined();
+  });
+
+  it("reports the failure reason on a failed run", async () => {
+    await notifyGenerationRunFinished(
+      run({ status: "failed", error: "Provider timed out" }),
+      "failed",
+    );
+
+    const [input] = mocks.notifyWithDelivery.mock.calls[0];
+    expect(input.severity).toBe("warning");
+    expect(input.title).toBe("Generation failed");
+    expect(input.body).toContain("Provider timed out");
+  });
+
+  it("does not turn a delivery failure into a thrown generation error", async () => {
+    mocks.notifyWithDelivery.mockRejectedValue(new Error("SMTP down"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await notifyGenerationRunFinished(run(), "completed");
+
+    expect(result).toEqual({ status: "notification-error", emailed: false });
+  });
+});

--- a/templates/assets/server/lib/generation-run-notifications.ts
+++ b/templates/assets/server/lib/generation-run-notifications.ts
@@ -1,0 +1,89 @@
+/**
+ * "Your generation finished" notifications.
+ *
+ * Only terminal transitions that happen *out of band* call this — a polled video
+ * run landing, or a stale image run being declared interrupted. Synchronous
+ * `generate-image` hands the result straight back to the caller, so emailing
+ * there would mail a user who is already looking at the image.
+ */
+import { notifyWithDelivery } from "@agent-native/core/notifications";
+import { getUserSetting } from "@agent-native/core/settings";
+
+import {
+  ASSETS_USER_PREFS_KEY,
+  type AssetsUserPrefs,
+} from "../../shared/assets-user-prefs.js";
+import type { schema } from "../db/index.js";
+
+type GenerationRun = typeof schema.assetGenerationRuns.$inferSelect;
+
+export type GenerationRunNotificationStatus =
+  | "no-recipient"
+  | "notified"
+  | "notification-error";
+
+export interface GenerationRunNotificationResult {
+  status: GenerationRunNotificationStatus;
+  emailed: boolean;
+}
+
+async function wantsEmail(email: string): Promise<boolean> {
+  const stored = await getUserSetting(email, ASSETS_USER_PREFS_KEY);
+  if (!stored || typeof stored !== "object" || Array.isArray(stored)) {
+    // No stored preference is a real state, and its meaning is "opted in".
+    return true;
+  }
+  return (stored as AssetsUserPrefs).emailNotifications !== false;
+}
+
+function summarize(run: GenerationRun): string {
+  const kind = run.mediaType === "video" ? "Video" : "Image";
+  const prompt = run.prompt.trim();
+  return prompt.length > 80
+    ? `${kind}: ${prompt.slice(0, 77)}…`
+    : `${kind}: ${prompt}`;
+}
+
+export async function notifyGenerationRunFinished(
+  run: GenerationRun,
+  outcome: "completed" | "failed",
+): Promise<GenerationRunNotificationResult> {
+  const owner = run.ownerEmail?.trim().toLowerCase();
+  if (!owner) return { status: "no-recipient", emailed: false };
+
+  try {
+    const emailed = await wantsEmail(owner);
+    const failed = outcome === "failed";
+    const title = failed ? "Generation failed" : "Generation finished";
+    const body = failed
+      ? `${summarize(run)}\n\n${run.error ?? "The run ended without a result."}`
+      : summarize(run);
+
+    await notifyWithDelivery(
+      {
+        severity: failed ? "warning" : "info",
+        title,
+        body,
+        channels: emailed ? ["inbox", "email"] : ["inbox"],
+        metadata: {
+          kind: "generation_run",
+          runId: run.id,
+          libraryId: run.libraryId,
+          outcome,
+          // The email channel is a no-op without explicit recipients.
+          ...(emailed ? { emailRecipients: [owner], emailSubject: title } : {}),
+        },
+      },
+      { owner },
+    );
+    return { status: "notified", emailed };
+  } catch (err) {
+    // A generation that produced an asset must not be reported as failed just
+    // because the mail server was down.
+    console.error(
+      `[assets] Could not notify ${owner} that run ${run.id} ${outcome}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+    return { status: "notification-error", emailed: false };
+  }
+}

--- a/templates/assets/server/lib/video-runs.ts
+++ b/templates/assets/server/lib/video-runs.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 
 import { getDb, schema } from "../db/index.js";
 import { createAssetFromBuffer } from "./assets.js";
+import { notifyGenerationRunFinished } from "./generation-run-notifications.js";
 import { nowIso, parseJson, stringifyJson } from "./json.js";
 import { pollGeminiVideoGeneration } from "./video-generation.js";
 
@@ -59,6 +60,7 @@ async function markRunCompletedWithAsset(
       metadata: nextRun.metadata,
     })
     .where(eq(schema.assetGenerationRuns.id, run.id));
+  await notifyGenerationRunFinished(nextRun, "completed");
   return nextRun;
 }
 
@@ -217,14 +219,19 @@ export async function completeVideoGenerationRun(
   } catch (err) {
     const message =
       err instanceof Error ? err.message : "Video generation failed.";
+    const completedAt = nowIso();
     await getDb()
       .update(schema.assetGenerationRuns)
       .set({
         status: "failed",
         error: message,
-        completedAt: nowIso(),
+        completedAt,
       })
       .where(eq(schema.assetGenerationRuns.id, run.id));
+    await notifyGenerationRunFinished(
+      { ...run, status: "failed", error: message, completedAt },
+      "failed",
+    );
     throw err;
   }
 }

--- a/templates/assets/server/routes/_agent-native/assets/user-prefs.get.ts
+++ b/templates/assets/server/routes/_agent-native/assets/user-prefs.get.ts
@@ -1,0 +1,17 @@
+import { getSession } from "@agent-native/core/server";
+import { getUserSetting } from "@agent-native/core/settings";
+import { defineEventHandler, setResponseStatus } from "h3";
+
+import { ASSETS_USER_PREFS_KEY } from "../../../../shared/assets-user-prefs.js";
+
+export default defineEventHandler(async (event) => {
+  const session = await getSession(event);
+  if (!session?.email) {
+    setResponseStatus(event, 401);
+    return { error: "unauthorized" };
+  }
+
+  const stored = await getUserSetting(session.email, ASSETS_USER_PREFS_KEY);
+  // coercion-ok: a null read means this user has no preferences yet, which is a real state.
+  return stored ?? {};
+});

--- a/templates/assets/server/routes/_agent-native/assets/user-prefs.put.ts
+++ b/templates/assets/server/routes/_agent-native/assets/user-prefs.put.ts
@@ -1,0 +1,36 @@
+import { getSession } from "@agent-native/core/server";
+import { getUserSetting, putUserSetting } from "@agent-native/core/settings";
+import { defineEventHandler, getHeader, readBody, setResponseStatus } from "h3";
+
+import { ASSETS_USER_PREFS_KEY } from "../../../../shared/assets-user-prefs.js";
+
+export default defineEventHandler(async (event) => {
+  const session = await getSession(event);
+  if (!session?.email) {
+    setResponseStatus(event, 401);
+    return { error: "unauthorized" };
+  }
+
+  // coercion-ok: an unparsable body is rejected with 400 immediately below.
+  const body = await readBody(event).catch(() => null);
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    setResponseStatus(event, 400);
+    return { error: "Invalid settings payload" };
+  }
+
+  // Merge so a partial save never wipes preferences written elsewhere.
+  const stored = await getUserSetting(session.email, ASSETS_USER_PREFS_KEY);
+  // coercion-ok: a null read means this user has no preferences yet, which is a real state.
+  const existing = stored ?? {};
+  const next = {
+    ...(typeof existing === "object" && existing && !Array.isArray(existing)
+      ? existing
+      : {}),
+    ...(body as Record<string, unknown>),
+  };
+
+  await putUserSetting(session.email, ASSETS_USER_PREFS_KEY, next, {
+    requestSource: getHeader(event, "x-request-source") || undefined,
+  });
+  return next;
+});

--- a/templates/assets/shared/assets-user-prefs.ts
+++ b/templates/assets/shared/assets-user-prefs.ts
@@ -1,0 +1,10 @@
+/**
+ * Per-user Assets preferences, stored under one user-setting key so Settings
+ * and the generation pipeline agree on a single source of truth.
+ */
+export const ASSETS_USER_PREFS_KEY = "assets-user-prefs";
+
+export type AssetsUserPrefs = {
+  /** Email me when a generation run I started finishes or fails. */
+  emailNotifications?: boolean;
+};

--- a/templates/brain/app/routes/settings.tsx
+++ b/templates/brain/app/routes/settings.tsx
@@ -7,6 +7,8 @@ import { LanguagePicker, useT } from "@agent-native/core/client/i18n";
 import { TeamPage } from "@agent-native/core/client/org";
 import {
   AccountSettingsCard,
+  SettingsGroup,
+  SettingsRow,
   SettingsTabsPage,
   useAgentSettingsTabs,
   type SettingsSearchEntry,
@@ -717,21 +719,19 @@ export default function SettingsRoute() {
             </main>
 
             <aside className="grid content-start gap-5">
-              <Card id="language" className="scroll-mt-4">
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2 text-base">
-                    <IconAdjustments className="size-4 text-primary" />
-                    {t("settings.languageTitle")}
-                  </CardTitle>
-                  <CardDescription>
-                    {t("settings.languageDescription")}
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-1.5">
-                  <Label>{t("settings.languageLabel")}</Label>
-                  <LanguagePicker label={t("settings.languageLabel")} />
-                </CardContent>
-              </Card>
+              <SettingsGroup className="scroll-mt-4">
+                <SettingsRow
+                  id="language"
+                  icon={<IconAdjustments className="text-primary" />}
+                  label={t("settings.languageTitle")}
+                  description={t("settings.languageDescription")}
+                  control={
+                    <div className="w-48">
+                      <LanguagePicker label={t("settings.languageLabel")} />
+                    </div>
+                  }
+                />
+              </SettingsGroup>
 
               <Card>
                 <CardHeader>

--- a/templates/calendar/app/pages/Settings.tsx
+++ b/templates/calendar/app/pages/Settings.tsx
@@ -4,6 +4,8 @@ import { LanguagePicker, useT } from "@agent-native/core/client/i18n";
 import { TeamPage } from "@agent-native/core/client/org";
 import {
   AccountSettingsCard,
+  SettingsGroup,
+  SettingsRow,
   SettingsTabsPage,
   useAgentSettingsTabs,
   type SettingsSearchEntry,
@@ -209,20 +211,36 @@ export default function Settings() {
             {t("settings.description")}
           </p>
 
-          <Card id="language" className="scroll-mt-16">
-            <CardHeader>
-              <CardTitle className="text-lg">
-                {t("settings.languageTitle")}
-              </CardTitle>
-              <CardDescription>
-                {t("settings.languageDescription")}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="max-w-xs space-y-1.5">
-              <Label>{t("settings.languageLabel")}</Label>
-              <LanguagePicker label={t("settings.languageLabel")} />
-            </CardContent>
-          </Card>
+          <SettingsGroup>
+            <SettingsRow
+              id="language"
+              label={t("settings.languageTitle")}
+              description={t("settings.languageDescription")}
+              control={
+                <div className="w-56">
+                  <LanguagePicker label={t("settings.languageLabel")} />
+                </div>
+              }
+            />
+            <SettingsRow
+              id="appearance"
+              label={t("settings.appearance")}
+              description={t("settings.appearanceDescription")}
+            >
+              <AppearancePicker
+                onChange={(preset: AppearancePresetId) => {
+                  // Persist server-side so the choice survives reload and syncs
+                  // across devices; the local UI has already updated optimistically.
+                  callAction(
+                    "change-appearance" as any,
+                    { preset } as any,
+                  ).catch(() => {
+                    // Server write failed; the local DOM change still stands.
+                  });
+                }}
+              />
+            </SettingsRow>
+          </SettingsGroup>
 
           {/* Google Calendar Connection */}
           <Card id="google-calendar" className="scroll-mt-16">
@@ -458,32 +476,6 @@ export default function Settings() {
                   </Link>
                 </Button>
               </div>
-            </CardContent>
-          </Card>
-
-          {/* Appearance */}
-          <Card id="appearance" className="scroll-mt-16">
-            <CardHeader>
-              <CardTitle className="text-lg">
-                {t("settings.appearance")}
-              </CardTitle>
-              <CardDescription>
-                {t("settings.appearanceDescription")}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <AppearancePicker
-                onChange={(preset: AppearancePresetId) => {
-                  // Persist server-side so the choice survives reload and syncs
-                  // across devices; the local UI has already updated optimistically.
-                  callAction(
-                    "change-appearance" as any,
-                    { preset } as any,
-                  ).catch(() => {
-                    // Server write failed; the local DOM change still stands.
-                  });
-                }}
-              />
             </CardContent>
           </Card>
         </div>

--- a/templates/calendar/changelog/2026-08-01-language-and-appearance-now-sit-together-in-one-preferences-.md
+++ b/templates/calendar/changelog/2026-08-01-language-and-appearance-now-sit-together-in-one-preferences-.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-01
+---
+
+Language and appearance now sit together in one Preferences card in Settings

--- a/templates/chat/app/routes/settings.tsx
+++ b/templates/chat/app/routes/settings.tsx
@@ -3,6 +3,8 @@ import { LanguagePicker, useT } from "@agent-native/core/client/i18n";
 import { TeamPage } from "@agent-native/core/client/org";
 import {
   AccountSettingsCard,
+  SettingsGroup,
+  SettingsRow,
   SettingsTabsPage,
   useAgentSettingsTabs,
   type SettingsSearchEntry,
@@ -10,14 +12,6 @@ import {
 import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
 import { useMemo } from "react";
 
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
 import { APP_TITLE } from "@/lib/app-config";
 
 import changelog from "../../CHANGELOG.md?raw";
@@ -55,20 +49,18 @@ export default function SettingsRoute() {
             {t("settings.description")}
           </p>
 
-          <Card id="language" className="scroll-mt-16">
-            <CardHeader>
-              <CardTitle className="text-base">
-                {t("settings.languageTitle")}
-              </CardTitle>
-              <CardDescription>
-                {t("settings.languageDescription")}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="max-w-xs space-y-1.5">
-              <Label>{t("settings.languageLabel")}</Label>
-              <LanguagePicker label={t("settings.languageLabel")} />
-            </CardContent>
-          </Card>
+          <SettingsGroup>
+            <SettingsRow
+              id="language"
+              label={t("settings.languageTitle")}
+              description={t("settings.languageDescription")}
+              control={
+                <div className="w-56">
+                  <LanguagePicker label={t("settings.languageLabel")} />
+                </div>
+              }
+            />
+          </SettingsGroup>
         </div>
       }
       team={

--- a/templates/clips/actions/add-comment.ts
+++ b/templates/clips/actions/add-comment.ts
@@ -15,6 +15,7 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import { notifyRecordingComment } from "../server/lib/activity-notifications.js";
 import { nanoid } from "../server/lib/recordings.js";
 
 export default defineAction({
@@ -80,12 +81,22 @@ export default defineAction({
       updatedAt: now,
     });
 
+    const notified = await notifyRecordingComment({
+      recordingId: args.recordingId,
+      threadId,
+      authorEmail,
+      authorName: args.authorName,
+      content: args.content,
+      videoTimestampMs: args.videoTimestampMs,
+      isReply: Boolean(parentId),
+    });
+
     await writeAppState("refresh-signal", { ts: Date.now() });
 
     console.log(
       `Added comment to recording ${args.recordingId} @ ${args.videoTimestampMs}ms (thread: ${threadId})`,
     );
 
-    return { id, threadId };
+    return { id, threadId, notified };
   },
 });

--- a/templates/clips/actions/create-meeting.ts
+++ b/templates/clips/actions/create-meeting.ts
@@ -17,7 +17,7 @@ import { getDb, schema } from "../server/db/index.js";
 import {
   getCurrentOwnerEmail,
   getActiveOrganizationId,
-  getOrganizationDefaultVisibility,
+  getDefaultRecordingVisibility,
   nanoid,
 } from "../server/lib/recordings.js";
 
@@ -191,7 +191,7 @@ export default defineAction({
     }
 
     const visibility =
-      args.visibility ?? (await getOrganizationDefaultVisibility(orgId));
+      args.visibility ?? (await getDefaultRecordingVisibility(orgId));
 
     try {
       await db.insert(schema.meetings).values({

--- a/templates/clips/actions/create-recording.ts
+++ b/templates/clips/actions/create-recording.ts
@@ -20,7 +20,7 @@ import { createError } from "h3";
 import { getDb, schema } from "../server/db/index.js";
 import {
   getCurrentOwnerEmail,
-  getOrganizationDefaultVisibility,
+  getDefaultRecordingVisibility,
   nanoid,
   requireOrganizationAccess,
   stringifySpaceIds,
@@ -53,7 +53,7 @@ export default defineAction({
       args.organizationId,
     );
     const defaultVisibility =
-      await getOrganizationDefaultVisibility(organizationId);
+      await getDefaultRecordingVisibility(organizationId);
 
     const spaceIds = (args.spaceIds ?? []).filter(
       (value, index, arr) => value && arr.indexOf(value) === index,

--- a/templates/clips/actions/import-loom-recording.test.ts
+++ b/templates/clips/actions/import-loom-recording.test.ts
@@ -19,7 +19,7 @@ const mocks = vi.hoisted(() => ({
   uploadFile: vi.fn(),
   getDb: vi.fn(),
   getCurrentOwnerEmail: vi.fn(),
-  getOrganizationDefaultVisibility: vi.fn(),
+  getDefaultRecordingVisibility: vi.fn(),
   nanoid: vi.fn(),
   parseSpaceIds: vi.fn(),
   requireOrganizationAccess: vi.fn(),
@@ -79,8 +79,8 @@ vi.mock("../server/lib/builder-media-compression.js", () => ({
 vi.mock("../server/lib/recordings.js", () => ({
   getCurrentOwnerEmail: (...args: unknown[]) =>
     mocks.getCurrentOwnerEmail(...args),
-  getOrganizationDefaultVisibility: (...args: unknown[]) =>
-    mocks.getOrganizationDefaultVisibility(...args),
+  getDefaultRecordingVisibility: (...args: unknown[]) =>
+    mocks.getDefaultRecordingVisibility(...args),
   nanoid: (...args: unknown[]) => mocks.nanoid(...args),
   ownerEmailMatches: (...args: unknown[]) => mocks.ownerEmailMatches(...args),
   parseSpaceIds: (...args: unknown[]) => mocks.parseSpaceIds(...args),
@@ -224,7 +224,7 @@ describe("first imported recording transactional email", () => {
     mocks.requireOrganizationAccess.mockResolvedValue({
       organizationId: "org-1",
     });
-    mocks.getOrganizationDefaultVisibility.mockResolvedValue("private");
+    mocks.getDefaultRecordingVisibility.mockResolvedValue("private");
     mocks.nanoid.mockReturnValue("recording-webm");
     mocks.parseSpaceIds.mockReturnValue([]);
     mocks.stringifySpaceIds.mockReturnValue("[]");
@@ -274,7 +274,7 @@ describe("first imported recording transactional email", () => {
     mocks.requireOrganizationAccess.mockResolvedValue({
       organizationId: "org-1",
     });
-    mocks.getOrganizationDefaultVisibility.mockResolvedValue("private");
+    mocks.getDefaultRecordingVisibility.mockResolvedValue("private");
     mocks.nanoid.mockReturnValue("recording-imported");
     mocks.parseSpaceIds.mockReturnValue([]);
     mocks.stringifySpaceIds.mockReturnValue("[]");

--- a/templates/clips/actions/import-loom-recording.ts
+++ b/templates/clips/actions/import-loom-recording.ts
@@ -12,7 +12,7 @@ import { queueBuilderMediaCompression } from "../server/lib/builder-media-compre
 import { dispatchPostFinalizeJob } from "../server/lib/post-finalize-dispatch.js";
 import {
   getCurrentOwnerEmail,
-  getOrganizationDefaultVisibility,
+  getDefaultRecordingVisibility,
   nanoid,
   ownerEmailMatches,
   parseSpaceIds,
@@ -215,7 +215,7 @@ export default defineAction({
       existingRecording?.organizationId ?? args.organizationId,
     );
     const defaultVisibility =
-      await getOrganizationDefaultVisibility(organizationId);
+      await getDefaultRecordingVisibility(organizationId);
 
     const now = new Date().toISOString();
     const id = existingRecording?.id ?? nanoid();

--- a/templates/clips/actions/react-to-comment.ts
+++ b/templates/clips/actions/react-to-comment.ts
@@ -17,6 +17,7 @@ import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import { notifyRecordingReaction } from "../server/lib/activity-notifications.js";
 
 const MAX_CAS_ATTEMPTS = 3;
 
@@ -90,12 +91,24 @@ export default defineAction({
         .returning({ id: schema.recordingComments.id });
 
       if (updated.length > 0) {
+        // Removing a reaction is not an event worth emailing about.
+        const notified = had
+          ? null
+          : await notifyRecordingReaction({
+              recordingId: existing.recordingId,
+              emoji: args.emoji,
+              viewerEmail,
+              videoTimestampMs: existing.videoTimestampMs,
+              extraRecipients: [existing.authorEmail],
+            });
+
         await writeAppState("refresh-signal", { ts: Date.now() });
         return {
           id: args.commentId,
           emoji: args.emoji,
           reacted: !had,
           reactions: next,
+          notified,
         };
       }
     }

--- a/templates/clips/actions/react-to-recording.ts
+++ b/templates/clips/actions/react-to-recording.ts
@@ -12,6 +12,7 @@ import { assertAccess } from "@agent-native/core/sharing";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import { notifyRecordingReaction } from "../server/lib/activity-notifications.js";
 import { nanoid } from "../server/lib/recordings.js";
 
 export default defineAction({
@@ -50,8 +51,16 @@ export default defineAction({
       createdAt: now,
     });
 
+    const notified = await notifyRecordingReaction({
+      recordingId: args.recordingId,
+      emoji: args.emoji,
+      viewerEmail,
+      viewerName: args.viewerName,
+      videoTimestampMs: args.videoTimestampMs,
+    });
+
     await writeAppState("refresh-signal", { ts: Date.now() });
 
-    return { id };
+    return { id, notified };
   },
 });

--- a/templates/clips/actions/reply-to-comment.ts
+++ b/templates/clips/actions/reply-to-comment.ts
@@ -15,6 +15,7 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import { notifyRecordingComment } from "../server/lib/activity-notifications.js";
 import { nanoid } from "../server/lib/recordings.js";
 
 export default defineAction({
@@ -58,12 +59,22 @@ export default defineAction({
       updatedAt: now,
     });
 
+    const notified = await notifyRecordingComment({
+      recordingId: parent.recordingId,
+      threadId: parent.threadId,
+      authorEmail,
+      authorName: args.authorName,
+      content: args.content,
+      videoTimestampMs: parent.videoTimestampMs,
+      isReply: true,
+    });
+
     await writeAppState("refresh-signal", { ts: Date.now() });
 
     console.log(
       `Replied to comment ${args.commentId} (thread: ${parent.threadId})`,
     );
 
-    return { id, threadId: parent.threadId, parentId: parent.id };
+    return { id, threadId: parent.threadId, parentId: parent.id, notified };
   },
 });

--- a/templates/clips/actions/stitch-recordings.ts
+++ b/templates/clips/actions/stitch-recordings.ts
@@ -36,7 +36,7 @@ import { parseEdits, serializeEdits } from "../app/lib/timestamp-mapping.js";
 import { getDb, schema } from "../server/db/index.js";
 import {
   getCurrentOwnerEmail,
-  getOrganizationDefaultVisibility,
+  getDefaultRecordingVisibility,
   nanoid,
   ownerEmailMatches,
 } from "../server/lib/recordings.js";
@@ -121,7 +121,7 @@ export default defineAction({
     }
     const organizationId = ordered[0].organizationId;
     const defaultVisibility =
-      await getOrganizationDefaultVisibility(organizationId);
+      await getDefaultRecordingVisibility(organizationId);
 
     const totalDuration =
       args.durationMs ??

--- a/templates/clips/app/components/settings/ai-setup-section.tsx
+++ b/templates/clips/app/components/settings/ai-setup-section.tsx
@@ -1,0 +1,441 @@
+import { agentNativePath } from "@agent-native/core/client/api-path";
+import { useActionQuery } from "@agent-native/core/client/hooks";
+import { useT } from "@agent-native/core/client/i18n";
+import {
+  BUILDER_CREDITS_UPGRADE_URL,
+  type BuilderCreditsStatus,
+} from "@shared/builder-credits";
+import {
+  IconBolt,
+  IconBrain,
+  IconCheck,
+  IconChevronDown,
+  IconExternalLink,
+  IconKey,
+  IconLoader2,
+} from "@tabler/icons-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { SecretStatus } from "@/hooks/use-secret-status";
+import { cn } from "@/lib/utils";
+
+import type { BuilderConnection } from "./types";
+
+const BUILDER_CREDITS_FEATURE_LABELS = [
+  "builderCredits.featureBackupTranscription",
+  "builderCredits.featureCleanup",
+  "builderCredits.featureSummaries",
+  "builderCredits.featureTitles",
+] as const;
+
+const AI_PROVIDER_FIELDS = [
+  {
+    key: "ANTHROPIC_API_KEY",
+    label: "Anthropic",
+    placeholder: "sk-ant-...",
+    storage: "agent-engine",
+    engine: "anthropic",
+  },
+  {
+    key: "OPENAI_API_KEY",
+    label: "OpenAI",
+    placeholder: "sk-...",
+    storage: "agent-engine",
+    engine: "ai-sdk:openai",
+  },
+  {
+    key: "GEMINI_API_KEY",
+    label: "Gemini",
+    placeholder: "AI...",
+    storage: "secret",
+  },
+  {
+    key: "GROQ_API_KEY",
+    label: "Groq",
+    placeholder: "gsk_...",
+    storage: "secret",
+    engine: "ai-sdk:groq",
+  },
+  {
+    key: "OPENROUTER_API_KEY",
+    label: "OpenRouter",
+    placeholder: "sk-or-...",
+    storage: "agent-engine",
+    engine: "ai-sdk:openrouter",
+  },
+] as const;
+
+async function saveAgentEngineApiKey(
+  key: string,
+  value: string,
+): Promise<void> {
+  const res = await fetch(
+    agentNativePath("/_agent-native/agent-engine/api-key"),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key, value, scope: "user" }),
+    },
+  );
+
+  if (!res.ok) {
+    // coercion-ok: an error body may not be JSON; the failure is still raised with the status code.
+    const body = (await res.json().catch(() => null)) as {
+      error?: string;
+    } | null;
+    throw new Error(body?.error ?? `Save failed (${res.status})`);
+  }
+}
+
+async function applyAgentEngine(engine: string): Promise<void> {
+  const res = await fetch(
+    agentNativePath("/_agent-native/actions/manage-agent-engine"),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "set", engine }),
+    },
+  );
+
+  // coercion-ok: an error body may not be JSON; the failure is still raised with the status code.
+  const body = (await res.json().catch(() => null)) as {
+    error?: string;
+    result?: unknown;
+  } | null;
+  if (!res.ok) {
+    throw new Error(body?.error ?? `Engine switch failed (${res.status})`);
+  }
+  const result = body?.result ?? body;
+  const text =
+    typeof result === "string"
+      ? result.trim()
+      : result && typeof result === "object"
+        ? JSON.stringify(result)
+        : "";
+  if (/^(Error|Warning):/i.test(text)) {
+    throw new Error(text);
+  }
+}
+
+async function saveRegisteredSecret(key: string, value: string): Promise<void> {
+  const res = await fetch(
+    agentNativePath(`/_agent-native/secrets/${encodeURIComponent(key)}`),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ value }),
+    },
+  );
+
+  if (!res.ok) {
+    // coercion-ok: an error body may not be JSON; the failure is still raised with the status code.
+    const body = (await res.json().catch(() => null)) as {
+      error?: string;
+    } | null;
+    throw new Error(body?.error ?? `Save failed (${res.status})`);
+  }
+}
+
+export interface AiSetupSectionProps {
+  builder: BuilderConnection;
+  secrets: SecretStatus;
+}
+
+export function AiSetupSection({ builder, secrets }: AiSetupSectionProps) {
+  const t = useT();
+  const creditStatus = useActionQuery<BuilderCreditsStatus>(
+    "get-builder-credit-status",
+    undefined,
+    { retry: false },
+  );
+  const [expanded, setExpanded] = useState(false);
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [savingKey, setSavingKey] = useState<string | null>(null);
+
+  const configuredCount = AI_PROVIDER_FIELDS.filter(
+    (field) => secrets.configured[field.key],
+  ).length;
+  const creditsPaused = creditStatus.data?.exhausted === true;
+  const upgradeUrl =
+    creditStatus.data?.upgradeUrl ?? BUILDER_CREDITS_UPGRADE_URL;
+
+  async function handleSaveApiKey(key: string) {
+    const value = (values[key] ?? "").trim();
+    if (!value) {
+      toast.error(t("settings.pasteProviderKey"));
+      return;
+    }
+
+    setSavingKey(key);
+    try {
+      const field = AI_PROVIDER_FIELDS.find((item) => item.key === key);
+      if (field?.storage === "secret") {
+        await saveRegisteredSecret(key, value);
+      } else {
+        await saveAgentEngineApiKey(key, value);
+      }
+      if (field && "engine" in field) {
+        await applyAgentEngine(field.engine);
+      }
+      setValues((current) => ({ ...current, [key]: "" }));
+      window.dispatchEvent(new CustomEvent("agent-engine:configured-changed"));
+      await secrets.refresh();
+      toast.success(t("settings.apiKeySaved"));
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : t("settings.apiKeyFailed"),
+      );
+    } finally {
+      setSavingKey(null);
+    }
+  }
+
+  function openProviderSetup() {
+    setExpanded(true);
+    window.requestAnimationFrame(() => {
+      document
+        .getElementById("ai-provider-keys")
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+      const firstEmptyField =
+        AI_PROVIDER_FIELDS.find((field) => !secrets.configured[field.key]) ??
+        AI_PROVIDER_FIELDS[0];
+      window.setTimeout(() => {
+        document.getElementById(firstEmptyField.key)?.focus();
+      }, 150);
+    });
+  }
+
+  return (
+    <Card id="ai-providers" className="scroll-mt-16">
+      <CardHeader>
+        <CardTitle className="text-base flex items-center gap-2">
+          <IconBrain className="size-4 text-primary" />
+          {t("settings.apiSetup")}
+        </CardTitle>
+        <CardDescription>{t("settings.apiSetupDescription")}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div
+          className={cn(
+            "flex flex-col gap-3 rounded-md border px-3 py-3 sm:flex-row sm:items-center sm:justify-between",
+            builder.connected
+              ? "border-border bg-muted/20"
+              : "border-border bg-accent/30",
+          )}
+        >
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 text-sm font-medium">
+              {builder.connected ? (
+                <IconCheck className="h-4 w-4 text-primary" />
+              ) : (
+                <IconKey className="h-4 w-4 text-muted-foreground" />
+              )}
+              {builder.loading
+                ? t("settings.checkingBuilder")
+                : builder.connected
+                  ? t("settings.builderAiAvailable")
+                  : t("settings.builderEasySetup")}
+            </div>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {builder.connected
+                ? t("settings.apiSetupDescription")
+                : t("settings.builderAiDescription")}
+            </p>
+          </div>
+          {!builder.connected ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="shrink-0"
+              onClick={() =>
+                builder.start({
+                  trackingSource: "clips_settings_ai_setup",
+                  trackingFlow: "connect_llm",
+                })
+              }
+              disabled={builder.connecting || builder.loading}
+            >
+              {builder.connecting ? (
+                <IconLoader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <IconExternalLink className="h-4 w-4" />
+              )}
+              {t("settings.connectBuilder")}
+            </Button>
+          ) : null}
+        </div>
+
+        {creditsPaused ? (
+          <div className="rounded-md border border-amber-300/70 bg-amber-50/80 p-3 text-amber-950 shadow-sm dark:border-amber-400/30 dark:bg-amber-950/25 dark:text-amber-100">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2 text-sm font-semibold">
+                  <span className="rounded-md bg-amber-100 p-1 dark:bg-amber-400/15">
+                    <IconBolt className="h-4 w-4 text-amber-700 dark:text-amber-200" />
+                  </span>
+                  {t("builderCredits.pausedTitle")}
+                </div>
+                <p className="mt-1.5 text-xs leading-relaxed text-amber-900/80 dark:text-amber-100/80">
+                  {t("builderCredits.settingsDescription")}
+                </p>
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {BUILDER_CREDITS_FEATURE_LABELS.map((key) => (
+                    <span
+                      key={key}
+                      className="rounded-full border border-amber-300/70 bg-background/70 px-2 py-0.5 text-[11px] font-medium text-amber-900 dark:border-amber-400/30 dark:bg-amber-950/30 dark:text-amber-100"
+                    >
+                      {t(key)}
+                    </span>
+                  ))}
+                </div>
+              </div>
+              <div className="flex shrink-0 flex-wrap gap-2">
+                <Button asChild size="sm" className="h-8">
+                  <a
+                    href={upgradeUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <IconExternalLink className="h-4 w-4" />
+                    {t("builderCredits.upgrade")}
+                  </a>
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-8 border-amber-300/80 bg-background/70 text-amber-950 hover:bg-amber-100 dark:border-amber-400/40 dark:bg-amber-950/30 dark:text-amber-100 dark:hover:bg-amber-900/40"
+                  onClick={openProviderSetup}
+                >
+                  {t("builderCredits.openAiSetup")}
+                </Button>
+              </div>
+            </div>
+          </div>
+        ) : null}
+
+        <Collapsible open={expanded} onOpenChange={setExpanded}>
+          <div className="rounded-md border border-border">
+            <CollapsibleTrigger asChild>
+              <button
+                id="ai-provider-keys"
+                type="button"
+                className="flex w-full items-center justify-between gap-3 px-3 py-3 text-start"
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2 text-sm font-medium">
+                    <IconKey className="h-4 w-4 text-muted-foreground" />
+                    {t("settings.providerKeyTitle")}
+                    {configuredCount > 0 ? (
+                      <Badge variant="secondary" className="text-[10px]">
+                        {t("settings.providerKeysSet", {
+                          count: configuredCount,
+                        })}
+                      </Badge>
+                    ) : null}
+                  </div>
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    {t("settings.providerKeyDescription")}
+                  </p>
+                </div>
+                <IconChevronDown
+                  className={cn(
+                    "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+                    expanded && "rotate-180",
+                  )}
+                />
+              </button>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <div className="space-y-3 border-t border-border px-3 py-4">
+                {secrets.loading ? (
+                  <div className="text-xs text-muted-foreground">
+                    {t("settings.checkingProviderKeys")}
+                  </div>
+                ) : null}
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {AI_PROVIDER_FIELDS.map((field) => {
+                    const configured = Boolean(secrets.configured[field.key]);
+                    const savingThisKey = savingKey === field.key;
+                    return (
+                      <div key={field.key} className="space-y-1.5">
+                        <div className="flex items-center justify-between gap-2">
+                          <Label htmlFor={field.key}>{field.label}</Label>
+                          {configured ? (
+                            <span className="flex items-center gap-1 text-[10px] font-medium text-primary">
+                              <IconCheck className="h-3 w-3" />
+                              {t("settings.keySet")}
+                            </span>
+                          ) : null}
+                        </div>
+                        <div className="flex gap-2">
+                          <Input
+                            id={field.key}
+                            type="password"
+                            value={values[field.key] ?? ""}
+                            onChange={(event) =>
+                              setValues((current) => ({
+                                ...current,
+                                [field.key]: event.target.value,
+                              }))
+                            }
+                            onKeyDown={(event) => {
+                              if (event.key === "Enter") {
+                                void handleSaveApiKey(field.key);
+                              }
+                            }}
+                            placeholder={
+                              configured
+                                ? t("settings.replaceKey")
+                                : field.placeholder
+                            }
+                            autoComplete="off"
+                            disabled={savingThisKey}
+                          />
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            className="shrink-0"
+                            onClick={() => handleSaveApiKey(field.key)}
+                            disabled={
+                              savingThisKey || !(values[field.key] ?? "").trim()
+                            }
+                          >
+                            {savingThisKey ? (
+                              <IconLoader2 className="h-4 w-4 animate-spin" />
+                            ) : (
+                              t("common.save")
+                            )}
+                          </Button>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </CollapsibleContent>
+          </div>
+        </Collapsible>
+      </CardContent>
+    </Card>
+  );
+}

--- a/templates/clips/app/components/settings/slack-section.tsx
+++ b/templates/clips/app/components/settings/slack-section.tsx
@@ -1,0 +1,329 @@
+import {
+  agentNativePath,
+  appApiPath,
+} from "@agent-native/core/client/api-path";
+import { useActionQuery } from "@agent-native/core/client/hooks";
+import { useT } from "@agent-native/core/client/i18n";
+import {
+  IconBrandSlack,
+  IconExternalLink,
+  IconLoader2,
+  IconTrash,
+} from "@tabler/icons-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+interface SlackInstallation {
+  id: string;
+  teamId: string;
+  teamName: string | null;
+  enterpriseName: string | null;
+  apiAppId: string | null;
+  ownerEmail: string;
+  orgId: string | null;
+  status: string;
+  updatedAt: string;
+}
+
+interface SlackInstallationsResponse {
+  oauthConfigured: boolean;
+  signingConfigured: boolean;
+  scopes: string[];
+  installations: SlackInstallation[];
+}
+
+function absoluteAppUrl(url: string): string {
+  const withBase = url.startsWith("/api/") ? appApiPath(url) : url;
+  return new URL(withBase, window.location.origin).toString();
+}
+
+async function waitForPopupClose(popup: Window): Promise<void> {
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      window.clearInterval(interval);
+      window.clearTimeout(timeout);
+      window.removeEventListener("focus", onFocus);
+      resolve();
+    };
+    const interval = window.setInterval(() => {
+      if (popup.closed) finish();
+    }, 500);
+    const onFocus = () => {
+      if (popup.closed) finish();
+    };
+    window.addEventListener("focus", onFocus);
+    const timeout = window.setTimeout(finish, 5 * 60 * 1000);
+  });
+}
+
+async function startSlackOAuth(): Promise<void> {
+  const res = await fetch(
+    agentNativePath("/_agent-native/actions/connect-slack?returnUrl=/settings"),
+  );
+  const text = await res.text();
+  let data: {
+    url?: string;
+    error?: string;
+    result?: { url?: string };
+  } = {};
+  try {
+    data = JSON.parse(text);
+    // coercion-ok: a non-JSON body still fails below on `!res.ok` or the missing URL.
+  } catch {
+    // Keep the fallback below.
+  }
+  if (!res.ok) throw new Error(data.error || `Failed (${res.status})`);
+  const url = data.result?.url ?? data.url;
+  if (!url) throw new Error("No Slack OAuth URL returned");
+  const popup = window.open(
+    absoluteAppUrl(url),
+    "clips-slack-oauth",
+    "width=600,height=760",
+  );
+  if (!popup) {
+    throw new Error(
+      "Popup blocked — please allow popups for this site and try again.",
+    );
+  }
+  await waitForPopupClose(popup);
+}
+
+async function requestDisconnectSlack(id: string): Promise<void> {
+  const res = await fetch(
+    agentNativePath("/_agent-native/actions/disconnect-slack"),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id }),
+    },
+  );
+  if (!res.ok) {
+    // coercion-ok: an error body may not be JSON; the failure is still raised with the status code.
+    const body = (await res.json().catch(() => null)) as {
+      error?: string;
+    } | null;
+    throw new Error(body?.error ?? `Disconnect failed (${res.status})`);
+  }
+}
+
+export function SlackSection() {
+  const t = useT();
+  const slackStatus = useActionQuery<SlackInstallationsResponse>(
+    "list-slack-installations",
+    undefined,
+    { retry: false },
+  );
+  const [connecting, setConnecting] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
+  const [disconnectTarget, setDisconnectTarget] =
+    useState<SlackInstallation | null>(null);
+
+  const installations = slackStatus.data?.installations ?? [];
+  const oauthConfigured = slackStatus.data?.oauthConfigured ?? false;
+  const signingConfigured = slackStatus.data?.signingConfigured ?? false;
+  const connected = installations.length > 0;
+
+  async function handleConnect() {
+    const beforeCount = installations.length;
+    setConnecting(true);
+    try {
+      await startSlackOAuth();
+      const refreshed = await slackStatus.refetch();
+      const afterCount = refreshed.data?.installations?.length ?? beforeCount;
+      if (afterCount > beforeCount) {
+        toast.success(t("settings.slackConnectedToast"));
+      } else {
+        toast.message(t("settings.slackCheckedToast"));
+      }
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : t("settings.slackConnectFailed"),
+      );
+    } finally {
+      setConnecting(false);
+    }
+  }
+
+  async function handleDisconnect() {
+    const target = disconnectTarget;
+    if (!target) return;
+    setDisconnecting(true);
+    try {
+      await requestDisconnectSlack(target.id);
+      setDisconnectTarget(null);
+      await slackStatus.refetch();
+      toast.success(t("settings.slackDisconnectedToast"));
+    } catch (err) {
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : t("settings.slackDisconnectFailed"),
+      );
+    } finally {
+      setDisconnecting(false);
+    }
+  }
+
+  return (
+    <>
+      <Card id="slack" className="scroll-mt-16">
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <IconBrandSlack className="size-4 text-primary" />
+            {t("settings.slackTitle")}
+          </CardTitle>
+          <CardDescription>{t("settings.slackDescription")}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-col gap-3 rounded-md border border-border bg-accent/30 px-3 py-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                <IconBrandSlack className="h-4 w-4 text-muted-foreground" />
+                {slackStatus.isLoading
+                  ? t("settings.checkingSlack")
+                  : connected
+                    ? t("settings.slackConnected", {
+                        count: installations.length,
+                      })
+                    : oauthConfigured
+                      ? t("common.notConnected")
+                      : t("settings.slackOauthNeeded")}
+              </div>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                {t("settings.slackPreviewDescription")}
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="shrink-0"
+              onClick={handleConnect}
+              disabled={connecting || slackStatus.isLoading || !oauthConfigured}
+            >
+              {connecting ? (
+                <IconLoader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <IconExternalLink className="h-4 w-4" />
+              )}
+              {t("settings.connectSlack")}
+            </Button>
+          </div>
+
+          {!oauthConfigured ? (
+            <div className="rounded-md border border-border p-3 text-xs text-muted-foreground">
+              {t("settings.slackClientMissing")}
+            </div>
+          ) : null}
+
+          {!signingConfigured ? (
+            <div className="rounded-md border border-border p-3 text-xs text-muted-foreground">
+              {t("settings.slackSigningMissing")}
+            </div>
+          ) : null}
+
+          {installations.length > 0 ? (
+            <div className="space-y-2">
+              {installations.map((installation) => (
+                <div
+                  key={installation.id}
+                  className="flex items-center justify-between gap-3 rounded-md border border-border px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium">
+                      {installation.teamName || installation.teamId}
+                    </div>
+                    <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+                      <span>{installation.status}</span>
+                      {installation.enterpriseName ? (
+                        <span>{installation.enterpriseName}</span>
+                      ) : null}
+                      <span>
+                        {t("settings.connectedBy", {
+                          email: installation.ownerEmail,
+                        })}
+                      </span>
+                    </div>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="shrink-0"
+                    aria-label={t("settings.disconnectSlackLabel", {
+                      team: installation.teamName || installation.teamId,
+                    })}
+                    onClick={() => setDisconnectTarget(installation)}
+                  >
+                    <IconTrash className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <AlertDialog
+        open={!!disconnectTarget}
+        onOpenChange={(open) => {
+          if (!open && !disconnecting) setDisconnectTarget(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t("settings.disconnectSlackTitle")}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("settings.disconnectSlackDescription", {
+                team:
+                  disconnectTarget?.teamName ||
+                  disconnectTarget?.teamId ||
+                  t("settings.thisWorkspace"),
+              })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={disconnecting}>
+              {t("common.cancel")}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(event) => {
+                event.preventDefault();
+                void handleDisconnect();
+              }}
+              disabled={disconnecting}
+            >
+              {disconnecting
+                ? t("common.disconnecting")
+                : t("common.disconnect")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/templates/clips/app/components/settings/types.ts
+++ b/templates/clips/app/components/settings/types.ts
@@ -1,0 +1,14 @@
+import type { BuilderConnectStartOptions } from "@agent-native/core/client/settings";
+
+/**
+ * The Builder.io connection as the settings sections need it. Video storage
+ * and AI setup both offer the same connect affordance, so the settings page
+ * owns the flow and hands this view of it to each section.
+ */
+export interface BuilderConnection {
+  connected: boolean;
+  loading: boolean;
+  connecting: boolean;
+  orgName: string | null;
+  start: (options?: BuilderConnectStartOptions) => void;
+}

--- a/templates/clips/app/components/settings/video-storage-section.tsx
+++ b/templates/clips/app/components/settings/video-storage-section.tsx
@@ -1,0 +1,443 @@
+import { agentNativePath } from "@agent-native/core/client/api-path";
+import { useT } from "@agent-native/core/client/i18n";
+import {
+  IconCheck,
+  IconChevronDown,
+  IconCloud,
+  IconExternalLink,
+  IconKey,
+  IconLoader2,
+  IconServer,
+  IconTrash,
+} from "@tabler/icons-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { SecretStatus } from "@/hooks/use-secret-status";
+import type { useVideoStorageStatus } from "@/hooks/use-video-storage-status";
+import { cn } from "@/lib/utils";
+
+import type { BuilderConnection } from "./types";
+
+export const S3_STORAGE_FIELDS = [
+  {
+    key: "S3_ENDPOINT",
+    labelKey: "settings.s3EndpointLabel",
+    placeholder: "https://s3.us-east-1.amazonaws.com",
+    required: true,
+  },
+  {
+    key: "S3_BUCKET",
+    labelKey: "settings.s3BucketLabel",
+    placeholder: "my-clips-bucket",
+    required: true,
+  },
+  {
+    key: "S3_ACCESS_KEY_ID",
+    labelKey: "settings.s3AccessKeyLabel",
+    placeholder: "AKIA...",
+    required: true,
+  },
+  {
+    key: "S3_SECRET_ACCESS_KEY",
+    labelKey: "settings.s3SecretAccessKeyLabel",
+    placeholder: "••••••••",
+    required: true,
+    secret: true,
+  },
+  {
+    key: "S3_REGION",
+    labelKey: "settings.s3RegionLabel",
+    placeholder: "us-east-1",
+  },
+  {
+    key: "S3_PUBLIC_BASE_URL",
+    labelKey: "settings.s3PublicBaseUrlLabel",
+    placeholder: "https://cdn.example.com",
+  },
+] as const;
+
+async function saveS3StorageSettings(
+  values: Record<string, string>,
+): Promise<void> {
+  const vars = S3_STORAGE_FIELDS.map((field) => ({
+    key: field.key,
+    value: (values[field.key] ?? "").trim(),
+  })).filter((entry) => entry.value.length > 0);
+
+  if (vars.length === 0) {
+    throw new Error("Enter at least one storage value.");
+  }
+
+  for (const { key, value } of vars) {
+    const res = await fetch(agentNativePath("/_agent-native/secrets/adhoc"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: key,
+        value,
+        scope: "workspace",
+        description: "Clips S3-compatible storage", // i18n-ignore -- secret metadata description, not visible UI
+      }),
+    });
+
+    if (!res.ok) {
+      // coercion-ok: an error body may not be JSON; the failure is still raised with the status code.
+      const body = (await res.json().catch(() => null)) as {
+        error?: string;
+      } | null;
+      throw new Error(body?.error ?? `Save failed (${res.status})`);
+    }
+  }
+}
+
+export interface VideoStorageSectionProps {
+  builder: BuilderConnection;
+  secrets: SecretStatus;
+  storageStatus: ReturnType<typeof useVideoStorageStatus>;
+}
+
+export function VideoStorageSection({
+  builder,
+  secrets,
+  storageStatus,
+}: VideoStorageSectionProps) {
+  const t = useT();
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [expanded, setExpanded] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [clearing, setClearing] = useState(false);
+
+  const storageConfigured = !!storageStatus.data?.configured;
+  const activeProviderName = storageStatus.data?.activeProvider?.name ?? null;
+  const s3Configured = storageStatus.data?.activeProvider?.id === "s3";
+
+  function validate(current: Record<string, string>): Record<string, string> {
+    const next: Record<string, string> = {};
+    for (const key of ["S3_ENDPOINT", "S3_PUBLIC_BASE_URL"]) {
+      const value = (current[key] ?? "").trim();
+      if (!value) continue;
+      try {
+        const parsed = new URL(value);
+        if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+          next[key] = t("settings.s3UrlInvalid");
+        }
+      } catch {
+        next[key] = t("settings.s3UrlInvalid");
+      }
+    }
+    const bucket = (current["S3_BUCKET"] ?? "").trim();
+    if (bucket && !/^[a-z0-9][a-z0-9\-.]{1,61}[a-z0-9]$/.test(bucket)) {
+      next["S3_BUCKET"] = t("settings.s3BucketInvalid");
+    }
+    return next;
+  }
+
+  async function handleSave() {
+    const validationErrors = validate(values);
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+    const missing = s3Configured
+      ? []
+      : S3_STORAGE_FIELDS.filter(
+          (field) =>
+            "required" in field &&
+            field.required &&
+            !(values[field.key] ?? "").trim(),
+        );
+    if (missing.length > 0) {
+      toast.error(t("settings.storageRequired"));
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await saveS3StorageSettings(values);
+      setValues((current) => ({ ...current, S3_SECRET_ACCESS_KEY: "" }));
+      await Promise.all([storageStatus.refetch(), secrets.refresh()]);
+      toast.success(t("settings.storageSaved"));
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : t("settings.saveFailed"),
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleClearAll() {
+    setClearing(true);
+    try {
+      const results = await Promise.all(
+        S3_STORAGE_FIELDS.filter((field) => secrets.configured[field.key]).map(
+          async (field) => {
+            const res = await fetch(
+              agentNativePath(
+                `/_agent-native/secrets/adhoc/${encodeURIComponent(field.key)}`,
+              ),
+              { method: "DELETE" },
+            );
+            if (!res.ok) {
+              // coercion-ok: an error body may not be JSON; the failure is still raised with the status code.
+              const body = (await res.json().catch(() => null)) as {
+                error?: string;
+              } | null;
+              throw new Error(
+                body?.error ?? `Failed to clear ${field.key} (${res.status})`,
+              );
+            }
+            // coercion-ok: an error body may not be JSON; the failure is still raised with the status code.
+            const body = (await res.json().catch(() => null)) as {
+              removed?: boolean;
+            } | null;
+            return { key: field.key, removed: body?.removed !== false };
+          },
+        ),
+      );
+      const failed = results.filter((r) => !r.removed).map((r) => r.key);
+      if (failed.length > 0) {
+        throw new Error(
+          `Could not remove: ${failed.join(", ")}. You may not have permission.`,
+        );
+      }
+      setValues({});
+      await Promise.all([secrets.refresh(), storageStatus.refetch()]);
+      toast.success(t("settings.keyCleared"));
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : t("settings.saveFailed"),
+      );
+    } finally {
+      setClearing(false);
+    }
+  }
+
+  return (
+    <Card id="video-storage" className="scroll-mt-16">
+      <CardHeader>
+        <CardTitle className="text-base flex items-center gap-2">
+          <IconCloud className="size-4 text-primary" />
+          {t("settings.videoStorage")}
+        </CardTitle>
+        <CardDescription>
+          {t("settings.videoStorageDescription")}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div
+          className={cn(
+            "flex flex-col gap-3 rounded-md border px-3 py-3 sm:flex-row sm:items-center sm:justify-between",
+            builder.connected
+              ? "border-primary/35 bg-primary/5"
+              : "border-border bg-accent/30",
+          )}
+        >
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 text-sm font-medium">
+              {builder.connected ? (
+                <IconCheck className="h-4 w-4 text-primary" />
+              ) : (
+                <IconKey className="h-4 w-4 text-muted-foreground" />
+              )}
+              {builder.loading
+                ? t("settings.checkingBuilder")
+                : builder.connected
+                  ? t("settings.builderConnected")
+                  : t("settings.connectBuilder")}
+            </div>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {builder.connected
+                ? builder.orgName
+                  ? t("settings.builderConnectedFor", {
+                      orgName: builder.orgName,
+                    })
+                  : t("settings.builderConnectedGeneric")
+                : t("settings.builderIncludes")}
+            </p>
+          </div>
+          {builder.connected ? (
+            <Badge variant="secondary" className="shrink-0">
+              {t("common.connected")}
+            </Badge>
+          ) : (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="shrink-0"
+              onClick={() =>
+                builder.start({
+                  trackingSource: "clips_settings_video_storage",
+                  trackingFlow: "video_storage",
+                })
+              }
+              disabled={builder.connecting || builder.loading}
+            >
+              {builder.connecting ? (
+                <IconLoader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <IconExternalLink className="h-4 w-4" />
+              )}
+              {t("settings.connectBuilder")}
+            </Button>
+          )}
+        </div>
+
+        <Collapsible open={expanded} onOpenChange={setExpanded}>
+          <div className="rounded-md border border-border">
+            <div className="flex flex-col gap-3 px-3 py-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2 text-sm font-medium">
+                  <IconServer className="h-4 w-4 text-muted-foreground" />
+                  {t("settings.s3Title")}
+                  <Badge variant="outline" className="text-[10px]">
+                    {t("settings.secondary")}
+                  </Badge>
+                  {s3Configured ? (
+                    <Badge variant="secondary" className="text-[10px]">
+                      {t("settings.active")}
+                    </Badge>
+                  ) : null}
+                </div>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  {builder.connected
+                    ? t("settings.s3BuilderConnectedDescription")
+                    : storageConfigured && activeProviderName
+                      ? t("settings.s3CurrentProvider", {
+                          providerName: activeProviderName,
+                        })
+                      : t("settings.s3OwnBucketDescription")}
+                </p>
+              </div>
+              <CollapsibleTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="shrink-0"
+                >
+                  {expanded ? t("settings.hideS3") : t("settings.configureS3")}
+                  <IconChevronDown
+                    className={cn(
+                      "h-4 w-4 transition-transform",
+                      expanded && "rotate-180",
+                    )}
+                  />
+                </Button>
+              </CollapsibleTrigger>
+            </div>
+
+            <CollapsibleContent>
+              <div className="space-y-4 border-t border-border px-3 py-4">
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {S3_STORAGE_FIELDS.map((field) => {
+                    const configured = Boolean(secrets.configured[field.key]);
+                    const last4 = secrets.last4[field.key];
+                    return (
+                      <div key={field.key} className="space-y-1.5">
+                        <div className="flex items-center justify-between gap-2">
+                          <Label htmlFor={field.key}>{t(field.labelKey)}</Label>
+                          {configured ? (
+                            <span className="flex items-center gap-1 text-[10px] font-medium text-primary">
+                              <IconCheck className="h-3 w-3" />
+                              {last4 ? `••••${last4}` : t("settings.keySet")}
+                            </span>
+                          ) : null}
+                        </div>
+                        <Input
+                          id={field.key}
+                          type={
+                            "secret" in field && field.secret
+                              ? "password"
+                              : "text"
+                          }
+                          value={values[field.key] ?? ""}
+                          onChange={(event) => {
+                            setValues((current) => ({
+                              ...current,
+                              [field.key]: event.target.value,
+                            }));
+                            if (errors[field.key]) {
+                              setErrors((current) => {
+                                const next = { ...current };
+                                delete next[field.key];
+                                return next;
+                              });
+                            }
+                          }}
+                          placeholder={
+                            configured
+                              ? t("settings.replaceKey")
+                              : field.placeholder
+                          }
+                          autoComplete="off"
+                          disabled={saving}
+                          className={
+                            errors[field.key] ? "border-destructive" : undefined
+                          }
+                        />
+                        {errors[field.key] ? (
+                          <p className="text-[11px] text-destructive">
+                            {errors[field.key]}
+                          </p>
+                        ) : null}
+                      </div>
+                    );
+                  })}
+                </div>
+
+                <div className="flex items-center justify-end gap-2">
+                  {S3_STORAGE_FIELDS.some(
+                    (field) => secrets.configured[field.key],
+                  ) ? (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleClearAll}
+                      disabled={clearing || saving}
+                      className="text-muted-foreground hover:text-destructive"
+                    >
+                      {clearing ? (
+                        <IconLoader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <IconTrash className="h-4 w-4" />
+                      )}
+                      {t("settings.clearAllS3")}
+                    </Button>
+                  ) : null}
+                  <Button
+                    onClick={handleSave}
+                    disabled={saving || storageStatus.isLoading}
+                  >
+                    {saving && <IconLoader2 className="h-4 w-4 animate-spin" />}
+                    {t("settings.saveStorage")}
+                  </Button>
+                </div>
+              </div>
+            </CollapsibleContent>
+          </div>
+        </Collapsible>
+      </CardContent>
+    </Card>
+  );
+}

--- a/templates/clips/app/hooks/use-secret-status.ts
+++ b/templates/clips/app/hooks/use-secret-status.ts
@@ -1,0 +1,69 @@
+import { agentNativePath } from "@agent-native/core/client/api-path";
+import { useCallback, useEffect, useState } from "react";
+
+export interface SecretStatus {
+  /** Key name to whether a value is stored for it. */
+  configured: Record<string, boolean>;
+  /** Last four characters of ad-hoc secrets, when the store exposes them. */
+  last4: Record<string, string>;
+  loading: boolean;
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Which API keys and storage credentials are configured. Both the video
+ * storage and AI setup sections read the same three stores, so the settings
+ * page resolves this once and hands it to each of them.
+ */
+export function useSecretStatus(): SecretStatus {
+  const [configured, setConfigured] = useState<Record<string, boolean>>({});
+  const [last4, setLast4] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [envRes, secretsRes, adhocRes] = await Promise.all([
+        fetch(agentNativePath("/_agent-native/env-status")),
+        fetch(agentNativePath("/_agent-native/secrets")),
+        fetch(agentNativePath("/_agent-native/secrets/adhoc")),
+      ]);
+      const envData = envRes.ok
+        ? ((await envRes.json()) as Array<{
+            key: string;
+            configured?: boolean;
+          }>)
+        : [];
+      const secretsData = secretsRes.ok
+        ? ((await secretsRes.json()) as Array<{ key: string; status?: string }>)
+        : [];
+      const adhocData = adhocRes.ok
+        ? ((await adhocRes.json()) as Array<{ name: string; last4?: string }>)
+        : [];
+
+      const next = Object.fromEntries(
+        envData.map((entry) => [entry.key, Boolean(entry.configured)]),
+      );
+      for (const entry of secretsData) {
+        next[entry.key] = entry.status === "set";
+      }
+      const nextLast4: Record<string, string> = {};
+      for (const entry of adhocData) {
+        next[entry.name] = true;
+        if (entry.last4) nextLast4[entry.name] = entry.last4;
+      }
+      setLast4(nextLast4);
+      setConfigured(next);
+    } catch {
+      setConfigured({});
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return { configured, last4, loading, refresh };
+}

--- a/templates/clips/app/i18n/ar-SA.ts
+++ b/templates/clips/app/i18n/ar-SA.ts
@@ -657,9 +657,16 @@ const messages = {
     transcriptCleanupDescription:
       "اعرض النص الأصلي فورًا، ثم نظفه في الخلفية عند توفره.",
     notifications: "الإشعارات",
+    sharing: "المشاركة",
+    defaultVisibility: "الرؤية الافتراضية للتسجيلات الجديدة",
+    defaultVisibilityDescription:
+      "تُطبَّق على كل تسجيل تنشئه. لا يزال بإمكانك تغيير الرؤية لكل تسجيل.",
+    visibilityPrivate: "خاص - أنت فقط",
+    visibilityOrg: "المؤسسة - أي شخص في مساحة عملك",
+    visibilityPublic: "عام - أي شخص لديه الرابط",
     emailNotifications: "إشعارات البريد الإلكتروني",
     emailNotificationsDescription:
-      "احصل على بريد إلكتروني عندما يعلّق شخص أو يتفاعل أو يشارك تسجيلًا معك.",
+      "احصل على بريد إلكتروني عندما يعلّق شخص على تسجيلك أو يتفاعل معه.",
     saved: "تم حفظ الإعدادات",
     saveFailed: "فشل الحفظ",
     builderConnectedToast: "تم اتصال Builder.io",

--- a/templates/clips/app/i18n/ar-SA.ts
+++ b/templates/clips/app/i18n/ar-SA.ts
@@ -621,6 +621,7 @@ const messages = {
     title: "الإعدادات",
     pageTitle: "الإعدادات · Clips",
     intro: "التفضيلات والخدمات المتصلة لمساحة Clips هذه.",
+    preferencesTitle: "التفضيلات",
     languageTitle: "اللغة",
     languageDescription:
       "اختر لغة الواجهة لهذا الحساب. سيتذكرها Clips عبر أجهزتك.",

--- a/templates/clips/app/i18n/de-DE.ts
+++ b/templates/clips/app/i18n/de-DE.ts
@@ -640,6 +640,7 @@ const messages = {
     pageTitle: "Einstellungen · Clips",
     intro:
       "Einstellungen und verbundene Dienste für diesen Clips-Arbeitsbereich.",
+    preferencesTitle: "Voreinstellungen",
     languageTitle: "Sprache",
     languageDescription:
       "Wähle die Oberflächensprache für dieses Konto. Clips merkt sie sich geräteübergreifend.",

--- a/templates/clips/app/i18n/de-DE.ts
+++ b/templates/clips/app/i18n/de-DE.ts
@@ -678,9 +678,16 @@ Alle sichtbaren Änderungen für Clips-Nutzer werden hier dokumentiert. Du kanns
     transcriptCleanupDescription:
       "Zeige das native Transkript sofort an und bereinige es im Hintergrund, sobald es verfügbar ist.",
     notifications: "Benachrichtigungen",
+    sharing: "Teilen",
+    defaultVisibility: "Standard-Sichtbarkeit neuer Aufnahmen",
+    defaultVisibilityDescription:
+      "Gilt für jede Aufnahme, die du erstellst. Du kannst die Sichtbarkeit pro Aufnahme weiterhin ändern.",
+    visibilityPrivate: "Privat - nur du",
+    visibilityOrg: "Organisation - alle in deinem Workspace",
+    visibilityPublic: "Öffentlich - alle mit dem Link",
     emailNotifications: "E-Mail-Benachrichtigungen",
     emailNotificationsDescription:
-      "Erhalte eine E-Mail, wenn jemand eine Aufnahme kommentiert, reagiert oder mit dir teilt.",
+      "Erhalte eine E-Mail, wenn jemand deine Aufnahme kommentiert oder darauf reagiert.",
     saved: "Einstellungen gespeichert",
     saveFailed: "Speichern fehlgeschlagen",
     builderConnectedToast: "Builder.io verbunden",

--- a/templates/clips/app/i18n/en-US.ts
+++ b/templates/clips/app/i18n/en-US.ts
@@ -653,9 +653,16 @@ All notable user-facing changes to Clips are documented here. Open it any time f
     transcriptCleanupDescription:
       "Show the native transcript immediately, then clean it up in the background when available.",
     notifications: "Notifications",
+    sharing: "Sharing",
+    defaultVisibility: "Default visibility for new recordings",
+    defaultVisibilityDescription:
+      "Applied to every recording you create. You can still change visibility per recording.",
+    visibilityPrivate: "Private - only you",
+    visibilityOrg: "Organization - anyone in your workspace",
+    visibilityPublic: "Public - anyone with the link",
     emailNotifications: "Email notifications",
     emailNotificationsDescription:
-      "Get an email when someone comments, reacts, or shares a recording with you.",
+      "Get an email when someone comments on or reacts to your recording.",
     saved: "Settings saved",
     saveFailed: "Failed to save",
     builderConnectedToast: "Builder.io connected",

--- a/templates/clips/app/i18n/en-US.ts
+++ b/templates/clips/app/i18n/en-US.ts
@@ -617,6 +617,7 @@ const messages = {
     title: "Settings",
     pageTitle: "Settings · Clips",
     intro: "Preferences and connected services for this Clips workspace.",
+    preferencesTitle: "Preferences",
     languageTitle: "Language",
     languageDescription:
       "Choose the interface language for this account. Clips remembers it across devices.",

--- a/templates/clips/app/i18n/es-ES.ts
+++ b/templates/clips/app/i18n/es-ES.ts
@@ -672,9 +672,16 @@ Todos los cambios visibles para los usuarios de Clips se documentan aquí. Puede
     transcriptCleanupDescription:
       "Muestra la transcripción nativa de inmediato y luego la mejora en segundo plano cuando esté disponible.",
     notifications: "Notificaciones",
+    sharing: "Compartir",
+    defaultVisibility: "Visibilidad predeterminada de las nuevas grabaciones",
+    defaultVisibilityDescription:
+      "Se aplica a cada grabación que crees. Puedes cambiar la visibilidad en cada grabación.",
+    visibilityPrivate: "Privado - solo tú",
+    visibilityOrg: "Organización - cualquiera de tu espacio",
+    visibilityPublic: "Público - cualquiera con el enlace",
     emailNotifications: "Notificaciones por correo",
     emailNotificationsDescription:
-      "Recibe un correo cuando alguien comenta, reacciona o comparte una grabación contigo.",
+      "Recibe un correo cuando alguien comente o reaccione a tu grabación.",
     saved: "Ajustes guardados",
     saveFailed: "No se pudo guardar",
     builderConnectedToast: "Builder.io conectado",

--- a/templates/clips/app/i18n/es-ES.ts
+++ b/templates/clips/app/i18n/es-ES.ts
@@ -635,6 +635,7 @@ const messages = {
     title: "Ajustes",
     pageTitle: "Ajustes · Clips",
     intro: "Preferencias y servicios conectados para este espacio de Clips.",
+    preferencesTitle: "Preferencias",
     languageTitle: "Idioma",
     languageDescription:
       "Elige el idioma de la interfaz para esta cuenta. Clips lo recordará en todos tus dispositivos.",

--- a/templates/clips/app/i18n/fr-FR.ts
+++ b/templates/clips/app/i18n/fr-FR.ts
@@ -635,6 +635,7 @@ const messages = {
     title: "Paramètres",
     pageTitle: "Paramètres · Clips",
     intro: "Préférences et services connectés pour cet espace Clips.",
+    preferencesTitle: "Préférences",
     languageTitle: "Langue",
     languageDescription:
       "Choisissez la langue de l’interface pour ce compte. Clips s’en souviendra sur tous vos appareils.",

--- a/templates/clips/app/i18n/fr-FR.ts
+++ b/templates/clips/app/i18n/fr-FR.ts
@@ -672,9 +672,16 @@ Tous les changements visibles par les utilisateurs de Clips sont documentés ici
     transcriptCleanupDescription:
       "Affichez immédiatement la transcription native, puis nettoyez-la en arrière-plan lorsqu’elle est disponible.",
     notifications: "Alertes",
+    sharing: "Partage",
+    defaultVisibility: "Visibilité par défaut des nouveaux enregistrements",
+    defaultVisibilityDescription:
+      "Appliquée à chaque enregistrement que vous créez. Vous pouvez toujours la modifier enregistrement par enregistrement.",
+    visibilityPrivate: "Privé - vous uniquement",
+    visibilityOrg: "Organisation - tout le monde dans votre espace",
+    visibilityPublic: "Public - toute personne disposant du lien",
     emailNotifications: "Notifications par e-mail",
     emailNotificationsDescription:
-      "Recevez un e-mail lorsqu’une personne commente, réagit ou partage un enregistrement avec vous.",
+      "Recevez un e-mail lorsqu’une personne commente votre enregistrement ou y réagit.",
     saved: "Paramètres enregistrés",
     saveFailed: "Échec de l’enregistrement",
     builderConnectedToast: "Builder.io connecté",

--- a/templates/clips/app/i18n/hi-IN.ts
+++ b/templates/clips/app/i18n/hi-IN.ts
@@ -649,9 +649,16 @@ Clips में उपयोगकर्ताओं को दिखने व�
     transcriptCleanupDescription:
       "नेटिव ट्रांसक्रिप्ट तुरंत दिखाएँ, फिर उपलब्ध होने पर बैकग्राउंड में साफ़ करें।",
     notifications: "सूचनाएँ",
+    sharing: "साझा करना",
+    defaultVisibility: "नई रिकॉर्डिंग की डिफ़ॉल्ट दृश्यता",
+    defaultVisibilityDescription:
+      "आपकी बनाई हर रिकॉर्डिंग पर लागू होती है। आप हर रिकॉर्डिंग की दृश्यता बदल सकते हैं।",
+    visibilityPrivate: "निजी - केवल आप",
+    visibilityOrg: "संगठन - आपके वर्कस्पेस में कोई भी",
+    visibilityPublic: "सार्वजनिक - लिंक वाला कोई भी",
     emailNotifications: "ईमेल सूचनाएँ",
     emailNotificationsDescription:
-      "जब कोई टिप्पणी करे, प्रतिक्रिया दे या आपके साथ रिकॉर्डिंग शेयर करे तो ईमेल पाएँ।",
+      "जब कोई आपकी रिकॉर्डिंग पर टिप्पणी करे या प्रतिक्रिया दे तो ईमेल पाएँ।",
     saved: "सेटिंग्स सहेजी गईं",
     saveFailed: "सहेजने में विफल",
     builderConnectedToast: "Builder.io कनेक्टेड",

--- a/templates/clips/app/i18n/hi-IN.ts
+++ b/templates/clips/app/i18n/hi-IN.ts
@@ -614,6 +614,7 @@ const messages = {
     title: "सेटिंग्स",
     pageTitle: "सेटिंग्स · Clips",
     intro: "इस Clips वर्कस्पेस के लिए प्राथमिकताएँ और कनेक्टेड सेवाएँ।",
+    preferencesTitle: "प्राथमिकताएँ",
     languageTitle: "भाषा",
     languageDescription:
       "इस खाते के लिए इंटरफ़ेस भाषा चुनें। Clips इसे आपके डिवाइसों पर याद रखेगा।",

--- a/templates/clips/app/i18n/ja-JP.ts
+++ b/templates/clips/app/i18n/ja-JP.ts
@@ -665,9 +665,16 @@ Clips のユーザー向けの主な変更はここに記録されます。コ�
     transcriptCleanupDescription:
       "まずネイティブの文字起こしを表示し、利用可能になったらバックグラウンドで整形します。",
     notifications: "通知",
+    sharing: "共有",
+    defaultVisibility: "新しい録画のデフォルトの公開範囲",
+    defaultVisibilityDescription:
+      "作成するすべての録画に適用されます。録画ごとに公開範囲を変更できます。",
+    visibilityPrivate: "非公開 - 自分のみ",
+    visibilityOrg: "組織 - ワークスペースの全員",
+    visibilityPublic: "公開 - リンクを知っている全員",
     emailNotifications: "メール通知",
     emailNotificationsDescription:
-      "誰かがコメント、リアクション、または録画を共有したときにメールを受け取ります。",
+      "誰かがあなたの録画にコメントまたはリアクションしたときにメールを受け取ります。",
     saved: "設定を保存しました",
     saveFailed: "保存に失敗しました",
     builderConnectedToast: "Builder.io に接続しました",

--- a/templates/clips/app/i18n/ja-JP.ts
+++ b/templates/clips/app/i18n/ja-JP.ts
@@ -628,6 +628,7 @@ const messages = {
     title: "設定",
     pageTitle: "設定 · Clips",
     intro: "この Clips ワークスペースの設定と接続済みサービスです。",
+    preferencesTitle: "環境設定",
     languageTitle: "言語",
     languageDescription:
       "このアカウントのインターフェイス言語を選択します。Clips はデバイス間で設定を記憶します。",

--- a/templates/clips/app/i18n/ko-KR.ts
+++ b/templates/clips/app/i18n/ko-KR.ts
@@ -621,6 +621,7 @@ const messages = {
     title: "설정",
     pageTitle: "설정 · Clips",
     intro: "이 Clips 워크스페이스의 환경설정과 연결된 서비스입니다.",
+    preferencesTitle: "환경설정",
     languageTitle: "언어",
     languageDescription:
       "이 계정의 인터페이스 언어를 선택하세요. Clips가 여러 기기에서 기억합니다.",

--- a/templates/clips/app/i18n/ko-KR.ts
+++ b/templates/clips/app/i18n/ko-KR.ts
@@ -657,9 +657,16 @@ Clips의 모든 사용자 대상 변경 사항은 여기에 기록됩니다. 명
     transcriptCleanupDescription:
       "기본 대본을 즉시 표시하고, 사용 가능해지면 백그라운드에서 정리합니다.",
     notifications: "알림",
+    sharing: "공유",
+    defaultVisibility: "새 녹화의 기본 공개 범위",
+    defaultVisibilityDescription:
+      "생성하는 모든 녹화에 적용됩니다. 녹화별로 공개 범위를 변경할 수 있습니다.",
+    visibilityPrivate: "비공개 - 나만",
+    visibilityOrg: "조직 - 워크스페이스의 모든 사람",
+    visibilityPublic: "공개 - 링크가 있는 모든 사람",
     emailNotifications: "이메일 알림",
     emailNotificationsDescription:
-      "누군가 댓글을 달거나 반응하거나 녹화를 공유하면 이메일을 받습니다.",
+      "누군가 내 녹화에 댓글을 달거나 반응하면 이메일을 받습니다.",
     saved: "설정이 저장됨",
     saveFailed: "저장 실패",
     builderConnectedToast: "Builder.io 연결됨",

--- a/templates/clips/app/i18n/pt-BR.ts
+++ b/templates/clips/app/i18n/pt-BR.ts
@@ -632,6 +632,7 @@ const messages = {
     title: "Configurações",
     pageTitle: "Configurações · Clips",
     intro: "Preferências e serviços conectados para este espaço do Clips.",
+    preferencesTitle: "Preferências",
     languageTitle: "Idioma",
     languageDescription:
       "Escolha o idioma da interface para esta conta. O Clips lembrará em todos os seus dispositivos.",

--- a/templates/clips/app/i18n/pt-BR.ts
+++ b/templates/clips/app/i18n/pt-BR.ts
@@ -669,9 +669,16 @@ Todas as mudanças visíveis para usuários do Clips são documentadas aqui. Voc
     transcriptCleanupDescription:
       "Mostre a transcrição nativa imediatamente e depois limpe em segundo plano quando disponível.",
     notifications: "Notificações",
+    sharing: "Compartilhamento",
+    defaultVisibility: "Visibilidade padrão de novas gravações",
+    defaultVisibilityDescription:
+      "Aplicada a cada gravação que você cria. Você ainda pode mudar a visibilidade por gravação.",
+    visibilityPrivate: "Privado - somente você",
+    visibilityOrg: "Organização - qualquer pessoa do seu espaço",
+    visibilityPublic: "Público - qualquer pessoa com o link",
     emailNotifications: "Notificações por e-mail",
     emailNotificationsDescription:
-      "Receba um e-mail quando alguém comentar, reagir ou compartilhar uma gravação com você.",
+      "Receba um e-mail quando alguém comentar ou reagir à sua gravação.",
     saved: "Configurações salvas",
     saveFailed: "Falha ao salvar",
     builderConnectedToast: "Builder.io conectado",

--- a/templates/clips/app/i18n/zh-CN.ts
+++ b/templates/clips/app/i18n/zh-CN.ts
@@ -595,6 +595,7 @@ const messages = {
     title: "设置",
     pageTitle: "设置 · Clips",
     intro: "此 Clips 工作区的偏好设置和已连接服务。",
+    preferencesTitle: "偏好设置",
     languageTitle: "语言",
     languageDescription:
       "选择此账号的界面语言。Clips 会在不同设备上记住你的选择。",

--- a/templates/clips/app/i18n/zh-CN.ts
+++ b/templates/clips/app/i18n/zh-CN.ts
@@ -629,9 +629,15 @@ Clips 中所有面向用户的重要更改都会记录在这里。你可以随�
     transcriptCleanup: "后台清理",
     transcriptCleanupDescription: "先立即显示原生转录，后台可用时再进行清理。",
     notifications: "通知",
+    sharing: "共享",
+    defaultVisibility: "新录制内容的默认可见性",
+    defaultVisibilityDescription:
+      "应用于你创建的每个录制内容，你仍可为单个录制内容更改可见性。",
+    visibilityPrivate: "私密 - 仅自己",
+    visibilityOrg: "组织 - 工作区中的任何人",
+    visibilityPublic: "公开 - 任何拥有链接的人",
     emailNotifications: "邮件通知",
-    emailNotificationsDescription:
-      "当有人评论、回应或与你分享录制时，收到邮件通知。",
+    emailNotificationsDescription: "当有人评论或回应你的录制时，收到邮件通知。",
     saved: "设置已保存",
     saveFailed: "保存失败",
     builderConnectedToast: "Builder.io 已连接",

--- a/templates/clips/app/i18n/zh-TW.ts
+++ b/templates/clips/app/i18n/zh-TW.ts
@@ -595,6 +595,7 @@ const messages = {
     title: "設定",
     pageTitle: "設定 · Clips",
     intro: "此 Clips 工作區的偏好設定和已連線服務。",
+    preferencesTitle: "偏好設定",
     languageTitle: "語言",
     languageDescription:
       "選取此帳號的介面語言。Clips 會在不同設備上記住你的選取。",

--- a/templates/clips/app/i18n/zh-TW.ts
+++ b/templates/clips/app/i18n/zh-TW.ts
@@ -622,9 +622,15 @@ const messages = {
     transcriptCleanup: "背景清理",
     transcriptCleanupDescription: "先立即顯示原生轉錄，背景可用時再進行清理。",
     notifications: "通知",
+    sharing: "共用",
+    defaultVisibility: "新錄製內容的預設可見性",
+    defaultVisibilityDescription:
+      "套用於你建立的每個錄製內容，你仍可為個別錄製內容變更可見性。",
+    visibilityPrivate: "私密 - 僅自己",
+    visibilityOrg: "組織 - 工作區中的任何人",
+    visibilityPublic: "公開 - 任何擁有連結的人",
     emailNotifications: "郵件通知",
-    emailNotificationsDescription:
-      "當有人評論、回應或與你分享錄製時，收到郵件通知。",
+    emailNotificationsDescription: "當有人評論或回應你的錄製時，收到郵件通知。",
     saved: "設定已儲存",
     saveFailed: "儲存失敗",
     builderConnectedToast: "Builder.io 已連線",

--- a/templates/clips/app/routes/_app.settings._index.tsx
+++ b/templates/clips/app/routes/_app.settings._index.tsx
@@ -18,6 +18,7 @@ import {
   BUILDER_CREDITS_UPGRADE_URL,
   type BuilderCreditsStatus,
 } from "@shared/builder-credits";
+import type { ClipsDefaultVisibility } from "@shared/clips-ai-prefs";
 import {
   IconBrain,
   IconBolt,
@@ -168,6 +169,7 @@ interface ClipsUserSettings {
   emailNotifications?: boolean;
   transcriptCleanupEnabled?: boolean;
   includeFullVideoInAi?: boolean;
+  defaultRecordingVisibility?: ClipsDefaultVisibility;
 }
 
 interface SlackInstallation {
@@ -446,6 +448,8 @@ export default function SettingsIndexRoute() {
     useState<SlackInstallation | null>(null);
   const [defaultSpeed, setDefaultSpeed] = useState("1.2");
   const [emailNotifications, setEmailNotifications] = useState(true);
+  const [defaultVisibility, setDefaultVisibility] =
+    useState<ClipsDefaultVisibility>("private");
   const [transcriptCleanupEnabled, setTranscriptCleanupEnabled] =
     useState(true);
   const [s3Values, setS3Values] = useState<Record<string, string>>({});
@@ -511,6 +515,7 @@ export default function SettingsIndexRoute() {
       if (cancelled) return;
       setDefaultSpeed(v.defaultPlaybackSpeed ?? "1.2");
       setEmailNotifications(v.emailNotifications ?? true);
+      setDefaultVisibility(v.defaultRecordingVisibility ?? "private");
       setTranscriptCleanupEnabled(v.transcriptCleanupEnabled !== false);
       setLoading(false);
     });
@@ -546,6 +551,7 @@ export default function SettingsIndexRoute() {
         defaultPlaybackSpeed: defaultSpeed,
         emailNotifications,
         transcriptCleanupEnabled,
+        defaultRecordingVisibility: defaultVisibility,
       });
       toast.success(t("settings.saved"));
     } catch (err) {
@@ -825,6 +831,12 @@ export default function SettingsIndexRoute() {
         label: t("settings.transcript"),
         keywords: "transcript cleanup captions",
         hash: "transcript",
+      },
+      {
+        id: "clips-sharing",
+        label: t("settings.sharing"),
+        keywords: "sharing visibility private public organization default",
+        hash: "sharing",
       },
       {
         id: "clips-notifications",
@@ -1543,6 +1555,46 @@ export default function SettingsIndexRoute() {
                       onCheckedChange={setTranscriptCleanupEnabled}
                       disabled={loading}
                     />
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card id="sharing" className="scroll-mt-16">
+                <CardHeader>
+                  <CardTitle className="text-base">
+                    {t("settings.sharing")}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="default-visibility">
+                      {t("settings.defaultVisibility")}
+                    </Label>
+                    <Select
+                      value={defaultVisibility}
+                      onValueChange={(value) =>
+                        setDefaultVisibility(value as ClipsDefaultVisibility)
+                      }
+                      disabled={loading}
+                    >
+                      <SelectTrigger id="default-visibility" className="w-56">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="private">
+                          {t("settings.visibilityPrivate")}
+                        </SelectItem>
+                        <SelectItem value="org">
+                          {t("settings.visibilityOrg")}
+                        </SelectItem>
+                        <SelectItem value="public">
+                          {t("settings.visibilityPublic")}
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <p className="text-xs text-muted-foreground">
+                      {t("settings.defaultVisibilityDescription")}
+                    </p>
                   </div>
                 </CardContent>
               </Card>

--- a/templates/clips/app/routes/_app.settings._index.tsx
+++ b/templates/clips/app/routes/_app.settings._index.tsx
@@ -1,68 +1,26 @@
-import {
-  agentNativePath,
-  appApiPath,
-} from "@agent-native/core/client/api-path";
+import { agentNativePath } from "@agent-native/core/client/api-path";
 import { ChangelogSettingsCard } from "@agent-native/core/client/changelog";
-import { useActionQuery } from "@agent-native/core/client/hooks";
 import { LanguagePicker, useT } from "@agent-native/core/client/i18n";
 import { useOrg, useSwitchOrg } from "@agent-native/core/client/org";
 import {
   AccountSettingsCard,
-  useBuilderConnectFlow,
-  useBuilderStatus,
+  SettingsGroup,
+  SettingsRow,
   SettingsTabsPage,
   useAgentSettingsTabs,
+  useBuilderConnectFlow,
+  useBuilderStatus,
   type SettingsSearchEntry,
 } from "@agent-native/core/client/settings";
-import {
-  BUILDER_CREDITS_UPGRADE_URL,
-  type BuilderCreditsStatus,
-} from "@shared/builder-credits";
 import type { ClipsDefaultVisibility } from "@shared/clips-ai-prefs";
-import {
-  IconBrain,
-  IconBolt,
-  IconBrandSlack,
-  IconCheck,
-  IconChevronDown,
-  IconCloud,
-  IconExternalLink,
-  IconKey,
-  IconLoader2,
-  IconServer,
-  IconTrash,
-  IconUsersGroup,
-} from "@tabler/icons-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import { PageHeader } from "@/components/library/page-header";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import { Badge } from "@/components/ui/badge";
+import { AiSetupSection } from "@/components/settings/ai-setup-section";
+import { SlackSection } from "@/components/settings/slack-section";
+import { VideoStorageSection } from "@/components/settings/video-storage-section";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
@@ -72,9 +30,9 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { OrganizationIdentityCard } from "@/components/workspace/organization-identity-card";
+import { useSecretStatus } from "@/hooks/use-secret-status";
 import { useVideoStorageStatus } from "@/hooks/use-video-storage-status";
 import enMessages from "@/i18n/en-US";
-import { cn } from "@/lib/utils";
 
 export function meta() {
   return [{ title: enMessages.settings.pageTitle }];
@@ -82,113 +40,12 @@ export function meta() {
 
 const SPEEDS = ["1", "1.2", "1.5", "1.75", "2"];
 
-const BUILDER_CREDITS_FEATURE_LABELS = [
-  "builderCredits.featureBackupTranscription",
-  "builderCredits.featureCleanup",
-  "builderCredits.featureSummaries",
-  "builderCredits.featureTitles",
-] as const;
-
-const S3_STORAGE_FIELDS = [
-  {
-    key: "S3_ENDPOINT",
-    labelKey: "settings.s3EndpointLabel",
-    placeholder: "https://s3.us-east-1.amazonaws.com",
-    required: true,
-  },
-  {
-    key: "S3_BUCKET",
-    labelKey: "settings.s3BucketLabel",
-    placeholder: "my-clips-bucket",
-    required: true,
-  },
-  {
-    key: "S3_ACCESS_KEY_ID",
-    labelKey: "settings.s3AccessKeyLabel",
-    placeholder: "AKIA...",
-    required: true,
-  },
-  {
-    key: "S3_SECRET_ACCESS_KEY",
-    labelKey: "settings.s3SecretAccessKeyLabel",
-    placeholder: "••••••••",
-    required: true,
-    secret: true,
-  },
-  {
-    key: "S3_REGION",
-    labelKey: "settings.s3RegionLabel",
-    placeholder: "us-east-1",
-  },
-  {
-    key: "S3_PUBLIC_BASE_URL",
-    labelKey: "settings.s3PublicBaseUrlLabel",
-    placeholder: "https://cdn.example.com",
-  },
-] as const;
-
-const AI_PROVIDER_FIELDS = [
-  {
-    key: "ANTHROPIC_API_KEY",
-    label: "Anthropic",
-    placeholder: "sk-ant-...",
-    storage: "agent-engine",
-    engine: "anthropic",
-  },
-  {
-    key: "OPENAI_API_KEY",
-    label: "OpenAI",
-    placeholder: "sk-...",
-    storage: "agent-engine",
-    engine: "ai-sdk:openai",
-  },
-  {
-    key: "GEMINI_API_KEY",
-    label: "Gemini",
-    placeholder: "AI...",
-    storage: "secret",
-  },
-  {
-    key: "GROQ_API_KEY",
-    label: "Groq",
-    placeholder: "gsk_...",
-    storage: "secret",
-    engine: "ai-sdk:groq",
-  },
-  {
-    key: "OPENROUTER_API_KEY",
-    label: "OpenRouter",
-    placeholder: "sk-or-...",
-    storage: "agent-engine",
-    engine: "ai-sdk:openrouter",
-  },
-] as const;
-
 interface ClipsUserSettings {
   defaultPlaybackSpeed?: string;
   emailNotifications?: boolean;
   transcriptCleanupEnabled?: boolean;
   includeFullVideoInAi?: boolean;
   defaultRecordingVisibility?: ClipsDefaultVisibility;
-}
-
-interface SlackInstallation {
-  id: string;
-  teamId: string;
-  teamName: string | null;
-  enterpriseName: string | null;
-  apiAppId: string | null;
-  ownerEmail: string;
-  orgId: string | null;
-  status: string;
-  updatedAt: string;
-}
-
-interface SlackInstallationsResponse {
-  oauthConfigured: boolean;
-  signingConfigured: boolean;
-  scopes: string[];
-  installations: SlackInstallation[];
 }
 
 async function loadSettings(): Promise<ClipsUserSettings> {
@@ -217,182 +74,6 @@ async function saveSettings(value: ClipsUserSettings): Promise<void> {
   }
 }
 
-function absoluteAppUrl(url: string): string {
-  const withBase = url.startsWith("/api/") ? appApiPath(url) : url;
-  return new URL(withBase, window.location.origin).toString();
-}
-
-async function waitForPopupClose(popup: Window): Promise<void> {
-  await new Promise<void>((resolve) => {
-    let settled = false;
-    const finish = () => {
-      if (settled) return;
-      settled = true;
-      window.clearInterval(interval);
-      window.clearTimeout(timeout);
-      window.removeEventListener("focus", onFocus);
-      resolve();
-    };
-    const interval = window.setInterval(() => {
-      if (popup.closed) finish();
-    }, 500);
-    const onFocus = () => {
-      if (popup.closed) finish();
-    };
-    window.addEventListener("focus", onFocus);
-    const timeout = window.setTimeout(finish, 5 * 60 * 1000);
-  });
-}
-
-async function startSlackOAuth(): Promise<void> {
-  const res = await fetch(
-    agentNativePath("/_agent-native/actions/connect-slack?returnUrl=/settings"),
-  );
-  const text = await res.text();
-  let data: {
-    url?: string;
-    error?: string;
-    result?: { url?: string };
-  } = {};
-  try {
-    data = JSON.parse(text);
-  } catch {
-    // Keep the fallback below.
-  }
-  if (!res.ok) throw new Error(data.error || `Failed (${res.status})`);
-  const url = data.result?.url ?? data.url;
-  if (!url) throw new Error("No Slack OAuth URL returned");
-  const popup = window.open(
-    absoluteAppUrl(url),
-    "clips-slack-oauth",
-    "width=600,height=760",
-  );
-  if (!popup) {
-    throw new Error(
-      "Popup blocked — please allow popups for this site and try again.",
-    );
-  }
-  await waitForPopupClose(popup);
-}
-
-async function requestDisconnectSlack(id: string): Promise<void> {
-  const res = await fetch(
-    agentNativePath("/_agent-native/actions/disconnect-slack"),
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ id }),
-    },
-  );
-  if (!res.ok) {
-    const body = (await res.json().catch(() => null)) as {
-      error?: string;
-    } | null;
-    throw new Error(body?.error ?? `Disconnect failed (${res.status})`);
-  }
-}
-
-async function saveS3StorageSettings(
-  values: Record<string, string>,
-): Promise<void> {
-  const vars = S3_STORAGE_FIELDS.map((field) => ({
-    key: field.key,
-    value: (values[field.key] ?? "").trim(),
-  })).filter((entry) => entry.value.length > 0);
-
-  if (vars.length === 0) {
-    throw new Error("Enter at least one storage value.");
-  }
-
-  for (const { key, value } of vars) {
-    const res = await fetch(agentNativePath("/_agent-native/secrets/adhoc"), {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        name: key,
-        value,
-        scope: "workspace",
-        description: "Clips S3-compatible storage", // i18n-ignore -- secret metadata description, not visible UI
-      }),
-    });
-
-    if (!res.ok) {
-      const body = (await res.json().catch(() => null)) as {
-        error?: string;
-      } | null;
-      throw new Error(body?.error ?? `Save failed (${res.status})`);
-    }
-  }
-}
-
-async function saveAgentEngineApiKey(
-  key: string,
-  value: string,
-): Promise<void> {
-  const res = await fetch(
-    agentNativePath("/_agent-native/agent-engine/api-key"),
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ key, value, scope: "user" }),
-    },
-  );
-
-  if (!res.ok) {
-    const body = (await res.json().catch(() => null)) as {
-      error?: string;
-    } | null;
-    throw new Error(body?.error ?? `Save failed (${res.status})`);
-  }
-}
-
-async function applyAgentEngine(engine: string): Promise<void> {
-  const res = await fetch(
-    agentNativePath("/_agent-native/actions/manage-agent-engine"),
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ action: "set", engine }),
-    },
-  );
-
-  const body = (await res.json().catch(() => null)) as {
-    error?: string;
-    result?: unknown;
-  } | null;
-  if (!res.ok) {
-    throw new Error(body?.error ?? `Engine switch failed (${res.status})`);
-  }
-  const result = body?.result ?? body;
-  const text =
-    typeof result === "string"
-      ? result.trim()
-      : result && typeof result === "object"
-        ? JSON.stringify(result)
-        : "";
-  if (/^(Error|Warning):/i.test(text)) {
-    throw new Error(text);
-  }
-}
-
-async function saveRegisteredSecret(key: string, value: string): Promise<void> {
-  const res = await fetch(
-    agentNativePath(`/_agent-native/secrets/${encodeURIComponent(key)}`),
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ value }),
-    },
-  );
-
-  if (!res.ok) {
-    const body = (await res.json().catch(() => null)) as {
-      error?: string;
-    } | null;
-    throw new Error(body?.error ?? `Save failed (${res.status})`);
-  }
-}
-
 export default function SettingsIndexRoute() {
   const t = useT();
   const agentSettingsTabs = useAgentSettingsTabs();
@@ -418,6 +99,7 @@ export default function SettingsIndexRoute() {
   const { data: org } = useOrg();
   const switchOrg = useSwitchOrg();
   const storageStatus = useVideoStorageStatus();
+  const secrets = useSecretStatus();
   const builderStatus = useBuilderStatus();
   const builderConnect = useBuilderConnectFlow({
     popupUrl:
@@ -429,85 +111,14 @@ export default function SettingsIndexRoute() {
       toast.success(t("settings.builderConnectedToast"));
     },
   });
-  const slackStatus = useActionQuery<SlackInstallationsResponse>(
-    "list-slack-installations",
-    undefined,
-    { retry: false },
-  );
-  const builderCreditStatus = useActionQuery<BuilderCreditsStatus>(
-    "get-builder-credit-status",
-    undefined,
-    { retry: false },
-  );
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [savingStorage, setSavingStorage] = useState(false);
-  const [connectingSlack, setConnectingSlack] = useState(false);
-  const [disconnectingSlack, setDisconnectingSlack] = useState(false);
-  const [disconnectSlackTarget, setDisconnectSlackTarget] =
-    useState<SlackInstallation | null>(null);
   const [defaultSpeed, setDefaultSpeed] = useState("1.2");
   const [emailNotifications, setEmailNotifications] = useState(true);
   const [defaultVisibility, setDefaultVisibility] =
     useState<ClipsDefaultVisibility>("private");
   const [transcriptCleanupEnabled, setTranscriptCleanupEnabled] =
     useState(true);
-  const [s3Values, setS3Values] = useState<Record<string, string>>({});
-  const [s3Errors, setS3Errors] = useState<Record<string, string>>({});
-  const [clearingS3, setClearingS3] = useState(false);
-  const [s3Expanded, setS3Expanded] = useState(false);
-  const [apiKeysExpanded, setApiKeysExpanded] = useState(false);
-  const [apiKeyValues, setApiKeyValues] = useState<Record<string, string>>({});
-  const [apiKeyStatus, setApiKeyStatus] = useState<Record<string, boolean>>({});
-  const [secretLast4, setSecretLast4] = useState<Record<string, string>>({});
-  const [apiKeyStatusLoading, setApiKeyStatusLoading] = useState(true);
-  const [savingApiKey, setSavingApiKey] = useState<string | null>(null);
-
-  const refreshApiKeyStatus = useCallback(async () => {
-    setApiKeyStatusLoading(true);
-    try {
-      const [envRes, secretsRes, adhocRes] = await Promise.all([
-        fetch(agentNativePath("/_agent-native/env-status")),
-        fetch(agentNativePath("/_agent-native/secrets")),
-        fetch(agentNativePath("/_agent-native/secrets/adhoc")),
-      ]);
-      const envData = envRes.ok
-        ? ((await envRes.json()) as Array<{
-            key: string;
-            configured?: boolean;
-          }>)
-        : [];
-      const secretsData = secretsRes.ok
-        ? ((await secretsRes.json()) as Array<{
-            key: string;
-            status?: string;
-          }>)
-        : [];
-      const adhocData = adhocRes.ok
-        ? ((await adhocRes.json()) as Array<{
-            name: string;
-            last4?: string;
-          }>)
-        : [];
-      const next = Object.fromEntries(
-        envData.map((entry) => [entry.key, Boolean(entry.configured)]),
-      );
-      for (const entry of secretsData) {
-        next[entry.key] = entry.status === "set";
-      }
-      const nextLast4: Record<string, string> = {};
-      for (const entry of adhocData) {
-        next[entry.name] = true;
-        if (entry.last4) nextLast4[entry.name] = entry.last4;
-      }
-      setSecretLast4(nextLast4);
-      setApiKeyStatus(next);
-    } catch {
-      setApiKeyStatus({});
-    } finally {
-      setApiKeyStatusLoading(false);
-    }
-  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -524,11 +135,26 @@ export default function SettingsIndexRoute() {
     };
   }, []);
 
-  useEffect(() => {
-    void refreshApiKeyStatus();
-  }, [refreshApiKeyStatus]);
-
   const orgs = org?.orgs ?? [];
+
+  const builder = useMemo(
+    () => ({
+      connected: Boolean(
+        builderConnect.configured ||
+        builderStatus.status?.configured ||
+        storageStatus.data?.builderConfigured ||
+        storageStatus.data?.activeProvider?.id === "builder",
+      ),
+      loading:
+        storageStatus.isLoading ||
+        builderStatus.loading ||
+        !builderConnect.hasFetchedStatus,
+      connecting: builderConnect.connecting,
+      orgName: builderConnect.orgName ?? builderStatus.status?.orgName ?? null,
+      start: builderConnect.start,
+    }),
+    [builderConnect, builderStatus, storageStatus],
+  );
 
   async function handleUploadWorkspaceChange(organizationId: string) {
     if (!organizationId || organizationId === org?.orgId) return;
@@ -563,229 +189,10 @@ export default function SettingsIndexRoute() {
     }
   }
 
-  function validateS3Values(
-    values: Record<string, string>,
-  ): Record<string, string> {
-    const errors: Record<string, string> = {};
-    const urlFields = ["S3_ENDPOINT", "S3_PUBLIC_BASE_URL"];
-    for (const key of urlFields) {
-      const val = (values[key] ?? "").trim();
-      if (!val) continue;
-      try {
-        const parsed = new URL(val);
-        if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
-          errors[key] = t("settings.s3UrlInvalid");
-        }
-      } catch {
-        errors[key] = t("settings.s3UrlInvalid");
-      }
-    }
-    const bucket = (values["S3_BUCKET"] ?? "").trim();
-    if (bucket && !/^[a-z0-9][a-z0-9\-.]{1,61}[a-z0-9]$/.test(bucket)) {
-      errors["S3_BUCKET"] = t("settings.s3BucketInvalid");
-    }
-    return errors;
-  }
-
-  async function handleSaveS3Storage() {
-    const validationErrors = validateS3Values(s3Values);
-    if (Object.keys(validationErrors).length > 0) {
-      setS3Errors(validationErrors);
-      return;
-    }
-    const s3Configured = storageStatus.data?.activeProvider?.id === "s3";
-    const missing = s3Configured
-      ? []
-      : S3_STORAGE_FIELDS.filter(
-          (field) =>
-            "required" in field &&
-            field.required &&
-            !(s3Values[field.key] ?? "").trim(),
-        );
-    if (missing.length > 0) {
-      toast.error(t("settings.storageRequired"));
-      return;
-    }
-
-    setSavingStorage(true);
-    try {
-      await saveS3StorageSettings(s3Values);
-      setS3Values((current) => ({
-        ...current,
-        S3_SECRET_ACCESS_KEY: "",
-      }));
-      await Promise.all([storageStatus.refetch(), refreshApiKeyStatus()]);
-      toast.success(t("settings.storageSaved"));
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : t("settings.saveFailed"),
-      );
-    } finally {
-      setSavingStorage(false);
-    }
-  }
-
-  async function handleClearAllS3() {
-    setClearingS3(true);
-    try {
-      const results = await Promise.all(
-        S3_STORAGE_FIELDS.filter((field) => apiKeyStatus[field.key]).map(
-          async (field) => {
-            const res = await fetch(
-              agentNativePath(
-                `/_agent-native/secrets/adhoc/${encodeURIComponent(field.key)}`,
-              ),
-              { method: "DELETE" },
-            );
-            if (!res.ok) {
-              const body = (await res.json().catch(() => null)) as {
-                error?: string;
-              } | null;
-              throw new Error(
-                body?.error ?? `Failed to clear ${field.key} (${res.status})`,
-              );
-            }
-            const body = (await res.json().catch(() => null)) as {
-              removed?: boolean;
-            } | null;
-            return { key: field.key, removed: body?.removed !== false };
-          },
-        ),
-      );
-      const failed = results.filter((r) => !r.removed).map((r) => r.key);
-      if (failed.length > 0) {
-        throw new Error(
-          `Could not remove: ${failed.join(", ")}. You may not have permission.`,
-        );
-      }
-      setS3Values({});
-      await Promise.all([refreshApiKeyStatus(), storageStatus.refetch()]);
-      toast.success(t("settings.keyCleared"));
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : t("settings.saveFailed"),
-      );
-    } finally {
-      setClearingS3(false);
-    }
-  }
-
-  async function handleSaveApiKey(key: string) {
-    const value = (apiKeyValues[key] ?? "").trim();
-    if (!value) {
-      toast.error(t("settings.pasteProviderKey"));
-      return;
-    }
-
-    setSavingApiKey(key);
-    try {
-      const field = AI_PROVIDER_FIELDS.find((item) => item.key === key);
-      if (field?.storage === "secret") {
-        await saveRegisteredSecret(key, value);
-      } else {
-        await saveAgentEngineApiKey(key, value);
-      }
-      if (field && "engine" in field) {
-        await applyAgentEngine(field.engine);
-      }
-      setApiKeyValues((current) => ({ ...current, [key]: "" }));
-      setApiKeyStatus((current) => ({ ...current, [key]: true }));
-      window.dispatchEvent(new CustomEvent("agent-engine:configured-changed"));
-      await refreshApiKeyStatus();
-      toast.success(t("settings.apiKeySaved"));
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : t("settings.apiKeyFailed"),
-      );
-    } finally {
-      setSavingApiKey(null);
-    }
-  }
-
-  function openAiProviderSetup() {
-    setApiKeysExpanded(true);
-    window.requestAnimationFrame(() => {
-      const section = document.getElementById("ai-provider-keys");
-      section?.scrollIntoView({ behavior: "smooth", block: "start" });
-      const firstEmptyField =
-        AI_PROVIDER_FIELDS.find((field) => !apiKeyStatus[field.key]) ??
-        AI_PROVIDER_FIELDS[0];
-      window.setTimeout(() => {
-        document.getElementById(firstEmptyField.key)?.focus();
-      }, 150);
-    });
-  }
-
-  async function handleConnectSlack() {
-    const beforeCount = slackInstallations.length;
-    setConnectingSlack(true);
-    try {
-      await startSlackOAuth();
-      const refreshed = await slackStatus.refetch();
-      const afterCount = refreshed.data?.installations?.length ?? beforeCount;
-      if (afterCount > beforeCount) {
-        toast.success(t("settings.slackConnectedToast"));
-      } else {
-        toast.message(t("settings.slackCheckedToast"));
-      }
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : t("settings.slackConnectFailed"),
-      );
-    } finally {
-      setConnectingSlack(false);
-    }
-  }
-
-  async function handleDisconnectSlack() {
-    const target = disconnectSlackTarget;
-    if (!target) return;
-    setDisconnectingSlack(true);
-    try {
-      await requestDisconnectSlack(target.id);
-      setDisconnectSlackTarget(null);
-      await slackStatus.refetch();
-      toast.success(t("settings.slackDisconnectedToast"));
-    } catch (err) {
-      toast.error(
-        err instanceof Error
-          ? err.message
-          : t("settings.slackDisconnectFailed"),
-      );
-    } finally {
-      setDisconnectingSlack(false);
-    }
-  }
-
-  const storageConfigured = !!storageStatus.data?.configured;
-  const activeProviderName = storageStatus.data?.activeProvider?.name ?? null;
-  const activeProviderId = storageStatus.data?.activeProvider?.id ?? null;
-  const builderConnected = Boolean(
-    builderConnect.configured ||
-    builderStatus.status?.configured ||
-    storageStatus.data?.builderConfigured ||
-    activeProviderId === "builder",
-  );
-  const builderOrgName =
-    builderConnect.orgName ?? builderStatus.status?.orgName ?? null;
-  const builderStatusLoading =
-    storageStatus.isLoading ||
-    builderStatus.loading ||
-    !builderConnect.hasFetchedStatus;
-  const s3Configured = activeProviderId === "s3";
-  const s3Collapsed = !s3Expanded;
-  const configuredApiKeyCount = AI_PROVIDER_FIELDS.filter(
-    (field) => apiKeyStatus[field.key],
-  ).length;
-  const slackInstallations = slackStatus.data?.installations ?? [];
-  const slackOauthConfigured = slackStatus.data?.oauthConfigured ?? false;
-  const slackSigningConfigured = slackStatus.data?.signingConfigured ?? false;
-  const slackConnected = slackInstallations.length > 0;
   const localizedChangelog = t("settings.changelogMarkdown");
-  const builderCreditsPaused = builderCreditStatus.data?.exhausted === true;
-  const builderCreditsUpgradeUrl =
-    builderCreditStatus.data?.upgradeUrl ?? BUILDER_CREDITS_UPGRADE_URL;
 
+  // Hashes match the row ids below, so a search hit still scrolls to the
+  // individual setting now that the one-control cards are rows in a group.
   const generalSearchEntries = useMemo<SettingsSearchEntry[]>(
     () => [
       {
@@ -867,646 +274,25 @@ export default function SettingsIndexRoute() {
                 {t("settings.intro")}
               </p>
 
-              <Card id="language" className="scroll-mt-16">
-                <CardHeader>
-                  <CardTitle className="text-base">
-                    {t("settings.languageTitle")}
-                  </CardTitle>
-                  <CardDescription>
-                    {t("settings.languageDescription")}
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="max-w-xs space-y-1.5">
-                  <Label>{t("settings.languageLabel")}</Label>
-                  <LanguagePicker label={t("settings.languageLabel")} />
-                </CardContent>
-              </Card>
-
-              {orgs.length > 0 ? (
-                <Card id="upload-workspace" className="scroll-mt-16">
-                  <CardHeader>
-                    <CardTitle className="flex items-center gap-2 text-base">
-                      <IconUsersGroup className="size-4 text-primary" />
-                      {t("settings.uploadWorkspaceTitle")}
-                    </CardTitle>
-                    <CardDescription>
-                      {t("settings.uploadWorkspaceDescription")}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent className="max-w-md space-y-1.5">
-                    <Label htmlFor="upload-workspace-select">
-                      {t("settings.uploadWorkspaceLabel")}
-                    </Label>
-                    <Select
-                      value={org?.orgId ?? undefined}
-                      onValueChange={handleUploadWorkspaceChange}
-                      disabled={switchOrg.isPending || orgs.length < 2}
-                    >
-                      <SelectTrigger id="upload-workspace-select">
-                        <SelectValue
-                          placeholder={t("settings.uploadWorkspacePlaceholder")}
-                        />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {orgs.map((workspace) => (
-                          <SelectItem
-                            key={workspace.orgId}
-                            value={workspace.orgId}
-                          >
-                            {workspace.orgName}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    <p className="text-xs text-muted-foreground">
-                      {switchOrg.isPending
-                        ? t("settings.uploadWorkspaceSaving")
-                        : t("settings.uploadWorkspaceHint")}
-                    </p>
-                  </CardContent>
-                </Card>
-              ) : null}
-
-              <Card id="video-storage" className="scroll-mt-16">
-                <CardHeader>
-                  <CardTitle className="text-base flex items-center gap-2">
-                    <IconCloud className="size-4 text-primary" />
-                    {t("settings.videoStorage")}
-                  </CardTitle>
-                  <CardDescription>
-                    {t("settings.videoStorageDescription")}
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div
-                    className={cn(
-                      "flex flex-col gap-3 rounded-md border px-3 py-3 sm:flex-row sm:items-center sm:justify-between",
-                      builderConnected
-                        ? "border-primary/35 bg-primary/5"
-                        : "border-border bg-accent/30",
-                    )}
-                  >
-                    <div className="min-w-0">
-                      <div className="flex items-center gap-2 text-sm font-medium">
-                        {builderConnected ? (
-                          <IconCheck className="h-4 w-4 text-primary" />
-                        ) : (
-                          <IconKey className="h-4 w-4 text-muted-foreground" />
-                        )}
-                        {builderStatusLoading
-                          ? t("settings.checkingBuilder")
-                          : builderConnected
-                            ? t("settings.builderConnected")
-                            : t("settings.connectBuilder")}
-                      </div>
-                      <p className="mt-0.5 text-xs text-muted-foreground">
-                        {builderConnected
-                          ? builderOrgName
-                            ? t("settings.builderConnectedFor", {
-                                orgName: builderOrgName,
-                              })
-                            : t("settings.builderConnectedGeneric")
-                          : t("settings.builderIncludes")}
-                      </p>
+              <SettingsGroup
+                id="preferences"
+                title={t("settings.preferencesTitle")}
+              >
+                <SettingsRow
+                  id="language"
+                  label={t("settings.languageLabel")}
+                  description={t("settings.languageDescription")}
+                  control={
+                    <div className="w-56">
+                      <LanguagePicker label={t("settings.languageLabel")} />
                     </div>
-                    {builderConnected ? (
-                      <Badge variant="secondary" className="shrink-0">
-                        {t("common.connected")}
-                      </Badge>
-                    ) : (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        className="shrink-0"
-                        onClick={() =>
-                          builderConnect.start({
-                            trackingSource: "clips_settings_video_storage",
-                            trackingFlow: "video_storage",
-                          })
-                        }
-                        disabled={
-                          builderConnect.connecting || builderStatusLoading
-                        }
-                      >
-                        {builderConnect.connecting ? (
-                          <IconLoader2 className="h-4 w-4 animate-spin" />
-                        ) : (
-                          <IconExternalLink className="h-4 w-4" />
-                        )}
-                        {t("settings.connectBuilder")}
-                      </Button>
-                    )}
-                  </div>
-
-                  <Collapsible
-                    open={!s3Collapsed}
-                    onOpenChange={(open) => setS3Expanded(open)}
-                  >
-                    <div className="rounded-md border border-border">
-                      <div className="flex flex-col gap-3 px-3 py-3 sm:flex-row sm:items-center sm:justify-between">
-                        <div className="min-w-0">
-                          <div className="flex flex-wrap items-center gap-2 text-sm font-medium">
-                            <IconServer className="h-4 w-4 text-muted-foreground" />
-                            {t("settings.s3Title")}
-                            <Badge variant="outline" className="text-[10px]">
-                              {t("settings.secondary")}
-                            </Badge>
-                            {s3Configured ? (
-                              <Badge
-                                variant="secondary"
-                                className="text-[10px]"
-                              >
-                                {t("settings.active")}
-                              </Badge>
-                            ) : null}
-                          </div>
-                          <p className="mt-0.5 text-xs text-muted-foreground">
-                            {builderConnected
-                              ? t("settings.s3BuilderConnectedDescription")
-                              : storageConfigured && activeProviderName
-                                ? t("settings.s3CurrentProvider", {
-                                    providerName: activeProviderName,
-                                  })
-                                : t("settings.s3OwnBucketDescription")}
-                          </p>
-                        </div>
-                        <CollapsibleTrigger asChild>
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            className="shrink-0"
-                          >
-                            {s3Collapsed
-                              ? t("settings.configureS3")
-                              : t("settings.hideS3")}
-                            <IconChevronDown
-                              className={cn(
-                                "h-4 w-4 transition-transform",
-                                !s3Collapsed && "rotate-180",
-                              )}
-                            />
-                          </Button>
-                        </CollapsibleTrigger>
-                      </div>
-
-                      <CollapsibleContent>
-                        <div className="space-y-4 border-t border-border px-3 py-4">
-                          <div className="grid gap-4 sm:grid-cols-2">
-                            {S3_STORAGE_FIELDS.map((field) => {
-                              const configured = Boolean(
-                                apiKeyStatus[field.key],
-                              );
-                              const last4 = secretLast4[field.key];
-                              return (
-                                <div key={field.key} className="space-y-1.5">
-                                  <div className="flex items-center justify-between gap-2">
-                                    <Label htmlFor={field.key}>
-                                      {t(field.labelKey)}
-                                    </Label>
-                                    {configured ? (
-                                      <span className="flex items-center gap-1 text-[10px] font-medium text-primary">
-                                        <IconCheck className="h-3 w-3" />
-                                        {last4
-                                          ? `••••${last4}`
-                                          : t("settings.keySet")}
-                                      </span>
-                                    ) : null}
-                                  </div>
-                                  <Input
-                                    id={field.key}
-                                    type={
-                                      "secret" in field && field.secret
-                                        ? "password"
-                                        : "text"
-                                    }
-                                    value={s3Values[field.key] ?? ""}
-                                    onChange={(event) => {
-                                      setS3Values((current) => ({
-                                        ...current,
-                                        [field.key]: event.target.value,
-                                      }));
-                                      if (s3Errors[field.key]) {
-                                        setS3Errors((current) => {
-                                          const next = { ...current };
-                                          delete next[field.key];
-                                          return next;
-                                        });
-                                      }
-                                    }}
-                                    placeholder={
-                                      configured
-                                        ? t("settings.replaceKey")
-                                        : field.placeholder
-                                    }
-                                    autoComplete="off"
-                                    disabled={savingStorage}
-                                    className={
-                                      s3Errors[field.key]
-                                        ? "border-destructive"
-                                        : undefined
-                                    }
-                                  />
-                                  {s3Errors[field.key] ? (
-                                    <p className="text-[11px] text-destructive">
-                                      {s3Errors[field.key]}
-                                    </p>
-                                  ) : null}
-                                </div>
-                              );
-                            })}
-                          </div>
-
-                          <div className="flex items-center justify-end gap-2">
-                            {S3_STORAGE_FIELDS.some(
-                              (field) => apiKeyStatus[field.key],
-                            ) ? (
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="sm"
-                                onClick={handleClearAllS3}
-                                disabled={clearingS3 || savingStorage}
-                                className="text-muted-foreground hover:text-destructive"
-                              >
-                                {clearingS3 ? (
-                                  <IconLoader2 className="h-4 w-4 animate-spin" />
-                                ) : (
-                                  <IconTrash className="h-4 w-4" />
-                                )}
-                                {t("settings.clearAllS3")}
-                              </Button>
-                            ) : null}
-                            <Button
-                              onClick={handleSaveS3Storage}
-                              disabled={
-                                savingStorage || storageStatus.isLoading
-                              }
-                            >
-                              {savingStorage && (
-                                <IconLoader2 className="h-4 w-4 animate-spin" />
-                              )}
-                              {t("settings.saveStorage")}
-                            </Button>
-                          </div>
-                        </div>
-                      </CollapsibleContent>
-                    </div>
-                  </Collapsible>
-                </CardContent>
-              </Card>
-
-              <Card id="slack" className="scroll-mt-16">
-                <CardHeader>
-                  <CardTitle className="text-base flex items-center gap-2">
-                    <IconBrandSlack className="size-4 text-primary" />
-                    {t("settings.slackTitle")}
-                  </CardTitle>
-                  <CardDescription>
-                    {t("settings.slackDescription")}
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div className="flex flex-col gap-3 rounded-md border border-border bg-accent/30 px-3 py-3 sm:flex-row sm:items-center sm:justify-between">
-                    <div className="min-w-0">
-                      <div className="flex items-center gap-2 text-sm font-medium">
-                        <IconBrandSlack className="h-4 w-4 text-muted-foreground" />
-                        {slackStatus.isLoading
-                          ? t("settings.checkingSlack")
-                          : slackConnected
-                            ? t("settings.slackConnected", {
-                                count: slackInstallations.length,
-                              })
-                            : slackOauthConfigured
-                              ? t("common.notConnected")
-                              : t("settings.slackOauthNeeded")}
-                      </div>
-                      <p className="mt-0.5 text-xs text-muted-foreground">
-                        {t("settings.slackPreviewDescription")}
-                      </p>
-                    </div>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="shrink-0"
-                      onClick={handleConnectSlack}
-                      disabled={
-                        connectingSlack ||
-                        slackStatus.isLoading ||
-                        !slackOauthConfigured
-                      }
-                    >
-                      {connectingSlack ? (
-                        <IconLoader2 className="h-4 w-4 animate-spin" />
-                      ) : (
-                        <IconExternalLink className="h-4 w-4" />
-                      )}
-                      {t("settings.connectSlack")}
-                    </Button>
-                  </div>
-
-                  {!slackOauthConfigured ? (
-                    <div className="rounded-md border border-border p-3 text-xs text-muted-foreground">
-                      {t("settings.slackClientMissing")}
-                    </div>
-                  ) : null}
-
-                  {!slackSigningConfigured ? (
-                    <div className="rounded-md border border-border p-3 text-xs text-muted-foreground">
-                      {t("settings.slackSigningMissing")}
-                    </div>
-                  ) : null}
-
-                  {slackInstallations.length > 0 ? (
-                    <div className="space-y-2">
-                      {slackInstallations.map((installation) => (
-                        <div
-                          key={installation.id}
-                          className="flex items-center justify-between gap-3 rounded-md border border-border px-3 py-2"
-                        >
-                          <div className="min-w-0">
-                            <div className="truncate text-sm font-medium">
-                              {installation.teamName || installation.teamId}
-                            </div>
-                            <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
-                              <span>{installation.status}</span>
-                              {installation.enterpriseName ? (
-                                <span>{installation.enterpriseName}</span>
-                              ) : null}
-                              <span>
-                                {t("settings.connectedBy", {
-                                  email: installation.ownerEmail,
-                                })}
-                              </span>
-                            </div>
-                          </div>
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="icon"
-                            className="shrink-0"
-                            aria-label={t("settings.disconnectSlackLabel", {
-                              team:
-                                installation.teamName || installation.teamId,
-                            })}
-                            onClick={() =>
-                              setDisconnectSlackTarget(installation)
-                            }
-                          >
-                            <IconTrash className="h-4 w-4" />
-                          </Button>
-                        </div>
-                      ))}
-                    </div>
-                  ) : null}
-                </CardContent>
-              </Card>
-
-              <Card id="ai-providers" className="scroll-mt-16">
-                <CardHeader>
-                  <CardTitle className="text-base flex items-center gap-2">
-                    <IconBrain className="size-4 text-primary" />
-                    {t("settings.apiSetup")}
-                  </CardTitle>
-                  <CardDescription>
-                    {t("settings.apiSetupDescription")}
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div
-                    className={cn(
-                      "flex flex-col gap-3 rounded-md border px-3 py-3 sm:flex-row sm:items-center sm:justify-between",
-                      builderConnected
-                        ? "border-border bg-muted/20"
-                        : "border-border bg-accent/30",
-                    )}
-                  >
-                    <div className="min-w-0">
-                      <div className="flex items-center gap-2 text-sm font-medium">
-                        {builderConnected ? (
-                          <IconCheck className="h-4 w-4 text-primary" />
-                        ) : (
-                          <IconKey className="h-4 w-4 text-muted-foreground" />
-                        )}
-                        {builderStatusLoading
-                          ? t("settings.checkingBuilder")
-                          : builderConnected
-                            ? t("settings.builderAiAvailable")
-                            : t("settings.builderEasySetup")}
-                      </div>
-                      <p className="mt-0.5 text-xs text-muted-foreground">
-                        {builderConnected
-                          ? t("settings.apiSetupDescription")
-                          : t("settings.builderAiDescription")}
-                      </p>
-                    </div>
-                    {!builderConnected ? (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        className="shrink-0"
-                        onClick={() =>
-                          builderConnect.start({
-                            trackingSource: "clips_settings_ai_setup",
-                            trackingFlow: "connect_llm",
-                          })
-                        }
-                        disabled={
-                          builderConnect.connecting || builderStatusLoading
-                        }
-                      >
-                        {builderConnect.connecting ? (
-                          <IconLoader2 className="h-4 w-4 animate-spin" />
-                        ) : (
-                          <IconExternalLink className="h-4 w-4" />
-                        )}
-                        {t("settings.connectBuilder")}
-                      </Button>
-                    ) : null}
-                  </div>
-
-                  {builderCreditsPaused ? (
-                    <div className="rounded-md border border-amber-300/70 bg-amber-50/80 p-3 text-amber-950 shadow-sm dark:border-amber-400/30 dark:bg-amber-950/25 dark:text-amber-100">
-                      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                        <div className="min-w-0 flex-1">
-                          <div className="flex items-center gap-2 text-sm font-semibold">
-                            <span className="rounded-md bg-amber-100 p-1 dark:bg-amber-400/15">
-                              <IconBolt className="h-4 w-4 text-amber-700 dark:text-amber-200" />
-                            </span>
-                            {t("builderCredits.pausedTitle")}
-                          </div>
-                          <p className="mt-1.5 text-xs leading-relaxed text-amber-900/80 dark:text-amber-100/80">
-                            {t("builderCredits.settingsDescription")}
-                          </p>
-                          <div className="mt-2 flex flex-wrap gap-1.5">
-                            {BUILDER_CREDITS_FEATURE_LABELS.map((key) => (
-                              <span
-                                key={key}
-                                className="rounded-full border border-amber-300/70 bg-white/70 px-2 py-0.5 text-[11px] font-medium text-amber-900 dark:border-amber-400/30 dark:bg-amber-950/30 dark:text-amber-100"
-                              >
-                                {t(key)}
-                              </span>
-                            ))}
-                          </div>
-                        </div>
-                        <div className="flex shrink-0 flex-wrap gap-2">
-                          <Button asChild size="sm" className="h-8">
-                            <a
-                              href={builderCreditsUpgradeUrl}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              <IconExternalLink className="h-4 w-4" />
-                              {t("builderCredits.upgrade")}
-                            </a>
-                          </Button>
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            className="h-8 border-amber-300/80 bg-white/70 text-amber-950 hover:bg-amber-100 dark:border-amber-400/40 dark:bg-amber-950/30 dark:text-amber-100 dark:hover:bg-amber-900/40"
-                            onClick={openAiProviderSetup}
-                          >
-                            {t("builderCredits.openAiSetup")}
-                          </Button>
-                        </div>
-                      </div>
-                    </div>
-                  ) : null}
-
-                  <Collapsible
-                    open={apiKeysExpanded}
-                    onOpenChange={setApiKeysExpanded}
-                  >
-                    <div className="rounded-md border border-border">
-                      <CollapsibleTrigger asChild>
-                        <button
-                          id="ai-provider-keys"
-                          type="button"
-                          className="flex w-full items-center justify-between gap-3 px-3 py-3 text-start"
-                        >
-                          <div className="min-w-0">
-                            <div className="flex items-center gap-2 text-sm font-medium">
-                              <IconKey className="h-4 w-4 text-muted-foreground" />
-                              {t("settings.providerKeyTitle")}
-                              {configuredApiKeyCount > 0 ? (
-                                <Badge
-                                  variant="secondary"
-                                  className="text-[10px]"
-                                >
-                                  {t("settings.providerKeysSet", {
-                                    count: configuredApiKeyCount,
-                                  })}
-                                </Badge>
-                              ) : null}
-                            </div>
-                            <p className="mt-0.5 text-xs text-muted-foreground">
-                              {t("settings.providerKeyDescription")}
-                            </p>
-                          </div>
-                          <IconChevronDown
-                            className={cn(
-                              "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
-                              apiKeysExpanded && "rotate-180",
-                            )}
-                          />
-                        </button>
-                      </CollapsibleTrigger>
-                      <CollapsibleContent>
-                        <div className="space-y-3 border-t border-border px-3 py-4">
-                          {apiKeyStatusLoading ? (
-                            <div className="text-xs text-muted-foreground">
-                              {t("settings.checkingProviderKeys")}
-                            </div>
-                          ) : null}
-                          <div className="grid gap-3 sm:grid-cols-2">
-                            {AI_PROVIDER_FIELDS.map((field) => {
-                              const configured = Boolean(
-                                apiKeyStatus[field.key],
-                              );
-                              const savingThisKey = savingApiKey === field.key;
-                              return (
-                                <div key={field.key} className="space-y-1.5">
-                                  <div className="flex items-center justify-between gap-2">
-                                    <Label htmlFor={field.key}>
-                                      {field.label}
-                                    </Label>
-                                    {configured ? (
-                                      <span className="flex items-center gap-1 text-[10px] font-medium text-primary">
-                                        <IconCheck className="h-3 w-3" />
-                                        {t("settings.keySet")}
-                                      </span>
-                                    ) : null}
-                                  </div>
-                                  <div className="flex gap-2">
-                                    <Input
-                                      id={field.key}
-                                      type="password"
-                                      value={apiKeyValues[field.key] ?? ""}
-                                      onChange={(event) =>
-                                        setApiKeyValues((current) => ({
-                                          ...current,
-                                          [field.key]: event.target.value,
-                                        }))
-                                      }
-                                      onKeyDown={(event) => {
-                                        if (event.key === "Enter") {
-                                          void handleSaveApiKey(field.key);
-                                        }
-                                      }}
-                                      placeholder={
-                                        configured
-                                          ? t("settings.replaceKey")
-                                          : field.placeholder
-                                      }
-                                      autoComplete="off"
-                                      disabled={savingThisKey}
-                                    />
-                                    <Button
-                                      type="button"
-                                      variant="outline"
-                                      size="sm"
-                                      className="shrink-0"
-                                      onClick={() =>
-                                        handleSaveApiKey(field.key)
-                                      }
-                                      disabled={
-                                        savingThisKey ||
-                                        !(apiKeyValues[field.key] ?? "").trim()
-                                      }
-                                    >
-                                      {savingThisKey ? (
-                                        <IconLoader2 className="h-4 w-4 animate-spin" />
-                                      ) : (
-                                        t("common.save")
-                                      )}
-                                    </Button>
-                                  </div>
-                                </div>
-                              );
-                            })}
-                          </div>
-                        </div>
-                      </CollapsibleContent>
-                    </div>
-                  </Collapsible>
-                </CardContent>
-              </Card>
-
-              <Card id="playback" className="scroll-mt-16">
-                <CardHeader>
-                  <CardTitle className="text-base">
-                    {t("settings.playback")}
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div className="space-y-1.5">
-                    <Label htmlFor="speed">
-                      {t("settings.defaultPlaybackSpeed")}
-                    </Label>
+                  }
+                />
+                <SettingsRow
+                  id="playback"
+                  label={t("settings.defaultPlaybackSpeed")}
+                  description={t("settings.playbackDescription")}
+                  control={
                     <Select
                       value={defaultSpeed}
                       onValueChange={setDefaultSpeed}
@@ -1523,53 +309,13 @@ export default function SettingsIndexRoute() {
                         ))}
                       </SelectContent>
                     </Select>
-                    <p className="text-xs text-muted-foreground">
-                      {t("settings.playbackDescription")}
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-
-              <Card id="transcript" className="scroll-mt-16">
-                <CardHeader>
-                  <CardTitle className="text-base">
-                    {t("settings.transcript")}
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="flex items-center justify-between gap-4">
-                    <div>
-                      <Label
-                        htmlFor="transcript-cleanup"
-                        className="cursor-pointer"
-                      >
-                        {t("settings.transcriptCleanup")}
-                      </Label>
-                      <p className="text-xs text-muted-foreground mt-0.5">
-                        {t("settings.transcriptCleanupDescription")}
-                      </p>
-                    </div>
-                    <Switch
-                      id="transcript-cleanup"
-                      checked={transcriptCleanupEnabled}
-                      onCheckedChange={setTranscriptCleanupEnabled}
-                      disabled={loading}
-                    />
-                  </div>
-                </CardContent>
-              </Card>
-
-              <Card id="sharing" className="scroll-mt-16">
-                <CardHeader>
-                  <CardTitle className="text-base">
-                    {t("settings.sharing")}
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="space-y-1.5">
-                    <Label htmlFor="default-visibility">
-                      {t("settings.defaultVisibility")}
-                    </Label>
+                  }
+                />
+                <SettingsRow
+                  id="sharing"
+                  label={t("settings.defaultVisibility")}
+                  description={t("settings.defaultVisibilityDescription")}
+                  control={
                     <Select
                       value={defaultVisibility}
                       onValueChange={(value) =>
@@ -1592,38 +338,92 @@ export default function SettingsIndexRoute() {
                         </SelectItem>
                       </SelectContent>
                     </Select>
-                    <p className="text-xs text-muted-foreground">
-                      {t("settings.defaultVisibilityDescription")}
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-
-              <Card id="notifications" className="scroll-mt-16">
-                <CardHeader>
-                  <CardTitle className="text-base">
-                    {t("settings.notifications")}
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <Label htmlFor="email-notif" className="cursor-pointer">
-                        {t("settings.emailNotifications")}
-                      </Label>
-                      <p className="text-xs text-muted-foreground mt-0.5">
-                        {t("settings.emailNotificationsDescription")}
-                      </p>
-                    </div>
+                  }
+                />
+                <SettingsRow
+                  id="transcript"
+                  label={t("settings.transcriptCleanup")}
+                  description={t("settings.transcriptCleanupDescription")}
+                  control={
+                    <Switch
+                      id="transcript-cleanup"
+                      aria-label={t("settings.transcriptCleanup")}
+                      checked={transcriptCleanupEnabled}
+                      onCheckedChange={setTranscriptCleanupEnabled}
+                      disabled={loading}
+                    />
+                  }
+                />
+                <SettingsRow
+                  id="notifications"
+                  label={t("settings.emailNotifications")}
+                  description={t("settings.emailNotificationsDescription")}
+                  control={
                     <Switch
                       id="email-notif"
+                      aria-label={t("settings.emailNotifications")}
                       checked={emailNotifications}
                       onCheckedChange={setEmailNotifications}
                       disabled={loading}
                     />
-                  </div>
-                </CardContent>
-              </Card>
+                  }
+                />
+              </SettingsGroup>
+
+              {orgs.length > 0 ? (
+                <SettingsGroup
+                  title={t("settings.uploadWorkspaceTitle")}
+                  description={t("settings.uploadWorkspaceDescription")}
+                >
+                  <SettingsRow
+                    id="upload-workspace"
+                    label={t("settings.uploadWorkspaceLabel")}
+                    description={
+                      switchOrg.isPending
+                        ? t("settings.uploadWorkspaceSaving")
+                        : t("settings.uploadWorkspaceHint")
+                    }
+                    control={
+                      <Select
+                        value={org?.orgId ?? undefined}
+                        onValueChange={handleUploadWorkspaceChange}
+                        disabled={switchOrg.isPending || orgs.length < 2}
+                      >
+                        <SelectTrigger
+                          id="upload-workspace-select"
+                          className="w-64"
+                        >
+                          <SelectValue
+                            placeholder={t(
+                              "settings.uploadWorkspacePlaceholder",
+                            )}
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {orgs.map((workspace) => (
+                            <SelectItem
+                              key={workspace.orgId}
+                              value={workspace.orgId}
+                            >
+                              {workspace.orgName}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    }
+                  />
+                </SettingsGroup>
+              ) : null}
+
+              <VideoStorageSection
+                builder={builder}
+                secrets={secrets}
+                storageStatus={storageStatus}
+              />
+
+              <AiSetupSection builder={builder} secrets={secrets} />
+
+              <SlackSection />
 
               <div className="flex justify-end">
                 <Button
@@ -1649,44 +449,6 @@ export default function SettingsIndexRoute() {
           </div>
         }
       />
-      <AlertDialog
-        open={!!disconnectSlackTarget}
-        onOpenChange={(open) => {
-          if (!open && !disconnectingSlack) setDisconnectSlackTarget(null);
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {t("settings.disconnectSlackTitle")}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              {t("settings.disconnectSlackDescription", {
-                team:
-                  disconnectSlackTarget?.teamName ||
-                  disconnectSlackTarget?.teamId ||
-                  t("settings.thisWorkspace"),
-              })}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={disconnectingSlack}>
-              {t("common.cancel")}
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={(event) => {
-                event.preventDefault();
-                void handleDisconnectSlack();
-              }}
-              disabled={disconnectingSlack}
-            >
-              {disconnectingSlack
-                ? t("common.disconnecting")
-                : t("common.disconnect")}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </>
   );
 }

--- a/templates/clips/changelog/2026-07-31-email-notifications-now-go-out-when-someone-comments-on-or-r.md
+++ b/templates/clips/changelog/2026-07-31-email-notifications-now-go-out-when-someone-comments-on-or-r.md
@@ -1,0 +1,6 @@
+---
+type: added
+date: 2026-07-31
+---
+
+Email notifications now go out when someone comments on or reacts to your recording, following your Settings preference.

--- a/templates/clips/changelog/2026-07-31-you-can-now-set-a-default-visibility-for-new-recordings-in-s.md
+++ b/templates/clips/changelog/2026-07-31-you-can-now-set-a-default-visibility-for-new-recordings-in-s.md
@@ -1,0 +1,6 @@
+---
+type: added
+date: 2026-07-31
+---
+
+You can now set a default visibility for new recordings in Settings, so clips no longer default to public unless you choose that.

--- a/templates/clips/changelog/2026-08-01-email-notifications-for-comments-and-reactions-now-actually-.md
+++ b/templates/clips/changelog/2026-08-01-email-notifications-for-comments-and-reactions-now-actually-.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-01
+---
+
+Email notifications for comments and reactions now actually send, and General settings is one Preferences card instead of five

--- a/templates/clips/server/lib/activity-notifications.spec.ts
+++ b/templates/clips/server/lib/activity-notifications.spec.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   notifyActivity: vi.fn(),
   select: vi.fn(),
   sendClipsTransactionalEmail: vi.fn(),
+  filterRecipients: vi.fn(),
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -13,12 +14,37 @@ vi.mock("drizzle-orm", () => ({
 
 vi.mock("@agent-native/core/server", () => ({
   notifyActivity: (...args: unknown[]) => mocks.notifyActivity(...args),
+  runActivityNotification: async (
+    _logLabel: string,
+    resolve: () => Promise<unknown>,
+  ) => {
+    try {
+      return await resolve();
+    } catch (error) {
+      return {
+        status: "notification-error",
+        error: error instanceof Error ? error.message : String(error),
+        sent: [],
+        failed: [],
+      };
+    }
+  },
+}));
+
+vi.mock("@agent-native/core/sharing", () => ({
+  filterRecipientsByResourceAccess: (...args: unknown[]) =>
+    mocks.filterRecipients(...args),
 }));
 
 vi.mock("../db/index.js", () => ({
   getDb: () => ({ select: (...args: unknown[]) => mocks.select(...args) }),
   schema: {
-    recordings: { id: "id", title: "title", ownerEmail: "owner_email" },
+    recordings: {
+      id: "id",
+      title: "title",
+      ownerEmail: "owner_email",
+      orgId: "org_id",
+    },
     recordingComments: {
       recordingId: "recording_id",
       threadId: "thread_id",
@@ -42,6 +68,7 @@ const RECORDING = {
   id: "rec_1",
   title: "Sprint demo",
   ownerEmail: "owner@example.com",
+  orgId: null,
 };
 
 /**
@@ -85,6 +112,10 @@ describe("clips activity notifications", () => {
       failed: [],
     });
     stubDb({ recording: RECORDING });
+    // Access filtering has its own tests; these assert who is offered.
+    mocks.filterRecipients.mockImplementation(
+      async ({ emails }: { emails: string[] }) => [...emails],
+    );
   });
 
   it("notifies the recording owner against the Clips preference key", async () => {
@@ -174,5 +205,45 @@ describe("clips activity notifications", () => {
 
     expect(mocks.notifyActivity).not.toHaveBeenCalled();
     expect(result.status).toBe("recording-missing");
+  });
+
+  it("drops a participant who can no longer open the recording", async () => {
+    stubDb({
+      recording: RECORDING,
+      participants: ["revoked@example.com", "still@example.com"],
+    });
+    mocks.filterRecipients.mockResolvedValue([
+      "owner@example.com",
+      "still@example.com",
+    ]);
+
+    await notifyRecordingComment({
+      recordingId: "rec_1",
+      threadId: "thread_1",
+      authorEmail: "viewer@example.com",
+      content: "Agreed",
+      isReply: true,
+    });
+
+    const args = mocks.notifyActivity.mock.calls[0][0] as {
+      candidates: string[];
+    };
+    expect(args.candidates).toEqual(["owner@example.com", "still@example.com"]);
+  });
+
+  it("returns notification-error instead of throwing when the recording read fails", async () => {
+    mocks.select.mockImplementation(() => {
+      throw new Error("db down");
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await notifyRecordingComment({
+      recordingId: "rec_1",
+      threadId: "thread_1",
+      authorEmail: "viewer@example.com",
+      content: "Hello",
+    });
+
+    expect(result.status).toBe("notification-error");
   });
 });

--- a/templates/clips/server/lib/activity-notifications.spec.ts
+++ b/templates/clips/server/lib/activity-notifications.spec.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  notifyActivity: vi.fn(),
+  select: vi.fn(),
+  sendClipsTransactionalEmail: vi.fn(),
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: (...conditions: unknown[]) => ({ type: "and", conditions }),
+  eq: (left: unknown, right: unknown) => ({ type: "eq", left, right }),
+}));
+
+vi.mock("@agent-native/core/server", () => ({
+  notifyActivity: (...args: unknown[]) => mocks.notifyActivity(...args),
+}));
+
+vi.mock("../db/index.js", () => ({
+  getDb: () => ({ select: (...args: unknown[]) => mocks.select(...args) }),
+  schema: {
+    recordings: { id: "id", title: "title", ownerEmail: "owner_email" },
+    recordingComments: {
+      recordingId: "recording_id",
+      threadId: "thread_id",
+      authorEmail: "author_email",
+    },
+  },
+}));
+
+vi.mock("./transactional-email-templates.js", () => ({
+  sendClipsTransactionalEmail: (...args: unknown[]) =>
+    mocks.sendClipsTransactionalEmail(...args),
+}));
+
+import { CLIPS_USER_PREFS_KEY } from "../../shared/clips-ai-prefs.js";
+import {
+  notifyRecordingComment,
+  notifyRecordingReaction,
+} from "./activity-notifications.js";
+
+const RECORDING = {
+  id: "rec_1",
+  title: "Sprint demo",
+  ownerEmail: "owner@example.com",
+};
+
+/**
+ * `select().from().where().limit()` reads the recording;
+ * `select().from().where()` (no limit) reads thread participants.
+ */
+function stubDb(options: {
+  recording: typeof RECORDING | null;
+  participants?: string[];
+}) {
+  const participants = (options.participants ?? []).map((authorEmail) => ({
+    authorEmail,
+  }));
+  mocks.select.mockReturnValue({
+    from: () => ({
+      where: () => {
+        const rows = options.recording ? [options.recording] : [];
+        return Object.assign(Promise.resolve(participants), {
+          limit: async () => rows,
+        });
+      },
+    }),
+  });
+}
+
+function notifyArgs() {
+  return mocks.notifyActivity.mock.calls[0]?.[0] as {
+    candidates: (string | null | undefined)[];
+    actorEmail?: string | null;
+    preferenceKey: string;
+    send: (to: string) => Promise<unknown>;
+  };
+}
+
+describe("clips activity notifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.notifyActivity.mockResolvedValue({
+      status: "delivered",
+      sent: [],
+      failed: [],
+    });
+    stubDb({ recording: RECORDING });
+  });
+
+  it("notifies the recording owner against the Clips preference key", async () => {
+    await notifyRecordingComment({
+      recordingId: "rec_1",
+      threadId: "thread_1",
+      authorEmail: "Viewer@Example.com",
+      content: "Nice work",
+    });
+
+    const args = notifyArgs();
+    expect(args.candidates).toEqual(["owner@example.com"]);
+    expect(args.actorEmail).toBe("Viewer@Example.com");
+    expect(args.preferenceKey).toBe(CLIPS_USER_PREFS_KEY);
+  });
+
+  it("adds thread participants on a reply", async () => {
+    stubDb({
+      recording: RECORDING,
+      participants: ["first@example.com", "second@example.com"],
+    });
+
+    await notifyRecordingComment({
+      recordingId: "rec_1",
+      threadId: "thread_1",
+      authorEmail: "second@example.com",
+      content: "Agreed",
+      isReply: true,
+    });
+
+    expect(notifyArgs().candidates).toEqual([
+      "owner@example.com",
+      "first@example.com",
+      "second@example.com",
+    ]);
+  });
+
+  it("builds the reaction email for each recipient", async () => {
+    await notifyRecordingReaction({
+      recordingId: "rec_1",
+      emoji: "🎉",
+      viewerEmail: "viewer@example.com",
+      videoTimestampMs: 4200,
+    });
+
+    await notifyArgs().send("owner@example.com");
+
+    expect(mocks.sendClipsTransactionalEmail).toHaveBeenCalledWith({
+      kind: "activity-reaction",
+      to: "owner@example.com",
+      recordingId: "rec_1",
+      title: "Sprint demo",
+      emoji: "🎉",
+      authorEmail: "viewer@example.com",
+      authorName: null,
+      videoTimestampMs: 4200,
+    });
+  });
+
+  it("passes the email-not-configured status through to the caller", async () => {
+    mocks.notifyActivity.mockResolvedValue({
+      status: "email-not-configured",
+      sent: [],
+      failed: [],
+    });
+
+    const result = await notifyRecordingReaction({
+      recordingId: "rec_1",
+      emoji: "🎉",
+      viewerEmail: "viewer@example.com",
+    });
+
+    expect(mocks.sendClipsTransactionalEmail).not.toHaveBeenCalled();
+    expect(result.status).toBe("email-not-configured");
+  });
+
+  it("reports a missing recording instead of a clean empty result", async () => {
+    stubDb({ recording: null });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await notifyRecordingComment({
+      recordingId: "missing",
+      threadId: "thread_1",
+      authorEmail: "viewer@example.com",
+      content: "Nice work",
+    });
+
+    expect(mocks.notifyActivity).not.toHaveBeenCalled();
+    expect(result.status).toBe("recording-missing");
+  });
+});

--- a/templates/clips/server/lib/activity-notifications.ts
+++ b/templates/clips/server/lib/activity-notifications.ts
@@ -1,0 +1,175 @@
+/**
+ * Email notifications for Activity events (comments, replies, reactions).
+ *
+ * Recipients are resolved from the recording owner plus the other humans in a
+ * comment thread, then filtered by each recipient's `emailNotifications`
+ * preference. Share invites are deliberately NOT routed through this
+ * preference — they have their own delivery path.
+ */
+
+import { isEmailConfigured } from "@agent-native/core/server";
+import { getUserSetting } from "@agent-native/core/settings";
+import { and, eq } from "drizzle-orm";
+
+import {
+  CLIPS_USER_PREFS_KEY,
+  type ClipsUserPrefs,
+} from "../../shared/clips-ai-prefs.js";
+import { getDb, schema } from "../db/index.js";
+import { sendClipsTransactionalEmail } from "./transactional-email-templates.js";
+
+export type ActivityNotificationResult = {
+  sent: string[];
+  failed: { email: string; error: string }[];
+};
+
+const EMPTY_RESULT: ActivityNotificationResult = { sent: [], failed: [] };
+
+function normalizeEmail(value: string | null | undefined): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+async function wantsEmailNotifications(email: string): Promise<boolean> {
+  const prefs = ((await getUserSetting(email, CLIPS_USER_PREFS_KEY)) ??
+    {}) as ClipsUserPrefs;
+  return prefs.emailNotifications !== false;
+}
+
+async function recipientsFor(
+  candidates: (string | null | undefined)[],
+  actorEmail: string | null | undefined,
+): Promise<string[]> {
+  const actor = normalizeEmail(actorEmail);
+  const unique = new Set<string>();
+  for (const candidate of candidates) {
+    const email = normalizeEmail(candidate);
+    if (!email || email === actor || !email.includes("@")) continue;
+    unique.add(email);
+  }
+
+  const allowed = await Promise.all(
+    [...unique].map(async (email) =>
+      (await wantsEmailNotifications(email)) ? email : null,
+    ),
+  );
+  return allowed.filter((email): email is string => email !== null);
+}
+
+async function getRecording(recordingId: string) {
+  const [row] = await getDb()
+    .select({
+      id: schema.recordings.id,
+      title: schema.recordings.title,
+      ownerEmail: schema.recordings.ownerEmail,
+    })
+    .from(schema.recordings)
+    .where(eq(schema.recordings.id, recordingId))
+    .limit(1);
+  return row ?? null;
+}
+
+async function threadParticipants(
+  recordingId: string,
+  threadId: string,
+): Promise<string[]> {
+  const rows = await getDb()
+    .select({ authorEmail: schema.recordingComments.authorEmail })
+    .from(schema.recordingComments)
+    .where(
+      and(
+        eq(schema.recordingComments.recordingId, recordingId),
+        eq(schema.recordingComments.threadId, threadId),
+      ),
+    );
+  return rows.map((row) => row.authorEmail);
+}
+
+async function deliver(
+  recipients: string[],
+  build: (to: string) => Parameters<typeof sendClipsTransactionalEmail>[0],
+): Promise<ActivityNotificationResult> {
+  const result: ActivityNotificationResult = { sent: [], failed: [] };
+  for (const to of recipients) {
+    try {
+      await sendClipsTransactionalEmail(build(to));
+      result.sent.push(to);
+    } catch (error) {
+      result.failed.push({
+        email: to,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  if (result.failed.length > 0) {
+    console.error(
+      `[clips] activity notification delivery failed for ${result.failed
+        .map((f) => `${f.email} (${f.error})`)
+        .join(", ")}`,
+    );
+  }
+  return result;
+}
+
+export async function notifyRecordingComment(input: {
+  recordingId: string;
+  threadId: string;
+  authorEmail: string;
+  authorName?: string | null;
+  content: string;
+  videoTimestampMs?: number | null;
+  isReply?: boolean;
+}): Promise<ActivityNotificationResult> {
+  if (!isEmailConfigured()) return EMPTY_RESULT;
+
+  const recording = await getRecording(input.recordingId);
+  if (!recording) return EMPTY_RESULT;
+
+  const candidates = [recording.ownerEmail];
+  if (input.isReply) {
+    candidates.push(
+      ...(await threadParticipants(input.recordingId, input.threadId)),
+    );
+  }
+
+  const recipients = await recipientsFor(candidates, input.authorEmail);
+  return deliver(recipients, (to) => ({
+    kind: "activity-comment",
+    to,
+    recordingId: recording.id,
+    title: recording.title,
+    authorEmail: input.authorEmail,
+    authorName: input.authorName ?? null,
+    content: input.content,
+    videoTimestampMs: input.videoTimestampMs ?? null,
+    isReply: input.isReply ?? false,
+  }));
+}
+
+export async function notifyRecordingReaction(input: {
+  recordingId: string;
+  emoji: string;
+  viewerEmail: string;
+  viewerName?: string | null;
+  videoTimestampMs?: number | null;
+  extraRecipients?: (string | null | undefined)[];
+}): Promise<ActivityNotificationResult> {
+  if (!isEmailConfigured()) return EMPTY_RESULT;
+
+  const recording = await getRecording(input.recordingId);
+  if (!recording) return EMPTY_RESULT;
+
+  const recipients = await recipientsFor(
+    [recording.ownerEmail, ...(input.extraRecipients ?? [])],
+    input.viewerEmail,
+  );
+  return deliver(recipients, (to) => ({
+    kind: "activity-reaction",
+    to,
+    recordingId: recording.id,
+    title: recording.title,
+    emoji: input.emoji,
+    authorEmail: input.viewerEmail,
+    authorName: input.viewerName ?? null,
+    videoTimestampMs: input.videoTimestampMs ?? null,
+  }));
+}

--- a/templates/clips/server/lib/activity-notifications.ts
+++ b/templates/clips/server/lib/activity-notifications.ts
@@ -10,8 +10,10 @@
 
 import {
   notifyActivity,
+  runActivityNotification,
   type ActivityNotificationResult,
 } from "@agent-native/core/server";
+import { filterRecipientsByResourceAccess } from "@agent-native/core/sharing";
 import { and, eq } from "drizzle-orm";
 
 import { CLIPS_USER_PREFS_KEY } from "../../shared/clips-ai-prefs.js";
@@ -41,6 +43,7 @@ async function getRecording(recordingId: string) {
       id: schema.recordings.id,
       title: schema.recordings.title,
       ownerEmail: schema.recordings.ownerEmail,
+      orgId: schema.recordings.orgId,
     })
     .from(schema.recordings)
     .where(eq(schema.recordings.id, recordingId))
@@ -64,7 +67,7 @@ async function threadParticipants(
   return rows.map((row) => row.authorEmail);
 }
 
-export async function notifyRecordingComment(input: {
+export interface RecordingCommentNotificationInput {
   recordingId: string;
   threadId: string;
   authorEmail: string;
@@ -72,7 +75,19 @@ export async function notifyRecordingComment(input: {
   content: string;
   videoTimestampMs?: number | null;
   isReply?: boolean;
-}): Promise<ClipsActivityNotificationResult> {
+}
+
+export async function notifyRecordingComment(
+  input: RecordingCommentNotificationInput,
+): Promise<ClipsActivityNotificationResult> {
+  return runActivityNotification(LOG_LABEL, () =>
+    deliverRecordingCommentEmails(input),
+  );
+}
+
+async function deliverRecordingCommentEmails(
+  input: RecordingCommentNotificationInput,
+): Promise<ClipsActivityNotificationResult> {
   const recording = await getRecording(input.recordingId);
   if (!recording) {
     console.error(`${LOG_LABEL}: recording ${input.recordingId} not found`);
@@ -86,8 +101,17 @@ export async function notifyRecordingComment(input: {
     );
   }
 
+  // Thread rows are history, not an access grant: a viewer whose share was
+  // revoked must stop receiving the recording's comment bodies.
+  const allowed = await filterRecipientsByResourceAccess({
+    resourceType: "recording",
+    resourceId: recording.id,
+    emails: candidates,
+    orgId: recording.orgId,
+  });
+
   return notifyActivity({
-    candidates,
+    candidates: allowed,
     actorEmail: input.authorEmail,
     preferenceKey: CLIPS_USER_PREFS_KEY,
     logLabel: LOG_LABEL,
@@ -106,22 +130,43 @@ export async function notifyRecordingComment(input: {
   });
 }
 
-export async function notifyRecordingReaction(input: {
+export interface RecordingReactionNotificationInput {
   recordingId: string;
   emoji: string;
   viewerEmail: string;
   viewerName?: string | null;
   videoTimestampMs?: number | null;
   extraRecipients?: (string | null | undefined)[];
-}): Promise<ClipsActivityNotificationResult> {
+}
+
+export async function notifyRecordingReaction(
+  input: RecordingReactionNotificationInput,
+): Promise<ClipsActivityNotificationResult> {
+  return runActivityNotification(LOG_LABEL, () =>
+    deliverRecordingReactionEmails(input),
+  );
+}
+
+async function deliverRecordingReactionEmails(
+  input: RecordingReactionNotificationInput,
+): Promise<ClipsActivityNotificationResult> {
   const recording = await getRecording(input.recordingId);
   if (!recording) {
     console.error(`${LOG_LABEL}: recording ${input.recordingId} not found`);
     return RECORDING_MISSING;
   }
 
+  const allowed = await filterRecipientsByResourceAccess({
+    resourceType: "recording",
+    resourceId: recording.id,
+    emails: [recording.ownerEmail, ...(input.extraRecipients ?? [])].filter(
+      (email): email is string => Boolean(email),
+    ),
+    orgId: recording.orgId,
+  });
+
   return notifyActivity({
-    candidates: [recording.ownerEmail, ...(input.extraRecipients ?? [])],
+    candidates: allowed,
     actorEmail: input.viewerEmail,
     preferenceKey: CLIPS_USER_PREFS_KEY,
     logLabel: LOG_LABEL,

--- a/templates/clips/server/lib/activity-notifications.ts
+++ b/templates/clips/server/lib/activity-notifications.ts
@@ -1,59 +1,39 @@
 /**
  * Email notifications for Activity events (comments, replies, reactions).
  *
- * Recipients are resolved from the recording owner plus the other humans in a
- * comment thread, then filtered by each recipient's `emailNotifications`
- * preference. Share invites are deliberately NOT routed through this
- * preference — they have their own delivery path.
+ * Recipient resolution and delivery reporting live in
+ * `@agent-native/core/server`; this module only knows which Clips rows are
+ * involved and which template to render. Share invites are deliberately NOT
+ * routed through the `emailNotifications` preference — they have their own
+ * delivery path.
  */
 
-import { isEmailConfigured } from "@agent-native/core/server";
-import { getUserSetting } from "@agent-native/core/settings";
+import {
+  notifyActivity,
+  type ActivityNotificationResult,
+} from "@agent-native/core/server";
 import { and, eq } from "drizzle-orm";
 
-import {
-  CLIPS_USER_PREFS_KEY,
-  type ClipsUserPrefs,
-} from "../../shared/clips-ai-prefs.js";
+import { CLIPS_USER_PREFS_KEY } from "../../shared/clips-ai-prefs.js";
 import { getDb, schema } from "../db/index.js";
 import { sendClipsTransactionalEmail } from "./transactional-email-templates.js";
 
-export type ActivityNotificationResult = {
-  sent: string[];
-  failed: { email: string; error: string }[];
+/**
+ * `recording-missing` is kept distinct from `no-recipients`: one means the row
+ * we were asked to notify about could not be read, the other means nobody
+ * wanted the email.
+ */
+export type ClipsActivityNotificationResult =
+  | ActivityNotificationResult
+  | { status: "recording-missing"; sent: []; failed: [] };
+
+const RECORDING_MISSING: ClipsActivityNotificationResult = {
+  status: "recording-missing",
+  sent: [],
+  failed: [],
 };
 
-const EMPTY_RESULT: ActivityNotificationResult = { sent: [], failed: [] };
-
-function normalizeEmail(value: string | null | undefined): string {
-  return (value ?? "").trim().toLowerCase();
-}
-
-async function wantsEmailNotifications(email: string): Promise<boolean> {
-  const prefs = ((await getUserSetting(email, CLIPS_USER_PREFS_KEY)) ??
-    {}) as ClipsUserPrefs;
-  return prefs.emailNotifications !== false;
-}
-
-async function recipientsFor(
-  candidates: (string | null | undefined)[],
-  actorEmail: string | null | undefined,
-): Promise<string[]> {
-  const actor = normalizeEmail(actorEmail);
-  const unique = new Set<string>();
-  for (const candidate of candidates) {
-    const email = normalizeEmail(candidate);
-    if (!email || email === actor || !email.includes("@")) continue;
-    unique.add(email);
-  }
-
-  const allowed = await Promise.all(
-    [...unique].map(async (email) =>
-      (await wantsEmailNotifications(email)) ? email : null,
-    ),
-  );
-  return allowed.filter((email): email is string => email !== null);
-}
+const LOG_LABEL = "[clips] activity notification";
 
 async function getRecording(recordingId: string) {
   const [row] = await getDb()
@@ -84,32 +64,6 @@ async function threadParticipants(
   return rows.map((row) => row.authorEmail);
 }
 
-async function deliver(
-  recipients: string[],
-  build: (to: string) => Parameters<typeof sendClipsTransactionalEmail>[0],
-): Promise<ActivityNotificationResult> {
-  const result: ActivityNotificationResult = { sent: [], failed: [] };
-  for (const to of recipients) {
-    try {
-      await sendClipsTransactionalEmail(build(to));
-      result.sent.push(to);
-    } catch (error) {
-      result.failed.push({
-        email: to,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-  }
-  if (result.failed.length > 0) {
-    console.error(
-      `[clips] activity notification delivery failed for ${result.failed
-        .map((f) => `${f.email} (${f.error})`)
-        .join(", ")}`,
-    );
-  }
-  return result;
-}
-
 export async function notifyRecordingComment(input: {
   recordingId: string;
   threadId: string;
@@ -118,11 +72,12 @@ export async function notifyRecordingComment(input: {
   content: string;
   videoTimestampMs?: number | null;
   isReply?: boolean;
-}): Promise<ActivityNotificationResult> {
-  if (!isEmailConfigured()) return EMPTY_RESULT;
-
+}): Promise<ClipsActivityNotificationResult> {
   const recording = await getRecording(input.recordingId);
-  if (!recording) return EMPTY_RESULT;
+  if (!recording) {
+    console.error(`${LOG_LABEL}: recording ${input.recordingId} not found`);
+    return RECORDING_MISSING;
+  }
 
   const candidates = [recording.ownerEmail];
   if (input.isReply) {
@@ -131,18 +86,24 @@ export async function notifyRecordingComment(input: {
     );
   }
 
-  const recipients = await recipientsFor(candidates, input.authorEmail);
-  return deliver(recipients, (to) => ({
-    kind: "activity-comment",
-    to,
-    recordingId: recording.id,
-    title: recording.title,
-    authorEmail: input.authorEmail,
-    authorName: input.authorName ?? null,
-    content: input.content,
-    videoTimestampMs: input.videoTimestampMs ?? null,
-    isReply: input.isReply ?? false,
-  }));
+  return notifyActivity({
+    candidates,
+    actorEmail: input.authorEmail,
+    preferenceKey: CLIPS_USER_PREFS_KEY,
+    logLabel: LOG_LABEL,
+    send: (to) =>
+      sendClipsTransactionalEmail({
+        kind: "activity-comment",
+        to,
+        recordingId: recording.id,
+        title: recording.title,
+        authorEmail: input.authorEmail,
+        authorName: input.authorName ?? null,
+        content: input.content,
+        videoTimestampMs: input.videoTimestampMs ?? null,
+        isReply: input.isReply ?? false,
+      }),
+  });
 }
 
 export async function notifyRecordingReaction(input: {
@@ -152,24 +113,28 @@ export async function notifyRecordingReaction(input: {
   viewerName?: string | null;
   videoTimestampMs?: number | null;
   extraRecipients?: (string | null | undefined)[];
-}): Promise<ActivityNotificationResult> {
-  if (!isEmailConfigured()) return EMPTY_RESULT;
-
+}): Promise<ClipsActivityNotificationResult> {
   const recording = await getRecording(input.recordingId);
-  if (!recording) return EMPTY_RESULT;
+  if (!recording) {
+    console.error(`${LOG_LABEL}: recording ${input.recordingId} not found`);
+    return RECORDING_MISSING;
+  }
 
-  const recipients = await recipientsFor(
-    [recording.ownerEmail, ...(input.extraRecipients ?? [])],
-    input.viewerEmail,
-  );
-  return deliver(recipients, (to) => ({
-    kind: "activity-reaction",
-    to,
-    recordingId: recording.id,
-    title: recording.title,
-    emoji: input.emoji,
-    authorEmail: input.viewerEmail,
-    authorName: input.viewerName ?? null,
-    videoTimestampMs: input.videoTimestampMs ?? null,
-  }));
+  return notifyActivity({
+    candidates: [recording.ownerEmail, ...(input.extraRecipients ?? [])],
+    actorEmail: input.viewerEmail,
+    preferenceKey: CLIPS_USER_PREFS_KEY,
+    logLabel: LOG_LABEL,
+    send: (to) =>
+      sendClipsTransactionalEmail({
+        kind: "activity-reaction",
+        to,
+        recordingId: recording.id,
+        title: recording.title,
+        emoji: input.emoji,
+        authorEmail: input.viewerEmail,
+        authorName: input.viewerName ?? null,
+        videoTimestampMs: input.videoTimestampMs ?? null,
+      }),
+  });
 }

--- a/templates/clips/server/lib/recordings.spec.ts
+++ b/templates/clips/server/lib/recordings.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({ getDb: vi.fn() }));
+const mocks = vi.hoisted(() => ({
+  getDb: vi.fn(),
+  getUserSetting: vi.fn(),
+  getRequestUserEmail: vi.fn(),
+}));
 
 const tables = vi.hoisted(() => ({
   recordingViewers: {
@@ -9,6 +13,10 @@ const tables = vi.hoisted(() => ({
   },
   recordingViews: {
     recordingId: "recording_views.recording_id",
+  },
+  organizationSettings: {
+    organizationId: "organization_settings.workspace_id",
+    defaultVisibility: "organization_settings.default_visibility",
   },
 }));
 
@@ -36,8 +44,13 @@ vi.mock("@agent-native/core/org", () => ({
 
 vi.mock("@agent-native/core/server", () => ({ getSession: vi.fn() }));
 
+vi.mock("@agent-native/core/settings", () => ({
+  getUserSetting: (...args: unknown[]) => mocks.getUserSetting(...args),
+}));
+
 vi.mock("@agent-native/core/server/request-context", () => ({
-  getRequestUserEmail: vi.fn(),
+  getRequestUserEmail: (...args: unknown[]) =>
+    mocks.getRequestUserEmail(...args),
   getRequestOrgId: vi.fn(),
 }));
 
@@ -46,7 +59,11 @@ vi.mock("../db/index.js", () => ({
   schema: tables,
 }));
 
-import { countedViewCondition, countRecordingViews } from "./recordings.js";
+import {
+  countedViewCondition,
+  countRecordingViews,
+  getDefaultRecordingVisibility,
+} from "./recordings.js";
 
 /**
  * Two counts come back per call — one per table — so the fake resolves each
@@ -145,5 +162,38 @@ describe("countRecordingViews", () => {
     mocks.getDb.mockReturnValue(db);
 
     await expect(countRecordingViews("rec-1")).resolves.toBe(12);
+  });
+});
+
+describe("getDefaultRecordingVisibility", () => {
+  it("prefers the personal default over the organization default", async () => {
+    mocks.getRequestUserEmail.mockReturnValue("Owner@Example.test");
+    mocks.getUserSetting.mockResolvedValue({
+      defaultRecordingVisibility: "private",
+    });
+
+    await expect(getDefaultRecordingVisibility("org-1")).resolves.toBe(
+      "private",
+    );
+    expect(mocks.getUserSetting).toHaveBeenCalledWith(
+      "owner@example.test",
+      "clips-user-prefs",
+    );
+  });
+
+  it("falls back to the organization default when no preference is set", async () => {
+    mocks.getRequestUserEmail.mockReturnValue("owner@example.test");
+    mocks.getUserSetting.mockResolvedValue({});
+    mocks.getDb.mockReturnValue({
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: async () => [{ defaultVisibility: "org" }],
+          }),
+        }),
+      }),
+    });
+
+    await expect(getDefaultRecordingVisibility("org-1")).resolves.toBe("org");
   });
 });

--- a/templates/clips/server/lib/recordings.ts
+++ b/templates/clips/server/lib/recordings.ts
@@ -5,9 +5,14 @@ import {
   getRequestUserEmail,
   getRequestOrgId,
 } from "@agent-native/core/server/request-context";
+import { getUserSetting } from "@agent-native/core/settings";
 import { and, count, desc, eq, sql } from "drizzle-orm";
 import { HTTPError, type H3Event } from "h3";
 
+import {
+  CLIPS_USER_PREFS_KEY,
+  type ClipsUserPrefs,
+} from "../../shared/clips-ai-prefs.js";
 import { getDb, schema } from "../db/index.js";
 
 export function getCurrentOwnerEmail(): string {
@@ -97,6 +102,25 @@ export async function getOrganizationDefaultVisibility(
   } catch {
     return DEFAULT_RECORDING_VISIBILITY;
   }
+}
+
+/**
+ * Visibility for a new recording: the personal preference of the creator
+ * wins, then the organization default, then the built-in default.
+ */
+export async function getDefaultRecordingVisibility(
+  organizationId: string | null | undefined,
+): Promise<RecordingVisibility> {
+  const email = getRequestUserEmail();
+  if (email) {
+    const prefs = (await getUserSetting(
+      normalizeOwnerEmail(email),
+      CLIPS_USER_PREFS_KEY,
+    )) as ClipsUserPrefs | null;
+    const preferred = prefs?.defaultRecordingVisibility;
+    if (isRecordingVisibility(preferred)) return preferred;
+  }
+  return getOrganizationDefaultVisibility(organizationId);
 }
 
 const ORG_ROLE_RANK: Record<OrganizationAccessRole, number> = {

--- a/templates/clips/server/lib/transactional-email-templates.test.ts
+++ b/templates/clips/server/lib/transactional-email-templates.test.ts
@@ -81,6 +81,33 @@ describe("renderClipsTransactionalEmail", () => {
       heading: "You’ve received two Agent-Native Clips",
       cta: "Record an Agent-Native Clip: https://clips.example/record",
     },
+    {
+      input: {
+        kind: "activity-comment" as const,
+        to: "owner@example.test",
+        recordingId: "rec-4",
+        title: "Product tour",
+        authorEmail: "jane.doe@example.test",
+        content: "The pricing step needs a callout.",
+        videoTimestampMs: 65_000,
+      },
+      subject: "Jane Doe commented on “Product tour”",
+      heading: "Jane Doe commented on your Clip",
+      cta: "Read and reply: https://clips.example/r/rec-4?panel=comments&t=65",
+    },
+    {
+      input: {
+        kind: "activity-reaction" as const,
+        to: "owner@example.test",
+        recordingId: "rec-5",
+        title: "Launch notes",
+        emoji: "🔥",
+        authorEmail: "sam@example.test",
+      },
+      subject: "Sam reacted 🔥 on “Launch notes”",
+      heading: "Someone reacted to your Clip",
+      cta: "See Clip activity: https://clips.example/r/rec-5?panel=comments",
+    },
   ])(
     "renders the approved $input.kind subject, heading, and CTA",
     (testCase) => {

--- a/templates/clips/server/lib/transactional-email-templates.ts
+++ b/templates/clips/server/lib/transactional-email-templates.ts
@@ -9,6 +9,8 @@ const CLIPS_BRAND_NAME = "Clips";
 const EMAIL_SEND_TIMEOUT_MS = 60_000;
 const FRIENDLY_REPLY_TO = "hello@agent-native.com";
 const UNTITLED_CLIP = "Untitled Clip";
+const ACTIVITY_EMAIL_FOOTER =
+  "You received this because email notifications are on in your Clips settings.";
 
 interface TransactionalEmailBase {
   to: string;
@@ -37,6 +39,25 @@ export type ClipsTransactionalEmailInput =
   | (TransactionalEmailBase & {
       kind: "two-clips";
       generatedSummary?: string | null;
+    })
+  | (TransactionalEmailBase & {
+      kind: "activity-comment";
+      recordingId: string;
+      title?: string | null;
+      authorEmail?: string | null;
+      authorName?: string | null;
+      content: string;
+      videoTimestampMs?: number | null;
+      isReply?: boolean;
+    })
+  | (TransactionalEmailBase & {
+      kind: "activity-reaction";
+      recordingId: string;
+      title?: string | null;
+      emoji: string;
+      authorEmail?: string | null;
+      authorName?: string | null;
+      videoTimestampMs?: number | null;
     });
 
 export interface ClipsTransactionalEmailRenderOptions {
@@ -101,6 +122,31 @@ function clipUrl(
   options: ClipsTransactionalEmailRenderOptions,
 ): string {
   return appUrlForPath(`/r/${encodeURIComponent(recordingId)}`, options);
+}
+
+function clipCommentsUrl(
+  recordingId: string,
+  videoTimestampMs: number | null | undefined,
+  options: ClipsTransactionalEmailRenderOptions,
+): string {
+  const url = new URL(clipUrl(recordingId, options));
+  url.searchParams.set("panel", "comments");
+  if (typeof videoTimestampMs === "number" && videoTimestampMs > 0) {
+    url.searchParams.set("t", String(Math.floor(videoTimestampMs / 1000)));
+  }
+  return url.toString();
+}
+
+function formatTimestamp(ms: number): string {
+  const total = Math.floor(ms / 1000);
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+function quotedExcerpt(value: string): string {
+  const text = singleLine(value);
+  return text.length > 280 ? `${text.slice(0, 277)}…` : text;
 }
 
 function recordUrl(options: ClipsTransactionalEmailRenderOptions): string {
@@ -229,6 +275,69 @@ export function renderClipsTransactionalEmail(
         },
         footer:
           "This one-time note was sent after two Clips were shared with you.",
+      });
+      return { subject, ...rendered };
+    }
+
+    case "activity-comment": {
+      const author =
+        singleLine(input.authorName) ||
+        normalizeEmailDisplayName(input.authorEmail, "Someone");
+      const at =
+        typeof input.videoTimestampMs === "number" && input.videoTimestampMs > 0
+          ? ` at ${formatTimestamp(input.videoTimestampMs)}`
+          : "";
+      const subject = input.isReply
+        ? `${author} replied on “${title}”`
+        : `${author} commented on “${title}”`;
+      const rendered = renderEmail({
+        brandName: CLIPS_BRAND_NAME,
+        preheader: subject,
+        heading: input.isReply
+          ? `${author} replied on your Clip`
+          : `${author} commented on your Clip`,
+        paragraphs: [
+          `${emailStrong(author)} left a ${input.isReply ? "reply" : "comment"} on ${emailStrong(title!)}${at}.`,
+          `“${quotedExcerpt(input.content)}”`,
+        ],
+        cta: {
+          label: "Read and reply",
+          url: clipCommentsUrl(
+            input.recordingId,
+            input.videoTimestampMs,
+            options,
+          ),
+        },
+        footer: ACTIVITY_EMAIL_FOOTER,
+      });
+      return { subject, ...rendered };
+    }
+
+    case "activity-reaction": {
+      const author =
+        singleLine(input.authorName) ||
+        normalizeEmailDisplayName(input.authorEmail, "Someone");
+      const at =
+        typeof input.videoTimestampMs === "number" && input.videoTimestampMs > 0
+          ? ` at ${formatTimestamp(input.videoTimestampMs)}`
+          : "";
+      const subject = `${author} reacted ${input.emoji} on “${title}”`;
+      const rendered = renderEmail({
+        brandName: CLIPS_BRAND_NAME,
+        preheader: subject,
+        heading: "Someone reacted to your Clip",
+        paragraphs: [
+          `${emailStrong(author)} reacted ${emailStrong(input.emoji)} on ${emailStrong(title!)}${at}.`,
+        ],
+        cta: {
+          label: "See Clip activity",
+          url: clipCommentsUrl(
+            input.recordingId,
+            input.videoTimestampMs,
+            options,
+          ),
+        },
+        footer: ACTIVITY_EMAIL_FOOTER,
       });
       return { subject, ...rendered };
     }

--- a/templates/clips/shared/clips-ai-prefs.ts
+++ b/templates/clips/shared/clips-ai-prefs.ts
@@ -27,9 +27,15 @@ export type ClipsAiPrefs = {
 
 export type ClipsUserPrefs = ClipsAiPrefs & {
   defaultPlaybackSpeed?: string;
+  /** Activity emails (comments, replies, reactions) only — never share invites. */
   emailNotifications?: boolean;
   transcriptCleanupEnabled?: boolean;
+  /** Overrides the organization default visibility for new recordings. */
+  defaultRecordingVisibility?: ClipsDefaultVisibility;
 };
+
+/** Visibility applied to new recordings unless the creator picks another. */
+export type ClipsDefaultVisibility = "private" | "org" | "public";
 
 export function isIncludeFullVideoInAiEnabled(
   prefs: ClipsAiPrefs | Record<string, unknown> | null | undefined,

--- a/templates/content/actions/add-comment.ts
+++ b/templates/content/actions/add-comment.ts
@@ -119,6 +119,7 @@ export default defineAction({
     const notified = await notifyDocumentComment({
       documentId,
       documentTitle: (access.resource.title as string | null) ?? "",
+      orgId: (access.resource.orgId as string | null) ?? null,
       threadId,
       ownerEmail,
       authorEmail: email,

--- a/templates/content/actions/add-comment.ts
+++ b/templates/content/actions/add-comment.ts
@@ -4,6 +4,7 @@ import { assertAccess } from "@agent-native/core/sharing";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import { notifyDocumentComment } from "../server/lib/comment-notifications.js";
 
 type Mention = { email: string; name: string };
 
@@ -115,6 +116,18 @@ export default defineAction({
       authorName: name,
     });
 
-    return { id, threadId };
+    const notified = await notifyDocumentComment({
+      documentId,
+      documentTitle: (access.resource.title as string | null) ?? "",
+      threadId,
+      ownerEmail,
+      authorEmail: email,
+      authorName: name,
+      content,
+      mentions,
+      isReply: Boolean(parentId ?? args.threadId),
+    });
+
+    return { id, threadId, notified };
   },
 });

--- a/templates/content/app/components/ui/switch.tsx
+++ b/templates/content/app/components/ui/switch.tsx
@@ -1,0 +1,1 @@
+export * from "@agent-native/toolkit/ui/switch";

--- a/templates/content/app/hooks/use-content-prefs.ts
+++ b/templates/content/app/hooks/use-content-prefs.ts
@@ -1,0 +1,55 @@
+import { agentNativePath } from "@agent-native/core/client/api-path";
+import type { ContentUserPrefs } from "@shared/content-user-prefs";
+import { useCallback, useEffect, useState } from "react";
+
+const PREFS_PATH = "/_agent-native/content/user-prefs";
+
+export interface ContentPrefsState {
+  prefs: ContentUserPrefs;
+  loading: boolean;
+  /** Applies the patch optimistically and rolls back if the write fails. */
+  save: (patch: ContentUserPrefs) => Promise<void>;
+}
+
+export function useContentPrefs(): ContentPrefsState {
+  const [prefs, setPrefs] = useState<ContentUserPrefs>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(agentNativePath(PREFS_PATH));
+        const json = res.ok ? await res.json() : null;
+        if (cancelled) return;
+        if (json && typeof json === "object" && !("error" in json)) {
+          setPrefs(json as ContentUserPrefs);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const save = useCallback(
+    async (patch: ContentUserPrefs) => {
+      const previous = prefs;
+      setPrefs((current) => ({ ...current, ...patch }));
+      const res = await fetch(agentNativePath(PREFS_PATH), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+      });
+      if (!res.ok) {
+        setPrefs(previous);
+        throw new Error(`Save failed (${res.status})`);
+      }
+    },
+    [prefs],
+  );
+
+  return { prefs, loading, save };
+}

--- a/templates/content/app/i18n-data.ts
+++ b/templates/content/app/i18n-data.ts
@@ -2924,6 +2924,10 @@ const enUS = {
     metaTitle: "Settings - Content",
     title: "Settings",
     description: "Language and workspace preferences for Content.",
+    emailNotifications: "Email notifications",
+    emailNotificationsDescription:
+      "Get an email when someone comments on, replies in, or mentions you on your document.",
+    saveFailed: "Failed to save",
     languageTitle: "Language",
     languageDescription:
       "Choose the interface language. This preference is saved for your account.",
@@ -9001,6 +9005,10 @@ export const messagesByLocale = {
     settings: {
       title: "设置",
       description: "Content 的语言和工作区偏好设置。",
+      emailNotifications: "邮件通知",
+      emailNotificationsDescription:
+        "当有人评论你的文档、在讨论串中回复或提到你时，收到邮件通知。",
+      saveFailed: "保存失败",
       languageTitle: "语言",
       languageDescription: "选择界面语言。此偏好会保存到你的账户。",
       languageLabel: "界面语言",
@@ -9192,6 +9200,10 @@ export const messagesByLocale = {
     settings: {
       title: "Ajustes",
       description: "Preferencias de idioma y espacio de trabajo para Content.",
+      emailNotifications: "Notificaciones por correo",
+      emailNotificationsDescription:
+        "Recibe un correo cuando alguien comente, responda o te mencione en tu documento.",
+      saveFailed: "No se pudo guardar",
       languageTitle: "Idioma",
       languageDescription:
         "Elige el idioma de la interfaz. Esta preferencia se guarda en tu cuenta.",
@@ -9390,6 +9402,10 @@ export const messagesByLocale = {
     settings: {
       title: "Paramètres",
       description: "Préférences de langue et d’espace de travail pour Content.",
+      emailNotifications: "Notifications par e-mail",
+      emailNotificationsDescription:
+        "Recevez un e-mail lorsqu’une personne commente, répond ou vous mentionne dans votre document.",
+      saveFailed: "Échec de l’enregistrement",
       languageTitle: "Langue",
       languageDescription:
         "Choisissez la langue de l’interface. Cette préférence est enregistrée dans votre compte.",
@@ -9586,6 +9602,10 @@ export const messagesByLocale = {
     settings: {
       title: "Einstellungen",
       description: "Sprach- und Arbeitsbereichseinstellungen für Content.",
+      emailNotifications: "E-Mail-Benachrichtigungen",
+      emailNotificationsDescription:
+        "Erhalte eine E-Mail, wenn jemand dein Dokument kommentiert, antwortet oder dich erwähnt.",
+      saveFailed: "Speichern fehlgeschlagen",
       languageTitle: "Sprache",
       languageDescription:
         "Wähle die Sprache der Oberfläche. Diese Einstellung wird in deinem Konto gespeichert.",
@@ -9781,6 +9801,10 @@ export const messagesByLocale = {
     settings: {
       title: "設定",
       description: "Content の言語とワークスペース設定。",
+      emailNotifications: "メール通知",
+      emailNotificationsDescription:
+        "誰かがあなたのドキュメントにコメント、返信、またはあなたにメンションしたときにメールを受け取ります。",
+      saveFailed: "保存に失敗しました",
       languageTitle: "言語",
       languageDescription:
         "インターフェース言語を選択します。この設定はアカウントに保存されます。",
@@ -9968,6 +9992,10 @@ export const messagesByLocale = {
     settings: {
       title: "설정",
       description: "Content의 언어 및 워크스페이스 환경설정입니다.",
+      emailNotifications: "이메일 알림",
+      emailNotificationsDescription:
+        "누군가 내 문서에 댓글을 달거나 답글을 남기거나 나를 멘션하면 이메일을 받습니다.",
+      saveFailed: "저장 실패",
       languageTitle: "언어",
       languageDescription:
         "인터페이스 언어를 선택하세요. 이 기본 설정은 계정에 저장됩니다.",
@@ -10161,6 +10189,10 @@ export const messagesByLocale = {
     settings: {
       title: "Configurações",
       description: "Preferências de idioma e espaço de trabalho do Content.",
+      emailNotifications: "Notificações por e-mail",
+      emailNotificationsDescription:
+        "Receba um e-mail quando alguém comentar, responder ou mencionar você no seu documento.",
+      saveFailed: "Falha ao salvar",
       languageTitle: "Idioma",
       languageDescription:
         "Escolha o idioma da interface. Essa preferência é salva na sua conta.",
@@ -10347,6 +10379,10 @@ export const messagesByLocale = {
     settings: {
       title: "सेटिंग्स",
       description: "Content के लिए भाषा और कार्यस्थान प्राथमिकताएं।",
+      emailNotifications: "ईमेल सूचनाएँ",
+      emailNotificationsDescription:
+        "जब कोई आपके दस्तावेज़ पर टिप्पणी करे, जवाब दे या आपका उल्लेख करे तो ईमेल पाएँ।",
+      saveFailed: "सहेजने में विफल",
       languageTitle: "भाषा",
       languageDescription: "इंटरफ़ेस भाषा चुनें। यह पसंद आपके खाते में सहेजी जाती है।",
       languageLabel: "इंटरफ़ेस भाषा",
@@ -10532,6 +10568,10 @@ export const messagesByLocale = {
     settings: {
       title: "الإعدادات",
       description: "تفضيلات اللغة ومساحة العمل في Content.",
+      emailNotifications: "إشعارات البريد الإلكتروني",
+      emailNotificationsDescription:
+        "احصل على بريد إلكتروني عندما يعلّق شخص على مستندك أو يرد أو يذكرك.",
+      saveFailed: "فشل الحفظ",
       languageTitle: "اللغة",
       languageDescription: "اختر لغة الواجهة. يتم حفظ هذا التفضيل في حسابك.",
       languageLabel: "لغة الواجهة",

--- a/templates/content/app/i18n/zh-TW.ts
+++ b/templates/content/app/i18n/zh-TW.ts
@@ -46,6 +46,10 @@ const messages = {
     metaTitle: "設定 - Content",
     title: "設定",
     description: "Content 的語言和工作區偏好設定。",
+    emailNotifications: "郵件通知",
+    emailNotificationsDescription:
+      "當有人評論你的文件、在討論串中回覆或提到你時，收到郵件通知。",
+    saveFailed: "儲存失敗",
     languageTitle: "語言",
     languageDescription: "選取介面語言。此偏好會儲存到你的帳戶。",
     languageLabel: "介面語言",

--- a/templates/content/app/routes/_app.settings.tsx
+++ b/templates/content/app/routes/_app.settings.tsx
@@ -3,6 +3,8 @@ import { LanguagePicker, useT } from "@agent-native/core/client/i18n";
 import { TeamPage } from "@agent-native/core/client/org";
 import {
   AccountSettingsCard,
+  SettingsGroup,
+  SettingsRow,
   SettingsTabsPage,
   useAgentSettingsTabs,
   type SettingsSearchEntry,
@@ -11,7 +13,6 @@ import { CreativeContextSettingsLink } from "@agent-native/creative-context/clie
 import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
 import { useMemo } from "react";
 
-import { Label } from "@/components/ui/label";
 import { messagesByLocale } from "@/i18n-data";
 
 import changelog from "../../CHANGELOG.md?raw";
@@ -52,23 +53,18 @@ export default function SettingsRoute() {
 
             <CreativeContextSettingsLink />
 
-            <section
-              id="language"
-              className="scroll-mt-16 rounded-lg border border-border bg-card p-5"
-            >
-              <div className="space-y-1">
-                <h2 className="text-base font-semibold">
-                  {t("settings.languageTitle")}
-                </h2>
-                <p className="text-sm leading-6 text-muted-foreground">
-                  {t("settings.languageDescription")}
-                </p>
-              </div>
-              <div className="mt-4 max-w-xs space-y-1.5">
-                <Label>{t("settings.languageLabel")}</Label>
-                <LanguagePicker label={t("settings.languageLabel")} />
-              </div>
-            </section>
+            <SettingsGroup>
+              <SettingsRow
+                id="language"
+                label={t("settings.languageTitle")}
+                description={t("settings.languageDescription")}
+                control={
+                  <div className="w-56">
+                    <LanguagePicker label={t("settings.languageLabel")} />
+                  </div>
+                }
+              />
+            </SettingsGroup>
           </main>
         }
         team={

--- a/templates/content/app/routes/_app.settings.tsx
+++ b/templates/content/app/routes/_app.settings.tsx
@@ -12,7 +12,10 @@ import {
 import { CreativeContextSettingsLink } from "@agent-native/creative-context/client";
 import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
 import { useMemo } from "react";
+import { toast } from "sonner";
 
+import { Switch } from "@/components/ui/switch";
+import { useContentPrefs } from "@/hooks/use-content-prefs";
 import { messagesByLocale } from "@/i18n-data";
 
 import changelog from "../../CHANGELOG.md?raw";
@@ -25,6 +28,7 @@ export default function SettingsRoute() {
   const t = useT();
   const agentSettingsTabs = useAgentSettingsTabs();
   useSetPageTitle(t("settings.title"));
+  const { prefs, loading: prefsLoading, save: savePrefs } = useContentPrefs();
 
   const generalSearchEntries = useMemo<SettingsSearchEntry[]>(
     () => [
@@ -33,6 +37,12 @@ export default function SettingsRoute() {
         label: t("settings.languageTitle"),
         keywords: "language locale translation i18n",
         hash: "language",
+      },
+      {
+        id: "content-notifications",
+        label: t("settings.emailNotifications"),
+        keywords: "email notifications comments replies mentions alerts",
+        hash: "notifications",
       },
     ],
     [t],
@@ -62,6 +72,29 @@ export default function SettingsRoute() {
                   <div className="w-56">
                     <LanguagePicker label={t("settings.languageLabel")} />
                   </div>
+                }
+              />
+              <SettingsRow
+                id="notifications"
+                label={t("settings.emailNotifications")}
+                description={t("settings.emailNotificationsDescription")}
+                control={
+                  <Switch
+                    aria-label={t("settings.emailNotifications")}
+                    checked={prefs.emailNotifications !== false}
+                    disabled={prefsLoading}
+                    onCheckedChange={(checked) => {
+                      savePrefs({ emailNotifications: checked }).catch(
+                        (err) => {
+                          toast.error(
+                            err instanceof Error
+                              ? err.message
+                              : t("settings.saveFailed"),
+                          );
+                        },
+                      );
+                    }}
+                  />
                 }
               />
             </SettingsGroup>

--- a/templates/content/changelog/2026-08-01-get-an-email-when-someone-comments-on-replies-in-or-mentions.md
+++ b/templates/content/changelog/2026-08-01-get-an-email-when-someone-comments-on-replies-in-or-mentions.md
@@ -1,0 +1,6 @@
+---
+type: added
+date: 2026-08-01
+---
+
+Get an email when someone comments on, replies in, or mentions you on your document, with a new toggle in Settings

--- a/templates/content/server/lib/comment-notifications.spec.ts
+++ b/templates/content/server/lib/comment-notifications.spec.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   notifyActivity: vi.fn(),
   sendEmail: vi.fn(),
   select: vi.fn(),
+  filterRecipients: vi.fn(),
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -20,6 +21,26 @@ vi.mock("@agent-native/core/server", () => ({
     text: [args.heading, ...args.paragraphs].join("\n"),
   }),
   sendEmail: (...args: unknown[]) => mocks.sendEmail(...args),
+  runActivityNotification: async (
+    _logLabel: string,
+    resolve: () => Promise<unknown>,
+  ) => {
+    try {
+      return await resolve();
+    } catch (error) {
+      return {
+        status: "notification-error",
+        error: error instanceof Error ? error.message : String(error),
+        sent: [],
+        failed: [],
+      };
+    }
+  },
+}));
+
+vi.mock("@agent-native/core/sharing", () => ({
+  filterRecipientsByResourceAccess: (...args: unknown[]) =>
+    mocks.filterRecipients(...args),
 }));
 
 vi.mock("../db/index.js", () => ({
@@ -75,6 +96,10 @@ describe("content comment notifications", () => {
       failed: [],
     });
     stubDb();
+    // Access filtering has its own tests; these assert who is offered.
+    mocks.filterRecipients.mockImplementation(
+      async ({ emails }: { emails: string[] }) => [...emails],
+    );
   });
 
   it("notifies the owner and mentioned people against the Documents key", async () => {
@@ -120,5 +145,28 @@ describe("content comment notifications", () => {
     expect(mention.subject).toBe('Writer mentioned you on "Launch plan"');
     expect(mention.text).toContain("You were mentioned");
     expect(owner.subject).toBe('Writer commented on "Launch plan"');
+  });
+
+  it("drops a mentioned address with no access to the document", async () => {
+    mocks.filterRecipients.mockResolvedValue(["owner@example.com"]);
+
+    await notifyDocumentComment({
+      ...BASE,
+      mentions: [{ email: "outsider@evil.test", name: "Outsider" }],
+    });
+
+    expect(notifyArgs().candidates).toEqual(["owner@example.com"]);
+    expect(
+      (mocks.filterRecipients.mock.calls[0][0] as { emails: string[] }).emails,
+    ).toContain("outsider@evil.test");
+  });
+
+  it("returns notification-error instead of throwing when a lookup fails", async () => {
+    mocks.filterRecipients.mockRejectedValue(new Error("acl store down"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await notifyDocumentComment({ ...BASE, isReply: true });
+
+    expect(result.status).toBe("notification-error");
   });
 });

--- a/templates/content/server/lib/comment-notifications.spec.ts
+++ b/templates/content/server/lib/comment-notifications.spec.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  notifyActivity: vi.fn(),
+  sendEmail: vi.fn(),
+  select: vi.fn(),
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: (...conditions: unknown[]) => ({ type: "and", conditions }),
+  eq: (left: unknown, right: unknown) => ({ type: "eq", left, right }),
+}));
+
+vi.mock("@agent-native/core/server", () => ({
+  emailStrong: (value: string) => value,
+  getAppProductionUrl: () => "https://docs.test",
+  notifyActivity: (...args: unknown[]) => mocks.notifyActivity(...args),
+  renderEmail: (args: { heading: string; paragraphs: string[] }) => ({
+    html: `<h1>${args.heading}</h1>`,
+    text: [args.heading, ...args.paragraphs].join("\n"),
+  }),
+  sendEmail: (...args: unknown[]) => mocks.sendEmail(...args),
+}));
+
+vi.mock("../db/index.js", () => ({
+  getDb: () => ({ select: (...args: unknown[]) => mocks.select(...args) }),
+  schema: {
+    documentComments: {
+      documentId: "document_id",
+      threadId: "thread_id",
+      authorEmail: "author_email",
+    },
+  },
+}));
+
+import { CONTENT_USER_PREFS_KEY } from "../../shared/content-user-prefs.js";
+import { notifyDocumentComment } from "./comment-notifications.js";
+
+function stubDb(participants: string[] = []) {
+  mocks.select.mockReturnValue({
+    from: () => ({
+      where: () =>
+        Promise.resolve(participants.map((authorEmail) => ({ authorEmail }))),
+    }),
+  });
+}
+
+function notifyArgs() {
+  return mocks.notifyActivity.mock.calls[0]?.[0] as {
+    candidates: string[];
+    actorEmail?: string | null;
+    preferenceKey: string;
+    send: (to: string) => Promise<unknown>;
+  };
+}
+
+const BASE = {
+  documentId: "doc_1",
+  documentTitle: "Launch plan",
+  threadId: "thread_1",
+  ownerEmail: "owner@example.com",
+  authorEmail: "writer@example.com",
+  authorName: "Writer",
+  content: "This section needs a source",
+  mentions: [] as { email: string; name: string }[],
+  isReply: false,
+};
+
+describe("content comment notifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.notifyActivity.mockResolvedValue({
+      status: "delivered",
+      sent: [],
+      failed: [],
+    });
+    stubDb();
+  });
+
+  it("notifies the owner and mentioned people against the Documents key", async () => {
+    await notifyDocumentComment({
+      ...BASE,
+      mentions: [{ email: "Reviewer@Example.com", name: "Reviewer" }],
+    });
+
+    const args = notifyArgs();
+    expect(args.candidates).toEqual([
+      "owner@example.com",
+      "reviewer@example.com",
+    ]);
+    expect(args.actorEmail).toBe("writer@example.com");
+    expect(args.preferenceKey).toBe(CONTENT_USER_PREFS_KEY);
+  });
+
+  it("adds thread participants on a reply", async () => {
+    stubDb(["first@example.com", "writer@example.com"]);
+
+    await notifyDocumentComment({ ...BASE, isReply: true });
+
+    expect(notifyArgs().candidates).toEqual([
+      "owner@example.com",
+      "first@example.com",
+      "writer@example.com",
+    ]);
+  });
+
+  it("tells a mentioned recipient they were mentioned", async () => {
+    await notifyDocumentComment({
+      ...BASE,
+      mentions: [{ email: "reviewer@example.com", name: "Reviewer" }],
+    });
+
+    const send = notifyArgs().send;
+    await send("reviewer@example.com");
+    await send("owner@example.com");
+
+    const [mention, owner] = mocks.sendEmail.mock.calls.map(
+      (call) => call[0] as { subject: string; text: string },
+    );
+    expect(mention.subject).toBe('Writer mentioned you on "Launch plan"');
+    expect(mention.text).toContain("You were mentioned");
+    expect(owner.subject).toBe('Writer commented on "Launch plan"');
+  });
+});

--- a/templates/content/server/lib/comment-notifications.ts
+++ b/templates/content/server/lib/comment-notifications.ts
@@ -1,0 +1,121 @@
+/**
+ * Email notifications for document comments, replies, and mentions.
+ *
+ * Recipient resolution, preference filtering, and delivery reporting come from
+ * `@agent-native/core/server`; this module owns only the Documents rows and the
+ * email copy. Share invites are not routed through the `emailNotifications`
+ * preference — they have their own delivery path.
+ */
+
+import {
+  emailStrong,
+  getAppProductionUrl,
+  notifyActivity,
+  renderEmail,
+  sendEmail,
+  type ActivityNotificationResult,
+} from "@agent-native/core/server";
+import { and, eq } from "drizzle-orm";
+
+import { CONTENT_USER_PREFS_KEY } from "../../shared/content-user-prefs.js";
+import { getDb, schema } from "../db/index.js";
+
+export type DocumentCommentNotificationResult = ActivityNotificationResult;
+
+const LOG_LABEL = "[content] comment notification";
+const EXCERPT_LIMIT = 240;
+
+function excerpt(content: string): string {
+  const collapsed = content.replace(/\s+/g, " ").trim();
+  return collapsed.length > EXCERPT_LIMIT
+    ? `${collapsed.slice(0, EXCERPT_LIMIT - 1)}…`
+    : collapsed;
+}
+
+function documentUrl(documentId: string): string {
+  const base = getAppProductionUrl().replace(/\/+$/, "");
+  return `${base}/page/${encodeURIComponent(documentId)}`;
+}
+
+async function threadParticipants(
+  documentId: string,
+  threadId: string,
+): Promise<string[]> {
+  const rows = await getDb()
+    .select({ authorEmail: schema.documentComments.authorEmail })
+    .from(schema.documentComments)
+    .where(
+      and(
+        eq(schema.documentComments.documentId, documentId),
+        eq(schema.documentComments.threadId, threadId),
+      ),
+    );
+  return rows.map((row) => row.authorEmail);
+}
+
+export async function notifyDocumentComment(input: {
+  documentId: string;
+  /** Read from the access-checked resource by the caller, never re-queried. */
+  documentTitle: string;
+  threadId: string;
+  ownerEmail: string;
+  authorEmail: string;
+  authorName?: string | null;
+  content: string;
+  mentions: { email: string; name: string }[];
+  isReply: boolean;
+}): Promise<DocumentCommentNotificationResult> {
+  const title = input.documentTitle.trim() || "Untitled";
+  const mentioned = new Set(
+    input.mentions.map((mention) => mention.email.trim().toLowerCase()),
+  );
+
+  const candidates = [input.ownerEmail, ...mentioned];
+  if (input.isReply) {
+    candidates.push(
+      ...(await threadParticipants(input.documentId, input.threadId)),
+    );
+  }
+
+  const actor = input.authorName?.trim() || input.authorEmail;
+  const url = documentUrl(input.documentId);
+
+  return notifyActivity({
+    candidates,
+    actorEmail: input.authorEmail,
+    preferenceKey: CONTENT_USER_PREFS_KEY,
+    logLabel: LOG_LABEL,
+    send: async (to) => {
+      const wasMentioned = mentioned.has(to);
+      const lead = wasMentioned
+        ? `${emailStrong(actor)} mentioned you in a comment on ${emailStrong(title)}.`
+        : input.isReply
+          ? `${emailStrong(actor)} replied in a comment thread on ${emailStrong(title)}.`
+          : `${emailStrong(actor)} commented on ${emailStrong(title)}.`;
+
+      const { html, text } = renderEmail({
+        preheader: `${actor} commented on ${title}.`,
+        heading: wasMentioned
+          ? "You were mentioned"
+          : input.isReply
+            ? "New reply on your document"
+            : "New comment",
+        paragraphs: [lead, `"${excerpt(input.content)}"`],
+        cta: { label: "Open document", url },
+        footer:
+          "You received this because you own, were mentioned in, or participated in this thread. Turn these off in Documents settings.",
+      });
+
+      await sendEmail({
+        to,
+        subject: wasMentioned
+          ? `${actor} mentioned you on "${title}"`
+          : input.isReply
+            ? `${actor} replied to a comment on "${title}"`
+            : `${actor} commented on "${title}"`,
+        html,
+        text,
+      });
+    },
+  });
+}

--- a/templates/content/server/lib/comment-notifications.ts
+++ b/templates/content/server/lib/comment-notifications.ts
@@ -12,9 +12,11 @@ import {
   getAppProductionUrl,
   notifyActivity,
   renderEmail,
+  runActivityNotification,
   sendEmail,
   type ActivityNotificationResult,
 } from "@agent-native/core/server";
+import { filterRecipientsByResourceAccess } from "@agent-native/core/sharing";
 import { and, eq } from "drizzle-orm";
 
 import { CONTENT_USER_PREFS_KEY } from "../../shared/content-user-prefs.js";
@@ -53,10 +55,12 @@ async function threadParticipants(
   return rows.map((row) => row.authorEmail);
 }
 
-export async function notifyDocumentComment(input: {
+export interface DocumentCommentNotificationInput {
   documentId: string;
   /** Read from the access-checked resource by the caller, never re-queried. */
   documentTitle: string;
+  /** The document's org, so `org` visibility resolves for its members. */
+  orgId?: string | null;
   threadId: string;
   ownerEmail: string;
   authorEmail: string;
@@ -64,7 +68,19 @@ export async function notifyDocumentComment(input: {
   content: string;
   mentions: { email: string; name: string }[];
   isReply: boolean;
-}): Promise<DocumentCommentNotificationResult> {
+}
+
+export async function notifyDocumentComment(
+  input: DocumentCommentNotificationInput,
+): Promise<DocumentCommentNotificationResult> {
+  return runActivityNotification(LOG_LABEL, () =>
+    deliverDocumentCommentEmails(input),
+  );
+}
+
+async function deliverDocumentCommentEmails(
+  input: DocumentCommentNotificationInput,
+): Promise<DocumentCommentNotificationResult> {
   const title = input.documentTitle.trim() || "Untitled";
   const mentioned = new Set(
     input.mentions.map((mention) => mention.email.trim().toLowerCase()),
@@ -77,11 +93,20 @@ export async function notifyDocumentComment(input: {
     );
   }
 
+  // Mentions are caller-supplied and thread rows are historical; re-check both
+  // against the document's live ACL before mailing anyone its contents.
+  const allowed = await filterRecipientsByResourceAccess({
+    resourceType: "document",
+    resourceId: input.documentId,
+    emails: candidates,
+    orgId: input.orgId,
+  });
+
   const actor = input.authorName?.trim() || input.authorEmail;
   const url = documentUrl(input.documentId);
 
   return notifyActivity({
-    candidates,
+    candidates: allowed,
     actorEmail: input.authorEmail,
     preferenceKey: CONTENT_USER_PREFS_KEY,
     logLabel: LOG_LABEL,

--- a/templates/content/server/routes/_agent-native/content/user-prefs.get.ts
+++ b/templates/content/server/routes/_agent-native/content/user-prefs.get.ts
@@ -1,0 +1,17 @@
+import { getSession } from "@agent-native/core/server";
+import { getUserSetting } from "@agent-native/core/settings";
+import { defineEventHandler, setResponseStatus } from "h3";
+
+import { CONTENT_USER_PREFS_KEY } from "../../../../shared/content-user-prefs.js";
+
+export default defineEventHandler(async (event) => {
+  const session = await getSession(event);
+  if (!session?.email) {
+    setResponseStatus(event, 401);
+    return { error: "unauthorized" };
+  }
+
+  const stored = await getUserSetting(session.email, CONTENT_USER_PREFS_KEY);
+  // coercion-ok: a null read means this user has no preferences yet, which is a real state.
+  return stored ?? {};
+});

--- a/templates/content/server/routes/_agent-native/content/user-prefs.put.ts
+++ b/templates/content/server/routes/_agent-native/content/user-prefs.put.ts
@@ -1,0 +1,36 @@
+import { getSession } from "@agent-native/core/server";
+import { getUserSetting, putUserSetting } from "@agent-native/core/settings";
+import { defineEventHandler, getHeader, readBody, setResponseStatus } from "h3";
+
+import { CONTENT_USER_PREFS_KEY } from "../../../../shared/content-user-prefs.js";
+
+export default defineEventHandler(async (event) => {
+  const session = await getSession(event);
+  if (!session?.email) {
+    setResponseStatus(event, 401);
+    return { error: "unauthorized" };
+  }
+
+  // coercion-ok: an unparsable body is rejected with 400 immediately below.
+  const body = await readBody(event).catch(() => null);
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    setResponseStatus(event, 400);
+    return { error: "Invalid settings payload" };
+  }
+
+  // Merge so a partial save never wipes preferences written elsewhere.
+  const stored = await getUserSetting(session.email, CONTENT_USER_PREFS_KEY);
+  // coercion-ok: a null read means this user has no preferences yet, which is a real state.
+  const existing = stored ?? {};
+  const next = {
+    ...(typeof existing === "object" && !Array.isArray(existing)
+      ? existing
+      : {}),
+    ...(body as Record<string, unknown>),
+  };
+
+  await putUserSetting(session.email, CONTENT_USER_PREFS_KEY, next, {
+    requestSource: getHeader(event, "x-request-source") || undefined,
+  });
+  return next;
+});

--- a/templates/content/shared/content-user-prefs.ts
+++ b/templates/content/shared/content-user-prefs.ts
@@ -1,0 +1,11 @@
+/**
+ * Per-user Documents preferences, stored under one user-setting key so
+ * Settings and the notification senders read and write the same object.
+ */
+
+export const CONTENT_USER_PREFS_KEY = "content-user-prefs";
+
+export type ContentUserPrefs = {
+  /** Comment, reply, and mention emails only — never share invites. */
+  emailNotifications?: boolean;
+};

--- a/templates/crm/app/routes/settings.tsx
+++ b/templates/crm/app/routes/settings.tsx
@@ -20,14 +20,6 @@ import { AdvancedSettings } from "@/components/crm/settings/AdvancedSettings";
 import { ConnectionSettings } from "@/components/crm/settings/ConnectionSettings";
 import { FieldsSettings } from "@/components/crm/settings/FieldsSettings";
 import { ListsSettings } from "@/components/crm/settings/ListsSettings";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
 
 import changelog from "../../CHANGELOG.md?raw";
 
@@ -117,20 +109,18 @@ export default function SettingsRoute() {
             </p>
           </div>
 
-          <Card id="language" className="scroll-mt-16">
-            <CardHeader>
-              <CardTitle className="text-base">
-                {t("settings.languageTitle")}
-              </CardTitle>
-              <CardDescription>
-                {t("settings.languageDescription")}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="max-w-xs space-y-1.5">
-              <Label>{t("settings.languageLabel")}</Label>
-              <LanguagePicker label={t("settings.languageLabel")} />
-            </CardContent>
-          </Card>
+          <SettingsGroup>
+            <SettingsRow
+              id="language"
+              label={t("settings.languageTitle")}
+              description={t("settings.languageDescription")}
+              control={
+                <div className="w-56">
+                  <LanguagePicker label={t("settings.languageLabel")} />
+                </div>
+              }
+            />
+          </SettingsGroup>
         </div>
       }
       whatsNew={

--- a/templates/crm/app/routes/settings.tsx
+++ b/templates/crm/app/routes/settings.tsx
@@ -1,6 +1,8 @@
 import { ChangelogSettingsCard } from "@agent-native/core/client/changelog";
 import { LanguagePicker, useT } from "@agent-native/core/client/i18n";
 import {
+  SettingsGroup,
+  SettingsRow,
   SettingsTabsPage,
   useAgentSettingsTabs,
   type SettingsTabItem,

--- a/templates/design/app/routes/settings.tsx
+++ b/templates/design/app/routes/settings.tsx
@@ -3,6 +3,8 @@ import { LanguagePicker, useT } from "@agent-native/core/client/i18n";
 import { TeamPage } from "@agent-native/core/client/org";
 import {
   AccountSettingsCard,
+  SettingsGroup,
+  SettingsRow,
   SettingsTabsPage,
   useAgentSettingsTabs,
   type SettingsSearchEntry,
@@ -10,14 +12,6 @@ import {
 import { CreativeContextSettingsLink } from "@agent-native/creative-context/client";
 import { useMemo } from "react";
 
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
 import { messagesByLocale } from "@/i18n-data";
 
 import changelog from "../../CHANGELOG.md?raw";
@@ -52,20 +46,18 @@ export default function SettingsRoute() {
           <div className="mx-auto w-full max-w-2xl space-y-6">
             <CreativeContextSettingsLink />
 
-            <Card id="language" className="scroll-mt-16">
-              <CardHeader>
-                <CardTitle className="text-base">
-                  {t("settings.languageTitle")}
-                </CardTitle>
-                <CardDescription>
-                  {t("settings.languageDescription")}
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="max-w-xs space-y-1.5">
-                <Label>{t("settings.languageLabel")}</Label>
-                <LanguagePicker label={t("settings.languageLabel")} />
-              </CardContent>
-            </Card>
+            <SettingsGroup>
+              <SettingsRow
+                id="language"
+                label={t("settings.languageTitle")}
+                description={t("settings.languageDescription")}
+                control={
+                  <div className="w-56">
+                    <LanguagePicker label={t("settings.languageLabel")} />
+                  </div>
+                }
+              />
+            </SettingsGroup>
           </div>
         }
         team={

--- a/templates/design/changelog/2026-08-01-review-comments-replies-and-mentions-now-send-an-email-to-th.md
+++ b/templates/design/changelog/2026-08-01-review-comments-replies-and-mentions-now-send-an-email-to-th.md
@@ -1,0 +1,6 @@
+---
+type: added
+date: 2026-08-01
+---
+
+Review comments, replies, and mentions now send an email to the people involved

--- a/templates/dispatch/app/routes/settings.tsx
+++ b/templates/dispatch/app/routes/settings.tsx
@@ -3,19 +3,13 @@ import { LanguagePicker, useT } from "@agent-native/core/client/i18n";
 import { TeamPage } from "@agent-native/core/client/org";
 import {
   AccountSettingsCard,
+  SettingsGroup,
+  SettingsRow,
   SettingsTabsPage,
   useAgentSettingsTabs,
   type SettingsSearchEntry,
 } from "@agent-native/core/client/settings";
 import { Button } from "@agent-native/dispatch/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@agent-native/dispatch/components/ui/card";
-import { Label } from "@agent-native/dispatch/components/ui/label";
 import { useMemo } from "react";
 import { Link } from "react-router";
 
@@ -60,38 +54,30 @@ export default function SettingsRoute() {
             {t("settings.description")}
           </p>
 
-          <Card id="language" className="scroll-mt-16">
-            <CardHeader>
-              <CardTitle className="text-base">
-                {t("settings.languageTitle")}
-              </CardTitle>
-              <CardDescription>
-                {t("settings.languageDescription")}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="max-w-xs space-y-1.5">
-              <Label>{t("settings.languageLabel")}</Label>
-              <LanguagePicker label={t("settings.languageLabel")} />
-            </CardContent>
-          </Card>
-
-          <Card id="workspace-resources" className="scroll-mt-16">
-            <CardHeader>
-              <CardTitle className="text-base">
-                {t("settings.workspaceTitle")}
-              </CardTitle>
-              <CardDescription>
-                {t("settings.workspaceDescription")}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <Button variant="outline" asChild>
-                <Link to="/workspace">
-                  {t("settings.openResourceSettings")}
-                </Link>
-              </Button>
-            </CardContent>
-          </Card>
+          <SettingsGroup>
+            <SettingsRow
+              id="language"
+              label={t("settings.languageTitle")}
+              description={t("settings.languageDescription")}
+              control={
+                <div className="w-56">
+                  <LanguagePicker label={t("settings.languageLabel")} />
+                </div>
+              }
+            />
+            <SettingsRow
+              id="workspace-resources"
+              label={t("settings.workspaceTitle")}
+              description={t("settings.workspaceDescription")}
+              control={
+                <Button variant="outline" asChild>
+                  <Link to="/workspace">
+                    {t("settings.openResourceSettings")}
+                  </Link>
+                </Button>
+              }
+            />
+          </SettingsGroup>
         </div>
       }
       team={

--- a/templates/factory/app/routes/settings.tsx
+++ b/templates/factory/app/routes/settings.tsx
@@ -3,6 +3,8 @@ import { LanguagePicker, useT } from "@agent-native/core/client/i18n";
 import { TeamPage } from "@agent-native/core/client/org";
 import {
   AccountSettingsCard,
+  SettingsGroup,
+  SettingsRow,
   SettingsTabsPage,
   useAgentSettingsTabs,
   type SettingsSearchEntry,
@@ -10,14 +12,6 @@ import {
 import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
 import { useMemo } from "react";
 
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
 import { APP_TITLE } from "@/lib/app-config";
 
 import changelog from "../../CHANGELOG.md?raw";
@@ -55,20 +49,18 @@ export default function SettingsRoute() {
             {t("settings.description")}
           </p>
 
-          <Card id="language" className="scroll-mt-16">
-            <CardHeader>
-              <CardTitle className="text-base">
-                {t("settings.languageTitle")}
-              </CardTitle>
-              <CardDescription>
-                {t("settings.languageDescription")}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="max-w-xs space-y-1.5">
-              <Label>{t("settings.languageLabel")}</Label>
-              <LanguagePicker label={t("settings.languageLabel")} />
-            </CardContent>
-          </Card>
+          <SettingsGroup>
+            <SettingsRow
+              id="language"
+              label={t("settings.languageTitle")}
+              description={t("settings.languageDescription")}
+              control={
+                <div className="w-56">
+                  <LanguagePicker label={t("settings.languageLabel")} />
+                </div>
+              }
+            />
+          </SettingsGroup>
         </div>
       }
       team={

--- a/templates/forms/app/routes/_app.settings.tsx
+++ b/templates/forms/app/routes/_app.settings.tsx
@@ -3,6 +3,8 @@ import { LanguagePicker, useT } from "@agent-native/core/client/i18n";
 import { TeamPage } from "@agent-native/core/client/org";
 import {
   AccountSettingsCard,
+  SettingsGroup,
+  SettingsRow,
   SettingsTabsPage,
   useAgentSettingsTabs,
   type SettingsSearchEntry,
@@ -10,14 +12,6 @@ import {
 import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
 import { useMemo } from "react";
 
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
 import messages from "@/i18n/en-US";
 
 import changelog from "../../CHANGELOG.md?raw";
@@ -55,20 +49,18 @@ export default function SettingsRoute() {
             {t("settings.description")}
           </p>
 
-          <Card id="language" className="forms-settings-card scroll-mt-16">
-            <CardHeader>
-              <CardTitle className="text-base">
-                {t("settings.languageTitle")}
-              </CardTitle>
-              <CardDescription>
-                {t("settings.languageDescription")}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="max-w-xs space-y-1.5">
-              <Label>{t("settings.languageLabel")}</Label>
-              <LanguagePicker label={t("settings.languageLabel")} />
-            </CardContent>
-          </Card>
+          <SettingsGroup className="forms-settings-card">
+            <SettingsRow
+              id="language"
+              label={t("settings.languageTitle")}
+              description={t("settings.languageDescription")}
+              control={
+                <div className="w-56">
+                  <LanguagePicker label={t("settings.languageLabel")} />
+                </div>
+              }
+            />
+          </SettingsGroup>
         </div>
       }
       team={

--- a/templates/macros/app/routes/settings.tsx
+++ b/templates/macros/app/routes/settings.tsx
@@ -3,6 +3,8 @@ import { LanguagePicker, useT } from "@agent-native/core/client/i18n";
 import { TeamPage } from "@agent-native/core/client/org";
 import {
   AccountSettingsCard,
+  SettingsGroup,
+  SettingsRow,
   SettingsTabsPage,
   useAgentSettingsTabs,
   type SettingsSearchEntry,
@@ -10,14 +12,6 @@ import {
 import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
 import { useMemo } from "react";
 
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
 import messages from "@/i18n/en-US";
 
 import changelog from "../../CHANGELOG.md?raw";
@@ -55,20 +49,18 @@ export default function SettingsRoute() {
             {t("settings.description")}
           </p>
 
-          <Card id="language" className="scroll-mt-16">
-            <CardHeader>
-              <CardTitle className="text-base">
-                {t("settings.languageTitle")}
-              </CardTitle>
-              <CardDescription>
-                {t("settings.languageDescription")}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="max-w-xs space-y-1.5">
-              <Label>{t("settings.languageLabel")}</Label>
-              <LanguagePicker label={t("settings.languageLabel")} />
-            </CardContent>
-          </Card>
+          <SettingsGroup>
+            <SettingsRow
+              id="language"
+              label={t("settings.languageTitle")}
+              description={t("settings.languageDescription")}
+              control={
+                <div className="w-56">
+                  <LanguagePicker label={t("settings.languageLabel")} />
+                </div>
+              }
+            />
+          </SettingsGroup>
         </div>
       }
       team={

--- a/templates/mail/app/pages/SettingsPage.tsx
+++ b/templates/mail/app/pages/SettingsPage.tsx
@@ -10,6 +10,8 @@ import { LanguagePicker, useT } from "@agent-native/core/client/i18n";
 import { TeamPage } from "@agent-native/core/client/org";
 import {
   AccountSettingsCard,
+  SettingsGroup,
+  SettingsRow,
   SettingsTabsPage,
   useAgentSettingsTabs,
   type SettingsSearchEntry,
@@ -1431,22 +1433,18 @@ function GeneralSection() {
         </p>
       </div>
 
-      <div
-        id="language"
-        className="max-w-2xl scroll-mt-4 rounded-lg border border-border/20 bg-card/50 p-4"
-      >
-        <div className="mb-3">
-          <h3 className="text-[13px] font-semibold text-foreground">
-            {t("settings.languageTitle")}
-          </h3>
-          <p className="mt-0.5 text-[12px] text-muted-foreground">
-            {t("settings.languageDescription")}
-          </p>
-        </div>
-        <div className="max-w-sm">
-          <LanguagePicker label={t("settings.languageLabel")} />
-        </div>
-      </div>
+      <SettingsGroup className="max-w-2xl border-border/20 bg-card/50">
+        <SettingsRow
+          id="language"
+          label={t("settings.languageTitle")}
+          description={t("settings.languageDescription")}
+          control={
+            <div className="w-56">
+              <LanguagePicker label={t("settings.languageLabel")} />
+            </div>
+          }
+        />
+      </SettingsGroup>
     </div>
   );
 }

--- a/templates/plan/app/routes/settings.tsx
+++ b/templates/plan/app/routes/settings.tsx
@@ -3,6 +3,8 @@ import { LanguagePicker, useT } from "@agent-native/core/client/i18n";
 import { TeamPage } from "@agent-native/core/client/org";
 import {
   AccountSettingsCard,
+  SettingsGroup,
+  SettingsRow,
   SettingsTabsPage,
   useAgentSettingsTabs,
   type SettingsSearchEntry,
@@ -11,14 +13,6 @@ import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
 import { useMemo } from "react";
 
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
 import { APP_TITLE } from "@/lib/app-config";
 
 import changelog from "../../CHANGELOG.md?raw";
@@ -62,42 +56,34 @@ export default function SettingsRoute() {
             {t("settings.description")}
           </p>
 
-          <Card id="language" className="scroll-mt-16">
-            <CardHeader>
-              <CardTitle className="text-base">
-                {t("settings.languageTitle")}
-              </CardTitle>
-              <CardDescription>
-                {t("settings.languageDescription")}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="max-w-xs space-y-1.5">
-              <Label>{t("settings.languageLabel")}</Label>
-              <LanguagePicker label={t("settings.languageLabel")} />
-            </CardContent>
-          </Card>
-
-          <Card id="editor" className="scroll-mt-16">
-            <CardHeader>
-              <CardTitle className="text-base">
-                {t("settings.editorTitle")}
-              </CardTitle>
-              <CardDescription>
-                {t("settings.editorDescription")}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <Button variant="outline" asChild>
-                <a
-                  href="https://marketplace.visualstudio.com/items?itemName=Builder.agent-native"
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
-                  {t("settings.openEditorExtension")}
-                </a>
-              </Button>
-            </CardContent>
-          </Card>
+          <SettingsGroup>
+            <SettingsRow
+              id="language"
+              label={t("settings.languageTitle")}
+              description={t("settings.languageDescription")}
+              control={
+                <div className="w-56">
+                  <LanguagePicker label={t("settings.languageLabel")} />
+                </div>
+              }
+            />
+            <SettingsRow
+              id="editor"
+              label={t("settings.editorTitle")}
+              description={t("settings.editorDescription")}
+              control={
+                <Button variant="outline" asChild>
+                  <a
+                    href="https://marketplace.visualstudio.com/items?itemName=Builder.agent-native"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    {t("settings.openEditorExtension")}
+                  </a>
+                </Button>
+              }
+            />
+          </SettingsGroup>
         </div>
       }
       team={

--- a/templates/slides/actions/add-slide-comment.ts
+++ b/templates/slides/actions/add-slide-comment.ts
@@ -8,6 +8,7 @@ import { assertAccess } from "@agent-native/core/sharing";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js"; // ensure registerShareableResource runs
+import { notifyDeckComment } from "../server/lib/comment-notifications.js";
 
 function displayNameFromEmail(email: string): string {
   const local = email.split("@")[0] || email;
@@ -56,6 +57,16 @@ export default defineAction({
       authorName,
     });
 
-    return { id, threadId };
+    const notified = await notifyDeckComment({
+      deckId,
+      slideId,
+      threadId,
+      authorEmail,
+      authorName,
+      content,
+      isReply: Boolean(parentId ?? args.threadId),
+    });
+
+    return { id, threadId, notified };
   },
 });

--- a/templates/slides/app/components/ui/switch.tsx
+++ b/templates/slides/app/components/ui/switch.tsx
@@ -1,0 +1,1 @@
+export * from "@agent-native/toolkit/ui/switch";

--- a/templates/slides/app/hooks/use-slides-prefs.ts
+++ b/templates/slides/app/hooks/use-slides-prefs.ts
@@ -1,0 +1,55 @@
+import { agentNativePath } from "@agent-native/core/client/api-path";
+import type { SlidesUserPrefs } from "@shared/slides-user-prefs";
+import { useCallback, useEffect, useState } from "react";
+
+const PREFS_PATH = "/_agent-native/slides/user-prefs";
+
+export interface SlidesPrefsState {
+  prefs: SlidesUserPrefs;
+  loading: boolean;
+  /** Applies the patch optimistically and rolls back if the write fails. */
+  save: (patch: SlidesUserPrefs) => Promise<void>;
+}
+
+export function useSlidesPrefs(): SlidesPrefsState {
+  const [prefs, setPrefs] = useState<SlidesUserPrefs>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(agentNativePath(PREFS_PATH));
+        const json = res.ok ? await res.json() : null;
+        if (cancelled) return;
+        if (json && typeof json === "object" && !("error" in json)) {
+          setPrefs(json as SlidesUserPrefs);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const save = useCallback(
+    async (patch: SlidesUserPrefs) => {
+      const previous = prefs;
+      setPrefs((current) => ({ ...current, ...patch }));
+      const res = await fetch(agentNativePath(PREFS_PATH), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+      });
+      if (!res.ok) {
+        setPrefs(previous);
+        throw new Error(`Save failed (${res.status})`);
+      }
+    },
+    [prefs],
+  );
+
+  return { prefs, loading, save };
+}

--- a/templates/slides/app/i18n/ar-SA.ts
+++ b/templates/slides/app/i18n/ar-SA.ts
@@ -28,6 +28,10 @@ const messages = {
   settings: {
     title: "الإعدادات",
     description: "تفضيلات اللغة ومساحة العمل لهذا التطبيق.",
+    emailNotifications: "إشعارات البريد الإلكتروني",
+    emailNotificationsDescription:
+      "احصل على بريد إلكتروني عندما يعلّق شخص على عرضك أو يرد في مناقشة.",
+    saveFailed: "فشل الحفظ",
     languageTitle: "اللغة",
     languageDescription: "اختر لغة الواجهة. يتم حفظ هذا التفضيل في حسابك.",
     languageLabel: "لغة الواجهة",

--- a/templates/slides/app/i18n/de-DE.ts
+++ b/templates/slides/app/i18n/de-DE.ts
@@ -28,6 +28,10 @@ const messages = {
   settings: {
     title: "Einstellungen",
     description: "Sprach- und Arbeitsbereichseinstellungen für diese App.",
+    emailNotifications: "E-Mail-Benachrichtigungen",
+    emailNotificationsDescription:
+      "Erhalte eine E-Mail, wenn jemand dein Deck kommentiert oder in einem Thread antwortet.",
+    saveFailed: "Speichern fehlgeschlagen",
     languageTitle: "Sprache",
     languageDescription:
       "Wähle die Sprache der Oberfläche. Diese Einstellung wird in deinem Konto gespeichert.",

--- a/templates/slides/app/i18n/en-US.ts
+++ b/templates/slides/app/i18n/en-US.ts
@@ -28,6 +28,10 @@ const messages = {
   settings: {
     title: "Settings",
     description: "Language and workspace preferences for this app.",
+    emailNotifications: "Email notifications",
+    emailNotificationsDescription:
+      "Get an email when someone comments on or replies in your deck.",
+    saveFailed: "Failed to save",
     languageTitle: "Language",
     languageDescription:
       "Choose the interface language. This preference is saved for your account.",

--- a/templates/slides/app/i18n/es-ES.ts
+++ b/templates/slides/app/i18n/es-ES.ts
@@ -28,6 +28,10 @@ const messages = {
   settings: {
     title: "Ajustes",
     description: "Preferencias de idioma y espacio de trabajo para esta app.",
+    emailNotifications: "Notificaciones por correo",
+    emailNotificationsDescription:
+      "Recibe un correo cuando alguien comente o responda en tu presentación.",
+    saveFailed: "No se pudo guardar",
     languageTitle: "Idioma",
     languageDescription:
       "Elige el idioma de la interfaz. Esta preferencia se guarda en tu cuenta.",

--- a/templates/slides/app/i18n/fr-FR.ts
+++ b/templates/slides/app/i18n/fr-FR.ts
@@ -28,6 +28,10 @@ const messages = {
   settings: {
     title: "Paramètres",
     description: "Préférences de langue et d’espace de travail pour cette app.",
+    emailNotifications: "Notifications par e-mail",
+    emailNotificationsDescription:
+      "Recevez un e-mail lorsqu’une personne commente votre deck ou répond dans un fil.",
+    saveFailed: "Échec de l’enregistrement",
     languageTitle: "Langue",
     languageDescription:
       "Choisissez la langue de l’interface. Cette préférence est enregistrée dans votre compte.",

--- a/templates/slides/app/i18n/hi-IN.ts
+++ b/templates/slides/app/i18n/hi-IN.ts
@@ -28,6 +28,10 @@ const messages = {
   settings: {
     title: "सेटिंग्स",
     description: "इस ऐप के लिए भाषा और कार्यस्थान प्राथमिकताएं।",
+    emailNotifications: "ईमेल सूचनाएँ",
+    emailNotificationsDescription:
+      "जब कोई आपके डेक पर टिप्पणी करे या किसी थ्रेड में जवाब दे तो ईमेल पाएँ।",
+    saveFailed: "सहेजने में विफल",
     languageTitle: "भाषा",
     languageDescription: "इंटरफ़ेस भाषा चुनें। यह पसंद आपके खाते में सहेजी जाती है।",
     languageLabel: "इंटरफ़ेस भाषा",

--- a/templates/slides/app/i18n/ja-JP.ts
+++ b/templates/slides/app/i18n/ja-JP.ts
@@ -28,6 +28,10 @@ const messages = {
   settings: {
     title: "設定",
     description: "このアプリの言語とワークスペース設定。",
+    emailNotifications: "メール通知",
+    emailNotificationsDescription:
+      "誰かがあなたのデッキにコメントまたは返信したときにメールを受け取ります。",
+    saveFailed: "保存に失敗しました",
     languageTitle: "言語",
     languageDescription:
       "インターフェース言語を選択します。この設定はアカウントに保存されます。",

--- a/templates/slides/app/i18n/ko-KR.ts
+++ b/templates/slides/app/i18n/ko-KR.ts
@@ -28,6 +28,10 @@ const messages = {
   settings: {
     title: "설정",
     description: "이 앱의 언어 및 워크스페이스 환경설정입니다.",
+    emailNotifications: "이메일 알림",
+    emailNotificationsDescription:
+      "누군가 내 덱에 댓글을 달거나 답글을 남기면 이메일을 받습니다.",
+    saveFailed: "저장 실패",
     languageTitle: "언어",
     languageDescription:
       "인터페이스 언어를 선택하세요. 이 기본 설정은 계정에 저장됩니다.",

--- a/templates/slides/app/i18n/pt-BR.ts
+++ b/templates/slides/app/i18n/pt-BR.ts
@@ -28,6 +28,10 @@ const messages = {
   settings: {
     title: "Configurações",
     description: "Preferências de idioma e espaço de trabalho deste app.",
+    emailNotifications: "Notificações por e-mail",
+    emailNotificationsDescription:
+      "Receba um e-mail quando alguém comentar ou responder na sua apresentação.",
+    saveFailed: "Falha ao salvar",
     languageTitle: "Idioma",
     languageDescription:
       "Escolha o idioma da interface. Essa preferência é salva na sua conta.",

--- a/templates/slides/app/i18n/zh-CN.ts
+++ b/templates/slides/app/i18n/zh-CN.ts
@@ -28,6 +28,10 @@ const messages = {
   settings: {
     title: "设置",
     description: "此应用的语言和工作区偏好设置。",
+    emailNotifications: "邮件通知",
+    emailNotificationsDescription:
+      "当有人评论你的演示文稿或在讨论串中回复时，收到邮件通知。",
+    saveFailed: "保存失败",
     languageTitle: "语言",
     languageDescription: "选择界面语言。此偏好会保存到你的账户。",
     languageLabel: "界面语言",

--- a/templates/slides/app/i18n/zh-TW.ts
+++ b/templates/slides/app/i18n/zh-TW.ts
@@ -28,6 +28,10 @@ const messages = {
   settings: {
     title: "設定",
     description: "此應用的語言和工作區偏好設定。",
+    emailNotifications: "郵件通知",
+    emailNotificationsDescription:
+      "當有人評論你的簡報或在討論串中回覆時，收到郵件通知。",
+    saveFailed: "儲存失敗",
     languageTitle: "語言",
     languageDescription: "選取介面語言。此偏好會儲存到你的帳戶。",
     languageLabel: "介面語言",

--- a/templates/slides/app/routes/settings.tsx
+++ b/templates/slides/app/routes/settings.tsx
@@ -3,6 +3,8 @@ import { LanguagePicker, useT } from "@agent-native/core/client/i18n";
 import { TeamPage } from "@agent-native/core/client/org";
 import {
   AccountSettingsCard,
+  SettingsGroup,
+  SettingsRow,
   SettingsTabsPage,
   useAgentSettingsTabs,
   type SettingsSearchEntry,
@@ -11,14 +13,6 @@ import { CreativeContextSettingsLink } from "@agent-native/creative-context/clie
 import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
 import { useMemo } from "react";
 
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
 import messages from "@/i18n/en-US";
 
 import changelog from "../../CHANGELOG.md?raw";
@@ -58,20 +52,18 @@ export default function SettingsRoute() {
 
           <CreativeContextSettingsLink />
 
-          <Card id="language" className="scroll-mt-16">
-            <CardHeader>
-              <CardTitle className="text-base">
-                {t("settings.languageTitle")}
-              </CardTitle>
-              <CardDescription>
-                {t("settings.languageDescription")}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="max-w-xs space-y-1.5">
-              <Label>{t("settings.languageLabel")}</Label>
-              <LanguagePicker label={t("settings.languageLabel")} />
-            </CardContent>
-          </Card>
+          <SettingsGroup>
+            <SettingsRow
+              id="language"
+              label={t("settings.languageTitle")}
+              description={t("settings.languageDescription")}
+              control={
+                <div className="w-56">
+                  <LanguagePicker label={t("settings.languageLabel")} />
+                </div>
+              }
+            />
+          </SettingsGroup>
         </div>
       }
       team={

--- a/templates/slides/app/routes/settings.tsx
+++ b/templates/slides/app/routes/settings.tsx
@@ -11,10 +11,10 @@ import {
 } from "@agent-native/core/client/settings";
 import { CreativeContextSettingsLink } from "@agent-native/creative-context/client";
 import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
-import { Switch } from "@agent-native/toolkit/ui/switch";
 import { useMemo } from "react";
 import { toast } from "sonner";
 
+import { Switch } from "@/components/ui/switch";
 import { useSlidesPrefs } from "@/hooks/use-slides-prefs";
 import messages from "@/i18n/en-US";
 

--- a/templates/slides/app/routes/settings.tsx
+++ b/templates/slides/app/routes/settings.tsx
@@ -11,8 +11,11 @@ import {
 } from "@agent-native/core/client/settings";
 import { CreativeContextSettingsLink } from "@agent-native/creative-context/client";
 import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
+import { Switch } from "@agent-native/toolkit/ui/switch";
 import { useMemo } from "react";
+import { toast } from "sonner";
 
+import { useSlidesPrefs } from "@/hooks/use-slides-prefs";
 import messages from "@/i18n/en-US";
 
 import changelog from "../../CHANGELOG.md?raw";
@@ -25,6 +28,7 @@ export default function SettingsRoute() {
   const t = useT();
   const agentSettingsTabs = useAgentSettingsTabs();
   useSetPageTitle(t("settings.title"));
+  const { prefs, loading: prefsLoading, save: savePrefs } = useSlidesPrefs();
 
   const generalSearchEntries = useMemo<SettingsSearchEntry[]>(
     () => [
@@ -33,6 +37,12 @@ export default function SettingsRoute() {
         label: t("settings.languageTitle"),
         keywords: "language locale translation i18n",
         hash: "language",
+      },
+      {
+        id: "slides-notifications",
+        label: t("settings.emailNotifications"),
+        keywords: "email notifications comments replies alerts",
+        hash: "notifications",
       },
     ],
     [t],
@@ -61,6 +71,27 @@ export default function SettingsRoute() {
                 <div className="w-56">
                   <LanguagePicker label={t("settings.languageLabel")} />
                 </div>
+              }
+            />
+            <SettingsRow
+              id="notifications"
+              label={t("settings.emailNotifications")}
+              description={t("settings.emailNotificationsDescription")}
+              control={
+                <Switch
+                  aria-label={t("settings.emailNotifications")}
+                  checked={prefs.emailNotifications !== false}
+                  disabled={prefsLoading}
+                  onCheckedChange={(checked) => {
+                    savePrefs({ emailNotifications: checked }).catch((err) => {
+                      toast.error(
+                        err instanceof Error
+                          ? err.message
+                          : t("settings.saveFailed"),
+                      );
+                    });
+                  }}
+                />
               }
             />
           </SettingsGroup>

--- a/templates/slides/changelog/2026-08-01-get-an-email-when-someone-comments-on-or-replies-in-your-dec.md
+++ b/templates/slides/changelog/2026-08-01-get-an-email-when-someone-comments-on-or-replies-in-your-dec.md
@@ -1,0 +1,6 @@
+---
+type: added
+date: 2026-08-01
+---
+
+Get an email when someone comments on or replies in your deck, with a new toggle in Settings

--- a/templates/slides/server/lib/comment-notifications.spec.ts
+++ b/templates/slides/server/lib/comment-notifications.spec.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  notifyActivity: vi.fn(),
+  sendEmail: vi.fn(),
+  select: vi.fn(),
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: (...conditions: unknown[]) => ({ type: "and", conditions }),
+  eq: (left: unknown, right: unknown) => ({ type: "eq", left, right }),
+}));
+
+vi.mock("@agent-native/core/server", () => ({
+  emailStrong: (value: string) => value,
+  notifyActivity: (...args: unknown[]) => mocks.notifyActivity(...args),
+  renderEmail: (args: { heading: string; paragraphs: string[] }) => ({
+    html: `<h1>${args.heading}</h1>`,
+    text: [args.heading, ...args.paragraphs].join("\n"),
+  }),
+  sendEmail: (...args: unknown[]) => mocks.sendEmail(...args),
+}));
+
+vi.mock("../../actions/_app-url.js", () => ({
+  getDeckUrl: (deckId: string) => `https://slides.test/deck/${deckId}`,
+}));
+
+vi.mock("../db/index.js", () => ({
+  getDb: () => ({ select: (...args: unknown[]) => mocks.select(...args) }),
+  schema: {
+    decks: { id: "id", title: "title", ownerEmail: "owner_email" },
+    slideComments: {
+      deckId: "deck_id",
+      threadId: "thread_id",
+      authorEmail: "author_email",
+    },
+  },
+}));
+
+import { SLIDES_USER_PREFS_KEY } from "../../shared/slides-user-prefs.js";
+import { notifyDeckComment } from "./comment-notifications.js";
+
+const DECK = {
+  id: "deck_1",
+  title: "Q3 review",
+  ownerEmail: "owner@example.com",
+};
+
+function stubDb(options: {
+  deck: typeof DECK | null;
+  participants?: string[];
+}) {
+  const participants = (options.participants ?? []).map((authorEmail) => ({
+    authorEmail,
+  }));
+  mocks.select.mockReturnValue({
+    from: () => ({
+      where: () =>
+        Object.assign(Promise.resolve(participants), {
+          limit: async () => (options.deck ? [options.deck] : []),
+        }),
+    }),
+  });
+}
+
+function notifyArgs() {
+  return mocks.notifyActivity.mock.calls[0]?.[0] as {
+    candidates: string[];
+    actorEmail?: string | null;
+    preferenceKey: string;
+    send: (to: string) => Promise<unknown>;
+  };
+}
+
+describe("slides comment notifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.notifyActivity.mockResolvedValue({
+      status: "delivered",
+      sent: [],
+      failed: [],
+    });
+    stubDb({ deck: DECK });
+  });
+
+  it("notifies the deck owner against the Slides preference key", async () => {
+    await notifyDeckComment({
+      deckId: "deck_1",
+      slideId: "slide_2",
+      threadId: "thread_1",
+      authorEmail: "viewer@example.com",
+      authorName: "Viewer",
+      content: "Slide 2 needs a source",
+      isReply: false,
+    });
+
+    const args = notifyArgs();
+    expect(args.candidates).toEqual(["owner@example.com"]);
+    expect(args.actorEmail).toBe("viewer@example.com");
+    expect(args.preferenceKey).toBe(SLIDES_USER_PREFS_KEY);
+  });
+
+  it("adds thread participants on a reply", async () => {
+    stubDb({
+      deck: DECK,
+      participants: ["first@example.com", "viewer@example.com"],
+    });
+
+    await notifyDeckComment({
+      deckId: "deck_1",
+      slideId: "slide_2",
+      threadId: "thread_1",
+      authorEmail: "viewer@example.com",
+      content: "Agreed",
+      isReply: true,
+    });
+
+    expect(notifyArgs().candidates).toEqual([
+      "owner@example.com",
+      "first@example.com",
+      "viewer@example.com",
+    ]);
+  });
+
+  it("sends a deep-linked email per recipient", async () => {
+    await notifyDeckComment({
+      deckId: "deck_1",
+      slideId: "slide_2",
+      threadId: "thread_1",
+      authorEmail: "viewer@example.com",
+      authorName: "Viewer",
+      content: "Slide 2 needs a source",
+      isReply: false,
+    });
+
+    await notifyArgs().send("owner@example.com");
+
+    expect(mocks.sendEmail).toHaveBeenCalledTimes(1);
+    const email = mocks.sendEmail.mock.calls[0][0] as {
+      to: string;
+      subject: string;
+      text: string;
+    };
+    expect(email.to).toBe("owner@example.com");
+    expect(email.subject).toBe('Viewer commented on "Q3 review"');
+    expect(email.text).toContain("Slide 2 needs a source");
+  });
+
+  it("reports a missing deck instead of a clean empty result", async () => {
+    stubDb({ deck: null });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await notifyDeckComment({
+      deckId: "missing",
+      slideId: "slide_2",
+      threadId: "thread_1",
+      authorEmail: "viewer@example.com",
+      content: "Hello",
+      isReply: false,
+    });
+
+    expect(mocks.notifyActivity).not.toHaveBeenCalled();
+    expect(result.status).toBe("deck-missing");
+  });
+});

--- a/templates/slides/server/lib/comment-notifications.spec.ts
+++ b/templates/slides/server/lib/comment-notifications.spec.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   notifyActivity: vi.fn(),
   sendEmail: vi.fn(),
   select: vi.fn(),
+  filterRecipients: vi.fn(),
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -14,11 +15,35 @@ vi.mock("drizzle-orm", () => ({
 vi.mock("@agent-native/core/server", () => ({
   emailStrong: (value: string) => value,
   notifyActivity: (...args: unknown[]) => mocks.notifyActivity(...args),
-  renderEmail: (args: { heading: string; paragraphs: string[] }) => ({
+  renderEmail: (args: {
+    heading: string;
+    paragraphs: string[];
+    cta?: { url: string };
+  }) => ({
     html: `<h1>${args.heading}</h1>`,
-    text: [args.heading, ...args.paragraphs].join("\n"),
+    text: [args.heading, ...args.paragraphs, args.cta?.url ?? ""].join("\n"),
   }),
   sendEmail: (...args: unknown[]) => mocks.sendEmail(...args),
+  runActivityNotification: async (
+    logLabel: string,
+    resolve: () => Promise<unknown>,
+  ) => {
+    try {
+      return await resolve();
+    } catch (error) {
+      return {
+        status: "notification-error",
+        error: error instanceof Error ? error.message : String(error),
+        sent: [],
+        failed: [],
+      };
+    }
+  },
+}));
+
+vi.mock("@agent-native/core/sharing", () => ({
+  filterRecipientsByResourceAccess: (...args: unknown[]) =>
+    mocks.filterRecipients(...args),
 }));
 
 vi.mock("../../actions/_app-url.js", () => ({
@@ -28,7 +53,13 @@ vi.mock("../../actions/_app-url.js", () => ({
 vi.mock("../db/index.js", () => ({
   getDb: () => ({ select: (...args: unknown[]) => mocks.select(...args) }),
   schema: {
-    decks: { id: "id", title: "title", ownerEmail: "owner_email" },
+    decks: {
+      id: "id",
+      title: "title",
+      ownerEmail: "owner_email",
+      orgId: "org_id",
+      data: "data",
+    },
     slideComments: {
       deckId: "deck_id",
       threadId: "thread_id",
@@ -44,6 +75,10 @@ const DECK = {
   id: "deck_1",
   title: "Q3 review",
   ownerEmail: "owner@example.com",
+  orgId: null,
+  data: JSON.stringify({
+    slides: [{ id: "slide_1" }, { id: "slide_2" }, { id: "slide_3" }],
+  }),
 };
 
 function stubDb(options: {
@@ -81,6 +116,10 @@ describe("slides comment notifications", () => {
       failed: [],
     });
     stubDb({ deck: DECK });
+    // Access filtering has its own tests; these assert who is offered.
+    mocks.filterRecipients.mockImplementation(
+      async ({ emails }: { emails: string[] }) => [...emails],
+    );
   });
 
   it("notifies the deck owner against the Slides preference key", async () => {
@@ -144,6 +183,68 @@ describe("slides comment notifications", () => {
     expect(email.to).toBe("owner@example.com");
     expect(email.subject).toBe('Viewer commented on "Q3 review"');
     expect(email.text).toContain("Slide 2 needs a source");
+  });
+
+  it("links to the slide by its one-based position, not its id", async () => {
+    await notifyDeckComment({
+      deckId: "deck_1",
+      slideId: "slide_3",
+      threadId: "thread_1",
+      authorEmail: "viewer@example.com",
+      content: "Third slide",
+      isReply: false,
+    });
+    await notifyArgs().send("owner@example.com");
+
+    const email = mocks.sendEmail.mock.calls[0][0] as { text: string };
+    expect(email.text).toContain("https://slides.test/deck/deck_1?slide=3");
+    expect(email.text).not.toContain("slide=slide_3");
+  });
+
+  it("drops a participant who can no longer open the deck", async () => {
+    stubDb({
+      deck: DECK,
+      participants: ["revoked@example.com", "still@example.com"],
+    });
+    mocks.filterRecipients.mockResolvedValue([
+      "owner@example.com",
+      "still@example.com",
+    ]);
+
+    await notifyDeckComment({
+      deckId: "deck_1",
+      slideId: "slide_2",
+      threadId: "thread_1",
+      authorEmail: "viewer@example.com",
+      content: "Agreed",
+      isReply: true,
+    });
+
+    expect(notifyArgs().candidates).toEqual([
+      "owner@example.com",
+      "still@example.com",
+    ]);
+    expect(
+      (mocks.filterRecipients.mock.calls[0][0] as { emails: string[] }).emails,
+    ).toContain("revoked@example.com");
+  });
+
+  it("returns notification-error instead of throwing when the deck read fails", async () => {
+    mocks.select.mockImplementation(() => {
+      throw new Error("db down");
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await notifyDeckComment({
+      deckId: "deck_1",
+      slideId: "slide_2",
+      threadId: "thread_1",
+      authorEmail: "viewer@example.com",
+      content: "Hello",
+      isReply: false,
+    });
+
+    expect(result.status).toBe("notification-error");
   });
 
   it("reports a missing deck instead of a clean empty result", async () => {

--- a/templates/slides/server/lib/comment-notifications.ts
+++ b/templates/slides/server/lib/comment-notifications.ts
@@ -1,0 +1,131 @@
+/**
+ * Email notifications for deck comments and replies.
+ *
+ * Recipient resolution, preference filtering, and delivery reporting come from
+ * `@agent-native/core/server`; this module owns only the Slides rows and the
+ * email copy. Share invites are not routed through the `emailNotifications`
+ * preference — they have their own delivery path.
+ */
+
+import {
+  emailStrong,
+  notifyActivity,
+  renderEmail,
+  sendEmail,
+  type ActivityNotificationResult,
+} from "@agent-native/core/server";
+import { and, eq } from "drizzle-orm";
+
+import { getDeckUrl } from "../../actions/_app-url.js";
+import { SLIDES_USER_PREFS_KEY } from "../../shared/slides-user-prefs.js";
+import { getDb, schema } from "../db/index.js";
+
+/**
+ * `deck-missing` stays distinct from `no-recipients`: one means the deck could
+ * not be read, the other means nobody wanted the email.
+ */
+export type SlidesCommentNotificationResult =
+  | ActivityNotificationResult
+  | { status: "deck-missing"; sent: []; failed: [] };
+
+const LOG_LABEL = "[slides] comment notification";
+const EXCERPT_LIMIT = 240;
+
+function excerpt(content: string): string {
+  const collapsed = content.replace(/\s+/g, " ").trim();
+  return collapsed.length > EXCERPT_LIMIT
+    ? `${collapsed.slice(0, EXCERPT_LIMIT - 1)}…`
+    : collapsed;
+}
+
+function deckUrl(deckId: string, slideId: string): string {
+  return `${getDeckUrl(deckId)}?slide=${encodeURIComponent(slideId)}`;
+}
+
+async function getDeck(deckId: string) {
+  const [row] = await getDb()
+    .select({
+      id: schema.decks.id,
+      title: schema.decks.title,
+      ownerEmail: schema.decks.ownerEmail,
+    })
+    .from(schema.decks)
+    .where(eq(schema.decks.id, deckId))
+    .limit(1);
+  return row ?? null;
+}
+
+async function threadParticipants(
+  deckId: string,
+  threadId: string,
+): Promise<string[]> {
+  const rows = await getDb()
+    .select({ authorEmail: schema.slideComments.authorEmail })
+    .from(schema.slideComments)
+    .where(
+      and(
+        eq(schema.slideComments.deckId, deckId),
+        eq(schema.slideComments.threadId, threadId),
+      ),
+    );
+  return rows.map((row) => row.authorEmail);
+}
+
+export async function notifyDeckComment(input: {
+  deckId: string;
+  slideId: string;
+  threadId: string;
+  authorEmail: string;
+  authorName?: string | null;
+  content: string;
+  isReply: boolean;
+}): Promise<SlidesCommentNotificationResult> {
+  const deck = await getDeck(input.deckId);
+  if (!deck) {
+    console.error(`${LOG_LABEL}: deck ${input.deckId} not found`);
+    return { status: "deck-missing", sent: [], failed: [] };
+  }
+
+  const candidates = [deck.ownerEmail];
+  if (input.isReply) {
+    candidates.push(
+      ...(await threadParticipants(input.deckId, input.threadId)),
+    );
+  }
+
+  const actor = input.authorName?.trim() || input.authorEmail;
+  const url = deckUrl(deck.id, input.slideId);
+
+  return notifyActivity({
+    candidates,
+    actorEmail: input.authorEmail,
+    preferenceKey: SLIDES_USER_PREFS_KEY,
+    logLabel: LOG_LABEL,
+    send: async (to) => {
+      const { html, text } = renderEmail({
+        preheader: input.isReply
+          ? `${actor} replied to a comment on ${deck.title}.`
+          : `${actor} commented on ${deck.title}.`,
+        heading: input.isReply ? "New reply on your deck" : "New comment",
+        paragraphs: [
+          input.isReply
+            ? `${emailStrong(actor)} replied in a comment thread on ${emailStrong(deck.title)}.`
+            : `${emailStrong(actor)} commented on ${emailStrong(deck.title)}.`,
+          `"${excerpt(input.content)}"`,
+        ],
+        cta: { label: "Open deck", url },
+        footer:
+          "You received this because you own or participated in this thread. Turn these off in Slides settings.",
+      });
+
+      await sendEmail({
+        to,
+        subject: input.isReply
+          ? `${actor} replied to a comment on "${deck.title}"`
+          : `${actor} commented on "${deck.title}"`,
+        html,
+        text,
+      });
+    },
+  });
+}

--- a/templates/slides/server/lib/comment-notifications.ts
+++ b/templates/slides/server/lib/comment-notifications.ts
@@ -11,9 +11,11 @@ import {
   emailStrong,
   notifyActivity,
   renderEmail,
+  runActivityNotification,
   sendEmail,
   type ActivityNotificationResult,
 } from "@agent-native/core/server";
+import { filterRecipientsByResourceAccess } from "@agent-native/core/sharing";
 import { and, eq } from "drizzle-orm";
 
 import { getDeckUrl } from "../../actions/_app-url.js";
@@ -38,8 +40,32 @@ function excerpt(content: string): string {
     : collapsed;
 }
 
-function deckUrl(deckId: string, slideId: string): string {
-  return `${getDeckUrl(deckId)}?slide=${encodeURIComponent(slideId)}`;
+/**
+ * The editor reads `?slide=` as a one-based ordinal, not a slide id — passing
+ * `slide_2` parses to NaN and silently lands on slide 1.
+ */
+function deckUrl(deckId: string, slideNumber: number | null): string {
+  const base = getDeckUrl(deckId);
+  return slideNumber ? `${base}?slide=${slideNumber}` : base;
+}
+
+function slideNumberIn(deckData: string, slideId: string): number | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(deckData);
+  } catch (error) {
+    // Unparsable deck JSON is a real anomaly, so say so — but the comment email
+    // still goes out with a deck-level link rather than being dropped.
+    console.error(
+      `${LOG_LABEL}: deck data could not be parsed for a slide link:`,
+      error instanceof Error ? error.message : String(error),
+    );
+    return null;
+  }
+  const slides = (parsed as { slides?: { id?: string }[] } | null)?.slides;
+  if (!Array.isArray(slides)) return null;
+  const index = slides.findIndex((slide) => slide?.id === slideId);
+  return index >= 0 ? index + 1 : null;
 }
 
 async function getDeck(deckId: string) {
@@ -48,6 +74,8 @@ async function getDeck(deckId: string) {
       id: schema.decks.id,
       title: schema.decks.title,
       ownerEmail: schema.decks.ownerEmail,
+      orgId: schema.decks.orgId,
+      data: schema.decks.data,
     })
     .from(schema.decks)
     .where(eq(schema.decks.id, deckId))
@@ -80,6 +108,20 @@ export async function notifyDeckComment(input: {
   content: string;
   isReply: boolean;
 }): Promise<SlidesCommentNotificationResult> {
+  return runActivityNotification(LOG_LABEL, () =>
+    deliverDeckCommentEmails(input),
+  );
+}
+
+async function deliverDeckCommentEmails(input: {
+  deckId: string;
+  slideId: string;
+  threadId: string;
+  authorEmail: string;
+  authorName?: string | null;
+  content: string;
+  isReply: boolean;
+}): Promise<SlidesCommentNotificationResult> {
   const deck = await getDeck(input.deckId);
   if (!deck) {
     console.error(`${LOG_LABEL}: deck ${input.deckId} not found`);
@@ -93,11 +135,20 @@ export async function notifyDeckComment(input: {
     );
   }
 
+  // Thread rows are history, not an access grant: someone removed from the
+  // deck must stop receiving its comment bodies.
+  const allowed = await filterRecipientsByResourceAccess({
+    resourceType: "deck",
+    resourceId: deck.id,
+    emails: candidates,
+    orgId: deck.orgId,
+  });
+
   const actor = input.authorName?.trim() || input.authorEmail;
-  const url = deckUrl(deck.id, input.slideId);
+  const url = deckUrl(deck.id, slideNumberIn(deck.data, input.slideId));
 
   return notifyActivity({
-    candidates,
+    candidates: allowed,
     actorEmail: input.authorEmail,
     preferenceKey: SLIDES_USER_PREFS_KEY,
     logLabel: LOG_LABEL,

--- a/templates/slides/server/routes/_agent-native/slides/user-prefs.get.ts
+++ b/templates/slides/server/routes/_agent-native/slides/user-prefs.get.ts
@@ -1,0 +1,16 @@
+import { getSession } from "@agent-native/core/server";
+import { getUserSetting } from "@agent-native/core/settings";
+import { defineEventHandler, setResponseStatus } from "h3";
+
+import { SLIDES_USER_PREFS_KEY } from "../../../../shared/slides-user-prefs.js";
+
+export default defineEventHandler(async (event) => {
+  const session = await getSession(event);
+  if (!session?.email) {
+    setResponseStatus(event, 401);
+    return { error: "unauthorized" };
+  }
+
+  // coercion-ok: no stored blob means no preferences set yet, which is a real state, not a read failure.
+  return (await getUserSetting(session.email, SLIDES_USER_PREFS_KEY)) ?? {};
+});

--- a/templates/slides/server/routes/_agent-native/slides/user-prefs.put.ts
+++ b/templates/slides/server/routes/_agent-native/slides/user-prefs.put.ts
@@ -1,0 +1,36 @@
+import { getSession } from "@agent-native/core/server";
+import { getUserSetting, putUserSetting } from "@agent-native/core/settings";
+import { defineEventHandler, getHeader, readBody, setResponseStatus } from "h3";
+
+import { SLIDES_USER_PREFS_KEY } from "../../../../shared/slides-user-prefs.js";
+
+export default defineEventHandler(async (event) => {
+  const session = await getSession(event);
+  if (!session?.email) {
+    setResponseStatus(event, 401);
+    return { error: "unauthorized" };
+  }
+
+  // coercion-ok: an unparsable body is rejected with 400 immediately below.
+  const body = await readBody(event).catch(() => null);
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    setResponseStatus(event, 400);
+    return { error: "Invalid settings payload" };
+  }
+
+  // Merge so a partial save never wipes preferences written elsewhere.
+  const stored = await getUserSetting(session.email, SLIDES_USER_PREFS_KEY);
+  // coercion-ok: a null read means this user has no preferences yet, which is a real state.
+  const existing = stored ?? {};
+  const next = {
+    ...(typeof existing === "object" && existing && !Array.isArray(existing)
+      ? existing
+      : {}),
+    ...(body as Record<string, unknown>),
+  };
+
+  await putUserSetting(session.email, SLIDES_USER_PREFS_KEY, next, {
+    requestSource: getHeader(event, "x-request-source") || undefined,
+  });
+  return next;
+});

--- a/templates/slides/shared/slides-user-prefs.ts
+++ b/templates/slides/shared/slides-user-prefs.ts
@@ -1,0 +1,11 @@
+/**
+ * Per-user Slides preferences, stored under one user-setting key so Settings
+ * and the notification senders read and write the same object.
+ */
+
+export const SLIDES_USER_PREFS_KEY = "slides-user-prefs";
+
+export type SlidesUserPrefs = {
+  /** Comment and reply emails only — never share invites. */
+  emailNotifications?: boolean;
+};

--- a/templates/tasks/app/routes/settings.tsx
+++ b/templates/tasks/app/routes/settings.tsx
@@ -5,14 +5,6 @@ import {
 } from "@agent-native/core/client/settings";
 import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
 
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
 import { APP_TITLE } from "@/lib/app-config";
 
 export function meta() {
@@ -33,20 +25,18 @@ export default function SettingsRoute() {
             {t("header.pageSettings")}
           </p>
 
-          <Card id="language" className="scroll-mt-16">
-            <CardHeader>
-              <CardTitle className="text-base">
-                {t("settings.languageTitle")}
-              </CardTitle>
-              <CardDescription>
-                {t("settings.languageDescription")}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="max-w-xs space-y-1.5">
-              <Label>{t("settings.languageLabel")}</Label>
-              <LanguagePicker label={t("settings.languageLabel")} />
-            </CardContent>
-          </Card>
+          <SettingsGroup>
+            <SettingsRow
+              id="language"
+              label={t("settings.languageTitle")}
+              description={t("settings.languageDescription")}
+              control={
+                <div className="w-56">
+                  <LanguagePicker label={t("settings.languageLabel")} />
+                </div>
+              }
+            />
+          </SettingsGroup>
         </div>
       }
     />

--- a/templates/tasks/app/routes/settings.tsx
+++ b/templates/tasks/app/routes/settings.tsx
@@ -1,5 +1,7 @@
 import { LanguagePicker, useT } from "@agent-native/core/client/i18n";
 import {
+  SettingsGroup,
+  SettingsRow,
   SettingsTabsPage,
   useAgentSettingsTabs,
 } from "@agent-native/core/client/settings";


### PR DESCRIPTION
### Summary
Adds shared `SettingsGroup`/`SettingsRow` primitives for a flatter Settings UI, and core `resolveActivityRecipients`/`notifyActivity` helpers that back real, preference-aware email notifications for review comments, replies, and mentions.

### Problem
Clips exposed an email-notification preference for comments/reacts in the Activity stream that was never actually wired to any email-sending logic, so the UI made a promise it didn't keep. Additionally, Settings pages tended toward one card per single setting, making them visually sprawling and inconsistent across apps.

### Solution
Introduced reusable `SettingsGroup`/`SettingsRow` components in `@agent-native/core/client/settings` so multiple one-line settings can live in a single card while preserving per-row anchor ids for settings-search links. On the server side, added `resolveActivityRecipients` and `notifyActivity` to centralize recipient resolution (owner, thread participants, mentions, excluding the actor), preference filtering, and delivery-status reporting (`delivered` / `no-recipients` / `email-not-configured`). Wired these into the core review actions so comment/reply/mention emails are sent from `notifyReviewComment`, and applied the same pattern to the Slides template for deck comment notifications, backed by a dedicated per-user preferences key/endpoints.

### Key Changes
- New `SettingsGroup` / `SettingsRow` components (`packages/core/src/client/settings/SettingsRow.tsx`) with tests, exported from `@agent-native/core/client/settings`.
- New `resolveActivityRecipients` and `notifyActivity` primitives (`@agent-native/core/server`) with delivery status reporting instead of silently collapsing failures into success.
- `notifyReviewComment` now sends comment/reply/mention emails from core; `create-review-comment` and `reply-review-comment` actions call it and return a `notified` result.
- `ReviewableResourceRegistration` gained an optional `resolveUrl` so review emails can deep-link to the resource.
- Added `guard:dead-settings-keys` script to `package.json`.
- Slides template: new `comment-notifications.ts` using `notifyActivity` to send deck comment/reply emails (owner + thread participants, excluding actor and share invites), plus `SLIDES_USER_PREFS_KEY` shared constant and `user-prefs.get`/`user-prefs.put` routes for per-user preference storage.
- Tasks template `settings.tsx` refactored from a single-setting `Card` to the new `SettingsGroup`/`SettingsRow` layout.
- Added a changeset documenting the new `@agent-native/core` primitives.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/hyper-flow-e5acy2lq"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-hyper-flow-e5acy2lq.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2567`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>hyper-flow-e5acy2lq</branchName>-->