### PR TITLE
fix(cli): avoid overwriting unreadable MCP configs

### DIFF
--- a/.changeset/protect-unreadable-mcp-configs.md
+++ b/.changeset/protect-unreadable-mcp-configs.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Prevent unreadable MCP client configuration files from being overwritten during setup.

--- a/.changeset/protect-unreadable-mcp-configs.md
+++ b/.changeset/protect-unreadable-mcp-configs.md
@@ -1,5 +1,6 @@
 ---
 "@agent-native/core": patch
+"@agent-native/skills": patch
 ---
 
 Prevent unreadable MCP client configuration files from being overwritten during setup.

--- a/packages/core/src/cli/mcp-config-writers.spec.ts
+++ b/packages/core/src/cli/mcp-config-writers.spec.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   buildCodexHttpBlock,
@@ -123,6 +123,38 @@ describe("writeJsonMcpEntry", () => {
 
     // File must be untouched
     expect(fs.readFileSync(file, "utf-8")).toBe(corruptContent);
+  });
+
+  it("throws and preserves an existing config when reading it is denied", () => {
+    const dir = tmpDir();
+    const file = path.join(dir, "claude.json");
+    const original =
+      '{"projects":{"/work":{"name":"work"}},"mcpServers":{"old":{"url":"https://old.example.com/mcp"}}}\n';
+    fs.writeFileSync(file, original, "utf-8");
+    const denied = Object.assign(new Error("EACCES: permission denied"), {
+      code: "EACCES",
+    });
+    const read = vi.spyOn(fs, "readFileSync").mockImplementationOnce(() => {
+      throw denied;
+    });
+
+    let thrown: Error | null = null;
+    try {
+      writeJsonMcpEntry(file, "new", {
+        type: "http",
+        url: "https://new.example.com/mcp",
+      });
+    } catch (error) {
+      thrown = error as Error;
+    } finally {
+      read.mockRestore();
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown!.message).toContain("Cannot read MCP config file");
+    expect(thrown!.message).toContain(file);
+    expect(thrown!.message).toContain("has not been modified");
+    expect(fs.readFileSync(file, "utf-8")).toBe(original);
   });
 
   it("error message includes the file path and actionable guidance", () => {
@@ -814,6 +846,39 @@ describe("writeCodexBlock", () => {
     writeCodexBlock(file, "plan", null);
     expect(fs.readFileSync(file, "utf-8")).toBe('model = "gpt-5.5"\n');
   });
+
+  it("throws and preserves an existing config when reading it is denied", () => {
+    const dir = tmpDir();
+    const file = path.join(dir, "config.toml");
+    const original =
+      'model = "gpt-5.5"\n\n[mcp_servers.existing]\ncommand = "existing"\n';
+    fs.writeFileSync(file, original, "utf-8");
+    const denied = Object.assign(new Error("EACCES: permission denied"), {
+      code: "EACCES",
+    });
+    const read = vi.spyOn(fs, "readFileSync").mockImplementationOnce(() => {
+      throw denied;
+    });
+
+    let thrown: Error | null = null;
+    try {
+      writeCodexBlock(
+        file,
+        "plan",
+        buildCodexHttpBlock("plan", PLAN_URL, "token"),
+      );
+    } catch (error) {
+      thrown = error as Error;
+    } finally {
+      read.mockRestore();
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown!.message).toContain("Cannot read MCP config file");
+    expect(thrown!.message).toContain(file);
+    expect(thrown!.message).toContain("has not been modified");
+    expect(fs.readFileSync(file, "utf-8")).toBe(original);
+  });
 });
 
 describe("codexHasBlock", () => {
@@ -831,5 +896,29 @@ describe("codexHasBlock", () => {
     );
     expect(codexHasBlock(file, "plan")).toBe(true);
     expect(codexHasBlock(file, "other")).toBe(false);
+  });
+
+  it("throws instead of reporting an unreadable config as absent", () => {
+    const dir = tmpDir();
+    const file = path.join(dir, "config.toml");
+    fs.writeFileSync(file, '[mcp_servers.plan]\ncommand = "plan"\n', "utf-8");
+    const denied = Object.assign(new Error("EACCES: permission denied"), {
+      code: "EACCES",
+    });
+    const read = vi.spyOn(fs, "readFileSync").mockImplementationOnce(() => {
+      throw denied;
+    });
+
+    let thrown: Error | null = null;
+    try {
+      codexHasBlock(file, "plan");
+    } catch (error) {
+      thrown = error as Error;
+    } finally {
+      read.mockRestore();
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown!.message).toContain("Cannot read MCP config file");
   });
 });

