### PR TITLE
fix: route legacy agent settings to canonical tabs

### DIFF
--- a/.changeset/legacy-agent-settings-routes.md
+++ b/.changeset/legacy-agent-settings-routes.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/creative-context": patch
+---
+
+Redirect legacy `/agent` management URLs to the canonical settings routes and preserve app-owned settings tabs.

--- a/apps/email-automation-console/app/components/layout/Layout.tsx
+++ b/apps/email-automation-console/app/components/layout/Layout.tsx
@@ -174,7 +174,7 @@ export function Layout({ children }: LayoutProps) {
             openOnChatRunning={chatHomeHandoffActive}
             onFullscreenRequest={openAskAgentFullscreen}
             emptyStateText={t("chat.inspectEmptyState")}
-            agentPageHref="/agent"
+            agentPageHref="/settings/agent"
             suggestions={[
               t("chat.inspectSuggestionCapabilities"),
               t("chat.inspectSuggestionHello"),

--- a/apps/email-automation-console/app/hooks/use-navigation-state.ts
+++ b/apps/email-automation-console/app/hooks/use-navigation-state.ts
@@ -44,7 +44,10 @@ function viewForPath(pathname: string): string {
   if (pathname.startsWith("/automations")) return "automations";
   if (pathname.startsWith("/extensions")) return "extensions";
   if (pathname.startsWith("/observability")) return "observability";
-  if (pathname.startsWith("/agent")) return "agent";
+  if (pathname.startsWith("/settings/agent") || pathname.startsWith("/agent")) {
+    return "agent";
+  }
+  if (pathname.startsWith("/settings")) return "settings";
   if (pathname.startsWith("/team")) return "settings";
   return "chat";
 }
@@ -64,7 +67,7 @@ function pathForView(view?: string): string {
     case "observability":
       return "/observability";
     case "agent":
-      return "/agent";
+      return "/settings/agent";
     case "settings":
       return "/settings";
     case "team":

--- a/apps/email-automation-console/app/root.tsx
+++ b/apps/email-automation-console/app/root.tsx
@@ -134,7 +134,7 @@ function AppContent() {
             {t("root.commandSearch")}
           </CommandMenu.Item>
           <CommandMenu.Item
-            onSelect={() => navigate("/agent")}
+            onSelect={() => navigate("/settings/agent")}
             keywords={[
               "agent",
               "context",

--- a/apps/email-automation-console/app/routes/agent.tsx
+++ b/apps/email-automation-console/app/routes/agent.tsx
@@ -1,11 +1,6 @@
-import {
-  AgentChatSurface,
-  AgentTabsPage,
-} from "@agent-native/core/client/agent-chat";
-import { useT } from "@agent-native/core/client/i18n";
-import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
+import { buildLegacyAgentSettingsRoute } from "@agent-native/core/client/navigation";
+import { Navigate, useLocation } from "react-router";
 
-import { resolveAgentPageComponent } from "@/lib/agent-page";
 import { APP_TITLE } from "@/lib/app-config";
 
 export function meta() {
@@ -13,12 +8,11 @@ export function meta() {
 }
 
 export default function AgentRoute() {
-  const t = useT();
-  useSetPageTitle(t("settings.agentTitle"));
-
-  const AgentPage = resolveAgentPageComponent({
-    AgentChatSurface,
-    AgentTabsPage,
-  });
-  return <AgentPage appName={APP_TITLE} />;
+  const location = useLocation();
+  return (
+    <Navigate
+      to={buildLegacyAgentSettingsRoute(location.hash, location.search)}
+      replace
+    />
+  );
 }

--- a/examples/chat-antd/app/components/layout/Layout.tsx
+++ b/examples/chat-antd/app/components/layout/Layout.tsx
@@ -169,7 +169,7 @@ export function Layout({ children }: LayoutProps) {
             openOnChatRunning={chatHomeHandoffActive}
             onFullscreenRequest={openAskAgentFullscreen}
             emptyStateText={t("chat.inspectEmptyState")}
-            agentPageHref="/agent"
+            agentPageHref="/settings/agent"
             suggestions={[
               t("chat.inspectSuggestionCapabilities"),
               t("chat.inspectSuggestionHello"),

--- a/examples/chat-antd/app/components/layout/Sidebar.tsx
+++ b/examples/chat-antd/app/components/layout/Sidebar.tsx
@@ -39,7 +39,7 @@ const bottomNavItems = [
   {
     icon: IconHierarchy2,
     labelKey: "settings.agentTitle",
-    href: "/agent",
+    href: "/settings/agent",
     view: "agent",
   },
   {

--- a/examples/chat-antd/app/hooks/use-navigation-state.ts
+++ b/examples/chat-antd/app/hooks/use-navigation-state.ts
@@ -57,7 +57,10 @@ function viewForPath(pathname: string): string {
   if (pathname.startsWith("/database")) return "database";
   if (pathname.startsWith("/extensions")) return "extensions";
   if (pathname.startsWith("/observability")) return "observability";
-  if (pathname.startsWith("/agent")) return "agent";
+  if (pathname.startsWith("/settings/agent") || pathname.startsWith("/agent")) {
+    return "agent";
+  }
+  if (pathname.startsWith("/settings")) return "settings";
   if (pathname.startsWith("/team")) return "settings";
   return "chat";
 }
@@ -75,7 +78,7 @@ function pathForView(view?: string): string {
     case "observability":
       return "/observability";
     case "agent":
-      return "/agent";
+      return "/settings/agent";
     case "settings":
       return "/settings";
     case "team":

--- a/examples/chat-antd/app/root.tsx
+++ b/examples/chat-antd/app/root.tsx
@@ -137,7 +137,7 @@ function AppContent() {
             {t("root.commandSearch")}
           </CommandMenu.Item>
           <CommandMenu.Item
-            onSelect={() => navigate("/agent")}
+            onSelect={() => navigate("/settings/agent")}
             keywords={[
               "agent",
               "context",

--- a/examples/chat-antd/app/routes/agent.tsx
+++ b/examples/chat-antd/app/routes/agent.tsx
@@ -1,11 +1,6 @@
-import {
-  AgentChatSurface,
-  AgentTabsPage,
-} from "@agent-native/core/client/agent-chat";
-import { useT } from "@agent-native/core/client/i18n";
-import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
+import { buildLegacyAgentSettingsRoute } from "@agent-native/core/client/navigation";
+import { Navigate, useLocation } from "react-router";
 
-import { resolveAgentPageComponent } from "@/lib/agent-page";
 import { APP_TITLE } from "@/lib/app-config";
 
 export function meta() {
@@ -13,12 +8,11 @@ export function meta() {
 }
 
 export default function AgentRoute() {
-  const t = useT();
-  useSetPageTitle(t("settings.agentTitle"));
-
-  const AgentPage = resolveAgentPageComponent({
-    AgentChatSurface,
-    AgentTabsPage,
-  });
-  return <AgentPage appName={APP_TITLE} />;
+  const location = useLocation();
+  return (
+    <Navigate
+      to={buildLegacyAgentSettingsRoute(location.hash, location.search)}
+      replace
+    />
+  );
 }

--- a/examples/chat-mui/app/components/layout/Layout.tsx
+++ b/examples/chat-mui/app/components/layout/Layout.tsx
@@ -169,7 +169,7 @@ export function Layout({ children }: LayoutProps) {
             openOnChatRunning={chatHomeHandoffActive}
             onFullscreenRequest={openAskAgentFullscreen}
             emptyStateText={t("chat.inspectEmptyState")}
-            agentPageHref="/agent"
+            agentPageHref="/settings/agent"
             suggestions={[
               t("chat.inspectSuggestionCapabilities"),
               t("chat.inspectSuggestionHello"),

--- a/examples/chat-mui/app/components/layout/Sidebar.tsx
+++ b/examples/chat-mui/app/components/layout/Sidebar.tsx
@@ -39,7 +39,7 @@ const bottomNavItems = [
   {
     icon: IconHierarchy2,
     labelKey: "settings.agentTitle",
-    href: "/agent",
+    href: "/settings/agent",
     view: "agent",
   },
   {

--- a/examples/chat-mui/app/hooks/use-navigation-state.ts
+++ b/examples/chat-mui/app/hooks/use-navigation-state.ts
@@ -57,7 +57,10 @@ function viewForPath(pathname: string): string {
   if (pathname.startsWith("/database")) return "database";
   if (pathname.startsWith("/extensions")) return "extensions";
   if (pathname.startsWith("/observability")) return "observability";
-  if (pathname.startsWith("/agent")) return "agent";
+  if (pathname.startsWith("/settings/agent") || pathname.startsWith("/agent")) {
+    return "agent";
+  }
+  if (pathname.startsWith("/settings")) return "settings";
   if (pathname.startsWith("/team")) return "settings";
   return "chat";
 }
@@ -75,7 +78,7 @@ function pathForView(view?: string): string {
     case "observability":
       return "/observability";
     case "agent":
-      return "/agent";
+      return "/settings/agent";
     case "settings":
       return "/settings";
     case "team":

--- a/examples/chat-mui/app/root.tsx
+++ b/examples/chat-mui/app/root.tsx
@@ -137,7 +137,7 @@ function AppContent() {
             {t("root.commandSearch")}
           </CommandMenu.Item>
           <CommandMenu.Item
-            onSelect={() => navigate("/agent")}
+            onSelect={() => navigate("/settings/agent")}
             keywords={[
               "agent",
               "context",

--- a/examples/chat-mui/app/routes/agent.tsx
+++ b/examples/chat-mui/app/routes/agent.tsx
@@ -1,11 +1,6 @@
-import {
-  AgentChatSurface,
-  AgentTabsPage,
-} from "@agent-native/core/client/agent-chat";
-import { useT } from "@agent-native/core/client/i18n";
-import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
+import { buildLegacyAgentSettingsRoute } from "@agent-native/core/client/navigation";
+import { Navigate, useLocation } from "react-router";
 
-import { resolveAgentPageComponent } from "@/lib/agent-page";
 import { APP_TITLE } from "@/lib/app-config";
 
 export function meta() {
@@ -13,12 +8,11 @@ export function meta() {
 }
 
 export default function AgentRoute() {
-  const t = useT();
-  useSetPageTitle(t("settings.agentTitle"));
-
-  const AgentPage = resolveAgentPageComponent({
-    AgentChatSurface,
-    AgentTabsPage,
-  });
-  return <AgentPage appName={APP_TITLE} />;
+  const location = useLocation();
+  return (
+    <Navigate
+      to={buildLegacyAgentSettingsRoute(location.hash, location.search)}
+      replace
+    />
+  );
 }

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -57,6 +57,8 @@ export {
   getAgentSettingsSearchTabs,
   openBuilderConnectPopup,
   useAgentSettingsTabs,
+  type AgentSettingsTabFactory,
+  type AgentSettingsTabFactoryContext,
   useBuilderConnectFlow,
   useBuilderStatus,
   withBuilderConnectTrackingParams,

--- a/packages/core/src/client/navigation/index.ts
+++ b/packages/core/src/client/navigation/index.ts
@@ -32,6 +32,7 @@ export {
 export {
   buildOpenRouteLink,
   buildOpenRoutePath,
+  buildLegacyAgentSettingsRoute,
   buildResourceRoute,
   buildSettingsRoute,
   buildStandardAppRoute,

--- a/packages/core/src/client/org/OrgSwitcher.tsx
+++ b/packages/core/src/client/org/OrgSwitcher.tsx
@@ -128,7 +128,7 @@ const COMPACT_SWITCHER_BUTTON_CLASS =
 
 const DEFAULT_ORGANIZATION_SETTINGS_PATH = "/settings/organization";
 const DEFAULT_PROFILE_PATH = "/settings/account";
-const DEFAULT_AGENT_PATH = "/agent";
+const DEFAULT_AGENT_PATH = "/settings/agent";
 
 const APP_ICON_MAP: Record<string, typeof IconApps> = {
   Mail: IconMail,

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -69,6 +69,7 @@ import {
   TooltipTrigger,
 } from "../components/ui/tooltip.js";
 import { useT } from "../i18n.js";
+import { useOrg } from "../org/hooks.js";
 import { TeamPage } from "../org/TeamPage.js";
 import { BuilderConnectCard } from "../setup-connections/BuilderConnectCard.js";
 import { callAction } from "../use-action.js";
@@ -2802,7 +2803,19 @@ export interface AgentSettingsTabsOptions {
   extensionTools?: boolean;
   /** Optional page-level settings to show in the Agent section. */
   agentAdditionalContent?: React.ReactNode;
+  /** Optional app-owned tabs that share the Agent settings scope. */
+  agentAdditionalTabFactories?: AgentSettingsTabFactory[];
 }
+
+export interface AgentSettingsTabFactoryContext {
+  scope: "user";
+  canManageOrg?: boolean;
+  scopeControl: React.ReactNode;
+}
+
+export type AgentSettingsTabFactory = (
+  context: AgentSettingsTabFactoryContext,
+) => SettingsTabItem;
 
 export function areExtensionSettingsEnabled(
   options: AgentSettingsTabsOptions = {},
@@ -3626,8 +3639,12 @@ export function useAgentSettingsTabs(
   options: AgentSettingsTabsOptions = {},
 ): SettingsTabItem[] {
   const { isDevMode, canToggle, setDevMode } = useDevMode();
+  const { data: org } = useOrg();
+  const canManageOrg =
+    !org?.orgId || org.role === "owner" || org.role === "admin";
   const extensionToolsEnabled = areExtensionSettingsEnabled(options);
   const agentAdditionalContent = options.agentAdditionalContent;
+  const agentAdditionalTabFactories = options.agentAdditionalTabFactories ?? [];
   const baseProps = useMemo<SettingsPanelProps>(
     () => ({
       isDevMode,
@@ -3637,6 +3654,17 @@ export function useAgentSettingsTabs(
       showDevToggle: canToggle,
     }),
     [canToggle, isDevMode, setDevMode],
+  );
+  const additionalTabs = useMemo(
+    () =>
+      agentAdditionalTabFactories.map((factory) =>
+        factory({
+          scope: "user",
+          canManageOrg,
+          scopeControl: null,
+        }),
+      ),
+    [agentAdditionalTabFactories, canManageOrg],
   );
 
   return useMemo<SettingsTabItem[]>(() => {
@@ -3837,6 +3865,12 @@ export function useAgentSettingsTabs(
         ],
         content: <AgentWorkspaceContent activeTab="agents" overview={null} />,
       },
+      ...additionalTabs,
     ];
-  }, [agentAdditionalContent, baseProps, extensionToolsEnabled]);
+  }, [
+    agentAdditionalContent,
+    additionalTabs,
+    baseProps,
+    extensionToolsEnabled,
+  ]);
 }

--- a/packages/core/src/client/settings/index.ts
+++ b/packages/core/src/client/settings/index.ts
@@ -3,6 +3,8 @@ export {
   areExtensionSettingsEnabled,
   SettingsPanel,
   useAgentSettingsTabs,
+  type AgentSettingsTabFactory,
+  type AgentSettingsTabFactoryContext,
   type AgentSettingsTabsOptions,
   type SettingsPanelProps,
 } from "./SettingsPanel.js";

--- a/packages/core/src/navigation/index.spec.ts
+++ b/packages/core/src/navigation/index.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildOpenRouteLink,
   buildOpenRoutePath,
+  buildLegacyAgentSettingsRoute,
   buildResourceRoute,
   buildSettingsRoute,
   buildStandardAppRoute,
@@ -32,6 +33,26 @@ describe("navigation kit helpers", () => {
     expect(
       buildResourceRoute("content/pages", "home", { basePath: "/admin" }),
     ).toBe("/admin/content/pages/home");
+  });
+
+  it.each([
+    ["", "/settings/agent"],
+    ["#files", "/settings/agent/resources/files"],
+    ["#instructions", "/settings/agent/resources/instructions"],
+    ["#remote-agents", "/settings/agent/agents"],
+    ["#connections", "/settings/integrations"],
+    ["#jobs", "/settings/agent/automations"],
+    ["#library", "/settings/library"],
+    ["#voice", "/settings/agent/voice"],
+    ["#unknown", "/settings/agent"],
+  ])("maps legacy agent hash %s", (hash, expected) => {
+    expect(buildLegacyAgentSettingsRoute(hash)).toBe(expected);
+  });
+
+  it("preserves the query string while consuming the legacy hash", () => {
+    expect(
+      buildLegacyAgentSettingsRoute("#connections", "?return=/agent"),
+    ).toBe("/settings/integrations?return=/agent");
   });
 
   it("builds open-route links with sidebar collapsed", () => {

--- a/packages/core/src/navigation/index.ts
+++ b/packages/core/src/navigation/index.ts
@@ -54,6 +54,23 @@ export interface StandardOpenPathResolverOptions {
   fallback?: StandardOpenPathRoute;
 }
 
+const LEGACY_AGENT_RESOURCE_TABS = new Set([
+  "files",
+  "instructions",
+  "agents",
+  "memory",
+  "skills",
+  "learnings",
+]);
+
+const LEGACY_AGENT_SETTINGS_TABS = new Set([
+  "llm",
+  "app-models",
+  "limits",
+  "voice",
+  "background",
+]);
+
 function normalizeLeadingPath(path: string): string {
   const trimmed = path.trim();
   if (!trimmed || trimmed === "/") return "/";
@@ -102,6 +119,30 @@ export function buildSettingsRoute(
     .map((segment) => pathSegment(segment))
     .filter(Boolean);
   return `${path}/${segments.join("/")}`;
+}
+
+export function buildLegacyAgentSettingsRoute(
+  hash?: string | null,
+  search = "",
+): string {
+  const legacyTab = hash?.replace(/^#/, "").toLowerCase() ?? "";
+  const destination = LEGACY_AGENT_RESOURCE_TABS.has(legacyTab)
+    ? buildSettingsRoute(`agent:resources:${legacyTab}`)
+    : legacyTab === "remote-agents"
+      ? buildSettingsRoute("agent:agents")
+      : legacyTab === "connections"
+        ? buildSettingsRoute("connections")
+        : legacyTab === "jobs"
+          ? buildSettingsRoute("agent:automations")
+          : legacyTab === "library"
+            ? buildSettingsRoute("library")
+            : legacyTab === "access"
+              ? buildSettingsRoute("agent")
+              : LEGACY_AGENT_SETTINGS_TABS.has(legacyTab)
+                ? buildSettingsRoute(`agent:${legacyTab}`)
+                : buildSettingsRoute("agent");
+
+  return `${destination}${search}`;
 }
 
 export function buildTeamRoute(

--- a/packages/core/src/templates/default/app/routes/_index.tsx
+++ b/packages/core/src/templates/default/app/routes/_index.tsx
@@ -76,7 +76,7 @@ export default function IndexPage() {
             </p>
           </Link>
           <Link
-            to="/agent"
+            to="/settings/agent"
             className="group rounded-lg border border-border/50 px-4 py-3 hover:bg-accent/50 transition-colors"
           >
             <p className="text-[13px] font-medium text-foreground">

--- a/packages/core/src/templates/default/app/routes/agent.tsx
+++ b/packages/core/src/templates/default/app/routes/agent.tsx
@@ -1,34 +1,16 @@
-import { AgentTabsPage } from "@agent-native/core/client/agent-chat";
-import { useT } from "@agent-native/core/client/i18n";
-import { Link } from "react-router";
+import { buildLegacyAgentSettingsRoute } from "@agent-native/core/client/navigation";
+import { Navigate, useLocation } from "react-router";
 
 export function meta() {
   return [{ title: "Agent - {{APP_TITLE}}" }];
 }
 
 export default function AgentPage() {
-  const t = useT();
-
+  const location = useLocation();
   return (
-    <main className="min-h-screen bg-background px-6 py-10">
-      <div className="mx-auto w-full max-w-5xl space-y-6">
-        <div className="space-y-2">
-          <Link
-            to="/settings"
-            className="text-[13px] text-muted-foreground hover:text-foreground"
-          >
-            {t("settings.title")}
-          </Link>
-          <h1 className="text-2xl font-semibold tracking-tight text-foreground">
-            {t("settings.agentTitle")}
-          </h1>
-          <p className="text-[14px] leading-relaxed text-muted-foreground">
-            {t("settings.agentDescription")}
-          </p>
-        </div>
-
-        <AgentTabsPage className="min-h-[640px] rounded-lg border border-border/50" />
-      </div>
-    </main>
+    <Navigate
+      to={buildLegacyAgentSettingsRoute(location.hash, location.search)}
+      replace
+    />
   );
 }

--- a/packages/creative-context/src/actions/list-context-connections.spec.ts
+++ b/packages/creative-context/src/actions/list-context-connections.spec.ts
@@ -17,7 +17,7 @@ describe("creative context connection paths", () => {
         `/_agent-native/connections/oauth/${provider}/start`,
       );
       expect(url.searchParams.get("appId")).toBe(appId);
-      expect(url.searchParams.get("return")).toBe("/agent#library");
+      expect(url.searchParams.get("return")).toBe("/settings/library");
     },
   );
 });

--- a/packages/creative-context/src/actions/list-context-connections.ts
+++ b/packages/creative-context/src/actions/list-context-connections.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import { getCreativeContext } from "../server/context.js";
 
-const CREATIVE_CONTEXT_LIBRARY_PATH = "/agent#library";
+const CREATIVE_CONTEXT_LIBRARY_PATH = "/settings/library";
 
 export function creativeContextConnectionPath(input: {
   provider: "google_drive" | "figma" | "notion";

--- a/packages/creative-context/src/client/CreativeContextChip.tsx
+++ b/packages/creative-context/src/client/CreativeContextChip.tsx
@@ -99,7 +99,7 @@ export function CreativeContextChip({
 }
 
 export function CreativeContextComposerChip({
-  href = "/agent#library",
+  href = "/settings/library",
   className,
 }: {
   href?: string;

--- a/packages/creative-context/src/client/CreativeContextPanel.tsx
+++ b/packages/creative-context/src/client/CreativeContextPanel.tsx
@@ -3191,7 +3191,7 @@ export function CreativeContextPanel({
                                   : t("creativeContext.applyBrandContext")}
                               </Button>
                               <Button asChild type="button" variant="outline">
-                                <a href="/agent">
+                                <a href="/settings/agent">
                                   {t("creativeContext.generateWithContext")}
                                   <IconArrowUpRight />
                                 </a>

--- a/packages/creative-context/src/client/CreativeContextSettingsLink.tsx
+++ b/packages/creative-context/src/client/CreativeContextSettingsLink.tsx
@@ -2,7 +2,7 @@ import { useT } from "@agent-native/core/client/i18n";
 import { IconArrowUpRight, IconBooks } from "@tabler/icons-react";
 
 export function CreativeContextSettingsLink({
-  href = "/agent#library",
+  href = "/settings/library",
 }: {
   href?: string;
 }) {

--- a/packages/creative-context/src/server/resource-paths.spec.ts
+++ b/packages/creative-context/src/server/resource-paths.spec.ts
@@ -4,6 +4,6 @@ import { getCreativeContextResourcePath } from "./resource-paths.js";
 
 describe("creative context shareable resource paths", () => {
   it("opens the Library tab exposed by each app", () => {
-    expect(getCreativeContextResourcePath()).toBe("/agent#library");
+    expect(getCreativeContextResourcePath()).toBe("/settings/library");
   });
 });

--- a/packages/creative-context/src/server/resource-paths.ts
+++ b/packages/creative-context/src/server/resource-paths.ts
@@ -1,4 +1,4 @@
-export const CREATIVE_CONTEXT_LIBRARY_PATH = "/agent#library";
+export const CREATIVE_CONTEXT_LIBRARY_PATH = "/settings/library";
 
 export function getCreativeContextResourcePath(): string {
   return CREATIVE_CONTEXT_LIBRARY_PATH;

--- a/templates/analytics/app/components/layout/CommandPalette.tsx
+++ b/templates/analytics/app/components/layout/CommandPalette.tsx
@@ -508,7 +508,7 @@ export function CommandPalette() {
               <CommandGroup key="settings" heading={t("navigation.settings")}>
                 <CommandItem
                   value={`setting:agent-page:${t("settings.agentTitle")}`}
-                  onSelect={() => go("/agent")}
+                  onSelect={() => go("/settings/agent")}
                   keywords={commandPaletteKeywords(
                     t("settings.agentTitle"),
                     "agent",

--- a/templates/analytics/app/components/layout/Layout.tsx
+++ b/templates/analytics/app/components/layout/Layout.tsx
@@ -205,7 +205,7 @@ function InteractiveLayout({ children }: LayoutProps) {
               openOnChatRunning={chatHomeHandoffActive}
               onFullscreenRequest={openAskAgentFullscreen}
               emptyStateText={t("chat.emptyState")}
-              agentPageHref="/agent"
+              agentPageHref="/settings/agent"
               suggestions={[
                 t("chat.suggestionArrGrowth"),
                 t("chat.suggestionChurn"),

--- a/templates/analytics/app/pages/Settings.tsx
+++ b/templates/analytics/app/pages/Settings.tsx
@@ -13,6 +13,7 @@ import {
   useAgentSettingsTabs,
   type SettingsTabItem,
 } from "@agent-native/core/client/settings";
+import { createCreativeContextAgentTab } from "@agent-native/creative-context/client";
 import { IconBell } from "@tabler/icons-react";
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router";
@@ -136,7 +137,10 @@ export default function Settings() {
       }
     />
   );
-  const agentSettingsTabs = useAgentSettingsTabs({ agentAdditionalContent });
+  const agentSettingsTabs = useAgentSettingsTabs({
+    agentAdditionalContent,
+    agentAdditionalTabFactories: [createCreativeContextAgentTab],
+  });
 
   const extraTabs = useMemo<SettingsTabItem[]>(
     () => [

--- a/templates/analytics/app/routes/agent.tsx
+++ b/templates/analytics/app/routes/agent.tsx
@@ -1,11 +1,13 @@
-import { AgentTabsPage } from "@agent-native/core/client/agent-chat";
-import { createCreativeContextAgentTab } from "@agent-native/creative-context/client";
+import { buildLegacyAgentSettingsRoute } from "@agent-native/core/client/navigation";
+import { Navigate, useLocation } from "react-router";
 
 export default function AgentRoute() {
+  const location = useLocation();
+
   return (
-    <AgentTabsPage
-      appName="Analytics"
-      extraTabFactories={[createCreativeContextAgentTab]}
+    <Navigate
+      to={buildLegacyAgentSettingsRoute(location.hash, location.search)}
+      replace
     />
   );
 }

--- a/templates/assets/app/components/layout/Layout.tsx
+++ b/templates/assets/app/components/layout/Layout.tsx
@@ -165,7 +165,7 @@ export function Layout({ children }: LayoutProps) {
         openOnChatRunning={chatHomeHandoffActive}
         onFullscreenRequest={openCreateChatFullscreen}
         emptyStateText={t("chat.emptyState")}
-        agentPageHref="/agent"
+        agentPageHref="/settings/agent"
         suggestions={[
           t("chat.suggestionBlogHeroes"),
           t("chat.suggestionProductVideo"),

--- a/templates/assets/app/routes/agent.tsx
+++ b/templates/assets/app/routes/agent.tsx
@@ -1,11 +1,13 @@
-import { AgentTabsPage } from "@agent-native/core/client/agent-chat";
-import { createCreativeContextAgentTab } from "@agent-native/creative-context/client";
+import { buildLegacyAgentSettingsRoute } from "@agent-native/core/client/navigation";
+import { Navigate, useLocation } from "react-router";
 
 export default function AgentRoute() {
+  const location = useLocation();
+
   return (
-    <AgentTabsPage
-      appName="Assets"
-      extraTabFactories={[createCreativeContextAgentTab]}
+    <Navigate
+      to={buildLegacyAgentSettingsRoute(location.hash, location.search)}
+      replace
     />
   );
 }

--- a/templates/assets/app/routes/settings.tsx
+++ b/templates/assets/app/routes/settings.tsx
@@ -18,7 +18,10 @@ import {
   useBuilderStatus,
   type SettingsSearchEntry,
 } from "@agent-native/core/client/settings";
-import { CreativeContextSettingsLink } from "@agent-native/creative-context/client";
+import {
+  CreativeContextSettingsLink,
+  createCreativeContextAgentTab,
+} from "@agent-native/creative-context/client";
 import {
   IconAlertCircle,
   IconCheck,
@@ -87,7 +90,9 @@ type FormOnboardingMethod = Extract<OnboardingMethod, { kind: "form" }>;
 
 export default function SettingsPage() {
   const t = useT();
-  const agentSettingsTabs = useAgentSettingsTabs();
+  const agentSettingsTabs = useAgentSettingsTabs({
+    agentAdditionalTabFactories: [createCreativeContextAgentTab],
+  });
   const { data } = useActionQuery("list-libraries", { compact: true }) as {
     data?: { count?: number };
   };

--- a/templates/assets/server/plugins/creative-context.ts
+++ b/templates/assets/server/plugins/creative-context.ts
@@ -191,7 +191,7 @@ registerOnboardingStep({
       kind: "link",
       primary: true,
       label: "Open Library",
-      payload: { url: "/agent#library", external: false },
+      payload: { url: "/settings/library", external: false },
     },
   ],
   isComplete: async () => {

--- a/templates/brain/app/components/layout/Layout.tsx
+++ b/templates/brain/app/components/layout/Layout.tsx
@@ -137,7 +137,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         openOnChatRunning={chatHomeHandoffActive}
         onFullscreenRequest={openAskAgentFullscreen}
         emptyStateText={t("chat.emptyState")}
-        agentPageHref="/agent"
+        agentPageHref="/settings/agent"
         suggestions={[
           t("chat.suggestionSecurity"),
           t("chat.suggestionStaleFacts"),

--- a/templates/brain/app/lib/brain.ts
+++ b/templates/brain/app/lib/brain.ts
@@ -1050,7 +1050,9 @@ export function viewFromPath(pathname: string): BrainView {
   if (pathname.startsWith("/review")) return "review";
   if (pathname.startsWith("/sources")) return "sources";
   if (pathname.startsWith("/ops")) return "ops";
-  if (pathname.startsWith("/agent")) return "agent";
+  if (pathname.startsWith("/settings/agent") || pathname.startsWith("/agent")) {
+    return "agent";
+  }
   if (pathname.startsWith("/settings")) return "settings";
   return "ask";
 }
@@ -1070,7 +1072,7 @@ export function pathFromView(view?: string): string {
     case "ops":
       return "/ops";
     case "agent":
-      return "/agent";
+      return "/settings/agent";
     case "settings":
       return "/settings";
     case "ask":

--- a/templates/brain/app/root.tsx
+++ b/templates/brain/app/root.tsx
@@ -183,7 +183,7 @@ function AppContent() {
             {t("navigation.settings")}
           </CommandMenu.Item>
           <CommandMenu.Item
-            onSelect={() => navigate("/agent")}
+            onSelect={() => navigate("/settings/agent")}
             keywords={[
               "agent",
               "context",

--- a/templates/brain/app/routes/agent.tsx
+++ b/templates/brain/app/routes/agent.tsx
@@ -1,4 +1,5 @@
-import { AgentTabsPage } from "@agent-native/core/client/agent-chat";
+import { buildLegacyAgentSettingsRoute } from "@agent-native/core/client/navigation";
+import { Navigate, useLocation } from "react-router";
 
 import { messagesByLocale } from "@/i18n-data";
 
@@ -7,5 +8,12 @@ export function meta() {
 }
 
 export default function AgentRoute() {
-  return <AgentTabsPage appName="Brain" />;
+  const location = useLocation();
+
+  return (
+    <Navigate
+      to={buildLegacyAgentSettingsRoute(location.hash, location.search)}
+      replace
+    />
+  );
 }

--- a/templates/calendar/app/components/layout/AppLayout.tsx
+++ b/templates/calendar/app/components/layout/AppLayout.tsx
@@ -394,7 +394,7 @@ export function AppLayout({ children }: AppLayoutProps) {
               position="right"
               defaultOpen={false}
               emptyStateText={t("agentSidebar.emptyState")}
-              agentPageHref="/agent"
+              agentPageHref="/settings/agent"
               suggestions={[
                 t("agentSidebar.suggestions.today"),
                 t("agentSidebar.suggestions.findSlot"),

--- a/templates/calendar/app/root.tsx
+++ b/templates/calendar/app/root.tsx
@@ -223,7 +223,7 @@ function AppContent() {
             {t("root.commandSearch")}
           </CommandMenu.Item>
           <CommandMenu.Item
-            onSelect={() => navigate("/agent")}
+            onSelect={() => navigate("/settings/agent")}
             keywords={[
               "agent",
               "context",

--- a/templates/calendar/app/routes/_app.agent.tsx
+++ b/templates/calendar/app/routes/_app.agent.tsx
@@ -1,8 +1,6 @@
-import { AgentTabsPage } from "@agent-native/core/client/agent-chat";
-import { useT } from "@agent-native/core/client/i18n";
-import { useMemo } from "react";
+import { buildLegacyAgentSettingsRoute } from "@agent-native/core/client/navigation";
+import { Navigate, useLocation } from "react-router";
 
-import { useAppHeaderControls } from "@/components/layout/AppLayout";
 import { messagesByLocale } from "@/i18n-data";
 
 export function meta() {
@@ -10,17 +8,11 @@ export function meta() {
 }
 
 export default function AgentRoute() {
-  const t = useT();
-  const controls = useMemo(
-    () => ({
-      left: (
-        <h1 className="truncate text-lg font-semibold tracking-tight">
-          {t("settings.agentTitle")}
-        </h1>
-      ),
-    }),
-    [t],
+  const location = useLocation();
+  return (
+    <Navigate
+      to={buildLegacyAgentSettingsRoute(location.hash, location.search)}
+      replace
+    />
   );
-  useAppHeaderControls(controls);
-  return <AgentTabsPage appName="Calendar" />;
 }

--- a/templates/chat/app/hooks/use-navigation-state.ts
+++ b/templates/chat/app/hooks/use-navigation-state.ts
@@ -42,7 +42,10 @@ function viewForPath(pathname: string): string {
   if (pathname.startsWith("/database")) return "database";
   if (pathname.startsWith("/extensions")) return "extensions";
   if (pathname.startsWith("/observability")) return "observability";
-  if (pathname.startsWith("/agent")) return "agent";
+  if (pathname.startsWith("/settings/agent") || pathname.startsWith("/agent")) {
+    return "agent";
+  }
+  if (pathname.startsWith("/settings")) return "settings";
   if (pathname.startsWith("/team")) return "settings";
   return "chat";
 }
@@ -60,7 +63,7 @@ function pathForView(view?: string): string {
     case "observability":
       return "/observability";
     case "agent":
-      return "/agent";
+      return "/settings/agent";
     case "settings":
       return "/settings";
     case "team":

--- a/templates/chat/app/routes/agent.tsx
+++ b/templates/chat/app/routes/agent.tsx
@@ -1,5 +1,4 @@
-import { useT } from "@agent-native/core/client/i18n";
-import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
+import { buildLegacyAgentSettingsRoute } from "@agent-native/core/client/navigation";
 import { Navigate, useLocation } from "react-router";
 
 export function meta() {
@@ -7,34 +6,11 @@ export function meta() {
 }
 
 export default function AgentRoute() {
-  const t = useT();
   const location = useLocation();
-  useSetPageTitle(t("settings.agentTitle"));
-
-  const legacyTab = location.hash.replace(/^#/, "").toLowerCase();
-  const resourceTabs = new Set([
-    "files",
-    "instructions",
-    "agents",
-    "memory",
-    "skills",
-    "learnings",
-  ]);
-  const destination = resourceTabs.has(legacyTab)
-    ? `/settings/agent/resources/${legacyTab}`
-    : legacyTab === "remote-agents"
-      ? "/settings/agent/agents"
-      : legacyTab === "connections"
-        ? "/settings/integrations"
-        : legacyTab === "jobs"
-          ? "/settings/agent/automations"
-          : legacyTab === "access"
-            ? "/settings/agent"
-            : ["llm", "app-models", "limits", "voice", "background"].includes(
-                  legacyTab,
-                )
-              ? `/settings/agent/${legacyTab}`
-              : "/settings/agent";
-
-  return <Navigate to={destination} replace />;
+  return (
+    <Navigate
+      to={buildLegacyAgentSettingsRoute(location.hash, location.search)}
+      replace
+    />
+  );
 }

--- a/templates/clips/app/components/library/library-layout.tsx
+++ b/templates/clips/app/components/library/library-layout.tsx
@@ -722,7 +722,7 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
           t("navigation.agentSuggestionPricing"),
           t("navigation.agentSuggestionFiller"),
         ]}
-        agentPageHref="/agent"
+        agentPageHref="/settings/agent"
         scope={recordingScope}
         browserTabId={getBrowserTabId()}
       >

--- a/templates/clips/app/root.tsx
+++ b/templates/clips/app/root.tsx
@@ -369,7 +369,7 @@ function AppContent() {
           changelogKey="clips"
         >
           <CommandMenu.Group heading={t("root.commandActions")}>
-            <CommandMenu.Item onSelect={() => navigate("/agent")}>
+            <CommandMenu.Item onSelect={() => navigate("/settings/agent")}>
               <IconHierarchy2 size={16} />
               {t("root.openAgent")}
             </CommandMenu.Item>

--- a/templates/clips/app/routes/_app.agent.tsx
+++ b/templates/clips/app/routes/_app.agent.tsx
@@ -1,6 +1,5 @@
-import { AgentTabsPage } from "@agent-native/core/client/agent-chat";
-import { useT } from "@agent-native/core/client/i18n";
-import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
+import { buildLegacyAgentSettingsRoute } from "@agent-native/core/client/navigation";
+import { Navigate, useLocation } from "react-router";
 
 import messages from "@/i18n/en-US";
 
@@ -9,8 +8,11 @@ export function meta() {
 }
 
 export default function AgentRoute() {
-  const t = useT();
-  useSetPageTitle(t("settings.agentTitle"));
-
-  return <AgentTabsPage />;
+  const location = useLocation();
+  return (
+    <Navigate
+      to={buildLegacyAgentSettingsRoute(location.hash, location.search)}
+      replace
+    />
+  );
 }

--- a/templates/content/app/components/layout/Layout.tsx
+++ b/templates/content/app/components/layout/Layout.tsx
@@ -192,7 +192,7 @@ export function Layout({ children }: LayoutProps) {
         <AgentSidebar
           position="right"
           defaultOpen={false}
-          agentPageHref="/agent"
+          agentPageHref="/settings/agent"
           emptyStateText={t("chat.emptyState")}
           suggestions={[
             t("chat.suggestionPrd"),

--- a/templates/content/app/root.tsx
+++ b/templates/content/app/root.tsx
@@ -570,7 +570,7 @@ function ContentCommandMenu({
       )}
     >
       <CommandMenu.Group heading={t("root.commandContent")}>
-        <CommandMenu.Item onSelect={() => navigate("/agent")}>
+        <CommandMenu.Item onSelect={() => navigate("/settings/agent")}>
           <IconHierarchy2 size={16} />
           {t("root.openAgent")}
         </CommandMenu.Item>

--- a/templates/content/app/routes/_app.agent.tsx
+++ b/templates/content/app/routes/_app.agent.tsx
@@ -1,7 +1,5 @@
-import { AgentTabsPage } from "@agent-native/core/client/agent-chat";
-import { useT } from "@agent-native/core/client/i18n";
-import { createCreativeContextAgentTab } from "@agent-native/creative-context/client";
-import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
+import { buildLegacyAgentSettingsRoute } from "@agent-native/core/client/navigation";
+import { Navigate, useLocation } from "react-router";
 
 import { messagesByLocale } from "@/i18n-data";
 
@@ -10,8 +8,11 @@ export function meta() {
 }
 
 export default function AgentRoute() {
-  const t = useT();
-  useSetPageTitle(t("settings.agentTitle"));
-
-  return <AgentTabsPage extraTabFactories={[createCreativeContextAgentTab]} />;
+  const location = useLocation();
+  return (
+    <Navigate
+      to={buildLegacyAgentSettingsRoute(location.hash, location.search)}
+      replace
+    />
+  );
 }

--- a/templates/content/app/routes/_app.settings.tsx
+++ b/templates/content/app/routes/_app.settings.tsx
@@ -9,7 +9,10 @@ import {
   useAgentSettingsTabs,
   type SettingsSearchEntry,
 } from "@agent-native/core/client/settings";
-import { CreativeContextSettingsLink } from "@agent-native/creative-context/client";
+import {
+  CreativeContextSettingsLink,
+  createCreativeContextAgentTab,
+} from "@agent-native/creative-context/client";
 import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
 import { useMemo } from "react";
 import { toast } from "sonner";
@@ -26,7 +29,9 @@ export function meta() {
 
 export default function SettingsRoute() {
   const t = useT();
-  const agentSettingsTabs = useAgentSettingsTabs();
+  const agentSettingsTabs = useAgentSettingsTabs({
+    agentAdditionalTabFactories: [createCreativeContextAgentTab],
+  });
   useSetPageTitle(t("settings.title"));
   const { prefs, loading: prefsLoading, save: savePrefs } = useContentPrefs();
 

--- a/templates/content/server/plugins/creative-context.ts
+++ b/templates/content/server/plugins/creative-context.ts
@@ -20,7 +20,7 @@ registerOnboardingStep({
       kind: "link",
       primary: true,
       label: "Open Library",
-      payload: { url: "/agent#library", external: false },
+      payload: { url: "/settings/library", external: false },
     },
   ],
   isComplete: async () => {

--- a/templates/crm/app/components/crm/RecordActions.tsx
+++ b/templates/crm/app/components/crm/RecordActions.tsx
@@ -601,7 +601,10 @@ function CallEvidenceAutomationDialog({ record }: { record: CrmRecordDetail }) {
         </div>
         <DialogFooter className="flex-row flex-wrap justify-end gap-2 sm:justify-end">
           <Button asChild variant="ghost" size="sm" className="gap-1.5">
-            <Link to="/agent#jobs" onClick={() => setOpen(false)}>
+            <Link
+              to="/settings/agent/automations"
+              onClick={() => setOpen(false)}
+            >
               <IconExternalLink className="size-4" />{" "}
               {t("recordActions.manageAutomations")}
             </Link>

--- a/templates/crm/app/components/layout/CrmLayout.tsx
+++ b/templates/crm/app/components/layout/CrmLayout.tsx
@@ -121,7 +121,7 @@ export function CrmLayout({ children }: { children: React.ReactNode }) {
           "Summarize this account",
           "Which opportunities need attention?",
         ]}
-        agentPageHref="/agent"
+        agentPageHref="/settings/agent"
       >
         {shell}
       </AgentSidebar>

--- a/templates/crm/app/routes/agent.tsx
+++ b/templates/crm/app/routes/agent.tsx
@@ -1,5 +1,13 @@
-import { AgentTabsPage } from "@agent-native/core/client/agent-chat";
+import { buildLegacyAgentSettingsRoute } from "@agent-native/core/client/navigation";
+import { Navigate, useLocation } from "react-router";
 
 export default function AgentRoute() {
-  return <AgentTabsPage appName="CRM" />;
+  const location = useLocation();
+
+  return (
+    <Navigate
+      to={buildLegacyAgentSettingsRoute(location.hash, location.search)}
+      replace
+    />
+  );
 }

--- a/templates/design/app/components/layout/Layout.tsx
+++ b/templates/design/app/components/layout/Layout.tsx
@@ -153,7 +153,7 @@ export function Layout({ children }: LayoutProps) {
         <AgentSidebar
           position="right"
           storageKey={DESIGN_CHAT_STORAGE_KEY}
-          agentPageHref="/agent"
+          agentPageHref="/settings/agent"
           emptyStateText={t("chat.emptyState")}
           suggestions={[
             t("chat.suggestionLandingPage"),

--- a/templates/design/app/root.tsx
+++ b/templates/design/app/root.tsx
@@ -145,7 +145,7 @@ function DesignCommandMenu({
       changelogKey="design"
     >
       <CommandMenu.Group heading={t("root.commandActions")}>
-        <CommandMenu.Item onSelect={() => navigate("/agent")}>
+        <CommandMenu.Item onSelect={() => navigate("/settings/agent")}>
           <IconHierarchy2 size={16} />
           {t("root.openAgent")}
         </CommandMenu.Item>

--- a/templates/design/app/routes/agent.tsx
+++ b/templates/design/app/routes/agent.tsx
@@ -1,7 +1,5 @@
-import { AgentTabsPage } from "@agent-native/core/client/agent-chat";
-import { useT } from "@agent-native/core/client/i18n";
-import { createCreativeContextAgentTab } from "@agent-native/creative-context/client";
-import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
+import { buildLegacyAgentSettingsRoute } from "@agent-native/core/client/navigation";
+import { Navigate, useLocation } from "react-router";
 
 import messages from "@/i18n/en-US";
 
@@ -10,8 +8,12 @@ export function meta() {
 }
 
 export default function AgentRoute() {
-  const t = useT();
-  useSetPageTitle(t("settings.agentTitle"));
+  const location = useLocation();
 
-  return <AgentTabsPage extraTabFactories={[createCreativeContextAgentTab]} />;
+  return (
+    <Navigate
+      to={buildLegacyAgentSettingsRoute(location.hash, location.search)}
+      replace
+    />
+  );
 }

--- a/templates/design/app/routes/settings.tsx
+++ b/templates/design/app/routes/settings.tsx
@@ -9,7 +9,10 @@ import {
   useAgentSettingsTabs,
   type SettingsSearchEntry,
 } from "@agent-native/core/client/settings";
-import { CreativeContextSettingsLink } from "@agent-native/creative-context/client";
+import {
+  CreativeContextSettingsLink,
+  createCreativeContextAgentTab,
+} from "@agent-native/creative-context/client";
 import { useMemo } from "react";
 
 import { messagesByLocale } from "@/i18n-data";
@@ -21,7 +24,9 @@ export function meta() {
 }
 
 export default function SettingsRoute() {
-  const agentSettingsTabs = useAgentSettingsTabs();
+  const agentSettingsTabs = useAgentSettingsTabs({
+    agentAdditionalTabFactories: [createCreativeContextAgentTab],
+  });
   const t = useT();
 
   const generalSearchEntries = useMemo<SettingsSearchEntry[]>(

--- a/templates/design/server/plugins/creative-context.ts
+++ b/templates/design/server/plugins/creative-context.ts
@@ -20,7 +20,7 @@ registerOnboardingStep({
       kind: "link",
       primary: true,
       label: "Open Library",
-      payload: { url: "/agent#library", external: false },
+      payload: { url: "/settings/library", external: false },
     },
   ],
   isComplete: async () => {

--- a/templates/dispatch/app/root.tsx
+++ b/templates/dispatch/app/root.tsx
@@ -191,7 +191,7 @@ function AppContent() {
         changelogKey="dispatch"
       >
         <CommandMenu.Group heading={t("root.commandActions")}>
-          <CommandMenu.Item onSelect={() => navigate("/agent")}>
+          <CommandMenu.Item onSelect={() => navigate("/settings/agent")}>
             <IconHierarchy2 size={16} />
             {t("root.openAgent")}
           </CommandMenu.Item>
@@ -203,7 +203,10 @@ function AppContent() {
           <ThemeToggleItem />
         </CommandMenu.Group>
       </CommandMenu>
-      <AppLayout extensions={dispatchExtensions} agentPageHref="/agent">
+      <AppLayout
+        extensions={dispatchExtensions}
+        agentPageHref="/settings/agent"
+      >
         <Outlet />
       </AppLayout>
     </>

--- a/templates/dispatch/app/routes/agent.tsx
+++ b/templates/dispatch/app/routes/agent.tsx
@@ -1,6 +1,5 @@
-import { AgentTabsPage } from "@agent-native/core/client/agent-chat";
-import { useT } from "@agent-native/core/client/i18n";
-import { DispatchShell } from "@agent-native/dispatch/components";
+import { buildLegacyAgentSettingsRoute } from "@agent-native/core/client/navigation";
+import { Navigate, useLocation } from "react-router";
 
 import { messagesByLocale } from "@/i18n-data";
 
@@ -9,11 +8,12 @@ export function meta() {
 }
 
 export default function AgentRoute() {
-  const t = useT();
+  const location = useLocation();
 
   return (
-    <DispatchShell title={t("settings.agentTitle")}>
-      <AgentTabsPage />
-    </DispatchShell>
+    <Navigate
+      to={buildLegacyAgentSettingsRoute(location.hash, location.search)}
+      replace
+    />
   );
 }

--- a/templates/factory/app/components/layout/Layout.tsx
+++ b/templates/factory/app/components/layout/Layout.tsx
@@ -174,7 +174,7 @@ export function Layout({ children }: LayoutProps) {
             openOnChatRunning={chatHomeHandoffActive}
             onFullscreenRequest={openAskAgentFullscreen}
             emptyStateText={t("chat.inspectEmptyState")}
-            agentPageHref="/agent"
+            agentPageHref="/settings/agent"
             suggestions={[
               t("chat.inspectSuggestionCapabilities"),
               t("chat.inspectSuggestionHello"),

--- a/templates/factory/app/hooks/use-navigation-state.ts
+++ b/templates/factory/app/hooks/use-navigation-state.ts
@@ -67,7 +67,10 @@ function viewForPath(pathname: string): string {
   if (pathname.startsWith("/extensions")) return "extensions";
   if (pathname.startsWith("/observability")) return "observability";
   if (pathname.startsWith("/factory")) return "factory";
-  if (pathname.startsWith("/agent")) return "agent";
+  if (pathname.startsWith("/settings/agent") || pathname.startsWith("/agent")) {
+    return "agent";
+  }
+  if (pathname.startsWith("/settings")) return "settings";
   if (pathname.startsWith("/team")) return "settings";
   return "chat";
 }
@@ -87,7 +90,7 @@ function pathForView(view?: string): string {
     case "factory":
       return "/factory";
     case "agent":
-      return "/agent";
+      return "/settings/agent";
     case "settings":
       return "/settings";
     case "team":

--- a/templates/factory/app/root.tsx
+++ b/templates/factory/app/root.tsx
@@ -135,7 +135,7 @@ function AppContent() {
             {t("root.commandSearch")}
           </CommandMenu.Item>
           <CommandMenu.Item
-            onSelect={() => navigate("/agent")}
+            onSelect={() => navigate("/settings/agent")}
             keywords={[
               "agent",
               "context",

--- a/templates/factory/app/routes/agent.tsx
+++ b/templates/factory/app/routes/agent.tsx
@@ -1,11 +1,6 @@
-import {
-  AgentChatSurface,
-  AgentTabsPage,
-} from "@agent-native/core/client/agent-chat";
-import { useT } from "@agent-native/core/client/i18n";
-import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
+import { buildLegacyAgentSettingsRoute } from "@agent-native/core/client/navigation";
+import { Navigate, useLocation } from "react-router";
 
-import { resolveAgentPageComponent } from "@/lib/agent-page";
 import { APP_TITLE } from "@/lib/app-config";
 
 export function meta() {
@@ -13,12 +8,12 @@ export function meta() {
 }
 
 export default function AgentRoute() {
-  const t = useT();
-  useSetPageTitle(t("settings.agentTitle"));
+  const location = useLocation();
 
-  const AgentPage = resolveAgentPageComponent({
-    AgentChatSurface,
-    AgentTabsPage,
-  });
-  return <AgentPage appName={APP_TITLE} />;
+  return (
+    <Navigate
+      to={buildLegacyAgentSettingsRoute(location.hash, location.search)}
+      replace
+    />
+  );
 }

--- a/templates/forms/app/components/layout/Layout.tsx
+++ b/templates/forms/app/components/layout/Layout.tsx
@@ -89,7 +89,7 @@ export function Layout({ children }: LayoutProps) {
         ) : (
           <AgentSidebar
             position="right"
-            agentPageHref="/agent"
+            agentPageHref="/settings/agent"
             defaultOpen={false}
             chatViewTransition
             chatViewTransitionHandoff={chatHomeHandoffPending}

--- a/templates/forms/app/root.tsx
+++ b/templates/forms/app/root.tsx
@@ -244,7 +244,7 @@ function FormsCommandMenu({
         <CommandMenu.Item onSelect={() => {}}>
           {t("root.searchForms")}
         </CommandMenu.Item>
-        <CommandMenu.Item onSelect={() => navigate("/agent")}>
+        <CommandMenu.Item onSelect={() => navigate("/settings/agent")}>
           <IconHierarchy2 size={16} />
           {t("root.openAgent")}
         </CommandMenu.Item>

--- a/templates/forms/app/routes/_app.agent.tsx
+++ b/templates/forms/app/routes/_app.agent.tsx
@@ -1,6 +1,5 @@
-import { AgentTabsPage } from "@agent-native/core/client/agent-chat";
-import { useT } from "@agent-native/core/client/i18n";
-import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
+import { buildLegacyAgentSettingsRoute } from "@agent-native/core/client/navigation";
+import { Navigate, useLocation } from "react-router";
 
 import messages from "@/i18n/en-US";
 
@@ -9,8 +8,11 @@ export function meta() {
 }
 
 export default function AgentRoute() {
-  const t = useT();
-  useSetPageTitle(t("settings.agentTitle"));
-
-  return <AgentTabsPage />;
+  const location = useLocation();
+  return (
+    <Navigate
+      to={buildLegacyAgentSettingsRoute(location.hash, location.search)}
+      replace
+    />
+  );
 }

--- a/templates/macros/app/components/layout/AppLayout.tsx
+++ b/templates/macros/app/components/layout/AppLayout.tsx
@@ -62,7 +62,9 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
 
   const isAnalytics = location.pathname === "/analytics";
   const isSettings = location.pathname.startsWith("/settings");
-  const isAgent = location.pathname.startsWith("/agent");
+  const isAgent =
+    location.pathname.startsWith("/settings/agent") ||
+    location.pathname.startsWith("/agent");
 
   // Auto-close sidebar on route change (mobile)
   useEffect(() => {
@@ -120,7 +122,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
       } else if (cmd.view === "settings") {
         navigate("/settings");
       } else if (cmd.view === "agent") {
-        navigate("/agent");
+        navigate("/settings/agent");
       } else if (cmd.view === "entry") {
         navigate("/");
       }
@@ -144,7 +146,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
           t("agent.suggestionMacros"),
           t("agent.suggestionRun"),
         ]}
-        agentPageHref="/agent"
+        agentPageHref="/settings/agent"
       >
         <div className="agent-layout-shell flex flex-1 overflow-hidden">
           {/* Desktop sidebar */}

--- a/templates/macros/app/root.tsx
+++ b/templates/macros/app/root.tsx
@@ -166,7 +166,7 @@ function MacrosCommandMenu({
           {t("root.search")}
         </CommandMenu.Item>
         <CommandMenu.Item
-          onSelect={() => navigate("/agent")}
+          onSelect={() => navigate("/settings/agent")}
           keywords={["agent", "context", "connections", "jobs", "access"]}
         >
           <IconHierarchy2 size={16} />

--- a/templates/macros/app/routes/agent.tsx
+++ b/templates/macros/app/routes/agent.tsx
@@ -1,6 +1,5 @@
-import { AgentTabsPage } from "@agent-native/core/client/agent-chat";
-import { useT } from "@agent-native/core/client/i18n";
-import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
+import { buildLegacyAgentSettingsRoute } from "@agent-native/core/client/navigation";
+import { Navigate, useLocation } from "react-router";
 
 import messages from "@/i18n/en-US";
 
@@ -9,8 +8,12 @@ export function meta() {
 }
 
 export default function AgentRoute() {
-  const t = useT();
-  useSetPageTitle(t("settings.agentTitle"));
+  const location = useLocation();
 
-  return <AgentTabsPage appName="Macros" />;
+  return (
+    <Navigate
+      to={buildLegacyAgentSettingsRoute(location.hash, location.search)}
+      replace
+    />
+  );
 }

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -149,6 +149,7 @@ function AccountAvatar({
 function isStandardLayoutPath(pathname: string): boolean {
   return (
     pathname === "/settings" ||
+    pathname.startsWith("/settings/") ||
     pathname === "/agent" ||
     pathname === "/team" ||
     pathname === "/draft-queue" ||
@@ -201,7 +202,7 @@ export function AppLayout({ children }: AppLayoutProps) {
     <AgentSidebar
       position="right"
       defaultOpen={false}
-      agentPageHref="/agent"
+      agentPageHref="/settings/agent"
       emptyStateText={t("agent.emptyState")}
       suggestions={[
         t("agent.suggestionSummarize"),
@@ -2042,7 +2043,12 @@ function StandardLayout({ children }: AppLayoutProps) {
 
   const fallbackTitle = (() => {
     if (location.pathname === "/settings") return t("settings.title");
-    if (location.pathname === "/agent") return t("settings.agentTitle");
+    if (
+      location.pathname === "/agent" ||
+      location.pathname.startsWith("/settings/agent")
+    ) {
+      return t("settings.agentTitle");
+    }
     if (location.pathname === "/team") return t("mail.pages.team");
     if (location.pathname.startsWith("/draft-queue"))
       return t("mail.views.draftQueue");

--- a/templates/mail/app/components/layout/CommandPalette.tsx
+++ b/templates/mail/app/components/layout/CommandPalette.tsx
@@ -79,7 +79,7 @@ const navCommands = [
   {
     labelKey: "settings.openAgentSettings",
     icon: IconHierarchy2,
-    route: "/agent",
+    route: "/settings/agent",
   },
 ];
 

--- a/templates/mail/app/routes/agent.tsx
+++ b/templates/mail/app/routes/agent.tsx
@@ -1,6 +1,5 @@
-import { AgentTabsPage } from "@agent-native/core/client/agent-chat";
-import { useT } from "@agent-native/core/client/i18n";
-import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
+import { buildLegacyAgentSettingsRoute } from "@agent-native/core/client/navigation";
+import { Navigate, useLocation } from "react-router";
 
 import messages from "@/i18n/en-US";
 
@@ -9,8 +8,12 @@ export function meta() {
 }
 
 export default function AgentRoute() {
-  const t = useT();
-  useSetPageTitle(t("settings.agentTitle"));
+  const location = useLocation();
 
-  return <AgentTabsPage appName="Mail" />;
+  return (
+    <Navigate
+      to={buildLegacyAgentSettingsRoute(location.hash, location.search)}
+      replace
+    />
+  );
 }

--- a/templates/plan/app/components/layout/Layout.tsx
+++ b/templates/plan/app/components/layout/Layout.tsx
@@ -211,7 +211,7 @@ export function Layout({ children }: LayoutProps) {
             chatViewTransitionHandoff={chatHomeHandoffPending}
             storageKey="plans"
             openOnChatRunning={chatHomeHandoffActive}
-            agentPageHref="/agent"
+            agentPageHref="/settings/agent"
             emptyStateText={t("agent.emptyState")}
             suggestions={[
               t("agent.suggestionShipped"),

--- a/templates/plan/app/root.tsx
+++ b/templates/plan/app/root.tsx
@@ -177,7 +177,7 @@ function AppContent() {
             {t("root.openRecaps")}
           </CommandMenu.Item>
           <CommandMenu.Item
-            onSelect={() => go("/agent")}
+            onSelect={() => go("/settings/agent")}
             keywords={["agent", "context", "connections", "jobs", "access"]}
           >
             <IconHierarchy2 size={16} />

--- a/templates/plan/app/routes/agent.tsx
+++ b/templates/plan/app/routes/agent.tsx
@@ -1,6 +1,5 @@
-import { AgentTabsPage } from "@agent-native/core/client/agent-chat";
-import { useT } from "@agent-native/core/client/i18n";
-import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
+import { buildLegacyAgentSettingsRoute } from "@agent-native/core/client/navigation";
+import { Navigate, useLocation } from "react-router";
 
 import messages from "@/i18n/en-US";
 
@@ -9,8 +8,12 @@ export function meta() {
 }
 
 export default function AgentRoute() {
-  const t = useT();
-  useSetPageTitle(t("settings.agentTitle"));
+  const location = useLocation();
 
-  return <AgentTabsPage appName="Plan" />;
+  return (
+    <Navigate
+      to={buildLegacyAgentSettingsRoute(location.hash, location.search)}
+      replace
+    />
+  );
 }

--- a/templates/slides/app/components/layout/Layout.tsx
+++ b/templates/slides/app/components/layout/Layout.tsx
@@ -117,7 +117,7 @@ export function Layout({ children }: LayoutProps) {
         ]}
         scope={deckScope}
         browserTabId={TAB_ID}
-        agentPageHref="/agent"
+        agentPageHref="/settings/agent"
         suppressFirstRunOnboarding={isSlidesEditorRoute(location.pathname)}
         composerSlot={<CreativeContextComposerChip />}
         threadFooterSlot={<GoogleDriveConnectionCta />}

--- a/templates/slides/app/root.tsx
+++ b/templates/slides/app/root.tsx
@@ -229,7 +229,7 @@ function AppContent() {
             {t("root.searchDecks")}
           </CommandMenu.Item>
           <CommandMenu.Item
-            onSelect={() => navigate("/agent")}
+            onSelect={() => navigate("/settings/agent")}
             keywords={["agent", "context", "connections", "jobs", "access"]}
           >
             <IconHierarchy2 size={16} />

--- a/templates/slides/app/routes/agent.tsx
+++ b/templates/slides/app/routes/agent.tsx
@@ -1,7 +1,5 @@
-import { AgentTabsPage } from "@agent-native/core/client/agent-chat";
-import { useT } from "@agent-native/core/client/i18n";
-import { createCreativeContextAgentTab } from "@agent-native/creative-context/client";
-import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
+import { buildLegacyAgentSettingsRoute } from "@agent-native/core/client/navigation";
+import { Navigate, useLocation } from "react-router";
 
 import messages from "@/i18n/en-US";
 
@@ -10,13 +8,12 @@ export function meta() {
 }
 
 export default function AgentRoute() {
-  const t = useT();
-  useSetPageTitle(t("settings.agentTitle"));
+  const location = useLocation();
 
   return (
-    <AgentTabsPage
-      appName="Slides"
-      extraTabFactories={[createCreativeContextAgentTab]}
+    <Navigate
+      to={buildLegacyAgentSettingsRoute(location.hash, location.search)}
+      replace
     />
   );
 }

--- a/templates/slides/app/routes/settings.tsx
+++ b/templates/slides/app/routes/settings.tsx
@@ -9,7 +9,10 @@ import {
   useAgentSettingsTabs,
   type SettingsSearchEntry,
 } from "@agent-native/core/client/settings";
-import { CreativeContextSettingsLink } from "@agent-native/creative-context/client";
+import {
+  CreativeContextSettingsLink,
+  createCreativeContextAgentTab,
+} from "@agent-native/creative-context/client";
 import { useSetPageTitle } from "@agent-native/toolkit/app-shell";
 import { useMemo } from "react";
 import { toast } from "sonner";
@@ -26,7 +29,9 @@ export function meta() {
 
 export default function SettingsRoute() {
   const t = useT();
-  const agentSettingsTabs = useAgentSettingsTabs();
+  const agentSettingsTabs = useAgentSettingsTabs({
+    agentAdditionalTabFactories: [createCreativeContextAgentTab],
+  });
   useSetPageTitle(t("settings.title"));
   const { prefs, loading: prefsLoading, save: savePrefs } = useSlidesPrefs();
 

--- a/templates/slides/server/plugins/creative-context.ts
+++ b/templates/slides/server/plugins/creative-context.ts
@@ -165,7 +165,7 @@ registerOnboardingStep({
       kind: "link",
       primary: true,
       label: "Open Library",
-      payload: { url: "/agent#library", external: false },
+      payload: { url: "/settings/library", external: false },
     },
   ],
   isComplete: async () => {

--- a/templates/tasks/app/components/layout/Layout.tsx
+++ b/templates/tasks/app/components/layout/Layout.tsx
@@ -113,7 +113,7 @@ export function Layout({ children }: LayoutProps) {
           chatViewTransition
           storageKey="tasks"
           browserTabId={TAB_ID}
-          agentPageHref="/agent"
+          agentPageHref="/settings/agent"
           onFullscreenRequest={() => focusAgentChat()}
           emptyStateText={t("agent.emptyState")}
           dynamicSuggestions={false}

--- a/templates/tasks/app/routes/agent.tsx
+++ b/templates/tasks/app/routes/agent.tsx
@@ -1,4 +1,5 @@
-import { AgentTabsPage } from "@agent-native/core/client/agent-chat";
+import { buildLegacyAgentSettingsRoute } from "@agent-native/core/client/navigation";
+import { Navigate, useLocation } from "react-router";
 
 import { APP_TITLE } from "@/lib/app-config";
 
@@ -7,5 +8,12 @@ export function meta() {
 }
 
 export default function AgentRoute() {
-  return <AgentTabsPage appName={APP_TITLE} />;
+  const location = useLocation();
+
+  return (
+    <Navigate
+      to={buildLegacyAgentSettingsRoute(location.hash, location.search)}
+      replace
+    />
+  );
 }


### PR DESCRIPTION
Routes legacy /agent management URLs to canonical settings tabs across core, creative-context, templates, and examples.

Validation:
- pnpm prep: guards and typecheck passed; fast tests had one timing-sensitive templates/design failure.
- Targeted rerun: templates/design shared/html-integrity.test.ts passed.

Private bridge/** and local data/** artifacts are intentionally excluded.