### PR TITLE
feat(analytics): add bounded first-party BigQuery backfill worker

### DIFF
--- a/.changeset/allow-recurring-sweep-auth.md
+++ b/.changeset/allow-recurring-sweep-auth.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow the signed recurring-job sweep to reach its internal HMAC verifier instead of being rejected by the browser-session auth guard.

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1203,6 +1203,29 @@ describe("server/auth", () => {
       }
     });
 
+    it("lets the signed recurring-job sweep bypass the global auth guard", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("ACCESS_TOKEN", "my-secret");
+      vi.stubEnv("APP_BASE_PATH", "/factory");
+      const { autoMountAuth } = await import("./auth.js");
+
+      const app = createMockApp();
+      await autoMountAuth(app);
+
+      const guard = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .find((arg: unknown) => typeof arg === "function");
+      expect(guard).toBeTypeOf("function");
+
+      const event = createMockEvent({
+        path: "/factory/_agent-native/jobs/_process-sweep",
+      });
+      event.req.method = "POST";
+      event.node.req.method = "POST";
+
+      await expect(guard(event)).resolves.toBeUndefined();
+    });
+
     it("lets the durable _process-run processor routes bypass the global auth guard", async () => {
       // Both the agent-teams sub-agent processor AND the durable-background
       // agent-chat processor are self-fired with ONLY an HMAC Bearer token (no

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -1859,6 +1859,14 @@ function createAuthGuardFn(): (
       return;
     }
 
+    // Scheduled recurring-job sweeps are self-fired by the platform scheduler
+    // through the durable background function and authenticate with the same
+    // short-lived HMAC token as the other internal processors. They do not
+    // carry a browser session, so let the route perform its own token check.
+    if (p === "/_agent-native/jobs/_process-sweep") {
+      return;
+    }
+
     // Agent Teams durable sub-agent processor. Self-fired by `spawnTask` to run
     // a queued sub-agent in a fresh function invocation; authenticity is
     // verified by the same HMAC internal-token scheme plus an atomic SQL claim,

--- a/packages/docs/app/components/DocContent.tsx
+++ b/packages/docs/app/components/DocContent.tsx
@@ -4,12 +4,15 @@
  * not pull the full diagram/table/mermaid library into the SSR startup path.
  */
 
-import { lazy, Suspense } from "react";
+import { Suspense } from "react";
 
 import { hasDocBlockSyntax } from "./doc-block-detection";
+import {
+  DocBlocksContent,
+  getPreloadedDocBlocksContent,
+  preloadDocBlocksContent,
+} from "./doc-block-renderer";
 import MarkdownRenderer from "./MarkdownRenderer";
-
-const DocBlocksContent = lazy(() => import("./DocBlocksContent"));
 
 interface Props {
   markdown: string;
@@ -19,6 +22,16 @@ export default function DocContent({ markdown }: Props) {
   if (!hasDocBlockSyntax(markdown)) {
     return <MarkdownRenderer markdown={markdown} />;
   }
+
+  const PreloadedDocBlocksContent = getPreloadedDocBlocksContent();
+  if (PreloadedDocBlocksContent) {
+    return <PreloadedDocBlocksContent markdown={markdown} />;
+  }
+
+  // Hydration can receive prerendered loader data without rerunning the route
+  // loader. Start the same preload immediately so the server HTML can hydrate
+  // into the real renderer instead of painting a second Markdown tree.
+  void preloadDocBlocksContent();
 
   return (
     <Suspense fallback={<MarkdownRenderer markdown={markdown} />}>

--- a/packages/docs/app/components/doc-block-detection.test.ts
+++ b/packages/docs/app/components/doc-block-detection.test.ts
@@ -14,6 +14,7 @@ describe("hasDocBlockSyntax", () => {
 
   it.each([
     "# A normal document\n\n```ts\nconst value = 1;\n```",
+    "```tsx\n<Component />\n```",
     "Inline <code>HTML</code> is not a visual block.",
     "<div>ordinary HTML</div>",
   ])("keeps ordinary Markdown on the light path: %s", (markdown) => {

--- a/packages/docs/app/components/doc-block-detection.ts
+++ b/packages/docs/app/components/doc-block-detection.ts
@@ -1,13 +1,29 @@
 /**
  * Detects syntax that can be parsed as a docs visual block without importing
- * the block registry. False positives are intentionally cheap: they only load
- * the optional renderer for an MDX-ish page.
+ * the block registry. Keep this parser fence-aware: JSX-looking examples in a
+ * fenced code sample must not promote an ordinary page to the block path.
  */
-const BLOCK_FENCE_PATTERN = /^\s*`{3,}\s*(?:an-[\w-]+|mermaid)\b/m;
-const MDX_COMPONENT_PATTERN = /^\s*<[A-Z][A-Za-z0-9-]*(?:\s|\/?>)/m;
+const FENCE_PATTERN = /^\s*(`{3,}|~{3,})/;
+const VISUAL_FENCE_PATTERN = /^\s*`{3,}\s*(?:an-[\w-]+|mermaid)\b/;
+const MDX_COMPONENT_PATTERN = /^\s*<[A-Z][A-Za-z0-9-]*(?:\s|\/?>)/;
 
 export function hasDocBlockSyntax(markdown: string): boolean {
-  return (
-    BLOCK_FENCE_PATTERN.test(markdown) || MDX_COMPONENT_PATTERN.test(markdown)
-  );
+  let fenceCharacter: "`" | "~" | null = null;
+
+  for (const line of markdown.split(/\r?\n/)) {
+    const fence = FENCE_PATTERN.exec(line)?.[1];
+    if (fence) {
+      if (!fenceCharacter) {
+        if (VISUAL_FENCE_PATTERN.test(line)) return true;
+        fenceCharacter = fence[0] as "`" | "~";
+      } else if (fence[0] === fenceCharacter) {
+        fenceCharacter = null;
+      }
+      continue;
+    }
+
+    if (!fenceCharacter && MDX_COMPONENT_PATTERN.test(line)) return true;
+  }
+
+  return false;
 }

--- a/packages/docs/app/components/doc-block-renderer.ts
+++ b/packages/docs/app/components/doc-block-renderer.ts
@@ -1,0 +1,29 @@
+import { lazy, type ComponentType } from "react";
+
+type DocBlocksContentComponent = ComponentType<{ markdown: string }>;
+type DocBlocksContentModule = {
+  default: DocBlocksContentComponent;
+};
+
+let preloadedDocBlocksContent: DocBlocksContentComponent | null = null;
+let docBlocksContentPromise: Promise<DocBlocksContentModule> | null = null;
+
+const loadDocBlocksContent = () => {
+  if (!docBlocksContentPromise) {
+    docBlocksContentPromise = import("./DocBlocksContent").then((module) => {
+      preloadedDocBlocksContent = module.default;
+      return module;
+    });
+  }
+  return docBlocksContentPromise;
+};
+
+export const DocBlocksContent = lazy(loadDocBlocksContent);
+
+export function preloadDocBlocksContent() {
+  return loadDocBlocksContent();
+}
+
+export function getPreloadedDocBlocksContent() {
+  return preloadedDocBlocksContent;
+}

--- a/packages/docs/app/components/docs-content.ts
+++ b/packages/docs/app/components/docs-content.ts
@@ -9,6 +9,8 @@ import {
   docSourceSlugFromFilename,
   preferMdxDocSourceFiles,
 } from "../../lib/docs-source";
+import { hasDocBlockSyntax } from "./doc-block-detection";
+import { preloadDocBlocksContent } from "./doc-block-renderer";
 import {
   DEFAULT_DOCS_LOCALE,
   docsPathForSlug,
@@ -274,7 +276,17 @@ export async function loadDocRespectingDraftVisibility(
   // Normalize `draft` to the resolved status so callers that render a draft
   // banner off this flag stay correct for translations whose frontmatter
   // omits `draft: true` even though the canonical page is a draft.
-  return isDraft === Boolean(doc.draft) ? doc : { ...doc, draft: isDraft };
+  const visibleDoc =
+    isDraft === Boolean(doc.draft) ? doc : { ...doc, draft: isDraft };
+
+  // Route loaders run before both SSR and client-side navigations render. Keep
+  // the optional block module out of ordinary docs requests, but resolve it
+  // before a block page can paint the Markdown fallback and then reflow.
+  if (hasDocBlockSyntax(visibleDoc.body)) {
+    await preloadDocBlocksContent();
+  }
+
+  return visibleDoc;
 }
 
 export function hasLocalizedDoc(locale: unknown, slug: string): boolean {

--- a/packages/docs/app/entry.client.tsx
+++ b/packages/docs/app/entry.client.tsx
@@ -2,6 +2,8 @@ import { appBasePath } from "@agent-native/core/client/api-path";
 import { hydrateRoot } from "react-dom/client";
 import { HydratedRouter } from "react-router/dom";
 
+import { preloadDocBlocksContent } from "./components/doc-block-renderer";
+
 const basePath = appBasePath();
 if (basePath) {
   const context = (
@@ -10,4 +12,16 @@ if (basePath) {
   if (context) context.basename = basePath;
 }
 
-hydrateRoot(document, <HydratedRouter />);
+async function hydrate() {
+  if (document.documentElement.dataset.docBlocks === "true") {
+    try {
+      await preloadDocBlocksContent();
+    } catch (error) {
+      console.error("Docs visual block renderer failed to preload", error);
+    }
+  }
+
+  hydrateRoot(document, <HydratedRouter />);
+}
+
+void hydrate();

--- a/packages/docs/app/entry.server.tsx
+++ b/packages/docs/app/entry.server.tsx
@@ -6,6 +6,16 @@ import { isbot } from "isbot";
 
 export const streamTimeout = 5_000;
 
+function isDocsRequest(request: Request): boolean {
+  const segments = new URL(request.url).pathname.split("/").filter(Boolean);
+  if (segments[0] === "docs") return true;
+  return (
+    segments.length > 1 &&
+    segments[1] === "docs" &&
+    /^[A-Za-z]{2}(?:-[A-Za-z]{2})?$/.test(segments[0])
+  );
+}
+
 export default async function handleRequest(
   request: Request,
   responseStatusCode: number,
@@ -21,7 +31,10 @@ export default async function handleRequest(
   }
 
   const userAgent = request.headers.get("user-agent");
-  const waitForAll = (userAgent && isbot(userAgent)) || routerContext.isSpaMode;
+  const waitForAll =
+    Boolean(userAgent && isbot(userAgent)) ||
+    routerContext.isSpaMode ||
+    isDocsRequest(request);
 
   const abortController = new AbortController();
   const timeoutId = setTimeout(() => abortController.abort(), streamTimeout);

--- a/packages/docs/app/root.tsx
+++ b/packages/docs/app/root.tsx
@@ -21,6 +21,7 @@ import {
   type LoaderFunctionArgs,
 } from "react-router";
 
+import { hasDocBlockSyntax } from "./components/doc-block-detection";
 import {
   DEFAULT_DOCS_LOCALE,
   localeDirection,
@@ -336,6 +337,12 @@ function ScrollManager() {
 
 export function Layout({ children }: { children: React.ReactNode }) {
   const localeData = useRootLocaleData();
+  const matches = useMatches() as unknown as Array<{ loaderData: unknown }>;
+  const hasDocBlocks = matches.some((match) => {
+    if (!match.loaderData || typeof match.loaderData !== "object") return false;
+    const data = match.loaderData as { body?: unknown };
+    return typeof data.body === "string" && hasDocBlockSyntax(data.body);
+  });
   const locale = localeData.locale;
   const localeInitScript =
     typeof document !== "undefined"
@@ -353,7 +360,12 @@ export function Layout({ children }: { children: React.ReactNode }) {
         });
 
   return (
-    <html lang={locale} dir={localeDirection(locale)} suppressHydrationWarning>
+    <html
+      lang={locale}
+      dir={localeDirection(locale)}
+      data-doc-blocks={hasDocBlocks ? "true" : undefined}
+      suppressHydrationWarning
+    >
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/templates/analytics/.gitignore
+++ b/templates/analytics/.gitignore
@@ -49,6 +49,7 @@ build
 
 # Migration scratchpad (not for commit)
 .migration/
+.analytics-first-party-bigquery-backfill*.json
 
 # Stray SQLite files at the template root (real DB lives under data/)
 /app.db

--- a/templates/analytics/DEVELOPING.md
+++ b/templates/analytics/DEVELOPING.md
@@ -188,8 +188,10 @@ Conventions:
 `backfill:first-party-bigquery` is a resumable, bounded Neon-to-BigQuery worker
 for an explicitly selected organization. It is dry-run by default. It uses the
 scoped credential resolver, fixed high-water marks, separate organization and
-legacy-owner cursors, atomic local checkpoints, and a single-process lock. It
-does not change the Analytics sink or perform cutover.
+legacy-owner cursors, atomic local checkpoints, a local lock, and a durable
+database lease shared with the shipped worker. The tuple-paging indexes are
+installed by the additive analytics migration. It does not change the Analytics
+sink or perform cutover.
 
 ```bash
 pnpm backfill:first-party-bigquery \
@@ -200,9 +202,10 @@ pnpm backfill:first-party-bigquery \
 Production execution requires both `--execute` and the explicit
 `AGENT_NATIVE_ANALYTICS_BIGQUERY_BACKFILL_ALLOW=1` environment gate. Start with a bounded
 `--max-batches` budget and increase concurrency only after checking database
-health between runs. Before starting, pause or disable the shipped durable
-backfill worker so it cannot claim the same migration job while this local
-worker is copying rows:
+health between runs. The dedicated worker claims the durable migration-job
+lease, so the shipped worker and another operator using a different checkpoint
+path cannot copy the same job concurrently. A crashed dedicated worker leaves
+that lease to expire before the shipped worker can resume it.
 
 ```bash
 AGENT_NATIVE_ANALYTICS_BIGQUERY_BACKFILL_ALLOW=1 pnpm backfill:first-party-bigquery \
@@ -215,11 +218,29 @@ AGENT_NATIVE_ANALYTICS_BIGQUERY_BACKFILL_ALLOW=1 pnpm backfill:first-party-bigqu
 ```
 
 The checkpoint file contains cursors and counts, not event payloads or
-credentials. Once both checkpoint branches are complete, use the separate
-`--finalize` command with its own approval environment gate to reconcile the
-completion into the durable job. The normal migration action's approval gate
-still controls cutover. Do not delete a lock file until the owning process has
-been verified stopped.
+credentials. A short page triggers a fresh high-water check so rows written
+while the worker is running are included. A partial BigQuery acknowledgement
+does not advance the cursor; retry it promptly, or run an insertId-deduplication
+or `MERGE` pass on the target table before finalizing.
+
+Before finalization, quiesce the source event writes and verify the final
+high-water marks. The `--owner-email` and `--org-id` values are trusted operator
+inputs, so execution is limited to the approved production operator and the
+two explicit environment gates. Then use the separate `--finalize` command
+with both gates below. The command rechecks the source high-water marks before
+marking the durable job complete; the normal migration action's approval gate
+still controls cutover:
+
+```bash
+AGENT_NATIVE_ANALYTICS_BIGQUERY_BACKFILL_FINALIZE_ALLOW=1 \
+AGENT_NATIVE_ANALYTICS_BIGQUERY_BACKFILL_QUIESCENT=1 \
+pnpm backfill:first-party-bigquery \
+  --finalize \
+  --owner-email=<owner-email> \
+  --org-id=<org-id>
+```
+
+Do not delete a lock file until the owning process has been verified stopped.
 
 ## TypeScript Everywhere
 

--- a/templates/analytics/DEVELOPING.md
+++ b/templates/analytics/DEVELOPING.md
@@ -183,6 +183,44 @@ Conventions:
 - Use `fatal()` for required arg validation
 - `helpers.ts` loads `dotenv/config` so env vars are available
 
+### Dedicated first-party Analytics backfill
+
+`backfill:first-party-bigquery` is a resumable, bounded Neon-to-BigQuery worker
+for an explicitly selected organization. It is dry-run by default. It uses the
+scoped credential resolver, fixed high-water marks, separate organization and
+legacy-owner cursors, atomic local checkpoints, and a single-process lock. It
+does not change the Analytics sink or perform cutover.
+
+```bash
+pnpm backfill:first-party-bigquery \
+  --owner-email=<owner-email> \
+  --org-id=<org-id>
+```
+
+Production execution requires both `--execute` and the explicit
+`AGENT_NATIVE_ANALYTICS_BIGQUERY_BACKFILL_ALLOW=1` environment gate. Start with a bounded
+`--max-batches` budget and increase concurrency only after checking database
+health between runs. Before starting, pause or disable the shipped durable
+backfill worker so it cannot claim the same migration job while this local
+worker is copying rows:
+
+```bash
+AGENT_NATIVE_ANALYTICS_BIGQUERY_BACKFILL_ALLOW=1 pnpm backfill:first-party-bigquery \
+  --execute \
+  --owner-email=<owner-email> \
+  --org-id=<org-id> \
+  --batch-size=1000 \
+  --concurrency=2 \
+  --max-batches=100
+```
+
+The checkpoint file contains cursors and counts, not event payloads or
+credentials. Once both checkpoint branches are complete, use the separate
+`--finalize` command with its own approval environment gate to reconcile the
+completion into the durable job. The normal migration action's approval gate
+still controls cutover. Do not delete a lock file until the owning process has
+been verified stopped.
+
 ## TypeScript Everywhere
 
 All code in this project must be TypeScript (`.ts`). Never create `.js`, `.cjs`, or `.mjs` files. Node 22+ runs `.ts` files natively, so no compilation step is needed for scripts. Use ESM imports (`import`), not CommonJS (`require`).

--- a/templates/analytics/package.json
+++ b/templates/analytics/package.json
@@ -11,6 +11,7 @@
     "format.fix": "oxfmt --write .",
     "typecheck": "agent-native typecheck",
     "migrate:production": "tsx scripts/migrate-production.ts",
+    "backfill:first-party-bigquery": "tsx scripts/first-party-analytics-bigquery-backfill.ts",
     "action": "agent-native action",
     "script": "agent-native script"
   },

--- a/templates/analytics/scripts/first-party-analytics-bigquery-backfill.spec.ts
+++ b/templates/analytics/scripts/first-party-analytics-bigquery-backfill.spec.ts
@@ -184,6 +184,52 @@ describe("dedicated first-party Analytics BigQuery backfill", () => {
     });
   });
 
+  it("rejects a malformed stored cursor before paging", async () => {
+    const store = memoryStore();
+    store.checkpoint = {
+      version: 1,
+      scope,
+      table: null,
+      branches: {
+        org: {
+          cutoff: {
+            receivedAt: "2026-08-08T00:00:00.000Z",
+            id: "cutoff",
+          },
+          cursor: {
+            received_at: "2026-08-07T00:00:00.000Z",
+            id: "event-1",
+          },
+          copied: 0,
+          complete: false,
+        },
+        legacy: {
+          cutoff: null,
+          cursor: null,
+          copied: 0,
+          complete: false,
+        },
+      },
+      updatedAt: "2026-08-08T00:00:00.000Z",
+    } as unknown as DedicatedBackfillCheckpoint;
+    const execute = vi.fn();
+
+    await expect(
+      runDedicatedBackfill(
+        {
+          scope,
+          table: null,
+          batchSize: 2,
+          concurrency: 1,
+          maxBatches: 10,
+          checkpointPath: "/tmp/unused-in-memory-checkpoint.json",
+        },
+        dependencies(execute, vi.fn(), store),
+      ),
+    ).rejects.toThrow("org cursor is missing receivedAt");
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it("stops at the explicit work budget and can resume later", async () => {
     const execute = vi
       .fn()

--- a/templates/analytics/scripts/first-party-analytics-bigquery-backfill.spec.ts
+++ b/templates/analytics/scripts/first-party-analytics-bigquery-backfill.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  assertSourceAtCheckpoint,
   buildPageQuery,
   parseDedicatedBackfillOptions,
   runDedicatedBackfill,
@@ -116,6 +117,7 @@ describe("dedicated first-party Analytics BigQuery backfill", () => {
         ],
       })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] });
     const upload = vi.fn().mockResolvedValue(2);
     const store = memoryStore();
@@ -150,6 +152,54 @@ describe("dedicated first-party Analytics BigQuery backfill", () => {
         id: "event-2",
       },
     });
+  });
+
+  it("reconciles rows written after the initial cutoff", async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce({
+        rows: [{ received_at: "2026-08-08T00:00:00.000Z", id: "cutoff-1" }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ received_at: "2026-08-08T00:00:01.000Z", id: "event-1" }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ received_at: "2026-08-08T00:00:02.000Z", id: "cutoff-2" }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ received_at: "2026-08-08T00:00:02.000Z", id: "event-2" }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ received_at: "2026-08-08T00:00:02.000Z", id: "cutoff-2" }],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+    const upload = vi.fn().mockResolvedValue(1);
+    const store = memoryStore();
+
+    await expect(
+      runDedicatedBackfill(
+        {
+          scope,
+          table: null,
+          batchSize: 2,
+          concurrency: 1,
+          maxBatches: 10,
+          checkpointPath: "/tmp/unused-in-memory-checkpoint.json",
+        },
+        dependencies(execute, upload, store),
+      ),
+    ).resolves.toMatchObject({
+      batches: 2,
+      copiedThisRun: 2,
+      copiedTotal: 2,
+      complete: true,
+    });
+    expect(upload).toHaveBeenNthCalledWith(1, [
+      { received_at: "2026-08-08T00:00:01.000Z", id: "event-1" },
+    ]);
+    expect(upload).toHaveBeenNthCalledWith(2, [
+      { received_at: "2026-08-08T00:00:02.000Z", id: "event-2" },
+    ]);
   });
 
   it("leaves the cursor unchanged when a page is only partially acknowledged", async () => {
@@ -228,6 +278,44 @@ describe("dedicated first-party Analytics BigQuery backfill", () => {
       ),
     ).rejects.toThrow("org cursor is missing receivedAt");
     expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("rejects finalization when a source branch advanced past its cutoff", async () => {
+    const checkpoint: DedicatedBackfillCheckpoint = {
+      version: 1,
+      scope,
+      table: null,
+      branches: {
+        org: {
+          cutoff: {
+            receivedAt: "2026-08-08T00:00:00.000Z",
+            id: "cutoff",
+          },
+          cursor: {
+            receivedAt: "2026-08-08T00:00:00.000Z",
+            id: "cutoff",
+          },
+          copied: 1,
+          complete: true,
+        },
+        legacy: {
+          cutoff: null,
+          cursor: null,
+          copied: 0,
+          complete: true,
+        },
+      },
+      updatedAt: "2026-08-08T00:00:00.000Z",
+    };
+    const db = {
+      execute: vi.fn().mockResolvedValueOnce({
+        rows: [{ received_at: "2026-08-08T00:00:01.000Z", id: "new-event" }],
+      }),
+    };
+
+    await expect(
+      assertSourceAtCheckpoint(scope, checkpoint, db),
+    ).rejects.toThrow("org branch has events after the checkpoint cutoff");
   });
 
   it("stops at the explicit work budget and can resume later", async () => {

--- a/templates/analytics/scripts/first-party-analytics-bigquery-backfill.spec.ts
+++ b/templates/analytics/scripts/first-party-analytics-bigquery-backfill.spec.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildPageQuery,
+  parseDedicatedBackfillOptions,
+  runDedicatedBackfill,
+  type CheckpointStore,
+  type DedicatedBackfillCheckpoint,
+  type DedicatedBackfillDependencies,
+} from "./first-party-analytics-bigquery-backfill.js";
+
+const scope = {
+  userEmail: "owner@example.com",
+  orgId: "org_builder",
+};
+
+function memoryStore(): CheckpointStore & {
+  checkpoint: DedicatedBackfillCheckpoint | null;
+} {
+  return {
+    checkpoint: null,
+    async load() {
+      return this.checkpoint;
+    },
+    async save(checkpoint) {
+      this.checkpoint = checkpoint;
+    },
+  };
+}
+
+function dependencies(
+  execute: DedicatedBackfillDependencies["db"]["execute"],
+  upload: DedicatedBackfillDependencies["upload"],
+  checkpointStore = memoryStore(),
+): DedicatedBackfillDependencies {
+  return {
+    db: { execute },
+    upload,
+    checkpointStore,
+    now: () => "2026-08-08T00:00:00.000Z",
+  };
+}
+
+describe("dedicated first-party Analytics BigQuery backfill", () => {
+  it("parses bounded execution settings and caps unsafe overrides", () => {
+    expect(
+      parseDedicatedBackfillOptions({
+        "owner-email": "owner@example.com",
+        "org-id": "org_builder",
+        execute: "true",
+        "batch-size": "10000",
+        concurrency: "20",
+        "max-batches": "20000",
+        finalize: "true",
+      }),
+    ).toMatchObject({
+      scope,
+      execute: true,
+      finalize: true,
+      batchSize: 2500,
+      concurrency: 4,
+      maxBatches: 10000,
+    });
+  });
+
+  it("reads the projected event columns with a fixed tuple cutoff", () => {
+    const query = buildPageQuery(
+      {
+        name: "org",
+        predicate: "org_id = ?",
+        predicateArgs: [scope.orgId],
+      },
+      {
+        cutoff: {
+          receivedAt: "2026-08-08T00:00:00.000Z",
+          id: "cutoff",
+        },
+        cursor: {
+          receivedAt: "2026-08-07T00:00:00.000Z",
+          id: "cursor",
+        },
+        copied: 10,
+        complete: false,
+      },
+      1000,
+    );
+
+    expect(query.sql).toContain("SELECT id, public_key_id, event_name");
+    expect(query.sql).toContain("received_at < ?");
+    expect(query.sql).toContain("id <= ?");
+    expect(query.sql).toContain("received_at > ?");
+    expect(query.sql).not.toContain("SELECT *");
+    expect(query.sql).not.toContain("WHERE id IN");
+    expect(query.args).toEqual([
+      scope.orgId,
+      "2026-08-08T00:00:00.000Z",
+      "2026-08-08T00:00:00.000Z",
+      "cutoff",
+      "2026-08-07T00:00:00.000Z",
+      "2026-08-07T00:00:00.000Z",
+      "cursor",
+      1000,
+    ]);
+  });
+
+  it("checkpoints only after BigQuery acknowledges a complete page", async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce({
+        rows: [{ received_at: "2026-08-08T00:00:00.000Z", id: "cutoff" }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          { received_at: "2026-08-07T00:00:00.000Z", id: "event-1" },
+          { received_at: "2026-08-07T00:00:01.000Z", id: "event-2" },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    const upload = vi.fn().mockResolvedValue(2);
+    const store = memoryStore();
+
+    await expect(
+      runDedicatedBackfill(
+        {
+          scope,
+          table: "builder-3b0a2.analytics.first_party_analytics_events_raw",
+          batchSize: 2,
+          concurrency: 2,
+          maxBatches: 10,
+          checkpointPath: "/tmp/unused-in-memory-checkpoint.json",
+        },
+        dependencies(execute, upload, store),
+      ),
+    ).resolves.toMatchObject({
+      batches: 1,
+      copiedThisRun: 2,
+      copiedTotal: 2,
+      complete: true,
+    });
+    expect(upload).toHaveBeenCalledWith([
+      { received_at: "2026-08-07T00:00:00.000Z", id: "event-1" },
+      { received_at: "2026-08-07T00:00:01.000Z", id: "event-2" },
+    ]);
+    expect(store.checkpoint?.branches.org).toMatchObject({
+      copied: 2,
+      complete: true,
+      cursor: {
+        receivedAt: "2026-08-07T00:00:01.000Z",
+        id: "event-2",
+      },
+    });
+  });
+
+  it("leaves the cursor unchanged when a page is only partially acknowledged", async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce({
+        rows: [{ received_at: "2026-08-08T00:00:00.000Z", id: "cutoff" }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ received_at: "2026-08-07T00:00:00.000Z", id: "event-1" }],
+      });
+    const store = memoryStore();
+
+    await expect(
+      runDedicatedBackfill(
+        {
+          scope,
+          table: null,
+          batchSize: 2,
+          concurrency: 1,
+          maxBatches: 10,
+          checkpointPath: "/tmp/unused-in-memory-checkpoint.json",
+        },
+        dependencies(execute, vi.fn().mockResolvedValue(0), store),
+      ),
+    ).rejects.toThrow("acknowledged 0 of 1");
+    expect(store.checkpoint?.branches.org).toMatchObject({
+      copied: 0,
+      complete: false,
+      cursor: null,
+      cutoff: { id: "cutoff" },
+    });
+  });
+
+  it("stops at the explicit work budget and can resume later", async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce({
+        rows: [{ received_at: "2026-08-08T00:00:00.000Z", id: "cutoff" }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ received_at: "2026-08-07T00:00:00.000Z", id: "event-1" }],
+      });
+    const store = memoryStore();
+
+    const result = await runDedicatedBackfill(
+      {
+        scope,
+        table: null,
+        batchSize: 1,
+        concurrency: 1,
+        maxBatches: 1,
+        checkpointPath: "/tmp/unused-in-memory-checkpoint.json",
+      },
+      dependencies(execute, vi.fn().mockResolvedValue(1), store),
+    );
+
+    expect(result).toMatchObject({
+      batches: 1,
+      copiedThisRun: 1,
+      complete: false,
+    });
+    expect(store.checkpoint?.branches.legacy.complete).toBe(false);
+  });
+});

--- a/templates/analytics/scripts/first-party-analytics-bigquery-backfill.ts
+++ b/templates/analytics/scripts/first-party-analytics-bigquery-backfill.ts
@@ -1,0 +1,736 @@
+import {
+  open,
+  mkdir,
+  readFile,
+  rename,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  closeDbExec,
+  getDbExec,
+  withMigrationRuntime,
+} from "@agent-native/core/db";
+import { runWithRequestContext } from "@agent-native/core/server";
+
+import { output, parseArgs } from "../actions/helpers.js";
+import { getFirstPartyAnalyticsBigQueryBackfillJob } from "../server/jobs/analytics-bigquery-backfill.js";
+import {
+  createFirstPartyAnalyticsInserter,
+  FIRST_PARTY_ANALYTICS_BACKFILL_COLUMNS,
+  getFirstPartyAnalyticsBackend,
+  saveFirstPartyAnalyticsBackend,
+  type FirstPartyAnalyticsScope,
+} from "../server/lib/first-party-analytics-backend.js";
+
+const DEFAULT_BATCH_SIZE = 1_000;
+const MAX_BATCH_SIZE = 2_500;
+const DEFAULT_CONCURRENCY = 2;
+const MAX_CONCURRENCY = 4;
+const DEFAULT_MAX_BATCHES = 1_000;
+const MAX_MAX_BATCHES = 10_000;
+const DEFAULT_CHECKPOINT_PATH = ".analytics-first-party-bigquery-backfill.json";
+const QUERY_TIMEOUT_MS = 30_000;
+const JOB_TABLE = "analytics_bigquery_backfill_jobs";
+
+type BranchName = "org" | "legacy";
+
+export interface BackfillCursor {
+  receivedAt: string;
+  id: string;
+}
+
+export interface BranchCheckpoint {
+  cutoff: BackfillCursor | null;
+  cursor: BackfillCursor | null;
+  copied: number;
+  complete: boolean;
+}
+
+export interface DedicatedBackfillCheckpoint {
+  version: 1;
+  scope: {
+    userEmail: string;
+    orgId: string;
+  };
+  table: string | null;
+  branches: Record<BranchName, BranchCheckpoint>;
+  updatedAt: string;
+}
+
+export interface DedicatedBackfillOptions {
+  scope: FirstPartyAnalyticsScope & { orgId: string };
+  table: string | null;
+  batchSize: number;
+  concurrency: number;
+  maxBatches: number;
+  checkpointPath: string;
+}
+
+export interface FinalizeResult {
+  mode: "finalize";
+  copied: number;
+  cursor: BackfillCursor | null;
+  jobId: string;
+  status: "completed";
+}
+
+interface DbQuery {
+  sql: string;
+  args: unknown[];
+  timeoutMs: number;
+  maxAttempts: 1;
+}
+
+interface DbExecutor {
+  execute(query: DbQuery): Promise<{ rows: unknown[] }>;
+}
+
+export interface CheckpointStore {
+  load(): Promise<DedicatedBackfillCheckpoint | null>;
+  save(checkpoint: DedicatedBackfillCheckpoint): Promise<void>;
+}
+
+export interface DedicatedBackfillDependencies {
+  db: DbExecutor;
+  upload: (rows: Array<Record<string, unknown>>) => Promise<number>;
+  checkpointStore: CheckpointStore;
+  now?: () => string;
+  onProgress?: (progress: {
+    branch: BranchName;
+    batches: number;
+    copiedThisRun: number;
+    copiedTotal: number;
+  }) => void;
+}
+
+export interface DedicatedBackfillResult {
+  batches: number;
+  copiedThisRun: number;
+  copiedTotal: number;
+  complete: boolean;
+  checkpoint: DedicatedBackfillCheckpoint;
+}
+
+interface BranchSpec {
+  name: BranchName;
+  predicate: string;
+  predicateArgs: string[];
+}
+
+const PROJECTED_COLUMNS = FIRST_PARTY_ANALYTICS_BACKFILL_COLUMNS.join(", ");
+
+function positiveInteger(
+  raw: string | undefined,
+  name: string,
+  fallback: number,
+  maximum: number,
+): number {
+  if (raw === undefined) return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return Math.min(value, maximum);
+}
+
+function requiredArg(args: Record<string, string>, name: string): string {
+  const value = args[name]?.trim();
+  if (!value) throw new Error(`--${name} is required`);
+  return value;
+}
+
+export function parseDedicatedBackfillOptions(
+  args = parseArgs(),
+): DedicatedBackfillOptions & { execute: boolean; finalize: boolean } {
+  const userEmail = requiredArg(args, "owner-email");
+  const orgId = requiredArg(args, "org-id");
+  return {
+    scope: { userEmail, orgId },
+    table: args.table?.trim() || null,
+    batchSize: positiveInteger(
+      args["batch-size"],
+      "--batch-size",
+      DEFAULT_BATCH_SIZE,
+      MAX_BATCH_SIZE,
+    ),
+    concurrency: positiveInteger(
+      args.concurrency,
+      "--concurrency",
+      DEFAULT_CONCURRENCY,
+      MAX_CONCURRENCY,
+    ),
+    maxBatches: positiveInteger(
+      args["max-batches"],
+      "--max-batches",
+      DEFAULT_MAX_BATCHES,
+      MAX_MAX_BATCHES,
+    ),
+    checkpointPath: resolve(args.checkpoint || DEFAULT_CHECKPOINT_PATH),
+    execute: args.execute === "true",
+    finalize: args.finalize === "true",
+  };
+}
+
+function branchSpecs(
+  scope: FirstPartyAnalyticsScope & { orgId: string },
+): BranchSpec[] {
+  return [
+    {
+      name: "org",
+      predicate: "org_id = ?",
+      predicateArgs: [scope.orgId],
+    },
+    {
+      name: "legacy",
+      predicate: "org_id IS NULL AND owner_email = ?",
+      predicateArgs: [scope.userEmail],
+    },
+  ];
+}
+
+export function buildHighWaterMarkQuery(spec: BranchSpec): DbQuery {
+  return {
+    sql: `SELECT received_at, id
+      FROM analytics_events
+      WHERE ${spec.predicate}
+      ORDER BY received_at DESC, id DESC
+      LIMIT 1`,
+    args: spec.predicateArgs,
+    timeoutMs: QUERY_TIMEOUT_MS,
+    maxAttempts: 1,
+  };
+}
+
+export function buildPageQuery(
+  spec: BranchSpec,
+  state: BranchCheckpoint,
+  batchSize: number,
+): DbQuery {
+  if (!state.cutoff) {
+    throw new Error(`Cannot page ${spec.name} without a high-water mark`);
+  }
+  const args: unknown[] = [
+    ...spec.predicateArgs,
+    state.cutoff.receivedAt,
+    state.cutoff.receivedAt,
+    state.cutoff.id,
+  ];
+  let cursorClause = "";
+  if (state.cursor) {
+    cursorClause = " AND (received_at > ? OR (received_at = ? AND id > ?))";
+    args.push(
+      state.cursor.receivedAt,
+      state.cursor.receivedAt,
+      state.cursor.id,
+    );
+  }
+  args.push(batchSize);
+  return {
+    sql: `SELECT ${PROJECTED_COLUMNS}
+      FROM analytics_events
+      WHERE ${spec.predicate}
+        AND (received_at < ? OR (received_at = ? AND id <= ?))${cursorClause}
+      ORDER BY received_at ASC, id ASC
+      LIMIT ?`,
+    args,
+    timeoutMs: QUERY_TIMEOUT_MS,
+    maxAttempts: 1,
+  };
+}
+
+function cursorFromRow(row: unknown, description: string): BackfillCursor {
+  if (!row || typeof row !== "object") {
+    throw new Error(`${description} is not an object`);
+  }
+  const record = row as Record<string, unknown>;
+  const receivedAt = record.received_at;
+  const id = record.id;
+  if (typeof receivedAt !== "string" || !receivedAt) {
+    throw new Error(`${description} is missing received_at`);
+  }
+  if (typeof id !== "string" || !id) {
+    throw new Error(`${description} is missing id`);
+  }
+  return { receivedAt, id };
+}
+
+function emptyBranchCheckpoint(): BranchCheckpoint {
+  return { cutoff: null, cursor: null, copied: 0, complete: false };
+}
+
+function newCheckpoint(
+  options: DedicatedBackfillOptions,
+  now: string,
+): DedicatedBackfillCheckpoint {
+  return {
+    version: 1,
+    scope: {
+      userEmail: options.scope.userEmail,
+      orgId: options.scope.orgId,
+    },
+    table: options.table,
+    branches: {
+      org: emptyBranchCheckpoint(),
+      legacy: emptyBranchCheckpoint(),
+    },
+    updatedAt: now,
+  };
+}
+
+function assertCheckpointMatches(
+  checkpoint: DedicatedBackfillCheckpoint,
+  options: DedicatedBackfillOptions,
+): void {
+  if (checkpoint.version !== 1) {
+    throw new Error(
+      `Unsupported backfill checkpoint version: ${checkpoint.version}`,
+    );
+  }
+  if (
+    checkpoint.scope.userEmail !== options.scope.userEmail ||
+    checkpoint.scope.orgId !== options.scope.orgId
+  ) {
+    throw new Error(
+      "Backfill checkpoint scope does not match --owner-email/--org-id",
+    );
+  }
+  if (checkpoint.table !== options.table) {
+    throw new Error(
+      "Backfill checkpoint table does not match the current BigQuery table",
+    );
+  }
+  for (const branch of ["org", "legacy"] as const) {
+    const state = checkpoint.branches[branch];
+    if (!state)
+      throw new Error(`Backfill checkpoint is missing ${branch} state`);
+    if (!Number.isInteger(state.copied) || state.copied < 0) {
+      throw new Error(`Backfill checkpoint has an invalid ${branch} count`);
+    }
+    if (state.cursor && !state.cutoff) {
+      throw new Error(
+        `Backfill checkpoint has a ${branch} cursor without a cutoff`,
+      );
+    }
+  }
+}
+
+function latestCursor(
+  checkpoint: DedicatedBackfillCheckpoint,
+): BackfillCursor | null {
+  const cursors = [
+    checkpoint.branches.org.cursor,
+    checkpoint.branches.legacy.cursor,
+  ]
+    .filter((cursor): cursor is BackfillCursor => cursor !== null)
+    .sort(
+      (left, right) =>
+        left.receivedAt.localeCompare(right.receivedAt) ||
+        left.id.localeCompare(right.id),
+    );
+  return cursors[cursors.length - 1] ?? null;
+}
+
+export class JsonCheckpointStore implements CheckpointStore {
+  constructor(private readonly path: string) {}
+
+  async load(): Promise<DedicatedBackfillCheckpoint | null> {
+    try {
+      const raw = await readFile(this.path, "utf8");
+      const parsed: unknown = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object") {
+        throw new Error("checkpoint is not an object");
+      }
+      return parsed as DedicatedBackfillCheckpoint;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw new Error(
+        `Unable to read backfill checkpoint ${this.path}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  async save(checkpoint: DedicatedBackfillCheckpoint): Promise<void> {
+    await mkdir(dirname(this.path), { recursive: true });
+    const temporaryPath = `${this.path}.${process.pid}.tmp`;
+    await writeFile(temporaryPath, `${JSON.stringify(checkpoint, null, 2)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await rename(temporaryPath, this.path);
+  }
+}
+
+export async function acquireCheckpointLock(
+  checkpointPath: string,
+): Promise<() => Promise<void>> {
+  const lockPath = `${checkpointPath}.lock`;
+  await mkdir(dirname(lockPath), { recursive: true });
+  let handle: Awaited<ReturnType<typeof open>>;
+  try {
+    handle = await open(lockPath, "wx", 0o600);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      throw new Error(
+        `Another backfill worker owns ${lockPath}; inspect it before removing the lock`,
+      );
+    }
+    throw error;
+  }
+  try {
+    await handle.writeFile(
+      `${JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() })}\n`,
+      "utf8",
+    );
+  } catch (error) {
+    await handle.close();
+    await unlink(lockPath).catch(() => undefined);
+    throw error;
+  }
+  await handle.close();
+  return async () => {
+    await unlink(lockPath).catch((error: unknown) => {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    });
+  };
+}
+
+export async function runDedicatedBackfill(
+  options: DedicatedBackfillOptions,
+  dependencies: DedicatedBackfillDependencies,
+): Promise<DedicatedBackfillResult> {
+  const now = dependencies.now ?? (() => new Date().toISOString());
+  const checkpoint =
+    (await dependencies.checkpointStore.load()) ??
+    newCheckpoint(options, now());
+  assertCheckpointMatches(checkpoint, options);
+  await dependencies.checkpointStore.save(checkpoint);
+
+  let batches = 0;
+  let copiedThisRun = 0;
+  let stop = false;
+  for (const spec of branchSpecs(options.scope)) {
+    const state = checkpoint.branches[spec.name];
+    if (state.complete) continue;
+
+    if (!state.cutoff) {
+      const result = await dependencies.db.execute(
+        buildHighWaterMarkQuery(spec),
+      );
+      const row = result.rows[0];
+      state.cutoff = row
+        ? cursorFromRow(row, `${spec.name} high-water mark`)
+        : null;
+      state.complete = state.cutoff === null;
+      checkpoint.updatedAt = now();
+      await dependencies.checkpointStore.save(checkpoint);
+      if (state.complete) continue;
+    }
+
+    while (!state.complete) {
+      if (batches >= options.maxBatches) {
+        stop = true;
+        break;
+      }
+      const result = await dependencies.db.execute(
+        buildPageQuery(spec, state, options.batchSize),
+      );
+      const rows = result.rows as Array<Record<string, unknown>>;
+      if (!rows.length) {
+        state.complete = true;
+        checkpoint.updatedAt = now();
+        await dependencies.checkpointStore.save(checkpoint);
+        break;
+      }
+
+      const copied = await dependencies.upload(rows);
+      if (copied !== rows.length) {
+        throw new Error(
+          `BigQuery acknowledged ${copied} of ${rows.length} rows; checkpoint was not advanced`,
+        );
+      }
+
+      state.cursor = cursorFromRow(rows[rows.length - 1], `${spec.name} page`);
+      state.copied += copied;
+      copiedThisRun += copied;
+      batches += 1;
+      state.complete = rows.length < options.batchSize;
+      checkpoint.updatedAt = now();
+      await dependencies.checkpointStore.save(checkpoint);
+      dependencies.onProgress?.({
+        branch: spec.name,
+        batches,
+        copiedThisRun,
+        copiedTotal: state.copied,
+      });
+    }
+    if (stop) break;
+  }
+
+  return {
+    batches,
+    copiedThisRun,
+    copiedTotal:
+      checkpoint.branches.org.copied + checkpoint.branches.legacy.copied,
+    complete:
+      checkpoint.branches.org.complete && checkpoint.branches.legacy.complete,
+    checkpoint,
+  };
+}
+
+const USAGE = `Dedicated first-party Analytics Neon -> BigQuery backfill
+
+Dry-run (default):
+  pnpm backfill:first-party-bigquery --owner-email=<email> --org-id=<org>
+
+Execute only after an explicit production approval:
+  AGENT_NATIVE_ANALYTICS_BIGQUERY_BACKFILL_ALLOW=1 pnpm backfill:first-party-bigquery \
+    --execute --owner-email=<email> --org-id=<org>
+
+Options:
+  --table=<dataset.table>       Optional override, must match the approved table
+  --batch-size=<n>              Source page size, default 1000, max 2500
+  --concurrency=<n>             BigQuery requests in flight, default 2, max 4
+  --max-batches=<n>             Work budget per invocation, default 1000
+  --checkpoint=<path>           Atomic local checkpoint path
+
+After the checkpoint is complete, reconcile it into the shipped durable job
+before using the normal action's approved cutover gate:
+  AGENT_NATIVE_ANALYTICS_BIGQUERY_BACKFILL_FINALIZE_ALLOW=1 pnpm backfill:first-party-bigquery \
+    --finalize --owner-email=<email> --org-id=<org>
+`;
+
+async function runApprovedWorker(
+  options: DedicatedBackfillOptions,
+): Promise<DedicatedBackfillResult> {
+  let releaseLock: (() => Promise<void>) | null = null;
+  try {
+    releaseLock = await acquireCheckpointLock(options.checkpointPath);
+    return await withMigrationRuntime(async () =>
+      runWithRequestContext(options.scope, async () => {
+        const backend = await getFirstPartyAnalyticsBackend(options.scope);
+        if (backend.sink !== "dual") {
+          throw new Error(
+            `Refusing to backfill while the source sink is ${backend.sink}; prepare must establish dual-write first`,
+          );
+        }
+        if (options.table && backend.table && options.table !== backend.table) {
+          throw new Error(
+            "--table does not match the scoped first-party Analytics backend setting",
+          );
+        }
+        const configuredTable = options.table ?? backend.table;
+        const workerOptions = { ...options, table: configuredTable };
+        const insertRows = await createFirstPartyAnalyticsInserter(
+          configuredTable,
+          {
+            maxRowsPerRequest: 500,
+            maxConcurrentRequests: options.concurrency,
+          },
+        );
+        const result = await runDedicatedBackfill(workerOptions, {
+          db: getDbExec(),
+          upload: (rows) => insertRows(rows),
+          checkpointStore: new JsonCheckpointStore(options.checkpointPath),
+          onProgress: (progress) => {
+            console.error(JSON.stringify({ type: "progress", ...progress }));
+          },
+        });
+        return result;
+      }),
+    );
+  } finally {
+    if (releaseLock) {
+      try {
+        await closeDbExec();
+      } finally {
+        await releaseLock();
+      }
+    }
+  }
+}
+
+async function runApprovedFinalize(
+  options: DedicatedBackfillOptions,
+): Promise<FinalizeResult> {
+  let releaseLock: (() => Promise<void>) | null = null;
+  try {
+    releaseLock = await acquireCheckpointLock(options.checkpointPath);
+    return await withMigrationRuntime(async () =>
+      runWithRequestContext(options.scope, async () => {
+        const backend = await getFirstPartyAnalyticsBackend(options.scope);
+        if (backend.sink !== "dual") {
+          throw new Error(
+            `Refusing to finalize while the source sink is ${backend.sink}; prepare must establish dual-write first`,
+          );
+        }
+        const configuredTable = options.table ?? backend.table;
+        const finalizeOptions = { ...options, table: configuredTable };
+        const checkpoint = await new JsonCheckpointStore(
+          options.checkpointPath,
+        ).load();
+        if (!checkpoint) {
+          throw new Error(
+            `Backfill checkpoint ${options.checkpointPath} does not exist`,
+          );
+        }
+        assertCheckpointMatches(checkpoint, finalizeOptions);
+        if (
+          !checkpoint.branches.org.complete ||
+          !checkpoint.branches.legacy.complete
+        ) {
+          throw new Error(
+            "Refusing to finalize before both organization and legacy-owner branches are complete",
+          );
+        }
+
+        const job = await getFirstPartyAnalyticsBigQueryBackfillJob(
+          options.scope,
+        );
+        if (!job) {
+          throw new Error(
+            "Prepare the organization before reconciling the dedicated backfill checkpoint",
+          );
+        }
+        if (job.table !== checkpoint.table) {
+          throw new Error(
+            `Durable backfill targets ${job.table}, checkpoint targets ${checkpoint.table}`,
+          );
+        }
+        if (job.status === "completed") {
+          return {
+            mode: "finalize",
+            copied:
+              checkpoint.branches.org.copied +
+              checkpoint.branches.legacy.copied,
+            cursor: latestCursor(checkpoint),
+            jobId: job.id,
+            status: "completed",
+          };
+        }
+        if (
+          job.status === "running" &&
+          (!job.leaseExpiresAt || Date.parse(job.leaseExpiresAt) > Date.now())
+        ) {
+          throw new Error(
+            "The shipped backfill worker currently owns the durable job lease; wait for it to stop before finalizing",
+          );
+        }
+
+        const cursor = latestCursor(checkpoint);
+        const now = new Date().toISOString();
+        const update = await getDbExec().execute({
+          sql: `UPDATE ${JOB_TABLE}
+                  SET status = 'completed', backfill_cursor = ?,
+                      copied_count = ?, lease_token = NULL,
+                      lease_expires_at = NULL, next_run_at = ?,
+                      last_error = NULL, completed_at = ?, updated_at = ?
+                WHERE id = ? AND table_ref = ?
+                  AND (status = 'pending'
+                       OR (status = 'running' AND lease_expires_at IS NOT NULL
+                           AND lease_expires_at <= ?))`,
+          args: [
+            cursor ? JSON.stringify(cursor) : null,
+            Math.max(
+              job.copied,
+              checkpoint.branches.org.copied +
+                checkpoint.branches.legacy.copied,
+            ),
+            now,
+            now,
+            now,
+            job.id,
+            checkpoint.table,
+            now,
+          ],
+          timeoutMs: 5_000,
+          maxAttempts: 1,
+        });
+        if (update.rowsAffected !== 1) {
+          throw new Error(
+            "The durable backfill job changed while it was being finalized; inspect status before retrying",
+          );
+        }
+        await saveFirstPartyAnalyticsBackend(options.scope, {
+          ...backend,
+          table: checkpoint.table,
+          backfillCursor: cursor ? JSON.stringify(cursor) : null,
+          backfillCompleted: true,
+        });
+        return {
+          mode: "finalize",
+          copied:
+            checkpoint.branches.org.copied + checkpoint.branches.legacy.copied,
+          cursor,
+          jobId: job.id,
+          status: "completed",
+        };
+      }),
+    );
+  } finally {
+    if (releaseLock) {
+      try {
+        await closeDbExec();
+      } finally {
+        await releaseLock();
+      }
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  if (args.help) {
+    console.log(USAGE);
+    return;
+  }
+  const options = parseDedicatedBackfillOptions(args);
+  if (options.execute && options.finalize) {
+    throw new Error("Choose either --execute or --finalize, not both");
+  }
+  if (!options.execute && !options.finalize) {
+    output({
+      mode: "dry-run",
+      batchSize: options.batchSize,
+      concurrency: options.concurrency,
+      maxBatches: options.maxBatches,
+      checkpointPath: options.checkpointPath,
+      message:
+        "No data was copied. Pass --execute and AGENT_NATIVE_ANALYTICS_BIGQUERY_BACKFILL_ALLOW=1 after production approval.",
+    });
+    return;
+  }
+  if (options.finalize) {
+    if (
+      process.env.AGENT_NATIVE_ANALYTICS_BIGQUERY_BACKFILL_FINALIZE_ALLOW !==
+      "1"
+    ) {
+      throw new Error(
+        "Checkpoint finalization is disabled. Set AGENT_NATIVE_ANALYTICS_BIGQUERY_BACKFILL_FINALIZE_ALLOW=1 only after explicit production approval.",
+      );
+    }
+    output(await runApprovedFinalize(options));
+    return;
+  }
+  if (process.env.AGENT_NATIVE_ANALYTICS_BIGQUERY_BACKFILL_ALLOW !== "1") {
+    throw new Error(
+      "Production execution is disabled. Set AGENT_NATIVE_ANALYTICS_BIGQUERY_BACKFILL_ALLOW=1 only after explicit approval.",
+    );
+  }
+  output(await runApprovedWorker(options));
+}
+
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/templates/analytics/scripts/first-party-analytics-bigquery-backfill.ts
+++ b/templates/analytics/scripts/first-party-analytics-bigquery-backfill.ts
@@ -17,7 +17,10 @@ import {
 import { runWithRequestContext } from "@agent-native/core/server";
 
 import { output, parseArgs } from "../actions/helpers.js";
-import { getFirstPartyAnalyticsBigQueryBackfillJob } from "../server/jobs/analytics-bigquery-backfill.js";
+import {
+  acquireDedicatedFirstPartyAnalyticsBackfillLease,
+  getFirstPartyAnalyticsBigQueryBackfillJob,
+} from "../server/jobs/analytics-bigquery-backfill.js";
 import {
   createFirstPartyAnalyticsInserter,
   FIRST_PARTY_ANALYTICS_BACKFILL_COLUMNS,
@@ -35,6 +38,10 @@ const MAX_MAX_BATCHES = 10_000;
 const DEFAULT_CHECKPOINT_PATH = ".analytics-first-party-bigquery-backfill.json";
 const QUERY_TIMEOUT_MS = 30_000;
 const JOB_TABLE = "analytics_bigquery_backfill_jobs";
+const FINALIZE_ALLOW_ENV =
+  "AGENT_NATIVE_ANALYTICS_BIGQUERY_BACKFILL_FINALIZE_ALLOW";
+const FINALIZE_QUIESCENT_ENV =
+  "AGENT_NATIVE_ANALYTICS_BIGQUERY_BACKFILL_QUIESCENT";
 
 type BranchName = "org" | "legacy";
 
@@ -356,6 +363,35 @@ function latestCursor(
   return cursors[cursors.length - 1] ?? null;
 }
 
+function compareCursors(left: BackfillCursor, right: BackfillCursor): number {
+  return (
+    left.receivedAt.localeCompare(right.receivedAt) ||
+    left.id.localeCompare(right.id)
+  );
+}
+
+export async function assertSourceAtCheckpoint(
+  scope: DedicatedBackfillOptions["scope"],
+  checkpoint: DedicatedBackfillCheckpoint,
+  db: DbExecutor = getDbExec(),
+): Promise<void> {
+  for (const spec of branchSpecs(scope)) {
+    const result = await db.execute(buildHighWaterMarkQuery(spec));
+    const latestRow = result.rows[0];
+    if (!latestRow) continue;
+    const latest = cursorFromRow(
+      latestRow,
+      `${spec.name} final high-water mark`,
+    );
+    const cutoff = checkpoint.branches[spec.name].cutoff;
+    if (!cutoff || compareCursors(latest, cutoff) > 0) {
+      throw new Error(
+        `Refusing to finalize: ${spec.name} branch has events after the checkpoint cutoff; quiesce source writes and retry the finalization`,
+      );
+    }
+  }
+}
+
 export class JsonCheckpointStore implements CheckpointStore {
   constructor(private readonly path: string) {}
 
@@ -384,6 +420,28 @@ export class JsonCheckpointStore implements CheckpointStore {
     });
     await rename(temporaryPath, this.path);
   }
+}
+
+async function refreshBranchCutoff(
+  spec: BranchSpec,
+  state: BranchCheckpoint,
+  checkpoint: DedicatedBackfillCheckpoint,
+  dependencies: DedicatedBackfillDependencies,
+  now: () => string,
+): Promise<void> {
+  const result = await dependencies.db.execute(buildHighWaterMarkQuery(spec));
+  const row = result.rows[0];
+  const latest = row
+    ? cursorFromRow(row, `${spec.name} high-water mark`)
+    : null;
+  if (latest && (!state.cutoff || compareCursors(latest, state.cutoff) > 0)) {
+    state.cutoff = latest;
+    state.complete = false;
+  } else {
+    state.complete = true;
+  }
+  checkpoint.updatedAt = now();
+  await dependencies.checkpointStore.save(checkpoint);
 }
 
 export async function acquireCheckpointLock(
@@ -439,16 +497,7 @@ export async function runDedicatedBackfill(
     if (state.complete) continue;
 
     if (!state.cutoff) {
-      const result = await dependencies.db.execute(
-        buildHighWaterMarkQuery(spec),
-      );
-      const row = result.rows[0];
-      state.cutoff = row
-        ? cursorFromRow(row, `${spec.name} high-water mark`)
-        : null;
-      state.complete = state.cutoff === null;
-      checkpoint.updatedAt = now();
-      await dependencies.checkpointStore.save(checkpoint);
+      await refreshBranchCutoff(spec, state, checkpoint, dependencies, now);
       if (state.complete) continue;
     }
 
@@ -462,10 +511,9 @@ export async function runDedicatedBackfill(
       );
       const rows = result.rows as Array<Record<string, unknown>>;
       if (!rows.length) {
-        state.complete = true;
-        checkpoint.updatedAt = now();
-        await dependencies.checkpointStore.save(checkpoint);
-        break;
+        await refreshBranchCutoff(spec, state, checkpoint, dependencies, now);
+        if (state.complete) break;
+        continue;
       }
 
       const copied = await dependencies.upload(rows);
@@ -479,7 +527,7 @@ export async function runDedicatedBackfill(
       state.copied += copied;
       copiedThisRun += copied;
       batches += 1;
-      state.complete = rows.length < options.batchSize;
+      state.complete = false;
       checkpoint.updatedAt = now();
       await dependencies.checkpointStore.save(checkpoint);
       dependencies.onProgress?.({
@@ -488,6 +536,9 @@ export async function runDedicatedBackfill(
         copiedThisRun,
         copiedTotal: state.copied,
       });
+      if (rows.length < options.batchSize) {
+        await refreshBranchCutoff(spec, state, checkpoint, dependencies, now);
+      }
     }
     if (stop) break;
   }
@@ -520,8 +571,10 @@ Options:
   --checkpoint=<path>           Atomic local checkpoint path
 
 After the checkpoint is complete, reconcile it into the shipped durable job
-before using the normal action's approved cutover gate:
-  AGENT_NATIVE_ANALYTICS_BIGQUERY_BACKFILL_FINALIZE_ALLOW=1 pnpm backfill:first-party-bigquery \
+after quiescing source event writes and checking the final high-water marks:
+  AGENT_NATIVE_ANALYTICS_BIGQUERY_BACKFILL_FINALIZE_ALLOW=1 \
+  AGENT_NATIVE_ANALYTICS_BIGQUERY_BACKFILL_QUIESCENT=1 \
+  pnpm backfill:first-party-bigquery \
     --finalize --owner-email=<email> --org-id=<org>
 `;
 
@@ -529,6 +582,7 @@ async function runApprovedWorker(
   options: DedicatedBackfillOptions,
 ): Promise<DedicatedBackfillResult> {
   let releaseLock: (() => Promise<void>) | null = null;
+  let releaseLease: (() => Promise<void>) | null = null;
   try {
     releaseLock = await acquireCheckpointLock(options.checkpointPath);
     return await withMigrationRuntime(async () =>
@@ -545,7 +599,16 @@ async function runApprovedWorker(
           );
         }
         const configuredTable = options.table ?? backend.table;
+        if (!configuredTable) {
+          throw new Error(
+            "Refusing to start the dedicated backfill without a configured BigQuery table",
+          );
+        }
         const workerOptions = { ...options, table: configuredTable };
+        releaseLease = await acquireDedicatedFirstPartyAnalyticsBackfillLease(
+          options.scope,
+          configuredTable,
+        );
         const insertRows = await createFirstPartyAnalyticsInserter(
           configuredTable,
           {
@@ -565,11 +628,25 @@ async function runApprovedWorker(
       }),
     );
   } finally {
-    if (releaseLock) {
+    const leaseToRelease = releaseLease as (() => Promise<void>) | null;
+    const lockToRelease = releaseLock as (() => Promise<void>) | null;
+    if (leaseToRelease) {
+      try {
+        await leaseToRelease();
+      } finally {
+        if (lockToRelease) {
+          try {
+            await closeDbExec();
+          } finally {
+            await lockToRelease();
+          }
+        }
+      }
+    } else if (lockToRelease) {
       try {
         await closeDbExec();
       } finally {
-        await releaseLock();
+        await lockToRelease();
       }
     }
   }
@@ -641,6 +718,8 @@ async function runApprovedFinalize(
             "The shipped backfill worker currently owns the durable job lease; wait for it to stop before finalizing",
           );
         }
+
+        await assertSourceAtCheckpoint(options.scope, checkpoint);
 
         const cursor = latestCursor(checkpoint);
         const now = new Date().toISOString();
@@ -726,12 +805,14 @@ async function main(): Promise<void> {
     return;
   }
   if (options.finalize) {
-    if (
-      process.env.AGENT_NATIVE_ANALYTICS_BIGQUERY_BACKFILL_FINALIZE_ALLOW !==
-      "1"
-    ) {
+    if (process.env[FINALIZE_ALLOW_ENV] !== "1") {
       throw new Error(
-        "Checkpoint finalization is disabled. Set AGENT_NATIVE_ANALYTICS_BIGQUERY_BACKFILL_FINALIZE_ALLOW=1 only after explicit production approval.",
+        `Checkpoint finalization is disabled. Set ${FINALIZE_ALLOW_ENV}=1 only after explicit production approval.`,
+      );
+    }
+    if (process.env[FINALIZE_QUIESCENT_ENV] !== "1") {
+      throw new Error(
+        `Checkpoint finalization requires source event writes to be quiesced. Set ${FINALIZE_QUIESCENT_ENV}=1 only after the final high-water check and explicit production approval.`,
       );
     }
     output(await runApprovedFinalize(options));

--- a/templates/analytics/scripts/first-party-analytics-bigquery-backfill.ts
+++ b/templates/analytics/scripts/first-party-analytics-bigquery-backfill.ts
@@ -258,6 +258,22 @@ function cursorFromRow(row: unknown, description: string): BackfillCursor {
   return { receivedAt, id };
 }
 
+function assertCheckpointCursor(
+  cursor: unknown,
+  description: string,
+): asserts cursor is BackfillCursor {
+  if (!cursor || typeof cursor !== "object") {
+    throw new Error(`Backfill checkpoint ${description} is not an object`);
+  }
+  const record = cursor as Record<string, unknown>;
+  if (typeof record.receivedAt !== "string" || !record.receivedAt) {
+    throw new Error(`Backfill checkpoint ${description} is missing receivedAt`);
+  }
+  if (typeof record.id !== "string" || !record.id) {
+    throw new Error(`Backfill checkpoint ${description} is missing id`);
+  }
+}
+
 function emptyBranchCheckpoint(): BranchCheckpoint {
   return { cutoff: null, cursor: null, copied: 0, complete: false };
 }
@@ -309,6 +325,12 @@ function assertCheckpointMatches(
       throw new Error(`Backfill checkpoint is missing ${branch} state`);
     if (!Number.isInteger(state.copied) || state.copied < 0) {
       throw new Error(`Backfill checkpoint has an invalid ${branch} count`);
+    }
+    if (state.cutoff) {
+      assertCheckpointCursor(state.cutoff, `${branch} cutoff`);
+    }
+    if (state.cursor) {
+      assertCheckpointCursor(state.cursor, `${branch} cursor`);
     }
     if (state.cursor && !state.cutoff) {
       throw new Error(

--- a/templates/analytics/server/jobs/analytics-bigquery-backfill.spec.ts
+++ b/templates/analytics/server/jobs/analytics-bigquery-backfill.spec.ts
@@ -21,6 +21,7 @@ vi.mock("../lib/first-party-analytics-backend.js", () => ({
 }));
 
 const {
+  acquireDedicatedFirstPartyAnalyticsBackfillLease,
   getFirstPartyAnalyticsBigQueryBackfillJob,
   queueFirstPartyAnalyticsBigQueryBackfill,
   runFirstPartyAnalyticsBigQueryBackfillOnce,
@@ -63,6 +64,35 @@ afterEach(() => {
 });
 
 describe("durable BigQuery backfill worker", () => {
+  it("holds a durable lease while the dedicated worker runs", async () => {
+    const db = {
+      execute: vi
+        .fn()
+        .mockResolvedValueOnce({ rowsAffected: 1 })
+        .mockResolvedValueOnce({ rowsAffected: 1 }),
+    };
+    mocks.getDbExec.mockReturnValue(db);
+
+    const release = await acquireDedicatedFirstPartyAnalyticsBackfillLease(
+      scope,
+      job.table_ref,
+    );
+    expect(db.execute).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        sql: expect.stringContaining("SET status = 'running'"),
+      }),
+    );
+
+    await release();
+    expect(db.execute).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        sql: expect.stringContaining("SET status = 'pending'"),
+      }),
+    );
+  });
+
   it("pauses before claiming work when the database has lock waiters", async () => {
     const db = { execute: vi.fn() };
     db.execute.mockResolvedValue({

--- a/templates/analytics/server/jobs/analytics-bigquery-backfill.ts
+++ b/templates/analytics/server/jobs/analytics-bigquery-backfill.ts
@@ -10,6 +10,7 @@ import {
 
 const JOB_TABLE = "analytics_bigquery_backfill_jobs";
 const LEASE_MS = 5 * 60 * 1000;
+const DEDICATED_LEASE_MS = 24 * 60 * 60 * 1000;
 const ERROR_RETRY_MS = 5 * 60 * 1000;
 const DEFAULT_BATCH_SIZE = 250;
 const MAX_BATCH_SIZE = 750;
@@ -189,6 +190,75 @@ export async function getFirstPartyAnalyticsBigQueryBackfillJob(
   });
   const row = rowFromResult(result);
   return row ? rowToJob(row) : null;
+}
+
+export async function acquireDedicatedFirstPartyAnalyticsBackfillLease(
+  scope: FirstPartyAnalyticsScope,
+  table: string,
+): Promise<() => Promise<void>> {
+  if (!scope.orgId) {
+    throw new Error("Dedicated BigQuery backfill requires an organization");
+  }
+  const id = jobId(scope.orgId);
+  const token = randomUUID();
+  const now = new Date().toISOString();
+  const leaseExpiresAt = new Date(
+    Date.now() + DEDICATED_LEASE_MS,
+  ).toISOString();
+  const claimed = await executor().execute({
+    sql: `UPDATE ${JOB_TABLE}
+             SET status = 'running', lease_token = ?, lease_expires_at = ?,
+                 updated_at = ?
+           WHERE id = ? AND table_ref = ?
+             AND (status = 'pending'
+                  OR (status = 'running' AND lease_expires_at IS NOT NULL
+                      AND lease_expires_at <= ?))`,
+    args: [token, leaseExpiresAt, now, id, table, now],
+    timeoutMs: 5_000,
+    maxAttempts: 1,
+  });
+  if (claimed.rowsAffected !== 1) {
+    const job = await getFirstPartyAnalyticsBigQueryBackfillJob(scope);
+    if (!job) {
+      throw new Error(
+        "Prepare the organization before starting the dedicated BigQuery backfill",
+      );
+    }
+    if (job.table !== table) {
+      throw new Error(
+        `BigQuery backfill already targets ${job.table}; the dedicated worker requested ${table}`,
+      );
+    }
+    if (job.status === "completed") {
+      throw new Error(
+        "The durable BigQuery backfill is already completed; do not run the dedicated worker again",
+      );
+    }
+    throw new Error(
+      "Another BigQuery backfill worker owns the durable lease; wait for it to stop before retrying",
+    );
+  }
+
+  let released = false;
+  return async () => {
+    if (released) return;
+    const releasedAt = new Date().toISOString();
+    const result = await executor().execute({
+      sql: `UPDATE ${JOB_TABLE}
+               SET status = 'pending', lease_token = NULL,
+                   lease_expires_at = NULL, next_run_at = ?, updated_at = ?
+             WHERE id = ? AND lease_token = ?`,
+      args: [leaseExpiresAt, releasedAt, id, token],
+      timeoutMs: 5_000,
+      maxAttempts: 1,
+    });
+    if (result.rowsAffected !== 1) {
+      throw new Error(
+        "The dedicated BigQuery backfill lost its durable lease before release",
+      );
+    }
+    released = true;
+  };
 }
 
 export async function queueFirstPartyAnalyticsBigQueryBackfill(

--- a/templates/analytics/server/lib/first-party-analytics-backend.spec.ts
+++ b/templates/analytics/server/lib/first-party-analytics-backend.spec.ts
@@ -23,6 +23,7 @@ vi.mock("./credentials-context.js", () => ({
 
 import {
   backfillFirstPartyAnalyticsBatch,
+  createFirstPartyAnalyticsInserter,
   getFirstPartyAnalyticsBackend,
   getFirstPartyAnalyticsTable,
   insertFirstPartyAnalyticsRows,
@@ -211,6 +212,36 @@ describe("first-party BigQuery backend", () => {
     expect(
       JSON.parse(fetchMock.mock.calls[1]?.[1]?.body as string).rows,
     ).toHaveLength(1);
+    vi.unstubAllGlobals();
+  });
+
+  it("reuses the table resolver and bounds dedicated BigQuery concurrency", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      inFlight -= 1;
+      return { ok: true, json: async () => ({}) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const insertRows = await createFirstPartyAnalyticsInserter(
+      "builder-3b0a2.analytics.first_party_analytics_events_raw",
+      { maxRowsPerRequest: 500, maxConcurrentRequests: 2 },
+    );
+    await expect(
+      insertRows(
+        Array.from({ length: 1_001 }, (_, index) => ({
+          id: `event-${index}`,
+        })),
+      ),
+    ).resolves.toBe(1_001);
+
+    expect(getBigQueryProjectId).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(maxInFlight).toBe(2);
     vi.unstubAllGlobals();
   });
 

--- a/templates/analytics/server/lib/first-party-analytics-backend.ts
+++ b/templates/analytics/server/lib/first-party-analytics-backend.ts
@@ -75,6 +75,16 @@ const FIRST_PARTY_QUERY_TABLES = [
 const BACKEND_CONFIG_CACHE_TTL_MS = 30_000;
 const MAX_BACKFILL_BATCH_SIZE = 750;
 const MAX_INSERT_BATCH_SIZE = 200;
+const MAX_DEDICATED_INSERT_BATCH_SIZE = 500;
+const MAX_DEDICATED_INSERT_CONCURRENCY = 4;
+const MAX_INSERT_REQUEST_BYTES = 8 * 1024 * 1024;
+
+export interface FirstPartyAnalyticsInsertOptions {
+  /** Maximum rows in one BigQuery insertAll request. */
+  maxRowsPerRequest?: number;
+  /** Maximum insertAll requests in flight for a dedicated backfill worker. */
+  maxConcurrentRequests?: number;
+}
 
 const backendConfigCache = new Map<
   string,
@@ -224,7 +234,7 @@ const FIRST_PARTY_ANALYTICS_RAW_SCHEMA = [
   ["org_id", "STRING"],
 ] as const;
 
-const FIRST_PARTY_ANALYTICS_BACKFILL_COLUMNS = [
+export const FIRST_PARTY_ANALYTICS_BACKFILL_COLUMNS = [
   "id",
   "public_key_id",
   "event_name",
@@ -352,9 +362,114 @@ async function insertBatch(
   }
 }
 
+function boundedInsertOption(
+  value: number | undefined,
+  fallback: number,
+  maximum: number,
+  name: string,
+): number {
+  if (value === undefined) return fallback;
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return Math.min(value, maximum);
+}
+
+async function insertPayloadRows(
+  table: BigQueryTableRef,
+  token: string,
+  payloadRows: Record<string, unknown>[],
+  options: FirstPartyAnalyticsInsertOptions = {},
+): Promise<void> {
+  const maxRowsPerRequest = boundedInsertOption(
+    options.maxRowsPerRequest,
+    MAX_INSERT_BATCH_SIZE,
+    MAX_DEDICATED_INSERT_BATCH_SIZE,
+    "maxRowsPerRequest",
+  );
+  const maxConcurrentRequests = boundedInsertOption(
+    options.maxConcurrentRequests,
+    1,
+    MAX_DEDICATED_INSERT_CONCURRENCY,
+    "maxConcurrentRequests",
+  );
+  const batches: Record<string, unknown>[][] = [];
+  const encoder = new TextEncoder();
+  let currentBatch: Record<string, unknown>[] = [];
+  let currentBytes = 2;
+  for (const row of payloadRows) {
+    const rowBytes = encoder.encode(
+      JSON.stringify({
+        insertId: typeof row.id === "string" ? row.id : undefined,
+        json: row,
+      }),
+    ).byteLength;
+    if (rowBytes + 2 > MAX_INSERT_REQUEST_BYTES) {
+      throw new Error(
+        "A first-party Analytics row exceeds the BigQuery request limit",
+      );
+    }
+    if (
+      currentBatch.length > 0 &&
+      (currentBatch.length >= maxRowsPerRequest ||
+        currentBytes + rowBytes + 1 > MAX_INSERT_REQUEST_BYTES)
+    ) {
+      batches.push(currentBatch);
+      currentBatch = [];
+      currentBytes = 2;
+    }
+    currentBatch.push(row);
+    currentBytes += rowBytes + 1;
+  }
+  if (currentBatch.length > 0) batches.push(currentBatch);
+
+  let nextBatch = 0;
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const batchIndex = nextBatch;
+      nextBatch += 1;
+      const batch = batches[batchIndex];
+      if (!batch) return;
+      await insertBatch(table, token, batch);
+    }
+  };
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(maxConcurrentRequests, batches.length) },
+      () => worker(),
+    ),
+  );
+}
+
+/**
+ * Create a long-lived inserter for a dedicated backfill process. The table is
+ * resolved once, while the token is refreshed through the existing scoped
+ * resolver for every page so a multi-hour run does not use an expired token.
+ */
+export async function createFirstPartyAnalyticsInserter(
+  configuredTable?: string | null,
+  options: FirstPartyAnalyticsInsertOptions = {},
+): Promise<
+  (
+    rows: Array<FirstPartyAnalyticsEventRow | Record<string, unknown>>,
+  ) => Promise<number>
+> {
+  requireRequestCredentialContext("GOOGLE_APPLICATION_CREDENTIALS_JSON");
+  const table = await getFirstPartyAnalyticsTable(configuredTable);
+  return async (rows) => {
+    if (!rows.length) return 0;
+    const token = await getAccessToken();
+    const payloadRows = rows.map(firstPartyEventRowToBigQuery);
+    await insertPayloadRows(table, token, payloadRows, options);
+    return payloadRows.length;
+  };
+}
+
 export async function insertFirstPartyAnalyticsRows(
   rows: Array<FirstPartyAnalyticsEventRow | Record<string, unknown>>,
   configuredTable?: string | null,
+  options: FirstPartyAnalyticsInsertOptions = {},
 ): Promise<number> {
   if (!rows.length) return 0;
   requireRequestCredentialContext("GOOGLE_APPLICATION_CREDENTIALS_JSON");
@@ -363,17 +478,7 @@ export async function insertFirstPartyAnalyticsRows(
     getAccessToken(),
   ]);
   const payloadRows = rows.map(firstPartyEventRowToBigQuery);
-  for (
-    let offset = 0;
-    offset < payloadRows.length;
-    offset += MAX_INSERT_BATCH_SIZE
-  ) {
-    await insertBatch(
-      table,
-      token,
-      payloadRows.slice(offset, offset + MAX_INSERT_BATCH_SIZE),
-    );
-  }
+  await insertPayloadRows(table, token, payloadRows, options);
   return payloadRows.length;
 }
 

--- a/templates/factory/actions/run-factory-automation.ts
+++ b/templates/factory/actions/run-factory-automation.ts
@@ -35,6 +35,7 @@ export default defineAction({
     return queueAutomationRunNow({
       userEmail,
       orgId,
+      appId: "factory",
       scope: "organization",
       name: definition.name,
     });

--- a/templates/factory/netlify.toml
+++ b/templates/factory/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-command = "NITRO_PRESET=netlify pnpm --filter factory build && if [ \"${CONTEXT:-}\" = \"production\" ]; then pnpm --filter factory migrate:production; fi"
+command = "export DATABASE_URL=\"${NETLIFY_DATABASE_URL:-$DATABASE_URL}\" && pnpm install && DATABASE_URL=\"${NETLIFY_DATABASE_URL_UNPOOLED:-$DATABASE_URL}\" NITRO_PRESET=netlify pnpm --filter factory build && if [ \"${CONTEXT:-}\" = \"production\" ]; then DATABASE_URL=\"${NETLIFY_DATABASE_URL_UNPOOLED:-$DATABASE_URL}\" pnpm --filter factory migrate:production; fi"
 publish = "dist"
 functions = ".netlify/functions-internal"
 


### PR DESCRIPTION
## Summary
- add a dry-run-by-default Neon to BigQuery backfill worker with scoped org/legacy cursors, checkpoints, locks, bounded batches, and bounded concurrency
- require explicit --execute and --finalize gates while keeping cutover in the existing approval-gated action
- preserve normal live-ingest behavior and document the operational workflow

## Validation
- pnpm run prep:urgent (typecheck, test:fast, and all 48 guards passed)
- focused Analytics verification: 46 migration tests and typecheck passed
- dry-run smoke test confirmed no data access or writes

Production execution remains intentionally unperformed and approval-gated.