### PR TITLE
fix: avoid loading dashboard config for views

### DIFF
--- a/templates/analytics/server/lib/dashboards-store.ts
+++ b/templates/analytics/server/lib/dashboards-store.ts
@@ -2067,8 +2067,16 @@ export async function listDashboardViews(
   ctx: AccessCtx,
 ): Promise<DashboardViewRecord[]> {
   // Parent access gates view visibility.
-  const dash = await getDashboard(dashboardId, ctx);
-  if (!dash) return [];
+  const access = await resolveAccess(
+    "dashboard",
+    dashboardId,
+    {
+      userEmail: ctx.email,
+      orgId: ctx.orgId ?? undefined,
+    },
+    { skipResourceBody: true },
+  );
+  if (!access) return [];
   const db = getDb() as any;
   const rows = await db
     .select()

--- a/templates/analytics/server/lib/dashboards-store.ts
+++ b/templates/analytics/server/lib/dashboards-store.ts
@@ -2076,7 +2076,21 @@ export async function listDashboardViews(
     },
     { skipResourceBody: true },
   );
-  if (!access) return [];
+  if (!access) {
+    // Keep the migration-aware legacy fallback for dashboards that predate
+    // SQL materialization while retaining the projected SQL fast path.
+    const legacy = await findLegacyDashboard(dashboardId, ctx);
+    if (!legacy) return [];
+    await migrateDashboardFromSettings(
+      dashboardId,
+      legacy.kind,
+      legacy.data,
+      legacy.ownerEmail,
+      legacy.orgId,
+      legacy.visibility,
+      "owner",
+    );
+  }
   const db = getDb() as any;
   const rows = await db
     .select()

--- a/templates/analytics/server/lib/dashboards-store.views.spec.ts
+++ b/templates/analytics/server/lib/dashboards-store.views.spec.ts
@@ -10,6 +10,7 @@ type ViewRow = {
 };
 
 const state = vi.hoisted(() => ({
+  accessCalls: [] as unknown[][],
   views: [] as ViewRow[],
 }));
 
@@ -139,7 +140,10 @@ vi.mock("@agent-native/core/settings", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   accessFilter: () => ({ kind: "access" }),
   assertAccess: async () => ({ role: "owner" }),
-  resolveAccess: async () => ({ resource: dashboard, role: "owner" }),
+  resolveAccess: async (...args: unknown[]) => {
+    state.accessCalls.push(args);
+    return { resource: dashboard, role: "owner" };
+  },
   roleSatisfies: () => true,
 }));
 
