### PR TITLE
fix: preserve editable imported slide exports

### DIFF
--- a/templates/slides/actions/export-pptx.spec.ts
+++ b/templates/slides/actions/export-pptx.spec.ts
@@ -151,4 +151,21 @@ describe("parseSlideHtml", () => {
       }),
     ]);
   });
+
+  it("ignores imported grids with non-positive spacing", () => {
+    for (const backgroundSize of [
+      "0px 24px",
+      "-1px 24px",
+      "24px 0px",
+      "24px -1px",
+    ]) {
+      const result = parseSlideHtml(
+        `<div class="fmd-slide fmd-imported-pptx" data-imported-pptx="true" style="background-image:linear-gradient(#ffffff 0 1px, transparent 1px);background-size:${backgroundSize};background-position:0px 0px;"><div data-pptx-element-kind="text" style="left:0px;top:0px;width:100px;height:40px;">Title</div></div>`,
+        "16:9",
+        1,
+      );
+
+      expect(result.grid).toBeUndefined();
+    }
+  });
 });

--- a/templates/slides/actions/export-pptx.ts
+++ b/templates/slides/actions/export-pptx.ts
@@ -481,6 +481,8 @@ function parseImportedGrid(style: string): GridElement | undefined {
     size.length < 2 ||
     !Number.isFinite(size[0]) ||
     !Number.isFinite(size[1]) ||
+    size[0] <= 0 ||
+    size[1] <= 0 ||
     !position ||
     position.length < 2 ||
     !Number.isFinite(position[0]) ||

--- a/templates/slides/actions/import-google-slides-reference.ts
+++ b/templates/slides/actions/import-google-slides-reference.ts
@@ -2,8 +2,13 @@ import { defineAction } from "@agent-native/core";
 import { ssrfSafeFetch } from "@agent-native/core/extensions/url-safety";
 import { buildDeepLink } from "@agent-native/core/server";
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
+import pLimit from "p-limit";
 import { z } from "zod";
 
+import {
+  parsePptx,
+  type ParsedPresentation,
+} from "../server/handlers/import/pptx-parser.js";
 import { getGoogleDocsAccessToken } from "../server/lib/google-docs-oauth.js";
 import {
   importPptxBufferToDeck,
@@ -103,6 +108,18 @@ interface GoogleSlidesPresentationImages {
   }>;
 }
 
+interface GoogleSlidesImageCandidate {
+  slideIndex: number;
+  imageIndex: number;
+  objectId?: string;
+  contentUrl: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  crop?: ImportedImageFallback["crop"];
+}
+
 function finiteNumber(value: number | undefined): number | undefined {
   return value != null && Number.isFinite(value) ? value : undefined;
 }
@@ -115,6 +132,7 @@ function finiteNumber(value: number | undefined): number | undefined {
 async function fetchGoogleSlidesImageFallbacks(
   fileId: string,
   accessToken: string,
+  presentation: ParsedPresentation,
 ): Promise<ImportedImageFallback[]> {
   const fields =
     "slides(pageElements(objectId,size,transform,image(contentUrl,imageProperties(cropProperties))))";
@@ -128,11 +146,14 @@ async function fetchGoogleSlidesImageFallbacks(
       `Google Slides returned HTTP ${response.status} while reading native image elements. Reconnect Google Drive and try the import again.`,
     );
   }
-  const presentation =
+  const googlePresentation =
     (await response.json()) as GoogleSlidesPresentationImages;
-  const fallbacks: ImportedImageFallback[] = [];
+  const candidates: GoogleSlidesImageCandidate[] = [];
+  const candidateKeys = new Set<string>();
 
-  for (const [slideIndex, slide] of (presentation.slides ?? []).entries()) {
+  for (const [slideIndex, slide] of (
+    googlePresentation.slides ?? []
+  ).entries()) {
     for (const [imageIndex, element] of (slide.pageElements ?? []).entries()) {
       const contentUrl = element.image?.contentUrl;
       const baseWidth = finiteNumber(element.size?.width?.magnitude);
@@ -157,25 +178,16 @@ async function fetchGoogleSlidesImageFallbacks(
         continue;
       }
 
-      const imageResponse = await ssrfSafeFetch(
-        contentUrl,
-        { headers: { Authorization: `Bearer ${accessToken}` } },
-        { httpsOnly: true, maxRedirects: 2 },
+      const existingImage = presentation.slides[slideIndex]?.elements.some(
+        (existing) =>
+          existing.kind === "image" &&
+          Math.abs(existing.x - x) < 1000 &&
+          Math.abs(existing.y - y) < 1000 &&
+          Math.abs(existing.width - width) < 1000 &&
+          Math.abs(existing.height - height) < 1000,
       );
-      if (!imageResponse.ok) {
-        throw new Error(
-          `Google Slides returned HTTP ${imageResponse.status} while downloading image ${imageIndex + 1} on slide ${slideIndex + 1}.`,
-        );
-      }
-      const mimeType =
-        imageResponse.headers.get("content-type")?.split(";", 1)[0] ||
-        "image/png";
-      if (!mimeType.startsWith("image/")) {
-        throw new Error(
-          `Google Slides returned a non-image asset for image ${imageIndex + 1} on slide ${slideIndex + 1}.`,
-        );
-      }
-      const data = new Uint8Array(await imageResponse.arrayBuffer());
+      if (existingImage) continue;
+
       const cropProperties = element.image?.imageProperties?.cropProperties;
       const crop = cropProperties
         ? {
@@ -185,21 +197,76 @@ async function fetchGoogleSlidesImageFallbacks(
             bottom: cropProperties.bottomOffset ?? 0,
           }
         : undefined;
-      fallbacks.push({
+      const candidateKey = `${slideIndex}:${x}:${y}:${width}:${height}`;
+      if (candidateKeys.has(candidateKey)) continue;
+      candidateKeys.add(candidateKey);
+      candidates.push({
         slideIndex,
+        imageIndex,
+        ...(element.objectId ? { objectId: element.objectId } : {}),
+        contentUrl,
         x,
         y,
         width,
         height,
-        data,
-        mimeType,
-        name: `google-slides-${slideIndex + 1}-${element.objectId ?? imageIndex}.png`,
         ...(crop ? { crop } : {}),
       });
     }
   }
 
-  return fallbacks;
+  const downloadLimit = pLimit(4);
+  const imageDownloads = new Map<
+    string,
+    Promise<{ data: Uint8Array; mimeType: string }>
+  >();
+  const downloadImage = (candidate: GoogleSlidesImageCandidate) => {
+    const existing = imageDownloads.get(candidate.contentUrl);
+    if (existing) return existing;
+
+    const download = downloadLimit(async () => {
+      const imageResponse = await ssrfSafeFetch(
+        candidate.contentUrl,
+        { headers: { Authorization: `Bearer ${accessToken}` } },
+        { httpsOnly: true, maxRedirects: 2 },
+      );
+      if (!imageResponse.ok) {
+        throw new Error(
+          `Google Slides returned HTTP ${imageResponse.status} while downloading image ${candidate.imageIndex + 1} on slide ${candidate.slideIndex + 1}.`,
+        );
+      }
+      const mimeType =
+        imageResponse.headers.get("content-type")?.split(";", 1)[0] ||
+        "image/png";
+      if (!mimeType.startsWith("image/")) {
+        throw new Error(
+          `Google Slides returned a non-image asset for image ${candidate.imageIndex + 1} on slide ${candidate.slideIndex + 1}.`,
+        );
+      }
+      return {
+        data: new Uint8Array(await imageResponse.arrayBuffer()),
+        mimeType,
+      };
+    });
+    imageDownloads.set(candidate.contentUrl, download);
+    return download;
+  };
+
+  return Promise.all(
+    candidates.map(async (candidate) => {
+      const { data, mimeType } = await downloadImage(candidate);
+      return {
+        slideIndex: candidate.slideIndex,
+        x: candidate.x,
+        y: candidate.y,
+        width: candidate.width,
+        height: candidate.height,
+        data,
+        mimeType,
+        name: `google-slides-${candidate.slideIndex + 1}-${candidate.objectId ?? candidate.imageIndex}.png`,
+        ...(candidate.crop ? { crop: candidate.crop } : {}),
+      };
+    }),
+  );
 }
 
 export default defineAction({
@@ -246,12 +313,15 @@ export default defineAction({
       presentationId,
       connection.accessToken,
     );
+    const parsedPresentation = await parsePptx(fileBuffer);
     const imageFallbacks = await fetchGoogleSlidesImageFallbacks(
       presentationId,
       connection.accessToken,
+      parsedPresentation,
     );
     return importPptxBufferToDeck({
       fileBuffer,
+      parsedPresentation,
       title,
       source: "import-google-slides-reference",
       imageFallbacks,

--- a/templates/slides/actions/import-pptx.ts
+++ b/templates/slides/actions/import-pptx.ts
@@ -17,6 +17,7 @@ import {
   parsePptx,
   type ParsedElement,
   type ParsedImage,
+  type ParsedPresentation,
 } from "../server/handlers/import/pptx-parser.js";
 import { getDeckUrl } from "./_app-url.js";
 import { readUserUploadedFile } from "./_uploaded-files.js";
@@ -83,6 +84,7 @@ export async function importPptxBufferToDeck(args: {
   deckId?: string;
   source?: string;
   imageFallbacks?: ImportedImageFallback[];
+  parsedPresentation?: ParsedPresentation;
 }): Promise<{
   id: string;
   title: string;
@@ -98,8 +100,9 @@ export async function importPptxBufferToDeck(args: {
     deckId,
     source = "import-pptx",
     imageFallbacks,
+    parsedPresentation,
   } = args;
-  const presentation = await parsePptx(fileBuffer);
+  const presentation = parsedPresentation ?? (await parsePptx(fileBuffer));
   applyImageFallbacks(presentation, imageFallbacks);
   const deckTitle = title || presentation.title || "Imported Presentation";
   const ownerEmail = getRequestUserEmail();

--- a/templates/slides/app/lib/export-pptx-client.test.ts
+++ b/templates/slides/app/lib/export-pptx-client.test.ts
@@ -4,15 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   exportToPptx: vi.fn(),
-  rasterize: vi.fn(),
 }));
 
 vi.mock("dom-to-pptx", () => ({
   exportToPptx: mocks.exportToPptx,
-}));
-
-vi.mock("modern-screenshot", () => ({
-  domToPng: mocks.rasterize,
 }));
 
 import {
@@ -83,7 +78,6 @@ beforeEach(async () => {
     value: cssShim,
   });
   mocks.exportToPptx.mockResolvedValue(await buildMinimalPptxBlob());
-  mocks.rasterize.mockResolvedValue("data:image/png;base64,AAAA");
   vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:pptx");
   vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
   vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
@@ -147,18 +141,19 @@ describe("exportDeckAsPptx", () => {
     expect(image?.style.height).toBe("80px");
   });
 
-  it("rasterizes imported slides to preserve the rendered canvas during export", async () => {
+  it("keeps imported slide objects editable during export", async () => {
     setRenderedSlide(
-      '<div class="fmd-imported-pptx"><div data-pptx-element-kind="text">Editable imported title</div></div>',
+      '<div class="fmd-imported-pptx" data-imported-pptx="true"><div data-pptx-element-kind="text">Editable imported title</div></div>',
     );
 
     await exportDeckAsPptx("Imported Deck", [{ id: "slide-1" }], "16:9");
 
     const [targets] = mocks.exportToPptx.mock.calls[0];
     const [target] = targets as HTMLElement[];
-    expect(target.querySelector('[data-pptx-element-kind="text"]')).toBeNull();
-    expect(target.querySelector("img")?.src).toMatch(/^data:image\/png/);
-    expect(mocks.rasterize).toHaveBeenCalledTimes(1);
+    expect(
+      target.querySelector('[data-pptx-element-kind="text"]'),
+    ).not.toBeNull();
+    expect(target.textContent).toContain("Editable imported title");
   });
 
   it("passes custom aspect-ratio dimensions to the native exporter", async () => {

--- a/templates/slides/app/lib/export-pptx-client.ts
+++ b/templates/slides/app/lib/export-pptx-client.ts
@@ -350,6 +350,8 @@ function materializeImportedBackgroundGrid(root: HTMLElement) {
     size.length < 2 ||
     !Number.isFinite(size[0]) ||
     !Number.isFinite(size[1]) ||
+    size[0] <= 0 ||
+    size[1] <= 0 ||
     !position ||
     position.length < 2 ||
     !Number.isFinite(position[0]) ||
@@ -399,47 +401,6 @@ function materializeImportedBackgroundGrid(root: HTMLElement) {
   slideRoot.style.backgroundRepeat = "no-repeat";
 }
 
-async function rasterizeImportedSlide(
-  root: HTMLElement,
-  dims: { width: number; height: number },
-): Promise<boolean> {
-  const imported = root.querySelector<HTMLElement>(".fmd-imported-pptx");
-  if (!imported) return false;
-  const backgroundColor = window.getComputedStyle(imported).backgroundColor;
-
-  const { domToPng } = await importExportModule(
-    () => import("modern-screenshot"),
-  );
-  await preloadImagesWithCors(imported);
-  const dataUrl = await domToPng(imported, {
-    backgroundColor,
-    fetch: {
-      requestInit: { cache: "no-cache", credentials: "include", mode: "cors" },
-    },
-    height: dims.height,
-    scale: 2,
-    width: dims.width,
-  });
-
-  const image = document.createElement("img");
-  image.alt = "";
-  image.src = dataUrl;
-  Object.assign(image.style, {
-    display: "block",
-    height: `${dims.height}px`,
-    left: "0",
-    position: "absolute",
-    top: "0",
-    width: `${dims.width}px`,
-  });
-  root.replaceChildren(image);
-  root.style.background = backgroundColor;
-  root.style.position = "relative";
-  root.style.overflow = "hidden";
-  await image.decode();
-  return true;
-}
-
 export async function buildDeckPptxBlob(
   deckTitle: string,
   slides: PptxExportSlide[],
@@ -468,16 +429,10 @@ export async function buildDeckPptxBlob(
         height: dims.height,
       });
       exportClones.push(clone);
-      const isRasterized = await rasterizeImportedSlide(clone.element, {
-        width: dims.width,
-        height: dims.height,
-      });
-      if (!isRasterized) {
-        materializeImportedBackgroundGrid(clone.element);
-        widenNoWrapTextElements(clone.element);
-        await replaceInlineSvgsWithImages(clone.element);
-        await preloadImagesWithCors(clone.element);
-      }
+      materializeImportedBackgroundGrid(clone.element);
+      widenNoWrapTextElements(clone.element);
+      await replaceInlineSvgsWithImages(clone.element);
+      await preloadImagesWithCors(clone.element);
     }
 
     const initialBlob = await exportToPptx(

--- a/templates/slides/changelog/2026-08-06-imported-powerpoint-exports-keep-text-and-images-editable-an.md
+++ b/templates/slides/changelog/2026-08-06-imported-powerpoint-exports-keep-text-and-images-editable-an.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-06
+---
+
+Imported PowerPoint exports keep text and images editable and ignore malformed grid metadata.


### PR DESCRIPTION
## Summary
- keep imported PPTX text, images, and shapes editable in browser exports
- ignore zero or negative imported grid spacing before export loops
- skip duplicate Google Slides fallback images and download unique assets with bounded concurrency
- record the user-facing Slides export fix in the app changelog

## Validation
- `pnpm prep`
- `pnpm --filter slides test actions/export-pptx.spec.ts app/lib/export-pptx-client.test.ts actions/import-google-slides-reference.test.ts`
- `pnpm --filter slides typecheck`
