### PR TITLE
feat(automations): add run-now execution flow

### DIFF
--- a/.agents/skills/automations/SKILL.md
+++ b/.agents/skills/automations/SKILL.md
@@ -103,6 +103,7 @@ All automation operations are accessed through a single `manage-automations` too
 | `update`      | Update an existing automation (enabled, condition, body)             |
 | `delete`      | Delete an automation (always confirm with user first)                |
 | `fire-test`   | Emit a `test.event.fired` event to validate automations              |
+| `run-now`     | Run one automation immediately with its real actions and side effects |
 
 Additional tool: `web-request` — outbound HTTP with `${keys.NAME}` substitution.
 

--- a/.changeset/run-automation-now.md
+++ b/.changeset/run-automation-now.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add an explicit Run now flow for automations, including reliable unattended action delivery, durable run history, and clearer email output.

--- a/packages/core/src/client/agent-page/AgentJobsTab.blocked.spec.tsx
+++ b/packages/core/src/client/agent-page/AgentJobsTab.blocked.spec.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const jobMocks = vi.hoisted(() => ({
   manageRecurringJob: vi.fn(),
+  useRunAutomationNow: vi.fn(),
   useAutomations: vi.fn(),
   useAutomationRuns: vi.fn(),
   useManageAutomation: vi.fn(),
@@ -19,6 +20,7 @@ vi.mock("./use-jobs.js", () => ({
   useManageAutomation: jobMocks.useManageAutomation,
   useManageRecurringJob: jobMocks.useManageRecurringJob,
   useRecurringJobs: jobMocks.useRecurringJobs,
+  useRunAutomationNow: jobMocks.useRunAutomationNow,
 }));
 
 vi.mock("../AgentAskPopover.js", () => ({
@@ -96,6 +98,11 @@ describe("AgentJobsTab blocked automation", () => {
       mutate: jobMocks.manageRecurringJob,
     });
     jobMocks.useManageAutomation.mockReturnValue({
+      error: null,
+      isPending: false,
+      mutate: vi.fn(),
+    });
+    jobMocks.useRunAutomationNow.mockReturnValue({
       error: null,
       isPending: false,
       mutate: vi.fn(),

--- a/packages/core/src/client/agent-page/AgentJobsTab.spec.tsx
+++ b/packages/core/src/client/agent-page/AgentJobsTab.spec.tsx
@@ -9,6 +9,7 @@ const jobMocks = vi.hoisted(() => ({
     org: vi.fn(),
     user: vi.fn(),
   },
+  useRunAutomationNow: vi.fn(),
   useAutomations: vi.fn(),
   useManageAutomation: vi.fn(),
   useManageRecurringJob: vi.fn(),
@@ -20,6 +21,7 @@ vi.mock("./use-jobs.js", () => ({
   useManageAutomation: jobMocks.useManageAutomation,
   useManageRecurringJob: jobMocks.useManageRecurringJob,
   useRecurringJobs: jobMocks.useRecurringJobs,
+  useRunAutomationNow: jobMocks.useRunAutomationNow,
 }));
 
 vi.mock("../AgentAskPopover.js", () => ({
@@ -140,6 +142,7 @@ describe("AgentJobsTab organization automations", () => {
       ),
     );
     jobMocks.useManageRecurringJob.mockReturnValue(mutationResult());
+    jobMocks.useRunAutomationNow.mockReturnValue(mutationResult());
     jobMocks.useManageAutomation.mockImplementation((scope: "user" | "org") =>
       mutationResult(jobMocks.manageAutomation[scope]),
     );

--- a/packages/core/src/client/agent-page/AgentJobsTab.tsx
+++ b/packages/core/src/client/agent-page/AgentJobsTab.tsx
@@ -36,6 +36,7 @@ import {
   useAutomations,
   useManageAutomation,
   useManageRecurringJob,
+  useRunAutomationNow,
   useRecurringJobs,
   type Automation,
   type RecurringJob,
@@ -179,6 +180,7 @@ export function AgentJobsTab({ canManageOrg = false }: AgentPageTabProps) {
   const personalAutomationsMutation = useManageAutomation("user");
   const organizationJobsMutation = useManageRecurringJob("org");
   const organizationAutomationsMutation = useManageAutomation("org");
+  const runAutomationMutation = useRunAutomationNow();
   const [deleteTarget, setDeleteTarget] = useState<ListedAutomation | null>(
     null,
   );
@@ -188,6 +190,7 @@ export function AgentJobsTab({ canManageOrg = false }: AgentPageTabProps) {
   const [scheduleTarget, setScheduleTarget] = useState<ListedAutomation | null>(
     null,
   );
+  const [runTarget, setRunTarget] = useState<ListedAutomation | null>(null);
 
   const formatDateTime = (value: string | null) => {
     if (!value || Number.isNaN(new Date(value).getTime())) return null;
@@ -461,6 +464,19 @@ export function AgentJobsTab({ canManageOrg = false }: AgentPageTabProps) {
                     </Button>
                     {resource.canUpdate ? (
                       <>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="cursor-pointer px-2 text-xs"
+                          disabled={
+                            mutationPending || runAutomationMutation.isPending
+                          }
+                          onClick={() => setRunTarget(entry)}
+                        >
+                          <IconPlayerPlay className="size-3.5" />
+                          {t("jobs.runNow", { defaultValue: "Run now" })}
+                        </Button>
                         {entry.triggerType === "schedule" ? (
                           <Button
                             type="button"
@@ -523,7 +539,8 @@ export function AgentJobsTab({ canManageOrg = false }: AgentPageTabProps) {
     personalJobsMutation.error ||
     personalAutomationsMutation.error ||
     organizationJobsMutation.error ||
-    organizationAutomationsMutation.error;
+    organizationAutomationsMutation.error ||
+    runAutomationMutation.error;
 
   return (
     <AgentTabFrame
@@ -636,6 +653,65 @@ export function AgentJobsTab({ canManageOrg = false }: AgentPageTabProps) {
                 <IconLoader2 className="size-4 animate-spin" />
               ) : null}
               {t("jobs.delete", { defaultValue: "Delete" })}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={runTarget !== null}
+        onOpenChange={(open) => {
+          if (!open && !runAutomationMutation.isPending) setRunTarget(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {t("jobs.runNowTitle", { defaultValue: "Run automation now?" })}
+            </DialogTitle>
+            <DialogDescription>
+              {t("jobs.runNowDescription", {
+                defaultValue:
+                  "This runs the automation's real actions immediately. It may send messages or change data, and it will not change the next scheduled run.",
+              })}
+            </DialogDescription>
+          </DialogHeader>
+          {runAutomationMutation.error ? (
+            <p className="text-sm text-destructive">
+              {runAutomationMutation.error.message}
+            </p>
+          ) : null}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              className="cursor-pointer"
+              disabled={runAutomationMutation.isPending}
+              onClick={() => setRunTarget(null)}
+            >
+              {t("jobs.cancel", { defaultValue: "Cancel" })}
+            </Button>
+            <Button
+              type="button"
+              className="cursor-pointer"
+              disabled={runAutomationMutation.isPending}
+              onClick={() => {
+                if (!runTarget) return;
+                runAutomationMutation.mutate(
+                  {
+                    name: runTarget.resource.name,
+                    scope: runTarget.resource.scope,
+                  },
+                  { onSuccess: () => setRunTarget(null) },
+                );
+              }}
+            >
+              {runAutomationMutation.isPending ? (
+                <IconLoader2 className="size-4 animate-spin" />
+              ) : (
+                <IconPlayerPlay className="size-4" />
+              )}
+              {t("jobs.runNow", { defaultValue: "Run now" })}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/packages/core/src/client/agent-page/use-jobs.ts
+++ b/packages/core/src/client/agent-page/use-jobs.ts
@@ -64,6 +64,17 @@ export type ManageJobInput = {
 
 export type ManageAutomationInput = ManageJobInput;
 
+export interface RunAutomationNowInput {
+  name: string;
+  scope: "personal" | "organization";
+}
+
+export interface RunAutomationNowResult {
+  queued: true;
+  runId: string;
+  automationRunId: string;
+}
+
 export interface AutomationRun {
   id: string;
   automation: string;
@@ -168,6 +179,32 @@ export function useManageAutomation(scope: JobsScope) {
       }
     },
   });
+}
+
+export function useRunAutomationNow() {
+  const queryClient = useQueryClient();
+  return useActionMutation<RunAutomationNowResult, RunAutomationNowInput>(
+    "run-automation-now",
+    {
+      onSuccess: (_result, variables) => {
+        const scope =
+          variables.scope === "organization" ? "organization" : "personal";
+        queryClient.invalidateQueries({
+          queryKey: [
+            "action",
+            "list-automation-runs",
+            { scope, name: variables.name },
+          ],
+        });
+        queryClient.invalidateQueries({
+          queryKey: ["action", "list-automations", { scope }],
+        });
+        queryClient.invalidateQueries({
+          queryKey: ["action", "list-recurring-jobs", { scope }],
+        });
+      },
+    },
+  );
 }
 
 function optimisticPatch(variables: ManageJobInput) {

--- a/packages/core/src/jobs/actions/run-automation-now.ts
+++ b/packages/core/src/jobs/actions/run-automation-now.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+import { defineAction } from "../../action.js";
+import { queueAutomationRunNow } from "../run-now.js";
+
+export default defineAction({
+  description:
+    "Run one personal or organization automation immediately. This is an explicit send/run action and may perform the automation's real side effects.",
+  agentTool: false,
+  schema: z.object({
+    name: z.string().min(1),
+    scope: z.enum(["personal", "organization"]).default("personal"),
+  }),
+  run: async ({ name, scope }, ctx) => {
+    if (!ctx?.userEmail) throw new Error("Not authenticated.");
+    return queueAutomationRunNow({
+      userEmail: ctx.userEmail,
+      orgId: ctx.orgId,
+      scope,
+      name,
+    });
+  },
+});

--- a/packages/core/src/jobs/background-automation-runner.ts
+++ b/packages/core/src/jobs/background-automation-runner.ts
@@ -75,6 +75,8 @@ export interface BackgroundAutomationRunOptions {
   requestContext?: Omit<RequestContext, "userEmail" | "orgId">;
   actionCaller?: ActionCaller;
   actionAutomation?: ActionAutomationContext;
+  /** Reuse a history row created by a durable run-now enqueue. */
+  historyId?: string;
 }
 
 export interface BackgroundAutomationRunResult {
@@ -260,34 +262,39 @@ export async function runBackgroundAutomation(
   // that cannot be written should cost us the record, not the automation.
   // Everything downstream tolerates a null id by skipping its own write.
   let historyId: string | null = null;
-  try {
-    const historyOwner = options.orgId
-      ? organizationResourceOwner(options.orgId)
-      : automation.resource.owner === "__shared__"
-        ? options.ownerEmail
-        : automation.resource.owner;
-    historyId = await startAutomationRun({
-      owner: historyOwner,
-      automation: automation.name,
-      path: automation.resource.path,
-      scope: options.orgId ? "organization" : "personal",
-      orgId: options.orgId ?? null,
-    });
-  } catch (err) {
-    console.error(
-      `[automations] Could not open a history record for "${automation.name}"; running anyway:`,
-      err,
-    );
+  if (options.historyId) {
+    historyId = options.historyId;
+  } else {
+    try {
+      const historyOwner = options.orgId
+        ? organizationResourceOwner(options.orgId)
+        : automation.resource.owner === "__shared__"
+          ? options.ownerEmail
+          : automation.resource.owner;
+      historyId = await startAutomationRun({
+        owner: historyOwner,
+        automation: automation.name,
+        path: automation.resource.path,
+        scope: options.orgId ? "organization" : "personal",
+        orgId: options.orgId ?? null,
+      });
+    } catch (err) {
+      console.error(
+        `[automations] Could not open a history record for "${automation.name}"; running anyway:`,
+        err,
+      );
+    }
   }
 
   let result: BackgroundAutomationRunResult;
   try {
     result = await executeBackgroundAutomation(options, deps, historyId);
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
     await recordRunOutcome(
       historyId,
       "error",
-      err instanceof Error ? err.message : String(err),
+      `${message}. No delivery was confirmed.`,
     );
     throw err;
   }

--- a/packages/core/src/jobs/run-history.ts
+++ b/packages/core/src/jobs/run-history.ts
@@ -55,6 +55,11 @@ const MAX_ERROR_LENGTH = 500;
  */
 const RUN_LIVENESS_CEILING_MS = 15 * 60_000;
 
+// The background worker has a shorter hard timeout than this lease. A worker
+// that dies after claiming can therefore be redelivered without overlapping a
+// still-live execution under normal runtime limits.
+const CLAIM_LEASE_MS = RUN_LIVENESS_CEILING_MS;
+
 /** Rows kept per automation, so a per-minute schedule cannot grow forever. */
 const RUNS_RETAINED_PER_AUTOMATION = 50;
 
@@ -203,9 +208,10 @@ export async function getAutomationRun(
 /** Claim a manually queued run exactly once before loading its automation. */
 export async function claimAutomationRun(id: string): Promise<boolean> {
   await ensureTable();
+  const now = Date.now();
   const result = await getDbExec().execute({
-    sql: `UPDATE ${TABLE} SET claimed_at = ? WHERE id = ? AND dispatch_pending = 1 AND claimed_at IS NULL AND status = 'running'`,
-    args: [Date.now(), id],
+    sql: `UPDATE ${TABLE} SET claimed_at = ? WHERE id = ? AND dispatch_pending = 1 AND (claimed_at IS NULL OR claimed_at <= ?) AND status = 'running'`,
+    args: [now, id, now - CLAIM_LEASE_MS],
   });
   return Number(result.rowsAffected ?? 0) > 0;
 }
@@ -224,10 +230,10 @@ export async function listUnclaimedAutomationRuns(options?: {
   const limit = Math.min(Math.max(options?.limit ?? 50, 1), 100);
   const result = await getDbExec().execute({
     sql: `SELECT * FROM ${TABLE}
-          WHERE dispatch_pending = 1 AND claimed_at IS NULL AND status = 'running'
+          WHERE dispatch_pending = 1 AND (claimed_at IS NULL OR claimed_at <= ?) AND status = 'running'
             AND started_at <= ?
           ORDER BY started_at ASC LIMIT ${limit}`,
-    args: [Date.now() - olderThanMs],
+    args: [Date.now() - CLAIM_LEASE_MS, Date.now() - olderThanMs],
   });
   const now = Date.now();
   return (result.rows ?? []).map((row) =>

--- a/packages/core/src/jobs/run-history.ts
+++ b/packages/core/src/jobs/run-history.ts
@@ -42,6 +42,8 @@ export interface StartAutomationRunInput {
   orgId?: string | null;
   runId?: string | null;
   threadId?: string | null;
+  /** A pre-created row still waiting for its background worker handoff. */
+  dispatchPending?: boolean;
 }
 
 const TABLE = "automation_runs";
@@ -76,7 +78,8 @@ async function ensureTable(): Promise<void> {
           started_at ${intType()} NOT NULL,
           finished_at ${intType()},
           error TEXT,
-          claimed_at ${intType()}
+          claimed_at ${intType()},
+          dispatch_pending ${intType()} NOT NULL DEFAULT 0
         )
       `;
       const indexSql = `CREATE INDEX IF NOT EXISTS idx_${TABLE}_owner_automation ON ${TABLE} (owner, automation, started_at)`;
@@ -88,19 +91,28 @@ async function ensureTable(): Promise<void> {
           "claimed_at",
           `ALTER TABLE ${TABLE} ADD COLUMN IF NOT EXISTS claimed_at ${intType()}`,
         );
+        await ensureColumnExists(
+          TABLE,
+          "dispatch_pending",
+          `ALTER TABLE ${TABLE} ADD COLUMN IF NOT EXISTS dispatch_pending ${intType()} NOT NULL DEFAULT 0`,
+        );
         await ensureIndexExists(`idx_${TABLE}_owner_automation`, indexSql);
         return;
       }
 
       await client.execute(createSql);
       const { rows } = await client.execute(`PRAGMA table_info("${TABLE}")`);
-      const hasClaimedAt = rows.some(
-        (row) => String((row as Record<string, unknown>).name) === "claimed_at",
+      const columns = new Set(
+        rows.map((row) => String((row as Record<string, unknown>).name)),
       );
-      if (!hasClaimedAt) {
+      for (const [name, definition] of [
+        ["claimed_at", `${intType()}`],
+        ["dispatch_pending", `${intType()} NOT NULL DEFAULT 0`],
+      ] as const) {
+        if (columns.has(name)) continue;
         try {
           await client.execute(
-            `ALTER TABLE ${TABLE} ADD COLUMN claimed_at ${intType()}`,
+            `ALTER TABLE ${TABLE} ADD COLUMN ${name} ${definition}`,
           );
         } catch (error) {
           const message = String(
@@ -147,9 +159,9 @@ function toRun(row: Record<string, unknown>, now: number): AutomationRun {
 }
 
 /**
- * Record that an automation actually began executing. Returns the run id used
- * to close the record out. Only real executions get a row — a tick that
- * declined to run the automation must not appear in its history.
+ * Record an automation execution. Manual runs create the row before dispatch,
+ * so `dispatchPending` distinguishes that durable handoff from a run that has
+ * already entered the worker.
  */
 export async function startAutomationRun(
   input: StartAutomationRunInput,
@@ -157,8 +169,8 @@ export async function startAutomationRun(
   await ensureTable();
   const id = randomUUID();
   await getDbExec().execute({
-    sql: `INSERT INTO ${TABLE} (id, owner, automation, path, scope, org_id, run_id, thread_id, status, started_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'running', ?)`,
+    sql: `INSERT INTO ${TABLE} (id, owner, automation, path, scope, org_id, run_id, thread_id, status, started_at, dispatch_pending)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'running', ?, ?)`,
     args: [
       id,
       input.owner,
@@ -169,6 +181,7 @@ export async function startAutomationRun(
       input.runId ?? null,
       input.threadId ?? null,
       Date.now(),
+      input.dispatchPending ? 1 : 0,
     ],
   });
   await pruneAutomationRuns(input.owner, input.automation);
@@ -191,10 +204,35 @@ export async function getAutomationRun(
 export async function claimAutomationRun(id: string): Promise<boolean> {
   await ensureTable();
   const result = await getDbExec().execute({
-    sql: `UPDATE ${TABLE} SET claimed_at = ? WHERE id = ? AND claimed_at IS NULL AND status = 'running'`,
+    sql: `UPDATE ${TABLE} SET claimed_at = ? WHERE id = ? AND dispatch_pending = 1 AND claimed_at IS NULL AND status = 'running'`,
     args: [Date.now(), id],
   });
   return Number(result.rowsAffected ?? 0) > 0;
+}
+
+/**
+ * Find manual handoffs that have stayed unclaimed long enough to have missed
+ * their first self-dispatch. The row is the durable queue; callers may safely
+ * redeliver it because claimAutomationRun is an atomic CAS.
+ */
+export async function listUnclaimedAutomationRuns(options?: {
+  olderThanMs?: number;
+  limit?: number;
+}): Promise<AutomationRun[]> {
+  await ensureTable();
+  const olderThanMs = Math.max(options?.olderThanMs ?? 10_000, 0);
+  const limit = Math.min(Math.max(options?.limit ?? 50, 1), 100);
+  const result = await getDbExec().execute({
+    sql: `SELECT * FROM ${TABLE}
+          WHERE dispatch_pending = 1 AND claimed_at IS NULL AND status = 'running'
+            AND started_at <= ?
+          ORDER BY started_at ASC LIMIT ${limit}`,
+    args: [Date.now() - olderThanMs],
+  });
+  const now = Date.now();
+  return (result.rows ?? []).map((row) =>
+    toRun(row as Record<string, unknown>, now),
+  );
 }
 
 /**

--- a/packages/core/src/jobs/run-history.ts
+++ b/packages/core/src/jobs/run-history.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from "node:crypto";
 
 import { getDbExec, intType, isPostgres } from "../db/client.js";
-import { ensureIndexExists, ensureTableExists } from "../db/ddl-guard.js";
+import {
+  ensureColumnExists,
+  ensureIndexExists,
+  ensureTableExists,
+} from "../db/ddl-guard.js";
 
 /**
  * "interrupted" is derived at read time, never stored: a process killed
@@ -71,18 +75,45 @@ async function ensureTable(): Promise<void> {
           status TEXT NOT NULL DEFAULT 'running',
           started_at ${intType()} NOT NULL,
           finished_at ${intType()},
-          error TEXT
+          error TEXT,
+          claimed_at ${intType()}
         )
       `;
       const indexSql = `CREATE INDEX IF NOT EXISTS idx_${TABLE}_owner_automation ON ${TABLE} (owner, automation, started_at)`;
 
       if (isPostgres()) {
         await ensureTableExists(TABLE, createSql);
+        await ensureColumnExists(
+          TABLE,
+          "claimed_at",
+          `ALTER TABLE ${TABLE} ADD COLUMN IF NOT EXISTS claimed_at ${intType()}`,
+        );
         await ensureIndexExists(`idx_${TABLE}_owner_automation`, indexSql);
         return;
       }
 
       await client.execute(createSql);
+      const { rows } = await client.execute(`PRAGMA table_info("${TABLE}")`);
+      const hasClaimedAt = rows.some(
+        (row) => String((row as Record<string, unknown>).name) === "claimed_at",
+      );
+      if (!hasClaimedAt) {
+        try {
+          await client.execute(
+            `ALTER TABLE ${TABLE} ADD COLUMN claimed_at ${intType()}`,
+          );
+        } catch (error) {
+          const message = String(
+            (error as { message?: unknown } | null)?.message ?? error,
+          );
+          if (
+            !/duplicate column name/i.test(message) &&
+            !/column .* already exists/i.test(message)
+          ) {
+            throw error;
+          }
+        }
+      }
       await client.execute(indexSql);
     })().catch((err) => {
       _initPromise = undefined;
@@ -142,6 +173,28 @@ export async function startAutomationRun(
   });
   await pruneAutomationRuns(input.owner, input.automation);
   return id;
+}
+
+export async function getAutomationRun(
+  id: string,
+): Promise<AutomationRun | null> {
+  await ensureTable();
+  const result = await getDbExec().execute({
+    sql: `SELECT * FROM ${TABLE} WHERE id = ? LIMIT 1`,
+    args: [id],
+  });
+  const row = result.rows?.[0] as Record<string, unknown> | undefined;
+  return row ? toRun(row, Date.now()) : null;
+}
+
+/** Claim a manually queued run exactly once before loading its automation. */
+export async function claimAutomationRun(id: string): Promise<boolean> {
+  await ensureTable();
+  const result = await getDbExec().execute({
+    sql: `UPDATE ${TABLE} SET claimed_at = ? WHERE id = ? AND claimed_at IS NULL AND status = 'running'`,
+    args: [Date.now(), id],
+  });
+  return Number(result.rowsAffected ?? 0) > 0;
 }
 
 /**

--- a/packages/core/src/jobs/run-now.ts
+++ b/packages/core/src/jobs/run-now.ts
@@ -13,7 +13,11 @@ import {
 } from "../resources/store.js";
 import { fireInternalDispatch } from "../server/self-dispatch.js";
 import { parseJobResource } from "./frontmatter.js";
-import { startAutomationRun, finishAutomationRun } from "./run-history.js";
+import {
+  finishAutomationRun,
+  listUnclaimedAutomationRuns,
+  startAutomationRun,
+} from "./run-history.js";
 
 export interface RunAutomationNowInput {
   userEmail: string;
@@ -26,6 +30,23 @@ export interface QueuedAutomationRun {
   queued: true;
   runId: string;
   automationRunId: string;
+}
+
+async function dispatchAutomationRun(historyId: string): Promise<void> {
+  const dispatchPath = resolveAgentChatProcessRunDispatchPath();
+  await fireInternalDispatch({
+    path: dispatchPath,
+    taskId: historyId,
+    body: {
+      [AGENT_CHAT_BACKGROUND_RUN_FIELD]: {
+        runId: historyId,
+        automationRunId: historyId,
+      },
+    },
+    ...(dispatchPathTargetsNetlifyBackgroundFunction(dispatchPath)
+      ? { awaitResponse: true, responseTimeoutMs: 5_000 }
+      : {}),
+  });
 }
 
 function ownerForScope(input: RunAutomationNowInput): string {
@@ -79,22 +100,10 @@ export async function queueAutomationRunNow(
     path: resource.path,
     scope: input.scope,
     orgId: input.scope === "organization" ? input.orgId : null,
+    dispatchPending: true,
   });
-  const dispatchPath = resolveAgentChatProcessRunDispatchPath();
   try {
-    await fireInternalDispatch({
-      path: dispatchPath,
-      taskId: historyId,
-      body: {
-        [AGENT_CHAT_BACKGROUND_RUN_FIELD]: {
-          runId: historyId,
-          automationRunId: historyId,
-        },
-      },
-      ...(dispatchPathTargetsNetlifyBackgroundFunction(dispatchPath)
-        ? { awaitResponse: true, responseTimeoutMs: 5_000 }
-        : {}),
-    });
+    await dispatchAutomationRun(historyId);
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Background dispatch failed";
@@ -107,4 +116,26 @@ export async function queueAutomationRunNow(
   }
 
   return { queued: true, runId: historyId, automationRunId: historyId };
+}
+
+/**
+ * Recover manual rows whose first serverless handoff never reached a worker.
+ * This is intentionally a redelivery, not a second execution: the worker's
+ * claim CAS decides which request owns the run.
+ */
+export async function redispatchUnclaimedAutomationRuns(): Promise<number> {
+  const runs = await listUnclaimedAutomationRuns();
+  let attempted = 0;
+  for (const run of runs) {
+    try {
+      await dispatchAutomationRun(run.id);
+      attempted += 1;
+    } catch (error) {
+      console.error(
+        `[automations] Could not redeliver queued run ${run.id}:`,
+        error,
+      );
+    }
+  }
+  return attempted;
 }

--- a/packages/core/src/jobs/run-now.ts
+++ b/packages/core/src/jobs/run-now.ts
@@ -1,0 +1,110 @@
+import {
+  AGENT_CHAT_BACKGROUND_RUN_FIELD,
+  dispatchPathTargetsNetlifyBackgroundFunction,
+  resolveAgentChatProcessRunDispatchPath,
+} from "../agent/durable-background.js";
+import {
+  canUpdateAutomationResource,
+  type AutomationScope,
+} from "../automations/service.js";
+import {
+  organizationResourceOwner,
+  resourceGetByPath,
+} from "../resources/store.js";
+import { fireInternalDispatch } from "../server/self-dispatch.js";
+import { parseJobResource } from "./frontmatter.js";
+import { startAutomationRun, finishAutomationRun } from "./run-history.js";
+
+export interface RunAutomationNowInput {
+  userEmail: string;
+  orgId?: string | null;
+  scope: AutomationScope;
+  name: string;
+}
+
+export interface QueuedAutomationRun {
+  queued: true;
+  runId: string;
+  automationRunId: string;
+}
+
+function ownerForScope(input: RunAutomationNowInput): string {
+  if (input.scope === "personal") return input.userEmail.trim().toLowerCase();
+  if (!input.orgId) {
+    throw Object.assign(
+      new Error("An organization is required for organization automations."),
+      { statusCode: 400 },
+    );
+  }
+  return organizationResourceOwner(input.orgId);
+}
+
+export async function queueAutomationRunNow(
+  input: RunAutomationNowInput,
+): Promise<QueuedAutomationRun> {
+  const name = input.name.trim();
+  if (!name || name.includes("/") || name.endsWith(".md")) {
+    throw Object.assign(new Error("A valid automation name is required."), {
+      statusCode: 400,
+    });
+  }
+  const owner = ownerForScope(input);
+  const resource = await resourceGetByPath(owner, `jobs/${name}.md`);
+  if (!resource) {
+    throw Object.assign(new Error(`Automation "${name}" not found.`), {
+      statusCode: 404,
+    });
+  }
+  if (!(await canUpdateAutomationResource(input, resource))) {
+    throw Object.assign(
+      new Error(
+        "Only the automation's creator or an organization admin can run it.",
+      ),
+      { statusCode: 403 },
+    );
+  }
+  const { body } = parseJobResource(resource.content);
+  if (!body.trim()) {
+    throw Object.assign(
+      new Error(`Automation "${name}" has no instructions.`),
+      {
+        statusCode: 400,
+      },
+    );
+  }
+
+  const historyId = await startAutomationRun({
+    owner: resource.owner,
+    automation: name,
+    path: resource.path,
+    scope: input.scope,
+    orgId: input.scope === "organization" ? input.orgId : null,
+  });
+  const dispatchPath = resolveAgentChatProcessRunDispatchPath();
+  try {
+    await fireInternalDispatch({
+      path: dispatchPath,
+      taskId: historyId,
+      body: {
+        [AGENT_CHAT_BACKGROUND_RUN_FIELD]: {
+          runId: historyId,
+          automationRunId: historyId,
+        },
+      },
+      ...(dispatchPathTargetsNetlifyBackgroundFunction(dispatchPath)
+        ? { awaitResponse: true, responseTimeoutMs: 5_000 }
+        : {}),
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Background dispatch failed";
+    await finishAutomationRun(
+      historyId,
+      "error",
+      `Could not start the automation: ${message}. No delivery was confirmed.`,
+    ).catch(() => {});
+    throw error;
+  }
+
+  return { queued: true, runId: historyId, automationRunId: historyId };
+}

--- a/packages/core/src/jobs/run-now.ts
+++ b/packages/core/src/jobs/run-now.ts
@@ -7,6 +7,7 @@ import {
   canUpdateAutomationResource,
   type AutomationScope,
 } from "../automations/service.js";
+import { isLocalDatabase } from "../db/client.js";
 import {
   organizationResourceOwner,
   resourceGetByPath,
@@ -14,7 +15,6 @@ import {
 import { fireInternalDispatch } from "../server/self-dispatch.js";
 import { parseJobResource } from "./frontmatter.js";
 import {
-  finishAutomationRun,
   listUnclaimedAutomationRuns,
   startAutomationRun,
 } from "./run-history.js";
@@ -45,7 +45,9 @@ async function dispatchAutomationRun(historyId: string): Promise<void> {
     },
     ...(dispatchPathTargetsNetlifyBackgroundFunction(dispatchPath)
       ? { awaitResponse: true, responseTimeoutMs: 5_000 }
-      : {}),
+      : !isLocalDatabase()
+        ? { awaitResponse: true, responseTimeoutMs: 5_000 }
+        : {}),
   });
 }
 
@@ -94,6 +96,15 @@ export async function queueAutomationRunNow(
     );
   }
 
+  // A manual-run request is a guaranteed app request even on hosts without a
+  // durable timer. Use it to recover older rows before adding the new one.
+  await redispatchUnclaimedAutomationRuns().catch((error) => {
+    console.warn(
+      "[automations] Could not sweep queued runs before run-now:",
+      error,
+    );
+  });
+
   const historyId = await startAutomationRun({
     owner: resource.owner,
     automation: name,
@@ -107,11 +118,10 @@ export async function queueAutomationRunNow(
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Background dispatch failed";
-    await finishAutomationRun(
-      historyId,
-      "error",
-      `Could not start the automation: ${message}. No delivery was confirmed.`,
-    ).catch(() => {});
+    console.warn(
+      `[automations] Initial run-now dispatch failed; leaving ${historyId} queued for redelivery:`,
+      message,
+    );
     throw error;
   }
 

--- a/packages/core/src/jobs/scheduler.spec.ts
+++ b/packages/core/src/jobs/scheduler.spec.ts
@@ -4,7 +4,11 @@ import {
   buildTriggerContent,
   parseTriggerFrontmatter,
 } from "../triggers/dispatcher.js";
-import { classifyJobResource, processRecurringJobs } from "./scheduler.js";
+import {
+  classifyJobResource,
+  processRecurringJobs,
+  runJobNow,
+} from "./scheduler.js";
 
 const resourceListAllOwnersMock = vi.hoisted(() => vi.fn());
 const resourcePutMock = vi.hoisted(() => vi.fn());
@@ -213,6 +217,39 @@ Summarize the inbox.`,
       },
     );
     recordUsageMock.mockResolvedValue(undefined);
+  });
+
+  it("does not manually overlap an active automation", async () => {
+    const resource = {
+      id: "resource-running",
+      owner: "alice+jobs@agent-native.test",
+      path: "jobs/daily-report.md",
+      updatedAt: "2026-08-04T00:00:00.000Z",
+      content: `---
+schedule: "* * * * *"
+enabled: true
+createdBy: alice+jobs@agent-native.test
+lastRun: "${new Date().toISOString()}"
+lastStatus: running
+---
+
+Summarize the inbox.`,
+    };
+    resourceGetByPathMock.mockResolvedValueOnce(resource);
+
+    const result = await runJobNow(resource.owner, "daily-report", {
+      getActions: () => ({}),
+      getSystemPrompt: async () => "system",
+      engine: testEngine,
+      model: "test-model",
+    });
+
+    expect(result).toEqual({
+      status: "skipped",
+      error: "The automation is already running.",
+    });
+    expect(resourcePutIfCurrentMock).not.toHaveBeenCalled();
+    expect(runAgentLoopMock).not.toHaveBeenCalled();
   });
 
   it("seeds a scheduled automation without dropping its automation metadata", async () => {

--- a/packages/core/src/jobs/scheduler.ts
+++ b/packages/core/src/jobs/scheduler.ts
@@ -338,7 +338,7 @@ async function executeJob(
         usageLabel: `${options.manual ? "manual-automation" : "recurring-job"}:${jobName}`,
         requestContext,
         ...(options.historyId ? { historyId: options.historyId } : {}),
-        ...(options.manual ? { actionCaller: "automation" as const } : {}),
+        actionCaller: "automation" as const,
       },
       deps,
     );

--- a/packages/core/src/jobs/scheduler.ts
+++ b/packages/core/src/jobs/scheduler.ts
@@ -262,6 +262,21 @@ async function executeJob(
   const jobUserEmail = identity.identity.userEmail;
   const jobOrgId = identity.identity.orgId;
 
+  // Manual runs use the same resource row as scheduled runs for concurrency
+  // protection. The check is paired with the conditional write below: two
+  // requests that read the same idle snapshot cannot both claim it.
+  if (options.manual && isBackgroundAutomationRunActive(meta, now)) {
+    const error = "The automation is already running.";
+    if (options.historyId) {
+      await finishAutomationRun(
+        options.historyId,
+        "error",
+        `${error} No delivery was confirmed.`,
+      );
+    }
+    return { status: "skipped", error };
+  }
+
   // Mark as running
   meta.lastRun = now.toISOString();
   meta.lastStatus = "running";

--- a/packages/core/src/jobs/scheduler.ts
+++ b/packages/core/src/jobs/scheduler.ts
@@ -23,6 +23,11 @@ import {
   parseJobResource,
   type JobFrontmatter,
 } from "./frontmatter.js";
+import {
+  claimAutomationRun,
+  finishAutomationRun,
+  getAutomationRun,
+} from "./run-history.js";
 
 // ─── Frontmatter parsing ────────────────────────────────────────────────────
 
@@ -194,13 +199,26 @@ export async function processRecurringJobs(deps: SchedulerDeps): Promise<void> {
 
 export const jobRunCutOffReason = backgroundRunCutOffReason;
 
+interface JobExecutionResult {
+  status: "success" | "error" | "skipped";
+  runId?: string;
+  error?: string;
+}
+
+interface ExecuteJobOptions {
+  advanceSchedule?: boolean;
+  historyId?: string;
+  manual?: boolean;
+}
+
 async function executeJob(
   resource: Resource,
   meta: JobFrontmatter,
   body: string,
   deps: SchedulerDeps,
   now: Date,
-): Promise<void> {
+  options: ExecuteJobOptions = {},
+): Promise<JobExecutionResult> {
   const jobName = resource.path.replace(/^jobs\//, "").replace(/\.md$/, "");
 
   const jobContext: RecurringJobContext = {
@@ -232,7 +250,14 @@ async function executeJob(
     meta.lastStatus = "skipped";
     meta.lastError = identity.reason;
     if (!alreadyRecorded) await updateResource(resource, meta, body);
-    return;
+    if (options.historyId) {
+      await finishAutomationRun(
+        options.historyId,
+        "error",
+        `Automation did not run: ${identity.reason}. No delivery was confirmed.`,
+      );
+    }
+    return { status: "skipped", error: identity.reason };
   }
   const jobUserEmail = identity.identity.userEmail;
   const jobOrgId = identity.identity.orgId;
@@ -245,7 +270,17 @@ async function executeJob(
     console.log(
       `[recurring-jobs] "${resource.path}" changed before it could start; dropping this tick.`,
     );
-    return;
+    if (options.historyId) {
+      await finishAutomationRun(
+        options.historyId,
+        "error",
+        "The automation changed before the run could start. No delivery was confirmed.",
+      );
+    }
+    return {
+      status: "error",
+      error: "The automation changed before the run could start.",
+    };
   }
 
   const requestContext =
@@ -275,16 +310,20 @@ async function executeJob(
       : undefined;
 
   try {
-    await runBackgroundAutomation(
+    const result = await runBackgroundAutomation(
       {
         automation: jobContext,
         ownerEmail: jobUserEmail,
         orgId: jobOrgId,
-        prompt: `[Recurring Job: ${jobName}]\nSchedule: ${describeCron(meta.schedule, effectiveTimezone(meta.timezone))}\n\nExecute the following job instructions:\n\n${body}`,
-        threadTitle: `Job: ${jobName} — ${now.toLocaleDateString()}`,
-        runIdPrefix: `job-${jobName}`,
-        usageLabel: `recurring-job:${jobName}`,
+        prompt: options.manual
+          ? `[Manual Automation Run: ${jobName}]\nThis run was explicitly started by the automation owner. Execute the following instructions now:\n\n${body}`
+          : `[Recurring Job: ${jobName}]\nSchedule: ${describeCron(meta.schedule, effectiveTimezone(meta.timezone))}\n\nExecute the following job instructions:\n\n${body}`,
+        threadTitle: `${options.manual ? "Automation" : "Job"}: ${jobName} — ${now.toLocaleDateString()}`,
+        runIdPrefix: `${options.manual ? "manual" : "job"}-${jobName}`,
+        usageLabel: `${options.manual ? "manual-automation" : "recurring-job"}:${jobName}`,
         requestContext,
+        ...(options.historyId ? { historyId: options.historyId } : {}),
+        ...(options.manual ? { actionCaller: "automation" as const } : {}),
       },
       deps,
     );
@@ -293,18 +332,63 @@ async function executeJob(
       lastRun: meta.lastRun,
       lastStatus: "success",
       lastError: undefined,
+      advanceSchedule: options.advanceSchedule,
     });
     console.log(`[recurring-jobs] Job "${jobName}" completed.`);
+    return { status: "success", runId: result.runId };
   } catch (err) {
     const lastError =
       err instanceof Error ? err.message.slice(0, 200) : "Unknown error";
+    const reportedError = `${lastError}. No delivery was confirmed.`;
     await recordExecutionOutcome(resource, {
       lastRun: meta.lastRun,
       lastStatus: "error",
-      lastError,
+      lastError: reportedError,
+      advanceSchedule: options.advanceSchedule,
     });
-    console.error(`[recurring-jobs] Job "${jobName}" failed:`, lastError);
+    console.error(`[recurring-jobs] Job "${jobName}" failed:`, reportedError);
+    return { status: "error", error: reportedError };
   }
+}
+
+/** Execute one stored automation without changing its scheduled next run. */
+export async function runJobNow(
+  owner: string,
+  name: string,
+  deps: SchedulerDeps,
+  options: { historyId?: string } = {},
+): Promise<JobExecutionResult> {
+  const path = `jobs/${name}.md`;
+  const resource = await resourceGetByPath(owner, path);
+  if (!resource) throw new Error(`Automation "${name}" not found.`);
+  const { meta, body } = parseJobFrontmatter(resource.content);
+  if (!body.trim())
+    throw new Error(`Automation "${name}" has no instructions.`);
+  return executeJob(resource, meta, body, deps, new Date(), {
+    advanceSchedule: false,
+    historyId: options.historyId,
+    manual: true,
+  });
+}
+
+/** Process a durable run-now history row exactly once in the background worker. */
+export async function runQueuedAutomation(
+  historyId: string,
+  deps: SchedulerDeps,
+): Promise<{ skipped: boolean; runId?: string; error?: string }> {
+  const queued = await getAutomationRun(historyId);
+  if (!queued) throw new Error(`Automation run "${historyId}" not found.`);
+  if (!(await claimAutomationRun(historyId))) {
+    return { skipped: true };
+  }
+  const result = await runJobNow(queued.owner, queued.automation, deps, {
+    historyId,
+  });
+  return {
+    skipped: false,
+    ...(result.runId ? { runId: result.runId } : {}),
+    ...(result.error ? { error: result.error } : {}),
+  };
 }
 
 async function updateResource(
@@ -328,7 +412,7 @@ async function updateResource(
 type ExecutionOutcome = Pick<
   JobFrontmatter,
   "lastRun" | "lastCheck" | "lastStatus" | "lastError"
->;
+> & { advanceSchedule?: boolean };
 
 /**
  * Persist the result of a run without clobbering a concurrent edit.
@@ -362,8 +446,13 @@ async function recordExecutionOutcome(
   }
   const current = parseJobResource(latest.content);
 
-  const meta: JobFrontmatter = { ...current.meta, ...outcome };
-  if (meta.schedule && isValidCron(meta.schedule)) {
+  const { advanceSchedule, ...execution } = outcome;
+  const meta: JobFrontmatter = { ...current.meta, ...execution };
+  if (
+    advanceSchedule !== false &&
+    meta.schedule &&
+    isValidCron(meta.schedule)
+  ) {
     // Measured from completion so a long run cannot immediately re-fire.
     meta.nextRun = nextOccurrence(
       meta.schedule,

--- a/packages/core/src/localization/default-messages.ts
+++ b/packages/core/src/localization/default-messages.ts
@@ -628,6 +628,10 @@ const messages = {
     deleteAutomationTitle: "Delete automation?",
     deleteAutomationDescription:
       "This permanently removes the automation and cannot be undone.",
+    runNow: "Run now",
+    runNowTitle: "Run automation now?",
+    runNowDescription:
+      "This runs the automation's real actions immediately. It may send messages or change data, and it will not change the next scheduled run.",
     automationDetails: "Automation details",
     automationEventDetails: "Runs when {{event}}.",
     condition: "Condition",

--- a/packages/core/src/server/action-discovery.ts
+++ b/packages/core/src/server/action-discovery.ts
@@ -626,6 +626,10 @@ export async function mergeCoreSharingActions(
       () => import("../jobs/actions/manage-recurring-job.js"),
     ],
     [
+      "run-automation-now",
+      () => import("../jobs/actions/run-automation-now.js"),
+    ],
+    [
       "list-automation-runs",
       () => import("../jobs/actions/list-automation-runs.js"),
     ],

--- a/packages/core/src/server/agent-chat-plugin.surface.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin.surface.spec.ts
@@ -163,6 +163,22 @@ describe("interactive agent run options — wiring guards", () => {
   });
 });
 
+describe("background automation action surface — wiring guards", () => {
+  it("uses one shared background action builder with unattended email tools", () => {
+    const source = readFileSync("src/server/agent-chat-plugin.ts", {
+      encoding: "utf-8",
+    });
+
+    expect(source).toContain(
+      "backgroundCoreEmailTools = createCoreEmailActionEntries({",
+    );
+    expect(source).toContain("...backgroundCoreEmailTools,");
+    expect(
+      source.match(/getActions: getBackgroundActionEntries/g),
+    ).toHaveLength(2);
+  });
+});
+
 describe("delegated agent run policy — wiring guards", () => {
   it("forwards non-default delegated budgets to MCP ask_app", () => {
     const source = readFileSync("src/server/agent-chat-plugin.ts", {

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -5588,34 +5588,60 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
               ? (preparedMarker as Record<string, unknown>).automationRunId
               : undefined;
           if (typeof automationRunId === "string" && automationRunId) {
-            try {
-              if (!runNowSchedulerDeps) {
-                throw new Error("Automation runner is not initialized.");
+            const runAutomation = async () => {
+              try {
+                if (!runNowSchedulerDeps) {
+                  throw new Error("Automation runner is not initialized.");
+                }
+                const { runQueuedAutomation } =
+                  await import("../jobs/scheduler.js");
+                const result = await runQueuedAutomation(
+                  automationRunId,
+                  runNowSchedulerDeps,
+                );
+                return { ok: true, automationRunId, ...result };
+              } catch (error) {
+                const message =
+                  error instanceof Error ? error.message : String(error);
+                const { finishAutomationRun } =
+                  await import("../jobs/run-history.js");
+                await finishAutomationRun(
+                  automationRunId,
+                  "error",
+                  `Automation worker failed: ${message}. No delivery was confirmed.`,
+                ).catch((finishError) => {
+                  console.warn(
+                    `[automations] could not record run-now worker failure for ${automationRunId}:`,
+                    finishError,
+                  );
+                });
+                console.error(
+                  `[automations] run-now worker failed for ${automationRunId}:`,
+                  error,
+                );
+                throw error;
               }
-              const { runQueuedAutomation } =
-                await import("../jobs/scheduler.js");
-              const result = await runQueuedAutomation(
-                automationRunId,
-                runNowSchedulerDeps,
-              );
-              return { ok: true, automationRunId, ...result };
-            } catch (error) {
-              const message =
-                error instanceof Error ? error.message : String(error);
-              const { finishAutomationRun } =
-                await import("../jobs/run-history.js");
-              await finishAutomationRun(
-                automationRunId,
-                "error",
-                `Automation worker failed: ${message}. No delivery was confirmed.`,
-              ).catch(() => {});
-              console.error(
-                `[automations] run-now worker failed for ${automationRunId}:`,
-                error,
-              );
-              setResponseStatus(event, 500);
-              return { error: "Automation worker failed" };
+            };
+
+            // Netlify background functions must keep the handler open for the
+            // full automation. Other runtimes get an immediate receipt and
+            // use waitUntil when the platform provides it; long-lived Node
+            // processes can safely continue the promise after the response.
+            if (isInBackgroundFunctionRuntime()) {
+              try {
+                return await runAutomation();
+              } catch {
+                setResponseStatus(event, 500);
+                return { error: "Automation worker failed" };
+              }
             }
+            const waitUntil = event.req?.waitUntil;
+            const runPromise = runAutomation().catch(() => {});
+            if (typeof waitUntil === "function") {
+              waitUntil(runPromise);
+            }
+            setResponseStatus(event, 202);
+            return { ok: true, accepted: true, automationRunId };
           }
 
           const expectsBackgroundRuntime =

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -5862,6 +5862,31 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
         );
       }
 
+      // A non-Netlify self-dispatch only waits for the request to leave the
+      // current invocation. Keep the durable history row as a retryable queue
+      // so a frozen serverless handoff is recovered on the next sweep.
+      (() => {
+        let inFlight = false;
+        const sweep = async () => {
+          if (inFlight) return;
+          inFlight = true;
+          try {
+            const { redispatchUnclaimedAutomationRuns } =
+              await import("../jobs/run-now.js");
+            await redispatchUnclaimedAutomationRuns();
+          } catch (error) {
+            console.warn(
+              "[automations] queued-run sweep failed; retrying next tick:",
+              error,
+            );
+          } finally {
+            inFlight = false;
+          }
+        };
+        setTimeout(() => void sweep(), 15_000);
+        setInterval(() => void sweep(), 30_000);
+      })();
+
       mcpInitializationPromise = initializeMcpManager().catch((err) => {
         console.warn(
           `[mcp-client] deferred initialization failed: ${err?.message ?? err}`,

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -140,7 +140,7 @@ import {
   verifyInternalToken,
   extractBearerToken,
 } from "../integrations/internal-token.js";
-import type { RecurringJobContext } from "../jobs/scheduler.js";
+import type { RecurringJobContext, SchedulerDeps } from "../jobs/scheduler.js";
 import {
   McpClientManager,
   loadMcpConfig,
@@ -730,6 +730,7 @@ export function createAgentChatPlugin(
         ...loopSettingsScripts,
       };
       const callAgentScript = await createCallAgentScriptEntry(options?.appId);
+      let runNowSchedulerDeps: SchedulerDeps | null = null;
       const browserTools = createBuilderBrowserTool({
         getOrigin: () =>
           getRequestRunContext()?.requestOrigin ?? "http://localhost:3000",
@@ -1099,16 +1100,19 @@ export function createAgentChatPlugin(
         });
       } catch {}
 
-      // Core send-email tool — only registered when RESEND_API_KEY or
-      // SENDGRID_API_KEY is set. Keyed "core-send-email" to avoid colliding
+      // Core send-email tool. Keyed "core-send-email" to avoid colliding
       // with the mail template's richer "send-email" action (template wins
       // when both surfaces spread into the same object, but distinct keys
       // keep both visible and avoid silent shadowing).
       let coreEmailTools: Record<string, ActionEntry> = {};
+      let backgroundCoreEmailTools: Record<string, ActionEntry> = {};
       try {
         const { createCoreEmailActionEntries } =
           await import("./email-actions.js");
         coreEmailTools = createCoreEmailActionEntries();
+        backgroundCoreEmailTools = createCoreEmailActionEntries({
+          unattended: true,
+        });
       } catch {}
 
       // Core read-attachment tool — always registered so the agent can page
@@ -1119,6 +1123,32 @@ export function createAgentChatPlugin(
           await import("./attachment-actions.js");
         coreAttachmentTools = createCoreAttachmentActionEntries();
       } catch {}
+
+      // Keep scheduler and event-trigger runs on one deliberately bounded
+      // background surface. Interactive-only tools stay out of it, while
+      // shared capabilities such as call-agent and core-send-email cannot
+      // drift independently between the two background entry points.
+      const getBackgroundActionEntries = (
+        automation?: RecurringJobContext,
+      ): Record<string, ActionEntry> => ({
+        ...templateScripts,
+        ...resourceScripts,
+        ...docsScripts,
+        ...(lazyContext ? frameworkContextTool : {}),
+        ...urlTools,
+        ...chatScripts,
+        ...callAgentScript,
+        ...jobTools,
+        ...automationTools,
+        ...notificationTools,
+        ...progressTools,
+        ...fetchTool,
+        ...webSearchTool,
+        ...toolActions,
+        ...backgroundCoreEmailTools,
+        ...coreAttachmentTools,
+        ...getJobMcpActionEntries(automation),
+      });
 
       // -----------------------------------------------------------------------
       // Production code-execution mode resolution.
@@ -5553,6 +5583,41 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
           const preparedMarker = (prepared.body as Record<string, unknown>)[
             AGENT_CHAT_BACKGROUND_RUN_FIELD
           ];
+          const automationRunId =
+            preparedMarker && typeof preparedMarker === "object"
+              ? (preparedMarker as Record<string, unknown>).automationRunId
+              : undefined;
+          if (typeof automationRunId === "string" && automationRunId) {
+            try {
+              if (!runNowSchedulerDeps) {
+                throw new Error("Automation runner is not initialized.");
+              }
+              const { runQueuedAutomation } =
+                await import("../jobs/scheduler.js");
+              const result = await runQueuedAutomation(
+                automationRunId,
+                runNowSchedulerDeps,
+              );
+              return { ok: true, automationRunId, ...result };
+            } catch (error) {
+              const message =
+                error instanceof Error ? error.message : String(error);
+              const { finishAutomationRun } =
+                await import("../jobs/run-history.js");
+              await finishAutomationRun(
+                automationRunId,
+                "error",
+                `Automation worker failed: ${message}. No delivery was confirmed.`,
+              ).catch(() => {});
+              console.error(
+                `[automations] run-now worker failed for ${automationRunId}:`,
+                error,
+              );
+              setResponseStatus(event, 500);
+              return { error: "Automation worker failed" };
+            }
+          }
+
           const expectsBackgroundRuntime =
             backgroundRunMarkerExpectsBackgroundRuntime(preparedMarker);
           const runtimeGlobals = globalThis as Record<string, unknown>;
@@ -5733,62 +5798,49 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
       // Poll every 60 seconds for due recurring jobs and execute them.
       // Uses setInterval so it works in all deployment environments without
       // requiring Nitro experimental tasks configuration.
-      if (disableRecurringJobsRuntime) {
-        if (process.env.DEBUG) {
-          console.log(
-            "[recurring-jobs] Scheduler disabled for local development",
-          );
-        }
-      } else {
-        try {
-          const { processRecurringJobs } = await import("../jobs/scheduler.js");
+      try {
+        const { processRecurringJobs } = await import("../jobs/scheduler.js");
 
-          const schedulerDeps = {
-            getActions: (job?: RecurringJobContext) => ({
-              ...templateScripts,
-              ...resourceScripts,
-              ...docsScripts,
-              ...(lazyContext ? frameworkContextTool : {}),
-              ...chatScripts,
-              ...jobTools,
-              ...automationTools,
-              ...notificationTools,
-              ...progressTools,
-              ...fetchTool,
-              ...webSearchTool,
-              ...toolActions,
-              ...getJobMcpActionEntries(job),
-            }),
-            getSystemPrompt: async (owner: string) => {
-              const resources = await loadResourcesForPrompt(
-                owner,
-                lazyContext,
-                options?.appId,
-              );
-              const schemaBlock = lazyContext
-                ? ""
-                : await buildSchemaBlock(owner, databaseToolsMode);
-              return basePrompt + resources + schemaBlock;
-            },
-            // `basePrompt` above is the same prompt the interactive chat
-            // handler builds, so it teaches the same template actions plus
-            // `manage-jobs` (Extended Capabilities / recurring jobs) and
-            // `manage-progress` (SHARED_RULE_14) BY NAME — both are present in
-            // getActions() via jobTools/progressTools. Keep the job runner's
-            // first request on the same compact surface as interactive chat
-            // instead of the full jobTools/automationTools/notificationTools/
-            // fetchTool/webSearchTool/toolActions catalog every tick.
-            getInitialToolNames: (job?: RecurringJobContext) => [
-              ...effectiveInitialToolNames,
-              "manage-jobs",
-              "manage-progress",
-              ...(job?.meta.mcpTools ?? []),
-            ],
-            apiKey: options?.apiKey,
-            model: options?.model,
-            appId: options?.appId,
-          };
+        const schedulerDeps: SchedulerDeps = {
+          getActions: getBackgroundActionEntries,
+          getSystemPrompt: async (owner: string) => {
+            const resources = await loadResourcesForPrompt(
+              owner,
+              lazyContext,
+              options?.appId,
+            );
+            const schemaBlock = lazyContext
+              ? ""
+              : await buildSchemaBlock(owner, databaseToolsMode);
+            return basePrompt + resources + schemaBlock;
+          },
+          // `basePrompt` above is the same prompt the interactive chat
+          // handler builds, so it teaches the same template actions plus
+          // `manage-jobs` (Extended Capabilities / recurring jobs) and
+          // `manage-progress` (SHARED_RULE_14) BY NAME — both are present in
+          // getActions() via jobTools/progressTools. Keep the job runner's
+          // first request on the same compact surface as interactive chat
+          // instead of the full jobTools/automationTools/notificationTools/
+          // fetchTool/webSearchTool/toolActions catalog every tick.
+          getInitialToolNames: (job?: RecurringJobContext) => [
+            ...effectiveInitialToolNames,
+            "manage-jobs",
+            "manage-progress",
+            ...(job?.meta.mcpTools ?? []),
+          ],
+          apiKey: options?.apiKey,
+          model: options?.model,
+          appId: options?.appId,
+        };
+        runNowSchedulerDeps = schedulerDeps;
 
+        if (disableRecurringJobsRuntime) {
+          if (process.env.DEBUG) {
+            console.log(
+              "[recurring-jobs] Scheduler disabled for local development",
+            );
+          }
+        } else {
           // Start after a 10-second delay to let the server fully initialize
           setTimeout(() => {
             setInterval(() => {
@@ -5802,9 +5854,12 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
             if (process.env.DEBUG)
               console.log("[recurring-jobs] Scheduler started (60s interval)");
           }, 10_000);
-        } catch (err) {
-          // Jobs module not available — skip silently
         }
+      } catch (error) {
+        console.warn(
+          "[recurring-jobs] Scheduler module unavailable:",
+          error instanceof Error ? error.message : error,
+        );
       }
 
       mcpInitializationPromise = initializeMcpManager().catch((err) => {
@@ -6110,21 +6165,7 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
           const { initTriggerDispatcher } =
             await import("../triggers/dispatcher.js");
           await initTriggerDispatcher({
-            getActions: (automation?: RecurringJobContext) => ({
-              ...templateScripts,
-              ...resourceScripts,
-              ...docsScripts,
-              ...(lazyContext ? frameworkContextTool : {}),
-              ...chatScripts,
-              ...jobTools,
-              ...automationTools,
-              ...notificationTools,
-              ...progressTools,
-              ...fetchTool,
-              ...webSearchTool,
-              ...toolActions,
-              ...getJobMcpActionEntries(automation),
-            }),
+            getActions: getBackgroundActionEntries,
             getSystemPrompt: async (owner: string) => {
               const resources = await loadResourcesForPrompt(
                 owner,

--- a/packages/core/src/server/email-actions.spec.ts
+++ b/packages/core/src/server/email-actions.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { createCoreEmailActionEntries } from "./email-actions.js";
+
+describe("core-send-email action guidance", () => {
+  it("keeps interactive email sends draft-first", () => {
+    const description =
+      createCoreEmailActionEntries()["core-send-email"].tool.description;
+
+    expect(description).toContain("DRAFT-FIRST SAFETY RULE");
+    expect(description).not.toContain("unattended automation run");
+  });
+
+  it("authorizes delivery for unattended automation runs", () => {
+    const description = createCoreEmailActionEntries({ unattended: true })[
+      "core-send-email"
+    ].tool.description;
+
+    expect(description).toContain(
+      "explicitly authorized unattended automation",
+    );
+    expect(description).toContain(
+      "without asking for an interactive confirmation",
+    );
+    expect(description).not.toContain("DRAFT-FIRST SAFETY RULE");
+  });
+});

--- a/packages/core/src/server/email-actions.ts
+++ b/packages/core/src/server/email-actions.ts
@@ -5,8 +5,9 @@
  * Registered as a native tool in every template. sendEmail() checks the
  * scoped Resend/SendGrid configuration at call time.
  *
- * SAFETY: the action description instructs the agent to draft-first and only
- * send when the user explicitly confirms, matching the mail template convention.
+ * SAFETY: interactive runs are draft-first. Unattended automation runs are
+ * already authorized when the automation is created, so they get a separate
+ * description that permits delivery without interactive confirmation.
  *
  * COLLISION: the mail template registers its own richer "send-email" action.
  * The template's registration comes after this one in the spread, so it wins
@@ -15,117 +16,35 @@
  */
 
 import type { ActionEntry } from "../agent/production-agent.js";
+import {
+  markdownToHtml,
+  markdownToText,
+  wrapInEmailTemplate,
+} from "./email-markdown.js";
 import { sendEmail } from "./email.js";
 
-function markdownToText(md: string): string {
-  return md
-    .replace(/!\[([^\]]*)\]\([^\s)]+\)/g, "$1")
-    .replace(/\[([^\]]+)\]\([^\s)]+\)/g, "$1 ($2)")
-    .replace(/`([^`]+)`/g, "$1")
-    .replace(/\*\*([^*]+)\*\*/g, "$1")
-    .replace(/\*([^*\n]+)\*/g, "$1")
-    .replace(/^#{1,6}\s+/gm, "")
-    .trim();
-}
-
-function markdownToHtml(md: string): string {
-  const normalized = md.replace(/\r\n/g, "\n").trim();
-  if (!normalized) return "<p></p>";
-
-  // Escape HTML entities in a string, preserving already-encoded references.
-  const esc = (s: string) =>
-    s
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      .replace(/"/g, "&quot;");
-
-  // Inline markdown: links, bold, italic, code, bare URLs.
-  const inline = (s: string): string =>
-    s
-      .replace(
-        /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
-        (_m, label: string, url: string) =>
-          `<a href="${esc(url)}" target="_blank" rel="noopener noreferrer">${esc(label)}</a>`,
-      )
-      .replace(
-        /(^|[^\w"'=])(https?:\/\/[^\s<]+)/g,
-        (_m, pre: string, url: string) =>
-          `${pre}<a href="${esc(url)}" target="_blank" rel="noopener noreferrer">${esc(url)}</a>`,
-      )
-      .replace(/`([^`]+)`/g, (_m, code: string) => `<code>${esc(code)}</code>`)
-      .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
-      .replace(/(^|[\s(])\*([^*\n]+)\*(?=$|[\s).,!?:;])/g, "$1<em>$2</em>");
-
-  const blocks = normalized.split(/\n{2,}/);
-  const html = blocks
-    .map((block) => {
-      const trimmed = block.trim();
-
-      // Fenced code block
-      if (trimmed.startsWith("```") && trimmed.endsWith("```")) {
-        const code = trimmed
-          .replace(/^```[^\n]*\n?/, "")
-          .replace(/\n?```$/, "");
-        return `<pre><code>${esc(code)}</code></pre>`;
-      }
-
-      // Heading
-      const hm = trimmed.match(/^(#{1,6})\s+(.+)$/);
-      if (hm) {
-        const level = hm[1].length;
-        return `<h${level}>${inline(hm[2])}</h${level}>`;
-      }
-
-      // Unordered list
-      if (/^[-*+]\s+/m.test(trimmed)) {
-        const items = trimmed
-          .split("\n")
-          .filter(Boolean)
-          .map((l) => `<li>${inline(l.replace(/^[-*+]\s+/, ""))}</li>`)
-          .join("");
-        return `<ul style="margin:0 0 1em;padding-left:1.5em">${items}</ul>`;
-      }
-
-      // Ordered list
-      if (/^\d+\.\s+/m.test(trimmed)) {
-        const items = trimmed
-          .split("\n")
-          .filter(Boolean)
-          .map((l) => `<li>${inline(l.replace(/^\d+\.\s+/, ""))}</li>`)
-          .join("");
-        return `<ol style="margin:0 0 1em;padding-left:1.5em">${items}</ol>`;
-      }
-
-      // Blockquote
-      if (trimmed.startsWith("> ")) {
-        const inner = trimmed
-          .split("\n")
-          .map((l) => (l.startsWith("> ") ? l.slice(2) : l))
-          .join("\n");
-        return `<blockquote style="margin:0 0 1em 1em;border-left:3px solid #ccc;padding-left:0.75em;color:#555">${inline(inner)}</blockquote>`;
-      }
-
-      return `<p style="margin:0 0 1em">${inline(trimmed).replace(/\n/g, "<br />")}</p>`;
-    })
-    .join("");
-
-  return html;
-}
-
-export function createCoreEmailActionEntries(): Record<string, ActionEntry> {
+export function createCoreEmailActionEntries(options?: {
+  unattended?: boolean;
+}): Record<string, ActionEntry> {
+  const unattended = options?.unattended === true;
   return {
     "core-send-email": {
       tool: {
         description: [
           "Send a transactional email via the app's configured email provider (Resend or SendGrid).",
           "",
-          "IMPORTANT — DRAFT-FIRST SAFETY RULE: Never call this tool until the user has explicitly",
-          "confirmed they want to send. Always compose the full email content first, show it to the",
-          "user, and wait for an explicit 'yes, send it' before invoking this action.",
+          ...(unattended
+            ? [
+                "This is an explicitly authorized unattended automation run. Send the email without asking for an interactive confirmation.",
+              ]
+            : [
+                "IMPORTANT — DRAFT-FIRST SAFETY RULE: Never call this tool until the user has explicitly",
+                "confirmed they want to send. Always compose the full email content first, show it to the",
+                "user, and wait for an explicit 'yes, send it' before invoking this action.",
+              ]),
           "",
           "The body is written in markdown. Tables, lists, bold, italic, links, and code blocks",
-          "are all supported and will render correctly in email clients.",
+          "are all supported and will render correctly in email clients. Write the body in markdown; do not hand-write HTML.",
           "",
           "This sends via the framework transport (Resend/SendGrid). It is NOT the Gmail-based",
           "send-email action in the mail template — use this for system/notification emails from",
@@ -199,7 +118,7 @@ export function createCoreEmailActionEntries(): Record<string, ActionEntry> {
           await sendEmail({
             to,
             subject,
-            html: markdownToHtml(bodyMd),
+            html: wrapInEmailTemplate(markdownToHtml(bodyMd)),
             text: markdownToText(bodyMd),
             ...(from ? { from } : {}),
             ...(cc ? { cc } : {}),

--- a/packages/core/src/server/email-markdown.spec.ts
+++ b/packages/core/src/server/email-markdown.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  markdownToHtml,
+  markdownToText,
+  wrapInEmailTemplate,
+} from "./email-markdown.js";
+
+describe("email markdown rendering", () => {
+  it("renders structured markdown inside a styled email surface", () => {
+    const body = markdownToHtml(
+      "# Digest\n\n| Name | Status |\n| --- | --- |\n| API | **Ready** |",
+    );
+    const html = wrapInEmailTemplate(body);
+
+    expect(html).toContain("max-width:640px");
+    expect(html).toContain("<h1");
+    expect(html).toContain("<table");
+    expect(html).toContain("<strong>Ready</strong>");
+  });
+
+  it("escapes URL query parameters exactly once", () => {
+    const html = markdownToHtml(
+      "[Open report](https://app.example.test/d?utm=x&ref=y) https://app.example.test/d?utm=x&ref=y",
+    );
+
+    expect(html).toContain('href="https://app.example.test/d?utm=x&amp;ref=y"');
+    expect(html).not.toContain("&amp;amp;");
+  });
+
+  it("keeps the plain-text alternative readable", () => {
+    expect(
+      markdownToText("# Digest\n\n- **Ready**: [open](https://example.test)"),
+    ).toBe("Digest\nReady: open (https://example.test)");
+  });
+});

--- a/packages/core/src/server/email-markdown.ts
+++ b/packages/core/src/server/email-markdown.ts
@@ -35,14 +35,10 @@ function inlineMarkdown(value: string): string {
         url = url.slice(0, -1);
       }
       let label = "Open link";
-      try {
-        const host = new URL(url.replace(/&amp;/g, "&")).hostname.replace(
-          /^www\./,
-          "",
-        );
+      const normalizedUrl = url.replace(/&amp;/g, "&");
+      if (URL.canParse(normalizedUrl)) {
+        const host = new URL(normalizedUrl).hostname.replace(/^www\./, "");
         if (host) label = `Open ${host}`;
-      } catch {
-        // Keep the generic label for malformed URLs.
       }
       return `${prefix}<a href="${url}" style="color:${EMAIL_TEXT};text-decoration:underline;">${label}</a>${trailing}`;
     },

--- a/packages/core/src/server/email-markdown.ts
+++ b/packages/core/src/server/email-markdown.ts
@@ -1,0 +1,224 @@
+const EMAIL_BACKGROUND = "#f6f7f9"; // guard:allow-raw-color - email clients need inlined colors
+const EMAIL_TEXT = "#1f2937"; // guard:allow-raw-color - email clients need inlined colors
+const EMAIL_MUTED = "#64748b"; // guard:allow-raw-color - email clients need inlined colors
+const EMAIL_BORDER = "#dbe3ec"; // guard:allow-raw-color - email clients need inlined colors
+const EMAIL_CODE = "#eef2f7"; // guard:allow-raw-color - email clients need inlined colors
+const EMAIL_SURFACE = "#ffffff"; // guard:allow-raw-color - email clients need inlined colors
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\"/g, "&quot;");
+}
+
+function inlineMarkdown(value: string): string {
+  let html = escapeHtml(value);
+  const protectedLinks: string[] = [];
+  html = html.replace(
+    /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
+    (_match, label: string, url: string) => {
+      const index = protectedLinks.push(
+        `<a href="${url}" style="color:${EMAIL_TEXT};text-decoration:underline;">${label}</a>`,
+      );
+      return `\u0000${index - 1}\u0000`;
+    },
+  );
+  html = html.replace(
+    /(^|[^\w"'=])(https?:\/\/[^\s<]+)/g,
+    (_match, prefix: string, rawUrl: string) => {
+      let url = rawUrl;
+      let trailing = "";
+      while (/[.,!?;:]$/.test(url)) {
+        trailing = url.slice(-1) + trailing;
+        url = url.slice(0, -1);
+      }
+      let label = "Open link";
+      try {
+        const host = new URL(url.replace(/&amp;/g, "&")).hostname.replace(
+          /^www\./,
+          "",
+        );
+        if (host) label = `Open ${host}`;
+      } catch {
+        // Keep the generic label for malformed URLs.
+      }
+      return `${prefix}<a href="${url}" style="color:${EMAIL_TEXT};text-decoration:underline;">${label}</a>${trailing}`;
+    },
+  );
+  html = html
+    .replace(
+      /`([^`]+)`/g,
+      `<code style="background:${EMAIL_CODE};padding:2px 5px;border-radius:4px;font-size:0.92em;">$1</code>`,
+    )
+    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(/__([^_]+)__/g, "<strong>$1</strong>")
+    .replace(/(^|[\s(])\*([^*\n]+)\*(?=$|[\s).,!?:;])/g, "$1<em>$2</em>")
+    .replace(/(^|[\s(])_([^_\n]+)_(?=$|[\s).,!?:;])/g, "$1<em>$2</em>");
+  html = html.replace(/\u0000(\d+)\u0000/g, (_match, index: string) => {
+    return protectedLinks[Number(index)] ?? "";
+  });
+  return html;
+}
+
+function renderTable(lines: string[]): string | null {
+  if (lines.length < 2 || !lines.every((line) => line.includes("|"))) {
+    return null;
+  }
+  const parseRow = (line: string) =>
+    line
+      .trim()
+      .replace(/^\|/, "")
+      .replace(/\|$/, "")
+      .split("|")
+      .map((cell) => cell.trim());
+  const header = parseRow(lines[0]);
+  const divider = parseRow(lines[1]);
+  if (!header.length || !divider.every((cell) => /^:?-{3,}:?$/.test(cell))) {
+    return null;
+  }
+  const body = lines.slice(2).map(parseRow);
+  const headHtml = header
+    .map(
+      (cell) =>
+        `<th align="left" style="border:1px solid ${EMAIL_BORDER};padding:8px 10px;background:${EMAIL_CODE};font-weight:600;">${inlineMarkdown(cell)}</th>`,
+    )
+    .join("");
+  const bodyHtml = body
+    .map(
+      (row) =>
+        `<tr>${header
+          .map(
+            (_cell, index) =>
+              `<td style="border:1px solid ${EMAIL_BORDER};padding:8px 10px;vertical-align:top;">${inlineMarkdown(row[index] ?? "")}</td>`,
+          )
+          .join("")}</tr>`,
+    )
+    .join("");
+  return `<div style="overflow-x:auto;margin:0 0 18px;"><table role="presentation" style="border-collapse:collapse;width:100%;font-size:14px;"><thead><tr>${headHtml}</tr></thead><tbody>${bodyHtml}</tbody></table></div>`;
+}
+
+export function markdownToText(md: string): string {
+  return md
+    .replace(/^(?:```[^\n]*\n|```$)/gm, "")
+    .replace(/!\[([^\]]*)\]\([^\s)]+\)/g, "$1")
+    .replace(/\[([^\]]+)\]\(([^\s)]+)\)/g, "$1 ($2)")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/__([^_]+)__/g, "$1")
+    .replace(/(^|[\s(])\*([^*\n]+)\*(?=$|[\s).,!?:;])/gm, "$1$2")
+    .replace(/(^|[\s(])_([^_\n]+)_(?=$|[\s).,!?:;])/gm, "$1$2")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/^\s*[-*+]\s+/gm, "")
+    .replace(/^\s*\d+\.\s+/gm, "")
+    .replace(/^>\s?/gm, "")
+    .trim();
+}
+
+export function markdownToHtml(md: string): string {
+  const lines = md.replace(/\r\n/g, "\n").trim().split("\n");
+  if (!md.trim()) return '<p style="margin:0;">&nbsp;</p>';
+
+  const blocks: string[] = [];
+  let index = 0;
+  while (index < lines.length) {
+    if (!lines[index].trim()) {
+      index += 1;
+      continue;
+    }
+    const line = lines[index].trim();
+    if (
+      line.startsWith("```") &&
+      lines.slice(index + 1).some((item) => item.trim() === "```")
+    ) {
+      const end = lines.findIndex(
+        (item, offset) => offset > index && item.trim() === "```",
+      );
+      const code = lines.slice(index + 1, end).join("\n");
+      blocks.push(
+        `<pre style="margin:0 0 18px;padding:14px 16px;background:${EMAIL_CODE};border-radius:6px;overflow-x:auto;white-space:pre-wrap;"><code>${escapeHtml(code)}</code></pre>`,
+      );
+      index = end + 1;
+      continue;
+    }
+    const heading = line.match(/^(#{1,6})\s+(.+)$/);
+    if (heading) {
+      const level = Math.min(heading[1].length, 3);
+      const sizes = ["24px", "19px", "16px"];
+      blocks.push(
+        `<h${level} style="margin:0 0 10px;color:${EMAIL_TEXT};font-size:${sizes[level - 1]};line-height:1.3;">${inlineMarkdown(heading[2])}</h${level}>`,
+      );
+      index += 1;
+      continue;
+    }
+    if (/^(?:-{3,}|\*{3,})$/.test(line)) {
+      blocks.push(
+        `<hr style="border:0;border-top:1px solid ${EMAIL_BORDER};margin:4px 0 18px;" />`,
+      );
+      index += 1;
+      continue;
+    }
+
+    const listMatch = line.match(/^([-*+] |\d+\. )/);
+    if (listMatch) {
+      const ordered = /^\d/.test(listMatch[1]);
+      const items: string[] = [];
+      while (index < lines.length) {
+        const item = lines[index]
+          .trim()
+          .match(ordered ? /^\d+\.\s+(.+)$/ : /^[-*+]\s+(.+)$/);
+        if (!item) break;
+        items.push(
+          `<li style="margin:0 0 6px;">${inlineMarkdown(item[1])}</li>`,
+        );
+        index += 1;
+      }
+      const tag = ordered ? "ol" : "ul";
+      blocks.push(
+        `<${tag} style="margin:0 0 18px;padding-left:24px;">${items.join("")}</${tag}>`,
+      );
+      continue;
+    }
+
+    const tableLines = [line];
+    let tableEnd = index + 1;
+    while (
+      tableEnd < lines.length &&
+      lines[tableEnd].trim() &&
+      lines[tableEnd].includes("|")
+    ) {
+      tableLines.push(lines[tableEnd].trim());
+      tableEnd += 1;
+    }
+    const table = renderTable(tableLines);
+    if (table) {
+      blocks.push(table);
+      index = tableEnd;
+      continue;
+    }
+
+    const paragraph: string[] = [line];
+    index += 1;
+    while (index < lines.length && lines[index].trim()) {
+      if (/^(?:#{1,6}\s|[-*+]\s|\d+\.\s|>\s|```)/.test(lines[index].trim()))
+        break;
+      paragraph.push(lines[index].trim());
+      index += 1;
+    }
+    if (paragraph.every((item) => item.startsWith("> "))) {
+      blocks.push(
+        `<blockquote style="margin:0 0 18px;padding:4px 0 4px 14px;border-left:3px solid ${EMAIL_BORDER};color:${EMAIL_MUTED};">${inlineMarkdown(paragraph.map((item) => item.slice(2)).join("\n")).replace(/\n/g, "<br />")}</blockquote>`,
+      );
+    } else {
+      blocks.push(
+        `<p style="margin:0 0 18px;line-height:1.65;">${inlineMarkdown(paragraph.join("\n")).replace(/\n/g, "<br />")}</p>`,
+      );
+    }
+  }
+  return blocks.join("\n");
+}
+
+export function wrapInEmailTemplate(bodyHtml: string): string {
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head><body style="margin:0;padding:0;background:${EMAIL_BACKGROUND};font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:${EMAIL_TEXT};"><div style="padding:24px 12px;"><div style="box-sizing:border-box;max-width:640px;margin:0 auto;padding:28px 30px;background:${EMAIL_SURFACE};border:1px solid ${EMAIL_BORDER};border-radius:8px;font-size:15px;line-height:1.65;">${bodyHtml}</div></div></body></html>`;
+}

--- a/packages/core/src/templates/workspace-core/.agents/skills/automations/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/automations/SKILL.md
@@ -103,6 +103,7 @@ All automation operations are accessed through a single `manage-automations` too
 | `update`      | Update an existing automation (enabled, condition, body)             |
 | `delete`      | Delete an automation (always confirm with user first)                |
 | `fire-test`   | Emit a `test.event.fired` event to validate automations              |
+| `run-now`     | Run one automation immediately with its real actions and side effects |
 
 Additional tool: `web-request` — outbound HTTP with `${keys.NAME}` substitution.
 

--- a/packages/core/src/triggers/actions.spec.ts
+++ b/packages/core/src/triggers/actions.spec.ts
@@ -351,4 +351,14 @@ Record the signal.`,
       { owner },
     );
   });
+
+  it("does not allow an automation to recursively queue another automation", async () => {
+    const result = await tool().run(
+      { action: "run-now", name: "another-automation" },
+      { caller: "automation" },
+    );
+
+    expect(result).toBe("Error: an automation cannot run another automation.");
+    expect(resourceGetByPathMock).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/triggers/actions.ts
+++ b/packages/core/src/triggers/actions.ts
@@ -5,10 +5,11 @@
  * available in every template. The agent uses them to create, list, and
  * manage automations from chat.
  *
- * All six operations are consolidated into a single `manage-automations` tool
+ * All seven operations are consolidated into a single `manage-automations` tool
  * with an `action` discriminator to keep the tool registry compact.
  */
 
+import type { ActionRunContext } from "../action.js";
 import type { ActionEntry } from "../agent/production-agent.js";
 import {
   defineAutomation,
@@ -19,6 +20,7 @@ import {
 } from "../automations/service.js";
 import { listEvents } from "../event-bus/index.js";
 import { describeCron, effectiveTimezone } from "../jobs/cron.js";
+import { queueAutomationRunNow } from "../jobs/run-now.js";
 import {
   getIntegrationRequestContext,
   getRequestOrgId,
@@ -289,6 +291,27 @@ async function handleFireTest(
   return `Test event fired with payload: ${JSON.stringify({ data })}. Any automations subscribed to "test.event.fired" will be evaluated.`;
 }
 
+async function handleRunNow(
+  args: Record<string, unknown>,
+  getCurrentUser: () => string,
+  context?: ActionRunContext,
+): Promise<string> {
+  if (context?.caller === "automation") {
+    return "Error: an automation cannot run another automation.";
+  }
+  try {
+    const result = await queueAutomationRunNow({
+      userEmail: getCurrentUser(),
+      orgId: getRequestOrgId(),
+      scope: automationScope(args.scope),
+      name: typeof args.name === "string" ? args.name : "",
+    });
+    return JSON.stringify(result);
+  } catch (error) {
+    return `Error: ${(error as Error).message}`;
+  }
+}
+
 /* ------------------------------------------------------------------ */
 /*  Consolidated tool entry                                           */
 /* ------------------------------------------------------------------ */
@@ -300,6 +323,7 @@ const VALID_ACTIONS = [
   "update",
   "delete",
   "fire-test",
+  "run-now",
 ] as const;
 
 export function createAutomationToolEntries(
@@ -315,20 +339,21 @@ export function createAutomationToolEntries(
 - **define**: Create a new automation. IMPORTANT: Always confirm with the user before calling — show them a summary of what will be created. Required params: name, trigger_type, body. Optional: scope, event, schedule, timezone, condition, mode, domain, delegated_policy_id, model, mcpTools.
 - **update**: Update an existing automation's settings without changing its creator (enabled, schedule, timezone, condition, body, policy, model, MCP allowlist). Required param: name. Use the same scope it was created in.
 - **delete**: Delete an automation. Always confirm with the user first. Required param: name.
-- **fire-test**: Fire a test event to validate automations. Emits a test.event.fired event. Optional param: data (JSON string).`,
+- **fire-test**: Fire a test event to validate automations. Emits a test.event.fired event. Optional param: data (JSON string).
+- **run-now**: Run one automation immediately using its real actions and side effects. This is an explicit user-authorized run and returns a durable run id; it does not change the automation's next scheduled run. Required params: name; optional scope.`,
         parameters: {
           type: "object" as const,
           properties: {
             action: {
               type: "string",
               description:
-                "The operation to perform: list-events, list, define, update, delete, or fire-test.",
+                "The operation to perform: list-events, list, define, update, delete, fire-test, or run-now.",
               enum: [...VALID_ACTIONS],
             },
             name: {
               type: "string",
               description:
-                "Slug name for the automation (lowercase, hyphens). Used by define, update, and delete.",
+                "Slug name for the automation (lowercase, hyphens). Used by define, update, delete, and run-now.",
             },
             scope: {
               type: "string",
@@ -420,7 +445,10 @@ export function createAutomationToolEntries(
         allowedValues: { action: ["list-events", "list"] },
         description: "Plan mode allows listing automations and event types.",
       },
-      run: async (args: Record<string, unknown>) => {
+      run: async (
+        args: Record<string, unknown>,
+        context?: ActionRunContext,
+      ) => {
         const action = args.action;
 
         switch (action) {
@@ -436,6 +464,8 @@ export function createAutomationToolEntries(
             return handleDelete(args, getCurrentUser);
           case "fire-test":
             return handleFireTest(args, getCurrentUser);
+          case "run-now":
+            return handleRunNow(args, getCurrentUser, context);
           default:
             return `Error: unknown action "${action}". Valid actions: ${VALID_ACTIONS.join(", ")}.`;
         }


### PR DESCRIPTION
## Summary

- Add an explicit Run now flow for personal and organization automations with durable queued history, atomic claim, and unchanged nextRun scheduling.
- Share the bounded background action surface between scheduler and event triggers, including unattended core email delivery.
- Add a confirmation UI and styled Markdown email rendering with clearer failure status.

## Verification

- `pnpm --filter @agent-native/core typecheck`
- Focused automation, scheduler, run-history, email, and AgentJobsTab tests: 78 passed, plus the recursion guard test
- `pnpm guards`: all 42 checks passed
- `git diff --check`

The full workspace fast test run still reports known environment and baseline failures: the core suite has a better-sqlite3 Node ABI mismatch in one runner test, existing timezone fixture expectations, existing action fixture failures, and unrelated local service/browser failures.