### PR TITLE
Cap vitest worker pools with a shared, configurable base config

### DIFF
--- a/.changeset/plenty-jokes-shave.md
+++ b/.changeset/plenty-jokes-shave.md
@@ -1,7 +1,11 @@
 ---
+"@agent-native/creative-context": patch
 "@agent-native/scheduling": patch
+"@agent-native/recap-cli": patch
 "@agent-native/pinpoint": patch
 "@agent-native/dispatch": patch
+"@agent-native/toolkit": patch
+"@agent-native/skills": patch
 "@agent-native/core": minor
 ---
 

--- a/.changeset/plenty-jokes-shave.md
+++ b/.changeset/plenty-jokes-shave.md
@@ -2,9 +2,10 @@
 "@agent-native/scheduling": patch
 "@agent-native/pinpoint": patch
 "@agent-native/dispatch": patch
-"@agent-native/core": patch
+"@agent-native/core": minor
 ---
 
-Cap each vitest suite at a share of the machine through a shared root config so
-concurrent test runs no longer oversubscribe the CPU. Defaults to 25% of cores;
-override with `VITEST_CONCURRENCY`.
+Add `@agent-native/core/vitest-config`, a base vitest config that caps a suite's
+worker pool so concurrent test runs no longer oversubscribe the CPU. Defaults to
+25% of cores; override with `VITEST_CONCURRENCY`. Every template and package
+config merges it in.

--- a/.changeset/plenty-jokes-shave.md
+++ b/.changeset/plenty-jokes-shave.md
@@ -1,0 +1,10 @@
+---
+"@agent-native/scheduling": patch
+"@agent-native/pinpoint": patch
+"@agent-native/dispatch": patch
+"@agent-native/core": patch
+---
+
+Cap each vitest suite at a share of the machine through a shared root config so
+concurrent test runs no longer oversubscribe the CPU. Defaults to 25% of cores;
+override with `VITEST_CONCURRENCY`.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -119,6 +119,28 @@ Run these from the repo root:
 | `pnpm run guards`    | Run all security/consistency guard scripts (see Guards below)          |
 | `pnpm run lint`      | Format check + typecheck                                               |
 
+## Concurrency
+
+Each runner sizes itself off the whole machine, which oversubscribes the CPU
+when several agent sessions or checkouts run checks at once. Every lid has an
+env override:
+
+| Variable                                                | Controls                            | Default                         |
+| ------------------------------------------------------- | ----------------------------------- | ------------------------------- |
+| `VITEST_CONCURRENCY`, `AGENT_NATIVE_VITEST_CONCURRENCY` | Workers per vitest suite            | `25%` of cores                  |
+| `GUARD_CONCURRENCY`, `AGENT_NATIVE_GUARD_CONCURRENCY`   | Guards running in parallel          | `cores / 2`, clamped to 2--6    |
+| `WORKSPACE_CONCURRENCY`, `PNPM_WORKSPACE_CONCURRENCY`   | Packages running a task in parallel | per-profile, derived from cores |
+
+`VITEST_CONCURRENCY` takes a percentage (`25%`) or a worker count (`2`), and is
+applied by `vitest.shared.ts`, which every package's vitest config merges in. A
+package that needs a different value sets `test.maxWorkers` in its own config;
+that wins the merge.
+
+Vitest's own `VITEST_MAX_WORKERS` still works for a one-off integer, but never
+give it a percentage: vitest applies it as `Number.parseInt`, so `25%` becomes
+25 workers rather than a quarter of the machine (vitest#9631). The config
+throws rather than let that through.
+
 ## Guards
 
 The `guards` script (`scripts/run-guards.ts`) runs the fixed list of checks

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -131,10 +131,17 @@ env override:
 | `GUARD_CONCURRENCY`, `AGENT_NATIVE_GUARD_CONCURRENCY`   | Guards running in parallel          | `cores / 2`, clamped to 2--6    |
 | `WORKSPACE_CONCURRENCY`, `PNPM_WORKSPACE_CONCURRENCY`   | Packages running a task in parallel | per-profile, derived from cores |
 
-`VITEST_CONCURRENCY` takes a percentage (`25%`) or a worker count (`2`), and is
-applied by `vitest.shared.ts`, which every package's vitest config merges in. A
-package that needs a different value sets `test.maxWorkers` in its own config;
-that wins the merge.
+`VITEST_CONCURRENCY` takes a percentage (`25%`) or a worker count (`2`). The
+base config every vitest config merges in ships from
+`@agent-native/core/vitest-config`; templates and examples import it by package
+name, and `packages/*` go through the `vitest.shared.ts` re-export at the repo
+root so they need no dependency on core. A package that needs a different value
+sets `test.maxWorkers` in its own config; that wins the merge.
+
+Template configs must import the package path, never the root re-export.
+`agent-native create` extracts a template directory with `--strip-components=1`,
+so anything a template reaches for above its own directory resolves to nothing
+in the scaffolded app.
 
 Vitest's own `VITEST_MAX_WORKERS` still works for a one-off integer, but never
 give it a percentage: vitest applies it as `Number.parseInt`, so `25%` becomes

--- a/examples/chat-antd/vitest.config.ts
+++ b/examples/chat-antd/vitest.config.ts
@@ -1,8 +1,13 @@
 import { resolve } from "node:path";
 
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-export default defineConfig({
-  resolve: { alias: { "@": resolve("./app") } },
-  test: { environment: "happy-dom", passWithNoTests: true },
-});
+import baseConfig from "../../vitest.shared";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: { alias: { "@": resolve("./app") } },
+    test: { environment: "happy-dom", passWithNoTests: true },
+  }),
+);

--- a/examples/chat-antd/vitest.config.ts
+++ b/examples/chat-antd/vitest.config.ts
@@ -1,8 +1,7 @@
 import { resolve } from "node:path";
 
+import baseConfig from "@agent-native/core/vitest-config";
 import { defineConfig, mergeConfig } from "vitest/config";
-
-import baseConfig from "../../vitest.shared";
 
 export default mergeConfig(
   baseConfig,

--- a/examples/chat-mui/vitest.config.ts
+++ b/examples/chat-mui/vitest.config.ts
@@ -1,8 +1,13 @@
 import { resolve } from "node:path";
 
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-export default defineConfig({
-  resolve: { alias: { "@": resolve("./app") } },
-  test: { environment: "happy-dom", passWithNoTests: true },
-});
+import baseConfig from "../../vitest.shared";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: { alias: { "@": resolve("./app") } },
+    test: { environment: "happy-dom", passWithNoTests: true },
+  }),
+);

--- a/examples/chat-mui/vitest.config.ts
+++ b/examples/chat-mui/vitest.config.ts
@@ -1,8 +1,7 @@
 import { resolve } from "node:path";
 
+import baseConfig from "@agent-native/core/vitest-config";
 import { defineConfig, mergeConfig } from "vitest/config";
