### PR TITLE
fix: refresh dev action registry

### DIFF
--- a/.changeset/action-registry-dev-refresh.md
+++ b/.changeset/action-registry-dev-refresh.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Refresh the dev server action registry when action files are added or removed so chat and action routes use the regenerated registry immediately.

--- a/packages/core/src/vite/action-types-plugin.spec.ts
+++ b/packages/core/src/vite/action-types-plugin.spec.ts
@@ -1,10 +1,14 @@
+import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { generateActionRegistryForProject } from "./action-types-plugin.js";
+import {
+  actionTypesPlugin,
+  generateActionRegistryForProject,
+} from "./action-types-plugin.js";
 
 describe("generateActionRegistryForProject", () => {
   it("does not import test files from actions/ into the runtime registry", () => {
@@ -53,6 +57,74 @@ describe("generateActionRegistryForProject", () => {
       expect(types).toContain('"set-localization-preference"');
       expect(types).toContain('"list-resource-history"');
       expect(types).toContain('"list-review-comments"');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refreshes the server registry when an action file changes it", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "an-action-watch-"));
+    const watcher = new EventEmitter() as EventEmitter & {
+      add: (path: string) => void;
+    };
+    watcher.add = vi.fn();
+    const restart = vi.fn().mockResolvedValue(undefined);
+    const logger = {
+      error: vi.fn(),
+      info: vi.fn(),
+    };
+
+    try {
+      const actionsDir = path.join(root, "actions");
+      fs.mkdirSync(actionsDir);
+      fs.writeFileSync(path.join(root, ".gitignore"), "");
+
+      const plugin = actionTypesPlugin();
+      plugin.configResolved?.({ root } as any);
+      const registryModule = {};
+      const invalidateModule = vi.fn();
+      const send = vi.fn();
+      await plugin.configureServer?.({
+        config: { logger },
+        httpServer: new EventEmitter(),
+        environments: {
+          nitro: {
+            config: { consumer: "server" },
+            hot: { send },
+            moduleGraph: {
+              getModuleById: (id: string) =>
+                id === path.join(root, ".generated", "actions-registry.ts")
+                  ? registryModule
+                  : undefined,
+              invalidateModule,
+            },
+          },
+        },
+        restart,
+        watcher,
+      } as any);
+
+      const actionPath = path.join(actionsDir, "create-note.ts");
+      fs.writeFileSync(
+        actionPath,
+        `import { defineAction } from "@agent-native/core";\nexport default defineAction({ tool: { description: "Create a note", parameters: { type: "object", properties: {} } }, run: async () => ({ ok: true }) });\n`,
+      );
+      watcher.emit("add", actionPath);
+
+      await vi.waitFor(() => expect(send).toHaveBeenCalledOnce());
+      expect(restart).not.toHaveBeenCalled();
+      expect(invalidateModule).toHaveBeenCalledWith(registryModule);
+      expect(send).toHaveBeenCalledWith({ type: "full-reload" });
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining("refreshing the server action registry"),
+        { timestamp: true },
+      );
+      expect(
+        fs.readFileSync(
+          path.join(root, ".generated", "actions-registry.ts"),
+          "utf-8",
+        ),
+      ).toContain('"create-note"');
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }

--- a/packages/core/src/vite/action-types-plugin.ts
+++ b/packages/core/src/vite/action-types-plugin.ts
@@ -17,7 +17,15 @@ import fs from "fs";
  */
 import path from "path";
 
-import type { Plugin } from "vite";
+import type { Plugin, ViteDevServer } from "vite";
+
+/**
+ * Action-file creation/removal changes the generated registry module itself.
+ * Coalesce editor unlink+add pairs into one registry refresh so the Nitro
+ * plugin re-imports the registry and the chat tool set sees the same actions
+ * as the HTTP/frontend surfaces.
+ */
+const ACTION_REGISTRY_REFRESH_DELAY_MS = 300;
 
 /** Files to skip during discovery (matches action-discovery.ts). */
 const SKIP_FILES = new Set([
@@ -217,6 +225,36 @@ function writeIfChanged(outFile: string, content: string): void {
     fs.mkdirSync(path.dirname(outFile), { recursive: true });
     fs.writeFileSync(outFile, content);
   }
+}
+
+/**
+ * Refresh the server environment that owns the generated registry without
+ * reloading the browser. Nitro keeps a separate module runner from Vite's
+ * client graph, so invalidating only the legacy graph leaves the chat plugin
+ * holding the previous action snapshot.
+ */
+function refreshActionRegistryInDevServer(
+  server: ViteDevServer,
+  projectRoot: string,
+): boolean {
+  const registryPath = path.resolve(
+    projectRoot,
+    ".generated",
+    "actions-registry.ts",
+  );
+
+  for (const environment of Object.values(server.environments)) {
+    const module = environment.moduleGraph.getModuleById(registryPath);
+    if (!module) continue;
+
+    environment.moduleGraph.invalidateModule(module);
+    if (environment.config.consumer !== "client") {
+      environment.hot.send({ type: "full-reload" });
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function findWorkspaceCoreActionsDir(projectRoot: string): string | null {
@@ -459,6 +497,47 @@ export function actionTypesPlugin(): Plugin {
 
       // Watch for changes in actions/
       const watcher = server.watcher;
+      let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+      let closed = false;
+      const scheduleActionRegistryRefresh = () => {
+        if (refreshTimer) clearTimeout(refreshTimer);
+        refreshTimer = setTimeout(() => {
+          refreshTimer = null;
+          if (closed) return;
+
+          server.config.logger.info(
+            "[agent-native] Action files changed; refreshing the server action registry so chat and action routes use the updated registry.",
+            { timestamp: true },
+          );
+          try {
+            if (refreshActionRegistryInDevServer(server, projectRoot)) return;
+          } catch (error: unknown) {
+            server.config.logger.warn(
+              `[agent-native] Targeted action registry refresh failed: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+              { timestamp: true },
+            );
+          }
+
+          // Vite 7+ exposes separate server environments. Older compatible
+          // hosts may not expose the Nitro graph, so retain a safe fallback.
+          void server.restart().catch((error: unknown) => {
+            server.config.logger.error(
+              `[agent-native] Failed to restart after an action registry change: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+              { timestamp: true },
+            );
+          });
+        }, ACTION_REGISTRY_REFRESH_DELAY_MS);
+        refreshTimer.unref?.();
+      };
+      server.httpServer?.once("close", () => {
+        closed = true;
+        if (refreshTimer) clearTimeout(refreshTimer);
+        refreshTimer = null;
+      });
       const handleChange = (file: string) => {
         const inAppActions = file.startsWith(actionsDir);
         const inWorkspaceActions = workspaceActionsDir
@@ -466,6 +545,7 @@ export function actionTypesPlugin(): Plugin {
           : false;
         if ((inAppActions || inWorkspaceActions) && /\.(ts|js)$/.test(file)) {
           generateActionArtifacts(actionsDir, projectRoot);
+          scheduleActionRegistryRefresh();
         }
       };
       watcher.add(actionsDir);


### PR DESCRIPTION
## Summary
- refresh the generated server action registry when action files change during development
- target the Nitro server module graph before falling back to a full dev-server restart
- add focused coverage and a core changeset

## Validation
- `pnpm prep`
- `pnpm --filter @agent-native/core exec vitest run src/vite/action-types-plugin.spec.ts`
- `pnpm --filter @agent-native/core typecheck`