### PR TITLE
Fix dead assertion in Slack private-channel audience test

### DIFF
--- a/templates/brain/server/lib/brain.test.ts
+++ b/templates/brain/server/lib/brain.test.ts
@@ -3639,9 +3639,13 @@ describe("Brain connector smoke coverage", () => {
         String(call[0]).includes("users.info"),
       ),
     ).toHaveLength(4);
-    expect(
-      mocks.rows.audienceMembers.map((member) => member.principalId),
-    ).toEqual(["ada@example.test"]);
+    expect(vi.mocked(ensureCaptureAudience)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "slack-private-channel",
+        memberEmails: ["ada@example.test"],
+        upstreamRefHash: "G123",
+      }),
+    );
   });
 
   it("caches private Slack member emails and bounds concurrent user lookups within a sync", async () => {


### PR DESCRIPTION
## Problem

The test \`"ignores Slack bot and app members when deriving a private-channel audience"\` in `templates/brain/server/lib/brain.test.ts` asserted:

```ts
expect(
  mocks.rows.audienceMembers.map((member) => member.principalId),
).toEqual(["ada@example.test"]);
```

But `./audiences.js` is fully mocked at the top of the same test file, and the mocked `ensureCaptureAudience` never writes to `mocks.rows.audienceMembers` — it always hardcodes `kind: "org"` and ignores whatever `memberEmails`/`kind` are actually passed in. So the real audience-membership logic in `audiences.ts` never runs during this test, and `mocks.rows.audienceMembers` is always `[]`. The assertion could never pass — deterministic, not a flake.

This was blocking [PR #2711](https://github.com/BuilderIO/agent-native/pull/2711) (an unrelated docs-only PR) from going green in CI.

## Fix

Switched the assertion to the same convention already used by sibling tests in this describe block (e.g. around L2979/L3025/L3031): assert on what the mocked `ensureCaptureAudience` was actually called with, rather than reading back a mock table the stub never populates.

```ts
expect(vi.mocked(ensureCaptureAudience)).toHaveBeenCalledWith(
  expect.objectContaining({
    kind: "slack-private-channel",
    memberEmails: ["ada@example.test"],
    upstreamRefHash: "G123",
  }),
);
```

This matches what `createSlackThreadCapture` in `connectors.ts` actually passes through `createCapture` → `ensureCaptureAudience`.

## Verification

- Target test passes in isolation.
- Confirmed the test actually catches a regression: temporarily disabled the bot/app-user filter (`is_bot`/`is_app_user`/`is_workflow_bot`/`deleted`) in `connectors.ts`, reran, saw it fail, then restored the filter (`git diff` on `connectors.ts` shows no residual changes).
- Full `brain` suite: 282/282 tests passing across 34 files.

Only one file changed — `templates/brain/server/lib/brain.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)