### PR TITLE
docs: add Notice, Banner, Accordion, and Badge components

### DIFF
--- a/.changeset/add-notice-banner-accordion-badge.md
+++ b/.changeset/add-notice-banner-accordion-badge.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add four new docs MDX components — `Notice`, `Banner`, `Accordion`, `Badge` — for content that doesn't belong in a `Cards` grid: a bold alert card, a page/section-top announcement strip, collapsed-by-default FAQ items, and a small status chip. Also fixes the `Steps`/`Cards`/`Comparison`/`Accordion` markdown parser to be fence-aware (a `###` inside a code sample no longer splits into a new item) and to round-trip items with a genuinely empty body, and teaches the docs' crawlable markdown mirror to render all seven docs-only block types as readable text instead of a raw JSON fence.

--- a/packages/core/docs/content/docs-components.mdx
+++ b/packages/core/docs/content/docs-components.mdx
@@ -191,6 +191,107 @@ Each card is a `###` heading (optionally linked) followed by the description. Ca
 
 ---
 
+## Notice
+
+<Notice tone="risk" title="Bold, not subtle">
+
+Use `Notice` when a `Callout` would be too easy to skim past — something the reader must not miss, like a destructive action or a hard requirement. It shares the same five tones as `Callout` (`info`, `decision`, `risk`, `warning`, `success`) but renders as a filled card with an icon and optional title instead of a left-border note.
+
+</Notice>
+
+```mdx
+<Notice tone="risk" title="Bold, not subtle">
+
+Use `Notice` when a `Callout` would be too easy to skim past — something the reader must not miss, like a destructive action or a hard requirement.
+
+</Notice>
+```
+
+`title` is optional — omit it for a shorter card with just the icon and body. Leave a blank line between the opening tag and the body, same as `Callout`. Reach for `Callout` first; use `Notice` only when a subtle left-border note isn't enough attention.
+
+---
+
+## Banner
+
+<Banner tone="warning" body="This page describes the v9 API. See [Migrating to v10](/docs/migrating-v10) for what changed." />
+
+```mdx
+<Banner tone="warning" body="This page describes the v9 API. See [Migrating to v10](/docs/migrating-v10) for what changed." />
+```
+
+`Banner` is self-closing — `body` is a flat attribute (kept short and single-purpose on purpose), not markdown children. Place it right under a page's title or a section heading — deprecated, beta, moved, version-scoped. For content the reader needs to actually read (not just notice), use `Notice` or `Callout` instead.
+
+---
+
+## Accordion
+
+<Accordion>
+
+### Do I need Toolkit to use Core?
+
+No. Toolkit is optional shared UI — Core works standalone.
+
+### Can I mix Templates and Toolkit?
+
+Yes, most first-party templates already do.
+
+### Where do I ask questions?
+
+The `#agent-native` Discord channel, linked in the site header.
+
+</Accordion>
+
+```mdx
+<Accordion>
+
+### Do I need Toolkit to use Core?
+
+No. Toolkit is optional shared UI — Core works standalone.
+
+### Can I mix Templates and Toolkit?
+
+Yes, most first-party templates already do.
+
+</Accordion>
+```
+
+Same authoring shape as `Steps`/`Cards` — a `### Question` heading per item followed by its answer — but each item renders collapsed behind native `<details>`. Best for FAQ-style content where most readers only need one or two entries, not a full top-to-bottom read.
+
+---
+
+## Badge
+
+<Badge label="Beta" color="orange" icon="rocket" />
+
+<Badge label="Deprecated" color="red" />
+
+<Badge label="v9.1+" color="blue" shape="pill" />
+
+<Badge label="Server-only" color="gray" stroke />
+
+```mdx
+<Badge label="Beta" color="orange" icon="rocket" />
+
+<Badge label="Deprecated" color="red" />
+
+<Badge label="v9.1+" color="blue" shape="pill" />
+
+<Badge label="Server-only" color="gray" stroke />
+```
+
+A small status chip for the top of a page or section. Self-closing, block-level only — **not** embeddable mid-sentence (the docs MDX pipeline only recognizes a custom component when its tag opens its own line, so `text <Badge label="x"/> more text` renders as literal text, not a chip). Place it on its own line, typically right after a heading. Leave a blank line between adjacent Badges (or any two block components) — without one, the scanner can't tell where one ends and the next begins and falls back to rendering literal text.
+
+| Prop | Values |
+| --- | --- |
+| `color` | `gray` · `blue` · `green` · `yellow` · `orange` · `red` · `purple` · `white` · `surface` · `white-destructive` · `surface-destructive` |
+| `size` | `xs` · `sm` · `md` · `lg` |
+| `shape` | `rounded` (default) · `pill` |
+| `icon` | one of a curated set — `circle-check`, `circle-info`, `alert-triangle`, `alert-octagon`, `ban`, `clock`, `star`, `flame`, `sparkles`, `lock`, `rocket` |
+| `stroke` | `true` for an outlined, transparent-background variant |
+| `disabled` | `true` to dim it for an inactive/unavailable state |
+
+---
+
 ## Comparison
 
 <Comparison>
@@ -478,10 +579,14 @@ Like `TabsBlock`, `Columns` is self-closing with a single JSON `columns` attribu
 
 ## When to use which component
 
-| Situation                                 | Component                            |
-| ----------------------------------------- | ------------------------------------ |
-| Reader must not miss something            | `Callout` (warning / info / success) |
+| Situation                                    | Component                            |
+| --------------------------------------------- | ------------------------------------ |
+| Reader must not miss something, inline in prose | `Callout` (warning / info / success) |
+| Reader must not miss something, standalone      | `Notice`                              |
+| Deprecated/beta/version notice at page or section top | `Banner`                       |
+| Status or version tag at page or section top    | `Badge`                               |
 | Sequential procedure with titled steps    | `Steps`                              |
+| FAQ-style content, one answer at a time   | `Accordion`                          |
 | Navigation or feature overview grid       | `Cards`                              |
 | Before vs. after, old vs. new (prose)     | `Comparison`                         |
 | Same task in multiple tools or frameworks | `Tabs`                               |

--- a/packages/core/docs/content/docs-components.mdx
+++ b/packages/core/docs/content/docs-components.mdx
@@ -213,10 +213,16 @@ Use `Notice` when a `Callout` would be too easy to skim past — something the r
 
 ## Banner
 
-<Banner tone="warning" body="This page describes the v9 API. See [Migrating to v10](/docs/migrating-v10) for what changed." />
+<Banner
+  tone="warning"
+  body="This page describes the v9 API. See [Migrating to v10](/docs/migrating-v10) for what changed."
+/>
 
 ```mdx
-<Banner tone="warning" body="This page describes the v9 API. See [Migrating to v10](/docs/migrating-v10) for what changed." />
+<Banner
+  tone="warning"
+  body="This page describes the v9 API. See [Migrating to v10](/docs/migrating-v10) for what changed."
+/>
 ```
 
 `Banner` is self-closing — `body` is a flat attribute (kept short and single-purpose on purpose), not markdown children. Place it right under a page's title or a section heading — deprecated, beta, moved, version-scoped. For content the reader needs to actually read (not just notice), use `Notice` or `Callout` instead.
@@ -281,14 +287,14 @@ Same authoring shape as `Steps`/`Cards` — a `### Question` heading per item fo
 
 A small status chip for the top of a page or section. Self-closing, block-level only — **not** embeddable mid-sentence (the docs MDX pipeline only recognizes a custom component when its tag opens its own line, so `text <Badge label="x"/> more text` renders as literal text, not a chip). Place it on its own line, typically right after a heading. Leave a blank line between adjacent Badges (or any two block components) — without one, the scanner can't tell where one ends and the next begins and falls back to rendering literal text.
 
-| Prop | Values |
-| --- | --- |
-| `color` | `gray` · `blue` · `green` · `yellow` · `orange` · `red` · `purple` · `white` · `surface` · `white-destructive` · `surface-destructive` |
-| `size` | `xs` · `sm` · `md` · `lg` |
-| `shape` | `rounded` (default) · `pill` |
-| `icon` | one of a curated set — `circle-check`, `circle-info`, `alert-triangle`, `alert-octagon`, `ban`, `clock`, `star`, `flame`, `sparkles`, `lock`, `rocket` |
-| `stroke` | `true` for an outlined, transparent-background variant |
-| `disabled` | `true` to dim it for an inactive/unavailable state |
+| Prop       | Values                                                                                                                                                 |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `color`    | `gray` · `blue` · `green` · `yellow` · `orange` · `red` · `purple` · `white` · `surface` · `white-destructive` · `surface-destructive`                 |
+| `size`     | `xs` · `sm` · `md` · `lg`                                                                                                                              |
+| `shape`    | `rounded` (default) · `pill`                                                                                                                           |
+| `icon`     | one of a curated set — `circle-check`, `circle-info`, `alert-triangle`, `alert-octagon`, `ban`, `clock`, `star`, `flame`, `sparkles`, `lock`, `rocket` |
+| `stroke`   | `true` for an outlined, transparent-background variant                                                                                                 |
+| `disabled` | `true` to dim it for an inactive/unavailable state                                                                                                     |
 
 ---
 
@@ -579,18 +585,18 @@ Like `TabsBlock`, `Columns` is self-closing with a single JSON `columns` attribu
 
 ## When to use which component
 
-| Situation                                    | Component                            |
-| --------------------------------------------- | ------------------------------------ |
-| Reader must not miss something, inline in prose | `Callout` (warning / info / success) |
-| Reader must not miss something, standalone      | `Notice`                              |
-| Deprecated/beta/version notice at page or section top | `Banner`                       |
-| Status or version tag at page or section top    | `Badge`                               |
-| Sequential procedure with titled steps    | `Steps`                              |
-| FAQ-style content, one answer at a time   | `Accordion`                          |
-| Navigation or feature overview grid       | `Cards`                              |
-| Before vs. after, old vs. new (prose)     | `Comparison`                         |
-| Same task in multiple tools or frameworks | `Tabs`                               |
-| Side-by-side code (labeled columns)       | `Columns`                            |
-| Project directory structure               | `FileTree`                           |
-| Inline keyboard shortcut                  | `[[Key]]`                            |
-| Architecture or flow diagram              | Mermaid fence                        |
+| Situation                                             | Component                            |
+| ----------------------------------------------------- | ------------------------------------ |
+| Reader must not miss something, inline in prose       | `Callout` (warning / info / success) |
+| Reader must not miss something, standalone            | `Notice`                             |
+| Deprecated/beta/version notice at page or section top | `Banner`                             |
+| Status or version tag at page or section top          | `Badge`                              |
+| Sequential procedure with titled steps                | `Steps`                              |
+| FAQ-style content, one answer at a time               | `Accordion`                          |
+| Navigation or feature overview grid                   | `Cards`                              |
+| Before vs. after, old vs. new (prose)                 | `Comparison`                         |
+| Same task in multiple tools or frameworks             | `Tabs`                               |
+| Side-by-side code (labeled columns)                   | `Columns`                            |
+| Project directory structure                           | `FileTree`                           |
+| Inline keyboard shortcut                              | `[[Key]]`                            |
+| Architecture or flow diagram                          | Mermaid fence                        |

