### PR TITLE
fix: keep durable analytics workers clear of startup contention

### DIFF
--- a/.changeset/quiet-background-migrations.md
+++ b/.changeset/quiet-background-migrations.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep durable background workers from retrying serialized startup migrations and maintenance sweeps while processing an agent task.

--- a/.changeset/quiet-core-package-maps.md
+++ b/.changeset/quiet-core-package-maps.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Strip source-map references from published core build artifacts when the maps are excluded from the package.

--- a/packages/core/scripts/finalize-build.mjs
+++ b/packages/core/scripts/finalize-build.mjs
@@ -35,6 +35,27 @@ function pruneSpecArtifacts(dir) {
   }
 }
 
+// The published package excludes dist/**/*.map to keep installs small. Remove
+// the compiler trailers too, or Vite spends startup time trying to read maps
+// that the package intentionally does not ship.
+function stripSourceMapComments(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      stripSourceMapComments(full);
+      continue;
+    }
+    if (!/\.(?:[cm]?js|d\.ts)$/.test(entry.name)) continue;
+
+    const source = readFileSync(full, "utf8");
+    const stripped = source.replace(
+      /\r?\n\/\/# sourceMappingURL=[^\r\n]*\r?\n?$/u,
+      "\n",
+    );
+    if (stripped !== source) writeFileSync(full, stripped);
+  }
+}
+
 function collectSourceStems(dir, root = dir, stems = new Set()) {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name);
