### PR TITLE
Make transactional email footer settings links clickable

### DIFF
--- a/.changeset/tender-moons-attack.md
+++ b/.changeset/tender-moons-attack.md
@@ -1,0 +1,7 @@
+---
+"@agent-native/core": minor
+---
+
+`renderEmail` accepts a `footerLink`, so a footer can point at a real
+destination. A `{link}` token in `footer` becomes an anchor in the HTML part and
+`label (url)` in the plain-text part.

--- a/.changeset/tender-moons-attack.md
+++ b/.changeset/tender-moons-attack.md
@@ -5,3 +5,10 @@
 `renderEmail` accepts a `footerLink`, so a footer can point at a real
 destination. A `{link}` token in `footer` becomes an anchor in the HTML part and
 `label (url)` in the plain-text part.
+
+Notification emails now render through `renderEmail` instead of a bare
+paragraph pair, so they carry the same branding as the rest of the framework's
+mail. A sender can name the surface that controls the notification with
+`metadata.emailFooter`, `emailFooterLinkLabel`, and `emailFooterLinkUrl`;
+notifications that name none get no footer, so env-configured ops recipients
+are never told to turn off a toggle they do not have.

--- a/packages/core/src/notifications/channels.spec.ts
+++ b/packages/core/src/notifications/channels.spec.ts
@@ -535,6 +535,49 @@ describe("email notification channel", () => {
     expect(sent.html).not.toContain("<pre>");
   });
 