-
-import baseConfig from "../../vitest.shared";
 
 export default mergeConfig(
   baseConfig,

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "tsx scripts/workspace-run.ts test",
     "test:fast": "tsx scripts/workspace-run.ts test -- --exclude \"**/*.db.test.ts\" --exclude \"**/*.integration.spec.ts\" --exclude \"**/*.integration.test.ts\" --exclude \"**/*.e2e.spec.ts\" --exclude \"**/*.e2e.test.ts\" --exclude \"**/e2e/**\" --exclude \"**/*.live.spec.ts\" --exclude \"**/*.live.test.ts\" --exclude \"**/*.perf.spec.ts\" --exclude \"**/*.perf.test.ts\" --exclude \"**/create-e2e.spec.ts\"",
     "test:content-db": "pnpm --filter content exec vitest --run actions/bind-content-database-source-field.db.test.ts actions/blocks-seeding.db.test.ts actions/builder-source-review-gates.db.test.ts actions/content-database-lifecycle.db.test.ts actions/database-row-batch-actions.db.test.ts actions/list-content-databases.db.test.ts actions/move-document.db.test.ts actions/resync-content-database-source.db.test.ts actions/slack-correction-identity.db.test.ts actions/stage-builder-source-bulk-update.db.test.ts actions/submit-content-database-form.db.test.ts actions/update-document.db.test.ts --config vitest.config.ts",
-    "test:core-integration": "pnpm --filter @agent-native/core exec vitest --run src/agent/engine/translate-ai-sdk.integration.spec.ts src/agent/run-loop-with-resume.integration.spec.ts src/client/extensions/AgentNativeExtensionFrame.e2e.spec.ts src/client/session-replay-iframe.e2e.spec.ts src/scripts/db/migrate-encrypt-credentials.e2e.spec.ts src/scripts/db/scope-isolation.e2e.spec.ts src/server/csrf-plugin-ordering.integration.spec.ts src/server/embedded.integration.spec.ts --maxWorkers=25% --passWithNoTests",
+    "test:core-integration": "pnpm --filter @agent-native/core exec vitest --run src/agent/engine/translate-ai-sdk.integration.spec.ts src/agent/run-loop-with-resume.integration.spec.ts src/client/extensions/AgentNativeExtensionFrame.e2e.spec.ts src/client/session-replay-iframe.e2e.spec.ts src/scripts/db/migrate-encrypt-credentials.e2e.spec.ts src/scripts/db/scope-isolation.e2e.spec.ts src/server/csrf-plugin-ordering.integration.spec.ts src/server/embedded.integration.spec.ts --passWithNoTests",
     "test:plan-e2e": "pnpm --filter plan exec vitest --run actions/create-visual-recap.e2e.spec.ts --passWithNoTests",
     "test:trusted-acceptance": "tsx --test scripts/trusted-acceptance.spec.ts scripts/guard-trusted-acceptance-workflow.spec.ts scripts/trusted-acceptance/*.spec.ts",
     "test:brain-evals": "pnpm --filter brain eval:ci",
@@ -133,6 +133,7 @@
     "prettier": "^3.6.2",
     "tsx": "^4.20.3",
     "typescript-7": "catalog:",
+    "vitest": "catalog:",
     "wrangler": "^4.80.0",
     "yaml": "2.9.0"
   },

--- a/packages/agent-browser-extension/vite.config.ts
+++ b/packages/agent-browser-extension/vite.config.ts
@@ -1,48 +1,53 @@
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
+
+import baseConfig from "../../vitest.shared";
 
 const root = dirname(fileURLToPath(import.meta.url));
 
-export default defineConfig({
-  root,
-  base: "./",
-  publicDir: "public",
-  resolve: {
-    alias: {
-      "@agent-native/browser-control-extension-core": resolve(
-        root,
-        "../browser-control-extension-core/src/index.ts",
-      ),
-      "@agent-native/core/browser-context": resolve(
-        root,
-        "../core/src/browser-context/index.ts",
-      ),
-      "@agent-native/core/integrations/computer-supervision": resolve(
-        root,
-        "../core/src/integrations/computer-supervision.ts",
-      ),
-    },
-  },
-  build: {
-    outDir: "dist",
-    emptyOutDir: true,
-    sourcemap: false,
-    rollupOptions: {
-      input: {
-        background: resolve(root, "src/background.ts"),
-        "capture-page": resolve(root, "src/capture-page.ts"),
-        sidepanel: resolve(root, "src/sidepanel.html"),
-      },
-      output: {
-        entryFileNames: "assets/[name].js",
-        chunkFileNames: "assets/[name].js",
-        assetFileNames: "assets/[name][extname]",
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    root,
+    base: "./",
+    publicDir: "public",
+    resolve: {
+      alias: {
+        "@agent-native/browser-control-extension-core": resolve(
+          root,
+          "../browser-control-extension-core/src/index.ts",
+        ),
+        "@agent-native/core/browser-context": resolve(
+          root,
+          "../core/src/browser-context/index.ts",
+        ),
+        "@agent-native/core/integrations/computer-supervision": resolve(
+          root,
+          "../core/src/integrations/computer-supervision.ts",
+        ),
       },
     },
-  },
-  test: {
-    include: ["src/**/*.spec.ts"],
-  },
-});
+    build: {
+      outDir: "dist",
+      emptyOutDir: true,
+      sourcemap: false,
+      rollupOptions: {
+        input: {
+          background: resolve(root, "src/background.ts"),
+          "capture-page": resolve(root, "src/capture-page.ts"),
+          sidepanel: resolve(root, "src/sidepanel.html"),
+        },
+        output: {
+          entryFileNames: "assets/[name].js",
+          chunkFileNames: "assets/[name].js",
+          assetFileNames: "assets/[name][extname]",
+        },
+      },
+    },
+    test: {
+      include: ["src/**/*.spec.ts"],
+    },
+  }),
+);

--- a/packages/agent-chrome-extension/vite.config.ts
+++ b/packages/agent-chrome-extension/vite.config.ts
@@ -1,32 +1,27 @@
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { defineConfig, mergeConfig } from "vitest/config";
-
-import baseConfig from "../../vitest.shared";
+import { defineConfig } from "vite";
 
 const root = dirname(fileURLToPath(import.meta.url));
 
-export default mergeConfig(
-  baseConfig,
-  defineConfig({
-    root,
-    base: "./",
-    publicDir: "public",
-    build: {
-      outDir: "dist",
-      emptyOutDir: true,
-      sourcemap: true,
-      rollupOptions: {
-        input: {
-          background: resolve(root, "src/background.ts"),
-        },
-        output: {
-          entryFileNames: "assets/[name].js",
-          chunkFileNames: "assets/[name].js",
-          assetFileNames: "assets/[name][extname]",
-        },
+export default defineConfig({
+  root,
+  base: "./",
+  publicDir: "public",
+  build: {
+    outDir: "dist",
+    emptyOutDir: true,
+    sourcemap: true,
+    rollupOptions: {
+      input: {
+        background: resolve(root, "src/background.ts"),
+      },
+      output: {
+        entryFileNames: "assets/[name].js",
+        chunkFileNames: "assets/[name].js",
+        assetFileNames: "assets/[name][extname]",
       },
     },
-  }),
-);
+  },
+});

--- a/packages/agent-chrome-extension/vite.config.ts
+++ b/packages/agent-chrome-extension/vite.config.ts
@@ -1,27 +1,32 @@
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { defineConfig } from "vite";
+import { defineConfig, mergeConfig } from "vitest/config";
+
+import baseConfig from "../../vitest.shared";
 
 const root = dirname(fileURLToPath(import.meta.url));
 
-export default defineConfig({
-  root,
-  base: "./",
-  publicDir: "public",
-  build: {
-    outDir: "dist",
-    emptyOutDir: true,
-    sourcemap: true,
-    rollupOptions: {
-      input: {
-        background: resolve(root, "src/background.ts"),
-      },
-      output: {
-        entryFileNames: "assets/[name].js",
-        chunkFileNames: "assets/[name].js",
-        assetFileNames: "assets/[name][extname]",
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    root,
+    base: "./",
+    publicDir: "public",
+    build: {
+      outDir: "dist",
+      emptyOutDir: true,
+      sourcemap: true,
+      rollupOptions: {
+        input: {
+          background: resolve(root, "src/background.ts"),
+        },
+        output: {
+          entryFileNames: "assets/[name].js",
+          chunkFileNames: "assets/[name].js",
+          assetFileNames: "assets/[name][extname]",
+        },
       },
     },
-  },
-});
+  }),
+);

--- a/packages/agent-chrome-extension/vitest.config.ts
+++ b/packages/agent-chrome-extension/vitest.config.ts
@@ -1,0 +1,9 @@
+import { mergeConfig } from "vitest/config";
+
+import baseConfig from "../../vitest.shared";
+import viteConfig from "./vite.config";
+
+// Kept separate from vite.config.ts so the production config never imports
+// vitest: `agent-native build` loads vite.config.ts in installs where vitest
+// is absent.
+export default mergeConfig(viteConfig, baseConfig);

--- a/packages/browser-control-extension-core/vitest.config.ts
+++ b/packages/browser-control-extension-core/vitest.config.ts
@@ -1,0 +1,3 @@
+import baseConfig from "../../vitest.shared";
+
+export default baseConfig;

--- a/packages/code-agents-ui/vitest.config.ts
+++ b/packages/code-agents-ui/vitest.config.ts
@@ -1,0 +1,3 @@
+import baseConfig from "../../vitest.shared";
+
+export default baseConfig;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,6 +61,7 @@
       "default": "./dist/index.js"
     },
     "./vite": "./dist/vite/index.js",
