### PR TITLE
fix: agent can resize Design frames

### DIFF
--- a/templates/design/.agents/skills/design-generation/SKILL.md
+++ b/templates/design/.agents/skills/design-generation/SKILL.md
@@ -330,6 +330,8 @@ canonical sizes to reuse instead of guessing:
 - **Social**: Instagram Post 1080×1080, Instagram Story 1080×1920, X Post
   1200×675, Facebook Cover 820×312, LinkedIn Cover 1584×396.
 
+Frame geometry is always numbers — `"width": 800`, never `"800"` or `"800px"`. String dimensions are rejected.
+
 At small ad-unit sizes (320×50, 160×600), text commonly runs 9-11px — smaller
 than this skill's general 16px body-text floor — because there is no room to
 reflow. That is expected for these formats; it stays legible in @2x+ exports

--- a/templates/design/actions/generate-design.ts
+++ b/templates/design/actions/generate-design.ts
@@ -439,7 +439,7 @@ const generateDesignAgentParameters = {
       type: "string",
       description:
         "Optional JSON array of overview-canvas placements keyed by filename or fileId. " +
-        "Pass explicit x/y/width/height for every generated screen; desktop is 1440x900.",
+        "Pass explicit x/y/width/height for every generated screen as numbers; desktop is 1440x900.",
     },
     contextPackId: {
       type: "string",
@@ -504,7 +504,8 @@ const generateDesignAction = defineAction({
     "for a mobile- or tablet-primary design when not passing `devices`. " +
     "Do not report a design as ready until this action succeeds. " +
     "When adding multiple screens or states, pass canvasFrames with filenames " +
-    "and x/y/width/height so the new screens appear placed on the overview canvas.",
+    "and numeric x/y/width/height so the new screens appear placed on the " +
+    "overview canvas.",
   schema: z.object({
     designId: z.string().describe("Design project ID to save content to"),
     prompt: z.string().describe("The generation prompt (stored for reference)"),

--- a/templates/design/actions/update-design.spec.ts
+++ b/templates/design/actions/update-design.spec.ts
@@ -376,6 +376,30 @@ describe("update-design data concurrency", () => {
     ).toBe(false);
   });
 
+  it("rejects string frame dimensions", async () => {
+    expect(
+      action.schema.safeParse({
+        id: "design-1",
+        dataOperations: [
+          {
+            op: "set",
+            path: ["canvasFrames", "frame-a"],
+            value: { x: 0, y: 0, width: "800", height: 600 },
+          },
+        ],
+      }).success,
+    ).toBe(false);
+
+    await expect(
+      action.run({
+        id: "design-1",
+        data: JSON.stringify({
+          canvasFrames: { "frame-a": { width: "800" } },
+        }),
+      } as never),
+    ).rejects.toThrow(/must be a finite JSON number/);
+  });
+
   it("CAS-matches a legacy null data row", async () => {
     mocks.state.row.data = null;
 

--- a/templates/design/actions/update-design.ts
+++ b/templates/design/actions/update-design.ts
@@ -4,6 +4,7 @@ import { and, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import { numericDesignDataWriteError } from "../shared/canvas-frames.js";
 
 const MAX_DATA_CAS_ATTEMPTS = 5;
 const MAX_DATA_OPERATION_SOURCES = 128;
@@ -26,17 +27,28 @@ const dataPathSchema = z
   .min(1)
   .max(8);
 
-const dataOperationSchema = z.discriminatedUnion("op", [
-  z.object({
-    op: z.literal("set"),
-    path: dataPathSchema,
-    value: z.json(),
-  }),
-  z.object({
-    op: z.literal("delete"),
-    path: dataPathSchema,
-  }),
-]);
+const dataOperationSchema = z
+  .discriminatedUnion("op", [
+    z.object({
+      op: z.literal("set"),
+      path: dataPathSchema,
+      value: z.json(),
+    }),
+    z.object({
+      op: z.literal("delete"),
+      path: dataPathSchema,
+    }),
+  ])
+  .superRefine((operation, context) => {
+    if (operation.op !== "set") return;
+    const message = numericDesignDataWriteError(
+      operation.path,
+      operation.value,
+    );
+    if (message) {
+      context.addIssue({ code: "custom", path: ["value"], message });
+    }
+  });
 
 type DataOperation = z.infer<typeof dataOperationSchema>;
 
@@ -195,7 +207,9 @@ export default defineAction({
     "Update an existing design project. Requires editor access. " +
     "Only provided fields are updated; omitted fields are left unchanged. " +
     "For map entries such as canvasFrames, use dataOperations " +
-    "with explicit set/delete paths instead of a full data snapshot.",
+    "with explicit set/delete paths instead of a full data snapshot. " +
+    "Dimensions and positions (x, y, width, height, rotation, z) are " +
+    'numbers. String values are rejected.',
   schema: z
     .object({
       id: z.string().describe("Design ID"),
@@ -213,7 +227,7 @@ export default defineAction({
         .max(500)
         .optional()
         .describe(
-          "Atomic path-addressed set/delete operations for design data. Safe to CAS-retry across concurrent writers.",
+          "Atomic path-addressed set/delete operations for design data. Safe to CAS-retry across concurrent writers. Geometry values must be numbers, not strings.",
         ),
       operationSource: z
         .string()
@@ -284,10 +298,17 @@ export default defineAction({
     designSystemId,
   }) => {
     if (data !== undefined) {
+      let parsedSnapshot: unknown;
       try {
-        JSON.parse(data);
+        parsedSnapshot = JSON.parse(data);
       } catch {
         throw new Error("data must be a valid JSON string");
+      }
+      if (isRecord(parsedSnapshot)) {
+        for (const [key, value] of Object.entries(parsedSnapshot)) {
+          const message = numericDesignDataWriteError([key], value);
+          if (message) throw new Error(message);
+        }
       }
     }
 

--- a/templates/design/actions/update-design.ts
+++ b/templates/design/actions/update-design.ts
@@ -209,7 +209,7 @@ export default defineAction({
     "For map entries such as canvasFrames, use dataOperations " +
     "with explicit set/delete paths instead of a full data snapshot. " +
     "Dimensions and positions (x, y, width, height, rotation, z) are " +
-    'numbers. String values are rejected.',
+    "numbers. String values are rejected.",
   schema: z
     .object({
       id: z.string().describe("Design ID"),

--- a/templates/design/shared/canvas-frames.test.ts
+++ b/templates/design/shared/canvas-frames.test.ts
@@ -3,8 +3,70 @@ import { describe, expect, it } from "vitest";
 import {
   mergeCanvasFramePlacements,
   nextFreeCanvasRowY,
+  numericDesignDataWriteError,
   parseCanvasFrameGeometryById,
 } from "./canvas-frames";
+
+describe("numericDesignDataWriteError", () => {
+  it("rejects string dimensions", () => {
+    expect(
+      numericDesignDataWriteError(["canvasFrames", "screen_a"], {
+        x: 0,
+        width: "800",
+      }),
+    ).toContain('must be a finite JSON number, received the string "800"');
+    expect(
+      numericDesignDataWriteError(
+        ["canvasFrames", "screen_a", "height"],
+        "600px",
+      ),
+    ).toContain("must be a finite JSON number");
+    expect(
+      numericDesignDataWriteError(
+        ["screenMetadata", "screen_a", "width"],
+        "800",
+      ),
+    ).toContain("must be a finite JSON number");
+    expect(
+      numericDesignDataWriteError(["canvasFrames"], {
+        screen_a: { width: 800 },
+        screen_b: { width: "800" },
+      }),
+    ).toContain("must be a finite JSON number");
+  });
+
+  it("rejects null and non-finite dimensions", () => {
+    expect(
+      numericDesignDataWriteError(["canvasFrames", "screen_a", "width"], null),
+    ).toContain("received null");
+    expect(
+      numericDesignDataWriteError(
+        ["canvasFrames", "screen_a", "width"],
+        Number.NaN,
+      ),
+    ).toContain("non-finite number");
+  });
+
+  it("accepts numeric geometry and ignores unrelated paths", () => {
+    expect(
+      numericDesignDataWriteError(["canvasFrames", "screen_a"], {
+        x: 0,
+        y: 0,
+        width: 300,
+        height: 250,
+      }),
+    ).toBeNull();
+    expect(
+      numericDesignDataWriteError(
+        ["screenMetadata", "screen_a", "title"],
+        "Home",
+      ),
+    ).toBeNull();
+    expect(
+      numericDesignDataWriteError(["tweakSelections"], { accent: "blue" }),
+    ).toBeNull();
+  });
+});
 
 describe("canvas frame geometry helpers", () => {
   it("parses only finite frame geometry values", () => {

--- a/templates/design/shared/canvas-frames.ts
+++ b/templates/design/shared/canvas-frames.ts
@@ -58,6 +58,87 @@ export function parseCanvasFrameGeometryById(
   );
 }
 
+/** Design-data maps whose per-entry dimension keys must be persisted as JSON
+ *  numbers. Every reader treats a non-number as absent, so accepting `"800"`
+ *  would silently drop the write instead of resizing anything. */
+const NUMERIC_DESIGN_DATA_ENTRY_KEYS: Record<string, ReadonlySet<string>> = {
+  canvasFrames: new Set(CANVAS_FRAME_GEOMETRY_KEYS),
+  screenMetadata: new Set(["width", "height"]),
+  localhostScreens: new Set(["width", "height"]),
+};
+
+function describeRejectedValue(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value === "string") return `the string ${JSON.stringify(value)}`;
+  if (typeof value === "number") return `the non-finite number ${value}`;
+  if (Array.isArray(value)) return "an array";
+  return `a ${typeof value}`;
+}
+
+function numericValueError(
+  map: string,
+  key: string,
+  value: unknown,
+): string | null {
+  if (typeof value === "number" && Number.isFinite(value)) return null;
+  return (
+    `Design ${map} "${key}" must be a finite JSON number, received ${describeRejectedValue(value)}. ` +
+    `Write dimensions and positions as numbers (800), not strings ("800" or "800px"); ` +
+    `use a delete operation to clear one.`
+  );
+}
+
+function numericEntryError(
+  map: string,
+  entry: unknown,
+  numericKeys: ReadonlySet<string>,
+): string | null {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
+  for (const [key, value] of Object.entries(entry)) {
+    if (!numericKeys.has(key)) continue;
+    const error = numericValueError(map, key, value);
+    if (error) return error;
+  }
+  return null;
+}
+
+/**
+ * Message describing why a path-addressed design-data write carries a
+ * non-numeric dimension, or null when the write is acceptable.
+ *
+ * Callers must reject on a message rather than coercing: the readers below
+ * drop non-numbers, so a coerced write and an ignored one are indistinguishable
+ * to whoever asked for the resize.
+ */
+export function numericDesignDataWriteError(
+  path: readonly string[],
+  value: unknown,
+): string | null {
+  const map = path[0];
+  const numericKeys = map ? NUMERIC_DESIGN_DATA_ENTRY_KEYS[map] : undefined;
+  if (!map || !numericKeys) return null;
+
+  if (path.length === 1) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return null;
+    }
+    for (const entry of Object.values(value)) {
+      const error = numericEntryError(map, entry, numericKeys);
+      if (error) return error;
+    }
+    return null;
+  }
+
+  if (path.length === 2) return numericEntryError(map, value, numericKeys);
+
+  const key = path[2]!;
+  if (!numericKeys.has(key)) return null;
+  if (path.length > 3) {
+    return `Design ${map} "${key}" is a single number and has no nested values.`;
+  }
+  return numericValueError(map, key, value);
+}
+
 /** Y a new group must start at to clear existing frames, or 0 when the board is
  *  empty. Placing at y=0 unconditionally stacks each new group on the last. */
 export function nextFreeCanvasRowY(


### PR DESCRIPTION
Agent was setting resize dimensions as strings, not numbers. As a result, this operation would silently fail. This PR fixes the issue by ensuring the agent sets the dimensions as numbers.