### PR TITLE
Allow scoped Thread Debug operator access

### DIFF
--- a/.changeset/thread-debug-operators.md
+++ b/.changeset/thread-debug-operators.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Allow approved read-only Thread Debug operators to inspect organization-owned service-principal traces and keep failed lookups distinct from successful empty results.

--- a/packages/dispatch/src/actions/get-agent-thread-debug.ts
+++ b/packages/dispatch/src/actions/get-agent-thread-debug.ts
@@ -27,7 +27,9 @@ export default defineAction({
       ownerEmail: z
         .string()
         .optional()
-        .describe("Optional owner email scope for admin cross-user lookups."),
+        .describe(
+          "Optional owner email filter inside the organization-visible scope available to approved Thread Debug operators and admins.",
+        ),
       maxRuns: z.coerce.number().int().min(1).max(50).default(20),
       maxEvents: z.coerce.number().int().min(1).max(2000).default(600),
       maxTraceSpans: z.coerce.number().int().min(1).max(2000).default(500),

--- a/packages/dispatch/src/actions/list-agent-run-failures.ts
+++ b/packages/dispatch/src/actions/list-agent-run-failures.ts
@@ -17,7 +17,7 @@ export default defineAction({
       .string()
       .optional()
       .describe(
-        "Optional owner email filter. Organization admins may only select members of their current organization.",
+        "Optional owner email filter inside the caller's permitted scope. Approved Thread Debug operators and admins remain limited to their current organization.",
       ),
     status: z
       .enum(["all", "errored", "aborted", "truncated"])

--- a/packages/dispatch/src/actions/search-agent-threads.ts
+++ b/packages/dispatch/src/actions/search-agent-threads.ts
@@ -5,7 +5,7 @@ import { searchAgentThreads } from "../server/lib/thread-debug-store.js";
 
 export default defineAction({
   description:
-    "Search agent chat threads by title, preview, full persisted thread content, or an exact request/run ID. Non-admins are limited to their own current Dispatch DB threads.",
+    "Search agent chat threads by title, preview, full persisted thread content, or an exact request/run ID. Approved read-only Thread Debug operators and organization admins may inspect organization-owned threads across connected sources; other callers are limited to their own current Dispatch threads.",
   schema: z.object({
     sourceId: z
       .string()
@@ -21,7 +21,7 @@ export default defineAction({
       .string()
       .optional()
       .describe(
-        "Optional owner email filter. Admins may pass '*' or omit to search the admin-visible scope.",
+        "Optional owner email filter inside the caller's permitted scope. Approved Thread Debug operators and admins may pass '*' or omit it to search their organization-visible scope.",
       ),
     limit: z.coerce.number().int().min(1).max(100).default(25),
   }),

--- a/packages/dispatch/src/routes/pages/thread-debug.spec.tsx
+++ b/packages/dispatch/src/routes/pages/thread-debug.spec.tsx
@@ -12,6 +12,9 @@ const queryState = vi.hoisted(() => ({
     params: Record<string, unknown>;
     enabled: boolean;
   }>,
+  errorNames: new Set<string>(),
+  emptyNames: new Set<string>(),
+  unavailableFailures: false,
 }));
 
 const failedRun = {
@@ -85,8 +88,10 @@ vi.mock("@agent-native/core/client/hooks", () => ({
     queryState.calls.push({ name, params, enabled });
     const base = {
       isLoading: false,
-      isError: false,
-      error: null,
+      isError: queryState.errorNames.has(name),
+      error: queryState.errorNames.has(name)
+        ? new Error("Thread Debug request failed")
+        : null,
       refetch: vi.fn(),
     };
     if (name === "list-agent-thread-sources") {
@@ -98,6 +103,7 @@ vi.mock("@agent-native/core/client/hooks", () => ({
             orgId: "org-1",
             role: "admin",
             envAdmin: false,
+            threadDebugOperator: false,
             canInspectAll: true,
             memberCount: 1,
           },
@@ -127,30 +133,87 @@ vi.mock("@agent-native/core/client/hooks", () => ({
       };
     }
     if (name === "list-agent-run-failures") {
+      if (queryState.errorNames.has(name)) {
+        return { ...base, data: undefined };
+      }
+      const failures =
+        queryState.emptyNames.has(name) || queryState.unavailableFailures
+          ? []
+          : [failedRun];
       return {
         ...base,
         data: enabled
           ? {
-              failures: [failedRun],
-              count: 1,
-              partial: true,
+              failures,
+              count: failures.length,
+              partial:
+                queryState.unavailableFailures ||
+                !queryState.emptyNames.has(name),
               access: {
                 viewerEmail: "ops@example.com",
                 scope: "current organization",
                 canInspectAll: true,
               },
-              sources: [
-                {
-                  source: failedRun.source,
-                  status: "ok",
-                  failureCount: 1,
-                },
-                {
-                  source: { id: "clips", label: "Clips" },
-                  status: "unavailable",
-                  failureCount: 0,
-                },
-              ],
+              sources: queryState.unavailableFailures
+                ? queryState.emptyNames.has(name)
+                  ? [
+                      {
+                        source: failedRun.source,
+                        status: "ok",
+                        failureCount: 0,
+                      },
+                      {
+                        source: { id: "clips", label: "Clips" },
+                        status: "unavailable",
+                        failureCount: 0,
+                      },
+                    ]
+                  : [
+                      {
+                        source: failedRun.source,
+                        status: "unavailable",
+                        failureCount: 0,
+                      },
+                    ]
+                : queryState.emptyNames.has(name)
+                  ? [
+                      {
+                        source: failedRun.source,
+                        status: "ok",
+                        failureCount: 0,
+                      },
+                    ]
+                  : [
+                      {
+                        source: failedRun.source,
+                        status: "ok",
+                        failureCount: failures.length,
+                      },
+                      {
+                        source: { id: "clips", label: "Clips" },
+                        status: "unavailable",
+                        failureCount: 0,
+                      },
+                    ],
+            }
+          : undefined,
+      };
+    }
+    if (name === "search-agent-threads") {
+      if (queryState.errorNames.has(name)) {
+        return { ...base, data: undefined };
+      }
+      return {
+        ...base,
+        data: enabled
+          ? {
+              count: 0,
+              threads: [],
+              access: {
+                scope: "current organization",
+                canInspectAll: true,
+              },
+              source: { id: "mail", label: "Mail" },
             }
           : undefined,
       };
@@ -192,6 +255,9 @@ describe("ThreadDebugRoute", () => {
   beforeEach(() => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
     queryState.calls = [];
+    queryState.errorNames.clear();
+    queryState.emptyNames.clear();
+    queryState.unavailableFailures = false;
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -268,5 +334,106 @@ describe("ThreadDebugRoute", () => {
       status: "errored",
       lookbackHours: 168,
     });
+  });
+
+  it("does not render a failed run request as a successful empty result", async () => {
+    queryState.errorNames.add("list-agent-run-failures");
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/thread-debug"]}>
+          <ThreadDebugRoute />
+        </MemoryRouter>,
+      );
+    });
+
+    expect(container.textContent).toContain("dispatch.pages.dataLoadFailed");
+    expect(container.textContent).not.toContain("0 failed runs");
+    expect(container.textContent).not.toContain("No failed runs found.");
+  });
+
+  it("does not render a failed thread search as a successful empty result", async () => {
+    queryState.errorNames.add("search-agent-threads");
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter
+          initialEntries={[
+            "/thread-debug?mode=threads&source=mail&query=AN-SLACK-CANARY-EXAMPLE",
+          ]}
+        >
+          <ThreadDebugRoute />
+        </MemoryRouter>,
+      );
+    });
+
+    expect(container.textContent).toContain("dispatch.pages.dataLoadFailed");
+    expect(container.textContent).not.toContain("0 results");
+    expect(container.textContent).not.toContain("No threads found.");
+  });
+
+  it("renders a genuine empty failed-run request as zero results", async () => {
+    queryState.emptyNames.add("list-agent-run-failures");
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/thread-debug"]}>
+          <ThreadDebugRoute />
+        </MemoryRouter>,
+      );
+    });
+
+    expect(container.textContent).toContain("0 failed runs");
+    expect(container.textContent).toContain("No failed runs found.");
+  });
+
+  it("does not render an unavailable failure source as zero results", async () => {
+    queryState.unavailableFailures = true;
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/thread-debug?source=mail"]}>
+          <ThreadDebugRoute />
+        </MemoryRouter>,
+      );
+    });
+
+    expect(container.textContent).toContain("Mail (unavailable)");
+    expect(container.textContent).not.toContain("0 failed runs");
+    expect(container.textContent).not.toContain("No failed runs found.");
+  });
+
+  it("does not render mixed empty and unavailable sources as a genuine zero", async () => {
+    queryState.emptyNames.add("list-agent-run-failures");
+    queryState.unavailableFailures = true;
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/thread-debug"]}>
+          <ThreadDebugRoute />
+        </MemoryRouter>,
+      );
+    });
+
+    expect(container.textContent).toContain("Clips (unavailable)");
+    expect(container.textContent).not.toContain("0 failed runs");
+    expect(container.textContent).not.toContain("No failed runs found.");
+  });
+
+  it("renders a genuine empty thread search as zero results", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter
+          initialEntries={[
+            "/thread-debug?mode=threads&source=mail&query=AN-SLACK-CANARY-EXAMPLE",
+          ]}
+        >
+          <ThreadDebugRoute />
+        </MemoryRouter>,
+      );
+    });
+
+    expect(container.textContent).toContain("0 results");
+    expect(container.textContent).toContain("No threads found.");
   });
 });