+    "./vitest-config": "./dist/vitest-config.js",
     "./server": "./dist/server/index.js",
     "./server/edge": "./dist/server/edge.js",
     "./server/entry-server": "./dist/server/entry-server.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -326,7 +326,7 @@
     "build": "tsc && tsc -p tsconfig.cli.json && node scripts/finalize-build.mjs && node scripts/check-dist-imports.mjs",
     "dev": "tsc --watch",
     "typecheck": "tsc --noEmit",
-    "test": "vitest --run --dir src --maxWorkers=25%",
+    "test": "vitest --run --dir src",
     "prepack": "tsx ../../scripts/sync-core-first-party-templates.ts && tsx ../../scripts/sync-workspace-core-skills.ts --check && npm run build && cp ../../README.md ./README.md",
     "postpack": "tsx ../../scripts/sync-core-first-party-templates.ts --clean",
     "prepublishOnly": "npm run build"

--- a/packages/core/src/vitest-config.ts
+++ b/packages/core/src/vitest-config.ts
@@ -1,0 +1,68 @@
+import type { ViteUserConfig } from "vitest/config";
+
+/**
+ * Base vitest config that caps a suite's worker pool at a share of the machine.
+ *
+ * Vitest sizes its pool at `cores - 1` with no awareness of peer processes, so
+ * several suites running at once — concurrent agent sessions, or a workspace
+ * running packages in parallel — each try to claim the whole box. Set
+ * `VITEST_CONCURRENCY` to a percentage or a worker count to change the lid; a
+ * package that needs its own value sets `test.maxWorkers` in its own config,
+ * which wins the merge.
+ *
+ * This ships from core rather than living at the monorepo root because template
+ * directories are scaffolded out verbatim as standalone apps — a config that
+ * reaches above the template would resolve to nothing in the generated app.
+ *
+ * Keep this module free of runtime imports so loading it costs a config file
+ * nothing beyond reading the environment.
+ */
+
+const DEFAULT_MAX_WORKERS = "25%";
+const ENV_KEYS = ["VITEST_CONCURRENCY", "AGENT_NATIVE_VITEST_CONCURRENCY"];
+
+/**
+ * Resolve the worker lid from the environment, throwing on anything that is
+ * neither a percentage nor a worker count. A bad value must not quietly become
+ * the default — that reads as "configured" while running at some other size.
+ */
+export function resolveMaxWorkers(
+  env: NodeJS.ProcessEnv = process.env,
+): string | number {
+  const rawMaxWorkers = env.VITEST_MAX_WORKERS;
+  if (rawMaxWorkers?.includes("%")) {
+    throw new Error(
+      `VITEST_MAX_WORKERS=${rawMaxWorkers} is not a percentage to vitest — it parses as ` +
+        `${Number.parseInt(rawMaxWorkers)} workers. Use VITEST_CONCURRENCY for percentages, ` +
+        `or an integer for VITEST_MAX_WORKERS.`,
+    );
+  }
+
+  const key = ENV_KEYS.find((name) => env[name]);
+  if (!key) return DEFAULT_MAX_WORKERS;
+
+  const value = env[key]!.trim();
+  if (/^\d+%$/.test(value)) {
+    const percent = Number.parseInt(value);
+    if (percent < 1 || percent > 100) {
+      throw new Error(`${key}=${value} is out of range — use 1% to 100%.`);
+    }
+    return value;
+  }
+
+  const count = Number(value);
+  if (!Number.isInteger(count) || count < 1) {
+    throw new Error(
+      `${key}=${value} is not a percentage like "25%" or a worker count like "2".`,
+    );
+  }
+  return count;
+}
+
+const vitestBaseConfig: ViteUserConfig = {
+  test: {
+    maxWorkers: resolveMaxWorkers(),
+  },
+};
+
+export default vitestBaseConfig;

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,3 @@
+import baseConfig from "../../vitest.shared";
+
+export default baseConfig;

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,3 +1,5 @@
-import baseConfig from "../../vitest.shared";
+// Core owns the shared base config, so it reads the source directly rather than
+// going through the monorepo-root re-export.
+import baseConfig from "./src/vitest-config";
 
 export default baseConfig;

--- a/packages/creative-context/vitest.config.ts
+++ b/packages/creative-context/vitest.config.ts
@@ -1,0 +1,3 @@
+import baseConfig from "../../vitest.shared";
+
+export default baseConfig;

--- a/packages/desktop-app/vitest.config.ts
+++ b/packages/desktop-app/vitest.config.ts
@@ -1,11 +1,16 @@
 import { resolve } from "node:path";
 
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      "@shared": resolve(__dirname, "shared"),
+import baseConfig from "../../vitest.shared";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        "@shared": resolve(__dirname, "shared"),
+      },
     },
-  },
-});
+  }),
+);

--- a/packages/dispatch/vitest.config.ts
+++ b/packages/dispatch/vitest.config.ts
@@ -1,11 +1,16 @@
 import path from "node:path";
 
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "src"),
+import baseConfig from "../../vitest.shared";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "src"),
+      },
     },
-  },
-});
+  }),
+);

--- a/packages/docs/vitest.config.ts
+++ b/packages/docs/vitest.config.ts
@@ -1,13 +1,18 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-export default defineConfig({
-  test: {
-    passWithNoTests: true,
-    exclude: [
-      "**/node_modules/**",
-      "**/dist/**",
-      "**/.output/**",
-      "**/.{idea,git,cache,output,temp}/**",
-    ],
-  },
-});
+import baseConfig from "../../vitest.shared";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      passWithNoTests: true,
+      exclude: [
+        "**/node_modules/**",
+        "**/dist/**",
+        "**/.output/**",
+        "**/.{idea,git,cache,output,temp}/**",
+      ],
+    },
+  }),
+);

--- a/packages/embedding/vitest.config.ts
+++ b/packages/embedding/vitest.config.ts
@@ -1,0 +1,3 @@
+import baseConfig from "../../vitest.shared";
+
+export default baseConfig;

--- a/packages/migrate/vitest.config.ts
+++ b/packages/migrate/vitest.config.ts
@@ -1,0 +1,3 @@
+import baseConfig from "../../vitest.shared";
+
+export default baseConfig;

--- a/packages/mobile-app/vitest.config.ts
+++ b/packages/mobile-app/vitest.config.ts
@@ -1,9 +1,14 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      "@": new URL(".", import.meta.url).pathname,
+import baseConfig from "../../vitest.shared";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        "@": new URL(".", import.meta.url).pathname,
+      },
     },
-  },
-});
+  }),
+);

--- a/packages/pinpoint/vitest.config.ts
+++ b/packages/pinpoint/vitest.config.ts
@@ -1,0 +1,3 @@
+import baseConfig from "../../vitest.shared";
+
+export default baseConfig;

--- a/packages/recap-cli/vitest.config.ts
+++ b/packages/recap-cli/vitest.config.ts
@@ -1,0 +1,3 @@
+import baseConfig from "../../vitest.shared";
+
+export default baseConfig;

