### PR TITLE
Fix analytics ingest lock convoy under concurrent events

### DIFF
--- a/templates/analytics/changelog/2026-08-07-analytics-no-longer-stalls-under-bursts-of-event-ingest-key-.md
+++ b/templates/analytics/changelog/2026-08-07-analytics-no-longer-stalls-under-bursts-of-event-ingest-key-.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-07
+---
+
+Analytics no longer stalls under bursts of event ingest — key bookkeeping writes no longer serialize the whole pipeline

--- a/templates/analytics/server/lib/first-party-analytics.spec.ts
+++ b/templates/analytics/server/lib/first-party-analytics.spec.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const execute = vi.fn();
@@ -123,6 +125,53 @@ beforeEach(() => {
     schema: [{ name: "events", type: "number" }],
   });
   exceptionMocks.ingest.mockResolvedValue(undefined);
+});
+
+describe("public-key last-used stamp", () => {
+  // Production outage 2026-08-07: this UPDATE ran inside the ingest
+  // transaction, so every concurrent request for one public key took an
+  // exclusive row lock on that key and held it through the rollup upsert.
+  // 36 writers stacked on three hot rows waiting 38-57s, the connection pool
+  // starved, and Analytics stopped loading for everyone.
+  const source = readFileSync(
+    new URL("./first-party-analytics.ts", import.meta.url),
+    "utf8",
+  );
+
+  it("never writes the stamp inside a transaction", () => {
+    // Everything between `db.transaction(` and its closing `});` must be free
+    // of the stamp write, whatever else the transaction grows to do.
+    const start = source.indexOf("db.transaction(");
+    expect(start).toBeGreaterThan(0);
+    const body = source.slice(start, source.indexOf("\n  }", start));
+    expect(body).not.toContain("analyticsPublicKeys");
+    expect(body).not.toContain("lastUsedAt");
+  });
+
+  it("throttles the stamp in SQL, not in the caller", () => {
+    // A JS-side check would still let every racing request issue its own
+    // unconditional write. The predicate must be in the statement so Postgres
+    // matches — and therefore locks — zero rows for a freshly stamped key.
+    const fn = source.slice(source.indexOf("touchPublicKeyLastUsedAt("));
+    const update = fn.slice(fn.indexOf(".update(schema.analyticsPublicKeys)"));
+    const where = update.slice(0, update.indexOf("} catch"));
+    expect(where).toContain("isNull(schema.analyticsPublicKeys.lastUsedAt)");
+    expect(where).toContain("lt(schema.analyticsPublicKeys.lastUsedAt");
+    expect(where).toContain("staleBefore");
+  });
+
+  it("routes every stamp write through the throttled helper", () => {
+    // Two call sites drifted apart once already; a third unconditional write
+    // anywhere re-creates the convoy on its own.
+    // Exactly one place may set the stamp: the throttled helper. Other writes
+    // to this table (revocation) are rare admin actions and not the convoy.
+    let stampWrites = 0;
+    for (const file of ["first-party-analytics.ts", "session-replay.ts"]) {
+      const text = readFileSync(new URL(`./${file}`, import.meta.url), "utf8");
+      stampWrites += (text.match(/\.set\(\{\s*lastUsedAt:/g) ?? []).length;
+    }
+    expect(stampWrites).toBe(1);
+  });
 });
 
 describe("resolveAnalyticsEventDimensions", () => {

--- a/templates/analytics/server/lib/first-party-analytics.spec.ts
+++ b/templates/analytics/server/lib/first-party-analytics.spec.ts
@@ -21,6 +21,7 @@ const exceptionMocks = vi.hoisted(() => ({
   ingest: vi.fn(),
 }));
 const analyticsDbMocks = vi.hoisted(() => {
+  const getDb = vi.fn();
   const selectLimit = vi.fn();
   const insertValues = vi.fn();
   const updateWhere = vi.fn();
@@ -37,7 +38,9 @@ const analyticsDbMocks = vi.hoisted(() => {
   db.update = vi.fn(() => ({
     set: vi.fn(() => ({ where: updateWhere })),
   }));
+  getDb.mockReturnValue(db);
   return {
+    getDb,
     selectLimit,
     insertValues,
     updateWhere,
@@ -51,7 +54,7 @@ vi.mock("@agent-native/core/db", async (importOriginal) => ({
 }));
 vi.mock("../db/index.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../db/index.js")>()),
-  getDb: () => analyticsDbMocks.db,
+  getDb: analyticsDbMocks.getDb,
 }));
 vi.mock("./first-party-analytics-rollups.js", () => ({
   upsertFirstPartyAnalyticsRollups: rollupMocks.upsert,
@@ -79,11 +82,14 @@ import {
   recordAnalyticsEvents,
   resolveAnalyticsEventDimensions,
   scopedAnalyticsSql,
+  touchPublicKeyLastUsedAt,
   validateFirstPartyAnalyticsSql,
 } from "./first-party-analytics";
 
 beforeEach(() => {
   execute.mockReset();
+  analyticsDbMocks.getDb.mockReset();
+  analyticsDbMocks.getDb.mockReturnValue(analyticsDbMocks.db);
   analyticsDbMocks.selectLimit.mockReset();
   analyticsDbMocks.insertValues.mockReset();
   analyticsDbMocks.updateWhere.mockReset();
@@ -171,6 +177,14 @@ describe("public-key last-used stamp", () => {
       stampWrites += (text.match(/\.set\(\{\s*lastUsedAt:/g) ?? []).length;
     }
     expect(stampWrites).toBe(1);
+  });
+
+  it("does not reject when acquiring the stamp database fails", async () => {
+    analyticsDbMocks.getDb.mockRejectedValueOnce(new Error("db unavailable"));
+
+    await expect(
+      touchPublicKeyLastUsedAt("apk_123", "2026-08-07T17:00:00.000Z"),
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/templates/analytics/server/lib/first-party-analytics.ts
+++ b/templates/analytics/server/lib/first-party-analytics.ts
@@ -219,8 +219,8 @@ export async function touchPublicKeyLastUsedAt(
     return;
   }
   const staleBefore = new Date(parsed - LAST_USED_AT_REFRESH_MS).toISOString();
-  const db = await getDb();
   try {
+    const db = await getDb();
     await db
       .update(schema.analyticsPublicKeys)
       .set({ lastUsedAt: receivedAt })

--- a/templates/analytics/server/lib/first-party-analytics.ts
+++ b/templates/analytics/server/lib/first-party-analytics.ts
@@ -1,6 +1,6 @@
 import { getDbExec } from "@agent-native/core/db";
 import { runWithRequestContext } from "@agent-native/core/server";
-import { and, eq, isNull, or } from "drizzle-orm";
+import { and, eq, isNull, lt, or } from "drizzle-orm";
 
 import { FIRST_PARTY_ANALYTICS_QUERY_TIMEOUT_MS } from "../../shared/dashboard-report-timeouts.js";
 import { getDb, schema } from "../db/index.js";
@@ -179,6 +179,68 @@ export async function listAnalyticsPublicKeys(
     revokedAt: row.revokedAt ?? null,
     orgId: row.orgId ?? null,
   }));
+}
+
+/** How stale the last-used stamp must be before a request pays to refresh it. */
+const LAST_USED_AT_REFRESH_MS = 60_000;
+
+/**
+ * Refresh a public key's last-used stamp without serializing ingest behind it.
+ *
+ * This UPDATE used to sit inside the ingest transaction, so every concurrent
+ * request for one public key took an exclusive row lock on that key's row and
+ * held it until the transaction committed — which meant through the rollup
+ * upsert. Production stacked 36 writers on three hot rows waiting 38-57s each;
+ * that exhausted the connection pool, and the whole app stopped loading while
+ * Postgres reported "no server connection available, client being queued". The
+ * stamp is bookkeeping: it needs neither atomicity with the events nor
+ * second-precision, and losing one is harmless.
+ *
+ * The staleness predicate throttles in SQL rather than in the caller, because
+ * Postgres only locks rows an UPDATE actually matches — a request whose key was
+ * stamped seconds ago matches nothing and takes no lock at all. Doing the same
+ * check in JS would reintroduce the convoy, since every racing request would
+ * still issue its own unconditional write.
+ *
+ * `last_used_at` is TEXT holding ISO-8601 UTC (always `Z`-suffixed), so `lt` is
+ * a lexicographic comparison that happens to be chronological. Storing a local
+ * or offset-bearing timestamp here would silently break this ordering.
+ */
+export async function touchPublicKeyLastUsedAt(
+  keyId: string,
+  receivedAt: string,
+): Promise<void> {
+  const parsed = Date.parse(receivedAt);
+  if (!Number.isFinite(parsed)) {
+    console.warn(
+      "[first-party-analytics] Skipping last-used stamp: unparseable receivedAt",
+      receivedAt,
+    );
+    return;
+  }
+  const staleBefore = new Date(parsed - LAST_USED_AT_REFRESH_MS).toISOString();
+  const db = await getDb();
+  try {
+    await db
+      .update(schema.analyticsPublicKeys)
+      .set({ lastUsedAt: receivedAt })
+      .where(
+        and(
+          eq(schema.analyticsPublicKeys.id, keyId),
+          or(
+            isNull(schema.analyticsPublicKeys.lastUsedAt),
+            lt(schema.analyticsPublicKeys.lastUsedAt, staleBefore),
+          ),
+        ),
+      );
+  } catch (error) {
+    // Best-effort by design: a failed stamp must not reject an ingest whose
+    // events already committed. Loud enough to see if it starts failing always.
+    console.warn(
+      "[first-party-analytics] Failed to refresh key last-used stamp:",
+      error,
+    );
+  }
 }
 
 function parseReplayAllowedOrigins(value: unknown): string[] {
@@ -539,18 +601,11 @@ export async function recordAnalyticsEvents(
   if (rows.length && backend.sink !== "bigquery") {
     await db.transaction(async (tx: any) => {
       await tx.insert(schema.analyticsEvents).values(rows);
-      await tx
-        .update(schema.analyticsPublicKeys)
-        .set({ lastUsedAt: receivedAt })
-        .where(eq(schema.analyticsPublicKeys.id, key.id));
       await upsertFirstPartyAnalyticsRollups(rows, tx);
     });
   }
-  if (rows.length && backend.sink === "bigquery") {
-    await db
-      .update(schema.analyticsPublicKeys)
-      .set({ lastUsedAt: receivedAt })
-      .where(eq(schema.analyticsPublicKeys.id, key.id));
+  if (rows.length) {
+    await touchPublicKeyLastUsedAt(key.id, receivedAt);
   }
 
   // Fork captured exceptions into the dedicated error-capture tables. This is

--- a/templates/analytics/server/lib/session-replay.ts
+++ b/templates/analytics/server/lib/session-replay.ts
@@ -39,7 +39,10 @@ import {
   SESSION_REPLAY_NETWORK_EVENT_TAG,
 } from "../../shared/session-replay-diagnostics.js";
 import { getDb, schema } from "../db/index.js";
-import { resolveAnalyticsEventDimensions } from "./first-party-analytics.js";
+import {
+  resolveAnalyticsEventDimensions,
+  touchPublicKeyLastUsedAt,
+} from "./first-party-analytics.js";
 
 export type ReplayRange = "24h" | "7d" | "30d" | "90d" | "all";
 
@@ -1654,10 +1657,7 @@ export async function recordSessionReplayChunks(
     })
     .where(eq(schema.sessionRecordings.id, recording.id));
 
-  await db
-    .update(schema.analyticsPublicKeys)
-    .set({ lastUsedAt: ingestedAt })
-    .where(eq(schema.analyticsPublicKeys.id, key.id));
+  await touchPublicKeyLastUsedAt(key.id, ingestedAt);
 
   recordChange({
     source: "session-recordings",


### PR DESCRIPTION
## Summary
- move public-key last-used bookkeeping out of the ingest transaction
- throttle the best-effort timestamp update in SQL
- cover the lock-convoy boundary and session replay path

## Validation
- pnpm --dir templates/analytics exec vitest run server/lib/first-party-analytics.spec.ts