### PR TITLE
Fix video editor selection box and search highlight color

### DIFF
--- a/templates/clips/app/components/editor/editor-layout.tsx
+++ b/templates/clips/app/components/editor/editor-layout.tsx
@@ -255,6 +255,11 @@ export function EditorLayout({ recordingId, className }: EditorLayoutProps) {
     [viewportWidth, zoom],
   );
 
+  const clampedScrollLeft = Math.min(
+    scrollLeft,
+    Math.max(0, totalWidth - viewportWidth),
+  );
+
   const calculateAnchoredScrollLeft = useCallback(
     (
       nextZoom: number,
@@ -815,7 +820,7 @@ export function EditorLayout({ recordingId, className }: EditorLayoutProps) {
                 splitPoints={splitPoints}
                 activityRanges={transcriptSegments}
                 onSeek={seek}
-                scrollLeft={scrollLeft}
+                scrollLeft={clampedScrollLeft}
                 onScroll={(s) => setScrollLeft(s)}
               />
               <div
@@ -826,7 +831,7 @@ export function EditorLayout({ recordingId, className }: EditorLayoutProps) {
                   className="relative h-full"
                   style={{
                     width: totalWidth,
-                    transform: `translateX(${-scrollLeft}px)`,
+                    transform: `translateX(${-clampedScrollLeft}px)`,
                   }}
                 >
                   {durationMs > 0 && (
@@ -849,7 +854,7 @@ export function EditorLayout({ recordingId, className }: EditorLayoutProps) {
             >
               <div
                 style={{
-                  transform: `translateX(${-scrollLeft}px)`,
+                  transform: `translateX(${-clampedScrollLeft}px)`,
                   width: totalWidth,
                 }}
               >

--- a/templates/clips/app/components/editor/waveform.tsx
+++ b/templates/clips/app/components/editor/waveform.tsx
@@ -185,7 +185,8 @@ export function Waveform({
 
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
-    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    const scaleX = canvas.width / totalWidth;
+    ctx.setTransform(scaleX, 0, 0, dpr, 0, 0);
 
     const hasPeaks = Boolean(
       peaks?.bucketCount &&

--- a/templates/clips/app/components/library/search-bar.tsx
+++ b/templates/clips/app/components/library/search-bar.tsx
@@ -31,7 +31,7 @@ function highlight(
     parts.push(
       <mark
         key={`${idx}-${parts.length}`}
-        className="bg-yellow-200 text-foreground rounded-sm px-0.5"
+        className="bg-highlight/30 text-foreground rounded-sm px-0.5"
       >
         {text.slice(idx, idx + q.length)}
       </mark>,

--- a/templates/clips/app/global.css
+++ b/templates/clips/app/global.css
@@ -36,6 +36,8 @@
   --sidebar-accent-foreground: 0 0% 15%;
   --sidebar-border: 0 0% 90%;
   --sidebar-ring: 0 0% 40%;
+  --highlight: 197 100% 50%;
+  --highlight-foreground: 0 0% 10%;
 }
 
 .dark {
@@ -67,6 +69,13 @@
   --sidebar-accent-foreground: 0 0% 90%;
   --sidebar-border: 0 0% 20%;
   --sidebar-ring: 0 0% 60%;
+  --highlight: 197 100% 50%;
+  --highlight-foreground: 0 0% 10%;
+}
+
+@theme inline {
+  --color-highlight: hsl(var(--highlight));
+  --color-highlight-foreground: hsl(var(--highlight-foreground));
 }
 
 @layer base {


### PR DESCRIPTION
- **Video editor timeline**: the trim selection box and the matching highlight under the waveform could drift apart at higher zoom levels, or briefly when resizing the panel. Both are fixed, so the boxes always line up.
- **Search highlight color**: search result highlights now use the app's blue accent color instead of a plain yellow, added as a reusable color token.
<img width="636" height="225" alt="image" src="https://github.com/user-attachments/assets/e1dc86fe-cc0e-4a1f-a586-b770aea4c0f7" />