--- a/packages/scheduling/vitest.config.ts
+++ b/packages/scheduling/vitest.config.ts
@@ -1,0 +1,3 @@
+import baseConfig from "../../vitest.shared";
+
+export default baseConfig;

--- a/packages/skills/vitest.config.ts
+++ b/packages/skills/vitest.config.ts
@@ -1,7 +1,12 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-export default defineConfig({
-  test: {
-    environment: "node",
-  },
-});
+import baseConfig from "../../vitest.shared";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      environment: "node",
+    },
+  }),
+);

--- a/packages/toolkit/vitest.config.ts
+++ b/packages/toolkit/vitest.config.ts
@@ -1,0 +1,3 @@
+import baseConfig from "../../vitest.shared";
+
+export default baseConfig;

--- a/packages/vscode-extension/vitest.config.ts
+++ b/packages/vscode-extension/vitest.config.ts
@@ -1,0 +1,3 @@
+import baseConfig from "../../vitest.shared";
+
+export default baseConfig;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3468,6 +3468,9 @@ importers:
         specifier: 10.62.0
         version: 10.62.0
     devDependencies:
+      '@agent-native/core':
+        specifier: workspace:*
+        version: link:../../../packages/core
       '@types/chrome':
         specifier: ^0.2.0
         version: 0.2.0
@@ -3526,6 +3529,9 @@ importers:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
     devDependencies:
+      '@agent-native/core':
+        specifier: workspace:*
+        version: link:../../../packages/core
       '@tauri-apps/cli':
         specifier: ^2.11.2
         version: 2.11.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       typescript-7:
         specifier: 'catalog:'
         version: typescript@7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(happy-dom@20.11.1)(jsdom@29.1.1(@noble/hashes@2.2.0)(canvas@3.2.3))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
       wrangler:
         specifier: ^4.80.0
         version: 4.81.0
@@ -30483,6 +30486,14 @@ snapshots:
     optionalDependencies:
       vite: 8.1.5(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.23.1)(yaml@2.9.0)
 
+  '@vitest/mocker@4.1.9(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
+
   '@vitest/mocker@4.1.9(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.9
@@ -38528,6 +38539,36 @@ snapshots:
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.23.1)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 26.1.1
+      happy-dom: 20.11.1
+      jsdom: 29.1.1(@noble/hashes@2.2.0)(canvas@3.2.3)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(happy-dom@20.11.1)(jsdom@29.1.1(@noble/hashes@2.2.0)(canvas@3.2.3))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1

--- a/templates/analytics/vitest.config.ts
+++ b/templates/analytics/vitest.config.ts
@@ -1,16 +1,21 @@
 import path from "node:path";
 
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./app"),
-      "@shared": path.resolve(__dirname, "./shared"),
+import baseConfig from "../../vitest.shared";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./app"),
+        "@shared": path.resolve(__dirname, "./shared"),
+      },
     },
-  },
-  test: {
-    include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
-    exclude: ["**/node_modules/**", "**/.git/**", "**/dist/**"],
-  },
-});
+    test: {
+      include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
+      exclude: ["**/node_modules/**", "**/.git/**", "**/dist/**"],
+    },
+  }),
+);

--- a/templates/analytics/vitest.config.ts
+++ b/templates/analytics/vitest.config.ts
@@ -1,8 +1,7 @@
 import path from "node:path";
 
+import baseConfig from "@agent-native/core/vitest-config";
 import { defineConfig, mergeConfig } from "vitest/config";
-
-import baseConfig from "../../vitest.shared";
 
 export default mergeConfig(
   baseConfig,

--- a/templates/assets/vitest.config.ts
+++ b/templates/assets/vitest.config.ts
@@ -1,16 +1,21 @@
 import path from "node:path";
 
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./app"),
-      "@shared": path.resolve(__dirname, "./shared"),
+import baseConfig from "../../vitest.shared";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./app"),
+        "@shared": path.resolve(__dirname, "./shared"),
+      },
     },
-  },
-  test: {
-    include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
-    exclude: ["**/node_modules/**", "**/.git/**", "**/dist/**"],
-  },
-});
+    test: {
+      include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
+      exclude: ["**/node_modules/**", "**/.git/**", "**/dist/**"],
+    },
+  }),
+);

--- a/templates/assets/vitest.config.ts
+++ b/templates/assets/vitest.config.ts
@@ -1,8 +1,7 @@
 import path from "node:path";
 
+import baseConfig from "@agent-native/core/vitest-config";
 import { defineConfig, mergeConfig } from "vitest/config";
-
-import baseConfig from "../../vitest.shared";
 
 export default mergeConfig(
   baseConfig,

--- a/templates/brain/vitest.config.ts
+++ b/templates/brain/vitest.config.ts
@@ -1,13 +1,18 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-export default defineConfig({
-  test: {
-    passWithNoTests: true,
-    exclude: [
-      "**/node_modules/**",
-      "**/dist/**",
-      "**/.output/**",
-      "**/.{idea,git,cache,output,temp}/**",
-    ],
-  },
-});
+import baseConfig from "../../vitest.shared";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      passWithNoTests: true,
+      exclude: [
+        "**/node_modules/**",
+        "**/dist/**",
+        "**/.output/**",
+        "**/.{idea,git,cache,output,temp}/**",
+      ],
+    },
+  }),
+);

--- a/templates/brain/vitest.config.ts
+++ b/templates/brain/vitest.config.ts
@@ -1,6 +1,5 @@
+import baseConfig from "@agent-native/core/vitest-config";
 import { defineConfig, mergeConfig } from "vitest/config";
-
-import baseConfig from "../../vitest.shared";
 
 export default mergeConfig(
   baseConfig,

--- a/templates/calendar/vitest.config.ts
+++ b/templates/calendar/vitest.config.ts
@@ -1,16 +1,21 @@
 import path from "node:path";
 
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./app"),
-      "@shared": path.resolve(__dirname, "./shared"),
+import baseConfig from "../../vitest.shared";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./app"),
+        "@shared": path.resolve(__dirname, "./shared"),
+      },
     },
-  },
-  test: {
-    include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
-    exclude: ["**/node_modules/**", "**/.git/**", "**/dist/**"],
-  },
-});
+    test: {
+      include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
+      exclude: ["**/node_modules/**", "**/.git/**", "**/dist/**"],
+    },
+  }),
+);

--- a/templates/calendar/vitest.config.ts
+++ b/templates/calendar/vitest.config.ts
@@ -1,8 +1,7 @@
 import path from "node:path";
 
+import baseConfig from "@agent-native/core/vitest-config";
 import { defineConfig, mergeConfig } from "vitest/config";
-
-import baseConfig from "../../vitest.shared";
 
 export default mergeConfig(
   baseConfig,

--- a/templates/chat/vite.config.ts
+++ b/templates/chat/vite.config.ts
@@ -1,19 +1,24 @@
 import { agentNative } from "@agent-native/core/vite";
 import { reactRouter } from "@react-router/dev/vite";
-import { defineConfig } from "vite";
+import { defineConfig, mergeConfig } from "vitest/config";
+
+import baseConfig from "../../vitest.shared";
 
 const reactRouterPlugins = reactRouter as unknown as () => any[];
 const agentNativePlugins = agentNative as unknown as (
   options?: Parameters<typeof agentNative>[0],
 ) => any[];
 
-export default defineConfig({
-  plugins: [
-    ...reactRouterPlugins(),
-    ...agentNativePlugins({
-      // shiki only runs in AssistantChat's useEffect — keep it out of the
-      // CF Pages Functions bundle (25 MiB limit).
-      ssrStubs: ["shiki"],
-    }),
-  ],
-});
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    plugins: [
+      ...reactRouterPlugins(),
+      ...agentNativePlugins({
+        // shiki only runs in AssistantChat's useEffect — keep it out of the
+        // CF Pages Functions bundle (25 MiB limit).
+        ssrStubs: ["shiki"],
+      }),
+    ],
+  }),
+);

