### PR TITLE
Fix Clips meeting notes stopping too early

### DIFF
--- a/templates/clips/desktop/src-tauri/src/silence_detector.rs
+++ b/templates/clips/desktop/src-tauri/src/silence_detector.rs
@@ -392,7 +392,6 @@ fn install_call_ended_watcher(app: &AppHandle, threshold_ms: u64) {
             let mut ever_seen_front = false;
             let mut last_front_at: Option<Instant> = None;
             let mut fired = false;
-            let mut last_front_was_generic_browser = false;
             let mut call_app_used_microphone = false;
             let mut microphone_released_at: Option<Instant> = None;
             let mut generation: Option<u64> = None;
@@ -408,7 +407,6 @@ fn install_call_ended_watcher(app: &AppHandle, threshold_ms: u64) {
                     ever_seen_front = false;
                     last_front_at = None;
                     fired = false;
-                    last_front_was_generic_browser = false;
                     call_app_used_microphone = false;
                     microphone_released_at = None;
                     continue;
@@ -417,7 +415,6 @@ fn install_call_ended_watcher(app: &AppHandle, threshold_ms: u64) {
                     ever_seen_front = false;
                     last_front_at = None;
                     fired = false;
-                    last_front_was_generic_browser = false;
                     call_app_used_microphone = false;
                     microphone_released_at = None;
                     generation = Some(active_generation);
@@ -450,7 +447,6 @@ fn install_call_ended_watcher(app: &AppHandle, threshold_ms: u64) {
                 if is_strong_vc || is_generic_browser {
                     ever_seen_front = true;
                     last_front_at = Some(Instant::now());
-                    last_front_was_generic_browser = is_generic_browser;
                 }
                 if fired {
                     continue;
@@ -485,12 +481,11 @@ fn install_call_ended_watcher(app: &AppHandle, threshold_ms: u64) {
                             Instant::now().duration_since(t).as_millis() as u64 >= threshold_ms
                         })
                         .unwrap_or(false)
-                    // Require audio corroboration for browser-hosted calls:
-                    // backgrounding Chrome/Arc alone does not prove that the
-                    // Meet tab ended. Use the last known conference app, not
-                    // the unrelated app now in front.
-                    && (!last_front_was_generic_browser
-                        || audio_recently_silent(&state, threshold_ms));
+                    // Require audio corroboration: backgrounding the call app
+                    // (native or browser-hosted) to type notes in another app
+                    // does not prove the call ended — only quiet mic+system
+                    // audio alongside the background transition does.
+                    && audio_recently_silent(&state, threshold_ms);
 
                 if microphone_released || frontmost_call_ended {
                     let _ = app.emit("meetings:call-ended", ());

--- a/templates/clips/desktop/src-tauri/src/silence_detector.rs
+++ b/templates/clips/desktop/src-tauri/src/silence_detector.rs
@@ -470,10 +470,18 @@ fn install_call_ended_watcher(app: &AppHandle, threshold_ms: u64) {
                     _ => {}
                 }
 
+                // Require audio corroboration for every trigger in this
+                // watcher: backgrounding the call app, or its process
+                // dropping its mic input, does not by itself prove the call
+                // ended — a browser tab can report either transition while
+                // the meeting is still playing through system audio. Only
+                // quiet mic+system audio alongside the signal does.
+                let audio_quiet = audio_recently_silent(&state, threshold_ms);
+
                 let microphone_released = microphone_release_stop_ready(
                     call_app_used_microphone,
                     microphone_released_at.map(|at| Instant::now().duration_since(at)),
-                );
+                ) && audio_quiet;
 
                 let frontmost_call_ended = ever_seen_front
                     && last_front_at
@@ -481,11 +489,7 @@ fn install_call_ended_watcher(app: &AppHandle, threshold_ms: u64) {
                             Instant::now().duration_since(t).as_millis() as u64 >= threshold_ms
                         })
                         .unwrap_or(false)
-                    // Require audio corroboration: backgrounding the call app
-                    // (native or browser-hosted) to type notes in another app
-                    // does not prove the call ended — only quiet mic+system
-                    // audio alongside the background transition does.
-                    && audio_recently_silent(&state, threshold_ms);
+                    && audio_quiet;
 
                 if microphone_released || frontmost_call_ended {
                     let _ = app.emit("meetings:call-ended", ());


### PR DESCRIPTION
Clips sometimes says a meeting is over and stops taking notes, even though the meeting is still going. This fixes that.

## What was happening

Clips watches your screen to guess when a call ends. If your Zoom or Teams window is not the window you are looking at for 2 minutes, Clips assumed the call was over and stopped recording notes. But looking away from Zoom for a bit is normal, you might be checking Slack or writing something down, while the meeting keeps going in the background. Clips stopped anyway, cutting notes short in the middle of real meetings like the All Hands.

## What changed

Now Clips also checks if the room is actually quiet before deciding a call has ended. It only stops taking notes when both things are true: you have looked away from the call window for a while, and no one is talking anymore. If the meeting is still loud, Clips keeps recording, even if you are looking at another app. This was already how Clips handled calls happening inside a browser tab, like Google Meet. Now Zoom and Teams work the same way.