@@ -85,6 +106,7 @@ function pruneStaleCompiledArtifacts(sourceDir, compiledDir) {
 
 if (existsSync("dist")) {
   pruneSpecArtifacts("dist");
+  stripSourceMapComments("dist");
   for (const entry of ["editor", "composer", "rich-markdown-editor"]) {
     pruneStaleCompiledArtifacts(
       join("src", "client", entry),

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -32,8 +32,11 @@ export type DrizzleDb = Awaited<ReturnType<typeof createDb>>;
 
 export { createGetDb } from "./create-get-db.js";
 export {
+  deferMigration,
+  MIGRATION_DEFERRED,
   runMigrations,
   type MigrationEntry,
+  type MigrationRunResult,
   type MigrationSql,
 } from "./migrations.js";
 export {

--- a/packages/core/src/db/migrations.spec.ts
+++ b/packages/core/src/db/migrations.spec.ts
@@ -28,7 +28,7 @@ import {
   getCloudflareD1Binding,
   getMigrationDatabaseUrl,
 } from "./client.js";
-import { runMigrations } from "./migrations.js";
+import { deferMigration, runMigrations } from "./migrations.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -210,6 +210,23 @@ describe("runMigrations – run-only entries", () => {
     expect(directExec.insertedNames).toEqual(["repair-counts"]);
     expect(directExec.insertedVersions).toEqual([1]);
     expect(directExec.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves a deferred run-only migration unrecorded", async () => {
+    vi.mocked(isPostgres).mockReturnValue(false);
+    const exec = makeNamedExec({ version: 0, appliedNames: [] });
+    vi.mocked(getDbExec).mockReturnValue(exec);
+    const run = vi.fn(async () => deferMigration());
+
+    const plugin = runMigrations(
+      [{ version: 1, name: "serialized-backfill", sql: {}, run }],
+      { table: "deferred_run_only_migrations" },
+    );
+    await plugin(null);
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(exec.insertedNames).toEqual([]);
+    expect(exec.insertedVersions).toEqual([]);
   });
 
   it("records D1 run-only bookkeeping in one atomic batch", async () => {

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -219,6 +219,19 @@ export interface RunMigrationsOptions {
  */
 export type MigrationSql = string | { postgres?: string; sqlite?: string };
 
+/**
+ * A run-only migration can defer its work without recording itself as applied.
+ * This is for serialized backfills where another instance owns the advisory
+ * lock; throwing would turn an expected loser into a startup retry storm.
+ */
+export const MIGRATION_DEFERRED = Symbol("migration-deferred");
+
+export function deferMigration(): typeof MIGRATION_DEFERRED {
+  return MIGRATION_DEFERRED;
+}
+
+export type MigrationRunResult = void | typeof MIGRATION_DEFERRED;
+
 export interface MigrationEntry {
   version: number;
   sql: MigrationSql;
@@ -234,11 +247,13 @@ export interface MigrationEntry {
    * JS step for a backfill SQL cannot express — e.g. a repair whose value comes
    * from application-level parsing of a stored blob. Runs BEFORE this entry's
    * SQL and before the bookkeeping row is written, so a throw leaves the
-   * migration unrecorded and it retries on the next boot. Pass `sql: {}` for a
-   * run-only entry. Give run-only entries a `name`: the legacy version gate
+   * migration unrecorded and it retries on the next boot. Return
+   * `deferMigration()` when another instance owns a serialized backfill; the
+   * entry stays pending without logging a startup failure. Pass `sql: {}` for
+   * a run-only entry. Give run-only entries a `name`: the legacy version gate
    * would otherwise mark them applied via any later migration's MAX advance.
    */
-  run?: () => Promise<void>;
+  run?: () => Promise<MigrationRunResult>;
 }
 
 function resolveMigrationSql(sql: MigrationSql, pg: boolean): string | null {
@@ -382,7 +397,13 @@ export function runMigrations(
           try {
             // D1 is SQLite-compatible
             const raw = resolveMigrationSql(m.sql, false);
-            if (m.run) await m.run();
+            const runResult = m.run ? await m.run() : undefined;
+            if (runResult === MIGRATION_DEFERRED) {
+              console.info(
+                `[db] Deferred migration ${m.name ? `"${m.name}" ` : ""}v${m.version}; it remains pending for a later boot`,
+              );
+              continue;
+            }
             const recordStatements = [
               m.name
                 ? d1
@@ -642,7 +663,13 @@ export function runMigrations(
           // A throw here escapes to the outer handler with nothing recorded,
           // so the entry is retried on the next boot rather than being marked
           // applied against work that never happened.
-          if (m.run) await m.run();
+          const runResult = m.run ? await m.run() : undefined;
+          if (runResult === MIGRATION_DEFERRED) {
+            console.info(
+              `[db] Deferred migration ${label}; it remains pending for a later boot`,
+            );
+            continue;
+          }
 
           if (raw == null) {
             // Dialect-gated migration with no SQL for this dialect; still mark

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -5832,7 +5832,9 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
         }),
       );
 
-      const disableRecurringJobsRuntime = shouldDisableRecurringJobsRuntime();
+      const isBackgroundRuntime = isInBackgroundFunctionRuntime();
+      const disableRecurringJobsRuntime =
+        isBackgroundRuntime || shouldDisableRecurringJobsRuntime();
 
       // ─── Recurring Jobs Scheduler ──────────────────────────────────────
       // Poll every 60 seconds for due recurring jobs and execute them.
@@ -5905,27 +5907,29 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
       // A non-Netlify self-dispatch only waits for the request to leave the
       // current invocation. Keep the durable history row as a retryable queue
       // so a frozen serverless handoff is recovered on the next sweep.
-      (() => {
-        let inFlight = false;
-        const sweep = async () => {
-          if (inFlight) return;
-          inFlight = true;
-          try {
-            const { redispatchUnclaimedAutomationRuns } =
-              await import("../jobs/run-now.js");
-            await redispatchUnclaimedAutomationRuns();
-          } catch (error) {
-            console.warn(
-              "[automations] queued-run sweep failed; retrying next tick:",
-              error,
-            );
-          } finally {
-            inFlight = false;
-          }
-        };
-        setTimeout(() => void sweep(), 15_000);
-        setInterval(() => void sweep(), 30_000);
-      })();
+      if (!isBackgroundRuntime) {
+        (() => {
+          let inFlight = false;
+          const sweep = async () => {
+            if (inFlight) return;
+            inFlight = true;
+            try {
+              const { redispatchUnclaimedAutomationRuns } =
+                await import("../jobs/run-now.js");
+              await redispatchUnclaimedAutomationRuns();
+            } catch (error) {
+              console.warn(
+                "[automations] queued-run sweep failed; retrying next tick:",
+                error,
+              );
+            } finally {
+              inFlight = false;
+            }
+          };
+          setTimeout(() => void sweep(), 15_000);
+          setInterval(() => void sweep(), 30_000);
+        })();
+      }
 
       mcpInitializationPromise = initializeMcpManager().catch((err) => {
         console.warn(
@@ -5940,6 +5944,7 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
       // per instance; cheap (one indexed query when no active tasks are found).
       // Throttled by the same per-owner interval guard inside reconcileAgentTeamRunsForOwner.
       (() => {
+        if (isBackgroundRuntime) return;
         // Track when this instance last ran the sweep so only one sweep fires
         // per 2-min window even if multiple timers fire in overlapping invocations.
         let lastSweep = 0;
@@ -6100,6 +6105,7 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
       // comment above for why this exists and the timing budget in
       // run-store.ts's `UNCLAIMED_BACKGROUND_RUN_FAST_SWEEP_MS` doc comment.
       (() => {
+        if (isBackgroundRuntime) return;
         setTimeout(() => {
           (async () => {
             const { UNCLAIMED_BACKGROUND_RUN_FAST_SWEEP_MS } =
@@ -6151,6 +6157,7 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
       // still fails loud, and it survives the fast sweep having missed a row
       // entirely (e.g. a restart landed between fast-sweep ticks).
       (() => {
+        if (isBackgroundRuntime) return;
         let lastSweep = 0;
         const SWEEP_INTERVAL_MS = 2 * 60 * 1000;
 

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -8,6 +8,7 @@ export {
   AGENT_BACKGROUND_PROCESSOR_ROUTE,
   AGENT_BACKGROUND_PROCESSOR_ROUTE_FIELD,
   dispatchPathTargetsNetlifyBackgroundFunction,
+  isInBackgroundFunctionRuntime,
   resolveDurableBackgroundDispatchPath,
 } from "../agent/durable-background.js";
 
@@ -542,8 +543,10 @@ export {
 export {
   sendEmail,
   isEmailConfigured,
+  getEmailReadiness,
   getEmailProvider,
   type EmailAttachment,
+  type EmailReadiness,
   type EmailProvider,
   type SendEmailArgs,
 } from "./email.js";

--- a/templates/analytics/changelog/2026-08-05-durable-a2a-workers-avoid-startup-migration-contention.md
+++ b/templates/analytics/changelog/2026-08-05-durable-a2a-workers-avoid-startup-migration-contention.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-05
+---
+
+Durable A2A workers now avoid startup migration contention so Analytics requests can complete while rollup maintenance runs separately.

--- a/templates/analytics/server/plugins/db.ts
+++ b/templates/analytics/server/plugins/db.ts
@@ -1,10 +1,12 @@
 import {
+  deferMigration,
   ensureAdditiveColumns,
   getDialect,
   getDbExec,
   isPostgres,
   runMigrations,
 } from "@agent-native/core/db";
+import { isInBackgroundFunctionRuntime } from "@agent-native/core/server";
 
 // Side-effect import: ensures registerShareableResource runs on server
 // startup so the dashboard / analysis share actions know where to dispatch.
@@ -141,7 +143,17 @@ const ANALYTICS_ROLLUP_BACKFILL_STATEMENTS = {
   ],
 } as const;
 
-async function runHistoricalAnalyticsRollupBackfill(): Promise<void> {
+async function runHistoricalAnalyticsRollupBackfill() {
+  // Durable agent workers share this plugin bundle with the regular server,
+  // but they must not become a second migration runner for an expensive
+  // historical scan. The keep-warm/regular server path owns this work.
+  if (isInBackgroundFunctionRuntime()) {
+    console.info(
+      "[db] Deferring historical Analytics rollup backfill from durable background runtime",
+    );
+    return deferMigration();
+  }
+
   const db = getDbExec();
 
   if (isPostgres()) {
@@ -151,11 +163,12 @@ async function runHistoricalAnalyticsRollupBackfill(): Promise<void> {
       );
     }
 
-    await db.transaction(async (tx) => {
+    const result = await db.transaction(async (tx) => {
       // Only one serverless instance should perform the expensive scan. A
-      // try-lock is intentional: competing cold starts fail fast instead of
-      // holding pooled Neon connections while waiting for the winner. The
-      // monotonic rollup upsert below keeps a live increment from being
+      // A try-lock keeps competing cold starts from holding pooled Neon
+      // connections while waiting for the winner. A lock loser defers without
+      // recording the migration so a failed winner can be retried safely.
+      // The monotonic rollup upsert below keeps a live increment from being
       // overwritten if ingest commits during the historical snapshot.
       const lockResult = await tx.execute({
         sql: "SELECT pg_try_advisory_xact_lock(hashtextextended(?, 0::bigint)) AS acquired",
@@ -163,15 +176,16 @@ async function runHistoricalAnalyticsRollupBackfill(): Promise<void> {
       });
       const acquired = lockResult.rows[0]?.acquired;
       if (acquired !== true && acquired !== "t") {
-        throw new Error(
-          "Analytics rollup backfill is already running on another instance",
+        console.info(
+          "[db] Deferring historical Analytics rollup backfill; another instance owns the advisory lock",
         );
+        return deferMigration();
       }
       for (const statement of ANALYTICS_ROLLUP_BACKFILL_STATEMENTS.postgres) {
         await tx.execute(statement);
       }
     });
-    return;
+    return result;
   }
 
   const statements = ANALYTICS_ROLLUP_BACKFILL_STATEMENTS.sqlite;
@@ -1557,6 +1571,9 @@ const runAnalyticsMigrations = runMigrations(
  */
 export default async (nitroApp: any): Promise<void> => {
   await runAnalyticsMigrations(nitroApp);
+  if (isInBackgroundFunctionRuntime()) {
+    return;
+  }
   try {
     if (await repairPersistedFirstPartyDashboardQueries()) {
       console.info(


### PR DESCRIPTION
## What changed\n\nDurable Analytics A2A workers were booting the full server, retrying the serialized historical rollup migration, and starting maintenance sweeps while processing the delegated task. That exhausted Neon connections before Analytics could answer.\n\nThis change:\n- lets serialized run-only migrations defer without recording success\n- defers the historical rollup backfill from durable workers and leaves it pending for the regular server\n- disables unrelated recurring, automation, team, and background-run sweeps in durable workers\n- skips nonessential Analytics startup repair work in durable workers\n\n## Verification\n\n- core migration and agent-chat focused tests pass\n- Analytics migration tests pass\n- core and Analytics typechecks pass\n- Analytics production build passes\n- 
> agentnative@1.0.0 guards /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/run-guards.ts


[guard:env-documentation] output

> agentnative@1.0.0 guard:env-documentation /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/guard-env-documentation.ts

[env-doc] Covered 790 static environment variables in the maintainer inventory and curated framework docs (281 inventory entries, 58 public entries).

[guard:no-env-mutation] output

> agentnative@1.0.0 guard:no-env-mutation /Users/steve/Projects/builder/agent-native/framework
> node scripts/guard-no-env-mutation.mjs

guard-no-env-mutation: clean (no process.env mutations/deletions in production code).

[guard:no-empty-migrations] output

> agentnative@1.0.0 guard:no-empty-migrations /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/guard-no-empty-migrations.ts

No empty migration plugins found.

[guard:google-auth-redirects] output

> agentnative@1.0.0 guard:google-auth-redirects /Users/steve/Projects/builder/agent-native/framework
> node scripts/guard-google-auth-redirects.mjs

guard-google-auth-redirects: clean (11 auth-url files checked).

[guard:no-drizzle-push] output

> agentnative@1.0.0 guard:no-drizzle-push /Users/steve/Projects/builder/agent-native/framework
> node scripts/guard-no-drizzle-push.mjs

guard-no-drizzle-push: clean (no `drizzle-kit push` in any build/deploy path).

[guard:template-list] output

> agentnative@1.0.0 guard:template-list /Users/steve/Projects/builder/agent-native/framework
> node scripts/guard-template-list.mjs

guard-template-list: clean (13 public templates: analytics, assets, brain, calendar, chat, clips, content, design, dispatch, forms, mail, plan, slides).

[guard:no-env-credentials] output

> agentnative@1.0.0 guard:no-env-credentials /Users/steve/Projects/builder/agent-native/framework
> node scripts/guard-no-env-credentials.mjs

guard-no-env-credentials: clean (no forbidden process.env reads in credential paths).

[guard:no-localhost-fallback] output

> agentnative@1.0.0 guard:no-localhost-fallback /Users/steve/Projects/builder/agent-native/framework
> node scripts/guard-no-localhost-fallback.mjs

guard-no-localhost-fallback: clean (no "local@localhost" literals and no ambient-identity fallbacks in production code).

[guard:db-tool-scoping] output

> agentnative@1.0.0 guard:db-tool-scoping /Users/steve/Projects/builder/agent-native/framework
> node scripts/guard-db-tool-scoping.mjs

guard-db-tool-scoping: clean (54 intentionally denied template table(s))

[guard:trusted-acceptance] output

> agentnative@1.0.0 guard:trusted-acceptance /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/guard-trusted-acceptance-workflow.ts

Trusted acceptance workflow boundary checks passed.

[guard:content-product-conformance] output

> agentnative@1.0.0 guard:content-product-conformance /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/validate-content-product-impact-workflow.ts

Content product conformance workflow boundary checks passed.

[guard:content-product-docs] output

> agentnative@1.0.0 guard:content-product-docs /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/validate-content-product-docs.ts

[content-product-docs] Validated 6 Chapters, 32 Features, and 124 Capabilities

[guard:workspace-skills] output

> agentnative@1.0.0 guard:workspace-skills /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/sync-workspace-core-skills.ts --check

Workspace-core, default-template, and template shared skills are in sync.

[guard:no-unscoped-credentials] output

> agentnative@1.0.0 guard:no-unscoped-credentials /Users/steve/Projects/builder/agent-native/framework
> node scripts/guard-no-unscoped-credentials.mjs

guard-no-unscoped-credentials: clean (every credential call passes context).

[guard:template-standard] output

> agentnative@1.0.0 guard:template-standard /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/template-standard/index.ts --check

[template-standard] checked 17 templates: analytics, assets, brain, calendar, chat, clips, content, crm, design, dispatch, factory, forms, macros, mail, plan, slides, tasks
[template-standard] core-routes surface: investigated, not enforced (see manifest.ts CORE_ROUTES_FINDING).
[template-standard] never-standardized surfaces (no checks by design): actions/ (app-specific operations); drizzle schema (app-specific data model); app/ UI (app-specific screens/components); app-specific skills beyond the shared set sync-workspace-core-skills.ts governs; agent-native.json / app-skill.json content; changelog/ entries

[template-standard] 9 known gap(s), accepted in the baseline (Phase 2/3 should shrink these):
  - byte-sync:learnings-defaults:mismatch :: analytics — templates/analytics/learnings.defaults.md content differs from the canonical copy (/Users/steve/Projects/builder/agent-native/framework/scripts/template-standard/assets/learnings.defaults.md).
  - byte-sync:learnings-defaults:mismatch :: clips — templates/clips/learnings.defaults.md content differs from the canonical copy (/Users/steve/Projects/builder/agent-native/framework/scripts/template-standard/assets/learnings.defaults.md).
  - byte-sync:gitignore-source:mismatch :: assets — templates/assets/_gitignore content differs from the canonical copy (/Users/steve/Projects/builder/agent-native/framework/scripts/template-standard/assets/_gitignore).
  - byte-sync:gitignore-source:mismatch :: brain — templates/brain/_gitignore content differs from the canonical copy (/Users/steve/Projects/builder/agent-native/framework/scripts/template-standard/assets/_gitignore).
  - byte-sync:gitignore-source:mismatch :: chat — templates/chat/_gitignore content differs from the canonical copy (/Users/steve/Projects/builder/agent-native/framework/scripts/template-standard/assets/_gitignore).
  - byte-sync:gitignore-source:mismatch :: crm — templates/crm/_gitignore content differs from the canonical copy (/Users/steve/Projects/builder/agent-native/framework/scripts/template-standard/assets/_gitignore).
  - byte-sync:gitignore-source:mismatch :: design — templates/design/_gitignore content differs from the canonical copy (/Users/steve/Projects/builder/agent-native/framework/scripts/template-standard/assets/_gitignore).
  - byte-sync:gitignore-source:mismatch :: dispatch — templates/dispatch/_gitignore content differs from the canonical copy (/Users/steve/Projects/builder/agent-native/framework/scripts/template-standard/assets/_gitignore).
  - byte-sync:gitignore-source:mismatch :: plan — templates/plan/_gitignore content differs from the canonical copy (/Users/steve/Projects/builder/agent-native/framework/scripts/template-standard/assets/_gitignore).

[template-standard] 12 baseline entrie(s) no longer reproduce — safe to delete from /Users/steve/Projects/builder/agent-native/framework/scripts/template-standard-baseline.json:
  - byte-sync:learnings-defaults:missing :: content — Never got the starter learnings.defaults.md scaffold. Add via `pnpm sync:template-standard` once this entry is removed.
  - byte-sync:learnings-defaults:missing :: forms — Never got the starter learnings.defaults.md scaffold. Add via `pnpm sync:template-standard` once this entry is removed.
  - byte-sync:learnings-defaults:missing :: macros — Never got the starter learnings.defaults.md scaffold. Add via `pnpm sync:template-standard` once this entry is removed.
  - byte-sync:gitignore-source:missing :: analytics — Has a working .gitignore but no _gitignore, so scaffolding a new app from this template won't get the canonical ignore rules re-applied. Add via `pnpm sync:template-standard` once this entry is removed.
  - byte-sync:gitignore-source:missing :: calendar — Has a working .gitignore but no _gitignore. Add via `pnpm sync:template-standard` once this entry is removed.
  - byte-sync:gitignore-source:missing :: content — Has a working .gitignore but no _gitignore. Add via `pnpm sync:template-standard` once this entry is removed.
  - byte-sync:gitignore-source:missing :: forms — Has a working .gitignore but no _gitignore. Add via `pnpm sync:template-standard` once this entry is removed.
  - byte-sync:gitignore-source:missing :: macros — Has a working .gitignore but no _gitignore. Add via `pnpm sync:template-standard` once this entry is removed.
  - byte-sync:gitignore-source:missing :: mail — Has a working .gitignore but no _gitignore — this is the template the canonical learnings.defaults.md scaffold is sourced from, but it never got a _gitignore of its own. Add via `pnpm sync:template-standard` once this entry is removed.
  - byte-sync:gitignore-source:missing :: slides — Has a working .gitignore but no _gitignore. Add via `pnpm sync:template-standard` once this entry is removed.
  - byte-sync:gitignore-source:missing :: tasks — Has a working .gitignore but no _gitignore. Add via `pnpm sync:template-standard` once this entry is removed.
  - agents-md-placeholder :: chat — AGENTS.md still starts with the unrendered `{{APP_NAME}}` scaffold placeholder from template generation; needs the real title substituted in Phase 2.

[template-standard] 6 version-drift warning(s) (WARN-level, does not fail the guard):
  - dep-version-band:zod :: brain — templates/brain/package.json uses zod@"^4.4.3"; the majority of templates use "^4.3.6".
  - dep-version-band:zod :: chat — templates/chat/package.json uses zod@"^4.4.3"; the majority of templates use "^4.3.6".
  - dep-version-band:zod :: factory — templates/factory/package.json uses zod@"^4.4.3"; the majority of templates use "^4.3.6".
  - dep-version-band:zod :: macros — templates/macros/package.json uses zod@"^4.4.3"; the majority of templates use "^4.3.6".
  - dep-version-band:zod :: plan — templates/plan/package.json uses zod@"^4.4.3"; the majority of templates use "^4.3.6".
  - dep-version-band:zod :: tasks — templates/tasks/package.json uses zod@"^4.4.3"; the majority of templates use "^4.3.6".

[template-standard] no new drift. 9 baselined gap(s) remain open.

[guard:public-packages] output

> agentnative@1.0.0 guard:public-packages /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/guard-public-packages.ts

OK Agent-Native package publish metadata is public.

[guard:shared-ui-singletons] output

> agentnative@1.0.0 guard:shared-ui-singletons /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/guard-shared-ui-singletons.ts

[guard:shared-ui-singletons] clean (13 catalog-shared dependencies; 7 singleton-critical resolutions)

[guard:toolkit-must-not-import-core] output

> agentnative@1.0.0 guard:toolkit-must-not-import-core /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/guard-toolkit-must-not-import-core.ts

[guard:toolkit-must-not-import-core] clean

[guard:controller-boundaries] output

> agentnative@1.0.0 guard:controller-boundaries /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/guard-controller-boundaries.ts

[guard:controller-boundaries] clean

[guard:template-ui-imports] output

> agentnative@1.0.0 guard:template-ui-imports /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/guard-template-ui-imports.ts

[guard:template-ui-imports] clean

[guard:no-generated-artifacts] output

> agentnative@1.0.0 guard:no-generated-artifacts /Users/steve/Projects/builder/agent-native/framework
> node scripts/guard-no-generated-artifacts.mjs


[guard:extension-no-public] output

> agentnative@1.0.0 guard:extension-no-public /Users/steve/Projects/builder/agent-native/framework
> node scripts/guard-extension-no-public.mjs

[guard-extension-no-public] OK — scanned 14675 files, no violations.

[guard:eject-manifests] output

> agentnative@1.0.0 guard:eject-manifests /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/guard-eject-manifests.ts

Eject manifests cover 28 units across 4 packages and all six first-party catalogs.

[guard:no-one-off-mcp-app-html] output

> agentnative@1.0.0 guard:no-one-off-mcp-app-html /Users/steve/Projects/builder/agent-native/framework
> node scripts/guard-no-one-off-mcp-app-html.mjs

[guard-no-one-off-mcp-app-html] OK - scanned 6061 template source files.

[guard:netlify-private-env] output

> agentnative@1.0.0 guard:netlify-private-env /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/guard-netlify-private-env.ts

guard-netlify-private-env: clean (no Builder private key in Netlify deploy config).

[guard:plan-skills] output

> agentnative@1.0.0 guard:plan-skills /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/sync-plan-skills.ts --check

Exported app skills are in sync with skills.ts constants.

[guard:no-error-string-returns] output

> agentnative@1.0.0 guard:no-error-string-returns /Users/steve/Projects/builder/agent-native/framework
> node scripts/guard-no-error-string-returns.mjs

guard-no-error-string-returns: OK

[guard:plan-marketplace] output

> agentnative@1.0.0 guard:plan-marketplace /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/sync-plan-marketplace.ts --check

App marketplace bundles are in sync (agent-native-visual-plans 1.0.0+codex.93102d6bf147, agent-native-design 1.0.0+codex.825b86beaa93).

[guard:no-core-client-barrel-imports] output

> agentnative@1.0.0 guard:no-core-client-barrel-imports /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/guard-no-core-client-barrel-imports.ts

[guard:no-core-client-barrel-imports] clean

[guard:no-action-twin-routes] output

> agentnative@1.0.0 guard:no-action-twin-routes /Users/steve/Projects/builder/agent-native/framework
> node scripts/guard-no-action-twin-routes.mjs

guard-no-action-twin-routes: OK (17 grandfathered routes remaining in baseline)

[guard:provider-action-factories] output

> agentnative@1.0.0 guard:provider-action-factories /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/guard-provider-action-factories.ts

[guard:provider-action-factories] all shared action factories are in use

[guard:agent-chat-context] output

> agentnative@1.0.0 guard:agent-chat-context /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/guard-agent-chat-context.ts

[guard:agent-chat-context] packages/core/src/templates/default/AGENTS.md: 4608/6000 instruction chars
[guard:agent-chat-context] packages/core/src/templates/headless/AGENTS.md: 5286/6000 instruction chars
[guard:agent-chat-context] packages/core/src/templates/workspace-core/AGENTS.md: 5489/6000 instruction chars
[guard:agent-chat-context] templates/analytics/AGENTS.md: 5954/6000 instruction chars
[guard:agent-chat-context] templates/assets/AGENTS.md: 5358/6000 instruction chars
[guard:agent-chat-context] templates/brain/AGENTS.md: 5936/6000 instruction chars
[guard:agent-chat-context] templates/calendar/AGENTS.md: 5810/6000 instruction chars
[guard:agent-chat-context] templates/chat/AGENTS.md: 5458/6000 instruction chars
[guard:agent-chat-context] templates/clips/AGENTS.md: 5932/6000 instruction chars
[guard:agent-chat-context] templates/content/AGENTS.md: 5728/6000 instruction chars
[guard:agent-chat-context] templates/crm/AGENTS.md: 5841/6000 instruction chars
[guard:agent-chat-context] templates/design/AGENTS.md: 5792/6000 instruction chars
[guard:agent-chat-context] templates/dispatch/AGENTS.md: 5008/6000 instruction chars
[guard:agent-chat-context] templates/factory/AGENTS.md: 5950/6000 instruction chars
[guard:agent-chat-context] templates/forms/AGENTS.md: 5650/6000 instruction chars
[guard:agent-chat-context] templates/macros/AGENTS.md: 1823/6000 instruction chars
[guard:agent-chat-context] templates/mail/AGENTS.md: 5481/6000 instruction chars
[guard:agent-chat-context] templates/plan/AGENTS.md: 5399/6000 instruction chars
[guard:agent-chat-context] templates/slides/AGENTS.md: 5995/6000 instruction chars
[guard:agent-chat-context] templates/tasks/AGENTS.md: 5426/6000 instruction chars
[guard:agent-chat-context] packages/dispatch/src/server/plugins/agent-chat.ts: 21 starter tools
[guard:agent-chat-context] templates/analytics/server/plugins/agent-chat.ts: 33 starter tools
[guard:agent-chat-context] templates/assets/server/plugins/agent-chat.ts: 16 starter tools
[guard:agent-chat-context] templates/brain/server/plugins/agent-chat.ts: 23 starter tools
[guard:agent-chat-context] templates/calendar/server/plugins/agent-chat.ts: 20 starter tools
[guard:agent-chat-context] templates/chat/server/plugins/agent-chat.ts: 3 starter tools
[guard:agent-chat-context] templates/clips/server/plugins/agent-chat.ts: 21 starter tools
[guard:agent-chat-context] templates/content/server/plugins/agent-chat.ts: 16 starter tools
[guard:agent-chat-context] templates/crm/server/plugins/agent-chat.ts: 36 starter tools
[guard:agent-chat-context] templates/design/server/plugins/agent-chat.ts: 34 starter tools
[guard:agent-chat-context] templates/factory/server/plugins/agent-chat.ts: 20 starter tools
[guard:agent-chat-context] templates/forms/server/plugins/agent-chat.ts: 13 starter tools
[guard:agent-chat-context] templates/macros/server/plugins/agent-chat.ts: 9 starter tools
[guard:agent-chat-context] templates/mail/server/plugins/agent-chat.ts: 19 starter tools
[guard:agent-chat-context] templates/plan/server/plugins/agent-chat.ts: 12 starter tools
[guard:agent-chat-context] templates/slides/server/plugins/agent-chat.ts: 19 starter tools
[guard:agent-chat-context] templates/tasks/server/plugins/agent-chat.ts: 17 starter tools
[guard:agent-chat-context] clean (17 first-party agent chat plugins)

[guard:ssr-cache-shell] output

> agentnative@1.0.0 guard:ssr-cache-shell /Users/steve/Projects/builder/agent-native/framework
> node scripts/guard-ssr-cache-shell.mjs

guard-ssr-cache-shell: clean (SSR HTML/.data stays a public, anonymous, hard-CDN-cached shell).

[guard:route-chunk-recovery] output

> agentnative@1.0.0 guard:route-chunk-recovery /Users/steve/Projects/builder/agent-native/framework
> node scripts/guard-route-chunk-recovery.mjs

[guard:route-chunk-recovery] OK — 17 template client entr(ies) install stale-chunk recovery.

[guard:one-sign-in] output

> agentnative@1.0.0 guard:one-sign-in /Users/steve/Projects/builder/agent-native/framework
> node scripts/guard-one-sign-in.mjs

[guard-one-sign-in] OK - scanned 4546 template source files.

[guard:i18n-catalogs] output

> agentnative@1.0.0 guard:i18n-catalogs /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/guard-i18n-catalogs.ts

[guard:i18n-catalogs] 19 issue(s):
- templates/factory/app/routes/factory.tsx:680: i18n key "factoryRoute.automationHealthHealthy" is missing from templates/factory/app/i18n/en-US.ts; add the English fallback string or // i18n-key-ignore for a deliberate dynamic/stable key
- templates/factory/app/routes/factory.tsx:681: i18n key "factoryRoute.automationHealthStale" is missing from templates/factory/app/i18n/en-US.ts; add the English fallback string or // i18n-key-ignore for a deliberate dynamic/stable key
- templates/factory/app/routes/factory.tsx:682: i18n key "factoryRoute.automationHealthError" is missing from templates/factory/app/i18n/en-US.ts; add the English fallback string or // i18n-key-ignore for a deliberate dynamic/stable key
- templates/factory/app/routes/factory.tsx:683: i18n key "factoryRoute.automationHealthNoData" is missing from templates/factory/app/i18n/en-US.ts; add the English fallback string or // i18n-key-ignore for a deliberate dynamic/stable key
- templates/factory/app/routes/factory.tsx:685: i18n key "factoryRoute.automationHealthNoData" is missing from templates/factory/app/i18n/en-US.ts; add the English fallback string or // i18n-key-ignore for a deliberate dynamic/stable key
- templates/factory/app/routes/factory.tsx:692: i18n key "factoryRoute.automationHealthTitle" is missing from templates/factory/app/i18n/en-US.ts; add the English fallback string or // i18n-key-ignore for a deliberate dynamic/stable key
- templates/factory/app/routes/factory.tsx:695: i18n key "factoryRoute.automationHealthDescription" is missing from templates/factory/app/i18n/en-US.ts; add the English fallback string or // i18n-key-ignore for a deliberate dynamic/stable key
- templates/factory/app/routes/factory.tsx:705: i18n key "factoryRoute.automationLastCheck" is missing from templates/factory/app/i18n/en-US.ts; add the English fallback string or // i18n-key-ignore for a deliberate dynamic/stable key
- templates/factory/app/routes/factory.tsx:711: i18n key "factoryRoute.automationRuntime" is missing from templates/factory/app/i18n/en-US.ts; add the English fallback string or // i18n-key-ignore for a deliberate dynamic/stable key
- templates/factory/app/routes/factory.tsx:717: i18n key "factoryRoute.automationHealthNoDataHint" is missing from templates/factory/app/i18n/en-US.ts; add the English fallback string or // i18n-key-ignore for a deliberate dynamic/stable key
- templates/factory/app/routes/factory.tsx:722: i18n key "factoryRoute.automationHealthStaleHint" is missing from templates/factory/app/i18n/en-US.ts; add the English fallback string or // i18n-key-ignore for a deliberate dynamic/stable key
- templates/factory/app/routes/factory.tsx:727: i18n key "factoryRoute.automationHealthErrorDetail" is missing from templates/factory/app/i18n/en-US.ts; add the English fallback string or // i18n-key-ignore for a deliberate dynamic/stable key
- templates/factory/app/routes/factory.tsx:952: i18n key "factoryRoute.automationOpenThread" is missing from templates/factory/app/i18n/en-US.ts; add the English fallback string or // i18n-key-ignore for a deliberate dynamic/stable key
- templates/factory/app/routes/factory.tsx:1507: i18n key "factoryRoute.automationFailureAlertsTitle" is missing from templates/factory/app/i18n/en-US.ts; add the English fallback string or // i18n-key-ignore for a deliberate dynamic/stable key
- templates/factory/app/routes/factory.tsx:1510: i18n key "factoryRoute.automationFailureAlertsDescription" is missing from templates/factory/app/i18n/en-US.ts; add the English fallback string or // i18n-key-ignore for a deliberate dynamic/stable key
- templates/factory/app/routes/factory.tsx:1520: i18n key "factoryRoute.automationFailureAlertsEnabled" is missing from templates/factory/app/i18n/en-US.ts; add the English fallback string or // i18n-key-ignore for a deliberate dynamic/stable key
- templates/factory/app/routes/factory.tsx:1524: i18n key "factoryRoute.automationFailureAlertEmail" is missing from templates/factory/app/i18n/en-US.ts; add the English fallback string or // i18n-key-ignore for a deliberate dynamic/stable key
- templates/factory/app/routes/factory.tsx:1533: i18n key "factoryRoute.automationFailureAlertEmailPlaceholder" is missing from templates/factory/app/i18n/en-US.ts; add the English fallback string or // i18n-key-ignore for a deliberate dynamic/stable key
- templates/factory/app/routes/factory.tsx:1539: i18n key "factoryRoute.automationFailureEmailReadiness" is missing from templates/factory/app/i18n/en-US.ts; add the English fallback string or // i18n-key-ignore for a deliberate dynamic/stable key

Fix:
  - "missing key" / "missing plural key/category" means that locale
    catalog (<dir>/<locale>.ts) doesn't have a key that the en-US
    source catalog (<dir>/en-US.ts) defines. Add the key to that
    locale file with a translated value in the same shape.
  - "stale key" means a locale catalog has a key en-US no longer
    defines; remove it from that locale file.
  - English-value / raw-literal / doc-coverage debt that's real and
    already reviewed can be recorded in the tracked baseline via
    UPDATE_I18N_CATALOG_VALUE_BASELINE=1, UPDATE_I18N_RAW_LITERAL_BASELINE=1,
    UPDATE_I18N_DOC_COVERAGE_BASELINE=1, or UPDATE_I18N_DOCS_BASELINE=1
    -- only after confirming the debt is expected, not a fresh miss.
 ELIFECYCLE  Command failed with exit code 1.

[guard:additive-migrations] output

> agentnative@1.0.0 guard:additive-migrations /Users/steve/Projects/builder/agent-native/framework
> node scripts/guard-additive-migrations.mjs

guard-additive-migrations: OK (26 migration source file(s) scanned)

[guard:no-raw-colors] output

> agentnative@1.0.0 guard:no-raw-colors /Users/steve/Projects/builder/agent-native/framework
> node scripts/guard-no-raw-colors.mjs

guard-no-raw-colors: OK

[guard:no-silent-coercion] output

> agentnative@1.0.0 guard:no-silent-coercion /Users/steve/Projects/builder/agent-native/framework
> node scripts/guard-no-silent-coercion.mjs


guard-no-silent-coercion: 1 violation(s) found on lines this branch added.

A catch, default, or coercion that returns a value callers cannot
distinguish from success is a bug, not a guard. Throw, log-and-rethrow,
or return a typed 'absent' value the caller can tell apart from an
empty/successful one.

  packages/core/src/deploy/build.ts:2735  const body = await response.text().catch(() => "");
    (.catch() discards the rejection into a default value)

To opt out for a specific line add the comment:
  // coercion-ok: <reason>
on the same line or the line immediately above it.

 ELIFECYCLE  Command failed with exit code 1.

[guard:no-secret-literals] output

> agentnative@1.0.0 guard:no-secret-literals /Users/steve/Projects/builder/agent-native/framework
> node scripts/guard-no-secret-literals.mjs

guard-no-secret-literals: OK

[guard:request-storms] output

> agentnative@1.0.0 guard:request-storms /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/guard-request-storms.ts

[guard:request-storms] clean (7519 maintained TypeScript files)

[guard:migration-manifest] output

> agentnative@1.0.0 guard:migration-manifest /Users/steve/Projects/builder/agent-native/framework
> tsx scripts/guard-migration-manifest.ts

[guard:migration-manifest] clean

[guard:dead-settings-keys] output

> agentnative@1.0.0 guard:dead-settings-keys /Users/steve/Projects/builder/agent-native/framework
> node scripts/guard-dead-settings-keys.mjs

guard-dead-settings-keys: OK

[guard:no-unscoped-queries] output

> agentnative@1.0.0 guard:no-unscoped-queries /Users/steve/Projects/builder/agent-native/framework
> node scripts/guard-no-unscoped-queries.mjs

guard-no-unscoped-queries: clean (343 schema dirs scanned).
 ELIFECYCLE  Command failed with exit code 1. passes all 44 checks\n\nProduction deployment is intentionally pending merge; the current live Analytics deploy is the prior merge commit and was verified separately.