### PR TITLE
docs: add docs commit message convention to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,8 @@ read the relevant skill before changing that area.
   meaning changes. If translations cannot be updated in the same change, call
   out the specific locales that need follow-up; reviewers should flag docs
   changes that only update one language.
+- Docs-only commits start with `docs: ` in the present tense, e.g.
+  `docs: fix broken link in provider API guide`, not `docs: fixed broken link`.
 
 ## Final Status Block
 


### PR DESCRIPTION
Adds a rule to AGENTS.md: docs-only commits start with `docs: ` and are written in the present tense.

Example: `docs: fix broken link in provider API guide`, not `docs: fixed broken link`.