### PR TITLE
Fix delayed sign-out after email verification

### DIFF
--- a/.changeset/fix-auth-signout-cookie-cache.md
+++ b/.changeset/fix-auth-signout-cookie-cache.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Clear Better Auth session cache cookies when signing out.

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -224,7 +224,7 @@ describe("server/auth", () => {
       errorSpy.mockRestore();
     });
 
-    it("lets logout opt the current browser out of AUTH_DISABLED inside an HTTPS iframe", async () => {
+    it("opts the current browser out and forwards Better Auth logout cookies", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("AUTH_DISABLED", "1");
       delete process.env.ACCESS_TOKEN;
@@ -237,7 +237,14 @@ describe("server/auth", () => {
             getSession: vi.fn(async () => null),
             signInEmail: vi.fn(),
             signUpEmail: vi.fn(),
-            signOut: vi.fn(),
+            signOut: vi.fn(async () => {
+              const headers = new Headers();
+              headers.append(
+                "set-cookie",
+                "better-auth.session_data=; Max-Age=0; Path=/",
+              );
+              return { headers };
+            }),
           },
         })),
         getBetterAuthSync: vi.fn(() => undefined),
@@ -264,6 +271,9 @@ describe("server/auth", () => {
       expect(setCookie).toContain("SameSite=None");
       expect(setCookie).toContain("Secure");
       expect(setCookie).toContain("Partitioned");
+      expect(setCookie).toContain(
+        "better-auth.session_data=; Max-Age=0; Path=/",
+      );
     });
 
     it("mounts generic Google OAuth routes by default when credentials are configured", async () => {

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -661,23 +661,23 @@ async function readDesktopSsoSafely(
  * user. Returns undefined if no session cookie was minted (the common
  * case — Better Auth's reset doesn't auto-sign-in by default).
  */
+function getSetCookieHeaders(headers: Headers): string[] {
+  const responseHeaders = headers as Headers & {
+    getSetCookie?: () => string[];
+  };
+  return typeof responseHeaders.getSetCookie === "function"
+    ? responseHeaders.getSetCookie()
+    : (responseHeaders.get("set-cookie") ?? "")
+        .split(/,(?=[^;]+=)/)
+        .map((value) => value.trim())
+        .filter(Boolean);
+}
+
 function extractSessionTokenFromSetCookies(
   response: Response,
 ): string | undefined {
   try {
-    // Headers may have multiple Set-Cookie entries; iterate via getSetCookie
-    // when available (Node 20+ / undici), else fall back to comma split.
-    const headers = response.headers as Headers & {
-      getSetCookie?: () => string[];
-    };
-    const setCookies =
-      typeof headers.getSetCookie === "function"
-        ? headers.getSetCookie()
-        : (headers.get("set-cookie") ?? "")
-            .split(/,(?=[^;]+=)/)
-            .map((s) => s.trim())
-            .filter(Boolean);
-    for (const sc of setCookies) {
+    for (const sc of getSetCookieHeaders(response.headers)) {
       // Better Auth's session cookie name is configurable but defaults to
       // `<prefix>.session_token`. Match either the Better Auth default or
       // our COOKIE_NAME (`an_session`) on the same line.
@@ -690,6 +690,15 @@ function extractSessionTokenFromSetCookies(
     // Best-effort; treat as no token.
   }
   return undefined;
+}
+
+function forwardBetterAuthSetCookies(event: H3Event, result: unknown): void {
+  if (!result || typeof result !== "object") return;
+  const headers = (result as { headers?: Headers }).headers;
+  if (!headers || typeof headers.get !== "function") return;
+  for (const cookie of getSetCookieHeaders(headers)) {
+    event.res?.headers?.append("set-cookie", cookie);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -3444,7 +3453,11 @@ async function mountBetterAuthRoutes(
       optOutOfAuthDisabledSession(event);
 
       try {
-        await auth.api.signOut({ headers: event.headers });
+        const result = await auth.api.signOut({
+          headers: event.headers,
+          returnHeaders: true,
+        });
+        forwardBetterAuthSetCookies(event, result);
       } catch {
         // Ignore if no Better Auth session
       }
@@ -3511,7 +3524,11 @@ async function mountBetterAuthRoutes(
         clearFrameworkSessionCookies(event);
         optOutOfAuthDisabledSession(event);
         try {
-          await auth.api.signOut({ headers: event.headers });
+          const result = await auth.api.signOut({
+            headers: event.headers,
+            returnHeaders: true,
+          });
+          forwardBetterAuthSetCookies(event, result);
         } catch {
           // Ignore — sessions are already gone in DB.
         }
@@ -3692,7 +3709,11 @@ function mountAuthFallbackRoutes(app: H3App): void {
 
       try {
         const auth = await getBetterAuth();
-        await auth.api.signOut({ headers: event.headers });
+        const result = await auth.api.signOut({
+          headers: event.headers,
+          returnHeaders: true,
+        });
+        forwardBetterAuthSetCookies(event, result);
       } catch {
         // Ignore if Better Auth is still unavailable
       }

--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -395,7 +395,10 @@ export interface BetterAuthInstance {
       };
       headers?: Headers;
     }) => Promise<any>;
-    signOut: (opts: { headers: Headers }) => Promise<any>;
+    signOut: (opts: {
+      headers: Headers;
+      returnHeaders?: boolean;
+    }) => Promise<any>;
   };
 }
 

--- a/packages/mobile-app/components/AppWebView.tsx
+++ b/packages/mobile-app/components/AppWebView.tsx
@@ -90,6 +90,7 @@ const SESSION_BRIDGE_SCRIPT = `
     window.__agentNativeSessionBridgeRunning = true;
     var postToken = function () {
       fetch('/_agent-native/auth/session', {
+        cache: 'no-store',
         credentials: 'include',
         headers: { Accept: 'application/json' }
       })

--- a/templates/clips/changelog/2026-08-04-signing-out-now-takes-effect-immediately-after-verifying-a-n.md
+++ b/templates/clips/changelog/2026-08-04-signing-out-now-takes-effect-immediately-after-verifying-a-n.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-04
+---
+
+Signing out now takes effect immediately after verifying a new account.

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -1206,7 +1206,7 @@ export function App() {
     try {
       const res = await fetch(
         `${serverUrl.replace(/\/+$/, "")}/_agent-native/auth/session`,
-        { credentials: "include" },
+        { credentials: "include", cache: "no-store" },
       );
       if (!res.ok) {
         if (res.status === 401 || res.status === 403) {


### PR DESCRIPTION
**Short description:** Make sign-out take effect immediately for newly verified accounts across web, desktop, and mobile.

## Summary

This change fixes an issue where users who had just verified a new email and password account could appear to remain signed in after choosing sign out. Sign-out now takes effect immediately instead of waiting for a cached session to expire.

## Changes

- Update shared authentication sign-out handling so the current session is cleared consistently.
- Keep Clips desktop and the mobile WebView aligned with the latest session state after sign-out.
- Add regression coverage for the shared authentication behavior.
- Add release notes for the Clips user-visible fix.
