### PR TITLE
Make "Restart recording" actually restart

### DIFF
--- a/templates/clips/.agents/skills/recording/SKILL.md
+++ b/templates/clips/.agents/skills/recording/SKILL.md
@@ -189,6 +189,51 @@ When mode is `screen+camera`, "the bubble" is two different things:
 
 Because that draw loop runs continuously for the whole recording, keep its CPU/GPU cost bounded: a Worker-based timer drives the draw loop at the capture frame rate (`SCREEN_CAPTURE_FRAME_RATE`, 24fps — falling back to `requestAnimationFrame` only if Worker creation fails, e.g. under a strict CSP), the canvas is hard-capped to 1080p-class dimensions (1920px on its longest edge) even if the source display track is Retina/4K, and the bubble's drop shadow is pre-rendered into a small cached sprite (keyed by bubble size) instead of re-blurring with `shadowBlur` every frame.
 
+## Restart (desktop)
+
+Restart throws the current take away and immediately starts another one. It
+must never re-acquire the screen: the toolbar click reaches the popover through
+async Tauri IPC, which carries no user activation, so a second `getDisplayMedia`
+would throw. Instead the dying session hands its live display and mic streams to
+the replacement — `RecorderHandle.discardForRestart()` returns a `RestartHandoff`
+that `startRecording` accepts as `preAcquiredDisplayStream` /
+`preAcquiredAudioStream`.
+
+Ownership is the opposite of the camera's. The popover owns the camera stream for
+the whole session and re-hands it unchanged, so restart must not bump
+`bubbleSessionEpoch` or clear `bubbleStreamTransferredToRecorder`. The handed-off
+display and mic streams belong to the **recorder**, so the new session stops them
+on its own stop/cancel, and whoever asked for the restart must stop them if the
+new session never comes up.
+
+`cancel()` and `discardForRestart()` share one `discardTake(forRestart)` per
+backend, and the difference is which teardown they run. Cancel ends the
+*session*: `hide_overlays` (which destroys the camera bubble window too) and
+`clearRecordingState()`. A restart ends only the *take*, so it uses
+`hide_recording_chrome`, which spares the bubble, and leaves the recording state
+active.
+
+Native full-screen backends re-acquire capture in Rust and hand off nothing.
+`resolveRestartHandoff` vets the inherited streams before anything is acquired,
+and it treats the two kinds of capture differently: an ended display share is
+fatal and fails with `RESTART_CAPTURE_ENDED_MESSAGE`, because re-acquiring it
+would surface an activation error that names the wrong cause, while an ended
+microphone is just dropped and re-acquired normally. A restart also has to wait
+for the old take's `transcriptionCapture.cancel()` — the engine is process-global
+(`audio_transcription_stop` / `native_speech_stop`), so a late cancel would stop
+the replacement's engine. And `stop()` after a discard must throw rather than
+answer with the discarded take's id, or an aborted recording gets published as a
+finished one. The
+recording-flow latches (`recordingFlowGateRef`, `recordingFlowActive`,
+`clipsForceAlive`, `set_recording_state`) stay held across the restart; releasing
+them the way cancel does lets the popover blur auto-hide fire mid-restart.
+
+Holding those latches has a catch. The `show_toolbar` effect is keyed on
+`isRecording || recordingFlowActive`, so it does not re-run when the flow never
+leaves — but the discard already closed the toolbar window. Restart therefore
+bumps `recordingChromeEpoch` to rebuild it. The countdown needs no such nudge;
+the recorder recreates it on every start.
+
 ## Error recovery
 
 | Failure                       | Handling                                                                  |

--- a/templates/clips/.agents/skills/recording/SKILL.md
+++ b/templates/clips/.agents/skills/recording/SKILL.md
@@ -213,6 +213,14 @@ backend, and the difference is which teardown they run. Cancel ends the
 `hide_recording_chrome`, which spares the bubble, and leaves the recording state
 active.
 
+Stop, cancel and restart are mutually exclusive terminal transitions, so each
+gets its own promise slot — never reuse `cancelPromise` for a discard, or a
+cancel arriving mid-restart returns the take-level teardown and the session
+never ends. A cancel that lands after a discard still owes the session half,
+plus stopping the capture the retake never took ownership of. On the app side
+`restartInFlightRef` latches synchronously so stop and cancel events cannot act
+on the recorder a restart is already tearing down.
+
 Native full-screen backends re-acquire capture in Rust and hand off nothing.
 `resolveRestartHandoff` vets the inherited streams before anything is acquired,
 and it treats the two kinds of capture differently: an ended display share is

--- a/templates/clips/changelog/2026-08-03-restart-during-a-recording-now-immediately-starts-a-fresh-ta.md
+++ b/templates/clips/changelog/2026-08-03-restart-during-a-recording-now-immediately-starts-a-fresh-ta.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-03
+---
+
+Restart during a recording now immediately starts a fresh take instead of cancelling.

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -90,6 +90,7 @@ import {
   type PendingBrowserRecordingUpload,
   type RecorderHandle,
   type RecorderStopResult,
+  type RestartHandoff,
 } from "./lib/recorder";
 import {
   copyRecordingShareLink,
@@ -375,6 +376,12 @@ const DEFAULT_URL = import.meta.env.DEV
 function normalizeCaptureSource(value: string): CaptureSource {
   if (value === "region" && isMacPlatform()) return "region";
   return value === "window" ? "window" : "full-screen";
+}
+
+function stopRestartHandoff(handoff: RestartHandoff): void {
+  [handoff.displayStream, handoff.audioStream].forEach((stream) =>
+    stream?.getTracks().forEach((track) => track.stop()),
+  );
 }
 
 type FetchInput = Parameters<typeof fetch>[0];
@@ -1039,6 +1046,12 @@ export function App() {
     refreshHomeScreenMemoryStatus,
   ]);
   const recordShortcutHandlerRef = useRef<() => void>(() => {});
+  const handleStartRecordingRef = useRef<
+    (options?: {
+      ignoreActiveRecorder?: boolean;
+      resumeCapture?: RestartHandoff;
+    }) => Promise<RecorderHandle | null>
+  >(async () => null);
   // Mirrors `bubbleActive` (assigned below once it is computed) so device
   // probes can synchronously tell whether the camera bubble owns the grant.
   const bubbleActiveRef = useRef(false);
@@ -2197,6 +2210,11 @@ export function App() {
   // bubble effect re-acquires even if bubbleActive/cameraId are unchanged
   // (post-stop reopen with a blank "Default Camera" preview).
   const [bubbleSessionEpoch, setBubbleSessionEpoch] = useState(0);
+  // Bumped when a session tears the recording chrome down without leaving the
+  // recording flow, which only a restart does. `toolbarActive` stays true
+  // across that handoff, so without an epoch the toolbar effect never re-runs
+  // and the closed toolbar window is never rebuilt.
+  const [recordingChromeEpoch, setRecordingChromeEpoch] = useState(0);
   const wantsCamera = mode !== "screen" && cameraOn;
   const nativeFullscreenRecordingActive =
     mode !== "camera" && shouldUseNativeFullscreenRecording(source);
@@ -2252,7 +2270,7 @@ export function App() {
         }).catch(() => {});
       }
     };
