### PR TITLE
Hide system pages from Content breadcrumb menus

### DIFF
--- a/templates/content/actions/content-spaces.db.test.ts
+++ b/templates/content/actions/content-spaces.db.test.ts
@@ -853,6 +853,11 @@ describe("Content space provisioning", () => {
     );
     expect(ids).not.toContain("private-org-a");
     expect(ids).not.toContain("favorite-unrelated");
+    expect(
+      result.documents.find(
+        (document) => document.id === memberProvisioned.favoritesDocumentId,
+      )?.database,
+    ).toMatchObject({ systemRole: "favorites" });
     const favorites = await runWithRequestContext(
       { userEmail: favoritesMember, orgId: "org-favorites-a" },
       () =>

--- a/templates/content/actions/list-documents.ts
+++ b/templates/content/actions/list-documents.ts
@@ -337,6 +337,7 @@ export default defineAction({
                 id: database.id,
                 documentId: database.documentId,
                 title: database.title,
+                systemRole: database.systemRole,
                 description: d.description,
                 viewConfig: parseDatabaseViewConfig(database.viewConfigJson),
                 createdAt: database.createdAt,

--- a/templates/content/app/components/editor/DocumentEditor.layout.test.ts
+++ b/templates/content/app/components/editor/DocumentEditor.layout.test.ts
@@ -15,7 +15,10 @@ import {
   shouldAwaitAuthoritativeDocument,
   titleMatchConfirmsSave,
 } from "./DocumentEditor";
-import { compactToolbarBreadcrumbItems } from "./DocumentToolbar";
+import {
+  compactToolbarBreadcrumbItems,
+  firstSelectableBreadcrumbMenuItemId,
+} from "./DocumentToolbar";
 
 describe("document editor layout", () => {
   it("waits for the first authoritative document fetch, then stays mounted", () => {
@@ -307,6 +310,7 @@ describe("document editor layout", () => {
       "relative z-10 flex h-12 shrink-0 items-center gap-3 bg-background px-4",
     );
     expect(source).toContain("ToolbarBreadcrumb");
+    expect(source).toContain("disabled={menuItem.id === currentDocumentId}");
     expect(source).toContain("formatEditedLabel");
     expect(source).toContain("editor.toolbar.copyPageLink");
     expect(source).toContain("editor.toolbar.info");
@@ -680,6 +684,19 @@ describe("document editor layout", () => {
     ).toEqual(["Personal", "…", "Page 2", "Draft"]);
   });
 
+  it("focuses the first real breadcrumb destination on keyboard open", () => {
+    expect(
+      firstSelectableBreadcrumbMenuItemId(
+        [
+          { id: "draft", title: "Draft" },
+          { id: "notes", title: "Notes" },
+        ],
+        "draft",
+      ),
+    ).toBe("notes");
+    expect(firstSelectableBreadcrumbMenuItemId([], "draft")).toBeNull();
+  });
+
   it("offers workspace and same-level page choices from breadcrumbs", () => {
     const items = documentEditorBreadcrumbNavigationItems(
       [
@@ -730,6 +747,74 @@ describe("document editor layout", () => {
       "folder",
     ]);
     expect(items[1].menuItems?.map((item) => item.title)).toEqual([
+      "Draft",
+      "Notes",
+    ]);
+  });
+
+  it("excludes system documents from top-level breadcrumb peers", () => {
+    const items = documentEditorBreadcrumbNavigationItems(
+      [{ id: "draft", title: "Draft" }],
+      [
+        {
+          id: "draft",
+          parentId: null,
+          title: "Draft",
+          icon: null,
+          position: 0,
+          databaseMembership: {
+            databaseId: "personal",
+            databaseDocumentId: "personal-files",
+            databaseTitle: "Personal",
+            position: 0,
+          },
+        },
+        {
+          id: "notes",
+          parentId: null,
+          title: "Notes",
+          icon: null,
+          position: 1,
+          databaseMembership: {
+            databaseId: "personal",
+            databaseDocumentId: "personal-files",
+            databaseTitle: "Personal",
+            position: 1,
+          },
+        },
+        {
+          id: "trash",
+          parentId: null,
+          title: "Trash",
+          icon: null,
+          position: 2,
+          databaseMembership: {
+            databaseId: "personal",
+            databaseDocumentId: "personal-files",
+            databaseTitle: "Personal",
+            position: 2,
+          },
+          database: {
+            id: "trash-database",
+            documentId: "trash",
+            title: "Trash",
+            systemRole: "trash",
+            viewConfig: {
+              activeViewId: "default",
+              views: [],
+              sorts: [],
+              filters: [],
+              columnWidths: {},
+            },
+            createdAt: "2026-07-30T00:00:00.000Z",
+            updatedAt: "2026-07-30T00:00:00.000Z",
+          },
+        },
+      ],
+      [],
+    );
+
+    expect(items[0].menuItems?.map((item) => item.title)).toEqual([
       "Draft",
       "Notes",
     ]);

--- a/templates/content/app/components/editor/DocumentEditor.layout.test.ts
+++ b/templates/content/app/components/editor/DocumentEditor.layout.test.ts
@@ -820,6 +820,42 @@ describe("document editor layout", () => {
     ]);
   });
 
+  it("keeps local-file folders as breadcrumb anchors but not peer destinations", () => {
+    const items = documentEditorBreadcrumbNavigationItems(
+      [{ id: "guides-folder", title: "Guides" }],
+      [
+        {
+          id: "guides-folder",
+          parentId: "docs-folder",
+          title: "Guides",
+          icon: null,
+          position: 0,
+          source: { mode: "local-files", kind: "folder", path: "docs/guides" },
+        },
+        {
+          id: "setup-page",
+          parentId: "docs-folder",
+          title: "Setup",
+          icon: null,
+          position: 1,
+        },
+        {
+          id: "reference-page",
+          parentId: "docs-folder",
+          title: "Reference",
+          icon: null,
+          position: 2,
+        },
+      ],
+      [],
+    );
+
+    expect(items[0].menuItems?.map((item) => item.title)).toEqual([
+      "Setup",
+      "Reference",
+    ]);
+  });
+
   it("links a top-level Files database back to Workspaces", () => {
     const items = documentEditorBreadcrumbNavigationItems(
       [{ id: "personal-files", title: "Personal" }],

--- a/templates/content/app/components/editor/DocumentEditor.tsx
+++ b/templates/content/app/components/editor/DocumentEditor.tsx
@@ -445,6 +445,7 @@ export function documentEditorBreadcrumbNavigationItems(
     | "title"
     | "icon"
     | "position"
+    | "database"
     | "databaseMembership"
     | "source"
   >[], // i18n-ignore type expression
@@ -457,7 +458,12 @@ export function documentEditorBreadcrumbNavigationItems(
     workspacesTitle: string;
   },
 ): ToolbarBreadcrumbItem[] {
-  const documentById = new Map(documents.map((item) => [item.id, item]));
+  const navigableDocuments = documents.filter(
+    (item) => !item.database?.systemRole && item.source?.kind !== "folder",
+  );
+  const documentById = new Map(
+    navigableDocuments.map((item) => [item.id, item]),
+  );
   const workspaceDocumentIds = new Set(
     spaces.map((space) => space.filesDocumentId),
   );
@@ -480,9 +486,8 @@ export function documentEditorBreadcrumbNavigationItems(
     if (!current) return item;
     const membershipDocumentId =
       current.databaseMembership?.databaseDocumentId ?? null;
-    const siblings = documents
+    const siblings = navigableDocuments
       .filter((candidate) => {
-        if (candidate.source?.kind === "folder") return false;
         if (candidate.parentId !== current.parentId) return false;
         if (current.parentId) return true;
         return (

--- a/templates/content/app/components/editor/DocumentEditor.tsx
+++ b/templates/content/app/components/editor/DocumentEditor.tsx
@@ -458,12 +458,10 @@ export function documentEditorBreadcrumbNavigationItems(
     workspacesTitle: string;
   },
 ): ToolbarBreadcrumbItem[] {
-  const navigableDocuments = documents.filter(
+  const peerDocuments = documents.filter(
     (item) => !item.database?.systemRole && item.source?.kind !== "folder",
   );
-  const documentById = new Map(
-    navigableDocuments.map((item) => [item.id, item]),
-  );
+  const documentById = new Map(documents.map((item) => [item.id, item]));
   const workspaceDocumentIds = new Set(
     spaces.map((space) => space.filesDocumentId),
   );
@@ -486,7 +484,7 @@ export function documentEditorBreadcrumbNavigationItems(
     if (!current) return item;
     const membershipDocumentId =
       current.databaseMembership?.databaseDocumentId ?? null;
-    const siblings = navigableDocuments
+    const siblings = peerDocuments
       .filter((candidate) => {
         if (candidate.parentId !== current.parentId) return false;
         if (current.parentId) return true;

--- a/templates/content/app/components/editor/DocumentToolbar.tsx
+++ b/templates/content/app/components/editor/DocumentToolbar.tsx
@@ -318,6 +318,15 @@ export function compactToolbarBreadcrumbItems(
   ];
 }
 
+export function firstSelectableBreadcrumbMenuItemId(
+  menuItems: ToolbarBreadcrumbItem["menuItems"],
+  currentDocumentId: string,
+): string | null {
+  return (
+    menuItems?.find((menuItem) => menuItem.id !== currentDocumentId)?.id ?? null
+  );
+}
+
 function ToolbarBreadcrumbMenu({
   item,
   label,
@@ -337,6 +346,12 @@ function ToolbarBreadcrumbMenu({
 }) {
   const [open, setOpen] = useState(false);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const openedWithKeyboardRef = useRef(false);
+  const firstSelectableItemRef = useRef<HTMLDivElement | null>(null);
+  const firstSelectableItemId = firstSelectableBreadcrumbMenuItemId(
+    item.menuItems,
+    currentDocumentId,
+  );
 
   function cancelClose() {
     if (!closeTimerRef.current) return;
@@ -349,8 +364,25 @@ function ToolbarBreadcrumbMenu({
     closeTimerRef.current = setTimeout(() => setOpen(false), 140);
   }
 
+  useEffect(() => {
+    if (!open || !openedWithKeyboardRef.current) return;
+    openedWithKeyboardRef.current = false;
+    const frame = requestAnimationFrame(() => {
+      firstSelectableItemRef.current?.focus();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [open]);
+
   return (
-    <DropdownMenu modal={false} open={open} onOpenChange={setOpen}>
+    <DropdownMenu
+      modal={false}
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (nextOpen) cancelClose();
+        else openedWithKeyboardRef.current = false;
+        setOpen(nextOpen);
+      }}
+    >
       <DropdownMenuTrigger asChild>
         <button
           type="button"
@@ -364,6 +396,16 @@ function ToolbarBreadcrumbMenu({
             setOpen(true);
           }}
           onPointerLeave={scheduleClose}
+          onKeyDown={(event) => {
+            if (
+              event.key === "Enter" ||
+              event.key === " " ||
+              event.key === "ArrowDown"
+            ) {
+              openedWithKeyboardRef.current = true;
+              cancelClose();
+            }
+          }}
         >
           {children}
         </button>
@@ -371,6 +413,7 @@ function ToolbarBreadcrumbMenu({
       <DropdownMenuContent
         align="start"
         className="w-64"
+        onKeyDown={cancelClose}
         onPointerEnter={cancelClose}
         onPointerLeave={scheduleClose}
       >
@@ -379,7 +422,13 @@ function ToolbarBreadcrumbMenu({
           return (
             <DropdownMenuItem
               key={menuItem.id}
+              ref={
+                menuItem.id === firstSelectableItemId
+                  ? firstSelectableItemRef
+                  : undefined
+              }
               className="gap-2"
+              disabled={menuItem.id === currentDocumentId}
               onSelect={() => onOpen(menuItem.id)}
             >
               <span className="flex size-4 shrink-0 items-center justify-center">

--- a/templates/content/changelog/2026-07-30-breadcrumb-menus-now-hide-internal-system-pages.md
+++ b/templates/content/changelog/2026-07-30-breadcrumb-menus-now-hide-internal-system-pages.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-07-30
+---
+
+Breadcrumb menus now show only relevant page peers instead of internal system pages, with reliable keyboard selection between pages.


### PR DESCRIPTION
## Problem

Content breadcrumb menus treated internal system-backed documents, including Trash, as ordinary page peers. That made top-level navigation misleading: hovering or opening a page breadcrumb could offer destinations that belong to the app's internal workspace structure rather than the user's pages.

## Approach

Carry each document database's existing system role through the shared document-list action, then filter only breadcrumb peer destinations in the editor. Keep the complete document map for resolving breadcrumb anchors so local-file folders still participate in navigation without appearing as selectable page peers.

The menu continues to show the current page for orientation, but disables it as a no-op destination. Keyboard-opened menus move focus to the first real destination, while pointer-opened menus retain their existing hover behavior.

## What changed

- Include `database.systemRole` in `list-documents` results.
- Exclude system-backed documents and local-file folders from breadcrumb peer destinations while preserving all documents as breadcrumb anchors.
- Disable the current page in peer menus and focus the first selectable destination when a menu opens from the keyboard.
- Add regression coverage for system-page exclusion, local-folder anchors, system-role serialization, and keyboard destination selection.
- Add a Content changelog entry for the corrected breadcrumb behavior.

## Safety and operations

This is a scoped UI and action-serialization repair. It adds no schema migration, data write, backfill, credential, permission, or network behavior. No feature flag is needed. Reverting the PR restores the previous breadcrumb behavior without changing stored data.

## Verification

- `pnpm --filter content test` — 1,965 passed, 3 expected failures, and 5 skipped across the Content suite.
- `pnpm --filter content typecheck` — confirmed the action response and editor changes remain type-safe.
- `pnpm --filter content exec vitest run app/components/editor/DocumentEditor.layout.test.ts actions/content-spaces.db.test.ts` — 50 focused tests passed, covering peer filtering, folder anchors, keyboard selection, and system-role serialization.
- `pnpm test:content-product-impact` — all 30 product-impact checks passed.
- Independent Chrome QA on `bbbc77718c806aef975c64bba98b66da756fbf6f` confirmed that system roots were absent and pointer and keyboard navigation still reached peer, workspace, parent, and child destinations. The retained browser fixture had no local-file folder, so that boundary is covered by the automated regression test rather than browser evidence.

## Content impact declaration

```yaml
content_product_impact:
  lane: contract_repair
  features:
    - content.feature.find-your-place-again
  capabilities:
    - content.source.spaces-files
    - content.navigation.sidebar
  record_change: none
  proof:
    - pnpm --filter content test
    - pnpm --filter content typecheck
    - independent Chrome breadcrumb QA
  rationale: This repairs existing breadcrumb navigation so internal system documents do not appear as page peers, without changing the accepted product records.
```

## Review focus

- Does filtering remain limited to selectable peer destinations while the complete document map preserves folder breadcrumb anchors?
- Do hover-open and keyboard-open menus manage focus and delayed closing without interfering with one another?
- Is the current page visibly disabled while the first real keyboard destination receives focus reliably?

## Follow-up

- Optional test hardening: scope the source-string assertion for the breadcrumb menu's `modal={false}` setting to `ToolbarBreadcrumbMenu`, or replace it with a rendered interaction test. Exact-head Chrome QA covers the current runtime behavior; the reviewer classified this as a low-severity coverage issue rather than a functional defect.