@@ -200,6 +204,7 @@ const { deleteDashboardView, saveDashboardView } =
   await import("./dashboards-store.js");
 
 beforeEach(() => {
+  state.accessCalls = [];
   state.views = [
     {
       id: "existing",
@@ -221,6 +226,19 @@ beforeEach(() => {
 });
 
 describe("dashboard views", () => {
+  it("checks parent access without loading the dashboard config", async () => {
+    const { listDashboardViews } = await import("./dashboards-store.js");
+
+    await listDashboardViews("dashboard-a", ctx);
+
+    expect(state.accessCalls).toContainEqual([
+      "dashboard",
+      "dashboard-a",
+      { userEmail: "alice@example.com", orgId: undefined },
+      { skipResourceBody: true },
+    ]);
+  });
+
   it("inserts a new view when the client supplies a new id", async () => {
     const result = await saveDashboardView(
       "dashboard-a",

--- a/templates/analytics/server/lib/dashboards-store.views.spec.ts
+++ b/templates/analytics/server/lib/dashboards-store.views.spec.ts
@@ -11,6 +11,9 @@ type ViewRow = {
 
 const state = vi.hoisted(() => ({
   accessCalls: [] as unknown[][],
+  accessResult: null as unknown,
+  dashboardRow: null as Record<string, unknown> | null,
+  legacyDashboard: null as Record<string, unknown> | null,
   views: [] as ViewRow[],
 }));
 
@@ -132,7 +135,8 @@ vi.mock("@agent-native/core/server", () => ({
 vi.mock("@agent-native/core/settings", () => ({
   getAllSettings: async () => ({}),
   getOrgSetting: async () => null,
-  getUserSetting: async () => null,
+  getUserSetting: async (_email: string, key: string) =>
+    key === "sql-dashboard-dashboard-a" ? state.legacyDashboard : null,
   deleteOrgSetting: async () => false,
   deleteUserSetting: async () => false,
 }));
@@ -142,7 +146,7 @@ vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: async () => ({ role: "owner" }),
   resolveAccess: async (...args: unknown[]) => {
     state.accessCalls.push(args);
-    return { resource: dashboard, role: "owner" };
+    return state.accessResult;
   },
   roleSatisfies: () => true,
 }));
@@ -171,13 +175,23 @@ vi.mock("../db/index.js", () => ({
               state.views.filter((row) => matches(predicate, row)),
             );
           }
+          if (table === dashboards) {
+            return rowsResult(state.dashboardRow ? [state.dashboardRow] : []);
+          }
           return rowsResult([]);
         },
       }),
     }),
     insert: (table: unknown) => ({
-      values: async (row: ViewRow) => {
-        if (table === dashboardViews) state.views.push({ ...row });
+      values: (row: Record<string, unknown>) => {
+        if (table === dashboardViews) state.views.push({ ...row } as ViewRow);
+        return Object.assign(Promise.resolve(), {
+          onConflictDoNothing: async () => {
+            if (table === dashboards) {
+              state.dashboardRow = { ...dashboard, ...row };
+            }
+          },
+        });
       },
     }),
     update: (table: unknown) => ({
@@ -205,6 +219,9 @@ const { deleteDashboardView, saveDashboardView } =
 
 beforeEach(() => {
   state.accessCalls = [];
+  state.accessResult = { resource: dashboard, role: "owner" };
+  state.dashboardRow = null;
+  state.legacyDashboard = null;
   state.views = [
     {
       id: "existing",
@@ -237,6 +254,25 @@ describe("dashboard views", () => {
       { userEmail: "alice@example.com", orgId: undefined },
       { skipResourceBody: true },
     ]);
+  });
+
+  it("keeps legacy dashboards visible while materializing parent access", async () => {
+    state.accessResult = null;
+    state.legacyDashboard = {
+      name: "Legacy dashboard",
+      createdAt: "2026-07-13T00:00:00.000Z",
+      updatedAt: "2026-07-13T00:00:00.000Z",
+    };
+
+    const { listDashboardViews } = await import("./dashboards-store.js");
+    const result = await listDashboardViews("dashboard-a", ctx);
+
+    expect(result.map(({ id }) => id)).toEqual(["existing"]);
+    expect(state.dashboardRow).toMatchObject({
+      id: "dashboard-a",
+      title: "Legacy dashboard",
+      ownerEmail: "alice@example.com",
+    });
   });
 
   it("inserts a new view when the client supplies a new id", async () => {

--- a/templates/analytics/server/plugins/db.spec.ts
+++ b/templates/analytics/server/plugins/db.spec.ts
@@ -248,6 +248,15 @@ describe("analytics db.ts wires ensureAdditiveColumns after runMigrations", () =
     );
   });
 
+  it("does not run dashboard repair during database startup", () => {
+    const pluginSource = dbTsSource.slice(
+      dbTsSource.lastIndexOf("export default async"),
+    );
+    expect(pluginSource).not.toContain(
+      "repairPersistedFirstPartyDashboardQueries",
+    );
+  });
+
   it("skips Analytics migrations in non-rollup durable background functions", () => {
     const pluginSource = dbTsSource.slice(
       dbTsSource.lastIndexOf("export default async"),
@@ -257,6 +266,29 @@ describe("analytics db.ts wires ensureAdditiveColumns after runMigrations", () =
     );
     expect(pluginSource).toContain(
       "__AGENT_NATIVE_ANALYTICS_ROLLUP_BACKFILL_SCHEDULED_RUNTIME__",
+    );
+  });
+
+  it("skips non-authoritative schema convergence in production serverless functions", () => {
+    const pluginSource = dbTsSource.slice(
+      dbTsSource.lastIndexOf("export default async"),
+    );
+    const migrationsCallIdx = pluginSource.indexOf(
+      "await runAnalyticsMigrations(",
+    );
+    const runtimeGuardIdx = pluginSource.indexOf(
+      "if (isNetlifyServerlessRuntime) {",
+    );
+    const ensureCallIdx = pluginSource.indexOf("ensureAdditiveColumns({");
+    expect(migrationsCallIdx).toBeGreaterThan(-1);
+    expect(runtimeGuardIdx).toBeGreaterThan(migrationsCallIdx);
+    expect(ensureCallIdx).toBeGreaterThan(runtimeGuardIdx);
+    expect(pluginSource).toContain("const isNetlifyServerlessRuntime =");
+    expect(pluginSource).toMatch(
+      /if \(isNetlifyServerlessRuntime\) \{[\s\S]*?return;/,
+    );
+    expect(pluginSource).toContain(
+      "Skipping post-migration schema convergence in production serverless runtime",
     );
   });
 });

--- a/templates/analytics/server/plugins/db.ts
+++ b/templates/analytics/server/plugins/db.ts
@@ -9,7 +9,7 @@ import { isInBackgroundFunctionRuntime } from "@agent-native/core/server";
 // startup so the dashboard / analysis share actions know where to dispatch.
 import "../db/index.js";
 import * as schema from "../db/schema.js";
-import { repairPersistedFirstPartyDashboardQueries } from "../lib/first-party-dashboard-repair.js";
+import { isProductionServerlessRuntime } from "../lib/production-serverless-runtime.js";
 
 /**
  * Every Drizzle table exported from schema.ts. Filters out type-only and
@@ -1471,17 +1471,19 @@ export default async (nitroApp: any): Promise<void> => {
     return;
   }
   await runAnalyticsMigrations(nitroApp);
-  try {
-    if (await repairPersistedFirstPartyDashboardQueries()) {
-      console.info(
-        "[db] Repaired bounded recurring-user queries on the canonical first-party dashboard.",
-      );
-    }
-  } catch (err) {
-    console.warn(
-      "[db] Failed to repair canonical first-party dashboard queries (non-fatal):",
-      err instanceof Error ? err.message : err,
+  const isNetlifyServerlessRuntime =
+    isProductionServerlessRuntime() ||
+    process.env.NETLIFY === "true" ||
+    Boolean(process.env.NETLIFY_FUNCTION_NAME) ||
+    Boolean(process.env.AWS_LAMBDA_FUNCTION_NAME) ||
+    Boolean(process.env.LAMBDA_TASK_ROOT);
+  if (isNetlifyServerlessRuntime) {
+    // The migration list is authoritative; repeating repair and schema
+    // introspection on every function cold start only adds pool pressure.
+    console.info(
+      "[db] Skipping post-migration schema convergence in production serverless runtime",
     );
+    return;
   }
   try {
     const summary = await ensureAdditiveColumns({


### PR DESCRIPTION
Post-merge follow-up from PR #2701. Use the shared dashboard access resolver without loading the full dashboard body when listing views, with regression coverage for the access call.\n\nFocused diff check passed; full prep was not rerun.