-  }, [toolbarActive]);
+  }, [toolbarActive, recordingChromeEpoch]);
 
   useEffect(() => {
     if (!bubbleActive) return;
@@ -2759,7 +2777,9 @@ export function App() {
 
   async function handleStartRecording(options?: {
     ignoreActiveRecorder?: boolean;
-  }) {
+    /** Live capture inherited from the take a restart is replacing. */
+    resumeCapture?: RestartHandoff;
+  }): Promise<RecorderHandle | null> {
     if (recorder && !options?.ignoreActiveRecorder) {
       console.warn(
         "[clips-popover] handleStartRecording ignored — recorder already active",
@@ -2767,7 +2787,7 @@ export function App() {
       setRecError(
         "Still finishing the last recording. Wait a moment, then try again.",
       );
-      return;
+      return null;
     }
     const bubbleTracks = bubbleStreamRef.current?.getTracks() ?? [];
     const bubbleStreamDead =
@@ -2782,11 +2802,11 @@ export function App() {
     if (localRecordingMode === "off") {
       if (videoStorageStatus === "checking") {
         setRecError("Checking video storage. Try again in a moment.");
-        return;
+        return null;
       }
       if (videoStorageStatus === "missing") {
         openVideoStorageSetup();
-        return;
+        return null;
       }
     }
     setRecError(null);
@@ -2810,12 +2830,12 @@ export function App() {
           setReadinessOpen(true);
           setRecError(MACOS_SCREEN_PERMISSION_MESSAGE);
           openPrivacySettings("screen");
-          return;
+          return null;
         }
       } catch (err) {
         setReadinessOpen(true);
         setRecError(err instanceof Error ? err.message : String(err));
-        return;
+        return null;
       }
     }
 
@@ -2901,6 +2921,8 @@ export function App() {
         systemAudioOn,
         localRecordingMode,
         preAcquiredCameraStream,
+        preAcquiredDisplayStream: options?.resumeCapture?.displayStream ?? null,
+        preAcquiredAudioStream: options?.resumeCapture?.audioStream ?? null,
       });
       // macOS: park the popover to its 2×2 pinhole IMMEDIATELY so it
       // doesn't appear in the screen picker window list. The native
@@ -2967,7 +2989,7 @@ export function App() {
 
     if (handle) {
       setRecorder(handle);
-      return;
+      return handle;
     }
 
     // Failure path — the recorder never came up. Side-effects (recording
@@ -2988,13 +3010,13 @@ export function App() {
       errName === "AbortError" ||
       /was cancelled|dismissed|region selection cancelled/i.test(message)
     ) {
-      return;
+      return null;
     }
     if (
       errName === "NotAllowedError" &&
       !isHardCapturePermissionError(message)
     ) {
-      return;
+      return null;
     }
     if (isHardCapturePermissionError(message)) {
       // If an update has finished downloading and is waiting to install, the
@@ -3009,15 +3031,21 @@ export function App() {
             ? MACOS_CAPTURE_PERMISSION_MESSAGE
             : DESKTOP_CAPTURE_PERMISSION_MESSAGE,
       );
-      return;
+      return null;
     }
     if (isStorageSetupFailureMessage(message)) {
       setRecError(STORAGE_SETUP_HELP_TEXT);
       openVideoStorageSetup();
-      return;
+      return null;
     }
     setRecError(message);
+    return null;
   }
+
+  // The restart listener lives in an effect keyed on `recorder`; calling the
+  // start flow through this ref keeps that dependency list from having to
+  // include a function that is recreated every render.
+  handleStartRecordingRef.current = handleStartRecording;
 
   recordShortcutHandlerRef.current = () => {
     if (recorder) {
@@ -3206,27 +3234,39 @@ export function App() {
     );
     track(
       listen("clips:recorder-restart", async () => {
+        if (recordingStopFinalizingRef.current) return;
+        let handoff: RestartHandoff;
         try {
-          await recorder.cancel();
-        } finally {
-          if (!cancelled) {
-            (
-              window as unknown as { clipsForceAlive?: boolean }
-            ).clipsForceAlive = false;
-            bubbleStreamTransferredToRecorder.current = false;
-            bubbleStreamRef.current = null;
-            recordingFlowGateRef.current = false;
-            setRecorder(null);
-            setRecordingFlowActive(false);
-            setBubbleSessionEpoch((epoch) => epoch + 1);
-            invoke("set_recording_state", { active: false }).catch(() => {});
-            // Starting a new browser capture must come from a fresh click in
-            // this webview. The toolbar click arrives here through async Tauri
-            // IPC, so reopen the popover and let the next Start click provide
-            // the required user activation.
-            invoke("show_popover").catch(() => {});
-          }
+          handoff = await recorder.discardForRestart();
+        } catch (err) {
+          console.error("[clips-popover] restart discard failed:", err);
+          setRecError(err instanceof Error ? err.message : String(err));
+          return;
         }
+        if (cancelled) {
+          stopRestartHandoff(handoff);
+          return;
+        }
+        // The recording flow stays latched across the restart. Releasing
+        // `clipsForceAlive` / `recordingFlowGateRef` / `recordingFlowActive` /
+        // `set_recording_state` the way cancel does would let the popover's
+        // blur auto-hide fire and flicker the pill between the two takes. The
+        // camera also stays owned by the popover, so the bubble session epoch
+        // is deliberately not bumped and the stream is re-handed unchanged.
+        //
+        // The discard did close the countdown and toolbar windows. The recorder
+        // rebuilds the countdown on every start, but the toolbar is owned by an
+        // effect keyed on the flow latches we just kept held — so it has to be
+        // told the chrome is gone.
+        setRecordingChromeEpoch((epoch) => epoch + 1);
+        setRecorder(null);
+        const restarted = await handleStartRecordingRef.current({
+          ignoreActiveRecorder: true,
+          resumeCapture: handoff,
+        });
+        // The new session owns the handed-off capture only once it exists.
+        // Without this the screen would stay captured with nothing recording.
+        if (!restarted) stopRestartHandoff(handoff);
       }),
     );
     return () => {

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -2227,6 +2227,10 @@ export function App() {
   // fresh camera session can recover immediately. Keep that post-stop phase
   // separate so React cleanup does not close the finalizing progress window.
   const recordingStopFinalizingRef = useRef(false);
+  // Held from the restart click until the replacement recorder is up (or has
+  // failed). Stop and cancel are terminal transitions on the recorder a
+  // restart is already tearing down, so they must not run against it.
+  const restartInFlightRef = useRef(false);
   const recordingInFlight = isRecording || recordingFlowActive;
   useLayoutEffect(() => {
     recordingFlowGateRef.current = recordingInFlight;
@@ -3152,6 +3156,7 @@ export function App() {
     };
     track(
       listen("clips:recorder-stop", async () => {
+        if (restartInFlightRef.current) return;
         // Detach the React Start/bubble gate immediately. The recorder keeps
         // Rust `is_recording_active` and the finalizing overlay guarded until
         // its durable backup/finalize boundary; keeping this React handle set
@@ -3213,6 +3218,7 @@ export function App() {
     );
     track(
       listen("clips:recorder-cancel", async () => {
+        if (restartInFlightRef.current) return;
         try {
           await recorder.cancel();
         } finally {
@@ -3235,38 +3241,43 @@ export function App() {
     track(
       listen("clips:recorder-restart", async () => {
         if (recordingStopFinalizingRef.current) return;
-        let handoff: RestartHandoff;
+        // Latched synchronously: a restart is a terminal transition on this
+        // recorder, and stop/cancel must not act on it while the replacement
+        // is being brought up.
+        if (restartInFlightRef.current) return;
+        restartInFlightRef.current = true;
+        let handoff: RestartHandoff | null = null;
         try {
           handoff = await recorder.discardForRestart();
+          if (cancelled) return;
+          // The recording flow stays latched across the restart. Releasing
+          // `clipsForceAlive` / `recordingFlowGateRef` / `recordingFlowActive`
+          // / `set_recording_state` the way cancel does would let the popover's
+          // blur auto-hide fire and flicker the pill between the two takes. The
+          // camera also stays owned by the popover, so the bubble session epoch
+          // is deliberately not bumped and the stream is re-handed unchanged.
+          //
+          // The discard did close the countdown and toolbar windows. The
+          // recorder rebuilds the countdown on every start, but the toolbar is
+          // owned by an effect keyed on the flow latches we just kept held — so
+          // it has to be told the chrome is gone.
+          setRecordingChromeEpoch((epoch) => epoch + 1);
+          setRecorder(null);
+          const restarted = await handleStartRecordingRef.current({
+            ignoreActiveRecorder: true,
+            resumeCapture: handoff,
+          });
+          // The new session owns the handed-off capture only once it exists.
+          if (restarted) handoff = null;
         } catch (err) {
-          console.error("[clips-popover] restart discard failed:", err);
+          console.error("[clips-popover] restart failed:", err);
           setRecError(err instanceof Error ? err.message : String(err));
-          return;
+        } finally {
+          // Anything still held here belongs to a retake that never came up.
+          // Leaving it would keep the screen captured with nothing recording.
+          if (handoff) stopRestartHandoff(handoff);
+          restartInFlightRef.current = false;
         }
-        if (cancelled) {
-          stopRestartHandoff(handoff);
-          return;
-        }
-        // The recording flow stays latched across the restart. Releasing
-        // `clipsForceAlive` / `recordingFlowGateRef` / `recordingFlowActive` /
-        // `set_recording_state` the way cancel does would let the popover's
-        // blur auto-hide fire and flicker the pill between the two takes. The
-        // camera also stays owned by the popover, so the bubble session epoch
-        // is deliberately not bumped and the stream is re-handed unchanged.
-        //
-        // The discard did close the countdown and toolbar windows. The recorder
-        // rebuilds the countdown on every start, but the toolbar is owned by an
-        // effect keyed on the flow latches we just kept held — so it has to be
-        // told the chrome is gone.
-        setRecordingChromeEpoch((epoch) => epoch + 1);
-        setRecorder(null);
-        const restarted = await handleStartRecordingRef.current({
-          ignoreActiveRecorder: true,
-          resumeCapture: handoff,
-        });
-        // The new session owns the handed-off capture only once it exists.
-        // Without this the screen would stay captured with nothing recording.
-        if (!restarted) stopRestartHandoff(handoff);
       }),
     );
     return () => {

--- a/templates/clips/desktop/src/lib/recorder-restart.test.ts
+++ b/templates/clips/desktop/src/lib/recorder-restart.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  RESTART_CAPTURE_ENDED_MESSAGE,
+  recorderWithCaptureSuspension,
+  resolveRestartHandoff,
+  type RecorderHandle,
+  type RestartHandoff,
+  type StartParams,
+} from "./recorder";
+
+function fakeStream(...readyStates: Array<"live" | "ended">): MediaStream {
+  const tracks = readyStates.map((readyState) => ({
+    readyState,
+    stop: vi.fn(function stop(this: { readyState: string }) {
+      this.readyState = "ended";
+    }),
+  }));
+  return { getTracks: () => tracks } as unknown as MediaStream;
+}
+
+function restartParams(handoff: Partial<RestartHandoff>): StartParams {
+  return {
+    serverUrl: "http://localhost:8080",
+    mode: "screen",
+    micOn: true,
+    cameraOn: false,
+    preAcquiredDisplayStream: handoff.displayStream ?? null,
+    preAcquiredAudioStream: handoff.audioStream ?? null,
+  };
+}
+
+function stubHandle(overrides: Partial<RecorderHandle> = {}): RecorderHandle {
+  return {
+    stop: vi.fn(async () => ({ recordingId: "rec_1", viewUrl: "/r/rec_1" })),
+    cancel: vi.fn(async () => {}),
+    discardForRestart: vi.fn(async () => ({
+      displayStream: null,
+      audioStream: null,
+    })),
+    ...overrides,
+  };
+}
+
+describe("resolveRestartHandoff", () => {
+  it("passes through a restart with no handed-off capture", () => {
+    expect(resolveRestartHandoff(restartParams({}), true, true)).toEqual({
+      displayStream: null,
+      audioStream: null,
+    });
+  });
+
+  it("keeps live handed-off display and mic capture", () => {
+    const display = fakeStream("live", "live");
+    const audio = fakeStream("live");
+
+    expect(
+      resolveRestartHandoff(
+        restartParams({ displayStream: display, audioStream: audio }),
+        true,
+        true,
+      ),
+    ).toEqual({ displayStream: display, audioStream: audio });
+    expect(
+      [...display.getTracks(), ...audio.getTracks()].every(
+        (track) => track.readyState === "live",
+      ),
+    ).toBe(true);
+  });
+
+  it("reports the ended share rather than silently re-acquiring", () => {
+    const display = fakeStream("ended");
+    const audio = fakeStream("live");
+
+    expect(() =>
+      resolveRestartHandoff(
+        restartParams({ displayStream: display, audioStream: audio }),
+        true,
+        true,
+      ),
+    ).toThrow(RESTART_CAPTURE_ENDED_MESSAGE);
+    // The surviving mic must not be left running behind a failed restart.
+    expect(audio.getTracks()[0].readyState).toBe("ended");
+  });
+
+  it("treats a track-less handed-off display stream as dead capture", () => {
+    expect(() =>
+      resolveRestartHandoff(
+        restartParams({ displayStream: fakeStream() }),
+        true,
+        true,
+      ),
+    ).toThrow(RESTART_CAPTURE_ENDED_MESSAGE);
+  });
+
+  it("drops a dead mic for re-acquisition instead of failing a live restart", () => {
+    const display = fakeStream("live");
+    const audio = fakeStream("ended");
+
+    expect(
+      resolveRestartHandoff(
+        restartParams({ displayStream: display, audioStream: audio }),
+        true,
+        true,
+      ),
+    ).toEqual({ displayStream: display, audioStream: null });
+    expect(display.getTracks()[0].readyState).toBe("live");
+  });
+
+  it("stops handed-off capture the new session no longer wants", () => {
+    const display = fakeStream("live");
+    const audio = fakeStream("live");
+
+    expect(
+      resolveRestartHandoff(
+        restartParams({ displayStream: display, audioStream: audio }),
+        true,
+        false,
+      ),
+    ).toEqual({ displayStream: display, audioStream: null });
+    expect(audio.getTracks()[0].readyState).toBe("ended");
+  });
+});
+
+describe("recorderWithCaptureSuspension", () => {
+  it("releases the capture lease so the retake can re-acquire it", async () => {
+    const release = vi.fn(async () => {});
+    const display = fakeStream("live");
+    const handle = recorderWithCaptureSuspension(
+      stubHandle({
+        discardForRestart: vi.fn(async () => ({
+          displayStream: display,
+          audioStream: null,
+        })),
+      }),
+      release,
+    );
+
+    await expect(handle.discardForRestart()).resolves.toEqual({
+      displayStream: display,
+      audioStream: null,
+    });
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("discards only once when restart is clicked twice", async () => {
+    const discard = vi.fn(async () => ({
+      displayStream: null,
+      audioStream: null,
+    }));
+    const handle = recorderWithCaptureSuspension(
+      stubHandle({ discardForRestart: discard }),
+      async () => {},
+    );
+
+    const [first, second] = await Promise.all([
+      handle.discardForRestart(),
+      handle.discardForRestart(),
+    ]);
+
+    expect(first).toBe(second);
+    expect(discard).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses to hand off capture from an already stopped recording", async () => {
+    const discard = vi.fn(async () => ({
+      displayStream: null,
+      audioStream: null,
+    }));
+    const handle = recorderWithCaptureSuspension(
+      stubHandle({ discardForRestart: discard }),
+      async () => {},
+    );
+
+    await handle.stop();
+
+    await expect(handle.discardForRestart()).rejects.toThrow(
+      "Recording was already stopped",
+    );
+    expect(discard).not.toHaveBeenCalled();
+  });
+
+  it("refuses to finalize a take that was discarded for a restart", async () => {
+    const stop = vi.fn(async () => ({
+      recordingId: "rec_1",
+      viewUrl: "/r/rec_1",
+    }));
+    const handle = recorderWithCaptureSuspension(
+      stubHandle({ stop }),
+      async () => {},
+    );
+
+    await handle.discardForRestart();
+
+    await expect(handle.stop()).rejects.toThrow(
+      "Recording was already discarded for a restart",
+    );
+    expect(stop).not.toHaveBeenCalled();
+  });
+
+  it("keeps the handoff when releasing the capture lease fails", async () => {
+    const display = fakeStream("live");
+    const handle = recorderWithCaptureSuspension(
+      stubHandle({
+        discardForRestart: vi.fn(async () => ({
+          displayStream: display,
+          audioStream: null,
+        })),
+      }),
+      async () => {
+        throw new Error("lease release failed");
+      },
+    );
+
+    // Losing the handoff here would strand a live screen capture with nobody
+    // holding a reference to stop it.
+    await expect(handle.discardForRestart()).resolves.toEqual({
+      displayStream: display,
+      audioStream: null,
+    });
+  });
+
+  it("refuses to hand off capture from an already cancelled recording", async () => {
+    const discard = vi.fn(async () => ({
+      displayStream: null,
+      audioStream: null,
+    }));
+    const handle = recorderWithCaptureSuspension(
+      stubHandle({ discardForRestart: discard }),
+      async () => {},
+    );
+
+    await handle.cancel();
+
+    await expect(handle.discardForRestart()).rejects.toThrow(
+      "Recording was already cancelled",
+    );
+    expect(discard).not.toHaveBeenCalled();
+  });
+});

--- a/templates/clips/desktop/src/lib/recorder-restart.test.ts
+++ b/templates/clips/desktop/src/lib/recorder-restart.test.ts
@@ -198,6 +198,31 @@ describe("recorderWithCaptureSuspension", () => {
     expect(stop).not.toHaveBeenCalled();
   });
 
+  it("stops handed-off capture when the take is cancelled instead of retaken", async () => {
+    const display = fakeStream("live");
+    const audio = fakeStream("live");
+    const cancel = vi.fn(async () => {});
+    const handle = recorderWithCaptureSuspension(
+      stubHandle({
+        cancel,
+        discardForRestart: vi.fn(async () => ({
+          displayStream: display,
+          audioStream: audio,
+        })),
+      }),
+      async () => {},
+    );
+
+    await handle.discardForRestart();
+    await handle.cancel();
+
+    // The backend still gets its cancel — it owns whatever session teardown a
+    // restart deliberately skipped.
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(display.getTracks()[0].readyState).toBe("ended");
+    expect(audio.getTracks()[0].readyState).toBe("ended");
+  });
+
   it("keeps the handoff when releasing the capture lease fails", async () => {
     const display = fakeStream("live");
     const handle = recorderWithCaptureSuspension(

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -2396,13 +2396,16 @@ export function recorderWithCaptureSuspension(
       await stopPromise;
       return;
     }
-    if (discardPromise) {
-      await discardPromise;
-      return;
-    }
     cancelPromise = (async () => {
       try {
+        // Cancelling after a restart discard means the retake will never take
+        // ownership of the capture handed to it, and nothing else would stop
+        // it. The backend's own cancel decides what else a late cancel owes.
+        const handoff = await discardPromise;
         await cancel();
+        [handoff?.displayStream, handoff?.audioStream].forEach((stream) =>
+          stream?.getTracks().forEach((track) => track.stop()),
+        );
       } finally {
         await release();
       }
@@ -2634,6 +2637,7 @@ async function tryStartRewindFullscreenRecording(
   let stopped = false;
   let stopPromise: Promise<RecorderStopResult> | null = null;
   let cancelPromise: Promise<void> | null = null;
+  let discardPromise: Promise<RestartHandoff> | null = null;
   let stateUnlistens: UnlistenFn[] = [];
   let tickHandle: ReturnType<typeof setInterval> | null = null;
   let pausedAt: number | null = null;
@@ -2666,10 +2670,15 @@ async function tryStartRewindFullscreenRecording(
     stateUnlistens = [];
   };
 
-  // Throw the current take away. A restart keeps the SESSION alive, so it must
-  // not run the session-level teardown: `hide_overlays` destroys the camera
-  // bubble along with the recording chrome, and clearing the recording state
-  // would let the popover's blur auto-hide fire between the two takes.
+  // End the whole recording session. `hide_overlays` destroys the camera bubble
+  // along with the recording chrome, and clearing the recording state releases
+  // the popover's blur auto-hide — both wrong between the two takes of a
+  // restart, which is why `discardTake` only runs this for a real cancel.
+  const endSession = async () => {
+    await invoke("hide_overlays").catch(() => {});
+    await clearRecordingState();
+  };
+
   const discardTake = async (forRestart: boolean) => {
     stopped = true;
     cleanupUi();
@@ -2681,10 +2690,11 @@ async function tryStartRewindFullscreenRecording(
       });
     await invoke("rewind_clip_cancel").catch(() => {});
     audioCue.cleanup();
-    await invoke(forRestart ? "hide_recording_chrome" : "hide_overlays").catch(
-      () => {},
-    );
-    if (!forRestart) await clearRecordingState();
+    if (forRestart) {
+      await invoke("hide_recording_chrome").catch(() => {});
+    } else {
+      await endSession();
+    }
     if (!localOnly && id) {
       forgetRewindClipOrigin(id);
       await cleanupCancelledRemoteRecording(params.serverUrl, id).catch(
@@ -2700,11 +2710,15 @@ async function tryStartRewindFullscreenRecording(
     async stop() {
       if (stopPromise) return stopPromise;
       // This handle runs unwrapped (the Rewind producer holds no capture
-      // suspension lease), so the discarded-take guard lives here. Answering
-      // with `id` would publish a take that was already aborted and trashed.
+      // suspension lease), so the terminal-transition guards live here.
+      // Answering with `id` would publish a take that was already trashed.
       if (cancelPromise) {
         await cancelPromise;
-        throw new Error("Recording was already discarded");
+        throw new Error("Recording was already cancelled");
+      }
+      if (discardPromise) {
+        await discardPromise;
+        throw new Error("Recording was already discarded for a restart");
       }
       if (stopped) return { recordingId: id, viewUrl: `/r/${id}` };
       stopPromise = (async () => {
@@ -2829,19 +2843,33 @@ async function tryStartRewindFullscreenRecording(
     },
     async cancel() {
       if (cancelPromise) return cancelPromise;
+      // A cancel landing on an already-discarded take still has to end the
+      // session — the restart skipped that half deliberately, so returning
+      // here would leave the bubble up and the recording state active.
+      if (discardPromise) {
+        cancelPromise = discardPromise.then(endSession);
+        return cancelPromise;
+      }
       if (stopped) return;
       cancelPromise = discardTake(false);
       return cancelPromise;
     },
     async discardForRestart() {
-      if (cancelPromise || stopped) {
+      if (discardPromise) return discardPromise;
+      if (cancelPromise) {
+        await cancelPromise;
+        throw new Error("Recording was already cancelled");
+      }
+      if (stopped) {
         throw new Error("Recording already finished — nothing to restart");
       }
-      cancelPromise = discardTake(true);
-      await cancelPromise;
       // The Rewind producer re-acquires capture natively, so the retake needs
       // nothing handed to it.
-      return { displayStream: null, audioStream: null };
+      discardPromise = discardTake(true).then(() => ({
+        displayStream: null,
+        audioStream: null,
+      }));
+      return discardPromise;
     },
   };
 
@@ -3220,6 +3248,7 @@ async function startNativeFullscreenRecording(
   let stopped = false;
   let stopPromise: Promise<RecorderStopResult> | null = null;
   let cancelPromise: Promise<void> | null = null;
+  let discardPromise: Promise<RestartHandoff> | null = null;
   let stateUnlistens: UnlistenFn[] = [];
   let tickHandle: ReturnType<typeof setInterval> | null = null;
   let segmentRotateHandle: ReturnType<typeof setInterval> | null = null;
@@ -3292,9 +3321,13 @@ async function startNativeFullscreenRecording(
     }).catch(() => {});
   }
 
-  // Throw the current take away. A restart keeps the SESSION alive, so it uses
-  // `hide_recording_chrome` instead of `hide_overlays` — the latter destroys
-  // the camera bubble window along with the countdown and toolbar.
+  // End the whole recording session. `hide_overlays` destroys the camera
+  // bubble window along with the countdown and toolbar, which is wrong between
+  // the two takes of a restart — hence the split with `discardTake`.
+  const endSession = async () => {
+    await invoke("hide_overlays").catch(() => {});
+  };
+
   const discardTake = async (forRestart: boolean) => {
     stopped = true;
     clearSegmentRotator();
@@ -3327,9 +3360,11 @@ async function startNativeFullscreenRecording(
       localCameraStream?.getTracks().forEach((track) => track.stop());
     }
     streamCleanups.forEach((cleanup) => cleanup());
-    await invoke(forRestart ? "hide_recording_chrome" : "hide_overlays").catch(
-      () => {},
-    );
+    if (forRestart) {
+      await invoke("hide_recording_chrome").catch(() => {});
+    } else {
+      await endSession();
+    }
     if (!localOnly && id) {
       void cleanupCancelledRemoteRecording(params.serverUrl, id).catch(
         (err) => {
@@ -3575,20 +3610,34 @@ async function startNativeFullscreenRecording(
 
     async cancel() {
       if (cancelPromise) return cancelPromise;
+      // A cancel landing on an already-discarded take still has to end the
+      // session — the restart skipped that half deliberately, so returning
+      // here would leave the camera bubble up.
+      if (discardPromise) {
+        cancelPromise = discardPromise.then(endSession);
+        return cancelPromise;
+      }
       if (stopped) return;
       cancelPromise = discardTake(false);
       return cancelPromise;
     },
 
     async discardForRestart() {
-      if (cancelPromise || stopped) {
+      if (discardPromise) return discardPromise;
+      if (cancelPromise) {
+        await cancelPromise;
+        throw new Error("Recording was already cancelled");
+      }
+      if (stopped) {
         throw new Error("Recording already finished — nothing to restart");
       }
-      cancelPromise = discardTake(true);
-      await cancelPromise;
       // ScreenCaptureKit is driven from Rust, so the retake re-acquires
       // capture natively without needing a user gesture.
-      return { displayStream: null, audioStream: null };
+      discardPromise = discardTake(true).then(() => ({
+        displayStream: null,
+        audioStream: null,
+      }));
+      return discardPromise;
     },
   };
 

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -229,6 +229,17 @@ export interface StartParams {
    * or turns the camera off).
    */
   preAcquiredCameraStream?: MediaStream | null;
+  /**
+   * Live screen capture handed over by the session this start is replacing
+   * (see `RestartHandoff`). Present only on a restart.
+   *
+   * Ownership is the OPPOSITE of `preAcquiredCameraStream`: the popover keeps
+   * the camera, but these streams belong to the recorder, so this session
+   * stops them on its own stop/cancel exactly as if it had acquired them.
+   */
+  preAcquiredDisplayStream?: MediaStream | null;
+  /** Live microphone capture handed over on restart. See `preAcquiredDisplayStream`. */
+  preAcquiredAudioStream?: MediaStream | null;
 }
 
 const REWIND_CLIP_ORIGINS_KEY = "clips.rewindClipOrigins.v1";
@@ -286,11 +297,27 @@ export function forgetRewindClipOrigin(recordingId: string): void {
   writeRewindClipOrigins(origins);
 }
 
+export const RESTART_CAPTURE_ENDED_MESSAGE =
+  "Screen sharing ended — start a new recording.";
+
+/**
+ * Live capture streams a discarded session hands to its replacement so the
+ * retake never calls `getDisplayMedia` again — a Tauri event listener carries
+ * no user activation, so re-acquiring here would always fail.
+ */
+export interface RestartHandoff {
+  /** Null when the backend re-acquires capture natively (no user gesture needed). */
+  displayStream: MediaStream | null;
+  audioStream: MediaStream | null;
+}
+
 export interface RecorderHandle {
   /** Stop the recording and resolve once the server has finalized. */
   stop(): Promise<RecorderStopResult>;
   /** Discard the recording without saving. */
   cancel(): Promise<void>;
+  /** Discard this take but keep gesture-bound capture alive for an immediate retake. */
+  discardForRestart(): Promise<RestartHandoff>;
 }
 
 export interface RecorderStopResult {
@@ -2327,7 +2354,7 @@ function captureSuspensionReleaser(
   };
 }
 
-function recorderWithCaptureSuspension(
+export function recorderWithCaptureSuspension(
   handle: RecorderHandle,
   release: () => Promise<void>,
 ): RecorderHandle {
@@ -2337,13 +2364,22 @@ function recorderWithCaptureSuspension(
   // the suspension after the physical recorder has actually torn down.
   const stop = handle.stop.bind(handle);
   const cancel = handle.cancel.bind(handle);
+  const discardForRestart = handle.discardForRestart.bind(handle);
   let stopPromise: Promise<RecorderStopResult> | null = null;
   let cancelPromise: Promise<void> | null = null;
+  let discardPromise: Promise<RestartHandoff> | null = null;
   handle.stop = async () => {
     if (stopPromise) return stopPromise;
     if (cancelPromise) {
       await cancelPromise;
       throw new Error("Recording was already cancelled");
+    }
+    // Without this a stop racing a restart reaches the backend's `stopped`
+    // short-circuit, which answers with the discarded take's id — the caller
+    // would publish an aborted recording as a finished one.
+    if (discardPromise) {
+      await discardPromise;
+      throw new Error("Recording was already discarded for a restart");
     }
     stopPromise = (async () => {
       try {
@@ -2360,6 +2396,10 @@ function recorderWithCaptureSuspension(
       await stopPromise;
       return;
     }
+    if (discardPromise) {
+      await discardPromise;
+      return;
+    }
     cancelPromise = (async () => {
       try {
         await cancel();
@@ -2368,6 +2408,31 @@ function recorderWithCaptureSuspension(
       }
     })();
     return cancelPromise;
+  };
+  handle.discardForRestart = async () => {
+    if (discardPromise) return discardPromise;
+    if (stopPromise) {
+      await stopPromise;
+      throw new Error("Recording was already stopped");
+    }
+    if (cancelPromise) {
+      await cancelPromise;
+      throw new Error("Recording was already cancelled");
+    }
+    discardPromise = (async () => {
+      const handoff = await discardForRestart();
+      // The discard succeeded and the caller now owns live capture. Letting a
+      // failed lease release reject in its place would strand those tracks
+      // with nobody holding a reference to stop them.
+      await release().catch((err) =>
+        console.error(
+          "[clips-recorder] capture suspension release failed after restart discard:",
+          err,
+        ),
+      );
+      return handoff;
+    })();
+    return discardPromise;
   };
   return handle;
 }
@@ -2601,9 +2666,46 @@ async function tryStartRewindFullscreenRecording(
     stateUnlistens = [];
   };
 
+  // Throw the current take away. A restart keeps the SESSION alive, so it must
+  // not run the session-level teardown: `hide_overlays` destroys the camera
+  // bubble along with the recording chrome, and clearing the recording state
+  // would let the popover's blur auto-hide fire between the two takes.
+  const discardTake = async (forRestart: boolean) => {
+    stopped = true;
+    cleanupUi();
+    transcriptionAborted = true;
+    const transcriptionTornDown = transcriptionCapture
+      ?.cancel()
+      .catch((err) => {
+        console.warn("[clips-recorder] transcription cancel failed:", err);
+      });
+    await invoke("rewind_clip_cancel").catch(() => {});
+    audioCue.cleanup();
+    await invoke(forRestart ? "hide_recording_chrome" : "hide_overlays").catch(
+      () => {},
+    );
+    if (!forRestart) await clearRecordingState();
+    if (!localOnly && id) {
+      forgetRewindClipOrigin(id);
+      await cleanupCancelledRemoteRecording(params.serverUrl, id).catch(
+        () => {},
+      );
+    }
+    // The transcription engine is process-global, so this stop must land
+    // before the replacement session starts it again.
+    if (forRestart) await transcriptionTornDown;
+  };
+
   const handle: RecorderHandle = {
     async stop() {
       if (stopPromise) return stopPromise;
+      // This handle runs unwrapped (the Rewind producer holds no capture
+      // suspension lease), so the discarded-take guard lives here. Answering
+      // with `id` would publish a take that was already aborted and trashed.
+      if (cancelPromise) {
+        await cancelPromise;
+        throw new Error("Recording was already discarded");
+      }
       if (stopped) return { recordingId: id, viewUrl: `/r/${id}` };
       stopPromise = (async () => {
         stopped = true;
@@ -2728,25 +2830,18 @@ async function tryStartRewindFullscreenRecording(
     async cancel() {
       if (cancelPromise) return cancelPromise;
       if (stopped) return;
-      cancelPromise = (async () => {
-        stopped = true;
-        cleanupUi();
-        transcriptionAborted = true;
-        void transcriptionCapture?.cancel().catch((err) => {
-          console.warn("[clips-recorder] transcription cancel failed:", err);
-        });
-        await invoke("rewind_clip_cancel").catch(() => {});
-        audioCue.cleanup();
-        await invoke("hide_overlays").catch(() => {});
-        await clearRecordingState();
-        if (!localOnly && id) {
-          forgetRewindClipOrigin(id);
-          await cleanupCancelledRemoteRecording(params.serverUrl, id).catch(
-            () => {},
-          );
-        }
-      })();
+      cancelPromise = discardTake(false);
       return cancelPromise;
+    },
+    async discardForRestart() {
+      if (cancelPromise || stopped) {
+        throw new Error("Recording already finished — nothing to restart");
+      }
+      cancelPromise = discardTake(true);
+      await cancelPromise;
+      // The Rewind producer re-acquires capture natively, so the retake needs
+      // nothing handed to it.
+      return { displayStream: null, audioStream: null };
     },
   };
 
@@ -3197,6 +3292,59 @@ async function startNativeFullscreenRecording(
     }).catch(() => {});
   }
 
+  // Throw the current take away. A restart keeps the SESSION alive, so it uses
+  // `hide_recording_chrome` instead of `hide_overlays` — the latter destroys
+  // the camera bubble window along with the countdown and toolbar.
+  const discardTake = async (forRestart: boolean) => {
+    stopped = true;
+    clearSegmentRotator();
+    pauseQueue?.dispose();
+    if (tickHandle) {
+      clearInterval(tickHandle);
+      tickHandle = null;
+    }
+    stateUnlistens.forEach((u) => u());
+    stateUnlistens = [];
+    const transcriptionTornDown = transcriptionCapture
+      ?.cancel()
+      .catch((err) => {
+        console.warn(
+          "[clips-recorder] native transcription cancel failed:",
+          err,
+        );
+      });
+    await localCameraExport?.cancel().catch(() => {});
+    await invoke("native_fullscreen_recording_cancel").catch((err) =>
+      console.warn("[clips-recorder] native fullscreen cancel failed:", err),
+    );
+    if (bubbleCaptureExcluded) {
+      await invoke("set_bubble_capture_excluded", { excluded: false }).catch(
+        () => {},
+      );
+      bubbleCaptureExcluded = false;
+    }
+    if (localOwnsCameraStream) {
+      localCameraStream?.getTracks().forEach((track) => track.stop());
+    }
+    streamCleanups.forEach((cleanup) => cleanup());
+    await invoke(forRestart ? "hide_recording_chrome" : "hide_overlays").catch(
+      () => {},
+    );
+    if (!localOnly && id) {
+      void cleanupCancelledRemoteRecording(params.serverUrl, id).catch(
+        (err) => {
+          console.warn(
+            "[clips-recorder] cancelled recording cleanup failed:",
+            err,
+          );
+        },
+      );
+    }
+    // The transcription engine is process-global, so this stop must land
+    // before the replacement session starts it again.
+    if (forRestart) await transcriptionTornDown;
+  };
+
   const handle: RecorderHandle = {
     async stop() {
       if (stopPromise) return stopPromise;
@@ -3428,52 +3576,19 @@ async function startNativeFullscreenRecording(
     async cancel() {
       if (cancelPromise) return cancelPromise;
       if (stopped) return;
-      cancelPromise = (async () => {
-        stopped = true;
-        clearSegmentRotator();
-        pauseQueue?.dispose();
-        if (tickHandle) {
-          clearInterval(tickHandle);
-          tickHandle = null;
-        }
-        stateUnlistens.forEach((u) => u());
-        stateUnlistens = [];
-        void transcriptionCapture?.cancel().catch((err) => {
-          console.warn(
-            "[clips-recorder] native transcription cancel failed:",
-            err,
-          );
-        });
-        await localCameraExport?.cancel().catch(() => {});
-        await invoke("native_fullscreen_recording_cancel").catch((err) =>
-          console.warn(
-            "[clips-recorder] native fullscreen cancel failed:",
-            err,
-          ),
-        );
-        if (bubbleCaptureExcluded) {
-          await invoke("set_bubble_capture_excluded", {
-            excluded: false,
-          }).catch(() => {});
-          bubbleCaptureExcluded = false;
-        }
-        if (localOwnsCameraStream) {
-          localCameraStream?.getTracks().forEach((track) => track.stop());
-        }
-        streamCleanups.forEach((cleanup) => cleanup());
-        await invoke("hide_overlays").catch(() => {});
-        if (!localOnly && id) {
-          void cleanupCancelledRemoteRecording(params.serverUrl, id).catch(
-            (err) => {
-              console.warn(
-                "[clips-recorder] cancelled recording cleanup failed:",
-                err,
-              );
-            },
-          );
-        }
-      })();
+      cancelPromise = discardTake(false);
       return cancelPromise;
+    },
+
+    async discardForRestart() {
+      if (cancelPromise || stopped) {
+        throw new Error("Recording already finished — nothing to restart");
+      }
+      cancelPromise = discardTake(true);
+      await cancelPromise;
+      // ScreenCaptureKit is driven from Rust, so the retake re-acquires
+      // capture natively without needing a user gesture.
+      return { displayStream: null, audioStream: null };
     },
   };
 
@@ -3667,12 +3782,58 @@ export async function startRecording(
   }
 }
 
+/**
+ * Vet the capture a restart inherited. A handed-off track can die between the
+ * restart click and this call — the user may have hit the OS "Stop sharing"
+ * control, or unplugged the microphone.
+ *
+ * The two are not interchangeable. Screen capture cannot be re-acquired here
+ * (this start carries no user activation), so an ended display share is fatal
+ * and has to name itself; re-acquiring would surface an activation error that
+ * blames the wrong thing. A microphone needs no gesture, so an ended one is
+ * simply dropped and picked up again by the normal acquisition path.
+ */
+export function resolveRestartHandoff(
+  params: StartParams,
+  wantsScreen: boolean,
+  wantsAudio: boolean,
+): RestartHandoff {
+  const stopStream = (stream: MediaStream | null) =>
+    stream?.getTracks().forEach((track) => track.stop());
+  const isLive = (stream: MediaStream) =>
+    stream.getTracks().length > 0 &&
+    stream.getTracks().every((track) => track.readyState === "live");
+
+  let displayStream = params.preAcquiredDisplayStream ?? null;
+  let audioStream = params.preAcquiredAudioStream ?? null;
+
+  // Nothing downstream will ever own capture this session did not ask for.
+  if (displayStream && !wantsScreen) {
+    stopStream(displayStream);
+    displayStream = null;
+  }
+  if (audioStream && (!wantsAudio || !isLive(audioStream))) {
+    stopStream(audioStream);
+    audioStream = null;
+  }
+
+  if (displayStream && !isLive(displayStream)) {
+    stopStream(displayStream);
+    stopStream(audioStream);
+    throw new Error(RESTART_CAPTURE_ENDED_MESSAGE);
+  }
+  return { displayStream, audioStream };
+}
+
 async function startRecordingInner(
   params: StartParams,
 ): Promise<RecorderHandle> {
   const wantsScreen = params.mode !== "camera";
   const wantsCamera = params.mode !== "screen" && params.cameraOn;
   const wantsAudio = params.micOn;
+  // Vetted before anything is acquired so an ended display share cannot strand
+  // a capture-suspension lease behind it.
+  const restartHandoff = resolveRestartHandoff(params, wantsScreen, wantsAudio);
   const wantsSystemAudio = wantsScreen && params.systemAudioOn !== false;
   const wantsRecordedAudio = wantsAudio || wantsSystemAudio;
   const canTranscribeLocally =
@@ -3758,30 +3919,42 @@ async function startRecordingInner(
     requiresMicrophone: wantsAudio,
   });
 
-  const displayStreamPromise: Promise<MediaStream> | null = wantsScreen
-    ? (() => {
-        if (!devSyntheticCapture) {
-          // Do not pass displaySurface as an input constraint. Modern runtimes
-          // can reject it with "Invalid constraint", and it cannot reliably
-          // pre-filter the OS picker anyway; the selected track reports its
-          // actual surface through getSettings() after capture starts.
-          return navigator.mediaDevices.getDisplayMedia(
-            buildDesktopDisplayMediaOptions({
-              audio: wantsSystemAudio,
-              frameRate: CLOUD_CAPTURE_FRAME_RATE,
-              maxWidth: CLOUD_CAPTURE_MAX_WIDTH,
-              maxHeight: CLOUD_CAPTURE_MAX_HEIGHT,
-            }),
+  // A restart inherits live capture from the take it replaces, so the two
+  // gesture-bound acquisitions are skipped entirely. See `RestartHandoff`.
+  const resumedDisplayStream = restartHandoff.displayStream;
+  const resumedAudioStream = restartHandoff.audioStream;
+  if (resumedDisplayStream || resumedAudioStream) {
+    console.log("[clips-recorder] reusing handed-off capture streams", {
+      display: Boolean(resumedDisplayStream),
+      audio: Boolean(resumedAudioStream),
+    });
+  }
+  const displayStreamPromise: Promise<MediaStream> | null = resumedDisplayStream
+    ? Promise.resolve(resumedDisplayStream)
+    : wantsScreen
+      ? (() => {
+          if (!devSyntheticCapture) {
+            // Do not pass displaySurface as an input constraint. Modern runtimes
+            // can reject it with "Invalid constraint", and it cannot reliably
+            // pre-filter the OS picker anyway; the selected track reports its
+            // actual surface through getSettings() after capture starts.
+            return navigator.mediaDevices.getDisplayMedia(
+              buildDesktopDisplayMediaOptions({
+                audio: wantsSystemAudio,
+                frameRate: CLOUD_CAPTURE_FRAME_RATE,
+                maxWidth: CLOUD_CAPTURE_MAX_WIDTH,
+                maxHeight: CLOUD_CAPTURE_MAX_HEIGHT,
+              }),
+            );
+          }
+          console.warn(
+            "[clips-recorder] using opt-in dev synthetic screen capture; remove localStorage clips:dev-synthetic-capture to use the native picker",
           );
-        }
-        console.warn(
-          "[clips-recorder] using opt-in dev synthetic screen capture; remove localStorage clips:dev-synthetic-capture to use the native picker",
-        );
-        const syntheticDisplay = createSyntheticScreenStream();
-        streamCleanups.push(syntheticDisplay.cleanup);
-        return Promise.resolve(syntheticDisplay.stream);
-      })()
-    : null;
+          const syntheticDisplay = createSyntheticScreenStream();
+          streamCleanups.push(syntheticDisplay.cleanup);
+          return Promise.resolve(syntheticDisplay.stream);
+        })()
+      : null;
   // If the popover handed us a live camera stream from the pre-record
   // preview we reuse it verbatim and SKIP getUserMedia — see the
   // `preAcquiredCameraStream` field doc for the WebKit rationale. This
@@ -3800,9 +3973,11 @@ async function startRecordingInner(
     wantsCamera && !reusedCameraStream
       ? getCameraStreamWithFallback(params.cameraId)
       : null;
-  const audioStreamPromise: Promise<MediaStream> | null = wantsAudio
-    ? getAudioStreamWithFallback(params.micId, params.micLabel)
-    : null;
+  const audioStreamPromise: Promise<MediaStream> | null = resumedAudioStream
+    ? Promise.resolve(resumedAudioStream)
+    : wantsAudio
+      ? getAudioStreamWithFallback(params.micId, params.micLabel)
+      : null;
 
   let captureSuspension: RewindCaptureSuspensionLease;
   try {
@@ -4103,10 +4278,12 @@ async function startRecordingInner(
         }
       };
 
-      const stopOwnedStreams = () => {
-        [displayStream, audioStream].forEach((stream) =>
-          stream?.getTracks().forEach((track) => track.stop()),
-        );
+      const stopOwnedStreams = (keepCaptureStreams = false) => {
+        if (!keepCaptureStreams) {
+          [displayStream, audioStream].forEach((stream) =>
+            stream?.getTracks().forEach((track) => track.stop()),
+          );
+        }
         streamCleanups.forEach((cleanup) => cleanup());
         if (!popoverOwnsCamera) {
           bubbleCameraStream?.getTracks().forEach((track) => track.stop());
@@ -4117,6 +4294,25 @@ async function startRecordingInner(
         await invoke("hide_recording_chrome").catch((err) =>
           console.error(`[clips-recorder] hide_recording_chrome failed:`, err),
         );
+      };
+
+      const discardTake = async (
+        keepCaptureStreams: boolean,
+      ): Promise<RestartHandoff> => {
+        // Synthetic dev capture belongs to `streamCleanups`, which always runs
+        // here, so it is never handed over — the retake recreates it.
+        const handsOff = keepCaptureStreams && !devSyntheticCapture;
+        stopped = true;
+        if (tickHandle) clearInterval(tickHandle);
+        stateUnlistens.forEach((unlisten) => unlisten());
+        stateUnlistens = [];
+        await localExport.cancel();
+        detachCombinedStream();
+        stopOwnedStreams(handsOff);
+        await hideChrome();
+        return handsOff
+          ? { displayStream, audioStream }
+          : { displayStream: null, audioStream: null };
       };
 
       const handle: RecorderHandle = {
@@ -4157,14 +4353,14 @@ async function startRecordingInner(
 
         async cancel() {
           if (stopped) return;
-          stopped = true;
-          if (tickHandle) clearInterval(tickHandle);
-          stateUnlistens.forEach((unlisten) => unlisten());
-          stateUnlistens = [];
-          await localExport.cancel();
-          detachCombinedStream();
-          stopOwnedStreams();
-          await hideChrome();
+          await discardTake(false);
+        },
+
+        async discardForRestart() {
+          if (stopped) {
+            throw new Error("Recording already finished — nothing to restart");
+          }
+          return discardTake(true);
         },
       };
 
@@ -4885,68 +5081,101 @@ async function startRecordingInner(
       }
     };
 
+    const discardTake = async (
+      keepCaptureStreams: boolean,
+    ): Promise<RestartHandoff> => {
+      // Synthetic dev capture is owned by `streamCleanups`, which always runs
+      // here — so there is nothing to hand over, and the next session recreates
+      // it. It needs no user gesture either.
+      const handsOff = keepCaptureStreams && !devSyntheticCapture;
+      stopped = true;
+      if (tickHandle) clearInterval(tickHandle);
+      stateUnlistens.forEach((u) => u());
+      stateUnlistens = [];
+      const transcriptionTornDown = transcriptionCapture
+        ?.cancel()
+        .catch((err) => {
+          console.warn("[clips-recorder] transcription cancel failed:", err);
+        });
+      // Remove MediaRecorder's data handler so any final `ondataavailable`
+      // from the stop() below doesn't push a new Blob into `inflight`
+      // after we've decided to discard everything.
+      recorder.ondataavailable = null;
+      try {
+        if (recorder.state !== "inactive") recorder.stop();
+        // coercion-ok: the take is already discarded — a MediaRecorder that refuses to stop has nothing left to report
+      } catch {
+        // ignore
+      }
+      // Drop stream track references — same rationale as in stop(). This
+      // detaches only from the MediaStreams; the originating streams own the
+      // tracks and we stop them below.
+      try {
+        uploadCombined
+          .getTracks()
+          .forEach((t) => uploadCombined.removeTrack(t));
+        combined.getTracks().forEach((t) => combined.removeTrack(t));
+        // coercion-ok: detaching tracks is bookkeeping; the streams below are stopped or handed over either way
+      } catch {
+        // ignore
+      }
+      // Stop the streams WE own. Camera stays alive when the popover
+      // owns it (see stop() for the same split). On a restart the display and
+      // mic streams also stay alive and become the next session's to own.
+      if (!handsOff) {
+        [displayStream, audioStream].forEach((s) =>
+          s?.getTracks().forEach((t) => t.stop()),
+        );
+      }
+      streamCleanups.forEach((cleanup) => cleanup());
+      if (!popoverOwnsCamera) {
+        bubbleCameraStream?.getTracks().forEach((t) => t.stop());
+      }
+      // Drop remaining in-flight chunk Blobs aggressively. Their fetches
+      // will still settle (we don't AbortController them — dev server is
+      // local and won't hang long) but we no longer hold references to the
+      // Blobs via this Set. Combined with the `ondataavailable = null`
+      // above, this guarantees no new Blobs latch on during the stop.
+      inflight.clear();
+      await invoke("hide_recording_chrome").catch(() => {});
+      // Tell the server to abort the partial recording (drops chunks from
+      // application_state, flips the recording row to 'failed'), then trash
+      // it. This is best-effort background cleanup: redo/cancel must release
+      // the desktop chrome immediately even if the server is slow or offline.
+      if (id) {
+        void cleanupCancelledRemoteRecording(params.serverUrl, id).catch(
+          (err) => {
+            console.warn("[clips-recorder] abort failed (non-fatal):", err);
+          },
+        );
+      }
+      await deleteBrowserRecordingBackup(id).catch((err) => {
+        console.warn("[clips-recorder] local backup cleanup failed:", err);
+      });
+      // The transcription engine is process-global, so this stop must land
+      // before the replacement session starts it again.
+      if (keepCaptureStreams) await transcriptionTornDown;
+      return handsOff
+        ? { displayStream, audioStream }
+        : { displayStream: null, audioStream: null };
+    };
+
     const handle: RecorderHandle = {
       stop: singleFlight(performStop),
 
       async cancel() {
         if (stopped) return;
-        stopped = true;
-        if (tickHandle) clearInterval(tickHandle);
-        stateUnlistens.forEach((u) => u());
-        stateUnlistens = [];
-        void transcriptionCapture?.cancel().catch((err) => {
-          console.warn("[clips-recorder] transcription cancel failed:", err);
-        });
-        // Remove MediaRecorder's data handler so any final `ondataavailable`
-        // from the stop() below doesn't push a new Blob into `inflight`
-        // after we've decided to discard everything.
-        recorder.ondataavailable = null;
-        try {
-          if (recorder.state !== "inactive") recorder.stop();
-        } catch {
-          // ignore
+        await discardTake(false);
+      },
+
+      // A restart reuses the same capture. `getDisplayMedia` cannot run from
+      // the Tauri event that carries the toolbar click, so the streams have to
+      // survive the take that is being thrown away.
+      async discardForRestart() {
+        if (stopped) {
+          throw new Error("Recording already finished — nothing to restart");
         }
-        // Drop stream track references — same rationale as in stop(). This
-        // detaches only from the MediaStreams; the originating streams own the
-        // tracks and we stop them below.
-        try {
-          uploadCombined
-            .getTracks()
-            .forEach((t) => uploadCombined.removeTrack(t));
-          combined.getTracks().forEach((t) => combined.removeTrack(t));
-        } catch {
-          // ignore
-        }
-        // Stop the streams WE own. Camera stays alive when the popover
-        // owns it (see stop() for the same split).
-        [displayStream, audioStream].forEach((s) =>
-          s?.getTracks().forEach((t) => t.stop()),
-        );
-        streamCleanups.forEach((cleanup) => cleanup());
-        if (!popoverOwnsCamera) {
-          bubbleCameraStream?.getTracks().forEach((t) => t.stop());
-        }
-        // Drop remaining in-flight chunk Blobs aggressively. Their fetches
-        // will still settle (we don't AbortController them — dev server is
-        // local and won't hang long) but we no longer hold references to the
-        // Blobs via this Set. Combined with the `ondataavailable = null`
-        // above, this guarantees no new Blobs latch on during the stop.
-        inflight.clear();
-        await invoke("hide_recording_chrome").catch(() => {});
-        // Tell the server to abort the partial recording (drops chunks from
-        // application_state, flips the recording row to 'failed'), then trash
-        // it. This is best-effort background cleanup: redo/cancel must release
-        // the desktop chrome immediately even if the server is slow or offline.
-        if (id) {
-          void cleanupCancelledRemoteRecording(params.serverUrl, id).catch(
-            (err) => {
-              console.warn("[clips-recorder] abort failed (non-fatal):", err);
-            },
-          );
-        }
-        await deleteBrowserRecordingBackup(id).catch((err) => {
-          console.warn("[clips-recorder] local backup cleanup failed:", err);
-        });
+        return discardTake(true);
       },
     };
 


### PR DESCRIPTION
**Restart used to just cancel your recording and send you back to the popover to click Start again. Now it drops the current take and starts a new one right away.**

You click Restart, the countdown replays, and recording begins again. No screen picker, no permission prompt, no extra click. It keeps the source you already picked and works for full screen, regions, single windows, camera and mic. The camera bubble and toolbar stay on screen, and the discarded take never reaches your library.

If your screen share ended in the meantime, Restart now says so plainly instead of failing with a confusing permissions error.

Also fixed: stopping and restarting at the same moment could save the discarded take as a real recording, and a failed restart could leave your screen still being captured.
