### PR TITLE
Add hover previews to calendar events

### DIFF
--- a/.changeset/calm-calendars-hover.md
+++ b/.changeset/calm-calendars-hover.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/toolkit": patch
+---
+
+Export the Hover Card portal for app-level overlay composition.

--- a/packages/toolkit/src/ui/hover-card.tsx
+++ b/packages/toolkit/src/ui/hover-card.tsx
@@ -7,6 +7,8 @@ const HoverCard = HoverCardPrimitive.Root;
 
 const HoverCardTrigger = HoverCardPrimitive.Trigger;
 
+const HoverCardPortal = HoverCardPrimitive.Portal;
+
 const HoverCardContent = React.forwardRef<
   React.ElementRef<typeof HoverCardPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
@@ -24,4 +26,4 @@ const HoverCardContent = React.forwardRef<
 ));
 HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
 
-export { HoverCard, HoverCardTrigger, HoverCardContent };
+export { HoverCard, HoverCardTrigger, HoverCardPortal, HoverCardContent };

--- a/templates/calendar/app/components/calendar/EventCard.test.tsx
+++ b/templates/calendar/app/components/calendar/EventCard.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+
+import type { CalendarEvent } from "@shared/api";
+import { createRef } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EventCard } from "./EventCard";
+
+vi.mock("@agent-native/core/client/i18n", () => ({
+  useT:
+    () =>
+    (key: string): string =>
+      key,
+}));
+
+const event: CalendarEvent = {
+  id: "event-1",
+  title: "Planning session",
+  description: "",
+  location: "Room A",
+  start: "2026-08-08T17:00:00.000Z",
+  end: "2026-08-08T18:00:00.000Z",
+  allDay: false,
+  source: "local",
+  createdAt: "2026-08-03T12:00:00.000Z",
+  updatedAt: "2026-08-03T12:00:00.000Z",
+  attendees: [],
+};
+
+describe("EventCard", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("forwards trigger props and its ref to the underlying button", () => {
+    const ref = createRef<HTMLButtonElement>();
+    const onPointerEnter = vi.fn();
+
+    act(() => {
+      root.render(
+        <EventCard
+          ref={ref}
+          event={event}
+          className="preview-trigger"
+          data-state="closed"
+          onPointerEnter={onPointerEnter}
+        />,
+      );
+    });
+
+    const button = container.querySelector("button");
+    expect(ref.current).toBe(button);
+    expect(button?.classList.contains("preview-trigger")).toBe(true);
+    expect(button?.getAttribute("data-state")).toBe("closed");
+
+    act(() => {
+      button?.dispatchEvent(new PointerEvent("pointerover", { bubbles: true }));
+    });
+
+    expect(onPointerEnter).toHaveBeenCalledOnce();
+  });
+});

--- a/templates/calendar/app/components/calendar/EventCard.tsx
+++ b/templates/calendar/app/components/calendar/EventCard.tsx
@@ -1,6 +1,7 @@
 import { useT } from "@agent-native/core/client/i18n";
 import type { CalendarEvent } from "@shared/api";
 import { IconAlertTriangleFilled, IconCalendarOff } from "@tabler/icons-react";