--- a/templates/chat/vite.config.ts
+++ b/templates/chat/vite.config.ts
@@ -1,23 +1,19 @@
 import { agentNative } from "@agent-native/core/vite";
-import baseConfig from "@agent-native/core/vitest-config";
 import { reactRouter } from "@react-router/dev/vite";
-import { defineConfig, mergeConfig } from "vitest/config";
+import { defineConfig } from "vite";
 
 const reactRouterPlugins = reactRouter as unknown as () => any[];
 const agentNativePlugins = agentNative as unknown as (
   options?: Parameters<typeof agentNative>[0],
 ) => any[];
 
-export default mergeConfig(
-  baseConfig,
-  defineConfig({
-    plugins: [
-      ...reactRouterPlugins(),
-      ...agentNativePlugins({
-        // shiki only runs in AssistantChat's useEffect — keep it out of the
-        // CF Pages Functions bundle (25 MiB limit).
-        ssrStubs: ["shiki"],
-      }),
-    ],
-  }),
-);
+export default defineConfig({
+  plugins: [
+    ...reactRouterPlugins(),
+    ...agentNativePlugins({
+      // shiki only runs in AssistantChat's useEffect — keep it out of the
+      // CF Pages Functions bundle (25 MiB limit).
+      ssrStubs: ["shiki"],
+    }),
+  ],
+});

--- a/templates/chat/vite.config.ts
+++ b/templates/chat/vite.config.ts
@@ -1,8 +1,7 @@
 import { agentNative } from "@agent-native/core/vite";
+import baseConfig from "@agent-native/core/vitest-config";
 import { reactRouter } from "@react-router/dev/vite";
 import { defineConfig, mergeConfig } from "vitest/config";
-
-import baseConfig from "../../vitest.shared";
 
 const reactRouterPlugins = reactRouter as unknown as () => any[];
 const agentNativePlugins = agentNative as unknown as (

--- a/templates/chat/vitest.config.ts
+++ b/templates/chat/vitest.config.ts
@@ -1,0 +1,9 @@
+import baseConfig from "@agent-native/core/vitest-config";
+import { mergeConfig } from "vitest/config";
+
+import viteConfig from "./vite.config";
+
+// Kept separate from vite.config.ts so the production config never imports
+// vitest: `agent-native build` loads vite.config.ts in installs where vitest
+// is absent.
+export default mergeConfig(viteConfig, baseConfig);

--- a/templates/clips/chrome-extension/package.json
+++ b/templates/clips/chrome-extension/package.json
@@ -15,6 +15,7 @@
     "@sentry/browser": "10.62.0"
   },
   "devDependencies": {
+    "@agent-native/core": "workspace:*",
     "@types/chrome": "^0.2.0",
     "tsx": "catalog:",
     "typescript-7": "catalog:",

--- a/templates/clips/chrome-extension/vitest.config.ts
+++ b/templates/clips/chrome-extension/vitest.config.ts
@@ -1,0 +1,9 @@
+import baseConfig from "@agent-native/core/vitest-config";
+import { mergeConfig } from "vitest/config";
+
+import viteConfig from "./vite.config";
+
+// Kept separate from vite.config.ts so the production config never imports
+// vitest: `agent-native build` loads vite.config.ts in installs where vitest
+// is absent.
+export default mergeConfig(viteConfig, baseConfig);

--- a/templates/clips/desktop/package.json
+++ b/templates/clips/desktop/package.json
@@ -33,6 +33,7 @@
     "react-dom": "^19.2.5"
   },
   "devDependencies": {
+    "@agent-native/core": "workspace:*",
     "@tauri-apps/cli": "^2.11.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/templates/clips/desktop/vitest.config.ts
+++ b/templates/clips/desktop/vitest.config.ts
@@ -1,0 +1,9 @@
+import baseConfig from "@agent-native/core/vitest-config";
+import { mergeConfig } from "vitest/config";
+
+import viteConfig from "./vite.config";
+
+// Kept separate from vite.config.ts so the production config never imports
+// vitest: `agent-native build` loads vite.config.ts in installs where vitest
+// is absent.
+export default mergeConfig(viteConfig, baseConfig);

--- a/templates/clips/vitest.config.ts
+++ b/templates/clips/vitest.config.ts
@@ -1,23 +1,28 @@
 import path from "node:path";
 
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./app"),
-      "@shared": path.resolve(__dirname, "./shared"),
+import baseConfig from "../../vitest.shared";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./app"),
+        "@shared": path.resolve(__dirname, "./shared"),
+      },
     },
-  },
-  test: {
-    include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
-    exclude: [
-      "**/node_modules/**",
-      "**/.git/**",
-      "**/dist/**",
-      "**/.output/**",
-      "**/.react-router/**",
-      "**/e2e/**",
-    ],
-  },
-});
+    test: {
+      include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
+      exclude: [
+        "**/node_modules/**",
+        "**/.git/**",
+        "**/dist/**",
+        "**/.output/**",
+        "**/.react-router/**",
+        "**/e2e/**",
+      ],
+    },
+  }),
+);

--- a/templates/clips/vitest.config.ts
+++ b/templates/clips/vitest.config.ts
@@ -1,8 +1,7 @@
 import path from "node:path";
 
+import baseConfig from "@agent-native/core/vitest-config";
 import { defineConfig, mergeConfig } from "vitest/config";
-
-import baseConfig from "../../vitest.shared";
 
 export default mergeConfig(
   baseConfig,

--- a/templates/content/vitest.config.ts
+++ b/templates/content/vitest.config.ts
@@ -1,21 +1,26 @@
 import path from "node:path";
 
 import react from "@vitejs/plugin-react-swc";
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./app"),
-      "@shared": path.resolve(__dirname, "./shared"),
+import baseConfig from "../../vitest.shared";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    plugins: [react()],
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./app"),
+        "@shared": path.resolve(__dirname, "./shared"),
+      },
     },
-  },
-  test: {
-    include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
-    exclude: ["**/node_modules/**", "**/.git/**", "**/dist/**", "**/e2e/**"],
-    hookTimeout: 60_000,
-    testTimeout: 60_000,
-    maxWorkers: "50%",
-  },
-});
+    test: {
+      include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
+      exclude: ["**/node_modules/**", "**/.git/**", "**/dist/**", "**/e2e/**"],
+      hookTimeout: 60_000,
+      testTimeout: 60_000,
+      maxWorkers: "50%",
+    },
+  }),
+);

--- a/templates/content/vitest.config.ts
+++ b/templates/content/vitest.config.ts
@@ -1,9 +1,8 @@
 import path from "node:path";
 
+import baseConfig from "@agent-native/core/vitest-config";
 import react from "@vitejs/plugin-react-swc";
 import { defineConfig, mergeConfig } from "vitest/config";
-
-import baseConfig from "../../vitest.shared";
 
 export default mergeConfig(
   baseConfig,

--- a/templates/crm/vitest.config.ts
+++ b/templates/crm/vitest.config.ts
@@ -1,5 +1,10 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-export default defineConfig({
-  test: { include: ["**/*.test.ts"], environment: "node" },
-});
+import baseConfig from "../../vitest.shared";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: { include: ["**/*.test.ts"], environment: "node" },
+  }),
+);

--- a/templates/crm/vitest.config.ts
+++ b/templates/crm/vitest.config.ts
@@ -1,6 +1,5 @@
+import baseConfig from "@agent-native/core/vitest-config";
 import { defineConfig, mergeConfig } from "vitest/config";
-
-import baseConfig from "../../vitest.shared";
 
 export default mergeConfig(
   baseConfig,

--- a/templates/design/vitest.config.ts
+++ b/templates/design/vitest.config.ts
@@ -1,15 +1,22 @@
 import path from "node:path";
 
-export default {
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./app"),
-      "@shared": path.resolve(__dirname, "./shared"),
+import { defineConfig, mergeConfig } from "vitest/config";
+
+import baseConfig from "../../vitest.shared";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./app"),
+        "@shared": path.resolve(__dirname, "./shared"),
+      },
     },
