### PR TITLE
fix: strip excluded core source map references

### DIFF
--- a/.changeset/quiet-core-package-maps.md
+++ b/.changeset/quiet-core-package-maps.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Strip source-map references from published core build artifacts when the maps are excluded from the package.

--- a/packages/core/scripts/finalize-build.mjs
+++ b/packages/core/scripts/finalize-build.mjs
@@ -35,6 +35,27 @@ function pruneSpecArtifacts(dir) {
   }
 }
 
+// The published package excludes dist/**/*.map to keep installs small. Remove
+// the compiler trailers too, or Vite spends startup time trying to read maps
+// that the package intentionally does not ship.
+function stripSourceMapComments(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      stripSourceMapComments(full);
+      continue;
+    }
+    if (!/\.(?:[cm]?js|d\.ts)$/.test(entry.name)) continue;
+
+    const source = readFileSync(full, "utf8");
+    const stripped = source.replace(
+      /\r?\n\/\/# sourceMappingURL=[^\r\n]*\r?\n?$/u,
+      "\n",
+    );
+    if (stripped !== source) writeFileSync(full, stripped);
+  }
+}
+
 function collectSourceStems(dir, root = dir, stems = new Set()) {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name);
@@ -85,6 +106,7 @@ function pruneStaleCompiledArtifacts(sourceDir, compiledDir) {
 
 if (existsSync("dist")) {
   pruneSpecArtifacts("dist");
+  stripSourceMapComments("dist");
   for (const entry of ["editor", "composer", "rich-markdown-editor"]) {
     pruneStaleCompiledArtifacts(
       join("src", "client", entry),


### PR DESCRIPTION
## Summary
- strip compiler source-map trailers from core build artifacts when published maps are excluded
- keep standalone Chat dev smoke startup from spending minutes resolving missing maps in generated local packages

## Verification
- CI-mode `pnpm qa:standalone-chat-dev`
- `pnpm --filter @agent-native/core build`
- `pnpm prep` reached all guards, typecheck, core tests, and 38/39 test workspaces; the remaining analytics test failure came from separate unstaged concurrent edits in the shared worktree