### PR TITLE
Improve system audio control

### DIFF
--- a/templates/clips/desktop/src/components/MediaDeviceRow.tsx
+++ b/templates/clips/desktop/src/components/MediaDeviceRow.tsx
@@ -1,8 +1,10 @@
+import { IconVinyl } from "@tabler/icons-react";
 import { useMemo } from "react";
 
 import { useMicMeter } from "../hooks/useMicMeter";
 import { CameraIcon, CheckIcon, ChevronDown, MicIcon } from "./Icons";
 import { Switch } from "./Switch";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./Tooltip";
 import { useRowMenu } from "./useRowMenu";
 
 function Toggle({
@@ -112,109 +114,71 @@ export function MediaDeviceRow({
     kind === "camera" ? "Refresh cameras" : "Refresh microphones";
 
   return (
-    <div className="media-device-row" ref={rowRef}>
-      <div className={`row ${on ? "row-on" : "row-off"}`}>
-        <span className="row-icon">
-          <Icon />
-        </span>
-        <button
-          type="button"
-          className="row-button"
-          onClick={() => setOpen((v) => !v)}
-          disabled={disabled}
-          title={label}
-        >
-          <span className="row-label">{label}</span>
-          {kind === "mic" && on ? (
-            <MicWave deviceId={selectedId} active={on && meterActive} />
-          ) : (
-            <span className="row-flex" aria-hidden />
-          )}
-        </button>
-        {canOpenMenu ? (
+    <div className="media-device-row">
+      <div className="media-device-picker" ref={rowRef}>
+        <div className={`row ${on ? "row-on" : "row-off"}`}>
+          <span className="row-icon">
+            <Icon />
+          </span>
           <button
             type="button"
-            className="row-menu-trigger"
-            onClick={() => setOpen((value) => !value)}
-            aria-label={on ? `Choose ${kind}` : "System audio settings"}
-            aria-expanded={open}
-            aria-haspopup="menu"
+            className="row-button"
+            onClick={() => setOpen((v) => !v)}
+            disabled={disabled}
+            title={label}
           >
-            <ChevronDown />
+            <span className="row-label">{label}</span>
+            {kind === "mic" && on ? (
+              <MicWave deviceId={selectedId} active={on && meterActive} />
+            ) : (
+              <span className="row-flex" aria-hidden />
+            )}
           </button>
-        ) : (
-          <span className="row-chev" aria-hidden>
-            <ChevronDown />
-          </span>
-        )}
-        <Toggle
-          on={on}
-          onChange={(v) => {
-            if (!v) setOpen(false);
-            onToggle(v);
-          }}
-          label={kind === "camera" ? "Camera" : "Microphone"}
-        />
-      </div>
-      {open && canOpenMenu ? (
-        <div className="row-menu" role="menu">
-          {on ? (
-            <>
-              <button
-                type="button"
-                className={`row-menu-item ${!selectedId ? "selected" : ""}`}
-                role="menuitemradio"
-                aria-checked={!selectedId}
-                onClick={() => {
-                  onSelect("", "");
-                  setOpen(false);
-                }}
-              >
-                <span className="row-menu-check" aria-hidden>
-                  {!selectedId ? <CheckIcon /> : null}
-                </span>
-                <span className="row-menu-label">{defaultLabel}</span>
-              </button>
-              {devices.length === 0 ? (
+          {canOpenMenu ? (
+            <button
+              type="button"
+              className="row-menu-trigger"
+              onClick={() => setOpen((value) => !value)}
+              aria-label={on ? `Choose ${kind}` : "System audio settings"}
+              aria-expanded={open}
+              aria-haspopup="menu"
+            >
+              <ChevronDown />
+            </button>
+          ) : (
+            <span className="row-chev" aria-hidden>
+              <ChevronDown />
+            </span>
+          )}
+          <Toggle
+            on={on}
+            onChange={(v) => {
+              if (!v) setOpen(false);
+              onToggle(v);
+            }}
+            label={kind === "camera" ? "Camera" : "Microphone"}
+          />
+        </div>
+        {open && canOpenMenu ? (
+          <div className="row-menu" role="menu">
+            {on ? (
+              <>
                 <button
                   type="button"
-                  className="row-menu-item row-menu-action"
-                  role="menuitem"
+                  className={`row-menu-item ${!selectedId ? "selected" : ""}`}
+                  role="menuitemradio"
+                  aria-checked={!selectedId}
                   onClick={() => {
-                    onRefresh();
+                    onSelect("", "");
                     setOpen(false);
                   }}
                 >
-                  <span className="row-menu-check" aria-hidden />
-                  <span className="row-menu-label">{accessLabel}</span>
+                  <span className="row-menu-check" aria-hidden>
+                    {!selectedId ? <CheckIcon /> : null}
+                  </span>
+                  <span className="row-menu-label">{defaultLabel}</span>
                 </button>
-              ) : (
-                <>
-                  {devices.map((d) => {
-                    const isSelected =
-                      !!selectedId && d.deviceId === selectedId;
-                    return (
-                      <button
-                        key={d.deviceId}
-                        type="button"
-                        className={`row-menu-item ${isSelected ? "selected" : ""}`}
-                        role="menuitemradio"
-                        aria-checked={isSelected}
-                        onClick={() => {
-                          onSelect(d.deviceId, d.label);
-                          setOpen(false);
-                        }}
-                      >
-                        <span className="row-menu-check" aria-hidden>
-                          {isSelected ? <CheckIcon /> : null}
-                        </span>
-                        <span className="row-menu-label">
-                          {d.label ||
-                            (kind === "camera" ? "Camera" : "Microphone")}
-                        </span>
-                      </button>
-                    );
-                  })}
+                {devices.length === 0 ? (
                   <button
                     type="button"
                     className="row-menu-item row-menu-action"
@@ -225,23 +189,78 @@ export function MediaDeviceRow({
                     }}
                   >
                     <span className="row-menu-check" aria-hidden />
-                    <span className="row-menu-label">{refreshLabel}</span>
+                    <span className="row-menu-label">{accessLabel}</span>
                   </button>
-                </>
-              )}
-            </>
-          ) : null}
-          {kind === "mic" && onSystemAudioToggle ? (
-            <div className="row-menu-toggle">
-              <span className="row-menu-toggle-label">Record System audio</span>
-              <Switch
+                ) : (
+                  <>
+                    {devices.map((d) => {
+                      const isSelected =
+                        !!selectedId && d.deviceId === selectedId;
+                      return (
+                        <button
+                          key={d.deviceId}
+                          type="button"
+                          className={`row-menu-item ${isSelected ? "selected" : ""}`}
+                          role="menuitemradio"
+                          aria-checked={isSelected}
+                          onClick={() => {
+                            onSelect(d.deviceId, d.label);
+                            setOpen(false);
+                          }}
+                        >
+                          <span className="row-menu-check" aria-hidden>
+                            {isSelected ? <CheckIcon /> : null}
+                          </span>
+                          <span className="row-menu-label">
+                            {d.label ||
+                              (kind === "camera" ? "Camera" : "Microphone")}
+                          </span>
+                        </button>
+                      );
+                    })}
+                    <button
+                      type="button"
+                      className="row-menu-item row-menu-action"
+                      role="menuitem"
+                      onClick={() => {
+                        onRefresh();
+                        setOpen(false);
+                      }}
+                    >
+                      <span className="row-menu-check" aria-hidden />
+                      <span className="row-menu-label">{refreshLabel}</span>
+                    </button>
+                  </>
+                )}
+              </>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+      {kind === "mic" && onSystemAudioToggle ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div
+              className={`row system-audio-option ${systemAudio ? "row-on" : "row-off"}`}
+            >
+              <span className="row-icon">
+                <IconVinyl size={18} stroke={1.75} />
+              </span>
+              <span className="system-audio-option-label">
+                Record System Audio
+              </span>
+              <span className="row-flex" aria-hidden />
+              <Toggle
                 on={!!systemAudio}
                 onChange={onSystemAudioToggle}
-                label="Record system audio"
+                label="Record System Audio"
               />
             </div>
-          ) : null}
-        </div>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            Record audio from other applications
+          </TooltipContent>
+        </Tooltip>
       ) : null}
     </div>
   );

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -606,7 +606,7 @@ body[data-clips-route="recording-pill"] #root {
 }
 
 /* Popover menu rendered below a device row. */
-.media-device-row {
+.media-device-picker {
   position: relative;
 }
 
@@ -665,19 +665,14 @@ body[data-clips-route="recording-pill"] #root {
   border-radius: 4px;
 }
 
-.row-menu-toggle {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  margin-top: 4px;
-  padding: 10px 10px 8px 34px;
-  border-top: 1px solid var(--border, rgba(255, 255, 255, 0.08));
+.system-audio-option {
+  margin-top: 8px;
 }
 
-.row-menu-toggle-label {
-  font-size: 13px;
+.system-audio-option-label {
   color: var(--fg);
+  font-size: 13px;
+  font-weight: 500;
 }
 
 .row-menu-check {


### PR DESCRIPTION
Add a clearer system-audio recording control to the Clips desktop capture settings


Currently on main:
- system audio toggle is in the mic dropdown, so its a bit hard to see it.
- when the mic is disabled, you could still control system audio from the dropdown, but its not really intuitive 

<img width="379" height="300" alt="image" src="https://github.com/user-attachments/assets/85e55457-6535-4be1-8223-cfeb16e7d3a2" />
<img width="400" height="257" alt="image" src="https://github.com/user-attachments/assets/4b0b4ab0-bdc0-4049-acd2-6726004116f1" />



With this PR:
- system audio would have it own section

<img width="415" height="458" alt="image" src="https://github.com/user-attachments/assets/bf84c582-045e-4c62-8aef-49865bed601f" />


