### PR TITLE
Allow users to test a replacement secret before saving it

### DIFF
--- a/.changeset/bright-secrets-validate.md
+++ b/.changeset/bright-secrets-validate.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow a replacement secret value to be validated before it is saved.

--- a/packages/core/src/client/settings/SecretsSection.tsx
+++ b/packages/core/src/client/settings/SecretsSection.tsx
@@ -302,8 +302,12 @@ function SecretCard({
   onOpenChange,
   focusInput,
 }: SecretCardProps) {
+  const t = useT();
   const [value, setValue] = useState("");
-  const [busy, setBusy] = useState<null | "save" | "delete" | "test">(null);
+  const [isRotating, setIsRotating] = useState(false);
+  const [busy, setBusy] = useState<
+    null | "save" | "delete" | "test" | "test-candidate"
+  >(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [toast, setToast] = useState<{
     kind: "ok" | "err";
@@ -312,10 +316,15 @@ function SecretCard({
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (open && focusInput && inputRef.current) {
+    if (!open) {
+      setValue("");
+      setIsRotating(false);
+      return;
+    }
+    if ((focusInput || isRotating) && inputRef.current) {
       inputRef.current.focus();
     }
-  }, [focusInput, open]);
+  }, [focusInput, isRotating, open]);
 
   const setToastAndClear = (kind: "ok" | "err", text: string, ms = 2500) => {
     setToast({ kind, text });
@@ -340,6 +349,7 @@ function SecretCard({
         return;
       }
       setValue("");
+      setIsRotating(false);
       setConfirmDelete(false);
       setToastAndClear("ok", "Saved");
       notifySecretsChanged();
@@ -374,14 +384,21 @@ function SecretCard({
     }
   };
 
-  const handleTest = async () => {
+  const handleTest = async (candidateValue?: string) => {
     if (busy) return;
-    setBusy("test");
+    const isCandidate = candidateValue !== undefined;
+    setBusy(isCandidate ? "test-candidate" : "test");
     try {
       const res = await fetch(
         `${ENDPOINT}/${encodeURIComponent(secret.key)}/test`,
         {
           method: "POST",
+          ...(isCandidate
+            ? {
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ value: candidateValue }),
+              }
+            : {}),
         },
       );
       const body = (await res.json().catch(() => ({}))) as {
@@ -389,11 +406,19 @@ function SecretCard({
         error?: string;
       };
       if (res.ok && body.ok) {
-        setToastAndClear("ok", "Working");
+        setToastAndClear(
+          "ok",
+          isCandidate
+            ? t("secrets.candidateValueWorking")
+            : t("secrets.storedValueWorking"),
+        );
       } else {
         setToastAndClear(
           "err",
-          body.error ?? (body.ok === false ? "Invalid" : `Test failed`),
+          body.error ??
+            (body.ok === false
+              ? t("secrets.invalid")
+              : t("secrets.testFailed")),
         );
       }
     } finally {
@@ -425,6 +450,7 @@ function SecretCard({
   }, [secret.status, secret.required]);
 
   const isOAuth = secret.kind === "oauth";
+  const showRotationForm = secret.status !== "set" || isRotating;
 
   return (
     <div className="border-b border-border last:border-b-0">
@@ -483,70 +509,43 @@ function SecretCard({
               )}
             </div>
           ) : (
-            <div className="mt-2 space-y-1.5">
+            <div className="mt-2 space-y-2">
               {secret.status === "set" && (
-                <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
-                  <span>Stored value ending in</span>
-                  <code className="rounded bg-background px-1 py-0.5 text-foreground">
-                    {secret.last4}
-                  </code>
-                </div>
-              )}
-              <div className="flex gap-1.5">
-                <TextField
-                  inputRef={inputRef}
-                  type="password"
-                  aria-label={secret.label}
-                  value={value}
-                  onChange={setValue}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter") handleSave();
-                  }}
-                  placeholder={
-                    secret.status === "set"
-                      ? "Enter new value to rotate"
-                      : "Paste key"
-                  }
-                  className="flex-1 text-[11px]"
-                />
-                <Button
-                  type="button"
-                  intent="primary"
-                  emphasis="solid"
-                  onClick={handleSave}
-                  disabled={!value.trim() || busy !== null}
-                  className="inline-flex items-center gap-1 rounded px-2 py-1 text-[10px] font-medium disabled:opacity-40"
-                  style={{ backgroundColor: "#00B5FF", color: "white" }}
-                >
-                  {busy === "save" ? (
-                    <IconLoader2 size={10} className="animate-spin" />
-                  ) : secret.status === "set" ? (
-                    <>
-                      <IconRefresh size={10} />
-                      Rotate
-                    </>
-                  ) : (
-                    "Save"
-                  )}
-                </Button>
-              </div>
-              <div className="flex items-center gap-1.5">
-                {secret.status === "set" && (
-                  <>
+                <>
+                  <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
+                    <span>Stored value ending in</span>
+                    <code className="mt-1 block w-fit rounded bg-background px-1 py-0.5 text-foreground">
+                      {secret.last4}
+                    </code>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-1.5">
                     <Button
                       type="button"
                       intent="neutral"
                       emphasis="outline"
-                      onClick={handleTest}
+                      onClick={() => handleTest()}
                       disabled={busy !== null}
                       className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] text-muted-foreground hover:text-foreground disabled:opacity-40"
                     >
                       {busy === "test" ? (
                         <IconLoader2 size={10} className="animate-spin" />
                       ) : (
-                        "Test"
+                        t("secrets.testStoredValue")
                       )}
                     </Button>
+                    <Button
+                      type="button"
+                      intent="primary"
+                      emphasis="solid"
+                      onClick={() => setIsRotating(true)}
+                      disabled={busy !== null}
+                      className="inline-flex items-center gap-1 rounded px-2 py-1 text-[10px] font-medium disabled:opacity-40"
+                      style={{ backgroundColor: "#00B5FF", color: "white" }}
+                    >
+                      <IconRefresh size={10} />
+                      Rotate
+                    </Button>
+
                     <Button
                       type="button"
                       intent="danger"
@@ -556,22 +555,89 @@ function SecretCard({
                       className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] text-muted-foreground hover:text-red-500 disabled:opacity-40"
                     >
                       <IconTrash size={10} />
-                      Remove
+                      Delete
                     </Button>
-                  </>
-                )}
-                {secret.docsUrl && (
-                  <a
-                    href={secret.docsUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] no-underline text-muted-foreground hover:text-foreground ms-auto"
-                  >
-                    Get key
-                    <IconExternalLink size={10} />
-                  </a>
-                )}
-              </div>
+                  </div>
+                </>
+              )}
+              {showRotationForm && (
+                <div className="space-y-1.5">
+                  <hr className="my-4" />
+                  <TextField
+                    inputRef={inputRef}
+                    type="password"
+                    aria-label={secret.label}
+                    value={value}
+                    onChange={setValue}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") handleSave();
+                    }}
+                    placeholder={
+                      secret.status === "set"
+                        ? "Enter new value to rotate"
+                        : "Paste key"
+                    }
+                    className="w-full text-[11px]"
+                  />
+                  <div className="flex flex-wrap items-center gap-1.5">
+                    <Button
+                      type="button"
+                      intent="neutral"
+                      emphasis="outline"
+                      onClick={() => handleTest(value.trim())}
+                      disabled={!value.trim() || busy !== null}
+                      className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] text-muted-foreground hover:text-foreground disabled:opacity-40"
+                    >
+                      {busy === "test-candidate" ? (
+                        <IconLoader2 size={10} className="animate-spin" />
+                      ) : (
+                        t("secrets.testStoredValue")
+                      )}
+                    </Button>
+                    {secret.docsUrl && (
+                      <a
+                        href={secret.docsUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] no-underline text-muted-foreground hover:text-foreground"
+                      >
+                        Get key
+                        <IconExternalLink size={10} />
+                      </a>
+                    )}
+                    {secret.status === "set" && (
+                      <Button
+                        type="button"
+                        intent="neutral"
+                        emphasis="outline"
+                        onClick={() => {
+                          setValue("");
+                          setIsRotating(false);
+                        }}
+                        disabled={busy !== null}
+                        className="rounded border border-border px-2 py-1 text-[10px] text-muted-foreground hover:text-foreground disabled:opacity-40"
+                      >
+                        Discard
+                      </Button>
+                    )}
+                    <Button
+                      type="button"
+                      intent="primary"
+                      emphasis="solid"
+                      onClick={handleSave}
+                      disabled={!value.trim() || busy !== null}
+                      className="inline-flex items-center gap-1 rounded px-2 py-1 text-[10px] font-medium disabled:opacity-40"
+                      style={{ backgroundColor: "#00B5FF", color: "white" }}
+                    >
+                      {busy === "save" ? (
+                        <IconLoader2 size={10} className="animate-spin" />
+                      ) : (
+                        "Save"
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              )}
               {confirmDelete && (
                 <div className="flex items-center gap-1.5 rounded border border-red-500/30 bg-red-500/10 px-2 py-1.5 text-[10px] text-red-500">
                   <span className="min-w-0 flex-1">

--- a/packages/core/src/localization/default-messages.ts
+++ b/packages/core/src/localization/default-messages.ts
@@ -66,6 +66,11 @@ const messages = {
     scopeLabel: "Scope",
     scopePersonal: "Personal",
     scopeWorkspace: "Workspace",
+    testStoredValue: "Test",
+    candidateValueWorking: "New value works",
+    storedValueWorking: "Working",
+    invalid: "Invalid",
+    testFailed: "Test failed",
     scopePersonalDescription:
       "Only your own signed-in sessions use this key. Integration, webhook, scheduled job, automation, and agent-to-agent runs sign in as their owner rather than as you, so they cannot read it.",
     scopeWorkspaceDescription:

--- a/packages/core/src/secrets/routes.spec.ts
+++ b/packages/core/src/secrets/routes.spec.ts
@@ -366,6 +366,80 @@ describe("secrets routes", () => {
     expect(JSON.stringify(result)).not.toContain("stored-secret-value");
   });
 
+  it("requires a signed-in user to validate a candidate user secret", async () => {
+    const validator = vi.fn();
+    mockGetSession.mockResolvedValue(null);
+    mockGetRequiredSecret.mockReturnValue({
+      key: "API_TOKEN",
+      label: "API token",
+      scope: "user",
+      kind: "api-key",
+      validator,
+    });
+
+    const handler = createTestSecretHandler();
+    const result = await handler(
+      event("/API_TOKEN/test", "POST", { value: "candidate-value" }),
+    );
+
+    expect(lastStatus).toBe(401);
+    expect(result).toEqual({ error: "Authentication required" });
+    expect(validator).not.toHaveBeenCalled();
+  });
+
+  it("requires an owner or admin to validate a stored workspace secret", async () => {
+    const validator = vi.fn();
+    mockGetOrgContext.mockResolvedValue({
+      orgId: "org-qa",
+      email: "bob+qa@example.com",
+      role: "member",
+    });
+    mockGetRequiredSecret.mockReturnValue({
+      key: "WORKSPACE_TOKEN",
+      label: "Workspace token",
+      scope: "workspace",
+      kind: "api-key",
+      validator,
+    });
+
+    const handler = createTestSecretHandler();
+    const result = await handler(event("/WORKSPACE_TOKEN/test", "POST"));
+
+    expect(lastStatus).toBe(403);
+    expect(result).toEqual({
+      error:
+        "Only organization owners and admins can set workspace-scoped secrets",
+    });
+    expect(validator).not.toHaveBeenCalled();
+  });
+
+  it("requires an owner or admin to validate a candidate org secret", async () => {
+    const validator = vi.fn();
+    mockGetOrgContext.mockResolvedValue({
+      orgId: "org-qa",
+      email: "bob+qa@example.com",
+      role: "member",
+    });
+    mockGetRequiredSecret.mockReturnValue({
+      key: "ORG_TOKEN",
+      label: "Org token",
+      scope: "org",
+      kind: "api-key",
+      validator,
+    });
+
+    const handler = createTestSecretHandler();
+    const result = await handler(
+      event("/ORG_TOKEN/test", "POST", { value: "candidate-value" }),
+    );
+
+    expect(lastStatus).toBe(403);
+    expect(result).toEqual({
+      error: "Only organization owners and admins can set org-scoped secrets",
+    });
+    expect(validator).not.toHaveBeenCalled();
+  });
+
   it("validates a candidate secret value without reading or writing storage", async () => {
     const validator = vi.fn(async () => ({ ok: true }));
     mockGetRequiredSecret.mockReturnValue({

--- a/packages/core/src/secrets/routes.spec.ts
+++ b/packages/core/src/secrets/routes.spec.ts
@@ -366,6 +366,71 @@ describe("secrets routes", () => {
     expect(JSON.stringify(result)).not.toContain("stored-secret-value");
   });
 
+  it("validates a candidate secret value without reading or writing storage", async () => {
+    const validator = vi.fn(async () => ({ ok: true }));
+    mockGetRequiredSecret.mockReturnValue({
+      key: "API_TOKEN",
+      label: "API token",
+      scope: "user",
+      kind: "api-key",
+      validator,
+    });
+
+    const handler = createTestSecretHandler();
+    const result = await handler(
+      event("/API_TOKEN/test", "POST", { value: "candidate-value" }),
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(validator).toHaveBeenCalledWith("candidate-value");
+    expect(mockReadAppSecret).not.toHaveBeenCalled();
+    expect(mockWriteAppSecret).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty candidate secret values", async () => {
+    const validator = vi.fn();
+    mockGetRequiredSecret.mockReturnValue({
+      key: "API_TOKEN",
+      label: "API token",
+      scope: "user",
+      kind: "api-key",
+      validator,
+    });
+
+    const handler = createTestSecretHandler();
+    const result = await handler(
+      event("/API_TOKEN/test", "POST", { value: " " }),
+    );
+
+    expect(lastStatus).toBe(400);
+    expect(result).toEqual({ error: "value must be a non-empty string" });
+    expect(validator).not.toHaveBeenCalled();
+  });
+
+  it("redacts candidate secret values from validator test responses", async () => {
+    mockGetRequiredSecret.mockReturnValue({
+      key: "API_TOKEN",
+      label: "API token",
+      scope: "user",
+      kind: "api-key",
+      validator: vi.fn(async () => ({
+        ok: false,
+        error: "Token candidate-secret-value is expired",
+      })),
+    });
+
+    const handler = createTestSecretHandler();
+    const result = await handler(
+      event("/API_TOKEN/test", "POST", { value: "candidate-secret-value" }),
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Token [redacted] is expired",
+    });
+    expect(JSON.stringify(result)).not.toContain("candidate-secret-value");
+  });
+
   it("redacts submitted secret values from registered secret storage errors", async () => {
     mockGetRequiredSecret.mockReturnValue({
       key: "API_TOKEN",

--- a/packages/core/src/secrets/routes.ts
+++ b/packages/core/src/secrets/routes.ts
@@ -396,17 +396,34 @@ export function createTestSecretHandler() {
       return { error: "value must be a non-empty string" };
     }
 
+    const { scopeId, reason } = await resolveScopeId(event, secret.scope);
+    if (!scopeId) {
+      setResponseStatus(event, 401);
+      return { error: reason ?? "Unable to resolve scope" };
+    }
+    if (
+      secret.scope === "workspace" &&
+      !(await canMutateWorkspaceScope(event, scopeId))
+    ) {
+      setResponseStatus(event, 403);
+      return {
+        error:
+          "Only organization owners and admins can set workspace-scoped secrets",
+      };
+    }
+    if (secret.scope === "org" && !(await canMutateOrgScope(event, scopeId))) {
+      setResponseStatus(event, 403);
+      return {
+        error: "Only organization owners and admins can set org-scoped secrets",
+      };
+    }
+
     if (!secret.validator) {
       return { ok: true, note: "No validator registered" };
     }
 
     let value = candidateValue;
     if (!value) {
-      const { scopeId } = await resolveScopeId(event, secret.scope);
-      if (!scopeId) {
-        setResponseStatus(event, 401);
-        return { error: "Unable to resolve scope" };
-      }
       const stored = await readAppSecret({
         key: secret.key,
         scope: secret.scope,

--- a/packages/core/src/secrets/routes.ts
+++ b/packages/core/src/secrets/routes.ts
@@ -357,8 +357,8 @@ async function handleDelete(event: H3Event, secret: RegisteredSecret) {
 }
 
 /**
- * POST /_agent-native/secrets/:key/test — re-run the validator against the
- * current stored value without changing anything. Useful for the "Test" button.
+ * POST /_agent-native/secrets/:key/test — validate an optional candidate value
+ * or the current stored value without changing anything.
  */
 export function createTestSecretHandler() {
   return defineEventHandler(async (event: H3Event) => {
@@ -383,25 +383,44 @@ export function createTestSecretHandler() {
       );
       return { ok: has };
     }
+
+    const body = (await readBody(event).catch(() => ({}))) as {
+      value?: unknown;
+    };
+    const hasCandidateValue = Object.hasOwn(body, "value");
+    const candidateValue =
+      typeof body.value === "string" ? body.value.trim() : undefined;
+
+    if (hasCandidateValue && !candidateValue) {
+      setResponseStatus(event, 400);
+      return { error: "value must be a non-empty string" };
+    }
+
     if (!secret.validator) {
       return { ok: true, note: "No validator registered" };
     }
-    const { scopeId } = await resolveScopeId(event, secret.scope);
-    if (!scopeId) {
-      setResponseStatus(event, 401);
-      return { error: "Unable to resolve scope" };
+
+    let value = candidateValue;
+    if (!value) {
+      const { scopeId } = await resolveScopeId(event, secret.scope);
+      if (!scopeId) {
+        setResponseStatus(event, 401);
+        return { error: "Unable to resolve scope" };
+      }
+      const stored = await readAppSecret({
+        key: secret.key,
+        scope: secret.scope,
+        scopeId,
+      });
+      if (!stored) {
+        setResponseStatus(event, 404);
+        return { error: "No value stored" };
+      }
+      value = stored.value;
     }
-    const stored = await readAppSecret({
-      key: secret.key,
-      scope: secret.scope,
-      scopeId,
-    });
-    if (!stored) {
-      setResponseStatus(event, 404);
-      return { error: "No value stored" };
-    }
+
     try {
-      const result = await secret.validator(stored.value);
+      const result = await secret.validator(value);
       const ok = typeof result === "boolean" ? result : result?.ok === true;
       if (!ok) {
         const err =
@@ -410,7 +429,7 @@ export function createTestSecretHandler() {
             : "Validator rejected the value";
         return {
           ok: false,
-          error: redactSecretFromMessage(err, stored.value),
+          error: redactSecretFromMessage(err, value),
         };
       }
       return { ok: true };
@@ -421,7 +440,7 @@ export function createTestSecretHandler() {
           : "Validator threw";
       return {
         ok: false,
-        error: redactSecretFromMessage(message, stored.value),
+        error: redactSecretFromMessage(message, value),
       };
     }
   });


### PR DESCRIPTION
Allow users to test a replacement secret before saving it
- Added a safer secret rotation flow: users can open a replacement form, test the new value, then save it or keep the current key.
- Updated the secret settings UI so saved-key actions and replacement-key actions are clearly separated.
- Kept secret values hidden in validation errors.
- Added tests for replacement-value validation and error redaction.

https://clips.agent-native.com/share/Jhecl2GRmpA2?ref=clip_share