### PR TITLE
Add draft docs mechanism (VITE_SHOW_DRAFTS)

### DIFF
--- a/packages/docs/.env.example
+++ b/packages/docs/.env.example
@@ -1,0 +1,3 @@
+# Show draft documentation pages in the sidebar and allow direct URL access.
+# Pages marked `draft: true` are hidden in production builds.
+# VITE_SHOW_DRAFTS=true

--- a/packages/docs/app/components/DocDraftBanner.tsx
+++ b/packages/docs/app/components/DocDraftBanner.tsx
@@ -1,4 +1,7 @@
+import { useT } from "@agent-native/core/client/i18n";
+
 export default function DocDraftBanner() {
+  const t = useT();
   return (
     <div
       className="mb-6 rounded-md border p-4 text-sm"
@@ -7,8 +10,7 @@ export default function DocDraftBanner() {
         color: "var(--approaches-warn)",
       }}
     >
-      <strong>Draft</strong> — This page is a work in progress. Content may be
-      incomplete or subject to change before publication.
+      <strong>{t("docs.draftLabel")}</strong> — {t("docs.draftDescription")}
     </div>
   );
 }

--- a/packages/docs/app/components/DocDraftBanner.tsx
+++ b/packages/docs/app/components/DocDraftBanner.tsx
@@ -1,0 +1,14 @@
+export default function DocDraftBanner() {
+  return (
+    <div
+      className="mb-6 rounded-md border p-4 text-sm"
+      style={{
+        borderColor: "var(--approaches-warn)",
+        color: "var(--approaches-warn)",
+      }}
+    >
+      <strong>Draft</strong> — This page is a work in progress. Content may be
+      incomplete or subject to change before publication.
+    </div>
+  );
+}

--- a/packages/docs/app/components/DocsSidebar.tsx
+++ b/packages/docs/app/components/DocsSidebar.tsx
@@ -12,6 +12,7 @@ import {
 
 const ALWAYS_OPEN_SECTION_INDEX = 0;
 
+
 function normalizePath(pathname: string) {
   return pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
 }
@@ -193,6 +194,11 @@ export default function DocsSidebar() {
                                 current === item.id ? null : item.id,
                               )
                             }
+                            style={
+                              item.draft
+                                ? { color: "var(--approaches-warn)" }
+                                : undefined
+                            }
                           >
                             <span>{item.label}</span>
                             <IconChevronRight
