### PR TITLE
Fix Loom imports getting stuck in processing

### DIFF
--- a/templates/clips/actions/import-loom-recording.ts
+++ b/templates/clips/actions/import-loom-recording.ts
@@ -389,7 +389,7 @@ export default defineAction({
       try {
         console.log("[import-loom-recording] dispatching loom-import job", {
           recordingId: id,
-          sourceUrl,
+          provider: providerId,
         });
         await dispatchPostFinalizeJob({
           recordingId: id,

--- a/templates/clips/actions/import-loom-recording.ts
+++ b/templates/clips/actions/import-loom-recording.ts
@@ -387,10 +387,17 @@ export default defineAction({
       await writeAppState("navigate", { view: "recording", recordingId: id });
 
       try {
+        console.log("[import-loom-recording] dispatching loom-import job", {
+          recordingId: id,
+          sourceUrl,
+        });
         await dispatchPostFinalizeJob({
           recordingId: id,
           kind: "loom-import",
           requireAccepted: true,
+        });
+        console.log("[import-loom-recording] loom-import job accepted", {
+          recordingId: id,
         });
       } catch (err) {
         const failureReason = `Could not start the Loom import: ${

--- a/templates/clips/actions/lib/loom-import-job.ts
+++ b/templates/clips/actions/lib/loom-import-job.ts
@@ -55,6 +55,11 @@ export async function failLoomImport(
   failureReason: string,
   claimId?: string,
 ): Promise<LoomImportJobResult> {
+  console.error("[loom-import] failed", {
+    recordingId,
+    claimId,
+    failureReason,
+  });
   const now = new Date().toISOString();
   const [updated] = await getDb()
     .update(schema.recordings)
@@ -140,9 +145,16 @@ export async function runLoomImportJob({
     );
   }
 
+  console.log("[loom-import] job started", { recordingId, claimId, loomId });
+
   let media: Awaited<ReturnType<typeof downloadLoomVideo>>;
   try {
     media = await downloadLoomVideo({ loomId, shareUrl });
+    console.log("[loom-import] download complete", {
+      recordingId,
+      bytes: media.sizeBytes,
+      mimeType: media.mimeType,
+    });
   } catch (err) {
     return failLoomImport(
       recordingId,
@@ -167,6 +179,10 @@ export async function runLoomImportJob({
         claimId,
       );
     }
+    console.log("[loom-import] reupload complete", {
+      recordingId,
+      videoUrl: upload.url,
+    });
 
     const now = new Date().toISOString();
     const [mediaReady] = await db
@@ -187,11 +203,15 @@ export async function runLoomImportJob({
       )
       .returning({ id: schema.recordings.id });
     if (!mediaReady) {
-      return {
-        status: "failed",
-        failureReason: "The Loom import lease was lost before media was saved.",
-      };
+      const failureReason =
+        "The Loom import lease was lost before media was saved.";
+      console.warn("[loom-import] lease lost before ready", {
+        recordingId,
+        claimId,
+      });
+      return { status: "failed", failureReason };
     }
+    console.log("[loom-import] recording ready", { recordingId });
 
     void queueBuilderMediaCompression({
       recordingId,

--- a/templates/clips/actions/lib/loom-import-job.ts
+++ b/templates/clips/actions/lib/loom-import-job.ts
@@ -145,7 +145,7 @@ export async function runLoomImportJob({
     );
   }
 
-  console.log("[loom-import] job started", { recordingId, claimId, loomId });
+  console.log("[loom-import] job started", { recordingId, claimId });
 
   let media: Awaited<ReturnType<typeof downloadLoomVideo>>;
   try {

--- a/templates/clips/server/lib/post-finalize-dispatch.ts
+++ b/templates/clips/server/lib/post-finalize-dispatch.ts
@@ -78,6 +78,12 @@ export async function dispatchPostFinalizeJob(args: {
         }
       : {}),
   });
+  console.log("[post-finalize] dispatching", {
+    recordingId: args.recordingId,
+    kind: args.kind,
+    workerUrl,
+    usesDurableBackground,
+  });
   const post = (url: string) =>
     fetch(url, {
       method: "POST",
@@ -89,7 +95,14 @@ export async function dispatchPostFinalizeJob(args: {
       usesDurableBackground && !initialResponse.ok
         ? await post(resolveWorkerUrl(processorRoute))
         : initialResponse;
-    if (response.ok) return;
+    if (response.ok) {
+      console.log("[post-finalize] dispatch accepted", {
+        recordingId: args.recordingId,
+        kind: args.kind,
+        status: response.status,
+      });
+      return;
+    }
     const detail = (await response.text().catch(() => "")).trim().slice(0, 300);
     throw new Error(
       `Post-finalize ${args.kind} worker returned HTTP ${response.status}${

--- a/templates/clips/server/plugins/auth.ts
+++ b/templates/clips/server/plugins/auth.ts
@@ -45,6 +45,15 @@ export default createAuthPlugin({
     "/api/video",
     "/api/thumbnail",
     "/api/auth/google-calendar",
+    // Internal post-finalize worker (media verification, seekable remux,
+    // transcript, brain-export, loom-import retries). It's a server-to-server
+    // self-dispatch with no session cookie — its own scoped, short-lived
+    // signed token (verifyScopedAgentAccessToken) is the real auth check, so
+    // it must bypass the session gate to ever reach that check. Exact path
+    // only, not the whole `_agent-native-background` namespace — a future
+    // route added under that prefix without its own auth check must not
+    // become silently public by inheriting this bypass.
+    "/api/_agent-native-background/post-finalize-worker",
     "/_agent-native/google/auth-url",
     "/_agent-native/google/callback",
   ],

--- a/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.ts
+++ b/templates/clips/server/routes/api/_agent-native-background/post-finalize-worker.post.ts
@@ -51,11 +51,17 @@ export default defineEventHandler(async (event: H3Event) => {
 
   const { recordingId, kind, token, delayMs, retryAttempt, regenerate } =
     parsed.data;
+  console.log("[post-finalize-worker] received job", { recordingId, kind });
   const verified = verifyScopedAgentAccessToken(token, {
     resourceKind: POST_FINALIZE_JOB_TOKEN_KIND,
     resourceId: postFinalizeJobResourceId(recordingId, kind),
   });
   if (!verified.ok) {
+    console.warn("[post-finalize-worker] token verification failed", {
+      recordingId,
+      kind,
+      reason: verified.reason,
+    });
     setResponseStatus(event, 401);
     return { ok: false, error: "Invalid or expired post-finalize job token" };
   }
@@ -153,6 +159,9 @@ export default defineEventHandler(async (event: H3Event) => {
           )
           .returning({ id: schema.recordings.id });
         if (!claimed) {
+          console.log("[post-finalize-worker] loom-import already running", {
+            recordingId,
+          });
           return {
             ok: true,
             recordingId,
@@ -161,6 +170,10 @@ export default defineEventHandler(async (event: H3Event) => {
             reason: "loom-import-already-running",
           };
         }
+        console.log("[post-finalize-worker] loom-import claimed", {
+          recordingId,
+          claimId,
+        });
         const result = await runLoomImportJob({
           recordingId,
           ownerEmail: recording.ownerEmail,


### PR DESCRIPTION
Loom video imports could get stuck forever in "processing" with no error shown. The cause was an internal background request getting silently blocked by auth. This PR fixes that and adds logging so this kind of issue is much easier to diagnose next time.