### PR TITLE
fix(core): reset poll backoff when sync health-gates to local

### DIFF
--- a/.changeset/local-fallback-backoff-reset.md
+++ b/.changeset/local-fallback-backoff-reset.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Reset the poll backoff when sync health-gates from the hosted gateway to local. The failure count earned against an unreachable gateway was carried into local mode, delaying the first local poll by up to 8 minutes even though the app's own origin was reachable.

--- a/packages/core/src/client/use-db-sync.gateway-reconnect.spec.tsx
+++ b/packages/core/src/client/use-db-sync.gateway-reconnect.spec.tsx
@@ -129,4 +129,71 @@ describe("hosted SSE reconnect ownership", () => {
 
     unsub();
   });
+
+  it("health-gates to the local stream once the gateway trips the threshold", async () => {
+    const unsub = subscribeSyncEvents({ onEvents: () => {} });
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(FakeEventSource.instances.at(-1)!.url).toContain("gw.example");
+
+    // Three consecutive hard-down (CLOSED) errors trip HOSTED_UNHEALTHY_THRESHOLD.
+    for (let i = 0; i < 3; i++) {
+      const current = FakeEventSource.instances.at(-1)!;
+      current.readyState = FakeEventSource.CLOSED;
+      current.onerror?.();
+      await vi.advanceTimersByTimeAsync(1500);
+    }
+
+    const afterGate = FakeEventSource.instances.at(-1)!;
+    expect(afterGate.url).toContain("/_agent-native/events");
+    expect(afterGate.url).not.toContain("gw.example");
+
+    unsub();
+  });
+
+  it("polls the local app at local cadence after health-gating, not gateway backoff", async () => {
+    const pollUrls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes("/_agent-native/realtime-token")) {
+          return {
+            ok: true,
+            json: async () => ({ token: "tok-1", ttlSeconds: 600 }),
+          };
+        }
+        if (url.includes("/poll")) pollUrls.push(url);
+        if (url.includes("gw.example")) throw new Error("gateway down");
+        return { ok: true, json: async () => ({ version: 0, events: [] }) };
+      }),
+    );
+
+    const unsub = subscribeSyncEvents({ onEvents: () => {} });
+    await vi.advanceTimersByTimeAsync(200);
+
+    for (let i = 0; i < 3; i++) {
+      const current = FakeEventSource.instances.at(-1)!;
+      current.readyState = FakeEventSource.CLOSED;
+      current.onerror?.();
+      await vi.advanceTimersByTimeAsync(1500);
+    }
+    expect(FakeEventSource.instances.at(-1)!.url).toContain(
+      "/_agent-native/events",
+    );
+
+    // The failure count was earned against the gateway. The local endpoint just
+    // served this page, so it must not inherit that backoff: one fallback
+    // interval (60s, +20% jitter) is enough to see the first local poll.
+    const before = pollUrls.filter((u) =>
+      u.includes("/_agent-native/poll"),
+    ).length;
+    await vi.advanceTimersByTimeAsync(75_000);
+    const after = pollUrls.filter((u) =>
+      u.includes("/_agent-native/poll"),
+    ).length;
+    expect(after).toBeGreaterThan(before);
+
+    unsub();
+  });
 });

--- a/packages/core/src/client/use-db-sync.ts
+++ b/packages/core/src/client/use-db-sync.ts
@@ -475,6 +475,10 @@ class SyncTransport {
     // collab on its fast presence cadence against the local stream. Subscribers
     // are re-notified via the close/connect cycle below.
     this.capabilities = [];
+    // The failure count was earned against the gateway. Carrying it over would
+    // back the local endpoint off by 2^failures (already 8min at the threshold)
+    // before its first poll, even though it just served this page.
+    this.consecutiveFailures = 0;
     if (this.gatewayReconnectTimer) {
       clearTimeout(this.gatewayReconnectTimer);
       this.gatewayReconnectTimer = null;


### PR DESCRIPTION
`revertToLocal()` did not reset `consecutiveFailures`, so the failure count earned against an unreachable gateway was inherited by the local transport. `schedulePoll()` then computed `60s * 2^3 = 480s` of backoff against the app's own origin, which had just served the page.

It compounds: `schedulePoll()` clears and re-arms the pending timer, and runs on every SSE open and error. A local stream that reconnects restarts the full 8 minute delay, so the poll can be starved indefinitely.

Found by an end to end run against a deployed app with the gateway blocked at the network layer. The client health-gated to its own `/_agent-native/events` in 2.8s, then issued zero polls in 9.5 minutes, with the local stream reconnecting at 5.4 minutes and pushing the timer out again.

Live sync is unaffected because events still flow over the local stream. What was starved is the poll backstop: the resync path that catches whatever the stream missed, and the only path left if the local stream is also down.

Adds two tests. One asserts the health-gate itself, which had no coverage and had only ever been verified by reading the source. The other fails before this change and passes after.