+  it("links the sender's opt-out surface in the footer when one is named", async () => {
+    process.env.NOTIFICATIONS_EMAIL_CHANNEL = "1";
+    const channels = await loadChannels();
+    const channel = channels.find((c) => c.name === "email")!;
+
+    await channel.deliver(
+      {
+        severity: "info",
+        title: "Generation finished",
+        metadata: {
+          emailRecipients: ["alice@example.com"],
+          emailFooter: "Email notifications are on in your {link}.",
+          emailFooterLinkLabel: "Assets settings",
+          emailFooterLinkUrl: "https://assets.example.test/settings",
+        },
+      },
+      { owner: "alice@example.com" },
+    );
+
+    const sent = sendEmail.mock.calls[0][0];
+    expect(sent.html).toContain(
+      '<a href="https://assets.example.test/settings"',
+    );
+    expect(sent.text).toContain(
+      "Email notifications are on in your Assets settings (https://assets.example.test/settings).",
+    );
+  });
+
+  it("adds no opt-out footer when the sender named none", async () => {
+    process.env.NOTIFICATIONS_EMAIL_CHANNEL = "1";
+    process.env.NOTIFICATIONS_EMAIL_RECIPIENTS = "ops@example.com";
+    const channels = await loadChannels();
+    const channel = channels.find((c) => c.name === "email")!;
+
+    await channel.deliver(
+      { severity: "critical", title: "Disk full" },
+      { owner: "ops@example.com" },
+    );
+
+    const sent = sendEmail.mock.calls[0][0];
+    expect(sent.text).not.toMatch(/turn|settings/i);
+  });
+
   it("does nothing when email has no recipients", async () => {
     process.env.NOTIFICATIONS_EMAIL_CHANNEL = "1";
     const channels = await loadChannels();

--- a/packages/core/src/notifications/channels.ts
+++ b/packages/core/src/notifications/channels.ts
@@ -25,6 +25,10 @@
  *                            → comma-separated fallback recipients for email
  *                              notifications that do not pass
  *                              `metadata.emailRecipients`.
+ *
+ * Per-notification email metadata: `emailRecipients`, `emailSubject`, and an
+ * optional `emailFooter` (a `{link}` token in it is filled from
+ * `emailFooterLinkLabel` + `emailFooterLinkUrl`).
  */
 
 import { ssrfSafeFetch } from "../extensions/url-safety.js";
@@ -35,6 +39,7 @@ import {
   resolveKeyReferencesWithRequestScopes,
   validateUrlAllowlist,
 } from "../secrets/substitution.js";
+import { renderEmail } from "../server/email-template.js";
 import { sendEmail } from "../server/email.js";
 import { registerNotificationChannel } from "./registry.js";
 import type { NotificationChannel, NotificationInput } from "./types.js";
@@ -191,11 +196,12 @@ function createEmailChannel(): NotificationChannel {
         input.metadata.emailSubject.trim()
           ? input.metadata.emailSubject.trim()
           : `[${input.severity}] ${input.title}`;
-      const text = `${input.title}\n\n${input.body ?? ""}`;
-      const html = [
-        `<p><strong>${escapeHtml(input.title)}</strong></p>`,
-        input.body ? `<p>${escapeHtml(input.body)}</p>` : "",
-      ].join("");
+      const { html, text } = renderEmail({
+        preheader: input.title,
+        heading: input.title,
+        paragraphs: input.body ? [escapeHtml(input.body)] : [],
+        ...notificationEmailFooter(input.metadata),
+      });
 
       await Promise.all(
         recipients.map((to) =>
@@ -336,6 +342,26 @@ function scrubDeliveryMetadata(
       key !== "delivery" && key !== "webhookUrl" && key !== "slackWebhookUrl",
   );
   return entries.length ? Object.fromEntries(entries) : undefined;
+}
+
+/**
+ * A notification only claims an opt-out exists when its sender named one.
+ * Env-configured ops recipients have no per-user toggle, so they must not be
+ * told to go turn one off.
+ */
+function notificationEmailFooter(
+  metadata: Record<string, unknown> | undefined,
+): { footer?: string; footerLink?: { label: string; url: string } } {
+  const footer = trimmedString(metadata?.emailFooter);
+  if (!footer) return {};
+  const label = trimmedString(metadata?.emailFooterLinkLabel);
+  const url = trimmedString(metadata?.emailFooterLinkUrl);
+  return label && url ? { footer, footerLink: { label, url } } : { footer };
+}
+
+function trimmedString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  return value.trim() || undefined;
 }
 
 function notificationEmailRecipients(

--- a/packages/core/src/server/email-template.spec.ts
+++ b/packages/core/src/server/email-template.spec.ts
@@ -135,4 +135,33 @@ describe("renderEmail", () => {
       "Open Clip: https://clips.example/r/rec-1?view=agent&mode=summary\n\nOr feed this link to your AI agent:\nhttps://clips.example/r/rec-1?view=agent&mode=summary",
     );
   });
+  it("turns the footer link token into an anchor and keeps its URL in text", () => {
+    const { html, text } = renderEmail({
+      heading: "New comment",
+      paragraphs: ["Someone commented."],
+      footer: "Notifications are on in your {link}.",
+      footerLink: {
+        label: "Clips settings",
+        url: "https://clips.example/settings?tab=general",
+      },
+    });
+
+    expect(html).toContain(
+      '<a href="https://clips.example/settings?tab=general" style="color:#a1a1aa; text-decoration:underline;">Clips settings</a>',
+    );
+    expect(text).toContain(
+      "Notifications are on in your Clips settings (https://clips.example/settings?tab=general).",
+    );
+  });
+
+  it("leaves the token visible when no footer link was supplied", () => {
+    const { html, text } = renderEmail({
+      heading: "New comment",
+      paragraphs: ["Someone commented."],
+      footer: "Notifications are on in your {link}.",
+    });
+
+    expect(html).toContain("Notifications are on in your {link}.");
+    expect(text).toContain("Notifications are on in your {link}.");
+  });
 });

--- a/packages/core/src/server/email-template.ts
+++ b/packages/core/src/server/email-template.ts
@@ -203,10 +203,12 @@ export function renderEmail(args: RenderEmailArgs): RenderedEmail {
     : "";
 
   const footerHtml = args.footer
-    ? `<p style="margin:28px 0 0 0; font-size:13px; line-height:1.5; color:#71717a;">${resolveFooterLink(
+    ? // guard:allow-raw-color — inlined for email clients
+      `<p style="margin:28px 0 0 0; font-size:13px; line-height:1.5; color:#71717a;">${resolveFooterLink(
         escapeHtml(args.footer),
         args.footerLink,
         (link) =>
+          // guard:allow-raw-color — inlined for email clients
           `<a href="${escapeAttr(link.url)}" style="color:#a1a1aa; text-decoration:underline;">${escapeHtml(link.label)}</a>`,
       )}</p>`
     : "";

--- a/packages/core/src/server/email-template.ts
+++ b/packages/core/src/server/email-template.ts
@@ -54,8 +54,14 @@ export interface RenderEmailArgs {
   heroHtml?: string;
   /** Body paragraphs rendered after the CTA and link block. Escaped-by-caller. */
   closingParagraphs?: string[];
-  /** Small muted text under the CTA (e.g. expiry note). */
+  /**
+   * Small muted text under the CTA (e.g. expiry note). A `{link}` token is
+   * replaced by `footerLink` — an anchor in the HTML part, and `label (url)` in
+   * the plain-text part so the destination survives there too.
+   */
   footer?: string;
+  /** Destination for the `{link}` token in `footer`. */
+  footerLink?: EmailCta;
   /** Optional app name shown beside the framework logo. */
   brandName?: string;
   /**
@@ -87,6 +93,18 @@ function escapeHtml(s: string): string {
 
 function escapeAttr(s: string): string {
   return escapeHtml(s);
+}
+
+/**
+ * Leaves the token in the copy when no link was supplied. A silently dropped
+ * token would read as a finished sentence that quietly points nowhere.
+ */
+function resolveFooterLink(
+  footer: string,
+  link: EmailCta | undefined,
+  render: (target: EmailCta) => string,
+): string {
+  return link ? footer.replace(/\{link\}/g, render(link)) : footer;
 }
 
 /**
@@ -185,7 +203,12 @@ export function renderEmail(args: RenderEmailArgs): RenderedEmail {
     : "";
 
   const footerHtml = args.footer
-    ? `<p style="margin:28px 0 0 0; font-size:13px; line-height:1.5; color:#71717a;">${escapeHtml(args.footer)}</p>`
+    ? `<p style="margin:28px 0 0 0; font-size:13px; line-height:1.5; color:#71717a;">${resolveFooterLink(
+        escapeHtml(args.footer),
+        args.footerLink,
+        (link) =>
+          `<a href="${escapeAttr(link.url)}" style="color:#a1a1aa; text-decoration:underline;">${escapeHtml(link.label)}</a>`,
+      )}</p>`
     : "";
 
   const brandHeaderHtml = `
@@ -273,7 +296,13 @@ export function renderEmail(args: RenderEmailArgs): RenderedEmail {
     textLines.push("");
   }
   if (args.footer) {
-    textLines.push(args.footer);
+    textLines.push(
+      resolveFooterLink(
+        args.footer,
+        args.footerLink,
+        (link) => `${link.label} (${link.url})`,
+      ),
+    );
   }
 
   return { html, text: textLines.join("\n").trim() };

--- a/templates/analytics/changelog/2026-08-04-error-alert-monitor-and-scheduled-report-emails-are-now-bran.md
+++ b/templates/analytics/changelog/2026-08-04-error-alert-monitor-and-scheduled-report-emails-are-now-bran.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-04
+---
+
+Error, alert, monitor, and scheduled-report emails are now branded and link to the exact setting that sent them.

--- a/templates/analytics/server/jobs/dashboard-report.ts
+++ b/templates/analytics/server/jobs/dashboard-report.ts
@@ -1,6 +1,7 @@
 import { notifyWithDelivery } from "@agent-native/core/notifications";
 import { runWithRequestContext } from "@agent-native/core/server/request-context";
 
+import { analyticsUrl } from "../lib/app-url";
 import { sendDashboardReportSubscription } from "../lib/dashboard-report";
 import {
   claimDueDashboardReportSubscriptions,
@@ -86,6 +87,14 @@ async function notifyDashboardReportGaveUp(
           // The email channel is a no-op without explicit recipients.
           emailRecipients: [sub.ownerEmail],
           emailSubject: "Your scheduled dashboard report did not send",
+          emailFooter:
+            "You received this because you scheduled this report. Change or cancel it in {link}.",
+          emailFooterLinkLabel: "your dashboard reports",
+          emailFooterLinkUrl: analyticsUrl(
+            sub.dashboardId
+              ? `/dashboards/${encodeURIComponent(sub.dashboardId)}`
+              : "/dashboards",
+          ),
         },
       },
       { owner: sub.ownerEmail },

--- a/templates/analytics/server/lib/analytics-alerts.ts
+++ b/templates/analytics/server/lib/analytics-alerts.ts
@@ -17,6 +17,7 @@ import {
 } from "drizzle-orm";
 
 import { getDb, schema } from "../db/index.js";
+import { analyticsUrl } from "./app-url.js";
 
 export type AnalyticsAlertFilterOp =
   | "equals"
@@ -883,6 +884,10 @@ export async function evaluateAndNotifyAnalyticsAlertRule(
         filters: rule.filters,
         sampleEvents: evaluation.sampleEvents,
         emailRecipients: rule.emailRecipients,
+        emailFooter:
+          "You received this because this alert rule emails you. Change its recipients in {link}.",
+        emailFooterLinkLabel: "Analytics settings",
+        emailFooterLinkUrl: analyticsUrl("/settings"),
         requestedChannels: rule.channels,
         ...(deliveryMetadata ? { delivery: deliveryMetadata } : {}),
       },

--- a/templates/analytics/server/lib/app-url.ts
+++ b/templates/analytics/server/lib/app-url.ts
@@ -1,0 +1,7 @@
+import { getAppProductionUrl } from "@agent-native/core/server";
+
+/** Absolute URL for an in-app path, for use in emails and notifications. */
+export function analyticsUrl(path: string): string {
+  const base = getAppProductionUrl().replace(/\/+$/, "");
+  return `${base}${path.startsWith("/") ? path : `/${path}`}`;
+}

--- a/templates/analytics/server/lib/error-capture.ts
+++ b/templates/analytics/server/lib/error-capture.ts
@@ -36,6 +36,7 @@ import {
 
 import { ANALYTICS_USER_PREFS_KEY } from "../../shared/analytics-user-prefs";
 import { getDb, schema } from "../db/index.js";
+import { analyticsUrl } from "./app-url.js";
 
 export type ExceptionLevel = "fatal" | "error" | "warning" | "info" | "debug";
 export type IssueStatus = "unresolved" | "resolved" | "ignored";
@@ -1012,6 +1013,10 @@ async function notifyNewIssue(
           ? {
               emailRecipients: [scope.ownerEmail],
               emailSubject: `New error in your app: ${issue.title}`,
+              emailFooter:
+                "You received this because new error emails are on in your {link}.",
+              emailFooterLinkLabel: "Analytics settings",
+              emailFooterLinkUrl: analyticsUrl("/settings"),
             }
           : {}),
       },

--- a/templates/analytics/server/lib/uptime-monitors.ts
+++ b/templates/analytics/server/lib/uptime-monitors.ts
@@ -43,6 +43,7 @@ import {
 } from "drizzle-orm";
 
 import { getDb, schema } from "../db/index.js";
+import { analyticsUrl } from "./app-url.js";
 
 declare global {
   var __AGENT_NATIVE_UPTIME_MONITOR_SCHEDULED_RUNTIME__: boolean | undefined;
@@ -706,6 +707,12 @@ function monitorNotifyMetadata(monitor: Monitor): Record<string, unknown> {
     monitorName: monitor.name,
     url: monitor.url,
     emailRecipients: monitor.emailRecipients,
+    emailFooter:
+      "You received this because this monitor emails you. Change its recipients in {link}.",
+    emailFooterLinkLabel: "the monitor's settings",
+    emailFooterLinkUrl: analyticsUrl(
+      `/monitoring?view=uptime&monitor=${encodeURIComponent(monitor.id)}`,
+    ),
     requestedChannels: monitor.channels,
   };
 }

--- a/templates/assets/changelog/2026-08-04-generation-finished-and-failed-emails-are-now-branded-and-li.md
+++ b/templates/assets/changelog/2026-08-04-generation-finished-and-failed-emails-are-now-branded-and-li.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-04
+---
+
+Generation finished and failed emails are now branded and link to your Assets settings.

--- a/templates/assets/server/lib/generation-run-notifications.ts
+++ b/templates/assets/server/lib/generation-run-notifications.ts
@@ -7,6 +7,7 @@
  * there would mail a user who is already looking at the image.
  */
 import { notifyWithDelivery } from "@agent-native/core/notifications";
+import { getAppProductionUrl } from "@agent-native/core/server";
 import { getUserSetting } from "@agent-native/core/settings";
 
 import {
@@ -71,7 +72,16 @@ export async function notifyGenerationRunFinished(
           libraryId: run.libraryId,
           outcome,
           // The email channel is a no-op without explicit recipients.
-          ...(emailed ? { emailRecipients: [owner], emailSubject: title } : {}),
+          ...(emailed
+            ? {
+                emailRecipients: [owner],
+                emailSubject: title,
+                emailFooter:
+                  "You received this because email notifications are on in your {link}.",
+                emailFooterLinkLabel: "Assets settings",
+                emailFooterLinkUrl: `${getAppProductionUrl().replace(/\/+$/, "")}/settings`,
+              }
+            : {}),
         },
       },
       { owner },

--- a/templates/clips/changelog/2026-08-04-clip-activity-emails-now-name-the-viewer-and-the-clip-in-the.md
+++ b/templates/clips/changelog/2026-08-04-clip-activity-emails-now-name-the-viewer-and-the-clip-in-the.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-04
+---
+
+Clip activity emails now name the viewer and the Clip in the subject heading, and link straight to your Clips settings.

--- a/templates/clips/server/lib/transactional-email-templates.test.ts
+++ b/templates/clips/server/lib/transactional-email-templates.test.ts
@@ -47,8 +47,8 @@ describe("renderClipsTransactionalEmail", () => {
         viewerEmail: "jane.doe@example.test",
       },
       subject: "Your Clip “Product tour” got its first view",
-      heading: "Someone watched your Clip",
-      cta: "See Clip activity: https://clips.example/r/rec-1",
+      heading: "Jane Doe watched “Product tour”",
+      cta: "See all Clip activity: https://clips.example/r/rec-1",
     },
     {
       input: {
@@ -140,7 +140,7 @@ describe("renderClipsTransactionalEmail", () => {
         appBasePath: "/clips/",
       }).text,
     ).toContain(
-      "See Clip activity: https://workspace.example/clips/r/rec%2Fwith%20space",
+      "See all Clip activity: https://workspace.example/clips/r/rec%2Fwith%20space",
     );
 
     expect(
@@ -149,7 +149,7 @@ describe("renderClipsTransactionalEmail", () => {
         appBasePath: "clips",
       }).text,
     ).toContain(
-      "See Clip activity: https://workspace.example/clips/r/rec%2Fwith%20space",
+      "See all Clip activity: https://workspace.example/clips/r/rec%2Fwith%20space",
     );
   });
 
@@ -292,6 +292,31 @@ describe("renderClipsTransactionalEmail", () => {
     });
     expect(unidentified.text).toContain(
       "An AI agent accessed Deploy walkthrough today",
+    );
+  });
+
+  it("names the reactor and the Clip, and links the settings footer", () => {
+    const result = render({
+      kind: "activity-reaction",
+      to: "owner@example.test",
+      recordingId: "rec-5",
+      title: "Deploy walkthrough",
+      emoji: "\u{1F389}",
+      authorEmail: "jane.doe@example.test",
+      videoTimestampMs: 65_000,
+    });
+
+    expect(result.html).toContain(
+      "Jane Doe reacted to \u201cDeploy walkthrough\u201d",
+    );
+    expect(result.html).toContain(
+      '<a href="https://clips.example/settings" style="color:#a1a1aa; text-decoration:underline;">Clips settings</a>',
+    );
+    expect(result.text).toContain(
+      "Clips settings (https://clips.example/settings)",
+    );
+    expect(result.text).toContain(
+      "See all Clip activity: https://clips.example/r/rec-5?panel=comments&t=65",
     );
   });
 