-  },
-  test: {
-    include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
-    // e2e/ holds Playwright (@playwright/test) specs; run via `pnpm e2e`, not vitest.
-    exclude: ["**/node_modules/**", "**/.git/**", "**/dist/**", "**/e2e/**"],
-  },
-};
+    test: {
+      include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
+      // e2e/ holds Playwright (@playwright/test) specs; run via `pnpm e2e`, not vitest.
+      exclude: ["**/node_modules/**", "**/.git/**", "**/dist/**", "**/e2e/**"],
+    },
+  }),
+);

--- a/templates/design/vitest.config.ts
+++ b/templates/design/vitest.config.ts
@@ -1,8 +1,7 @@
 import path from "node:path";
 
+import baseConfig from "@agent-native/core/vitest-config";
 import { defineConfig, mergeConfig } from "vitest/config";
-
-import baseConfig from "../../vitest.shared";
 
 export default mergeConfig(
   baseConfig,

--- a/templates/dispatch/vitest.config.ts
+++ b/templates/dispatch/vitest.config.ts
@@ -1,13 +1,18 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
+
+import baseConfig from "../../vitest.shared";
 
 /**
  * Minimal node test runner for the Dispatch template's server-side unit
  * tests (currently the identity-SSO redirect-allowlist + claim logic).
  * Scoped to `server/**` so it never tries to bundle the React app.
  */
-export default defineConfig({
-  test: {
-    environment: "node",
-    include: ["server/**/*.spec.ts"],
-  },
-});
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      environment: "node",
+      include: ["server/**/*.spec.ts"],
+    },
+  }),
+);

--- a/templates/dispatch/vitest.config.ts
+++ b/templates/dispatch/vitest.config.ts
@@ -1,6 +1,5 @@
+import baseConfig from "@agent-native/core/vitest-config";
 import { defineConfig, mergeConfig } from "vitest/config";
