### PR TITLE
feat(tracking): enhance PostHog error tracking integration

### DIFF
--- a/.agents/skills/observability/SKILL.md
+++ b/.agents/skills/observability/SKILL.md
@@ -232,6 +232,7 @@ All tables are dialect-agnostic (SQLite + Postgres) and strictly additive.
 | `packages/core/src/observability/types.ts` | Shared type definitions |
 | `packages/core/src/observability/store.ts` | SQL tables + CRUD |
 | `packages/core/src/observability/traces.ts` | Auto-instrumentation |
+| `packages/core/src/observability/posthog-ai.ts` | `$ai_trace` / `$ai_span` / `survey sent` emission, content bounding, `$ai_error` |
 | `packages/core/src/observability/feedback.ts` | Feedback + Frustration Index |
 | `packages/core/src/observability/evals.ts` | Eval engine (3 layers) |
 | `packages/core/src/observability/experiments.ts` | A/B testing system |
@@ -272,16 +273,66 @@ The loop emits `agent.run` (with `agent.run_id`, `agent.thread_id`, `agent.user_
 
 ## Tracking Bridge
 
-Instrumented agent loops also emit one server-side tracking event per completed
-LLM generation:
+Instrumented agent loops emit server-side tracking events for every run through
+`track()` from `@agent-native/core/tracking`, so configured PostHog, Agent Native
+Analytics, Mixpanel, Amplitude, and webhook providers receive them through the
+same best-effort fan-out as other tracking events.
 
-- Event name: `$ai_generation`
-- Provider path: `track()` from `@agent-native/core/tracking`, so configured
-  PostHog, Agent Native Analytics, Mixpanel, Amplitude, and webhook providers
-  receive it through the same best-effort fan-out as other tracking events.
-- PostHog shape: uses AI Observability properties such as `$ai_trace_id`,
-  `$ai_session_id`, `$ai_model`, `$ai_provider`, `$ai_input_tokens`,
-  `$ai_output_tokens`, `$ai_latency`, `$ai_total_cost_usd`, and `$ai_is_error`.
+### The PostHog trace tree
+
+PostHog models a run as a tree. The framework emits all three node types, and
+every node shares `$ai_trace_id` (the run id) and links upward via
+`$ai_parent_id`:
+
+| Event            | One per        | Key properties                                                                 |
+| ---------------- | -------------- | ------------------------------------------------------------------------------ |
+| `$ai_trace`      | agent run      | `$ai_span_name: "agent_run"`, `$ai_latency`, `$ai_is_error`, `$ai_error`        |
+| `$ai_generation` | model call     | `$ai_model`, `$ai_provider`, token counts, `$ai_input`/`$ai_output_choices`, `$ai_tools` |
+| `$ai_span`       | tool call      | `$ai_span_id`, `$ai_span_name` (tool name), `$ai_latency`, `$ai_is_error`       |
+
+`$ai_session_id` is the **thread**, grouping traces into a conversation. It is
+explicitly not PostHog's `$session_id`, which is the browser session used for
+session replay — the framework sends that separately, read from the
+`X-Agent-Native-Session-Id` header via `RequestContext.browserSessionId`.
+
+**One generation per run, not per round-trip.** The engine layer reports
+aggregate usage (`onUsage`) with no per-step hook, so a multi-step run collapses
+into a single generation node carrying the whole message list. Per-round-trip
+latency and intermediate assistant turns are not visible. Adding them requires a
+new engine seam in `ai-sdk-engine.ts` / `builder-engine.ts`.
+
+### Content capture
+
+`capturePrompts` (default `false`) gates `$ai_input` and the assistant's text in
+`$ai_output_choices`. `captureToolArgs` gates tool-call arguments and
+`$ai_input_state` on spans.
+
+When a flag is off the field is **omitted**, never sent as `[]` or `""` — an
+empty array is indistinguishable from a run that genuinely had no messages.
+Oversized content is replaced with an explicit truncation marker and
+`$ai_input_truncated` / `$ai_output_truncated`, never silently shortened.
+Runs that exceed the span cap stamp `$ai_spans_dropped` on the trace.
+
+**Tool calls ship even with `capturePrompts` off.** PostHog derives
+`$ai_tools_called` / `$ai_tool_call_count` only from tool-call blocks inside
+`$ai_output_choices`, so the structural call list (names, no arguments) is always
+emitted. The bespoke `tools` array below is kept in parallel because the
+first-party dashboards read it — that duplication is deliberate, not cleanup.
+
+### Errors and feedback
+
+`$ai_error` is a structured object (`message`, `terminal_state`,
+`terminal_code`, `retryable`), absent on healthy runs. Errors captured through
+`captureError({ aiTraceId })` carry a top-level `$ai_trace_id`, so an
+error-tracking issue and the LLM trace resolve to each other.
+
+Feedback emits `$ai_feedback` for all four feedback types; only thumbs carry
+`sentiment`, so a category follow-up to a thumbs-down does not double-count the
+vote. PostHog additionally shows feedback in LLM analytics only via a
+`survey sent` event keyed to a real survey — set
+`POSTHOG_AI_FEEDBACK_SURVEY_ID` (and optionally
+`POSTHOG_AI_FEEDBACK_SURVEY_QUESTION_ID`) to enable it. Unset means no survey
+event; the framework never invents a survey id.
 - Agent Native Analytics shape: the same event lands in `analytics_events` with
   mirrored query-friendly properties such as `run_id`, `thread_id`,
   `cost_cents_x100`, `duration_ms`, `tool_calls`, `successful_tools`,

--- a/.agents/skills/observability/SKILL.md
+++ b/.agents/skills/observability/SKILL.md
@@ -278,61 +278,12 @@ Instrumented agent loops emit server-side tracking events for every run through
 Analytics, Mixpanel, Amplitude, and webhook providers receive them through the
 same best-effort fan-out as other tracking events.
 
-### The PostHog trace tree
-
-PostHog models a run as a tree. The framework emits all three node types, and
-every node shares `$ai_trace_id` (the run id) and links upward via
-`$ai_parent_id`:
-
-| Event            | One per        | Key properties                                                                 |
-| ---------------- | -------------- | ------------------------------------------------------------------------------ |
-| `$ai_trace`      | agent run      | `$ai_span_name: "agent_run"`, `$ai_latency`, `$ai_is_error`, `$ai_error`        |
-| `$ai_generation` | model call     | `$ai_model`, `$ai_provider`, token counts, `$ai_input`/`$ai_output_choices`, `$ai_tools` |
-| `$ai_span`       | tool call      | `$ai_span_id`, `$ai_span_name` (tool name), `$ai_latency`, `$ai_is_error`       |
-
-`$ai_session_id` is the **thread**, grouping traces into a conversation. It is
-explicitly not PostHog's `$session_id`, which is the browser session used for
-session replay — the framework sends that separately, read from the
-`X-Agent-Native-Session-Id` header via `RequestContext.browserSessionId`.
-
-**One generation per run, not per round-trip.** The engine layer reports
-aggregate usage (`onUsage`) with no per-step hook, so a multi-step run collapses
-into a single generation node carrying the whole message list. Per-round-trip
-latency and intermediate assistant turns are not visible. Adding them requires a
-new engine seam in `ai-sdk-engine.ts` / `builder-engine.ts`.
-
-### Content capture
-
-`capturePrompts` (default `false`) gates `$ai_input` and the assistant's text in
-`$ai_output_choices`. `captureToolArgs` gates tool-call arguments and
-`$ai_input_state` on spans.
-
-When a flag is off the field is **omitted**, never sent as `[]` or `""` — an
-empty array is indistinguishable from a run that genuinely had no messages.
-Oversized content is replaced with an explicit truncation marker and
-`$ai_input_truncated` / `$ai_output_truncated`, never silently shortened.
-Runs that exceed the span cap stamp `$ai_spans_dropped` on the trace.
-
-**Tool calls ship even with `capturePrompts` off.** PostHog derives
-`$ai_tools_called` / `$ai_tool_call_count` only from tool-call blocks inside
-`$ai_output_choices`, so the structural call list (names, no arguments) is always
-emitted. The bespoke `tools` array below is kept in parallel because the
-first-party dashboards read it — that duplication is deliberate, not cleanup.
-
-### Errors and feedback
-
-`$ai_error` is a structured object (`message`, `terminal_state`,
-`terminal_code`, `retryable`), absent on healthy runs. Errors captured through
-`captureError({ aiTraceId })` carry a top-level `$ai_trace_id`, so an
-error-tracking issue and the LLM trace resolve to each other.
-
-Feedback emits `$ai_feedback` for all four feedback types; only thumbs carry
-`sentiment`, so a category follow-up to a thumbs-down does not double-count the
-vote. PostHog additionally shows feedback in LLM analytics only via a
-`survey sent` event keyed to a real survey — set
-`POSTHOG_AI_FEEDBACK_SURVEY_ID` (and optionally
-`POSTHOG_AI_FEEDBACK_SURVEY_QUESTION_ID`) to enable it. Unset means no survey
-event; the framework never invents a survey id.
+- Events: `$ai_trace` per run, `$ai_span` per tool call, and `$ai_generation`
+  per model call. Every node carries the run id as `$ai_trace_id` and links
+  upward through `$ai_parent_id` so a backend can rebuild the tree.
+  `$ai_session_id` is the thread; the browser session is separate and ships as
+  `$session_id`, read from `X-Agent-Native-Session-Id` via
+  `RequestContext.browserSessionId`. Emission lives in `posthog-ai.ts`.
 - Agent Native Analytics shape: the same event lands in `analytics_events` with
   mirrored query-friendly properties such as `run_id`, `thread_id`,
   `cost_cents_x100`, `duration_ms`, `tool_calls`, `successful_tools`,
@@ -343,6 +294,30 @@ event; the framework never invents a survey id.
   Delegated runs add `delegation_protocol`, `caller_app`, `a2a_task_id`, and
   `parent_run_id` when available. `parent_turn_id` is separate because one
   logical turn may span multiple concrete runs.
+
+Constraints that are not visible from the emit site:
+
+- **One generation per run, not per model round-trip.** The engine layer reports
+  aggregate usage through `onUsage` and exposes no per-step hook, so a multi-step
+  run collapses into a single generation carrying the whole message list.
+  Per-round-trip latency and intermediate turns are unavailable without a new
+  seam in `ai-sdk-engine.ts` / `builder-engine.ts`. Do not describe the current
+  output as per-step.
+- **Disabled capture omits the field rather than sending an empty one.** An
+  empty array is indistinguishable from a run that genuinely had no messages.
+  Truncated content is marked, and a run over the span cap stamps
+  `$ai_spans_dropped` — a truncated run must not read as a complete one.
+- **The structural tool-call list ships even when content capture is off.**
+  Backends derive their tool tags from tool-call blocks inside the output
+  choices and from nothing else, so tool names (without arguments) are always
+  emitted. The parallel first-party `tools` array stays because the dashboards
+  read it; that duplication is deliberate, not cleanup.
+- **Only thumbs carry `sentiment`.** All four feedback types are reported, but a
+  category follow-up to a thumbs-down is detail about the same vote — counting
+  it again inflates the metric.
+- **Never invent an external id to make an integration light up.** Survey-based
+  feedback is emitted only when a real survey id is configured, and nothing is
+  sent otherwise.
 
 Do not build a separate LLM-observability ingestion API unless there is a clear
 reason the tracking provider registry cannot express the use case. Keep prompt,

--- a/.agents/skills/tracking/SKILL.md
+++ b/.agents/skills/tracking/SKILL.md
@@ -79,7 +79,7 @@ Set the env var and the provider auto-registers at startup. No SDK dependencies 
 
 | Provider               | Env vars                                                                                                                                           |
 | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| PostHog                | `POSTHOG_API_KEY` (required), `POSTHOG_HOST` (optional, defaults to `https://us.i.posthog.com`)                                                    |
+| PostHog                | `POSTHOG_API_KEY` (required), `POSTHOG_HOST` (optional, defaults to `https://us.i.posthog.com`), `POSTHOG_ERROR_TRACKING=false` (optional opt-out) |
 | Mixpanel               | `MIXPANEL_TOKEN`                                                                                                                                   |
 | Amplitude              | `AMPLITUDE_API_KEY`                                                                                                                                |
 | Agent Native Analytics | `AGENT_NATIVE_ANALYTICS_PUBLIC_KEY` (server), `AGENT_NATIVE_ANALYTICS_ENDPOINT` (optional, defaults to `https://analytics.agent-native.com/track`) |
@@ -88,6 +88,57 @@ Set the env var and the provider auto-registers at startup. No SDK dependencies 
 Multiple providers can be active simultaneously. All receive every event.
 
 Browser-side `trackEvent()` also forwards to Agent Native Analytics when `VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY` is present. Use `VITE_AGENT_NATIVE_ANALYTICS_ENDPOINT` to override the default browser endpoint. The built-in Agent Native Analytics sender is quiet on localhost/local dev by default; set `AGENT_NATIVE_ANALYTICS_ALLOW_LOCALHOST=true` only for an intentional local ingestion test.
+
+## PostHog Error Tracking
+
+PostHog is a full error-reporting backend, not only an analytics sink. With
+`POSTHOG_API_KEY` set, `captureError()` reaches it whether or not a Sentry DSN
+exists.
+
+Three things are specific to PostHog and easy to get wrong:
+
+- **`$exception` needs `$exception_list`.** PostHog ingests an event named
+  `$exception` with any shape, then renders it as an empty, ungroupable issue —
+  so a broken payload looks like coverage rather than a failure. The PostHog
+  provider in `tracking/providers.ts` reshapes the framework's camelCase
+  exception properties through `tracking/posthog-exception.ts` before sending.
+  Emit exceptions with `captureError()` / `captureException()`; do not hand-roll
+  a `track("$exception", …)` call.
+- **`$exception` and `$ai_*` use `/i/v0/e/`, everything else uses `/capture/`.**
+  Handled by the provider; only relevant if you add a new PostHog event family.
+- **Stack frames are never symbolicated.** Frames ship as
+  `platform: "custom"`, `resolved: false` because the framework uploads no
+  source maps to PostHog. Server stacks are already readable; **minified browser
+  stacks stay minified**. Sentry symbolicates today and PostHog does not — this
+  is a known gap, not a bug to re-diagnose.
+
+### Where the wiring lives
+
+`core-routes-plugin.ts` owns the Nitro `error` hook and routes it through
+`captureError()`, filtered by `server/error-noise-filter.ts`. It is deliberately
+**not** in `sentry-plugin.ts`: that plugin returns early without a DSN, so
+hooking it there meant a PostHog-only app silently reported no route errors.
+
+The noise filter carries production-tuned drop rules (expected 4xx,
+access-control rejections, Lambda freeze/thaw `socket hang up`). Any new error
+backend must apply it or it receives a firehose — the `socket hang up` rule
+alone accounts for ~10k events/day.
+
+### Browser exceptions
+
+Set `POSTHOG_PUBLIC_KEY` (or `VITE_POSTHOG_KEY`) to enable browser capture. It
+ships in the CDN-cached SSR shell alongside the Sentry DSN — publishable and
+identical for every visitor. The browser posts straight to PostHog rather than
+relaying through `/_agent-native/track`, because that route requires a resolved
+session and would drop every signed-out crash.
+
+`POSTHOG_API_KEY` is **not** a fallback for the public key: it may be a private
+key, and this value is inlined into public HTML.
+
+When adding a client config field, update **both** `server/posthog-config.ts`
+and the mirrored worker emitter in `deploy/build.ts` — the worker bundles a
+string copy and cannot import the module, so a one-sided change drops the config
+silently in deployed builds.
 
 ## Default Baseline Events
 
@@ -199,6 +250,10 @@ interface TrackingEvent {
 | `packages/core/src/tracking/registry.ts`  | `track()`, `identify()`, `registerTrackingProvider()`, `flushTracking()`                                            |
 | `packages/core/src/tracking/providers.ts` | Built-in providers (PostHog, Mixpanel, Amplitude, Agent Native Analytics, Webhook) and `registerBuiltinProviders()` |
 | `packages/core/src/tracking/types.ts`     | `TrackingEvent` and `TrackingProvider` interfaces                                                                   |
+| `packages/core/src/tracking/posthog-exception.ts` | `$exception_list` builder + stack-frame parser (isomorphic: server and browser)                             |
+| `packages/core/src/tracking/redaction.ts` | Shared bounding/redaction helpers used by every exception emitter                                                   |
+| `packages/core/src/server/error-noise-filter.ts` | Provider-agnostic drop rules, applied by both Sentry `beforeSend` and the route error hook                   |
+| `packages/core/src/server/posthog-config.ts` | Public browser PostHog config (mirrored in `deploy/build.ts`)                                                    |
 
 ## Related Skills
 

--- a/.agents/skills/tracking/SKILL.md
+++ b/.agents/skills/tracking/SKILL.md
@@ -89,56 +89,55 @@ Multiple providers can be active simultaneously. All receive every event.
 
 Browser-side `trackEvent()` also forwards to Agent Native Analytics when `VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY` is present. Use `VITE_AGENT_NATIVE_ANALYTICS_ENDPOINT` to override the default browser endpoint. The built-in Agent Native Analytics sender is quiet on localhost/local dev by default; set `AGENT_NATIVE_ANALYTICS_ALLOW_LOCALHOST=true` only for an intentional local ingestion test.
 
-## PostHog Error Tracking
+## Error Capture
 
-PostHog is a full error-reporting backend, not only an analytics sink. With
-`POSTHOG_API_KEY` set, `captureError()` reaches it whether or not a Sentry DSN
-exists.
+Exceptions fan out through `server/capture-error.ts` to every registered
+backend — Sentry, PostHog, and the tracking providers — from one `captureError()`
+call. Backends are additive: configuring a second one does not displace the
+first, and no backend is required for the others to work.
 
-Three things are specific to PostHog and easy to get wrong:
+Emit through `captureError()` / `captureException()`. Never hand-roll a
+`track("$exception", …)`: each backend needs its own payload shape and the
+providers build it.
 
-- **`$exception` needs `$exception_list`.** PostHog ingests an event named
-  `$exception` with any shape, then renders it as an empty, ungroupable issue —
-  so a broken payload looks like coverage rather than a failure. The PostHog
-  provider in `tracking/providers.ts` reshapes the framework's camelCase
-  exception properties through `tracking/posthog-exception.ts` before sending.
-  Emit exceptions with `captureError()` / `captureException()`; do not hand-roll
-  a `track("$exception", …)` call.
-- **`$exception` and `$ai_*` use `/i/v0/e/`, everything else uses `/capture/`.**
-  Handled by the provider; only relevant if you add a new PostHog event family.
-- **Stack frames are never symbolicated.** Frames ship as
-  `platform: "custom"`, `resolved: false` because the framework uploads no
-  source maps to PostHog. Server stacks are already readable; **minified browser
-  stacks stay minified**. Sentry symbolicates today and PostHog does not — this
-  is a known gap, not a bug to re-diagnose.
+- **Provider-agnostic wiring must not live in a provider plugin.** The Nitro
+  `error` hook is in `core-routes-plugin.ts`, not `sentry-plugin.ts`, because
+  that plugin returns early when no `SENTRY_DSN` is set — hooking route errors
+  there meant an app on any other backend silently reported none.
+- **Every backend applies `server/error-noise-filter.ts`.** It holds
+  production-tuned drop rules (expected 4xx, access-control rejections, Lambda
+  freeze/thaw `socket hang up`). A backend that skips it receives a firehose;
+  the `socket hang up` rule alone is ~10k events/day.
+- **A backend can accept a malformed payload and still show a count.** PostHog
+  ingested the framework's camelCase `$exception` for a long time and rendered
+  empty, ungroupable issues — which reads as coverage, not as breakage. When
+  adding or changing a backend, check what an event looks like in its UI, not
+  just that the request returned 200.
+- **Attribute the error.** Without a user id, server exceptions land under
+  `anonymous` and split one person in two against their browser events. Pass
+  `aiTraceId` for anything inside an agent run so the issue and the LLM trace
+  resolve to each other.
 
-### Where the wiring lives
+Symbolication is per-backend and not automatic: the framework uploads no source
+maps to PostHog, so minified browser stacks stay minified there. Known gap, not
+a bug to re-diagnose.
 
-`core-routes-plugin.ts` owns the Nitro `error` hook and routes it through
-`captureError()`, filtered by `server/error-noise-filter.ts`. It is deliberately
-**not** in `sentry-plugin.ts`: that plugin returns early without a DSN, so
-hooking it there meant a PostHog-only app silently reported no route errors.
+### Browser keys and the SSR shell
 
-The noise filter carries production-tuned drop rules (expected 4xx,
-access-control rejections, Lambda freeze/thaw `socket hang up`). Any new error
-backend must apply it or it receives a firehose — the `socket hang up` rule
-alone accounts for ~10k events/day.
+Public keys (`POSTHOG_PUBLIC_KEY`, the Sentry client DSN) ship inside the
+CDN-cached SSR shell — publishable and identical for every visitor. Server keys
+never do, and are never a fallback for a public one: `POSTHOG_API_KEY` may be a
+private key and this value lands in public HTML.
 
-### Browser exceptions
-
-Set `POSTHOG_PUBLIC_KEY` (or `VITE_POSTHOG_KEY`) to enable browser capture. It
-ships in the CDN-cached SSR shell alongside the Sentry DSN — publishable and
-identical for every visitor. The browser posts straight to PostHog rather than
-relaying through `/_agent-native/track`, because that route requires a resolved
-session and would drop every signed-out crash.
-
-`POSTHOG_API_KEY` is **not** a fallback for the public key: it may be a private
-key, and this value is inlined into public HTML.
+Browser errors post directly to the backend rather than through
+`/_agent-native/track`, because that route requires a resolved session and
+relaying would drop every signed-out crash.
 
 When adding a client config field, update **both** `server/posthog-config.ts`
 and the mirrored worker emitter in `deploy/build.ts` — the worker bundles a
-string copy and cannot import the module, so a one-sided change drops the config
-silently in deployed builds.
+string copy and cannot import the module, so a one-sided edit drops the config
+silently in deployed builds. `posthog-config.spec.ts` pins the two outputs
+together.
 
 ## Default Baseline Events
 

--- a/.changeset/posthog-error-tracking-and-llm-traces.md
+++ b/.changeset/posthog-error-tracking-and-llm-traces.md
@@ -1,0 +1,55 @@
+---
+"@agent-native/core": minor
+---
+
+Make PostHog a first-class error-reporting and LLM-observability backend, and fix
+the malformed exception events it was already receiving.
+
+`captureException()` emitted an event named `$exception` carrying camelCase
+properties. PostHog ingests anything by that name and renders it as an issue, but
+it groups and symbolicates from `$exception_list` — so every PostHog-configured
+app was already collecting exceptions that arrived empty and ungroupable, which
+reads as coverage rather than as a failure. The PostHog provider now reshapes
+those into a real `$exception_list` with parsed stack frames.
+
+Route errors no longer depend on Sentry. The Nitro `error` hook lived inside
+`sentry-plugin.ts`, which returns early when no `SENTRY_DSN` is set, so an app
+running PostHog alone reported no route errors at all. The hook moved to
+`core-routes-plugin.ts` and goes through the provider-agnostic `captureError()`
+registry, so every configured backend receives it. The ~150 lines of
+production-tuned drop rules (expected 4xx, permission rejections, Lambda
+freeze/thaw `socket hang up`) moved out of Sentry's `beforeSend` into
+`server/error-noise-filter.ts` and now apply to every backend — without them a
+second backend receives a firehose. Server exceptions are also attributed to the
+in-flight user instead of landing under `anonymous`.
+
+Browser exceptions go to PostHog when `POSTHOG_PUBLIC_KEY` / `VITE_POSTHOG_KEY`
+is set, posted directly rather than relayed through `/_agent-native/track`, which
+requires a session and would drop every signed-out crash. `POSTHOG_API_KEY` is
+deliberately not a fallback for the public key: that value is inlined into the
+public HTML shell. Note that PostHog does not symbolicate without uploaded source
+maps, so minified browser stacks stay minified.
+
+LLM observability now emits the full PostHog trace tree. Previously a run
+produced a single `$ai_generation` labelled `agent_run` whose `$ai_parent_id`
+pointed at a span that was never sent, so PostHog wrapped it in a placeholder
+trace with no steps. Runs now emit `$ai_trace`, one `$ai_span` per tool call, and
+a generation parented to the trace. Tool calls ship inside `$ai_output_choices`
+even with content capture off, because that is the only thing PostHog derives
+`$ai_tools_called` from. The previously dead `capturePrompts` flag is now wired
+and gates `$ai_input` and assistant text; disabled fields are omitted rather than
+sent empty, and oversized content is replaced with an explicit truncation marker
+instead of being silently shortened. `$ai_error` became a structured object with
+the terminal code and retryability, and errors captured during a run carry the
+run's `$ai_trace_id` so an issue and its trace resolve to each other.
+
+Feedback previously emitted only for thumbs; category and free-text submissions
+emitted nothing. All four now report, with `sentiment` still limited to thumbs so
+a category follow-up does not double-count the vote. PostHog surfaces feedback in
+LLM analytics only through a `survey sent` event, so that is emitted too when
+`POSTHOG_AI_FEEDBACK_SURVEY_ID` is configured — and not at all when it is unset,
+rather than inventing a survey id.
+
+Agent traces carry the browser session as `$session_id` (read from a new
+`X-Agent-Native-Session-Id` header) so a trace joins its session replay, distinct
+from `$ai_session_id`, which remains the conversation thread.

--- a/packages/core/docs/content/observability.mdx
+++ b/packages/core/docs/content/observability.mdx
@@ -256,6 +256,7 @@ All settings are stored in the `observability-config` key:
   capturePrompts: false,   // Store prompt content in traces
   captureToolArgs: false,  // Store action input arguments
   captureToolResults: false, // Store action results
+  captureLlmSpans: true,   // Emit one $ai_span per tool call to PostHog
   evalSampleRate: 0,       // 0-1, fraction of runs to LLM-judge
   exporters: []            // OTLP export targets
 }
@@ -290,6 +291,39 @@ All auto-mounted at `/_agent-native/observability/`:
 | GET    | `/experiments/:id/results` | Get results                    |
 
 All endpoints support `?since=N` (ms timestamp) and `?limit=N` query params.
+
+## PostHog LLM analytics {#posthog}
+
+When `POSTHOG_API_KEY` is set, every instrumented run is mirrored to PostHog's
+LLM analytics as a full trace tree:
+
+| Event            | Emitted per | Carries                                                 |
+| ---------------- | ----------- | ------------------------------------------------------- |
+| `$ai_trace`      | agent run   | Latency, error state, token totals, cost                |
+| `$ai_generation` | model call  | Model, provider, tokens, cost, tool definitions offered |
+| `$ai_span`       | tool call   | Tool name, duration, error state                        |
+
+Nodes share the run id as `$ai_trace_id`, so PostHog renders one tree per run.
+`$ai_session_id` is the conversation thread; the browser session is sent
+separately as `$session_id` so a trace links to its session replay.
+
+Tool calls always appear (PostHog derives its tool tags from them), but their
+**arguments** require `captureToolArgs` and message content requires
+`capturePrompts`. When those are off the fields are omitted entirely rather than
+sent empty, so an unrecorded prompt is never mistaken for an empty one.
+
+Errors carry a structured `$ai_error` with the terminal code and whether the
+failure was retryable, and exceptions captured during a run carry the run's
+`$ai_trace_id` — so an issue in error tracking and the trace it came from link
+to each other.
+
+### Feedback in PostHog
+
+Thumbs, category, and free-text feedback all emit `$ai_feedback`. PostHog's LLM
+analytics feedback view reads a `survey sent` event instead, so set
+`POSTHOG_AI_FEEDBACK_SURVEY_ID` (and `POSTHOG_AI_FEEDBACK_SURVEY_QUESTION_ID`
+for multi-question surveys) to populate it. Without a survey id no survey event
+is sent.
 
 ## Export to external platforms {#export}
 
@@ -331,9 +365,15 @@ The agent loop emits three span kinds:
 
 Spans are finished with OK/ERROR status and record the error message on failure. Zero/sentinel attribute values are pruned so spans aren't cluttered with noise. This OTel layer is purely additive to the in-house `agent_trace_spans` / `agent_trace_summaries` tables that power the dashboard above — both are produced from the same run events.
 
-## Error reporting (Sentry) {#sentry}
+## Error reporting (Sentry or PostHog) {#sentry}
 
 Server-side errors that escape Nitro route handlers are reported to Sentry when a DSN is configured. Without it the SDK silently no-ops, so it's safe to leave the env vars unset in dev. Browser and server events can go to the same Sentry project; split them into separate projects only when you want operational separation for ownership, volume, quotas, or alert routing.
+
+Sentry is not required. Error reporting fans out to every configured backend, so
+setting only `POSTHOG_API_KEY` gives full server-side error tracking with no
+Sentry project at all — see [Tracking](/docs/tracking#posthog-error-tracking).
+Configure both and each error goes to both. The noise-filtering rules below are
+shared by every backend rather than being Sentry-specific.
 
 | Surface            | SDK               | Env var                                                        | Notes                                                                 |
 | ------------------ | ----------------- | -------------------------------------------------------------- | --------------------------------------------------------------------- |

--- a/packages/core/docs/content/tracking.mdx
+++ b/packages/core/docs/content/tracking.mdx
@@ -89,6 +89,31 @@ Set an env var and the provider auto-registers at server startup. No code change
 
 Multiple providers can be active simultaneously. Every event goes to all of them.
 
+## PostHog error tracking {#posthog-error-tracking}
+
+With `POSTHOG_API_KEY` set, PostHog also receives server exceptions — no Sentry
+DSN required. Server errors are captured automatically from the framework's
+route error hook and attributed to the signed-in user, with production-tuned
+noise filtering (expected 4xx responses, permission rejections, and serverless
+socket churn are dropped rather than reported).
+
+| Env var                  | Purpose                                                             |
+| ------------------------ | ------------------------------------------------------------------- |
+| `POSTHOG_ERROR_TRACKING` | Set to `false` to keep analytics but send exceptions somewhere else |
+| `POSTHOG_PUBLIC_KEY`     | Enables browser exception capture (also read as `VITE_POSTHOG_KEY`) |
+| `POSTHOG_PUBLIC_HOST`    | Browser ingest host (defaults to `POSTHOG_HOST`)                    |
+
+`POSTHOG_PUBLIC_KEY` is separate from `POSTHOG_API_KEY` on purpose: the public
+key is inlined into the HTML served to every visitor, so the server key is never
+used as a fallback for it.
+
+<Callout type="info">
+  PostHog does not symbolicate stack traces without uploaded source maps, so
+  **minified browser stacks stay minified**. Server-side stacks are unaffected.
+  If you need symbolicated browser traces today, keep Sentry configured
+  alongside PostHog — both receive every captured error.
+</Callout>
+
 ## API {#api}
 
 ### `track(name, properties?, meta?)` {#track}

--- a/packages/core/docs/content/tracking.mdx
+++ b/packages/core/docs/content/tracking.mdx
@@ -107,7 +107,7 @@ socket churn are dropped rather than reported).
 key is inlined into the HTML served to every visitor, so the server key is never
 used as a fallback for it.
 
-<Callout type="info">
+<Callout tone="info">
   PostHog does not symbolicate stack traces without uploaded source maps, so
   **minified browser stacks stay minified**. Server-side stacks are unaffected.
   If you need symbolicated browser traces today, keep Sentry configured

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -735,6 +735,7 @@ export function startRun(
   ) => {
     captureError(error, {
       route: "/_agent-native/agent-chat",
+      aiTraceId: runId,
       tags: {
         source: "agent-run-manager",
         phase,
@@ -1022,6 +1023,7 @@ export function startRun(
               phase: "abort-check",
               consecutiveFailures: String(consecutiveAbortCheckFailures),
             },
+            aiTraceId: runId,
             extra: { runId, threadId },
           });
           if (!abort.signal.aborted) {
@@ -1065,6 +1067,7 @@ export function startRun(
                 phase: "heartbeat",
                 consecutiveFailures: String(consecutiveHeartbeatFailures),
               },
+              aiTraceId: runId,
               extra: { runId, threadId },
             });
           }
@@ -1108,6 +1111,7 @@ export function startRun(
     const errorCode = getRunErrorCode(error);
     captureError(error, {
       route: "/_agent-native/agent-chat",
+      aiTraceId: runId,
       tags: {
         source: "agent-run-manager",
         phase,
@@ -1686,6 +1690,7 @@ function subscribeFromSQL(
         };
         captureError(error, {
           route: "/_agent-native/agent-chat/runs/:id/events",
+          aiTraceId: runId,
           tags: {
             source: "agent-run-manager",
             phase: "sql-subscription-poll",
@@ -2313,6 +2318,7 @@ export async function abortRunDurably(
     // the request report the abort it did complete.
     captureError(error, {
       route: "/_agent-native/agent-chat/runs/:id/abort",
+      aiTraceId: runId,
       tags: {
         source: "agent-run-manager",
         phase: "abort-run",
@@ -2356,6 +2362,7 @@ export async function abortTurnDurably(
     // visible rather than silent.
     captureError(error, {
       route: "/_agent-native/agent-chat/runs/:id/abort",
+      aiTraceId: runId,
       tags: { source: "agent-run-manager", phase: "abort-turn" },
       extra: { runId, reason, ...ref },
     });

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -18,6 +18,7 @@ import {
   clearActiveRun,
   setPendingTurn,
 } from "./active-run-state.js";
+import { getOrCreateAnalyticsSessionId } from "./analytics-session.js";
 import { captureError } from "./analytics.js";
 import { agentNativePath } from "./api-path.js";
 import { formatChatErrorText, normalizeChatError } from "./error-format.js";
@@ -2074,6 +2075,15 @@ export function createAgentChatAdapter(
           if (tz) headers["x-user-timezone"] = tz;
         } catch {
           // Non-browser or Intl unavailable — tool calls will fall back to UTC.
+        }
+        try {
+          // Lets the run's `$ai_*` events carry PostHog's `$session_id`, so an
+          // agent trace joins to the session replay it happened in.
+          const sessionId = getOrCreateAnalyticsSessionId();
+          if (sessionId) headers["x-agent-native-session-id"] = sessionId;
+          // coercion-ok: replay linkage must not block sending the message
+        } catch {
+          // Analytics session unavailable — traces just lose replay linkage.
         }
         // Surface hint — the server uses this to keep code-editing dev tools
         // out of the app-rendered sidebar. The outer dev frame passes

--- a/packages/core/src/client/analytics.ts
+++ b/packages/core/src/client/analytics.ts
@@ -5,6 +5,7 @@ import {
   llmConnectionTrackingProperties,
   type LlmConnectionStatus,
 } from "../shared/llm-connection.js";
+import { toPostHogExceptionProperties } from "../tracking/posthog-exception.js";
 import {
   getOrCreateAnalyticsAnonymousId,
   getOrCreateAnalyticsSessionId,
@@ -54,6 +55,14 @@ declare global {
     __AGENT_NATIVE_CONFIG__?: {
       sentryDsn?: string;
       sentryEnvironment?: string;
+      /**
+       * Public PostHog project key + host. Publishable and identical for every
+       * visitor, so it ships inside the CDN-cached SSR shell alongside the
+       * Sentry DSN. Absent when no public key is configured.
+       */
+      posthogKey?: string;
+      posthogHost?: string;
+      posthogErrorTracking?: boolean;
       /**
        * Hosted Realtime Gateway config. Impersonal (same for every visitor),
        * so it is safe inside the CDN-cached SSR shell — unlike the per-user
@@ -440,6 +449,15 @@ function applyTrackingIdentity(
   assign("userName", identity.userName);
   assign("orgId", identity.orgId);
   return next;
+}
+
+/**
+ * The signed-in user id used to attribute browser events, or `undefined` when
+ * signed out. Same value the server attributes its events to (email, falling
+ * back to the auth user id), so a person is one person across both.
+ */
+function getTrackingUserId(): string | undefined {
+  return _trackingIdentity?.userId;
 }
 
 function getOrCreateAnonymousId(): string | undefined {
@@ -1313,6 +1331,82 @@ function exceptionEventProperties(
   };
 }
 
+/**
+ * Resolve browser PostHog config, or `undefined` when error capture should not
+ * reach PostHog. Reads the SSR-injected shell config first, then Vite env for
+ * static/SPA builds that never render through the SSR handler.
+ */
+function posthogErrorConfig(): { key: string; host: string } | undefined {
+  const shell = window.__AGENT_NATIVE_CONFIG__;
+  if (shell?.posthogErrorTracking === false) return undefined;
+  const env = import.meta.env as Record<string, string | undefined>;
+  const key = shell?.posthogKey || env?.VITE_POSTHOG_KEY;
+  if (!key) return undefined;
+  const host = (
+    shell?.posthogHost ||
+    env?.VITE_POSTHOG_HOST ||
+    "https://us.i.posthog.com"
+  ).replace(/\/+$/, "");
+  return { key, host };
+}
+
+/**
+ * Send the exception straight to PostHog's event endpoint.
+ *
+ * Not relayed through `/_agent-native/track`: that route requires a resolved
+ * session, so every signed-out crash would be dropped without a trace.
+ *
+ * `distinct_id` uses the signed-in user id when we have one so browser events
+ * join the server's events for the same person; otherwise the stable anonymous
+ * id, which `$identify` later aliases on login.
+ */
+function sendPostHogExceptionEvent(event: CapturedExceptionEvent): void {
+  const config = posthogErrorConfig();
+  if (!config) return;
+
+  try {
+    const session = errorCaptureSessionContext();
+    const body = JSON.stringify({
+      api_key: config.key,
+      event: AGENT_NATIVE_EXCEPTION_EVENT_NAME,
+      properties: {
+        distinct_id: getTrackingUserId() || session.anonymousId || "anonymous",
+        ...toPostHogExceptionProperties({
+          type: event.type,
+          value: event.message,
+          stack: event.stack,
+          handled: event.handled,
+          level: event.level,
+        }),
+        $current_url: event.url,
+        $session_id: session.sessionId,
+        ...(session.replayId ? { $replay_id: session.replayId } : {}),
+        ...(event.release ? { release: event.release } : {}),
+        ...(event.environment ? { environment: event.environment } : {}),
+        ...(event.tags ? { exceptionTags: event.tags } : {}),
+        source: "browser",
+      },
+      timestamp: event.occurredAt,
+    });
+    const endpoint = `${config.host}/i/v0/e/`;
+
+    if (navigator.sendBeacon) {
+      // text/plain avoids a CORS preflight the page may not survive.
+      const blob = new Blob([body], { type: "text/plain;charset=UTF-8" });
+      if (navigator.sendBeacon(endpoint, blob)) return;
+    }
+    fetch(endpoint, {
+      method: "POST",
+      body,
+      keepalive: true,
+      headers: { "Content-Type": "text/plain;charset=UTF-8" },
+    }).catch(() => {});
+    // coercion-ok: throwing would replace the page's real error
+  } catch {
+    // Error reporting must never mask the original failure.
+  }
+}
+
 function sendExceptionEvent(event: CapturedExceptionEvent): void {
   // Route through the existing first-party analytics ingest as a dedicated
   // `$exception` event. This reuses the public-key auth + sendBeacon/keepalive
@@ -1322,6 +1416,7 @@ function sendExceptionEvent(event: CapturedExceptionEvent): void {
     AGENT_NATIVE_EXCEPTION_EVENT_NAME,
     exceptionEventProperties(event),
   );
+  sendPostHogExceptionEvent(event);
 }
 
 function emitExceptionToReplay(event: CapturedExceptionEvent): void {
@@ -1339,7 +1434,9 @@ function errorCaptureAutoEnabled(): boolean {
     _agentNativeAnalyticsPublicKey ||
     (import.meta.env as Record<string, string | undefined>)
       ?.VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY;
-  return !!publicKey;
+  // A PostHog public key is an equally explicit opt-in — an app running
+  // PostHog and no Agent Native Analytics should still report browser crashes.
+  return !!publicKey || !!posthogErrorConfig();
 }
 
 function maybeInstallErrorCapture(

--- a/packages/core/src/client/analytics.ts
+++ b/packages/core/src/client/analytics.ts
@@ -1340,6 +1340,13 @@ function posthogErrorConfig(): { key: string; host: string } | undefined {
   const shell = window.__AGENT_NATIVE_CONFIG__;
   if (shell?.posthogErrorTracking === false) return undefined;
   const env = import.meta.env as Record<string, string | undefined>;
+  // Static/SPA builds never render through the SSR handler, so they never see
+  // the shell config that carries the server-side opt-out. Without this a
+  // Vite-only deployment could not honour `POSTHOG_ERROR_TRACKING=false`
+  // short of deleting the public key.
+  if (env?.VITE_POSTHOG_ERROR_TRACKING?.trim().toLowerCase() === "false") {
+    return undefined;
+  }
   const key = shell?.posthogKey || env?.VITE_POSTHOG_KEY;
   if (!key) return undefined;
   const host = (

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -1157,6 +1157,39 @@ function getSentryClientConfigScript() {
   );
 }
 
+function getPostHogClientConfigScript() {
+  // MUST stay consistent with resolvePublicPostHogConfig in
+  // server/posthog-config.ts (worker bundles a string copy; it can't import it).
+  // Never falls back to POSTHOG_API_KEY — that key can be a private one and
+  // this string is inlined into the public, CDN-cached HTML shell.
+  const env = globalThis.process?.env || {};
+  const posthogKey = firstNonEmpty(
+    env.POSTHOG_PUBLIC_KEY,
+    env.VITE_POSTHOG_KEY,
+    env.VITE_POSTHOG_PUBLIC_KEY,
+  );
+  if (!posthogKey) return null;
+  const posthogHost = (
+    firstNonEmpty(
+      env.POSTHOG_PUBLIC_HOST,
+      env.VITE_POSTHOG_HOST,
+      env.POSTHOG_HOST,
+    ) || "https://us.i.posthog.com"
+  ).replace(/\\/+$/, "");
+  const config = {
+    posthogKey,
+    posthogHost,
+    posthogErrorTracking:
+      (env.POSTHOG_ERROR_TRACKING || "").trim().toLowerCase() !== "false",
+  };
+  return (
+    '<script data-agent-native-posthog-config>' +
+    'window.__AGENT_NATIVE_CONFIG__=Object.assign({},window.__AGENT_NATIVE_CONFIG__,' +
+    JSON.stringify(config) +
+    ");</script>"
+  );
+}
+
 function getRealtimeClientConfigScript() {
   // MUST stay byte-for-byte consistent with resolveRealtimeClientConfig in
   // server/sentry-config.ts (worker bundles a string copy; it can't import it).
@@ -1330,7 +1363,11 @@ function applyImmutableAssetCacheHeaders(response, request) {
 
 async function rewriteMountedResponse(response, basePath, pathname, request) {
   const clientConfigScript =
-    [getSentryClientConfigScript(), getRealtimeClientConfigScript()]
+    [
+      getSentryClientConfigScript(),
+      getPostHogClientConfigScript(),
+      getRealtimeClientConfigScript(),
+    ]
       .filter(Boolean)
       .join("") || null;
   const headers = new Headers(response.headers);

--- a/packages/core/src/observability/posthog-ai.spec.ts
+++ b/packages/core/src/observability/posthog-ai.spec.ts
@@ -23,10 +23,35 @@ function captureEvents(): TrackingEvent[] {
   return events;
 }
 
+/**
+ * Load the tracking + emission modules fresh, mirroring production startup:
+ * the built-in PostHog provider is registered whenever `POSTHOG_API_KEY` is
+ * set, and its `flush()` is what drains the shared send queue.
+ */
+async function freshModules() {
+  vi.resetModules();
+  const registry = await import("../tracking/registry.js");
+  for (const name of ["posthog", "mixpanel", "amplitude", "webhook"]) {
+    registry.unregisterTrackingProvider(name);
+  }
+  const providers = await import("../tracking/providers.js");
+  const posthogAi = await import("./posthog-ai.js");
+  const events: TrackingEvent[] = [];
+  registry.registerTrackingProvider({
+    name: "qa-posthog-ai",
+    track(event) {
+      events.push(event);
+    },
+  });
+  providers.registerBuiltinProviders();
+  return { ...registry, ...providers, ...posthogAi, events };
+}
+
 describe("emitAiFeedbackSurveyEvent", () => {
   afterEach(() => {
     unregisterTrackingProvider("qa-posthog-ai");
     vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
   });
 
   const base = {
@@ -49,38 +74,74 @@ describe("emitAiFeedbackSurveyEvent", () => {
     expect(events).toHaveLength(0);
   });
 
-  it("emits PostHog's `survey sent` linked to the AI trace", async () => {
+  it("emits nothing when PostHog itself is not configured", async () => {
     vi.stubEnv("POSTHOG_AI_FEEDBACK_SURVEY_ID", "survey-abc");
-    const events = captureEvents();
+    vi.stubEnv("POSTHOG_API_KEY", "");
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}"));
+    vi.stubGlobal("fetch", fetchMock);
 
-    expect(emitAiFeedbackSurveyEvent(base)).toBe(true);
+    expect(emitAiFeedbackSurveyEvent(base)).toBe(false);
     await new Promise((r) => setTimeout(r, 0));
 
-    expect(events).toHaveLength(1);
-    expect(events[0].name).toBe("survey sent");
-    expect(events[0].userId).toBe("alice@example.test");
-    expect(events[0].properties).toMatchObject({
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("sends `survey sent` to PostHog only, never through the provider fan-out", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}"));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("POSTHOG_AI_FEEDBACK_SURVEY_ID", "survey-abc");
+    vi.stubEnv("POSTHOG_API_KEY", "phc_test");
+    vi.stubEnv("POSTHOG_HOST", "https://us.i.posthog.com");
+    const mod = await freshModules();
+
+    expect(
+      mod.emitAiFeedbackSurveyEvent({
+        ...base,
+        feedbackType: "text",
+        value: "the answer cited the wrong doc",
+      }),
+    ).toBe(true);
+    await mod.flushTracking();
+
+    // The generic registry saw nothing — free-text feedback stays with PostHog
+    // instead of fanning out to Mixpanel/Amplitude/webhooks.
+    expect(mod.events).toHaveLength(0);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://us.i.posthog.com/capture/");
+    const body = JSON.parse(init.body);
+    expect(body.event).toBe("survey sent");
+    expect(body.distinct_id).toBe("alice@example.test");
+    expect(body.properties).toMatchObject({
       $survey_id: "survey-abc",
-      $survey_response: "thumbs_down",
+      $survey_response: "the answer cited the wrong doc",
       $survey_submission_id: "sub-1",
       $survey_completed: true,
       $ai_trace_id: "run-1",
       $ai_session_id: "thread-1",
-      $ai_model: "claude-test",
-      feedback_type: "thumbs_down",
+      feedback_type: "text",
     });
   });
 
   it("uses the per-question response key when a question id is configured", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}"));
+    vi.stubGlobal("fetch", fetchMock);
     vi.stubEnv("POSTHOG_AI_FEEDBACK_SURVEY_ID", "survey-abc");
     vi.stubEnv("POSTHOG_AI_FEEDBACK_SURVEY_QUESTION_ID", "q1");
-    const events = captureEvents();
+    vi.stubEnv("POSTHOG_API_KEY", "phc_test");
+    const mod = await freshModules();
 
-    emitAiFeedbackSurveyEvent({ ...base, feedbackType: "text", value: "slow" });
-    await new Promise((r) => setTimeout(r, 0));
+    mod.emitAiFeedbackSurveyEvent({
+      ...base,
+      feedbackType: "text",
+      value: "slow",
+    });
+    await mod.flushTracking();
 
-    expect(events[0].properties?.["$survey_response_q1"]).toBe("slow");
-    expect(events[0].properties).not.toHaveProperty("$survey_response");
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.properties["$survey_response_q1"]).toBe("slow");
+    expect(body.properties).not.toHaveProperty("$survey_response");
   });
 });
 

--- a/packages/core/src/observability/posthog-ai.spec.ts
+++ b/packages/core/src/observability/posthog-ai.spec.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  registerTrackingProvider,
+  unregisterTrackingProvider,
+} from "../tracking/registry.js";
+import type { TrackingEvent } from "../tracking/types.js";
+import {
+  MAX_AI_CONTENT_BYTES,
+  boundAiContent,
+  emitAiFeedbackSurveyEvent,
+  toAiErrorDetail,
+} from "./posthog-ai.js";
+
+function captureEvents(): TrackingEvent[] {
+  const events: TrackingEvent[] = [];
+  registerTrackingProvider({
+    name: "qa-posthog-ai",
+    track(event) {
+      events.push(event);
+    },
+  });
+  return events;
+}
+
+describe("emitAiFeedbackSurveyEvent", () => {
+  afterEach(() => {
+    unregisterTrackingProvider("qa-posthog-ai");
+    vi.unstubAllEnvs();
+  });
+
+  const base = {
+    runId: "run-1",
+    threadId: "thread-1",
+    userId: "alice@example.test",
+    feedbackType: "thumbs_down" as const,
+    value: "thumbs_down",
+    submissionId: "sub-1",
+    model: "claude-test",
+  };
+
+  it("emits nothing when no survey id is configured", async () => {
+    vi.stubEnv("POSTHOG_AI_FEEDBACK_SURVEY_ID", "");
+    const events = captureEvents();
+
+    expect(emitAiFeedbackSurveyEvent(base)).toBe(false);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(events).toHaveLength(0);
+  });
+
+  it("emits PostHog's `survey sent` linked to the AI trace", async () => {
+    vi.stubEnv("POSTHOG_AI_FEEDBACK_SURVEY_ID", "survey-abc");
+    const events = captureEvents();
+
+    expect(emitAiFeedbackSurveyEvent(base)).toBe(true);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(events).toHaveLength(1);
+    expect(events[0].name).toBe("survey sent");
+    expect(events[0].userId).toBe("alice@example.test");
+    expect(events[0].properties).toMatchObject({
+      $survey_id: "survey-abc",
+      $survey_response: "thumbs_down",
+      $survey_submission_id: "sub-1",
+      $survey_completed: true,
+      $ai_trace_id: "run-1",
+      $ai_session_id: "thread-1",
+      $ai_model: "claude-test",
+      feedback_type: "thumbs_down",
+    });
+  });
+
+  it("uses the per-question response key when a question id is configured", async () => {
+    vi.stubEnv("POSTHOG_AI_FEEDBACK_SURVEY_ID", "survey-abc");
+    vi.stubEnv("POSTHOG_AI_FEEDBACK_SURVEY_QUESTION_ID", "q1");
+    const events = captureEvents();
+
+    emitAiFeedbackSurveyEvent({ ...base, feedbackType: "text", value: "slow" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(events[0].properties?.["$survey_response_q1"]).toBe("slow");
+    expect(events[0].properties).not.toHaveProperty("$survey_response");
+  });
+});
+
+describe("boundAiContent", () => {
+  it("passes small payloads through untouched", () => {
+    const value = [{ role: "user", content: "hi" }];
+    expect(boundAiContent(value)).toEqual({ value, truncated: false });
+  });
+
+  it("replaces oversized payloads with a marker instead of a partial one", () => {
+    const huge = [{ role: "user", content: "x".repeat(MAX_AI_CONTENT_BYTES) }];
+    const result = boundAiContent(huge);
+
+    expect(result.truncated).toBe(true);
+    expect(String(result.value)).toContain("truncated");
+    // Never a silently shortened version of the real content.
+    expect(String(result.value)).not.toContain("xxxx");
+  });
+
+  it("marks unserializable values rather than dropping them silently", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+
+    expect(boundAiContent(cyclic)).toEqual({
+      value: "[unserializable]",
+      truncated: true,
+    });
+  });
+});
+
+describe("toAiErrorDetail", () => {
+  it("returns undefined for a healthy run", () => {
+    expect(toAiErrorDetail(null)).toBeUndefined();
+    expect(toAiErrorDetail(undefined, {})).toBeUndefined();
+  });
+
+  it("carries terminal classification alongside the message", () => {
+    expect(
+      toAiErrorDetail("model refused", {
+        state: "failed",
+        code: "provider_error",
+        retryable: true,
+      }),
+    ).toEqual({
+      message: "model refused",
+      terminal_state: "failed",
+      terminal_code: "provider_error",
+      retryable: true,
+    });
+  });
+
+  it("redacts secrets in the error message", () => {
+    const detail = toAiErrorDetail("failed with authorization: Bearer abc123");
+
+    expect(detail?.message).not.toContain("abc123");
+  });
+});

--- a/packages/core/src/observability/posthog-ai.ts
+++ b/packages/core/src/observability/posthog-ai.ts
@@ -1,0 +1,282 @@
+/**
+ * PostHog LLM-analytics events (`$ai_trace`, `$ai_span`, `$ai_generation`
+ * content fields).
+ *
+ * PostHog models an agent run as a tree: one `$ai_trace` per run, `$ai_span`
+ * for non-model work (tool calls), and `$ai_generation` for model round-trips.
+ * Every node shares `$ai_trace_id` and links upward through `$ai_parent_id`.
+ * Emitting only a generation — which is what this framework did — makes PostHog
+ * synthesize a placeholder trace with no tool steps in it.
+ *
+ * `$ai_session_id` groups traces into a conversation. It is deliberately NOT
+ * PostHog's `$session_id`: the latter is the browser session used for session
+ * replay, and the two are different lifetimes.
+ *
+ * Content (`$ai_input` / `$ai_output_choices` / `$ai_input_state` /
+ * `$ai_output_state`) is gated on config and always OMITTED when disabled.
+ * Sending `[]` instead would be indistinguishable from a run that genuinely had
+ * no messages.
+ *
+ * @see https://posthog.com/docs/ai-observability/traces
+ * @see https://posthog.com/docs/ai-observability/spans
+ */
+
+import { boundedText } from "../tracking/redaction.js";
+
+/** Hard ceiling on serialized content per `$ai_*` field. */
+export const MAX_AI_CONTENT_BYTES = 128 * 1024;
+/** Hard ceiling on emitted `$ai_span` events per run. */
+export const MAX_AI_SPANS_PER_RUN = 100;
+
+export interface AiErrorDetail {
+  message: string;
+  terminal_code?: string;
+  terminal_state?: string;
+  retryable?: boolean;
+}
+
+function trackAiEvent(
+  name: string,
+  properties: Record<string, unknown>,
+  userId: string | null,
+): void {
+  for (const key of Object.keys(properties)) {
+    if (properties[key] === undefined) delete properties[key];
+  }
+  try {
+    void import("../tracking/registry.js")
+      .then(({ track }) => {
+        track(name, properties, { userId: userId ?? undefined });
+      })
+      .catch(() => {});
+  } catch {
+    // Tracking must never affect the agent run or trace persistence.
+  }
+}
+
+/**
+ * Serialize a content value under a byte ceiling.
+ *
+ * Returns `{ truncated: true }` with a placeholder rather than a silently
+ * shortened payload — a trace that shows half a conversation as if it were the
+ * whole one is worse than one that says it was cut.
+ */
+export function boundAiContent(value: unknown): {
+  value: unknown;
+  truncated: boolean;
+} {
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    return { value: "[unserializable]", truncated: true };
+  }
+  if (serialized === undefined) return { value: undefined, truncated: false };
+
+  const bytes =
+    typeof Buffer !== "undefined"
+      ? Buffer.byteLength(serialized, "utf8")
+      : new TextEncoder().encode(serialized).length;
+  if (bytes <= MAX_AI_CONTENT_BYTES) return { value, truncated: false };
+
+  return {
+    value: `[truncated: ${bytes} bytes exceeded the ${MAX_AI_CONTENT_BYTES}-byte trace content limit]`,
+    truncated: true,
+  };
+}
+
+export interface AiTraceEventInput {
+  runId: string;
+  threadId: string | null;
+  userId: string | null;
+  /** Human-readable name for the run, e.g. the agent or thread name. */
+  spanName: string;
+  model: string;
+  provider: string;
+  latencySeconds: number;
+  isError: boolean;
+  error?: AiErrorDetail;
+  inputTokens?: number;
+  outputTokens?: number;
+  costUsd?: number;
+  createdAt: number;
+  /** Browser session id, when the run originated from a page. Links the trace
+   *  to PostHog session replay. */
+  browserSessionId?: string;
+  /** Omitted unless `capturePrompts` is on. */
+  inputState?: unknown;
+  outputState?: unknown;
+  extraProperties?: Record<string, unknown>;
+}
+
+export function emitAiTraceEvent(input: AiTraceEventInput): void {
+  const inputContent =
+    input.inputState === undefined
+      ? undefined
+      : boundAiContent(input.inputState);
+  const outputContent =
+    input.outputState === undefined
+      ? undefined
+      : boundAiContent(input.outputState);
+
+  trackAiEvent(
+    "$ai_trace",
+    {
+      ...input.extraProperties,
+      $ai_trace_id: input.runId,
+      $ai_session_id: input.threadId ?? undefined,
+      $ai_span_name: input.spanName,
+      $ai_model: input.model,
+      $ai_provider: input.provider,
+      $ai_latency: input.latencySeconds,
+      $ai_is_error: input.isError,
+      $ai_error: input.error,
+      $ai_input_tokens: input.inputTokens,
+      $ai_output_tokens: input.outputTokens,
+      $ai_total_cost_usd: input.costUsd,
+      $ai_input_state: inputContent?.value,
+      $ai_output_state: outputContent?.value,
+      $ai_input_truncated: inputContent?.truncated || undefined,
+      $ai_output_truncated: outputContent?.truncated || undefined,
+      $session_id: input.browserSessionId,
+      created_at: new Date(input.createdAt).toISOString(),
+    },
+    input.userId,
+  );
+}
+
+export interface AiSpanEventInput {
+  runId: string;
+  threadId: string | null;
+  userId: string | null;
+  spanId: string;
+  /** Defaults to the run's trace id, which is the tree root. */
+  parentId?: string;
+  spanName: string;
+  latencySeconds: number;
+  isError: boolean;
+  error?: AiErrorDetail;
+  createdAt: number;
+  browserSessionId?: string;
+  /** Omitted unless `captureToolArgs` / `captureToolResults` are on. */
+  inputState?: unknown;
+  outputState?: unknown;
+  extraProperties?: Record<string, unknown>;
+}
+
+export function emitAiSpanEvent(input: AiSpanEventInput): void {
+  const inputContent =
+    input.inputState === undefined
+      ? undefined
+      : boundAiContent(input.inputState);
+  const outputContent =
+    input.outputState === undefined
+      ? undefined
+      : boundAiContent(input.outputState);
+
+  trackAiEvent(
+    "$ai_span",
+    {
+      ...input.extraProperties,
+      $ai_trace_id: input.runId,
+      $ai_session_id: input.threadId ?? undefined,
+      $ai_span_id: input.spanId,
+      $ai_parent_id: input.parentId ?? input.runId,
+      $ai_span_name: input.spanName,
+      $ai_latency: input.latencySeconds,
+      $ai_is_error: input.isError,
+      $ai_error: input.error,
+      $ai_input_state: inputContent?.value,
+      $ai_output_state: outputContent?.value,
+      $ai_input_truncated: inputContent?.truncated || undefined,
+      $ai_output_truncated: outputContent?.truncated || undefined,
+      $session_id: input.browserSessionId,
+      created_at: new Date(input.createdAt).toISOString(),
+    },
+    input.userId,
+  );
+}
+
+export interface AiFeedbackSurveyInput {
+  runId: string | null;
+  threadId: string | null;
+  userId: string | null;
+  feedbackType: "thumbs_up" | "thumbs_down" | "category" | "text";
+  /** The submitted value: sentiment label, chosen category, or free text. */
+  value: string;
+  submissionId: string;
+  model?: string;
+  browserSessionId?: string;
+}
+
+/**
+ * Emit PostHog's documented manual feedback event for an LLM trace.
+ *
+ * PostHog surfaces feedback in LLM analytics only through `survey sent` keyed
+ * to a real survey id — `$ai_feedback` is not a PostHog event and renders
+ * nowhere. Returns `false` and emits nothing when no survey id is configured:
+ * inventing one would produce events attached to a survey that does not exist.
+ *
+ * @see https://posthog.com/docs/ai-observability/user-feedback/manual-event-capture
+ */
+export function emitAiFeedbackSurveyEvent(
+  input: AiFeedbackSurveyInput,
+): boolean {
+  const surveyId = process.env.POSTHOG_AI_FEEDBACK_SURVEY_ID?.trim();
+  if (!surveyId) return false;
+
+  const questionId = process.env.POSTHOG_AI_FEEDBACK_SURVEY_QUESTION_ID?.trim();
+  // PostHog accepts `$survey_response` for a single-question survey and
+  // `$survey_response_<questionId>` when the survey has named questions.
+  const responseKey = questionId
+    ? `$survey_response_${questionId}`
+    : "$survey_response";
+
+  trackAiEvent(
+    "survey sent",
+    {
+      $survey_id: surveyId,
+      [responseKey]: input.value,
+      $survey_submission_id: input.submissionId,
+      $survey_completed: true,
+      $ai_trace_id: input.runId ?? undefined,
+      $ai_session_id: input.threadId ?? undefined,
+      $ai_model: input.model,
+      $session_id: input.browserSessionId,
+      feedback_type: input.feedbackType,
+      source: "agent_observability",
+    },
+    input.userId,
+  );
+  return true;
+}
+
+/**
+ * Build a structured `$ai_error` from the run's failure information.
+ *
+ * Returns `undefined` when the run did not fail, so `$ai_error` is absent
+ * rather than an empty object on healthy traces.
+ */
+export function toAiErrorDetail(
+  errorMessage: string | null | undefined,
+  terminalOutcome?: {
+    state?: string;
+    code?: string;
+    retryable?: boolean;
+  },
+): AiErrorDetail | undefined {
+  if (!errorMessage && !terminalOutcome?.code) return undefined;
+  return {
+    message: boundedText(
+      errorMessage ?? terminalOutcome?.code ?? "error",
+      1000,
+    ),
+    ...(terminalOutcome?.state
+      ? { terminal_state: terminalOutcome.state }
+      : {}),
+    ...(terminalOutcome?.code ? { terminal_code: terminalOutcome.code } : {}),
+    ...(terminalOutcome?.retryable !== undefined
+      ? { retryable: terminalOutcome.retryable }
+      : {}),
+  };
+}

--- a/packages/core/src/observability/posthog-ai.ts
+++ b/packages/core/src/observability/posthog-ai.ts
@@ -21,6 +21,7 @@
  * @see https://posthog.com/docs/ai-observability/spans
  */
 
+import { sendPostHogEvent } from "../tracking/providers.js";
 import { boundedText } from "../tracking/redaction.js";
 
 /** Hard ceiling on serialized content per `$ai_*` field. */
@@ -49,6 +50,7 @@ function trackAiEvent(
         track(name, properties, { userId: userId ?? undefined });
       })
       .catch(() => {});
+    // coercion-ok: a throw here would break the run it is observing
   } catch {
     // Tracking must never affect the agent run or trace persistence.
   }
@@ -217,6 +219,12 @@ export interface AiFeedbackSurveyInput {
  * nowhere. Returns `false` and emits nothing when no survey id is configured:
  * inventing one would produce events attached to a survey that does not exist.
  *
+ * Sent to PostHog ONLY, not through `track()`. The survey response carries the
+ * user's free-text feedback verbatim, and configuring a PostHog survey id must
+ * not silently start shipping that text to Mixpanel, Amplitude, webhooks, or
+ * Agent Native Analytics. Those backends get the content-free `$ai_feedback`
+ * event instead.
+ *
  * @see https://posthog.com/docs/ai-observability/user-feedback/manual-event-capture
  */
 export function emitAiFeedbackSurveyEvent(
@@ -232,23 +240,27 @@ export function emitAiFeedbackSurveyEvent(
     ? `$survey_response_${questionId}`
     : "$survey_response";
 
-  trackAiEvent(
+  const properties: Record<string, unknown> = {
+    $survey_id: surveyId,
+    [responseKey]: input.value,
+    $survey_submission_id: input.submissionId,
+    $survey_completed: true,
+    $ai_trace_id: input.runId ?? undefined,
+    $ai_session_id: input.threadId ?? undefined,
+    $ai_model: input.model,
+    $session_id: input.browserSessionId,
+    feedback_type: input.feedbackType,
+    source: "agent_observability",
+  };
+  for (const key of Object.keys(properties)) {
+    if (properties[key] === undefined) delete properties[key];
+  }
+
+  return sendPostHogEvent(
     "survey sent",
-    {
-      $survey_id: surveyId,
-      [responseKey]: input.value,
-      $survey_submission_id: input.submissionId,
-      $survey_completed: true,
-      $ai_trace_id: input.runId ?? undefined,
-      $ai_session_id: input.threadId ?? undefined,
-      $ai_model: input.model,
-      $session_id: input.browserSessionId,
-      feedback_type: input.feedbackType,
-      source: "agent_observability",
-    },
-    input.userId,
+    properties,
+    input.userId ?? "anonymous",
   );
-  return true;
 }
 
 /**

--- a/packages/core/src/observability/routes.spec.ts
+++ b/packages/core/src/observability/routes.spec.ts
@@ -185,7 +185,7 @@ describe("observability routes", () => {
     },
   );
 
-  it("does not double-count a thumbs-down category as sentiment", async () => {
+  it("reports a category follow-up without counting it as a second sentiment", async () => {
     mockReadBody.mockResolvedValue({
       threadId: "thread-1",
       runId: "run-1",
@@ -198,7 +198,36 @@ describe("observability routes", () => {
     await handler(createEvent("/feedback", "POST"));
 
     expect(mockInsertFeedback).toHaveBeenCalledOnce();
-    expect(mockGetTraceSummary).not.toHaveBeenCalled();
-    expect(mockTrack).not.toHaveBeenCalled();
+    // The submission is visible...
+    expect(mockTrack).toHaveBeenCalledOnce();
+    const [name, properties] = mockTrack.mock.calls[0];
+    expect(name).toBe("$ai_feedback");
+    expect(properties).toMatchObject({
+      feedback_type: "category",
+      run_id: "run-1",
+      $ai_trace_id: "run-1",
+    });
+    // ...but carries no sentiment: the thumbs-down it follows already counted.
+    expect(properties).not.toHaveProperty("sentiment");
+  });
+
+  it("reports free-text feedback, which previously emitted nothing", async () => {
+    mockReadBody.mockResolvedValue({
+      threadId: "thread-1",
+      runId: "run-1",
+      feedbackType: "text",
+      value: "the answer cited the wrong doc",
+    });
+    const handler = createObservabilityHandler() as any;
+
+    await handler(createEvent("/feedback", "POST"));
+
+    expect(mockTrack).toHaveBeenCalledOnce();
+    const [, properties] = mockTrack.mock.calls[0];
+    expect(properties).toMatchObject({ feedback_type: "text" });
+    expect(properties).not.toHaveProperty("sentiment");
+    // The first-party event stays content-free; the text itself is persisted
+    // and, when a survey is configured, sent as the survey response.
+    expect(JSON.stringify(properties)).not.toContain("wrong doc");
   });
 });

--- a/packages/core/src/observability/routes.ts
+++ b/packages/core/src/observability/routes.ts
@@ -30,7 +30,9 @@ import {
 
 import { getSession } from "../server/auth.js";
 import { readBody } from "../server/h3-helpers.js";
+import { getRequestContext } from "../server/request-context.js";
 import { track } from "../tracking/registry.js";
+import { emitAiFeedbackSurveyEvent } from "./posthog-ai.js";
 import {
   getObservabilityOverview,
   getTraceSummaries,
@@ -207,11 +209,11 @@ export function createObservabilityHandler() {
         userId: owner,
         createdAt: Date.now(),
       });
-      // Emit one content-free analytics event for the explicit thumb itself.
-      // Category follow-ups intentionally do not emit: a thumbs-down followed
-      // by a category would otherwise double-count the same negative signal.
-      if (feedbackType === "thumbs_up" || feedbackType === "thumbs_down") {
+      {
         const runId = body.runId ? String(body.runId) : null;
+        const threadId = body.threadId ? String(body.threadId) : null;
+        const isThumb =
+          feedbackType === "thumbs_up" || feedbackType === "thumbs_down";
         let model: string | undefined;
         if (runId) {
           try {
@@ -223,13 +225,21 @@ export function createObservabilityHandler() {
           }
         }
 
-        const threadId = body.threadId ? String(body.threadId) : null;
+        // Every submission is reported, including `category` and `text`, which
+        // previously emitted nothing at all. Only thumbs carry `sentiment` —
+        // a category follow-up to a thumbs-down is extra detail about the same
+        // vote, so counting it as a second negative would inflate the metric.
         track(
           "$ai_feedback",
           {
             ...trackingIdentityProperties(),
             source: "agent_observability",
-            sentiment: feedbackType === "thumbs_up" ? "positive" : "negative",
+            ...(isThumb
+              ? {
+                  sentiment:
+                    feedbackType === "thumbs_up" ? "positive" : "negative",
+                }
+              : {}),
             feedback_type: feedbackType,
             run_id: runId,
             thread_id: threadId,
@@ -240,6 +250,19 @@ export function createObservabilityHandler() {
           },
           { userId: owner },
         );
+
+        // PostHog shows feedback in LLM analytics only via `survey sent`.
+        // No-ops unless a survey id is configured.
+        emitAiFeedbackSurveyEvent({
+          runId,
+          threadId,
+          userId: owner,
+          feedbackType,
+          value: isThumb ? feedbackType : value,
+          submissionId: id,
+          model,
+          browserSessionId: getRequestContext()?.browserSessionId,
+        });
       }
       // Fire-and-forget: recompute satisfaction score for the thread.
       if (body.threadId) {

--- a/packages/core/src/observability/traces.spec.ts
+++ b/packages/core/src/observability/traces.spec.ts
@@ -194,7 +194,7 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
     registerTrackingProvider({
       name: "qa-ai-generation",
       track(event) {
-        events.push(event);
+        if (event.name === "$ai_generation") events.push(event);
       },
     });
 
@@ -287,8 +287,280 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
     expect(event.properties?.["$ai_total_cost_usd"]).toEqual(
       expect.any(Number),
     );
+    // capturePrompts is off, so no message content leaves the process.
     expect(event.properties?.["$ai_input"]).toBeUndefined();
-    expect(event.properties?.["$ai_output_choices"]).toBeUndefined();
+    // Tool CALLS still ship: PostHog derives $ai_tools_called only from
+    // tool-call blocks inside $ai_output_choices. The assistant's text content
+    // and the call arguments stay withheld.
+    const choices = event.properties?.["$ai_output_choices"] as Array<{
+      role: string;
+      content?: unknown;
+      tool_calls?: Array<{ function: { name: string; arguments?: unknown } }>;
+    }>;
+    expect(choices).toHaveLength(1);
+    expect(choices[0].role).toBe("assistant");
+    expect(choices[0]).not.toHaveProperty("content");
+    expect(choices[0].tool_calls?.map((c) => c.function.name)).toEqual([
+      "read",
+    ]);
+    expect(choices[0].tool_calls?.[0].function).not.toHaveProperty("arguments");
+    expect(JSON.stringify(choices)).not.toContain("must-not-be-tracked");
+  });
+
+  it("exports messages and tool definitions when capturePrompts is on", async () => {
+    const events: TrackingEvent[] = [];
+    registerTrackingProvider({
+      name: "qa-ai-generation",
+      track(event) {
+        if (event.name === "$ai_generation") events.push(event);
+      },
+    });
+
+    const loopOpts: any = {
+      engine: { name: "anthropic" },
+      model: "claude-test",
+      systemPrompt: "",
+      tools: [
+        { name: "search", description: "Search the docs", inputSchema: {} },
+      ],
+      messages: [{ role: "user", content: "how do I deploy?" }],
+      actions: {},
+      send: () => {},
+      signal: new AbortController().signal,
+    };
+
+    await instrumentAgentLoop({
+      runAgentLoop: async ({ send }) => {
+        send({ type: "text", text: "Run " });
+        send({ type: "text", text: "pnpm deploy." });
+        return {
+          inputTokens: 5,
+          outputTokens: 3,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          model: "claude-test",
+          usageReported: true,
+        };
+      },
+      loopOpts,
+      runId: "run-content",
+      threadId: "thread-content",
+      userId: "user@example.com",
+      config: {
+        ...DEFAULT_OBSERVABILITY_CONFIG,
+        enabled: true,
+        capturePrompts: true,
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.properties?.["$ai_input"]).toEqual([
+      { role: "user", content: "how do I deploy?" },
+    ]);
+    expect(events[0]?.properties?.["$ai_output_choices"]).toEqual([
+      { role: "assistant", content: "Run pnpm deploy." },
+    ]);
+    expect(events[0]?.properties?.["$ai_tools"]).toEqual([
+      {
+        type: "function",
+        function: { name: "search", description: "Search the docs" },
+      },
+    ]);
+  });
+
+  it("emits an $ai_trace for the run and an $ai_span per tool call", async () => {
+    const events: TrackingEvent[] = [];
+    registerTrackingProvider({
+      name: "qa-ai-generation",
+      track(event) {
+        events.push(event);
+      },
+    });
+
+    const loopOpts: any = {
+      engine: { name: "anthropic" },
+      model: "claude-test",
+      systemPrompt: "",
+      tools: [],
+      messages: [],
+      actions: {},
+      send: () => {},
+      signal: new AbortController().signal,
+    };
+
+    await instrumentAgentLoop({
+      runAgentLoop: async ({ send }) => {
+        send({ type: "tool_start", id: "a", tool: "search", input: {} });
+        send({ type: "tool_done", id: "a", tool: "search", result: "ok" });
+        send({ type: "tool_start", id: "b", tool: "write", input: {} });
+        send({
+          type: "tool_done",
+          id: "b",
+          tool: "write",
+          result: "Error: disk full",
+          isError: true,
+        });
+        return {
+          inputTokens: 10,
+          outputTokens: 5,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          model: "claude-test",
+          usageReported: true,
+        };
+      },
+      loopOpts,
+      runId: "run-tree",
+      threadId: "thread-tree",
+      userId: "user@example.com",
+      browserSessionId: "browser-session-1",
+      config: { ...DEFAULT_OBSERVABILITY_CONFIG, enabled: true },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const traces = events.filter((e) => e.name === "$ai_trace");
+    const spans = events.filter((e) => e.name === "$ai_span");
+    const generations = events.filter((e) => e.name === "$ai_generation");
+
+    expect(traces).toHaveLength(1);
+    expect(generations).toHaveLength(1);
+    expect(spans).toHaveLength(2);
+
+    expect(traces[0]?.properties).toMatchObject({
+      $ai_trace_id: "run-tree",
+      $ai_session_id: "thread-tree",
+      $ai_span_name: "agent_run",
+      $ai_model: "claude-test",
+      $ai_provider: "anthropic",
+      $ai_is_error: false,
+      $session_id: "browser-session-1",
+    });
+    // A healthy trace carries no error object at all.
+    expect(traces[0]?.properties).not.toHaveProperty("$ai_error");
+
+    // Every node hangs off the run's trace id, so PostHog renders one tree.
+    for (const span of spans) {
+      expect(span.properties).toMatchObject({
+        $ai_trace_id: "run-tree",
+        $ai_parent_id: "run-tree",
+      });
+    }
+    expect(generations[0]?.properties?.["$ai_parent_id"]).toBe("run-tree");
+
+    expect(spans.map((s) => s.properties?.["$ai_span_name"]).sort()).toEqual([
+      "search",
+      "write",
+    ]);
+    const failed = spans.find((s) => s.properties?.["$ai_is_error"] === true);
+    expect(failed?.properties?.["$ai_span_name"]).toBe("write");
+    expect(failed?.properties?.["$ai_error"]).toMatchObject({
+      message: expect.stringContaining("disk full"),
+    });
+  });
+
+  it("omits tool span content unless capture is enabled", async () => {
+    const events: TrackingEvent[] = [];
+    registerTrackingProvider({
+      name: "qa-ai-generation",
+      track(event) {
+        if (event.name === "$ai_span") events.push(event);
+      },
+    });
+
+    const loopOpts: any = {
+      engine: { name: "anthropic" },
+      model: "claude-test",
+      systemPrompt: "",
+      tools: [],
+      messages: [],
+      actions: {},
+      send: () => {},
+      signal: new AbortController().signal,
+    };
+
+    await instrumentAgentLoop({
+      runAgentLoop: async ({ send }) => {
+        send({
+          type: "tool_start",
+          id: "a",
+          tool: "search",
+          input: { query: "must-not-be-tracked" },
+        });
+        send({ type: "tool_done", id: "a", tool: "search", result: "ok" });
+        return {
+          inputTokens: 1,
+          outputTokens: 1,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          model: "claude-test",
+        };
+      },
+      loopOpts,
+      runId: "run-no-content",
+      threadId: null,
+      userId: null,
+      config: { ...DEFAULT_OBSERVABILITY_CONFIG, enabled: true },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(events).toHaveLength(1);
+    // Absent, not empty — an empty object would read as "the tool took no args".
+    expect(events[0]?.properties).not.toHaveProperty("$ai_input_state");
+    expect(JSON.stringify(events[0])).not.toContain("must-not-be-tracked");
+  });
+
+  it("does not emit tool spans when captureLlmSpans is off", async () => {
+    const events: TrackingEvent[] = [];
+    registerTrackingProvider({
+      name: "qa-ai-generation",
+      track(event) {
+        events.push(event);
+      },
+    });
+
+    const loopOpts: any = {
+      engine: { name: "anthropic" },
+      model: "claude-test",
+      systemPrompt: "",
+      tools: [],
+      messages: [],
+      actions: {},
+      send: () => {},
+      signal: new AbortController().signal,
+    };
+
+    await instrumentAgentLoop({
+      runAgentLoop: async ({ send }) => {
+        send({ type: "tool_start", id: "a", tool: "search", input: {} });
+        send({ type: "tool_done", id: "a", tool: "search", result: "ok" });
+        return {
+          inputTokens: 1,
+          outputTokens: 1,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          model: "claude-test",
+        };
+      },
+      loopOpts,
+      runId: "run-no-spans",
+      threadId: null,
+      userId: null,
+      config: {
+        ...DEFAULT_OBSERVABILITY_CONFIG,
+        enabled: true,
+        captureLlmSpans: false,
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(events.filter((e) => e.name === "$ai_span")).toHaveLength(0);
+    // The trace itself still ships — spans are the opt-out, not the run.
+    expect(events.filter((e) => e.name === "$ai_trace")).toHaveLength(1);
   });
 
   it("keeps tool detail in invocation order and pairs parallel calls by id", async () => {
@@ -296,7 +568,7 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
     registerTrackingProvider({
       name: "qa-ai-generation",
       track(event) {
-        events.push(event);
+        if (event.name === "$ai_generation") events.push(event);
       },
     });
 
@@ -388,7 +660,7 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
     registerTrackingProvider({
       name: "qa-ai-generation",
       track(event) {
-        events.push(event);
+        if (event.name === "$ai_generation") events.push(event);
       },
     });
 
@@ -456,7 +728,7 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
     registerTrackingProvider({
       name: "qa-ai-generation",
       track(event) {
-        events.push(event);
+        if (event.name === "$ai_generation") events.push(event);
       },
     });
     const loopOpts: any = {
@@ -555,7 +827,7 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
       registerTrackingProvider({
         name: `qa-terminal-${event.type}`,
         track(tracked) {
-          events.push(tracked);
+          if (tracked.name === "$ai_generation") events.push(tracked);
         },
       });
       const loopOpts: any = {
@@ -608,7 +880,7 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
     registerTrackingProvider({
       name: "qa-terminal-recovered",
       track(tracked) {
-        events.push(tracked);
+        if (tracked.name === "$ai_generation") events.push(tracked);
       },
     });
     const loopOpts: any = {
@@ -653,7 +925,7 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
     registerTrackingProvider({
       name: "qa-typed-terminal",
       track(tracked) {
-        events.push(tracked);
+        if (tracked.name === "$ai_generation") events.push(tracked);
       },
     });
     const loopOpts: any = {
@@ -721,7 +993,7 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
     registerTrackingProvider({
       name: "qa-ai-generation",
       track(event) {
-        events.push(event);
+        if (event.name === "$ai_generation") events.push(event);
       },
     });
     const loopOpts: any = {
@@ -770,7 +1042,7 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
     registerTrackingProvider({
       name: "qa-ai-generation",
       track(event) {
-        events.push(event);
+        if (event.name === "$ai_generation") events.push(event);
       },
     });
     const loopOpts: any = {
@@ -894,7 +1166,7 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
     registerTrackingProvider({
       name: "qa-ai-generation",
       track(event) {
-        events.push(event);
+        if (event.name === "$ai_generation") events.push(event);
       },
     });
     const { tracer, spans } = createRecordingTracer();
@@ -978,7 +1250,7 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
     registerTrackingProvider({
       name: "qa-ai-generation",
       track(event) {
-        events.push(event);
+        if (event.name === "$ai_generation") events.push(event);
       },
     });
 

--- a/packages/core/src/observability/traces.spec.ts
+++ b/packages/core/src/observability/traces.spec.ts
@@ -456,9 +456,9 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
     ]);
     const failed = spans.find((s) => s.properties?.["$ai_is_error"] === true);
     expect(failed?.properties?.["$ai_span_name"]).toBe("write");
-    expect(failed?.properties?.["$ai_error"]).toMatchObject({
-      message: expect.stringContaining("disk full"),
-    });
+    // The failure is visible, but the tool's result text is withheld: this run
+    // has the default `captureToolResults: false`.
+    expect(failed?.properties).not.toHaveProperty("$ai_error");
   });
 
   it("omits tool span content unless capture is enabled", async () => {
@@ -511,6 +511,78 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
     // Absent, not empty — an empty object would read as "the tool took no args".
     expect(events[0]?.properties).not.toHaveProperty("$ai_input_state");
     expect(JSON.stringify(events[0])).not.toContain("must-not-be-tracked");
+  });
+
+  it("redacts and gates tool failure detail on tool spans", async () => {
+    const events: TrackingEvent[] = [];
+    registerTrackingProvider({
+      name: "qa-ai-generation",
+      track(event) {
+        if (event.name === "$ai_span") events.push(event);
+      },
+    });
+
+    const loopOpts: any = {
+      engine: { name: "anthropic" },
+      model: "claude-test",
+      systemPrompt: "",
+      tools: [],
+      messages: [],
+      actions: {},
+      send: () => {},
+      signal: new AbortController().signal,
+    };
+    // A tool result echoing an upstream response with credentials in it.
+    const leakyResult =
+      "Error: upstream rejected: authorization: Bearer abcdef123456 key=sk-not-a-real-key-000000000";
+
+    const run = (captureToolResults: boolean) =>
+      instrumentAgentLoop({
+        runAgentLoop: async ({ send }: any) => {
+          send({ type: "tool_start", id: "a", tool: "fetch", input: {} });
+          send({
+            type: "tool_done",
+            id: "a",
+            tool: "fetch",
+            result: leakyResult,
+            isError: true,
+          });
+          return {
+            inputTokens: 1,
+            outputTokens: 1,
+            cacheReadTokens: 0,
+            cacheWriteTokens: 0,
+            model: "claude-test",
+          };
+        },
+        loopOpts,
+        runId: `run-leak-${captureToolResults}`,
+        threadId: null,
+        userId: null,
+        config: {
+          ...DEFAULT_OBSERVABILITY_CONFIG,
+          enabled: true,
+          captureToolResults,
+        },
+      });
+
+    await run(false);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Withheld entirely, but the failure is still visible.
+    expect(events).toHaveLength(1);
+    expect(events[0]?.properties?.["$ai_is_error"]).toBe(true);
+    expect(events[0]?.properties).not.toHaveProperty("$ai_error");
+    expect(events[0]?.properties).not.toHaveProperty("$ai_output_state");
+
+    events.length = 0;
+    await run(true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(events).toHaveLength(1);
+    const serialized = JSON.stringify(events[0]);
+    expect(serialized).toContain("REDACTED");
+    expect(serialized).not.toContain("abcdef123456");
+    expect(serialized).not.toContain("sk-not-a-real-key-000000000");
   });
 
   it("does not emit tool spans when captureLlmSpans is off", async () => {

--- a/packages/core/src/observability/traces.ts
+++ b/packages/core/src/observability/traces.ts
@@ -3,6 +3,15 @@ import type {
   AgentLoopUsage,
 } from "../agent/production-agent.js";
 import type { AgentChatEvent, AgentToolInput } from "../agent/types.js";
+import { getRequestContext } from "../server/request-context.js";
+import {
+  MAX_AI_CONTENT_BYTES,
+  MAX_AI_SPANS_PER_RUN,
+  boundAiContent,
+  emitAiSpanEvent,
+  emitAiTraceEvent,
+  toAiErrorDetail,
+} from "./posthog-ai.js";
 import { type AgentSpan, endAgentSpan, startAgentSpan } from "./tracing.js";
 import { trackingIdentityProperties } from "./tracking-identity.js";
 import type { TraceSpan, TraceSummary, ObservabilityConfig } from "./types.js";
@@ -117,6 +126,17 @@ function emitLlmGenerationTrackingEvent(args: {
     variantId: string;
   }>;
   modelSelectionSource?: string;
+  /**
+   * PostHog content fields. Each is `undefined` unless the matching capture
+   * flag is on, and is then OMITTED from the event — never sent as `[]`, which
+   * PostHog would render as "the model was called with no messages".
+   */
+  aiInput?: unknown;
+  aiOutputChoices?: unknown;
+  aiTools?: unknown;
+  aiInputTruncated?: boolean;
+  aiOutputTruncated?: boolean;
+  browserSessionId?: string;
 }): void {
   const provider = llmProviderFromEngine(args.engineName, args.model);
   const costUsd =
@@ -128,6 +148,15 @@ function emitLlmGenerationTrackingEvent(args: {
       ? args.inputTokens + args.outputTokens
       : undefined;
   const error = args.errorMessage ?? undefined;
+  const terminalCode =
+    args.terminalOutcome?.state === "failed" ||
+    args.terminalOutcome?.state === "input_required"
+      ? args.terminalOutcome.code
+      : undefined;
+  const terminalRetryable =
+    args.terminalOutcome?.state === "failed"
+      ? args.terminalOutcome.retryable
+      : undefined;
   const properties: Record<string, unknown> = {
     ...trackingIdentityProperties(),
     source: "agent_observability",
@@ -154,15 +183,8 @@ function emitLlmGenerationTrackingEvent(args: {
     tools: args.tools,
     tools_truncated: args.toolsTruncated,
     terminal_state: args.terminalOutcome?.state,
-    terminal_code:
-      args.terminalOutcome?.state === "failed" ||
-      args.terminalOutcome?.state === "input_required"
-        ? args.terminalOutcome.code
-        : undefined,
-    terminal_retryable:
-      args.terminalOutcome?.state === "failed"
-        ? args.terminalOutcome.retryable
-        : undefined,
+    terminal_code: terminalCode,
+    terminal_retryable: terminalRetryable,
     delegated: args.delegation ? true : undefined,
     delegation_protocol: args.delegation?.protocol,
     caller_app: args.delegation?.callerApp,
@@ -175,19 +197,36 @@ function emitLlmGenerationTrackingEvent(args: {
     $ai_trace_id: args.runId,
     $ai_session_id: args.threadId ?? undefined,
     $ai_span_id: args.llmSpanId,
-    $ai_span_name: "agent_run",
-    $ai_parent_id: args.parentSpanId,
+    $ai_span_name: args.model,
+    // Parent is the run's trace, not the internal `agent_run` span id — the
+    // latter is never emitted to PostHog, so pointing at it orphaned the
+    // generation and PostHog rendered a placeholder trace around it.
+    $ai_parent_id: args.runId,
     $ai_model: args.model,
     $ai_provider: provider,
     $ai_input_tokens: args.inputTokens,
     $ai_output_tokens: args.outputTokens,
     $ai_latency: Math.round((args.durationMs / 1000) * 1000) / 1000,
     $ai_is_error: args.status === "error",
-    $ai_error: error,
+    $ai_error:
+      args.status === "error"
+        ? toAiErrorDetail(error, {
+            state: args.terminalOutcome?.state,
+            code: terminalCode,
+            retryable: terminalRetryable,
+          })
+        : undefined,
     $ai_cache_read_input_tokens: args.cacheReadTokens,
     $ai_cache_creation_input_tokens: args.cacheWriteTokens,
     $ai_request_count: 1,
     $ai_total_cost_usd: costUsd,
+    $ai_input: args.aiInput,
+    $ai_output_choices: args.aiOutputChoices,
+    $ai_tools: args.aiTools,
+    $ai_input_truncated: args.aiInputTruncated || undefined,
+    $ai_output_truncated: args.aiOutputTruncated || undefined,
+    $ai_time_to_first_token: args.firstTokenMs,
+    $session_id: args.browserSessionId,
   };
   if (args.experimentAssignments?.length) {
     properties.experiment_ids = args.experimentAssignments
@@ -218,6 +257,96 @@ function emitLlmGenerationTrackingEvent(args: {
   } catch {
     // Tracking must never affect the agent run or trace persistence.
   }
+}
+
+/**
+ * Build the PostHog content fields for a run's `$ai_generation`.
+ *
+ * This is one generation per run carrying the run's whole message list, not one
+ * per model round-trip: the engine layer reports aggregate usage only
+ * (`onUsage`) and exposes no per-step hook. Consequence to know when reading a
+ * trace — per-round-trip latency and intermediate assistant turns are not
+ * visible; a multi-step run collapses into a single generation node.
+ *
+ * `$ai_output_choices` is emitted whenever tool calls happened even with
+ * `capturePrompts` off, because PostHog derives `$ai_tools_called` /
+ * `$ai_tool_call_count` from tool-call blocks inside it and nothing else. The
+ * assistant's text content stays gated; only the structural call list ships.
+ */
+function buildGenerationContent(args: {
+  config: ObservabilityConfig;
+  messages: unknown;
+  tools: unknown;
+  assistantText: string;
+  toolSpans: TraceSpan[];
+}): {
+  aiInput?: unknown;
+  aiOutputChoices?: unknown;
+  aiTools?: unknown;
+  aiInputTruncated?: boolean;
+  aiOutputTruncated?: boolean;
+} {
+  const { config } = args;
+
+  const input = config.capturePrompts
+    ? boundAiContent(redactSensitiveFields(args.messages))
+    : undefined;
+
+  const toolCalls = args.toolSpans
+    .slice(0, MAX_TRACKED_GENERATION_TOOL_CALLS)
+    .map((span) => ({
+      type: "function" as const,
+      id: span.id,
+      function: {
+        name: span.name,
+        // Already redacted at span construction, and only present when
+        // `captureToolArgs` is on.
+        ...((span.metadata as { input?: unknown } | null)?.input !== undefined
+          ? { arguments: (span.metadata as { input?: unknown }).input }
+          : {}),
+      },
+    }));
+
+  const hasChoice = config.capturePrompts || toolCalls.length > 0;
+  const output = hasChoice
+    ? boundAiContent([
+        {
+          role: "assistant",
+          ...(config.capturePrompts
+            ? { content: redactToolErrorMessage(args.assistantText) }
+            : {}),
+          ...(toolCalls.length ? { tool_calls: toolCalls } : {}),
+        },
+      ])
+    : undefined;
+
+  const toolList = Array.isArray(args.tools)
+    ? args.tools
+        .filter(
+          (tool): tool is { name: string; description?: string } =>
+            !!tool && typeof (tool as { name?: unknown }).name === "string",
+        )
+        .map((tool) => ({
+          type: "function" as const,
+          function: {
+            name: tool.name,
+            ...(typeof tool.description === "string"
+              ? { description: tool.description }
+              : {}),
+          },
+        }))
+    : [];
+
+  return {
+    aiInput: input?.value,
+    aiOutputChoices: output?.value,
+    // Tool definitions are app configuration rather than user content, so they
+    // are not gated — without them a trace shows calls to tools nobody can
+    // identify. Schemas are excluded to keep the event small.
+    aiTools: toolList.length ? toolList : undefined,
+    aiInputTruncated: input?.truncated,
+    aiOutputTruncated: output?.truncated,
+  };
 }
 
 /** Keys whose values are stripped from persisted tool inputs when
@@ -324,6 +453,15 @@ export async function instrumentAgentLoop(opts: {
   };
   /** Raw user-authored message before prompt/context enrichment. */
   sentimentInput?: string;
+  /**
+   * Browser session id of the request that started this run, when it came from
+   * a page. Emitted as PostHog's `$session_id` so agent traces join to session
+   * replay — distinct from `$ai_session_id`, which is the thread.
+   *
+   * Defaults to the in-flight request context, which the agent-chat route
+   * populates from the `X-Agent-Native-Session-Id` header.
+   */
+  browserSessionId?: string;
   classifyError?: (error: unknown) =>
     | {
         status?: "success" | "error";
@@ -347,6 +485,11 @@ export async function instrumentAgentLoop(opts: {
           )
           .catch(() => null)
       : Promise.resolve(null);
+
+  // Falls back to the in-flight request so callers deep in the agent stack
+  // don't have to thread it down by hand.
+  const browserSessionId =
+    opts.browserSessionId ?? getRequestContext()?.browserSessionId;
 
   // Optional OpenTelemetry root span for this run. No-ops unless a host has
   // installed `@opentelemetry/api` and registered a provider. The promise is
@@ -389,6 +532,10 @@ export async function instrumentAgentLoop(opts: {
   const toolNameToCounters = new Map<string, number[]>();
   const toolCallIdToCounter = new Map<string, number>();
   const generationToolCalls = new Map<number, GenerationToolCall>();
+  // Assistant text, accumulated only when prompt capture is on so a disabled
+  // config never holds message content in memory in the first place.
+  const assistantTextParts: string[] = [];
+  let assistantTextLength = 0;
 
   let toolCallCount = 0;
   let successfulTools = 0;
@@ -432,6 +579,14 @@ export async function instrumentAgentLoop(opts: {
 
   const instrumentedSend = (event: AgentChatEvent): void => {
     try {
+      if (
+        config.capturePrompts &&
+        event.type === "text" &&
+        assistantTextLength < MAX_AI_CONTENT_BYTES
+      ) {
+        assistantTextParts.push(event.text);
+        assistantTextLength += event.text.length;
+      }
       // Some guardrails intentionally stop the loop by emitting a terminal
       // event and returning usage instead of throwing. Preserve that terminal
       // state in telemetry so a tripwire/loop-limit/provider error cannot be
@@ -741,6 +896,13 @@ export async function instrumentAgentLoop(opts: {
           ? Math.max(0, usage.firstEngineEventAtMs - runStart)
           : undefined;
       const llmSpanId = spanId();
+      const generationContent = buildGenerationContent({
+        config,
+        messages: loopOpts.messages,
+        tools: loopOpts.tools,
+        assistantText: assistantTextParts.join(""),
+        toolSpans: spans.filter((s) => s.spanType === "tool_call"),
+      });
       const llmSpan: TraceSpan = {
         id: llmSpanId,
         runId,
@@ -798,6 +960,8 @@ export async function instrumentAgentLoop(opts: {
         createdAt: runStart,
         experimentAssignments: opts.experimentAssignments,
         modelSelectionSource: opts.modelSelectionSource,
+        browserSessionId,
+        ...generationContent,
       });
     }
 
@@ -821,6 +985,105 @@ export async function instrumentAgentLoop(opts: {
       createdAt: runStart,
     };
     spans.push(parentSpan);
+
+    // PostHog LLM analytics: the run is a `$ai_trace`, each tool call an
+    // `$ai_span` under it. Emitted from the collected spans rather than from a
+    // second instrumentation pass, so the tree PostHog shows and the tree we
+    // persist cannot drift apart.
+    try {
+      const aiError =
+        runStatus === "error"
+          ? toAiErrorDetail(errorMessage, {
+              state: terminalOutcome?.state,
+              code:
+                terminalOutcome?.state === "failed" ||
+                terminalOutcome?.state === "input_required"
+                  ? terminalOutcome.code
+                  : undefined,
+              retryable:
+                terminalOutcome?.state === "failed"
+                  ? terminalOutcome.retryable
+                  : undefined,
+            })
+          : undefined;
+      const provider = llmProviderFromEngine(
+        typeof loopOpts.engine?.name === "string"
+          ? loopOpts.engine.name
+          : undefined,
+        usage?.model ?? loopOpts.model,
+      );
+
+      const toolSpans = config.captureLlmSpans
+        ? spans.filter((s) => s.spanType === "tool_call")
+        : [];
+      const emittedToolSpans = toolSpans.slice(0, MAX_AI_SPANS_PER_RUN);
+      const droppedToolSpans = toolSpans.length - emittedToolSpans.length;
+
+      emitAiTraceEvent({
+        runId,
+        threadId,
+        userId,
+        spanName: "agent_run",
+        model: usage?.model ?? loopOpts.model,
+        provider,
+        latencySeconds: Math.round(totalDurationMs) / 1000,
+        isError: runStatus === "error",
+        error: aiError,
+        inputTokens: usage?.usageReported ? usage.inputTokens : undefined,
+        outputTokens: usage?.usageReported ? usage.outputTokens : undefined,
+        costUsd: usage?.usageReported
+          ? costUsdFromCenticents(costCentsX100)
+          : undefined,
+        createdAt: runStart,
+        browserSessionId,
+        extraProperties: {
+          ...trackingIdentityProperties(),
+          source: "agent_observability",
+          run_id: runId,
+          thread_id: threadId,
+          // A truncated run must not read as a complete one.
+          ...(droppedToolSpans > 0
+            ? {
+                $ai_spans_dropped: droppedToolSpans,
+                $ai_spans_emitted: emittedToolSpans.length,
+              }
+            : {}),
+        },
+      });
+
+      for (const span of emittedToolSpans) {
+        emitAiSpanEvent({
+          runId,
+          threadId,
+          userId,
+          spanId: span.id,
+          spanName: span.name,
+          latencySeconds: Math.round(span.durationMs) / 1000,
+          isError: span.status === "error",
+          error:
+            span.status === "error"
+              ? toAiErrorDetail(span.errorMessage)
+              : undefined,
+          createdAt: span.createdAt,
+          browserSessionId,
+          // `metadata.input` is already redacted and only present when
+          // `captureToolArgs` is on; absent stays absent.
+          inputState: (span.metadata as { input?: unknown } | null)?.input,
+          outputState:
+            config.captureToolResults && span.errorMessage
+              ? span.errorMessage
+              : undefined,
+          extraProperties: {
+            ...trackingIdentityProperties(),
+            source: "agent_observability",
+            span_type: "tool_call",
+          },
+        });
+      }
+      // coercion-ok: a throw here would skip trace persistence below
+    } catch {
+      // LLM analytics must never affect the run or trace persistence.
+    }
 
     const summary: TraceSummary = {
       runId,

--- a/packages/core/src/observability/traces.ts
+++ b/packages/core/src/observability/traces.ts
@@ -1052,6 +1052,22 @@ export async function instrumentAgentLoop(opts: {
       });
 
       for (const span of emittedToolSpans) {
+        // `span.errorMessage` is the raw tool result. It routinely contains
+        // upstream response bodies with Authorization headers and standalone
+        // API keys, so it gets the same redaction + bounding the generation
+        // event's `tools[].error_message` already applies, and the same
+        // `captureToolResults` gate — exporting it here otherwise reintroduced
+        // the leak that gate exists to prevent. `$ai_is_error` still marks the
+        // failure when the content is withheld.
+        const toolErrorMessage =
+          span.status === "error" &&
+          span.errorMessage &&
+          config.captureToolResults
+            ? truncateToolErrorMessage(
+                redactToolErrorMessage(span.errorMessage),
+              )
+            : undefined;
+
         emitAiSpanEvent({
           runId,
           threadId,
@@ -1060,19 +1076,15 @@ export async function instrumentAgentLoop(opts: {
           spanName: span.name,
           latencySeconds: Math.round(span.durationMs) / 1000,
           isError: span.status === "error",
-          error:
-            span.status === "error"
-              ? toAiErrorDetail(span.errorMessage)
-              : undefined,
+          error: toolErrorMessage
+            ? toAiErrorDetail(toolErrorMessage)
+            : undefined,
           createdAt: span.createdAt,
           browserSessionId,
           // `metadata.input` is already redacted and only present when
           // `captureToolArgs` is on; absent stays absent.
           inputState: (span.metadata as { input?: unknown } | null)?.input,
-          outputState:
-            config.captureToolResults && span.errorMessage
-              ? span.errorMessage
-              : undefined,
+          outputState: toolErrorMessage,
           extraProperties: {
             ...trackingIdentityProperties(),
             source: "agent_observability",

--- a/packages/core/src/observability/types.ts
+++ b/packages/core/src/observability/types.ts
@@ -175,9 +175,19 @@ export interface ExperimentMetricResult {
 
 export interface ObservabilityConfig {
   enabled: boolean;
+  /**
+   * Export prompt and completion content (`$ai_input`, `$ai_output_choices`)
+   * to configured LLM-analytics backends. Off by default: message bodies are
+   * user data, and a trace backend is not a place to put it without a decision.
+   *
+   * When off the fields are OMITTED, never sent empty — an empty array is
+   * indistinguishable from a genuinely empty prompt.
+   */
   capturePrompts: boolean;
   captureToolArgs: boolean;
   captureToolResults: boolean;
+  /** Emit one `$ai_span` per tool call alongside the run's `$ai_trace`. */
+  captureLlmSpans: boolean;
   evalSampleRate: number;
   /**
    * Classify the raw user message as positive, negative, or neutral. Off by
@@ -203,6 +213,7 @@ export const DEFAULT_OBSERVABILITY_CONFIG: ObservabilityConfig = {
   capturePrompts: false,
   captureToolArgs: false,
   captureToolResults: false,
+  captureLlmSpans: true,
   evalSampleRate: 0,
   inferredSentimentEnabled: false,
   inferredSentimentSampleRate: 0,

--- a/packages/core/src/secrets/register-framework-secrets.ts
+++ b/packages/core/src/secrets/register-framework-secrets.ts
@@ -140,6 +140,22 @@ export function registerFrameworkSecrets(): void {
     });
   }
 
+  // PostHog — product analytics, error tracking, and LLM analytics. One key
+  // arms all three; `POSTHOG_ERROR_TRACKING=false` opts out of exceptions
+  // while keeping analytics.
+  if (!getRequiredSecret("POSTHOG_API_KEY")) {
+    registerRequiredSecret({
+      key: "POSTHOG_API_KEY",
+      label: "PostHog project API key",
+      description:
+        "Sends product analytics, server exceptions, and LLM traces to PostHog. Set POSTHOG_HOST for self-hosted or EU projects.",
+      docsUrl: "https://posthog.com/docs/getting-started/install",
+      scope: "workspace",
+      kind: "api-key",
+      required: false,
+    });
+  }
+
   // Web-search tool backends — optional; the tool selects the first
   // configured manual key at call time, then falls back to Builder Connect.
   const webSearchKeys: Array<{

--- a/packages/core/src/server/agent-run-context.ts
+++ b/packages/core/src/server/agent-run-context.ts
@@ -78,6 +78,25 @@ export function readAgentRunTimezone(event: H3Event): string | undefined {
     : undefined;
 }
 
+/**
+ * The caller's browser analytics session id, when the page sent one.
+ *
+ * Emitted as PostHog's `$session_id` on the run's `$ai_*` events so an agent
+ * trace joins to the session replay it happened in. Distinct from
+ * `$ai_session_id`, which is the conversation thread.
+ */
+export function readAgentRunBrowserSessionId(
+  event: H3Event,
+): string | undefined {
+  const raw = readHeaderValue(event, "x-agent-native-session-id");
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return typeof value === "string" &&
+    value.trim().length > 0 &&
+    value.trim().length < 128
+    ? value.trim()
+    : undefined;
+}
+
 export function seedAgentRunOwnerContext(
   event: H3Event,
   ownerContext: AgentRunOwnerContext,
@@ -186,6 +205,7 @@ export async function resolveAgentRunRequestContext(options: {
 }): Promise<RequestContext> {
   const orgId = await resolveAgentRunOrgId(options);
   const timezone = readAgentRunTimezone(options.event);
+  const browserSessionId = readAgentRunBrowserSessionId(options.event);
   const waitUntil = requestWaitUntil(options.event);
   const run = {
     ...(options.isBackgroundWorker ? { isBackgroundWorker: true } : {}),
@@ -196,6 +216,7 @@ export async function resolveAgentRunRequestContext(options: {
     userName: options.ownerContext.name,
     orgId,
     timezone,
+    ...(browserSessionId ? { browserSessionId } : {}),
     ...(Object.keys(run).length > 0 ? { run } : {}),
   };
 }

--- a/packages/core/src/server/capture-error.ts
+++ b/packages/core/src/server/capture-error.ts
@@ -11,6 +11,14 @@ export interface CaptureErrorContext {
   extra?: Record<string, unknown>;
   /** Grouped diagnostic cards shown on the captured event. */
   contexts?: Record<string, Record<string, unknown>>;
+  /**
+   * The agent run this error belongs to, when it belongs to one.
+   *
+   * Emitted as a top-level `$ai_trace_id` so an error-tracking issue and the
+   * LLM trace it came from resolve to each other. Nesting the run id inside
+   * `extra` (as callers did before) puts it somewhere no backend can join on.
+   */
+  aiTraceId?: string;
 }
 
 export type CaptureErrorProvider = (

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -157,7 +157,12 @@ import {
   readDeployCredentialEnv,
   resolveSecret,
 } from "./credential-provider.js";
+import {
+  resolveDeployEnvironment,
+  resolveServerRelease,
+} from "./deploy-environment.js";
 import { createEmbedStartRouteHandler } from "./embed-route.js";
+import { shouldReportError } from "./error-noise-filter.js";
 import {
   getH3App,
   awaitBootstrap,
@@ -178,7 +183,11 @@ import { createOpenRouteHandler } from "./open-route.js";
 import { createPollEventsHandler } from "./poll-events.js";
 import { createPollHandler } from "./poll.js";
 import { createRealtimeTokenHandler } from "./realtime-token.js";
-import { runWithRequestContext } from "./request-context.js";
+import {
+  getRequestContext,
+  hasRequestContext,
+  runWithRequestContext,
+} from "./request-context.js";
 import {
   findUnsupportedScopedKeyNames,
   saveKeyValuesToScopedSecrets,
@@ -1298,6 +1307,53 @@ export async function readLegacyCoreRouteInitSettings(
  *   PUT    /_agent-native/application-state/compose/:id — upsert compose draft
  *   DELETE /_agent-native/application-state/compose/:id — delete compose draft
  */
+/**
+ * Route every Nitro route error through the provider-agnostic `captureError()`
+ * registry, filtered by the shared noise rules.
+ *
+ * This lives here rather than in `sentry-plugin.ts` because that plugin bails
+ * out when no `SENTRY_DSN` is configured — wiring the hook there meant an app
+ * running PostHog (or any other backend) with no Sentry project reported no
+ * route errors at all, while still looking configured.
+ */
+function wireRouteErrorCapture(nitroApp: any): void {
+  nitroApp.hooks?.hook?.(
+    "error",
+    (error: unknown, ctx?: { event?: H3Event }) => {
+      try {
+        const event = ctx?.event;
+        const route = (() => {
+          try {
+            return event?.url?.pathname;
+            // coercion-ok: a missing route tag must not suppress the error
+          } catch {
+            return undefined;
+          }
+        })();
+        const userAgent = (() => {
+          try {
+            return event ? getHeader(event, "user-agent") : undefined;
+            // coercion-ok: a missing UA tag must not suppress the error
+          } catch {
+            return undefined;
+          }
+        })();
+
+        if (!shouldReportError(error, { tags: { route } })) return;
+
+        captureError(error, {
+          route,
+          method: event ? getMethod(event) : undefined,
+          userAgent,
+        });
+        // coercion-ok: rethrowing here would replace the app's real error
+      } catch {
+        // Error reporting must never escape into Nitro's error path.
+      }
+    },
+  );
+}
+
 export function createCoreRoutesPlugin(
   options: CoreRoutesPluginOptions = {},
 ): NitroPluginDef {
@@ -1375,14 +1431,29 @@ export function createCoreRoutesPlugin(
       // already registered the same key win.
       registerFrameworkSecrets();
       registerBuiltinProviders();
-      registerErrorCaptureProvider("agent-native-analytics", (error, context) =>
+      // Named for the destination it actually reaches: every configured
+      // tracking provider (PostHog, Mixpanel, Amplitude, Agent Native
+      // Analytics, webhook), not just one of them.
+      registerErrorCaptureProvider("tracking", (error, context) => {
+        // Attribute to the in-flight request's user so server exceptions and
+        // that same person's browser events share one `distinct_id`.
+        const requestContext = hasRequestContext()
+          ? getRequestContext()
+          : undefined;
         captureException(error, {
           ...context,
           handled: false,
           runtime: "node",
           source: "server",
-        }),
-      );
+          release: resolveServerRelease(),
+          environment: resolveDeployEnvironment(),
+          ...(requestContext?.userEmail
+            ? { userId: requestContext.userEmail }
+            : {}),
+          ...(requestContext?.orgId ? { orgId: requestContext.orgId } : {}),
+        });
+      });
+      wireRouteErrorCapture(nitroApp);
       registerBuiltinNotificationChannels();
 
       try {

--- a/packages/core/src/server/deploy-environment.ts
+++ b/packages/core/src/server/deploy-environment.ts
@@ -1,0 +1,56 @@
+/**
+ * Deployment identity shared by every error-reporting backend.
+ *
+ * These were originally Sentry-private helpers. They describe the deployment,
+ * not the vendor, and a second backend that reports errors without them
+ * produces issues nobody can tie to a release.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+function firstNonEmpty(
+  ...values: Array<string | undefined>
+): string | undefined {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
+}
+
+/** The deploy environment name, e.g. `production`, `deploy-preview`. */
+export function resolveDeployEnvironment(): string {
+  return (
+    firstNonEmpty(
+      process.env.SENTRY_ENVIRONMENT,
+      process.env.NETLIFY_CONTEXT,
+      process.env.VERCEL_ENV,
+      process.env.NODE_ENV,
+    ) ?? "production"
+  );
+}
+
+/**
+ * Resolve the agent-native version baked into core's package.json so the
+ * reported "release" reflects the running framework version. Mirrors how the
+ * CLI computes `_version` — same dist layout, same fallback string. Guarded so
+ * a missing/unreadable package.json never crashes server boot.
+ */
+export function resolveServerRelease(): string {
+  const explicit = process.env.AGENT_NATIVE_RELEASE;
+  if (explicit) return explicit;
+  try {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    // dist/server/deploy-environment.js → ../../package.json
+    const pkgPath = path.resolve(here, "../../package.json");
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8")) as {
+      version?: string;
+    };
+    if (pkg?.version) return `agent-native-server@${pkg.version}`;
+  } catch {
+    // ignore — fall through to "unknown"
+  }
+  return "agent-native-server@unknown";
+}

--- a/packages/core/src/server/deploy-environment.ts
+++ b/packages/core/src/server/deploy-environment.ts
@@ -49,6 +49,7 @@ export function resolveServerRelease(): string {
       version?: string;
     };
     if (pkg?.version) return `agent-native-server@${pkg.version}`;
+    // coercion-ok: falls through to the distinct "unknown" release marker
   } catch {
     // ignore — fall through to "unknown"
   }

--- a/packages/core/src/server/error-noise-filter.spec.ts
+++ b/packages/core/src/server/error-noise-filter.spec.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  errorSignalFromError,
+  errorSignalFromSentryEvent,
+  shouldReportError,
+  shouldReportErrorSignal,
+} from "./error-noise-filter.js";
+
+function named(name: string, message: string, stack?: string): Error {
+  const error = new Error(message);
+  error.name = name;
+  if (stack) error.stack = stack;
+  return error;
+}
+
+describe("shouldReportError (raw Error path)", () => {
+  it("drops ValidationError", () => {
+    expect(shouldReportError(named("ValidationError", "bad input"))).toBe(
+      false,
+    );
+  });
+
+  it("drops access-control rejections", () => {
+    expect(shouldReportError(named("ForbiddenError", "nope"))).toBe(false);
+    expect(shouldReportError(named("UnauthorizedError", "nope"))).toBe(false);
+  });
+
+  it("drops 4xx HTTPError by status code", () => {
+    const error = Object.assign(named("HTTPError", "Not Found"), {
+      statusCode: 404,
+    });
+
+    expect(shouldReportError(error)).toBe(false);
+  });
+
+  it("keeps 5xx HTTPError", () => {
+    const error = Object.assign(named("HTTPError", "Upstream exploded"), {
+      statusCode: 502,
+    });
+
+    expect(shouldReportError(error)).toBe(true);
+  });
+
+  it("falls back to message shape when HTTPError carries no status", () => {
+    expect(shouldReportError(named("H3Error", "Session not found"))).toBe(
+      false,
+    );
+    expect(shouldReportError(named("H3Error", "Unauthenticated"))).toBe(false);
+    expect(shouldReportError(named("H3Error", "database write failed"))).toBe(
+      true,
+    );
+  });
+
+  it("drops Lambda socket hang up rejections parsed from a real stack", () => {
+    const error = named(
+      "Error",
+      "socket hang up",
+      [
+        "Error: socket hang up",
+        "    at Socket.socketOnEnd (node:_http_client:526:11)",
+        "    at endReadableNT (node:internal/streams/readable:1400:12)",
+      ].join("\n"),
+    );
+
+    expect(
+      shouldReportError(error, { mechanismType: "onunhandledrejection" }),
+    ).toBe(false);
+  });
+
+  it("keeps socket hang up that is not an unhandled rejection", () => {
+    const error = named(
+      "Error",
+      "socket hang up",
+      "Error: socket hang up\n    at Socket.socketOnEnd (node:_http_client:526:11)",
+    );
+
+    expect(shouldReportError(error)).toBe(true);
+  });
+
+  it("keeps application socket errors without an http-client frame", () => {
+    const error = named(
+      "Error",
+      "socket hang up",
+      "Error: socket hang up\n    at proxyUpstream (/app/src/proxy.ts:9:1)",
+    );
+
+    expect(
+      shouldReportError(error, { mechanismType: "onunhandledrejection" }),
+    ).toBe(true);
+  });
+
+  it("reports ordinary errors", () => {
+    expect(shouldReportError(named("TypeError", "x is not a function"))).toBe(
+      true,
+    );
+  });
+
+  it("reports non-Error throws rather than guessing", () => {
+    expect(shouldReportError("something threw a string")).toBe(true);
+  });
+
+  it("honours a validation tag without relying on the class name", () => {
+    expect(
+      shouldReportError(new Error("bad input"), {
+        tags: { handled: "validation" },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("errorSignalFromError", () => {
+  it("reads statusCode from either statusCode or status", () => {
+    expect(
+      errorSignalFromError(Object.assign(new Error("x"), { status: "418" }))
+        .statusCode,
+    ).toBe(418);
+    expect(
+      errorSignalFromError(Object.assign(new Error("x"), { statusCode: 500 }))
+        .statusCode,
+    ).toBe(500);
+  });
+
+  it("leaves statusCode undefined when the error carries none", () => {
+    expect(errorSignalFromError(new Error("x")).statusCode).toBeUndefined();
+  });
+});
+
+describe("errorSignalFromSentryEvent", () => {
+  it("normalizes the first exception value with its frames and mechanism", () => {
+    const signal = errorSignalFromSentryEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "socket hang up",
+            mechanism: { type: "auto.node.onunhandledrejection" },
+            stacktrace: { frames: [{ filename: "node:_http_client" }] },
+          },
+        ],
+      },
+      tags: { statusCode: "404" },
+    });
+
+    expect(signal).toMatchObject({
+      type: "Error",
+      value: "socket hang up",
+      mechanismType: "auto.node.onunhandledrejection",
+      statusCode: 404,
+      hasExceptionValues: true,
+    });
+    expect(shouldReportErrorSignal(signal)).toBe(false);
+  });
+
+  it("reports metadata-only events that are not the SDK ErrorEvent shape", () => {
+    const signal = errorSignalFromSentryEvent({
+      metadata: { value: "[object ErrorEvent]", filename: "/app/src/app.ts" },
+      exception: { values: [] },
+    });
+
+    expect(signal.hasExceptionValues).toBe(false);
+    expect(shouldReportErrorSignal(signal)).toBe(true);
+  });
+});

--- a/packages/core/src/server/error-noise-filter.ts
+++ b/packages/core/src/server/error-noise-filter.ts
@@ -1,0 +1,268 @@
+/**
+ * Provider-agnostic drop rules for server error reporting.
+ *
+ * These rules were tuned against real production volume while Sentry was the
+ * only backend, and they lived inside its `beforeSend`. They are not Sentry
+ * policy — they describe which server errors are non-bugs in *this* framework
+ * (expected 4xx, access-control rejections, Lambda freeze/thaw socket noise).
+ * Any second backend that skips them receives a firehose rather than a signal:
+ * the `socket hang up` rule alone accounts for ~10k events/day.
+ *
+ * The rules operate on a normalized signal so the same predicate can judge a
+ * Sentry `Event` (already parsed by the SDK) and a raw `Error` reaching the
+ * PostHog provider. Fields a given source cannot supply stay `undefined`, and
+ * every rule requires the evidence it depends on — an unknown never reads as
+ * a match.
+ */
+
+import { parseStackFrames } from "../tracking/posthog-exception.js";
+
+export interface ErrorSignalFrame {
+  function?: string;
+  filename?: string;
+  in_app?: boolean;
+}
+
+export interface NormalizedErrorSignal {
+  /** Error class name, e.g. `ValidationError`. */
+  type?: string;
+  /** Error message. */
+  value?: string;
+  /** Capture mechanism, e.g. `onunhandledrejection`. */
+  mechanismType?: string;
+  frames?: ErrorSignalFrame[];
+  /** HTTP status carried by h3's `HTTPError` / `H3Error`. */
+  statusCode?: number;
+  tags?: Record<string, string | undefined>;
+  /**
+   * Sentry-only: some SDK-internal rejections arrive with no `exception.values`
+   * at all and only a `metadata` blob. Left `undefined` elsewhere.
+   */
+  metadataValue?: string;
+  metadataFilename?: string;
+  hasExceptionValues?: boolean;
+}
+
+function isUnhandledRejection(signal: NormalizedErrorSignal): boolean {
+  return (
+    typeof signal.mechanismType === "string" &&
+    signal.mechanismType.endsWith("onunhandledrejection")
+  );
+}
+
+/** Expected user-input rejections. The framework and CLI both throw these. */
+function isValidationNoise(signal: NormalizedErrorSignal): boolean {
+  return (
+    signal.type === "ValidationError" || signal.tags?.handled === "validation"
+  );
+}
+
+/**
+ * Access-control rejections. These are 4xx user-facing errors that reached the
+ * error hook because a route forgot to catch them — fixing the route is the
+ * right answer, but until then they bury real bugs. Auth routes report their
+ * own failures at `warning` level, so this only sees the escape path.
+ */
+function isAccessControlNoise(signal: NormalizedErrorSignal): boolean {
+  return (
+    signal.type === "ForbiddenError" || signal.type === "UnauthorizedError"
+  );
+}
+
+/**
+ * `socket hang up` unhandled rejections from Lambda freeze cycles. AWS recycles
+ * long-lived sockets (MCP Streamable HTTP long-polls, keep-alive agents) ~60s
+ * after a function returns 200; the next thaw delivers a socket-end event whose
+ * Promise has nobody left to await it. The function already returned correctly,
+ * so there is no user impact. The narrow frame match keeps genuine
+ * application-thrown socket errors visible.
+ */
+function isLambdaSocketHangUpNoise(signal: NormalizedErrorSignal): boolean {
+  if (signal.value !== "socket hang up" || !isUnhandledRejection(signal)) {
+    return false;
+  }
+  return (signal.frames ?? []).some(
+    (frame) =>
+      frame?.function === "Socket.socketOnEnd" ||
+      frame?.filename === "node:_http_client",
+  );
+}
+
+/**
+ * SDK-only `ErrorEvent` promise rejections — typically the Neon serverless
+ * driver's WebSocket dying across a freeze/thaw and rejecting a floating
+ * promise with the raw ErrorEvent (`db/client.ts` already records these with
+ * context). Events with real application frames stay visible.
+ *
+ * "Application frame" must exclude the Sentry SDK's own bundled chunks:
+ * serverless bundles place them under the app root (e.g.
+ * `/var/task/_libs/@sentry/node+….mjs`), outside node_modules, so the SDK marks
+ * them `in_app` and the instrumentation stack alone would defeat this filter.
+ */
+function isSdkErrorEventNoise(signal: NormalizedErrorSignal): boolean {
+  if (signal.value === "[object ErrorEvent]" && isUnhandledRejection(signal)) {
+    const frames = signal.frames ?? [];
+    const hasApplicationFrame = frames.some(
+      (frame) =>
+        frame?.in_app && !String(frame?.filename ?? "").includes("sentry"),
+    );
+    const hasSentryFrame = frames.some((frame) =>
+      String(frame?.filename ?? "").includes("sentry"),
+    );
+    if (!hasApplicationFrame && hasSentryFrame) return true;
+  }
+
+  return (
+    signal.metadataValue === "[object ErrorEvent]" &&
+    signal.hasExceptionValues === false &&
+    String(signal.metadataFilename ?? "").includes("sentry")
+  );
+}
+
+/**
+ * h3's `createError({ statusCode: 4xx })` produces an `HTTPError` (h3 v2) /
+ * `H3Error` (h3 v1). 4xx ones are handler-controlled "expected failure"
+ * responses that route through the error hook only because they bubble out of
+ * `defineEventHandler`. Capture when the status looks 5xx, or is missing on a
+ * generic Error masquerading as an HTTPError.
+ */
+function isExpectedHttpNoise(signal: NormalizedErrorSignal): boolean {
+  if (signal.type !== "HTTPError" && signal.type !== "H3Error") return false;
+
+  const code = signal.statusCode;
+  if (typeof code === "number" && Number.isFinite(code)) {
+    return code >= 400 && code < 500;
+  }
+
+  // No status in the payload — match the common 4xx messages so handler-thrown
+  // 404/400/403/401 don't pollute the backend. A heuristic, but the
+  // alternatives (every 4xx becomes a real issue, or every route grows a
+  // catch+return) are worse.
+  const value = signal.value ?? "";
+  return (
+    /^Cannot find any route matching/i.test(value) ||
+    / not found$/i.test(value) ||
+    /Unauthenticated$/i.test(value) ||
+    /^Unauthorized$/i.test(value) ||
+    /^No access to /i.test(value)
+  );
+}
+
+/**
+ * `false` when the error is known non-bug noise and should not be reported.
+ *
+ * Deliberately fails open: anything the rules cannot positively identify as
+ * noise is reported. A dropped real error is invisible; a kept noisy one is
+ * merely loud.
+ */
+export function shouldReportErrorSignal(
+  signal: NormalizedErrorSignal,
+): boolean {
+  return !(
+    isValidationNoise(signal) ||
+    isAccessControlNoise(signal) ||
+    isLambdaSocketHangUpNoise(signal) ||
+    isSdkErrorEventNoise(signal) ||
+    isExpectedHttpNoise(signal)
+  );
+}
+
+interface SentryLikeEvent {
+  exception?: {
+    values?: Array<{
+      type?: string;
+      value?: string;
+      mechanism?: { type?: string };
+      stacktrace?: { frames?: ErrorSignalFrame[] };
+    }>;
+  };
+  tags?: Record<string, unknown>;
+  contexts?: Record<string, Record<string, unknown> | undefined>;
+  metadata?: { value?: unknown; filename?: unknown };
+}
+
+function toNumericStatus(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = parseInt(value, 10);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+/** Normalize a Sentry event. Typed structurally so this module stays SDK-free. */
+export function errorSignalFromSentryEvent(
+  event: SentryLikeEvent,
+): NormalizedErrorSignal {
+  const first = event.exception?.values?.[0];
+  const tags: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(event.tags ?? {})) {
+    if (typeof value === "string") tags[key] = value;
+  }
+
+  return {
+    type: first?.type,
+    value: first?.value ?? "",
+    mechanismType: first?.mechanism?.type,
+    frames: first?.stacktrace?.frames ?? [],
+    statusCode: toNumericStatus(
+      event.tags?.statusCode ?? event.contexts?.h3?.statusCode,
+    ),
+    tags,
+    metadataValue:
+      typeof event.metadata?.value === "string"
+        ? event.metadata.value
+        : undefined,
+    metadataFilename:
+      typeof event.metadata?.filename === "string"
+        ? event.metadata.filename
+        : undefined,
+    hasExceptionValues: Boolean(event.exception?.values?.length),
+  };
+}
+
+export interface ErrorSignalFromErrorOptions {
+  mechanismType?: string;
+  tags?: Record<string, string | undefined>;
+}
+
+/** Normalize a raw thrown value for backends that never see a Sentry event. */
+export function errorSignalFromError(
+  error: unknown,
+  options: ErrorSignalFromErrorOptions = {},
+): NormalizedErrorSignal {
+  if (!(error instanceof Error)) {
+    return {
+      type: "Error",
+      value: typeof error === "string" ? error : String(error ?? ""),
+      mechanismType: options.mechanismType,
+      tags: options.tags,
+      hasExceptionValues: true,
+    };
+  }
+
+  const withStatus = error as Error & {
+    statusCode?: unknown;
+    status?: unknown;
+  };
+
+  return {
+    type: error.name || "Error",
+    value: error.message ?? "",
+    mechanismType: options.mechanismType,
+    frames: parseStackFrames(error.stack),
+    statusCode:
+      toNumericStatus(withStatus.statusCode) ??
+      toNumericStatus(withStatus.status),
+    tags: options.tags,
+    hasExceptionValues: true,
+  };
+}
+
+/** Convenience wrapper for the raw-error path. */
+export function shouldReportError(
+  error: unknown,
+  options: ErrorSignalFromErrorOptions = {},
+): boolean {
+  return shouldReportErrorSignal(errorSignalFromError(error, options));
+}

--- a/packages/core/src/server/posthog-config.spec.ts
+++ b/packages/core/src/server/posthog-config.spec.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getPostHogClientConfigScript,
+  resolvePublicPostHogConfig,
+} from "./posthog-config.js";
+
+describe("resolvePublicPostHogConfig", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("is absent when no public key is configured", () => {
+    vi.stubEnv("POSTHOG_PUBLIC_KEY", "");
+    vi.stubEnv("VITE_POSTHOG_KEY", "");
+    vi.stubEnv("VITE_POSTHOG_PUBLIC_KEY", "");
+
+    expect(resolvePublicPostHogConfig()).toBeUndefined();
+    expect(getPostHogClientConfigScript()).toBeNull();
+  });
+
+  it("never falls back to the server POSTHOG_API_KEY", () => {
+    vi.stubEnv("POSTHOG_PUBLIC_KEY", "");
+    vi.stubEnv("VITE_POSTHOG_KEY", "");
+    vi.stubEnv("VITE_POSTHOG_PUBLIC_KEY", "");
+    // A private key must never be inlined into the public HTML shell.
+    vi.stubEnv("POSTHOG_API_KEY", "phx_private_placeholder");
+
+    expect(resolvePublicPostHogConfig()).toBeUndefined();
+  });
+
+  it("resolves the key and normalizes a trailing slash on the host", () => {
+    vi.stubEnv("POSTHOG_PUBLIC_KEY", "phc_public_placeholder");
+    vi.stubEnv("POSTHOG_PUBLIC_HOST", "https://eu.i.posthog.com/");
+
+    expect(resolvePublicPostHogConfig()).toEqual({
+      posthogKey: "phc_public_placeholder",
+      posthogHost: "https://eu.i.posthog.com",
+      posthogErrorTracking: true,
+    });
+  });
+
+  it("honours the error-tracking opt-out", () => {
+    vi.stubEnv("POSTHOG_PUBLIC_KEY", "phc_public_placeholder");
+    vi.stubEnv("POSTHOG_ERROR_TRACKING", "false");
+
+    expect(resolvePublicPostHogConfig()?.posthogErrorTracking).toBe(false);
+  });
+
+  it("emits a shell script byte-identical to the worker copy in deploy/build.ts", () => {
+    vi.stubEnv("POSTHOG_PUBLIC_KEY", "phc_fake");
+    vi.stubEnv("POSTHOG_PUBLIC_HOST", "");
+    vi.stubEnv("VITE_POSTHOG_HOST", "");
+    vi.stubEnv("POSTHOG_HOST", "https://eu.i.posthog.com/");
+    vi.stubEnv("POSTHOG_ERROR_TRACKING", "");
+
+    // The worker bundles a string copy of this emitter and cannot import it, so
+    // the two must be kept in sync by hand. This is the assertion that catches
+    // a one-sided edit — the expected value is the worker's actual output.
+    expect(getPostHogClientConfigScript()).toBe(
+      '<script data-agent-native-posthog-config>window.__AGENT_NATIVE_CONFIG__=Object.assign({},window.__AGENT_NATIVE_CONFIG__,{"posthogKey":"phc_fake","posthogHost":"https://eu.i.posthog.com","posthogErrorTracking":true});</script>',
+    );
+  });
+});

--- a/packages/core/src/server/posthog-config.ts
+++ b/packages/core/src/server/posthog-config.ts
@@ -1,0 +1,75 @@
+/**
+ * Public PostHog config for the browser.
+ *
+ * PostHog project API keys are publishable — that is how `posthog-js` ships in
+ * every customer's bundle — so this mirrors how the Sentry client DSN already
+ * reaches the browser: env-derived, identical for every visitor, and therefore
+ * safe inside the CDN-cached SSR shell (see `guard:ssr-cache-shell`).
+ *
+ * The browser sends exceptions straight to PostHog rather than relaying them
+ * through `/_agent-native/track`: that route requires a resolved session by
+ * design, so relaying would silently drop every signed-out crash — exactly the
+ * class of failure that looks like "no errors" instead of "no reporting".
+ */
+
+const POSTHOG_DEFAULT_HOST = "https://us.i.posthog.com";
+
+function firstNonEmpty(
+  ...values: Array<string | undefined>
+): string | undefined {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
+}
+
+export interface PublicPostHogConfig {
+  posthogKey: string;
+  posthogHost: string;
+  posthogErrorTracking: boolean;
+}
+
+/**
+ * Resolve the browser-facing PostHog config, or `undefined` when none is set.
+ *
+ * Note this deliberately does NOT fall back to `POSTHOG_API_KEY`: a
+ * server-only personal/private key must never be inlined into the public HTML
+ * shell. Operators opt into browser capture by setting a public key explicitly.
+ */
+export function resolvePublicPostHogConfig(): PublicPostHogConfig | undefined {
+  const posthogKey = firstNonEmpty(
+    process.env.POSTHOG_PUBLIC_KEY,
+    process.env.VITE_POSTHOG_KEY,
+    process.env.VITE_POSTHOG_PUBLIC_KEY,
+  );
+  if (!posthogKey) return undefined;
+
+  const posthogHost = (
+    firstNonEmpty(
+      process.env.POSTHOG_PUBLIC_HOST,
+      process.env.VITE_POSTHOG_HOST,
+      process.env.POSTHOG_HOST,
+    ) ?? POSTHOG_DEFAULT_HOST
+  ).replace(/\/+$/, "");
+
+  return {
+    posthogKey,
+    posthogHost,
+    posthogErrorTracking:
+      process.env.POSTHOG_ERROR_TRACKING?.trim().toLowerCase() !== "false",
+  };
+}
+
+export function getPostHogClientConfigScript(): string | null {
+  const config = resolvePublicPostHogConfig();
+  if (!config) return null;
+
+  return [
+    "<script data-agent-native-posthog-config>",
+    "window.__AGENT_NATIVE_CONFIG__=Object.assign({},window.__AGENT_NATIVE_CONFIG__,",
+    JSON.stringify(config),
+    ");",
+    "</script>",
+  ].join("");
+}

--- a/packages/core/src/server/request-context.ts
+++ b/packages/core/src/server/request-context.ts
@@ -141,6 +141,12 @@ export interface RequestContext {
   authCapability?: string;
   timezone?: string;
   /**
+   * The caller's browser analytics session id, when the request came from a
+   * page. Emitted as PostHog's `$session_id` so agent traces join to session
+   * replay; never used for authorization.
+   */
+  browserSessionId?: string;
+  /**
    * Set when code reads authenticated request context. Public SSR shell/data
    * should not depend on this value; user/org-specific reads belong behind
    * client-side actions/API after hydration.

--- a/packages/core/src/server/sentry-config.ts
+++ b/packages/core/src/server/sentry-config.ts
@@ -1,3 +1,5 @@
+import { resolveDeployEnvironment } from "./deploy-environment.js";
+
 function firstNonEmpty(
   ...values: Array<string | undefined>
 ): string | undefined {
@@ -25,15 +27,9 @@ function resolveSentryDsnFromKeyProject(): string | undefined {
   return `https://${key}@${host}/${projectId}`;
 }
 
+/** @deprecated Use `resolveDeployEnvironment()` — it is not Sentry-specific. */
 export function resolveSentryEnvironment(): string {
-  return (
-    firstNonEmpty(
-      process.env.SENTRY_ENVIRONMENT,
-      process.env.NETLIFY_CONTEXT,
-      process.env.VERCEL_ENV,
-      process.env.NODE_ENV,
-    ) ?? "production"
-  );
+  return resolveDeployEnvironment();
 }
 
 export function resolveServerSentryDsn(): string | undefined {

--- a/packages/core/src/server/sentry-plugin.ts
+++ b/packages/core/src/server/sentry-plugin.ts
@@ -1,4 +1,4 @@
-import { getHeader, getMethod, type H3Event } from "h3";
+import { type H3Event } from "h3";
 
 import { getSession } from "./auth.js";
 import { registerErrorCaptureProvider } from "./capture-error.js";
@@ -9,12 +9,16 @@ import { registerErrorCaptureProvider } from "./capture-error.js";
  * Wires three pieces:
  *   1. On startup, `initServerSentry()` reads `SENTRY_SERVER_DSN`/`SENTRY_DSN` and arms
  *      the SDK (no-op when the env var is unset).
- *   2. On every request, hook into Nitro's `request` event: resolve the
+ *   2. Registers Sentry as a `captureError()` backend, so route errors and
+ *      explicit captures alike reach it through the shared registry.
+ *   3. On every request, hook into Nitro's `request` event: resolve the
  *      session via `getSession(event)` and tag the per-request isolation
  *      scope with the user's id/email/orgId. Wrapped in try/catch so a
  *      session-resolution failure can never 500 the request.
- *   3. On every Nitro `error` event, capture the exception with the route,
- *      method, and user-agent attached as searchable tags.
+ *
+ * It does NOT hook Nitro's `error` event — that is provider-agnostic and lives
+ * in `core-routes-plugin.ts`, so error reporting works with PostHog (or any
+ * other backend) configured and no Sentry DSN set at all.
  *
  * Mounted as a default plugin from `framework-request-handler.ts` —
  * templates that don't define `server/plugins/sentry.ts` get this for
@@ -39,14 +43,6 @@ type NitroPluginDef = (nitroApp: any) => void | Promise<void>;
 function readRoute(event: H3Event): string | undefined {
   try {
     return event.url?.pathname;
-  } catch {
-    return undefined;
-  }
-}
-
-function readUserAgent(event: H3Event): string | undefined {
-  try {
-    return getHeader(event, "user-agent");
   } catch {
     return undefined;
   }
@@ -109,23 +105,11 @@ export function createSentryPlugin(): NitroPluginDef {
       setSentryRequestContext({ userEmail: ctx.userEmail, orgId: ctx.orgId });
     });
 
-    // Per-error: capture with route/method/UA tags. Nitro's `error` hook
-    // signature is (error, { event, tags }) — we forward what we can.
-    nitroApp.hooks?.hook?.(
-      "error",
-      (error: unknown, ctx?: { event?: H3Event }) => {
-        try {
-          const event = ctx?.event;
-          captureRouteError(error, {
-            route: event ? readRoute(event) : undefined,
-            method: event ? getMethod(event) : undefined,
-            userAgent: event ? readUserAgent(event) : undefined,
-          });
-        } catch {
-          // Sentry capture must never escape into Nitro's error path.
-        }
-      },
-    );
+    // Route errors are NOT hooked here. `core-routes-plugin.ts` owns the
+    // provider-agnostic Nitro `error` hook and routes it through
+    // `captureError()`, which reaches Sentry via the registration above along
+    // with every other configured backend. Hooking it here too would report
+    // each route error to Sentry twice.
   };
 }
 

--- a/packages/core/src/server/sentry.ts
+++ b/packages/core/src/server/sentry.ts
@@ -1,7 +1,3 @@
-import fs from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
 /**
  * Server-side Sentry initialization for Nitro.
  *
@@ -24,35 +20,17 @@ import * as Sentry from "@sentry/node";
 
 import type { AuthSession } from "./auth.js";
 import {
-  resolveSentryEnvironment,
-  resolveServerSentryDsn,
-} from "./sentry-config.js";
+  resolveDeployEnvironment,
+  resolveServerRelease,
+} from "./deploy-environment.js";
+import {
+  errorSignalFromSentryEvent,
+  shouldReportErrorSignal,
+} from "./error-noise-filter.js";
+import { resolveServerSentryDsn } from "./sentry-config.js";
 
 let _initStarted = false;
 let _initSucceeded = false;
-
-/**
- * Resolve the agent-native version baked into core's package.json so Sentry
- * "release" reflects the running framework version. Mirrors how the CLI
- * computes `_version` — same dist layout, same fallback string. Guarded so
- * a missing/unreadable package.json never crashes server boot.
- */
-function resolveServerRelease(): string {
-  const explicit = process.env.AGENT_NATIVE_RELEASE;
-  if (explicit) return explicit;
-  try {
-    const here = path.dirname(fileURLToPath(import.meta.url));
-    // dist/server/sentry.js → ../../package.json
-    const pkgPath = path.resolve(here, "../../package.json");
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8")) as {
-      version?: string;
-    };
-    if (pkg?.version) return `agent-native-server@${pkg.version}`;
-  } catch {
-    // ignore — fall through to "unknown"
-  }
-  return "agent-native-server@unknown";
-}
 
 function parseTracesSampleRate(): number {
   const raw = process.env.SENTRY_SERVER_TRACES_SAMPLE_RATE;
@@ -88,7 +66,7 @@ export function initServerSentry(): boolean {
 
   Sentry.init({
     dsn,
-    environment: resolveSentryEnvironment(),
+    environment: resolveDeployEnvironment(),
     release: resolveServerRelease(),
     tracesSampleRate: parseTracesSampleRate(),
     // sendDefaultPii MUST stay false — the framework runs inside customer
@@ -96,132 +74,11 @@ export function initServerSentry(): boolean {
     // cookies, or process.env contents to Sentry without explicit consent.
     sendDefaultPii: false,
     beforeSend(event) {
-      // Drop expected user-input rejections so they don't pollute Sentry
-      // with non-bug noise. Mirrors the CLI's drop list — the framework
-      // and CLI both throw `ValidationError` for the same class of input
-      // failures, and exception type comes through as the class name.
-      const exceptionType = event.exception?.values?.[0]?.type;
-      if (
-        exceptionType === "ValidationError" ||
-        event.tags?.handled === "validation"
-      ) {
+      // Drop rules live in `error-noise-filter.ts` so every backend applies
+      // the same ones — they describe which server errors are non-bugs in
+      // this framework, not a Sentry preference.
+      if (!shouldReportErrorSignal(errorSignalFromSentryEvent(event))) {
         return null;
-      }
-      // Drop access-control rejections (caller lacks permission, signed
-      // out, etc.). These are 4xx user-facing errors that propagated to
-      // Nitro's error hook because a route forgot to catch them — fixing
-      // the route is the right answer, but in the meantime they bury
-      // real bugs and don't represent server failures. Auth-routes use
-      // `captureAuthError` directly with `level: warning` so this filter
-      // only sees the generic-handler escape path.
-      if (
-        exceptionType === "ForbiddenError" ||
-        exceptionType === "UnauthorizedError"
-      ) {
-        return null;
-      }
-      // Drop "socket hang up" unhandled promise rejections that fire from
-      // Lambda freeze cycles. AWS Lambda recycles long-lived sockets (e.g.
-      // MCP Streamable HTTP long-polls, keep-alive HTTP agents) ~60s after
-      // a function returns 200; the next thaw delivers a socket-end event
-      // whose Promise has nobody left to await it. The function itself
-      // already returned correctly, so there's no user impact — just
-      // ~10k events/day of noise. The narrow shape (unhandled rejection
-      // from `Socket.socketOnEnd` in `node:_http_client`) keeps real
-      // application-thrown socket errors from being silenced.
-      const exceptionValue = event.exception?.values?.[0]?.value ?? "";
-      const exceptionMechanism = event.exception?.values?.[0]?.mechanism?.type;
-      const isUnhandledRejection =
-        typeof exceptionMechanism === "string" &&
-        exceptionMechanism.endsWith("onunhandledrejection");
-      if (exceptionValue === "socket hang up" && isUnhandledRejection) {
-        const frames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
-        const fromHttpClient = frames.some(
-          (f) =>
-            f?.function === "Socket.socketOnEnd" ||
-            f?.filename === "node:_http_client",
-        );
-        if (fromHttpClient) {
-          return null;
-        }
-      }
-      // Drop SDK-only ErrorEvent promise rejections. These arrive as Node
-      // unhandled rejections with no application frames — typically the Neon
-      // serverless driver's WebSocket dying across a Lambda freeze/thaw and
-      // rejecting a floating promise with the raw ErrorEvent (the per-client
-      // logger in db/client.ts already records these with context). Keep any
-      // event with real app frames so thrown ErrorEvents stay visible.
-      //
-      // "Application frame" must exclude the Sentry SDK's own bundled chunks:
-      // serverless bundles place them under the app root (e.g.
-      // `/var/task/_libs/@sentry/node+….mjs`), outside node_modules, so the
-      // SDK marks them in_app and the unhandled-rejection instrumentation
-      // stack alone would defeat this filter.
-      if (exceptionValue === "[object ErrorEvent]" && isUnhandledRejection) {
-        const frames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
-        const hasApplicationFrame = frames.some(
-          (frame) =>
-            frame?.in_app && !String(frame?.filename ?? "").includes("sentry"),
-        );
-        const hasSentryFrame = frames.some((frame) =>
-          String(frame?.filename ?? "").includes("sentry"),
-        );
-        if (!hasApplicationFrame && hasSentryFrame) {
-          return null;
-        }
-      }
-      const metadata = (
-        event as {
-          metadata?: {
-            filename?: unknown;
-            value?: unknown;
-          };
-        }
-      ).metadata;
-      if (
-        metadata?.value === "[object ErrorEvent]" &&
-        !event.exception?.values?.length &&
-        String(metadata.filename ?? "").includes("sentry")
-      ) {
-        return null;
-      }
-      // h3's `createError({ statusCode: 4xx, ... })` produces an
-      // `HTTPError` (h3 v2) / `H3Error` (h3 v1). 4xx HTTPErrors are
-      // handler-controlled "expected failure" responses (404 not found,
-      // 400 bad input) that route through Nitro's error hook just
-      // because they bubble out of `defineEventHandler`. They aren't
-      // bugs — they're the documented way to return a 4xx in h3.
-      // Capture only when the statusCode looks like 5xx (real failure)
-      // or is missing (generic Error masquerading as HTTPError).
-      if (exceptionType === "HTTPError" || exceptionType === "H3Error") {
-        const statusCode = (event.tags?.statusCode ??
-          (
-            event.contexts as
-              | Record<string, Record<string, unknown>>
-              | undefined
-          )?.h3?.statusCode) as number | string | undefined;
-        const code =
-          typeof statusCode === "string"
-            ? parseInt(statusCode, 10)
-            : statusCode;
-        if (typeof code === "number" && code >= 400 && code < 500) {
-          return null;
-        }
-        // No statusCode in the event payload — fall back to matching the
-        // common 4xx messages so handler-thrown 404/400/403/401 don't
-        // pollute Sentry. This is a heuristic, but the alternatives
-        // (every 4xx becomes a "real" issue, or we patch every route to
-        // catch+return) are worse.
-        const value = event.exception?.values?.[0]?.value ?? "";
-        if (
-          /^Cannot find any route matching/i.test(value) ||
-          / not found$/i.test(value) ||
-          /Unauthenticated$/i.test(value) ||
-          /^Unauthorized$/i.test(value) ||
-          /^No access to /i.test(value)
-        ) {
-          return null;
-        }
       }
 
       // Defense in depth: scrub PII even if some integration auto-attached

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -36,6 +36,7 @@ import {
   stripAppBasePath as canonicalStripAppBasePath,
 } from "./app-base-path.js";
 import { captureError } from "./capture-error.js";
+import { getPostHogClientConfigScript } from "./posthog-config.js";
 import { runWithRequestContext } from "./request-context.js";
 import {
   getRealtimeClientConfigScript,
@@ -357,7 +358,11 @@ async function rewriteMountedResponse(
   requestUrl: string,
 ): Promise<Response> {
   const clientConfigScript =
-    [getSentryClientConfigScript(), getRealtimeClientConfigScript()]
+    [
+      getSentryClientConfigScript(),
+      getPostHogClientConfigScript(),
+      getRealtimeClientConfigScript(),
+    ]
       .filter(Boolean)
       .join("") || null;
   const headers = new Headers(response.headers);

--- a/packages/core/src/shared/mcp-embed-headers.ts
+++ b/packages/core/src/shared/mcp-embed-headers.ts
@@ -1,5 +1,5 @@
 export const MCP_EMBED_CORS_ALLOW_HEADERS =
-  "Content-Type,Authorization,X-Requested-With,X-Request-Source,X-Agent-Native-CSRF,X-Agent-Native-Frontend,X-Agent-Native-Client-Compatibility,X-Agent-Native-Build-Id,X-User-Timezone,X-Agent-Native-Embed-Target,X-Agent-Native-Embed-Transplant";
+  "Content-Type,Authorization,X-Requested-With,X-Request-Source,X-Agent-Native-CSRF,X-Agent-Native-Frontend,X-Agent-Native-Client-Compatibility,X-Agent-Native-Build-Id,X-User-Timezone,X-Agent-Native-Session-Id,X-Agent-Native-Embed-Target,X-Agent-Native-Embed-Transplant";
 export const EMBED_TRANSPLANT_HEADER = "x-agent-native-embed-transplant";
 
 const CLAUDE_MCP_CONTENT_HOST_RE = /^[a-f0-9]{32}\.claudemcpcontent\.com$/i;

--- a/packages/core/src/templates/workspace-core/.agents/skills/observability/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/observability/SKILL.md
@@ -232,6 +232,7 @@ All tables are dialect-agnostic (SQLite + Postgres) and strictly additive.
 | `packages/core/src/observability/types.ts` | Shared type definitions |
 | `packages/core/src/observability/store.ts` | SQL tables + CRUD |
 | `packages/core/src/observability/traces.ts` | Auto-instrumentation |
+| `packages/core/src/observability/posthog-ai.ts` | `$ai_trace` / `$ai_span` / `survey sent` emission, content bounding, `$ai_error` |
 | `packages/core/src/observability/feedback.ts` | Feedback + Frustration Index |
 | `packages/core/src/observability/evals.ts` | Eval engine (3 layers) |
 | `packages/core/src/observability/experiments.ts` | A/B testing system |
@@ -272,16 +273,66 @@ The loop emits `agent.run` (with `agent.run_id`, `agent.thread_id`, `agent.user_
 
 ## Tracking Bridge
 
-Instrumented agent loops also emit one server-side tracking event per completed
-LLM generation:
+Instrumented agent loops emit server-side tracking events for every run through
+`track()` from `@agent-native/core/tracking`, so configured PostHog, Agent Native
+Analytics, Mixpanel, Amplitude, and webhook providers receive them through the
+same best-effort fan-out as other tracking events.
 
-- Event name: `$ai_generation`
-- Provider path: `track()` from `@agent-native/core/tracking`, so configured
-  PostHog, Agent Native Analytics, Mixpanel, Amplitude, and webhook providers
-  receive it through the same best-effort fan-out as other tracking events.
-- PostHog shape: uses AI Observability properties such as `$ai_trace_id`,
-  `$ai_session_id`, `$ai_model`, `$ai_provider`, `$ai_input_tokens`,
-  `$ai_output_tokens`, `$ai_latency`, `$ai_total_cost_usd`, and `$ai_is_error`.
+### The PostHog trace tree
+
+PostHog models a run as a tree. The framework emits all three node types, and
+every node shares `$ai_trace_id` (the run id) and links upward via
+`$ai_parent_id`:
+
+| Event            | One per        | Key properties                                                                 |
+| ---------------- | -------------- | ------------------------------------------------------------------------------ |
+| `$ai_trace`      | agent run      | `$ai_span_name: "agent_run"`, `$ai_latency`, `$ai_is_error`, `$ai_error`        |
+| `$ai_generation` | model call     | `$ai_model`, `$ai_provider`, token counts, `$ai_input`/`$ai_output_choices`, `$ai_tools` |
+| `$ai_span`       | tool call      | `$ai_span_id`, `$ai_span_name` (tool name), `$ai_latency`, `$ai_is_error`       |
+
+`$ai_session_id` is the **thread**, grouping traces into a conversation. It is
+explicitly not PostHog's `$session_id`, which is the browser session used for
+session replay — the framework sends that separately, read from the
+`X-Agent-Native-Session-Id` header via `RequestContext.browserSessionId`.
+
+**One generation per run, not per round-trip.** The engine layer reports
+aggregate usage (`onUsage`) with no per-step hook, so a multi-step run collapses
+into a single generation node carrying the whole message list. Per-round-trip
+latency and intermediate assistant turns are not visible. Adding them requires a
+new engine seam in `ai-sdk-engine.ts` / `builder-engine.ts`.
+
+### Content capture
+
+`capturePrompts` (default `false`) gates `$ai_input` and the assistant's text in
+`$ai_output_choices`. `captureToolArgs` gates tool-call arguments and
+`$ai_input_state` on spans.
+
+When a flag is off the field is **omitted**, never sent as `[]` or `""` — an
+empty array is indistinguishable from a run that genuinely had no messages.
+Oversized content is replaced with an explicit truncation marker and
+`$ai_input_truncated` / `$ai_output_truncated`, never silently shortened.
+Runs that exceed the span cap stamp `$ai_spans_dropped` on the trace.
+
+**Tool calls ship even with `capturePrompts` off.** PostHog derives
+`$ai_tools_called` / `$ai_tool_call_count` only from tool-call blocks inside
+`$ai_output_choices`, so the structural call list (names, no arguments) is always
+emitted. The bespoke `tools` array below is kept in parallel because the
+first-party dashboards read it — that duplication is deliberate, not cleanup.
+
+### Errors and feedback
+
+`$ai_error` is a structured object (`message`, `terminal_state`,
+`terminal_code`, `retryable`), absent on healthy runs. Errors captured through
+`captureError({ aiTraceId })` carry a top-level `$ai_trace_id`, so an
+error-tracking issue and the LLM trace resolve to each other.
+
+Feedback emits `$ai_feedback` for all four feedback types; only thumbs carry
+`sentiment`, so a category follow-up to a thumbs-down does not double-count the
+vote. PostHog additionally shows feedback in LLM analytics only via a
+`survey sent` event keyed to a real survey — set
+`POSTHOG_AI_FEEDBACK_SURVEY_ID` (and optionally
+`POSTHOG_AI_FEEDBACK_SURVEY_QUESTION_ID`) to enable it. Unset means no survey
+event; the framework never invents a survey id.
 - Agent Native Analytics shape: the same event lands in `analytics_events` with
   mirrored query-friendly properties such as `run_id`, `thread_id`,
   `cost_cents_x100`, `duration_ms`, `tool_calls`, `successful_tools`,

--- a/packages/core/src/templates/workspace-core/.agents/skills/observability/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/observability/SKILL.md
@@ -278,61 +278,12 @@ Instrumented agent loops emit server-side tracking events for every run through
 Analytics, Mixpanel, Amplitude, and webhook providers receive them through the
 same best-effort fan-out as other tracking events.
 
-### The PostHog trace tree
-
-PostHog models a run as a tree. The framework emits all three node types, and
-every node shares `$ai_trace_id` (the run id) and links upward via
-`$ai_parent_id`:
-
-| Event            | One per        | Key properties                                                                 |
-| ---------------- | -------------- | ------------------------------------------------------------------------------ |
-| `$ai_trace`      | agent run      | `$ai_span_name: "agent_run"`, `$ai_latency`, `$ai_is_error`, `$ai_error`        |
-| `$ai_generation` | model call     | `$ai_model`, `$ai_provider`, token counts, `$ai_input`/`$ai_output_choices`, `$ai_tools` |
-| `$ai_span`       | tool call      | `$ai_span_id`, `$ai_span_name` (tool name), `$ai_latency`, `$ai_is_error`       |
-
-`$ai_session_id` is the **thread**, grouping traces into a conversation. It is
-explicitly not PostHog's `$session_id`, which is the browser session used for
-session replay — the framework sends that separately, read from the
-`X-Agent-Native-Session-Id` header via `RequestContext.browserSessionId`.
-
-**One generation per run, not per round-trip.** The engine layer reports
-aggregate usage (`onUsage`) with no per-step hook, so a multi-step run collapses
-into a single generation node carrying the whole message list. Per-round-trip
-latency and intermediate assistant turns are not visible. Adding them requires a
-new engine seam in `ai-sdk-engine.ts` / `builder-engine.ts`.
-
-### Content capture
-
-`capturePrompts` (default `false`) gates `$ai_input` and the assistant's text in
-`$ai_output_choices`. `captureToolArgs` gates tool-call arguments and
-`$ai_input_state` on spans.
-
-When a flag is off the field is **omitted**, never sent as `[]` or `""` — an
-empty array is indistinguishable from a run that genuinely had no messages.
-Oversized content is replaced with an explicit truncation marker and
-`$ai_input_truncated` / `$ai_output_truncated`, never silently shortened.
-Runs that exceed the span cap stamp `$ai_spans_dropped` on the trace.
-
-**Tool calls ship even with `capturePrompts` off.** PostHog derives
-`$ai_tools_called` / `$ai_tool_call_count` only from tool-call blocks inside
-`$ai_output_choices`, so the structural call list (names, no arguments) is always
-emitted. The bespoke `tools` array below is kept in parallel because the
-first-party dashboards read it — that duplication is deliberate, not cleanup.
-
-### Errors and feedback
-
-`$ai_error` is a structured object (`message`, `terminal_state`,
-`terminal_code`, `retryable`), absent on healthy runs. Errors captured through
-`captureError({ aiTraceId })` carry a top-level `$ai_trace_id`, so an
-error-tracking issue and the LLM trace resolve to each other.
-
-Feedback emits `$ai_feedback` for all four feedback types; only thumbs carry
-`sentiment`, so a category follow-up to a thumbs-down does not double-count the
-vote. PostHog additionally shows feedback in LLM analytics only via a
-`survey sent` event keyed to a real survey — set
-`POSTHOG_AI_FEEDBACK_SURVEY_ID` (and optionally
-`POSTHOG_AI_FEEDBACK_SURVEY_QUESTION_ID`) to enable it. Unset means no survey
-event; the framework never invents a survey id.
+- Events: `$ai_trace` per run, `$ai_span` per tool call, and `$ai_generation`
+  per model call. Every node carries the run id as `$ai_trace_id` and links
+  upward through `$ai_parent_id` so a backend can rebuild the tree.
+  `$ai_session_id` is the thread; the browser session is separate and ships as
+  `$session_id`, read from `X-Agent-Native-Session-Id` via
+  `RequestContext.browserSessionId`. Emission lives in `posthog-ai.ts`.
 - Agent Native Analytics shape: the same event lands in `analytics_events` with
   mirrored query-friendly properties such as `run_id`, `thread_id`,
   `cost_cents_x100`, `duration_ms`, `tool_calls`, `successful_tools`,
@@ -343,6 +294,30 @@ event; the framework never invents a survey id.
   Delegated runs add `delegation_protocol`, `caller_app`, `a2a_task_id`, and
   `parent_run_id` when available. `parent_turn_id` is separate because one
   logical turn may span multiple concrete runs.
+
+Constraints that are not visible from the emit site:
+
+- **One generation per run, not per model round-trip.** The engine layer reports
+  aggregate usage through `onUsage` and exposes no per-step hook, so a multi-step
+  run collapses into a single generation carrying the whole message list.
+  Per-round-trip latency and intermediate turns are unavailable without a new
+  seam in `ai-sdk-engine.ts` / `builder-engine.ts`. Do not describe the current
+  output as per-step.
+- **Disabled capture omits the field rather than sending an empty one.** An
+  empty array is indistinguishable from a run that genuinely had no messages.
+  Truncated content is marked, and a run over the span cap stamps
+  `$ai_spans_dropped` — a truncated run must not read as a complete one.
+- **The structural tool-call list ships even when content capture is off.**
+  Backends derive their tool tags from tool-call blocks inside the output
+  choices and from nothing else, so tool names (without arguments) are always
+  emitted. The parallel first-party `tools` array stays because the dashboards
+  read it; that duplication is deliberate, not cleanup.
+- **Only thumbs carry `sentiment`.** All four feedback types are reported, but a
+  category follow-up to a thumbs-down is detail about the same vote — counting
+  it again inflates the metric.
+- **Never invent an external id to make an integration light up.** Survey-based
+  feedback is emitted only when a real survey id is configured, and nothing is
+  sent otherwise.
 
 Do not build a separate LLM-observability ingestion API unless there is a clear
 reason the tracking provider registry cannot express the use case. Keep prompt,

--- a/packages/core/src/templates/workspace-core/.agents/skills/tracking/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/tracking/SKILL.md
@@ -79,7 +79,7 @@ Set the env var and the provider auto-registers at startup. No SDK dependencies 
 
 | Provider               | Env vars                                                                                                                                           |
 | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| PostHog                | `POSTHOG_API_KEY` (required), `POSTHOG_HOST` (optional, defaults to `https://us.i.posthog.com`)                                                    |
+| PostHog                | `POSTHOG_API_KEY` (required), `POSTHOG_HOST` (optional, defaults to `https://us.i.posthog.com`), `POSTHOG_ERROR_TRACKING=false` (optional opt-out) |
 | Mixpanel               | `MIXPANEL_TOKEN`                                                                                                                                   |
 | Amplitude              | `AMPLITUDE_API_KEY`                                                                                                                                |
 | Agent Native Analytics | `AGENT_NATIVE_ANALYTICS_PUBLIC_KEY` (server), `AGENT_NATIVE_ANALYTICS_ENDPOINT` (optional, defaults to `https://analytics.agent-native.com/track`) |
@@ -88,6 +88,57 @@ Set the env var and the provider auto-registers at startup. No SDK dependencies 
 Multiple providers can be active simultaneously. All receive every event.
 
 Browser-side `trackEvent()` also forwards to Agent Native Analytics when `VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY` is present. Use `VITE_AGENT_NATIVE_ANALYTICS_ENDPOINT` to override the default browser endpoint. The built-in Agent Native Analytics sender is quiet on localhost/local dev by default; set `AGENT_NATIVE_ANALYTICS_ALLOW_LOCALHOST=true` only for an intentional local ingestion test.
+
+## PostHog Error Tracking
+
+PostHog is a full error-reporting backend, not only an analytics sink. With
+`POSTHOG_API_KEY` set, `captureError()` reaches it whether or not a Sentry DSN
+exists.
+
+Three things are specific to PostHog and easy to get wrong:
+
+- **`$exception` needs `$exception_list`.** PostHog ingests an event named
+  `$exception` with any shape, then renders it as an empty, ungroupable issue —
+  so a broken payload looks like coverage rather than a failure. The PostHog
+  provider in `tracking/providers.ts` reshapes the framework's camelCase
+  exception properties through `tracking/posthog-exception.ts` before sending.
+  Emit exceptions with `captureError()` / `captureException()`; do not hand-roll
+  a `track("$exception", …)` call.
+- **`$exception` and `$ai_*` use `/i/v0/e/`, everything else uses `/capture/`.**
+  Handled by the provider; only relevant if you add a new PostHog event family.
+- **Stack frames are never symbolicated.** Frames ship as
+  `platform: "custom"`, `resolved: false` because the framework uploads no
+  source maps to PostHog. Server stacks are already readable; **minified browser
+  stacks stay minified**. Sentry symbolicates today and PostHog does not — this
+  is a known gap, not a bug to re-diagnose.
+
+### Where the wiring lives
+
+`core-routes-plugin.ts` owns the Nitro `error` hook and routes it through
+`captureError()`, filtered by `server/error-noise-filter.ts`. It is deliberately
+**not** in `sentry-plugin.ts`: that plugin returns early without a DSN, so
+hooking it there meant a PostHog-only app silently reported no route errors.
+
+The noise filter carries production-tuned drop rules (expected 4xx,
+access-control rejections, Lambda freeze/thaw `socket hang up`). Any new error
+backend must apply it or it receives a firehose — the `socket hang up` rule
+alone accounts for ~10k events/day.
+
+### Browser exceptions
+
+Set `POSTHOG_PUBLIC_KEY` (or `VITE_POSTHOG_KEY`) to enable browser capture. It
+ships in the CDN-cached SSR shell alongside the Sentry DSN — publishable and
+identical for every visitor. The browser posts straight to PostHog rather than
+relaying through `/_agent-native/track`, because that route requires a resolved
+session and would drop every signed-out crash.
+
+`POSTHOG_API_KEY` is **not** a fallback for the public key: it may be a private
+key, and this value is inlined into public HTML.
+
+When adding a client config field, update **both** `server/posthog-config.ts`
+and the mirrored worker emitter in `deploy/build.ts` — the worker bundles a
+string copy and cannot import the module, so a one-sided change drops the config
+silently in deployed builds.
 
 ## Default Baseline Events
 
@@ -199,6 +250,10 @@ interface TrackingEvent {
 | `packages/core/src/tracking/registry.ts`  | `track()`, `identify()`, `registerTrackingProvider()`, `flushTracking()`                                            |
 | `packages/core/src/tracking/providers.ts` | Built-in providers (PostHog, Mixpanel, Amplitude, Agent Native Analytics, Webhook) and `registerBuiltinProviders()` |
 | `packages/core/src/tracking/types.ts`     | `TrackingEvent` and `TrackingProvider` interfaces                                                                   |
+| `packages/core/src/tracking/posthog-exception.ts` | `$exception_list` builder + stack-frame parser (isomorphic: server and browser)                             |
+| `packages/core/src/tracking/redaction.ts` | Shared bounding/redaction helpers used by every exception emitter                                                   |
+| `packages/core/src/server/error-noise-filter.ts` | Provider-agnostic drop rules, applied by both Sentry `beforeSend` and the route error hook                   |
+| `packages/core/src/server/posthog-config.ts` | Public browser PostHog config (mirrored in `deploy/build.ts`)                                                    |
 
 ## Related Skills
 

--- a/packages/core/src/templates/workspace-core/.agents/skills/tracking/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/tracking/SKILL.md
@@ -89,56 +89,55 @@ Multiple providers can be active simultaneously. All receive every event.
 
 Browser-side `trackEvent()` also forwards to Agent Native Analytics when `VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY` is present. Use `VITE_AGENT_NATIVE_ANALYTICS_ENDPOINT` to override the default browser endpoint. The built-in Agent Native Analytics sender is quiet on localhost/local dev by default; set `AGENT_NATIVE_ANALYTICS_ALLOW_LOCALHOST=true` only for an intentional local ingestion test.
 
-## PostHog Error Tracking
+## Error Capture
 
-PostHog is a full error-reporting backend, not only an analytics sink. With
-`POSTHOG_API_KEY` set, `captureError()` reaches it whether or not a Sentry DSN
-exists.
+Exceptions fan out through `server/capture-error.ts` to every registered
+backend — Sentry, PostHog, and the tracking providers — from one `captureError()`
+call. Backends are additive: configuring a second one does not displace the
+first, and no backend is required for the others to work.
 
-Three things are specific to PostHog and easy to get wrong:
+Emit through `captureError()` / `captureException()`. Never hand-roll a
+`track("$exception", …)`: each backend needs its own payload shape and the
+providers build it.
 
-- **`$exception` needs `$exception_list`.** PostHog ingests an event named
-  `$exception` with any shape, then renders it as an empty, ungroupable issue —
-  so a broken payload looks like coverage rather than a failure. The PostHog
-  provider in `tracking/providers.ts` reshapes the framework's camelCase
-  exception properties through `tracking/posthog-exception.ts` before sending.
-  Emit exceptions with `captureError()` / `captureException()`; do not hand-roll
-  a `track("$exception", …)` call.
-- **`$exception` and `$ai_*` use `/i/v0/e/`, everything else uses `/capture/`.**
-  Handled by the provider; only relevant if you add a new PostHog event family.
-- **Stack frames are never symbolicated.** Frames ship as
-  `platform: "custom"`, `resolved: false` because the framework uploads no
-  source maps to PostHog. Server stacks are already readable; **minified browser
-  stacks stay minified**. Sentry symbolicates today and PostHog does not — this
-  is a known gap, not a bug to re-diagnose.
+- **Provider-agnostic wiring must not live in a provider plugin.** The Nitro
+  `error` hook is in `core-routes-plugin.ts`, not `sentry-plugin.ts`, because
+  that plugin returns early when no `SENTRY_DSN` is set — hooking route errors
+  there meant an app on any other backend silently reported none.
+- **Every backend applies `server/error-noise-filter.ts`.** It holds
+  production-tuned drop rules (expected 4xx, access-control rejections, Lambda
+  freeze/thaw `socket hang up`). A backend that skips it receives a firehose;
+  the `socket hang up` rule alone is ~10k events/day.
+- **A backend can accept a malformed payload and still show a count.** PostHog
+  ingested the framework's camelCase `$exception` for a long time and rendered
+  empty, ungroupable issues — which reads as coverage, not as breakage. When
+  adding or changing a backend, check what an event looks like in its UI, not
+  just that the request returned 200.
+- **Attribute the error.** Without a user id, server exceptions land under
+  `anonymous` and split one person in two against their browser events. Pass
+  `aiTraceId` for anything inside an agent run so the issue and the LLM trace
+  resolve to each other.
 
-### Where the wiring lives
+Symbolication is per-backend and not automatic: the framework uploads no source
+maps to PostHog, so minified browser stacks stay minified there. Known gap, not
+a bug to re-diagnose.
 
-`core-routes-plugin.ts` owns the Nitro `error` hook and routes it through
-`captureError()`, filtered by `server/error-noise-filter.ts`. It is deliberately
-**not** in `sentry-plugin.ts`: that plugin returns early without a DSN, so
-hooking it there meant a PostHog-only app silently reported no route errors.
+### Browser keys and the SSR shell
 
-The noise filter carries production-tuned drop rules (expected 4xx,
-access-control rejections, Lambda freeze/thaw `socket hang up`). Any new error
-backend must apply it or it receives a firehose — the `socket hang up` rule
-alone accounts for ~10k events/day.
+Public keys (`POSTHOG_PUBLIC_KEY`, the Sentry client DSN) ship inside the
+CDN-cached SSR shell — publishable and identical for every visitor. Server keys
+never do, and are never a fallback for a public one: `POSTHOG_API_KEY` may be a
+private key and this value lands in public HTML.
 
-### Browser exceptions
-
-Set `POSTHOG_PUBLIC_KEY` (or `VITE_POSTHOG_KEY`) to enable browser capture. It
-ships in the CDN-cached SSR shell alongside the Sentry DSN — publishable and
-identical for every visitor. The browser posts straight to PostHog rather than
-relaying through `/_agent-native/track`, because that route requires a resolved
-session and would drop every signed-out crash.
-
-`POSTHOG_API_KEY` is **not** a fallback for the public key: it may be a private
-key, and this value is inlined into public HTML.
+Browser errors post directly to the backend rather than through
+`/_agent-native/track`, because that route requires a resolved session and
+relaying would drop every signed-out crash.
 
 When adding a client config field, update **both** `server/posthog-config.ts`
 and the mirrored worker emitter in `deploy/build.ts` — the worker bundles a
-string copy and cannot import the module, so a one-sided change drops the config
-silently in deployed builds.
+string copy and cannot import the module, so a one-sided edit drops the config
+silently in deployed builds. `posthog-config.spec.ts` pins the two outputs
+together.
 
 ## Default Baseline Events
 

--- a/packages/core/src/tracking/error-capture.spec.ts
+++ b/packages/core/src/tracking/error-capture.spec.ts
@@ -45,4 +45,29 @@ describe("tracking captureException", () => {
     expect(properties.exceptionMessage).not.toContain("secret-token");
     expect(properties.exceptionStack.length).toBeLessThanOrEqual(8000);
   });
+
+  it("attributes the exception to the caller when a user is known", () => {
+    const track = vi.fn();
+    registerTrackingProvider({ name: "qa-exception", track });
+
+    captureException(new Error("boom"), {
+      userId: "person@example.test",
+      orgId: "org_1",
+    });
+
+    const [event] = track.mock.calls[0];
+    expect(event.userId).toBe("person@example.test");
+    expect(event.properties.orgId).toBe("org_1");
+  });
+
+  it("leaves the exception unattributed rather than guessing", () => {
+    const track = vi.fn();
+    registerTrackingProvider({ name: "qa-exception", track });
+
+    captureException(new Error("boom"));
+
+    const [event] = track.mock.calls[0];
+    expect(event.userId).toBeUndefined();
+    expect(event.properties).not.toHaveProperty("orgId");
+  });
 });

--- a/packages/core/src/tracking/error-capture.spec.ts
+++ b/packages/core/src/tracking/error-capture.spec.ts
@@ -46,6 +46,27 @@ describe("tracking captureException", () => {
     expect(properties.exceptionStack.length).toBeLessThanOrEqual(8000);
   });
 
+  it("keeps tags after an undefined one instead of dropping the rest", () => {
+    const track = vi.fn();
+    registerTrackingProvider({ name: "qa-exception", track });
+
+    captureException(new Error("boom"), {
+      // `undefined` sits before the rest — a `break` here silently lost every
+      // following tag, including route/method.
+      tags: { first: "kept", missing: undefined, second: "also-kept" },
+      route: "/api/things",
+      method: "POST",
+    });
+
+    const [event] = track.mock.calls[0];
+    expect(event.properties.exceptionTags).toEqual({
+      first: "kept",
+      second: "also-kept",
+      route: "/api/things",
+      method: "POST",
+    });
+  });
+
   it("attributes the exception to the caller when a user is known", () => {
     const track = vi.fn();
     registerTrackingProvider({ name: "qa-exception", track });

--- a/packages/core/src/tracking/error-capture.ts
+++ b/packages/core/src/tracking/error-capture.ts
@@ -1,5 +1,11 @@
 import { trackingIdentityProperties } from "../observability/tracking-identity.js";
 import type { CaptureErrorContext } from "../server/capture-error.js";
+import {
+  boundedText,
+  exceptionParts,
+  safeTags,
+  safeValue,
+} from "./redaction.js";
 import { track } from "./registry.js";
 
 export type TrackingExceptionLevel =
@@ -17,95 +23,13 @@ export interface TrackingExceptionContext extends CaptureErrorContext {
   environment?: string;
   runtime?: "node" | "cli";
   source?: "server" | "cli";
-}
-
-const MAX_MESSAGE_LENGTH = 1000;
-const MAX_STACK_LENGTH = 8000;
-const MAX_TAGS = 30;
-const MAX_EXTRA_KEYS = 30;
-const MAX_EXTRA_VALUE_LENGTH = 1000;
-const SECRET_RE = /\b(?:bearer|basic)\s+[^\s]+/gi;
-const SECRET_KEY_RE =
-  /(?:authorization|cookie|set[-_]?cookie|token|secret|password|passwd|pwd|api[-_]?key|apikey|credential)/i;
-
-function redact(value: string): string {
-  return value
-    .replace(SECRET_RE, (match) => `${match.split(/\s+/, 1)[0]} <redacted>`)
-    .replace(
-      /([A-Za-z0-9_$.-]*(?:authorization|cookie|token|secret|password|passwd|pwd|api[-_]?key|apikey|credential)[A-Za-z0-9_$.-]*\s*[:=]\s*)([^\s,;}]+)/gi,
-      "$1<redacted>",
-    );
-}
-
-function boundedText(value: unknown, max: number): string {
-  const text = typeof value === "string" ? value : String(value ?? "");
-  const safe = redact(text);
-  return safe.length > max ? safe.slice(0, max) : safe;
-}
-
-function safeValue(value: unknown, depth = 2): unknown {
-  if (
-    value == null ||
-    typeof value === "boolean" ||
-    typeof value === "number"
-  ) {
-    return value;
-  }
-  if (typeof value === "string")
-    return boundedText(value, MAX_EXTRA_VALUE_LENGTH);
-  if (depth <= 0) return boundedText(value, MAX_EXTRA_VALUE_LENGTH);
-  if (Array.isArray(value)) {
-    return value.slice(0, 20).map((item) => safeValue(item, depth - 1));
-  }
-  if (typeof value === "object") {
-    const out: Record<string, unknown> = {};
-    for (const [key, child] of Object.entries(value)) {
-      if (Object.keys(out).length >= MAX_EXTRA_KEYS) break;
-      const safeKey = boundedText(key, 100);
-      out[safeKey] = SECRET_KEY_RE.test(safeKey)
-        ? "<redacted>"
-        : safeValue(child, depth - 1);
-    }
-    return out;
-  }
-  return boundedText(value, MAX_EXTRA_VALUE_LENGTH);
-}
-
-function exceptionParts(error: unknown): {
-  type: string;
-  message: string;
-  stack?: string;
-} {
-  if (error instanceof Error) {
-    return {
-      type: boundedText(error.name || "Error", 200),
-      message: boundedText(
-        error.message || error.name || "Error",
-        MAX_MESSAGE_LENGTH,
-      ),
-      ...(error.stack
-        ? { stack: boundedText(error.stack, MAX_STACK_LENGTH) }
-        : {}),
-    };
-  }
-  return {
-    type: "Error",
-    message: boundedText(error, MAX_MESSAGE_LENGTH),
-  };
-}
-
-function safeTags(
-  tags: Record<string, string | undefined> | undefined,
-): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const [key, value] of Object.entries(tags ?? {})) {
-    if (Object.keys(out).length >= MAX_TAGS || value == null) break;
-    const safeKey = boundedText(key, 100);
-    out[safeKey] = SECRET_KEY_RE.test(safeKey)
-      ? "<redacted>"
-      : boundedText(value, 200);
-  }
-  return out;
+  /**
+   * Who the exception is attributed to. Without it every server exception is
+   * ingested as `anonymous`, which splits one person into two in any backend
+   * that also receives their browser events.
+   */
+  userId?: string;
+  orgId?: string;
 }
 
 /** Emit a bounded, redacted Node/CLI exception through first-party tracking. */
@@ -125,26 +49,37 @@ export function captureException(
       ...context.extra,
       ...(context.contexts ? { contexts: context.contexts } : {}),
     });
-    track("$exception", {
-      ...trackingIdentityProperties(),
-      exceptionType: parts.type,
-      exceptionMessage: parts.message,
-      ...(parts.stack ? { exceptionStack: parts.stack } : {}),
-      handled: context.handled ?? true,
-      level: context.level ?? "error",
-      occurredAt: new Date().toISOString(),
-      runtime: context.runtime ?? "node",
-      source: context.source ?? "server",
-      ...(context.route ? { url: boundedText(context.route, 500) } : {}),
-      ...(context.release
-        ? { release: boundedText(context.release, 200) }
-        : {}),
-      ...(context.environment
-        ? { environment: boundedText(context.environment, 100) }
-        : {}),
-      ...(Object.keys(tags).length ? { exceptionTags: tags } : {}),
-      ...(extra && typeof extra === "object" ? { exceptionExtra: extra } : {}),
-    });
+    track(
+      "$exception",
+      {
+        ...trackingIdentityProperties(),
+        exceptionType: parts.type,
+        exceptionMessage: parts.message,
+        ...(parts.stack ? { exceptionStack: parts.stack } : {}),
+        handled: context.handled ?? true,
+        level: context.level ?? "error",
+        occurredAt: new Date().toISOString(),
+        runtime: context.runtime ?? "node",
+        source: context.source ?? "server",
+        ...(context.route ? { url: boundedText(context.route, 500) } : {}),
+        ...(context.release
+          ? { release: boundedText(context.release, 200) }
+          : {}),
+        ...(context.environment
+          ? { environment: boundedText(context.environment, 100) }
+          : {}),
+        ...(context.orgId ? { orgId: boundedText(context.orgId, 200) } : {}),
+        // Top-level so error tracking and LLM analytics join on it.
+        ...(context.aiTraceId
+          ? { $ai_trace_id: boundedText(context.aiTraceId, 200) }
+          : {}),
+        ...(Object.keys(tags).length ? { exceptionTags: tags } : {}),
+        ...(extra && typeof extra === "object"
+          ? { exceptionExtra: extra }
+          : {}),
+      },
+      context.userId ? { userId: context.userId } : undefined,
+    );
   } catch {
     // Error reporting must never mask the original failure.
   }

--- a/packages/core/src/tracking/index.ts
+++ b/packages/core/src/tracking/index.ts
@@ -12,4 +12,15 @@ export {
   type TrackingExceptionContext,
   type TrackingExceptionLevel,
 } from "./error-capture.js";
+export {
+  errorToPostHogExceptionProperties,
+  parseStackFrames,
+  reshapeTrackedExceptionProperties,
+  toPostHogExceptionProperties,
+  type PostHogExceptionEntry,
+  type PostHogExceptionInput,
+  type PostHogExceptionLevel,
+  type PostHogExceptionProperties,
+  type PostHogStackFrame,
+} from "./posthog-exception.js";
 export type { TrackingProvider, TrackingEvent } from "./types.js";

--- a/packages/core/src/tracking/posthog-exception.spec.ts
+++ b/packages/core/src/tracking/posthog-exception.spec.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  errorToPostHogExceptionProperties,
+  parseStackFrames,
+  reshapeTrackedExceptionProperties,
+  toPostHogExceptionProperties,
+} from "./posthog-exception.js";
+
+const V8_STACK = [
+  "TypeError: Cannot read properties of undefined (reading 'id')",
+  "    at resolveOwner (/app/src/server/auth.ts:42:17)",
+  "    at async Object.handler (/app/src/routes/api.ts:9:3)",
+  "    at /app/node_modules/h3/dist/index.mjs:120:5",
+  "    at Socket.socketOnEnd (node:_http_client:526:11)",
+].join("\n");
+
+const GECKO_STACK = [
+  "resolveOwner@https://example.test/assets/app-a1b2.js:1:2345",
+  "@https://example.test/assets/app-a1b2.js:1:99",
+].join("\n");
+
+describe("parseStackFrames", () => {
+  it("parses V8 frames oldest-call-first and skips the Error header", () => {
+    const frames = parseStackFrames(V8_STACK);
+
+    expect(frames.map((f) => f.function)).toEqual([
+      "Socket.socketOnEnd",
+      "?",
+      "Object.handler",
+      "resolveOwner",
+    ]);
+    expect(frames.at(-1)).toMatchObject({
+      platform: "custom",
+      lang: "javascript",
+      function: "resolveOwner",
+      filename: "/app/src/server/auth.ts",
+      lineno: 42,
+      colno: 17,
+      in_app: true,
+      resolved: false,
+    });
+  });
+
+  it("marks node internals and node_modules as not in_app", () => {
+    const frames = parseStackFrames(V8_STACK);
+    const byFile = Object.fromEntries(
+      frames.map((f) => [f.filename, f.in_app]),
+    );
+
+    expect(byFile["node:_http_client"]).toBe(false);
+    expect(byFile["/app/node_modules/h3/dist/index.mjs"]).toBe(false);
+    expect(byFile["/app/src/server/auth.ts"]).toBe(true);
+  });
+
+  it("parses Gecko/Safari frames including anonymous ones", () => {
+    const frames = parseStackFrames(GECKO_STACK);
+
+    expect(frames).toHaveLength(2);
+    expect(frames.at(-1)).toMatchObject({
+      function: "resolveOwner",
+      filename: "https://example.test/assets/app-a1b2.js",
+      lineno: 1,
+      colno: 2345,
+    });
+    expect(frames[0]).toMatchObject({ function: "?", lineno: 1, colno: 99 });
+  });
+
+  it("returns no frames rather than an empty stack for missing input", () => {
+    expect(parseStackFrames(undefined)).toEqual([]);
+    expect(parseStackFrames("")).toEqual([]);
+  });
+
+  it("skips lines long enough to make the regexes backtrack", () => {
+    const frames = parseStackFrames(
+      `    at huge (${"x".repeat(1100)}.js:1:1)\n    at small (/app/a.ts:1:1)`,
+    );
+
+    expect(frames.map((f) => f.function)).toEqual(["small"]);
+  });
+
+  it("caps frames at 50", () => {
+    const stack = Array.from(
+      { length: 80 },
+      (_, i) => `    at fn${i} (/app/f${i}.ts:1:1)`,
+    ).join("\n");
+
+    expect(parseStackFrames(stack)).toHaveLength(50);
+  });
+});
+
+describe("toPostHogExceptionProperties", () => {
+  it("builds a $exception_list entry with mechanism and raw stacktrace", () => {
+    const props = toPostHogExceptionProperties({
+      type: "TypeError",
+      value: "boom",
+      stack: V8_STACK,
+      handled: false,
+      mechanismType: "onunhandledrejection",
+      level: "fatal",
+    });
+
+    expect(props.$exception_level).toBe("fatal");
+    expect(props.$exception_list).toHaveLength(1);
+    expect(props.$exception_list[0]).toMatchObject({
+      type: "TypeError",
+      value: "boom",
+      mechanism: {
+        handled: false,
+        synthetic: false,
+        type: "onunhandledrejection",
+      },
+    });
+    expect(props.$exception_list[0].stacktrace?.type).toBe("raw");
+  });
+
+  it("omits stacktrace entirely when nothing parsed", () => {
+    const props = toPostHogExceptionProperties({
+      type: "Error",
+      value: "no stack here",
+    });
+
+    expect(props.$exception_list[0]).not.toHaveProperty("stacktrace");
+  });
+
+  it("redacts secrets in the message", () => {
+    const props = toPostHogExceptionProperties({
+      type: "Error",
+      value: "request failed with authorization: Bearer sk-not-a-real-token",
+    });
+
+    expect(props.$exception_list[0].value).not.toContain("sk-not-a-real-token");
+    expect(props.$exception_list[0].value).toContain("<redacted>");
+  });
+
+  it("marks non-Error throws as synthetic", () => {
+    const props = errorToPostHogExceptionProperties("just a string");
+
+    expect(props.$exception_list[0].mechanism.synthetic).toBe(true);
+  });
+});
+
+describe("reshapeTrackedExceptionProperties", () => {
+  it("maps the camelCase tracking shape into $exception_list", () => {
+    const reshaped = reshapeTrackedExceptionProperties({
+      exceptionType: "ValidationError",
+      exceptionMessage: "bad input",
+      exceptionStack: V8_STACK,
+      handled: false,
+      level: "warning",
+      app: "content",
+      runtime: "node",
+    });
+
+    expect(reshaped).toMatchObject({
+      app: "content",
+      runtime: "node",
+      $exception_level: "warning",
+    });
+    expect(reshaped?.$exception_list).toMatchObject([
+      {
+        type: "ValidationError",
+        value: "bad input",
+        mechanism: { handled: false },
+      },
+    ]);
+    // The camelCase originals are replaced, not duplicated alongside.
+    expect(reshaped).not.toHaveProperty("exceptionType");
+    expect(reshaped).not.toHaveProperty("exceptionStack");
+  });
+
+  it("passes through properties already in PostHog form", () => {
+    const already = { $exception_list: [{ type: "Error", value: "x" }] };
+
+    expect(reshapeTrackedExceptionProperties(already)).toBe(already);
+  });
+
+  it("returns undefined when there is nothing exception-shaped to map", () => {
+    expect(reshapeTrackedExceptionProperties({ foo: "bar" })).toBeUndefined();
+    expect(reshapeTrackedExceptionProperties(undefined)).toBeUndefined();
+  });
+});

--- a/packages/core/src/tracking/posthog-exception.ts
+++ b/packages/core/src/tracking/posthog-exception.ts
@@ -1,0 +1,305 @@
+/**
+ * Build PostHog error-tracking payloads from a raw JS error or from the
+ * camelCase exception properties the framework's own `captureException()`
+ * emits.
+ *
+ * PostHog's error tracking only groups and renders an issue when the event
+ * carries `$exception_list` with per-frame stack data. An event named
+ * `$exception` without it is ingested and displayed as an empty, ungroupable
+ * issue — which is worse than no event, because the count looks like coverage.
+ *
+ * Frame parsing follows posthog-js (itself derived from Sentry's TraceKit
+ * fork), because PostHog's ingestion is written against that shape:
+ *   - `Error: …` header lines are skipped, not parsed as frames
+ *   - lines over 1 KB are skipped (the regexes backtrack)
+ *   - frames are capped at 50 and reversed to oldest-call-first
+ *   - an unresolvable function name is `?`, never empty
+ *
+ * Runs unchanged in Node and the browser: no `process`, no Node built-ins.
+ *
+ * @see https://posthog.com/docs/error-tracking/installation/manual
+ */
+
+import {
+  MAX_MESSAGE_LENGTH,
+  MAX_STACK_LENGTH,
+  boundedText,
+  exceptionParts,
+} from "./redaction.js";
+
+/** Matches posthog-js's `UNKNOWN_FUNCTION`. */
+const UNKNOWN_FUNCTION = "?";
+const STACKTRACE_FRAME_LIMIT = 50;
+const MAX_STACK_LINE_LENGTH = 1024;
+
+const ERROR_HEADER_RE = /\S*Error: /;
+const WEBPACK_ERROR_RE = /\(error: (.*)\)/;
+
+// "    at fn (file:1:2)" / "    at async Foo.bar (/app/x.js:2:3)" / "    at /app/x.js:1:2"
+const V8_FRAME_RE =
+  /^\s*at (?:async )?(?:(.+?)\s+\()?(?:(.+?):(\d+):(\d+)|([^)]+))\)?\s*$/;
+// "fn@https://example.com/s.js:1:2" / "@https://example.com/s.js:1:2"
+const GECKO_FRAME_RE = /^\s*(.*?)@(.+?)(?::(\d+))?(?::(\d+))?\s*$/;
+
+export type PostHogExceptionLevel =
+  | "fatal"
+  | "error"
+  | "warning"
+  | "info"
+  | "debug";
+
+export interface PostHogStackFrame {
+  /**
+   * Always `"custom"`. PostHog reserves the language-specific platforms for
+   * frames it will try to symbolicate against uploaded source maps; we upload
+   * none, so claiming one would render every minified frame as a failed
+   * resolution rather than as the raw frame it is.
+   */
+  platform: "custom";
+  lang: string;
+  function: string;
+  filename?: string;
+  lineno?: number;
+  colno?: number;
+  in_app: boolean;
+  resolved: boolean;
+}
+
+export interface PostHogExceptionEntry {
+  type: string;
+  value: string;
+  mechanism: { handled: boolean; synthetic: boolean; type?: string };
+  stacktrace?: { type: "raw"; frames: PostHogStackFrame[] };
+}
+
+export interface PostHogExceptionProperties {
+  $exception_list: PostHogExceptionEntry[];
+  $exception_level: PostHogExceptionLevel;
+  $exception_fingerprint?: string;
+  [key: string]: unknown;
+}
+
+export interface PostHogExceptionInput {
+  /** Error class name, e.g. `TypeError`. */
+  type: string;
+  /** Error message. */
+  value: string;
+  /** Raw `error.stack` string, when available. */
+  stack?: string;
+  /** `false` for errors that crashed the request/page rather than being caught. */
+  handled?: boolean;
+  /** `true` when the framework synthesized the error from a non-Error throw. */
+  synthetic?: boolean;
+  /** Mechanism label, e.g. `onunhandledrejection`, `nitro.error`. */
+  mechanismType?: string;
+  level?: PostHogExceptionLevel;
+  /** Overrides PostHog's default grouping. */
+  fingerprint?: string;
+  /** Frame language tag. Defaults to `javascript`. */
+  lang?: string;
+}
+
+function isInAppFrame(filename: string | undefined): boolean {
+  if (!filename) return true;
+  return (
+    !filename.startsWith("node:") &&
+    !filename.includes("node_modules") &&
+    !filename.includes("/internal/") &&
+    filename !== "native"
+  );
+}
+
+function makeFrame(
+  lang: string,
+  fn: string,
+  filename: string | undefined,
+  lineno: number | undefined,
+  colno: number | undefined,
+): PostHogStackFrame {
+  const name = !fn || fn === "<anonymous>" ? UNKNOWN_FUNCTION : fn;
+  return {
+    platform: "custom",
+    lang,
+    function: name,
+    ...(filename ? { filename } : {}),
+    ...(lineno !== undefined && Number.isFinite(lineno) ? { lineno } : {}),
+    ...(colno !== undefined && Number.isFinite(colno) ? { colno } : {}),
+    in_app: isInAppFrame(filename),
+    // Never `true`: we ship no source maps to PostHog, so a minified browser
+    // frame is exactly as informative as it looks. Claiming it is resolved
+    // would present a mangled name as the real one.
+    resolved: false,
+  };
+}
+
+function parseFrameLine(
+  line: string,
+  lang: string,
+): PostHogStackFrame | undefined {
+  const v8 = V8_FRAME_RE.exec(line);
+  if (v8) {
+    const [, fn, file, lineNo, colNo, bare] = v8;
+    const filename = (file ?? bare)?.replace(/^file:\/\//, "");
+    return makeFrame(
+      lang,
+      fn ?? UNKNOWN_FUNCTION,
+      filename,
+      lineNo ? Number(lineNo) : undefined,
+      colNo ? Number(colNo) : undefined,
+    );
+  }
+
+  const gecko = GECKO_FRAME_RE.exec(line);
+  if (gecko) {
+    const [, fn, file, lineNo, colNo] = gecko;
+    return makeFrame(
+      lang,
+      fn || UNKNOWN_FUNCTION,
+      file,
+      lineNo ? Number(lineNo) : undefined,
+      colNo ? Number(colNo) : undefined,
+    );
+  }
+
+  return undefined;
+}
+
+/**
+ * Parse a `error.stack` string into PostHog stack frames, oldest call first.
+ *
+ * Returns an empty array when nothing parsed. Callers must treat that as
+ * "no frames" and omit `stacktrace` entirely rather than sending an empty
+ * frame list — PostHog renders the latter as a stack that exists and is empty.
+ */
+export function parseStackFrames(
+  stack: string | undefined,
+  lang = "javascript",
+): PostHogStackFrame[] {
+  if (!stack) return [];
+  const frames: PostHogStackFrame[] = [];
+
+  for (const rawLine of stack.split("\n")) {
+    if (rawLine.length > MAX_STACK_LINE_LENGTH) continue;
+    const line = WEBPACK_ERROR_RE.test(rawLine)
+      ? rawLine.replace(WEBPACK_ERROR_RE, "$1")
+      : rawLine;
+    if (ERROR_HEADER_RE.test(line)) continue;
+
+    const frame = parseFrameLine(line, lang);
+    if (frame) frames.push(frame);
+    if (frames.length >= STACKTRACE_FRAME_LIMIT) break;
+  }
+
+  frames.reverse();
+  return frames;
+}
+
+/**
+ * Build the `$exception_*` properties for a PostHog error-tracking event.
+ *
+ * The caller merges these into the event properties alongside `distinct_id`
+ * and any app dimensions.
+ */
+export function toPostHogExceptionProperties(
+  input: PostHogExceptionInput,
+): PostHogExceptionProperties {
+  const lang = input.lang ?? "javascript";
+  const frames = parseStackFrames(input.stack, lang);
+  const entry: PostHogExceptionEntry = {
+    type: boundedText(input.type || "Error", 200),
+    value: boundedText(
+      input.value || input.type || "Error",
+      MAX_MESSAGE_LENGTH,
+    ),
+    mechanism: {
+      handled: input.handled ?? true,
+      synthetic: input.synthetic ?? false,
+      ...(input.mechanismType
+        ? { type: boundedText(input.mechanismType, 100) }
+        : {}),
+    },
+    ...(frames.length ? { stacktrace: { type: "raw" as const, frames } } : {}),
+  };
+
+  return {
+    $exception_list: [entry],
+    $exception_level: input.level ?? "error",
+    ...(input.fingerprint
+      ? { $exception_fingerprint: boundedText(input.fingerprint, 200) }
+      : {}),
+  };
+}
+
+/** Build `$exception_*` properties directly from a thrown value. */
+export function errorToPostHogExceptionProperties(
+  error: unknown,
+  options: Omit<PostHogExceptionInput, "type" | "value" | "stack"> = {},
+): PostHogExceptionProperties {
+  const parts = exceptionParts(error);
+  return toPostHogExceptionProperties({
+    ...options,
+    type: parts.type,
+    value: parts.message,
+    stack: parts.stack,
+    synthetic: options.synthetic ?? !(error instanceof Error),
+  });
+}
+
+/**
+ * Reshape the camelCase properties emitted by `tracking/error-capture.ts` into
+ * PostHog's `$exception_list` form.
+ *
+ * Returns `undefined` when the event carries no recognizable exception fields,
+ * so the caller can pass it through untouched instead of inventing an empty
+ * issue out of an unrelated event that happens to be named `$exception`.
+ */
+export function reshapeTrackedExceptionProperties(
+  properties: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!properties) return undefined;
+  // Already in PostHog form (e.g. relayed from the browser) — leave it alone.
+  if (Array.isArray(properties.$exception_list)) return properties;
+
+  const type = properties.exceptionType;
+  const message = properties.exceptionMessage;
+  if (typeof type !== "string" && typeof message !== "string") {
+    return undefined;
+  }
+
+  const stack =
+    typeof properties.exceptionStack === "string"
+      ? properties.exceptionStack.slice(0, MAX_STACK_LENGTH)
+      : undefined;
+  const level = properties.level;
+
+  const {
+    exceptionType: _type,
+    exceptionMessage: _message,
+    exceptionStack: _stack,
+    handled: _handled,
+    level: _level,
+    ...rest
+  } = properties;
+
+  return {
+    ...rest,
+    ...toPostHogExceptionProperties({
+      type: typeof type === "string" ? type : "Error",
+      value: typeof message === "string" ? message : "Error",
+      stack,
+      handled:
+        typeof properties.handled === "boolean" ? properties.handled : true,
+      level: isExceptionLevel(level) ? level : "error",
+    }),
+  };
+}
+
+function isExceptionLevel(value: unknown): value is PostHogExceptionLevel {
+  return (
+    value === "fatal" ||
+    value === "error" ||
+    value === "warning" ||
+    value === "info" ||
+    value === "debug"
+  );
+}

--- a/packages/core/src/tracking/providers.spec.ts
+++ b/packages/core/src/tracking/providers.spec.ts
@@ -130,6 +130,75 @@ describe("tracking providers", () => {
     });
   });
 
+  it("reshapes tracked exceptions into PostHog's $exception_list", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}"));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("POSTHOG_API_KEY", "ph_test");
+    vi.stubEnv("POSTHOG_HOST", "https://us.i.posthog.com");
+    const { flushTracking, registerBuiltinProviders, track } =
+      await freshTrackingModules();
+
+    registerBuiltinProviders();
+    track(
+      "$exception",
+      {
+        exceptionType: "TypeError",
+        exceptionMessage: "boom",
+        exceptionStack: "TypeError: boom\n    at run (/app/src/a.ts:3:5)",
+        handled: false,
+        level: "error",
+        app: "content",
+      },
+      { userId: "u1" },
+    );
+    await flushTracking();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://us.i.posthog.com/i/v0/e/");
+    const body = JSON.parse(init.body);
+    expect(body.event).toBe("$exception");
+    expect(body.properties.distinct_id).toBe("u1");
+    expect(body.properties.app).toBe("content");
+    expect(body.properties.$exception_level).toBe("error");
+    expect(body.properties.$exception_list[0]).toMatchObject({
+      type: "TypeError",
+      value: "boom",
+      mechanism: { handled: false },
+      stacktrace: {
+        type: "raw",
+        frames: [
+          {
+            platform: "custom",
+            lang: "javascript",
+            function: "run",
+            filename: "/app/src/a.ts",
+            lineno: 3,
+            colno: 5,
+          },
+        ],
+      },
+    });
+    expect(body.properties).not.toHaveProperty("exceptionType");
+  });
+
+  it("keeps non-exception-shaped $exception events on /capture/", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}"));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("POSTHOG_API_KEY", "ph_test");
+    vi.stubEnv("POSTHOG_HOST", "https://us.i.posthog.com");
+    const { flushTracking, registerBuiltinProviders, track } =
+      await freshTrackingModules();
+
+    registerBuiltinProviders();
+    track("$exception", { unrelated: true }, { userId: "u1" });
+    await flushTracking();
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://us.i.posthog.com/capture/",
+    );
+  });
+
   it("waits for queued provider sends when flushing", async () => {
     let resolveFetch: (() => void) | undefined;
     const fetchMock = vi.fn(

--- a/packages/core/src/tracking/providers.ts
+++ b/packages/core/src/tracking/providers.ts
@@ -248,6 +248,42 @@ function createPostHogProvider(
   };
 }
 
+/**
+ * Send one event to PostHog only, bypassing the provider fan-out.
+ *
+ * For payloads whose *shape* is PostHog-specific and whose *content* other
+ * backends must not receive. `track()` broadcasts to every configured provider,
+ * so a PostHog-only integration (e.g. enabling a survey id) would otherwise
+ * start exporting that integration's content — including user-authored text —
+ * to Mixpanel, Amplitude, webhooks, and Agent Native Analytics as a side
+ * effect nobody opted into.
+ *
+ * Returns `false` when PostHog is not configured, so callers can tell "not
+ * sent" from "sent".
+ */
+export function sendPostHogEvent(
+  name: string,
+  properties: Record<string, unknown>,
+  distinctId: string,
+): boolean {
+  const apiKey = process.env.POSTHOG_API_KEY;
+  if (!apiKey) return false;
+  const host = (process.env.POSTHOG_HOST || POSTHOG_DEFAULT_HOST).replace(
+    /\/+$/,
+    "",
+  );
+  enqueue(
+    `${host}/capture/`,
+    JSON.stringify({
+      api_key: apiKey,
+      event: name,
+      distinct_id: distinctId,
+      properties: { ...properties, timestamp: new Date().toISOString() },
+    }),
+  );
+  return true;
+}
+
 // ─── Mixpanel ──────────────────────────────────────────────────────────────
 
 function createMixpanelProvider(token: string): TrackingProvider {

--- a/packages/core/src/tracking/providers.ts
+++ b/packages/core/src/tracking/providers.ts
@@ -13,6 +13,7 @@
  * automatically by the core-routes plugin).
  */
 
+import { reshapeTrackedExceptionProperties } from "./posthog-exception.js";
 import { registerTrackingProvider } from "./registry.js";
 import type { TrackingProvider, TrackingEvent } from "./types.js";
 
@@ -162,25 +163,59 @@ function isPostHogAiObservabilityEvent(eventName: string): boolean {
   return eventName.startsWith("$ai_");
 }
 
-function createPostHogProvider(apiKey: string, host: string): TrackingProvider {
+/**
+ * `$ai_*` and `$exception` are ingested through PostHog's dedicated endpoint
+ * rather than `/capture/`, and `$exception` additionally has to carry
+ * `$exception_list` — the framework's own `captureException()` emits camelCase
+ * fields that PostHog would otherwise render as an empty, ungroupable issue.
+ */
+function createPostHogProvider(
+  apiKey: string,
+  host: string,
+  errorTracking: boolean,
+): TrackingProvider {
+  const sendToEventsEndpoint = (
+    event: TrackingEvent,
+    properties: Record<string, unknown> | undefined,
+    distinctId: string,
+  ): void => {
+    enqueue(
+      `${host}/i/v0/e/`,
+      JSON.stringify({
+        api_key: apiKey,
+        event: event.name,
+        properties: {
+          distinct_id: distinctId,
+          ...properties,
+          timestamp: event.timestamp,
+        },
+      }),
+    );
+  };
+
   return {
     name: "posthog",
     track(event: TrackingEvent) {
       const distinctId = event.userId || "anonymous";
       if (isPostHogAiObservabilityEvent(event.name)) {
-        enqueue(
-          `${host}/i/v0/e/`,
-          JSON.stringify({
-            api_key: apiKey,
-            event: event.name,
-            properties: {
-              distinct_id: distinctId,
-              ...event.properties,
-              timestamp: event.timestamp,
-            },
-          }),
-        );
+        sendToEventsEndpoint(event, event.properties, distinctId);
         return;
+      }
+
+      if (event.name === "$exception") {
+        // `POSTHOG_ERROR_TRACKING=false` keeps product analytics flowing while
+        // another backend owns crashes. Drop rather than downgrade to
+        // `/capture/`: a malformed exception is what this branch exists to
+        // prevent.
+        if (!errorTracking) return;
+        const reshaped = reshapeTrackedExceptionProperties(event.properties);
+        if (reshaped) {
+          sendToEventsEndpoint(event, reshaped, distinctId);
+          return;
+        }
+        // No recognizable exception fields. Fall through to `/capture/` so the
+        // event is still recorded as-is rather than becoming an issue with
+        // nothing in it.
       }
 
       enqueue(
@@ -383,7 +418,13 @@ export function registerBuiltinProviders(): void {
       /\/+$/,
       "",
     );
-    registerTrackingProvider(createPostHogProvider(posthogKey, host));
+    registerTrackingProvider(
+      createPostHogProvider(
+        posthogKey,
+        host,
+        process.env.POSTHOG_ERROR_TRACKING?.trim().toLowerCase() !== "false",
+      ),
+    );
   }
 
   const mixpanelToken = process.env.MIXPANEL_TOKEN;

--- a/packages/core/src/tracking/redaction.ts
+++ b/packages/core/src/tracking/redaction.ts
@@ -65,7 +65,11 @@ export function safeTags(
 ): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [key, value] of Object.entries(tags ?? {})) {
-    if (Object.keys(out).length >= MAX_TAGS || value == null) break;
+    if (Object.keys(out).length >= MAX_TAGS) break;
+    // Skip, don't stop: callers build tag objects with optional entries
+    // (`{ ...tags, route, method, userAgent }`), so breaking on the first
+    // undefined dropped every tag after it depending on key order.
+    if (value == null) continue;
     const safeKey = boundedText(key, 100);
     out[safeKey] = SECRET_KEY_RE.test(safeKey)
       ? "<redacted>"

--- a/packages/core/src/tracking/redaction.ts
+++ b/packages/core/src/tracking/redaction.ts
@@ -1,0 +1,101 @@
+/**
+ * Bounding and redaction helpers shared by every exception emitter.
+ *
+ * Kept free of `process.env` and Node built-ins so the browser bundle can use
+ * the same rules — an exception shaped one way on the server and another way
+ * in the client is how a leak ships in only one of them.
+ */
+
+export const MAX_MESSAGE_LENGTH = 1000;
+export const MAX_STACK_LENGTH = 8000;
+export const MAX_TAGS = 30;
+export const MAX_EXTRA_KEYS = 30;
+export const MAX_EXTRA_VALUE_LENGTH = 1000;
+
+const SECRET_RE = /\b(?:bearer|basic)\s+[^\s]+/gi;
+
+export const SECRET_KEY_RE =
+  /(?:authorization|cookie|set[-_]?cookie|token|secret|password|passwd|pwd|api[-_]?key|apikey|credential)/i;
+
+export function redact(value: string): string {
+  return value
+    .replace(SECRET_RE, (match) => `${match.split(/\s+/, 1)[0]} <redacted>`)
+    .replace(
+      /([A-Za-z0-9_$.-]*(?:authorization|cookie|token|secret|password|passwd|pwd|api[-_]?key|apikey|credential)[A-Za-z0-9_$.-]*\s*[:=]\s*)([^\s,;}]+)/gi,
+      "$1<redacted>",
+    );
+}
+
+export function boundedText(value: unknown, max: number): string {
+  const text = typeof value === "string" ? value : String(value ?? "");
+  const safe = redact(text);
+  return safe.length > max ? safe.slice(0, max) : safe;
+}
+
+export function safeValue(value: unknown, depth = 2): unknown {
+  if (
+    value == null ||
+    typeof value === "boolean" ||
+    typeof value === "number"
+  ) {
+    return value;
+  }
+  if (typeof value === "string")
+    return boundedText(value, MAX_EXTRA_VALUE_LENGTH);
+  if (depth <= 0) return boundedText(value, MAX_EXTRA_VALUE_LENGTH);
+  if (Array.isArray(value)) {
+    return value.slice(0, 20).map((item) => safeValue(item, depth - 1));
+  }
+  if (typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value)) {
+      if (Object.keys(out).length >= MAX_EXTRA_KEYS) break;
+      const safeKey = boundedText(key, 100);
+      out[safeKey] = SECRET_KEY_RE.test(safeKey)
+        ? "<redacted>"
+        : safeValue(child, depth - 1);
+    }
+    return out;
+  }
+  return boundedText(value, MAX_EXTRA_VALUE_LENGTH);
+}
+
+export function safeTags(
+  tags: Record<string, string | undefined> | undefined,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(tags ?? {})) {
+    if (Object.keys(out).length >= MAX_TAGS || value == null) break;
+    const safeKey = boundedText(key, 100);
+    out[safeKey] = SECRET_KEY_RE.test(safeKey)
+      ? "<redacted>"
+      : boundedText(value, 200);
+  }
+  return out;
+}
+
+export interface ExceptionParts {
+  type: string;
+  message: string;
+  stack?: string;
+}
+
+/** Split an unknown thrown value into bounded, redacted type/message/stack. */
+export function exceptionParts(error: unknown): ExceptionParts {
+  if (error instanceof Error) {
+    return {
+      type: boundedText(error.name || "Error", 200),
+      message: boundedText(
+        error.message || error.name || "Error",
+        MAX_MESSAGE_LENGTH,
+      ),
+      ...(error.stack
+        ? { stack: boundedText(error.stack, MAX_STACK_LENGTH) }
+        : {}),
+    };
+  }
+  return {
+    type: "Error",
+    message: boundedText(error, MAX_MESSAGE_LENGTH),
+  };
+}


### PR DESCRIPTION
- Added support for PostHog error tracking with the introduction of `POSTHOG_ERROR_TRACKING` environment variable to control error reporting.
- Implemented reshaping of exception properties into PostHog's `$exception_list` format to ensure proper error grouping and rendering.
- Introduced new utility functions for redaction and bounding of exception data to prevent sensitive information leakage.
- Updated `captureException` to include user and organization identifiers when available.
- Added tests to verify the correct transformation of exception data for PostHog.
- Enhanced documentation for PostHog error tracking configuration and usage.