### PR TITLE
fix: detect qualified boot data calls

### DIFF
--- a/scripts/guard-no-boot-data-work.mjs
+++ b/scripts/guard-no-boot-data-work.mjs
@@ -85,7 +85,7 @@ const SKIPPED = /(\.spec\.|\.test\.|\/__tests__\/|\/dist\/|\/node_modules\/)/;
  * exemption written by someone who never measured it.
  */
 const DATA_WORK = new RegExp(
-  String.raw`\bawait\s+(` +
+  String.raw`\bawait\s+(?:[$\w]+\.)*(` +
     [
       // Schema/migration work. Bounded in principle, 5-8s in practice on a
       // large database — and paid on every cold start, forever.


### PR DESCRIPTION
The boot-work guard matched only bare awaited calls, so qualified member calls such as `await db.runMigrations(...)` could bypass it. Match optional member-expression prefixes while preserving the existing pragma behavior.

Validation:
- `pnpm guard:no-boot-data-work`
- qualified-call fixtures for direct and member calls