-
-import baseConfig from "../../vitest.shared";
 
 /**
  * Minimal node test runner for the Dispatch template's server-side unit

--- a/templates/factory/vite.config.ts
+++ b/templates/factory/vite.config.ts
@@ -1,19 +1,24 @@
 import { agentNative } from "@agent-native/core/vite";
 import { reactRouter } from "@react-router/dev/vite";
-import { defineConfig } from "vite";
+import { defineConfig, mergeConfig } from "vitest/config";
+
+import baseConfig from "../../vitest.shared";
 
 const reactRouterPlugins = reactRouter as unknown as () => any[];
 const agentNativePlugins = agentNative as unknown as (
   options?: Parameters<typeof agentNative>[0],
 ) => any[];
 
-export default defineConfig({
-  plugins: [
-    ...reactRouterPlugins(),
-    ...agentNativePlugins({
-      // shiki only runs in AssistantChat's useEffect — keep it out of the
-      // CF Pages Functions bundle (25 MiB limit).
-      ssrStubs: ["shiki"],
-    }),
-  ],
-});
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    plugins: [
+      ...reactRouterPlugins(),
+      ...agentNativePlugins({
+        // shiki only runs in AssistantChat's useEffect — keep it out of the
+        // CF Pages Functions bundle (25 MiB limit).
+        ssrStubs: ["shiki"],
+      }),
+    ],
+  }),
+);

--- a/templates/factory/vite.config.ts
+++ b/templates/factory/vite.config.ts
@@ -1,23 +1,19 @@
 import { agentNative } from "@agent-native/core/vite";
-import baseConfig from "@agent-native/core/vitest-config";
 import { reactRouter } from "@react-router/dev/vite";
-import { defineConfig, mergeConfig } from "vitest/config";
+import { defineConfig } from "vite";
 
 const reactRouterPlugins = reactRouter as unknown as () => any[];
 const agentNativePlugins = agentNative as unknown as (
   options?: Parameters<typeof agentNative>[0],
 ) => any[];
 
-export default mergeConfig(
-  baseConfig,
-  defineConfig({
-    plugins: [
-      ...reactRouterPlugins(),
-      ...agentNativePlugins({
-        // shiki only runs in AssistantChat's useEffect — keep it out of the
-        // CF Pages Functions bundle (25 MiB limit).
-        ssrStubs: ["shiki"],
-      }),
-    ],
-  }),
-);
+export default defineConfig({
+  plugins: [
+    ...reactRouterPlugins(),
+    ...agentNativePlugins({
+      // shiki only runs in AssistantChat's useEffect — keep it out of the
+      // CF Pages Functions bundle (25 MiB limit).
+      ssrStubs: ["shiki"],
+    }),
+  ],
+});

--- a/templates/factory/vite.config.ts
+++ b/templates/factory/vite.config.ts
@@ -1,8 +1,7 @@
 import { agentNative } from "@agent-native/core/vite";
+import baseConfig from "@agent-native/core/vitest-config";
 import { reactRouter } from "@react-router/dev/vite";
 import { defineConfig, mergeConfig } from "vitest/config";
-
-import baseConfig from "../../vitest.shared";
 
 const reactRouterPlugins = reactRouter as unknown as () => any[];
 const agentNativePlugins = agentNative as unknown as (

--- a/templates/factory/vitest.config.ts
+++ b/templates/factory/vitest.config.ts
@@ -1,0 +1,9 @@
+import baseConfig from "@agent-native/core/vitest-config";
+import { mergeConfig } from "vitest/config";
+
+import viteConfig from "./vite.config";
+
+// Kept separate from vite.config.ts so the production config never imports
+// vitest: `agent-native build` loads vite.config.ts in installs where vitest
+// is absent.
+export default mergeConfig(viteConfig, baseConfig);

--- a/templates/forms/vitest.config.ts
+++ b/templates/forms/vitest.config.ts
@@ -1,27 +1,32 @@
 import path from "node:path";
 
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./app"),
-      "@shared": path.resolve(__dirname, "./shared"),
+import baseConfig from "../../vitest.shared";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./app"),
+        "@shared": path.resolve(__dirname, "./shared"),
+      },
     },
-  },
-  test: {
-    // The existing *.spec.ts files in this template are standalone tsx scripts
-    // that call process.exit() directly — they predate vitest and run via tsx.
-    // Exclude them so vitest does not attempt to execute them as test suites.
-    // Remove this exclude entry when those files are migrated to proper vitest tests.
-    include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
-    exclude: [
-      "**/node_modules/**",
-      "**/.git/**",
-      "**/dist/**",
-      "shared/types.public-settings.spec.ts",
-      "server/lib/submission-validation.spec.ts",
-    ],
-    passWithNoTests: true,
-  },
-});
+    test: {
+      // The existing *.spec.ts files in this template are standalone tsx scripts
+      // that call process.exit() directly — they predate vitest and run via tsx.
+      // Exclude them so vitest does not attempt to execute them as test suites.
+      // Remove this exclude entry when those files are migrated to proper vitest tests.
+      include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
+      exclude: [
+        "**/node_modules/**",
+        "**/.git/**",
+        "**/dist/**",
+        "shared/types.public-settings.spec.ts",
+        "server/lib/submission-validation.spec.ts",
+      ],
+      passWithNoTests: true,
+    },
+  }),
+);

--- a/templates/forms/vitest.config.ts
+++ b/templates/forms/vitest.config.ts
@@ -1,8 +1,7 @@
 import path from "node:path";
 
+import baseConfig from "@agent-native/core/vitest-config";
 import { defineConfig, mergeConfig } from "vitest/config";
-
-import baseConfig from "../../vitest.shared";
 
 export default mergeConfig(
   baseConfig,

--- a/templates/macros/vitest.config.ts
+++ b/templates/macros/vitest.config.ts
@@ -1,16 +1,21 @@
 import path from "node:path";
 
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./app"),
-      "@shared": path.resolve(__dirname, "./shared"),
+import baseConfig from "../../vitest.shared";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./app"),
+        "@shared": path.resolve(__dirname, "./shared"),
+      },
     },
-  },
-  test: {
-    include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
-    exclude: ["**/node_modules/**", "**/.git/**", "**/dist/**"],
-  },
-});
+    test: {
+      include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
+      exclude: ["**/node_modules/**", "**/.git/**", "**/dist/**"],
+    },
+  }),
+);

--- a/templates/macros/vitest.config.ts
+++ b/templates/macros/vitest.config.ts
@@ -1,8 +1,7 @@
 import path from "node:path";
 
+import baseConfig from "@agent-native/core/vitest-config";
 import { defineConfig, mergeConfig } from "vitest/config";
-
-import baseConfig from "../../vitest.shared";
 
 export default mergeConfig(
   baseConfig,

--- a/templates/mail/vitest.config.ts
+++ b/templates/mail/vitest.config.ts
@@ -1,16 +1,21 @@
 import path from "node:path";
 
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./app"),
-      "@shared": path.resolve(__dirname, "./shared"),
+import baseConfig from "../../vitest.shared";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./app"),
+        "@shared": path.resolve(__dirname, "./shared"),
+      },
     },
-  },
-  test: {
-    include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
-    exclude: ["**/node_modules/**", "**/.git/**", "**/dist/**"],
-  },
-});
+    test: {
+      include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
+      exclude: ["**/node_modules/**", "**/.git/**", "**/dist/**"],
+    },
+  }),
+);

--- a/templates/mail/vitest.config.ts
+++ b/templates/mail/vitest.config.ts
@@ -1,8 +1,7 @@
 import path from "node:path";
 
+import baseConfig from "@agent-native/core/vitest-config";
 import { defineConfig, mergeConfig } from "vitest/config";
-
-import baseConfig from "../../vitest.shared";
 
 export default mergeConfig(
   baseConfig,

--- a/templates/plan/vitest.config.ts
+++ b/templates/plan/vitest.config.ts
@@ -1,24 +1,29 @@
 import path from "node:path";
 
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./app"),
-      "@shared": path.resolve(__dirname, "./shared"),
+import baseConfig from "../../vitest.shared";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./app"),
+        "@shared": path.resolve(__dirname, "./shared"),
+      },
     },
-  },
-  test: {
-    hookTimeout: 60000,
-    include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
-    exclude: [
-      "**/node_modules/**",
-      "**/.git/**",
-      "**/dist/**",
-      "**/.output/**",
-      "**/.react-router/**",
-      "**/e2e/**",
-    ],
-  },
-});
+    test: {
+      hookTimeout: 60000,
+      include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
+      exclude: [
+        "**/node_modules/**",
+        "**/.git/**",
+        "**/dist/**",
+        "**/.output/**",
+        "**/.react-router/**",
+        "**/e2e/**",
+      ],
+    },
+  }),
+);

--- a/templates/plan/vitest.config.ts
+++ b/templates/plan/vitest.config.ts
@@ -1,8 +1,7 @@
 import path from "node:path";
 
+import baseConfig from "@agent-native/core/vitest-config";
 import { defineConfig, mergeConfig } from "vitest/config";
-
-import baseConfig from "../../vitest.shared";
 
 export default mergeConfig(
   baseConfig,

--- a/templates/slides/vitest.config.ts
+++ b/templates/slides/vitest.config.ts
@@ -1,18 +1,23 @@
 import path from "node:path";
 
 import react from "@vitejs/plugin-react-swc";
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./app"),
-      "@shared": path.resolve(__dirname, "./shared"),
+import baseConfig from "../../vitest.shared";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    plugins: [react()],
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./app"),
+        "@shared": path.resolve(__dirname, "./shared"),
+      },
     },
-  },
-  test: {
-    include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
-    exclude: ["**/node_modules/**", "**/.git/**", "**/dist/**"],
-  },
-});
+    test: {
+      include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
+      exclude: ["**/node_modules/**", "**/.git/**", "**/dist/**"],
+    },
+  }),
+);

--- a/templates/slides/vitest.config.ts
+++ b/templates/slides/vitest.config.ts
@@ -1,9 +1,8 @@
 import path from "node:path";
 
+import baseConfig from "@agent-native/core/vitest-config";
 import react from "@vitejs/plugin-react-swc";
 import { defineConfig, mergeConfig } from "vitest/config";
-
-import baseConfig from "../../vitest.shared";
 
 export default mergeConfig(
   baseConfig,

--- a/templates/tasks/vitest.config.ts
+++ b/templates/tasks/vitest.config.ts
@@ -1,8 +1,7 @@
 import path from "node:path";
 
+import baseConfig from "@agent-native/core/vitest-config";
 import { defineConfig, mergeConfig } from "vitest/config";
-
-import baseConfig from "../../vitest.shared";
 
 export default mergeConfig(
   baseConfig,

--- a/templates/tasks/vitest.config.ts
+++ b/templates/tasks/vitest.config.ts
@@ -1,17 +1,22 @@
 import path from "node:path";
 
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./app"),
-      "@shared": path.resolve(__dirname, "./shared"),
+import baseConfig from "../../vitest.shared";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./app"),
+        "@shared": path.resolve(__dirname, "./shared"),
+      },
     },
-  },
-  test: {
-    include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
-    exclude: ["**/node_modules/**", "**/.git/**", "**/dist/**", "**/e2e/**"],
-    environment: "node",
-  },
-});
+    test: {
+      include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
+      exclude: ["**/node_modules/**", "**/.git/**", "**/dist/**", "**/e2e/**"],
+      environment: "node",
+    },
+  }),
+);

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -1,61 +1,10 @@
-import type { ViteUserConfig } from "vitest/config";
-
 /**
- * Shared base config every package's vitest config merges into.
+ * Monorepo-only re-export of the shared vitest base config.
  *
- * Vitest sizes its pool off the whole machine (cores - 1) with no awareness of
- * peer processes, so several concurrent agent sessions on one box each try to
- * claim all of it. Set `VITEST_CONCURRENCY` to a percentage or a worker count
- * to change the lid; a package that genuinely needs its own value can set
- * `test.maxWorkers` in its own config, which wins the merge.
- *
- * Do not reach for vitest's own `VITEST_MAX_WORKERS` to pass a percentage.
- * Vitest applies it as `Number.parseInt(value)`, so `25%` parses to `25` and
- * silently grants 25 workers instead of a quarter of the machine
- * (vitest#9631). Integers there are fine and still override this file.
- *
- * Exported as a plain object rather than through `defineConfig` so `mergeConfig`
- * sees a concrete type instead of the callable `UserConfigExport` union.
+ * Packages under `packages/` use this path because they must not take a
+ * dependency on core. Templates and examples import
+ * `@agent-native/core/vitest-config` directly instead: a template directory is
+ * scaffolded out verbatim as a standalone app, so a config that reaches above
+ * the template would resolve to nothing once it ships.
  */