+import { forwardRef, type ButtonHTMLAttributes } from "react";
 
 import {
   getEventDisplayColor,
@@ -17,9 +18,11 @@ import {
   isWorkingLocationEvent,
 } from "@/lib/working-location";
 
-interface EventCardProps {
+interface EventCardProps extends Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  "draggable" | "onDragStart" | "onDragEnd"
+> {
   event: CalendarEvent;
-  onClick?: () => void;
   compact?: boolean;
   draggable?: boolean;
   onDragStart?: (id: string) => void;
@@ -28,155 +31,168 @@ interface EventCardProps {
   colorPreferences?: CalendarColorPreferences;
 }
 
-export function EventCard({
-  event,
-  onClick,
-  compact = false,
-  draggable = false,
-  onDragStart,
-  onDragEnd,
-  dimmed = false,
-  colorPreferences,
-}: EventCardProps) {
-  const t = useT();
-  const workingLocationLabels = createWorkingLocationDisplayLabels(t);
-  const accentColor = getEventDisplayColor(event, colorPreferences);
-  const ownerLabel = event.ownerName || event.overlayEmail;
-  const title = getWorkingLocationChipLabel(event, workingLocationLabels);
-  const ariaTitle = getWorkingLocationTitle(event, workingLocationLabels);
-  const isWorkingLocation = isWorkingLocationEvent(event);
-  const isOutOfOffice = isOutOfOfficeEvent(event);
+export const EventCard = forwardRef<HTMLButtonElement, EventCardProps>(
+  function EventCard(
+    {
+      event,
+      compact = false,
+      draggable = false,
+      onDragStart,
+      onDragEnd,
+      dimmed = false,
+      colorPreferences,
+      className,
+      style,
+      ...buttonProps
+    },
+    forwardedRef,
+  ) {
+    const t = useT();
+    const workingLocationLabels = createWorkingLocationDisplayLabels(t);
+    const accentColor = getEventDisplayColor(event, colorPreferences);
+    const ownerLabel = event.ownerName || event.overlayEmail;
+    const title = getWorkingLocationChipLabel(event, workingLocationLabels);
+    const ariaTitle = getWorkingLocationTitle(event, workingLocationLabels);
+    const isWorkingLocation = isWorkingLocationEvent(event);
+    const isOutOfOffice = isOutOfOfficeEvent(event);
 
-  const handleDragStart = (e: React.DragEvent) => {
-    e.dataTransfer.setData("text/plain", event.id);
-    e.dataTransfer.effectAllowed = "move";
-    onDragStart?.(event.id);
-  };
+    const handleDragStart = (e: React.DragEvent) => {
+      e.dataTransfer.setData("text/plain", event.id);
+      e.dataTransfer.effectAllowed = "move";
+      onDragStart?.(event.id);
+    };
 
-  const canDrag = draggable && !event.overlayEmail;
+    const canDrag = draggable && !event.overlayEmail;
 
-  if (compact) {
+    if (compact) {
+      return (
+        <button
+          ref={forwardedRef}
+          {...buttonProps}
+          draggable={canDrag}
+          onDragStart={canDrag ? handleDragStart : undefined}
+          onDragEnd={canDrag ? onDragEnd : undefined}
+          className={cn(
+            "relative flex w-full items-center gap-1.5 rounded px-1.5 py-0.5 text-left text-xs text-foreground transition-[filter,transform] hover:brightness-110 active:scale-[0.98]",
+            canDrag && "cursor-grab active:cursor-grabbing",
+            dimmed && "opacity-40",
+            event.ownerColor && "pr-3.5",
+            className,
+          )}
+          aria-label={
+            ownerLabel ? `${ariaTitle}, ${ownerLabel}'s calendar` : ariaTitle
+          }
+          style={{
+            backgroundColor: `${accentColor}25`,
+            ...style,
+          }}
+        >
+          {isOutOfOffice ? (
+            <IconCalendarOff
+              aria-hidden="true"
+              className="size-3 shrink-0"
+              style={{ color: accentColor }}
+            />
+          ) : allOtherDeclined(event) ? (
+            <IconAlertTriangleFilled
+              size={10}
+              className="shrink-0 text-current opacity-70"
+            />
+          ) : (
+            <span
+              className="h-1.5 w-1.5 shrink-0 rounded-full"
+              style={{ backgroundColor: accentColor }}
+            />
+          )}
+          <EventStatusIcon event={event} />
+          <span className="truncate font-medium">{title}</span>
+          {isWorkingLocation && (
+            <span className="hidden shrink-0 text-[10px] font-normal text-foreground/65 sm:inline">
+              {t("eventForm.workingLocation")}
+            </span>
+          )}
+          {isOutOfOffice && (
+            <span className="hidden shrink-0 text-[10px] font-normal text-foreground/65 sm:inline">
+              {t("eventForm.outOfOffice")}
+            </span>
+          )}
+          {event.ownerColor && (
+            <span
+              aria-hidden="true"
+              className="absolute right-1 top-1/2 size-1.5 -translate-y-1/2 rounded-full ring-1 ring-background/70"
+              style={{ backgroundColor: event.ownerColor }}
+            />
+          )}
+        </button>
+      );
+    }
+
     return (
       <button
-        onClick={onClick}
+        ref={forwardedRef}
+        {...buttonProps}
         draggable={canDrag}
         onDragStart={canDrag ? handleDragStart : undefined}
         onDragEnd={canDrag ? onDragEnd : undefined}
         className={cn(
-          "relative flex w-full items-center gap-1.5 rounded px-1.5 py-0.5 text-left text-xs text-foreground transition-[filter,transform] hover:brightness-110 active:scale-[0.98]",
+          "relative flex w-full flex-col gap-0.5 rounded-md px-2 py-1.5 text-left text-xs text-foreground transition-[filter,transform] hover:brightness-110 active:scale-[0.98]",
           canDrag && "cursor-grab active:cursor-grabbing",
           dimmed && "opacity-40",
-          event.ownerColor && "pr-3.5",
+          event.ownerColor && "pr-4",
+          className,
         )}
         aria-label={
           ownerLabel ? `${ariaTitle}, ${ownerLabel}'s calendar` : ariaTitle
         }
         style={{
           backgroundColor: `${accentColor}25`,
+          borderLeft: `2px solid ${accentColor}`,
+          ...style,
         }}
       >
-        {isOutOfOffice ? (
-          <IconCalendarOff
-            aria-hidden="true"
-            className="size-3 shrink-0"
-            style={{ color: accentColor }}
-          />
-        ) : allOtherDeclined(event) ? (
-          <IconAlertTriangleFilled
-            size={10}
-            className="shrink-0 text-current opacity-70"
-          />
-        ) : (
-          <span
-            className="h-1.5 w-1.5 shrink-0 rounded-full"
-            style={{ backgroundColor: accentColor }}
-          />
-        )}
-        <EventStatusIcon event={event} />
-        <span className="truncate font-medium">{title}</span>
+        <div className="flex items-center gap-1 truncate">
+          {isOutOfOffice && (
+            <IconCalendarOff
+              aria-hidden="true"
+              className="size-3 shrink-0"
+              style={{ color: accentColor }}
+            />
+          )}
+          {!isOutOfOffice && allOtherDeclined(event) && (
+            <IconAlertTriangleFilled
+              size={12}
+              className="shrink-0 text-current opacity-70"
+            />
+          )}
+          <EventStatusIcon event={event} />
+          <span className="truncate font-medium">{title}</span>
+        </div>
         {isWorkingLocation && (
-          <span className="hidden shrink-0 text-[10px] font-normal text-foreground/65 sm:inline">
+          <span className="truncate text-foreground/70">
             {t("eventForm.workingLocation")}
           </span>
         )}
         {isOutOfOffice && (
-          <span className="hidden shrink-0 text-[10px] font-normal text-foreground/65 sm:inline">
+          <span className="truncate text-foreground/70">
             {t("eventForm.outOfOffice")}
+          </span>
+        )}
+        {!event.allDay && (
+          <span className="text-foreground/70">
+            {new Date(event.start).toLocaleTimeString([], {
+              hour: "numeric",
+              minute: "2-digit",
+            })}
           </span>
         )}
         {event.ownerColor && (
           <span
             aria-hidden="true"
-            className="absolute right-1 top-1/2 size-1.5 -translate-y-1/2 rounded-full ring-1 ring-background/70"
+            className="absolute right-1.5 top-1.5 size-1.5 rounded-full ring-1 ring-background/70"
             style={{ backgroundColor: event.ownerColor }}
           />
         )}
       </button>
     );
-  }
-
-  return (
-    <button
-      onClick={onClick}
-      draggable={canDrag}
-      onDragStart={canDrag ? handleDragStart : undefined}
-      onDragEnd={canDrag ? onDragEnd : undefined}
-      className={cn(
-        "relative flex w-full flex-col gap-0.5 rounded-md px-2 py-1.5 text-left text-xs text-foreground transition-[filter,transform] hover:brightness-110 active:scale-[0.98]",
-        canDrag && "cursor-grab active:cursor-grabbing",
-        dimmed && "opacity-40",
-        event.ownerColor && "pr-4",
-      )}
-      aria-label={
-        ownerLabel ? `${ariaTitle}, ${ownerLabel}'s calendar` : ariaTitle
-      }
-      style={{
-        backgroundColor: `${accentColor}25`,
-        borderLeft: `2px solid ${accentColor}`,
-      }}
-    >
-      <div className="flex items-center gap-1 truncate">
-        {isOutOfOffice && (
-          <IconCalendarOff
-            aria-hidden="true"
-            className="size-3 shrink-0"
-            style={{ color: accentColor }}
-          />
-        )}
-        {!isOutOfOffice && allOtherDeclined(event) && (
-          <IconAlertTriangleFilled
-            size={12}
-            className="shrink-0 text-current opacity-70"
-          />
-        )}
-        <EventStatusIcon event={event} />
-        <span className="truncate font-medium">{title}</span>
-      </div>
-      {isWorkingLocation && (
-        <span className="truncate text-foreground/70">
-          {t("eventForm.workingLocation")}
-        </span>
-      )}
-      {isOutOfOffice && (
-        <span className="truncate text-foreground/70">
-          {t("eventForm.outOfOffice")}
-        </span>
-      )}
-      {!event.allDay && (
-        <span className="text-foreground/70">
-          {new Date(event.start).toLocaleTimeString([], {
-            hour: "numeric",
-            minute: "2-digit",
-          })}
-        </span>
-      )}
-      {event.ownerColor && (
-        <span
-          aria-hidden="true"
-          className="absolute right-1.5 top-1.5 size-1.5 rounded-full ring-1 ring-background/70"
-          style={{ backgroundColor: event.ownerColor }}
-        />
-      )}
-    </button>
-  );
-}
+  },
+);

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -1409,7 +1409,7 @@ export function EventDetailPopover({
             event={event}
             disabled={hoverPreviewDisabled || detailsOpen}
           >
-            {children as React.ReactElement}
+            {children as React.ReactElement<{ className?: string }>}
           </EventHoverPreview>
         ) : (
           children

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -35,6 +35,7 @@ import {
   RenderedDescription,
   AutoGrowTextarea,
 } from "@/components/calendar/EventDescription";
+import { EventHoverPreview } from "@/components/calendar/EventHoverPreview";
 import {
   AttachmentControls,
   ReminderControls,
@@ -96,6 +97,7 @@ import {
   type ReminderMode,
   validateAttachmentDrafts,
 } from "@/lib/event-form-utils";
+import { extractMeetingLink } from "@/lib/event-meeting";
 import { isOutOfOfficeEvent } from "@/lib/out-of-office";
 import {
   createEventDetailPopoverToken,
@@ -198,54 +200,6 @@ function formatTimeShort(dateStr: string): string {
   return `${hour12}:${m.toString().padStart(2, "0")} ${period}`;
 }
 
-/** Extract a Zoom/Meet/Teams link from location or description */
-function extractMeetingLink(event: CalendarEvent): {
-  url: string;
-  type: "zoom" | "meet" | "teams" | "link";
-  label?: string;
-  pin?: string;
-  passcode?: string;
-} | null {
-  if (event.meetingLink) {
-    return { url: event.meetingLink, type: getMeetingType(event.meetingLink) };
-  }
-
-  // Check conferenceData first
-  if (event.conferenceData?.entryPoints) {
-    const videoEntry = event.conferenceData.entryPoints.find(
-      (ep) => ep.entryPointType === "video",
-    );
-    if (videoEntry) {
-      let type: "zoom" | "meet" | "teams" | "link" = "link";
-      if (videoEntry.uri.includes("zoom.us")) type = "zoom";
-      else if (videoEntry.uri.includes("meet.google.com")) type = "meet";
-      else if (videoEntry.uri.includes("teams.microsoft.com")) type = "teams";
-      return {
-        url: videoEntry.uri,
-        type,
-        label: videoEntry.label || undefined,
-        pin: videoEntry.pin || undefined,
-        passcode: videoEntry.passcode || undefined,
-      };
-    }
-  }
-
-  // Fall back to the legacy hangoutLink (Google Meet)
-  if (event.hangoutLink) {
-    return { url: event.hangoutLink, type: "meet" };
-  }
-
-  // Fall back to text matching
-  const text = `${event.location || ""} ${event.description || ""}`;
-  const zoom = text.match(/https?:\/\/[^\s]*zoom\.us\/j\/[^\s)"]*/i);
-  if (zoom) return { url: zoom[0], type: "zoom" };
-  const meet = text.match(/https?:\/\/meet\.google\.com\/[^\s)"]*/i);
-  if (meet) return { url: meet[0], type: "meet" };
-  const teams = text.match(/https?:\/\/teams\.microsoft\.com\/[^\s)"]*/i);
-  if (teams) return { url: teams[0], type: "teams" };
-  return null;
-}
-
 function getMeetingLabel(
   type: "zoom" | "meet" | "teams" | "link",
   t: ReturnType<typeof useT>,
@@ -260,13 +214,6 @@ function getMeetingLabel(
     default:
       return t("eventForm.joinMeeting");
   }
-}
-
-function getMeetingType(url: string): "zoom" | "meet" | "teams" | "link" {
-  if (url.includes("zoom.us")) return "zoom";
-  if (url.includes("meet.google.com")) return "meet";
-  if (url.includes("teams.microsoft.com")) return "teams";
-  return "link";
 }
 
 function MeetingLinkSkeleton({ provider }: { provider: "meet" | "zoom" }) {
@@ -500,6 +447,10 @@ interface EventDetailPopoverProps {
   onDismissNew?: (eventId: string, accountEmail?: string) => void;
   /** Called after the popover's visible open state changes through its normal lifecycle. */
   onOpenChange?: (open: boolean) => void;
+  /** Adds the compact, read-only Month/Week disclosure without changing click details. */
+  showHoverPreview?: boolean;
+  /** Temporarily suppresses the preview while a parent owns pointer drag state. */
+  hoverPreviewDisabled?: boolean;
   onDraftUpdate?: (
     eventId: string,
     updates: Partial<CalendarEvent> & {
@@ -528,6 +479,8 @@ export function EventDetailPopover({
   onTitleSave,
   onDismissNew,
   onOpenChange,
+  showHoverPreview = false,
+  hoverPreviewDisabled = false,
   onDraftUpdate,
   onDraftCreate,
   onDraftDiscard,
@@ -1431,6 +1384,8 @@ export function EventDetailPopover({
     sidebarEvent?.id === event.id &&
     sidebarEvent.accountEmail === event.accountEmail;
   const detailsOpen = popoverOpen || sidebarDetailsOpen;
+  const hoverPreviewEnabled =
+    showHoverPreview && !isMobile && !isWorkingLocation && !isOutOfOffice;
   const previousDetailsOpenRef = useRef(false);
 
   useEffect(() => {
@@ -1449,7 +1404,16 @@ export function EventDetailPopover({
   return (
     <Popover open={popoverOpen} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild onClick={handleTriggerClick}>
-        {children}
+        {hoverPreviewEnabled ? (
+          <EventHoverPreview
+            event={event}
+            disabled={hoverPreviewDisabled || detailsOpen}
+          >
+            {children as React.ReactElement}
+          </EventHoverPreview>
+        ) : (
+          children
+        )}
       </PopoverTrigger>
       <PopoverContent
         align={isMobile ? "center" : "start"}

--- a/templates/calendar/app/components/calendar/EventHoverPreview.test.tsx
+++ b/templates/calendar/app/components/calendar/EventHoverPreview.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment happy-dom
+
+import type { CalendarEvent } from "@shared/api";
+import { type ReactNode } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EventHoverPreview } from "./EventHoverPreview";
+
+vi.mock("@agent-native/core/client/i18n", () => ({
+  useT:
+    () =>
+    (key: string): string =>
+      key,
+}));
+
+vi.mock("@/components/ui/hover-card", () => ({
+  HoverCard: ({ children }: { children: ReactNode }) => <>{children}</>,
+  HoverCardPortal: ({ children }: { children: ReactNode }) => <>{children}</>,
+  HoverCardTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  HoverCardContent: ({
+    children,
+    side,
+    align,
+  }: {
+    children: ReactNode;
+    side: string;
+    align: string;
+  }) => (
+    <aside data-testid="preview" data-side={side} data-align={align}>
+      {children}
+    </aside>
+  ),
+}));
+
+function event(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    id: "event-1",
+    title: "A planning session with a deliberately long title",
+    description: "",
+    location: "Room A",
+    start: "2026-07-10T16:00:00.000Z",
+    end: "2026-07-10T17:00:00.000Z",
+    allDay: false,
+    source: "google",
+    createdAt: "2026-07-10T15:00:00.000Z",
+    updatedAt: "2026-07-10T15:00:00.000Z",
+    attendees: [],
+    ...overrides,
+  };
+}
+
+describe("EventHoverPreview", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the event once beside its trigger with available details", () => {
+    act(() => {
+      root.render(
+        <EventHoverPreview
+          event={event({
+            meetingLink: "https://meet.google.com/abc-defg-hij",
+            attendees: [
+              { email: "alice@example.com", displayName: "Alice" },
+              { email: "brent@example.com" },
+              { email: "sam@example.com", displayName: "Sam" },
+              { email: "jules@example.com", displayName: "Jules" },
+            ],
+          })}
+        >
+          <button type="button">Source event</button>
+        </EventHoverPreview>,
+      );
+    });
+
+    const preview = container.querySelector('[data-testid="preview"]');
+    expect(preview?.getAttribute("data-side")).toBe("right");
+    expect(preview?.getAttribute("data-align")).toBe("center");
+    expect(
+      container.textContent?.match(/deliberately long title/g),
+    ).toHaveLength(1);
+    expect(container.textContent).toContain("Room A");
+    expect(container.textContent).toContain("Alice, brent@example.com, Sam +1");
+
+    const meetingLink = container.querySelector<HTMLAnchorElement>(
+      'a[href="https://meet.google.com/abc-defg-hij"]',
+    );
+    expect(meetingLink?.textContent).toContain("eventForm.joinMeet");
+    expect(meetingLink?.target).toBe("_blank");
+    expect(meetingLink?.rel).toBe("noopener noreferrer");
+  });
+
+  it("omits unavailable optional rows and avoids duplicating a meeting URL", () => {
+    act(() => {
+      root.render(
+        <EventHoverPreview
+          event={event({
+            location: "Join https://zoom.us/j/123",
+            attendees: [],
+          })}
+        >
+          <button type="button">Source event</button>
+        </EventHoverPreview>,
+      );
+    });
+
+    expect(container.textContent).not.toContain("Join https://zoom.us/j/123");
+    expect(container.textContent).toContain("eventForm.joinZoom");
+    expect(container.querySelectorAll("svg")).toHaveLength(3);
+  });
+});

--- a/templates/calendar/app/components/calendar/EventHoverPreview.test.tsx
+++ b/templates/calendar/app/components/calendar/EventHoverPreview.test.tsx
@@ -16,7 +16,19 @@ vi.mock("@agent-native/core/client/i18n", () => ({
 }));
 
 vi.mock("@/components/ui/hover-card", () => ({
-  HoverCard: ({ children }: { children: ReactNode }) => <>{children}</>,
+  HoverCard: ({
+    children,
+    openDelay,
+    closeDelay,
+  }: {
+    children: ReactNode;
+    openDelay: number;
+    closeDelay: number;
+  }) => (
+    <div data-open-delay={openDelay} data-close-delay={closeDelay}>
+      {children}
+    </div>
+  ),
   HoverCardPortal: ({ children }: { children: ReactNode }) => <>{children}</>,
   HoverCardTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
   HoverCardContent: ({
@@ -88,6 +100,9 @@ describe("EventHoverPreview", () => {
     });
 
     const preview = container.querySelector('[data-testid="preview"]');
+    const hoverCard = container.querySelector("[data-open-delay]");
+    expect(hoverCard?.getAttribute("data-open-delay")).toBe("50");
+    expect(hoverCard?.getAttribute("data-close-delay")).toBe("100");
     expect(preview?.getAttribute("data-side")).toBe("right");
     expect(preview?.getAttribute("data-align")).toBe("center");
     expect(

--- a/templates/calendar/app/components/calendar/EventHoverPreview.tsx
+++ b/templates/calendar/app/components/calendar/EventHoverPreview.tsx
@@ -1,0 +1,193 @@
+import { useT } from "@agent-native/core/client/i18n";
+import type { CalendarEvent } from "@shared/api";
+import {
+  IconClock,
+  IconExternalLink,
+  IconMapPin,
+  IconUsers,
+  IconVideo,
+} from "@tabler/icons-react";
+import { format, isSameDay, parseISO } from "date-fns";
+import {
+  forwardRef,
+  useEffect,
+  useMemo,
+  useState,
+  type ElementRef,
+  type HTMLAttributes,
+  type ReactElement,
+} from "react";
+
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardPortal,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { extractMeetingLink } from "@/lib/event-meeting";
+
+interface EventHoverPreviewProps extends HTMLAttributes<HTMLElement> {
+  event: CalendarEvent;
+  children: ReactElement;
+  disabled?: boolean;
+}
+
+function formatPreviewTime(event: CalendarEvent, allDayLabel: string): string {
+  const start = parseISO(event.start);
+  const end = parseISO(event.end);
+
+  if (event.allDay) {
+    return `${format(start, "EEE, MMM d")} · ${allDayLabel}`;
+  }
+  if (isSameDay(start, end)) {
+    return `${format(start, "EEE, MMM d")} · ${format(start, "h:mm a")}–${format(end, "h:mm a")}`;
+  }
+  return `${format(start, "EEE, MMM d · h:mm a")}–${format(end, "EEE, MMM d · h:mm a")}`;
+}
+
+export const EventHoverPreview = forwardRef<
+  ElementRef<typeof HoverCardTrigger>,
+  EventHoverPreviewProps
+>(function EventHoverPreview(
+  {
+    event,
+    children,
+    disabled = false,
+    onPointerDown,
+    onPointerUp,
+    ...triggerProps
+  },
+  forwardedRef,
+) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+  const [pointerDown, setPointerDown] = useState(false);
+  const meetingLink = useMemo(() => extractMeetingLink(event), [event]);
+  const attendees = event.attendees ?? [];
+  const visibleAttendees = attendees.slice(0, 3);
+  const attendeeRemainder = attendees.length - visibleAttendees.length;
+
+  useEffect(() => {
+    if (disabled || pointerDown) setOpen(false);
+  }, [disabled, pointerDown]);
+
+  useEffect(() => {
+    if (!pointerDown) return;
+    const releasePointer = () => setPointerDown(false);
+    window.addEventListener("pointerup", releasePointer, { once: true });
+    window.addEventListener("pointercancel", releasePointer, { once: true });
+    return () => {
+      window.removeEventListener("pointerup", releasePointer);
+      window.removeEventListener("pointercancel", releasePointer);
+    };
+  }, [pointerDown]);
+
+  const meetingLabel = meetingLink
+    ? meetingLink.type === "zoom"
+      ? t("eventForm.joinZoom")
+      : meetingLink.type === "meet"
+        ? t("eventForm.joinMeet")
+        : meetingLink.type === "teams"
+          ? t("eventForm.joinTeams")
+          : t("eventForm.joinMeeting")
+    : null;
+
+  return (
+    <HoverCard
+      open={disabled || pointerDown ? false : open}
+      onOpenChange={(nextOpen) => {
+        if (!disabled && !pointerDown) setOpen(nextOpen);
+      }}
+      openDelay={150}
+      closeDelay={150}
+    >
+      <HoverCardTrigger
+        asChild
+        ref={forwardedRef}
+        onPointerDown={(pointerEvent) => {
+          setPointerDown(true);
+          setOpen(false);
+          onPointerDown?.(pointerEvent);
+        }}
+        onPointerUp={(pointerEvent) => {
+          setPointerDown(false);
+          onPointerUp?.(pointerEvent);
+        }}
+        {...triggerProps}
+      >
+        {children}
+      </HoverCardTrigger>
+      <HoverCardPortal>
+        <HoverCardContent
+          side="right"
+          align="center"
+          sideOffset={8}
+          collisionPadding={12}
+          className="w-72 space-y-3 rounded-xl p-3.5 shadow-xl motion-reduce:animate-none"
+          data-event-hover-preview={event.id}
+          onClick={(clickEvent) => clickEvent.stopPropagation()}
+        >
+          <p className="break-words text-sm font-semibold leading-snug text-foreground">
+            {event.title}
+          </p>
+
+          <div className="space-y-2 text-xs text-muted-foreground">
+            <div className="flex items-start gap-2">
+              <IconClock
+                aria-hidden="true"
+                className="mt-0.5 size-3.5 shrink-0"
+              />
+              <span>{formatPreviewTime(event, t("eventForm.allDay"))}</span>
+            </div>
+
+            {event.location &&
+              (!meetingLink || !event.location.includes(meetingLink.url)) && (
+                <div className="flex items-start gap-2">
+                  <IconMapPin
+                    aria-hidden="true"
+                    className="mt-0.5 size-3.5 shrink-0"
+                  />
+                  <span className="break-words">{event.location}</span>
+                </div>
+              )}
+
+            {attendees.length > 0 && (
+              <div className="flex items-start gap-2">
+                <IconUsers
+                  aria-hidden="true"
+                  className="mt-0.5 size-3.5 shrink-0"
+                />
+                <span className="break-words">
+                  {visibleAttendees
+                    .map((attendee) => attendee.displayName || attendee.email)
+                    .join(", ")}
+                  {attendeeRemainder > 0 ? ` +${attendeeRemainder}` : ""}
+                </span>
+              </div>
+            )}
+          </div>
+
+          {meetingLink && meetingLabel && (
+            <a
+              href={meetingLink.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-between gap-3 rounded-lg bg-primary px-3 py-2 text-xs font-medium text-primary-foreground outline-none transition-colors hover:bg-primary/90 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:transition-none"
+              onPointerDown={(pointerEvent) => pointerEvent.stopPropagation()}
+              onClick={(clickEvent) => clickEvent.stopPropagation()}
+            >
+              <span className="flex min-w-0 items-center gap-2">
+                <IconVideo aria-hidden="true" className="size-3.5 shrink-0" />
+                <span className="truncate">{meetingLabel}</span>
+              </span>
+              <IconExternalLink
+                aria-hidden="true"
+                className="size-3.5 shrink-0"
+              />
+            </a>
+          )}
+        </HoverCardContent>
+      </HoverCardPortal>
+    </HoverCard>
+  );
+});

--- a/templates/calendar/app/components/calendar/EventHoverPreview.tsx
+++ b/templates/calendar/app/components/calendar/EventHoverPreview.tsx
@@ -107,8 +107,8 @@ export const EventHoverPreview = forwardRef<
       onOpenChange={(nextOpen) => {
         if (!disabled && !pointerDown) setOpen(nextOpen);
       }}
-      openDelay={150}
-      closeDelay={150}
+      openDelay={50}
+      closeDelay={100}
     >
       <HoverCardTrigger
         asChild
@@ -132,7 +132,7 @@ export const EventHoverPreview = forwardRef<
           align="center"
           sideOffset={8}
           collisionPadding={12}
-          className="w-72 space-y-3 rounded-xl p-3.5 shadow-xl motion-reduce:animate-none"
+          className="w-72 space-y-3 rounded-xl p-3.5 shadow-xl data-[state=closed]:duration-100 data-[state=open]:duration-150 data-[state=closed]:ease-out data-[state=open]:ease-out motion-reduce:animate-none"
           data-event-hover-preview={event.id}
           onClick={(clickEvent) => clickEvent.stopPropagation()}
         >

--- a/templates/calendar/app/components/calendar/EventHoverPreview.tsx
+++ b/templates/calendar/app/components/calendar/EventHoverPreview.tsx
@@ -9,6 +9,7 @@ import {
 } from "@tabler/icons-react";
 import { format, isSameDay, parseISO } from "date-fns";
 import {
+  cloneElement,
   forwardRef,
   useEffect,
   useMemo,
@@ -25,10 +26,11 @@ import {
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
 import { extractMeetingLink } from "@/lib/event-meeting";
+import { cn } from "@/lib/utils";
 
 interface EventHoverPreviewProps extends HTMLAttributes<HTMLElement> {
   event: CalendarEvent;
-  children: ReactElement;
+  children: ReactElement<{ className?: string }>;
   disabled?: boolean;
 }
 
@@ -91,6 +93,13 @@ export const EventHoverPreview = forwardRef<
           ? t("eventForm.joinTeams")
           : t("eventForm.joinMeeting")
     : null;
+  const previewOpen = open && !disabled && !pointerDown;
+  const trigger = cloneElement(children, {
+    className: cn(
+      children.props.className,
+      previewOpen && "ring-2 ring-ring/50 ring-offset-1 ring-offset-background",
+    ),
+  });
 
   return (
     <HoverCard
@@ -115,7 +124,7 @@ export const EventHoverPreview = forwardRef<
         }}
         {...triggerProps}
       >
-        {children}
+        {trigger}
       </HoverCardTrigger>
       <HoverCardPortal>
         <HoverCardContent

--- a/templates/calendar/app/components/calendar/MonthView.tsx
+++ b/templates/calendar/app/components/calendar/MonthView.tsx
@@ -279,6 +279,8 @@ export const MonthView = memo(function MonthView({
                         onDraftUpdate={onDraftUpdate}
                         onDraftCreate={onDraftCreate}
                         onDraftDiscard={onDraftDiscard}
+                        showHoverPreview
+                        hoverPreviewDisabled={draggingId !== null}
                       >
                         <div
                           onClick={(e) => e.stopPropagation()}
@@ -292,7 +294,7 @@ export const MonthView = memo(function MonthView({
                             }
                           }}
                           className={cn(
-                            "relative",
+                            "relative rounded-sm data-[state=open]:ring-2 data-[state=open]:ring-ring/50 data-[state=open]:ring-offset-1",
                             !isStart &&
                               "-ml-1 -mr-1 border-l-2 border-dashed border-current pl-[calc(0.25rem-2px)] opacity-90 sm:-ml-1.5 sm:-mr-1.5 sm:pl-[calc(0.375rem-2px)]",
                           )}

--- a/templates/calendar/app/components/calendar/MonthView.tsx
+++ b/templates/calendar/app/components/calendar/MonthView.tsx
@@ -271,33 +271,33 @@ export const MonthView = memo(function MonthView({
                   dayOccurrences
                     .slice(0, isMobile ? 2 : 3)
                     .map(({ event, isStart, continuesNext }) => (
-                      <EventDetailPopover
+                      <div
                         key={event.id}
-                        event={event}
-                        onDelete={onDeleteEvent ?? (() => {})}
-                        isDraft={draftEventIds.includes(event.id)}
-                        onDraftUpdate={onDraftUpdate}
-                        onDraftCreate={onDraftCreate}
-                        onDraftDiscard={onDraftDiscard}
-                        showHoverPreview
-                        hoverPreviewDisabled={draggingId !== null}
+                        onClick={(e) => e.stopPropagation()}
+                        onDragStart={(e) => {
+                          if (!isStart) return;
+                          const ghost = e.currentTarget.querySelector(
+                            "button",
+                          ) as HTMLElement | null;
+                          if (ghost) {
+                            e.dataTransfer.setDragImage(ghost, 12, 12);
+                          }
+                        }}
+                        className={cn(
+                          "relative rounded-sm",
+                          !isStart &&
+                            "-ml-1 -mr-1 border-l-2 border-dashed border-current pl-[calc(0.25rem-2px)] opacity-90 sm:-ml-1.5 sm:-mr-1.5 sm:pl-[calc(0.375rem-2px)]",
+                        )}
                       >
-                        <div
-                          onClick={(e) => e.stopPropagation()}
-                          onDragStart={(e) => {
-                            if (!isStart) return;
-                            const ghost = e.currentTarget.querySelector(
-                              "button",
-                            ) as HTMLElement | null;
-                            if (ghost) {
-                              e.dataTransfer.setDragImage(ghost, 12, 12);
-                            }
-                          }}
-                          className={cn(
-                            "relative rounded-sm data-[state=open]:ring-2 data-[state=open]:ring-ring/50 data-[state=open]:ring-offset-1",
-                            !isStart &&
-                              "-ml-1 -mr-1 border-l-2 border-dashed border-current pl-[calc(0.25rem-2px)] opacity-90 sm:-ml-1.5 sm:-mr-1.5 sm:pl-[calc(0.375rem-2px)]",
-                          )}
+                        <EventDetailPopover
+                          event={event}
+                          onDelete={onDeleteEvent ?? (() => {})}
+                          isDraft={draftEventIds.includes(event.id)}
+                          onDraftUpdate={onDraftUpdate}
+                          onDraftCreate={onDraftCreate}
+                          onDraftDiscard={onDraftDiscard}
+                          showHoverPreview
+                          hoverPreviewDisabled={draggingId !== null}
                         >
                           <EventCard
                             event={event}
@@ -311,16 +311,16 @@ export const MonthView = memo(function MonthView({
                             }}
                             dimmed={draggingId === event.id}
                           />
-                          {continuesNext && (
-                            <span
-                              aria-hidden="true"
-                              className="pointer-events-none absolute right-0.5 top-1/2 -translate-y-1/2 text-[9px] leading-none text-current opacity-60"
-                            >
-                              &rsaquo;
-                            </span>
-                          )}
-                        </div>
-                      </EventDetailPopover>
+                        </EventDetailPopover>
+                        {continuesNext && (
+                          <span
+                            aria-hidden="true"
+                            className="pointer-events-none absolute right-0.5 top-1/2 -translate-y-1/2 text-[9px] leading-none text-current opacity-60"
+                          >
+                            &rsaquo;
+                          </span>
+                        )}
+                      </div>
                     ))}
                 {!isLoading && dayOccurrences.length > (isMobile ? 2 : 3) && (
                   <button

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -411,7 +411,7 @@ const WeekEventCard = memo(function WeekEventCard({
         }
       }}
       className={cn(
-        "absolute overflow-hidden px-1.5 py-0.5 text-left text-[11px] flex flex-col hover:brightness-110 hover:shadow-md group data-[state=open]:ring-2 data-[state=open]:ring-ring/50",
+        "absolute overflow-hidden px-1.5 py-0.5 text-left text-[11px] flex flex-col hover:brightness-110 hover:shadow-md group",
         segmentStartsHere ? "rounded-t-md" : "rounded-t-none",
         isEnd ? "rounded-b-md" : "rounded-b-none",
         durationMin <= 30 ? "justify-center" : "justify-start",
@@ -1209,7 +1209,7 @@ export const WeekView = memo(function WeekView({
                       >
                         <button
                           className={cn(
-                            "absolute flex items-center gap-1 truncate rounded px-1.5 text-left text-[11px] font-medium text-foreground transition-opacity hover:opacity-80 data-[state=open]:ring-2 data-[state=open]:ring-ring/50",
+                            "absolute flex items-center gap-1 truncate rounded px-1.5 text-left text-[11px] font-medium text-foreground transition-opacity hover:opacity-80",
                             event.ownerColor && "pr-3.5",
                           )}
                           aria-label={

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -411,7 +411,7 @@ const WeekEventCard = memo(function WeekEventCard({
         }
       }}
       className={cn(
-        "absolute overflow-hidden px-1.5 py-0.5 text-left text-[11px] flex flex-col hover:brightness-110 hover:shadow-md group",
+        "absolute overflow-hidden px-1.5 py-0.5 text-left text-[11px] flex flex-col hover:brightness-110 hover:shadow-md group data-[state=open]:ring-2 data-[state=open]:ring-ring/50",
         segmentStartsHere ? "rounded-t-md" : "rounded-t-none",
         isEnd ? "rounded-b-md" : "rounded-b-none",
         durationMin <= 30 ? "justify-center" : "justify-start",
@@ -568,6 +568,8 @@ const WeekEventCard = memo(function WeekEventCard({
       onDraftCreate={onDraftCreate}
       onDraftDiscard={onDraftDiscard}
       onOpenChange={(open) => onPopoverOpenChange(event, open)}
+      showHoverPreview
+      hoverPreviewDisabled={isDragging || isBeingDragged}
     >
       {eventButton}
     </EventDetailPopover>
@@ -1203,10 +1205,11 @@ export const WeekView = memo(function WeekView({
                         onDraftUpdate={onDraftUpdate}
                         onDraftCreate={onDraftCreate}
                         onDraftDiscard={onDraftDiscard}
+                        showHoverPreview
                       >
                         <button
                           className={cn(
-                            "absolute flex items-center gap-1 truncate rounded px-1.5 text-left text-[11px] font-medium text-foreground transition-opacity hover:opacity-80",
+                            "absolute flex items-center gap-1 truncate rounded px-1.5 text-left text-[11px] font-medium text-foreground transition-opacity hover:opacity-80 data-[state=open]:ring-2 data-[state=open]:ring-ring/50",
                             event.ownerColor && "pr-3.5",
                           )}
                           aria-label={

--- a/templates/calendar/app/components/ui/hover-card.tsx
+++ b/templates/calendar/app/components/ui/hover-card.tsx
@@ -1,2 +1,1 @@
 export * from "@agent-native/toolkit/ui/hover-card";
-export { Portal as HoverCardPortal } from "@radix-ui/react-hover-card";

--- a/templates/calendar/app/components/ui/hover-card.tsx
+++ b/templates/calendar/app/components/ui/hover-card.tsx
@@ -1,0 +1,2 @@
+export * from "@agent-native/toolkit/ui/hover-card";
+export { Portal as HoverCardPortal } from "@radix-ui/react-hover-card";

--- a/templates/calendar/app/lib/event-meeting.test.ts
+++ b/templates/calendar/app/lib/event-meeting.test.ts
@@ -1,0 +1,81 @@
+import type { CalendarEvent } from "@shared/api";
+import { describe, expect, it } from "vitest";
+
+import { extractMeetingLink } from "./event-meeting";
+
+function event(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    id: "event-1",
+    title: "Team sync",
+    description: "",
+    location: "",
+    start: "2026-07-10T16:00:00.000Z",
+    end: "2026-07-10T17:00:00.000Z",
+    allDay: false,
+    source: "google",
+    createdAt: "2026-07-10T15:00:00.000Z",
+    updatedAt: "2026-07-10T15:00:00.000Z",
+    attendees: [],
+    ...overrides,
+  };
+}
+
+describe("extractMeetingLink", () => {
+  it("prefers the provider meeting link", () => {
+    expect(
+      extractMeetingLink(
+        event({
+          meetingLink: "https://meet.google.com/abc-defg-hij",
+          description: "Backup https://zoom.us/j/123",
+        }),
+      ),
+    ).toEqual({
+      url: "https://meet.google.com/abc-defg-hij",
+      type: "meet",
+    });
+  });
+
+  it("preserves conference entry-point metadata", () => {
+    expect(
+      extractMeetingLink(
+        event({
+          conferenceData: {
+            entryPoints: [
+              {
+                entryPointType: "video",
+                uri: "https://zoom.us/j/123",
+                label: "Zoom",
+                pin: "123",
+                passcode: "456",
+              },
+            ],
+          },
+        }),
+      ),
+    ).toEqual({
+      url: "https://zoom.us/j/123",
+      type: "zoom",
+      label: "Zoom",
+      pin: "123",
+      passcode: "456",
+    });
+  });
+
+  it("finds a supported meeting URL in event text", () => {
+    expect(
+      extractMeetingLink(
+        event({
+          description:
+            "Join at https://teams.microsoft.com/l/meetup-join/abc when ready",
+        }),
+      ),
+    ).toEqual({
+      url: "https://teams.microsoft.com/l/meetup-join/abc",
+      type: "teams",
+    });
+  });
+
+  it("returns null when no meeting access exists", () => {
+    expect(extractMeetingLink(event({ location: "Room A" }))).toBeNull();
+  });
+});

--- a/templates/calendar/app/lib/event-meeting.ts
+++ b/templates/calendar/app/lib/event-meeting.ts
@@ -1,0 +1,51 @@
+import type { CalendarEvent } from "@shared/api";
+
+export type EventMeetingLink = {
+  url: string;
+  type: "zoom" | "meet" | "teams" | "link";
+  label?: string;
+  pin?: string;
+  passcode?: string;
+};
+
+export function getMeetingType(url: string): EventMeetingLink["type"] {
+  if (url.includes("zoom.us")) return "zoom";
+  if (url.includes("meet.google.com")) return "meet";
+  if (url.includes("teams.microsoft.com")) return "teams";
+  return "link";
+}
+
+/** Extract a Zoom, Meet, or Teams link from the provider data or event text. */
+export function extractMeetingLink(
+  event: CalendarEvent,
+): EventMeetingLink | null {
+  if (event.meetingLink) {
+    return { url: event.meetingLink, type: getMeetingType(event.meetingLink) };
+  }
+
+  const videoEntry = event.conferenceData?.entryPoints?.find(
+    (entryPoint) => entryPoint.entryPointType === "video",
+  );
+  if (videoEntry) {
+    return {
+      url: videoEntry.uri,
+      type: getMeetingType(videoEntry.uri),
+      label: videoEntry.label || undefined,
+      pin: videoEntry.pin || undefined,
+      passcode: videoEntry.passcode || undefined,
+    };
+  }
+
+  if (event.hangoutLink) {
+    return { url: event.hangoutLink, type: "meet" };
+  }
+
+  const text = `${event.location || ""} ${event.description || ""}`;
+  const zoom = text.match(/https?:\/\/[^\s]*zoom\.us\/j\/[^\s)"]*/i);
+  if (zoom) return { url: zoom[0], type: "zoom" };
+  const meet = text.match(/https?:\/\/meet\.google\.com\/[^\s)"]*/i);
+  if (meet) return { url: meet[0], type: "meet" };
+  const teams = text.match(/https?:\/\/teams\.microsoft\.com\/[^\s)"]*/i);
+  if (teams) return { url: teams[0], type: "teams" };
+  return null;
+}

--- a/templates/calendar/changelog/2026-08-03-hover-over-month-and-week-events-to-preview-time-location-at.md
+++ b/templates/calendar/changelog/2026-08-03-hover-over-month-and-week-events-to-preview-time-location-at.md
@@ -3,4 +3,4 @@ type: improved
 date: 2026-08-03
 ---
 
-Hover over Month and Week events to preview time, location, attendees, and meeting access without leaving the calendar.
+Hover over Month and Week events to quickly preview time, location, attendees, and meeting access without leaving the calendar.

--- a/templates/calendar/changelog/2026-08-03-hover-over-month-and-week-events-to-preview-time-location-at.md
+++ b/templates/calendar/changelog/2026-08-03-hover-over-month-and-week-events-to-preview-time-location-at.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-03
+---
+
+Hover over Month and Week events to preview time, location, attendees, and meeting access without leaving the calendar.


### PR DESCRIPTION
## Problem

Calendar's compact Month and Week event cards often hide the context needed to recognize or join an event. Opening full details works, but it is heavier than a quick glance and interrupts scanning a dense calendar.

## Approach

Add a small, read-only preview beside an individual event after a brief hover-intent pause. The preview is layered over the calendar instead of resizing or moving events, while existing full-detail, drag, and resize behavior remains authoritative.

This deliberately applies only to ordinary Month and Week events. Day already has richer inline cards, and status-event lanes keep their existing rendering.

## What changed

- Added a portaled event preview with title, time, optional location, attendee summary, and existing meeting access.
- Reduced hover intent from 150 ms to 50 ms and matched the app's overlay cadence: 150 ms opening, 100 ms closing, with reduced-motion behavior preserved.
- Preferred right-side placement with collision-aware flipping to the left and a visible source halo.
- Suppressed or closed the preview during pointer-down, drag, resize, and full-detail interactions.
- Shared meeting-link detection between the preview and full details.
- Made `EventCard` forward native button props and refs so overlay triggers compose with the real event control.
- Exported the Hover Card portal from Toolkit, restored Calendar's one-line Toolkit adapter, and added the required Toolkit changeset.
- Added focused preview, timing, trigger-composition, meeting-link, and detail-popover coverage, plus a Calendar changelog entry.

## Safety and operations

This is a presentation change with no schema, action, route, authentication, credential, or stored-data migration. Reverting the preview wrapper restores the previous UI. The Toolkit change is an additive export covered by a patch changeset.

## Verification

- Current head `1761867b305f66c16bd54e4e88143e07f440494b`: focused hover-preview tests passed (2 tests), Calendar typecheck passed, formatting passed, and `git diff --check` passed.
- Local browser review on the current head used 22 disposable events across a dense August Month and a fully populated Week. A real pointer opened a varied Week-event preview within the shortened timing window; Month and Week both rendered the expanded fixture set with no observed console warning or error. This is implementer visual evidence, not independent acceptance.
- Previous head `6d0466f68610d55bef798e5a9e4f06a9ed42e317`: CI completed with 58 successful, 42 skipped/neutral, zero failed, and zero pending checks; Calendar's full suite passed 52 files and 354 tests; production build, Core UI-primitives sync, and changeset validation passed.
- Fresh full CI for the current timing head is pending.
- Independent H1-H7 acceptance remains blocked. The last sealed tester capsule proved the corrected fixture exposes `Join Meet`, but the tester's context-local browser tab disappeared between the short turns needed to finish bootstrap and begin H1 (`Existing tabs: none`). H2-H7 were not executed, and no implementer interaction is being substituted.

## Review focus

- Does `EventDetailPopover` preserve existing click/sidebar behavior while isolating hover state?
- Does the 50 ms intent delay feel immediate without making incidental pointer travel noisy, while the 100 ms close grace still permits entering the preview?
- Are drag, resize, pointer-down, and full-detail suppression paths sufficient to prevent stale previews or accidental clicks?
- Is side-only collision behavior calm and legible for dense Month and Week layouts?
- Is the additive Toolkit portal export the correct ownership boundary for Calendar's adapter?

## Required before readiness

- Complete fresh CI on the current head.
- Complete frozen independent H1-H7 browser acceptance in one uninterrupted browser session or on a browser surface whose tab persists across test turns.
- Year view remains a later product decision; Calendar does not currently expose that view mode.