--- a/packages/core/src/cli/mcp-config-writers.ts
+++ b/packages/core/src/cli/mcp-config-writers.ts
@@ -260,6 +260,24 @@ export function configPathFor(
 // ---------------------------------------------------------------------------
 
 /**
+ * Read an existing MCP config without conflating missing and unreadable files.
+ * Only ENOENT means the config is absent; any other read failure must abort
+ * before a caller can overwrite existing user configuration.
+ */
+function readExistingConfigFile(file: string): string | undefined {
+  try {
+    return fs.readFileSync(file, "utf-8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    const detail = error instanceof Error ? ` (${error.message})` : "";
+    throw new Error(
+      `Cannot read MCP config file: ${file}\n` +
+        `Check that the file is readable and re-run. The file has not been modified.${detail}`,
+    );
+  }
+}
+
+/**
  * Read and parse a JSON config file.
  *
  * - Missing file → returns `{}` (fresh config).
@@ -269,13 +287,8 @@ export function configPathFor(
  *   file with only the new MCP entry (data-loss hazard).
  */
 function readJsonFile(file: string): Record<string, any> {
-  let raw: string;
-  try {
-    raw = fs.readFileSync(file, "utf-8");
-  } catch {
-    // Missing (ENOENT) or unreadable file — treat as empty.
-    return {};
-  }
+  const raw = readExistingConfigFile(file);
+  if (raw === undefined) return {};
   if (!raw.trim()) return {};
   try {
     const parsed = JSON.parse(raw);
@@ -576,12 +589,7 @@ export function writeCodexBlock(
   name: string,
   block: string | null,
 ): void {
-  let content = "";
-  try {
-    content = fs.readFileSync(file, "utf-8");
-  } catch {
-    content = "";
-  }
+  const content = readExistingConfigFile(file) ?? "";
 
   const lines = content.split(/\r?\n/);
   const out: string[] = [];
@@ -616,14 +624,12 @@ export function writeCodexBlock(
 }
 
 export function codexHasBlock(file: string, name: string): boolean {
-  try {
-    const content = fs.readFileSync(file, "utf-8");
-    return content
-      .split(/\r?\n/)
-      .some((line) => codexServerNameOfHeader(line) === name);
-  } catch {
-    return false;
-  }
+  const content = readExistingConfigFile(file);
+  return (
+    content
+      ?.split(/\r?\n/)
+      .some((line) => codexServerNameOfHeader(line) === name) ?? false
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/skills/src/mcp-config-writers.ts
+++ b/packages/skills/src/mcp-config-writers.ts
@@ -260,6 +260,24 @@ export function configPathFor(
 // ---------------------------------------------------------------------------
 
 /**
+ * Read an existing MCP config without conflating missing and unreadable files.
+ * Only ENOENT means the config is absent; any other read failure must abort
+ * before a caller can overwrite existing user configuration.
+ */
+function readExistingConfigFile(file: string): string | undefined {
+  try {
+    return fs.readFileSync(file, "utf-8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    const detail = error instanceof Error ? ` (${error.message})` : "";
+    throw new Error(
+      `Cannot read MCP config file: ${file}\n` +
+        `Check that the file is readable and re-run. The file has not been modified.${detail}`,
+    );
+  }
+}
+
+/**
  * Read and parse a JSON config file.
  *
  * - Missing file → returns `{}` (fresh config).
@@ -269,13 +287,8 @@ export function configPathFor(
  *   file with only the new MCP entry (data-loss hazard).
  */
 function readJsonFile(file: string): Record<string, any> {
-  let raw: string;
-  try {
-    raw = fs.readFileSync(file, "utf-8");
-  } catch {
-    // Missing (ENOENT) or unreadable file — treat as empty.
-    return {};
-  }
+  const raw = readExistingConfigFile(file);
+  if (raw === undefined) return {};
   if (!raw.trim()) return {};
   try {
     const parsed = JSON.parse(raw);
@@ -576,12 +589,7 @@ export function writeCodexBlock(
   name: string,
   block: string | null,
 ): void {
-  let content = "";
-  try {
-    content = fs.readFileSync(file, "utf-8");
-  } catch {
-    content = "";
-  }
+  const content = readExistingConfigFile(file) ?? "";
 
   const lines = content.split(/\r?\n/);
   const out: string[] = [];
@@ -616,14 +624,12 @@ export function writeCodexBlock(
 }
 
 export function codexHasBlock(file: string, name: string): boolean {
-  try {
-    const content = fs.readFileSync(file, "utf-8");
-    return content
-      .split(/\r?\n/)
-      .some((line) => codexServerNameOfHeader(line) === name);
-  } catch {
-    return false;
-  }
+  const content = readExistingConfigFile(file);
+  return (
+    content
+      ?.split(/\r?\n/)
+      .some((line) => codexServerNameOfHeader(line) === name) ?? false
+  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- distinguish missing MCP configuration files from unreadable ones
- abort JSON and Codex TOML updates on non-`ENOENT` read failures
- keep the Core and standalone Skills writers synchronized
- preserve existing behavior for missing, empty, and malformed configurations

## Problem

The shared MCP config writers treated every `readFileSync` failure as if the
target file did not exist:

- `readJsonFile` returned an empty object
- `writeCodexBlock` continued with an empty string
- `codexHasBlock` reported the server as absent

The write path then created a temporary file and atomically renamed it over the
target. If an existing config was unreadable but its parent directory still
allowed replacement, the command succeeded while replacing the entire config
with only the new MCP entry.

This path is reachable from `agent-native mcp install`,
`mcp install-screen-memory`, and `connect`, including the standalone
`@agent-native/skills` connector. It affects the supported Claude Code,
Cowork, Cursor, OpenCode, GitHub Copilot, and Codex config files. The impact is
especially significant for `~/.claude.json` and `~/.codex/config.toml`,
which can contain unrelated project, auth, model, sandbox, and provider
settings.

## Reproduction

The regression tests start with existing JSON and TOML configurations, make
their first read fail with `EACCES`, and then assert that the operation throws
and the original bytes remain unchanged.

Against the base implementation, all three new tests fail because neither
writer nor `codexHasBlock` throws. The writer paths continue toward replacing
the target as an empty configuration.

I also reproduced the issue on Windows with real filesystem permissions, using
synthetic files outside the repository:

1. Denied file read access while retaining inherited modify permission on the
   parent directory.
2. Confirmed that reading the target failed with an OS permission error.
3. Ran the writer from upstream commit
   `d04621c8cdab6e090a0557792cc9be8c93d94c79`.
4. The old writer returned successfully. The JSON file lost its existing
   projects/auth/MCP data, and the TOML file lost its model/sandbox/existing MCP
   settings.
5. Under the same permission condition, this change throws before writing.
   After restoring read access, both fixed files retained their original
   SHA-256 hashes.

## Fix

Add a shared `readExistingConfigFile` boundary to both shipped writer copies:

- `ENOENT` means the config is absent and keeps the existing creation behavior
- every other read error aborts before a write and includes the target path in
  an actionable error
- the Skills drift guard verifies that its standalone writer stays
  code-identical to Core

Missing and empty configs are still initialized normally. Malformed JSON keeps
its existing parse-error behavior.

The guarantee is per target file. This does not make a multi-client `connect`
operation transactional or roll back earlier successful client updates if a
later client fails.

## Validation

- Core `mcp-config-writers.spec.ts`: 42 tests passed
- Skills writer + Core synchronization specs: 3 tests passed
- Core and Skills TypeScript typechecks passed
- Changeset status passed (`@agent-native/core` and `@agent-native/skills`: patch)
- `git diff --check` passed

## Changeset

Prevent unreadable MCP client configuration files from being overwritten
during setup.