-
-const DEFAULT_MAX_WORKERS = "25%";
-const ENV_KEYS = ["VITEST_CONCURRENCY", "AGENT_NATIVE_VITEST_CONCURRENCY"];
-
-function resolveMaxWorkers(): string | number {
-  const rawEnvMaxWorkers = process.env.VITEST_MAX_WORKERS;
-  if (rawEnvMaxWorkers?.includes("%")) {
-    throw new Error(
-      `VITEST_MAX_WORKERS=${rawEnvMaxWorkers} is not a percentage to vitest — it parses as ` +
-        `${Number.parseInt(rawEnvMaxWorkers)} workers. Use VITEST_CONCURRENCY for percentages, ` +
-        `or an integer for VITEST_MAX_WORKERS.`,
-    );
-  }
-
-  const key = ENV_KEYS.find((name) => process.env[name]);
-  if (!key) return DEFAULT_MAX_WORKERS;
-
-  const value = process.env[key]!.trim();
-  if (/^\d+%$/.test(value)) {
-    const percent = Number.parseInt(value);
-    if (percent < 1 || percent > 100) {
-      throw new Error(`${key}=${value} is out of range — use 1% to 100%.`);
-    }
-    return value;
-  }
-
-  const count = Number(value);
-  if (!Number.isInteger(count) || count < 1) {
-    throw new Error(
-      `${key}=${value} is not a percentage like "25%" or a worker count like "2".`,
-    );
-  }
-  return count;
-}
-
-const baseConfig: ViteUserConfig = {
-  test: {
-    maxWorkers: resolveMaxWorkers(),
-  },
-};
-
-export default baseConfig;
+export { default, resolveMaxWorkers } from "./packages/core/src/vitest-config";

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -1,0 +1,61 @@
+import type { ViteUserConfig } from "vitest/config";
+
+/**
+ * Shared base config every package's vitest config merges into.
+ *
+ * Vitest sizes its pool off the whole machine (cores - 1) with no awareness of
+ * peer processes, so several concurrent agent sessions on one box each try to
+ * claim all of it. Set `VITEST_CONCURRENCY` to a percentage or a worker count
+ * to change the lid; a package that genuinely needs its own value can set
+ * `test.maxWorkers` in its own config, which wins the merge.
+ *
+ * Do not reach for vitest's own `VITEST_MAX_WORKERS` to pass a percentage.
+ * Vitest applies it as `Number.parseInt(value)`, so `25%` parses to `25` and
+ * silently grants 25 workers instead of a quarter of the machine
+ * (vitest#9631). Integers there are fine and still override this file.
+ *
+ * Exported as a plain object rather than through `defineConfig` so `mergeConfig`
+ * sees a concrete type instead of the callable `UserConfigExport` union.
+ */
+
+const DEFAULT_MAX_WORKERS = "25%";
+const ENV_KEYS = ["VITEST_CONCURRENCY", "AGENT_NATIVE_VITEST_CONCURRENCY"];
+
+function resolveMaxWorkers(): string | number {
+  const rawEnvMaxWorkers = process.env.VITEST_MAX_WORKERS;
+  if (rawEnvMaxWorkers?.includes("%")) {
+    throw new Error(
+      `VITEST_MAX_WORKERS=${rawEnvMaxWorkers} is not a percentage to vitest — it parses as ` +
+        `${Number.parseInt(rawEnvMaxWorkers)} workers. Use VITEST_CONCURRENCY for percentages, ` +
+        `or an integer for VITEST_MAX_WORKERS.`,
+    );
+  }
+
+  const key = ENV_KEYS.find((name) => process.env[name]);
+  if (!key) return DEFAULT_MAX_WORKERS;
+
+  const value = process.env[key]!.trim();
+  if (/^\d+%$/.test(value)) {
+    const percent = Number.parseInt(value);
+    if (percent < 1 || percent > 100) {
+      throw new Error(`${key}=${value} is out of range — use 1% to 100%.`);
+    }
+    return value;
+  }
+
+  const count = Number(value);
+  if (!Number.isInteger(count) || count < 1) {
+    throw new Error(
+      `${key}=${value} is not a percentage like "25%" or a worker count like "2".`,
+    );
+  }
+  return count;
+}
+
+const baseConfig: ViteUserConfig = {
+  test: {
+    maxWorkers: resolveMaxWorkers(),
+  },
+};
+
+export default baseConfig;


### PR DESCRIPTION
## Problem

No `vitest.config.ts` in the repo sets `maxWorkers`. Vitest sizes its pool at `cores - 1` with no awareness of peer processes, so every suite grabs ~7 workers on an 8-core box. With ~10 concurrent agent sessions the load average sits around 30 and the machine is ~98% busy.

Eleven packages had no vitest config at all; four more only had a `vite.config.ts`. `packages/core` was the one place already capped, via `--maxWorkers=25%` on its `test` script.

## Change

- **`@agent-native/core/vitest-config`** — a new export holding the base config. `test.maxWorkers` defaults to `25%` of cores.
- Every template, example, and package config merges it in via `mergeConfig`, including the eleven packages that got a new config file and the four whose `vite.config.ts` vitest reads directly.
- `VITEST_CONCURRENCY` / `AGENT_NATIVE_VITEST_CONCURRENCY` override it, taking either a percentage (`25%`) or a worker count (`2`). A package needing its own value sets `test.maxWorkers` in its own config, which wins the merge.
- Dropped the now-redundant `--maxWorkers=25%` from `packages/core`'s `test` script and root `test:core-integration`, so the lid has one source.
- Added `vitest` to root devDependencies — without it `vitest/config` is unresolvable from the root directory and Vite externalizes it with a warning on every config load.

### Why the config ships from core

A template directory is the unit that ships — `agent-native create` extracts it with `--strip-components=1`, so nothing above it survives. A base config living at the monorepo root would resolve to nothing in every scaffolded app, and for `chat`/`factory` (whose test config is their `vite.config.ts`) that breaks `dev` and `build`, not just `vitest`.

So templates and examples import the package path, exactly as they already do for `@agent-native/core/vite`. `packages/*` go through a thin `vitest.shared.ts` re-export at the repo root instead, so they take no dependency on core — `guard:toolkit-must-not-import-core` stays satisfied.

Verified by extracting `templates/tasks` the way the CLI does, with nothing above it: resolves `maxWorkers=2`. The same tree with a repo-root import fails to load the config at all.

## The `VITEST_MAX_WORKERS` trap

Vitest's own env var stays usable for a one-off integer and still overrides this config. But a percentage there is worse than rejected — vitest applies it as `Number.parseInt`, so `VITEST_MAX_WORKERS=25%` silently resolves to **25 workers** rather than a quarter of the machine (vitest#9631). The config throws with a pointer to `VITEST_CONCURRENCY` instead of letting that through.

Measured, 8 cores:

| invocation | resolved `maxWorkers` |
| --- | --- |
| `--maxWorkers=25%` | 2 |
| config `maxWorkers: "25%"` | 2 |
| `VITEST_MAX_WORKERS=25%` | 25 |
| `VITEST_MAX_WORKERS=3` | 3 |

## Verification

`templates/tasks`, 8 cores, box under sustained load throughout:

| | resolved `maxWorkers` | peak child processes | result |
| --- | --- | --- | --- |
| before | `undefined` → default `cores-1` = 7 | 10 | 30 files / 146 tests passed |
| after | 2 | 3--4 | 30 files / 146 tests passed |

`maxWorkers` read from the resolved config via `createVitest()` from `vitest/node`; child-process peak sampled at 5 Hz against the vitest PID.

Override handling, confirmed against the resolved config from inside a template:

| env | result |
| --- | --- |
| _(unset)_ | 2 |
| `VITEST_CONCURRENCY=50%` | 4 |
| `VITEST_CONCURRENCY=3` | 3 |
| `AGENT_NATIVE_VITEST_CONCURRENCY=12%` | 1 |
| `VITEST_CONCURRENCY=bogus` / `=0` / `=150%` | throws, naming the variable and value |

Also: `packages/scheduling` (newly configured) passes 9 files / 65 tests; all 41 guards pass; `packages/core` builds clean and emits `dist/vitest-config.js`; `tsc --noEmit` clean on core and on the touched config files in `templates/tasks`, `packages/mobile-app`, `packages/desktop-app`, and both extension packages; oxfmt clean across the tree.

Single-suite wall clock is flat to slightly worse, which is the trade — the point is that ten concurrent suites no longer ask for 70 workers.

## Not included

`scripts/run-guards.ts` and `scripts/workspace-run.ts` still size off the whole box (they already honour `GUARD_CONCURRENCY` and `WORKSPACE_CONCURRENCY`, so no code change was needed). With the vitest lid at 25%, a full `pnpm test` can still run ~4 packages × 2 workers concurrently. `DEVELOPMENT.md` now documents all three knobs in one table.