@@ -208,6 +214,11 @@ export default function DocsSidebar() {
                             to={item.to!}
                             className={`sidebar-link${active ? " is-active" : ""}`}
                             tabIndex={isOpen ? undefined : -1}
+                            style={
+                              item.draft
+                                ? { color: "var(--approaches-warn)" }
+                                : undefined
+                            }
                           >
                             {item.label}
                           </Link>
@@ -235,6 +246,11 @@ export default function DocsSidebar() {
                                       className={`sidebar-link sidebar-sublink${childActive ? " is-active" : ""}`}
                                       tabIndex={
                                         childrenTabbable ? undefined : -1
+                                      }
+                                      style={
+                                        child.draft
+                                          ? { color: "var(--approaches-warn)" }
+                                          : undefined
                                       }
                                     >
                                       {child.label}

--- a/packages/docs/app/components/DocsSidebar.tsx
+++ b/packages/docs/app/components/DocsSidebar.tsx
@@ -12,7 +12,6 @@ import {
 
 const ALWAYS_OPEN_SECTION_INDEX = 0;
 
-
 function normalizePath(pathname: string) {
   return pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
 }

--- a/packages/docs/app/components/docs-content.ts
+++ b/packages/docs/app/components/docs-content.ts
@@ -245,6 +245,32 @@ export async function loadDoc(
   return promise;
 }
 
+/**
+ * Loads a doc and applies draft visibility, checking the canonical
+ * (default-locale) entry's draft status even when serving a localized
+ * translation. A translation's frontmatter can drift from the canonical
+ * page it was translated from, so gating on the localized doc alone lets a
+ * draft leak through any locale whose translator forgot `draft: true`.
+ */
+export async function loadDocRespectingDraftVisibility(
+  slug: string,
+  locale: unknown = DEFAULT_DOCS_LOCALE,
+): Promise<DocEntry | undefined> {
+  const doc = await loadDoc(slug, locale);
+  if (!doc) return undefined;
+
+  const docsLocale = normalizeDocsLocale(locale);
+  const canonical =
+    docsLocale === DEFAULT_DOCS_LOCALE ? doc : await loadDoc(slug, DEFAULT_DOCS_LOCALE);
+  const isDraft = Boolean(doc.draft || canonical?.draft);
+
+  if (isDraft && import.meta.env.VITE_SHOW_DRAFTS !== "true") return undefined;
+  // Normalize `draft` to the resolved status so callers that render a draft
+  // banner off this flag stay correct for translations whose frontmatter
+  // omits `draft: true` even though the canonical page is a draft.
+  return isDraft === Boolean(doc.draft) ? doc : { ...doc, draft: isDraft };
+}
+
 export function hasLocalizedDoc(locale: unknown, slug: string): boolean {
   const docsLocale = normalizeDocsLocale(locale);
   if (docsLocale === DEFAULT_DOCS_LOCALE) {

--- a/packages/docs/app/components/docs-content.ts
+++ b/packages/docs/app/components/docs-content.ts
@@ -50,6 +50,7 @@ export interface DocEntry {
   title: string;
   description: string;
   search: string;
+  draft?: boolean;
   body: string; // markdown body (without frontmatter)
   headings: { id: string; label: string; level: number }[];
 }
@@ -150,6 +151,7 @@ function docEntryFromPath(path: string, raw: string): DocEntry {
     title: data.title || slug,
     description: data.description || "",
     search: data.search || "",
+    draft: data.draft === "true" || undefined,
     body,
     headings,
   };

--- a/packages/docs/app/components/docs-content.ts
+++ b/packages/docs/app/components/docs-content.ts
@@ -261,7 +261,9 @@ export async function loadDocRespectingDraftVisibility(
 
   const docsLocale = normalizeDocsLocale(locale);
   const canonical =
-    docsLocale === DEFAULT_DOCS_LOCALE ? doc : await loadDoc(slug, DEFAULT_DOCS_LOCALE);
+    docsLocale === DEFAULT_DOCS_LOCALE
+      ? doc
+      : await loadDoc(slug, DEFAULT_DOCS_LOCALE);
   const isDraft = Boolean(doc.draft || canonical?.draft);
 
   if (isDraft && import.meta.env.VITE_SHOW_DRAFTS !== "true") return undefined;

--- a/packages/docs/app/components/docsNavItems.ts
+++ b/packages/docs/app/components/docsNavItems.ts
@@ -9,6 +9,7 @@ export type NavItem = {
   id: string;
   label: string;
   to?: string;
+  draft?: boolean;
   children?: NavItem[];
 };
 export type NavSection = { id: string; title: string; items: NavItem[] };
@@ -19,6 +20,7 @@ type NavItemConfig = {
   id: string;
   labelKey: keyof typeof enUS.nav;
   slug?: string;
+  draft?: boolean;
   children?: NavItemConfig[];
 };
 
@@ -892,17 +894,24 @@ function navLabel(t: Translate, key: keyof typeof enUS.nav): string {
   return t(`nav.${key}`) || enMessage(`nav.${key}`);
 }
 
+const SHOW_DRAFTS = import.meta.env.VITE_SHOW_DRAFTS === "true";
+
 function toNavItem(
   config: NavItemConfig,
   locale: DocsLocale,
   t: Translate,
-): NavItem {
+): NavItem | null {
+  if (config.draft && !SHOW_DRAFTS) return null;
   const slug = config.slug;
+  const children = config.children
+    ?.map((child) => toNavItem(child, locale, t))
+    .filter((item): item is NavItem => item !== null);
   return {
     id: config.id,
     label: navLabel(t, config.labelKey),
     to: slug ? docsPathForSlug(slug, locale) : undefined,
-    children: config.children?.map((child) => toNavItem(child, locale, t)),
+    draft: config.draft || undefined,
+    children,
   };
 }
 
@@ -913,8 +922,10 @@ export function getDocsNavSections(
   return NAV_SECTION_CONFIG.map((section) => ({
     id: section.id,
     title: navLabel(t, section.titleKey),
-    items: section.items.map((item) => toNavItem(item, locale, t)),
-  }));
+    items: section.items
+      .map((item) => toNavItem(item, locale, t))
+      .filter((item): item is NavItem => item !== null),
+  })).filter((section) => section.items.length > 0);
 }
 
 // Flat list for prev/next navigation and current-item lookups. Nested

--- a/packages/docs/app/i18n/ar-SA.ts
+++ b/packages/docs/app/i18n/ar-SA.ts
@@ -53,6 +53,9 @@ const arSA = {
     copyMarkdownError: "تعذر نسخ Markdown",
     previous: "السابق",
     next: "التالي",
+    draftLabel: "مسودة",
+    draftDescription:
+      "هذه الصفحة قيد الإنشاء. قد يكون المحتوى غير مكتمل أو عرضة للتغيير قبل النشر.",
   },
   search: {
     dialogLabel: "البحث في الوثائق",

--- a/packages/docs/app/i18n/de-DE.ts
+++ b/packages/docs/app/i18n/de-DE.ts
@@ -53,6 +53,9 @@ const deDE = {
     copyMarkdownError: "Markdown konnte nicht kopiert werden",
     previous: "Zurück",
     next: "Weiter",
+    draftLabel: "Entwurf",
+    draftDescription:
+      "Diese Seite befindet sich in Bearbeitung. Der Inhalt kann unvollständig sein oder sich vor der Veröffentlichung ändern.",
   },
   search: {
     dialogLabel: "Dokumentation durchsuchen",

--- a/packages/docs/app/i18n/en-US.ts
+++ b/packages/docs/app/i18n/en-US.ts
@@ -51,6 +51,9 @@ const enUS = {
     copyMarkdownError: "Couldn't copy Markdown",
     previous: "Previous",
     next: "Next",
+    draftLabel: "Draft",
+    draftDescription:
+      "This page is a work in progress. Content may be incomplete or subject to change before publication.",
   },
   common: {
     copied: "Copied",

--- a/packages/docs/app/i18n/es-ES.ts
+++ b/packages/docs/app/i18n/es-ES.ts
@@ -53,6 +53,9 @@ const esES = {
     copyMarkdownError: "No se pudo copiar Markdown",
     previous: "Anterior",
     next: "Siguiente",
+    draftLabel: "Borrador",
+    draftDescription:
+      "Esta página está en construcción. El contenido puede estar incompleto o sujeto a cambios antes de su publicación.",
   },
   search: {
     dialogLabel: "Buscar documentación",

--- a/packages/docs/app/i18n/fr-FR.ts
+++ b/packages/docs/app/i18n/fr-FR.ts
@@ -53,6 +53,9 @@ const frFR = {
     copyMarkdownError: "Impossible de copier le Markdown",
     previous: "Précédent",
     next: "Suivant",
+    draftLabel: "Brouillon",
+    draftDescription:
+      "Cette page est en cours de rédaction. Le contenu peut être incomplet ou sujet à modification avant publication.",
   },
   search: {
     dialogLabel: "Rechercher la documentation",

--- a/packages/docs/app/i18n/hi-IN.ts
+++ b/packages/docs/app/i18n/hi-IN.ts
@@ -53,6 +53,9 @@ const hiIN = {
     copyMarkdownError: "Markdown कॉपी नहीं हो सका",
     previous: "पिछला",
     next: "अगला",
+    draftLabel: "ड्राफ़्ट",
+    draftDescription:
+      "यह पेज अभी तैयार किया जा रहा है। प्रकाशन से पहले सामग्री अधूरी हो सकती है या इसमें बदलाव हो सकता है।",
   },
   search: {
     dialogLabel: "दस्तावेज़ खोजें",

--- a/packages/docs/app/i18n/ja-JP.ts
+++ b/packages/docs/app/i18n/ja-JP.ts
@@ -53,6 +53,9 @@ const jaJP = {
     copyMarkdownError: "Markdownをコピーできませんでした",
     previous: "前へ",
     next: "次へ",
+    draftLabel: "ドラフト",
+    draftDescription:
+      "このページは作成中です。内容は公開前に不完全であったり変更される場合があります。",
   },
   search: {
     dialogLabel: "ドキュメントを検索",

--- a/packages/docs/app/i18n/ko-KR.ts
+++ b/packages/docs/app/i18n/ko-KR.ts
@@ -53,6 +53,9 @@ const koKR = {
     copyMarkdownError: "Markdown을 복사할 수 없음",
     previous: "이전",
     next: "다음",
+    draftLabel: "초안",
+    draftDescription:
+      "이 페이지는 작업 중입니다. 게시 전까지 콘텐츠가 불완전하거나 변경될 수 있습니다.",
   },
   search: {
     dialogLabel: "문서 검색",

--- a/packages/docs/app/i18n/pt-BR.ts
+++ b/packages/docs/app/i18n/pt-BR.ts
@@ -53,6 +53,9 @@ const ptBR = {
     copyMarkdownError: "Não foi possível copiar Markdown",
     previous: "Anterior",
     next: "Próximo",
+    draftLabel: "Rascunho",
+    draftDescription:
+      "Esta página está em andamento. O conteúdo pode estar incompleto ou sujeito a alterações antes da publicação.",
   },
   search: {
     dialogLabel: "Pesquisar documentação",

--- a/packages/docs/app/i18n/zh-CN.ts
+++ b/packages/docs/app/i18n/zh-CN.ts
@@ -53,6 +53,8 @@ const zhCN = {
     copyMarkdownError: "无法复制 Markdown",
     previous: "上一页",
     next: "下一页",
+    draftLabel: "草稿",
+    draftDescription: "此页面仍在编写中。内容在发布前可能不完整或有所变动。",
   },
   search: {
     dialogLabel: "搜索文档",

--- a/packages/docs/app/i18n/zh-TW.ts
+++ b/packages/docs/app/i18n/zh-TW.ts
@@ -51,6 +51,8 @@ const messages = {
     copyMarkdownError: "無法複製 Markdown",
     previous: "上一頁面",
     next: "下一頁面",
+    draftLabel: "草稿",
+    draftDescription: "此頁面仍在製作中。內容在發布前可能不完整或有所變動。",
   },
   search: {
     dialogLabel: "搜尋檔案",

--- a/packages/docs/app/routes/docs.$locale.$slug.tsx
+++ b/packages/docs/app/routes/docs.$locale.$slug.tsx
@@ -6,7 +6,11 @@ import {
 } from "react-router";
 
 import DocContent from "../components/DocContent";
-import { loadDoc, type DocEntry } from "../components/docs-content";
+import DocDraftBanner from "../components/DocDraftBanner";
+import {
+  loadDocRespectingDraftVisibility,
+  type DocEntry,
+} from "../components/docs-content";
 import {
   DEFAULT_DOCS_LOCALE,
   docsPathForSlug,
@@ -34,21 +38,6 @@ const SLUG_REDIRECTS: Record<string, string> = {
   "migration-workbench": "code-agents-ui",
 };
 
-function DraftBanner() {
-  return (
-    <div
-      className="mb-6 rounded-md border p-4 text-sm"
-      style={{
-        borderColor: "var(--approaches-warn)",
-        color: "var(--approaches-warn)",
-      }}
-    >
-      <strong>Draft</strong> — This page is a work in progress. Content may be
-      incomplete or subject to change before publication.
-    </div>
-  );
-}
-
 function requireLocale(value: unknown): DocsLocale {
   if (isDocsLocale(value)) return value;
   throw new Response("Not Found", { status: 404 });
@@ -72,11 +61,8 @@ export async function loader({ params, request, url }: LoaderFunctionArgs) {
     throw redirect(docsPathForSlug(slug, locale), 301);
   }
 
-  const doc = await loadDoc(slug, locale);
+  const doc = await loadDocRespectingDraftVisibility(slug, locale);
   if (!doc) {
-    throw new Response("Not Found", { status: 404 });
-  }
-  if (doc.draft && import.meta.env.VITE_SHOW_DRAFTS !== "true") {
     throw new Response("Not Found", { status: 404 });
   }
   return doc;
@@ -124,7 +110,7 @@ export default function LocalizedDocPage() {
       toc={toc}
       markdownUrl={docsMarkdownPathForDoc(doc.slug, locale) ?? undefined}
     >
-      {doc.draft && <DraftBanner />}
+      {doc.draft && <DocDraftBanner />}
       <DocContent markdown={doc.body} />
     </DocsLayout>
   );

--- a/packages/docs/app/routes/docs.$locale.$slug.tsx
+++ b/packages/docs/app/routes/docs.$locale.$slug.tsx
@@ -34,6 +34,21 @@ const SLUG_REDIRECTS: Record<string, string> = {
   "migration-workbench": "code-agents-ui",
 };
 
+function DraftBanner() {
+  return (
+    <div
+      className="mb-6 rounded-md border p-4 text-sm"
+      style={{
+        borderColor: "var(--approaches-warn)",
+        color: "var(--approaches-warn)",
+      }}
+    >
+      <strong>Draft</strong> — This page is a work in progress. Content may be
+      incomplete or subject to change before publication.
+    </div>
+  );
+}
+
 function requireLocale(value: unknown): DocsLocale {
   if (isDocsLocale(value)) return value;
   throw new Response("Not Found", { status: 404 });
@@ -59,6 +74,9 @@ export async function loader({ params, request, url }: LoaderFunctionArgs) {
 
   const doc = await loadDoc(slug, locale);
   if (!doc) {
+    throw new Response("Not Found", { status: 404 });
+  }
+  if (doc.draft && import.meta.env.VITE_SHOW_DRAFTS !== "true") {
     throw new Response("Not Found", { status: 404 });
   }
   return doc;
@@ -106,6 +124,7 @@ export default function LocalizedDocPage() {
       toc={toc}
       markdownUrl={docsMarkdownPathForDoc(doc.slug, locale) ?? undefined}
     >
+      {doc.draft && <DraftBanner />}
       <DocContent markdown={doc.body} />
     </DocsLayout>
   );

--- a/packages/docs/app/routes/docs.$slug.tsx
+++ b/packages/docs/app/routes/docs.$slug.tsx
@@ -1,7 +1,11 @@
 import { redirect, useLoaderData, type LoaderFunctionArgs } from "react-router";
 
 import DocContent from "../components/DocContent";
-import { loadDoc, type DocEntry } from "../components/docs-content";
+import DocDraftBanner from "../components/DocDraftBanner";
+import {
+  loadDocRespectingDraftVisibility,
+  type DocEntry,
+} from "../components/docs-content";
 import {
   DEFAULT_DOCS_LOCALE,
   docsPathForSlug,
@@ -29,21 +33,6 @@ const SLUG_REDIRECTS: Record<string, string> = {
   "migration-workbench": "code-agents-ui",
 };
 
-function DraftBanner() {
-  return (
-    <div
-      className="mb-6 rounded-md border p-4 text-sm"
-      style={{
-        borderColor: "var(--approaches-warn)",
-        color: "var(--approaches-warn)",
-      }}
-    >
-      <strong>Draft</strong> — This page is a work in progress. Content may be
-      incomplete or subject to change before publication.
-    </div>
-  );
-}
-
 export async function loader({ params }: LoaderFunctionArgs) {
   const slug = params.slug!;
   if (isDocsLocale(slug)) {
@@ -54,11 +43,8 @@ export async function loader({ params }: LoaderFunctionArgs) {
   if (target) {
     throw redirect(docsPathForSlug(target, DEFAULT_DOCS_LOCALE), 301);
   }
-  const doc = await loadDoc(slug);
+  const doc = await loadDocRespectingDraftVisibility(slug);
   if (!doc) {
-    throw new Response("Not Found", { status: 404 });
-  }
-  if (doc.draft && import.meta.env.VITE_SHOW_DRAFTS !== "true") {
     throw new Response("Not Found", { status: 404 });
   }
   return doc;
@@ -102,7 +88,7 @@ export default function DocPage() {
         docsMarkdownPathForDoc(doc.slug, DEFAULT_DOCS_LOCALE) ?? undefined
       }
     >
-      {doc.draft && <DraftBanner />}
+      {doc.draft && <DocDraftBanner />}
       <DocContent markdown={doc.body} />
     </DocsLayout>
   );

--- a/packages/docs/app/routes/docs.$slug.tsx
+++ b/packages/docs/app/routes/docs.$slug.tsx
@@ -29,6 +29,21 @@ const SLUG_REDIRECTS: Record<string, string> = {
   "migration-workbench": "code-agents-ui",
 };
 
+function DraftBanner() {
+  return (
+    <div
+      className="mb-6 rounded-md border p-4 text-sm"
+      style={{
+        borderColor: "var(--approaches-warn)",
+        color: "var(--approaches-warn)",
+      }}
+    >
+      <strong>Draft</strong> — This page is a work in progress. Content may be
+      incomplete or subject to change before publication.
+    </div>
+  );
+}
+
 export async function loader({ params }: LoaderFunctionArgs) {
   const slug = params.slug!;
   if (isDocsLocale(slug)) {
@@ -41,6 +56,9 @@ export async function loader({ params }: LoaderFunctionArgs) {
   }
   const doc = await loadDoc(slug);
   if (!doc) {
+    throw new Response("Not Found", { status: 404 });
+  }
+  if (doc.draft && import.meta.env.VITE_SHOW_DRAFTS !== "true") {
     throw new Response("Not Found", { status: 404 });
   }
   return doc;
@@ -84,6 +102,7 @@ export default function DocPage() {
         docsMarkdownPathForDoc(doc.slug, DEFAULT_DOCS_LOCALE) ?? undefined
       }
     >
+      {doc.draft && <DraftBanner />}
       <DocContent markdown={doc.body} />
     </DocsLayout>
   );

--- a/packages/docs/app/routes/docs._index.tsx
+++ b/packages/docs/app/routes/docs._index.tsx
@@ -5,7 +5,11 @@ import {
 } from "react-router";
 
 import DocContent from "../components/DocContent";
-import { loadDoc, type DocEntry } from "../components/docs-content";
+import DocDraftBanner from "../components/DocDraftBanner";
+import {
+  loadDocRespectingDraftVisibility,
+  type DocEntry,
+} from "../components/docs-content";
 import { DEFAULT_DOCS_LOCALE, isDocsLocale } from "../components/docs-locale";
 import { docsMarkdownPathForDoc } from "../components/docs-seo";
 import DocsLayout from "../components/DocsLayout";
@@ -20,7 +24,10 @@ function routeLocale(params: LoaderFunctionArgs["params"]) {
 export async function loader({
   params,
 }: LoaderFunctionArgs): Promise<DocEntry> {
-  const doc = await loadDoc(GETTING_STARTED_SLUG, routeLocale(params));
+  const doc = await loadDocRespectingDraftVisibility(
+    GETTING_STARTED_SLUG,
+    routeLocale(params),
+  );
   if (!doc) throw new Response("Not Found", { status: 404 });
   return doc;
 }
@@ -61,6 +68,7 @@ export default function DocsIndex() {
       toc={toc}
       markdownUrl={docsMarkdownPathForDoc(currentDoc.slug, locale) ?? undefined}
     >
+      {currentDoc.draft && <DocDraftBanner />}
       <DocContent markdown={currentDoc.body} />
     </DocsLayout>
   );


### PR DESCRIPTION
Pages with `draft: true` in their frontmatter are hidden from the nav and return 404 when accessed directly unless VITE_SHOW_DRAFTS=true is set. In preview mode, draft nav items render in warning amber and draft pages show a callout banner.

<img width="1920" height="1050" alt="image" src="https://github.com/user-attachments/assets/071a9040-f777-487e-af78-94d74a3f31dc" />

This is useful so we can edit docs while still referring back to the existing content. I've found this useful for me and for the AI, as I can have it compare what was there to the new content being written.

If we don't like this idea though, it's fine. It's a bit of work for a somewhat minor convenience.