### PR TITLE
Better timestamped comments on the video player

### DIFF
--- a/templates/clips/actions/add-comment.ts
+++ b/templates/clips/actions/add-comment.ts
@@ -66,6 +66,10 @@ export default defineAction({
 
     if (!rec) throw new Error(`Recording not found: ${args.recordingId}`);
 
+    // Floor to the nearest second so nearby comments land on the same
+    // timestamp bucket for scrubber grouping and the playback overlay.
+    const videoTimestampMs = Math.floor(args.videoTimestampMs / 1000) * 1000;
+
     await db.insert(schema.recordingComments).values({
       id,
       recordingId: args.recordingId,
@@ -75,7 +79,7 @@ export default defineAction({
       authorEmail,
       authorName: args.authorName ?? null,
       content: args.content,
-      videoTimestampMs: args.videoTimestampMs,
+      videoTimestampMs,
       createdAt: now,
       updatedAt: now,
     });
@@ -83,7 +87,7 @@ export default defineAction({
     await writeAppState("refresh-signal", { ts: Date.now() });
 
     console.log(
-      `Added comment to recording ${args.recordingId} @ ${args.videoTimestampMs}ms (thread: ${threadId})`,
+      `Added comment to recording ${args.recordingId} @ ${videoTimestampMs}ms (thread: ${threadId})`,
     );
 
     return { id, threadId };

--- a/templates/clips/app/components/player/comments-panel.test.tsx
+++ b/templates/clips/app/components/player/comments-panel.test.tsx
@@ -24,6 +24,7 @@ vi.mock("@agent-native/core/client/hooks", () => ({
           ? actionMocks.updateComment
           : actionMocks.otherMutation,
   }),
+  useAvatarUrl: () => null,
 }));
 
 vi.mock("@agent-native/core/client/i18n", () => ({

--- a/templates/clips/app/components/player/comments-panel.tsx
+++ b/templates/clips/app/components/player/comments-panel.tsx
@@ -1,4 +1,7 @@
-import { useActionMutation } from "@agent-native/core/client/hooks";
+import {
+  useActionMutation,
+  useAvatarUrl,
+} from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import {
   IconSend,
@@ -12,7 +15,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { type Ref, useEffect, useMemo, useRef, useState } from "react";
 
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -860,10 +863,14 @@ function CommentCard({
   }
 
   const commentContent = linkifyCommentContent(comment.content);
+  const avatarUrl = useAvatarUrl(comment.authorEmail);
 
   return (
     <div className={cn("flex gap-2", comment.resolved && "opacity-60")}>
       <Avatar className="h-7 w-7 shrink-0">
+        {avatarUrl ? (
+          <AvatarImage src={avatarUrl} alt={displayName(comment)} />
+        ) : null}
         <AvatarFallback className="text-[10px] bg-primary text-primary-foreground">
           {initials(displayName(comment))}
         </AvatarFallback>

--- a/templates/clips/app/components/player/playback-comment-overlay.test.tsx
+++ b/templates/clips/app/components/player/playback-comment-overlay.test.tsx
@@ -15,6 +15,10 @@ import {
   type PlaybackComment,
 } from "./playback-comment-overlay";
 
+vi.mock("@agent-native/core/client/hooks", () => ({
+  useAvatarUrl: () => null,
+}));
+
 const comment: PlaybackComment = {
   id: "comment-1",
   authorEmail: "madison@example.com",
@@ -26,7 +30,7 @@ const comment: PlaybackComment = {
 };
 
 describe("playback comment timing", () => {
-  it("shows a root comment from its timestamp for four seconds", () => {
+  it("shows a root comment from its timestamp for one second", () => {
     expect(getActivePlaybackComments([comment], 11_999)).toEqual([]);
     expect(getActivePlaybackComments([comment], 12_000)).toEqual([comment]);
     expect(
@@ -44,11 +48,11 @@ describe("playback comment timing", () => {
   });
 
   it("scales the media-time window with playback speed", () => {
-    expect(getPlaybackCommentVisibleMs(2.5)).toBe(10_000);
-    expect(getActivePlaybackComments([comment], 12_000 + 9_999, 2.5)).toEqual([
+    expect(getPlaybackCommentVisibleMs(2.5)).toBe(2_500);
+    expect(getActivePlaybackComments([comment], 12_000 + 2_499, 2.5)).toEqual([
       comment,
     ]);
-    expect(getActivePlaybackComments([comment], 12_000 + 10_000, 2.5)).toEqual(
+    expect(getActivePlaybackComments([comment], 12_000 + 2_500, 2.5)).toEqual(
       [],
     );
   });
@@ -74,7 +78,7 @@ describe("PlaybackCommentOverlay", () => {
 
     act(() => {
       root.render(
-        <PlaybackCommentOverlay comments={[comment]} currentMs={13_000} />,
+        <PlaybackCommentOverlay comments={[comment]} currentMs={12_500} />,
       );
     });
 

--- a/templates/clips/app/components/player/playback-comment-overlay.tsx
+++ b/templates/clips/app/components/player/playback-comment-overlay.tsx
@@ -1,4 +1,9 @@
-export const PLAYBACK_COMMENT_VISIBLE_MS = 4_000;
+import { useAvatarUrl } from "@agent-native/core/client/hooks";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { cn } from "@/lib/utils";
+
+export const PLAYBACK_COMMENT_VISIBLE_MS = 1_000;
 
 export function getPlaybackCommentVisibleMs(playbackRate = 1): number {
   const safePlaybackRate =
@@ -50,17 +55,24 @@ export function PlaybackCommentOverlay({
   comments,
   currentMs,
   playbackRate = 1,
+  onClick,
 }: {
   comments: PlaybackComment[] | undefined;
   currentMs: number;
   playbackRate?: number;
+  onClick?: () => void;
 }) {
   const activeComments = getActivePlaybackComments(
     comments,
     currentMs,
     playbackRate,
   );
+  const avatarUrl = useAvatarUrl(activeComments[0]?.authorEmail);
   if (activeComments.length === 0) return null;
+
+  const [comment, ...rest] = activeComments;
+  const author = displayAuthor(comment);
+  const Card = (onClick ? "button" : "div") as "button" | "div";
 
   return (
     <div
@@ -68,32 +80,37 @@ export function PlaybackCommentOverlay({
       className="pointer-events-none absolute inset-x-3 bottom-[5.25rem] z-20 flex justify-center sm:inset-x-6"
       aria-live="polite"
     >
-      <div className="flex w-full max-w-xl flex-col items-center gap-2">
-        {activeComments.map((comment) => {
-          const author = displayAuthor(comment);
-          return (
-            <div
-              key={comment.id}
-              className="animate-in fade-in slide-in-from-bottom-2 flex max-w-full items-start gap-2.5 rounded-xl bg-black/85 px-3 py-2.5 text-white shadow-2xl ring-1 ring-white/15 backdrop-blur-md duration-200"
-            >
-              <span
-                aria-hidden="true"
-                className="flex size-7 shrink-0 items-center justify-center rounded-full bg-white/15 text-[10px] font-semibold text-white"
-              >
-                {initials(author)}
-              </span>
-              <div className="min-w-0">
-                <p className="truncate text-xs font-semibold text-white/80">
-                  {author}
-                </p>
-                <p className="line-clamp-3 break-words text-sm leading-5 text-white">
-                  {comment.content}
-                </p>
-              </div>
-            </div>
-          );
-        })}
-      </div>
+      <Card
+        key={comment.id}
+        type={onClick ? "button" : undefined}
+        onClick={onClick}
+        className={cn(
+          "animate-in fade-in slide-in-from-bottom-2 flex w-full max-w-xl flex-col gap-1.5 rounded-xl bg-black/85 px-3 py-2.5 text-left text-white shadow-2xl ring-1 ring-white/15 backdrop-blur-md duration-200",
+          onClick && "pointer-events-auto cursor-pointer hover:bg-black/95",
+        )}
+      >
+        <div className="flex max-w-full items-start gap-2.5">
+          <Avatar aria-hidden="true" className="size-7 shrink-0">
+            {avatarUrl ? <AvatarImage src={avatarUrl} alt={author} /> : null}
+            <AvatarFallback className="bg-white/15 text-[10px] font-semibold text-white">
+              {initials(author)}
+            </AvatarFallback>
+          </Avatar>
+          <div className="min-w-0">
+            <p className="truncate text-xs font-semibold text-white/80">
+              {author}
+            </p>
+            <p className="line-clamp-3 break-words text-sm leading-5 text-white">
+              {comment.content}
+            </p>
+          </div>
+        </div>
+        {rest.length > 0 && (
+          <p className="pl-[2.375rem] text-xs text-white/60">
+            +{rest.length} other comment{rest.length > 1 ? "s" : ""}
+          </p>
+        )}
+      </Card>
     </div>
   );
 }

--- a/templates/clips/app/components/player/scrubber.tsx
+++ b/templates/clips/app/components/player/scrubber.tsx
@@ -1,3 +1,4 @@
+import { IconMessage2Filled } from "@tabler/icons-react";
 import { useMemo, useRef, useState } from "react";
 
 import { cn } from "@/lib/utils";
@@ -225,10 +226,17 @@ export function Scrubber(props: ScrubberProps) {
               e.stopPropagation();
               onSeek(ms);
             }}
-            className="absolute -top-1 -translate-x-1/2 h-3.5 w-3.5 rounded-full bg-yellow-400 border-2 border-black/50 hover:scale-125 transition-transform"
+            className="absolute top-1/2 -translate-x-1/2 -translate-y-1/2 flex h-4 w-4 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-md ring-2 ring-background transition-transform hover:scale-125"
             style={{ left: (ms / Math.max(1, durationMs)) * 100 + "%" }}
             aria-label={`${list.length} comment${list.length > 1 ? "s" : ""}`}
-          />
+          >
+            <IconMessage2Filled className="h-2.5 w-2.5" />
+            {list.length > 1 && (
+              <span className="absolute -top-1.5 -right-1.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-primary px-0.5 text-[8px] font-bold leading-none text-primary-foreground ring-2 ring-background">
+                {list.length}
+              </span>
+            )}
+          </button>
         ))}
 
         {/* Reaction dots */}

--- a/templates/clips/app/components/player/video-player.test.tsx
+++ b/templates/clips/app/components/player/video-player.test.tsx
@@ -29,6 +29,11 @@ vi.mock("@agent-native/core/client/api-path", () => ({
   appBasePath: () => "",
 }));
 
+vi.mock("@agent-native/core/client/hooks", () => ({
+  // Pulled in transitively by PlaybackCommentOverlay's avatar lookup.
+  useAvatarUrl: () => null,
+}));
+
 vi.mock("@agent-native/core/client/i18n", () => ({
   useT: () => (key: string) => key,
 }));

--- a/templates/clips/app/components/player/video-player.tsx
+++ b/templates/clips/app/components/player/video-player.tsx
@@ -218,6 +218,8 @@ export interface VideoPlayerProps {
    * lifecycle instead of polling an imperative-handle getter.
    */
   onVideoElementChange?: (video: HTMLVideoElement | null) => void;
+  /** Called when the viewer clicks the timestamped-comment overlay. */
+  onCommentClick?: () => void;
 }
 
 export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
@@ -255,6 +257,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       recordingId,
       role,
       onVideoElementChange,
+      onCommentClick,
     } = props;
 
     const resolvedVideoSrc = useMemo(
@@ -1651,6 +1654,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
             comments={comments}
             currentMs={currentMs}
             playbackRate={speed}
+            onClick={onCommentClick}
           />
         ) : null}
 

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -261,15 +261,26 @@ export default function RecordingPage() {
   // The compact layout stacks the panel below the video, so switching tabs
   // alone leaves the user looking at the player. Desktop always renders the
   // side aside, so nothing to scroll there.
-  const openInsightsPanel = useCallback(() => {
-    setPanel("insights");
-    if (!isCompactLayout) return;
-    requestAnimationFrame(() => {
-      document
-        .getElementById("clip-activity-panel")
-        ?.scrollIntoView({ block: "start" });
-    });
-  }, [isCompactLayout]);
+  const openSidePanel = useCallback(
+    (next: SidePanel) => {
+      setPanel(next);
+      if (!isCompactLayout) return;
+      requestAnimationFrame(() => {
+        document
+          .getElementById("clip-activity-panel")
+          ?.scrollIntoView({ block: "start" });
+      });
+    },
+    [isCompactLayout],
+  );
+  const openInsightsPanel = useCallback(
+    () => openSidePanel("insights"),
+    [openSidePanel],
+  );
+  const openCommentsPanel = useCallback(
+    () => openSidePanel("comments"),
+    [openSidePanel],
+  );
   const transcriptKickedRef = useRef<string | null>(null);
   // When the recording lands in the processing state but never flips to
   // 'ready', stop spinning forever and surface an error banner so the user
@@ -1608,6 +1619,7 @@ export default function RecordingPage() {
                   cta={firstCta}
                   onCtaClick={() => tracking.reportCtaClick()}
                   onTimeUpdate={(ms) => setCurrentMs(ms)}
+                  onCommentClick={openCommentsPanel}
                   className="h-full w-full rounded-none sm:rounded-xl"
                 />
                 {commentOpen ? (
@@ -1667,12 +1679,7 @@ export default function RecordingPage() {
                       className="shrink-0"
                       onOpen={() => {
                         if (isCompactLayout) {
-                          setPanel("comments");
-                          requestAnimationFrame(() => {
-                            document
-                              .getElementById("clip-activity-panel")
-                              ?.scrollIntoView({ block: "start" });
-                          });
+                          openCommentsPanel();
                           return;
                         }
                         setCommentAtMs(resolvePlaybackMs());

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -997,6 +997,7 @@ export default function ShareRoute() {
               cta={firstCta}
               onCtaClick={() => tracking.reportCtaClick()}
               onTimeUpdate={(ms) => setCurrentMs(ms)}
+              onCommentClick={() => setPanel("comments")}
               className="h-full w-full rounded-none sm:rounded-xl"
             />
           </div>


### PR DESCRIPTION
This PR improves how comments show up while watching a Clips recording: a cleaner popup over the video, better markers on the scrubber, and real avatar photos instead of initials.

## What changed

**Playback comment popup.** When playback passes a comment's timestamp, we show a single comment card for one second instead of stacking every comment on screen. If more than one comment lands in that moment, the card shows "+N other comments" instead of listing them all.

**Click to open the full thread.** Clicking that popup now opens the Activity/Comments tab on the side, so you can see the whole conversation and reply. This works on both the recording page and the public share page.

**Redesigned scrubber markers.** The yellow dot on the video scrubber is replaced with a small comment-bubble icon that matches the app's own colors. When multiple comments share a timestamp, a small count badge appears on the icon.

**Consistent comment grouping.** New comments now save with their timestamp rounded down to the nearest second. This keeps comments left around the same moment grouped together instead of scattering across near-identical timestamps.

**Real avatars.** Both the playback popup and the Activity tab now show the commenter's actual avatar photo when they have one, falling back to their initials otherwise.

<img width="1512" height="779" alt="image" src="https://github.com/user-attachments/assets/097ab34e-2860-423d-899f-c44792f12d13" />
