### PR TITLE
Add 👀 emoji and unify reaction sets in Clips comments

### DIFF
--- a/templates/clips/app/components/player/comments-panel.tsx
+++ b/templates/clips/app/components/player/comments-panel.tsx
@@ -60,7 +60,7 @@ const defaultLens: CommentsLens = {
     data ? { ...(data as object), comments: next } : data,
 };
 
-const COMMENT_EMOJIS = ["👍", "❤️", "🔥", "👏", "🎉", "😂"];
+const COMMENT_EMOJIS = ["👍", "❤️", "🔥", "👏", "🎉", "😂", "👀"];
 
 export interface Comment {
   id: string;

--- a/templates/clips/app/components/player/comments-panel.tsx
+++ b/templates/clips/app/components/player/comments-panel.tsx
@@ -31,6 +31,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 
+import { REACTION_EMOJIS } from "./reaction-emojis";
 import { msToClock } from "./scrubber";
 
 function makeTempId() {
@@ -59,8 +60,6 @@ const defaultLens: CommentsLens = {
   applyComments: (data, next) =>
     data ? { ...(data as object), comments: next } : data,
 };
-
-const COMMENT_EMOJIS = ["👍", "❤️", "🔥", "👏", "🎉", "😂", "👀"];
 
 export interface Comment {
   id: string;
@@ -928,7 +927,7 @@ function CommentCard({
                 </PopoverTrigger>
                 <PopoverContent side="top" align="start" className="p-1 w-auto">
                   <div className="flex gap-0.5">
-                    {COMMENT_EMOJIS.map((e) => (
+                    {REACTION_EMOJIS.map((e) => (
                       <button
                         key={e}
                         onClick={() => {

--- a/templates/clips/app/components/player/reaction-emojis.ts
+++ b/templates/clips/app/components/player/reaction-emojis.ts
@@ -1,0 +1,10 @@
+export const REACTION_EMOJIS = [
+  "👍",
+  "❤️",
+  "🔥",
+  "👏",
+  "🎉",
+  "😂",
+  "🤯",
+  "👀",
+] as const;

--- a/templates/clips/app/components/player/reactions-tray.tsx
+++ b/templates/clips/app/components/player/reactions-tray.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
-const EMOJIS = ["👍", "❤️", "🔥", "👏", "🎉", "😂", "🤯"] as const;
+import { REACTION_EMOJIS } from "./reaction-emojis";
 
 export interface ReactionsTrayProps {
   onReact: (emoji: string) => void;
@@ -38,7 +38,7 @@ export function ReactionsTray({ onReact, disabled }: ReactionsTrayProps) {
 
   return (
     <div className="relative flex w-fit max-w-full items-center gap-0.5 rounded-full border border-border bg-card px-1.5 py-1 shadow-sm sm:gap-1 sm:px-2">
-      {EMOJIS.map((emoji) => (
+      {REACTION_EMOJIS.map((emoji) => (
         <Tooltip key={emoji}>
           <TooltipTrigger asChild>
             <button

--- a/templates/clips/changelog/2026-08-05-comment-and-video-reaction-pickers-now-include-eyes-and-mind.md
+++ b/templates/clips/changelog/2026-08-05-comment-and-video-reaction-pickers-now-include-eyes-and-mind.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-05
+---
+
+Comment and video reaction pickers now include eyes and mind-blown reactions consistently.


### PR DESCRIPTION
### Summary
Adds the missing 👀 (eyes) emoji to the comment reaction picker in the Clips app and consolidates the two previously-separate reaction emoji lists into a single shared source of truth.

### Problem
The comment reaction picker in Clips was missing the 👀 (eyes) reaction. Additionally, the reaction set used for comments and the one used in the video reactions tray were defined separately (`COMMENT_EMOJIS` vs `EMOJIS`), differing only by the 🤯 (exploding head) emoji — a difference too thin to justify keeping them as separate, drift-prone lists.

### Solution
Extracted a single shared `REACTION_EMOJIS` constant and updated both the comments panel and the reactions tray to use it, ensuring both surfaces now show the same consistent reaction set, including 👀.

### Key Changes
- Added `templates/clips/app/components/player/reaction-emojis.ts` exporting `REACTION_EMOJIS` with the full set: 👍 ❤️ 🔥 👏 🎉 😂 🤯 👀
- Updated `comments-panel.tsx` to import `REACTION_EMOJIS` instead of defining its own local `COMMENT_EMOJIS` array
- Updated `reactions-tray.tsx` to import `REACTION_EMOJIS` instead of its local `EMOJIS` array
- Added a changelog entry documenting that comment and video reaction pickers now consistently include the eyes and mind-blown reactions

---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/scout-skyline-jh1e8arn"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-scout-skyline-jh1e8arn.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2665`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>scout-skyline-jh1e8arn</branchName>-->