--- a/packages/dispatch/src/routes/pages/thread-debug.tsx
+++ b/packages/dispatch/src/routes/pages/thread-debug.tsx
@@ -736,6 +736,7 @@ export default function ThreadDebugRoute() {
       orgId: string | null;
       role: string | null;
       envAdmin: boolean;
+      threadDebugOperator: boolean;
       canInspectAll: boolean;
       memberCount: number;
     };
@@ -768,6 +769,9 @@ export default function ThreadDebugRoute() {
   const unavailableFailureSources = (failuresData?.sources ?? []).filter(
     (source) => source.status !== "ok",
   );
+  const allFailureSourcesSucceeded =
+    (failuresData?.sources.length ?? 0) > 0 &&
+    failuresData?.sources.every((source) => source.status === "ok");
   const failureSourceStatusLabels = {
     ok: "ok",
     disconnected: t("dispatch.pages.threadDebugDisconnected", {
@@ -1024,19 +1028,20 @@ export default function ThreadDebugRoute() {
                 </Select>
               </div>
               <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                <span>
-                  {failuresData?.count ?? failures.length}{" "}
-                  {t("dispatch.pages.threadDebugFailureResults", {
-                    defaultValue: "failed runs",
-                  })}
-                </span>
-                <span>·</span>
-                <span>
-                  {failuresData?.access?.scope ??
-                    t("dispatch.pages.threadDebugCurrentScope", {
-                      defaultValue: "current scope",
-                    })}
-                </span>
+                {!failuresError &&
+                failuresData &&
+                allFailureSourcesSucceeded ? (
+                  <>
+                    <span>
+                      {failuresData.count}{" "}
+                      {t("dispatch.pages.threadDebugFailureResults", {
+                        defaultValue: "failed runs",
+                      })}
+                    </span>
+                    <span>·</span>
+                    <span>{failuresData.access.scope}</span>
+                  </>
+                ) : null}
                 {failuresData?.partial ? (
                   <Badge variant="outline">
                     {t("dispatch.pages.threadDebugPartialResults", {
@@ -1098,7 +1103,11 @@ export default function ThreadDebugRoute() {
                       <Skeleton className="h-32 w-full rounded-lg" />
                     </>
                   ) : null}
-                  {!failuresLoading && failures.length === 0 ? (
+                  {!failuresLoading &&
+                  !failuresError &&
+                  failuresData &&
+                  allFailureSourcesSucceeded &&
+                  failures.length === 0 ? (
                     <div className="flex min-h-64 flex-col items-center justify-center rounded-lg border border-dashed px-4 text-center text-sm text-muted-foreground">
                       <IconDatabase className="mb-2 size-5" />
                       {t("dispatch.pages.threadDebugNoFailures", {
@@ -1247,13 +1256,17 @@ export default function ThreadDebugRoute() {
                 {sourcesData?.access ? (
                   <span>
                     {sourcesData.access.viewerEmail} ·{" "}
-                    {sourcesData.access.canInspectAll
-                      ? t("dispatch.pages.threadDebugAdminScope", {
-                          defaultValue: "admin scope",
+                    {sourcesData.access.threadDebugOperator
+                      ? t("dispatch.pages.threadDebugCurrentScope", {
+                          defaultValue: "organization scope",
                         })
-                      : t("dispatch.pages.threadDebugOwnScope", {
-                          defaultValue: "own scope",
-                        })}
+                      : sourcesData.access.canInspectAll
+                        ? t("dispatch.pages.threadDebugAdminScope", {
+                            defaultValue: "admin scope",
+                          })
+                        : t("dispatch.pages.threadDebugOwnScope", {
+                            defaultValue: "own scope",
+                          })}
                   </span>
                 ) : null}
               </div>
@@ -1276,15 +1289,15 @@ export default function ThreadDebugRoute() {
                       })}
                     </div>
                     <div className="text-xs text-muted-foreground">
-                      {searchData?.count ?? 0}{" "}
-                      {t("dispatch.pages.threadDebugResults", {
-                        defaultValue: "results",
-                      })}{" "}
-                      ·{" "}
-                      {searchData?.access?.scope ??
-                        t("dispatch.pages.threadDebugCurrentScope", {
-                          defaultValue: "current scope",
-                        })}
+                      {!searchError && searchData ? (
+                        <>
+                          {searchData.count}{" "}
+                          {t("dispatch.pages.threadDebugResults", {
+                            defaultValue: "results",
+                          })}{" "}
+                          · {searchData.access.scope}
+                        </>
+                      ) : null}
                     </div>
                   </div>
                   <Button
@@ -1307,7 +1320,10 @@ export default function ThreadDebugRoute() {
                       <Skeleton className="h-28 w-full rounded-lg" />
                     </>
                   ) : null}
-                  {!searchLoading && searchThreads.length === 0 ? (
+                  {!searchLoading &&
+                  !searchError &&
+                  searchData &&
+                  searchThreads.length === 0 ? (
                     <div className="flex min-h-64 flex-col items-center justify-center rounded-lg border border-dashed px-4 text-center text-sm text-muted-foreground">
                       <IconDatabase className="mb-2 size-5" />
                       {t("dispatch.pages.threadDebugNoThreads", {

--- a/packages/dispatch/src/server/lib/thread-debug-store.spec.ts
+++ b/packages/dispatch/src/server/lib/thread-debug-store.spec.ts
@@ -387,20 +387,237 @@ describe("thread-debug-store", () => {
     expect(mocks.createDbExec).not.toHaveBeenCalled();
   });
 
-  it("keeps explicit remote sources admin-only", async () => {
+  it("returns an explicit 403 when a non-operator requests a remote source", async () => {
     vi.stubEnv("REMOTE_DATABASE_URL", "libsql://remote");
 
-    await expect(listAgentRunFailures({ sourceId: "remote" })).rejects.toThrow(
-      "Only Dispatch admins",
+    const denial = await listAgentRunFailures({ sourceId: "remote" }).catch(
+      (error) => error as Error & { statusCode?: number },
     );
+
+    expect(denial).toMatchObject({
+      name: "ForbiddenError",
+      statusCode: 403,
+      message:
+        "Thread Debug operator access is required to inspect thread databases from other apps.",
+    });
     expect(mocks.createDbExec).not.toHaveBeenCalled();
   });
 
-  it("prevents organization admins from requesting an owner outside their organization", async () => {
+  it("lets read-only operators inspect organization-owned service-principal threads", async () => {
+    vi.stubEnv("DISPATCH_THREAD_DEBUG_OPERATOR_EMAILS", "owner@example.com");
+    vi.stubEnv("CONTENT_DATABASE_URL", "libsql://content-operator");
     mocks.orgId = "org-1";
     mocks.currentExecute.mockImplementation(async ({ sql }) => {
       if (sql.includes("SELECT role FROM org_members")) {
-        return { rows: [{ role: "admin" }] };
+        return { rows: [{ role: "member" }] };
+      }
+      if (sql.includes("SELECT email FROM org_members")) {
+        return { rows: [{ email: "owner@example.com" }] };
+      }
+      if (sql.includes("SELECT allowed_domain FROM organizations")) {
+        return { rows: [{ allowed_domain: "example.com" }] };
+      }
+      return { rows: [] };
+    });
+    const remoteQueries: Array<{ sql: string; args: unknown[] }> = [];
+    mocks.createDbExec.mockResolvedValue({
+      execute: async ({ sql, args }: { sql: string; args: unknown[] }) => {
+        remoteQueries.push({ sql, args });
+        if (sql.includes("FROM organizations")) {
+          return { rows: [{ id: "content-org-1" }] };
+        }
+        if (sql.includes("FROM agent_runs") && sql.includes("WHERE id = ?")) {
+          return { rows: [] };
+        }
+        if (sql.includes("FROM chat_threads")) {
+          return {
+            rows: [
+              {
+                ...thread,
+                owner_email: "integration@slack",
+                org_id: "content-org-1",
+              },
+            ],
+          };
+        }
+        return { rows: [] };
+      },
+    });
+
+    const result = await searchAgentThreads({
+      sourceId: "content",
+      query: "AN-SLACK-CANARY-EXAMPLE",
+      ownerEmail: "integration@slack",
+    });
+
+    expect(result).toMatchObject({
+      count: 1,
+      access: {
+        scope: "integration@slack",
+        canInspectAll: true,
+      },
+      threads: [{ ownerEmail: "integration@slack" }],
+    });
+    const threadQuery = remoteQueries.find(({ sql }) =>
+      sql.includes("FROM chat_threads"),
+    );
+    expect(threadQuery?.sql).toContain("org_id = ? AND owner_email = ?");
+    expect(threadQuery?.args).toEqual(
+      expect.arrayContaining(["content-org-1", "integration@slack"]),
+    );
+
+    const detail = await getAgentThreadDebug({
+      sourceId: "content",
+      threadId: thread.id,
+      ownerEmail: "integration@slack",
+    });
+    expect(detail.thread).toMatchObject({
+      id: thread.id,
+      ownerEmail: "integration@slack",
+    });
+  });
+
+  it("keeps operator searches inside their organization and returns a truthful empty result", async () => {
+    vi.stubEnv("DISPATCH_THREAD_DEBUG_OPERATOR_EMAILS", "owner@example.com");
+    vi.stubEnv("CONTENT_DATABASE_URL", "libsql://content-empty");
+    mocks.orgId = "org-1";
+    mocks.currentExecute.mockImplementation(async ({ sql }) => {
+      if (sql.includes("SELECT role FROM org_members")) {
+        return { rows: [{ role: "member" }] };
+      }
+      if (sql.includes("SELECT email FROM org_members")) {
+        return { rows: [{ email: "owner@example.com" }] };
+      }
+      if (sql.includes("SELECT allowed_domain FROM organizations")) {
+        return { rows: [{ allowed_domain: "example.com" }] };
+      }
+      return { rows: [] };
+    });
+    const remoteQueries: Array<{ sql: string; args: unknown[] }> = [];
+    mocks.createDbExec.mockResolvedValue({
+      execute: async ({ sql, args }: { sql: string; args: unknown[] }) => {
+        remoteQueries.push({ sql, args });
+        if (sql.includes("FROM organizations")) {
+          return { rows: [{ id: "content-org-1" }] };
+        }
+        return { rows: [] };
+      },
+    });
+
+    const result = await searchAgentThreads({
+      sourceId: "content",
+      query: "AN-SLACK-CANARY-EXAMPLE",
+      ownerEmail: "integration@slack",
+    });
+
+    expect(result).toMatchObject({
+      count: 0,
+      access: {
+        scope: "integration@slack",
+        canInspectAll: true,
+      },
+      threads: [],
+    });
+    expect(remoteQueries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sql: expect.stringContaining("org_id = ? AND owner_email = ?"),
+          args: expect.arrayContaining(["content-org-1", "integration@slack"]),
+        }),
+      ]),
+    );
+  });
+
+  it("denies cross-app access when the target source has duplicate organization domains", async () => {
+    vi.stubEnv("DISPATCH_THREAD_DEBUG_OPERATOR_EMAILS", "owner@example.com");
+    vi.stubEnv("CONTENT_DATABASE_URL", "libsql://content-duplicate-domain");
+    mocks.orgId = "org-1";
+    mocks.currentExecute.mockImplementation(async ({ sql }) => {
+      if (sql.includes("SELECT role FROM org_members")) {
+        return { rows: [{ role: "member" }] };
+      }
+      if (sql.includes("SELECT email FROM org_members")) {
+        return { rows: [{ email: "owner@example.com" }] };
+      }
+      if (sql.includes("SELECT allowed_domain FROM organizations")) {
+        return { rows: [{ allowed_domain: "example.com" }] };
+      }
+      return { rows: [] };
+    });
+    mocks.createDbExec.mockResolvedValue({
+      execute: async ({ sql }: { sql: string }) => {
+        if (sql.includes("FROM organizations")) {
+          return {
+            rows: [{ id: "content-org-1" }, { id: "content-org-2" }],
+          };
+        }
+        return { rows: [] };
+      },
+    });
+
+    const denial = await searchAgentThreads({
+      sourceId: "content",
+      query: "AN-SLACK-CANARY-EXAMPLE",
+    }).catch((error) => error as Error & { statusCode?: number });
+
+    expect(denial).toMatchObject({
+      name: "ForbiddenError",
+      statusCode: 403,
+      message:
+        "The active organization could not be uniquely resolved in the selected Thread Debug source.",
+    });
+  });
+
+  it.each([
+    ["no", []],
+    ["multiple", [{ id: "content-org-1" }, { id: "content-org-2" }]],
+  ])(
+    "preserves an explicit 403 when failed-run lookup finds %s target organization matches",
+    async (_label, organizationRows) => {
+      vi.stubEnv("DISPATCH_THREAD_DEBUG_OPERATOR_EMAILS", "owner@example.com");
+      vi.stubEnv("CONTENT_DATABASE_URL", "libsql://content-invalid-domain");
+      mocks.orgId = "org-1";
+      mocks.currentExecute.mockImplementation(async ({ sql }) => {
+        if (sql.includes("SELECT role FROM org_members")) {
+          return { rows: [{ role: "member" }] };
+        }
+        if (sql.includes("SELECT email FROM org_members")) {
+          return { rows: [{ email: "owner@example.com" }] };
+        }
+        if (sql.includes("SELECT allowed_domain FROM organizations")) {
+          return { rows: [{ allowed_domain: "example.com" }] };
+        }
+        return { rows: [] };
+      });
+      mocks.createDbExec.mockResolvedValue({
+        execute: async ({ sql }: { sql: string }) => {
+          if (sql.includes("FROM organizations")) {
+            return { rows: organizationRows };
+          }
+          return { rows: [] };
+        },
+      });
+
+      const denial = await listAgentRunFailures({
+        sourceId: "content",
+      }).catch((error) => error as Error & { statusCode?: number });
+
+      expect(denial).toMatchObject({
+        name: "ForbiddenError",
+        statusCode: 403,
+        message:
+          "The active organization could not be uniquely resolved in the selected Thread Debug source.",
+      });
+    },
+  );
+
+  it("denies cross-app operator access when the organization has no stable domain mapping", async () => {
+    vi.stubEnv("DISPATCH_THREAD_DEBUG_OPERATOR_EMAILS", "owner@example.com");
+    vi.stubEnv("CONTENT_DATABASE_URL", "libsql://content-no-domain");
+    mocks.orgId = "org-1";
+    mocks.currentExecute.mockImplementation(async ({ sql }) => {
+      if (sql.includes("SELECT role FROM org_members")) {
+        return { rows: [{ role: "member" }] };
       }
       if (sql.includes("SELECT email FROM org_members")) {
         return { rows: [{ email: "owner@example.com" }] };
@@ -408,11 +625,17 @@ describe("thread-debug-store", () => {
       return { rows: [] };
     });
 
-    await expect(
-      listAgentRunFailures({
-        sourceId: "current",
-        ownerEmail: "outsider@example.com",
-      }),
-    ).rejects.toThrow("not a member of the current organization");
+    const denial = await searchAgentThreads({
+      sourceId: "content",
+      query: "AN-SLACK-CANARY-EXAMPLE",
+    }).catch((error) => error as Error & { statusCode?: number });
+
+    expect(denial).toMatchObject({
+      name: "ForbiddenError",
+      statusCode: 403,
+      message:
+        "The active organization needs an allowed domain before operators can inspect cross-app traces.",
+    });
+    expect(mocks.createDbExec).not.toHaveBeenCalled();
   });
 });

--- a/packages/dispatch/src/server/lib/thread-debug-store.ts
+++ b/packages/dispatch/src/server/lib/thread-debug-store.ts
@@ -3,6 +3,7 @@ import {
   type AgentFailureRegime,
 } from "@agent-native/core/agent/engine";
 import { createDbExec, getDbExec, type DbExec } from "@agent-native/core/db";
+import { ForbiddenError } from "@agent-native/core/sharing";
 
 import { currentOrgId, currentOwnerEmail } from "./dispatch-store.js";
 
@@ -38,8 +39,10 @@ export interface ThreadDebugSource {
 export interface DebugAccess {
   viewerEmail: string;
   orgId: string | null;
+  orgDomain: string | null;
   role: string | null;
   envAdmin: boolean;
+  threadDebugOperator: boolean;
   canInspectAll: boolean;
   memberEmails: string[];
 }
@@ -126,6 +129,12 @@ function isEnvAdmin(email: string): boolean {
     ...envEmails("WORKSPACE_OWNER_EMAIL"),
     ...envEmails("DISPATCH_DEFAULT_OWNER_EMAIL"),
   ].includes(normalized);
+}
+
+function isThreadDebugOperator(email: string): boolean {
+  return envEmails("DISPATCH_THREAD_DEBUG_OPERATOR_EMAILS").includes(
+    email.trim().toLowerCase(),
+  );
 }
 
 function missingTableName(error: unknown): string | null {
@@ -471,20 +480,38 @@ async function currentOrgMembers(orgId: string | null): Promise<string[]> {
   return rows.map((row) => String(row.email ?? "").trim()).filter(Boolean);
 }
 
+async function viewerOrgDomain(orgId: string | null): Promise<string | null> {
+  if (!orgId) return null;
+  const rows = await currentDbRows<{ allowed_domain?: string }>(
+    `SELECT allowed_domain FROM organizations WHERE id = ? LIMIT 1`,
+    [orgId],
+  );
+  const domain = String(rows[0]?.allowed_domain ?? "")
+    .trim()
+    .toLowerCase();
+  return domain || null;
+}
+
 async function resolveDebugAccess(): Promise<DebugAccess> {
   const viewerEmail = currentOwnerEmail();
   const orgId = currentOrgId();
   const role = await viewerOrgRole(orgId, viewerEmail);
   const envAdmin = isEnvAdmin(viewerEmail);
-  const canInspectAll = envAdmin || role === "owner" || role === "admin";
+  const threadDebugOperator =
+    Boolean(orgId) && isThreadDebugOperator(viewerEmail);
+  const canInspectAll =
+    envAdmin || threadDebugOperator || role === "owner" || role === "admin";
+  const orgDomain = canInspectAll ? await viewerOrgDomain(orgId) : null;
   const memberEmails = canInspectAll
     ? await currentOrgMembers(orgId)
     : [viewerEmail];
   return {
     viewerEmail,
     orgId,
+    orgDomain,
     role,
     envAdmin,
+    threadDebugOperator,
     canInspectAll,
     memberEmails: memberEmails.length > 0 ? memberEmails : [viewerEmail],
   };
@@ -496,62 +523,94 @@ function assertSourceAccess(
 ) {
   if (source.kind === "current") return;
   if (!access.canInspectAll) {
-    throw new Error(
-      "Only Dispatch admins can inspect thread databases from other apps.",
+    throw new ForbiddenError(
+      "Thread Debug operator access is required to inspect thread databases from other apps.",
+    );
+  }
+  if (access.orgId && !access.orgDomain) {
+    throw new ForbiddenError(
+      "The active organization needs an allowed domain before operators can inspect cross-app traces.",
     );
   }
 }
 
 function ownerScope(
   access: DebugAccess,
+  source: ThreadDebugSourceConfig,
   ownerEmail?: string,
-  column = "owner_email",
+  ownerColumn = "owner_email",
+  orgColumn = "org_id",
+  remoteOrgId?: string | null,
 ): OwnerScope {
   const requested = ownerEmail?.trim();
   if (!access.canInspectAll) {
     return {
-      sql: `${column} = ?`,
+      sql: `${ownerColumn} = ?`,
       args: [access.viewerEmail],
       label: access.viewerEmail,
     };
   }
 
-  if (requested && requested !== "*") {
-    if (
-      access.orgId &&
-      !access.memberEmails.some(
-        (email) => email.toLowerCase() === requested.toLowerCase(),
-      )
-    ) {
-      throw new Error(
-        "The requested owner is not a member of the current organization.",
-      );
+  if (access.orgId) {
+    const clauses: string[] = [];
+    const args: unknown[] = [];
+    if (source.kind === "current") {
+      clauses.push(`${orgColumn} = ?`);
+      args.push(access.orgId);
+    } else {
+      if (!remoteOrgId) {
+        throw new ForbiddenError(
+          "The active organization could not be uniquely resolved in the selected Thread Debug source.",
+        );
+      }
+      clauses.push(`${orgColumn} = ?`);
+      args.push(remoteOrgId);
+    }
+    if (requested && requested !== "*") {
+      clauses.push(`${ownerColumn} = ?`);
+      args.push(requested);
     }
     return {
-      sql: `${column} = ?`,
+      sql: clauses.join(" AND "),
+      args,
+      label:
+        requested && requested !== "*" ? requested : "current organization",
+    };
+  }
+
+  if (requested && requested !== "*") {
+    return {
+      sql: `${ownerColumn} = ?`,
       args: [requested],
       label: requested,
     };
   }
 
-  if (access.envAdmin && !access.orgId) {
-    return { sql: "1 = 1", args: [], label: "all users" };
-  }
+  return { sql: "1 = 1", args: [], label: "all users" };
+}
 
-  const emails = access.memberEmails;
-  if (emails.length === 0) {
-    return {
-      sql: `${column} = ?`,
-      args: [access.viewerEmail],
-      label: access.viewerEmail,
-    };
+async function resolveRemoteOrgId(
+  access: DebugAccess,
+  source: ThreadDebugSourceConfig,
+  exec: DbExec,
+): Promise<string | null> {
+  if (source.kind === "current" || !access.orgId) return null;
+  if (!access.orgDomain) {
+    throw new ForbiddenError(
+      "The active organization needs an allowed domain before operators can inspect cross-app traces.",
+    );
   }
-  const placeholders = emails.map(() => "?").join(", ");
-  return {
-    sql: `${column} IN (${placeholders})`,
-    args: emails,
-    label: access.orgId ? "current organization" : "all users",
-  };
+  const rows = await queryRows<{ id: string }>(
+    exec,
+    `SELECT id FROM organizations WHERE LOWER(allowed_domain) = ? LIMIT 2`,
+    [access.orgDomain],
+  );
+  if (rows.length !== 1) {
+    throw new ForbiddenError(
+      "The active organization could not be uniquely resolved in the selected Thread Debug source.",
+    );
+  }
+  return String(rows[0].id);
 }
 
 function serializeThreadSummary(row: ChatThreadRow, query = "") {
@@ -600,7 +659,7 @@ function parseRunEvent(row: Record<string, unknown>) {
 }
 
 export async function listThreadDebugSources(): Promise<{
-  access: Omit<DebugAccess, "memberEmails" | "envAdmin"> & {
+  access: Omit<DebugAccess, "memberEmails" | "envAdmin" | "orgDomain"> & {
     envAdmin: boolean;
     memberCount: number;
   };
@@ -613,6 +672,7 @@ export async function listThreadDebugSources(): Promise<{
       orgId: access.orgId,
       role: access.role,
       envAdmin: access.envAdmin,
+      threadDebugOperator: access.threadDebugOperator,
       canInspectAll: access.canInspectAll,
       memberCount: access.memberEmails.length,
     },
@@ -712,6 +772,7 @@ function sourceHealth(
 
 async function failuresForSource(
   source: ThreadDebugSourceConfig,
+  exec: DbExec,
   scope: OwnerScope,
   input: {
     status: AgentRunFailureStatus | "all";
@@ -720,7 +781,6 @@ async function failuresForSource(
     limit: number;
   },
 ) {
-  const exec = await execForSource(source);
   const statuses =
     input.status === "all" ? [...UNSUCCESSFUL_RUN_STATUSES] : [input.status];
   const statusPlaceholders = statuses.map(() => "?").join(", ");
@@ -770,7 +830,6 @@ export async function listAgentRunFailures(input: {
   const regime = input.regime ?? "all";
   const lookbackHours = Math.max(1, Math.min(720, input.lookbackHours ?? 168));
   const limit = Math.max(1, Math.min(100, input.limit ?? DEFAULT_SEARCH_LIMIT));
-  const scope = ownerScope(access, input.ownerEmail, "t.owner_email");
   const cutoff = Date.now() - lookbackHours * 60 * 60 * 1000;
 
   let sources: ThreadDebugSourceConfig[];
@@ -806,7 +865,17 @@ export async function listAgentRunFailures(input: {
         };
       }
       try {
-        const failures = await failuresForSource(source, scope, {
+        const exec = await execForSource(source);
+        const remoteOrgId = await resolveRemoteOrgId(access, source, exec);
+        const scope = ownerScope(
+          access,
+          source,
+          input.ownerEmail,
+          "t.owner_email",
+          "t.org_id",
+          remoteOrgId,
+        );
+        const failures = await failuresForSource(source, exec, scope, {
           status,
           regime,
           cutoff,
@@ -817,6 +886,7 @@ export async function listAgentRunFailures(input: {
           health: sourceHealth(source, "ok", failures.length, null),
         };
       } catch (error) {
+        if (error instanceof ForbiddenError) throw error;
         if (error instanceof UnsupportedThreadDebugSchemaError) {
           return {
             failures: [] as ReturnType<typeof serializeRunFailure>[],
@@ -861,7 +931,11 @@ export async function listAgentRunFailures(input: {
     partial: results.some((result) => result.health.status !== "ok"),
     access: {
       viewerEmail: access.viewerEmail,
-      scope: scope.label,
+      scope: ownerScope(
+        access,
+        resolveSourceConfig("current"),
+        input.ownerEmail,
+      ).label,
       canInspectAll: access.canInspectAll,
     },
     sources: results.map((result) => result.health),
@@ -879,12 +953,20 @@ export async function searchAgentThreads(input: {
   const access = await resolveDebugAccess();
   assertSourceAccess(source, access);
   const exec = await execForSource(source);
+  const remoteOrgId = await resolveRemoteOrgId(access, source, exec);
+  const scope = ownerScope(
+    access,
+    source,
+    input.ownerEmail,
+    "owner_email",
+    "org_id",
+    remoteOrgId,
+  );
   const limit = Math.max(
     1,
     Math.min(MAX_SEARCH_LIMIT, input.limit ?? DEFAULT_SEARCH_LIMIT),
   );
   const q = input.query?.trim() ?? "";
-  const scope = ownerScope(access, input.ownerEmail);
   const where = [scope.sql];
   const args: unknown[] = [...scope.args];
   const runThreadIds = q
@@ -914,7 +996,7 @@ export async function searchAgentThreads(input: {
   }
   args.push(limit);
 
-  const rows = await optionalRows<ChatThreadRow>(
+  const rows = await queryRows<ChatThreadRow>(
     exec,
     `SELECT id, owner_email, title, preview, thread_data, message_count, created_at, updated_at
        FROM chat_threads
@@ -954,7 +1036,15 @@ export async function getAgentThreadDebug(input: {
   const access = await resolveDebugAccess();
   assertSourceAccess(source, access);
   const exec = await execForSource(source);
-  const scope = ownerScope(access, input.ownerEmail);
+  const remoteOrgId = await resolveRemoteOrgId(access, source, exec);
+  const scope = ownerScope(
+    access,
+    source,
+    input.ownerEmail,
+    "owner_email",
+    "org_id",
+    remoteOrgId,
+  );
   const requestedId = input.runId?.trim() || input.threadId?.trim() || "";
   if (!requestedId) {
     throw new Error("A thread ID or request/run ID is required.");

--- a/templates/dispatch/AGENTS.md
+++ b/templates/dispatch/AGENTS.md
@@ -58,7 +58,9 @@ ladder.
   returned run with `get-agent-thread-debug` using the same source id. Do not
   infer run failure from thread text search. Cross-app results may be partial;
   preserve the returned per-source health instead of treating an unavailable
-  source as zero failures.
+  source as zero failures. Read-only Thread Debug operators can inspect
+  organization-owned service-principal traces, but not another organization's
+  traces or any broader Dispatch mutation surface.
 - For a Slack-linked issue, call `read-slack-thread-context` with the exact
   permalink before diagnosing it. It resolves child links to the parent thread,
   preserves attachments and related URLs, and reports whether pagination is

--- a/templates/dispatch/DEVELOPING.md
+++ b/templates/dispatch/DEVELOPING.md
@@ -212,6 +212,16 @@ logs. Do not grant deploy previews access to production app databases by
 default. Thread Debug reports configured-but-missing or unreadable sources
 separately from sources that returned zero failures.
 
+Organization owners and admins can inspect connected sources. To grant the
+same read-only troubleshooting capability without broader Dispatch admin
+authority, set `DISPATCH_THREAD_DEBUG_OPERATOR_EMAILS` to a comma-separated
+allowlist. Operators may inspect only threads whose `org_id` matches their
+active organization. Because organization IDs are app-local, connected sources
+resolve that boundary through the shared `organizations.allowed_domain` value;
+an organization without that stable mapping is denied. This includes
+service-principal threads such as Slack runs, and the allowlist never grants
+mutation access.
+
 ## Extensions (Framework Feature)
 
 The framework provides **Extensions** — mini sandboxed Alpine.js apps that run inside iframes. Extensions let users (or the agent) create interactive widgets, dashboards, and utilities without modifying the app's source code. They appear in the sidebar under an "Extensions" section. (Distinct from LLM tools — the function-calling primitives the agent invokes.)

--- a/templates/dispatch/changelog/2026-08-04-thread-debug-operator-access.md
+++ b/templates/dispatch/changelog/2026-08-04-thread-debug-operator-access.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-04
+---
+
+Thread Debug now lets approved operators inspect organization-owned service runs and clearly distinguishes failed lookups from empty results.


### PR DESCRIPTION
## Problem

Slack-triggered runs are stored under a service-principal owner such as `integration@slack`. Thread Debug previously limited ordinary members to their own human-owned Dispatch threads, so a Builder operator could not inspect an organization-owned Slack-to-Content trace without broader Dispatch admin access. Failed or unavailable lookups could also appear as successful zero-result searches, hiding the distinction operators needed most.

## Approach

Add a dedicated read-only Thread Debug operator permission. Cross-app organization IDs are local to each app, so the selected source resolves the caller's active organization through its stable allowed domain and permits the trace query only when that mapping identifies exactly one target organization. Service-principal ownership is then an optional filter inside that organization boundary—not a fake human membership.

This permission applies only to the existing read-only Thread Debug actions and does not grant any Dispatch mutation capability.

## What changed

- Added `DISPATCH_THREAD_DEBUG_OPERATOR_EMAILS` as a narrow operator allowlist for callers with an active organization.
- Scoped current-app reads by the exact local organization ID and connected-app reads by one uniquely resolved target organization ID.
- Return explicit 403 denials for unauthorized cross-app access, missing organization mappings, and zero or duplicate target mappings.
- Kept request failures and unavailable sources distinct from successful empty results in both the store and Thread Debug UI.
- Updated action descriptions and Dispatch guidance so agents understand the read-only operator boundary.
- Added a Dispatch package changeset and user-facing changelog entry.

## Safety and operations

- No schema migration or production-data mutation is included.
- The allowlist grants only the existing read-only Thread Debug action surface.
- Cross-organization reads fail closed: the remote organization mapping must resolve to exactly one row.
- Deployment configuration must add the approved operator email to `DISPATCH_THREAD_DEBUG_OPERATOR_EMAILS` before the production canary can exercise the new path.

## Verification

- `pnpm --filter @agent-native/dispatch test` — 61 files and 349 tests passed, covering the exact Slack canary marker shape, organization-owned service principals, zero and duplicate organization mappings, explicit 403 propagation, genuine empty results, and mixed unavailable results.
- `pnpm --filter @agent-native/dispatch typecheck` — passed.
- `pnpm guards` — all repository guards passed.
- Independent authorization-boundary review — passed after correcting duplicate-domain handling, mixed-result truthfulness, action descriptions, and 403 propagation through aggregate failure lookup.
- Production Slack canary — intentionally not rerun during Work; it remains the post-deploy acceptance check.

## Review focus

- Does the allowed-domain resolution fail closed under every ambiguous or missing mapping?
- Can the operator allowlist reach any mutation surface or any organization outside the active organization?
- Does every failed or partial load remain visibly distinguishable from a genuine empty result?
