### PR TITLE
Let users pick which screen to record on multi-monitor Macs

### DIFF
--- a/templates/clips/changelog/2026-08-07-full-screen-recordings-on-a-multi-monitor-mac-now-let-you-pi.md
+++ b/templates/clips/changelog/2026-08-07-full-screen-recordings-on-a-multi-monitor-mac-now-let-you-pi.md
@@ -1,0 +1,6 @@
+---
+type: added
+date: 2026-08-07
+---
+
+Full-screen recordings on a multi-monitor Mac now let you pick which display to record before capture starts.

--- a/templates/clips/desktop/src-tauri/capabilities/default.json
+++ b/templates/clips/desktop/src-tauri/capabilities/default.json
@@ -16,7 +16,8 @@
     "recording-pill",
     "region-guides",
     "region-guide-editor",
-    "region-record-border"
+    "region-record-border",
+    "monitor-picker-*"
   ],
   "permissions": [
     "core:default",

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -1235,7 +1235,10 @@ pub async fn hide_overlays(
 /// by the popover's session effect (show on popover-open, hide on
 /// popover-close).
 #[tauri::command]
-pub async fn hide_recording_chrome(app: AppHandle) -> Result<(), String> {
+pub async fn hide_recording_chrome(
+    app: AppHandle,
+    preserve_display_override: Option<bool>,
+) -> Result<(), String> {
     stop_countdown_control_tracking();
     // The countdown + toolbar always tear down on recording stop. The region
     // guides only tear down when they aren't pinned on-screen via the always-on
@@ -1256,7 +1259,13 @@ pub async fn hide_recording_chrome(app: AppHandle) -> Result<(), String> {
     // A recording that used the multi-monitor picker is over — clear its
     // display override so the NEXT recording (which might skip the picker
     // entirely on a single monitor) doesn't inherit a stale target screen.
-    crate::state::SelectedRecordingDisplay::set(&app, None);
+    // A native restart is the one exception: it discards this take and
+    // immediately starts a replacement on the SAME screen without re-running
+    // the picker (see `pickFullscreenRecordingDisplay`'s skip condition in
+    // recorder.ts), so the caller passes `preserve_display_override: true`.
+    if !preserve_display_override.unwrap_or(false) {
+        crate::state::SelectedRecordingDisplay::set(&app, None);
+    }
     // If meeting or voice flows showed a recording pill, auto-hide it after
     // recording stops. Bail early if a new recording came up in the meantime.
     let app_for_pill = app.clone();

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -47,6 +47,7 @@ const FLOW_BAR_LABEL: &str = "flow-bar";
 const REGION_GUIDES_LABEL: &str = "region-guides";
 const REGION_GUIDE_EDITOR_LABEL: &str = "region-guide-editor";
 const REGION_RECORD_BORDER_LABEL: &str = "region-record-border";
+const MONITOR_PICKER_LABEL_PREFIX: &str = "monitor-picker-";
 const ONBOARDING_LABEL: &str = "onboarding";
 const OVERLAY_LABELS: &[&str] = &[
     COUNTDOWN_LABEL,
@@ -859,6 +860,134 @@ pub async fn show_region_capture_selector(app: AppHandle) -> Result<(), String> 
     Ok(())
 }
 
+fn close_monitor_picker_windows(app: &AppHandle) {
+    for (label, window) in app.webview_windows() {
+        if label.starts_with(MONITOR_PICKER_LABEL_PREFIX) {
+            let _ = window.close();
+        }
+    }
+}
+
+/// Resolve the CGDirectDisplayID a monitor's own center point maps to, using
+/// that monitor's own scale factor (mixed-DPI multi-monitor setups can differ
+/// per screen, unlike the single popover-scale shortcut `tray_display_id`
+/// uses elsewhere).
+#[cfg(target_os = "macos")]
+fn display_id_for_monitor_rect(x: i32, y: i32, width: u32, height: u32, scale: f64) -> Option<u32> {
+    let cx_phys = x as f64 + width as f64 / 2.0;
+    let cy_phys = y as f64 + height as f64 / 2.0;
+    crate::native_screen::cg_display_id_at_physical_point(cx_phys, cy_phys, scale)
+}
+
+/// One small "record this screen" popup centered on every connected monitor,
+/// shown before a full-screen native recording starts when more than one
+/// monitor is connected. The React view in each window emits
+/// `clips:monitor-picker-selected` (with the display id baked into its own
+/// URL) or `clips:monitor-picker-cancelled`; the recorder driver listens for
+/// either and calls `close_monitor_picker` to tear all of them down. Returns
+/// `false` without opening anything when there's only one monitor, so the
+/// caller can skip straight to its existing single-monitor start path.
+#[tauri::command]
+pub async fn show_monitor_picker(app: AppHandle) -> Result<bool, String> {
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app;
+        Ok(false)
+    }
+    #[cfg(target_os = "macos")]
+    {
+        close_monitor_picker_windows(&app);
+        // Every fresh pick starts clean — a leftover pick from a previous
+        // recording must never apply here, including the single-monitor
+        // early-return below.
+        crate::state::SelectedRecordingDisplay::set(&app, None);
+        let monitors = app
+            .get_webview_window("popover")
+            .and_then(|w| w.available_monitors().ok())
+            .unwrap_or_default();
+        if monitors.len() <= 1 {
+            return Ok(false);
+        }
+        let total = monitors.len();
+        // Only the LAST window gets the full activate/makeKey/focus dance —
+        // `present_interactive_window` steals key-window status from
+        // whichever window had it, so calling it once per monitor just
+        // re-steals focus from the previous iteration's window for no
+        // lasting effect. A plain `show()` is enough for the rest.
+        let mut last_window: Option<WebviewWindow> = None;
+        for (index, monitor) in monitors.iter().enumerate() {
+            let pos = monitor.position();
+            let size = monitor.size();
+            let scale = monitor.scale_factor().max(1.0);
+            let display_id =
+                display_id_for_monitor_rect(pos.x, pos.y, size.width, size.height, scale)
+                    .unwrap_or(0);
+            let gutter = overlay_shadow_gutter_physical(&app);
+            let content_w: u32 = (240.0 * scale).round() as u32;
+            let content_h: u32 = (150.0 * scale).round() as u32;
+            let w = content_w + gutter * 2;
+            let h = content_h + gutter * 2;
+            let x = pos.x + (size.width as i32 - w as i32) / 2;
+            let y = pos.y + (size.height as i32 - h as i32) / 2;
+            let label = format!("{MONITOR_PICKER_LABEL_PREFIX}{index}");
+            let url = WebviewUrl::App(
+                format!(
+                    "index.html?index={}&total={}&displayId={}#monitor-picker",
+                    index + 1,
+                    total,
+                    display_id
+                )
+                .into(),
+            );
+            let win = WebviewWindowBuilder::new(&app, &label, url)
+                .title("Choose a screen to record")
+                .decorations(false)
+                .transparent(true)
+                .always_on_top(true)
+                .skip_taskbar(true)
+                .resizable(false)
+                .shadow(false)
+                .visible(false)
+                .focused(true)
+                .accept_first_mouse(true)
+                .build()
+                .map_err(|e| {
+                    eprintln!("[clips-tray] monitor picker build failed: {}", e);
+                    e.to_string()
+                })?;
+            let _ = win.set_size(tauri::Size::Physical(PhysicalSize::new(w, h)));
+            let _ = win.set_position(PhysicalPosition::new(x, y));
+            let _ = win.set_ignore_cursor_events(false);
+            set_capture_excluded_always(&win);
+            configure_overlay_behavior(&win);
+            let _ = win.show();
+            last_window = Some(win);
+        }
+        if let Some(win) = last_window {
+            present_interactive_window(&win);
+        }
+        Ok(true)
+    }
+}
+
+#[tauri::command]
+pub async fn close_monitor_picker(app: AppHandle) -> Result<(), String> {
+    close_monitor_picker_windows(&app);
+    Ok(())
+}
+
+/// Stash the user's monitor-picker pick for `tray_display_id` to consume the
+/// next time it resolves a target display — i.e. for the native full-screen
+/// recording about to start.
+#[tauri::command]
+pub async fn set_recording_display_override(
+    app: AppHandle,
+    display_id: Option<u32>,
+) -> Result<(), String> {
+    crate::state::SelectedRecordingDisplay::set(&app, display_id);
+    Ok(())
+}
+
 /// Vertical recording pill anchored to the left edge. Stop + timer + pause,
 /// with hover-revealed restart/cancel controls matching Loom's left-rail
 /// placement. Draggable, always on top.
@@ -1066,6 +1195,7 @@ pub async fn hide_overlays(
     preserve_finalizing: Option<bool>,
 ) -> Result<(), String> {
     stop_countdown_control_tracking();
+    close_monitor_picker_windows(&app);
     for label in overlay_labels_to_hide(preserve_finalizing.unwrap_or(false)) {
         if let Some(w) = app.get_webview_window(label) {
             let _ = w.close();
@@ -1104,6 +1234,10 @@ pub async fn hide_recording_chrome(app: AppHandle) -> Result<(), String> {
             let _ = w.close();
         }
     }
+    // A recording that used the multi-monitor picker is over — clear its
+    // display override so the NEXT recording (which might skip the picker
+    // entirely on a single monitor) doesn't inherit a stale target screen.
+    crate::state::SelectedRecordingDisplay::set(&app, None);
     // If meeting or voice flows showed a recording pill, auto-hide it after
     // recording stops. Bail early if a new recording came up in the meantime.
     let app_for_pill = app.clone();

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -919,9 +919,20 @@ pub async fn show_monitor_picker(app: AppHandle) -> Result<bool, String> {
             let pos = monitor.position();
             let size = monitor.size();
             let scale = monitor.scale_factor().max(1.0);
-            let display_id =
+            // Fail closed: a `0` placeholder here would round-trip through
+            // the URL and back as a `null` pick, which `set_recording_display_override`
+            // accepts as "no override" — clicking this exact card would then
+            // silently record whatever the tray-anchor heuristic picks
+            // instead of the screen the user is looking at right now.
+            let Some(display_id) =
                 display_id_for_monitor_rect(pos.x, pos.y, size.width, size.height, scale)
-                    .unwrap_or(0);
+            else {
+                eprintln!(
+                    "[clips-tray] monitor picker: could not resolve a display id for monitor {index}"
+                );
+                close_monitor_picker_windows(&app);
+                return Err("Could not identify one of the connected displays.".to_string());
+            };
             let gutter = overlay_shadow_gutter_physical(&app);
             let content_w: u32 = (240.0 * scale).round() as u32;
             let content_h: u32 = (150.0 * scale).round() as u32;
@@ -939,7 +950,7 @@ pub async fn show_monitor_picker(app: AppHandle) -> Result<bool, String> {
                 )
                 .into(),
             );
-            let win = WebviewWindowBuilder::new(&app, &label, url)
+            let win = match WebviewWindowBuilder::new(&app, &label, url)
                 .title("Choose a screen to record")
                 .decorations(false)
                 .transparent(true)
@@ -951,10 +962,18 @@ pub async fn show_monitor_picker(app: AppHandle) -> Result<bool, String> {
                 .focused(true)
                 .accept_first_mouse(true)
                 .build()
-                .map_err(|e| {
+            {
+                Ok(win) => win,
+                Err(e) => {
                     eprintln!("[clips-tray] monitor picker build failed: {}", e);
-                    e.to_string()
-                })?;
+                    // Earlier iterations already built and showed windows for
+                    // other monitors — without this they'd stay open and
+                    // always-on-top indefinitely since nothing else tears
+                    // them down after this function errors out.
+                    close_monitor_picker_windows(&app);
+                    return Err(e.to_string());
+                }
+            };
             let _ = win.set_size(tauri::Size::Physical(PhysicalSize::new(w, h)));
             let _ = win.set_position(PhysicalPosition::new(x, y));
             let _ = win.set_ignore_cursor_events(false);

--- a/templates/clips/desktop/src-tauri/src/lib.rs
+++ b/templates/clips/desktop/src-tauri/src/lib.rs
@@ -46,7 +46,8 @@ use tauri::{Emitter, Manager};
 use clips::{position_popover, toggle_popover};
 use state::{
     ActiveMeetingId, DictationActive, DictationEnabled, LastTranscript, MeetingActive,
-    PopoverShownAt, RecordingActive, TrayAnchor, TrayMeetings, VoiceTargetBundle, VoiceWakePopover,
+    PopoverShownAt, RecordingActive, SelectedRecordingDisplay, TrayAnchor, TrayMeetings,
+    VoiceTargetBundle, VoiceWakePopover,
 };
 use util::{
     configure_overlay_behavior, is_recording_active, present_interactive_window,
@@ -98,6 +99,9 @@ pub fn run() {
             clips::hide_region_record_border,
             clips::show_region_guide_editor,
             clips::show_region_capture_selector,
+            clips::show_monitor_picker,
+            clips::close_monitor_picker,
+            clips::set_recording_display_override,
             clips::close_bubble,
             clips::show_popover,
             clips::park_popover_offscreen,
@@ -270,6 +274,7 @@ pub fn run() {
         .manage(VoiceWakePopover::default())
         .manage(VoiceTargetBundle::default())
         .manage(LastTranscript::default())
+        .manage(SelectedRecordingDisplay::default())
         .manage(native_screen::NativeFullscreenRecordingState::default())
         .manage(screen_memory::ScreenMemoryState::default())
         .manage(capture_graph::CaptureGraphState::default())

--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -1358,7 +1358,6 @@ fn start_native_session_locked(
 #[tauri::command]
 pub async fn native_fullscreen_recording_warm(
     app: AppHandle,
-    state: State<'_, NativeFullscreenRecordingState>,
     recording_id: String,
     include_audio: bool,
     capture_system_audio: bool,
@@ -1370,7 +1369,6 @@ pub async fn native_fullscreen_recording_warm(
     {
         let _ = (
             app,
-            state,
             recording_id,
             include_audio,
             capture_system_audio,
@@ -1383,25 +1381,49 @@ pub async fn native_fullscreen_recording_warm(
 
     #[cfg(target_os = "macos")]
     {
-        // Only the mic introduces a warm-up gap; with mic off there's nothing
-        // to pre-warm, so `begin` just starts normally. SCK failures are
-        // swallowed too — `begin` detects the absent warm session and falls
-        // back to an immediate start, so warming is always best-effort.
-        if include_audio {
-            if let Err(err) = start_native_session_locked(
-                &app,
+        // Warm regardless of mic: the real cost here is SCShareableContent
+        // lookup + SCStream/output construction + `start_capture`, not just
+        // the microphone. Gating this on `include_audio` left every mic-off
+        // recording to do that full setup synchronously inside `begin` —
+        // i.e. after the countdown — which is exactly the multi-second gap
+        // between "countdown hits zero" and "capture actually starts" that
+        // mic-on recordings never had. SCK failures here are swallowed —
+        // `begin` detects the absent warm session and falls back to an
+        // immediate start, so warming is always best-effort.
+        //
+        // `SCShareableContent::get()` blocks its calling thread on a real
+        // condvar wait (not polling) that this file's own comments elsewhere
+        // clock at multi-second — that's the whole reason this exists instead
+        // of running at `begin`. Run it via `spawn_blocking` so that wait
+        // parks a blocking-pool thread instead of a tokio worker, which the
+        // countdown's `Promise.all` overlap is also relying on to stay
+        // responsive.
+        let app_for_warm = app.clone();
+        let recording_id_for_warm = recording_id.clone();
+        let warm_result = tauri::async_runtime::spawn_blocking(move || {
+            let state = app_for_warm.state::<NativeFullscreenRecordingState>();
+            start_native_session_locked(
+                &app_for_warm,
                 &state,
-                &recording_id,
+                &recording_id_for_warm,
                 include_audio,
                 capture_system_audio,
                 mic_device_id,
                 mic_device_label,
                 capture_region,
                 true,
-            ) {
+            )
+        })
+        .await;
+        match warm_result {
+            Ok(Ok(_)) => {}
+            Ok(Err(err)) => {
                 eprintln!(
-                    "[clips-tray] microphone pre-warm unavailable; will start normally at begin: {err}"
+                    "[clips-tray] recording pre-warm unavailable; will start normally at begin: {err}"
                 );
+            }
+            Err(join_err) => {
+                eprintln!("[clips-tray] recording pre-warm task panicked: {join_err}");
             }
         }
         Ok(())
@@ -2094,6 +2116,7 @@ pub(crate) fn kill_active_screencapture_child(state: &NativeFullscreenRecordingS
 
 #[tauri::command]
 pub async fn native_fullscreen_recording_cancel(
+    app: AppHandle,
     state: State<'_, NativeFullscreenRecordingState>,
 ) -> Result<(), String> {
     let session = {
@@ -2103,6 +2126,10 @@ pub async fn native_fullscreen_recording_cancel(
     if let Some(mut session) = session {
         discard_session(&mut session);
     }
+    // An aborted start (countdown/warm cancelled before `begin`) never reaches
+    // `hide_recording_chrome`, so the picker's monitor override must also be
+    // cleared here or it would wrongly apply to the next recording attempt.
+    crate::state::SelectedRecordingDisplay::set(&app, None);
     Ok(())
 }
 
@@ -3895,7 +3922,21 @@ pub(crate) fn clear_shared_clip_recording(app: &AppHandle, recording_id: &str, p
     let _ = app.emit("clips:pending-uploads-changed", ());
 }
 
+/// Convert a physical-pixel point to the logical-point coordinate space
+/// `CGDisplay::displays_with_point` requires (dividing by the monitor's own
+/// scale factor) and resolve which display owns it. Shared by every place in
+/// this file that maps a screen point to a `CGDirectDisplayID`.
 #[cfg(target_os = "macos")]
+pub(crate) fn cg_display_id_at_physical_point(
+    cx_phys: f64,
+    cy_phys: f64,
+    scale: f64,
+) -> Option<u32> {
+    let point = CGPoint::new(cx_phys / scale, cy_phys / scale);
+    let (ids, _) = CGDisplay::displays_with_point(point, 4).ok()?;
+    ids.into_iter().next()
+}
+
 /// Return the `CGDirectDisplayID` of the display containing the centre of
 /// the last-clicked tray icon. Uses the Tauri monitor list to locate the
 /// right monitor and converts from physical pixels to the logical-point
@@ -3904,6 +3945,12 @@ pub(crate) fn clear_shared_clip_recording(app: &AppHandle, recording_id: &str, p
 /// fails — callers fall back to the first available display.
 #[cfg(target_os = "macos")]
 pub(crate) fn tray_display_id(app: &AppHandle) -> Option<u32> {
+    // A multi-monitor picker pick always wins over the tray-anchor heuristic
+    // below — see `SelectedRecordingDisplay`'s doc comment for its lifecycle.
+    if let Some(id) = crate::state::SelectedRecordingDisplay::get(app) {
+        return Some(id);
+    }
+
     let tray_rect = app
         .try_state::<crate::state::TrayAnchor>()
         .and_then(|a| a.0.lock().ok().and_then(|g| *g))?;
@@ -3946,9 +3993,43 @@ pub(crate) fn tray_display_id(app: &AppHandle) -> Option<u32> {
         .map(|m| m.scale_factor())
         .unwrap_or(2.0);
 
-    let point = CGPoint::new(cx_phys / scale, cy_phys / scale);
-    let (ids, _) = CGDisplay::displays_with_point(point, 4).ok()?;
-    ids.into_iter().next()
+    cg_display_id_at_physical_point(cx_phys, cy_phys, scale)
+}
+
+/// Reverse of the monitor-center-to-CGDisplayID resolution above: given a
+/// CGDirectDisplayID (as picked in the multi-monitor screen picker), find the
+/// Tauri monitor whose center resolves to it and return its physical rect.
+/// Used so overlay windows (countdown, toolbar, finalizing, ...) shown during
+/// a recording that used the picker land on the same screen the user picked,
+/// not the tray icon's screen.
+#[cfg(target_os = "macos")]
+pub(crate) fn monitor_rect_for_display_id(
+    app: &AppHandle,
+    display_id: u32,
+) -> Option<(i32, i32, u32, u32)> {
+    let monitors = app
+        .get_webview_window("popover")?
+        .available_monitors()
+        .ok()?;
+    for monitor in monitors {
+        let pos = monitor.position();
+        let size = monitor.size();
+        let scale = monitor.scale_factor().max(1.0);
+        let cx_phys = pos.x as f64 + size.width as f64 / 2.0;
+        let cy_phys = pos.y as f64 + size.height as f64 / 2.0;
+        if cg_display_id_at_physical_point(cx_phys, cy_phys, scale) == Some(display_id) {
+            return Some((pos.x, pos.y, size.width, size.height));
+        }
+    }
+    None
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn monitor_rect_for_display_id(
+    _app: &AppHandle,
+    _display_id: u32,
+) -> Option<(i32, i32, u32, u32)> {
+    None
 }
 
 #[cfg(target_os = "macos")]

--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -270,6 +270,14 @@ mod native_upload_mode_tests {
 #[derive(Default)]
 pub struct NativeFullscreenRecordingState {
     inner: Mutex<Option<NativeFullscreenSession>>,
+    /// Bumped by `native_fullscreen_recording_cancel`. The warm task runs on
+    /// a blocking-pool thread and can still be mid-setup when a cancel
+    /// arrives — at that point `inner` is still empty, so cancel's own
+    /// `take()` finds nothing to discard. The warm task re-checks this
+    /// generation right after it installs its session; if it moved on, a
+    /// cancel arrived while it was working and it must undo the install
+    /// instead of leaving an orphaned, still-capturing stream behind.
+    warm_generation: AtomicU64,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize)]
@@ -1400,9 +1408,13 @@ pub async fn native_fullscreen_recording_warm(
         // responsive.
         let app_for_warm = app.clone();
         let recording_id_for_warm = recording_id.clone();
+        let generation_before_warm = app
+            .state::<NativeFullscreenRecordingState>()
+            .warm_generation
+            .load(Ordering::SeqCst);
         let warm_result = tauri::async_runtime::spawn_blocking(move || {
             let state = app_for_warm.state::<NativeFullscreenRecordingState>();
-            start_native_session_locked(
+            let result = start_native_session_locked(
                 &app_for_warm,
                 &state,
                 &recording_id_for_warm,
@@ -1412,7 +1424,23 @@ pub async fn native_fullscreen_recording_warm(
                 mic_device_label,
                 capture_region,
                 true,
-            )
+            );
+            // A cancel that arrived while ScreenCaptureKit setup was still in
+            // flight bumped the generation and found nothing to discard (see
+            // `native_fullscreen_recording_cancel`). Now that a session IS
+            // installed, check again — if the generation moved on, undo the
+            // install instead of leaving an orphaned stream capturing after
+            // the user cancelled.
+            if result.is_ok()
+                && state.warm_generation.load(Ordering::SeqCst) != generation_before_warm
+            {
+                let stale = state.inner.lock().ok().and_then(|mut guard| guard.take());
+                if let Some(mut stale) = stale {
+                    discard_session(&mut stale);
+                }
+                return Err("Recording cancelled while warming up.".to_string());
+            }
+            result
         })
         .await;
         match warm_result {
@@ -2119,6 +2147,11 @@ pub async fn native_fullscreen_recording_cancel(
     app: AppHandle,
     state: State<'_, NativeFullscreenRecordingState>,
 ) -> Result<(), String> {
+    // Bump BEFORE taking the session: a warm task on a blocking-pool thread
+    // may still be mid-setup right now, with nothing installed yet for this
+    // `take()` to find. Bumping first guarantees that when it later checks
+    // the generation after installing its session, it sees this cancel.
+    state.warm_generation.fetch_add(1, Ordering::SeqCst);
     let session = {
         let mut guard = state.inner.lock().map_err(|e| e.to_string())?;
         guard.take()

--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -1281,6 +1281,7 @@ fn start_native_session_locked(
     mic_device_label: Option<String>,
     capture_region: Option<NativeCaptureRegion>,
     defer_recording_output: bool,
+    expected_generation: Option<u64>,
 ) -> Result<NativeFullscreenStartInfo, String> {
     let safe_id = sanitize_recording_id(recording_id);
     reset_native_upload_completion_state();
@@ -1290,7 +1291,7 @@ fn start_native_session_locked(
         || mic_device_label
             .as_deref()
             .is_some_and(|v| !v.trim().is_empty());
-    let session = match start_screencapturekit_recording(
+    let mut session = match start_screencapturekit_recording(
         app,
         &safe_id,
         include_audio,
@@ -1337,15 +1338,19 @@ fn start_native_session_locked(
 
     let previous = {
         let mut guard = state.inner.lock().map_err(|e| e.to_string())?;
-        guard.take()
+        if let Some(expected) = expected_generation {
+            if state.warm_generation.load(Ordering::SeqCst) != expected {
+                drop(guard);
+                discard_session(&mut session);
+                return Err("Recording cancelled while warming up.".to_string());
+            }
+        }
+        let previous = guard.take();
+        *guard = Some(session);
+        previous
     };
     if let Some(mut previous) = previous {
         discard_session(&mut previous);
-    }
-
-    {
-        let mut guard = state.inner.lock().map_err(|e| e.to_string())?;
-        *guard = Some(session);
     }
 
     Ok(NativeFullscreenStartInfo {
@@ -1414,7 +1419,7 @@ pub async fn native_fullscreen_recording_warm(
             .load(Ordering::SeqCst);
         let warm_result = tauri::async_runtime::spawn_blocking(move || {
             let state = app_for_warm.state::<NativeFullscreenRecordingState>();
-            let result = start_native_session_locked(
+            start_native_session_locked(
                 &app_for_warm,
                 &state,
                 &recording_id_for_warm,
@@ -1424,23 +1429,8 @@ pub async fn native_fullscreen_recording_warm(
                 mic_device_label,
                 capture_region,
                 true,
-            );
-            // A cancel that arrived while ScreenCaptureKit setup was still in
-            // flight bumped the generation and found nothing to discard (see
-            // `native_fullscreen_recording_cancel`). Now that a session IS
-            // installed, check again — if the generation moved on, undo the
-            // install instead of leaving an orphaned stream capturing after
-            // the user cancelled.
-            if result.is_ok()
-                && state.warm_generation.load(Ordering::SeqCst) != generation_before_warm
-            {
-                let stale = state.inner.lock().ok().and_then(|mut guard| guard.take());
-                if let Some(mut stale) = stale {
-                    discard_session(&mut stale);
-                }
-                return Err("Recording cancelled while warming up.".to_string());
-            }
-            result
+                Some(generation_before_warm),
+            )
         })
         .await;
         match warm_result {
@@ -1540,6 +1530,7 @@ pub async fn native_fullscreen_recording_begin(
                 mic_device_label,
                 capture_region,
                 false,
+                None,
             )?;
             {
                 let mut guard = state.inner.lock().map_err(|e| e.to_string())?;

--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -1520,6 +1520,15 @@ pub async fn native_fullscreen_recording_begin(
                 .unwrap_or(false)
         };
         if !is_warmed {
+            // A warm task can still be mid-`SCShareableContent` lookup on a
+            // blocking-pool thread right now — that's exactly why nothing is
+            // installed yet. Bump the generation before building our own
+            // session below: without this, when that warm task eventually
+            // finishes, it sees no cancel occurred, assumes its generation is
+            // still current, and silently replaces the live session we're
+            // about to install with its own (never actually attached)
+            // deferred-output one.
+            state.warm_generation.fetch_add(1, Ordering::SeqCst);
             let info = start_native_session_locked(
                 &app,
                 &state,
@@ -2137,6 +2146,7 @@ pub(crate) fn kill_active_screencapture_child(state: &NativeFullscreenRecordingS
 pub async fn native_fullscreen_recording_cancel(
     app: AppHandle,
     state: State<'_, NativeFullscreenRecordingState>,
+    preserve_display_override: Option<bool>,
 ) -> Result<(), String> {
     // Bump BEFORE taking the session: a warm task on a blocking-pool thread
     // may still be mid-setup right now, with nothing installed yet for this
@@ -2153,7 +2163,11 @@ pub async fn native_fullscreen_recording_cancel(
     // An aborted start (countdown/warm cancelled before `begin`) never reaches
     // `hide_recording_chrome`, so the picker's monitor override must also be
     // cleared here or it would wrongly apply to the next recording attempt.
-    crate::state::SelectedRecordingDisplay::set(&app, None);
+    // A native restart is the exception — see `hide_recording_chrome`'s
+    // matching `preserve_display_override` doc comment.
+    if !preserve_display_override.unwrap_or(false) {
+        crate::state::SelectedRecordingDisplay::set(&app, None);
+    }
     Ok(())
 }
 

--- a/templates/clips/desktop/src-tauri/src/state.rs
+++ b/templates/clips/desktop/src-tauri/src/state.rs
@@ -1,6 +1,6 @@
 use std::sync::Mutex;
 use std::time::Instant;
-use tauri::Rect;
+use tauri::{AppHandle, Manager, Rect};
 
 use crate::tray_meetings::MeetingItem;
 
@@ -63,3 +63,29 @@ pub struct VoiceTargetBundle(pub Mutex<Option<String>>);
 /// Last dictation result for "paste last".
 #[derive(Default)]
 pub struct LastTranscript(pub Mutex<Option<String>>);
+
+/// CGDirectDisplayID the user picked in the multi-monitor screen picker,
+/// applying for the whole lifetime of the recording it was picked for (not
+/// just the first read) — `tray_display_id` and `tray_monitor_physical_rect`
+/// both read it via `get`. Cleared via `set(app, None)` by `show_monitor_picker`
+/// (next pick), `hide_recording_chrome` (stop), and
+/// `native_fullscreen_recording_cancel` (aborted start) — a stale pick must
+/// never leak into a later recording that skipped the picker (e.g. only one
+/// monitor connected).
+#[derive(Default)]
+pub struct SelectedRecordingDisplay(pub Mutex<Option<u32>>);
+
+impl SelectedRecordingDisplay {
+    pub fn get(app: &AppHandle) -> Option<u32> {
+        app.try_state::<Self>()
+            .and_then(|s| s.0.lock().ok().and_then(|g| *g))
+    }
+
+    pub fn set(app: &AppHandle, display_id: Option<u32>) {
+        if let Some(state) = app.try_state::<Self>() {
+            if let Ok(mut guard) = state.0.lock() {
+                *guard = display_id;
+            }
+        }
+    }
+}

--- a/templates/clips/desktop/src-tauri/src/util.rs
+++ b/templates/clips/desktop/src-tauri/src/util.rs
@@ -2,7 +2,8 @@ use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindow, WebviewWindo
 
 use crate::dlog;
 use crate::state::{
-    DictationActive, PopoverShownAt, RecordingActive, TrayAnchor, VoiceWakePopover,
+    DictationActive, PopoverShownAt, RecordingActive, SelectedRecordingDisplay, TrayAnchor,
+    VoiceWakePopover,
 };
 
 const POPOVER_SHADOW_GUTTER_LOGICAL: f64 = 24.0;
@@ -369,6 +370,16 @@ pub fn present_interactive_window(window: &WebviewWindow) {
 /// instead of `primary_monitor_physical_size` for any overlay that should appear
 /// on the same screen as the recording.
 pub fn tray_monitor_physical_rect(app: &AppHandle) -> (i32, i32, u32, u32) {
+    // A monitor picked in the multi-monitor screen picker wins over the tray
+    // icon's monitor for every overlay shown during that recording
+    // (countdown, toolbar, finalizing, region guides, ...) — see
+    // `SelectedRecordingDisplay`'s doc comment for its lifecycle.
+    if let Some(id) = SelectedRecordingDisplay::get(app) {
+        if let Some(rect) = crate::native_screen::monitor_rect_for_display_id(app, id) {
+            return rect;
+        }
+    }
+
     let tray_rect = app
         .try_state::<TrayAnchor>()
         .and_then(|a| a.0.lock().ok().and_then(|g| *g));

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -92,6 +92,7 @@ import {
   exportBrowserRecordingBackup,
   getRewindClipOrigin,
   listBrowserRecordingBackups,
+  pickFullscreenRecordingDisplay,
   retryBrowserRecordingBackup,
   scheduleNativeBackupCleanupAfterProcessing,
   shouldUseNativeFullscreenRecording,
@@ -2955,6 +2956,21 @@ export function App() {
         setReadinessOpen(true);
         setRecError(err instanceof Error ? err.message : String(err));
         return null;
+      }
+      // A restart hands off the already-live display stream from the take
+      // it's replacing (see `discardForRestart`/`preAcquiredDisplayStream`
+      // below) — it must keep recording the same screen, not re-prompt.
+      if (source === "full-screen" && !options?.resumeCapture) {
+        try {
+          // Must resolve before `recordingFlowActive` flips the toolbar on
+          // below — the toolbar reads the pick to place itself on the
+          // chosen screen the first time it's shown.
+          await pickFullscreenRecordingDisplay();
+        } catch {
+          // User cancelled the screen picker (Escape) — abort silently,
+          // same as dismissing the native macOS screen picker.
+          return null;
+        }
       }
     }
 

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -2900,7 +2900,10 @@ export function App() {
     /** Live capture inherited from the take a restart is replacing. */
     resumeCapture?: RestartHandoff;
   }): Promise<RecorderHandle | null> {
-    if (recorder && !options?.ignoreActiveRecorder) {
+    if (
+      (recorder || recordingFlowGateRef.current) &&
+      !options?.ignoreActiveRecorder
+    ) {
       console.warn(
         "[clips-popover] handleStartRecording ignored — recorder already active",
       );
@@ -2942,17 +2945,27 @@ export function App() {
     });
 
     if (mode !== "camera" && nativeFullscreenRecordingActive) {
+      // Latch re-entry protection before these awaits, not after — both the
+      // permission prompt and the monitor picker below can take a while (the
+      // picker waits on the user), and without this a double-click while
+      // either is pending passes the top-of-function guard and starts a
+      // second, competing recording-start flow. The real flow-active latch
+      // further below hasn't run yet at this point, so reset this on every
+      // early return in this block.
+      recordingFlowGateRef.current = true;
       try {
         const granted = await invoke<boolean>(
           "request_macos_screen_recording_access",
         );
         if (!granted) {
+          recordingFlowGateRef.current = false;
           setReadinessOpen(true);
           setRecError(MACOS_SCREEN_PERMISSION_MESSAGE);
           openPrivacySettings("screen");
           return null;
         }
       } catch (err) {
+        recordingFlowGateRef.current = false;
         setReadinessOpen(true);
         setRecError(err instanceof Error ? err.message : String(err));
         return null;
@@ -2969,6 +2982,7 @@ export function App() {
         } catch {
           // User cancelled the screen picker (Escape) — abort silently,
           // same as dismissing the native macOS screen picker.
+          recordingFlowGateRef.current = false;
           return null;
         }
       }

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -2979,10 +2979,17 @@ export function App() {
           // below — the toolbar reads the pick to place itself on the
           // chosen screen the first time it's shown.
           await pickFullscreenRecordingDisplay();
-        } catch {
-          // User cancelled the screen picker (Escape) — abort silently,
-          // same as dismissing the native macOS screen picker.
+        } catch (err) {
           recordingFlowGateRef.current = false;
+          if (err instanceof Error && err.name === "AbortError") {
+            // User cancelled the screen picker (Escape) — abort silently,
+            // same as dismissing the native macOS screen picker.
+            return null;
+          }
+          // A real failure (picker window construction, persisting the
+          // pick, etc.) — surface it instead of silently aborting like a
+          // cancel, or the user has no idea why nothing happened.
+          setRecError(err instanceof Error ? err.message : String(err));
           return null;
         }
       }

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -2111,6 +2111,114 @@ async function selectRegionForRecording(): Promise<RegionCaptureRect> {
   }
 }
 
+class MonitorPickerCancelledError extends Error {
+  constructor() {
+    super("Full-screen monitor selection cancelled");
+    this.name = "AbortError";
+  }
+}
+
+function waitForMonitorPickerSelection(): {
+  promise: Promise<number | null>;
+  cleanup: () => void;
+} {
+  let settled = false;
+  const unlistens: UnlistenFn[] = [];
+
+  const cleanup = () => {
+    settled = true;
+    for (const unlisten of unlistens.splice(0)) {
+      try {
+        unlisten();
+      } catch {
+        // ignore
+      }
+    }
+  };
+
+  const promise = new Promise<number | null>((resolve, reject) => {
+    const finish = (cancelled: boolean, displayId: number | null) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (cancelled) reject(new MonitorPickerCancelledError());
+      else resolve(displayId);
+    };
+
+    const track = (listener: Promise<UnlistenFn>) => {
+      listener
+        .then((unlisten) => {
+          if (settled) {
+            try {
+              unlisten();
+            } catch {
+              // ignore
+            }
+            return;
+          }
+          unlistens.push(unlisten);
+        })
+        .catch((err) => {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          reject(err);
+        });
+    };
+
+    track(
+      listen<{ displayId?: number | null }>(
+        "clips:monitor-picker-selected",
+        (event) => {
+          const raw = event.payload?.displayId;
+          const displayId =
+            typeof raw === "number" && Number.isFinite(raw) && raw > 0
+              ? raw
+              : null;
+          finish(false, displayId);
+        },
+      ),
+    );
+    track(
+      listen("clips:monitor-picker-cancelled", () => {
+        finish(true, null);
+      }),
+    );
+  });
+
+  return { promise, cleanup };
+}
+
+/**
+ * When more than one monitor is connected, shows a small "record this
+ * screen" popup centered on each one and waits for the user to pick one —
+ * or cancel with Escape, which aborts the whole recording start. Resolves
+ * immediately with no popup when there's only one monitor, matching the
+ * prior single-monitor behavior.
+ *
+ * Callers must await this BEFORE flipping any "recording is starting" UI
+ * state (toolbar, timer, etc.) — that chrome positions itself on whatever
+ * `tray_monitor_physical_rect` returns at the moment it's shown, which
+ * reads this pick. Called from `startNativeFullscreenRecording` instead,
+ * the toolbar was already up (and pinned to the wrong screen) by the time
+ * the user finished picking.
+ */
+export async function pickFullscreenRecordingDisplay(): Promise<void> {
+  const shown = await invoke<boolean>("show_monitor_picker");
+  if (!shown) return;
+  const selection = waitForMonitorPickerSelection();
+  let displayId: number | null = null;
+  try {
+    displayId = await selection.promise;
+  } catch (err) {
+    selection.cleanup();
+    await invoke("close_monitor_picker").catch(() => {});
+    throw err;
+  }
+  await invoke("set_recording_display_override", { displayId }).catch(() => {});
+  await invoke("close_monitor_picker").catch(() => {});
+}
+
 async function prepareCountdownEventWaiter(
   timeoutMs = 4000,
   signal?: AbortSignal,
@@ -3063,6 +3171,9 @@ async function startNativeFullscreenRecording(
       // down on stop, cancel, and the error paths below.
       await showRegionRecordBorder(captureRegion);
     }
+    // Full-screen's monitor pick already happened in the caller, before
+    // `recordingFlowActive`/the toolbar went up — see
+    // `pickFullscreenRecordingDisplay`'s doc comment for why.
 
     if (localOnly && localRecordingMode === "separate" && wantsCamera) {
       localCameraStream =

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -2223,9 +2223,22 @@ function waitForMonitorPickerSelection(): {
  * the user finished picking.
  */
 export async function pickFullscreenRecordingDisplay(): Promise<void> {
-  const shown = await invoke<boolean>("show_monitor_picker");
-  if (!shown) return;
+  // Registered BEFORE showing the picker windows: a fast click (or keyboard
+  // activation) can otherwise fire the selection event before these
+  // listeners exist, and Tauri does not replay events to a listener
+  // registered after the fact — the wait would then sit until its timeout.
   const selection = waitForMonitorPickerSelection();
+  let shown: boolean;
+  try {
+    shown = await invoke<boolean>("show_monitor_picker");
+  } catch (err) {
+    selection.cleanup();
+    throw err;
+  }
+  if (!shown) {
+    selection.cleanup();
+    return;
+  }
   let displayId: number | null = null;
   try {
     displayId = await selection.promise;

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -2118,15 +2118,30 @@ class MonitorPickerCancelledError extends Error {
   }
 }
 
+/**
+ * Safety net only — a normal pick takes as long as the user needs. This
+ * guards against the picker windows being torn down by something other than
+ * a click or Escape (a monitor disconnecting mid-pick, some other teardown)
+ * with neither selection event ever firing, which would otherwise hang the
+ * recording-start flow forever. Matches the "abandon after a while" window
+ * used elsewhere in this file (see `CUE_IDLE_CLEANUP_MS` in audio-cue.ts).
+ */
+const MONITOR_PICKER_SELECTION_TIMEOUT_MS = 5 * 60_000;
+
 function waitForMonitorPickerSelection(): {
   promise: Promise<number | null>;
   cleanup: () => void;
 } {
   let settled = false;
   const unlistens: UnlistenFn[] = [];
+  let timer: ReturnType<typeof setTimeout> | null = null;
 
   const cleanup = () => {
     settled = true;
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
     for (const unlisten of unlistens.splice(0)) {
       try {
         unlisten();
@@ -2144,6 +2159,10 @@ function waitForMonitorPickerSelection(): {
       if (cancelled) reject(new MonitorPickerCancelledError());
       else resolve(displayId);
     };
+
+    timer = setTimeout(() => {
+      finish(true, null);
+    }, MONITOR_PICKER_SELECTION_TIMEOUT_MS);
 
     const track = (listener: Promise<UnlistenFn>) => {
       listener
@@ -2215,8 +2234,16 @@ export async function pickFullscreenRecordingDisplay(): Promise<void> {
     await invoke("close_monitor_picker").catch(() => {});
     throw err;
   }
-  await invoke("set_recording_display_override", { displayId }).catch(() => {});
-  await invoke("close_monitor_picker").catch(() => {});
+  try {
+    // Deliberately not swallowed: if this fails, `tray_display_id` falls
+    // back to the tray-anchor screen with no way for the caller to tell
+    // that happened, silently recording a different screen than the one
+    // the user just picked. Propagate so the caller aborts the start
+    // instead.
+    await invoke("set_recording_display_override", { displayId });
+  } finally {
+    await invoke("close_monitor_picker").catch(() => {});
+  }
 }
 
 async function prepareCountdownEventWaiter(

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -3595,7 +3595,16 @@ async function startNativeFullscreenRecording(
         );
       });
     await localCameraExport?.cancel().catch(() => {});
-    await invoke("native_fullscreen_recording_cancel").catch((err) =>
+    // A restart discards this take and immediately starts a replacement on
+    // the SAME screen without re-running the monitor picker (native restarts
+    // hand off the live capture, not a browser display stream — see
+    // `pickFullscreenRecordingDisplay`'s skip condition in app.tsx). Without
+    // `preserveDisplayOverride`, these calls would clear the pick before the
+    // replacement recording ever reads it, silently falling back to the
+    // tray-anchor screen.
+    await invoke("native_fullscreen_recording_cancel", {
+      preserveDisplayOverride: forRestart,
+    }).catch((err) =>
       console.warn("[clips-recorder] native fullscreen cancel failed:", err),
     );
     if (bubbleCaptureExcluded) {
@@ -3609,7 +3618,9 @@ async function startNativeFullscreenRecording(
     }
     streamCleanups.forEach((cleanup) => cleanup());
     if (forRestart) {
-      await invoke("hide_recording_chrome").catch(() => {});
+      await invoke("hide_recording_chrome", {
+        preserveDisplayOverride: true,
+      }).catch(() => {});
     } else {
       await endSession();
     }

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -2255,6 +2255,7 @@ export async function pickFullscreenRecordingDisplay(): Promise<void> {
     // instead.
     await invoke("set_recording_display_override", { displayId });
   } finally {
+    selection.cleanup();
     await invoke("close_monitor_picker").catch(() => {});
   }
 }

--- a/templates/clips/desktop/src/main.tsx
+++ b/templates/clips/desktop/src/main.tsx
@@ -10,6 +10,7 @@ import { Finalizing } from "./overlays/finalizing";
 import { FlowBar } from "./overlays/flow-bar";
 import { MeetingNotification } from "./overlays/meeting-notification";
 import { MeetingNub } from "./overlays/meeting-nub";
+import { MonitorPicker } from "./overlays/monitor-picker";
 import { Onboarding } from "./overlays/onboarding";
 import { Preparing } from "./overlays/preparing";
 import { RecordingPill } from "./overlays/recording-pill";
@@ -64,6 +65,8 @@ function pickRoute(route: string): React.ReactElement {
       return <RegionGuideEditor mode="capture" />;
     case "region-record-border":
       return <RegionRecordBorder />;
+    case "monitor-picker":
+      return <MonitorPicker />;
     default:
       return <App />;
   }

--- a/templates/clips/desktop/src/overlays/monitor-picker.tsx
+++ b/templates/clips/desktop/src/overlays/monitor-picker.tsx
@@ -1,0 +1,70 @@
+import { emit } from "@tauri-apps/api/event";
+import { useEffect } from "react";
+
+interface MonitorPickerParams {
+  index: number;
+  total: number;
+  displayId: number | null;
+}
+
+function parseParams(search: string): MonitorPickerParams {
+  const params = new URLSearchParams(search);
+  const index = Number.parseInt(params.get("index") ?? "", 10);
+  const total = Number.parseInt(params.get("total") ?? "", 10);
+  const displayIdRaw = Number.parseInt(params.get("displayId") ?? "", 10);
+  return {
+    index: Number.isFinite(index) && index > 0 ? index : 1,
+    total: Number.isFinite(total) && total > 0 ? total : 1,
+    displayId:
+      Number.isFinite(displayIdRaw) && displayIdRaw > 0 ? displayIdRaw : null,
+  };
+}
+
+/**
+ * One of these opens centered on every connected monitor before a
+ * full-screen native recording starts with more than one monitor attached
+ * (see `show_monitor_picker` on the Rust side). The display id this specific
+ * monitor resolves to is baked into this window's own URL rather than looked
+ * up again here, so a click can report it without a round trip. The recorder
+ * driver — not this component — closes every sibling window once it hears
+ * either event, so a click never closes just itself.
+ */
+export function MonitorPicker() {
+  const { index, total, displayId } =
+    typeof window === "undefined"
+      ? { index: 1, total: 1, displayId: null }
+      : parseParams(window.location.search);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      emit("clips:monitor-picker-cancelled").catch(() => {});
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  function select() {
+    emit("clips:monitor-picker-selected", { displayId }).catch(() => {});
+  }
+
+  return (
+    <div className="monitor-picker-root">
+      <button
+        type="button"
+        className="monitor-picker-card"
+        onClick={select}
+        autoFocus
+      >
+        <span className="monitor-picker-title">Screen {index}</span>
+        <span className="monitor-picker-subtitle">
+          Click to record this display
+        </span>
+        <span className="monitor-picker-hint">
+          {total} displays connected · Esc to cancel
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -6229,3 +6229,67 @@ body[data-clips-route="recording-pill"] #root {
     transform: rotate(360deg);
   }
 }
+
+/*
+ * One of these windows opens centered on every connected monitor when a
+ * full-screen native recording is about to start with more than one monitor
+ * attached (see `show_monitor_picker`). The window itself is already sized
+ * and positioned by Rust, so the card just fills it.
+ */
+.monitor-picker-root {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+  background: transparent;
+}
+
+.monitor-picker-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  height: 100%;
+  padding: 16px;
+  border-radius: 20px;
+  background: rgba(20, 22, 28, 0.94);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
+  color: white;
+  text-align: center;
+  cursor: pointer;
+  transition:
+    background 120ms,
+    border-color 120ms;
+}
+
+.monitor-picker-card:hover,
+.monitor-picker-card:focus-visible {
+  background: rgba(32, 35, 43, 0.96);
+  border-color: rgba(255, 255, 255, 0.24);
+  outline: none;
+}
+
+.monitor-picker-title {
+  font-size: 17px;
+  font-weight: 700;
+}
+
+.monitor-picker-subtitle {
+  font-size: 13px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.monitor-picker-hint {
+  margin-top: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.45);
+}


### PR DESCRIPTION
This PR adds a screen picker, fixes the chrome (toolbar, countdown, etc.) to show up on the picked screen, and fixes a delay that made recordings start a couple of seconds after the countdown finished.

So now when a user clicks on start a recording, for fullscreen recordings they will first be prompted to select the screen:

<img width="573" height="730" alt="image" src="https://github.com/user-attachments/assets/cec72afb-9a30-4c20-8951-6cefc0b5626e" />
