### PR TITLE
Keep Content pages in their opened database context

### DIFF
--- a/templates/content/actions/_database-utils.ts
+++ b/templates/content/actions/_database-utils.ts
@@ -1225,10 +1225,15 @@ export async function getDatabaseByDocumentId(
 
 export async function getDatabaseItemByDocumentId(
   documentId: string,
-  options: { includeDeleted?: boolean } = {},
+  options: { includeDeleted?: boolean; databaseId?: string } = {},
   db = getDb(),
 ) {
   const clauses = [eq(schema.contentDatabaseItems.documentId, documentId)];
+  if (options.databaseId) {
+    clauses.push(
+      eq(schema.contentDatabaseItems.databaseId, options.databaseId),
+    );
+  }
   if (!options.includeDeleted) {
     clauses.push(isNull(schema.contentDatabases.deletedAt));
   }
@@ -1253,19 +1258,123 @@ export async function getDatabaseItemByDocumentId(
     )
     .leftJoin(
       schema.contentDatabaseBodyHydrationQueue,
-      eq(
-        schema.contentDatabaseBodyHydrationQueue.databaseItemId,
-        schema.contentDatabaseItems.id,
+      and(
+        eq(
+          schema.contentDatabaseBodyHydrationQueue.databaseItemId,
+          schema.contentDatabaseItems.id,
+        ),
+        eq(
+          schema.contentDatabaseBodyHydrationQueue.sourceId,
+          schema.contentDatabaseSourceRows.sourceId,
+        ),
+        eq(
+          schema.contentDatabaseBodyHydrationQueue.sourceRowId,
+          schema.contentDatabaseSourceRows.sourceRowId,
+        ),
       ),
     )
     .where(and(...clauses))
     .orderBy(
+      sql`CASE
+        WHEN ${schema.contentDatabaseSourceRows.sourceId} IS NOT NULL
+          AND (
+            ${schema.contentDatabaseItems.bodyHydrationStatus} IN ('pending', 'hydrating')
+            OR ${schema.contentDatabaseBodyHydrationQueue.id} IS NOT NULL
+          ) THEN 0
+        WHEN ${schema.contentDatabaseSourceRows.sourceId} IS NOT NULL
+          AND ${schema.contentDatabaseItems.bodyHydrationStatus} = 'error' THEN 1
+        ELSE 2
+      END`,
       sql`CASE WHEN ${schema.contentDatabaseSourceRows.sourceId} IS NOT NULL THEN 0 ELSE 1 END`,
       sql`CASE WHEN ${schema.contentDatabases.systemRole} IS NULL THEN 0 ELSE 1 END`,
       sql`CASE WHEN ${schema.contentDatabases.systemRole} = 'files' THEN 0 ELSE 1 END`,
       asc(schema.contentDatabases.id),
     );
   return row ?? null;
+}
+
+export async function getBuilderBodyHydrationMembershipByDocumentId(
+  documentId: string,
+  db = getDb(),
+) {
+  const rows = await db
+    .select({
+      item: schema.contentDatabaseItems,
+      database: schema.contentDatabases,
+      sourceId: schema.contentDatabaseSourceRows.sourceId,
+      sourceRowId: schema.contentDatabaseSourceRows.sourceRowId,
+      queueId: schema.contentDatabaseBodyHydrationQueue.id,
+      queueSourceId: schema.contentDatabaseBodyHydrationQueue.sourceId,
+      queueSourceRowId: schema.contentDatabaseBodyHydrationQueue.sourceRowId,
+    })
+    .from(schema.contentDatabaseSourceRows)
+    .innerJoin(
+      schema.contentDatabaseSources,
+      eq(
+        schema.contentDatabaseSources.id,
+        schema.contentDatabaseSourceRows.sourceId,
+      ),
+    )
+    .innerJoin(
+      schema.contentDatabaseItems,
+      eq(
+        schema.contentDatabaseItems.id,
+        schema.contentDatabaseSourceRows.databaseItemId,
+      ),
+    )
+    .innerJoin(
+      schema.contentDatabases,
+      eq(schema.contentDatabases.id, schema.contentDatabaseItems.databaseId),
+    )
+    .leftJoin(
+      schema.contentDatabaseBodyHydrationQueue,
+      eq(
+        schema.contentDatabaseBodyHydrationQueue.databaseItemId,
+        schema.contentDatabaseItems.id,
+      ),
+    )
+    .where(
+      and(
+        eq(schema.contentDatabaseSourceRows.documentId, documentId),
+        eq(schema.contentDatabaseItems.documentId, documentId),
+        eq(schema.contentDatabaseSources.sourceType, "builder-cms"),
+        isNull(schema.contentDatabases.deletedAt),
+      ),
+    );
+
+  const boundRows = rows.filter(
+    (row) =>
+      !row.queueId ||
+      (row.queueSourceId === row.sourceId &&
+        row.queueSourceRowId === row.sourceRowId),
+  );
+  if (boundRows.length === 0) return null;
+
+  const priority = (row: (typeof boundRows)[number]) => {
+    if (
+      row.queueId ||
+      row.item.bodyHydrationStatus === "pending" ||
+      row.item.bodyHydrationStatus === "hydrating"
+    ) {
+      return 0;
+    }
+    if (row.item.bodyHydrationStatus === "error") return 1;
+    return 2;
+  };
+  const topPriority = Math.min(...boundRows.map(priority));
+  const candidates = boundRows
+    .filter((row) => priority(row) === topPriority)
+    .sort((left, right) =>
+      `${left.database.id}:${left.sourceId}:${left.sourceRowId}`.localeCompare(
+        `${right.database.id}:${right.sourceId}:${right.sourceRowId}`,
+      ),
+    );
+  const sourceIds = new Set(candidates.map((row) => row.sourceId));
+
+  return {
+    membership: candidates[0]!,
+    hydrationSourceId: sourceIds.size === 1 ? candidates[0]!.sourceId : null,
+  };
 }
 
 export async function deleteDatabaseDataForDocument(

--- a/templates/content/actions/_database-utils.ts
+++ b/templates/content/actions/_database-utils.ts
@@ -1303,7 +1303,7 @@ export async function getBuilderBodyHydrationMembershipByDocumentId(
       database: schema.contentDatabases,
       sourceId: schema.contentDatabaseSourceRows.sourceId,
       sourceRowId: schema.contentDatabaseSourceRows.sourceRowId,
-      queueId: schema.contentDatabaseBodyHydrationQueue.id,
+      bodyHydrationQueueId: schema.contentDatabaseBodyHydrationQueue.id,
       queueSourceId: schema.contentDatabaseBodyHydrationQueue.sourceId,
       queueSourceRowId: schema.contentDatabaseBodyHydrationQueue.sourceRowId,
     })
@@ -1344,7 +1344,7 @@ export async function getBuilderBodyHydrationMembershipByDocumentId(
 
   const boundRows = rows.filter(
     (row) =>
-      !row.queueId ||
+      !row.bodyHydrationQueueId ||
       (row.queueSourceId === row.sourceId &&
         row.queueSourceRowId === row.sourceRowId),
   );
@@ -1352,7 +1352,7 @@ export async function getBuilderBodyHydrationMembershipByDocumentId(
 
   const priority = (row: (typeof boundRows)[number]) => {
     if (
-      row.queueId ||
+      row.bodyHydrationQueueId ||
       row.item.bodyHydrationStatus === "pending" ||
       row.item.bodyHydrationStatus === "hydrating"
     ) {

--- a/templates/content/actions/content-database-lifecycle.db.test.ts
+++ b/templates/content/actions/content-database-lifecycle.db.test.ts
@@ -579,6 +579,9 @@ describe("database-scoped document properties", () => {
         documentId: rowDocumentId,
         position: 0,
         bodyHydrationStatus: "pending",
+        bodyHydrationAttemptedAt: now,
+        bodyHydrationError: "Private Builder diagnostic",
+        bodyHydrationVersion: "private-builder-version",
         createdAt: now,
         updatedAt: now,
       },
@@ -616,7 +619,12 @@ describe("database-scoped document properties", () => {
 
     expect(result.databaseMembership?.databaseId).toBe(local.databaseId);
     expect(result.bodyHydration).toEqual({
-      hydration: expect.objectContaining({ status: "pending" }),
+      hydration: {
+        status: "pending",
+        attemptedAt: null,
+        error: null,
+        version: null,
+      },
     });
     await expect(
       runWithRequestContext({ userEmail: OWNER }, () =>
@@ -646,7 +654,12 @@ describe("database-scoped document properties", () => {
     );
     expect(viewerResult.canEdit).toBe(true);
     expect(viewerResult.bodyHydration).toEqual({
-      hydration: expect.objectContaining({ status: "pending" }),
+      hydration: {
+        status: "pending",
+        attemptedAt: now,
+        error: "Private Builder diagnostic",
+        version: "private-builder-version",
+      },
     });
   });
 

--- a/templates/content/actions/content-database-lifecycle.db.test.ts
+++ b/templates/content/actions/content-database-lifecycle.db.test.ts
@@ -553,7 +553,7 @@ describe("database-scoped document properties", () => {
     expect(result.bodyHydration).toBeUndefined();
   });
 
-  it("gates hidden source hydration without leaking its provenance", async () => {
+  it("gates hidden or viewer-only source hydration without leaking a pump target", async () => {
     const db = getDb();
     const now = new Date().toISOString();
     const rowDocumentId = await createDocument({ title: "Shared row" });
@@ -627,6 +627,27 @@ describe("database-scoped document properties", () => {
         }),
       ),
     ).rejects.toThrow();
+
+    await db.insert(schema.documentShares).values({
+      id: nextId("share"),
+      resourceId: hiddenBuilder.databaseDocumentId,
+      principalType: "user",
+      principalId: OWNER,
+      role: "viewer",
+      createdBy: COLLABORATOR,
+      createdAt: now,
+    });
+    const viewerResult = await runWithRequestContext({ userEmail: OWNER }, () =>
+      getDocumentAction.run({
+        id: rowDocumentId,
+        databaseId: local.databaseId,
+        databaseDocumentId: local.databaseDocumentId,
+      }),
+    );
+    expect(viewerResult.canEdit).toBe(true);
+    expect(viewerResult.bodyHydration).toEqual({
+      hydration: expect.objectContaining({ status: "pending" }),
+    });
   });
 
   it("does not gate a Page for a non-Builder source membership", async () => {

--- a/templates/content/actions/content-database-lifecycle.db.test.ts
+++ b/templates/content/actions/content-database-lifecycle.db.test.ts
@@ -425,7 +425,7 @@ describe("database-scoped document properties", () => {
         databaseId: builder.databaseId,
         documentId: rowDocumentId,
         position: 0,
-        bodyHydrationStatus: "pending",
+        bodyHydrationStatus: "complete" as any,
         createdAt: now,
         updatedAt: now,
       },
@@ -449,6 +449,18 @@ describe("database-scoped document properties", () => {
       sourceRowId: "example-row",
       sourceQualifiedId: "example-model:example-row",
       sourceDisplayKey: "Example row",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(schema.contentDatabaseBodyHydrationQueue).values({
+      id: nextId("builder_body_queue"),
+      ownerEmail: OWNER,
+      sourceId: builderSourceId,
+      databaseItemId: builderItemId,
+      documentId: rowDocumentId,
+      sourceRowId: "example-row",
+      sourceTable: "example-model",
+      sourceEntryJson: "{}",
       createdAt: now,
       updatedAt: now,
     });

--- a/templates/content/actions/content-database-lifecycle.db.test.ts
+++ b/templates/content/actions/content-database-lifecycle.db.test.ts
@@ -395,6 +395,385 @@ describe("database-scoped document properties", () => {
       ),
     ).rejects.toThrow();
   });
+
+  it("keeps the requested membership separate from Page body hydration", async () => {
+    const db = getDb();
+    const now = new Date().toISOString();
+    const rowDocumentId = await createDocument({
+      title: "Shared local and Builder row",
+    });
+    const local = await createDatabase({});
+    const builder = await createDatabase({});
+    const localItemId = nextId("local_item");
+    const builderItemId = nextId("builder_item");
+    const builderSourceId = nextId("builder_source");
+
+    await db.insert(schema.contentDatabaseItems).values([
+      {
+        id: localItemId,
+        ownerEmail: OWNER,
+        databaseId: local.databaseId,
+        documentId: rowDocumentId,
+        position: 0,
+        bodyHydrationStatus: "hydrated",
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: builderItemId,
+        ownerEmail: OWNER,
+        databaseId: builder.databaseId,
+        documentId: rowDocumentId,
+        position: 0,
+        bodyHydrationStatus: "pending",
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
+    await db.insert(schema.contentDatabaseSources).values({
+      id: builderSourceId,
+      ownerEmail: OWNER,
+      databaseId: builder.databaseId,
+      sourceType: "builder-cms",
+      sourceName: "Builder",
+      sourceTable: "example-model",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(schema.contentDatabaseSourceRows).values({
+      id: nextId("source_row"),
+      ownerEmail: OWNER,
+      sourceId: builderSourceId,
+      databaseItemId: builderItemId,
+      documentId: rowDocumentId,
+      sourceRowId: "example-row",
+      sourceQualifiedId: "example-model:example-row",
+      sourceDisplayKey: "Example row",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const [localResult, builderResult, contextFreeResult] =
+      await runWithRequestContext({ userEmail: OWNER }, () =>
+        Promise.all([
+          getDocumentAction.run({
+            id: rowDocumentId,
+            databaseId: local.databaseId,
+            databaseDocumentId: local.databaseDocumentId,
+          }),
+          getDocumentAction.run({
+            id: rowDocumentId,
+            databaseId: builder.databaseId,
+            databaseDocumentId: builder.databaseDocumentId,
+          }),
+          getDocumentAction.run({ id: rowDocumentId }),
+        ]),
+      );
+
+    expect(localResult.databaseMembership).toMatchObject({
+      databaseId: local.databaseId,
+      sourceId: null,
+    });
+    expect(localResult.contextPath).toEqual([
+      expect.objectContaining({ id: local.databaseId, kind: "database" }),
+    ]);
+    expect(localResult.bodyHydration).toMatchObject({
+      provider: "builder",
+      sourceId: builderSourceId,
+      databaseDocumentId: builder.databaseDocumentId,
+      hydration: { status: "pending" },
+    });
+    expect(builderResult.databaseMembership).toMatchObject({
+      databaseId: builder.databaseId,
+      sourceId: builderSourceId,
+    });
+    expect(builderResult.contextPath).toEqual([
+      expect.objectContaining({ id: builder.databaseId, kind: "database" }),
+    ]);
+    expect(contextFreeResult.databaseMembership).toMatchObject({
+      databaseId: builder.databaseId,
+    });
+
+    await expect(
+      runWithRequestContext({ userEmail: OWNER }, () =>
+        getDocumentAction.run({
+          id: rowDocumentId,
+          databaseId: local.databaseId,
+          databaseDocumentId: builder.databaseDocumentId,
+        }),
+      ),
+    ).rejects.toThrow("Database context not found");
+    await expect(
+      runWithRequestContext({ userEmail: OWNER }, () =>
+        getDocumentAction.run({
+          id: rowDocumentId,
+          databaseId: nextId("forged_database"),
+        }),
+      ),
+    ).rejects.toThrow("Database context not found");
+  });
+
+  it("does not invent Builder hydration for a local-only Page", async () => {
+    const db = getDb();
+    const now = new Date().toISOString();
+    const rowDocumentId = await createDocument({ title: "Local-only row" });
+    const local = await createDatabase({});
+    await db.insert(schema.contentDatabaseItems).values({
+      id: nextId("local_only_item"),
+      ownerEmail: OWNER,
+      databaseId: local.databaseId,
+      documentId: rowDocumentId,
+      position: 0,
+      bodyHydrationStatus: "hydrated",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await runWithRequestContext({ userEmail: OWNER }, () =>
+      getDocumentAction.run({
+        id: rowDocumentId,
+        databaseId: local.databaseId,
+        databaseDocumentId: local.databaseDocumentId,
+      }),
+    );
+
+    expect(result.databaseMembership?.databaseId).toBe(local.databaseId);
+    expect(result.bodyHydration).toBeUndefined();
+  });
+
+  it("gates hidden source hydration without leaking its provenance", async () => {
+    const db = getDb();
+    const now = new Date().toISOString();
+    const rowDocumentId = await createDocument({ title: "Shared row" });
+    const local = await createDatabase({});
+    const hiddenBuilder = await createDatabase({ ownerEmail: COLLABORATOR });
+    const hiddenItemId = nextId("hidden_builder_item");
+    const hiddenBuilderSourceId = nextId("hidden_builder_source");
+    await db.insert(schema.contentDatabaseItems).values([
+      {
+        id: nextId("visible_local_item"),
+        ownerEmail: OWNER,
+        databaseId: local.databaseId,
+        documentId: rowDocumentId,
+        position: 0,
+        bodyHydrationStatus: "hydrated",
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: hiddenItemId,
+        ownerEmail: COLLABORATOR,
+        databaseId: hiddenBuilder.databaseId,
+        documentId: rowDocumentId,
+        position: 0,
+        bodyHydrationStatus: "pending",
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
+    await db.insert(schema.contentDatabaseSources).values({
+      id: hiddenBuilderSourceId,
+      ownerEmail: COLLABORATOR,
+      databaseId: hiddenBuilder.databaseId,
+      sourceType: "builder-cms",
+      sourceName: "Builder",
+      sourceTable: "hidden-model",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(schema.contentDatabaseSourceRows).values({
+      id: nextId("hidden_source_row"),
+      ownerEmail: COLLABORATOR,
+      sourceId: hiddenBuilderSourceId,
+      databaseItemId: hiddenItemId,
+      documentId: rowDocumentId,
+      sourceRowId: "hidden-row",
+      sourceQualifiedId: "hidden-model:hidden-row",
+      sourceDisplayKey: "Hidden row",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await runWithRequestContext({ userEmail: OWNER }, () =>
+      getDocumentAction.run({
+        id: rowDocumentId,
+        databaseId: local.databaseId,
+        databaseDocumentId: local.databaseDocumentId,
+      }),
+    );
+
+    expect(result.databaseMembership?.databaseId).toBe(local.databaseId);
+    expect(result.bodyHydration).toEqual({
+      hydration: expect.objectContaining({ status: "pending" }),
+    });
+    await expect(
+      runWithRequestContext({ userEmail: OWNER }, () =>
+        getDocumentAction.run({
+          id: rowDocumentId,
+          databaseId: hiddenBuilder.databaseId,
+          databaseDocumentId: hiddenBuilder.databaseDocumentId,
+        }),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("does not gate a Page for a non-Builder source membership", async () => {
+    const db = getDb();
+    const now = new Date().toISOString();
+    const rowDocumentId = await createDocument({ title: "Notion row" });
+    const notion = await createDatabase({});
+    const itemId = nextId("notion_item");
+    const sourceId = nextId("notion_source");
+    await db.insert(schema.contentDatabaseItems).values({
+      id: itemId,
+      ownerEmail: OWNER,
+      databaseId: notion.databaseId,
+      documentId: rowDocumentId,
+      position: 0,
+      bodyHydrationStatus: "pending",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(schema.contentDatabaseSources).values({
+      id: sourceId,
+      ownerEmail: OWNER,
+      databaseId: notion.databaseId,
+      sourceType: "notion-database",
+      sourceName: "Notion",
+      sourceTable: "example-database",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(schema.contentDatabaseSourceRows).values({
+      id: nextId("notion_source_row"),
+      ownerEmail: OWNER,
+      sourceId,
+      databaseItemId: itemId,
+      documentId: rowDocumentId,
+      sourceRowId: "notion-row",
+      sourceQualifiedId: "notion:example-database:notion-row",
+      sourceDisplayKey: "Notion row",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await runWithRequestContext({ userEmail: OWNER }, () =>
+      getDocumentAction.run({ id: rowDocumentId }),
+    );
+
+    expect(result.bodyHydration).toBeUndefined();
+  });
+
+  it("does not expose a Builder pump target when the queue source is stale", async () => {
+    const db = getDb();
+    const now = new Date().toISOString();
+    const rowDocumentId = await createDocument({ title: "Stale queue row" });
+    const builder = await createDatabase({});
+    const itemId = nextId("stale_queue_item");
+    const sourceId = nextId("current_builder_source");
+    await db.insert(schema.contentDatabaseItems).values({
+      id: itemId,
+      ownerEmail: OWNER,
+      databaseId: builder.databaseId,
+      documentId: rowDocumentId,
+      position: 0,
+      bodyHydrationStatus: "pending",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(schema.contentDatabaseSources).values({
+      id: sourceId,
+      ownerEmail: OWNER,
+      databaseId: builder.databaseId,
+      sourceType: "builder-cms",
+      sourceName: "Builder",
+      sourceTable: "example-model",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(schema.contentDatabaseSourceRows).values({
+      id: nextId("current_builder_source_row"),
+      ownerEmail: OWNER,
+      sourceId,
+      databaseItemId: itemId,
+      documentId: rowDocumentId,
+      sourceRowId: "current-row",
+      sourceQualifiedId: "example-model:current-row",
+      sourceDisplayKey: "Current row",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(schema.contentDatabaseBodyHydrationQueue).values({
+      id: nextId("stale_queue"),
+      ownerEmail: OWNER,
+      sourceId,
+      databaseItemId: itemId,
+      documentId: rowDocumentId,
+      sourceRowId: "stale-row",
+      sourceTable: "example-model",
+      sourceEntryJson: "{}",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await runWithRequestContext({ userEmail: OWNER }, () =>
+      getDocumentAction.run({ id: rowDocumentId }),
+    );
+
+    expect(result.bodyHydration).toBeUndefined();
+  });
+
+  it("gates ambiguously sourced Builder hydration without choosing a pump target", async () => {
+    const db = getDb();
+    const now = new Date().toISOString();
+    const rowDocumentId = await createDocument({ title: "Ambiguous row" });
+    const first = await createDatabase({});
+    const second = await createDatabase({});
+    for (const [index, database] of [first, second].entries()) {
+      const itemId = nextId(`ambiguous_item_${index}`);
+      const sourceId = nextId(`ambiguous_source_${index}`);
+      await db.insert(schema.contentDatabaseItems).values({
+        id: itemId,
+        ownerEmail: OWNER,
+        databaseId: database.databaseId,
+        documentId: rowDocumentId,
+        position: 0,
+        bodyHydrationStatus: "pending",
+        createdAt: now,
+        updatedAt: now,
+      });
+      await db.insert(schema.contentDatabaseSources).values({
+        id: sourceId,
+        ownerEmail: OWNER,
+        databaseId: database.databaseId,
+        sourceType: "builder-cms",
+        sourceName: `Builder ${index}`,
+        sourceTable: `model-${index}`,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await db.insert(schema.contentDatabaseSourceRows).values({
+        id: nextId(`ambiguous_source_row_${index}`),
+        ownerEmail: OWNER,
+        sourceId,
+        databaseItemId: itemId,
+        documentId: rowDocumentId,
+        sourceRowId: `row-${index}`,
+        sourceQualifiedId: `model-${index}:row-${index}`,
+        sourceDisplayKey: `Row ${index}`,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+
+    const result = await runWithRequestContext({ userEmail: OWNER }, () =>
+      getDocumentAction.run({ id: rowDocumentId }),
+    );
+
+    expect(result.bodyHydration).toEqual({
+      hydration: expect.objectContaining({ status: "pending" }),
+    });
+  });
 });
 
 describe("document trash lifecycle", () => {

--- a/templates/content/actions/get-document.ts
+++ b/templates/content/actions/get-document.ts
@@ -170,7 +170,9 @@ export default defineAction({
         ? {
             hydration: serializeDatabaseMembership(bodyHydrationMembership)
               .bodyHydration,
-            ...(bodyHydrationAccess && bodyHydrationTarget?.hydrationSourceId
+            ...(bodyHydrationAccess &&
+            canEditRole(bodyHydrationAccess.role) &&
+            bodyHydrationTarget?.hydrationSourceId
               ? {
                   provider: "builder" as const,
                   sourceId: bodyHydrationTarget.hydrationSourceId,

--- a/templates/content/actions/get-document.ts
+++ b/templates/content/actions/get-document.ts
@@ -11,6 +11,7 @@ import { favoriteDocumentIds } from "./_content-favorites.js";
 import { resolveContentSpaceAccess } from "./_content-space-access.js";
 import {
   getDatabaseByDocumentId,
+  getBuilderBodyHydrationMembershipByDocumentId,
   getDocumentContextPath,
   getDatabaseItemByDocumentId,
   isSoftDeletedDatabaseDocument,
@@ -18,7 +19,9 @@ import {
 } from "./_database-utils.js";
 import { serializeDocumentSource } from "./_document-source.js";
 import {
+  getDatabaseById,
   listPropertiesForDocument,
+  resolvePropertyDatabaseForDocument,
   serializeDatabase,
 } from "./_property-utils.js";
 
@@ -54,6 +57,14 @@ export default defineAction({
   description: "Get a single document by ID with full content.",
   schema: z.object({
     id: z.string().optional().describe("Document ID (required)"),
+    databaseId: z
+      .string()
+      .optional()
+      .describe("Exact Database context for membership-local data"),
+    databaseDocumentId: z
+      .string()
+      .optional()
+      .describe("Backing document ID for the exact Database context"),
   }),
   http: { method: "GET" },
   readOnly: true,
@@ -79,8 +90,51 @@ export default defineAction({
       });
     }
     const doc = access.resource;
+    if (args.databaseDocumentId && !args.databaseId) {
+      throw Object.assign(new Error("databaseDocumentId requires databaseId"), {
+        statusCode: 404,
+      });
+    }
+
     const database = await getDatabaseByDocumentId(doc.id);
-    const databaseMembership = await getDatabaseItemByDocumentId(doc.id);
+    const databaseMembership = args.databaseId
+      ? await getDatabaseItemByDocumentId(doc.id, {
+          databaseId: args.databaseId,
+        })
+      : await getDatabaseItemByDocumentId(doc.id);
+    const propertyDatabase = args.databaseId
+      ? await getDatabaseById(args.databaseId)
+      : await resolvePropertyDatabaseForDocument(doc);
+    const propertyDatabaseAccess =
+      args.databaseId && propertyDatabase
+        ? await resolveDocumentAccess(propertyDatabase.documentId)
+        : null;
+    if (
+      args.databaseId &&
+      (!propertyDatabase ||
+        !propertyDatabaseAccess ||
+        (propertyDatabase.documentId !== doc.id && !databaseMembership))
+    ) {
+      throw Object.assign(new Error("Database context not found"), {
+        statusCode: 404,
+      });
+    }
+    if (
+      args.databaseDocumentId &&
+      propertyDatabase?.documentId !== args.databaseDocumentId
+    ) {
+      throw Object.assign(new Error("Database context not found"), {
+        statusCode: 404,
+      });
+    }
+    const bodyHydrationTarget =
+      await getBuilderBodyHydrationMembershipByDocumentId(doc.id);
+    const bodyHydrationMembership = bodyHydrationTarget?.membership;
+    const bodyHydrationAccess = bodyHydrationTarget?.hydrationSourceId
+      ? await resolveDocumentAccess(
+          bodyHydrationMembership!.database.documentId,
+        )
+      : null;
     const userEmail = getRequestUserEmail();
     const favoriteIds = userEmail
       ? await favoriteDocumentIds(getDb(), userEmail, [doc.id])
@@ -112,10 +166,26 @@ export default defineAction({
       databaseMembership: databaseMembership
         ? serializeDatabaseMembership(databaseMembership)
         : undefined,
+      bodyHydration: bodyHydrationMembership
+        ? {
+            hydration: serializeDatabaseMembership(bodyHydrationMembership)
+              .bodyHydration,
+            ...(bodyHydrationAccess && bodyHydrationTarget?.hydrationSourceId
+              ? {
+                  provider: "builder" as const,
+                  sourceId: bodyHydrationTarget.hydrationSourceId,
+                  databaseDocumentId:
+                    bodyHydrationMembership.database.documentId,
+                }
+              : {}),
+          }
+        : undefined,
       createdAt: doc.createdAt,
       updatedAt: doc.updatedAt,
-      properties: await listPropertiesForDocument(doc),
-      contextPath: await getDocumentContextPath(doc),
+      properties: await listPropertiesForDocument(doc, args.databaseId),
+      contextPath: await getDocumentContextPath(doc, {
+        databaseId: args.databaseId,
+      }),
     };
   },
   link: ({ result }) => {

--- a/templates/content/actions/get-document.ts
+++ b/templates/content/actions/get-document.ts
@@ -135,6 +135,9 @@ export default defineAction({
           bodyHydrationMembership!.database.documentId,
         )
       : null;
+    const bodyHydration = bodyHydrationMembership
+      ? serializeDatabaseMembership(bodyHydrationMembership).bodyHydration
+      : null;
     const userEmail = getRequestUserEmail();
     const favoriteIds = userEmail
       ? await favoriteDocumentIds(getDb(), userEmail, [doc.id])
@@ -168,8 +171,14 @@ export default defineAction({
         : undefined,
       bodyHydration: bodyHydrationMembership
         ? {
-            hydration: serializeDatabaseMembership(bodyHydrationMembership)
-              .bodyHydration,
+            hydration: bodyHydrationAccess
+              ? bodyHydration!
+              : {
+                  status: bodyHydration!.status,
+                  attemptedAt: null,
+                  error: null,
+                  version: null,
+                },
             ...(bodyHydrationAccess &&
             canEditRole(bodyHydrationAccess.role) &&
             bodyHydrationTarget?.hydrationSourceId

--- a/templates/content/app/components/editor/BuilderBodySyncingNotice.test.tsx
+++ b/templates/content/app/components/editor/BuilderBodySyncingNotice.test.tsx
@@ -1,0 +1,33 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { BuilderBodySyncingNotice } from "./BuilderBodySyncingNotice";
+
+describe("BuilderBodySyncingNotice", () => {
+  it("announces Page-body hydration as a polite status", () => {
+    const html = renderToStaticMarkup(
+      <BuilderBodySyncingNotice
+        title="This page's content is still syncing from Builder"
+        description="Editing is paused until the page body is safe."
+      />,
+    );
+
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-live="polite"');
+    expect(html).toContain(
+      "This page&#x27;s content is still syncing from Builder",
+    );
+    expect(html).toContain("Editing is paused until the page body is safe.");
+  });
+
+  it("can render generic copy without source provenance", () => {
+    const html = renderToStaticMarkup(
+      <BuilderBodySyncingNotice
+        title="This page's content is still syncing"
+        description="Editing is paused until the page body is safe."
+      />,
+    );
+
+    expect(html).not.toContain("Builder");
+  });
+});

--- a/templates/content/app/components/editor/BuilderBodySyncingNotice.tsx
+++ b/templates/content/app/components/editor/BuilderBodySyncingNotice.tsx
@@ -8,9 +8,16 @@ export function BuilderBodySyncingNotice({
   description: string;
 }) {
   return (
-    <div className="rounded-lg border border-dashed border-border bg-muted/35 px-4 py-5 text-sm">
+    <div
+      className="rounded-lg border border-dashed border-border bg-muted/35 px-4 py-5 text-sm"
+      role="status"
+      aria-live="polite"
+    >
       <div className="flex items-center gap-2 font-medium text-foreground">
-        <IconLoader2 className="size-4 animate-spin text-muted-foreground" />
+        <IconLoader2
+          className="size-4 animate-spin text-muted-foreground"
+          aria-hidden="true"
+        />
         {title}
       </div>
       <p className="mt-2 max-w-2xl leading-6 text-muted-foreground">

--- a/templates/content/app/components/editor/DocumentEditor.layout.test.ts
+++ b/templates/content/app/components/editor/DocumentEditor.layout.test.ts
@@ -400,8 +400,34 @@ describe("document editor layout", () => {
     expect(documentEditorSource).toContain(
       "(isLocalFileDocument || collabSynced)",
     );
+    expect(documentEditorSource).toContain(
+      "!canEdit ||\n      !hydrationContext?.sourceId",
+    );
     expect(documentEditorSource).not.toContain(
       "(isLocalFileDocument || !collabLoading)",
+    );
+  });
+
+  it("keeps database-local context when local-file history recovery updates caches", () => {
+    const source = readFileSync(
+      new URL("./DocumentEditor.tsx", import.meta.url),
+      "utf8",
+    );
+    const fallbackStart = source.indexOf(
+      'toast.warning(t("editor.localFileSavedHistoryNotUpdated")',
+    );
+    const fallbackEnd = source.indexOf(
+      "return fileFirstDocument;",
+      fallbackStart,
+    );
+    const fallback = source.slice(fallbackStart, fallbackEnd);
+
+    expect(fallbackStart).toBeGreaterThan(-1);
+    expect(fallback).toContain(
+      "mergeDocumentIntoDocumentCache(old, fileFirstDocument)",
+    );
+    expect(fallback).not.toContain(
+      "documentQueryFilter(documentId),\n          fileFirstDocument",
     );
   });
 

--- a/templates/content/app/components/editor/DocumentEditor.layout.test.ts
+++ b/templates/content/app/components/editor/DocumentEditor.layout.test.ts
@@ -232,7 +232,9 @@ describe("document editor layout", () => {
       },
     );
 
-    expect(source).toContain("const documentQuery = useDocument(documentId)");
+    expect(source).toContain("const documentQuery = useDocument(documentId, {");
+    expect(source).toContain("databaseId,");
+    expect(source).toContain("databaseDocumentId,");
     expect(source).toContain("isFetchedAfterMount");
     expect(source).toContain("isFetching");
     expect(source).toContain("queriedDocument?.id === documentId");

--- a/templates/content/app/components/editor/DocumentEditor.tsx
+++ b/templates/content/app/components/editor/DocumentEditor.tsx
@@ -64,6 +64,7 @@ import {
 import {
   isDocumentUpdateConflict,
   patchDocumentCaches,
+  documentQueryFilter,
   useDocument,
   useDeleteDocument,
   useDocuments,
@@ -247,7 +248,10 @@ export function DocumentEditor({
   databaseId,
   databaseDocumentId,
 }: DocumentEditorProps) {
-  const documentQuery = useDocument(documentId);
+  const documentQuery = useDocument(documentId, {
+    databaseId,
+    databaseDocumentId,
+  });
   const {
     data: queriedDocument,
     isError,
@@ -536,7 +540,7 @@ function DocumentEditorBody({
   const deleteDocument = useDeleteDocument();
   const queryClient = useQueryClient();
   const processBuilderBodies = useProcessBuilderBodyHydration(
-    document.databaseMembership?.databaseDocumentId ?? documentId,
+    document.bodyHydration?.databaseDocumentId ?? documentId,
   );
   const canEdit = document.canEdit ?? true;
   const canEditRef = useRef(canEdit);
@@ -661,24 +665,24 @@ function DocumentEditorBody({
   );
 
   useEffect(() => {
-    const membership = document.databaseMembership;
-    const hydration = membership?.bodyHydration;
+    const hydrationContext = document.bodyHydration;
+    const hydration = hydrationContext?.hydration;
     if (
-      !membership?.sourceId ||
+      !hydrationContext?.sourceId ||
       !hydration ||
       (hydration.status !== "pending" && hydration.status !== "error")
     ) {
       return;
     }
-    const promotionKey = `${membership.sourceId}:${documentId}:${hydration.status}:${hydration.version ?? ""}`;
+    const promotionKey = `${hydrationContext.sourceId}:${documentId}:${hydration.status}:${hydration.version ?? ""}`;
     if (promotedBuilderBodyRef.current === promotionKey) return;
     promotedBuilderBodyRef.current = promotionKey;
     processBuilderBodies.mutate({
-      sourceId: membership.sourceId,
+      sourceId: hydrationContext.sourceId,
       documentId,
       limit: 1,
     });
-  }, [document.databaseMembership, documentId, processBuilderBodies.mutate]);
+  }, [document.bodyHydration, documentId, processBuilderBodies.mutate]);
   const titleFocusedRef = useRef(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const titleInputRef = useRef<HTMLTextAreaElement>(null);
@@ -973,8 +977,8 @@ function DocumentEditorBody({
           description:
             error instanceof Error ? error.message : t("empty.genericError"),
         });
-        queryClient.setQueryData(
-          ["action", "get-document", { id: documentId }],
+        queryClient.setQueriesData(
+          documentQueryFilter(documentId),
           fileFirstDocument,
         );
         queryClient.invalidateQueries({
@@ -1887,9 +1891,15 @@ function DocumentEditorBody({
                       if (bodyHydrationPending) {
                         return (
                           <BuilderBodySyncingNotice
-                            title={t("editor.builderBodySyncing")}
+                            title={t(
+                              document.bodyHydration?.provider === "builder"
+                                ? "editor.builderBodySyncing"
+                                : "editor.pageBodySyncing",
+                            )}
                             description={t(
-                              "editor.builderBodySyncingDescription",
+                              document.bodyHydration?.provider === "builder"
+                                ? "editor.builderBodySyncingDescription"
+                                : "editor.pageBodySyncingDescription",
                             )}
                           />
                         );

--- a/templates/content/app/components/editor/DocumentEditor.tsx
+++ b/templates/content/app/components/editor/DocumentEditor.tsx
@@ -62,6 +62,7 @@ import {
   type ContentSpaceSummary,
 } from "@/hooks/use-content-spaces";
 import {
+  mergeDocumentIntoDocumentCache,
   isDocumentUpdateConflict,
   patchDocumentCaches,
   documentQueryFilter,
@@ -668,6 +669,7 @@ function DocumentEditorBody({
     const hydrationContext = document.bodyHydration;
     const hydration = hydrationContext?.hydration;
     if (
+      !canEdit ||
       !hydrationContext?.sourceId ||
       !hydration ||
       (hydration.status !== "pending" && hydration.status !== "error")
@@ -682,7 +684,12 @@ function DocumentEditorBody({
       documentId,
       limit: 1,
     });
-  }, [document.bodyHydration, documentId, processBuilderBodies.mutate]);
+  }, [
+    canEdit,
+    document.bodyHydration,
+    documentId,
+    processBuilderBodies.mutate,
+  ]);
   const titleFocusedRef = useRef(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const titleInputRef = useRef<HTMLTextAreaElement>(null);
@@ -977,9 +984,8 @@ function DocumentEditorBody({
           description:
             error instanceof Error ? error.message : t("empty.genericError"),
         });
-        queryClient.setQueriesData(
-          documentQueryFilter(documentId),
-          fileFirstDocument,
+        queryClient.setQueriesData(documentQueryFilter(documentId), (old) =>
+          mergeDocumentIntoDocumentCache(old, fileFirstDocument),
         );
         queryClient.invalidateQueries({
           queryKey: ["action", "list-documents"],

--- a/templates/content/app/components/editor/DocumentToolbar.tsx
+++ b/templates/content/app/components/editor/DocumentToolbar.tsx
@@ -90,6 +90,7 @@ import {
   useSearchNotionPages,
   useCreateAndLinkNotionPage,
 } from "@/hooks/use-notion";
+import { documentQueryFilter } from "@/lib/document-query";
 import {
   localSourceAbsolutePath,
   revealLinkedLocalSourceFile,
@@ -523,12 +524,8 @@ export function DocumentToolbar({
       const previous = hideFromSearch;
       setPendingHideFromSearch(next);
 
-      queryClient.setQueryData(
-        ["action", "get-document", { id: documentId }],
-        (old: any) =>
-          old && typeof old === "object"
-            ? { ...old, hideFromSearch: next }
-            : old,
+      queryClient.setQueriesData(documentQueryFilter(documentId), (old: any) =>
+        old && typeof old === "object" ? { ...old, hideFromSearch: next } : old,
       );
       queryClient.setQueryData(
         ["action", "list-documents", undefined],
@@ -552,9 +549,7 @@ export function DocumentToolbar({
         });
       } catch (err) {
         setPendingHideFromSearch(previous);
-        queryClient.invalidateQueries({
-          queryKey: ["action", "get-document", { id: documentId }],
-        });
+        queryClient.invalidateQueries(documentQueryFilter(documentId));
         queryClient.invalidateQueries({
           queryKey: ["action", "list-documents"],
         });
@@ -565,9 +560,7 @@ export function DocumentToolbar({
         throw err;
       } finally {
         setPendingHideFromSearch(null);
-        queryClient.invalidateQueries({
-          queryKey: ["action", "get-document", { id: documentId }],
-        });
+        queryClient.invalidateQueries(documentQueryFilter(documentId));
         queryClient.invalidateQueries({
           queryKey: ["action", "list-documents"],
         });

--- a/templates/content/app/components/editor/body-hydration.test.ts
+++ b/templates/content/app/components/editor/body-hydration.test.ts
@@ -41,6 +41,17 @@ function documentWithHydration(
         version: null,
       },
     },
+    bodyHydration: {
+      provider: "builder",
+      sourceId: "builder-source",
+      databaseDocumentId: "database-page",
+      hydration: {
+        status,
+        attemptedAt: null,
+        error: null,
+        version: null,
+      },
+    },
   } satisfies Document;
 }
 
@@ -66,12 +77,12 @@ describe("body hydration editing gates", () => {
   it("detects terminal Builder body hydration errors separately from pending gates", () => {
     expect(
       builderBodyHydrationIsTerminalError(
-        documentWithHydration("error").databaseMembership?.bodyHydration,
+        documentWithHydration("error").bodyHydration?.hydration,
       ),
     ).toBe(true);
     expect(
       builderBodyHydrationIsTerminalError(
-        documentWithHydration("pending").databaseMembership?.bodyHydration,
+        documentWithHydration("pending").bodyHydration?.hydration,
       ),
     ).toBe(false);
   });
@@ -164,15 +175,37 @@ describe("body hydration editing gates", () => {
   it("treats source-backed empty documents with no body hydration as pending", () => {
     const document = {
       ...documentWithHydration("hydrated"),
-      databaseMembership: {
-        databaseId: "database",
-        databaseDocumentId: "database-page",
-        databaseTitle: "Content calendar",
-        position: 0,
+      bodyHydration: {
+        provider: "builder" as const,
         sourceId: "builder-source",
+        databaseDocumentId: "database-page",
+        hydration: undefined,
       },
     } satisfies Document;
 
+    expect(documentBodyHydrationIsPending(document)).toBe(true);
+  });
+
+  it("keeps current Database membership separate from Page body hydration", () => {
+    const document = {
+      ...documentWithHydration("pending"),
+      databaseMembership: {
+        databaseId: "local-database",
+        databaseDocumentId: "local-database-page",
+        databaseTitle: "Local projects",
+        position: 0,
+        sourceId: null,
+        bodyHydration: {
+          status: "hydrated" as const,
+          attemptedAt: null,
+          error: null,
+          version: null,
+        },
+      },
+    } satisfies Document;
+
+    expect(document.databaseMembership.sourceId).toBeNull();
+    expect(document.bodyHydration?.sourceId).toBe("builder-source");
     expect(documentBodyHydrationIsPending(document)).toBe(true);
   });
 

--- a/templates/content/app/components/editor/body-hydration.ts
+++ b/templates/content/app/components/editor/body-hydration.ts
@@ -54,12 +54,12 @@ export function databaseItemBodyHydrationIsPending(
 }
 
 export function documentBodyHydrationIsPending(
-  document: Pick<Document, "content" | "databaseMembership">,
+  document: Pick<Document, "content" | "bodyHydration">,
 ) {
-  const hydration = document.databaseMembership?.bodyHydration;
+  const hydration = document.bodyHydration?.hydration;
   if (
     sourceBackedEmptyBodyNeedsHydration({
-      sourceId: document.databaseMembership?.sourceId,
+      sourceId: document.bodyHydration ? "source-backed" : undefined,
       content: document.content,
       hydration,
     })
@@ -81,7 +81,10 @@ export function newDocumentPageChoiceIsDisabled(args: {
 
 export function previewBodyHydrationIsPending(args: {
   item: Pick<ContentDatabaseItem, "bodyHydration" | "document">;
-  document: Pick<Document, "content" | "databaseMembership"> | null | undefined;
+  document:
+    | Pick<Document, "content" | "databaseMembership" | "bodyHydration">
+    | null
+    | undefined;
 }) {
   const membership =
     args.document?.databaseMembership ?? args.item.document.databaseMembership;
@@ -128,11 +131,14 @@ export function previewDraftConflictsWithHydratedBody(args: {
 
 export function previewBodyHydrationIsTerminalError(args: {
   item: Pick<ContentDatabaseItem, "bodyHydration" | "document">;
-  document: Pick<Document, "databaseMembership"> | null | undefined;
+  document:
+    | Pick<Document, "databaseMembership" | "bodyHydration">
+    | null
+    | undefined;
 }) {
   return (
     builderBodyHydrationIsTerminalError(
-      args.document?.databaseMembership?.bodyHydration,
+      args.document?.bodyHydration?.hydration,
     ) ||
     builderBodyHydrationIsTerminalError(
       args.item.bodyHydration ??

--- a/templates/content/app/components/editor/database/DatabaseView.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.tsx
@@ -204,6 +204,7 @@ import {
 } from "@/hooks/use-document-properties";
 import {
   isDocumentUpdateConflict,
+  documentQueryFilter,
   type DocumentUpdateResult,
   useDeleteDocument,
   useDocument,
@@ -4803,9 +4804,7 @@ function DatabaseItemPreview({
           void queryClient.invalidateQueries({
             queryKey: contentDatabaseQueryKey(databaseDocumentId),
           });
-          void queryClient.invalidateQueries({
-            queryKey: ["action", "get-document", { id: document.id }],
-          });
+          void queryClient.invalidateQueries(documentQueryFilter(document.id));
           void queryClient.invalidateQueries({
             queryKey: ["action", "list-documents"],
           });

--- a/templates/content/app/components/sidebar/DocumentSidebar.tsx
+++ b/templates/content/app/components/sidebar/DocumentSidebar.tsx
@@ -126,6 +126,7 @@ import {
   useUpdateDocument,
   buildDocumentTree,
   filterDocumentTreeDocuments,
+  documentQueryFilter,
 } from "@/hooks/use-documents";
 import { useLocalStorage } from "@/hooks/use-local-storage";
 import {
@@ -1191,16 +1192,12 @@ export function DocumentSidebar({
           created,
         );
         if (nextId !== id) {
-          queryClient.removeQueries({
-            queryKey: ["action", "get-document", { id }],
-          });
+          queryClient.removeQueries(documentQueryFilter(id));
           navigateToDocument(nextId);
         }
         // Replace optimistic doc with real server doc + clear any 404 error
         // state from the in-flight fetch that ran before create completed.
-        queryClient.invalidateQueries({
-          queryKey: ["action", "get-document", { id: nextId }],
-        });
+        queryClient.invalidateQueries(documentQueryFilter(nextId));
         queryClient.invalidateQueries({
           queryKey: ["action", "list-documents"],
         });
@@ -1214,9 +1211,7 @@ export function DocumentSidebar({
         queryClient.invalidateQueries({
           queryKey: ["action", "list-documents"],
         });
-        queryClient.removeQueries({
-          queryKey: ["action", "get-document", { id }],
-        });
+        queryClient.removeQueries(documentQueryFilter(id));
         if (rootFilesDatabaseId) {
           queryClient.setQueryData<ContentDatabaseResponse>(
             contentDatabaseByIdQueryKey(rootFilesDatabaseId),
@@ -1300,9 +1295,7 @@ export function DocumentSidebar({
         );
       });
       for (const deletedId of deletedIds) {
-        queryClient.removeQueries({
-          queryKey: ["action", "get-document", { id: deletedId }],
-        });
+        queryClient.removeQueries(documentQueryFilter(deletedId));
       }
 
       if (activeDeleted) {

--- a/templates/content/app/hooks/use-content-database.test.ts
+++ b/templates/content/app/hooks/use-content-database.test.ts
@@ -932,9 +932,15 @@ describe("invalidateBuilderBodyHydrationQueries", () => {
   });
 
   it("invalidates the opened row document only for priority hydration", () => {
-    const calls: Array<{ queryKey?: readonly unknown[] }> = [];
+    const calls: Array<{
+      queryKey?: readonly unknown[];
+      predicate?: (query: { queryKey: readonly unknown[] }) => boolean;
+    }> = [];
     const queryClient = {
-      invalidateQueries: (options: { queryKey?: readonly unknown[] }) => {
+      invalidateQueries: (options: {
+        queryKey?: readonly unknown[];
+        predicate?: (query: { queryKey: readonly unknown[] }) => boolean;
+      }) => {
         calls.push(options);
       },
     };
@@ -953,7 +959,21 @@ describe("invalidateBuilderBodyHydrationQueries", () => {
           { documentId: "database-page" },
         ],
       },
-      { queryKey: ["action", "get-document", { id: "row-page" }] },
+      {
+        queryKey: ["action", "get-document"],
+        predicate: expect.any(Function),
+      },
     ]);
+    const documentFilter = calls[calls.length - 1]?.predicate;
+    expect(
+      documentFilter?.({
+        queryKey: ["action", "get-document", { id: "row-page" }],
+      }),
+    ).toBe(true);
+    expect(
+      documentFilter?.({
+        queryKey: ["action", "get-document", { id: "other-page" }],
+      }),
+    ).toBe(false);
   });
 });

--- a/templates/content/app/hooks/use-content-database.ts
+++ b/templates/content/app/hooks/use-content-database.ts
@@ -57,6 +57,8 @@ import type {
 import type { Query, QueryClient } from "@tanstack/react-query";
 import { useQueryClient } from "@tanstack/react-query";
 
+import { documentQueryFilter } from "../lib/document-query";
+
 export function contentDatabaseQueryKey(documentId: string) {
   return ["action", "get-content-database", { documentId }] as const;
 }
@@ -421,9 +423,7 @@ export function clearDeletedContentDatabaseFromCache(
   documentId: string,
 ) {
   queryClient.removeQueries(contentDatabaseQueryFilter(documentId));
-  queryClient.removeQueries({
-    queryKey: ["action", "get-document", { id: documentId }],
-  });
+  queryClient.removeQueries(documentQueryFilter(documentId));
   queryClient.invalidateQueries({
     queryKey: ["action", "get-content-database"],
   });
@@ -713,20 +713,14 @@ export function useCreateContentDatabase(documentId: string | null) {
     {
       onSuccess: (data) => {
         if (documentId) {
-          queryClient.invalidateQueries({
-            queryKey: ["action", "get-document", { id: documentId }],
-          });
+          queryClient.invalidateQueries(documentQueryFilter(documentId));
           queryClient.invalidateQueries({
             queryKey: contentDatabaseQueryKey(documentId),
           });
         }
-        queryClient.invalidateQueries({
-          queryKey: [
-            "action",
-            "get-document",
-            { id: data.database.documentId },
-          ],
-        });
+        queryClient.invalidateQueries(
+          documentQueryFilter(data.database.documentId),
+        );
         queryClient.invalidateQueries({
           queryKey: ["action", "list-documents"],
         });
@@ -743,17 +737,11 @@ export function useCreateInlineContentDatabase(hostDocumentId: string | null) {
   >("create-inline-content-database", {
     onSuccess: (data) => {
       if (hostDocumentId) {
-        queryClient.invalidateQueries({
-          queryKey: ["action", "get-document", { id: hostDocumentId }],
-        });
+        queryClient.invalidateQueries(documentQueryFilter(hostDocumentId));
       }
-      queryClient.invalidateQueries({
-        queryKey: [
-          "action",
-          "get-document",
-          { id: data.block.databaseDocumentId },
-        ],
-      });
+      queryClient.invalidateQueries(
+        documentQueryFilter(data.block.databaseDocumentId),
+      );
       queryClient.invalidateQueries({
         queryKey: contentDatabaseQueryKey(data.block.databaseDocumentId),
       });
@@ -1488,7 +1476,10 @@ export function useProcessBuilderBodyHydration(documentId: string) {
 
 export function invalidateBuilderBodyHydrationQueries(
   queryClient: {
-    invalidateQueries: (filters: { queryKey: readonly unknown[] }) => unknown;
+    invalidateQueries: (filters: {
+      queryKey?: readonly unknown[];
+      predicate?: (query: { queryKey: readonly unknown[] }) => boolean;
+    }) => unknown;
   },
   documentId: string,
   variables?: Pick<ProcessBuilderBodyHydrationRequest, "documentId"> | null,
@@ -1501,9 +1492,7 @@ export function invalidateBuilderBodyHydrationQueries(
     queryKey: ["action", "get-content-database-source", { documentId }],
   });
   if (variables?.documentId) {
-    queryClient.invalidateQueries({
-      queryKey: ["action", "get-document", { id: variables.documentId }],
-    });
+    queryClient.invalidateQueries(documentQueryFilter(variables.documentId));
   }
 }
 

--- a/templates/content/app/hooks/use-create-page.test.tsx
+++ b/templates/content/app/hooks/use-create-page.test.tsx
@@ -135,7 +135,8 @@ describe("useCreatePage", () => {
     );
     expect(isDatabaseChoicePending(persistedDocument, false)).toBe(false);
     expect(mocks.invalidateQueries).toHaveBeenCalledWith({
-      queryKey: ["action", "get-document", { id: documentId }],
+      queryKey: ["action", "get-document"],
+      predicate: expect.any(Function),
     });
   });
 });

--- a/templates/content/app/hooks/use-create-page.ts
+++ b/templates/content/app/hooks/use-create-page.ts
@@ -12,6 +12,7 @@ import {
 import { useContentSpaces } from "@/hooks/use-content-spaces";
 import { useCreateDocument } from "@/hooks/use-documents";
 import { useLocalStorage } from "@/hooks/use-local-storage";
+import { documentQueryFilter } from "@/lib/document-query";
 import { markDocumentCreationPending } from "@/lib/optimistic-document";
 
 const LIST_DOCUMENTS_QUERY_KEY = [
@@ -103,9 +104,7 @@ export function useCreatePage(opts?: {
         );
         // Replace optimistic doc with real server doc + clear any 404 error
         // state from the in-flight fetch that ran before create completed.
-        queryClient.invalidateQueries({
-          queryKey: ["action", "get-document", { id }],
-        });
+        queryClient.invalidateQueries(documentQueryFilter(id));
         queryClient.invalidateQueries({
           queryKey: ["action", "list-documents"],
         });
@@ -115,9 +114,7 @@ export function useCreatePage(opts?: {
         queryClient.invalidateQueries({
           queryKey: ["action", "list-documents"],
         });
-        queryClient.removeQueries({
-          queryKey: ["action", "get-document", { id }],
-        });
+        queryClient.removeQueries(documentQueryFilter(id));
         if (shouldNavigate) navigate("/");
         toast.error("Failed to create page", {
           description:

--- a/templates/content/app/hooks/use-document-properties.test.ts
+++ b/templates/content/app/hooks/use-document-properties.test.ts
@@ -104,9 +104,10 @@ describe("useSetDocumentProperty", () => {
             { documentId: "row-1", databaseId: "database-1" },
           ],
         },
-        {
-          queryKey: ["action", "get-document", { id: "row-1" }],
-        },
+        expect.objectContaining({
+          queryKey: ["action", "get-document"],
+          predicate: expect.any(Function),
+        }),
         {
           queryKey: [
             "action",

--- a/templates/content/app/hooks/use-document-properties.ts
+++ b/templates/content/app/hooks/use-document-properties.ts
@@ -22,7 +22,10 @@ import {
   contentDatabaseQueryKey,
   removeDocumentPropertyFromDatabaseResponse,
 } from "./use-content-database";
-import { documentPropertiesQueryKey } from "./use-documents";
+import {
+  documentPropertiesQueryKey,
+  documentQueryFilter,
+} from "./use-documents";
 
 type DatabaseScopedRequest = { databaseId: string };
 
@@ -91,9 +94,7 @@ export function useConfigureDocumentProperty(
       queryClient.invalidateQueries({
         queryKey: documentPropertiesQueryKey(documentId, databaseId),
       });
-      queryClient.invalidateQueries({
-        queryKey: ["action", "get-document", { id: documentId }],
-      });
+      queryClient.invalidateQueries(documentQueryFilter(documentId));
       queryClient.invalidateQueries(
         contentDatabaseConstrainedQueryFilter(databaseDocumentId),
       );
@@ -158,9 +159,7 @@ export function useSetDocumentProperty(
       queryClient.invalidateQueries({
         queryKey: documentPropertiesQueryKey(variables.documentId, databaseId),
       });
-      queryClient.invalidateQueries({
-        queryKey: ["action", "get-document", { id: variables.documentId }],
-      });
+      queryClient.invalidateQueries(documentQueryFilter(variables.documentId));
       queryClient.invalidateQueries(
         contentDatabaseConstrainedQueryFilter(databaseDocumentId),
       );
@@ -195,9 +194,7 @@ export function useDuplicateDocumentProperty(
       queryClient.invalidateQueries({
         queryKey: documentPropertiesQueryKey(documentId, databaseId),
       });
-      queryClient.invalidateQueries({
-        queryKey: ["action", "get-document", { id: documentId }],
-      });
+      queryClient.invalidateQueries(documentQueryFilter(documentId));
       queryClient.invalidateQueries({
         ...contentDatabaseQueryFilter(databaseDocumentId),
       });
@@ -220,9 +217,7 @@ export function useReorderDocumentProperty(
       queryClient.invalidateQueries({
         queryKey: documentPropertiesQueryKey(documentId, databaseId),
       });
-      queryClient.invalidateQueries({
-        queryKey: ["action", "get-document", { id: documentId }],
-      });
+      queryClient.invalidateQueries(documentQueryFilter(documentId));
       queryClient.invalidateQueries({
         queryKey: contentDatabaseQueryKey(databaseDocumentId),
       });
@@ -277,9 +272,7 @@ export function useDeleteDocumentProperty(
       queryClient.invalidateQueries({
         queryKey: documentPropertiesQueryKey(documentId, databaseId),
       });
-      queryClient.invalidateQueries({
-        queryKey: ["action", "get-document", { id: documentId }],
-      });
+      queryClient.invalidateQueries(documentQueryFilter(documentId));
       queryClient.invalidateQueries({
         ...contentDatabaseQueryFilter(databaseDocumentId),
       });

--- a/templates/content/app/hooks/use-document-versions.ts
+++ b/templates/content/app/hooks/use-document-versions.ts
@@ -5,6 +5,8 @@ import {
 import type { Document, DocumentVersion } from "@shared/api";
 import { useQueryClient } from "@tanstack/react-query";
 
+import { documentQueryFilter } from "./use-documents";
+
 export function useDocumentVersions(documentId: string | null) {
   return useActionQuery<DocumentVersion[]>(
     "list-document-versions",
@@ -29,9 +31,7 @@ export function useRestoreDocumentVersion(documentId: string) {
         queryClient.invalidateQueries({
           queryKey: ["action", "list-document-versions", { documentId }],
         });
-        queryClient.invalidateQueries({
-          queryKey: ["action", "get-document", { id: documentId }],
-        });
+        queryClient.invalidateQueries(documentQueryFilter(documentId));
       },
     },
   );

--- a/templates/content/app/hooks/use-documents.test.ts
+++ b/templates/content/app/hooks/use-documents.test.ts
@@ -30,6 +30,39 @@ describe("document query freshness", () => {
       retry: false,
     });
   });
+
+  it("keeps membership contexts in separate Page query keys", () => {
+    expect(
+      documentQueryKey("shared-page", {
+        databaseId: "local-database",
+        databaseDocumentId: "local-database-page",
+      }),
+    ).toEqual([
+      "action",
+      "get-document",
+      {
+        id: "shared-page",
+        databaseId: "local-database",
+        databaseDocumentId: "local-database-page",
+      },
+    ]);
+    expect(
+      documentQueryKey("shared-page", {
+        databaseId: "builder-database",
+        databaseDocumentId: "builder-database-page",
+      }),
+    ).not.toEqual(
+      documentQueryKey("shared-page", {
+        databaseId: "local-database",
+        databaseDocumentId: "local-database-page",
+      }),
+    );
+    expect(documentQueryKey("shared-page")).toEqual([
+      "action",
+      "get-document",
+      { id: "shared-page" },
+    ]);
+  });
 });
 
 function doc(id: string, parentId: string | null, position = 0): Document {
@@ -397,6 +430,53 @@ describe("optimistic document titles", () => {
       queryClient.getQueryData<any>(databaseKey)?.items[0].document.content,
     ).toBe("Saved body");
   });
+
+  it("patches Page-owned fields across contexts without exchanging memberships", () => {
+    const queryClient = new QueryClient();
+    const localKey = documentQueryKey("shared-page", {
+      databaseId: "local-database",
+      databaseDocumentId: "local-database-page",
+    });
+    const builderKey = documentQueryKey("shared-page", {
+      databaseId: "builder-database",
+      databaseDocumentId: "builder-database-page",
+    });
+    queryClient.setQueryData(localKey, {
+      ...doc("shared-page", null),
+      databaseMembership: {
+        databaseId: "local-database",
+        databaseDocumentId: "local-database-page",
+        databaseTitle: "Local",
+        position: 0,
+      },
+    });
+    queryClient.setQueryData(builderKey, {
+      ...doc("shared-page", null),
+      databaseMembership: {
+        databaseId: "builder-database",
+        databaseDocumentId: "builder-database-page",
+        databaseTitle: "Builder",
+        position: 0,
+        sourceId: "builder-source",
+      },
+    });
+
+    patchDocumentCaches(queryClient, "shared-page", {
+      title: "Shared title",
+      content: "Shared body",
+    });
+
+    expect(queryClient.getQueryData<Document>(localKey)).toMatchObject({
+      title: "Shared title",
+      content: "Shared body",
+      databaseMembership: { databaseId: "local-database" },
+    });
+    expect(queryClient.getQueryData<Document>(builderKey)).toMatchObject({
+      title: "Shared title",
+      content: "Shared body",
+      databaseMembership: { databaseId: "builder-database" },
+    });
+  });
 });
 
 describe("mergeDocumentIntoDocumentCache", () => {
@@ -426,6 +506,46 @@ describe("mergeDocumentIntoDocumentCache", () => {
         updated,
       ),
     ).toEqual({ ...updated, database });
+  });
+
+  it("never copies membership or hydration context between query variants", () => {
+    const localMembership = {
+      databaseId: "local-database",
+      databaseDocumentId: "local-database-page",
+      databaseTitle: "Local",
+      position: 0,
+    };
+    const merged = mergeDocumentIntoDocumentCache(
+      {
+        ...doc("shared-page", null),
+        databaseMembership: localMembership,
+      },
+      {
+        ...doc("shared-page", null),
+        title: "Server title",
+        databaseMembership: {
+          databaseId: "builder-database",
+          databaseDocumentId: "builder-database-page",
+          databaseTitle: "Builder",
+          position: 0,
+        },
+        bodyHydration: {
+          provider: "builder",
+          hydration: {
+            status: "pending",
+            attemptedAt: null,
+            error: null,
+            version: null,
+          },
+        },
+      },
+    );
+
+    expect(merged).toMatchObject({
+      title: "Server title",
+      databaseMembership: localMembership,
+    });
+    expect(merged).not.toHaveProperty("bodyHydration");
   });
 });
 

--- a/templates/content/app/hooks/use-documents.ts
+++ b/templates/content/app/hooks/use-documents.ts
@@ -20,21 +20,48 @@ import { toast } from "sonner";
 
 import type { DocumentUpdateConflictResponse } from "../../actions/update-document";
 import {
+  documentQueryFilter,
+  documentQueryKey,
+  type DocumentQueryContext,
+} from "../lib/document-query";
+import {
   removeOptimisticItemFromContentDatabase,
   useRestoreContentDatabase,
 } from "./use-content-database";
 
+export {
+  documentQueryFilter,
+  documentQueryKey,
+  type DocumentQueryContext,
+} from "../lib/document-query";
+
 export type { DocumentUpdateConflictResponse };
+
+export type PageOwnedDocumentCachePatch = Pick<
+  Partial<Document>,
+  | "id"
+  | "parentId"
+  | "title"
+  | "content"
+  | "description"
+  | "icon"
+  | "position"
+  | "isFavorite"
+  | "hideFromSearch"
+  | "visibility"
+  | "accessRole"
+  | "canEdit"
+  | "canManage"
+  | "source"
+  | "createdAt"
+  | "updatedAt"
+>;
 
 export const LIST_DOCUMENTS_QUERY_KEY = [
   "action",
   "list-documents",
   undefined,
 ] as const;
-
-export function documentQueryKey(documentId: string) {
-  return ["action", "get-document", { id: documentId }] as const;
-}
 
 export function documentPropertiesQueryKey(
   documentId: string,
@@ -74,7 +101,27 @@ export function mergeDocumentIntoDocumentCache(
   old: unknown,
   document: Document,
 ) {
-  return old && typeof old === "object" ? { ...old, ...document } : document;
+  const pageOwnedPatch: PageOwnedDocumentCachePatch = {
+    id: document.id,
+    parentId: document.parentId,
+    title: document.title,
+    content: document.content,
+    description: document.description,
+    icon: document.icon,
+    position: document.position,
+    isFavorite: document.isFavorite,
+    hideFromSearch: document.hideFromSearch,
+    visibility: document.visibility,
+    accessRole: document.accessRole,
+    canEdit: document.canEdit,
+    canManage: document.canManage,
+    source: document.source,
+    createdAt: document.createdAt,
+    updatedAt: document.updatedAt,
+  };
+  return old && typeof old === "object"
+    ? { ...old, ...pageOwnedPatch }
+    : pageOwnedPatch;
 }
 
 export function mergeDocumentIntoListDocumentsCache(
@@ -157,9 +204,9 @@ function patchDocumentWithFavoriteMembershipInDatabaseCache(
 export function patchDocumentCaches(
   queryClient: Pick<QueryClient, "setQueryData" | "setQueriesData">,
   documentId: string,
-  patch: Partial<Document>,
+  patch: PageOwnedDocumentCachePatch,
 ) {
-  queryClient.setQueryData(documentQueryKey(documentId), (old: unknown) =>
+  queryClient.setQueriesData(documentQueryFilter(documentId), (old: unknown) =>
     old && typeof old === "object" ? { ...old, ...patch } : old,
   );
   queryClient.setQueryData(LIST_DOCUMENTS_QUERY_KEY, (old: unknown) =>
@@ -219,7 +266,7 @@ export function patchContentSpaceNameCaches(
 export function documentUpdateSuccessPatch(
   data: DocumentUpdateResponse,
   variables: DocumentUpdateRequestWithCas,
-): Partial<Document> {
+): PageOwnedDocumentCachePatch {
   return {
     updatedAt: data.updatedAt,
     ...(variables.title !== undefined ? { title: data.title } : {}),
@@ -289,13 +336,28 @@ export const DOCUMENT_QUERY_FRESHNESS_OPTIONS = {
   retry: false,
 };
 
-export function useDocument(id: string | null) {
-  return useActionQuery<Document>("get-document", id ? { id } : undefined, {
-    enabled: !!id,
-    // Doc-not-found / no-access errors are deterministic — retrying just keeps
-    // the spinner up for ~7s before the UI can render "Not found".
-    ...DOCUMENT_QUERY_FRESHNESS_OPTIONS,
-  });
+export function useDocument(
+  id: string | null,
+  context: DocumentQueryContext = {},
+) {
+  return useActionQuery<Document>(
+    "get-document",
+    id
+      ? {
+          id,
+          ...(context.databaseId ? { databaseId: context.databaseId } : {}),
+          ...(context.databaseDocumentId
+            ? { databaseDocumentId: context.databaseDocumentId }
+            : {}),
+        }
+      : undefined,
+    {
+      enabled: !!id,
+      // Doc-not-found / no-access errors are deterministic — retrying just keeps
+      // the spinner up for ~7s before the UI can render "Not found".
+      ...DOCUMENT_QUERY_FRESHNESS_OPTIONS,
+    },
+  );
 }
 
 export interface PreviewDocumentDraftRecord {
@@ -368,7 +430,7 @@ export function useUpdateDocument() {
         };
         if (Object.keys(optimisticPatch).length === 0) return undefined;
 
-        const documentKey = documentQueryKey(variables.id);
+        const documentFilter = documentQueryFilter(variables.id);
         const databaseFilter = {
           queryKey: ["action", "get-content-database"],
         } as const;
@@ -376,14 +438,14 @@ export function useUpdateDocument() {
           queryKey: ["action", "list-content-spaces"],
         } as const;
         await Promise.all([
-          queryClient.cancelQueries({ queryKey: documentKey }),
+          queryClient.cancelQueries(documentFilter),
           queryClient.cancelQueries({ queryKey: LIST_DOCUMENTS_QUERY_KEY }),
           queryClient.cancelQueries(databaseFilter),
           queryClient.cancelQueries(contentSpacesFilter),
         ]);
 
         const previous: Array<[readonly unknown[], unknown]> = [
-          [documentKey, queryClient.getQueryData(documentKey)],
+          ...queryClient.getQueriesData(documentFilter),
           [
             LIST_DOCUMENTS_QUERY_KEY,
             queryClient.getQueryData(LIST_DOCUMENTS_QUERY_KEY),
@@ -423,8 +485,8 @@ export function useUpdateDocument() {
         // just-applied write.
         if (isDocumentUpdateConflict(data)) {
           const serverDocument = data.document;
-          queryClient.setQueryData(
-            ["action", "get-document", { id: variables.id }],
+          queryClient.setQueriesData(
+            documentQueryFilter(variables.id),
             (old: unknown) =>
               mergeDocumentIntoDocumentCache(old, serverDocument),
           );
@@ -453,9 +515,7 @@ export function useUpdateDocument() {
               queryKey: ["action", "get-content-database"],
             });
           }
-          queryClient.invalidateQueries({
-            queryKey: ["action", "get-document", { id: variables.id }],
-          });
+          queryClient.invalidateQueries(documentQueryFilter(variables.id));
           queryClient.invalidateQueries({
             queryKey: ["action", "list-documents"],
           });
@@ -525,9 +585,7 @@ export function useDeleteDocument() {
       queryClient.invalidateQueries({
         queryKey: ["action", "list-documents"],
       });
-      queryClient.invalidateQueries({
-        queryKey: ["action", "get-document", { id: variables.id }],
-      });
+      queryClient.invalidateQueries(documentQueryFilter(variables.id));
       queryClient.invalidateQueries({
         queryKey: ["action", "get-content-database"],
       });
@@ -606,9 +664,7 @@ export function useMoveDocument() {
         queryClient.invalidateQueries({
           queryKey: ["action", "list-documents"],
         });
-        queryClient.invalidateQueries({
-          queryKey: ["action", "get-document", { id: variables.id }],
-        });
+        queryClient.invalidateQueries(documentQueryFilter(variables.id));
       },
     },
   );

--- a/templates/content/app/hooks/use-notion.test.ts
+++ b/templates/content/app/hooks/use-notion.test.ts
@@ -85,11 +85,10 @@ describe("invalidateDocumentQueries", () => {
       ),
     ).toBe(false);
 
-    expect(calledKeys).toContainEqual([
-      "action",
-      "get-document",
-      { id: "doc-1" },
-    ]);
+    expect(calledKeys).toContainEqual(["action", "get-document"]);
+    expect(invalidateQueries.mock.calls[0]?.[0]?.predicate).toEqual(
+      expect.any(Function),
+    );
     expect(calledKeys).toContainEqual(["action", "list-documents"]);
   });
 });

--- a/templates/content/app/hooks/use-notion.ts
+++ b/templates/content/app/hooks/use-notion.ts
@@ -16,6 +16,8 @@ import type {
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 
+import { documentQueryFilter } from "./use-documents";
+
 // The server signs a `redirect` query param into the OAuth `state` and the
 // callback route sends the user back there once the connection completes. If
 // we never send it, `state.redirectPath` defaults to "/" server-side and
@@ -55,9 +57,7 @@ export function invalidateDocumentQueries(
   // path after every debounced editor save). Invalidating the bare ["action"]
   // key would refetch every mounted query app-wide (sidebar tree, comments,
   // database views, search, connection status, ...) on each cycle.
-  queryClient.invalidateQueries({
-    queryKey: ["action", "get-document", { id: documentId }],
-  });
+  queryClient.invalidateQueries(documentQueryFilter(documentId));
   queryClient.invalidateQueries({
     queryKey: ["action", "list-documents"],
   });
@@ -155,21 +155,23 @@ export function useDocumentSyncStatus(
 
     lastObservedSyncedAtRef.current = query.data.lastSyncedAt;
 
-    const cachedDocument = queryClient.getQueryData<Document>([
-      "action",
-      "get-document",
-      { id: normalizedDocumentId },
-    ]);
+    const cachedDocuments = queryClient
+      .getQueriesData<Document>(documentQueryFilter(normalizedDocumentId))
+      .map(([, document]) => document)
+      .filter((document): document is Document => !!document);
     const syncedLocalUpdatedAt = query.data.lastPushedLocalUpdatedAt;
 
     if (
-      cachedDocument?.updatedAt &&
+      cachedDocuments.some(
+        (cachedDocument) =>
+          !!cachedDocument.updatedAt &&
+          !!syncedLocalUpdatedAt &&
+          syncedLocalUpdatedAt > cachedDocument.updatedAt,
+      ) &&
       syncedLocalUpdatedAt &&
-      syncedLocalUpdatedAt > cachedDocument.updatedAt
+      cachedDocuments.length > 0
     ) {
-      queryClient.invalidateQueries({
-        queryKey: ["action", "get-document", { id: normalizedDocumentId }],
-      });
+      queryClient.invalidateQueries(documentQueryFilter(normalizedDocumentId));
       queryClient.invalidateQueries({ queryKey: ["action", "list-documents"] });
     }
   }, [

--- a/templates/content/app/i18n-data.ts
+++ b/templates/content/app/i18n-data.ts
@@ -2986,9 +2986,12 @@ const enUS = {
     liveDocumentSaveBeforeSyncFailed:
       "The live document could not be saved before syncing.",
     documentTitle: "Document title",
-    builderBodySyncing: "Content is still syncing from Builder",
+    builderBodySyncing: "This page's content is still syncing from Builder",
     builderBodySyncingDescription:
       "Editing is paused until the Builder body finishes syncing, so the existing article content is not overwritten.",
+    pageBodySyncing: "This page's content is still syncing",
+    pageBodySyncingDescription:
+      "Editing is paused until the page body finishes syncing, so existing content is not overwritten.",
     localFileSavedHistoryNotUpdated:
       "Local file saved, but history was not updated",
     reorderField: "Reorder {{name}}",
@@ -5481,6 +5484,9 @@ const editorMessagesByLocale = {
     builderBodySyncing: "内容仍在从 Builder 同步",
     builderBodySyncingDescription:
       "同步 Builder 正文完成前会暂停编辑，避免覆盖现有文章内容。",
+    pageBodySyncing: "此页面的内容仍在同步",
+    pageBodySyncingDescription:
+      "在页面正文完成同步之前，编辑会暂停，以免覆盖现有内容。",
     creatingDatabase: "正在创建内联数据库...",
     databaseCreated: "内联数据库已创建",
     emptyBlockPlaceholder: "按“/”使用命令",
@@ -5826,6 +5832,9 @@ const editorMessagesByLocale = {
     builderBodySyncing: "El contenido aún se está sincronizando desde Builder",
     builderBodySyncingDescription:
       "La edición está en pausa hasta que el cuerpo de Builder termine de sincronizarse, para no sobrescribir el contenido existente del artículo.",
+    pageBodySyncing: "El contenido de esta página aún se está sincronizando",
+    pageBodySyncingDescription:
+      "La edición está en pausa hasta que el contenido de la página termine de sincronizarse, para no sobrescribir el contenido existente.",
     creatingDatabase: "Creando base de datos integrada...",
     databaseCreated: "Base de datos integrada creada",
     emptyBlockPlaceholder: "Pulsa «/» para ver los comandos",
@@ -6183,6 +6192,10 @@ const editorMessagesByLocale = {
       "Le contenu est encore en cours de synchronisation depuis Builder",
     builderBodySyncingDescription:
       "La modification est suspendue jusqu'à la fin de la synchronisation du corps Builder, afin de ne pas écraser le contenu existant de l'article.",
+    pageBodySyncing:
+      "Le contenu de cette page est encore en cours de synchronisation",
+    pageBodySyncingDescription:
+      "La modification est suspendue jusqu'à la fin de la synchronisation du contenu de la page, afin de ne pas écraser le contenu existant.",
     creatingDatabase: "Création d'une base de données intégrée...",
     databaseCreated: "Base de données intégrée créée",
     emptyBlockPlaceholder: "Appuyez sur « / » pour afficher les commandes",
@@ -6542,6 +6555,9 @@ const editorMessagesByLocale = {
     builderBodySyncing: "Inhalte werden noch von Builder synchronisiert",
     builderBodySyncingDescription:
       "Die Bearbeitung ist pausiert, bis der Builder-Textkörper fertig synchronisiert ist, damit der bestehende Artikelinhalt nicht überschrieben wird.",
+    pageBodySyncing: "Der Inhalt dieser Seite wird noch synchronisiert",
+    pageBodySyncingDescription:
+      "Die Bearbeitung ist pausiert, bis der Seiteninhalt fertig synchronisiert ist, damit bestehende Inhalte nicht überschrieben werden.",
     creatingDatabase: "Inline-Datenbank wird erstellt...",
     databaseCreated: "Inline-Datenbank erstellt",
     emptyBlockPlaceholder: "Drücke „/“ für Befehle",
@@ -6906,6 +6922,9 @@ const editorMessagesByLocale = {
     builderBodySyncing: "コンテンツはまだ Builder から同期中です",
     builderBodySyncingDescription:
       "既存の記事内容を上書きしないよう、Builder 本文の同期が完了するまで編集は一時停止されます。",
+    pageBodySyncing: "このページのコンテンツはまだ同期中です",
+    pageBodySyncingDescription:
+      "既存のコンテンツを上書きしないよう、ページ本文の同期が完了するまで編集は一時停止されます。",
     creatingDatabase: "インラインデータベースを作成しています...",
     databaseCreated: "インラインデータベースが作成されました",
     emptyBlockPlaceholder: "「/」でコマンドを表示",
@@ -7259,6 +7278,9 @@ const editorMessagesByLocale = {
     builderBodySyncing: "콘텐츠가 아직 Builder에서 동기화되는 중입니다",
     builderBodySyncingDescription:
       "기존 문서 내용을 덮어쓰지 않도록 Builder 본문 동기화가 완료될 때까지 편집이 일시 중지됩니다.",
+    pageBodySyncing: "이 페이지의 콘텐츠가 아직 동기화 중입니다",
+    pageBodySyncingDescription:
+      "기존 콘텐츠를 덮어쓰지 않도록 페이지 본문 동기화가 완료될 때까지 편집이 일시 중지됩니다.",
     creatingDatabase: "인라인 데이터베이스 생성 중...",
     databaseCreated: "인라인 데이터베이스가 생성되었습니다.",
     emptyBlockPlaceholder: "‘/’를 눌러 명령 사용",
@@ -7611,6 +7633,9 @@ const editorMessagesByLocale = {
     builderBodySyncing: "O conteúdo ainda está sincronizando do Builder",
     builderBodySyncingDescription:
       "A edição fica pausada até o corpo do Builder terminar de sincronizar, para não sobrescrever o conteúdo existente do artigo.",
+    pageBodySyncing: "O conteúdo desta página ainda está sincronizando",
+    pageBodySyncingDescription:
+      "A edição fica pausada até o conteúdo da página terminar de sincronizar, para não sobrescrever o conteúdo existente.",
     creatingDatabase: "Criando banco de dados embutido...",
     databaseCreated: "Banco de dados embutido criado",
     emptyBlockPlaceholder: "Pressione “/” para comandos",
@@ -7969,6 +7994,9 @@ const editorMessagesByLocale = {
     builderBodySyncing: "सामग्री अभी भी Builder से सिंक हो रही है",
     builderBodySyncingDescription:
       "Builder का मुख्य भाग सिंक पूरा होने तक संपादन रोका गया है, ताकि मौजूदा लेख सामग्री अधिलेखित न हो।",
+    pageBodySyncing: "इस पेज की सामग्री अभी भी सिंक हो रही है",
+    pageBodySyncingDescription:
+      "पेज का मुख्य भाग सिंक पूरा होने तक संपादन रोका गया है, ताकि मौजूदा सामग्री अधिलेखित न हो।",
     creatingDatabase: "इनलाइन डेटाबेस बनाया जा रहा है...",
     databaseCreated: "इनलाइन डेटाबेस बनाया गया",
     emptyBlockPlaceholder: "कमांड के लिए '/' दबाएं",
@@ -8316,6 +8344,9 @@ const editorMessagesByLocale = {
     builderBodySyncing: "لا يزال المحتوى قيد المزامنة من Builder",
     builderBodySyncingDescription:
       "يتم إيقاف التحرير مؤقتًا حتى تكتمل مزامنة نص Builder، حتى لا يتم استبدال محتوى المقالة الحالي.",
+    pageBodySyncing: "لا يزال محتوى هذه الصفحة قيد المزامنة",
+    pageBodySyncingDescription:
+      "يتم إيقاف التحرير مؤقتًا حتى تكتمل مزامنة محتوى الصفحة، حتى لا تتم الكتابة فوق المحتوى الحالي.",
     creatingDatabase: "جارٍ إنشاء قاعدة بيانات مضمنة...",
     databaseCreated: "تم إنشاء قاعدة البيانات المضمنة",
     emptyBlockPlaceholder: 'اضغط على "/" للأوامر',

--- a/templates/content/app/i18n/zh-TW.ts
+++ b/templates/content/app/i18n/zh-TW.ts
@@ -105,6 +105,9 @@ const messages = {
     builderBodySyncing: "內容仍在從 Builder 同步",
     builderBodySyncingDescription:
       "同步 Builder 正文完成前會暫停編輯，避免覆寫既有文章內容。",
+    pageBodySyncing: "此頁面的內容仍在同步",
+    pageBodySyncingDescription:
+      "在頁面正文完成同步之前，編輯會暫停，以免覆寫既有內容。",
     localFileSavedHistoryNotUpdated: "本機檔案已儲存，但歷史紀錄未更新",
     reorderField: "重新排序 {{name}}",
     title: "標題",

--- a/templates/content/app/lib/document-query.ts
+++ b/templates/content/app/lib/document-query.ts
@@ -1,0 +1,36 @@
+export interface DocumentQueryContext {
+  databaseId?: string | null;
+  databaseDocumentId?: string | null;
+}
+
+export function documentQueryKey(
+  documentId: string,
+  context: DocumentQueryContext = {},
+) {
+  return [
+    "action",
+    "get-document",
+    {
+      id: documentId,
+      ...(context.databaseId ? { databaseId: context.databaseId } : {}),
+      ...(context.databaseDocumentId
+        ? { databaseDocumentId: context.databaseDocumentId }
+        : {}),
+    },
+  ] as const;
+}
+
+export function documentQueryFilter(documentId: string) {
+  return {
+    queryKey: ["action", "get-document"] as const,
+    predicate: (query: { queryKey: readonly unknown[] }) => {
+      const args = query.queryKey[2];
+      return (
+        !!args &&
+        typeof args === "object" &&
+        "id" in args &&
+        args.id === documentId
+      );
+    },
+  };
+}

--- a/templates/content/changelog/2026-08-02-pages-opened-from-a-database-now-keep-that-database-s-fields.md
+++ b/templates/content/changelog/2026-08-02-pages-opened-from-a-database-now-keep-that-database-s-fields.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-02
+---
+
+Pages opened from a database now keep that database’s fields and loading state, even when the page also belongs to a Builder-connected database.

--- a/templates/content/server/lib/document-context.ts
+++ b/templates/content/server/lib/document-context.ts
@@ -14,6 +14,7 @@ export type DocumentContextPathEntry = {
  * assembles the live path without copying ancestor prose into descendants. */
 export async function getDocumentContextPath(
   document: Pick<typeof schema.documents.$inferSelect, "id" | "parentId">,
+  options: { databaseId?: string } = {},
 ): Promise<DocumentContextPathEntry[]> {
   const db = getDb();
   const path: DocumentContextPathEntry[] = [];
@@ -43,6 +44,15 @@ export async function getDocumentContextPath(
     parentId = parent.parentId;
   }
 
+  const membershipClauses = [
+    eq(schema.contentDatabaseItems.documentId, document.id),
+    isNull(schema.contentDatabases.deletedAt),
+  ];
+  if (options.databaseId) {
+    membershipClauses.push(
+      eq(schema.contentDatabaseItems.databaseId, options.databaseId),
+    );
+  }
   const [membership] = await db
     .select({ database: schema.contentDatabases })
     .from(schema.contentDatabaseItems)
@@ -50,12 +60,7 @@ export async function getDocumentContextPath(
       schema.contentDatabases,
       eq(schema.contentDatabases.id, schema.contentDatabaseItems.databaseId),
     )
-    .where(
-      and(
-        eq(schema.contentDatabaseItems.documentId, document.id),
-        isNull(schema.contentDatabases.deletedAt),
-      ),
-    )
+    .where(and(...membershipClauses))
     .orderBy(
       sql`CASE WHEN ${schema.contentDatabases.systemRole} IS NULL THEN 0 ELSE 1 END`,
       asc(schema.contentDatabases.id),

--- a/templates/content/shared/api.ts
+++ b/templates/content/shared/api.ts
@@ -35,6 +35,7 @@ export interface Document {
   properties?: DocumentProperty[];
   database?: ContentDatabase;
   databaseMembership?: ContentDatabaseMembership;
+  bodyHydration?: ContentDocumentBodyHydration;
   contextPath?: ContentContextPathEntry[];
   createdAt: string;
   updatedAt: string;
@@ -404,6 +405,13 @@ export interface ContentDatabaseMembership {
   position: number;
   sourceId?: string | null;
   bodyHydration?: ContentDatabaseBodyHydration;
+}
+
+export interface ContentDocumentBodyHydration {
+  provider?: "builder";
+  hydration?: ContentDatabaseBodyHydration;
+  sourceId?: string;
+  databaseDocumentId?: string;
 }
 
 export type ContentDatabaseBodyHydrationState =


### PR DESCRIPTION
## Problem

A page can belong to more than one Content database. When one membership came from Builder, opening that page through a different local database could briefly project the Builder membership instead of the database in the URL. The page then showed “This page’s content is still syncing from Builder” in a frame that implied the local database itself was Builder-connected, and could show the wrong fields or breadcrumb.

## Approach

Treat the database named by the page route as the exact membership context for fields, breadcrumb, and database-local UI. Keep Builder body hydration as a separate page-level safety state, because the shared page body must still remain read-only while genuine Builder content is incomplete.

Context-free callers retain their existing behavior. Invalid, inaccessible, deleted, mismatched, or ambiguous source contexts fail closed rather than selecting a hidden “primary” membership.

## What changed

- Extend `get-document` with optional database context and validate the exact database, backing document, access, and page membership before returning membership-local data.
- Return page-body hydration separately from the current database membership, selecting only Builder sources and binding queued hydration to the exact source and source-row identity.
- Preserve the serializer’s queue contract, keep viewer sessions from launching editor-only hydration work, expose pump coordinates only to source editors, and redact Builder diagnostic details when the caller cannot read the source membership.
- Merge only Page-owned fields during local-file recovery.
- Key document queries by database context and fan page-owned cache updates across variants without copying membership, properties, breadcrumb, or hydration state between them.
- Use the route context on the first editor read, keep local pages editable, and show page-scoped Builder copy only when authorized provenance is available.
- Add polite status semantics, translated fallback copy, focused action/cache/hydration regressions, and a Content changelog entry.

## Safety and operations

This is an action, cache, and UI contract repair. It adds no schema migration, backfill, destructive write, credential, permission, or provider-network behavior. Ambiguous or stale Builder source bindings withhold the hydration pump target. Callers without source-database read access receive generic hydration status but no timestamps, errors, versions, provenance, or pump coordinates. Reverting the commits restores the prior projection behavior without changing stored data.

## Verification

- `pnpm --filter content typecheck` — passed for the context-aware action response, query keys, and editor changes.
- `NODE_OPTIONS=--localstorage-file=/tmp/codex-builder-membership-context-localstorage.json pnpm --filter content test` — 162 files passed and 1 skipped; 2,014 tests passed, 3 expected failures, and 5 skipped.
- `pnpm test:content-product-impact` — all 30 Content roadmap/conformance checks passed.
- `pnpm guards` — all 41 repository guards passed, including i18n catalogs, no-silent-coercion, query scoping, and secret checks.
- Real `get-document` action invocation against a disposable multi-membership fixture returned the requested local database membership and breadcrumb while separately returning the authorized Builder page-body hydration target.
- Independent technical review passed the initial artifact and every follow-up review fix. On exact final artifact digest `76fcc956bcc796611f5d4b2635d7d7f4256ca54c52c57413dd8b355049dcd10a`, it rechecked the queue serializer alias, Page-viewer mutation gate, source-viewer pump concealment, hidden-source diagnostic redaction, local-file recovery cache isolation, and focused regressions.
- Independent DOM-aware browser QA passed local-only refresh, shared-local, shared-Builder, and switch/refresh stories on browser-tested digest `55cff7ef5ea24dc7de8db3f491b0064cb23299f081d8e58ee9846cfd3d46b61d`; the final action-only authorization refinements preserve that rendered owner/editor path and are covered by the exact access-matrix action regression. It verified exact breadcrumbs, local editability, shared-page read-only behavior, page-scoped copy, `role="status"`, `aria-live="polite"`, and a decorative `aria-hidden="true"` spinner. An earlier screenshot-only Chrome run mistook the app’s explicit compile-time loading shell for a finished blank page; the final run waited for that state and observed no console warnings or errors.

## Content impact declaration

```yaml
content_product_impact:
  lane: contract_repair
  features:
    - content.feature.make-the-workspace-yours
  capabilities:
    - content.object.multi-membership
  record_change: none
  proof:
    - pnpm --filter content test
    - pnpm --filter content typecheck
    - pnpm test:content-product-impact
    - pnpm guards
    - independent browser QA
  rationale: This repairs exact membership context without changing the accepted multi-membership contract.
```

## Review focus

- Does explicit route context fail closed without revealing inaccessible database or Builder provenance?
- Is Builder hydration selected only from a genuine, unambiguous, source-bound Builder membership while remaining separate from the current database frame?
- Do page-owned cache updates reach every context variant without carrying membership-local state across variants?
