### PR TITLE
Keep the dev route table live when route files are added or deleted

### DIFF
--- a/.changeset/fix-dev-route-add-delete.md
+++ b/.changeset/fix-dev-route-add-delete.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep the dev server's route table live when route files are added or deleted. React Router's framework-mode plugin invalidates its virtual modules through Vite's deprecated back-compat module graph, which proxies only the `client` and `ssr` environments — never the Nitro environment that actually serves SSR. The route table therefore froze at whatever it was when the dev server booted: a new route file 404'd forever, and deleting one left the stale manifest importing a file that no longer existed, so every page returned `Internal Server Error: Failed to load url … Does the file exist?` until the process was restarted. Agent Native now mirrors that invalidation into every environment and reloads the affected server runners. Also escapes control bytes in dev SSR error bodies, so Vite's NUL-prefixed virtual-module ids print as `\0virtual:react-router/server-build` instead of making `curl` treat the response as binary and hide the only line describing the failure.

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -135,6 +135,75 @@ describe("createH3SSRHandler", () => {
     }
   });
 
+  it("keeps the dev 500 body printable when the error names a Vite virtual module", async () => {
+    // Vite ids virtual modules with a leading NUL, and module-resolution errors
+    // carry that id verbatim. A raw NUL in the body makes curl (and some proxies)
+    // treat the only useful line as binary — but the NUL is part of the real id,
+    // so it has to survive as a visible escape rather than be dropped.
+    const error = new Error(
+      "Failed to load url /app/routes/chat.$threadId.tsx in \0virtual:react-router/server-build. Does the file exist?",
+    );
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mocks.requestHandler.mockImplementationOnce(async () => {
+      throw error;
+    });
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    try {
+      const response = await handler(createEvent("/chat/abc"));
+      const body = await response.text();
+
+      expect(response.status).toBe(500);
+      expect(body).not.toContain("\0");
+      expect(body).toContain("in \\0virtual:react-router/server-build");
+      expect(body).toContain("/app/routes/chat.$threadId.tsx");
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("escapes other C0 control bytes but keeps real whitespace intact", async () => {
+    const error = new Error("broke\ton\nline\r\n\u001b[31mred\u001b[0m\u0007");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mocks.requestHandler.mockImplementationOnce(async () => {
+      throw error;
+    });
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    try {
+      const body = await (await handler(createEvent("/"))).text();
+
+      expect(body).toBe(
+        "Internal Server Error: broke\ton\nline\r\n\\x1b[31mred\\x1b[0m\\x07",
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("keeps the dev 500 path safe when an error message is not a string", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mocks.requestHandler.mockImplementationOnce(async () => {
+      throw { message: 500 };
+    });
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    try {
+      const response = await handler(createEvent("/chat/abc"));
+
+      expect(response.status).toBe(500);
+      await expect(response.text()).resolves.toBe("Internal Server Error: 500");
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it("strips APP_BASE_PATH from React Router lazy route manifest paths", async () => {
     process.env.APP_BASE_PATH = "/dispatch";
     const handler = createH3SSRHandler(() => ({})) as any;

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -332,6 +332,28 @@ function removeDocumentCsp(headers: Headers): void {
   headers.delete("content-security-policy-report-only");
 }
 
+/**
+ * Render an error message safely as a `text/plain` body.
+ *
+ * Vite ids its virtual modules with a leading NUL (`\0virtual:react-router/…`),
+ * and those ids travel verbatim inside module-resolution error messages. One raw
+ * NUL is enough for curl to refuse to print the response as text, hiding the only
+ * line that says what broke. Escape the control bytes rather than deleting them:
+ * the NUL is part of the real resolved id, so a reader who greps for it or pastes
+ * it into a bug report must be able to see that it is there.
+ */
+function textSafeErrorMessage(err: unknown): string {
+  const message = String((err as { message?: unknown })?.message ?? err);
+  // C0 controls except tab, newline, and carriage return, which are real formatting.
+  return message.replace(
+    /[\u0000-\u0008\u000b\u000c\u000e-\u001f]/g,
+    (char) => {
+      const code = char.codePointAt(0) ?? 0;
+      return code === 0 ? "\\0" : `\\x${code.toString(16).padStart(2, "0")}`;
+    },
+  );
+}
+
 function isFrameworkOrAssetPath(pathname: string): boolean {
   return (
     isMcpPublicPath(pathname) ||
@@ -478,7 +500,7 @@ export function createH3SSRHandler(getBuild: () => Promise<unknown> | unknown) {
       const isProd = process.env.NODE_ENV === "production";
       const body = isProd
         ? "Internal Server Error"
-        : `Internal Server Error: ${(err as Error)?.message ?? err}`;
+        : `Internal Server Error: ${textSafeErrorMessage(err)}`;
       return new Response(body, {
         status: 500,
         headers: { "content-type": "text/plain" },

--- a/packages/core/src/vite/client.spec.ts
+++ b/packages/core/src/vite/client.spec.ts
@@ -13,6 +13,8 @@ import {
   _getClientDedupe,
   _getDefaultOptimizeDeps,
   _getReactRouterAliases,
+  _installReactRouterVirtualInvalidationMirror,
+  _mirrorReactRouterVirtualInvalidation,
   _nitroModuleGraphSignature,
   _nitroStartupGate,
   _nitroStartupRecovery,
@@ -1539,6 +1541,157 @@ describe("Nitro dev full-reload debounce", () => {
   it("leaves plugins without a hotUpdate hook unchanged", () => {
     const plugin = { name: "nitro:env" } as any;
     expect(_debounceNitroFullReloadHotUpdate(plugin)).toBe(plugin);
+  });
+});
+
+describe("React Router virtual-module invalidation mirror", () => {
+  const SERVER_BUILD_ID = "\0virtual:react-router/server-build";
+  const BROWSER_MANIFEST_ID = "\0virtual:react-router/browser-manifest";
+
+  // These fakes mirror the shapes both sides of the bug actually use:
+  // react-router's framework plugin calls `server.moduleGraph.invalidateModule`
+  // (Vite's back-compat graph, which proxies only client + ssr), while requests
+  // are served from Nitro's own environment.
+  function fakeEnvironment(
+    name: string,
+    { ids = [] as string[], consumer = "server" } = {},
+  ) {
+    const modules = new Map(
+      ids.map((id) => [id, { id, transformResult: {}, lastHMRTimestamp: 0 }]),
+    );
+    return {
+      name,
+      config: { consumer },
+      hot: { send: vi.fn() },
+      moduleGraph: {
+        idToModuleMap: modules,
+        getModuleById: (id: string) => modules.get(id) ?? null,
+        invalidateModule: vi.fn(
+          (mod: any, _seen: unknown, timestamp: number, isHmr: boolean) => {
+            mod.transformResult = null;
+            if (isHmr) mod.lastHMRTimestamp = timestamp;
+          },
+        ),
+      },
+    };
+  }
+
+  function fakeServer(environments: ReturnType<typeof fakeEnvironment>[]) {
+    return {
+      environments: Object.fromEntries(environments.map((e) => [e.name, e])),
+      // Vite's deprecated back-compat graph. Only its `invalidateModule` matters
+      // here — react-router calls it, and it never reaches `nitro`.
+      moduleGraph: { invalidateModule: vi.fn(() => "original-result") },
+    } as any;
+  }
+
+  it("invalidates the server build in Nitro's environment when react-router only invalidated ssr", () => {
+    vi.useFakeTimers();
+    try {
+      const ssr = fakeEnvironment("ssr", { ids: [SERVER_BUILD_ID] });
+      const nitro = fakeEnvironment("nitro", { ids: [SERVER_BUILD_ID] });
+      const server = fakeServer([ssr, nitro]);
+
+      expect(_installReactRouterVirtualInvalidationMirror(server)).toBe(true);
+      server.moduleGraph.invalidateModule({ id: SERVER_BUILD_ID });
+      vi.advanceTimersByTime(300);
+
+      expect(nitro.moduleGraph.invalidateModule).toHaveBeenCalledTimes(1);
+      expect(nitro.hot.send).toHaveBeenCalledWith({ type: "full-reload" });
+      expect(
+        nitro.moduleGraph.getModuleById(SERVER_BUILD_ID)?.transformResult,
+      ).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("coalesces a burst of route-file changes into a single reload", () => {
+    vi.useFakeTimers();
+    try {
+      const nitro = fakeEnvironment("nitro", { ids: [SERVER_BUILD_ID] });
+      const server = fakeServer([nitro]);
+      _installReactRouterVirtualInvalidationMirror(server);
+
+      for (let i = 0; i < 8; i++) {
+        server.moduleGraph.invalidateModule({ id: SERVER_BUILD_ID });
+      }
+
+      expect(nitro.hot.send).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(299);
+      expect(nitro.hot.send).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(1);
+      expect(nitro.hot.send).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("passes the original invalidation through untouched", () => {
+    const server = fakeServer([fakeEnvironment("nitro")]);
+    const original = server.moduleGraph.invalidateModule;
+    _installReactRouterVirtualInvalidationMirror(server);
+
+    const mod = { id: SERVER_BUILD_ID };
+    expect(server.moduleGraph.invalidateModule(mod, "seen")).toBe(
+      "original-result",
+    );
+    expect(original).toHaveBeenCalledWith(mod, "seen");
+  });
+
+  it("ignores invalidations of modules react-router does not own", () => {
+    vi.useFakeTimers();
+    try {
+      const nitro = fakeEnvironment("nitro", { ids: [SERVER_BUILD_ID] });
+      const server = fakeServer([nitro]);
+      _installReactRouterVirtualInvalidationMirror(server);
+
+      server.moduleGraph.invalidateModule({ id: "/app/root.tsx" });
+      server.moduleGraph.invalidateModule({ id: undefined });
+      vi.advanceTimersByTime(300);
+
+      expect(nitro.moduleGraph.invalidateModule).not.toHaveBeenCalled();
+      expect(nitro.hot.send).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("never broadcasts a server reload to a client environment", () => {
+    const client = fakeEnvironment("client", {
+      ids: [BROWSER_MANIFEST_ID],
+      consumer: "client",
+    });
+    const nitro = fakeEnvironment("nitro", { ids: [SERVER_BUILD_ID] });
+
+    expect(
+      _mirrorReactRouterVirtualInvalidation(fakeServer([client, nitro])),
+    ).toEqual(["client", "nitro"]);
+    expect(client.moduleGraph.invalidateModule).toHaveBeenCalledTimes(1);
+    expect(client.hot.send).not.toHaveBeenCalled();
+    expect(nitro.hot.send).toHaveBeenCalledWith({ type: "full-reload" });
+  });
+
+  it("leaves environments with no react-router virtual modules alone", () => {
+    const nitro = fakeEnvironment("nitro", { ids: ["/app/server.ts"] });
+
+    expect(_mirrorReactRouterVirtualInvalidation(fakeServer([nitro]))).toEqual(
+      [],
+    );
+    expect(nitro.hot.send).not.toHaveBeenCalled();
+  });
+
+  it("warns loudly instead of silently doing nothing when Vite drops the back-compat graph", () => {
+    const warn = vi.fn();
+
+    expect(
+      _installReactRouterVirtualInvalidationMirror(
+        { environments: {} } as any,
+        { warn },
+      ),
+    ).toBe(false);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("dev server restart");
   });
 });
 

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -358,6 +358,138 @@ function debounceNitroFullReloadHotUpdate(plugin: Plugin): Plugin {
   return { ...plugin, hotUpdate: wrappedHotUpdate } as Plugin;
 }
 
+/** Prefix Vite gives React Router's virtual modules. */
+const REACT_ROUTER_VIRTUAL_ID_PREFIX = "\0virtual:react-router/";
+
+/**
+ * Debounce window for coalescing mirrored route-table reloads.
+ *
+ * A coding agent that rewrites a route tree emits one watcher event per file,
+ * and React Router re-resolves its config for each one. Keep this independent
+ * of `NITRO_FULL_RELOAD_DEBOUNCE_MS`: that one throttles Nitro's own reload
+ * broadcasts, this one throttles ours, and tuning either must not silently
+ * retune the other.
+ */
+const REACT_ROUTER_INVALIDATION_MIRROR_DEBOUNCE_MS = 300;
+
+/**
+ * Invalidate every React Router virtual module in every Vite environment, and
+ * tell each affected server environment's runner to re-import.
+ *
+ * Returns the environment names that had something to invalidate.
+ */
+function mirrorReactRouterVirtualInvalidation(
+  server: any,
+  now: () => number = Date.now,
+): string[] {
+  const timestamp = now();
+  const touched: string[] = [];
+  for (const [name, environment] of Object.entries<any>(
+    server?.environments ?? {},
+  )) {
+    const moduleGraph = environment?.moduleGraph;
+    if (!moduleGraph?.idToModuleMap) continue;
+
+    const seen = new Set<unknown>();
+    let invalidated = 0;
+    for (const id of [...moduleGraph.idToModuleMap.keys()] as string[]) {
+      if (!id.startsWith(REACT_ROUTER_VIRTUAL_ID_PREFIX)) continue;
+      const mod = moduleGraph.getModuleById(id);
+      if (!mod) continue;
+      moduleGraph.invalidateModule(mod, seen, timestamp, true);
+      invalidated += 1;
+    }
+    if (invalidated === 0) continue;
+
+    touched.push(name);
+    // Server environments evaluate the build inside a runner that keeps its own
+    // module cache; graph invalidation alone never reaches it. Client
+    // environments get their update through React Router's own HMR handling.
+    if (environment?.config?.consumer !== "client") {
+      environment?.hot?.send?.({ type: "full-reload" });
+    }
+  }
+  return touched;
+}
+
+/**
+ * Mirror React Router's dev-time virtual-module invalidation into the
+ * environment that actually serves requests.
+ *
+ * `@react-router/dev`'s framework-mode plugin invalidates its virtual modules
+ * through `server.moduleGraph` — Vite's deprecated back-compat graph, which
+ * proxies only the `client` and `ssr` environments. Agent Native serves SSR
+ * from Nitro's `nitro` environment, so that invalidation never reaches the
+ * `virtual:react-router/server-build` the request path evaluates, and the route
+ * table stays frozen at whatever it was when the dev server booted. A new route
+ * file then 404s forever, and a deleted one makes the stale manifest import a
+ * file that no longer exists — which fails the whole build, so EVERY page 500s
+ * with "Failed to load url … Does the file exist?" until the process restarts.
+ * Editing a route's contents hides all of this, because that path goes through
+ * Vite's normal HMR pipeline, which is environment-aware.
+ *
+ * Hooking React Router's call rather than the file watcher is what makes this
+ * ordering-safe: it awaits `updatePluginContext()` before invalidating, so by
+ * the time we mirror, the freshly resolved routes are already in place.
+ *
+ * React Router's RSC plugin already iterates `environments`; only the classic
+ * plugin still uses the back-compat graph (still true in 8.3.0). Delete this
+ * once upstream's classic path is environment-aware.
+ */
+function installReactRouterVirtualInvalidationMirror(
+  server: any,
+  {
+    debounceMs = REACT_ROUTER_INVALIDATION_MIRROR_DEBOUNCE_MS,
+    now = Date.now,
+    warn = console.warn,
+  }: {
+    debounceMs?: number;
+    now?: () => number;
+    warn?: (message: string) => void;
+  } = {},
+): boolean {
+  const backCompatGraph = server?.moduleGraph;
+  const original = backCompatGraph?.invalidateModule;
+  if (typeof original !== "function") {
+    warn(
+      "[agent-native] Vite's server.moduleGraph.invalidateModule is unavailable, " +
+        "so React Router route additions and deletions cannot be mirrored into " +
+        "the Nitro dev environment. Adding or deleting a route file will need a " +
+        "dev server restart to take effect.",
+    );
+    return false;
+  }
+
+  let pending: ReturnType<typeof setTimeout> | undefined;
+  backCompatGraph.invalidateModule = function patchedInvalidateModule(
+    this: unknown,
+    mod: { id?: string | null } | undefined,
+    ...rest: unknown[]
+  ) {
+    const result = original.call(this, mod, ...rest);
+    if (!mod?.id?.startsWith(REACT_ROUTER_VIRTUAL_ID_PREFIX)) return result;
+    if (pending) clearTimeout(pending);
+    pending = setTimeout(() => {
+      pending = undefined;
+      mirrorReactRouterVirtualInvalidation(server, now);
+    }, debounceMs);
+    // Never hold the process open just for a pending reload.
+    pending.unref?.();
+    return result;
+  };
+  return true;
+}
+
+function reactRouterVirtualInvalidationMirrorPlugin(): Plugin {
+  return {
+    name: "agent-native-react-router-invalidation-mirror",
+    apply: "serve",
+    configureServer(server) {
+      installReactRouterVirtualInvalidationMirror(server);
+    },
+  };
+}
+
 /**
  * Sync discovery for the workspace-core in an enterprise monorepo.
  *
@@ -3039,6 +3171,7 @@ function createAgentNativePlugins(
     baseRedirectGuard(),
     portExposer(),
     nitroStartupGate(),
+    reactRouterVirtualInvalidationMirrorPlugin(),
     silenceConnectionResets(),
     rolldownInputFix(),
     // Nitro Vite plugin for dev-mode API route serving and HMR.
@@ -3466,4 +3599,6 @@ export {
   nitroStartupRecovery as _nitroStartupRecovery,
   nitroModuleGraphSignature as _nitroModuleGraphSignature,
   debounceNitroFullReloadHotUpdate as _debounceNitroFullReloadHotUpdate,
+  installReactRouterVirtualInvalidationMirror as _installReactRouterVirtualInvalidationMirror,
+  mirrorReactRouterVirtualInvalidation as _mirrorReactRouterVirtualInvalidation,
 };


### PR DESCRIPTION
Replaces #2605, which picked up unrelated commits from a concurrent session.

## The bug

Deleting a route file while `agent-native dev` runs makes **every** page 500 — not just the deleted route — until the dev server restarts:

```
$ curl localhost:8080
Internal Server Error: Failed to load url /app/routes/chat.$threadId.tsx (resolved id: …) in ^@virtual:react-router/server-build. Does the file exist?
```

Adding a route file is the silent half of the same bug: it 404s forever.

This lands on codegen sessions constantly, since generating new routes and removing old ones is routine. Reproduced from a clean `agent-native create --template chat` app as well as from `templates/chat`.

## Root cause

`@react-router/dev`'s framework-mode plugin invalidates its virtual modules through `server.moduleGraph` — Vite's **deprecated back-compat graph**, which Vite hardwires to two environments:

```js
new ModuleGraph({
  client: () => environments.client.moduleGraph,
  ssr: () => environments.ssr.moduleGraph
});
```

Agent Native serves SSR from Nitro's `nitro` environment, so the invalidation never reaches the `virtual:react-router/server-build` the request path actually evaluates. Measured with a probe plugin after adding a route file:

```
env=client ctor=DevEnvironment          hasVid=false
env=ssr    ctor=FetchableDevEnvironment hasVid=true  hasTransform=false   ← invalidated
env=nitro  ctor=FetchableDevEnvironment hasVid=true  hasTransform=true    ← NOT invalidated
```

React Router's config loader *does* reload correctly (`[react-router] Config changed.` fires on every add/unlink) — its fresh route table just never reaches the environment that serves requests. In dev, route modules are imported lazily per request, so the frozen manifest keeps importing a file that no longer exists and the whole server build fails to load.

Nothing short of a restart recovers: touching `app/routes.ts`, editing an unrelated route, and adding new routes all leave it broken. Editing a route's *contents* works and hides the problem, because that path goes through Vite's normal HMR pipeline, which is environment-aware.

## The fix

A serve-only plugin mirrors React Router's invalidation into every environment and sends `full-reload` to each affected server runner, trailing-debounced 300ms so a burst of generated files collapses into one reload.

Hooking React Router's call rather than the file watcher is what makes it ordering-safe: React Router awaits `updatePluginContext()` *before* invalidating, so by the time we mirror, the freshly resolved routes are already in place. A watcher-based trigger would race that and go stale intermittently. It warns loudly rather than silently no-opping if Vite ever drops the back-compat graph.

Also escapes control bytes in dev SSR error bodies — Vite ids virtual modules with a leading NUL, which made `curl` treat the one useful line as binary. The id now renders as `\0virtual:react-router/server-build`, escaped rather than dropped, since the NUL is part of the real resolved id. The message is coerced with `String(...)` first (thanks @steve8708) so an error carrying a non-string `message` can't throw a `TypeError` inside the 500 handler itself.

## Not doing here

Upstream is the real home for this: React Router's own RSC plugin already iterates `Object.values(viteDevServer.environments)`; only the classic plugin still uses the back-compat graph, and that's still true in the latest 8.3.0 (checked the published tarball, so upgrading does not help). Their `future.v8_viteEnvironmentApi` flag was removed because "Vite Environment API usage is now always enabled", which makes this call site a straggler rather than an intentional legacy path. Filing that PR is deliberately left for a follow-up so apps on published core get unblocked now.

## Verification

| Check | Result |
| --- | --- |
| `client.spec.ts` + `ssr-handler.spec.ts` | 121 passed (7 new mirror tests, 3 new error-body tests) |
| Live dev server: add / delete / delete-a-boot-time-route | 10/10 PASS — new routes serve without restart, deletions 404 instead of 500ing every page |
| Codegen-shaped burst: 3 deletes + 3 adds at once | all existing pages 200, all new routes 200, deleted route 404 |
| Forced module-resolution 500 (deleted `root.tsx`) | body prints as text with 0 NUL bytes, shows `\0virtual:…` |
| `pnpm --filter @agent-native/core typecheck` | clean |
| `pnpm guards` | All checks passed |

Genuine breakage still fails loudly — deleting `app/root.tsx` correctly 500s no matter how fresh the route table is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)