### PR TITLE
fix(mcp): match loopback redirect_uri ignoring port per RFC 8252

### DIFF
--- a/.changeset/quiet-badgers-redirect.md
+++ b/.changeset/quiet-badgers-redirect.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow native OAuth clients to use ephemeral ports on registered HTTP loopback redirect URIs while rejecting fragments and userinfo.

--- a/packages/core/src/mcp/oauth-client-metadata.ts
+++ b/packages/core/src/mcp/oauth-client-metadata.ts
@@ -118,6 +118,7 @@ function isLoopbackRedirectHost(hostname: string): boolean {
 export function matchesRegisteredRedirectUri(
   registered: readonly string[],
   redirectUri: string,
+  applicationType: "native" | "web",
 ): boolean {
   let candidate: URL;
   try {
@@ -129,6 +130,7 @@ export function matchesRegisteredRedirectUri(
   if (candidate.hash || candidate.username || candidate.password) return false;
   if (registered.includes(redirectUri)) return true;
   if (
+    applicationType !== "native" ||
     candidate.protocol !== "http:" ||
     !isLoopbackRedirectHost(candidate.hostname)
   ) {

--- a/packages/core/src/mcp/oauth-client-metadata.ts
+++ b/packages/core/src/mcp/oauth-client-metadata.ts
@@ -119,13 +119,15 @@ export function matchesRegisteredRedirectUri(
   registered: readonly string[],
   redirectUri: string,
 ): boolean {
-  if (registered.includes(redirectUri)) return true;
   let candidate: URL;
   try {
     candidate = new URL(redirectUri);
+    // coercion-ok: a malformed candidate is an invalid redirect, not a runtime failure.
   } catch {
     return false;
   }
+  if (candidate.hash || candidate.username || candidate.password) return false;
+  if (registered.includes(redirectUri)) return true;
   if (
     candidate.protocol !== "http:" ||
     !isLoopbackRedirectHost(candidate.hostname)
@@ -136,9 +138,11 @@ export function matchesRegisteredRedirectUri(
     let allowed: URL;
     try {
       allowed = new URL(value);
+      // coercion-ok: a malformed registration cannot match a valid redirect.
     } catch {
       return false;
     }
+    if (allowed.hash || allowed.username || allowed.password) return false;
     return (
       allowed.protocol === candidate.protocol &&
       allowed.hostname === candidate.hostname &&

--- a/packages/core/src/mcp/oauth-client-metadata.ts
+++ b/packages/core/src/mcp/oauth-client-metadata.ts
@@ -100,6 +100,54 @@ export function isAllowedOAuthRedirectUri(value: unknown): value is string {
   }
 }
 
+function isLoopbackRedirectHost(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname === "[::1]"
+  );
+}
+
+/**
+ * RFC 8252 section 7.3: a native client's loopback redirect URI uses a port
+ * chosen at request time, so the authorization server must ignore the port when
+ * comparing loopback redirect URIs against the registered set. Non-loopback
+ * redirects keep exact matching, so this cannot widen into an open redirect.
+ */
+export function matchesRegisteredRedirectUri(
+  registered: readonly string[],
+  redirectUri: string,
+): boolean {
+  if (registered.includes(redirectUri)) return true;
+  let candidate: URL;
+  try {
+    candidate = new URL(redirectUri);
+  } catch {
+    return false;
+  }
+  if (
+    candidate.protocol !== "http:" ||
+    !isLoopbackRedirectHost(candidate.hostname)
+  ) {
+    return false;
+  }
+  return registered.some((value) => {
+    let allowed: URL;
+    try {
+      allowed = new URL(value);
+    } catch {
+      return false;
+    }
+    return (
+      allowed.protocol === candidate.protocol &&
+      allowed.hostname === candidate.hostname &&
+      allowed.pathname === candidate.pathname &&
+      allowed.search === candidate.search
+    );
+  });
+}
+
 export function applicationTypeForRedirectUris(
   redirectUris: string[],
 ): "native" | "web" {

--- a/packages/core/src/mcp/oauth-route.spec.ts
+++ b/packages/core/src/mcp/oauth-route.spec.ts
@@ -53,6 +53,7 @@ vi.mock("./oauth-store.js", () => ({
       grantTypes: params.grantTypes ?? ["authorization_code", "refresh_token"],
       responseTypes: params.responseTypes ?? ["code"],
       tokenEndpointAuthMethod: params.tokenEndpointAuthMethod ?? "none",
+      applicationType: params.applicationType,
       createdAt: 1_700_000_000_000,
     };
     clients.set(row.clientId, row);
@@ -455,6 +456,40 @@ describe("MCP OAuth route", () => {
 
     expect(response.status).toBe(200);
     await expect(response.text()).resolves.toContain("Authorize Claude");
+  });
+
+  it("rejects an ephemeral loopback port for a registered web client", async () => {
+    const client = await (
+      await handleMcpOAuth(
+        event({
+          method: "POST",
+          body: {
+            application_type: "web",
+            redirect_uris: ["http://localhost/callback"],
+          } as any,
+        }),
+        "/register",
+      )
+    ).json();
+
+    const response = await handleMcpOAuth(
+      event({
+        query: {
+          response_type: "code",
+          client_id: client.client_id,
+          redirect_uri: "http://localhost:54263/callback",
+          resource: "https://mail.agent-native.com/mcp",
+          code_challenge: challenge("v".repeat(50)),
+          code_challenge_method: "S256",
+        },
+      }),
+      "/authorize",
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "invalid_client",
+    });
   });
 
   it.each([

--- a/packages/core/src/mcp/oauth-route.spec.ts
+++ b/packages/core/src/mcp/oauth-route.spec.ts
@@ -457,6 +457,54 @@ describe("MCP OAuth route", () => {
     await expect(response.text()).resolves.toContain("Authorize Claude");
   });
 
+  it.each([
+    "http://localhost:54263/callback#fragment",
+    "http://user@localhost:54263/callback",
+  ])(
+    "rejects a loopback redirect with disallowed URL components: %s",
+    async (redirectUri) => {
+      const clientId = "https://claude.example.com/oauth/client.json";
+      ssrfSafeFetchMock.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            client_id: clientId,
+            client_name: "Claude",
+            redirect_uris: ["http://localhost/callback"],
+            grant_types: ["authorization_code", "refresh_token"],
+            response_types: ["code"],
+            token_endpoint_auth_method: "none",
+            application_type: "native",
+          }),
+          {
+            headers: {
+              "content-type": "application/json",
+              "cache-control": "no-store",
+            },
+          },
+        ),
+      );
+
+      const response = await handleMcpOAuth(
+        event({
+          query: {
+            response_type: "code",
+            client_id: clientId,
+            redirect_uri: redirectUri,
+            resource: "https://mail.agent-native.com/mcp",
+            code_challenge: challenge("v".repeat(50)),
+            code_challenge_method: "S256",
+          },
+        }),
+        "/authorize",
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        error: "invalid_client",
+      });
+    },
+  );
+
   it("rejects a non-loopback redirect that only differs by port", async () => {
     const clientId = "https://cursor.example.com/oauth/client.json";
     ssrfSafeFetchMock.mockResolvedValueOnce(

--- a/packages/core/src/mcp/oauth-route.spec.ts
+++ b/packages/core/src/mcp/oauth-route.spec.ts
@@ -411,6 +411,91 @@ describe("MCP OAuth route", () => {
     });
   });
 
+  it("authorizes a Client ID Metadata Document client on an ephemeral loopback port", async () => {
+    const clientId = "https://claude.example.com/oauth/client.json";
+    ssrfSafeFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          client_id: clientId,
+          client_name: "Claude",
+          redirect_uris: [
+            "http://localhost/callback",
+            "http://127.0.0.1/callback",
+          ],
+          grant_types: ["authorization_code", "refresh_token"],
+          response_types: ["code"],
+          token_endpoint_auth_method: "none",
+          application_type: "native",
+        }),
+        {
+          headers: {
+            "content-type": "application/json",
+            "cache-control": "max-age=60",
+          },
+        },
+      ),
+    );
+
+    const response = await handleMcpOAuth(
+      event({
+        query: {
+          response_type: "code",
+          client_id: clientId,
+          redirect_uri: "http://localhost:54263/callback",
+          resource: "https://mail.agent-native.com/mcp",
+          scope: "mcp:read",
+          state: "state-loopback-port",
+          code_challenge: challenge("v".repeat(50)),
+          code_challenge_method: "S256",
+        },
+      }),
+      "/authorize",
+      { appName: "Mail" },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toContain("Authorize Claude");
+  });
+
+  it("rejects a non-loopback redirect that only differs by port", async () => {
+    const clientId = "https://cursor.example.com/oauth/client.json";
+    ssrfSafeFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          client_id: clientId,
+          client_name: "Cursor",
+          redirect_uris: ["https://cursor.example.com/callback"],
+          token_endpoint_auth_method: "none",
+        }),
+        {
+          headers: {
+            "content-type": "application/json",
+            "cache-control": "no-store",
+          },
+        },
+      ),
+    );
+
+    const response = await handleMcpOAuth(
+      event({
+        query: {
+          response_type: "code",
+          client_id: clientId,
+          redirect_uri: "https://cursor.example.com:8443/callback",
+          resource: "https://mail.agent-native.com/mcp",
+          code_challenge: challenge("v".repeat(50)),
+          code_challenge_method: "S256",
+        },
+      }),
+      "/authorize",
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "invalid_client",
+    });
+  });
+
   it("never falls back to DCR for a malformed URL client_id", async () => {
     const malformedUrlClientId = "http://client.example.com/oauth/client.json";
     clients.set(malformedUrlClientId, {

--- a/packages/core/src/mcp/oauth-route.ts
+++ b/packages/core/src/mcp/oauth-route.ts
@@ -375,8 +375,10 @@ async function handleRegister(event: H3Event): Promise<Response> {
       "application_type must be native or web",
     );
   }
-  const applicationType =
-    requestedApplicationType ?? applicationTypeForRedirectUris(redirectUris);
+  const applicationType: "native" | "web" =
+    requestedApplicationType === "native" || requestedApplicationType === "web"
+      ? requestedApplicationType
+      : applicationTypeForRedirectUris(redirectUris);
 
   const clientName =
     typeof body.client_name === "string"
@@ -390,6 +392,7 @@ async function handleRegister(event: H3Event): Promise<Response> {
       grantTypes: grantTypes.length ? grantTypes : undefined,
       responseTypes: responseTypes.length ? responseTypes : undefined,
       tokenEndpointAuthMethod: method,
+      applicationType,
     });
   } catch (err: any) {
     if (err?.message === "RATE_LIMITED") {
@@ -747,7 +750,11 @@ async function handleAuthorize(
     : await getOAuthClient(clientId);
   if (
     !client ||
-    !matchesRegisteredRedirectUri(client.redirectUris, redirectUri)
+    !matchesRegisteredRedirectUri(
+      client.redirectUris,
+      redirectUri,
+      client.applicationType,
+    )
   ) {
     return oauthError("invalid_client", "Unknown client or redirect_uri");
   }

--- a/packages/core/src/mcp/oauth-route.ts
+++ b/packages/core/src/mcp/oauth-route.ts
@@ -21,6 +21,7 @@ import {
   applicationTypeForRedirectUris,
   isAllowedOAuthRedirectUri,
   isUrlBasedOAuthClientId,
+  matchesRegisteredRedirectUri,
   resolveOAuthClientMetadataDocument,
 } from "./oauth-client-metadata.js";
 import {
@@ -744,7 +745,10 @@ async function handleAuthorize(
   const client = isUrlBasedOAuthClientId(clientId)
     ? await resolveOAuthClientMetadataDocument(clientId).catch(() => null)
     : await getOAuthClient(clientId);
-  if (!client || !client.redirectUris.includes(redirectUri)) {
+  if (
+    !client ||
+    !matchesRegisteredRedirectUri(client.redirectUris, redirectUri)
+  ) {
     return oauthError("invalid_client", "Unknown client or redirect_uri");
   }
 

--- a/packages/core/src/mcp/oauth-store.spec.ts
+++ b/packages/core/src/mcp/oauth-store.spec.ts
@@ -91,6 +91,44 @@ describe("oauth-store hashing & token generation", () => {
 });
 
 describe("client registration", () => {
+  it("infers native application type for a pre-migration loopback client", async () => {
+    sqlite.exec(`
+      CREATE TABLE mcp_oauth_clients (
+        client_id TEXT PRIMARY KEY,
+        client_name TEXT,
+        redirect_uris TEXT NOT NULL,
+        grant_types TEXT,
+        response_types TEXT,
+        token_endpoint_auth_method TEXT,
+        created_at INTEGER
+      );
+      INSERT INTO mcp_oauth_clients (
+        client_id,
+        client_name,
+        redirect_uris,
+        grant_types,
+        response_types,
+        token_endpoint_auth_method,
+        created_at
+      ) VALUES (
+        'legacy-native',
+        'Legacy native client',
+        '["http://localhost/callback"]',
+        '["authorization_code"]',
+        '["code"]',
+        'none',
+        1700000000000
+      );
+    `);
+    const s = await freshStore();
+
+    await expect(s.getOAuthClient("legacy-native")).resolves.toMatchObject({
+      clientId: "legacy-native",
+      applicationType: "native",
+      redirectUris: ["http://localhost/callback"],
+    });
+  });
+
   it("round-trips a registered client and applies grant/response defaults", async () => {
     const s = await freshStore();
     const reg = await s.registerOAuthClient({

--- a/packages/core/src/mcp/oauth-store.spec.ts
+++ b/packages/core/src/mcp/oauth-store.spec.ts
@@ -96,11 +96,13 @@ describe("client registration", () => {
     const reg = await s.registerOAuthClient({
       clientName: "Claude",
       redirectUris: ["https://claude.ai/cb"],
+      applicationType: "native",
     });
     expect(reg.clientId).toMatch(/^agent-native-oauth-client-/);
     expect(reg.grantTypes).toEqual(["authorization_code", "refresh_token"]);
     expect(reg.responseTypes).toEqual(["code"]);
     expect(reg.tokenEndpointAuthMethod).toBe("none");
+    expect(reg.applicationType).toBe("native");
 
     const fetched = await s.getOAuthClient(reg.clientId);
     expect(fetched).toMatchObject({
@@ -110,6 +112,7 @@ describe("client registration", () => {
       grantTypes: ["authorization_code", "refresh_token"],
       responseTypes: ["code"],
       tokenEndpointAuthMethod: "none",
+      applicationType: "native",
     });
   });
 

--- a/packages/core/src/mcp/oauth-store.ts
+++ b/packages/core/src/mcp/oauth-store.ts
@@ -15,6 +15,7 @@ import {
   isPostgres,
 } from "../db/client.js";
 import { ensureColumnExists, ensureTableExists } from "../db/ddl-guard.js";
+import { applicationTypeForRedirectUris } from "./oauth-client-metadata.js";
 
 let _initPromise: Promise<void> | undefined;
 
@@ -93,7 +94,7 @@ async function ensureTable(): Promise<void> {
           grant_types TEXT,
           response_types TEXT,
           token_endpoint_auth_method TEXT,
-          application_type TEXT NOT NULL DEFAULT 'web',
+          application_type TEXT,
           created_at ${intType()}
         )
       `;
@@ -140,7 +141,7 @@ async function ensureTable(): Promise<void> {
         await ensureColumnExists(
           "mcp_oauth_clients",
           "application_type",
-          `ALTER TABLE mcp_oauth_clients ADD COLUMN IF NOT EXISTS application_type TEXT NOT NULL DEFAULT 'web'`,
+          `ALTER TABLE mcp_oauth_clients ADD COLUMN IF NOT EXISTS application_type TEXT`,
         );
         await ensureTableExists("mcp_oauth_codes", createCodesSql);
         await ensureTableExists(
@@ -155,12 +156,12 @@ async function ensureTable(): Promise<void> {
       await client.execute(createClientsSql);
       try {
         await client.execute(
-          `ALTER TABLE mcp_oauth_clients ADD COLUMN IF NOT EXISTS application_type TEXT NOT NULL DEFAULT 'web'`,
+          `ALTER TABLE mcp_oauth_clients ADD COLUMN IF NOT EXISTS application_type TEXT`,
         );
       } catch {
         try {
           await client.execute(
-            `ALTER TABLE mcp_oauth_clients ADD COLUMN application_type TEXT NOT NULL DEFAULT 'web'`,
+            `ALTER TABLE mcp_oauth_clients ADD COLUMN application_type TEXT`,
           );
         } catch {
           // Fresh and previously migrated databases already have the column.
@@ -249,10 +250,14 @@ function numOrNull(v: unknown): number | null {
 }
 
 function mapClientRow(row: any): OAuthClientRow {
+  const redirectUris = parseJsonStringArray(
+    row.redirect_uris ?? row.redirectUris,
+  );
+  const storedApplicationType = row.application_type ?? row.applicationType;
   return {
     clientId: row.client_id ?? row.clientId,
     clientName: row.client_name ?? row.clientName ?? null,
-    redirectUris: parseJsonStringArray(row.redirect_uris ?? row.redirectUris),
+    redirectUris,
     grantTypes: parseJsonStringArray(row.grant_types ?? row.grantTypes, [
       "authorization_code",
       "refresh_token",
@@ -264,9 +269,9 @@ function mapClientRow(row: any): OAuthClientRow {
     tokenEndpointAuthMethod:
       row.token_endpoint_auth_method ?? row.tokenEndpointAuthMethod ?? "none",
     applicationType:
-      (row.application_type ?? row.applicationType) === "native"
-        ? "native"
-        : "web",
+      storedApplicationType === "native" || storedApplicationType === "web"
+        ? storedApplicationType
+        : applicationTypeForRedirectUris(redirectUris),
     createdAt: numOrNull(row.created_at ?? row.createdAt),
   };
 }

--- a/packages/core/src/mcp/oauth-store.ts
+++ b/packages/core/src/mcp/oauth-store.ts
@@ -14,7 +14,7 @@ import {
   intType,
   isPostgres,
 } from "../db/client.js";
-import { ensureTableExists } from "../db/ddl-guard.js";
+import { ensureColumnExists, ensureTableExists } from "../db/ddl-guard.js";
 
 let _initPromise: Promise<void> | undefined;
 
@@ -93,6 +93,7 @@ async function ensureTable(): Promise<void> {
           grant_types TEXT,
           response_types TEXT,
           token_endpoint_auth_method TEXT,
+          application_type TEXT NOT NULL DEFAULT 'web',
           created_at ${intType()}
         )
       `;
@@ -136,6 +137,11 @@ async function ensureTable(): Promise<void> {
         // DDL when the table is actually missing, wrapped in a
         // transaction-scoped lock_timeout so a contended lock fails fast.
         await ensureTableExists("mcp_oauth_clients", createClientsSql);
+        await ensureColumnExists(
+          "mcp_oauth_clients",
+          "application_type",
+          `ALTER TABLE mcp_oauth_clients ADD COLUMN IF NOT EXISTS application_type TEXT NOT NULL DEFAULT 'web'`,
+        );
         await ensureTableExists("mcp_oauth_codes", createCodesSql);
         await ensureTableExists(
           "mcp_oauth_refresh_tokens",
@@ -147,6 +153,19 @@ async function ensureTable(): Promise<void> {
       // SQLite (local dev): no ACCESS EXCLUSIVE lock problem — keep existing
       // create-then-execute behaviour.
       await client.execute(createClientsSql);
+      try {
+        await client.execute(
+          `ALTER TABLE mcp_oauth_clients ADD COLUMN IF NOT EXISTS application_type TEXT NOT NULL DEFAULT 'web'`,
+        );
+      } catch {
+        try {
+          await client.execute(
+            `ALTER TABLE mcp_oauth_clients ADD COLUMN application_type TEXT NOT NULL DEFAULT 'web'`,
+          );
+        } catch {
+          // Fresh and previously migrated databases already have the column.
+        }
+      }
       await client.execute(createCodesSql);
       await client.execute(createRefreshTokensSql);
     })().catch((err) => {
@@ -164,6 +183,7 @@ export interface OAuthClientRow {
   grantTypes: string[];
   responseTypes: string[];
   tokenEndpointAuthMethod: string;
+  applicationType: "native" | "web";
   createdAt: number | null;
 }
 
@@ -243,6 +263,10 @@ function mapClientRow(row: any): OAuthClientRow {
     ),
     tokenEndpointAuthMethod:
       row.token_endpoint_auth_method ?? row.tokenEndpointAuthMethod ?? "none",
+    applicationType:
+      (row.application_type ?? row.applicationType) === "native"
+        ? "native"
+        : "web",
     createdAt: numOrNull(row.created_at ?? row.createdAt),
   };
 }
@@ -289,6 +313,7 @@ export async function registerOAuthClient(params: {
   grantTypes?: string[];
   responseTypes?: string[];
   tokenEndpointAuthMethod?: string;
+  applicationType?: "native" | "web";
 }): Promise<OAuthClientRow> {
   await ensureTable();
   const client = getDbExec();
@@ -315,8 +340,9 @@ export async function registerOAuthClient(params: {
     ? params.responseTypes
     : ["code"];
   const tokenEndpointAuthMethod = params.tokenEndpointAuthMethod || "none";
+  const applicationType = params.applicationType ?? "web";
   await client.execute({
-    sql: `INSERT INTO mcp_oauth_clients (client_id, client_name, redirect_uris, grant_types, response_types, token_endpoint_auth_method, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    sql: `INSERT INTO mcp_oauth_clients (client_id, client_name, redirect_uris, grant_types, response_types, token_endpoint_auth_method, application_type, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
     args: [
       clientId,
       params.clientName ?? null,
@@ -324,6 +350,7 @@ export async function registerOAuthClient(params: {
       JSON.stringify(grantTypes),
       JSON.stringify(responseTypes),
       tokenEndpointAuthMethod,
+      applicationType,
       now,
     ],
   });
@@ -334,6 +361,7 @@ export async function registerOAuthClient(params: {
     grantTypes,
     responseTypes,
     tokenEndpointAuthMethod,
+    applicationType,
     createdAt: now,
   };
 }


### PR DESCRIPTION
## The bug

`handleAuthorize` in `packages/core/src/mcp/oauth-route.ts` compares `redirect_uri` against the client's registered redirect URIs with an exact string match:

```ts
if (!client || !client.redirectUris.includes(redirectUri)) {
  return oauthError("invalid_client", "Unknown client or redirect_uri");
}
```

Native and desktop MCP clients bind an **ephemeral loopback port** at request time, so they send `http://localhost:<port>/callback`. Their client metadata document registers the portless form — for example Claude Code's published CIMD at `https://claude.ai/oauth/claude-code-client-metadata` lists:

```json
"redirect_uris": ["http://localhost/callback", "http://127.0.0.1/callback"]
```

The port never matches, so **every** authorization attempt fails with `invalid_client`. Because the port is redrawn each attempt, retrying can't help.

[RFC 8252 §7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3) is explicit about this:

> The authorization server MUST allow any port to be specified at the time of the request for loopback IP redirect URIs, to accommodate clients that obtain an available ephemeral port from the operating system at the time of the request.

## Reproduction

Against a deployed instance. The only difference between accepted and rejected is the loopback port:

| `redirect_uri` | Before | After |
|---|---|---|
| `http://localhost/callback` | 200 consent page | 200 |
| `http://127.0.0.1/callback` | 200 consent page | 200 |
| `http://localhost:3118/callback` | **400 `invalid_client`** | 200 |

The `client_id` resolves and the CIMD document is fetched correctly in all three cases — only the redirect comparison rejects.

## Impact

Affects every MCP client using loopback OAuth: Claude Code, Cursor, VS Code / GitHub Copilot, and Codex. `isAllowedOAuthRedirectUri` already treats loopback hosts as legitimate at registration time, so registration succeeds and only authorization fails.

## The fix

Adds `matchesRegisteredRedirectUri` beside the existing loopback allow-list in `oauth-client-metadata.ts`, and uses it at the authorize call site.

Deliberately narrow:

- Exact match is still tried first.
- Port is ignored **only** for `http:` loopback hosts (`localhost`, `127.0.0.1`, `::1`, `[::1]`) — the same set `isAllowedOAuthRedirectUri` already accepts.
- Scheme, host, path, and query must still match exactly.
- Every non-loopback redirect keeps exact matching, so this cannot widen into an open redirect.

## Tests

Two added to `oauth-route.spec.ts`:

- a CIMD client authorizing from an ephemeral loopback port (`http://localhost:54263/callback` against portless registered URIs) now reaches the consent page;
- a non-loopback redirect differing **only** by port (`https://cursor.example.com:8443/callback` vs registered `https://cursor.example.com/callback`) must still be rejected.

The existing `rejects a Client ID Metadata Document redirect mismatch` test differs by *path*, so it continues to fail closed and passes unchanged.