--- a/packages/docs/app/components/blocks/accordion.config.ts
+++ b/packages/docs/app/components/blocks/accordion.config.ts
@@ -1,6 +1,8 @@
 import type { BlockMdxConfig } from "@agent-native/core/blocks";
 import { z } from "zod";
 
+import { splitMarkdownHeadingSections } from "./markdown-heading-sections";
+
 export interface AccordionItem {
   title: string;
   body: string;
@@ -18,16 +20,7 @@ export const accordionSchema = z.object({
 }) as unknown as z.ZodType<AccordionData>;
 
 export function parseAccordionFromMarkdown(children: string): AccordionItem[] {
-  const parts = children.split(/\n(?=###\s)/);
-  const items: AccordionItem[] = [];
-  for (const part of parts) {
-    const match = part.match(/^###\s+(.+?)\n([\s\S]*)$/);
-    if (!match) continue;
-    const title = match[1].trim();
-    const body = match[2].trim();
-    if (title) items.push({ title, body });
-  }
-  return items;
+  return splitMarkdownHeadingSections(children);
 }
 
 export function serializeAccordionToMarkdown(items: AccordionItem[]): string {

--- a/packages/docs/app/components/blocks/accordion.config.ts
+++ b/packages/docs/app/components/blocks/accordion.config.ts
@@ -1,0 +1,52 @@
+import type { BlockMdxConfig } from "@agent-native/core/blocks";
+import { z } from "zod";
+
+export interface AccordionItem {
+  title: string;
+  body: string;
+}
+
+export interface AccordionData {
+  items: AccordionItem[];
+}
+
+export const accordionSchema = z.object({
+  items: z
+    .array(z.object({ title: z.string(), body: z.string() }))
+    .min(1)
+    .max(30),
+}) as unknown as z.ZodType<AccordionData>;
+
+export function parseAccordionFromMarkdown(children: string): AccordionItem[] {
+  const parts = children.split(/\n(?=###\s)/);
+  const items: AccordionItem[] = [];
+  for (const part of parts) {
+    const match = part.match(/^###\s+(.+?)\n([\s\S]*)$/);
+    if (!match) continue;
+    const title = match[1].trim();
+    const body = match[2].trim();
+    if (title) items.push({ title, body });
+  }
+  return items;
+}
+
+export function serializeAccordionToMarkdown(items: AccordionItem[]): string {
+  return items.map((s) => `### ${s.title}\n\n${s.body}`).join("\n\n");
+}
+
+/**
+ * MDX config: identical authoring shape to `Steps`/`Cards` — a `### Title`
+ * heading per item followed by its markdown body — but rendered as
+ * collapsed-by-default `<details>` items instead of an always-expanded list.
+ * Good for FAQ-style content and reference material where most readers only
+ * need one or two entries, not the whole section read top to bottom.
+ */
+export const accordionMdx: BlockMdxConfig<AccordionData> = {
+  tag: "Accordion",
+  childrenField: "items" as never,
+  toAttrs: () => ({}),
+  fromAttrs: (_attrs, children) => ({
+    items: parseAccordionFromMarkdown(children),
+  }),
+  serializeChildren: (data) => serializeAccordionToMarkdown(data.items),
+};

--- a/packages/docs/app/components/blocks/accordion.tsx
+++ b/packages/docs/app/components/blocks/accordion.tsx
@@ -1,0 +1,46 @@
+import { defineBlock } from "@agent-native/core/blocks";
+import type { BlockReadProps } from "@agent-native/core/blocks";
+import { IconChevronDown } from "@tabler/icons-react";
+
+import {
+  accordionSchema,
+  accordionMdx,
+  type AccordionData,
+} from "./accordion.config";
+
+export type { AccordionData };
+
+export function AccordionBlock({ data, ctx }: BlockReadProps<AccordionData>) {
+  return (
+    <div className="docs-accordion">
+      {data.items.map((item, i) => (
+        <details key={i} className="docs-accordion-item">
+          <summary className="docs-accordion-trigger">
+            <span>{item.title}</span>
+            <IconChevronDown
+              className="docs-accordion-chevron"
+              aria-hidden="true"
+            />
+          </summary>
+          <div className="docs-accordion-body">
+            {ctx.renderMarkdown?.(item.body) ?? <p>{item.body}</p>}
+          </div>
+        </details>
+      ))}
+    </div>
+  );
+}
+
+export const accordionBlock = defineBlock<AccordionData>({
+  type: "accordion",
+  schema: accordionSchema,
+  mdx: accordionMdx,
+  Read: AccordionBlock,
+  placement: ["block"],
+  label: "Accordion",
+  description:
+    "Collapsed-by-default items for FAQ-style content — a title per item, expand on click, native <details> semantics.",
+  empty: () => ({
+    items: [{ title: "Question", body: "Answer." }],
+  }),
+});

--- a/packages/docs/app/components/blocks/badge.config.ts
+++ b/packages/docs/app/components/blocks/badge.config.ts
@@ -1,0 +1,93 @@
+import type { BlockMdxConfig } from "@agent-native/core/blocks";
+import { z } from "zod";
+
+/**
+ * Badge: a small status/label chip for the top of a page or section — "Beta",
+ * "Deprecated", "v9.1+", "Server-only". Block-level only (its own line, not
+ * embeddable mid-sentence): the docs MDX pipeline is a line-anchored block
+ * scanner (`splitDocSegments`), not a real MDX compiler, so a custom component
+ * can only be recognized when its opening tag starts its own line — true
+ * inline-in-prose usage isn't supported without a separate `marked` inline
+ * extension (the same trick `[[Ctrl+K]]` uses). Out of scope here by request.
+ */
+
+export const BADGE_COLORS = [
+  "gray",
+  "blue",
+  "green",
+  "yellow",
+  "orange",
+  "red",
+  "purple",
+  "white",
+  "surface",
+  "white-destructive",
+  "surface-destructive",
+] as const;
+
+export const BADGE_SIZES = ["xs", "sm", "md", "lg"] as const;
+
+export const BADGE_SHAPES = ["rounded", "pill"] as const;
+
+/** Small curated allow-list, not an arbitrary icon-name passthrough. */
+export const BADGE_ICONS = [
+  "circle-check",
+  "circle-info",
+  "alert-triangle",
+  "alert-octagon",
+  "ban",
+  "clock",
+  "star",
+  "flame",
+  "sparkles",
+  "lock",
+  "rocket",
+] as const;
+
+export type BadgeColor = (typeof BADGE_COLORS)[number];
+export type BadgeSize = (typeof BADGE_SIZES)[number];
+export type BadgeShape = (typeof BADGE_SHAPES)[number];
+export type BadgeIcon = (typeof BADGE_ICONS)[number];
+
+export interface BadgeData {
+  label: string;
+  color?: BadgeColor;
+  size?: BadgeSize;
+  shape?: BadgeShape;
+  icon?: BadgeIcon;
+  stroke?: boolean;
+  disabled?: boolean;
+}
+
+export const badgeSchema = z.object({
+  label: z.string().trim().min(1).max(60),
+  color: z.enum(BADGE_COLORS).optional(),
+  size: z.enum(BADGE_SIZES).optional(),
+  shape: z.enum(BADGE_SHAPES).optional(),
+  icon: z.enum(BADGE_ICONS).optional(),
+  stroke: z.boolean().optional(),
+  disabled: z.boolean().optional(),
+}) as unknown as z.ZodType<BadgeData>;
+
+/** MDX config: self-closing `<Badge label="Beta" color="orange" ... />`. */
+export const badgeMdx: BlockMdxConfig<BadgeData> = {
+  tag: "Badge",
+  toAttrs: (data) => ({
+    label: data.label,
+    color: data.color,
+    size: data.size,
+    shape: data.shape,
+    icon: data.icon,
+    stroke: data.stroke,
+    disabled: data.disabled,
+  }),
+  fromAttrs: (attrs) => ({
+    label: attrs.string("label") ?? "",
+    color: attrs.string("color") as BadgeColor | undefined,
+    size: attrs.string("size") as BadgeSize | undefined,
+    shape: attrs.string("shape") as BadgeShape | undefined,
+    icon: attrs.string("icon") as BadgeIcon | undefined,
+    stroke: attrs.bool("stroke"),
+    disabled: attrs.bool("disabled"),
+  }),
+};

--- a/packages/docs/app/components/blocks/badge.tsx
+++ b/packages/docs/app/components/blocks/badge.tsx
@@ -1,0 +1,67 @@
+import { defineBlock } from "@agent-native/core/blocks";
+import type { BlockReadProps } from "@agent-native/core/blocks";
+import {
+  IconAlertOctagon,
+  IconAlertTriangle,
+  IconBan,
+  IconCircleCheck,
+  IconClock,
+  IconFlame,
+  IconInfoCircle,
+  IconLock,
+  IconRocket,
+  IconSparkles,
+  IconStar,
+  type Icon as TablerIcon,
+} from "@tabler/icons-react";
+
+import { badgeSchema, badgeMdx, type BadgeData } from "./badge.config";
+
+export type { BadgeData };
+
+const BADGE_ICON: Record<string, TablerIcon> = {
+  "circle-check": IconCircleCheck,
+  "circle-info": IconInfoCircle,
+  "alert-triangle": IconAlertTriangle,
+  "alert-octagon": IconAlertOctagon,
+  ban: IconBan,
+  clock: IconClock,
+  star: IconStar,
+  flame: IconFlame,
+  sparkles: IconSparkles,
+  lock: IconLock,
+  rocket: IconRocket,
+};
+
+export function BadgeBlock({ data }: BlockReadProps<BadgeData>) {
+  const Icon = data.icon ? BADGE_ICON[data.icon] : undefined;
+  const color = data.color ?? "gray";
+  const size = data.size ?? "sm";
+  const shape = data.shape ?? "rounded";
+
+  return (
+    <span
+      className="docs-badge"
+      data-color={color}
+      data-size={size}
+      data-shape={shape}
+      data-stroke={data.stroke ? "true" : undefined}
+      data-disabled={data.disabled ? "true" : undefined}
+    >
+      {Icon && <Icon className="docs-badge-icon" aria-hidden="true" />}
+      {data.label}
+    </span>
+  );
+}
+
+export const badgeBlock = defineBlock<BadgeData>({
+  type: "badge",
+  schema: badgeSchema,
+  mdx: badgeMdx,
+  Read: BadgeBlock,
+  placement: ["block"],
+  label: "Badge",
+  description:
+    "A small status/label chip for the top of a page or section — Beta, Deprecated, v9.1+. Block-level only, not embeddable mid-sentence.",
+  empty: () => ({ label: "Beta", color: "orange" }),
+});

--- a/packages/docs/app/components/blocks/banner.config.ts
+++ b/packages/docs/app/components/blocks/banner.config.ts
@@ -1,0 +1,48 @@
+import type { BlockMdxConfig } from "@agent-native/core/blocks";
+import { z } from "zod";
+
+/**
+ * Banner: a compact, full-width, single-line announcement strip meant to sit
+ * right under a page's H1 or a section's heading — "this page moved", "beta
+ * feature", "deprecated in v9". Distinct from `Notice` (a boxed, multi-line
+ * card for content the reader must stop and read) and `Callout` (an inline
+ * note within the body copy): Banner is a header-adjacent marker, not body
+ * content, so it stays terse — one line of markdown, optionally linking out.
+ * Reuses the same five-tone vocabulary as `Callout`/`Notice`.
+ */
+
+export const BANNER_TONES = [
+  "info",
+  "decision",
+  "risk",
+  "warning",
+  "success",
+] as const;
+
+export type BannerTone = (typeof BANNER_TONES)[number];
+
+export interface BannerData {
+  tone: BannerTone;
+  body: string;
+}
+
+export const bannerSchema = z.object({
+  tone: z.enum(BANNER_TONES),
+  body: z.string().trim().min(1).max(400),
+}) as unknown as z.ZodType<BannerData>;
+
+/**
+ * MDX config: self-closing `<Banner tone="warning" body="..." />`. Kept as a
+ * flat `body` attribute (not markdown children) because a banner is meant to
+ * stay a single terse line — an attribute discourages authors from growing it
+ * into multi-paragraph content the way an open/close markdown-children block
+ * would invite.
+ */
+export const bannerMdx: BlockMdxConfig<BannerData> = {
+  tag: "Banner",
+  toAttrs: (data) => ({ tone: data.tone, body: data.body }),
+  fromAttrs: (attrs) => ({
+    tone: (attrs.string("tone") as BannerTone) ?? "info",
+    body: attrs.string("body") ?? "",
+  }),
+};

--- a/packages/docs/app/components/blocks/banner.tsx
+++ b/packages/docs/app/components/blocks/banner.tsx
@@ -1,0 +1,45 @@
+import { defineBlock } from "@agent-native/core/blocks";
+import type { BlockReadProps } from "@agent-native/core/blocks";
+import {
+  IconAlertOctagon,
+  IconAlertTriangle,
+  IconBulb,
+  IconCircleCheck,
+  IconInfoCircle,
+} from "@tabler/icons-react";
+
+import { bannerSchema, bannerMdx, type BannerData } from "./banner.config";
+
+export type { BannerData };
+
+const BANNER_ICON = {
+  info: IconInfoCircle,
+  decision: IconBulb,
+  risk: IconAlertOctagon,
+  warning: IconAlertTriangle,
+  success: IconCircleCheck,
+} as const;
+
+export function BannerBlock({ data, ctx }: BlockReadProps<BannerData>) {
+  const Icon = BANNER_ICON[data.tone] ?? IconInfoCircle;
+  return (
+    <div className="docs-banner" data-tone={data.tone}>
+      <Icon className="docs-banner-icon" aria-hidden="true" />
+      <div className="docs-banner-body">
+        {ctx.renderMarkdown?.(data.body) ?? data.body}
+      </div>
+    </div>
+  );
+}
+
+export const bannerBlock = defineBlock<BannerData>({
+  type: "banner",
+  schema: bannerSchema,
+  mdx: bannerMdx,
+  Read: BannerBlock,
+  placement: ["block"],
+  label: "Banner",
+  description:
+    "A compact, full-width, single-line announcement strip for the top of a page or section — beta, deprecated, moved. Tones: info, decision, risk, warning, success.",
+  empty: () => ({ tone: "info", body: "Banner text" }),
+});

--- a/packages/docs/app/components/blocks/cards.config.ts
+++ b/packages/docs/app/components/blocks/cards.config.ts
@@ -1,6 +1,8 @@
 import type { BlockMdxConfig } from "@agent-native/core/blocks";
 import { z } from "zod";
 
+import { splitMarkdownHeadingSections } from "./markdown-heading-sections";
+
 export interface CardItem {
   title: string;
   href?: string;
@@ -25,21 +27,12 @@ export const cardsSchema = z.object({
 }) as unknown as z.ZodType<CardsData>;
 
 export function parseCardsFromMarkdown(children: string): CardItem[] {
-  const parts = children.split(/\n(?=###\s)/);
-  const cards: CardItem[] = [];
-  for (const part of parts) {
-    const match = part.match(/^###\s+(.+?)\n([\s\S]*)$/);
-    if (!match) continue;
-    const rawTitle = match[1].trim();
-    const body = match[2].trim();
-    const linkMatch = rawTitle.match(/^\[(.+?)\]\((.+?)\)$/);
-    if (linkMatch) {
-      cards.push({ title: linkMatch[1], href: linkMatch[2], body });
-    } else {
-      cards.push({ title: rawTitle, body });
-    }
-  }
-  return cards;
+  return splitMarkdownHeadingSections(children).map(({ title, body }) => {
+    const linkMatch = title.match(/^\[(.+?)\]\((.+?)\)$/);
+    return linkMatch
+      ? { title: linkMatch[1], href: linkMatch[2], body }
+      : { title, body };
+  });
 }
 
 export function serializeCardsToMarkdown(cards: CardItem[]): string {

--- a/packages/docs/app/components/blocks/comparison.config.ts
+++ b/packages/docs/app/components/blocks/comparison.config.ts
@@ -1,6 +1,8 @@
 import type { BlockMdxConfig } from "@agent-native/core/blocks";
 import { z } from "zod";
 
+import { splitMarkdownHeadingSections } from "./markdown-heading-sections";
+
 export interface ComparisonSide {
   label: string;
   body: string;
@@ -18,16 +20,10 @@ export const comparisonSchema = z.object({
 }) as unknown as z.ZodType<ComparisonData>;
 
 export function parseSidesFromMarkdown(children: string): ComparisonSide[] {
-  const parts = children.split(/\n(?=###\s)/);
-  const sides: ComparisonSide[] = [];
-  for (const part of parts) {
-    const match = part.match(/^###\s+(.+?)\n([\s\S]*)$/);
-    if (!match) continue;
-    const label = match[1].trim();
-    const body = match[2].trim();
-    if (label) sides.push({ label, body });
-  }
-  return sides;
+  return splitMarkdownHeadingSections(children).map((section) => ({
+    label: section.title,
+    body: section.body,
+  }));
 }
 
 export function serializeSidesToMarkdown(sides: ComparisonSide[]): string {

--- a/packages/docs/app/components/blocks/markdown-heading-sections.test.ts
+++ b/packages/docs/app/components/blocks/markdown-heading-sections.test.ts
@@ -41,6 +41,76 @@ describe("splitMarkdownHeadingSections", () => {
     expect(sections[1].body).toBe("Body.");
   });
 
+  it("does not close a 4-backtick fence on a 3-backtick line inside it", () => {
+    const sections = splitMarkdownHeadingSections(
+      [
+        "### Writing headings",
+        "",
+        "````md",
+        "```md",
+        "### Not a real section",
+        "```",
+        "````",
+        "",
+        "### Next item",
+        "",
+        "Body.",
+      ].join("\n"),
+    );
+
+    expect(sections).toHaveLength(2);
+    expect(sections[0].title).toBe("Writing headings");
+    expect(sections[0].body).toContain("### Not a real section");
+    expect(sections[1].title).toBe("Next item");
+    expect(sections[1].body).toBe("Body.");
+  });
+
+  it("does not close a backtick fence on a tilde line inside it", () => {
+    const sections = splitMarkdownHeadingSections(
+      [
+        "### Writing headings",
+        "",
+        "```md",
+        "~~~",
+        "### Not a real section",
+        "~~~",
+        "```",
+        "",
+        "### Next item",
+        "",
+        "Body.",
+      ].join("\n"),
+    );
+
+    expect(sections).toHaveLength(2);
+    expect(sections[0].title).toBe("Writing headings");
+    expect(sections[0].body).toContain("### Not a real section");
+    expect(sections[1].title).toBe("Next item");
+    expect(sections[1].body).toBe("Body.");
+  });
+
+  it("does not close a fence on a shorter run of the same character", () => {
+    const sections = splitMarkdownHeadingSections(
+      [
+        "### Writing headings",
+        "",
+        "````md",
+        "some code",
+        "```",
+        "### Not a real section",
+        "````",
+        "",
+        "### Next item",
+        "",
+        "Body.",
+      ].join("\n"),
+    );
+
+    expect(sections).toHaveLength(2);
+    expect(sections[0].body).toContain("### Not a real section");
+    expect(sections[1].title).toBe("Next item");
+  });
+
   it("parses an item with a genuinely empty body", () => {
     const sections = splitMarkdownHeadingSections(
       ["### First", "", "Body.", "", "### Last"].join("\n"),

--- a/packages/docs/app/components/blocks/markdown-heading-sections.test.ts
+++ b/packages/docs/app/components/blocks/markdown-heading-sections.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { splitMarkdownHeadingSections } from "./markdown-heading-sections";
+
+describe("splitMarkdownHeadingSections", () => {
+  it("splits on ### headings outside of code fences", () => {
+    const sections = splitMarkdownHeadingSections(
+      ["### First", "", "Body one.", "", "### Second", "", "Body two."].join(
+        "\n",
+      ),
+    );
+
+    expect(sections).toEqual([
+      { title: "First", body: "Body one." },
+      { title: "Second", body: "Body two." },
+    ]);
+  });
+
+  it("does not split on ### that appears inside a fenced code block", () => {
+    const sections = splitMarkdownHeadingSections(
+      [
+        "### Writing headings",
+        "",
+        "Use `###` for a level-3 heading, for example:",
+        "",
+        "```md",
+        "### Not a real section",
+        "some body text",
+        "```",
+        "",
+        "### Next item",
+        "",
+        "Body.",
+      ].join("\n"),
+    );
+
+    expect(sections).toHaveLength(2);
+    expect(sections[0].title).toBe("Writing headings");
+    expect(sections[0].body).toContain("### Not a real section");
+    expect(sections[1].title).toBe("Next item");
+    expect(sections[1].body).toBe("Body.");
+  });
+
+  it("parses an item with a genuinely empty body", () => {
+    const sections = splitMarkdownHeadingSections(
+      ["### First", "", "Body.", "", "### Last"].join("\n"),
+    );
+
+    expect(sections).toEqual([
+      { title: "First", body: "Body." },
+      { title: "Last", body: "" },
+    ]);
+  });
+
+  it("round-trips serialize -> parse for an empty-body last item", () => {
+    // Mirrors what `serializeAccordionToMarkdown` (and its Steps/Cards/
+    // Comparison siblings) produce for `{ title: "Last", body: "" }`:
+    // `### Last\n\n` with nothing after — this used to get silently
+    // dropped because the old regex required a literal `\n` after the title.
+    const serialized = "### First\n\nBody.\n\n### Last\n\n";
+
+    expect(splitMarkdownHeadingSections(serialized)).toEqual([
+      { title: "First", body: "Body." },
+      { title: "Last", body: "" },
+    ]);
+  });
+});

--- a/packages/docs/app/components/blocks/markdown-heading-sections.ts
+++ b/packages/docs/app/components/blocks/markdown-heading-sections.ts
@@ -12,17 +12,48 @@
  *     serialized and reformatted — a regex that requires a literal `\n`
  *     after the heading drops the item when there's nothing after it.
  */
+interface FenceMarker {
+  char: "`" | "~";
+  length: number;
+}
+
+function matchFenceOpen(line: string): FenceMarker | null {
+  const match = /^\s*(`{3,}|~{3,})/.exec(line);
+  if (!match) return null;
+  return { char: match[1][0] as "`" | "~", length: match[1].length };
+}
+
+/**
+ * Per CommonMark, a fence only closes on a line that is (once trimmed)
+ * nothing but the SAME fence character, repeated AT LEAST as many times as
+ * the opener. A 4-backtick fence can safely contain a 3-backtick example; a
+ * backtick fence can contain a literal `~~~` line. Checking only "does this
+ * line look like some fence" (any char, any length >= 3) closes early on
+ * either case and starts parsing the remaining example body as real
+ * sections.
+ */
+function isFenceClose(line: string, opener: FenceMarker): boolean {
+  const trimmed = line.trim();
+  if (trimmed.length < opener.length) return false;
+  for (const ch of trimmed) {
+    if (ch !== opener.char) return false;
+  }
+  return true;
+}
+
 export function splitMarkdownHeadingSections(
   children: string,
 ): Array<{ title: string; body: string }> {
   const lines = children.split("\n");
   const sections: Array<{ title: string; body: string[] }> = [];
-  let fence: string | null = null;
+  let fence: FenceMarker | null = null;
 
   for (const line of lines) {
-    const fenceMarker = /^\s*(`{3,}|~{3,})/.exec(line)?.[1];
-    if (fenceMarker) {
-      fence = fence === null ? fenceMarker : null;
+    if (fence) {
+      if (isFenceClose(line, fence)) fence = null;
+    } else {
+      const opened = matchFenceOpen(line);
+      if (opened) fence = opened;
     }
 
     const headingMatch = !fence ? /^###\s+(.+)$/.exec(line) : null;

--- a/packages/docs/app/components/blocks/markdown-heading-sections.ts
+++ b/packages/docs/app/components/blocks/markdown-heading-sections.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared parser for the `### Title` + body authoring shape used by
+ * `Steps`/`Cards`/`Comparison`/`Accordion`. All four split their MDX children
+ * into per-item sections the same way; this is the one implementation instead
+ * of four copies of the same regex.
+ *
+ * Line-based rather than a single `split + regex` pass for two reasons a
+ * regex split can't handle:
+ *   - A `###` inside a fenced code block (a code sample showing markdown
+ *     syntax, or a comment) must not start a new item.
+ *   - An item with a genuinely empty body must still parse back after being
+ *     serialized and reformatted — a regex that requires a literal `\n`
+ *     after the heading drops the item when there's nothing after it.
+ */
+export function splitMarkdownHeadingSections(
+  children: string,
+): Array<{ title: string; body: string }> {
+  const lines = children.split("\n");
+  const sections: Array<{ title: string; body: string[] }> = [];
+  let fence: string | null = null;
+
+  for (const line of lines) {
+    const fenceMarker = /^\s*(`{3,}|~{3,})/.exec(line)?.[1];
+    if (fenceMarker) {
+      fence = fence === null ? fenceMarker : null;
+    }
+
+    const headingMatch = !fence ? /^###\s+(.+)$/.exec(line) : null;
+    if (headingMatch) {
+      sections.push({ title: headingMatch[1].trim(), body: [] });
+      continue;
+    }
+
+    sections[sections.length - 1]?.body.push(line);
+  }
+
+  return sections
+    .filter((section) => section.title)
+    .map((section) => ({
+      title: section.title,
+      body: section.body.join("\n").trim(),
+    }));
+}

--- a/packages/docs/app/components/blocks/notice.config.ts
+++ b/packages/docs/app/components/blocks/notice.config.ts
@@ -1,0 +1,51 @@
+import type { BlockMdxConfig } from "@agent-native/core/blocks";
+import { z } from "zod";
+
+/**
+ * Notice: a bold, filled alert card — title + icon + markdown body, colored by
+ * tone. Distinct from `Callout` (a subtle left-border note meant to sit inline
+ * in a paragraph flow without breaking stride) — Notice is a standalone,
+ * higher-attention block for something a reader must not skim past. Reuses the
+ * same five-tone vocabulary as `Callout` (info/decision/risk/warning/success)
+ * so the two components share one color language instead of introducing a
+ * second, parallel tone naming.
+ */
+
+export const NOTICE_TONES = [
+  "info",
+  "decision",
+  "risk",
+  "warning",
+  "success",
+] as const;
+
+export type NoticeTone = (typeof NOTICE_TONES)[number];
+
+export interface NoticeData {
+  tone: NoticeTone;
+  title?: string;
+  body: string;
+}
+
+export const noticeSchema = z.object({
+  tone: z.enum(NOTICE_TONES),
+  title: z.string().trim().max(200).optional(),
+  body: z.string(),
+}) as unknown as z.ZodType<NoticeData>;
+
+/**
+ * MDX config: `tone` and `title` are flat attrs; the body is the element's
+ * markdown children (`<Notice tone="risk" title="...">` … `</Notice>`), same
+ * shape as `Callout` so authoring feels familiar.
+ */
+export const noticeMdx: BlockMdxConfig<NoticeData> = {
+  tag: "Notice",
+  childrenField: "body" as never,
+  toAttrs: (data) => ({ tone: data.tone, title: data.title }),
+  fromAttrs: (attrs, children) => ({
+    tone: (attrs.string("tone") as NoticeTone) ?? "info",
+    title: attrs.string("title"),
+    body: children.trim(),
+  }),
+  serializeChildren: (data) => data.body,
+};

--- a/packages/docs/app/components/blocks/notice.tsx
+++ b/packages/docs/app/components/blocks/notice.tsx
@@ -1,0 +1,48 @@
+import { defineBlock } from "@agent-native/core/blocks";
+import type { BlockReadProps } from "@agent-native/core/blocks";
+import {
+  IconAlertOctagon,
+  IconAlertTriangle,
+  IconBulb,
+  IconCircleCheck,
+  IconInfoCircle,
+} from "@tabler/icons-react";
+
+import { noticeSchema, noticeMdx, type NoticeData } from "./notice.config";
+
+export type { NoticeData };
+
+const NOTICE_ICON = {
+  info: IconInfoCircle,
+  decision: IconBulb,
+  risk: IconAlertOctagon,
+  warning: IconAlertTriangle,
+  success: IconCircleCheck,
+} as const;
+
+export function NoticeBlock({ data, ctx }: BlockReadProps<NoticeData>) {
+  const Icon = NOTICE_ICON[data.tone] ?? IconInfoCircle;
+  return (
+    <div className="docs-notice" data-tone={data.tone}>
+      <Icon className="docs-notice-icon" aria-hidden="true" />
+      <div className="docs-notice-content">
+        {data.title && <p className="docs-notice-title">{data.title}</p>}
+        <div className="docs-notice-body">
+          {ctx.renderMarkdown?.(data.body) ?? <p>{data.body}</p>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const noticeBlock = defineBlock<NoticeData>({
+  type: "notice",
+  schema: noticeSchema,
+  mdx: noticeMdx,
+  Read: NoticeBlock,
+  placement: ["block"],
+  label: "Notice",
+  description:
+    "A bold, filled alert card with an icon and optional title, for something a reader must not skim past. Tones: info, decision, risk, warning, success.",
+  empty: () => ({ tone: "info", body: "Notice text" }),
+});

--- a/packages/docs/app/components/blocks/steps.config.ts
+++ b/packages/docs/app/components/blocks/steps.config.ts
@@ -1,6 +1,8 @@
 import type { BlockMdxConfig } from "@agent-native/core/blocks";
 import { z } from "zod";
 
+import { splitMarkdownHeadingSections } from "./markdown-heading-sections";
+
 export interface StepItem {
   title: string;
   body: string;
@@ -18,16 +20,7 @@ export const stepsSchema = z.object({
 }) as unknown as z.ZodType<StepsData>;
 
 export function parseStepsFromMarkdown(children: string): StepItem[] {
-  const parts = children.split(/\n(?=###\s)/);
-  const steps: StepItem[] = [];
-  for (const part of parts) {
-    const match = part.match(/^###\s+(.+?)\n([\s\S]*)$/);
-    if (!match) continue;
-    const title = match[1].trim();
-    const body = match[2].trim();
-    if (title) steps.push({ title, body });
-  }
-  return steps;
+  return splitMarkdownHeadingSections(children);
 }
 
 export function serializeStepsToMarkdown(steps: StepItem[]): string {

--- a/packages/docs/app/components/docBlocks.tsx
+++ b/packages/docs/app/components/docBlocks.tsx
@@ -43,8 +43,12 @@ import {
   resolveDocBlockType,
   type DocSegment,
 } from "../../lib/doc-block-segments";
+import { accordionBlock } from "./blocks/accordion";
+import { badgeBlock } from "./blocks/badge";
+import { bannerBlock } from "./blocks/banner";
 import { cardsBlock } from "./blocks/cards";
 import { comparisonBlock } from "./blocks/comparison";
+import { noticeBlock } from "./blocks/notice";
 import { stepsBlock } from "./blocks/steps";
 import { renderMarkdownToHtml } from "./MarkdownRenderer";
 
@@ -76,6 +80,10 @@ function getDocBlockRegistry(): BlockRegistry {
   registry.register(stepsBlock);
   registry.register(cardsBlock);
   registry.register(comparisonBlock);
+  registry.register(noticeBlock);
+  registry.register(bannerBlock);
+  registry.register(accordionBlock);
+  registry.register(badgeBlock);
   cachedRegistry = registry;
   return registry;
 }

--- a/packages/docs/app/global.css
+++ b/packages/docs/app/global.css
@@ -681,6 +681,270 @@ h4 {
   font-size: 14px;
 }
 
+/* Tone colors shared by Notice and Banner — same hues as the Callout block
+   library (packages/core/src/styles/blocks.css --an-callout-*), kept as plain
+   hex here since the docs site isn't on the shadcn/Tailwind token system. */
+.docs-notice,
+.docs-banner {
+  --tone-color: #3b82f6;
+}
+.docs-notice[data-tone="info"],
+.docs-banner[data-tone="info"] {
+  --tone-color: #3b82f6;
+}
+.docs-notice[data-tone="decision"],
+.docs-banner[data-tone="decision"] {
+  --tone-color: #8b5cf6;
+}
+.docs-notice[data-tone="risk"],
+.docs-banner[data-tone="risk"] {
+  --tone-color: #ef4444;
+}
+.docs-notice[data-tone="warning"],
+.docs-banner[data-tone="warning"] {
+  --tone-color: #f97316;
+}
+.docs-notice[data-tone="success"],
+.docs-banner[data-tone="success"] {
+  --tone-color: #22c55e;
+}
+
+/* Notice: bold, filled alert card — icon + optional title + markdown body
+   Usage in MDX: <Notice tone="risk" title="..."> body </Notice> */
+.docs-notice {
+  display: flex;
+  gap: 12px;
+  margin: 24px 0;
+  padding: 16px;
+  border: 1px solid color-mix(in srgb, var(--tone-color) 35%, var(--docs-border));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--tone-color) 10%, var(--bg));
+}
+
+.docs-notice-icon {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  margin-top: 1px;
+  color: var(--tone-color);
+}
+
+.docs-notice-content {
+  min-width: 0;
+  flex: 1;
+}
+
+.docs-notice-title {
+  margin: 0 0 4px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fg);
+}
+
+.docs-notice-body {
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--fg-secondary);
+}
+
+.docs-notice-body p {
+  margin: 0;
+  font-size: 14px;
+}
+
+.docs-notice-body p + p {
+  margin-top: 8px;
+}
+
+/* Banner: compact, full-width, single-line announcement strip for the top of
+   a page or section
+   Usage in MDX: <Banner tone="warning" body="This page covers the v9 API." /> */
+.docs-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 24px;
+  padding: 10px 14px;
+  border: 1px solid color-mix(in srgb, var(--tone-color) 35%, var(--docs-border));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--tone-color) 8%, var(--bg));
+  font-size: 13px;
+}
+
+.docs-banner-icon {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  color: var(--tone-color);
+}
+
+.docs-banner-body {
+  min-width: 0;
+  color: var(--fg);
+}
+
+.docs-banner-body p {
+  margin: 0;
+  font-size: 13px;
+}
+
+/* Accordion: collapsed-by-default items for FAQ-style content
+   Usage in MDX: <Accordion> ### Question\n\nAnswer </Accordion> */
+.docs-accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 24px 0;
+}
+
+.docs-accordion-item {
+  border: 1px solid var(--docs-border);
+  border-radius: 8px;
+  padding: 0;
+  background: var(--bg);
+}
+
+.docs-accordion-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fg);
+  cursor: pointer;
+  list-style: none;
+}
+
+.docs-accordion-trigger::-webkit-details-marker {
+  display: none;
+}
+
+.docs-accordion-chevron {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  color: var(--fg-secondary);
+  transition: transform 0.15s;
+}
+
+.docs-accordion-item[open] .docs-accordion-chevron {
+  transform: rotate(180deg);
+}
+
+.docs-accordion-body {
+  padding: 0 16px 14px;
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--fg-secondary);
+}
+
+.docs-accordion-body p {
+  margin: 0;
+  font-size: 14px;
+}
+
+/* Badge: small status chip for the top of a page or section
+   Usage in MDX: <Badge label="Beta" color="orange" icon="rocket" /> */
+.docs-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-weight: 600;
+  line-height: 1.4;
+  white-space: nowrap;
+  border: 1px solid transparent;
+}
+
+.docs-badge-icon {
+  flex-shrink: 0;
+  width: 1em;
+  height: 1em;
+}
+
+.docs-badge[data-shape="rounded"] {
+  border-radius: 6px;
+}
+.docs-badge[data-shape="pill"] {
+  border-radius: 999px;
+}
+
+.docs-badge[data-size="xs"] {
+  padding: 1px 6px;
+  font-size: 11px;
+}
+.docs-badge[data-size="sm"] {
+  padding: 2px 8px;
+  font-size: 12px;
+}
+.docs-badge[data-size="md"] {
+  padding: 4px 10px;
+  font-size: 13px;
+}
+.docs-badge[data-size="lg"] {
+  padding: 6px 12px;
+  font-size: 14px;
+}
+
+.docs-badge[data-color="gray"] {
+  background: var(--bg-secondary);
+  color: var(--fg-secondary);
+}
+.docs-badge[data-color="blue"] {
+  background: color-mix(in srgb, #3b82f6 15%, var(--bg));
+  color: color-mix(in srgb, #3b82f6 85%, var(--fg));
+}
+.docs-badge[data-color="green"] {
+  background: color-mix(in srgb, #22c55e 15%, var(--bg));
+  color: color-mix(in srgb, #22c55e 85%, var(--fg));
+}
+.docs-badge[data-color="yellow"] {
+  background: color-mix(in srgb, #eab308 18%, var(--bg));
+  color: color-mix(in srgb, #eab308 85%, var(--fg));
+}
+.docs-badge[data-color="orange"] {
+  background: color-mix(in srgb, #f97316 15%, var(--bg));
+  color: color-mix(in srgb, #f97316 85%, var(--fg));
+}
+.docs-badge[data-color="red"] {
+  background: color-mix(in srgb, #ef4444 15%, var(--bg));
+  color: color-mix(in srgb, #ef4444 85%, var(--fg));
+}
+.docs-badge[data-color="purple"] {
+  background: color-mix(in srgb, #8b5cf6 15%, var(--bg));
+  color: color-mix(in srgb, #8b5cf6 85%, var(--fg));
+}
+.docs-badge[data-color="white"] {
+  background: #fff;
+  color: #171717;
+  border-color: #ebebeb;
+}
+.docs-badge[data-color="surface"] {
+  background: var(--bg-secondary);
+  color: var(--fg);
+  border-color: var(--docs-border);
+}
+.docs-badge[data-color="white-destructive"] {
+  background: #fff;
+  color: #ef4444;
+  border-color: #ebebeb;
+}
+.docs-badge[data-color="surface-destructive"] {
+  background: var(--bg-secondary);
+  color: #ef4444;
+  border-color: var(--docs-border);
+}
+
+.docs-badge[data-stroke="true"] {
+  background: transparent;
+  border-color: currentColor;
+}
+
+.docs-badge[data-disabled="true"] {
+  opacity: 0.45;
+}
+
 /* Sidebar nav */
 .docs-sidebar-nav {
   overflow-anchor: none;

--- a/packages/docs/app/global.css
+++ b/packages/docs/app/global.css
@@ -957,6 +957,19 @@ h4 {
   background: transparent;
   border-color: currentColor;
 }
+/* white and white-destructive pick their text color assuming the badge's own
+   fixed white fill. Stroking clears that fill, so the page background shows
+   through instead — fall back to the theme-aware text used elsewhere for the
+   same purpose, or dark-theme stroke leaves near-black-on-black/white-on-white
+   text with no fill to provide contrast. */
+.docs-badge[data-color="white"][data-stroke="true"] {
+  color: var(--fg);
+  border-color: var(--docs-border);
+}
+.docs-badge[data-color="white-destructive"][data-stroke="true"] {
+  color: var(--docs-badge-red-text);
+  border-color: currentColor;
+}
 
 .docs-badge[data-disabled="true"] {
   opacity: 0.45;

--- a/packages/docs/app/global.css
+++ b/packages/docs/app/global.css
@@ -91,6 +91,10 @@
   --approaches-good: #15803d;
   --approaches-warn: #b45309;
   --approaches-bad: #b91c1c;
+  /* Destructive badge red needs to be darker than the accent red on a near-
+     white chip to clear WCAG AA (4.5:1); the bright accent red is only
+     legible enough against the dark-theme near-black chip. */
+  --docs-badge-red-text: #bf3636;
 }
 
 :root[data-theme="dark"] {
@@ -110,6 +114,7 @@
   --approaches-good: #86efac;
   --approaches-warn: #fcd34d;
   --approaches-bad: #fca5a5;
+  --docs-badge-red-text: #ef4444;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -130,6 +135,7 @@
     --approaches-good: #86efac;
     --approaches-warn: #fcd34d;
     --approaches-bad: #fca5a5;
+    --docs-badge-red-text: #ef4444;
   }
 }
 
@@ -716,7 +722,8 @@ h4 {
   gap: 12px;
   margin: 24px 0;
   padding: 16px;
-  border: 1px solid color-mix(in srgb, var(--tone-color) 35%, var(--docs-border));
+  border: 1px solid
+    color-mix(in srgb, var(--tone-color) 35%, var(--docs-border));
   border-radius: 8px;
   background: color-mix(in srgb, var(--tone-color) 10%, var(--bg));
 }
@@ -765,7 +772,8 @@ h4 {
   gap: 8px;
   margin: 0 0 24px;
   padding: 10px 14px;
-  border: 1px solid color-mix(in srgb, var(--tone-color) 35%, var(--docs-border));
+  border: 1px solid
+    color-mix(in srgb, var(--tone-color) 35%, var(--docs-border));
   border-radius: 8px;
   background: color-mix(in srgb, var(--tone-color) 8%, var(--bg));
   font-size: 13px;
@@ -891,29 +899,34 @@ h4 {
   background: var(--bg-secondary);
   color: var(--fg-secondary);
 }
+/* Text mix percentages below are each tuned per hue for >=4.5:1 contrast
+   against their own tinted background in both themes (WCAG AA for small
+   text) — a flat 85% color / 15% fg ratio cleared AA for none of them in the
+   light theme (measured 2.25-4.38:1). Lower % = more --fg mixed in = darker,
+   higher-contrast text. */
 .docs-badge[data-color="blue"] {
   background: color-mix(in srgb, #3b82f6 15%, var(--bg));
-  color: color-mix(in srgb, #3b82f6 85%, var(--fg));
+  color: color-mix(in srgb, #3b82f6 70%, var(--fg));
 }
 .docs-badge[data-color="green"] {
   background: color-mix(in srgb, #22c55e 15%, var(--bg));
-  color: color-mix(in srgb, #22c55e 85%, var(--fg));
+  color: color-mix(in srgb, #22c55e 52%, var(--fg));
 }
 .docs-badge[data-color="yellow"] {
   background: color-mix(in srgb, #eab308 18%, var(--bg));
-  color: color-mix(in srgb, #eab308 85%, var(--fg));
+  color: color-mix(in srgb, #eab308 48%, var(--fg));
 }
 .docs-badge[data-color="orange"] {
   background: color-mix(in srgb, #f97316 15%, var(--bg));
-  color: color-mix(in srgb, #f97316 85%, var(--fg));
+  color: color-mix(in srgb, #f97316 60%, var(--fg));
 }
 .docs-badge[data-color="red"] {
   background: color-mix(in srgb, #ef4444 15%, var(--bg));
-  color: color-mix(in srgb, #ef4444 85%, var(--fg));
+  color: color-mix(in srgb, #ef4444 72%, var(--fg));
 }
 .docs-badge[data-color="purple"] {
   background: color-mix(in srgb, #8b5cf6 15%, var(--bg));
-  color: color-mix(in srgb, #8b5cf6 85%, var(--fg));
+  color: color-mix(in srgb, #8b5cf6 78%, var(--fg));
 }
 .docs-badge[data-color="white"] {
   background: #fff;
@@ -926,13 +939,17 @@ h4 {
   border-color: var(--docs-border);
 }
 .docs-badge[data-color="white-destructive"] {
+  /* Background is always white regardless of theme, so the text needs the
+     always-dark red, not the theme-aware --docs-badge-red-text (which goes
+     bright for the dark-theme near-black background and would fail AA
+     against this fixed white chip). */
   background: #fff;
-  color: #ef4444;
+  color: #bf3636;
   border-color: #ebebeb;
 }
 .docs-badge[data-color="surface-destructive"] {
   background: var(--bg-secondary);
-  color: #ef4444;
+  color: var(--docs-badge-red-text);
   border-color: var(--docs-border);
 }
 

--- a/packages/docs/lib/doc-block-segments.ts
+++ b/packages/docs/lib/doc-block-segments.ts
@@ -10,11 +10,21 @@ import {
   registerLibraryBlockConfigs,
   type MdxJsxNode,
 } from "../../core/src/client/blocks/server";
+import {
+  accordionSchema,
+  accordionMdx,
+} from "../app/components/blocks/accordion.config";
+import { badgeSchema, badgeMdx } from "../app/components/blocks/badge.config";
+import {
+  bannerSchema,
+  bannerMdx,
+} from "../app/components/blocks/banner.config";
 import { cardsSchema, cardsMdx } from "../app/components/blocks/cards.config";
 import {
   comparisonSchema,
   comparisonMdx,
 } from "../app/components/blocks/comparison.config";
+import { noticeSchema, noticeMdx } from "../app/components/blocks/notice.config";
 import { stepsSchema, stepsMdx } from "../app/components/blocks/steps.config";
 
 const BLOCK_TYPE_ALIASES: Record<string, string> = {
@@ -95,6 +105,10 @@ const DOCS_EXTRA_BLOCKS: Array<{ type: string; schema: any; mdx: any }> = [
   { type: "steps", schema: stepsSchema, mdx: stepsMdx },
   { type: "cards", schema: cardsSchema, mdx: cardsMdx },
   { type: "comparison", schema: comparisonSchema, mdx: comparisonMdx },
+  { type: "notice", schema: noticeSchema, mdx: noticeMdx },
+  { type: "banner", schema: bannerSchema, mdx: bannerMdx },
+  { type: "accordion", schema: accordionSchema, mdx: accordionMdx },
+  { type: "badge", schema: badgeSchema, mdx: badgeMdx },
 ];
 
 function getDocBlockConfigRegistry(): BlockRegistry {

--- a/packages/docs/lib/doc-block-segments.ts
+++ b/packages/docs/lib/doc-block-segments.ts
@@ -24,7 +24,10 @@ import {
   comparisonSchema,
   comparisonMdx,
 } from "../app/components/blocks/comparison.config";
-import { noticeSchema, noticeMdx } from "../app/components/blocks/notice.config";
+import {
+  noticeSchema,
+  noticeMdx,
+} from "../app/components/blocks/notice.config";
 import { stepsSchema, stepsMdx } from "../app/components/blocks/steps.config";
 
 const BLOCK_TYPE_ALIASES: Record<string, string> = {

--- a/packages/docs/lib/docs-markdown-export.test.ts
+++ b/packages/docs/lib/docs-markdown-export.test.ts
@@ -47,7 +47,7 @@ describe("docsBodyToMarkdownMirror", () => {
     const mirror = docsBodyToMarkdownMirror(markdown);
 
     expect(mirror).toContain("### Wrapping `<AgentSidebar>`");
-    expect(mirror).not.toContain("### Wrapping <AgentSidebar>");
+    expect(mirror).not.toContain("### Wrapping <AgentSidebar>\n");
   });
 
   it("preserves filename-labeled fences as-is (G3 filename attribute)", () => {
@@ -152,6 +152,56 @@ describe("docsBodyToMarkdownMirror", () => {
     expect(mirror).not.toContain("<Cards");
     expect(mirror).not.toContain("<Steps");
     expect(mirror).not.toContain("<Comparison");
+  });
+
+  it("protects JSX-looking titles in Cards/Steps/Comparison/Accordion headings", () => {
+    const markdown = [
+      "<Cards>",
+      "",
+      "### Wrapping <AgentSidebar />",
+      "",
+      "Body.",
+      "",
+      "</Cards>",
+      "",
+      "<Steps>",
+      "",
+      "### Wrapping <AgentSidebar />",
+      "",
+      "Body.",
+      "",
+      "</Steps>",
+      "",
+      "<Comparison>",
+      "",
+      "### Wrapping <AgentSidebar />",
+      "",
+      "Old way.",
+      "",
+      "### After",
+      "",
+      "New way.",
+      "",
+      "</Comparison>",
+      "",
+      "<Accordion>",
+      "",
+      "### Wrapping <AgentSidebar />",
+      "",
+      "Body.",
+      "",
+      "</Accordion>",
+    ].join("\n");
+
+    const mirror = docsBodyToMarkdownMirror(markdown);
+
+    // Every occurrence must be backtick-wrapped so a Markdown renderer shows
+    // it as text and an MDX consumer never treats it as a real component.
+    // A negative lookbehind for the opening backtick catches any occurrence
+    // that slipped through unescaped.
+    const unescaped = mirror.match(/(?<!`)<AgentSidebar \/>/g) ?? [];
+    expect(unescaped).toEqual([]);
+    expect(mirror.match(/Wrapping `<AgentSidebar \/>`/g)?.length).toBe(4);
   });
 
   it("lowers Diagram MDX child fences to crawlable markdown", () => {

--- a/packages/docs/lib/docs-markdown-export.test.ts
+++ b/packages/docs/lib/docs-markdown-export.test.ts
@@ -68,6 +68,92 @@ describe("docsBodyToMarkdownMirror", () => {
     expect(docsBodyToMarkdownMirror(markdown)).toBe(`${markdown}\n`);
   });
 
+  it("lowers Notice/Banner/Badge/Accordion MDX to readable markdown instead of a JSON fence", () => {
+    const markdown = [
+      '<Notice id="n1" tone="risk" title="Heads up">',
+      "",
+      "Read this.",
+      "",
+      "</Notice>",
+      "",
+      '<Banner id="b1" tone="warning" body="This page covers v9." />',
+      "",
+      '<Badge id="bd1" label="Beta" color="orange" />',
+      "",
+      "<Accordion>",
+      "",
+      "### Question one",
+      "",
+      "Answer one.",
+      "",
+      "</Accordion>",
+    ].join("\n");
+
+    const mirror = docsBodyToMarkdownMirror(markdown);
+
+    expect(mirror).toContain("Heads up");
+    expect(mirror).toContain("Read this.");
+    expect(mirror).toContain("This page covers v9.");
+    expect(mirror).toContain("Beta");
+    expect(mirror).toContain("Question one");
+    expect(mirror).toContain("Answer one.");
+    expect(mirror).not.toContain('"tone"');
+    expect(mirror).not.toContain('"items"');
+    expect(mirror).not.toContain("<Notice");
+    expect(mirror).not.toContain("<Banner");
+    expect(mirror).not.toContain("<Badge");
+    expect(mirror).not.toContain("<Accordion");
+  });
+
+  it("lowers Cards/Steps/Comparison MDX to readable markdown instead of a JSON fence", () => {
+    const markdown = [
+      "<Cards>",
+      "",
+      "### [Actions](/docs/actions)",
+      "",
+      "Typed operations.",
+      "",
+      "</Cards>",
+      "",
+      "<Steps>",
+      "",
+      "### Install",
+      "",
+      "Run `pnpm install`.",
+      "",
+      "</Steps>",
+      "",
+      "<Comparison>",
+      "",
+      "### Before",
+      "",
+      "Old way.",
+      "",
+      "### After",
+      "",
+      "New way.",
+      "",
+      "</Comparison>",
+    ].join("\n");
+
+    const mirror = docsBodyToMarkdownMirror(markdown);
+
+    expect(mirror).toContain("[Actions](/docs/actions)");
+    expect(mirror).toContain("Typed operations.");
+    expect(mirror).toContain("Install");
+    expect(mirror).toContain("Run `pnpm install`.");
+    expect(mirror).toContain("Before");
+    expect(mirror).toContain("Old way.");
+    expect(mirror).toContain("After");
+    expect(mirror).toContain("New way.");
+    expect(mirror).not.toContain('"cards"');
+    expect(mirror).not.toContain('"steps"');
+    expect(mirror).not.toContain('"sides"');
+    expect(mirror).not.toContain("<Cards");
+    expect(mirror).not.toContain("<Steps");
+    expect(mirror).not.toContain("<Comparison");
+  });
+
   it("lowers Diagram MDX child fences to crawlable markdown", () => {
     const markdown = [
       '<Diagram title="Lifecycle" caption="Runtime lifecycle">',

--- a/packages/docs/lib/docs-markdown-export.test.ts
+++ b/packages/docs/lib/docs-markdown-export.test.ts
@@ -204,6 +204,38 @@ describe("docsBodyToMarkdownMirror", () => {
     expect(mirror.match(/Wrapping `<AgentSidebar \/>`/g)?.length).toBe(4);
   });
 
+  it("protects JSX-looking titles that carry attributes, including linked Cards headings", () => {
+    const markdown = [
+      "<Cards>",
+      "",
+      '### [Wrapping <AgentSidebar mode="compact" />](/docs/agent-sidebar)',
+      "",
+      "Body.",
+      "",
+      "</Cards>",
+      "",
+      "<Accordion>",
+      "",
+      '### Wrapping <AgentSidebar mode="compact" />',
+      "",
+      "Body.",
+      "",
+      "</Accordion>",
+    ].join("\n");
+
+    const mirror = docsBodyToMarkdownMirror(markdown);
+
+    const unescaped =
+      mirror.match(/(?<!`)<AgentSidebar mode="compact" \/>/g) ?? [];
+    expect(unescaped).toEqual([]);
+    expect(mirror).toContain(
+      '[Wrapping `<AgentSidebar mode="compact" />`](/docs/agent-sidebar)',
+    );
+    expect(
+      mirror.match(/Wrapping `<AgentSidebar mode="compact" \/>`/g)?.length,
+    ).toBe(2);
+  });
+
   it("lowers Diagram MDX child fences to crawlable markdown", () => {
     const markdown = [
       '<Diagram title="Lifecycle" caption="Runtime lifecycle">',

--- a/packages/docs/lib/docs-markdown-export.test.ts
+++ b/packages/docs/lib/docs-markdown-export.test.ts
@@ -236,6 +236,83 @@ describe("docsBodyToMarkdownMirror", () => {
     ).toBe(2);
   });
 
+  it("protects JSX titles whose attribute values have nested braces or a spread", () => {
+    const markdown = [
+      "<Accordion>",
+      "",
+      "### Wrapping <AgentSidebar mode={{ compact: true }} />",
+      "",
+      "Body one.",
+      "",
+      "### Wrapping <AgentSidebar {...props} />",
+      "",
+      "Body two.",
+      "",
+      "</Accordion>",
+    ].join("\n");
+
+    const mirror = docsBodyToMarkdownMirror(markdown);
+
+    expect(mirror).toContain(
+      "Wrapping `<AgentSidebar mode={{ compact: true }} />`",
+    );
+    expect(mirror).toContain("Wrapping `<AgentSidebar {...props} />`");
+  });
+
+  it("protects JSX-looking text even when a backslash-escaped attribute quote makes the block invalid MDX", () => {
+    // `\"` inside a double-quoted JSX attribute isn't valid JSX either — real
+    // MDX parsing rejects the whole block and falls back to the raw source
+    // (see the `invalid-block` branch of docsBodyToMarkdownMirror). The raw
+    // fallback must still get JSX-protected, since it still contains
+    // JSX-looking text that would otherwise ship unescaped into the mirror.
+    const markdown = [
+      "<Accordion>",
+      "",
+      '### Wrapping <AgentSidebar body="a \\"quoted\\" value" />',
+      "",
+      "Body one.",
+      "",
+      "</Accordion>",
+    ].join("\n");
+
+    const mirror = docsBodyToMarkdownMirror(markdown);
+
+    const unescaped =
+      mirror.match(/(?<!`)<AgentSidebar body="a \\"quoted\\" value" \/>/g) ??
+      [];
+    expect(unescaped).toEqual([]);
+    expect(mirror).toContain(
+      'Wrapping `<AgentSidebar body="a \\"quoted\\" value" />`',
+    );
+  });
+
+  it("carries a nested Notice's title through Tabs/Columns exports", () => {
+    const markdown =
+      '<TabsBlock tabs={[{ id: "setup", label: "Setup", blocks: [{ type: "notice", data: { tone: "risk", title: "Heads up", body: "Read this." } }] }]} />';
+
+    const mirror = docsBodyToMarkdownMirror(markdown);
+
+    expect(mirror).toContain("Heads up");
+    expect(mirror).toContain("Read this.");
+  });
+
+  it("protects JSX-looking tags inside Notice and Banner bodies", () => {
+    const markdown = [
+      '<Notice id="n1" tone="risk" title="Heads up">',
+      "",
+      "Wrapping <AgentSidebar /> changes behavior.",
+      "",
+      "</Notice>",
+      "",
+      '<Banner id="b1" tone="warning" body="Wrapping <AgentSidebar /> here." />',
+    ].join("\n");
+
+    const mirror = docsBodyToMarkdownMirror(markdown);
+
+    expect(mirror).toContain("Wrapping `<AgentSidebar />` changes behavior.");
+    expect(mirror).toContain("Wrapping `<AgentSidebar />` here.");
+  });
+
   it("lowers Diagram MDX child fences to crawlable markdown", () => {
     const markdown = [
       '<Diagram title="Lifecycle" caption="Runtime lifecycle">',

--- a/packages/docs/lib/docs-markdown-export.ts
+++ b/packages/docs/lib/docs-markdown-export.ts
@@ -34,19 +34,101 @@ function fenced(language: string, code: unknown): string {
   return [`\`\`\`${language}`, String(code ?? "").trimEnd(), "```"].join("\n");
 }
 
-const JSX_ATTR =
-  /\s+[a-zA-Z_][a-zA-Z0-9_-]*(?:=(?:"[^"]*"|'[^']*'|\{[^{}]*\}))?/;
-const JSX_TAG = new RegExp(
-  `<\\/?[A-Z][A-Za-z0-9.]*(?:${JSX_ATTR.source})*\\s*\\/?>`,
-  "g",
-);
+const ID_START = /[A-Za-z_]/;
+const ID_PART = /[A-Za-z0-9_-]/;
+
+/**
+ * Scans a quoted or brace-delimited attribute value starting at `i` (which
+ * must point at `"`, `'`, or `{`) and returns the index just past it, or
+ * `null` if it never closes. A single regex can't do this: quoted values can
+ * contain escaped quotes (`"a \"b\" c"`), and brace values can nest braces
+ * and strings arbitrarily (`{{ compact: true }}`, `{"}"}`).
+ */
+function skipJsxAttrValue(value: string, i: number): number | null {
+  const quote = value[i];
+  if (quote === '"' || quote === "'") {
+    i++;
+    while (i < value.length && value[i] !== quote) {
+      i += value[i] === "\\" ? 2 : 1;
+    }
+    return value[i] === quote ? i + 1 : null;
+  }
+  if (quote === "{") {
+    let depth = 0;
+    while (i < value.length) {
+      const ch = value[i];
+      if (ch === '"' || ch === "'") {
+        const end = skipJsxAttrValue(value, i);
+        if (end === null) return null;
+        i = end;
+        continue;
+      }
+      if (ch === "{") depth++;
+      else if (ch === "}") {
+        depth--;
+        if (depth === 0) return i + 1;
+      }
+      i++;
+    }
+    return null;
+  }
+  return null;
+}
+
+/** Scans one JSX-looking attribute (`name`, `name="value"`, `name={expr}`, or
+ * a bare spread `{...expr}`) starting at `i`, returning the index just past
+ * it, or `null` if `i` isn't the start of an attribute. */
+function skipJsxAttr(value: string, i: number): number | null {
+  if (value[i] === "{") return skipJsxAttrValue(value, i);
+  if (!ID_START.test(value[i] ?? "")) return null;
+  let j = i + 1;
+  while (ID_PART.test(value[j] ?? "")) j++;
+  if (value[j] !== "=") return j;
+  return skipJsxAttrValue(value, j + 1);
+}
+
+/**
+ * Finds the JSX tag (if any) starting at `value[start]`, returning its
+ * end index (exclusive) or `null`. Hand-written instead of a regex because a
+ * single pattern can't track attribute-value nesting (see
+ * {@link skipJsxAttrValue}); this walks the same grammar a JSX parser would.
+ */
+function matchJsxTagEnd(value: string, start: number): number | null {
+  if (value[start] !== "<") return null;
+  let i = start + 1;
+  if (value[i] === "/") i++;
+  if (!/[A-Z]/.test(value[i] ?? "")) return null;
+  i++;
+  while (/[A-Za-z0-9.]/.test(value[i] ?? "")) i++;
+
+  for (;;) {
+    const beforeSpace = i;
+    while (/\s/.test(value[i] ?? "")) i++;
+    if (value[i] === "/" && value[i + 1] === ">") return i + 2;
+    if (value[i] === ">") return i + 1;
+    if (i === beforeSpace) return null; // e.g. `<Foo bar` with no space
+    const end = skipJsxAttr(value, i);
+    if (end === null) return null;
+    i = end;
+  }
+}
 
 function protectInlineJsx(value: string): string {
-  return value.replace(JSX_TAG, (match, offset, source: string) => {
-    const before = source[offset - 1];
-    const after = source[offset + match.length];
-    return before === "`" && after === "`" ? match : `\`${match}\``;
-  });
+  let result = "";
+  let i = 0;
+  while (i < value.length) {
+    const end = value[i] === "<" ? matchJsxTagEnd(value, i) : null;
+    if (end === null) {
+      result += value[i];
+      i++;
+      continue;
+    }
+    const tag = value.slice(i, end);
+    const alreadyProtected = value[i - 1] === "`" && value[end] === "`";
+    result += alreadyProtected ? tag : `\`${tag}\``;
+    i = end;
+  }
+  return result;
 }
 
 function headingForBlock(segment: BlockSegment, fallback: string): string[] {
@@ -66,12 +148,27 @@ function formatCallout(data: Record<string, unknown>): string {
   return asString(data.body) ?? "";
 }
 
-function formatNotice(data: Record<string, unknown>): string {
-  return asString(data.body) ?? "";
+function formatNotice(
+  data: Record<string, unknown>,
+  segment: BlockSegment | undefined,
+): string {
+  const body = asString(data.body);
+  // A top-level Notice already gets its heading from headingForBlock via
+  // segment.title (toAttrs mirrors data.title into the MDX `title` attr).
+  // Nested Notices (inside Tabs/Columns) get no segment, so data.title is
+  // the only place their title survives — read it there instead of dropping it.
+  const title = !segment ? asString(data.title) : undefined;
+  return [
+    title ? `#### ${protectInlineJsx(title)}` : undefined,
+    body ? protectInlineJsx(body) : undefined,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
 }
 
 function formatBanner(data: Record<string, unknown>): string {
-  return asString(data.body) ?? "";
+  const body = asString(data.body);
+  return body ? protectInlineJsx(body) : "";
 }
 
 function formatBadge(data: Record<string, unknown>): string {
@@ -482,7 +579,13 @@ export function docsBodyToMarkdownMirror(body: string): string {
     splitDocSegments(body)
       .map((segment) => {
         if (segment.kind === "markdown") return segment.text.trim();
-        if (segment.kind === "invalid-block") return segment.body.trim();
+        // A block can fail real MDX parsing for reasons a well-formed JSX
+        // tag matcher will never see (e.g. a backslash-escaped quote inside
+        // an attribute value, which isn't valid JSX either) — that raw body
+        // still gets emitted verbatim below, so protect it the same as any
+        // other title/body text rather than leaving it as live-looking tags.
+        if (segment.kind === "invalid-block")
+          return protectInlineJsx(segment.body.trim());
         if (segment.source === "fence") return fenceSegmentToMarkdown(segment);
         return formatBlockData(segment.type, asRecord(segment.data), segment);
       })

--- a/packages/docs/lib/docs-markdown-export.ts
+++ b/packages/docs/lib/docs-markdown-export.ts
@@ -103,9 +103,7 @@ function formatComparison(data: Record<string, unknown>): string {
     .map((side) => {
       const row = asRecord(side);
       const label = asString(row.label) ?? "Option";
-      return [`#### ${label}`, asString(row.body)]
-        .filter(Boolean)
-        .join("\n\n");
+      return [`#### ${label}`, asString(row.body)].filter(Boolean).join("\n\n");
     })
     .join("\n\n");
 }

--- a/packages/docs/lib/docs-markdown-export.ts
+++ b/packages/docs/lib/docs-markdown-export.ts
@@ -62,6 +62,64 @@ function formatCallout(data: Record<string, unknown>): string {
   return asString(data.body) ?? "";
 }
 
+function formatNotice(data: Record<string, unknown>): string {
+  return asString(data.body) ?? "";
+}
+
+function formatBanner(data: Record<string, unknown>): string {
+  return asString(data.body) ?? "";
+}
+
+function formatBadge(data: Record<string, unknown>): string {
+  return asString(data.label) ?? "";
+}
+
+function formatCards(data: Record<string, unknown>): string {
+  return asArray(data.cards)
+    .map((card) => {
+      const row = asRecord(card);
+      const title = asString(row.title) ?? "Untitled";
+      const href = asString(row.href);
+      const heading = href ? `#### [${title}](${href})` : `#### ${title}`;
+      return [heading, asString(row.body)].filter(Boolean).join("\n\n");
+    })
+    .join("\n\n");
+}
+
+function formatSteps(data: Record<string, unknown>): string {
+  return asArray(data.steps)
+    .map((step, index) => {
+      const row = asRecord(step);
+      const title = asString(row.title) ?? `Step ${index + 1}`;
+      return [`#### ${index + 1}. ${title}`, asString(row.body)]
+        .filter(Boolean)
+        .join("\n\n");
+    })
+    .join("\n\n");
+}
+
+function formatComparison(data: Record<string, unknown>): string {
+  return asArray(data.sides)
+    .map((side) => {
+      const row = asRecord(side);
+      const label = asString(row.label) ?? "Option";
+      return [`#### ${label}`, asString(row.body)]
+        .filter(Boolean)
+        .join("\n\n");
+    })
+    .join("\n\n");
+}
+
+function formatAccordion(data: Record<string, unknown>): string {
+  return asArray(data.items)
+    .map((item) => {
+      const row = asRecord(item);
+      const title = asString(row.title) ?? "Untitled";
+      return [`#### ${title}`, asString(row.body)].filter(Boolean).join("\n\n");
+    })
+    .join("\n\n");
+}
+
 function formatChecklist(data: Record<string, unknown>): string {
   return asArray(data.items)
     .map((item) => {
@@ -340,6 +398,39 @@ function formatDiagram(data: Record<string, unknown>): string {
   return fenced("json", JSON.stringify(data, null, 2));
 }
 
+/**
+ * One formatter per block `type`. Keyed lookup instead of a type===chain so
+ * adding a block type is one line here, not a deeper ternary nest — the
+ * chain this replaced had grown to 21 levels before Notice/Banner/Badge/
+ * Cards/Steps/Comparison/Accordion were added.
+ */
+const blockFormatters: Record<
+  string,
+  (data: Record<string, unknown>, segment: BlockSegment | undefined) => string
+> = {
+  callout: formatCallout,
+  notice: formatNotice,
+  banner: formatBanner,
+  badge: formatBadge,
+  cards: formatCards,
+  steps: formatSteps,
+  comparison: formatComparison,
+  accordion: formatAccordion,
+  checklist: formatChecklist,
+  "file-tree": (data, segment) => formatFileTree(data, !segment),
+  table: formatTable,
+  "api-endpoint": formatApiEndpoint,
+  "data-model": formatDataModel,
+  "annotated-code": formatAnnotatedCode,
+  diff: formatDiff,
+  "json-explorer": formatJson,
+  "openapi-spec": formatOpenApi,
+  tabs: formatTabs,
+  columns: formatColumns,
+  wireframe: formatWireframe,
+  diagram: formatDiagram,
+};
+
 function formatBlockData(
   type: string,
   data: Record<string, unknown>,
@@ -350,36 +441,10 @@ function formatBlockData(
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ");
   const prefix = segment ? headingForBlock(segment, fallback) : [];
-  const body =
-    type === "callout"
-      ? formatCallout(data)
-      : type === "checklist"
-        ? formatChecklist(data)
-        : type === "file-tree"
-          ? formatFileTree(data, !segment)
-          : type === "table"
-            ? formatTable(data)
-            : type === "api-endpoint"
-              ? formatApiEndpoint(data)
-              : type === "data-model"
-                ? formatDataModel(data)
-                : type === "annotated-code"
-                  ? formatAnnotatedCode(data)
-                  : type === "diff"
-                    ? formatDiff(data)
-                    : type === "json-explorer"
-                      ? formatJson(data)
-                      : type === "openapi-spec"
-                        ? formatOpenApi(data)
-                        : type === "tabs"
-                          ? formatTabs(data)
-                          : type === "columns"
-                            ? formatColumns(data)
-                            : type === "wireframe"
-                              ? formatWireframe(data)
-                              : type === "diagram"
-                                ? formatDiagram(data)
-                                : fenced("json", JSON.stringify(data, null, 2));
+  const formatter = blockFormatters[type];
+  const body = formatter
+    ? formatter(data, segment)
+    : fenced("json", JSON.stringify(data, null, 2));
 
   return [...prefix, body].filter(Boolean).join("\n\n");
 }

--- a/packages/docs/lib/docs-markdown-export.ts
+++ b/packages/docs/lib/docs-markdown-export.ts
@@ -34,15 +34,19 @@ function fenced(language: string, code: unknown): string {
   return [`\`\`\`${language}`, String(code ?? "").trimEnd(), "```"].join("\n");
 }
 
+const JSX_ATTR =
+  /\s+[a-zA-Z_][a-zA-Z0-9_-]*(?:=(?:"[^"]*"|'[^']*'|\{[^{}]*\}))?/;
+const JSX_TAG = new RegExp(
+  `<\\/?[A-Z][A-Za-z0-9.]*(?:${JSX_ATTR.source})*\\s*\\/?>`,
+  "g",
+);
+
 function protectInlineJsx(value: string): string {
-  return value.replace(
-    /<\/?[A-Z][A-Za-z0-9.]*\s*\/?>/g,
-    (match, offset, source: string) => {
-      const before = source[offset - 1];
-      const after = source[offset + match.length];
-      return before === "`" && after === "`" ? match : `\`${match}\``;
-    },
-  );
+  return value.replace(JSX_TAG, (match, offset, source: string) => {
+    const before = source[offset - 1];
+    const after = source[offset + match.length];
+    return before === "`" && after === "`" ? match : `\`${match}\``;
+  });
 }
 
 function headingForBlock(segment: BlockSegment, fallback: string): string[] {

--- a/packages/docs/lib/docs-markdown-export.ts
+++ b/packages/docs/lib/docs-markdown-export.ts
@@ -78,7 +78,7 @@ function formatCards(data: Record<string, unknown>): string {
   return asArray(data.cards)
     .map((card) => {
       const row = asRecord(card);
-      const title = asString(row.title) ?? "Untitled";
+      const title = protectInlineJsx(asString(row.title) ?? "Untitled");
       const href = asString(row.href);
       const heading = href ? `#### [${title}](${href})` : `#### ${title}`;
       return [heading, asString(row.body)].filter(Boolean).join("\n\n");
@@ -90,7 +90,9 @@ function formatSteps(data: Record<string, unknown>): string {
   return asArray(data.steps)
     .map((step, index) => {
       const row = asRecord(step);
-      const title = asString(row.title) ?? `Step ${index + 1}`;
+      const title = protectInlineJsx(
+        asString(row.title) ?? `Step ${index + 1}`,
+      );
       return [`#### ${index + 1}. ${title}`, asString(row.body)]
         .filter(Boolean)
         .join("\n\n");
@@ -102,7 +104,7 @@ function formatComparison(data: Record<string, unknown>): string {
   return asArray(data.sides)
     .map((side) => {
       const row = asRecord(side);
-      const label = asString(row.label) ?? "Option";
+      const label = protectInlineJsx(asString(row.label) ?? "Option");
       return [`#### ${label}`, asString(row.body)].filter(Boolean).join("\n\n");
     })
     .join("\n\n");
@@ -112,7 +114,7 @@ function formatAccordion(data: Record<string, unknown>): string {
   return asArray(data.items)
     .map((item) => {
       const row = asRecord(item);
-      const title = asString(row.title) ?? "Untitled";
+      const title = protectInlineJsx(asString(row.title) ?? "Untitled");
       return [`#### ${title}`, asString(row.body)].filter(Boolean).join("\n\n");
     })
     .join("\n\n");

--- a/scripts/i18n-raw-literal-baseline.txt
+++ b/scripts/i18n-raw-literal-baseline.txt
@@ -1,8 +1,11 @@
 # Existing raw visible UI literals.
 # Keep this file sorted. Remove entries as surfaces move to i18n.
 # Format: relative/source/path.tsx|Visible string
+packages/docs/app/components/blocks/badge.tsx|A small status/label chip for the top of a page or section — Beta, Deprecated, v9.1+. Block-level only, not embeddable mid-sentence.
+packages/docs/app/components/blocks/banner.tsx|A compact, full-width, single-line announcement strip for the top of a page or section — beta, deprecated, moved. Tones: info, decision, risk, warning, success.
 packages/docs/app/components/blocks/cards.tsx|Feature name
 packages/docs/app/components/blocks/comparison.tsx|A side-by-side comparison of two to four options, e.g. Before/After or Option A/Option B.
+packages/docs/app/components/blocks/notice.tsx|A bold, filled alert card with an icon and optional title, for something a reader must not skim past. Tones: info, decision, risk, warning, success.
 packages/docs/app/components/blocks/steps.tsx|A numbered step-by-step procedure with circled step numbers.
 packages/docs/app/components/blocks/steps.tsx|Step title
 packages/docs/app/components/docBlocks.tsx|| Extract


### PR DESCRIPTION
**Add Notice, Banner, Accordion, and Badge docs components**

Adds four new MDX block components for the docs site to reduce reliance on `Cards` for content that isn't really a navigation/feature grid:

- **`Notice`** — a bold, filled alert card with an icon and optional title, for content the reader must not skim past. Reuses `Callout`'s existing five-tone vocabulary (`info` / `decision` / `risk` / `warning` / `success`) rather than introducing a second naming system.
- **`Banner`** — a compact, full-width, single-line strip for page- or section-top announcements (deprecated, beta, moved, version-scoped).
- **`Accordion`** — collapsed-by-default items for FAQ-style content, using native `<details>`. Same `### heading` authoring pattern as `Steps`/`Cards`.
- **`Badge`** — a small status/version chip (11 colors, 4 sizes, 2 shapes, curated icon set, stroke/disabled variants). Block-level only by design — the docs MDX pipeline is a line-anchored scanner, not a real MDX compiler, so a custom tag can only be recognized when it opens its own line; inline mid-sentence usage isn't supported.

All four are documented in `docs-components.mdx` with a live rendered example and a copy-paste `mdx` snippet each, and the "when to use which component" table is updated.

**Bug fix included:** the docs MDX pipeline has two separate block registries — a React-facing one (`docBlocks.tsx`) and a second, React-free one used purely for tag detection (`doc-block-segments.ts`'s `DOCS_EXTRA_BLOCKS`, which `Steps`/`Cards`/`Comparison` also need). All four new components are registered in both; missing the second one silently falls back to rendering literal escaped text with no error, so it's an easy trap for the next docs-only block someone adds.