--- a/templates/clips/server/lib/transactional-email-templates.ts
+++ b/templates/clips/server/lib/transactional-email-templates.ts
@@ -21,7 +21,7 @@ const EMAIL_SEND_TIMEOUT_MS = 60_000;
 const FRIENDLY_REPLY_TO = "hello@agent-native.com";
 const UNTITLED_CLIP = "Untitled Clip";
 const ACTIVITY_EMAIL_FOOTER =
-  "You received this because email notifications are on in your Clips settings.";
+  "You received this because email notifications are on in your {link}.";
 
 interface TransactionalEmailBase {
   to: string;
@@ -187,6 +187,10 @@ function quotedExcerpt(value: string): string {
 
 function recordUrl(options: ClipsTransactionalEmailRenderOptions): string {
   return appUrlForPath("/record", options);
+}
+
+function settingsLink(options: ClipsTransactionalEmailRenderOptions) {
+  return { label: "Clips settings", url: appUrlForPath("/settings", options) };
 }
 
 function resolveBrandLogoUrl(
@@ -378,13 +382,13 @@ export function renderClipsTransactionalEmail(
       const rendered = renderEmail({
         brandName: CLIPS_BRAND_NAME,
         preheader: subject,
-        heading: "Someone watched your Clip",
+        heading: `${viewer} watched “${title}”`,
         paragraphs: [
           `${emailStrong(viewer)} registered the first view of ${emailStrong(title!)}.`,
           "Clips tracks advanced analytics on your viewers' activity, and can even tell you whether your recipient took AI actions with your link. Come back to Clips to view analytics, or configure Clips AI to take agentic actions on your behalf.",
         ],
         cta: {
-          label: "See Clip activity",
+          label: "See all Clip activity",
           url: clipUrl(input.recordingId, options),
         },
         footer:
@@ -546,6 +550,7 @@ export function renderClipsTransactionalEmail(
           ),
         },
         footer: ACTIVITY_EMAIL_FOOTER,
+        footerLink: settingsLink(options),
       });
       return { subject, ...rendered };
     }
@@ -562,12 +567,12 @@ export function renderClipsTransactionalEmail(
       const rendered = renderEmail({
         brandName: CLIPS_BRAND_NAME,
         preheader: subject,
-        heading: "Someone reacted to your Clip",
+        heading: `${author} reacted to “${title}”`,
         paragraphs: [
           `${emailStrong(author)} reacted ${emailStrong(input.emoji)} on ${emailStrong(title!)}${at}.`,
         ],
         cta: {
-          label: "See Clip activity",
+          label: "See all Clip activity",
           url: clipCommentsUrl(
             input.recordingId,
             input.videoTimestampMs,
@@ -575,6 +580,7 @@ export function renderClipsTransactionalEmail(
           ),
         },
         footer: ACTIVITY_EMAIL_FOOTER,
+        footerLink: settingsLink(options),
       });
       return { subject, ...rendered };
     }

--- a/templates/content/changelog/2026-08-04-comment-notification-emails-now-link-directly-to-your-docume.md
+++ b/templates/content/changelog/2026-08-04-comment-notification-emails-now-link-directly-to-your-docume.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-04
+---
+
+Comment notification emails now link directly to your Documents settings so you can turn them off in one click.

--- a/templates/content/server/lib/comment-notifications.ts
+++ b/templates/content/server/lib/comment-notifications.ts
@@ -35,8 +35,15 @@ function excerpt(content: string): string {
 }
 
 function documentUrl(documentId: string): string {
-  const base = getAppProductionUrl().replace(/\/+$/, "");
-  return `${base}/page/${encodeURIComponent(documentId)}`;
+  return `${appBaseUrl()}/page/${encodeURIComponent(documentId)}`;
+}
+
+function settingsUrl(): string {
+  return `${appBaseUrl()}/settings`;
+}
+
+function appBaseUrl(): string {
+  return getAppProductionUrl().replace(/\/+$/, "");
 }
 
 async function threadParticipants(
@@ -128,7 +135,8 @@ async function deliverDocumentCommentEmails(
         paragraphs: [lead, `"${excerpt(input.content)}"`],
         cta: { label: "Open document", url },
         footer:
-          "You received this because you own, were mentioned in, or participated in this thread. Turn these off in Documents settings.",
+          "You received this because you own, were mentioned in, or participated in this thread. Turn these off in {link}.",
+        footerLink: { label: "Documents settings", url: settingsUrl() },
       });
 
       await sendEmail({

--- a/templates/forms/changelog/2026-08-04-new-response-emails-now-link-back-to-the-form-whose-notifica.md
+++ b/templates/forms/changelog/2026-08-04-new-response-emails-now-link-back-to-the-form-whose-notifica.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-04
+---
+
+New response emails now link back to the form whose notification setting sent them.

--- a/templates/forms/server/handlers/submissions.ts
+++ b/templates/forms/server/handlers/submissions.ts
@@ -260,6 +260,7 @@ export const submitForm = defineEventHandler(async (event: H3Event) => {
         () =>
           sendNewResponseEmail({
             to: form.ownerEmail!,
+            formId: id,
             formTitle: form.title,
             fields,
             data,

--- a/templates/forms/server/lib/response-email.ts
+++ b/templates/forms/server/lib/response-email.ts
@@ -1,9 +1,15 @@
-import { emailStrong, renderEmail, sendEmail } from "@agent-native/core/server";
+import {
+  emailStrong,
+  getAppProductionUrl,
+  renderEmail,
+  sendEmail,
+} from "@agent-native/core/server";
 
 import type { FormField } from "../../shared/types.js";
 
 export interface NewResponseEmailArgs {
   to: string;
+  formId: string;
   formTitle: string;
   fields: FormField[];
   data: Record<string, unknown>;
@@ -21,7 +27,13 @@ function formatResponseValue(value: unknown): string {
   return String(value);
 }
 
+function formSettingsUrl(formId: string): string {
+  const base = getAppProductionUrl().replace(/\/+$/, "");
+  return `${base}/forms/${encodeURIComponent(formId)}`;
+}
+
 export function renderNewResponseEmail({
+  formId,
   formTitle,
   fields,
   data,
@@ -50,7 +62,8 @@ export function renderNewResponseEmail({
           : "No response fields were submitted.",
       ],
       footer:
-        "You received this because email notifications are enabled for this form.",
+        "You received this because email notifications are enabled in this {link}.",
+      footerLink: { label: "form's settings", url: formSettingsUrl(formId) },
     }),
   };
 }

--- a/templates/plan/app/components/ui/switch.tsx
+++ b/templates/plan/app/components/ui/switch.tsx
@@ -1,0 +1,1 @@
+export * from "@agent-native/toolkit/ui/switch";

--- a/templates/plan/app/hooks/use-plan-prefs.ts
+++ b/templates/plan/app/hooks/use-plan-prefs.ts
@@ -1,0 +1,55 @@
+import { agentNativePath } from "@agent-native/core/client/api-path";
+import type { PlanUserPrefs } from "@shared/plan-user-prefs";
+import { useCallback, useEffect, useState } from "react";
+
+const PREFS_PATH = "/_agent-native/plan/user-prefs";
+
+export interface PlanPrefsState {
+  prefs: PlanUserPrefs;
+  loading: boolean;
+  /** Applies the patch optimistically and rolls back if the write fails. */
+  save: (patch: PlanUserPrefs) => Promise<void>;
+}
+
+export function usePlanPrefs(): PlanPrefsState {
+  const [prefs, setPrefs] = useState<PlanUserPrefs>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(agentNativePath(PREFS_PATH));
+        const json = res.ok ? await res.json() : null;
+        if (cancelled) return;
+        if (json && typeof json === "object" && !("error" in json)) {
+          setPrefs(json as PlanUserPrefs);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const save = useCallback(
+    async (patch: PlanUserPrefs) => {
+      const previous = prefs;
+      setPrefs((current) => ({ ...current, ...patch }));
+      const res = await fetch(agentNativePath(PREFS_PATH), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+      });
+      if (!res.ok) {
+        setPrefs(previous);
+        throw new Error(`Save failed (${res.status})`);
+      }
+    },
+    [prefs],
+  );
+
+  return { prefs, loading, save };
+}

--- a/templates/plan/app/i18n/ar-SA.ts
+++ b/templates/plan/app/i18n/ar-SA.ts
@@ -37,6 +37,10 @@ const messages = {
     editorDescription:
       "افتح الخطط وراجعها في لوحة جانبية داخل VS Code بدلاً من علامة تبويب منفصلة في المتصفح.",
     openEditorExtension: "احصل على إضافة VS Code",
+    emailNotifications: "إشعارات البريد الإلكتروني",
+    emailNotificationsDescription:
+      "احصل على بريد إلكتروني عندما يعلّق شخص على خطتك أو يرد أو يذكرك.",
+    saveFailed: "تعذّر الحفظ",
   },
   agent: {
     emptyState:

--- a/templates/plan/app/i18n/de-DE.ts
+++ b/templates/plan/app/i18n/de-DE.ts
@@ -38,6 +38,10 @@ const messages = {
     editorDescription:
       "Öffne und prüfe Pläne in einem Seitenbereich in VS Code statt in einem separaten Browser-Tab.",
     openEditorExtension: "VS-Code-Erweiterung holen",
+    emailNotifications: "E-Mail-Benachrichtigungen",
+    emailNotificationsDescription:
+      "Erhalte eine E-Mail, wenn jemand deinen Plan kommentiert, antwortet oder dich erwähnt.",
+    saveFailed: "Speichern fehlgeschlagen",
   },
   agent: {
     emptyState:

--- a/templates/plan/app/i18n/en-US.ts
+++ b/templates/plan/app/i18n/en-US.ts
@@ -38,6 +38,10 @@ const messages = {
     editorDescription:
       "Open and review plans in a side panel inside VS Code instead of a separate browser tab.",
     openEditorExtension: "Get the VS Code extension",
+    emailNotifications: "Email notifications",
+    emailNotificationsDescription:
+      "Get an email when someone comments on, replies in, or mentions you on your plan.",
+    saveFailed: "Couldn't save",
   },
   agent: {
     emptyState:

--- a/templates/plan/app/i18n/es-ES.ts
+++ b/templates/plan/app/i18n/es-ES.ts
@@ -38,6 +38,10 @@ const messages = {
     editorDescription:
       "Abre y revisa los planes en un panel lateral dentro de VS Code en lugar de una pestaña aparte del navegador.",
     openEditorExtension: "Obtener la extensión de VS Code",
+    emailNotifications: "Notificaciones por correo",
+    emailNotificationsDescription:
+      "Recibe un correo cuando alguien comente, responda o te mencione en tu plan.",
+    saveFailed: "No se pudo guardar",
   },
   agent: {
     emptyState:

--- a/templates/plan/app/i18n/fr-FR.ts
+++ b/templates/plan/app/i18n/fr-FR.ts
@@ -38,6 +38,10 @@ const messages = {
     editorDescription:
       "Ouvrez et examinez les plans dans un panneau latéral de VS Code plutôt que dans un onglet de navigateur séparé.",
     openEditorExtension: "Obtenir l’extension VS Code",
+    emailNotifications: "Notifications par e-mail",
+    emailNotificationsDescription:
+      "Recevez un e-mail lorsqu’une personne commente, répond ou vous mentionne dans votre plan.",
+    saveFailed: "Impossible d’enregistrer",
   },
   agent: {
     emptyState:

--- a/templates/plan/app/i18n/hi-IN.ts
+++ b/templates/plan/app/i18n/hi-IN.ts
@@ -37,6 +37,10 @@ const messages = {
     editorDescription:
       "अलग ब्राउज़र टैब के बजाय VS Code के साइड पैनल में योजनाएँ खोलें और उनकी समीक्षा करें।",
     openEditorExtension: "VS Code एक्सटेंशन पाएँ",
+    emailNotifications: "ईमेल सूचनाएँ",
+    emailNotificationsDescription:
+      "जब कोई आपकी योजना पर टिप्पणी करे, जवाब दे या आपका उल्लेख करे तो ईमेल पाएँ।",
+    saveFailed: "सहेजा नहीं जा सका",
   },
   agent: {
     emptyState:

--- a/templates/plan/app/i18n/ja-JP.ts
+++ b/templates/plan/app/i18n/ja-JP.ts
@@ -38,6 +38,10 @@ const messages = {
     editorDescription:
       "別のブラウザータブではなく、VS Code のサイドパネルでプランを開いてレビューします。",
     openEditorExtension: "VS Code 拡張機能を入手",
+    emailNotifications: "メール通知",
+    emailNotificationsDescription:
+      "誰かがあなたのプランにコメント、返信、またはあなたにメンションしたときにメールを受け取ります。",
+    saveFailed: "保存できませんでした",
   },
   agent: {
     emptyState:

--- a/templates/plan/app/i18n/ko-KR.ts
+++ b/templates/plan/app/i18n/ko-KR.ts
@@ -38,6 +38,10 @@ const messages = {
     editorDescription:
       "별도의 브라우저 탭 대신 VS Code 사이드 패널에서 계획을 열고 검토하세요.",
     openEditorExtension: "VS Code 확장 프로그램 받기",
+    emailNotifications: "이메일 알림",
+    emailNotificationsDescription:
+      "누군가 내 플랜에 댓글을 달거나 답글을 남기거나 나를 멘션하면 이메일을 받습니다.",
+    saveFailed: "저장하지 못했습니다",
   },
   agent: {
     emptyState:

--- a/templates/plan/app/i18n/pt-BR.ts
+++ b/templates/plan/app/i18n/pt-BR.ts
@@ -38,6 +38,10 @@ const messages = {
     editorDescription:
       "Abra e revise planos em um painel lateral dentro do VS Code em vez de uma aba separada do navegador.",
     openEditorExtension: "Obter a extensão do VS Code",
+    emailNotifications: "Notificações por e-mail",
+    emailNotificationsDescription:
+      "Receba um e-mail quando alguém comentar, responder ou mencionar você no seu plano.",
+    saveFailed: "Não foi possível salvar",
   },
   agent: {
     emptyState:

--- a/templates/plan/app/i18n/zh-CN.ts
+++ b/templates/plan/app/i18n/zh-CN.ts
@@ -35,6 +35,10 @@ const messages = {
     editorDescription:
       "在 VS Code 的侧边面板中打开并审阅计划，而不是切换到单独的浏览器标签页。",
     openEditorExtension: "获取 VS Code 扩展",
+    emailNotifications: "邮件通知",
+    emailNotificationsDescription:
+      "当有人评论你的计划、在讨论串中回复或提到你时，收到邮件通知。",
+    saveFailed: "保存失败",
   },
   agent: {
     emptyState:

--- a/templates/plan/app/i18n/zh-TW.ts
+++ b/templates/plan/app/i18n/zh-TW.ts
@@ -35,6 +35,10 @@ const messages = {
     editorDescription:
       "在 VS Code 的側邊面板中開啟並審閱計畫，而不是切換到單獨的瀏覽器標籤頁面。",
     openEditorExtension: "取得 VS Code 擴充功能",
+    emailNotifications: "郵件通知",
+    emailNotificationsDescription:
+      "當有人評論你的計畫、在討論串中回覆或提到你時，收到郵件通知。",
+    saveFailed: "儲存失敗",
   },
   agent: {
     emptyState:

--- a/templates/plan/app/routes/settings.tsx
+++ b/templates/plan/app/routes/settings.tsx
@@ -11,8 +11,11 @@ import {
 } from "@agent-native/core/client/settings";
 import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
 import { useMemo } from "react";
+import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { usePlanPrefs } from "@/hooks/use-plan-prefs";
 import { APP_TITLE } from "@/lib/app-config";
 
 import changelog from "../../CHANGELOG.md?raw";
@@ -25,6 +28,7 @@ export default function SettingsRoute() {
   const t = useT();
   const agentSettingsTabs = useAgentSettingsTabs();
   useSetPageTitle(t("settings.title"));
+  const { prefs, loading: prefsLoading, save: savePrefs } = usePlanPrefs();
 
   const generalSearchEntries = useMemo<SettingsSearchEntry[]>(
     () => [
@@ -33,6 +37,12 @@ export default function SettingsRoute() {
         label: t("settings.languageTitle"),
         keywords: "language locale translation i18n",
         hash: "language",
+      },
+      {
+        id: "plan-notifications",
+        label: t("settings.emailNotifications"),
+        keywords: "email notifications comments replies mentions alerts",
+        hash: "notifications",
       },
       {
         id: "plan-editor",
@@ -65,6 +75,27 @@ export default function SettingsRoute() {
                 <div className="w-56">
                   <LanguagePicker label={t("settings.languageLabel")} />
                 </div>
+              }
+            />
+            <SettingsRow
+              id="notifications"
+              label={t("settings.emailNotifications")}
+              description={t("settings.emailNotificationsDescription")}
+              control={
+                <Switch
+                  aria-label={t("settings.emailNotifications")}
+                  checked={prefs.emailNotifications !== false}
+                  disabled={prefsLoading}
+                  onCheckedChange={(checked) => {
+                    savePrefs({ emailNotifications: checked }).catch((err) => {
+                      toast.error(
+                        err instanceof Error
+                          ? err.message
+                          : t("settings.saveFailed"),
+                      );
+                    });
+                  }}
+                />
               }
             />
             <SettingsRow

--- a/templates/plan/changelog/2026-08-04-you-can-now-turn-plan-comment-reply-and-mention-emails-off-i.md
+++ b/templates/plan/changelog/2026-08-04-you-can-now-turn-plan-comment-reply-and-mention-emails-off-i.md
@@ -1,0 +1,6 @@
+---
+type: added
+date: 2026-08-04
+---
+
+You can now turn plan comment, reply, and mention emails off in Settings, and every notification email links there.

--- a/templates/plan/server/lib/comment-notifications.spec.ts
+++ b/templates/plan/server/lib/comment-notifications.spec.ts
@@ -10,6 +10,9 @@ const renderEmailMock = vi.hoisted(() =>
 const isEmailConfiguredMock = vi.hoisted(() => vi.fn(() => true));
 const selectPlanMock = vi.hoisted(() => vi.fn());
 const getDbMock = vi.hoisted(() => vi.fn());
+const resolveActivityRecipientsMock = vi.hoisted(() =>
+  vi.fn(async ({ candidates }: { candidates: string[] }) => candidates),
+);
 
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn((left: unknown, right: unknown) => ({ left, right })),
@@ -20,6 +23,8 @@ vi.mock("@agent-native/core/server", () => ({
   getAppProductionUrl: () => "https://plans.example.test",
   isEmailConfigured: () => isEmailConfiguredMock(),
   renderEmail: (args: unknown) => renderEmailMock(args),
+  resolveActivityRecipients: (args: { candidates: string[] }) =>
+    resolveActivityRecipientsMock(args),
   sendEmail: (args: unknown) => sendEmailMock(args),
 }));
 
@@ -107,6 +112,7 @@ describe("plan comment notification recipients", () => {
     renderEmailMock.mockClear();
     selectPlanMock.mockReset();
     sendEmailMock.mockReset();
+    resolveActivityRecipientsMock.mockClear();
   });
 
   it("notifies the plan owner for a new root comment", () => {
@@ -261,6 +267,48 @@ describe("plan comment notification recipients", () => {
       html: "<p>Email</p>",
       text: "Email",
     });
+  });
+
+  it("links Plan settings in the footer and skips recipients who opted out", async () => {
+    const newComment = comment("reviewer", {
+      authorEmail: "reviewer@example.com",
+      authorName: "Reviewer",
+    });
+    selectPlanMock.mockResolvedValue([
+      {
+        id: "plan_1",
+        title: "Launch Plan",
+        ownerEmail: "owner@example.com",
+        sourceAuthorEmail: null,
+      },
+    ]);
+
+    await notifyPlanCommentRecipients({
+      bundle: bundle([newComment]),
+      insertedCommentIds: [newComment.id],
+    });
+
+    expect(renderEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        footer:
+          "You received this because you own this plan. Turn these off in {link}.",
+        footerLink: {
+          label: "Plan settings",
+          url: "https://plans.example.test/settings",
+        },
+      }),
+    );
+
+    renderEmailMock.mockClear();
+    sendEmailMock.mockReset();
+    resolveActivityRecipientsMock.mockResolvedValueOnce([]);
+
+    await notifyPlanCommentRecipients({
+      bundle: bundle([newComment]),
+      insertedCommentIds: [newComment.id],
+    });
+
+    expect(sendEmailMock).not.toHaveBeenCalled();
   });
 
   it("does not notify later batch commenters for earlier replies", async () => {

--- a/templates/plan/server/lib/comment-notifications.ts
+++ b/templates/plan/server/lib/comment-notifications.ts
@@ -1,3 +1,12 @@
+/**
+ * Email notifications for plan comments, replies, and mentions.
+ *
+ * Recipient reasons (owner, mention, thread participant) are Plan's own; the
+ * per-user `emailNotifications` opt-out is the shared one from
+ * `@agent-native/core/server`. Access requests are not routed through that
+ * preference — they have their own delivery path.
+ */
+
 import {
   emailStrong,
   getAppProductionUrl,

--- a/templates/plan/server/lib/comment-notifications.ts
+++ b/templates/plan/server/lib/comment-notifications.ts
@@ -3,6 +3,7 @@ import {
   getAppProductionUrl,
   isEmailConfigured,
   renderEmail,
+  resolveActivityRecipients,
   sendEmail,
 } from "@agent-native/core/server";
 import { eq } from "drizzle-orm";
@@ -11,6 +12,7 @@ import {
   SOURCE_AUTHOR_COMMENT_MENTION_EMAIL,
   extractCommentMentions,
 } from "../../shared/comment-context.js";
+import { PLAN_USER_PREFS_KEY } from "../../shared/plan-user-prefs.js";
 import type { PlanBundle, PlanComment } from "../../shared/types.js";
 import { getDb, schema } from "../db/index.js";
 
@@ -96,14 +98,22 @@ function appPath(path: string): string {
   return `${normalizedBase}${path}`;
 }
 
-function planUrl(planId: string): string {
-  const appUrl = getAppProductionUrl().replace(/\/+$/, "");
-  const path = appPath(`/plans/${encodeURIComponent(planId)}`);
+function appUrl(path: string): string {
+  const base = getAppProductionUrl().replace(/\/+$/, "");
+  const resolved = appPath(path);
   try {
-    return new URL(path, `${appUrl}/`).toString();
+    return new URL(resolved, `${base}/`).toString();
   } catch {
-    return `${appUrl}${path}`;
+    return `${base}${resolved}`;
   }
+}
+
+function planUrl(planId: string): string {
+  return appUrl(`/plans/${encodeURIComponent(planId)}`);
+}
+
+function settingsLink() {
+  return { label: "Plan settings", url: appUrl("/settings") };
 }
 
 function appName(): string {
@@ -231,12 +241,14 @@ async function sendPlanCommentNotification(input: {
       `Comment: "${commentExcerpt(input.comment.message)}"`,
     ],
     cta: { label: "Open plan", url: planUrl(input.planId) },
-    footer:
+    footer: `${
       input.recipient.reason === "plan-owner"
         ? "You received this because you own this plan."
         : input.recipient.reason === "mention"
           ? "You received this because you were mentioned in this comment."
-          : "You received this because you participated in this comment thread.",
+          : "You received this because you participated in this comment thread."
+    } Turn these off in {link}.`,
+    footerLink: settingsLink(),
   });
   await sendEmail({ to: input.recipient.email, subject, html, text });
 }
@@ -281,7 +293,18 @@ export async function notifyPlanCommentRecipients({
       planOwnerEmail,
       sourceAuthorEmail,
     });
+    // Recipient resolution is Plan's own (owner/mention/thread reasons), so
+    // only the opt-out filter is borrowed from the shared activity helper.
+    const optedIn = new Set(
+      await resolveActivityRecipients({
+        candidates: recipients.map((recipient) => recipient.email),
+        actorEmail: comment.authorEmail,
+        preferenceKey: PLAN_USER_PREFS_KEY,
+      }),
+    );
+
     for (const recipient of recipients) {
+      if (!optedIn.has(recipient.email)) continue;
       try {
         await sendPlanCommentNotification({
           recipient,

--- a/templates/plan/server/routes/_agent-native/plan/user-prefs.get.ts
+++ b/templates/plan/server/routes/_agent-native/plan/user-prefs.get.ts
@@ -1,0 +1,16 @@
+import { getSession } from "@agent-native/core/server";
+import { getUserSetting } from "@agent-native/core/settings";
+import { defineEventHandler, setResponseStatus } from "h3";
+
+import { PLAN_USER_PREFS_KEY } from "../../../../shared/plan-user-prefs.js";
+
+export default defineEventHandler(async (event) => {
+  const session = await getSession(event);
+  if (!session?.email) {
+    setResponseStatus(event, 401);
+    return { error: "unauthorized" };
+  }
+
+  // coercion-ok: no stored blob means no preferences set yet, which is a real state, not a read failure.
+  return (await getUserSetting(session.email, PLAN_USER_PREFS_KEY)) ?? {};
+});

--- a/templates/plan/server/routes/_agent-native/plan/user-prefs.put.ts
+++ b/templates/plan/server/routes/_agent-native/plan/user-prefs.put.ts
@@ -1,0 +1,36 @@
+import { getSession } from "@agent-native/core/server";
+import { getUserSetting, putUserSetting } from "@agent-native/core/settings";
+import { defineEventHandler, getHeader, readBody, setResponseStatus } from "h3";
+
+import { PLAN_USER_PREFS_KEY } from "../../../../shared/plan-user-prefs.js";
+
+export default defineEventHandler(async (event) => {
+  const session = await getSession(event);
+  if (!session?.email) {
+    setResponseStatus(event, 401);
+    return { error: "unauthorized" };
+  }
+
+  // coercion-ok: an unparsable body is rejected with 400 immediately below.
+  const body = await readBody(event).catch(() => null);
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    setResponseStatus(event, 400);
+    return { error: "Invalid settings payload" };
+  }
+
+  // Merge so a partial save never wipes preferences written elsewhere.
+  const stored = await getUserSetting(session.email, PLAN_USER_PREFS_KEY);
+  // coercion-ok: a null read means this user has no preferences yet, which is a real state.
+  const existing = stored ?? {};
+  const next = {
+    ...(typeof existing === "object" && existing && !Array.isArray(existing)
+      ? existing
+      : {}),
+    ...(body as Record<string, unknown>),
+  };
+
+  await putUserSetting(session.email, PLAN_USER_PREFS_KEY, next, {
+    requestSource: getHeader(event, "x-request-source") || undefined,
+  });
+  return next;
+});

--- a/templates/plan/shared/plan-user-prefs.ts
+++ b/templates/plan/shared/plan-user-prefs.ts
@@ -1,0 +1,11 @@
+/**
+ * Per-user Plan preferences, stored under one user-setting key so Settings and
+ * the notification senders read and write the same object.
+ */
+
+export const PLAN_USER_PREFS_KEY = "plan-user-prefs";
+
+export type PlanUserPrefs = {
+  /** Comment, reply, and mention emails only — never access requests. */
+  emailNotifications?: boolean;
+};

--- a/templates/slides/actions/_app-url.ts
+++ b/templates/slides/actions/_app-url.ts
@@ -38,6 +38,10 @@ export function getDeckUrl(deckId: string): string {
   return `${getSlidesAppUrl()}/deck/${deckId}`;
 }
 
+export function getSettingsUrl(): string {
+  return `${getSlidesAppUrl()}/settings`;
+}
+
 export function getExportUrl(filename: string): string {
   return `${getSlidesAppUrl()}/api/exports/${filename}`;
 }

--- a/templates/slides/changelog/2026-08-04-comment-notification-emails-now-link-directly-to-your-slides.md
+++ b/templates/slides/changelog/2026-08-04-comment-notification-emails-now-link-directly-to-your-slides.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-04
+---
+
+Comment notification emails now link directly to your Slides settings so you can turn them off in one click.

--- a/templates/slides/server/lib/comment-notifications.spec.ts
+++ b/templates/slides/server/lib/comment-notifications.spec.ts
@@ -48,6 +48,7 @@ vi.mock("@agent-native/core/sharing", () => ({
 
 vi.mock("../../actions/_app-url.js", () => ({
   getDeckUrl: (deckId: string) => `https://slides.test/deck/${deckId}`,
+  getSettingsUrl: () => "https://slides.test/settings",
 }));
 
 vi.mock("../db/index.js", () => ({

--- a/templates/slides/server/lib/comment-notifications.ts
+++ b/templates/slides/server/lib/comment-notifications.ts
@@ -18,7 +18,7 @@ import {
 import { filterRecipientsByResourceAccess } from "@agent-native/core/sharing";
 import { and, eq } from "drizzle-orm";
 
-import { getDeckUrl } from "../../actions/_app-url.js";
+import { getDeckUrl, getSettingsUrl } from "../../actions/_app-url.js";
 import { SLIDES_USER_PREFS_KEY } from "../../shared/slides-user-prefs.js";
 import { getDb, schema } from "../db/index.js";
 
@@ -166,7 +166,8 @@ async function deliverDeckCommentEmails(input: {
         ],
         cta: { label: "Open deck", url },
         footer:
-          "You received this because you own or participated in this thread. Turn these off in Slides settings.",
+          "You received this because you own or participated in this thread. Turn these off in {link}.",
+        footerLink: { label: "Slides settings", url: getSettingsUrl() },
       });
 
       await sendEmail({


### PR DESCRIPTION
### Summary
Adds a `footerLink` capability to `renderEmail` so footer text can include a real, clickable link (e.g. to a settings page), and wires this through the core notifications channel and the Plan/Slides templates so "turn these off" copy actually links somewhere.

### Problem
Transactional emails referenced "Settings" in the footer as plain, non-clickable text, and env-configured ops notification recipients (who have no per-user opt-out toggle) were sometimes told to go turn one off anyway. There was also no consistent way for a notification sender to declare which settings surface controls a given email type.

### Solution
`renderEmail` now supports a `{link}` token in `footer` that is replaced with a real anchor (HTML) or `label (url)` (plain text) when a `footerLink` is supplied, and left untouched otherwise. The core notification email channel builds this footer from per-notification metadata (`emailFooter`, `emailFooterLinkLabel`, `emailFooterLinkUrl`), only adding an opt-out footer when the sender explicitly names one — so ops recipients without a toggle never get told to disable it. The Plan and Slides templates were updated to use this footer link for their comment-notification emails and to route through their own settings pages, with Plan gaining a dedicated user-preferences endpoint and opt-out filtering for comment notifications.

### Key Changes
- `renderEmail` (`email-template.ts`): new `footerLink` arg and `resolveFooterLink` helper that substitutes a `{link}` token with an anchor in HTML and `label (url)` in plain text, or leaves the token visible if no link is provided.
- Core notifications (`channels.ts`): notification emails now render via `renderEmail` instead of bare paragraphs, picking up shared branding; added `notificationEmailFooter` to build the footer/footerLink only when `metadata.emailFooter` is set, keeping ops-only notifications free of misleading opt-out text.
- Plan template: `comment-notifications.ts` adds a `settingsLink()` helper and appends a "Turn these off in {link}." footer with a link to Plan settings; introduces `PLAN_USER_PREFS_KEY` shared constant, new `user-prefs.get.ts`/`user-prefs.put.ts` routes for reading/writing per-user preferences, and filters comment recipients through `resolveActivityRecipients` so opted-out users are skipped.
- Slides template: `comment-notifications.ts` now uses a `{link}` footer token with `getSettingsUrl()` (new helper in `_app-url.ts`) instead of a static "Slides settings" string, plus a changelog entry documenting the clickable settings link.
- Added tests covering footer link rendering (with and without a link), the opt-in/opt-out footer behavior in the core email channel, and Plan comment notifications respecting opted-out users.
- Added changeset documenting the `renderEmail` `footerLink` API and the updated notification email behavior.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/cache-grip-tvdimmwq"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-cache-grip-tvdimmwq.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2619`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>cache-grip-tvdimmwq</branchName>-->